### PR TITLE
fix: Make handlers types compatibile with Express

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [browser] test: Add loader + integration tests
 - [core] ref: Move SDKInformation integration into core prepareEvent method
 - [core] ref: Move debug initialization as the first step
+- [node] fix: Make handlers types compatibile with Express
 
 ## 4.0.4
 

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -136,8 +136,12 @@ function parseRequest(
 }
 
 /** JSDoc */
-export function requestHandler(): (req: http.ClientRequest, res: http.ServerResponse, next: () => void) => void {
-  return function sentryRequestMiddleware(req: http.ClientRequest, _res: http.ServerResponse, next: () => void): void {
+export function requestHandler(): (req: http.IncomingMessage, res: http.ServerResponse, next: () => void) => void {
+  return function sentryRequestMiddleware(
+    req: http.IncomingMessage,
+    _res: http.ServerResponse,
+    next: () => void,
+  ): void {
     const local = domain.create();
     const hub = getHubFromCarrier(req);
     hub.bindClient(getCurrentHub().getClient());
@@ -169,13 +173,13 @@ function getStatusCodeFromResponse(error: MiddlewareError): number {
 /** JSDoc */
 export function errorHandler(): (
   error: MiddlewareError,
-  req: http.ClientRequest,
+  req: http.IncomingMessage,
   res: http.ServerResponse,
   next: (error: MiddlewareError) => void,
 ) => void {
   return function sentryErrorMiddleware(
     error: MiddlewareError,
-    req: http.ClientRequest,
+    req: http.IncomingMessage,
     _res: http.ServerResponse,
     next: (error: MiddlewareError) => void,
   ): void {

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -81,7 +81,7 @@ function loadWrapper(nativeModule: any): any {
       // just get that reference updated to use our new ClientRequest
       fill(originalModule, 'request', function(): any {
         return function(options: http.ClientRequestArgs, callback: () => void): any {
-          return new originalModule.ClientRequest(options, callback) as http.ClientRequest;
+          return new originalModule.ClientRequest(options, callback) as http.IncomingMessage;
         };
       });
 


### PR DESCRIPTION
Fix: https://github.com/getsentry/sentry-javascript/issues/1578
After merging, we need to get this one in as well: https://github.com/getsentry/sentry-docs/pull/379