### PR TITLE
request options expect a colon after protocol

### DIFF
--- a/packages/node/src/transports/base.ts
+++ b/packages/node/src/transports/base.ts
@@ -35,6 +35,7 @@ export abstract class BaseTransport implements Transport {
     };
 
     const dsn = this.api.getDsn();
+    const protocol = dsn.protocol ? `${dsn.protocol}:` : '';
     return {
       agent: this.client,
       headers,
@@ -42,7 +43,7 @@ export abstract class BaseTransport implements Transport {
       method: 'POST',
       path: this.api.getStoreEndpointPath(),
       port: dsn.port,
-      protocol: dsn.protocol,
+      protocol,
     };
   }
 


### PR DESCRIPTION
[In the DSN regex, `protocol` does _not_ include a colon](https://github.com/getsentry/sentry-javascript/blob/adbce6776255398d5ba50a6037687e5314c6b466/packages/core/src/dsn.ts#L7)

However, the Node `https` module that Sentry uses under the hood [expects a protocol with colon at the end](https://nodejs.org/api/https.html#https_https_request_options_callback).