### PR TITLE
fix: Provide es5 build for esm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.0.5
+
+- [esm]: `module` in `package.json` now provides a `es5` build instead of `es2015`
+
 ## 5.0.4
 
 - [integrations] fix: Not requiring angular types

--- a/packages/browser/test/manual/npm-build.js
+++ b/packages/browser/test/manual/npm-build.js
@@ -10,9 +10,9 @@ webpack(
       path: __dirname,
       filename: 'tmp.js',
     },
-    resolve: {
-      mainFields: ['main'],
-    },
+    // resolve: {
+    //   mainFields: ['main'],
+    // },
     mode: 'development',
   },
   (err, stats) => {

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -43,7 +43,7 @@
     "build:watch:es5": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
     "build:watch:esm": "tsc -p tsconfig.esm.json -w --preserveWatchOutput",
     "build:bundle": "rollup --config",
-    "clean": "rimraf dist coverage *.js *.js.map *.d.ts",
+    "clean": "rimraf dist coverage esm build .rpt2_cache",
     "link:yarn": "yarn link",
     "lint": "run-s lint:prettier lint:tslint",
     "lint:prettier": "prettier-check \"{src,test}/**/*.ts\"",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es6",
+    "target": "es5",
     "module": "es6"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/1989
Fixes https://github.com/getsentry/sentry-javascript/issues/1988
Fixes https://github.com/getsentry/sentry-javascript/issues/1984
Fixes https://github.com/getsentry/sentry-javascript/issues/1979