### PR TITLE
Angular plugin should configure and install Raven only once

### DIFF
--- a/plugins/angular.js
+++ b/plugins/angular.js
@@ -11,8 +11,6 @@ if (!angular) {
     return;
 }
 
-var isRavenInstalled = false;
-
 function ngRavenProvider($provide) {
     $provide.decorator('$exceptionHandler', [
         'RavenConfig', '$delegate',
@@ -24,10 +22,12 @@ function ngRavenExceptionHandler(RavenConfig, $delegate) {
     if (!RavenConfig)
         throw new Error('RavenConfig must be set before using this');
 
-    if (!isRavenInstalled) {
-        Raven.config(RavenConfig.dsn, RavenConfig.config).install();
-        isRavenInstalled = true;
-    }
+    if (!RavenConfig.notConfig)
+        Raven.config(RavenConfig.dsn, RavenConfig.config);
+
+    if (!RavenConfig.notInstall)
+        Raven.install();
+
     return function angularExceptionHandler(ex, cause) {
         $delegate(ex, cause);
         Raven.captureException(ex, {extra: {cause: cause}});


### PR DESCRIPTION
Hi!

There is an error when more than one angular app are on the page: [jsfiddle](http://jsfiddle.net/P3SQ7/3/).

It's happening because of globalOptions.ignoreErrors overwriting with RegExp object, so it's no longer array and next Raven configurations will fail.
