### PR TITLE
fix: Preserve function prototype when filling

### DIFF
--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -67,7 +67,7 @@ export function fill(source: { [key: string]: any }, name: string, replacement: 
   // otherwise it'll throw "TypeError: Object.defineProperties called on non-object"
   // tslint:disable-next-line:strict-type-predicates
   if (typeof wrapped === 'function') {
-    wrapped.prototype = {};
+    wrapped.prototype = wrapped.prototype || {};
     Object.defineProperties(wrapped, {
       __sentry__: {
         enumerable: false,

--- a/packages/utils/test/object.test.ts
+++ b/packages/utils/test/object.test.ts
@@ -340,6 +340,21 @@ describe('fill()', () => {
     expect(source.foo.__sentry_original__).toBe(source.foo);
     expect(source.foo.__sentry_wrapped__).toBe(source.foo);
   });
+
+  test('should preserve functions prototype if one exists', () => {
+    const source = {
+      foo: (): number => 42,
+    };
+    const bar = {};
+    source.foo.prototype = bar;
+    const name = 'foo';
+    const replacement = cb => cb;
+
+    fill(source, name, replacement);
+
+    // But should be accessible directly
+    expect(source.foo.prototype).toBe(bar);
+  });
 });
 
 describe('urlEncode()', () => {


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry-javascript/issues/1859#issuecomment-465114929

Fixes https://github.com/getsentry/sentry-javascript/issues/1859 and https://github.com/getsentry/sentry-javascript/issues/1884