### PR TITLE
fix: Use objectMerge util instead of Object.assign for IE

### DIFF
--- a/packages/raven-js/src/raven.js
+++ b/packages/raven-js/src/raven.js
@@ -877,7 +877,7 @@ Raven.prototype = {
     )
       return;
 
-    options = Object.assign(
+    options = objectMerge(
       {
         eventId: this.lastEventId(),
         dsn: this._dsn,


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/1477