### PR TITLE
console might not be defined (old ie versions)

### DIFF
--- a/plugins/console.js
+++ b/plugins/console.js
@@ -33,4 +33,4 @@ while(level) {
 // export
 window.console = console;
 
-}(this, Raven, console || {}));
+}(this, Raven, window.console || {}));


### PR DESCRIPTION
use `window.console` instead of `console`
