### PR TITLE
integrations/ember: Remove unnecessary `_addIntegrationToSdkInfo()` method

### DIFF
--- a/packages/integrations/src/captureconsole.ts
+++ b/packages/integrations/src/captureconsole.ts
@@ -51,12 +51,6 @@ export class CaptureConsole implements Integration {
             scope.setExtra('arguments', normalize(args, 3));
             scope.addEventProcessor(event => {
               event.logger = 'console';
-              if (event.sdk) {
-                event.sdk = {
-                  ...event.sdk,
-                  integrations: [...(event.sdk.integrations || []), 'console'],
-                };
-              }
               return event;
             });
 

--- a/packages/integrations/src/vue.ts
+++ b/packages/integrations/src/vue.ts
@@ -92,17 +92,6 @@ export class Vue implements Integration {
             scope.setExtra(key, metadata[key]);
           });
 
-          scope.addEventProcessor((event: Event) => {
-            if (event.sdk) {
-              const integrations = event.sdk.integrations || [];
-              event.sdk = {
-                ...event.sdk,
-                integrations: [...integrations, 'vue'],
-              };
-            }
-            return event;
-          });
-
           getCurrentHub().captureException(error);
         });
       }


### PR DESCRIPTION
The Ember integration is already listed in the `integrations` array, so there is no need to add `ember` a second time.

