### PR TITLE
Fix: Stop mangling double underscore properties

### DIFF
--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -16,7 +16,7 @@ const terserInstance = terser({
     // I listed all of them here just for the clarity sake, as they are all used in the frames manipulation process.
     reserved: ['captureException', 'captureMessage', 'sentryWrapped'],
     properties: {
-      regex: /^_/,
+      regex: /^_[^_]/,
     },
   },
 });


### PR DESCRIPTION
There are few properties surrounded with double underscores to reduce the chances of them clashing on objects or in the global scope. The obvious examples are `__SENTRY__` and `__sentry__` but there are others. Currently these are getting mangled to single characters which increases the chance of clashes. 

It looks like this change adds about 500 bytes to the non-ES6 bundle.