### PR TITLE
fix: Array.from is not available in old mobile browsers

### DIFF
--- a/packages/browser/src/integrations/helpers.ts
+++ b/packages/browser/src/integrations/helpers.ts
@@ -66,7 +66,7 @@ export function wrap(
       // NOTE: If you are a Sentry user, and you are seeing this stack frame, it
       //       means Raven caught an error invoking your application code. This is
       //       expected behavior and NOT indicative of a bug with Raven.js.
-      const wrappedArguments = Array.from(arguments).map(arg => wrap(arg, options));
+      const wrappedArguments = Array.prototype.slice.call(arguments).map((arg: any) => wrap(arg, options));
 
       if (fn.handleEvent) {
         return fn.handleEvent.apply(this, wrappedArguments);


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-javascript/issues/1569