### PR TITLE
feat: Skip beforeSend when throwing internal exception

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -8,6 +8,7 @@ import {
   Severity,
   Status,
 } from '@sentry/types';
+import { forget } from '@sentry/utils/async';
 import { uuid4 } from '@sentry/utils/misc';
 import { truncate } from '@sentry/utils/string';
 import { BackendClass } from './basebackend';
@@ -322,41 +323,45 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
       };
     }
 
-    try {
-      const isInternalException = hint && hint.data && hint.data.__sentry__ === true;
-      let finalEvent: SentryEvent | null = prepared;
+    let finalEvent: SentryEvent | null = prepared;
 
+    try {
+      const isInternalException = hint && hint.data && (hint.data as { [key: string]: any }).__sentry__ === true;
       if (!isInternalException && beforeSend) {
         finalEvent = await beforeSend(prepared, hint);
       }
-
-      if (finalEvent === null) {
-        return {
-          status: Status.Skipped,
-        };
-      }
-
-      const response = await send(finalEvent);
-      response.event = finalEvent;
-
-      if (response.status === Status.RateLimit) {
-        // TODO: Handle rate limits and maintain a queue. For now, we require SDK
-        // implementors to override this method and handle it themselves.
-      }
-
-      return response;
     } catch (exception) {
-      this.captureException(exception, {
-        data: {
-          __sentry__: true,
-        },
-        originalException: exception,
-      });
+      forget(
+        this.captureException(exception, {
+          data: {
+            __sentry__: true,
+          },
+          originalException: exception as Error,
+        }),
+      );
 
       return {
+        reason: 'Event processing in beforeSend method threw an exception',
         status: Status.Invalid,
       };
     }
+
+    if (finalEvent === null) {
+      return {
+        reason: 'Event dropped due to being discarded by beforeSend method',
+        status: Status.Skipped,
+      };
+    }
+
+    const response = await send(finalEvent);
+    response.event = finalEvent;
+
+    if (response.status === Status.RateLimit) {
+      // TODO: Handle rate limits and maintain a queue. For now, we require SDK
+      // implementors to override this method and handle it themselves.
+    }
+
+    return response;
   }
 
   /**

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -322,22 +322,41 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
       };
     }
 
-    const finalEvent = beforeSend ? await beforeSend(prepared, hint) : prepared;
-    if (finalEvent === null) {
+    try {
+      const isInternalException = hint && hint.data && hint.data.__sentry__ === true;
+      let finalEvent: SentryEvent | null = prepared;
+
+      if (!isInternalException && beforeSend) {
+        finalEvent = await beforeSend(prepared, hint);
+      }
+
+      if (finalEvent === null) {
+        return {
+          status: Status.Skipped,
+        };
+      }
+
+      const response = await send(finalEvent);
+      response.event = finalEvent;
+
+      if (response.status === Status.RateLimit) {
+        // TODO: Handle rate limits and maintain a queue. For now, we require SDK
+        // implementors to override this method and handle it themselves.
+      }
+
+      return response;
+    } catch (exception) {
+      this.captureException(exception, {
+        data: {
+          __sentry__: true,
+        },
+        originalException: exception,
+      });
+
       return {
-        status: Status.Skipped,
+        status: Status.Invalid,
       };
     }
-
-    const response = await send(finalEvent);
-    response.event = finalEvent;
-
-    if (response.status === Status.RateLimit) {
-      // TODO: Handle rate limits and maintain a queue. For now, we require SDK
-      // implementors to override this method and handle it themselves.
-    }
-
-    return response;
   }
 
   /**


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-javascript/issues/899

---

```js
Sentry.init({
  dsn: 'https://363a337c11a64611be4845ad6e24f3ac@sentry.io/297378',
  beforeSend(event, hint) { 
    event.nonExistent.replace('foo', 'bar');
    return event;
  } 
});

setTimeout(function () { 
  throw new Error('ex1')
}, 1000);

setTimeout(function () { 
  throw new Error('ex2')
}, 2000);

setTimeout(function () { 
  throw new Error('ex3')
}, 3000);
```

---

This is how it looks:
![screen shot 2018-09-13 at 11 59 20](https://user-images.githubusercontent.com/1523305/45481859-e90ad980-b74c-11e8-992d-b2bc76fc23a7.png)

---

We don't need to do this for processors, as we already have a different guard there:

```js
let processedEvent: SentryEvent | null = event;
for (const processor of this.eventProcessors) {
  try {
    processedEvent = await processor({ ...processedEvent }, hint);
    if (processedEvent === null) {
      return null;
    }
  } catch (e) {
    continue;
  }
}
return processedEvent;
```