### PR TITLE
don't remove anonymous functions from stack trace

### DIFF
--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -50,6 +50,29 @@ function now() {
 }
 
 describe('TraceKit', function(){
+    describe('stacktrace info', function() {
+        it('should not remove anonymous functions from the stack', function() {
+            // mock up an error object with a stack trace that includes both
+            // named functions and anonymous functions
+            var stack_str = "" +
+                "  Error: \n" +
+                "    at namedFunc0 (http://example.com/js/script.js:10)\n" +   // stack[0]
+                "    at http://example.com/js/test.js:65\n" +                  // stack[1]
+                "    at namedFunc2 (http://example.com/js/script.js:20)\n" +   // stack[2]
+                "    at http://example.com/js/test.js:67\n" +                  // stack[3]
+                "    at namedFunc4 (http://example.com/js/script.js:100001)";  // stack[4]
+            var mock_err = { stack: stack_str };
+            var trace = TraceKit.computeStackTrace.computeStackTraceFromStackProp(mock_err);
+
+            // Make sure TraceKit didn't remove the anonymous functions
+            // from the stack like it used to :)
+            assert.equal(trace.stack[0].func, 'namedFunc0');
+            assert.equal(trace.stack[1].func, '?');
+            assert.equal(trace.stack[2].func, 'namedFunc2');
+            assert.equal(trace.stack[3].func, '?');
+            assert.equal(trace.stack[4].func, 'namedFunc4');
+        });
+    });
     describe('error notifications', function(){
         var testMessage = "__mocha_ignore__";
         var subscriptionHandler;

--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -631,7 +631,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
             return null;
         }
 
-        var chrome = /^\s*at (.+?) ?\(?((?:file|https?|chrome-extension):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
+        var chrome = /^\s*at (\S*) ?\(?((?:file|https?|chrome-extension):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
             gecko = /^\s*(.*?)(?:\((.*?)\))?@((?:file|https?|chrome).*?):(\d+)(?::(\d+))?\s*$/i,
             lines = ex.stack.split('\n'),
             stack = [],
@@ -1064,6 +1064,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
     }
 
     computeStackTrace.augmentStackTraceWithInitialElement = augmentStackTraceWithInitialElement;
+    computeStackTrace.computeStackTraceFromStackProp = computeStackTraceFromStackProp;
     computeStackTrace.guessFunctionName = guessFunctionName;
     computeStackTrace.gatherContext = gatherContext;
     computeStackTrace.ofCaller = computeStackTraceOfCaller;


### PR DESCRIPTION
TraceKit's stacktrace regex for Chrome didn't match anonymous functions, so all anonymous functions in the stacktrace were being removed before reporting to Sentry.  This caused errors to be attributed to the wrong files, and was generally extremely confusing.  This change updates the regex to not _require_ a function name be present in the stacktrace.

see #289 
