### PR TITLE
Fix the Uglify invocation

### DIFF
--- a/docs/sourcemaps.rst
+++ b/docs/sourcemaps.rst
@@ -39,7 +39,7 @@ that maps the minified code back to the original source:
 ::
 
     uglifyjs app.js \
-      -o app.min.js.map \
+      -o app.min.js \
       --source-map url=app.min.js.map,includeSources
 
 


### PR DESCRIPTION
The output filename should not include .map.

The includeSources part is dubious (typically not necessary, I’d say),
but I’ll leave it in as it is unlikely to do real harm.