### PR TITLE
Ignore async exceptions when reading source files fails

### DIFF
--- a/packages/node/src/parsers.ts
+++ b/packages/node/src/parsers.ts
@@ -140,7 +140,7 @@ export async function parseStack(stack: stacktrace.StackFrame[]): Promise<StackF
   });
 
   try {
-    return addPrePostContext(filesToRead, frames);
+    return await addPrePostContext(filesToRead, frames);
   } catch (_) {
     // This happens in electron for example where we are not able to read files from asar.
     // So it's fine, we recover be just returning all frames without pre/post context.


### PR DESCRIPTION
This fixes a subtle bug where async exceptions thrown in `addPrePostContext()` where not caught by the try/catch block.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
