### PR TITLE
add the raven dependencies to the component.json file

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,4 +2,8 @@
   "name": "raven",
   "version": "0.7.1",
   "main": ["src/raven.js", "src/vendor/uri.js"]
+  "dependencies": {
+    "jquery": "*",
+    "zepto": "*"
+  }
 }


### PR DESCRIPTION
I don't think there's a mechanism to say "OR" in bower, but I don't think ensuring they are in the components directory is going to negatively effect anything.
