### PR TITLE
Remove 'critical' from LogLevel type

### DIFF
--- a/packages/raven-js/typescript/raven.d.ts
+++ b/packages/raven-js/typescript/raven.d.ts
@@ -329,5 +329,5 @@ declare namespace Raven {
     sentry?: boolean;
   }
 
-  type LogLevel = 'critical' | 'error' | 'warning' | 'info' | 'debug' | 'warn' | 'log';
+  type LogLevel = 'fatal' | 'error' | 'warning' | 'info' | 'debug' | 'warn' | 'log';
 }


### PR DESCRIPTION
I tried using the "criitcal" LogLevel but once it hit sentry, this error was presented "Discarded invalid value for parameter 'level'".

I tried a quick google to see if I could find the definitive list, but was unsuccessful.

So, I'm just removing `critical` from the TypeScript type definition here.

------

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
