### PR TITLE
Only log to console.error when Raven.debug is true

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -31,7 +31,7 @@ var _Raven = window.Raven,
 var Raven = {
     VERSION: '<%= pkg.version %>',
 
-    debug: false,
+    debug: true,
 
     /*
      * Allow multiple versions of Raven to be installed.

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -225,6 +225,7 @@ describe('globals', function() {
         it('should not write to console.error when Raven is not configured and Raven.debug is false', function() {
             hasJSON = true;    // be explicit
             globalServer = undefined;
+            Raven.debug = false;
             this.sinon.stub(console, 'error');
             isSetup();
             assert.isFalse(console.error.calledOnce);
@@ -232,7 +233,6 @@ describe('globals', function() {
 
         it('should write to console.error when Raven is not configured and Raven.debug is true', function() {
             hasJSON = true;    // be explicit
-            Raven.debug = true;
             globalServer = undefined;
             this.sinon.stub(console, 'error');
             isSetup();


### PR DESCRIPTION
This allows us to use Raven in production regardless of it being configured or not, without worrying about logging unnecessary errors to the console. Useful when Raven is only configured for a certain percentage of sessions to reduce the number of errors sent to sentry. 

If debugging is required, just set Raven.debug = true. 
