### PR TITLE
Add auto-flushing to middleware integration

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -222,18 +222,18 @@ export function requestHandler(options?: {
   transaction?: boolean | TransactionTypes;
   user?: boolean | string[];
   version?: boolean;
-  wait?: boolean;
+  flushTimeout?: number;
 }): (req: http.IncomingMessage, res: http.ServerResponse, next: (error?: any) => void) => void {
   return function sentryRequestMiddleware(
     req: http.IncomingMessage,
     res: http.ServerResponse,
     next: (error?: any) => void,
   ): void {
-    if (options && options.wait) {
+    if (options && options.flushTimeout && options.flushTimeout > 0) {
       const _end = res.end
 
       res.end = async function end (chunk?: any, encodingOrCb?: string | Function, cb?: Function) {
-        await flush(2000)
+        await flush(options.flushTimeout)
         return _end.call(this, chunk, encodingOrCb, cb)
       }
     }

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -1,6 +1,7 @@
 import { captureException, getCurrentHub } from '@sentry/core';
 import { Event } from '@sentry/types';
 import { forget, isString, logger, normalize } from '@sentry/utils';
+import { flush } from './sdk';
 import * as cookie from 'cookie';
 import * as domain from 'domain';
 import * as http from 'http';
@@ -221,12 +222,21 @@ export function requestHandler(options?: {
   transaction?: boolean | TransactionTypes;
   user?: boolean | string[];
   version?: boolean;
+  wait?: boolean;
 }): (req: http.IncomingMessage, res: http.ServerResponse, next: (error?: any) => void) => void {
   return function sentryRequestMiddleware(
     req: http.IncomingMessage,
     res: http.ServerResponse,
     next: (error?: any) => void,
   ): void {
+    if (options && options.wait) {
+      const _end = res.end
+
+      res.end = async function end (chunk?: any, encodingOrCb?: string | Function, cb?: Function) {
+        await flush(2000)
+        return _end.call(this, chunk, encodingOrCb, cb)
+      }
+    }
     const local = domain.create();
     local.add(req);
     local.add(res);


### PR DESCRIPTION
As per request I send PR implementing #2001

I've checked manually that it indeed flushes errors before request finishes if { wait: true } is used

- [ ] If you've added code that should be tested, please add tests.
Unfortunately there's no testing scaffold for existing code so it's hard for me to add new