### PR TITLE
Rename raven to raven-js to better support browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "raven",
+  "name": "raven-js",
   "version": "1.1.16",
   "scripts": {
     "pretest": "npm install",


### PR DESCRIPTION
[substack/browserify](https://github.com/substack/node-browserify) is an extremely popular client-side dependency solution. It uses npm as the package manager. Since I work in node, there is a conflict in npm with raven-node since both package.json files have the name listed as raven. It would be fantastic if you would consider changing the name.

Cheers :beers:!
