### PR TITLE
feat: Better mechanism detection in TraceKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [core]: ref: Check for node-env first and return more accurate global object
 - [core] ref: Remove Repo interface and repos attribute from Event
 - [browser]: ref: Include md5 lib and transcript it to TypeScript
+- [browser]: feat: Better mechanism detection in TraceKit
 
 ## 4.0.6
 

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -77,8 +77,11 @@ export class GlobalHandlers implements Integration {
       exception: {
         ...event.exception,
         mechanism: {
+          data: {
+            mode: stacktrace.mode,
+          },
           handled: false,
-          type: stacktrace.mode === 'onerror' ? 'onerror' : 'onunhandledrejection',
+          type: stacktrace.mechanism,
         },
       },
     };

--- a/packages/browser/src/tracekit.ts
+++ b/packages/browser/src/tracekit.ts
@@ -17,6 +17,7 @@ export interface StackTrace {
    * Known modes: callers, failed, multiline, onerror, stack, stacktrace
    */
   mode: string;
+  mechanism: string;
   name: string;
   message: string;
   url: string;
@@ -354,6 +355,7 @@ TraceKit.report = (function reportModuleWrapper() {
       processLastException();
     } else if (errorObj && isError(errorObj)) {
       stack = TraceKit.computeStackTrace(errorObj);
+      stack.mechanism = 'onerror';
       notifyHandlers(stack, true, errorObj);
     } else {
       var location: any = {
@@ -378,6 +380,7 @@ TraceKit.report = (function reportModuleWrapper() {
         name: name,
         message: msg,
         mode: 'onerror',
+        mechanism: 'onerror',
         stack: [
           {
             ...location,
@@ -410,6 +413,7 @@ TraceKit.report = (function reportModuleWrapper() {
   function traceKitWindowOnUnhandledRejection(e: any) {
     var err = (e && (e.detail ? e.detail.reason : e.reason)) || e;
     var stack = TraceKit.computeStackTrace(err);
+    stack.mechanism = 'onunhandledrejection';
     notifyHandlers(stack, true, err);
   }
 


### PR DESCRIPTION
Previous implementation too often reported `onunhandledrejection` for top-level errors.