### PR TITLE
Additional Data Section Missing Information

### DIFF
--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -74,7 +74,7 @@ Capturing a specific message
 
 Passing additional data
 ~~~~~~~~~~~~~~~~~~~~~~~
-``captureException``, ``context``, ``wrap``, and ``captureMessage`` functions all allow passing additional data to be tagged onto the error, such as ``tags``.
+``captureException``, ``context``, ``wrap``, and ``captureMessage`` functions all allow passing additional data to be tagged onto the error, such as ``tags`` or ``extra`` for additional context.
 
 .. code-block:: javascript
 


### PR DESCRIPTION
After having many captureMessage calls miss information as I believed I could simply pass an object as 'additional' context, I checked the source code and noticed that only 'tags' and 'extra' get passed along. The documentation makes no note of this, I think it would be helpful to make note of it.
