### PR TITLE
Do not append /api/projectId/store/ when projectId is not set.

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -26,7 +26,7 @@
         secretKey: undefined,  // The global key if not using project auth
         publicKey: undefined,  // Leave as undefined if not using project auth
         servers: [],
-        projectId: 1,
+        projectId: undefined,
         logger: 'javascript',
         site: undefined,
         signatureUrl: undefined,
@@ -59,7 +59,11 @@
             if (server.slice(-1) !== '/') {
                 server += '/';
             }
-            servers.push(server + 'api/' + self.options['projectId'] + '/store/');
+            if(self.options['projectId']) {
+                servers.push(server + 'api/' + self.options['projectId'] + '/store/');                
+            } else {
+                servers.push(server);
+            }
         });
         self.options['servers'] = servers;
 


### PR DESCRIPTION
That change allows to setup a specified url for logging if projectId is not set. We can setup a proxy for sentry store url under http server configuration, its more secure - we do not have to make sentry available publicly.
