### PR TITLE
Fix typo in CHANGELOG.md: CaptueConsole -> CaptureConsole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [utils] ref: Move `htmlTreeAsString` to `@sentry/browser`
 - [utils] ref: Remove `Window` typehint `getGlobalObject`
 - [core] fix: Make sure that flush/close works as advertised
-- [integrations] feat: Added `CaptueConsole` integration
+- [integrations] feat: Added `CaptureConsole` integration
 
 ## 5.0.6
 


### PR DESCRIPTION
The text on this page should be fixed too https://github.com/getsentry/sentry-javascript/releases/tag/5.0.7.