### PR TITLE
fix: Prevent iterating over SyntheticEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 4.6.3
+
+- [utils] fix: Normalize value before recursively walking down the tree
+
 ## 4.6.2
 
 - [utils] fix: Preserve function prototype when filling

--- a/packages/utils/src/is.ts
+++ b/packages/utils/src/is.ts
@@ -138,3 +138,15 @@ export function isRegExp(wat: any): boolean {
 export function isNaN(wat: any): boolean {
   return wat !== wat;
 }
+
+/**
+ * Checks whether given value's type is a SyntheticEvent
+ * {@link isSyntheticEvent}.
+ *
+ * @param wat A value to be checked.
+ * @returns A boolean representing the result.
+ */
+export function isSyntheticEvent(wat: any): boolean {
+  // tslint:disable-next-line:no-unsafe-any
+  return isPlainObject(wat) && 'nativeEvent' in wat && 'preventDefault' in wat && 'stopPropagation' in wat;
+}

--- a/packages/utils/test/object.test.ts
+++ b/packages/utils/test/object.test.ts
@@ -587,4 +587,24 @@ describe('safeNormalize()', () => {
       reason: '[Circular ~]',
     });
   });
+
+  test('normalizes value on every iteration of decycle and takes care of things like Reacts SyntheticEvents', () => {
+    const obj = {
+      foo: {
+        nativeEvent: 'wat',
+        preventDefault: 'wat',
+        stopPropagation: 'wat',
+      },
+      baz: NaN,
+      qux: function qux(): void {
+        /*no-empty*/
+      },
+    };
+    const result = safeNormalize(obj);
+    expect(result).toEqual({
+      foo: '[SyntheticEvent]',
+      baz: '[NaN]',
+      qux: '[Function: qux]',
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/1899