### PR TITLE
Clarify that Raven.context rethrows exceptions

### DIFF
--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -33,7 +33,7 @@ It's impossible to retrieve a stack trace from a string. If this happens, Raven 
 context/wrap
 ------------
 
-``Raven.context`` allows you to wrap any function to be immediately executed. Behind the scenes, Raven is just wrapping your code in a ``try...catch`` block.
+``Raven.context`` allows you to wrap any function to be immediately executed. Behind the scenes, Raven is just wrapping your code in a ``try...catch`` block to record the exception before re-throwing it.
 
 .. code-block:: javascript
 


### PR DESCRIPTION
The docs don't currently make it clear that an exception will be thrown again after Raven.context records it.

(This does raise a side question of whether it'd be useful to have a helper which absorbs caught exceptions to reduce the need for try / catch blocks all over the place)
