### PR TITLE
Restore docs for capturing early errors

### DIFF
--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -82,3 +82,41 @@ Dealing with minified source code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Raven and Sentry now support `Source Maps <http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/>`_. *Information coming soon*
+
+
+Capturing errors which occur before Raven has loaded
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If your application loads a significant amount of JavaScript you may want to record errors which
+occur before the raven JavaScript has loaded, especially as this allows you to avoid the raven.js
+request temporarily blocking a user-visible resource.
+
+This example installs a primitive error handler as early as possible — typically a `<script>` in
+the HTML `<head>` — which will be replaced as soon as Raven loads:
+
+.. code-block:: html
+
+    <html>
+        <head>
+            …
+            <script>
+                var _raven_queue = [];
+                window.onerror = function(message, file, line) {
+                   var msg = line ? message + " at " + line : message;
+                   _raven_queue.push([msg, {culprit: file}]);
+                }
+            </script>
+            …
+        </head>
+        <body>
+            …
+            <script src="{% static "external/raven-1.0.1.min.js" %}"></script>
+            <script>
+                window.onerror = null; /* Clear our temporary handler */
+                Raven.config(YOUR_DSN).install();
+                for (var i=0; i < _raven_queue.length; i++) {
+                    Raven.captureMessage.apply(this, _raven_queue[i]);
+                };
+            </script>
+        </body>
+    </html>


### PR DESCRIPTION
e6ca943d64a26384aa51f51855a39d4513ddd7d7 clobbered the instructions for 
capturing errors before Raven has loaded. This commit adds them to the usage 
instructions and updates the example for the incompatible API change in 1.0.
