### PR TITLE
browser/LinkedErrors: Improve test code to be more realistic

### DIFF
--- a/packages/browser/test/integrations/linkederrors.test.ts
+++ b/packages/browser/test/integrations/linkederrors.test.ts
@@ -54,14 +54,15 @@ describe('LinkedErrors', () => {
     });
 
     it('should recursively walk error to find linked exceptions and assign them to the event', async () => {
-      const one: ExtendedError = new Error('one');
-      const two: ExtendedError = new TypeError('two');
       const three: ExtendedError = new SyntaxError('three');
 
-      const originalException = one;
-      one.cause = two;
+      const two: ExtendedError = new TypeError('two');
       two.cause = three;
 
+      const one: ExtendedError = new Error('one');
+      one.cause = two;
+
+      const originalException = one;
       const backend = new BrowserBackend({});
       const event = await backend.eventFromException(originalException);
       const result = linkedErrors.handler(event, {
@@ -86,14 +87,15 @@ describe('LinkedErrors', () => {
         key: 'reason',
       });
 
-      const one: ExtendedError = new Error('one');
-      const two: ExtendedError = new TypeError('two');
       const three: ExtendedError = new SyntaxError('three');
 
-      const originalException = one;
-      one.reason = two;
+      const two: ExtendedError = new TypeError('two');
       two.reason = three;
 
+      const one: ExtendedError = new Error('one');
+      one.reason = two;
+
+      const originalException = one;
       const backend = new BrowserBackend({});
       const event = await backend.eventFromException(originalException);
       const result = linkedErrors.handler(event, {

--- a/packages/browser/test/integrations/linkederrors.test.ts
+++ b/packages/browser/test/integrations/linkederrors.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { stub } from 'sinon';
+import { BrowserBackend } from '../../src/backend';
 import { LinkedErrors } from '../../src/integrations/linkederrors';
 
 let linkedErrors: LinkedErrors;
@@ -52,14 +53,7 @@ describe('LinkedErrors', () => {
       expect(spy.calledOnce).equal(true);
     });
 
-    it('should recursively walk error to find linked exceptions and assign them to the event', () => {
-      const event = {
-        exception: {
-          values: [],
-        },
-        message: 'foo',
-      };
-
+    it('should recursively walk error to find linked exceptions and assign them to the event', async () => {
       const one: ExtendedError = new Error('one');
       const two: ExtendedError = new TypeError('two');
       const three: ExtendedError = new SyntaxError('three');
@@ -68,30 +62,29 @@ describe('LinkedErrors', () => {
       one.cause = two;
       two.cause = three;
 
+      const backend = new BrowserBackend({});
+      const event = await backend.eventFromException(originalException);
       const result = linkedErrors.handler(event, {
         originalException,
       });
 
       // It shouldn't include root exception, as it's already processed in the event by the main error handler
-      expect(result!.exception!.values!.length).equal(2);
-      expect(result!.exception!.values![0].type).equal('TypeError');
-      expect(result!.exception!.values![0].value).equal('two');
+      expect(result!.exception!.values!.length).equal(3);
+      expect(result!.exception!.values![0].type).equal('Error');
+      expect(result!.exception!.values![0].value).equal('one');
       expect(result!.exception!.values![0].stacktrace).to.have.property('frames');
-      expect(result!.exception!.values![1].type).equal('SyntaxError');
-      expect(result!.exception!.values![1].value).equal('three');
+      expect(result!.exception!.values![1].type).equal('TypeError');
+      expect(result!.exception!.values![1].value).equal('two');
       expect(result!.exception!.values![1].stacktrace).to.have.property('frames');
+      expect(result!.exception!.values![2].type).equal('SyntaxError');
+      expect(result!.exception!.values![2].value).equal('three');
+      expect(result!.exception!.values![2].stacktrace).to.have.property('frames');
     });
 
-    it('should allow to change walk key', () => {
+    it('should allow to change walk key', async () => {
       linkedErrors = new LinkedErrors({
         key: 'reason',
       });
-      const event = {
-        exception: {
-          values: [],
-        },
-        message: 'foo',
-      };
 
       const one: ExtendedError = new Error('one');
       const two: ExtendedError = new TypeError('two');
@@ -101,18 +94,23 @@ describe('LinkedErrors', () => {
       one.reason = two;
       two.reason = three;
 
+      const backend = new BrowserBackend({});
+      const event = await backend.eventFromException(originalException);
       const result = linkedErrors.handler(event, {
         originalException,
       });
 
       // It shouldn't include root exception, as it's already processed in the event by the main error handler
-      expect(result!.exception!.values!.length).equal(2);
-      expect(result!.exception!.values![0].type).equal('TypeError');
-      expect(result!.exception!.values![0].value).equal('two');
+      expect(result!.exception!.values!.length).equal(3);
+      expect(result!.exception!.values![0].type).equal('Error');
+      expect(result!.exception!.values![0].value).equal('one');
       expect(result!.exception!.values![0].stacktrace).to.have.property('frames');
-      expect(result!.exception!.values![1].type).equal('SyntaxError');
-      expect(result!.exception!.values![1].value).equal('three');
+      expect(result!.exception!.values![1].type).equal('TypeError');
+      expect(result!.exception!.values![1].value).equal('two');
       expect(result!.exception!.values![1].stacktrace).to.have.property('frames');
+      expect(result!.exception!.values![2].type).equal('SyntaxError');
+      expect(result!.exception!.values![2].value).equal('three');
+      expect(result!.exception!.values![2].stacktrace).to.have.property('frames');
     });
   });
 });


### PR DESCRIPTION
This PR slightly changes the test code for the `LinkedErrors` class to be more realistic. Specifically it orders the errors in the way that they depend on each other and uses the `BrowserBackend` class to generate a proper `event` object which now includes the original exception.