### PR TITLE
add option to prevent wrapping also the functions arguments

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -178,12 +178,12 @@ var Raven = {
         }
 
         function wrapped() {
-            var args = [], i = arguments.length;
+            var args = [], i = arguments.length,
+                deep = !options || options && options.deep !== false;
             // Recursively wrap all of a function's arguments that are
             // functions themselves.
-            if (!options || options && options.deep !== false) {
-                while(i--) args[i] = Raven.wrap(options, arguments[i]);
-            }
+
+            while(i--) args[i] = deep ? Raven.wrap(options, arguments[i]) : arguments[i];
 
             try {
                 /*jshint -W040*/

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1066,11 +1066,11 @@ describe('Raven (public API)', function() {
         it('should not wrap function arguments', function() {
             var spy = this.sinon.spy();
             var wrapped = Raven.wrap({ deep: false }, function(f) {
-                assert.isTrue(f.__raven__);
+                assert.isUndefined(f.__raven__);
                 f();
             });
             wrapped(spy);
-            assert.isFalse(spy.calledOnce);
+            assert.isTrue(spy.calledOnce);
         });
 
         it('should maintain the correct scope', function() {


### PR DESCRIPTION
Hey,

I've been running into some problems when wrapping require JS define and require functions. I often return functions that have to be called as constructor functions. My first approach was checking if the function is called as a constructor function and if so calling the wrapped function with the new keyword as well. Which is impossible as long as you want variable arguments.

The next approach was using a ES6 Object.setPrototypeOf() polyfill. It's working but it is strongly discouraged, because it is very slow and unavoidably slows down subsequent execution in modern JavaScript implementations.

So I ended up adding a option to prevent wrapping the functions arguments.

~ Tobi
