### PR TITLE
include angular-raven module for plugins

### DIFF
--- a/plugins/angular.js
+++ b/plugins/angular.js
@@ -1,0 +1,106 @@
+;(function(module, angular, undefined) {
+'use strict';
+
+module.provider('Raven', function() {
+  var _development = null;
+
+  this.development = function(config) {
+    _development = config || _development;
+    return this;
+  };
+
+  this.$get = ['$window', '$log', function($window, $log) {
+    var service = {
+      VERSION: ($window.Raven) ? $window.Raven.VERSION : 'development',
+      TraceKit: ($window.Raven) ? $window.Raven.TraceKit : 'development',
+      captureException: function captureException(exception, cause) {
+        if (_development) {
+          $log.error('Raven: Exception ', exception, cause);
+        } else {
+          $window.Raven.captureException(exception, cause);
+        }
+      },
+      captureMessage: function captureMessage(message, data) {
+        if (_development) {
+          $log.error('Raven: Message ', message, data);
+        } else {
+          $window.Raven.captureMessage(message, data);
+        }
+      },
+      setUser: function setUser(user) {
+        if (_development) {
+          $log.error('Raven: User ', user);
+        } else {
+          $window.Raven.setUser(user);
+        }
+      },
+      lastException: function lastException() {
+        if (_development) {
+          $log.error('Raven: Last Exception');
+        } else {
+          $window.Raven.lastException();
+        }
+      },
+      context: function(options, func, args) {
+        var RavenService = this;
+
+        if (angular.isFunction(options)) {
+          args = func || [];
+          func = options;
+          options = undefined;
+        }
+
+        return RavenService.wrap(options, func).apply(this, args);
+      },
+      wrap: function(options, func) {
+        var RavenService = this;
+
+        if (angular.isUndefined(func) && !angular.isFunction(options)) {
+          return options;
+        }
+
+        if (angular.isFunction(options)) {
+          func = options;
+          options = undefined;
+        }
+
+        if (!angular.isFunction(func)) {
+          return func;
+        }
+
+        if (func.__raven__) {
+          return func;
+        }
+
+        function wrapped() {
+          var args = [], i = arguments.length;
+          while(i--) args[i] = RavenService.wrap(options, arguments[i]);
+          try {
+            return func.apply(this, args);
+          } catch(e) {
+            RavenService.captureException(e, options);
+          }
+        }
+
+        for (var property in func) {
+          if (func.hasOwnProperty(property)) {
+            wrapped[property] = func[property];
+          }
+        }
+        wrapped.__raven__ = true;
+        return wrapped;
+      }
+
+    };
+
+    return service;
+  }]; // end $get
+}); // end provider
+
+module.factory('$exceptionHandler', ['Raven', function(Raven) {
+  return function(exception, cause) {
+    Raven.captureException(exception, cause);
+  };
+}]);
+
+}(angular.module('ngRaven', []), angular));


### PR DESCRIPTION
I created an Angular.js module for Raven.js and thought it might be great to include it as a plugin for core

Here is an example using the latest Angular

``` html
<body ng-app="YOUR_APP" ng-controller="MainCtrl">
  <a href="#error" ng-click="logError()">Log Error</a>
</body>
<script src="http://cdnjs.cloudflare.com/ajax/libs/raven.js/1.0.8/raven.min.js"></script>
<script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.0/angular.js"></script>
<script>
  Raven.config('YOUR_PUBLIC_DSN', {
      // Raven settings
    })
    .setUser({
      "id": "SERVER_RENDERED_ID",
      "email": "SERVER_RENDERED_EMAIL"
    })
    .install()
<script>
<script src="app/bower_components/angular-raven/angular-raven.js"></script>

<script>
  angular.module('YOUR_APP', [
    'ngRaven',
    'controllers'
  ])
  .config(function(RavenProvider) {
    // There is a development flag to log errors rather than sending it to Sentry
    RavenProvider.development(true);
  });

  angular.module('controllers', [])
    .controller('MainCtrl', function($scope, Raven) {
      $scope.logError = function() {
        Raven.captureMessage('Error');
      };
    });
</script>

```
