### PR TITLE
Fix onerror handling when the browser passes an exception arg.

### DIFF
--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -148,14 +148,15 @@ TraceKit.report = (function reportModuleWrapper() {
     function traceKitWindowOnError(message, url, lineNo, colNo, ex) {
         var stack = null;
 
-        if (!isUndefined(ex)) {
+        if (lastExceptionStack) {
+            TraceKit.computeStackTrace.augmentStackTraceWithInitialElement(lastExceptionStack, url, lineNo, message);
+            processLastException();
+        } else if (ex) {
             // New chrome and blink send along a real error object
             // Let's just report that like a normal error.
             // See: https://mikewest.org/2013/08/debugging-runtime-errors-with-window-onerror
-            report(ex, false);
-        } else if (lastExceptionStack) {
-            TraceKit.computeStackTrace.augmentStackTraceWithInitialElement(lastExceptionStack, url, lineNo, message);
-            processLastException();
+            stack = TraceKit.computeStackTrace(ex);
+            notifyHandlers(stack, true);
         } else {
             var location = {
                 'url': url,


### PR DESCRIPTION
I haven't had (and may not have for a little while) time to test this much, but the basic idea is:
- Need to check for `lastExceptionStack` first. If that exists, we always want to do processLastException, which will use the options that were originally passed via `Raven.wrap` or `Raven.context`, and clear the vars related to that so they don't get reused on the next call to `TraceKit.report`.
- Just check `ex` rather than `!isUndefined(ex)` since browsers will sometimes pass `null` (this happens when running `example/index.html` -- it's [this error](http://stackoverflow.com/questions/5913978/cryptic-script-error-reported-in-javascript-in-chrome-and-firefox)) and in that case, it makes more sense to fall down to the final `else` block
- Call `notifyHandlers` directly rather than `report`. The latter does a bunch of stuff we don't want/need here (including the 2000ms timeout thing). I think this means we can get rid of the `rethrow` arg on report as well (I think this was the only thing using it).

Would also be nice to add some tests that exercise the code path where onerror is called with the exception arg.
