### PR TITLE
feat: Collect breadcrumbs for native Fetch only

### DIFF
--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -5,7 +5,7 @@ import { isFunction, isString } from '@sentry/utils/is';
 import { getGlobalObject, parseUrl } from '@sentry/utils/misc';
 import { deserialize, fill } from '@sentry/utils/object';
 import { safeJoin } from '@sentry/utils/string';
-import { supportsBeacon, supportsFetch, supportsHistory } from '@sentry/utils/supports';
+import { supportsBeacon, supportsHistory, supportsNativeFetch } from '@sentry/utils/supports';
 import { BrowserOptions } from '../backend';
 import { breadcrumbEventHandler, keypressEventHandler, wrap } from './helpers';
 
@@ -187,7 +187,7 @@ export class Breadcrumbs implements Integration {
 
   /** JSDoc */
   private instrumentFetch(options: { filterUrl?: string }): void {
-    if (!supportsFetch()) {
+    if (!supportsNativeFetch()) {
       return;
     }
 

--- a/packages/utils/src/supports.ts
+++ b/packages/utils/src/supports.ts
@@ -77,6 +77,22 @@ export function supportsFetch(): boolean {
 }
 
 /**
+ * Tells whether current environment supports Fetch API natively
+ * {@link supportsNativeFetch}.
+ *
+ * @returns Answer to the given question.
+ */
+export function supportsNativeFetch(): boolean {
+  if (!supportsFetch()) {
+    return false;
+  }
+  const global = getGlobalObject();
+  const fetch = (global as any).fetch;
+  // tslint:disable-next-line:no-unsafe-any
+  return fetch.toString().indexOf('native') !== -1;
+}
+
+/**
  * Tells whether current environment supports sendBeacon API
  * {@link supportsBeacon}.
  *


### PR DESCRIPTION
This will help us avoid collecting same breadcrumb twice. From fetch and from XHR based fetch polyfill.

Fixes https://github.com/getsentry/sentry-javascript/issues/1428