### PR TITLE
[node] Allow configuring user attributes to be picked

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -116,10 +116,12 @@ function extractRequestData(req: { [key: string]: any }): { [key: string]: strin
 }
 
 /** JSDoc */
-function extractUserData(req: { [key: string]: any }): { [key: string]: string } {
+const DEFAULT_USER_ATTRIBUTES = ['id', 'username', 'email'];
+function extractUserData(req: { [key: string]: any }, userOption: boolean | Array<string>): { [key: string]: string } {
   const user: { [key: string]: string } = {};
+  const attributes = Array.isArray(userOption) && userOption.length ? userOption : DEFAULT_USER_ATTRIBUTES;
 
-  ['id', 'username', 'email'].forEach(key => {
+  attributes.forEach(key => {
     if ({}.hasOwnProperty.call(req.user, key)) {
       user[key] = (req.user as { [key: string]: string })[key];
     }
@@ -152,7 +154,7 @@ function parseRequest(
     request?: boolean;
     serverName?: boolean;
     transaction?: boolean | TransactionTypes;
-    user?: boolean;
+    user?: boolean | Array<string>;
     version?: boolean;
   },
 ): SentryEvent {
@@ -187,7 +189,7 @@ function parseRequest(
   if (options.user && req.user) {
     event.user = {
       ...event.user,
-      ...extractUserData(req),
+      ...extractUserData(req, options.user),
     };
   }
 
@@ -206,7 +208,7 @@ export function requestHandler(options?: {
   request?: boolean;
   serverName?: boolean;
   transaction?: boolean | TransactionTypes;
-  user?: boolean;
+  user?: boolean | Array<string>;
   version?: boolean;
 }): (req: http.IncomingMessage, res: http.ServerResponse, next: () => void) => void {
   return function sentryRequestMiddleware(


### PR DESCRIPTION
### Problem

User attributes to be extracted from `req` in `@sentry/node`'s `requestHandler` are hard-coded. Currently there's no way to modify them without forking this module.

### Proposed Solution

We already have `options.user` as a boolean, I propose we make it a dual-type that also accepts Arrays of strings. This change is backward compatible and falls back to the same list of keys previously used.

### Prior art

A similar feature was added to the now deprecated `raven-node` at https://github.com/getsentry/raven-node/pull/274