### PR TITLE
Added documentation for the TraceKit specific options

### DIFF
--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -157,3 +157,41 @@ Putting it all together
         <script src="myapp.js"></script>
     </body>
     </html>
+
+TraceKit specific optional settings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Usually there is no need to touch these settings, but they exist in case you need to tweak something.
+
+fetchContext
+------------
+
+Enable TraceKit to attempt to fetch source files to look up anonymous function names, this can be useful to enable if you don't get the context for some entries in the stack trace. Default value is ``false``.
+
+.. code-block:: javascript
+
+    {
+        fetchContext: true
+    }
+
+linesOfContext
+--------------
+
+The count of lines surrounding the error line that should be used as context in the stack trace, default value is ``11``. Only applicable when ``fetchContext` is enabled.
+
+.. code-block:: javascript
+
+    {
+        linesOfContext: 11
+    }
+
+collectWindowErrors
+-------------------
+
+Enable or disable the TraceKit ``window.onerror`` handler, default value is ``true``.
+
+.. code-block:: javascript
+
+    {
+        collectWindowErrors: true
+    }


### PR DESCRIPTION
I felt that these options had a place in the documentations, for example the `fetchContext` option solved the problem that I wanted to solve.

Added them in the bottom of the config page as a separate section to highlight that you normally don't need to touch them.

Related issue: #241
