### PR TITLE
Reverse stack traces

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -282,7 +282,7 @@ function handleStackInfo(stackInfo, options) {
         each(stackInfo.stack, function(i, stack) {
             var frame = normalizeFrame(stack);
             if (frame) {
-                frames.push(frame);
+                frames.unshift(frame);
             }
         });
     }


### PR DESCRIPTION
We were sending stack traces in the wrong order. Using
unshift instead of push makes sure we sent them in the
correct order.

Fixes #86
