### PR TITLE
fixed gecko regExp for parding more complicated stack lines

### DIFF
--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -632,7 +632,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
         }
 
         var chrome = /^\s*at (.+?) ?\(?((?:file|https?|chrome-extension):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
-            gecko = /^\s*(\S*)(?:\((.*?)\))?@((?:file|https?|chrome).*?):(\d+)(?::(\d+))?\s*$/i,
+            gecko = /^\s*(.*?)(?:\((.*?)\))?@((?:file|https?|chrome).*?):(\d+)(?::(\d+))?\s*$/i,
             lines = ex.stack.split('\n'),
             stack = [],
             parts,


### PR DESCRIPTION
Issue https://github.com/getsentry/raven-js/issues/249

I got stack like this in Firefox:

```
.events["click [data-test]"]@http://example.com/user/views/UserView.js:23:17
jQuery.event.dispatch@http://example.com/vendor/jquery/jquery.js:4641:1
jQuery.event.add/elemData.handle@http://example.com/vendor/jquery/jquery.js:4309:1
```

But in Sentry I got only 2 lines:

```
jQuery.event.dispatch@http://example.com/vendor/jquery/jquery.js:4641:1
jQuery.event.add/elemData.handle@http://example.com/vendor/jquery/jquery.js:4309:1
```

This pull request fixes this issue.
