### PR TITLE
Encode `project` as a string (master)

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -594,7 +594,7 @@ function send(data) {
     if (!isSetup()) return;
 
     data = objectMerge({
-        project: globalProject,
+        project: globalProject.toString(),
         logger: globalOptions.logger,
         site: globalOptions.site,
         platform: 'javascript',

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -549,7 +549,7 @@ describe('globals', function() {
 
             send({foo: 'bar'});
             assert.deepEqual(window.makeRequest.lastCall.args[0], {
-                project: 2,
+                project: '2',
                 logger: 'javascript',
                 site: 'THE BEST',
                 platform: 'javascript',
@@ -582,7 +582,7 @@ describe('globals', function() {
 
             send({foo: 'bar'});
             assert.deepEqual(window.makeRequest.lastCall.args, [{
-                project: 2,
+                project: '2',
                 logger: 'javascript',
                 site: 'THE BEST',
                 platform: 'javascript',
@@ -618,7 +618,7 @@ describe('globals', function() {
 
             send({tags: {tag2: 'value2'}});
             assert.deepEqual(window.makeRequest.lastCall.args, [{
-                project: 2,
+                project: '2',
                 logger: 'javascript',
                 site: 'THE BEST',
                 platform: 'javascript',
@@ -651,7 +651,7 @@ describe('globals', function() {
 
             send({extra: {key2: 'value2'}});
             assert.deepEqual(window.makeRequest.lastCall.args, [{
-                project: 2,
+                project: '2',
                 logger: 'javascript',
                 site: 'THE BEST',
                 platform: 'javascript',
@@ -706,7 +706,7 @@ describe('globals', function() {
 
             send({foo: 'bar', tags: {}, extra: {}});
             assert.deepEqual(window.makeRequest.lastCall.args[0], {
-                project: 2,
+                project: '2',
                 logger: 'javascript',
                 site: 'THE BEST',
                 platform: 'javascript',
@@ -794,7 +794,7 @@ describe('globals', function() {
             /* This is commented out because chai is broken.
 
             assert.deepEqual(window.makeRequest.lastCall.args, [{
-                project: 2,
+                project: '2',
                 logger: 'javascript',
                 platform: 'javascript',
                 request: {


### PR DESCRIPTION
As discussed in https://github.com/kisielk/raven-go/pull/15.
