### PR TITLE
browser/LinkedErrors: Fix `limit` to include the original exception

### DIFF
--- a/packages/browser/src/integrations/linkederrors.ts
+++ b/packages/browser/src/integrations/linkederrors.ts
@@ -72,7 +72,7 @@ export class LinkedErrors implements Integration {
    * @inheritDoc
    */
   public walkErrorTree(error: ExtendedError, key: string, stack: SentryException[] = []): SentryException[] {
-    if (!(error[key] instanceof Error) || stack.length >= this.limit) {
+    if (!(error[key] instanceof Error) || stack.length + 1 >= this.limit) {
       return stack;
     }
     const stacktrace = computeStackTrace(error[key]);


### PR DESCRIPTION
Up until now the `limit` option only counted the linked errors, but not the original exception. After this commit the `limit` will correspond to the number of exceptions that are actually being displayed by Sentry in the end.

/cc @kamilogorek 
