### PR TITLE
Revert "misc: Add node typings to packages/node"

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -28,7 +28,6 @@
   "devDependencies": {
     "@types/cookie": "0.3.1",
     "@types/md5": "2.1.32",
-    "@types/node": "^10.9.4",
     "@types/stack-trace": "0.0.29",
     "jest": "^22.4.3",
     "npm-run-all": "^4.1.2",
@@ -57,9 +56,14 @@
     "transform": {
       "^.+\\.ts$": "ts-jest"
     },
-    "moduleFileExtensions": ["js", "ts"],
+    "moduleFileExtensions": [
+      "js",
+      "ts"
+    ],
     "testEnvironment": "node",
-    "testMatch": ["**/*.test.ts"],
+    "testMatch": [
+      "**/*.test.ts"
+    ],
     "globals": {
       "ts-jest": {
         "tsConfigFile": "./tsconfig.json"


### PR DESCRIPTION
Reverts getsentry/sentry-javascript#1531

To fix https://github.com/getsentry/sentry-javascript/issues/1530, we just need to document:
```
{ 
  "compilerOptions": {
    "lib": ["dom"]
  }
}
```