### PR TITLE
fix: Wait for processing to finish before closing transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [utils] ref: Move `htmlTreeAsString` to `@sentry/browser`
 - [utils] ref: Remove `Window` typehint `getGlobalObject`
+- [core] fix: Make sure that flush/close works as advertised
 
 ## 5.0.6
 

--- a/packages/browser/test/index.test.ts
+++ b/packages/browser/test/index.test.ts
@@ -143,7 +143,7 @@ describe('SentryBrowser', () => {
       captureMessage('event222');
       captureMessage('event222');
 
-      await flush(2000);
+      await flush(10);
 
       expect(localBeforeSend.calledTwice).to.be.true;
     });

--- a/packages/browser/test/integration/test.js
+++ b/packages/browser/test/integration/test.js
@@ -64,7 +64,7 @@ function _alt(title, condition) {
   return condition ? '⚠️   Skipped: ' + title : title;
 }
 
-var frames = ['frame'];
+var frames = ['frame', 'loader', 'loader-lazy-no'];
 
 for (var idx in frames) {
   (function() {
@@ -911,7 +911,7 @@ for (var idx in frames) {
           );
         });
 
-        it.only("should capture built-in's handlers fn name in mechanism data", function(done) {
+        it("should capture built-in's handlers fn name in mechanism data", function(done) {
           var iframe = this.iframe;
 
           iframeExecute(

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -1,6 +1,6 @@
 import { Scope } from '@sentry/hub';
 import { Client, Event, EventHint, Integration, IntegrationClass, Options, SdkInfo, Severity } from '@sentry/types';
-import { getGlobalObject, isPrimitive, isThenable, logger, SyncPromise, truncate, uuid4 } from '@sentry/utils';
+import { isPrimitive, isThenable, logger, SyncPromise, truncate, uuid4 } from '@sentry/utils';
 
 import { Backend, BackendClass } from './basebackend';
 import { Dsn } from './dsn';
@@ -211,7 +211,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
       if (this._processingInterval) {
         clearInterval(this._processingInterval);
       }
-      this._processingInterval = getGlobalObject<Window>().setInterval(() => {
+      this._processingInterval = (setInterval(() => {
         if (!this._processing) {
           resolve(true);
         } else {
@@ -220,7 +220,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
             resolve(false);
           }
         }
-      }, tick);
+      }, tick) as unknown) as number;
     });
   }
 

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -1,6 +1,6 @@
 import { Scope } from '@sentry/hub';
 import { Client, Event, EventHint, Integration, IntegrationClass, Options, SdkInfo, Severity } from '@sentry/types';
-import { isPrimitive, isThenable, logger, SyncPromise, truncate, uuid4 } from '@sentry/utils';
+import { getGlobalObject, isPrimitive, isThenable, logger, SyncPromise, truncate, uuid4 } from '@sentry/utils';
 
 import { Backend, BackendClass } from './basebackend';
 import { Dsn } from './dsn';
@@ -59,7 +59,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
   protected _processing: boolean = false;
 
   /** Processing interval */
-  protected _processingInterval?: NodeJS.Timeout;
+  protected _processingInterval?: number;
 
   /**
    * Initializes this client instance.
@@ -211,7 +211,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
       if (this._processingInterval) {
         clearInterval(this._processingInterval);
       }
-      this._processingInterval = setInterval(() => {
+      this._processingInterval = getGlobalObject<Window>().setInterval(() => {
         if (!this._processing) {
           resolve(true);
         } else {

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -58,6 +58,9 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
   /** Is the client still processing a call? */
   protected _processing: boolean = false;
 
+  /** Processing interval */
+  protected _processingInterval?: NodeJS.Timeout;
+
   /**
    * Initializes this client instance.
    *
@@ -163,12 +166,11 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    * @inheritDoc
    */
   public async flush(timeout?: number): Promise<boolean> {
-    return (await Promise.all([
-      this._getBackend()
-        .getTransport()
-        .close(timeout),
-      this._isClientProcessing(),
-    ])).reduce((prev, current) => prev && current);
+    const clientReady = await this._isClientProcessing(timeout);
+    const transportFlushed = await this._getBackend()
+      .getTransport()
+      .close(timeout);
+    return clientReady && transportFlushed;
   }
 
   /**
@@ -200,19 +202,26 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
   }
 
   /** Waits for the client to be done with processing. */
-  protected async _isClientProcessing(counter: number = 0): Promise<boolean> {
+  protected async _isClientProcessing(timeout?: number): Promise<boolean> {
     return new Promise<boolean>(resolve => {
-      if (this._processing) {
-        // Safeguard in case of endless recursion
-        if (counter >= 10) {
-          resolve(false);
+      let ticked: number = 0;
+      const tick: number = 1;
+      if (this._processingInterval) {
+        clearInterval(this._processingInterval);
+      }
+      this._processingInterval = setInterval(() => {
+        if (!this._processing) {
+          resolve(true);
         } else {
-          setTimeout(async () => {
-            resolve(await this._isClientProcessing(counter + 1));
-          }, 10);
+          ticked += tick;
+          if (timeout && ticked >= timeout) {
+            resolve(false);
+          }
         }
-      } else {
-        resolve(true);
+      }, tick);
+    }).finally(() => {
+      if (this._processingInterval) {
+        clearInterval(this._processingInterval);
       }
     });
   }

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -167,6 +167,9 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    */
   public async flush(timeout?: number): Promise<boolean> {
     const clientReady = await this._isClientProcessing(timeout);
+    if (this._processingInterval) {
+      clearInterval(this._processingInterval);
+    }
     const transportFlushed = await this._getBackend()
       .getTransport()
       .close(timeout);
@@ -177,9 +180,8 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    * @inheritDoc
    */
   public async close(timeout?: number): Promise<boolean> {
-    return this.flush(timeout).finally(() => {
-      this.getOptions().enabled = false;
-    });
+    this.getOptions().enabled = false;
+    return this.flush(timeout);
   }
 
   /**
@@ -219,10 +221,6 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
           }
         }
       }, tick);
-    }).finally(() => {
-      if (this._processingInterval) {
-        clearInterval(this._processingInterval);
-      }
     });
   }
 

--- a/packages/core/test/mocks/transport.ts
+++ b/packages/core/test/mocks/transport.ts
@@ -1,0 +1,30 @@
+import { Event, Response, Status, Transport } from '@sentry/types';
+import { PromiseBuffer } from '@sentry/utils';
+
+async function sleep(delay: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, delay));
+}
+
+export class FakeTransport implements Transport {
+  /** A simple buffer holding all requests. */
+  protected readonly _buffer: PromiseBuffer<Response> = new PromiseBuffer(9999);
+
+  public sendCalled: number = 0;
+  public sentCount: number = 0;
+  public delay: number = 2000;
+
+  public async sendEvent(_event: Event): Promise<Response> {
+    this.sendCalled += 1;
+    return this._buffer.add(
+      new Promise(async res => {
+        await sleep(this.delay);
+        this.sentCount += 1;
+        res({ status: Status.Success });
+      }),
+    );
+  }
+
+  public async close(timeout?: number): Promise<boolean> {
+    return this._buffer.drain(timeout);
+  }
+}

--- a/packages/integrations/src/debug.ts
+++ b/packages/integrations/src/debug.ts
@@ -1,5 +1,5 @@
 import { Event, EventHint, EventProcessor, Hub, Integration } from '@sentry/types';
-import { consoleSandbox } from '@sentry/utils/misc';
+import { consoleSandbox } from '@sentry/utils';
 
 /** JSDoc */
 interface DebugOptions {

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -33,53 +33,6 @@ describe('SentryNode', () => {
     getCurrentHub().popScope();
   });
 
-  test('flush() with to short timeout', done => {
-    expect.assertions(1);
-    jest.useFakeTimers();
-    const client = new NodeClient({
-      dsn,
-      transport: SetTimeoutTransport,
-    });
-    getCurrentHub().bindClient(client);
-    captureMessage('test');
-    captureMessage('test');
-    captureMessage('test');
-    client
-      .flush(50)
-      .then(result => {
-        expect(result).toBeFalsy();
-        done();
-      })
-      .catch(() => {
-        // test
-      });
-    jest.runAllTimers();
-  });
-
-  test('flush() with timeout', done => {
-    expect.assertions(1);
-    jest.useFakeTimers();
-    const client = new NodeClient({
-      dsn,
-      transport: SetTimeoutTransport,
-    });
-    getCurrentHub().bindClient(client);
-    captureMessage('test');
-    captureMessage('test');
-    captureMessage('test');
-    jest.runAllTimers();
-    client
-      .flush(50)
-      .then(result => {
-        expect(result).toBeFalsy();
-        done();
-      })
-      .catch(() => {
-        // test
-      });
-    jest.runAllTimers();
-  });
-
   describe('getContext() / setContext()', () => {
     test('store/load extra', async () => {
       configureScope((scope: Scope) => {


### PR DESCRIPTION
Fixes #2000

There was an issue with flush that we have to wait for processing of the client to finish first before we ask the transport to drain.

cc @sheerun thanks for pointing this out