### PR TITLE
browserify support

### DIFF
--- a/plugins/angular.js
+++ b/plugins/angular.js
@@ -33,4 +33,4 @@ angular.module('ngRaven', [])
     .config(['$provide', ngRavenProvider])
     .value('Raven', Raven);
 
-})(Raven, window.angular);
+})(window.Raven, window.angular);

--- a/plugins/backbone.js
+++ b/plugins/backbone.js
@@ -37,4 +37,4 @@ for (; i < l; i++) {
   affected.bind = affected.on;
 }
 
-}(this, Raven, window.Backbone));
+}(window, window.Raven, window.Backbone));

--- a/plugins/console.js
+++ b/plugins/console.js
@@ -37,4 +37,4 @@ while(level) {
 // export
 window.console = console;
 
-}(this, Raven, window.console || {}));
+}(window, window.Raven, window.console || {}));

--- a/plugins/ember.js
+++ b/plugins/ember.js
@@ -20,4 +20,4 @@ Ember.onerror = function EmberOnError(error) {
 };
 
 
-}(this, Raven, window.Ember));
+}(window, window.Raven, window.Ember));

--- a/plugins/jquery.js
+++ b/plugins/jquery.js
@@ -72,4 +72,4 @@ $.ajax = function ravenAjaxWrapper(url, options) {
     }
 };
 
-}(this, Raven, window.jQuery));
+}(window, window.Raven, window.jQuery));

--- a/plugins/native.js
+++ b/plugins/native.js
@@ -30,4 +30,4 @@ var _helper = function _helper(fnName) {
 _helper('setTimeout');
 _helper('setInterval');
 
-}(this, Raven));
+}(window, window.Raven));

--- a/plugins/require.js
+++ b/plugins/require.js
@@ -11,4 +11,4 @@ if (typeof define === 'function' && define.amd) {
     window.require = Raven.wrap({deep: false}, require);
 }
 
-}(this, Raven));
+}(window, window.Raven));

--- a/template/_footer.js
+++ b/template/_footer.js
@@ -6,4 +6,4 @@ if (typeof define === 'function' && define.amd) {
     define('raven', [], function() { return Raven; });
 }
 
-})(this);
+})(window);


### PR DESCRIPTION
In a browserify package, this will refer to a node-style exports object, not
window. So just reference window directly.
