### PR TITLE
Encode `project` as a string (stable/1.0.x)

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -430,7 +430,7 @@ function send(data) {
     if (!isSetup()) return;
 
     data = arrayMerge({
-        project: globalProject,
+        project: globalProject ? globalProject.toString() : globalProject,
         logger: globalOptions.logger,
         site: globalOptions.site,
         platform: 'javascript',

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -433,7 +433,7 @@ describe('globals', function() {
 
       send({foo: 'bar'});
       assert.deepEqual(window.makeRequest.lastCall.args[0], {
-        project: 2,
+        project: '2',
         logger: 'javascript',
         site: 'THE BEST',
         platform: 'javascript',
@@ -469,7 +469,7 @@ describe('globals', function() {
 
       send({foo: 'bar'});
       assert.deepEqual(window.makeRequest.lastCall.args, [{
-        project: 2,
+        project: '2',
         logger: 'javascript',
         site: 'THE BEST',
         platform: 'javascript',
@@ -590,7 +590,7 @@ describe('globals', function() {
       /* This is commented out because chai is broken.
 
       assert.deepEqual(window.makeRequest.lastCall.args, [{
-        project: 2,
+        project: '2',
         logger: 'javascript',
         platform: 'javascript',
         'sentry.interfaces.Http': {


### PR DESCRIPTION
As discussed in https://github.com/kisielk/raven-go/pull/15.
