### PR TITLE
Don't call noConflict by default when loaded via AMD.

### DIFF
--- a/template/_footer.js
+++ b/template/_footer.js
@@ -3,7 +3,7 @@ window.Raven = Raven;
 
 // AMD
 if (typeof define === 'function' && define.amd) {
-    define('raven', [], function() { return Raven.noConflict(); });
+    define('raven', [], function() { return Raven; });
 }
 
 })(window);


### PR DESCRIPTION
Calling noConflict() makes it a pain to load the plugins, which depend on the
global variable (which is why jQuery's AMD handler, for example, doesn't do
that). For those that want noConflict(), that can be done with a wrapper (see
http://requirejs.org/docs/jquery.html#noconflictmap)
