### PR TITLE
A note about load order and plugins in install doc

### DIFF
--- a/docs/install/index.rst
+++ b/docs/install/index.rst
@@ -4,6 +4,7 @@ Installation
 Raven is distributed in a few different methods, but they all should be included inside the ``<head>`` of your page.
 
 You should try and include Raven as high up on the page as possible. Ideally, you'd like to include Raven first, in order to potentially catch errors from other JavaScript files.
+But to use plugins (e.g. to wrap all jQuery event handlers to catch, report and reraise exceptions), you must load Raven after the library you want it to patch.
 
 Using our CDN
 ~~~~~~~~~~~~~


### PR DESCRIPTION
I tested and confirmed that the jQuery plugin had no effect unless it was loaded after jQuery; then it worked fine. So adding a note to the install docs to that effect.
