### PR TITLE
feat: Make before hooks async

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -182,7 +182,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
 
     const timestamp = new Date().getTime() / 1000;
     const mergedBreadcrumb = { timestamp, ...breadcrumb };
-    const finalBreadcrumb = beforeBreadcrumb ? beforeBreadcrumb(mergedBreadcrumb, hint) : mergedBreadcrumb;
+    const finalBreadcrumb = beforeBreadcrumb ? await beforeBreadcrumb(mergedBreadcrumb, hint) : mergedBreadcrumb;
 
     if (finalBreadcrumb === null) {
       return;
@@ -322,7 +322,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
       };
     }
 
-    const finalEvent = beforeSend ? beforeSend(prepared, hint) : prepared;
+    const finalEvent = beforeSend ? await beforeSend(prepared, hint) : prepared;
     if (finalEvent === null) {
       return {
         status: Status.Skipped,

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -104,7 +104,7 @@ export interface Options {
    * @param hint May contain additional information about the original exception.
    * @returns A new event that will be sent | null.
    */
-  beforeSend?(event: SentryEvent, hint?: SentryEventHint): SentryEvent | null;
+  beforeSend?(event: SentryEvent, hint?: SentryEventHint): SentryEvent | null | Promise<SentryEvent | null>;
 
   /**
    * A callback invoked when adding a breadcrumb, allowing to optionally modify
@@ -117,7 +117,10 @@ export interface Options {
    * @param breadcrumb The breadcrumb as created by the SDK.
    * @returns The breadcrumb that will be added | null.
    */
-  beforeBreadcrumb?(breadcrumb: Breadcrumb, hint?: SentryBreadcrumbHint): Breadcrumb | null;
+  beforeBreadcrumb?(
+    breadcrumb: Breadcrumb,
+    hint?: SentryBreadcrumbHint,
+  ): Breadcrumb | null | Promise<Breadcrumb | null>;
 }
 
 /**


### PR DESCRIPTION
Both variants will work now. Sync and async. We just have to make sure to document very clearly that developers shouldn't perform too heavy or too time-consuming operations there.