### PR TITLE
Use Sentry.init instead of init

### DIFF
--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -22,20 +22,20 @@
 
 ## Usage
 
-To use this SDK, call `init(options)` as early as possible after loading the page. This will initialize the SDK and hook
+To use this SDK, call `Sentry.init(options)` as early as possible after loading the page. This will initialize the SDK and hook
 into the environment. Note that you can turn off almost all side effects using the respective options.
 
 ```javascript
-import { init } from '@sentry/browser';
+import * as Sentry from '@sentry/browser';
 
-init({
+Sentry.init({
   dsn: '__DSN__',
   // ...
 });
 ```
 
 To set context information or send manual events, use the exported functions of `@sentry/browser`. Note that these
-functions will not perform any action before you have called `init()`:
+functions will not perform any action before you have called `Sentry.init()`:
 
 ```javascript
 import * as Sentry from '@sentry/browser';


### PR DESCRIPTION
`init` is a very common name and has to  be looked upon to figure out what it is actually initializing. Using `Sentry.init` removes the confusion. The official docs does the same. 

https://docs.sentry.io/error-reporting/quickstart/?platform=browser#configure-the-sdk
