### PR TITLE
add beacon transport

### DIFF
--- a/packages/browser/src/transports/beacon.ts
+++ b/packages/browser/src/transports/beacon.ts
@@ -1,0 +1,22 @@
+import { SentryEvent, SentryResponse, Status } from '@sentry/types';
+import { getGlobalObject } from '@sentry/utils/misc';
+import { serialize } from '@sentry/utils/object';
+import { BaseTransport } from './base';
+
+const global = getGlobalObject() as Window;
+
+/** `sendBeacon` based transport */
+export class BeaconTransport extends BaseTransport {
+  /**
+   * @inheritDoc
+   */
+  public async send(event: SentryEvent): Promise<SentryResponse> {
+    const data = serialize(event);
+
+    const result = global.navigator.sendBeacon(this.url, data);
+
+    return {
+      status: result ? Status.Success : Status.Failed,
+    };
+  }
+}

--- a/packages/browser/src/transports/index.ts
+++ b/packages/browser/src/transports/index.ts
@@ -1,3 +1,4 @@
 export { BaseTransport } from './base';
 export { FetchTransport } from './fetch';
 export { XHRTransport } from './xhr';
+export { BeaconTransport } from './beacon';

--- a/packages/browser/test/transports/beacon.test.ts
+++ b/packages/browser/test/transports/beacon.test.ts
@@ -1,0 +1,53 @@
+import { expect } from 'chai';
+import { SinonStub, stub } from 'sinon';
+import { Status, Transports } from '../../src';
+
+const testDSN = 'https://123@sentry.io/42';
+const transportUrl = 'https://sentry.io/api/42/store/?sentry_key=123&sentry_version=7';
+const payload = {
+  event_id: '1337',
+  message: 'Pickle Rick',
+  user: {
+    username: 'Morty',
+  },
+};
+
+let sendBeacon: SinonStub;
+let transport: Transports.BaseTransport;
+
+describe('BeaconTransport', () => {
+  beforeEach(() => {
+    sendBeacon = stub(window.navigator, 'sendBeacon');
+    transport = new Transports.BeaconTransport({ dsn: testDSN });
+  });
+
+  afterEach(() => {
+    sendBeacon.restore();
+  });
+
+  it('inherits composeEndpointUrl() implementation', () => {
+    expect(transport.url).equal(transportUrl);
+  });
+
+  describe('send()', async () => {
+    it('sends a request to Sentry servers', async () => {
+      sendBeacon.returns(true);
+
+      return transport.send(payload).then(res => {
+        expect(res.status).equal(Status.Success);
+        expect(sendBeacon.calledOnce).equal(true);
+        expect(sendBeacon.calledWith(transportUrl, JSON.stringify(payload))).equal(true);
+      });
+    });
+
+    it('rejects with failed status', async () => {
+      sendBeacon.returns(false);
+
+      return transport.send(payload).catch(res => {
+        expect(res.status).equal(Status.Failed);
+        expect(sendBeacon.calledOnce).equal(true);
+        expect(sendBeacon.calledWith(transportUrl, JSON.stringify(payload))).equal(true);
+      });
+    });
+  });
+});

--- a/packages/utils/src/supports.ts
+++ b/packages/utils/src/supports.ts
@@ -77,6 +77,17 @@ export function supportsFetch(): boolean {
 }
 
 /**
+ * Tells whether current environment supports sendBeacon API
+ * {@link supportsBeacon}.
+ *
+ * @returns Answer to the given question.
+ */
+export function supportsBeacon(): boolean {
+  const global = getGlobalObject();
+  return 'navigator' in global && 'sendBeacon' in global.navigator;
+}
+
+/**
  * Tells whether current environment supports Referrer Policy API
  * {@link supportsReferrerPolicy}.
  *

--- a/packages/utils/test/supports.test.ts
+++ b/packages/utils/test/supports.test.ts
@@ -1,0 +1,35 @@
+import * as misc from '../src/misc';
+import * as supports from '../src/supports';
+
+describe('Supports', () => {
+  let global: any;
+  let getGlobalObject: any;
+
+  beforeEach(() => {
+    global = {};
+    getGlobalObject = jest.spyOn(misc, 'getGlobalObject');
+    getGlobalObject.mockReturnValue(global);
+  });
+
+  afterEach(() => {
+    getGlobalObject.mockRestore();
+  });
+
+  describe('supportsBeacon', () => {
+    it('should return false if no navigator in global', () => {
+      expect(supports.supportsBeacon()).toEqual(false);
+    });
+
+    it('should return false if navigator and no sendBeacon in global', () => {
+      global.navigator = {};
+      expect(supports.supportsBeacon()).toEqual(false);
+    });
+
+    it('should return true if navigator and sendBeacon in global', () => {
+      global.navigator = {
+        sendBeacon: jest.fn(),
+      };
+      expect(supports.supportsBeacon()).toEqual(true);
+    });
+  });
+});


### PR DESCRIPTION
Provide a new transport based on the browser [Beacon API](https://developer.mozilla.org/en-US/docs/Web/API/Beacon_API), supported in all major browsers except IE ([caniuse](https://caniuse.com/#feat=beacon)). Using `navigator.sendBeacon` instead of `fetch` or `XMLHttpRequest` could help sending reports at unload time, and possibly allow for bigger reports to be sent.
This pull request adds `BeaconTransport` to the `browser` package, leaving it as an opt-in:
```javascript
import { init, Transports } from '@sentry/browser';

init({
  dsn: '__DSN__',
  transport: Transports.BeaconTransport
});
```

If working good, beacon transport could be the default in the future? In [packages/browser/src/backend.ts](https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/backend.ts#L144):
```javascript
import { supportsBeacon, supportsFetch } from '@sentry/utils/supports';
import { BeaconTransport, FetchTransport, XHRTransport } from './transports';

const transportOptions = {
  dsn: this.options.dsn,
  ...this.options.transportOptions
};

let transportClass;
if (this.options.transport)
  { transportClass = this.options.transport; }
else if (supportsBeacon())
  { transportClass = BeaconTransport; }
else if (supportsFetch())
  { transportClass = FetchTransport; }
else
  { transportClass = XHRTransport; }

const transport = new transportClass(transportOptions);
```
BTW does transport needs to be instantiated at every `sendEvent`?