### PR TITLE
added ignoreUrls to ignore errors from specified scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ See below in the "Security" section for more details.
 
 **ignoreErrors** - An array of error messages that should not get passed to sentry. You'll probably want to set this to `["Script error."]`.
 
+**ignoreUrls** - An array of regular expressions matching urls which will not get passed to sentry. Ie. you should set it to [/maps.google.com/] to avoid logging of errors which happens in Google Maps scripts or to [/jquery.js$/] to ignore errors in jquery library.
 
 ## Logging Errors
 

--- a/src/raven.js
+++ b/src/raven.js
@@ -32,7 +32,8 @@
         signatureUrl: undefined,
         fetchHeaders: false,  // Generates a synchronous request to your server
         testMode: false,  // Disables some things that randomize the signature
-        ignoreErrors: []
+        ignoreErrors: [],
+        ignoreUrls: []
     };
 
     Raven.funcNameRE = /function\s*([\w\-$]+)?\s*\(/i;
@@ -363,6 +364,14 @@
         }
         if ($.inArray(message, self.options.ignoreErrors) >= 0) {
             return;
+        }
+
+        var len=ignoreUrls.length;
+
+        for(var i=0; i<len; i++) {
+            if(ignoreUrls[i].test(fileurl)) {
+                return;
+            }
         }
 
         label = lineno ? message + " at " + lineno : message;


### PR DESCRIPTION
It's almost the same as the ignoreErrors option, but allows ignore errors from specified scripts, ie. script that aren't our own.
