### PR TITLE
Fix console plugin infinite loop

### DIFF
--- a/plugins/console.js
+++ b/plugins/console.js
@@ -12,13 +12,14 @@ var originalConsole = console,
     level;
 
 var logForGivenLevel = function(level) {
+    var originalConsoleLevel = console[level];
     return function () {
         var args = [].slice.call(arguments);
         Raven.captureMessage('' + args, {level: level, logger: 'console'});
 
         // this fails for some browsers. :(
-        if (originalConsole[level]) {
-             originalConsole[level].apply(null, args);
+        if (originalConsoleLevel) {
+             originalConsoleLevel.apply(originalConsole, args);
         }
     };
 };


### PR DESCRIPTION
`originalConsole[level]` was referencing the wrapper and not the original console.

It was looping indefinitely.
