### PR TITLE
Add Sentry eventID to response

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -271,7 +271,8 @@ export function errorHandler(): (
       next(error);
       return;
     }
-    captureException(error);
+    const eventId = captureException(error);
+    _res.sentry = eventId;
     next(error);
   };
 }


### PR DESCRIPTION
Sets the eventId returned from captureException on ExpressJS middleware. This allows us to use the eventId to inform the user of a tracking ID they can use when in contact with Helpdesk. 

Implements behaviour as shown in https://docs.sentry.io/platforms/node/express/
Likely an oversight that was missed when moving from Raven to the new clients?

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
