### PR TITLE
Docs: Double escape regexp backslashes

### DIFF
--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -137,13 +137,13 @@ Putting it all together
             var options = {
                 logger: 'my-logger',
                 whitelistUrls: [
-                    /disqus\.com/, /getsentry\.com/
+                    /disqus\\.com/, /getsentry\\.com/
                 ],
                 ignoreErrors: [
                     'fb_xd_fragment', /ReferenceError:.*/
                 ],
                 includePaths: [
-                    /https?:\/\/(www\.)?getsentry\.com/
+                    /https?:\\/\\/(www\\.)?getsentry\\.com/
                 ]
             };
             Raven.config('https://public@app.getsentry.com/1', options).install();


### PR DESCRIPTION
Backslashes in regular expressions inside parsed-literal blocks need to be
double escaped in order to appear in the output.
