### PR TITLE
fix: Use node internal `path` / `fs` for `store.ts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [utils]: Use node internal `path` / `fs` for `store.ts`
+
 ## 4.2.4
 
 - [browser]: Use `withScope` in `Ember` integration instead of manual `pushPop/popScope` calls

--- a/packages/utils/src/fs.ts
+++ b/packages/utils/src/fs.ts
@@ -1,5 +1,5 @@
 import { mkdir, mkdirSync, readFile, statSync } from 'fs';
-import { dirname, resolve } from './path';
+import { dirname, resolve } from 'path';
 
 const _0777 = parseInt('0777', 8);
 

--- a/packages/utils/src/store.ts
+++ b/packages/utils/src/store.ts
@@ -1,8 +1,9 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
 import { mkdirpSync } from './fs';
-import { dirname, join } from './path';
 
 /**
+ * Note, this class is only compatible with Node.
  * Lazily serializes data to a JSON file to persist. When created, it loads data
  * from that file if it already exists.
  */

--- a/packages/utils/test/store.test.ts
+++ b/packages/utils/test/store.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as fs from 'fs';
 import * as os from 'os';
-import { join } from '../path';
+import { join } from 'path';
 
 import { Store } from '../src/store';
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/pull/1712