### PR TITLE
fix: Exception type/value, Loader promise reject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 4.5.2
+
+- [browser] fix: <unlabeled> event for unhandledRejection
+- [loader] fix: Handle unhandledRejection the same way as it would be thrown
+
 ## 4.5.1
 
 - [utils] fix: Don't npm ignore esm for utils

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -110,18 +110,11 @@ export class GlobalHandlers implements Integration {
       },
     };
 
-    let type = 'Error';
-    if (stacktrace.mechanism === 'onunhandledrejection') {
-      type = 'Unhandled Promise Rejection';
-    }
+    const fallbackValue = typeof stacktrace.original !== 'undefined' ? `${stacktrace.original}` : '';
+    const fallbackType = stacktrace.mechanism === 'onunhandledrejection' ? 'UnhandledRejection' : 'Error';
 
-    let value = '';
-    // stacktrace.original contains the string if it's an unhandledPromiseRejection with just a string
-    if (stacktrace.original) {
-      value = `${stacktrace.original}`;
-    }
     // This makes sure we have type/value in every exception
-    addExceptionTypeValue(newEvent, value, type);
+    addExceptionTypeValue(newEvent, fallbackValue, fallbackType);
 
     return newEvent;
   }

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -1,7 +1,7 @@
 import { getCurrentHub } from '@sentry/core';
 import { Integration, SentryEvent } from '@sentry/types';
 import { logger } from '@sentry/utils/logger';
-import { eventFromStacktrace } from '../parsers';
+import { addExceptionTypeValue, eventFromStacktrace } from '../parsers';
 import {
   installGlobalHandler,
   installGlobalUnhandledRejectionHandler,
@@ -78,21 +78,50 @@ export class GlobalHandlers implements Integration {
     }
   }
 
-  /** JSDoc */
+  /**
+   * This function creates an SentryEvent from an TraceKitStackTrace.
+   *
+   * @param stacktrace TraceKitStackTrace to be converted to an SentryEvent.
+   */
   private eventFromGlobalHandler(stacktrace: TraceKitStackTrace): SentryEvent {
     const event = eventFromStacktrace(stacktrace);
-    return {
+
+    const data: { [key: string]: string } = {
+      mode: stacktrace.mode,
+    };
+
+    if (stacktrace.message) {
+      data.message = stacktrace.message;
+    }
+
+    if (stacktrace.name) {
+      data.name = stacktrace.name;
+    }
+
+    const newEvent: SentryEvent = {
       ...event,
       exception: {
         ...event.exception,
         mechanism: {
-          data: {
-            mode: stacktrace.mode,
-          },
+          data,
           handled: false,
           type: stacktrace.mechanism,
         },
       },
     };
+
+    let type = 'Error';
+    if (stacktrace.mechanism === 'onunhandledrejection') {
+      type = 'Unhandled Promise Rejection';
+    }
+
+    let value = '';
+    if (stacktrace.original) {
+      value = `${stacktrace.original}`;
+    }
+    // This makes sure we have type/value in every exception
+    addExceptionTypeValue(newEvent, value, type);
+
+    return newEvent;
   }
 }

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -116,6 +116,7 @@ export class GlobalHandlers implements Integration {
     }
 
     let value = '';
+    // stacktrace.original contains the string if it's an unhandledPromiseRejection with just a string
     if (stacktrace.original) {
       value = `${stacktrace.original}`;
     }

--- a/packages/browser/src/loader.js
+++ b/packages/browser/src/loader.js
@@ -128,13 +128,14 @@
       // Because we installed the SDK, at this point we have an access to TraceKit's handler,
       // which can take care of browser differences (eg. missing exception argument in onerror)
       var tracekitErrorHandler = _window[_onerror];
+      var tracekitUnhandledRejectionHandler = _window[_onunhandledrejection];
 
       // And now capture all previously caught exceptions
       for (var i = 0; i < data.length; i++) {
-        if (data[i].e) {
+        if (data[i].e && tracekitErrorHandler) {
           tracekitErrorHandler.apply(_window, data[i].e);
-        } else if (data[i].p) {
-          SDK.captureException(data[i].p);
+        } else if (data[i].p && tracekitUnhandledRejectionHandler) {
+          tracekitUnhandledRejectionHandler.apply(_window, [data[i].p]);
         }
       }
     } catch (o_O) {

--- a/packages/browser/src/parsers.ts
+++ b/packages/browser/src/parsers.ts
@@ -6,15 +6,21 @@ import { computeStackTrace, StackFrame as TraceKitStackFrame, StackTrace as Trac
 
 const STACKTRACE_LIMIT = 50;
 
-/** JSDoc */
+/**
+ * This function creates an exception from an TraceKitStackTrace
+ * @param stacktrace TraceKitStackTrace that will be converted to an exception
+ */
 export function exceptionFromStacktrace(stacktrace: TraceKitStackTrace): SentryException {
   const frames = prepareFramesForEvent(stacktrace.stack);
 
-  const exception = {
-    stacktrace: { frames },
+  const exception: SentryException = {
     type: stacktrace.name,
     value: stacktrace.message,
   };
+
+  if (frames && frames.length) {
+    exception.stacktrace = { frames };
+  }
 
   // tslint:disable-next-line:strict-type-predicates
   if (exception.type === undefined && exception.value === '') {
@@ -96,12 +102,13 @@ export function prepareFramesForEvent(stack: TraceKitStackFrame[]): StackFrame[]
 /**
  * Adds exception values, type and value to an synthetic Exception.
  * @param event The event to modify.
- * @param message Message to be added.
+ * @param value Value of the exception.
+ * @param type Type of the exception.
  */
-export function addExceptionTypeValue(event: SentryEvent, message: string): void {
+export function addExceptionTypeValue(event: SentryEvent, value?: string, type?: string): void {
   event.exception = event.exception || {};
   event.exception.values = event.exception.values || [];
   event.exception.values[0] = event.exception.values[0] || {};
-  event.exception.values[0].value = event.exception.values[0].value || message;
-  event.exception.values[0].type = event.exception.values[0].type || 'Error';
+  event.exception.values[0].value = event.exception.values[0].value || value || '';
+  event.exception.values[0].type = event.exception.values[0].type || type || 'Error';
 }

--- a/packages/browser/src/tracekit.ts
+++ b/packages/browser/src/tracekit.ts
@@ -23,6 +23,7 @@ export interface StackTrace {
   url: string;
   stack: StackFrame[];
   useragent: string;
+  original?: string;
 }
 
 interface ComputeStackTrace {
@@ -1468,6 +1469,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
     }
 
     return {
+      original: ex,
       name: ex.name,
       message: ex.message,
       mode: 'failed',

--- a/packages/browser/test/integration/test.js
+++ b/packages/browser/test/integration/test.js
@@ -466,7 +466,7 @@ for (var idx in frames) {
             function(sentryData) {
               if (debounceAssertEventCount(sentryData, 1, done)) {
                 var sentryData = sentryData[0];
-                assert.equal(sentryData.exception.values[0].type, undefined);
+                assert.equal(sentryData.exception.values[0].type, 'Error');
 
                 // #<Object> is covering default Android 4.4 and 5.1 browser
                 assert.match(sentryData.exception.values[0].value, /^(\[object Object\]|#<Object>)$/);
@@ -613,6 +613,54 @@ for (var idx in frames) {
               var sentryData = iframe.contentWindow.sentryData[0];
               assert.equal(sentryData, null); // should never trigger error
               done();
+            }
+          );
+        });
+
+        it('should capture unhandledrejection with error', function(done) {
+          var iframe = this.iframe;
+
+          iframeExecute(
+            iframe,
+            done,
+            function() {
+              setTimeout(function() {
+                return Promise.reject(new Error('test2'));
+              });
+            },
+            function(sentryData) {
+              if (debounceAssertEventCount(sentryData, 1, done)) {
+                assert.equal(sentryData[0].exception.values[0].value, 'test2');
+                assert.equal(sentryData[0].exception.values[0].type, 'Error');
+                assert.isAtLeast(sentryData[0].exception.values[0].stacktrace.frames.length, 1);
+                assert.equal(sentryData[0].exception.mechanism.handled, false);
+                assert.equal(sentryData[0].exception.mechanism.type, 'onunhandledrejection');
+                done();
+              }
+            }
+          );
+        });
+
+        it('should capture unhandledrejection as string', function(done) {
+          var iframe = this.iframe;
+
+          iframeExecute(
+            iframe,
+            done,
+            function() {
+              setTimeout(function() {
+                return Promise.reject('test');
+              });
+            },
+            function(sentryData) {
+              if (debounceAssertEventCount(sentryData, 1, done)) {
+                assert.equal(sentryData[0].exception.values[0].value, 'test');
+                assert.equal(sentryData[0].exception.values[0].type, 'Unhandled Promise Rejection');
+                assert.equal(sentryData[0].exception.values[0].stacktrace, undefined);
+                assert.equal(sentryData[0].exception.mechanism.handled, false);
+                assert.equal(sentryData[0].exception.mechanism.type, 'onunhandledrejection');
+                done();
+              }
             }
           );
         });

--- a/packages/browser/test/integration/test.js
+++ b/packages/browser/test/integration/test.js
@@ -655,7 +655,7 @@ for (var idx in frames) {
             function(sentryData) {
               if (debounceAssertEventCount(sentryData, 1, done)) {
                 assert.equal(sentryData[0].exception.values[0].value, 'test');
-                assert.equal(sentryData[0].exception.values[0].type, 'Unhandled Promise Rejection');
+                assert.equal(sentryData[0].exception.values[0].type, 'UnhandledRejection');
                 assert.equal(sentryData[0].exception.values[0].stacktrace, undefined);
                 assert.equal(sentryData[0].exception.mechanism.handled, false);
                 assert.equal(sentryData[0].exception.mechanism.type, 'onunhandledrejection');

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -17,7 +17,7 @@ interface ExtendedError extends Error {
  * @returns A string containing the serialized object.
  */
 export function serialize<T>(object: T): string {
-  return JSON.stringify(object, serializer({ normalize: false }));
+  return JSON.stringify(decycle(object), serializer({ normalize: false }));
 }
 
 /**
@@ -294,6 +294,64 @@ function normalizeValue(value: any, key?: any): any {
   return value;
 }
 
+/** JSDoc */
+function decycle(object: any) {
+  const objects = new WeakMap(); // object to path mappings
+
+  return (function derez(value: any, path: string) {
+    // The derez function recurses through the object, producing the deep copy.
+
+    let oldPath; // The path of an earlier occurance of value
+    let nu: any; // The new object or array
+
+    // If a replacer function was provided, then call it to get a replacement value.
+
+    // if (replacer !== undefined) {
+    //   value = normalize(value);
+    // }
+
+    // typeof null === "object", so go on if this value is really an object but not
+    // one of the weird builtin objects.
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      !(value instanceof Boolean) &&
+      !(value instanceof Date) &&
+      !(value instanceof Number) &&
+      !(value instanceof RegExp) &&
+      !(value instanceof String)
+    ) {
+      // If the value is an object or array, look to see if we have already
+      // encountered it. If so, return a {"$ref":PATH} object. This uses an
+      // ES6 WeakMap.
+      oldPath = objects.get(value);
+      if (oldPath !== undefined) {
+        return { $ref: oldPath };
+      }
+
+      // Otherwise, accumulate the unique value and its path.
+      objects.set(value, path);
+
+      if (Array.isArray(value)) {
+        // If it is an array, replicate the array.
+        nu = [];
+        value.forEach((element: unknown, i: number) => {
+          nu[i] = derez(element, `${path}.${i}`);
+        });
+      } else {
+        // If it is an object, replicate the object.
+        nu = {};
+        Object.keys(value).forEach((name: string) => {
+          nu[name] = derez(value[name], `${path}.${name}`);
+        });
+      }
+      return nu;
+    }
+
+    return value;
+  })(object, '$');
+}
+
 /**
  * serializer()
  *
@@ -302,39 +360,45 @@ function normalizeValue(value: any, key?: any): any {
  * and takes care of Error objects serialization
  */
 function serializer(options: { normalize: boolean } = { normalize: true }): (key: string, value: any) => any {
-  const stack: any[] = [];
-  const keys: string[] = [];
+  // const stack: any[] = [];
+  // const keys: string[] = [];
 
-  /** recursive */
-  function cycleserializer(_key: string, value: any): any {
-    if (stack[0] === value) {
-      return '[Circular ~]';
-    }
-    return `[Circular ~.${keys.slice(0, stack.indexOf(value)).join('.')}]`;
-  }
+  // /** recursive */
+  // function cycleserializer(_key: string, value: any): any {
+  //   if (stack[0] === value) {
+  //     return '[Circular ~]';
+  //   }
+  //   return `[Circular ~.${keys.slice(0, stack.indexOf(value)).join('.')}]`;
+  // }
+  // const getCircularReplacer = () => {
+  // const seen = new WeakSet();
 
-  return function(this: any, key: string, value: any): any {
-    if (stack.length > 0) {
-      const thisPos = stack.indexOf(this);
+  return (key: string, value: object) => (options.normalize ? normalizeValue(value, key) : value);
+  // };
 
-      if (thisPos === -1) {
-        stack.push(this);
-        keys.push(key);
-      } else {
-        stack.splice(thisPos + 1);
-        keys.splice(thisPos, Infinity, key);
-      }
+  // return function(this: any, key: string, value: any): any {
+  // if (stack.length > 0) {
+  //   const thisPos = stack.indexOf(this);
 
-      if (stack.indexOf(value) !== -1) {
-        // tslint:disable-next-line:no-parameter-reassignment
-        value = cycleserializer.call(this, key, value);
-      }
-    } else {
-      stack.push(value);
-    }
+  //   if (thisPos === -1) {
+  //     stack.push(this);
+  //     keys.push(key);
+  //   } else {
+  //     stack.splice(thisPos + 1);
+  //     keys.splice(thisPos, Infinity, key);
+  //   }
 
-    return options.normalize ? normalizeValue(value, key) : value;
-  };
+  //   if (stack.indexOf(value) !== -1) {
+  //     // tslint:disable-next-line:no-parameter-reassignment
+  //     value = cycleserializer.call(this, key, value);
+  //   }
+  // } else {
+  //   stack.push(value);
+  // }
+
+  // const newValue = getCircularReplacer.call(this, key, value);
+  // return ;
+  // };
 }
 
 /**
@@ -344,7 +408,7 @@ function serializer(options: { normalize: boolean } = { normalize: true }): (key
  */
 export function safeNormalize(input: any): any {
   try {
-    return JSON.parse(JSON.stringify(input, serializer({ normalize: true })));
+    return JSON.parse(JSON.stringify(decycle(input), serializer({ normalize: true })));
   } catch (_oO) {
     return '**non-serializable**';
   }


### PR DESCRIPTION
This PR makes sure the `exception` always has type/value also for promise rejections with string.

Additionally, it fixes the loader so it unhandled promises also go through tracekit instead of `captureException`.

Fixes: https://github.com/getsentry/sentry-javascript/issues/1824