### PR TITLE
fix: Dont break when non-string is passed to truncate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [core] ref: Move SDKInformation integration into core prepareEvent method
 - [core] ref: Move debug initialization as the first step
 - [node] fix: Make handlers types compatibile with Express
+- [utils] fix: Dont break when non-string is passed to truncate
 
 ## 4.0.4
 

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -1,3 +1,5 @@
+import { isString } from './is';
+
 /**
  * Encodes given object into url-friendly format
  *
@@ -6,8 +8,8 @@
  * @returns string Encoded
  */
 
-export function truncate(str: string, max: number): string {
-  if (max === 0) {
+export function truncate(str: string, max: number = 0): string {
+  if (max === 0 || !isString(str)) {
     return str;
   }
   return str.length <= max ? str : `${str.substr(0, max)}\u2026`;

--- a/packages/utils/test/string.test.ts
+++ b/packages/utils/test/string.test.ts
@@ -7,4 +7,19 @@ describe('truncate()', () => {
     expect(truncate('lol', 3)).toEqual('lol');
     expect(truncate(new Array(1000).join('f'), 0)).toEqual(new Array(1000).join('f'));
   });
+
+  test('it instantly returns input when non-string is passed', () => {
+    // @ts-ignore
+    expect(truncate(2)).toEqual(2);
+    // @ts-ignore
+    expect(truncate(undefined, 123)).toEqual(undefined);
+    // @ts-ignore
+    expect(truncate(null)).toEqual(null);
+    const obj = {};
+    // @ts-ignore
+    expect(truncate(obj, '42')).toEqual(obj);
+    const arr: any[] = [];
+    // @ts-ignore
+    expect(truncate(arr)).toEqual(arr);
+  });
 });


### PR DESCRIPTION
Fix https://github.com/getsentry/sentry-javascript/issues/1580