### PR TITLE
Handle some quirks mode issues

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -235,7 +235,7 @@ var Raven = {
 function triggerEvent(eventType, options) {
     var event, key;
 
-    eventType = 'raven' + eventType.substr(0,1).toUpperCase() + eventType.substr(1);
+    eventType = 'raven' + eventType.substring(0,1).toUpperCase() + eventType.substring(1);
 
     if (document.createEvent) {
         event = document.createEvent('HTMLEvents');


### PR DESCRIPTION
- IE8 and 9 do not support array-style string parsing in quirks mode: `"abcdef"[0]` returns `""` whereas `"abcdef".substr(0,1)` returns `"a"`
- `document.fireEvent()` seems to return `Invalid argument` for almost every argument passed to it in IE8 and IE9 in quirks mode so I wrapped it in a try/catch block to be safe
