### PR TITLE
fix: Prevent options mutation

### DIFF
--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -62,7 +62,9 @@ export const defaultIntegrations = [
  *
  * @see BrowserOptions for documentation on configuration options.
  */
-export function init(options: BrowserOptions = {}): void {
+export function init(browserOptions: BrowserOptions = {}): void {
+  const options = { ...browserOptions };
+
   if (options.defaultIntegrations === undefined) {
     options.defaultIntegrations = defaultIntegrations;
   }

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -65,7 +65,9 @@ export const defaultIntegrations = [
  *
  * @see NodeOptions for documentation on configuration options.
  */
-export function init(options: NodeOptions = {}): void {
+export function init(nodeOptions: NodeOptions = {}): void {
+  const options = { ...nodeOptions };
+
   if (options.defaultIntegrations === undefined) {
     options.defaultIntegrations = defaultIntegrations;
   }


### PR DESCRIPTION
Hi!

This is possible to mutate sentry initialization options when using the same config on server and in browser.

Our common `config.js`:
```js
export default {
    sentry: {
        dsn: process.env.SENTRY_DSN
    }
};
```

Initialization on server:
```js
import * as Sentry from '@sentry/node';

import config from './config.js';

Sentry.init(config.sentry); // Writes default node integrations in config
```

And then initialization in browser:
```js
import * as Sentry from '@sentry/browser';

class App extends React.Component {
    componentDidMount() {
        const { data } = this.props;

        Sentry.init(data.config.sentry); // Uses node `defaultIntegrations` implicitly
    }
}
```

--------
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
