### PR TITLE
Fix globalOptions overwrite.

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -656,8 +656,8 @@ function send(data) {
     }, data);
 
     // Merge in the tags and extra separately since objectMerge doesn't handle a deep merge
-    data.tags = objectMerge(globalOptions.tags, data.tags);
-    data.extra = objectMerge(globalOptions.extra, data.extra);
+    data.tags = objectMerge(objectMerge({}, globalOptions.tags), data.tags);
+    data.extra = objectMerge(objectMerge({}, globalOptions.extra), data.extra);
 
     // Send along our own collected metadata with extra
     data.extra = objectMerge({

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -897,6 +897,11 @@ describe('globals', function() {
                 tags: {tag1: 'value1', tag2: 'value2'},
                 extra: {'session:duration': 100}
             }]);
+            assert.deepEqual(globalOptions, {
+                logger: 'javascript',
+                site: 'THE BEST',
+                tags: {tag1: 'value1'}
+            });
         });
 
         it('should merge in global extra', function() {
@@ -930,6 +935,11 @@ describe('globals', function() {
                 event_id: 'abc123',
                 extra: {key1: 'value1', key2: 'value2', 'session:duration': 100}
             }]);
+            assert.deepEqual(globalOptions, {
+                logger: 'javascript',
+                site: 'THE BEST',
+                extra: {key1: 'value1'}
+            });
         });
 
         it('should let dataCallback override everything', function() {


### PR DESCRIPTION
The `send` function was merging the user's `extra` and `tags` into globalOptions, so any call would inherit all previous calls' values.  I made a (simple-minded) fix and added regression tests.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-js/264)

<!-- Reviewable:end -->
