### PR TITLE
Don't infer AMD loaders implement `require` function

### DIFF
--- a/template/_footer.js
+++ b/template/_footer.js
@@ -1,4 +1,3 @@
-
 // Expose Raven to the world
 window.Raven = Raven;
 
@@ -8,7 +7,9 @@ if (isFunction(window.define) && define.amd) {
     define(function() { return Raven; });
 
     define = wrapArguments(define);
-    require = wrapArguments(require);
+    if (isFunction(window.require)) {
+        require = wrapArguments(require)
+    };
 }
 
 })(window);


### PR DESCRIPTION
Related to this comment: https://github.com/getsentry/raven-js/issues/68#issuecomment-13436705
