### PR TITLE
Add hashtags (if present) in URL to tags dictionary.

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -492,6 +492,11 @@ function send(data) {
     // Merge in the tags separately since arrayMerge doesn't handle a deep merge
     data.tags = arrayMerge(globalOptions.tags, data.tags);
 
+    // If there are hashtags present in the URL add these to the 'tags' dict.
+    if (window.location.hash){
+        data.tags = arrayMerge({hashtag:window.location.hash}, data.tags)
+    }
+
     // If there are no tags, strip the key from the payload alltogther.
     if (!data.tags) delete data.tags;
 


### PR DESCRIPTION
It seems that Sentry strips URLs off their hashtags and for some users this might pose a problem. My suggested solution is to add the hashes to the tags dictionary if they are present in the url (as told by the window.location.hash property). This way they will show up in the Sentry GUI under Tags.

Signed-off-by: parhamfh parhamfh@kth.se
