### PR TITLE
feat: Expose lastEventId in node package

### DIFF
--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -75,3 +75,12 @@ export function init(options: NodeOptions = {}): void {
 
   initAndBind(NodeClient, options);
 }
+
+/**
+ * This is the getter for lastEventId.
+ *
+ * @returns The last event id of a captured event.
+ */
+export function lastEventId(): string | undefined {
+  return getCurrentHub().lastEventId();
+}


### PR DESCRIPTION
It should be unified with `@sentry/browser`.
Fixes: https://github.com/getsentry/sentry-javascript/issues/1765