### PR TITLE
feat: Dedupe rewrite + tests + compare fingerprints for messageEvents

### DIFF
--- a/packages/browser/src/integrations/dedupe.ts
+++ b/packages/browser/src/integrations/dedupe.ts
@@ -40,22 +40,14 @@ export class Dedupe implements Integration {
       return false;
     }
 
-    if (this.isSameMessage(currentEvent, previousEvent)) {
-      if (!this.isSameFingerprint(currentEvent, previousEvent)) {
-        return false;
-      }
-
-      if (!this.isSameStacktrace(currentEvent, previousEvent)) {
-        return false;
-      }
-
+    if (this.isSameMessageEvent(currentEvent, previousEvent)) {
       logger.warn(
         `Event dropped due to being a duplicate of previous event (same message).\n  Event: ${currentEvent.event_id}`,
       );
       return true;
     }
 
-    if (this.isSameException(currentEvent, previousEvent)) {
+    if (this.isSameExceptionEvent(currentEvent, previousEvent)) {
       logger.warn(
         `Event dropped due to being a duplicate of previous event (same exception).\n  Event: ${currentEvent.event_id}`,
       );
@@ -66,7 +58,7 @@ export class Dedupe implements Integration {
   }
 
   /** JSDoc */
-  private isSameMessage(currentEvent: SentryEvent, previousEvent: SentryEvent): boolean {
+  private isSameMessageEvent(currentEvent: SentryEvent, previousEvent: SentryEvent): boolean {
     const currentMessage = currentEvent.message;
     const previousMessage = previousEvent.message;
 
@@ -80,8 +72,19 @@ export class Dedupe implements Integration {
       return false;
     }
 
-    // Otherwise, compare the two
-    return currentMessage === previousMessage;
+    if (currentMessage !== previousMessage) {
+      return false;
+    }
+
+    if (!this.isSameFingerprint(currentEvent, previousEvent)) {
+      return false;
+    }
+
+    if (!this.isSameStacktrace(currentEvent, previousEvent)) {
+      return false;
+    }
+
+    return true;
   }
 
   /** JSDoc */
@@ -149,7 +152,7 @@ export class Dedupe implements Integration {
   }
 
   /** JSDoc */
-  private isSameException(currentEvent: SentryEvent, previousEvent: SentryEvent): boolean {
+  private isSameExceptionEvent(currentEvent: SentryEvent, previousEvent: SentryEvent): boolean {
     const previousException = this.getExceptionFromEvent(previousEvent);
     const currentException = this.getExceptionFromEvent(currentEvent);
 
@@ -161,7 +164,15 @@ export class Dedupe implements Integration {
       return false;
     }
 
-    return this.isSameStacktrace(currentEvent, previousEvent);
+    if (!this.isSameFingerprint(currentEvent, previousEvent)) {
+      return false;
+    }
+
+    if (!this.isSameStacktrace(currentEvent, previousEvent)) {
+      return false;
+    }
+
+    return true;
   }
 
   /** JSDoc */

--- a/packages/browser/src/integrations/dedupe.ts
+++ b/packages/browser/src/integrations/dedupe.ts
@@ -61,6 +61,13 @@ export class Dedupe implements Integration {
       return true;
     }
 
+    if (this.isSameFingerprint(event)) {
+      logger.warn(
+        `Event dropped due to being a duplicate of previous event (same fingerprint).\n  Event: ${event.event_id}`,
+      );
+      return true;
+    }
+
     return false;
   }
 
@@ -143,5 +150,15 @@ export class Dedupe implements Integration {
     }
 
     return this.isSameStacktrace(event);
+  }
+
+  /** JSDoc */
+  private isSameFingerprint(event: SentryEvent): boolean {
+    if (!this.previousEvent) {
+      return false;
+    }
+
+    return Boolean(event.fingerprint && this.previousEvent.fingerprint) &&
+      JSON.stringify(event.fingerprint) === JSON.stringify(this.previousEvent.fingerprint)
   }
 }

--- a/packages/browser/test/integrations/dedupe.test.ts
+++ b/packages/browser/test/integrations/dedupe.test.ts
@@ -1,0 +1,130 @@
+import { expect } from 'chai';
+import { Dedupe } from '../../src/integrations/dedupe';
+
+function clone<T>(data: T): T {
+  return JSON.parse(JSON.stringify(data));
+}
+
+const dedupe = new Dedupe();
+const messageEvent = {
+  fingerprint: ['MrSnuffles'],
+  message: 'PickleRick',
+  stacktrace: {
+    frames: [
+      {
+        colno: 1,
+        filename: 'filename.js',
+        function: 'function',
+        lineno: 1,
+      },
+      {
+        colno: 2,
+        filename: 'filename.js',
+        function: 'function',
+        lineno: 2,
+      },
+    ],
+  },
+};
+const exceptionEvent = {
+  exception: {
+    values: [
+      {
+        stacktrace: {
+          frames: [
+            {
+              colno: 1,
+              filename: 'filename.js',
+              function: 'function',
+              lineno: 1,
+            },
+            {
+              colno: 2,
+              filename: 'filename.js',
+              function: 'function',
+              lineno: 2,
+            },
+          ],
+        },
+        type: 'SyntaxError',
+        value: 'missing ( on line 10',
+      },
+    ],
+  },
+};
+
+describe('Dedupe', () => {
+  describe('shouldDropEvent(messageEvent)', () => {
+    it('should not drop if there was no previous event', () => {
+      const event = clone(messageEvent);
+      expect(dedupe.shouldDropEvent(event)).equal(false);
+    });
+
+    it('should not drop if events have different messages', () => {
+      const eventA = clone(messageEvent);
+      const eventB = clone(messageEvent);
+      eventB.message = 'EvilMorty';
+      expect(dedupe.shouldDropEvent(eventA, eventB)).equal(false);
+    });
+
+    it('should not drop if events have same messages, but different stacktraces', () => {
+      const eventA = clone(messageEvent);
+      const eventB = clone(messageEvent);
+      eventB.stacktrace.frames[0].colno = 1337;
+      expect(dedupe.shouldDropEvent(eventA, eventB)).equal(false);
+    });
+
+    it('should drop if there are two events with same messages and no fingerprints', () => {
+      const eventA = clone(messageEvent);
+      delete eventA.fingerprint;
+      const eventB = clone(messageEvent);
+      delete eventB.fingerprint;
+      expect(dedupe.shouldDropEvent(eventA, eventB)).equal(true);
+    });
+
+    it('should drop if there are two events with same messages and same fingerprints', () => {
+      const eventA = clone(messageEvent);
+      const eventB = clone(messageEvent);
+      expect(dedupe.shouldDropEvent(eventA, eventB)).equal(true);
+    });
+
+    it('should not drop if there are two events with same message but different fingerprints', () => {
+      const eventA = clone(messageEvent);
+      const eventB = clone(messageEvent);
+      eventA.fingerprint = ['Birdperson'];
+      const eventC = clone(messageEvent);
+      delete eventC.fingerprint;
+      expect(dedupe.shouldDropEvent(eventA, eventB)).equal(false);
+      expect(dedupe.shouldDropEvent(eventA, eventC)).equal(false);
+      expect(dedupe.shouldDropEvent(eventB, eventC)).equal(false);
+    });
+  });
+
+  describe('shouldDropEvent(exceptionEvent)', () => {
+    it('should drop when events type, value and stacktrace are the same', () => {
+      const event = clone(exceptionEvent);
+      expect(dedupe.shouldDropEvent(event, event)).equal(true);
+    });
+
+    it('should not drop if types are different', () => {
+      const eventA = clone(exceptionEvent);
+      const eventB = clone(exceptionEvent);
+      eventB.exception.values[0].type = 'TypeError';
+      expect(dedupe.shouldDropEvent(eventA, eventB)).equal(false);
+    });
+
+    it('should not drop if values are different', () => {
+      const eventA = clone(exceptionEvent);
+      const eventB = clone(exceptionEvent);
+      eventB.exception.values[0].value = 'Expected number, got string';
+      expect(dedupe.shouldDropEvent(eventA, eventB)).equal(false);
+    });
+
+    it('should not drop if stacktraces are different', () => {
+      const eventA = clone(exceptionEvent);
+      const eventB = clone(exceptionEvent);
+      eventB.exception.values[0].stacktrace.frames[0].colno = 1337;
+      expect(dedupe.shouldDropEvent(eventA, eventB)).equal(false);
+    });
+  });
+});

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -9,8 +9,8 @@ import {
   Severity,
   Status,
 } from '@sentry/types';
-import { getGlobalObject, uuid4 } from '@sentry/utils/misc';
 import { forget } from '@sentry/utils/async';
+import { getGlobalObject, uuid4 } from '@sentry/utils/misc';
 import { truncate } from '@sentry/utils/string';
 import { BackendClass } from './basebackend';
 import { Dsn } from './dsn';

--- a/packages/raven-js/src/raven.js
+++ b/packages/raven-js/src/raven.js
@@ -1921,6 +1921,9 @@ Raven.prototype = {
     } else if (current.exception || last.exception) {
       // Exception interface (i.e. from captureException/onerror)
       return isSameException(current.exception, last.exception);
+    } else if (current.fingerprint || last.fingerprint) {
+      return Boolean(current.fingerprint && last.fingerprint) &&
+        JSON.stringify(current.fingerprint) === JSON.stringify(last.fingerprint)
     }
 
     return true;

--- a/packages/raven-js/test/raven.test.js
+++ b/packages/raven-js/test/raven.test.js
@@ -3856,6 +3856,30 @@ describe('Raven (private methods)', function() {
         assert.isFalse(Raven._isRepeatData(data));
       });
 
+      it('should return false for different fingerprints', function() {
+        var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
+        data.fingerprint = ['{{ default }}', 'grouping-identifier'];
+
+        assert.isFalse(Raven._isRepeatData(data));
+
+        Raven._lastData.fingerprint = ['{{ default }}', 'other-grouping-identifier'];
+
+        assert.isFalse(Raven._isRepeatData(data));
+
+        delete data.fingerprint;
+
+        assert.isFalse(Raven._isRepeatData(data));
+      });
+
+      it('should return false for different messages and identical fingerprints', function () {
+        Raven._lastData.message = 'the thing broke';
+        Raven._lastData.fingerprint = ['{{ default }}', 'grouping-identifier'];
+        var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
+        data.message = 'the other thing broke';
+
+        assert.isFalse(Raven._isRepeatData(data));
+      });
+
       it('should return false for different captureMessage payloads w/ synthetic traces', function() {
         Raven._lastData.stacktrace = {
           frames: [

--- a/packages/raven-js/test/raven.test.js
+++ b/packages/raven-js/test/raven.test.js
@@ -3859,15 +3859,10 @@ describe('Raven (private methods)', function() {
       it('should return false for different fingerprints', function() {
         var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
         data.fingerprint = ['{{ default }}', 'grouping-identifier'];
-
         assert.isFalse(Raven._isRepeatData(data));
-
         Raven._lastData.fingerprint = ['{{ default }}', 'other-grouping-identifier'];
-
         assert.isFalse(Raven._isRepeatData(data));
-
         delete data.fingerprint;
-
         assert.isFalse(Raven._isRepeatData(data));
       });
 
@@ -3876,7 +3871,6 @@ describe('Raven (private methods)', function() {
         Raven._lastData.fingerprint = ['{{ default }}', 'grouping-identifier'];
         var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
         data.message = 'the other thing broke';
-
         assert.isFalse(Raven._isRepeatData(data));
       });
 


### PR DESCRIPTION
Rebased https://github.com/getsentry/sentry-javascript/pull/1523 on top of master and squashed some commits together + updated logic behind dedupe integration in new SDK.

cc @kevinehosford (it should be compared for messages only, as previous logic would drop any event that had same fingerprints - eg. different message, but same fingerprint)