### PR TITLE
fix: TypeError read-only property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [core]: fix: Error in extraErrorData integration where event would not be send in case of non assignable object property.
+
 ## 4.5.2
 
 - [utils] fix: Decycling for objects to no produce an endless loop

--- a/packages/core/src/integrations/extraerrordata.ts
+++ b/packages/core/src/integrations/extraerrordata.ts
@@ -1,6 +1,6 @@
 import { addGlobalEventProcessor, getCurrentHub } from '@sentry/hub';
 import { Integration, SentryEvent, SentryEventHint } from '@sentry/types';
-import { isError } from '@sentry/utils/is';
+import { isError, isString } from '@sentry/utils/is';
 import { logger } from '@sentry/utils/logger';
 import { safeNormalize } from '@sentry/utils/object';
 
@@ -47,18 +47,19 @@ export class ExtraErrorData implements Integration {
     const errorData = this.extractErrorData(hint.originalException);
 
     if (errorData) {
-      let normalizedErrorData = {};
-      try {
-        normalizedErrorData = safeNormalize(errorData);
-      } catch (_) {
-        // We got something in errorData that we are not allowed to assign
+      let extra = {
+        ...event.extra,
+      };
+      const normalizedErrorData = safeNormalize(errorData);
+      if (!isString(normalizedErrorData)) {
+        extra = {
+          ...event.extra,
+          ...normalizedErrorData,
+        };
       }
       return {
         ...event,
-        extra: {
-          ...event.extra,
-          errorData: normalizedErrorData,
-        },
+        extra,
       };
     }
 


### PR DESCRIPTION
Fixes this error in Angular:

`Sentry Logger [Error]: TypeError: Cannot assign to read only property 'dataset' of object '[object HTMLElement]'`

Makes sure that this example works
https://github.com/getsentry/sentry-javascript/issues/1798#issuecomment-455275947