### PR TITLE
Added img.crossOrigin to add origin to request headers

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -694,6 +694,7 @@ function makeRequest(data) {
     var img = new Image(),
         src = globalServer + authQueryString + '&sentry_data=' + encodeURIComponent(JSON.stringify(data));
 
+    img.crossOrigin = 'anonymous';
     img.onload = function success() {
         triggerEvent('success', {
             data: data,


### PR DESCRIPTION
When trying to get raven.js working with our own Sentry server, the server kept rejecting all of the requests because 'origin' or 'referer' was missing. By adding img.crossOrigin, it adds the header needed to the request and Sentry then accepts the request.  
