### PR TITLE
browser/ember: Rethrow errors in testing mode

### DIFF
--- a/packages/browser/src/integrations/pluggable/ember.ts
+++ b/packages/browser/src/integrations/pluggable/ember.ts
@@ -49,6 +49,8 @@ export class Ember implements Integration {
 
       if (typeof oldOnError === 'function') {
         oldOnError.call(this.Ember, error);
+      } else if (this.Ember.testing) {
+        throw error;
       }
     };
 


### PR DESCRIPTION
see https://github.com/emberjs/ember-qunit/pull/304

When there is another error handler defined we still call it and rely on that one to rethrow the error in testing mode, but when there is no other handler we should make sure to rethrow the error ourselves.

Resolves #1708 

/cc @rwjblue