### PR TITLE
fix: Prevent decycling from referencing original objects

### DIFF
--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -3,7 +3,7 @@ import { Breadcrumb, Integration, SentryBreadcrumbHint, Severity } from '@sentry
 import { isFunction, isString } from '@sentry/utils/is';
 import { logger } from '@sentry/utils/logger';
 import { getEventDescription, getGlobalObject, parseUrl } from '@sentry/utils/misc';
-import { deserialize, fill, serializeObject } from '@sentry/utils/object';
+import { deserialize, fill, safeNormalize } from '@sentry/utils/object';
 import { includes, safeJoin } from '@sentry/utils/string';
 import { supportsBeacon, supportsHistory, supportsNativeFetch } from '@sentry/utils/supports';
 import { BrowserClient } from '../client';
@@ -130,7 +130,7 @@ export class Breadcrumbs implements Integration {
             category: 'console',
             data: {
               extra: {
-                arguments: serializeObject(args, 2),
+                arguments: safeNormalize(args, 3),
               },
               logger: 'console',
             },
@@ -141,7 +141,7 @@ export class Breadcrumbs implements Integration {
           if (level === 'assert') {
             if (args[0] === false) {
               breadcrumbData.message = `Assertion failed: ${safeJoin(args.slice(1), ' ') || 'console.assert'}`;
-              breadcrumbData.data.extra.arguments = serializeObject(args.slice(1), 2);
+              breadcrumbData.data.extra.arguments = safeNormalize(args.slice(1), 3);
             }
           }
 

--- a/packages/browser/src/integrations/helpers.ts
+++ b/packages/browser/src/integrations/helpers.ts
@@ -2,7 +2,7 @@ import { captureException, getCurrentHub, withScope } from '@sentry/core';
 import { Mechanism, SentryEvent, SentryWrappedFunction } from '@sentry/types';
 import { isFunction } from '@sentry/utils/is';
 import { htmlTreeAsString } from '@sentry/utils/misc';
-import { serializeObject } from '@sentry/utils/object';
+import { safeNormalize } from '@sentry/utils/object';
 
 const debounceDuration: number = 1000;
 let keypressTimeout: number | undefined;
@@ -90,7 +90,7 @@ export function wrap(
 
           processedEvent.extra = {
             ...processedEvent.extra,
-            arguments: serializeObject(args, 2),
+            arguments: safeNormalize(args, 3),
           };
 
           return processedEvent;

--- a/packages/browser/src/integrations/helpers.ts
+++ b/packages/browser/src/integrations/helpers.ts
@@ -132,6 +132,11 @@ export function wrap(
       enumerable: false,
       value: fn,
     },
+    name: {
+      get(): string {
+        return fn.name;
+      },
+    },
   });
 
   return sentryWrapped;

--- a/packages/browser/src/integrations/helpers.ts
+++ b/packages/browser/src/integrations/helpers.ts
@@ -132,12 +132,18 @@ export function wrap(
       enumerable: false,
       value: fn,
     },
-    name: {
+  });
+
+  // Restore original function name (not all browsers allow that)
+  try {
+    Object.defineProperty(sentryWrapped, 'name', {
       get(): string {
         return fn.name;
       },
-    },
-  });
+    });
+  } catch (_oO) {
+    /*no-empty*/
+  }
 
   return sentryWrapped;
 }

--- a/packages/browser/test/integration/console-logs.js
+++ b/packages/browser/test/integration/console-logs.js
@@ -1,6 +1,6 @@
 console.log('One');
 console.warn('Two', { a: 1 });
-console.error('Error 2', { b: { c: 1 } });
+console.error('Error 2', { b: { c: [] } });
 function a() {
   throw new Error('Error thrown 3');
 }

--- a/packages/browser/test/integration/test.js
+++ b/packages/browser/test/integration/test.js
@@ -1663,7 +1663,7 @@ for (var idx in frames) {
                 assert.lengthOf(sentryData.breadcrumbs, 3);
                 assert.deepEqual(sentryData.breadcrumbs[0].data.extra.arguments, ['One']);
                 assert.deepEqual(sentryData.breadcrumbs[1].data.extra.arguments, ['Two', { a: 1 }]);
-                assert.deepEqual(sentryData.breadcrumbs[2].data.extra.arguments, ['Error 2', { b: '[Object]' }]);
+                assert.deepEqual(sentryData.breadcrumbs[2].data.extra.arguments, ['Error 2', { b: { c: '[Array]' } }]);
                 done();
               }
             }

--- a/packages/browser/test/integrations/helpers.test.ts
+++ b/packages/browser/test/integrations/helpers.test.ts
@@ -22,6 +22,13 @@ describe('wrap()', () => {
     expect(wrap(num)).equal(num);
   });
 
+  it('should preserve correct function name when accessed', () => {
+    const namedFunction = () => 1337;
+    expect(wrap(namedFunction)).not.equal(namedFunction);
+    expect(namedFunction.name).equal('namedFunction');
+    expect(wrap(namedFunction).name).equal('namedFunction');
+  });
+
   it('bail out with the original if accessing custom props go bad', () => {
     const fn = (() => 1337) as SentryWrappedFunction;
     fn.__sentry__ = false;

--- a/packages/core/src/integrations/extraerrordata.ts
+++ b/packages/core/src/integrations/extraerrordata.ts
@@ -11,6 +11,11 @@ interface ExtendedError extends Error {
   [key: string]: unknown;
 }
 
+/** JSDoc */
+interface ExtraErrorDataOptions {
+  depth?: number;
+}
+
 /** Patch toString calls to return proper name for wrapped functions */
 export class ExtraErrorData implements Integration {
   /**
@@ -22,6 +27,11 @@ export class ExtraErrorData implements Integration {
    * @inheritDoc
    */
   public static id: string = 'ExtraErrorData';
+
+  /**
+   * @inheritDoc
+   */
+  public constructor(private readonly options: ExtraErrorDataOptions = { depth: 3 }) {}
 
   /**
    * @inheritDoc
@@ -50,7 +60,7 @@ export class ExtraErrorData implements Integration {
       let extra = {
         ...event.extra,
       };
-      const normalizedErrorData = safeNormalize(errorData);
+      const normalizedErrorData = safeNormalize(errorData, this.options.depth);
       if (!isString(normalizedErrorData)) {
         extra = {
           ...event.extra,

--- a/packages/raven-node/package.json
+++ b/packages/raven-node/package.json
@@ -1,7 +1,14 @@
 {
   "name": "raven",
   "description": "A standalone (Node.js) client for Sentry",
-  "keywords": ["debugging", "errors", "exceptions", "logging", "raven", "sentry"],
+  "keywords": [
+    "debugging",
+    "errors",
+    "exceptions",
+    "logging",
+    "raven",
+    "sentry"
+  ],
   "version": "2.6.4",
   "repository": "git://github.com/getsentry/raven-js.git",
   "license": "BSD-2-Clause",
@@ -13,8 +20,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test":
-      "NODE_ENV=test istanbul cover _mocha  -- --reporter dot && NODE_ENV=test coffee ./test/run.coffee",
+    "test": "NODE_ENV=test istanbul cover _mocha  -- --reporter dot && NODE_ENV=test coffee ./test/run.coffee",
     "test-mocha": "NODE_ENV=test mocha",
     "test-full": "npm run test && cd test/instrumentation && ./run.sh"
   },

--- a/packages/raven-node/test/raven.client.js
+++ b/packages/raven-node/test/raven.client.js
@@ -1411,7 +1411,12 @@ describe('raven.Client', function() {
         var y = Object.create(null);
         y.c = 'd';
         console.log(x, y);
-        client.getContext().breadcrumbs[0].message.should.equal("{ a: 'b' } { c: 'd' }");
+        client
+          .getContext()
+          .breadcrumbs[0].message.should.be.oneOf(
+            "{ a: 'b' } { c: 'd' }",
+            "[Object: null prototype] { a: 'b' } [Object: null prototype] { c: 'd' }"
+          );
         done();
       });
     });

--- a/packages/raven-node/test/raven.utils.js
+++ b/packages/raven-node/test/raven.utils.js
@@ -238,11 +238,11 @@ describe('raven.utils', function() {
       var callback = function(frames) {
         var frame1 = frames.pop();
         frame1.in_app.should.be.false;
-        frame1.filename.should.equal('querystring.js');
+        frame1.filename.should.be.oneOf('querystring.js', 'internal/querystring.js');
 
         var frame2 = frames.pop();
         frame2.in_app.should.be.false;
-        frame2.filename.should.equal('querystring.js');
+        frame2.filename.should.be.oneOf('querystring.js', 'internal/querystring.js');
 
         done();
       };


### PR DESCRIPTION
Fixes:
https://github.com/getsentry/sentry-javascript/issues/1915
https://github.com/getsentry/sentry-javascript/issues/1923
https://github.com/getsentry/sentry-javascript/issues/1843
https://github.com/getsentry/sentry-javascript/issues/1801 (i guess)