### PR TITLE
Use Raven.noConflict() when exporting as AMD module

### DIFF
--- a/template/_footer.js
+++ b/template/_footer.js
@@ -1,10 +1,9 @@
-
 // Expose Raven to the world
 window.Raven = Raven;
 
 // AMD
 if (typeof define === 'function' && define.amd) {
-    define('raven', [], function() { return Raven; });
+    define('raven', [], function() { return Raven.noConflict(); });
 }
 
 })(window);


### PR DESCRIPTION
This cleans up the global namespace a bit.
