### PR TITLE
Try to send stack trace over POST if XMLHttpRequest is available

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -459,7 +459,16 @@ function send(data) {
 }
 
 function makeRequest(data) {
-    new Image().src = globalServer + getAuthQueryString() + '&sentry_data=' + encodeURIComponent(JSON.stringify(data));
+    var uri = globalServer + getAuthQueryString();
+
+    if (window.XMLHttpRequest) {
+      var req = new XMLHttpRequest();
+      req.open("POST", uri);
+      req.setRequestHeader("content-type", "text/plain; charset=UTF-8");
+      req.send(JSON.stringify(data));
+    } else {
+      new Image().src = uri + '&sentry_data=' + encodeURIComponent(JSON.stringify(data));
+    }
 }
 
 function isSetup() {


### PR DESCRIPTION
Sending a long stack trace with a GET request can cause a lot of issues,
since many browsers / web servers limit the length of requests to a smallish
value (like 4096 bytes).

This patch checks if XMLHttpRequest is available, and if so uses that
instead of creating an image. We can send POST requests with XMLHttpRequest,
which avoids the length restrictions on GET requests.

Addresses some of the issues in #88. Doesn't address everything, since requests
in browsers without XMLHttpRequests will still silently fail.

Nice thing about this approach is there's no need for CORS headers or Sentry updates, since Sentry already supports text/plain requests with raw request data.
