### PR TITLE
Hide stack frames from raven.js

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -454,7 +454,7 @@ function normalizeFrame(frame) {
         // Now we check for fun, if the function name is Raven or TraceKit
         /(Raven|TraceKit)\./.test(normalized['function']) ||
         // finally, we do a last ditch effort and check for raven.min.js
-        /raven\.(min\.)js$/.test(normalized.filename)
+        /raven\.(min\.)?js$/.test(normalized.filename)
     );
 
     return normalized;


### PR DESCRIPTION
normalizeFrame() no not only hides stack frames from raven.min.js, but also from raven.js. This is useful if the uncompressed script is used in a development environment.

The parenthesis in the regex make me think that the original author intended to have the `.min` part optional.
