### PR TITLE
Mention `tags` as a valid option for Raven.config

### DIFF
--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -37,6 +37,17 @@ The name of the logger used by Sentry. Default: ``javascript``
 
 .. _config-whitelist-urls:
 
+tags
+----
+
+Additional `tags <https://www.getsentry.com/docs/tags/>`__ to assign to each event.
+
+.. code-block:: javascript
+
+    {
+      tags: {git_commit: 'c0deb10c4'}
+    }
+
 whitelistUrls
 -------------
 


### PR DESCRIPTION
I looked for a way to specify unchanging tags (such as git commit hash of my software), and mistakenly decided it wasn't possible to pass them to Raven.config() because the documentation enumerated various possible options but didn't mention `tags`.

Bugs like https://github.com/getsentry/raven-js/issues/75 convinced me that this was supposed to be a supported feature.  So here's a doc patch to avoid sending other users into confusion.
