### PR TITLE
Breadcrumbs Support IE9 while inject console

### DIFF
--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -163,7 +163,7 @@ export class Breadcrumbs implements Integration {
 
           // this fails for some browsers. :(
           if (originalConsoleLevel) {
-            originalConsoleLevel.apply(global.console, args);
+            Function.prototype.apply.call(originalConsoleLevel, global.console, args);
           }
         };
       });


### PR DESCRIPTION
Base on the solution from StackOverflow https://stackoverflow.com/questions/5538972/console-log-apply-not-working-in-ie9