### PR TITLE
feat: Dont blow up when someone puts console.log inside beforeBreadrumb

### DIFF
--- a/packages/browser/src/integrations/helpers.ts
+++ b/packages/browser/src/integrations/helpers.ts
@@ -41,8 +41,8 @@ export function wrap(
       return fn;
     }
     // If this has already been wrapped in the past, return that wrapped function
-    if (fn.__sentry_wrapper__) {
-      return fn.__sentry_wrapper__;
+    if (fn.__sentry_wrapped__) {
+      return fn.__sentry_wrapped__;
     }
   } catch (e) {
     // Just accessing custom props in some Selenium environments
@@ -97,7 +97,7 @@ export function wrap(
   } catch (_oO) {} // tslint:disable-line:no-empty
 
   wrapped.prototype = fn.prototype;
-  fn.__sentry_wrapper__ = wrapped;
+  fn.__sentry_wrapped__ = wrapped;
 
   // Signal that this function has been wrapped/filled already
   // for both debugging and to prevent it to being wrapped/filled twice

--- a/packages/browser/src/integrations/trycatch.ts
+++ b/packages/browser/src/integrations/trycatch.ts
@@ -149,9 +149,9 @@ export class TryCatch implements Integration {
       ): () => void {
         let callback = (fn as any) as SentryWrappedFunction;
         try {
-          callback = callback && (callback.__sentry_wrapper__ || callback);
+          callback = callback && (callback.__sentry_wrapped__ || callback);
         } catch (e) {
-          // ignore, accessing __sentry_wrapper__ will throw in some Selenium environments
+          // ignore, accessing __sentry_wrapped__ will throw in some Selenium environments
         }
         return original.call(this, eventName, callback, options);
       };

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -5,6 +5,7 @@ import {
   SentryEvent,
   SentryEventHint,
   SentryResponse,
+  SentryWrappedFunction,
   Severity,
   Status,
 } from '@sentry/types';
@@ -23,7 +24,7 @@ interface ExtensibleConsole extends Console {
 async function beforeBreadcrumbConsoleLoopGuard(
   callback: () => Breadcrumb | Promise<Breadcrumb | null> | null,
 ): Promise<Breadcrumb | null> {
-  const global = getGlobalObject();
+  const global = getGlobalObject() as Window;
   const levels = ['debug', 'info', 'warn', 'error', 'log'];
 
   if (!('console' in global)) {
@@ -34,8 +35,8 @@ async function beforeBreadcrumbConsoleLoopGuard(
 
   // Restore all wrapped console methods
   levels.forEach(level => {
-    if (level in global.console && originalConsole[level].__sentry__) {
-      originalConsole[level] = originalConsole[level].__sentry_original__;
+    if (level in global.console && (originalConsole[level] as SentryWrappedFunction).__sentry__) {
+      originalConsole[level] = (originalConsole[level] as SentryWrappedFunction).__sentry_original__;
     }
   });
 
@@ -44,8 +45,8 @@ async function beforeBreadcrumbConsoleLoopGuard(
 
   // Revert restoration to wrapped state
   levels.forEach(level => {
-    if (level in global.console && originalConsole[level].__sentry__) {
-      originalConsole[level] = originalConsole[level].__sentry_wrapped__;
+    if (level in global.console && (originalConsole[level] as SentryWrappedFunction).__sentry__) {
+      originalConsole[level] = (originalConsole[level] as SentryWrappedFunction).__sentry_wrapped__;
     }
   });
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -280,7 +280,7 @@ export namespace Status {
 export interface SentryWrappedFunction extends Function {
   [key: string]: any;
   __sentry__?: boolean;
-  __sentry_wrapper__?: SentryWrappedFunction;
+  __sentry_wrapped__?: SentryWrappedFunction;
   __sentry_original__?: SentryWrappedFunction;
 }
 

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -1,3 +1,4 @@
+import { SentryWrappedFunction } from '@sentry/types';
 import { isPlainObject, isUndefined } from './is';
 
 /**
@@ -156,14 +157,12 @@ export function fill(source: { [key: string]: any }, name: string, replacement: 
   if (!(name in source)) {
     return;
   }
-  const original = source[name];
-  source[name] = replacement(original);
-  // tslint:disable-next-line:no-unsafe-any
-  source[name].__sentry__ = true;
-  // tslint:disable-next-line:no-unsafe-any
-  source[name].__sentry_original__ = original;
-  // tslint:disable-next-line:no-unsafe-any
-  source[name].__sentry_wrapped__ = source[name];
+  const original = source[name] as () => any;
+  const wrapped = replacement(original) as SentryWrappedFunction;
+  wrapped.__sentry__ = true;
+  wrapped.__sentry_original__ = original;
+  wrapped.__sentry_wrapped__ = wrapped;
+  source[name] = wrapped;
 }
 
 /**

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -162,6 +162,8 @@ export function fill(source: { [key: string]: any }, name: string, replacement: 
   source[name].__sentry__ = true;
   // tslint:disable-next-line:no-unsafe-any
   source[name].__sentry_original__ = original;
+  // tslint:disable-next-line:no-unsafe-any
+  source[name].__sentry_wrapped__ = source[name];
 }
 
 /**


### PR DESCRIPTION
+ unify console wrapping between node and browser. Not the most beautiful, but works like a charm.

Fixes: https://github.com/getsentry/sentry-javascript/issues/813

To test:

```js
Sentry.init({
  dsn: 'http://fake@dsn.com/123',
  beforeBreadcrumb(breadcrumb) {
    console.log('inside raw');
    setTimeout(() => {
      console.log('inside timeout');
    }, 100);
    return breadcrumb;
  },
});

Sentry.addBreadcrumb({ message: '123' });
```