### PR TITLE
fix: use a static object as fallback of the global object

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -20,6 +20,8 @@ export function isNodeEnv(): boolean {
   return Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';
 }
 
+const fallbackGlobalObject = {};
+
 /**
  * Safely get global scope object
  *
@@ -27,7 +29,13 @@ export function isNodeEnv(): boolean {
  */
 // tslint:disable:strict-type-predicates
 export function getGlobalObject(): Window | NodeJS.Global | {} {
-  return isNodeEnv() ? global : typeof window !== 'undefined' ? window : typeof self !== 'undefined' ? self : {};
+  return isNodeEnv()
+    ? global
+    : typeof window !== 'undefined'
+    ? window
+    : typeof self !== 'undefined'
+    ? self
+    : fallbackGlobalObject;
 }
 // tslint:enable:strict-type-predicates
 

--- a/packages/utils/test/misc.test.ts
+++ b/packages/utils/test/misc.test.ts
@@ -1,4 +1,4 @@
-import { getEventDescription } from '../src/misc';
+import { getEventDescription, getGlobalObject } from '../src/misc';
 
 describe('getEventDescription()', () => {
   test('message event', () => {
@@ -106,5 +106,16 @@ describe('getEventDescription()', () => {
         really: '?',
       } as any),
     ).toEqual('<unknown>');
+  });
+});
+
+describe('getGlobalObject()', () => {
+  test('should return the same object', () => {
+    const backup = global.process;
+    delete global.process;
+    const first = getGlobalObject();
+    const second = getGlobalObject();
+    expect(first).toEqual(second);
+    global.process = backup;
   });
 });


### PR DESCRIPTION
I'm working on Mini Program (in WeChat etc.), which is not a Node environment nor standard browser environment.

```js
console.log('window', typeof window) // undefined
console.log('process', typeof process) //undefined
console.log('global', typeof global) // object
```

The `getGlobalObject` function returns a new object every time when it is called, so that `getMainCarrier` and `getCurrentHub` return a new instance every time and remain uninitialized. 

https://github.com/getsentry/sentry-javascript/blob/da7a115ef8a58a8af96c70068cde1a9b5e5fa75e/packages/hub/src/hub.ts#L299-L305

https://github.com/getsentry/sentry-javascript/blob/da7a115ef8a58a8af96c70068cde1a9b5e5fa75e/packages/hub/src/hub.ts#L326-L333

Exceptions will not be sent to server because `client` is not installed on the "current hub".
