### PR TITLE
ref: Transaction related updates to browser/node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - [core]: ref: Check for node-env first and return more accurate global object
 - [core] ref: Remove Repo interface and repos attribute from Event
 - [browser]: ref: Include md5 lib and transcript it to TypeScript
+- [node] feat: Transactions handling for RequestHandler in Express/Hapi
+- [node] feat: Allow requestHandler to be configured
+- [node] feat: Make node transactions a pluggable integration with tests 
+- [browser] ref: Remove transaction from browser
 
 ## 4.0.6
 

--- a/packages/browser/src/parsers.ts
+++ b/packages/browser/src/parsers.ts
@@ -48,13 +48,11 @@ export function eventFromPlainObject(exception: {}, syntheticException: Error | 
 /** JSDoc */
 export function eventFromStacktrace(stacktrace: TraceKitStackTrace): SentryEvent {
   const exception = exceptionFromStacktrace(stacktrace);
-  const transaction = stacktrace.url || (stacktrace.stack && stacktrace.stack[0].url) || '<unknown>';
 
   return {
     exception: {
       values: [exception],
     },
-    transaction,
   };
 }
 

--- a/packages/node/src/integrations/pluggable/transaction.ts
+++ b/packages/node/src/integrations/pluggable/transaction.ts
@@ -1,0 +1,51 @@
+import { Scope } from '@sentry/hub';
+import { Integration, SentryEvent, StackFrame } from '@sentry/types';
+import { NodeOptions } from '../../backend';
+import { getCurrentHub } from '../../hub';
+
+/** Add node transaction to the event */
+export class Transaction implements Integration {
+  /**
+   * @inheritDoc
+   */
+  public name: string = 'Transaction';
+
+  /**
+   * @inheritDoc
+   */
+  public install(_: NodeOptions = {}): void {
+    getCurrentHub().configureScope((scope: Scope) => {
+      scope.addEventProcessor(async event => this.process(event));
+    });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public async process(event: SentryEvent): Promise<SentryEvent> {
+    const frames = this.getFramesFromEvent(event);
+
+    // use for loop so we don't have to reverse whole frames array
+    for (let i = frames.length - 1; i >= 0; i--) {
+      const frame = frames[i];
+
+      if (frame.in_app === true) {
+        event.transaction = this.getTransaction(frame);
+        break;
+      }
+    }
+
+    return event;
+  }
+
+  /** JSDoc */
+  private getFramesFromEvent(event: SentryEvent): StackFrame[] {
+    const exception = event.exception && event.exception.values && event.exception.values[0];
+    return (exception && exception.stacktrace && exception.stacktrace.frames) || [];
+  }
+
+  /** JSDoc */
+  private getTransaction(frame: StackFrame): string {
+    return frame.module || frame.function ? `${frame.module || '?'}/${frame.function || '?'}` : '<unknown>';
+  }
+}

--- a/packages/node/src/parsers.ts
+++ b/packages/node/src/parsers.ts
@@ -25,11 +25,6 @@ function getFunction(frame: stacktrace.StackFrame): string {
   }
 }
 
-/** JSDoc */
-function getTransaction(frame: StackFrame): string {
-  return frame.module || frame.function ? `${frame.module || '?'} at ${frame.function || '?'}` : '<unknown>';
-}
-
 const mainModule: string = `${(require.main && require.main.filename && path.dirname(require.main.filename)) ||
   global.process.cwd()}/`;
 
@@ -214,17 +209,6 @@ export async function parseError(error: ExtendedError): Promise<SentryEvent> {
     event.extra = {
       [name]: extraErrorInfo,
     };
-  }
-
-  // use for loop so we don't have to reverse whole frames array
-  const frames = (exception.stacktrace && exception.stacktrace.frames) || [];
-  for (let i = frames.length - 1; i >= 0; i--) {
-    const frame = frames[i];
-
-    if (frame.in_app === true) {
-      event.transaction = getTransaction(frame);
-      break;
-    }
   }
 
   return event;

--- a/packages/node/test/integrations/transaction.test.ts
+++ b/packages/node/test/integrations/transaction.test.ts
@@ -1,0 +1,135 @@
+import { Transaction } from '../../src/integrations/pluggable/transaction';
+
+const transaction: Transaction = new Transaction();
+
+describe.only('Transaction', () => {
+  describe('extracts info from module/function of the first `in_app` frame', () => {
+    it('using module only', async () => {
+      const event = await transaction.process({
+        exception: {
+          values: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    filename: '/some/file1.js',
+                    in_app: false,
+                    module: 'Foo',
+                  },
+                  {
+                    filename: '/some/file2.js',
+                    in_app: true,
+                    module: 'Qux',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      });
+      expect(event.transaction).toEqual('Qux/?');
+    });
+
+    it('using function only', async () => {
+      const event = await transaction.process({
+        exception: {
+          values: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    filename: '/some/file1.js',
+                    function: 'Bar',
+                    in_app: false,
+                  },
+                  {
+                    filename: '/some/file2.js',
+                    function: 'Baz',
+                    in_app: true,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      });
+      expect(event.transaction).toEqual('?/Baz');
+    });
+
+    it('using module and function', async () => {
+      const event = await transaction.process({
+        exception: {
+          values: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    filename: '/some/file1.js',
+                    function: 'Bar',
+                    in_app: true,
+                    module: 'Foo',
+                  },
+                  {
+                    filename: '/some/file2.js',
+                    function: 'Baz',
+                    in_app: false,
+                    module: 'Qux',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      });
+      expect(event.transaction).toEqual('Foo/Bar');
+    });
+
+    it('using default', async () => {
+      const event = await transaction.process({
+        exception: {
+          values: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    filename: '/some/file1.js',
+                    in_app: false,
+                  },
+                  {
+                    filename: '/some/file2.js',
+                    in_app: true,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      });
+      expect(event.transaction).toEqual('<unknown>');
+    });
+
+    it('no value with no `in_app` frame', async () => {
+      const event = await transaction.process({
+        exception: {
+          values: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    filename: '/some/file1.js',
+                    in_app: false,
+                  },
+                  {
+                    filename: '/some/file2.js',
+                    in_app: false,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      });
+      expect(event.transaction).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Browser frameworks are still TBD.

One thing I'm concerned about is that Node.js frameworks are not done through integrations (because of their middleware/pipeline-like structure) and when someone uses `RequestHandler` and generic `Sentry.Integrations.Transaction`, they'll class and generic will win.