### PR TITLE
fix: Update user type in scope.setUser for unset case

### DIFF
--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -99,7 +99,7 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public setUser(user: User): this {
+  public setUser(user: User | null): this {
     this._user = normalize(user);
     this._notifyScopeListeners();
     return this;

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -57,6 +57,11 @@ describe('Scope', () => {
       scope.setUser({ id: '1' });
       expect((scope as any)._user).toEqual({ id: '1' });
     });
+    test('unset', () => {
+      const scope = new Scope();
+      scope.setUser(null);
+      expect((scope as any)._user).toEqual(null);
+    });
   });
 
   describe('level', () => {

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -14,9 +14,9 @@ export interface Scope {
   /**
    * Updates user context information for future events.
    *
-   * @param user User context object to be set in the current context.
+   * @param user User context object to be set in the current context. Pass `null` to unset the user.
    */
-  setUser(user: User): this;
+  setUser(user: User | null): this;
 
   /**
    * Set an object that will be merged sent as tags data with the event.


### PR DESCRIPTION
According to https://github.com/getsentry/sentry-docs/issues/500#issuecomment-433096674, we should be able to unset a user in global scope by setting a user to `null`.

---

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
