### PR TITLE
Allow setting truncate length through `globalOptions.maxMessageLength `

### DIFF
--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -125,6 +125,12 @@ A callback function that allows you to apply your own filters to determine if th
         }
     }
 
+maxMessageLength
+------------------
+
+By default, raven truncates messages to a max length of 100 characters. You can customize the max length with this parameter.
+
+
 Putting it all together
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/raven.js
+++ b/src/raven.js
@@ -19,6 +19,7 @@ var _Raven = window.Raven,
         includePaths: [],
         collectWindowErrors: true,
         tags: {},
+        maxMessageLength: 100,
         extra: {}
     },
     authQueryString,
@@ -585,7 +586,7 @@ function processException(type, message, fileurl, lineno, frames, options) {
     }
 
     // Truncate the message to a max of characters
-    message = truncate(message, 100);
+    message = truncate(message, globalOptions.maxMessageLength);
 
     if (globalOptions.ignoreUrls && globalOptions.ignoreUrls.test(fileurl)) return;
     if (globalOptions.whitelistUrls && !globalOptions.whitelistUrls.test(fileurl)) return;


### PR DESCRIPTION
closes #244
