### PR TITLE
ref: Provide originalException in minimal calls as well

### DIFF
--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -28,7 +28,10 @@ export function captureException(exception: any): string {
   } catch (exception) {
     syntheticException = exception as Error;
   }
-  return callOnHub('captureException', exception, { syntheticException });
+  return callOnHub('captureException', exception, {
+    originalException: exception,
+    syntheticException,
+  });
 }
 
 /**
@@ -45,7 +48,10 @@ export function captureMessage(message: string, level?: Severity): string {
   } catch (exception) {
     syntheticException = exception as Error;
   }
-  return callOnHub('captureMessage', message, level, { syntheticException });
+  return callOnHub('captureMessage', message, level, {
+    originalException: message,
+    syntheticException,
+  });
 }
 
 /**


### PR DESCRIPTION
I do this on `captureMessage` as well, as sometimes people pass malformed data to those calls and it's totally fine to let them see it.