### PR TITLE
Point doc link to index rather than install doc

### DIFF
--- a/docs/sentry-doc-config.json
+++ b/docs/sentry-doc-config.json
@@ -4,7 +4,7 @@
     "javascript": {
       "name": "JavaScript",
       "type": "language",
-      "doc_link": "install/",
+      "doc_link": "",
       "wizard": [
         "index#installation",
         "index#configuring-the-client",


### PR DESCRIPTION
When you create a new project on sentry.io, we show you installation/config info that is pulled from the docs. Above it there is a "learn more" link that takes you to the actual docs for each SDK. While every other SDK points you to the index page for that SDK, the JavaScript SDK points you to an Installation page.

This breaks the migrator because the doc_link value is the only thing it can go on for producing the new platform APIs. I can add a special case to account for this if people hate this idea, but it'd be easier in the long run if the landing location was consistent for all the docs, both for me and I'd venture for users.

The net change is that on the project blank slate page in getsentry, the "read more docs" will now point to the generic JavaScript installation page rather than the comprehensive installation page that talks about all of the possible options. The generic page points to the comprehensive page so I don't feel like this would be considered a bad thing, and the point will be moot once new docs are in place.