### PR TITLE
fix: Fix typos in setTag examples

### DIFF
--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -38,7 +38,7 @@ export const defaultIntegrations = [
  * import { configureScope } from '@sentry/browser';
  * configureScope((scope: Scope) => {
  *   scope.setExtra({ battery: 0.7 });
- *   scope.setTags({ user_mode: 'admin' });
+ *   scope.setTag({ user_mode: 'admin' });
  *   scope.setUser({ id: '4711' });
  * });
  *

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -40,7 +40,7 @@ export const defaultIntegrations = [
  * const { configureScope } = require('@sentry/node');
  * configureScope((scope: Scope) => {
  *   scope.setExtra({ battery: 0.7 });
- *   scope.setTags({ user_mode: 'admin' });
+ *   scope.setTag({ user_mode: 'admin' });
  *   scope.setUser({ id: '4711' });
  * });
  *


### PR DESCRIPTION
As seen [here](https://github.com/getsentry/sentry-javascript/blob/4dd82e83cb90dfcd8ea2d7f071c366efa126db93/packages/hub/src/scope.ts), the method is called `setTag`, not `setTags`.

Confirmed by @HazAT .