### PR TITLE
Always return Raven from install method

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -126,9 +126,9 @@ var Raven = {
      * @return {Raven}
      */
     install: function() {
-        if (!isSetup()) return;
-
-        TK.report.subscribe(handleStackInfo);
+        if (isSetup()) {
+            TK.report.subscribe(handleStackInfo);
+        }
 
         return Raven;
     },


### PR DESCRIPTION
This makes sure that Raven is always returned from `install()` so that you don't get an error when chaining methods if Raven isn't set up.
