### PR TITLE
[Bug Fix]: Adds fix for Vue attachProps, as it always evaluates true

### DIFF
--- a/packages/integrations/src/vue.ts
+++ b/packages/integrations/src/vue.ts
@@ -32,7 +32,7 @@ export class Vue implements Integration {
    * When set to false, Sentry will suppress reporting all props data
    * from your Vue components for privacy concerns.
    */
-  private readonly _attachProps: boolean;
+  private readonly _attachProps: boolean = true;
 
   /**
    * @inheritDoc
@@ -40,7 +40,9 @@ export class Vue implements Integration {
   public constructor(options: { Vue?: any; attachProps?: boolean } = {}) {
     // tslint:disable-next-line: no-unsafe-any
     this._Vue = options.Vue || getGlobalObject().Vue;
-    this._attachProps = options.attachProps || true;
+    if (options.attachProps === false) {
+      this._attachProps = false;
+    }
   }
 
   /** JSDoc */


### PR DESCRIPTION
## Summary

The original code from #1885 would _always_ evaluate as `true` because of an incorrectly written `||`. This code will actually set `attachProps` to `false` if it's passed in as such.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ x ] If you've added code that should be tested, please add tests.
- [ x ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
