### PR TITLE
feat: LinkedErrors integration for Node

### DIFF
--- a/packages/node/src/integrations/index.ts
+++ b/packages/node/src/integrations/index.ts
@@ -4,3 +4,4 @@ export { OnUncaughtException } from './onuncaughtexception';
 export { OnUnhandledRejection } from './onunhandledrejection';
 export { ClientOptions } from './clientoptions';
 export { SDKInformation } from './sdkinformation';
+export { LinkedErrors } from './linkederrors';

--- a/packages/node/src/integrations/linkederrors.ts
+++ b/packages/node/src/integrations/linkederrors.ts
@@ -1,0 +1,70 @@
+import { Integration, SentryEvent, SentryEventHint, SentryException } from '@sentry/types';
+import { getCurrentHub } from '../hub';
+import { getExceptionFromError } from '../parsers';
+
+const DEFAULT_KEY = 'cause';
+const DEFAULT_LIMIT = 5;
+
+/**
+ * Just an Error object with arbitrary attributes attached to it.
+ */
+interface ExtendedError extends Error {
+  [key: string]: any;
+}
+
+/** Adds SDK info to an event. */
+export class LinkedErrors implements Integration {
+  /**
+   * @inheritDoc
+   */
+  public name: string = 'LinkedErrors';
+
+  /**
+   * @inheritDoc
+   */
+  public constructor(
+    private readonly options: {
+      key: string;
+      limit: number;
+    } = {
+      key: DEFAULT_KEY,
+      limit: DEFAULT_LIMIT,
+    },
+  ) {}
+
+  /**
+   * @inheritDoc
+   */
+  public install(): void {
+    getCurrentHub().configureScope(scope => {
+      scope.addEventProcessor(this.handler.bind(this));
+    });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public async handler(event: SentryEvent, hint?: SentryEventHint): Promise<SentryEvent | null> {
+    if (!event.exception || !event.exception.values || !hint || !(hint.originalException instanceof Error)) {
+      return event;
+    }
+    const linkedErrors = await this.walkErrorTree(hint.originalException, this.options.key);
+    event.exception.values = [...event.exception.values, ...linkedErrors];
+    return event;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public async walkErrorTree(
+    error: ExtendedError,
+    key: string,
+    stack: SentryException[] = [],
+  ): Promise<SentryException[]> {
+    if (!(error[key] instanceof Error) || stack.length >= this.options.limit) {
+      return stack;
+    }
+    const exception = await getExceptionFromError(error[key]);
+    return this.walkErrorTree(error[key], key, [...stack, exception]);
+  }
+}

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -5,6 +5,7 @@ import {
   ClientOptions,
   Console,
   Http,
+  LinkedErrors,
   OnUncaughtException,
   OnUnhandledRejection,
   SDKInformation,
@@ -16,6 +17,7 @@ export const defaultIntegrations = [
   new OnUncaughtException(),
   new OnUnhandledRejection(),
   new ClientOptions(),
+  new LinkedErrors(),
   new SDKInformation(),
 ];
 

--- a/packages/node/test/integrations/linkederrors.test.ts
+++ b/packages/node/test/integrations/linkederrors.test.ts
@@ -1,0 +1,121 @@
+import { LinkedErrors } from '../../src/integrations/linkederrors';
+
+let linkedErrors: LinkedErrors;
+
+interface ExtendedError extends Error {
+  [key: string]: any;
+}
+
+describe('LinkedErrors', () => {
+  beforeEach(() => {
+    linkedErrors = new LinkedErrors();
+  });
+
+  describe('handler', () => {
+    it('should bail out if event doesnt contain exception', async () => {
+      const spy = jest.spyOn(linkedErrors, 'walkErrorTree');
+      const event = {
+        message: 'foo',
+      };
+      const result = await linkedErrors.handler(event);
+      expect(spy.mock.calls.length).toEqual(0);
+      expect(result).toEqual(event);
+    });
+
+    it('should bail out if event contains exception, but no hint', async () => {
+      const spy = jest.spyOn(linkedErrors, 'walkErrorTree');
+      const event = {
+        exception: {
+          values: [],
+        },
+        message: 'foo',
+      };
+      const result = await linkedErrors.handler(event);
+      expect(spy.mock.calls.length).toEqual(0);
+      expect(result).toEqual(event);
+    });
+
+    it('should call walkErrorTree if event contains exception and hint with originalException', async () => {
+      const spy = jest.spyOn(linkedErrors, 'walkErrorTree').mockImplementation(
+        async () =>
+          new Promise<[]>(resolve => {
+            resolve([]);
+          }),
+      );
+      const event = {
+        exception: {
+          values: [],
+        },
+        message: 'foo',
+      };
+      const hint = {
+        originalException: new Error('originalException'),
+      };
+      await linkedErrors.handler(event, hint);
+      expect(spy.mock.calls.length).toEqual(1);
+    });
+
+    it('should recursively walk error to find linked exceptions and assign them to the event', async () => {
+      const event = {
+        exception: {
+          values: [],
+        },
+        message: 'foo',
+      };
+
+      const one: ExtendedError = new Error('one');
+      const two: ExtendedError = new TypeError('two');
+      const three: ExtendedError = new SyntaxError('three');
+
+      const originalException = one;
+      one.cause = two;
+      two.cause = three;
+
+      const result = await linkedErrors.handler(event, {
+        originalException,
+      });
+
+      // It shouldn't include root exception, as it's already processed in the event by the main error handler
+      expect(result!.exception!.values!.length).toEqual(2);
+      expect(result!.exception!.values![0].type).toEqual('TypeError');
+      expect(result!.exception!.values![0].value).toEqual('two');
+      expect(result!.exception!.values![0].stacktrace).toHaveProperty('frames');
+      expect(result!.exception!.values![1].type).toEqual('SyntaxError');
+      expect(result!.exception!.values![1].value).toEqual('three');
+      expect(result!.exception!.values![1].stacktrace).toHaveProperty('frames');
+    });
+
+    it('should allow to change walk key', async () => {
+      linkedErrors = new LinkedErrors({
+        key: 'reason',
+      });
+      const event = {
+        exception: {
+          values: [],
+        },
+        message: 'foo',
+      };
+
+      const one: ExtendedError = new Error('one');
+      const two: ExtendedError = new TypeError('two');
+      const three: ExtendedError = new SyntaxError('three');
+
+      const originalException = one;
+      one.reason = two;
+      two.reason = three;
+
+      const result = await linkedErrors.handler(event, {
+        originalException,
+      });
+
+      // It shouldn't include root exception, as it's already processed in the event by the main error handler
+      expect(result!.exception!.values!.length).toEqual(2);
+      expect(result!.exception!.values![0].type).toEqual('TypeError');
+      expect(result!.exception!.values![0].value).toEqual('two');
+      expect(result!.exception!.values![0].stacktrace).toHaveProperty('frames');
+      expect(result!.exception!.values![1].type).toEqual('SyntaxError');
+      expect(result!.exception!.values![1].value).toEqual('three');
+      expect(result!.exception!.values![1].stacktrace).toHaveProperty('frames');
+    });
+  });
+});


### PR DESCRIPTION
See discussion on https://github.com/getsentry/sentry-javascript/issues/1401#issuecomment-418660333

It has to be ported to the browser though, as extracting stackframe is slightly different there and we cannot reuse exactly the same code.