### PR TITLE
ref: Remove install function from client and backend

### DIFF
--- a/packages/browser/src/backend.ts
+++ b/packages/browser/src/backend.ts
@@ -1,6 +1,5 @@
 import { BaseBackend, Options } from '@sentry/core';
 import { SentryEvent, SentryEventHint, Severity, Transport } from '@sentry/types';
-import { SentryError } from '@sentry/utils/error';
 import { isDOMError, isDOMException, isError, isErrorEvent, isPlainObject } from '@sentry/utils/is';
 import { supportsBeacon, supportsFetch } from '@sentry/utils/supports';
 import { SyncPromise } from '@sentry/utils/syncpromise';
@@ -33,23 +32,6 @@ export interface BrowserOptions extends Options {
  * @hidden
  */
 export class BrowserBackend extends BaseBackend<BrowserOptions> {
-  /**
-   * @inheritDoc
-   */
-  public install(): boolean {
-    // We are only called by the client if the SDK is enabled and a valid Dsn
-    // has been configured. If no Dsn is present, this indicates a programming
-    // error.
-    const dsn = this.options.dsn;
-    if (!dsn) {
-      throw new SentryError('Invariant exception: install() must not be called when disabled');
-    }
-
-    Error.stackTraceLimit = 50;
-
-    return true;
-  }
-
   /**
    * @inheritdoc
    */

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -43,7 +43,7 @@ export class BrowserClient extends BaseClient<BrowserBackend, BrowserOptions> {
    *
    * @param options Configuration options for this SDK.
    */
-  public constructor(options: BrowserOptions) {
+  public constructor(options: BrowserOptions = {}) {
     super(BrowserBackend, options);
   }
 

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -45,6 +45,8 @@ export class GlobalHandlers implements Integration {
    * @inheritDoc
    */
   public setupOnce(): void {
+    Error.stackTraceLimit = 50;
+
     subscribe((stack: TraceKitStackTrace, _: boolean, error: Error) => {
       // TODO: use stack.context to get a valuable information from TraceKit, eg.
       // [

--- a/packages/core/src/basebackend.ts
+++ b/packages/core/src/basebackend.ts
@@ -22,7 +22,7 @@ export abstract class BaseBackend<O extends Options> implements Backend {
   /** Cached transport used internally. */
   protected transport: Transport;
 
-  /** Creates a new browser backend instance. */
+  /** Creates a new backend instance. */
   public constructor(options: O) {
     this.options = options;
     if (!this.options.dsn) {

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -84,12 +84,6 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    */
   private readonly dsn?: Dsn;
 
-  /**
-   * Stores whether installation has been performed and was successful. Before
-   * installing, this is undefined. Then it contains the success state.
-   */
-  private installed?: boolean;
-
   /** Array of used integrations. */
   private readonly integrations: IntegrationIndex;
 
@@ -106,25 +100,8 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
     if (options.dsn) {
       this.dsn = new Dsn(options.dsn);
     }
-    // We have to setup the integrations in the constructor since we do not want
-    // that anyone needs to call client.install();
+
     this.integrations = setupIntegrations(this.options);
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public install(): boolean {
-    if (!this.isEnabled()) {
-      return (this.installed = false);
-    }
-
-    const backend = this.getBackend();
-    if (!this.installed && backend.install) {
-      backend.install();
-    }
-
-    return (this.installed = true);
   }
 
   /**

--- a/packages/core/src/interfaces.ts
+++ b/packages/core/src/interfaces.ts
@@ -146,17 +146,6 @@ export interface Options {
  */
 export interface Client<O extends Options = Options> {
   /**
-   * Installs the SDK if it hasn't been installed already.
-   *
-   * Since this performs modifications in the environment, such as instrumenting
-   * library functionality or adding signal handlers, this method will only
-   * execute once and cache its result.
-   *
-   * @returns If the installation was the successful or not.
-   */
-  install(): boolean;
-
-  /**
    * Captures an exception event and sends it to Sentry.
    *
    * @param exception An exception-like object.
@@ -240,9 +229,6 @@ export interface Client<O extends Options = Options> {
  * these any time and they should not be cached.
  */
 export interface Backend {
-  /** Installs the SDK into the environment. */
-  install?(): boolean;
-
   /** Creates a {@link SentryEvent} from an exception. */
   eventFromException(exception: any, hint?: SentryEventHint): SyncPromise<SentryEvent>;
 

--- a/packages/core/src/sdk.ts
+++ b/packages/core/src/sdk.ts
@@ -26,5 +26,4 @@ export function initAndBind<F extends Client, O extends Options>(clientClass: Cl
 
   const client = new clientClass(options);
   getCurrentHub().bindClient(client);
-  client.install();
 }

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -62,44 +62,6 @@ describe('BaseClient', () => {
     });
   });
 
-  describe('install()', () => {
-    test('calls install() on Backend', () => {
-      expect.assertions(1);
-      const client = new TestClient({ dsn: PUBLIC_DSN });
-      client.install();
-      expect(TestBackend.instance!.installed).toBe(1);
-    });
-
-    test('calls install() only once', () => {
-      expect.assertions(1);
-      const client = new TestClient({ dsn: PUBLIC_DSN });
-      client.install();
-      client.install();
-      expect(TestBackend.instance!.installed).toBe(1);
-    });
-
-    test('resolves the result of install()', () => {
-      expect.assertions(1);
-      const client = new TestClient({ mockInstallFailure: true });
-      const installed = client.install();
-      expect(installed).toBeFalsy();
-    });
-
-    test('does not install() when disabled', () => {
-      expect.assertions(1);
-      const client = new TestClient({ enabled: false, dsn: PUBLIC_DSN });
-      client.install();
-      expect(TestBackend.instance!.installed).toBe(0);
-    });
-
-    test('does not install() without Dsn', () => {
-      expect.assertions(1);
-      const client = new TestClient({});
-      client.install();
-      expect(TestBackend.instance!.installed).toBe(0);
-    });
-  });
-
   describe('getOptions()', () => {
     test('returns the options', () => {
       expect.assertions(1);


### PR DESCRIPTION
We should remove this function, it serves not actual purpose and SDKs that need this should move whatever they need into an integration