### PR TITLE
Add abitlity to configure global `extra`

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -15,7 +15,8 @@ var _Raven = window.Raven,
         ignoreUrls: [],
         whitelistUrls: [],
         includePaths: [],
-        tags: {}
+        tags: {},
+        extra: {}
     };
 
 var TK = TraceKit.noConflict();
@@ -496,11 +497,13 @@ function send(data) {
         'sentry.interfaces.Http': getHttpData()
     }, data);
 
-    // Merge in the tags separately since arrayMerge doesn't handle a deep merge
+    // Merge in the tags and extra separately since arrayMerge doesn't handle a deep merge
     data.tags = arrayMerge(globalOptions.tags, data.tags);
+    data.extra = arrayMerge(globalOptions.extra, data.extra);
 
-    // If there are no tags, strip the key from the payload alltogther.
+    // If there are no tags/extra, strip the key from the payload alltogther.
     if (!data.tags) delete data.tags;
+    if (!data.extra) delete data.extra;
 
     if (globalUser) data['sentry.interfaces.User'] = globalUser;
 

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -560,6 +560,38 @@ describe('globals', function() {
       }]);
     });
 
+    it('should merge in global extra', function() {
+      this.sinon.stub(window, 'isSetup').returns(true);
+      this.sinon.stub(window, 'makeRequest');
+      this.sinon.stub(window, 'getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      globalProject = 2;
+      globalOptions = {
+        logger: 'javascript',
+        site: 'THE BEST',
+        extra: {key1: 'value1'}
+      };
+
+
+      send({extra: {key2: 'value2'}});
+      assert.deepEqual(window.makeRequest.lastCall.args, [{
+        project: 2,
+        logger: 'javascript',
+        site: 'THE BEST',
+        platform: 'javascript',
+        'sentry.interfaces.Http': {
+          url: 'http://localhost/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser'
+          }
+        },
+        extra: {key1: 'value1', key2: 'value2'}
+      }]);
+    });
+
     it('should let dataCallback override everything', function() {
       this.sinon.stub(window, 'isSetup').returns(true);
       this.sinon.stub(window, 'makeRequest');


### PR DESCRIPTION
Same as https://github.com/getsentry/raven-js/issues/82 but for [additional metadata](https://sentry.readthedocs.org/en/latest/developer/client/index.html#extra) (`extra`).
