### PR TITLE
Update decycle() in objects.ts to avoid cycles in prototype

### DIFF
--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -332,6 +332,10 @@ function decycle(obj: any, memo: Memo = new Memo()): any {
     }
     // tslint:disable-next-line
     for (const key in obj) {
+      // Avoid iterating over fields in the prototype if they've somehow been exposed to enumeration.
+      if (!obj.hasOwnProperty(key)) {
+        continue;
+      }
       // tslint:disable-next-line
       obj[key] = decycle(obj[key], memo);
     }


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [X] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

We have some legacy pages that still use MooTools, and since MooTools exposes properties in the prototype of functions, objects, etc., cycles are created, and the page can crash once a breadcrumb is attempted to be added. E.g., MooTools will add a function "overloadSetter" to a prototype, and the overloadSetter function will have a prototype, and that prototype will have a function called overloadSetter, and so on. `decycle`'s for..in iterator will fall victim to this dangerous behavior of MooTools.

Without more context on this code, I can't say for sure if this is actually what we want in decycle() to handle this edge case, but this change will at least avoid diving into __proto__ of objects and functions.

This bug is blocking us from rolling out Sentry's JS SDK on all page.