### PR TITLE
fix: DOMError and DOMException should be error level events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [browser] fix: DOMError and DOMException should be error level events
 - [utils] ref: Update wrap method to hide internal sentry flags
 - [utils] fix: Make internal Sentry flags non-enumerable in fill util
 

--- a/packages/browser/src/backend.ts
+++ b/packages/browser/src/backend.ts
@@ -86,7 +86,7 @@ export class BrowserBackend extends BaseBackend<BrowserOptions> {
       const name = ex.name || (isDOMError(ex) ? 'DOMError' : 'DOMException');
       const message = ex.message ? `${name}: ${ex.message}` : name;
 
-      event = await this.eventFromMessage(message, undefined, hint);
+      event = await this.eventFromMessage(message, Severity.Error, hint);
       addExceptionTypeValue(event, message);
     } else if (isError(exception as Error)) {
       // we have a real Error object, do nothing


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/1864