### PR TITLE
compare fingerprint in repeat events

### DIFF
--- a/packages/raven-js/src/raven.js
+++ b/packages/raven-js/src/raven.js
@@ -1922,6 +1922,9 @@ Raven.prototype = {
     } else if (current.exception || last.exception) {
       // Exception interface (i.e. from captureException/onerror)
       return isSameException(current.exception, last.exception);
+    } else if (current.fingerprint || last.fingerprint) {
+      return Boolean(current.fingerprint && last.fingerprint) &&
+        JSON.stringify(current.fingerprint) === JSON.stringify(last.fingerprint)
     }
 
     return true;

--- a/packages/raven-js/test/raven.test.js
+++ b/packages/raven-js/test/raven.test.js
@@ -3859,7 +3859,7 @@ describe('Raven (private methods)', function() {
 
       it('should return false for different fingerprints', function() {
         var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
-        data.fingerprint = ['{{ default }}', 'grouping-identifier']
+        data.fingerprint = ['{{ default }}', 'grouping-identifier'];
 
         assert.isFalse(Raven._isRepeatData(data));
       });

--- a/packages/raven-js/test/raven.test.js
+++ b/packages/raven-js/test/raven.test.js
@@ -3862,6 +3862,14 @@ describe('Raven (private methods)', function() {
         data.fingerprint = ['{{ default }}', 'grouping-identifier'];
 
         assert.isFalse(Raven._isRepeatData(data));
+
+        Raven._lastData.fingerprint = ['{{ default }}', 'other-grouping-identifier'];
+
+        assert.isFalse(Raven._isRepeatData(data));
+
+        delete data.fingerprint;
+
+        assert.isFalse(Raven._isRepeatData(data));
       });
 
       it('should return false for different captureMessage payloads w/ synthetic traces', function() {

--- a/packages/raven-js/test/raven.test.js
+++ b/packages/raven-js/test/raven.test.js
@@ -3857,6 +3857,13 @@ describe('Raven (private methods)', function() {
         assert.isFalse(Raven._isRepeatData(data));
       });
 
+      it('should return false for different fingerprints', function() {
+        var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
+        data.fingerprint = ['{{ default }}', 'grouping-identifier']
+
+        assert.isFalse(Raven._isRepeatData(data));
+      });
+
       it('should return false for different captureMessage payloads w/ synthetic traces', function() {
         Raven._lastData.stacktrace = {
           frames: [


### PR DESCRIPTION
I noticed that event `fingerprint` isn't looked at when determining if `_isRepeatData`. That seems like a good value to check when assessing if two payloads are distinct.

I ran into this when I would `capture*` several events whose high-level messages were the same but were fingerprinted differently.

Please let me know if I've misunderstood something.
