### PR TITLE
fixing/improving parsing of chrome stack traces

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -222,7 +222,7 @@
             traceback.push({
                 'function': fn,
                 'filename': filename,
-                'lineno': isNaN(lineno) ? -1 : lineno
+                'lineno': isNaN(lineno) ? null : lineno
             });
         });
         return traceback;
@@ -275,7 +275,7 @@
                 traceback.push({
                     'function': fn,
                     'filename': filename,
-                    'lineno': isNaN(lineno) ? -1 : lineno,
+                    'lineno': isNaN(lineno) ? null : lineno,
                     'vars': {'arguments': args}
                 });
             }
@@ -301,7 +301,7 @@
             }
             traceback.push({
                 'filename': '(unknown source)',
-                'lineno': -1,
+                'lineno': null,
                 'function': fn,
                 'post_context': callee.toString().split('\n'),
                 'vars': {'arguments': args}


### PR DESCRIPTION
This pull request does a couple of things. 

First, it replaces the string parsing with a regex to add support for urls with :port in the url. Also improved support for stack traces that include stuff like "new child" as the function name.

Second, it forces the lineno to be a number, because getsentry bombs out when you give it a non-number for the line number.
