### PR TITLE
feat: Vue and Ember integrations

### DIFF
--- a/packages/browser/src/integrations/index.ts
+++ b/packages/browser/src/integrations/index.ts
@@ -5,3 +5,6 @@ export { TryCatch } from './trycatch';
 export { Breadcrumbs } from './breadcrumbs';
 export { SDKInformation } from './sdkinformation';
 export { InboundFilters } from './inboundfilters';
+
+export { Ember } from './pluggable/ember';
+export { Vue } from './pluggable/vue';

--- a/packages/browser/src/integrations/pluggable/ember.ts
+++ b/packages/browser/src/integrations/pluggable/ember.ts
@@ -1,0 +1,69 @@
+import { getCurrentHub, Scope } from '@sentry/hub';
+import { Integration } from '@sentry/types';
+import { getGlobalObject } from '@sentry/utils/misc';
+
+/** JSDoc */
+export class Ember implements Integration {
+  /**
+   * @inheritDoc
+   */
+  public name: string = 'Ember';
+
+  /**
+   * @inheritDoc
+   */
+  private readonly Ember: any; // tslint:disable-line:variable-name
+
+  /**
+   * @inheritDoc
+   */
+  public constructor(options: { Ember?: any } = {}) {
+    this.Ember =
+      options.Ember ||
+      (getGlobalObject() as {
+        Ember: any;
+      }).Ember;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public install(): void {
+    if (!this.Ember) {
+      return;
+    }
+
+    const oldOnError = this.Ember.onerror;
+
+    this.Ember.onerror = (error: Error): void => {
+      getCurrentHub().captureException(error, { originalException: error });
+
+      if (typeof oldOnError === 'function') {
+        oldOnError.call(this.Ember, error);
+      }
+    };
+
+    this.Ember.RSVP.on(
+      'error',
+      (reason: any): void => {
+        if (reason instanceof Error) {
+          getCurrentHub().withScope(() => {
+            getCurrentHub().configureScope((scope: Scope) => {
+              scope.setExtra('context', 'Unhandled Promise error detected');
+            });
+
+            getCurrentHub().captureException(reason, { originalException: reason });
+          });
+        } else {
+          getCurrentHub().withScope(() => {
+            getCurrentHub().configureScope((scope: Scope) => {
+              scope.setExtra('reason', reason);
+            });
+
+            getCurrentHub().captureMessage('Unhandled Promise error detected');
+          });
+        }
+      },
+    );
+  }
+}

--- a/packages/browser/src/integrations/pluggable/vue.ts
+++ b/packages/browser/src/integrations/pluggable/vue.ts
@@ -1,0 +1,88 @@
+import { getCurrentHub, Scope } from '@sentry/hub';
+import { Integration } from '@sentry/types';
+import { isPlainObject, isUndefined } from '@sentry/utils/is';
+import { getGlobalObject } from '@sentry/utils/misc';
+
+/** JSDoc */
+interface Metadata {
+  [key: string]: any;
+  componentName?: string;
+  propsData?: {
+    [key: string]: any;
+  };
+  lifecycleHook?: string;
+}
+
+/** JSDoc */
+export class Vue implements Integration {
+  /**
+   * @inheritDoc
+   */
+  public name: string = 'Vue';
+
+  /**
+   * @inheritDoc
+   */
+  private readonly Vue: any; // tslint:disable-line:variable-name
+
+  /**
+   * @inheritDoc
+   */
+  public constructor(options: { Vue?: any } = {}) {
+    this.Vue =
+      options.Vue ||
+      (getGlobalObject() as {
+        Vue: any;
+      }).Vue;
+  }
+
+  /** JSDoc */
+  private formatComponentName(vm: any): string {
+    if (vm.$root === vm) {
+      return 'root instance';
+    }
+    const name = vm._isVue ? vm.$options.name || vm.$options._componentTag : vm.name;
+    return (
+      (name ? `component <${name}>` : 'anonymous component') +
+      (vm._isVue && vm.$options.__file ? ` at ${vm.$options.__file}` : '')
+    );
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public install(): void {
+    if (!this.Vue || !this.Vue.config) {
+      return;
+    }
+
+    const oldOnError = this.Vue.config.errorHandler;
+
+    this.Vue.config.errorHandler = (error: Error, vm: { [key: string]: any }, info: string): void => {
+      const metadata: Metadata = {};
+
+      if (isPlainObject(vm)) {
+        metadata.componentName = this.formatComponentName(vm);
+        metadata.propsData = vm.$options.propsData;
+      }
+
+      if (!isUndefined(info)) {
+        metadata.lifecycleHook = info;
+      }
+
+      getCurrentHub().withScope(() => {
+        getCurrentHub().configureScope((scope: Scope) => {
+          Object.keys(metadata).forEach(key => {
+            scope.setExtra(key, metadata[key]);
+          });
+        });
+
+        getCurrentHub().captureException(error, { originalException: error });
+      });
+
+      if (typeof oldOnError === 'function') {
+        oldOnError.call(this.Vue, error, vm, info);
+      }
+    };
+  }
+}


### PR DESCRIPTION
For Angular it's

```js
export class RavenErrorHandler implements ErrorHandler {
  handleError(err:any) : void {
    captureException(err);
  }
}

providers: [ { provide: ErrorHandler, useClass: RavenErrorHandler } ]
```

Which is like 99% angular specific code, so I won't implement it until we need it.