### PR TITLE
change browser workspace building.

### DIFF
--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -20,6 +20,7 @@ const bundleConfig = {
     typescript({
       tsconfig: 'tsconfig.build.json',
       tsconfigOverride: { compilerOptions: { declaration: false } },
+      include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
     }),
     resolve({
       jsnext: true,
@@ -44,10 +45,11 @@ export default [
       interop: false,
       sourcemap: true,
     },
-    external: ['@sentry/core', '@sentry/hub', '@sentry/minimal'],
+    external: ['@sentry/core', '@sentry/hub', '@sentry/minimal', 'tslib'],
     plugins: [
       typescript({
         tsconfig: 'tsconfig.build.json',
+        include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
       }),
       resolve({
         jsnext: true,

--- a/packages/browser/tsconfig.build.json
+++ b/packages/browser/tsconfig.build.json
@@ -3,7 +3,14 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "dist",
-    "rootDir": "src"
+    // "rootDir": "src",
+    "paths": {
+      "@sentry/utils/*": ["../utils/src/*"],
+      "@sentry/core": ["../core/src"],
+      "@sentry/hub": ["../hub/src"],
+      "@sentry/types": ["../types/src"],
+      "@sentry/minimal": ["../minimal/src"]
+    }
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
ref: change browser workspace building. Use typescript code in another packages instead of using dist/*.js. It can reduce the bundle size by use tslib be shared.
In original building, there are many same code such as __assign, __generator builded by different package.
https://github.com/getsentry/sentry-javascript/issues/1552#issuecomment-438662300

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
