### PR TITLE
in the AMD case, reveal the global right away

### DIFF
--- a/template/_footer.js
+++ b/template/_footer.js
@@ -1,8 +1,9 @@
 // Expose Raven to the world
 if (typeof define === 'function' && define.amd) {
     // AMD
+    window.Raven = Raven;
     define('raven', function(Raven) {
-      return (window.Raven = Raven);
+      return Raven;
     });
 } else if (typeof module === 'object') {
     // browserify


### PR DESCRIPTION
This is to accomodate synchronous code that might be running alongside AMD modules.  The AMD case already exposes the `window.Raven` global, however previous to this patch it waited until the AMD module was specified as a dependency before initializing the global.

I figure that if the global is going to be exposed in the AMD case, it
may as well happen right away, so non-AMD code can depend on it being
there. :)
