### PR TITLE
Build all combinations of plugins by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "grunt-contrib-jshint": "~0.6.3",
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-clean": "~0.4.0",
     "grunt-mocha": "~0.4.1",
     "chai": "~1.8.1"
   },


### PR DESCRIPTION
Makes the default build command create all combinations of plugins that
are available under `plugins/` directory. Makes a shallow search for
*.js files so if the plugin directory structure is changed, it needs to
be adjusted a bit.
