### PR TITLE
Adding getGlobalOptions to the Raven object

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -134,6 +134,21 @@ var Raven = {
     },
 
     /*
+     * Get a copy of the global options.
+     *
+     * This allows plugins to be configurable by reading options from Raven
+     *
+     * @return Copy of Raven's global options. If JSON is not supported, returns null
+     */
+
+
+    getGlobalOptions: function() {
+        if (!hasJSON) return null;
+        
+        return isSetup() ? JSON.parse(JSON.stringify(globalOptions)) : {};
+    },
+
+    /*
      * Wrap code within a context so Raven can capture errors
      * reliably across domains that is executed immediately.
      *

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1310,6 +1310,35 @@ describe('Raven (public API)', function() {
         });
     });
 
+    describe('.getGlobalOptions', function() {
+        it('should return null if JSON is not supported', function() {
+            Raven.config(SENTRY_DSN);
+            hasJSON = false;
+            assert.isNull(Raven.getGlobalOptions());
+        });
+
+        it('should return an empty object if Raven has not been configured', function() {
+            hasJSON=true;
+            assert.deepEqual(Raven.getGlobalOptions(), {});
+        });
+
+        it('should return the global options of a configured Raven object', function() {
+            Raven.config(SENTRY_DSN);
+            assert.deepEqual(Raven.getGlobalOptions(), {
+                "collectWindowErrors": true,
+                "extra": {},
+                "ignoreErrors": {},
+                "ignoreUrls": false,
+                "includePaths": {},
+                "logger": "javascript",
+                "maxMessageLength": 100,
+                "tags": {},
+                "whitelistUrls": false
+            });
+        })
+
+    });
+
     describe('.install', function() {
         it('should check `isSetup`', function() {
             this.sinon.stub(window, 'isSetup').returns(false);


### PR DESCRIPTION
The thinking here is that this will allow users to pass options to plugins.

We pass back a clone of the options object so that callers can't use this as a back door to mess around with options .

[This jsperf](http://web.archive.org/web/20140328224025/http://jsperf.com/cloning-an-object/2) demonstrates that JSON method of cloning is pretty fast. It kills functions, but I don't think there are any config values that _are_ functions, so this shouldn't be an issue.
