### PR TITLE
Remove tab before semicolon in documentation

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -79,7 +79,7 @@ To use Raven with CommonJS imports:
 
 .. code-block:: javascript
 
-    var Raven = require('raven-js')	;
+    var Raven = require('raven-js');
     Raven
         .config('___PUBLIC_DSN___')
         .install();


### PR DESCRIPTION
There was a tab between a closing paren and semicolon which looked weird in the docs. Fixed now 👍