### PR TITLE
Allow no return value from beforeSend

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -366,6 +366,10 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
       const isInternalException = hint && hint.data && (hint.data as { [key: string]: any }).__sentry__ === true;
       if (!isInternalException && beforeSend) {
         finalEvent = await beforeSend(prepared, hint);
+
+        if (typeof finalEvent === 'undefined') {
+          finalEvent = prepared
+        }
       }
     } catch (exception) {
       forget(


### PR DESCRIPTION
This allows to return no value for beforeEvent.

Use case: I tried to use this method to log event before sending to sentry with console.log(event) and didn't bother to return event (no documentation on this topic) which resulted in event serializing to `[undefined]` and Sentry responding with "Bad data decoding request (TypeError, Incorrect padding)".

I think it's reasonable to use original event if nothing is returned.


