### PR TITLE
ref: Remove keepalive:true as a default and document payload size

### DIFF
--- a/packages/raven-js/src/raven.js
+++ b/packages/raven-js/src/raven.js
@@ -98,7 +98,6 @@ function Raven() {
   };
   this._fetchDefaults = {
     method: 'POST',
-    keepalive: true,
     // Despite all stars in the sky saying that Edge supports old draft syntax, aka 'never', 'always', 'origin' and 'default
     // https://caniuse.com/#feat=referrer-policy
     // It doesn't. And it throw exception instead of ignoring this parameter...

--- a/packages/raven-js/test/raven.test.js
+++ b/packages/raven-js/test/raven.test.js
@@ -1870,7 +1870,6 @@ describe('globals', function() {
           assert.deepEqual(window.fetch.lastCall.args, [
             'http://localhost/?a=1&b=2',
             {
-              keepalive: true,
               referrerPolicy: supportsReferrerPolicy() ? 'origin' : '',
               method: 'POST',
               body: '{"foo":"bar"}'


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-javascript/issues/1470
Fixes: https://github.com/getsentry/sentry-javascript/issues/1464
Fixes: https://github.com/getsentry/sentry-javascript/issues/339

Re: https://github.com/getsentry/sentry-docs/pull/310