### PR TITLE
fixed the "undefined/" url in Opera 12 

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -353,9 +353,14 @@
     };
 
     Raven.process = function(message, fileurl, lineno, traceback, timestamp) {
-        var label, stacktrace, data, encoded_msg, type,
-            url = root.location.origin + root.location.pathname,
+        var label, stacktrace, data, encoded_msg, type, url,
             querystring = root.location.search.slice(1);  // Remove the ?
+
+        if(root.location.origin) {
+            url = root.location.origin + root.location.pathname
+        } else {
+            url = root.location.href
+        }
 
         if (typeof(message) === 'object') {
             type = message.name;


### PR DESCRIPTION
In Opera 12 raven reported url as "undefined/" cause opera does not support .location.origin.

Added a case, to use .location.href when .location.origin is not available.
