### PR TITLE
Return wrapped function's return value

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -151,7 +151,7 @@ var Raven = {
 
         return function() {
             try {
-                func.apply(this, arguments);
+                return func.apply(this, arguments);
             } catch(e) {
                 Raven.captureException(e, options);
                 throw e;


### PR DESCRIPTION
When wrapping a function, mirror TraceKit's wrap function, and return the wrapped function's return value.
