### PR TITLE
TypeScript: use `unknown` to represent error

### DIFF
--- a/packages/raven-js/typescript/raven.d.ts
+++ b/packages/raven-js/typescript/raven.d.ts
@@ -202,7 +202,7 @@ declare namespace Raven {
      * @return {Raven}
      */
     captureException(
-      ex: Error | ErrorEvent | string,
+      ex: unknown,
       options?: RavenOptions
     ): RavenStatic;
 


### PR DESCRIPTION
WIP.

`unknown` makes more sense because an error can be any type—we don't know what the type will be.

Currently this would give a type error:

``` ts
const reportMyError = (error: unknown) => {
  Raven.captureException(error, {})
};
```

This fixes that.

There are probably other usages of `Error` that we should replace with `unknown`. I don't have the time to consider this right now, but I hope to come back to this PR. At the very least, this PR can act as an issue.

---

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
