### PR TITLE
fix: Check if value is error object, also use getOwnPropertyNames

### DIFF
--- a/packages/core/src/integrations/extraerrordata.ts
+++ b/packages/core/src/integrations/extraerrordata.ts
@@ -28,20 +28,22 @@ export class ExtraErrorData implements Integration {
   public setupOnce(): void {
     addGlobalEventProcessor(async (event: SentryEvent, hint?: SentryEventHint) => {
       const self = getCurrentHub().getIntegration(ExtraErrorData);
-
-      if (!self || !hint || !hint.originalException) {
+      if (!self) {
         return event;
       }
-
-      return this.enhanceEventWithErrorData(event, hint.originalException);
+      return self.enhanceEventWithErrorData(event, hint);
     });
   }
 
   /**
    * Attaches extracted information from the Error object to extra field in the SentryEvent
    */
-  public enhanceEventWithErrorData(event: SentryEvent, error: Error): SentryEvent {
-    const errorData = this.extractErrorData(error);
+  public enhanceEventWithErrorData(event: SentryEvent, hint?: SentryEventHint): SentryEvent {
+    if (!hint || !hint.originalException || !(hint.originalException instanceof Error)) {
+      return event;
+    }
+
+    const errorData = this.extractErrorData(hint.originalException);
 
     if (errorData) {
       return {
@@ -64,7 +66,7 @@ export class ExtraErrorData implements Integration {
     try {
       const nativeKeys = ['name', 'message', 'stack', 'line', 'column', 'fileName', 'lineNumber', 'columnNumber'];
       const name = error.name || error.constructor.name;
-      const errorKeys = Object.keys(error).filter(key => nativeKeys.indexOf(key) === -1);
+      const errorKeys = Object.getOwnPropertyNames(error).filter(key => nativeKeys.indexOf(key) === -1);
 
       if (errorKeys.length) {
         const extraErrorInfo: { [key: string]: unknown } = {};

--- a/packages/core/src/integrations/extraerrordata.ts
+++ b/packages/core/src/integrations/extraerrordata.ts
@@ -39,7 +39,7 @@ export class ExtraErrorData implements Integration {
    * Attaches extracted information from the Error object to extra field in the SentryEvent
    */
   public enhanceEventWithErrorData(event: SentryEvent, hint?: SentryEventHint): SentryEvent {
-    if (!hint || !hint.originalException || !(hint.originalException instanceof Error)) {
+    if (!hint || !hint.originalException || !isError(hint.originalException)) {
       return event;
     }
 

--- a/packages/core/test/lib/integrations/extraerrordata.test.ts
+++ b/packages/core/test/lib/integrations/extraerrordata.test.ts
@@ -21,7 +21,9 @@ describe('ExtraErrorData()', () => {
     error.baz = 42;
     error.foo = 'bar';
 
-    const enhancedEvent = extraErrorData.enhanceEventWithErrorData(event, error);
+    const enhancedEvent = extraErrorData.enhanceEventWithErrorData(event, {
+      originalException: error,
+    });
 
     expect(enhancedEvent.extra).toEqual({
       TypeError: {
@@ -35,7 +37,9 @@ describe('ExtraErrorData()', () => {
     const error = new TypeError('foo') as ExtendedError;
     error.cause = new SyntaxError('bar');
 
-    const enhancedEvent = extraErrorData.enhanceEventWithErrorData(event, error);
+    const enhancedEvent = extraErrorData.enhanceEventWithErrorData(event, {
+      originalException: error,
+    });
 
     expect(enhancedEvent.extra).toEqual({
       TypeError: {
@@ -53,7 +57,9 @@ describe('ExtraErrorData()', () => {
     const error = new TypeError('foo') as ExtendedError;
     error.baz = 42;
 
-    const enhancedEvent = extraErrorData.enhanceEventWithErrorData(event, error);
+    const enhancedEvent = extraErrorData.enhanceEventWithErrorData(event, {
+      originalException: error,
+    });
 
     expect(enhancedEvent.extra).toEqual({
       TypeError: {
@@ -61,5 +67,29 @@ describe('ExtraErrorData()', () => {
       },
       foo: 42,
     });
+  });
+
+  it('should return event if originalException is not an Error object', () => {
+    const error = 'error message, not object';
+
+    const enhancedEvent = extraErrorData.enhanceEventWithErrorData(event, {
+      originalException: error,
+    });
+
+    expect(enhancedEvent).toEqual(event);
+  });
+
+  it('should return event if there is no SentryEventHint', () => {
+    const enhancedEvent = extraErrorData.enhanceEventWithErrorData(event);
+
+    expect(enhancedEvent).toEqual(event);
+  });
+
+  it('should return event if there is no originalException', () => {
+    const enhancedEvent = extraErrorData.enhanceEventWithErrorData(event, {
+      notOriginalException: 'fooled you',
+    });
+
+    expect(enhancedEvent).toEqual(event);
   });
 });


### PR DESCRIPTION
We have been discussing an issue when logging a message, and not an `Error` object, some weird data is added on "Additional Data": https://github.com/getsentry/sentry-javascript/issues/1805

After tracking down the issue, it happens on the integration `ExtraErrorData`. It seems this integration should only try to extract data from an error object, but it is also being used on strings.

The issue: when reaching
```
const errorKeys = Object.keys(error).filter(key => nativeKeys.indexOf(key) === -1);
```
We get:
![image](https://user-images.githubusercontent.com/13631451/50637455-3cde4000-0f41-11e9-9d2d-c2a7f881f786.png)
Which is logged as additional data.

So instead I have added a check on `addGlobalEventProcessor` to only try to extract data if we are indeed dealing with an error object. I have slightly modified the code to look like other integrations (for instance, `LinkedErrors`) so that it was easier to add new tests.

Another change I have made is change `Object.keys` for `Object.getOwnPropertyNames`. This seems a safer way to extract (and filter) data from the Error object:

![image](https://user-images.githubusercontent.com/13631451/50637577-b118e380-0f41-11e9-88d8-4e705eca0ba6.png)
