### PR TITLE
fix: Expose lastEventId method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [browser] ref: Mangle more stuff, reduce bundle size
+- [node] fix: Expose lastEventId method
 
 ## 5.1.1
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -29,7 +29,7 @@ export {
 
 export { NodeOptions } from './backend';
 export { NodeClient } from './client';
-export { defaultIntegrations, init, flush, close } from './sdk';
+export { defaultIntegrations, init, lastEventId, flush, close } from './sdk';
 export { SDK_NAME, SDK_VERSION } from './version';
 
 import { Integrations as CoreIntegrations } from '@sentry/core';


### PR DESCRIPTION
This PR adds the final missing part of #1767 in that it adds the final top-level export required to `import { lastEventId } from "@sentry/node"`.

---

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] ~~If you've added code that should be tested, please add tests.~~
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
