### PR TITLE
Error: Can't resolve 'uuid/v4'

### DIFF
--- a/packages/raven-node/package.json
+++ b/packages/raven-node/package.json
@@ -32,7 +32,7 @@
     "md5": "^2.2.1",
     "stack-trace": "0.0.10",
     "timed-out": "4.0.1",
-    "uuid": "3.0.0"
+    "uuid": "3.3.2"
   },
   "devDependencies": {
     "coffee-script": "~1.10.0",


### PR DESCRIPTION
Upgrade [uuid](https://github.com/kelektiv/node-uuid) package to fix the error:

> ModuleNotFoundError: Module not found: Error: Can't resolve 'uuid/v4'

File [uuid/v4](https://github.com/kelektiv/node-uuid/blob/v3.0.1/v4.js) added in uuid v3.0.1.