### PR TITLE
browser/LinkedErrors: Fix exception order

### DIFF
--- a/packages/browser/src/integrations/linkederrors.ts
+++ b/packages/browser/src/integrations/linkederrors.ts
@@ -64,7 +64,7 @@ export class LinkedErrors implements Integration {
       return event;
     }
     const linkedErrors = this.walkErrorTree(hint.originalException, this.key);
-    event.exception.values = [...event.exception.values, ...linkedErrors];
+    event.exception.values = [...linkedErrors, ...event.exception.values];
     return event;
   }
 
@@ -77,6 +77,6 @@ export class LinkedErrors implements Integration {
     }
     const stacktrace = computeStackTrace(error[key]);
     const exception = exceptionFromStacktrace(stacktrace);
-    return this.walkErrorTree(error[key], key, [...stack, exception]);
+    return this.walkErrorTree(error[key], key, [exception, ...stack]);
   }
 }

--- a/packages/browser/test/integrations/linkederrors.test.ts
+++ b/packages/browser/test/integrations/linkederrors.test.ts
@@ -71,14 +71,14 @@ describe('LinkedErrors', () => {
 
       // It shouldn't include root exception, as it's already processed in the event by the main error handler
       expect(result!.exception!.values!.length).equal(3);
-      expect(result!.exception!.values![0].type).equal('Error');
-      expect(result!.exception!.values![0].value).equal('one');
+      expect(result!.exception!.values![0].type).equal('SyntaxError');
+      expect(result!.exception!.values![0].value).equal('three');
       expect(result!.exception!.values![0].stacktrace).to.have.property('frames');
       expect(result!.exception!.values![1].type).equal('TypeError');
       expect(result!.exception!.values![1].value).equal('two');
       expect(result!.exception!.values![1].stacktrace).to.have.property('frames');
-      expect(result!.exception!.values![2].type).equal('SyntaxError');
-      expect(result!.exception!.values![2].value).equal('three');
+      expect(result!.exception!.values![2].type).equal('Error');
+      expect(result!.exception!.values![2].value).equal('one');
       expect(result!.exception!.values![2].stacktrace).to.have.property('frames');
     });
 
@@ -104,14 +104,14 @@ describe('LinkedErrors', () => {
 
       // It shouldn't include root exception, as it's already processed in the event by the main error handler
       expect(result!.exception!.values!.length).equal(3);
-      expect(result!.exception!.values![0].type).equal('Error');
-      expect(result!.exception!.values![0].value).equal('one');
+      expect(result!.exception!.values![0].type).equal('SyntaxError');
+      expect(result!.exception!.values![0].value).equal('three');
       expect(result!.exception!.values![0].stacktrace).to.have.property('frames');
       expect(result!.exception!.values![1].type).equal('TypeError');
       expect(result!.exception!.values![1].value).equal('two');
       expect(result!.exception!.values![1].stacktrace).to.have.property('frames');
-      expect(result!.exception!.values![2].type).equal('SyntaxError');
-      expect(result!.exception!.values![2].value).equal('three');
+      expect(result!.exception!.values![2].type).equal('Error');
+      expect(result!.exception!.values![2].value).equal('one');
       expect(result!.exception!.values![2].stacktrace).to.have.property('frames');
     });
   });


### PR DESCRIPTION
see https://docs.sentry.io/clientdev/interfaces/exception/

Resolves #1693

/cc @kamilogorek 