### PR TITLE
[Feature]: Adds Optional Opt-out of Reporting Vue propsData

### DIFF
--- a/packages/browser/src/integrations/pluggable/vue.ts
+++ b/packages/browser/src/integrations/pluggable/vue.ts
@@ -31,21 +31,21 @@ export class Vue implements Integration {
   private readonly Vue: any; // tslint:disable-line:variable-name
 
   /**
-   * When set to true, Sentry will suppress reporting all props data
+   * When set to false, Sentry will suppress reporting all props data
    * from your Vue components for privacy concerns.
    */
-  private readonly hideProps: boolean;
+  private readonly attachProps: boolean;
 
   /**
    * @inheritDoc
    */
-  public constructor(options: { Vue?: any; hideProps?: boolean } = {}) {
+  public constructor(options: { Vue?: any; attachProps?: boolean } = {}) {
     this.Vue =
       options.Vue ||
       (getGlobalObject() as {
         Vue: any;
       }).Vue;
-    this.hideProps = options.hideProps || false;
+    this.attachProps = options.attachProps || true;
   }
 
   /** JSDoc */
@@ -77,7 +77,7 @@ export class Vue implements Integration {
       if (isPlainObject(vm)) {
         metadata.componentName = this.formatComponentName(vm);
 
-        if (!this.hideProps) {
+        if (this.attachProps) {
           metadata.propsData = vm.$options.propsData;
         }
       }

--- a/packages/browser/src/integrations/pluggable/vue.ts
+++ b/packages/browser/src/integrations/pluggable/vue.ts
@@ -31,7 +31,8 @@ export class Vue implements Integration {
   private readonly Vue: any; // tslint:disable-line:variable-name
 
   /**
-   * @inheritDoc
+   * When set to true, Sentry will suppress reporting all props data
+   * from your Vue components for privacy concerns.
    */
   private readonly hideProps: boolean;
 

--- a/packages/browser/src/integrations/pluggable/vue.ts
+++ b/packages/browser/src/integrations/pluggable/vue.ts
@@ -33,12 +33,18 @@ export class Vue implements Integration {
   /**
    * @inheritDoc
    */
-  public constructor(options: { Vue?: any } = {}) {
+  private readonly hideProps: boolean;
+
+  /**
+   * @inheritDoc
+   */
+  public constructor(options: { Vue?: any; hideProps?: boolean } = {}) {
     this.Vue =
       options.Vue ||
       (getGlobalObject() as {
         Vue: any;
       }).Vue;
+    this.hideProps = options.hideProps || false;
   }
 
   /** JSDoc */
@@ -69,7 +75,10 @@ export class Vue implements Integration {
 
       if (isPlainObject(vm)) {
         metadata.componentName = this.formatComponentName(vm);
-        metadata.propsData = vm.$options.propsData;
+
+        if (!this.hideProps) {
+          metadata.propsData = vm.$options.propsData;
+        }
       }
 
       if (!isUndefined(info)) {


### PR DESCRIPTION
## Summary

- Gives user the option to opt out of reporting props
    - `attachProps` is added to options at constructor

refs #1879 

## Notes

- No unit/integration tests seem to exist for `Integrations.Vue` -- if someone could point me to an example of how to get that together, I'd be happy to provide one
- It doesn't seem like y'all host your docs on GH, as I was looking to update that as well with this new option. If I just missed it somewhere in the repo, please lmk where it is and I'll update the Markdown file

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
