### PR TITLE
Fix: Ensure single instance of logger

### DIFF
--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -76,7 +76,7 @@ export class BrowserClient extends BaseClient<BrowserBackend, BrowserOptions> {
    */
   public showReportDialog(options: ReportDialogOptions = {}): void {
     // doesn't work without a document (React Native)
-    const document = (getGlobalObject() as Window).document;
+    const document = getGlobalObject<Window>().document;
     if (!document) {
       return;
     }

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -11,7 +11,7 @@ import { BrowserClient } from '../client';
 
 import { breadcrumbEventHandler, keypressEventHandler, wrap } from './helpers';
 
-const global = getGlobalObject() as Window;
+const global = getGlobalObject<Window>();
 let lastHref: string | undefined;
 
 /**

--- a/packages/browser/src/integrations/useragent.ts
+++ b/packages/browser/src/integrations/useragent.ts
@@ -2,7 +2,7 @@ import { addGlobalEventProcessor, getCurrentHub } from '@sentry/core';
 import { Event, Integration } from '@sentry/types';
 import { getGlobalObject } from '@sentry/utils/misc';
 
-const global = getGlobalObject() as Window;
+const global = getGlobalObject<Window>();
 
 /** UserAgent */
 export class UserAgent implements Integration {

--- a/packages/browser/src/tracekit.ts
+++ b/packages/browser/src/tracekit.ts
@@ -55,7 +55,7 @@ interface ComputeStackTrace {
  * @namespace TraceKit
  */
 
-var window = getGlobalObject() as Window;
+var window = getGlobalObject<Window>();
 
 interface TraceKit {
   report: any;

--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -4,7 +4,7 @@ import { supportsReferrerPolicy } from '@sentry/utils/supports';
 
 import { BaseTransport } from './base';
 
-const global = getGlobalObject() as Window;
+const global = getGlobalObject<Window>();
 
 /** `fetch` based transport */
 export class FetchTransport extends BaseTransport {

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -267,7 +267,7 @@ export class Hub implements HubInterface {
 
 /** Returns the global shim registry. */
 export function getMainCarrier(): Carrier {
-  const carrier: any = getGlobalObject();
+  const carrier = getGlobalObject();
   carrier.__SENTRY__ = carrier.__SENTRY__ || {
     hub: undefined,
   };
@@ -333,7 +333,7 @@ export function getCurrentHub(): Hub {
  * This will tell whether a carrier has a hub on it or not
  * @param carrier object
  */
-function hasHubOnCarrier(carrier: any): boolean {
+function hasHubOnCarrier(carrier: Carrier): boolean {
   if (carrier && carrier.__SENTRY__ && carrier.__SENTRY__.hub) {
     return true;
   }
@@ -346,7 +346,7 @@ function hasHubOnCarrier(carrier: any): boolean {
  * @param carrier object
  * @hidden
  */
-export function getHubFromCarrier(carrier: any): Hub {
+export function getHubFromCarrier(carrier: Carrier): Hub {
   if (carrier && carrier.__SENTRY__ && carrier.__SENTRY__.hub) {
     return carrier.__SENTRY__.hub;
   }
@@ -360,7 +360,7 @@ export function getHubFromCarrier(carrier: any): Hub {
  * @param carrier object
  * @param hub Hub
  */
-export function setHubOnCarrier(carrier: any, hub: Hub): boolean {
+export function setHubOnCarrier(carrier: Carrier, hub: Hub): boolean {
   if (!carrier) {
     return false;
   }

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -282,7 +282,7 @@ export class Scope implements ScopeInterface {
  * Retruns the global event processors.
  */
 function getGlobalEventProcessors(): EventProcessor[] {
-  const global: any = getGlobalObject();
+  const global = getGlobalObject();
   global.__SENTRY__ = global.__SENTRY__ || {};
   global.__SENTRY__.globalEventProcessors = global.__SENTRY__.globalEventProcessors || [];
   return global.__SENTRY__.globalEventProcessors;

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -282,7 +282,7 @@ export class Scope implements ScopeInterface {
  * Retruns the global event processors.
  */
 function getGlobalEventProcessors(): EventProcessor[] {
-  const global = getGlobalObject();
+  const global = getGlobalObject<Window | NodeJS.Global>();
   global.__SENTRY__ = global.__SENTRY__ || {};
   global.__SENTRY__.globalEventProcessors = global.__SENTRY__.globalEventProcessors || [];
   return global.__SENTRY__.globalEventProcessors;

--- a/packages/hub/test/global.test.ts
+++ b/packages/hub/test/global.test.ts
@@ -8,10 +8,10 @@ describe('global', () => {
 
   test('getHubFromCarrier', () => {
     const bla = { a: 'b' };
-    getHubFromCarrier(bla);
+    getHubFromCarrier(bla as any);
     expect((bla as any).__SENTRY__.hub).toBeTruthy();
     expect((bla as any).__SENTRY__.hub).toBe((bla as any).__SENTRY__.hub);
-    getHubFromCarrier(bla);
+    getHubFromCarrier(bla as any);
   });
 
   test('getGlobalHub', () => {

--- a/packages/integrations/src/angular.ts
+++ b/packages/integrations/src/angular.ts
@@ -39,11 +39,8 @@ export class Angular implements Integration {
    * @inheritDoc
    */
   public constructor(options: { angular?: ng.IAngularStatic } = {}) {
-    this._angular =
-      options.angular ||
-      (getGlobalObject() as {
-        angular: ng.IAngularStatic;
-      }).angular;
+    // tslint:disable-next-line: no-unsafe-any
+    this._angular = options.angular || (getGlobalObject().angular as ng.IAngularStatic);
   }
 
   /**

--- a/packages/integrations/src/ember.ts
+++ b/packages/integrations/src/ember.ts
@@ -21,11 +21,8 @@ export class Ember implements Integration {
    * @inheritDoc
    */
   public constructor(options: { Ember?: any } = {}) {
-    this._Ember =
-      options.Ember ||
-      (getGlobalObject() as {
-        Ember: any;
-      }).Ember;
+    // tslint:disable-next-line: no-unsafe-any
+    this._Ember = options.Ember || getGlobalObject().Ember;
   }
 
   /**

--- a/packages/integrations/src/reportingobserver.ts
+++ b/packages/integrations/src/reportingobserver.ts
@@ -90,9 +90,7 @@ export class ReportingObserver implements Integration {
 
     this._getCurrentHub = getCurrentHub;
 
-    const observer = new (getGlobalObject() as {
-      ReportingObserver: any;
-    }).ReportingObserver(this.handler.bind(this), {
+    const observer = new (getGlobalObject()).ReportingObserver(this.handler.bind(this), {
       buffered: true,
       types: this._options.types,
     });

--- a/packages/integrations/src/vue.ts
+++ b/packages/integrations/src/vue.ts
@@ -38,11 +38,8 @@ export class Vue implements Integration {
    * @inheritDoc
    */
   public constructor(options: { Vue?: any; attachProps?: boolean } = {}) {
-    this._Vue =
-      options.Vue ||
-      (getGlobalObject() as {
-        Vue: any;
-      }).Vue;
+    // tslint:disable-next-line: no-unsafe-any
+    this._Vue = options.Vue || getGlobalObject().Vue;
     this._attachProps = options.attachProps || true;
   }
 

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,7 +1,7 @@
 import { consoleSandbox, getGlobalObject } from './misc';
 
 // TODO: Implement different loggers for different environments
-const global = getGlobalObject() as Window;
+const global = getGlobalObject<Window | NodeJS.Global>();
 
 /** Prefix for logging strings */
 const PREFIX = 'Sentry Logger ';
@@ -57,6 +57,8 @@ class Logger {
   }
 }
 
-const logger = new Logger();
+// Ensure we only have a single logger instance, even if multiple versions of @sentry/utils are being used
+global.__SENTRY__ = global.__SENTRY__ || {};
+const logger = (global.__SENTRY__.logger as Logger) || (global.__SENTRY__.logger = new Logger());
 
 export { logger };

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -2,6 +2,15 @@ import { Event, Mechanism, WrappedFunction } from '@sentry/types';
 
 import { isString } from './is';
 
+/** Internal */
+interface SentryGlobal {
+  __SENTRY__: {
+    globalEventProcessors: any;
+    hub: any;
+    logger: any;
+  };
+}
+
 /**
  * Requires a module which is protected _against bundler minification.
  *
@@ -29,14 +38,14 @@ const fallbackGlobalObject = {};
  * @returns Global scope object
  */
 // tslint:disable:strict-type-predicates
-export function getGlobalObject(): Window | NodeJS.Global | {} {
-  return isNodeEnv()
+export function getGlobalObject<T extends Window | NodeJS.Global = any>(): T & SentryGlobal {
+  return (isNodeEnv()
     ? global
     : typeof window !== 'undefined'
     ? window
     : typeof self !== 'undefined'
     ? self
-    : fallbackGlobalObject;
+    : fallbackGlobalObject) as T & SentryGlobal;
 }
 // tslint:enable:strict-type-predicates
 
@@ -228,7 +237,7 @@ interface ExtensibleConsole extends Console {
 
 /** JSDoc */
 export function consoleSandbox(callback: () => any): any {
-  const global = getGlobalObject() as Window;
+  const global = getGlobalObject<Window>();
   const levels = ['debug', 'info', 'warn', 'error', 'log'];
 
   if (!('console' in global)) {

--- a/packages/utils/src/supports.ts
+++ b/packages/utils/src/supports.ts
@@ -59,7 +59,7 @@ export function supportsDOMException(): boolean {
  * @returns Answer to the given question.
  */
 export function supportsFetch(): boolean {
-  if (!('fetch' in getGlobalObject())) {
+  if (!('fetch' in getGlobalObject<Window>())) {
     return false;
   }
 
@@ -86,10 +86,8 @@ export function supportsNativeFetch(): boolean {
   if (!supportsFetch()) {
     return false;
   }
-  const global = getGlobalObject();
-  const fetch = (global as any).fetch;
-  // tslint:disable-next-line:no-unsafe-any
-  return fetch.toString().indexOf('native') !== -1;
+  const global = getGlobalObject<Window>();
+  return global.fetch.toString().indexOf('native') !== -1;
 }
 
 /**
@@ -99,6 +97,7 @@ export function supportsNativeFetch(): boolean {
  * @returns Answer to the given question.
  */
 export function supportsReportingObserver(): boolean {
+  // tslint:disable-next-line: no-unsafe-any
   return 'ReportingObserver' in getGlobalObject();
 }
 
@@ -139,7 +138,7 @@ export function supportsHistory(): boolean {
   // NOTE: in Chrome App environment, touching history.pushState, *even inside
   //       a try/catch block*, will cause Chrome to output an error to console.error
   // borrowed from: https://github.com/angular/angular.js/pull/13945/files
-  const global = getGlobalObject();
+  const global = getGlobalObject<Window>();
   const chrome = (global as any).chrome;
   // tslint:disable-next-line:no-unsafe-any
   const isChromePackagedApp = chrome && chrome.app && chrome.app.runtime;


### PR DESCRIPTION
I've tried using the `@sentry/utils/logger` in `@sentry/electron` but the `Logger` instance is never enabled. It looks like we're ending up with multiple instances of `Logger` and only the one called from `@sentry/core` ever gets enabled when `init({ debug: true })`.

This PR:
- Saves the `Logger` instance to `global.__SENTRY__.logger`
- Adds types for `__SENTRY__` global
- Cleans up types around `getGlobalObject()`