### PR TITLE
Added tracekit as a dependency in component.json to bower to understand

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,5 +1,5 @@
 {
-  "name": "raven",
+  "name": "raven-js",
   "version": "1.0.0",
   "dependencies": {
     "tracekit": "https://github.com/getsentry/TraceKit/archive/3c26e0b3a5d30400cf12d34ce0fd53167dbe0e06.zip"


### PR DESCRIPTION
As a workaround to getsentry/raven-js#61 

As side note yesterday I was hitting hard this wall twitter/bower#105 so no matter how, not even with `bower cache-clean && bower install iknite/raven-js --force` bower keep reading offical raven-js files.

I've had to make a clean repo to check things up. 
