### PR TITLE
integrations/vue: Remove unused import

### DIFF
--- a/packages/integrations/src/vue.ts
+++ b/packages/integrations/src/vue.ts
@@ -1,4 +1,4 @@
-import { Event, EventProcessor, Hub, Integration } from '@sentry/types';
+import { EventProcessor, Hub, Integration } from '@sentry/types';
 import { getGlobalObject, isPlainObject } from '@sentry/utils';
 
 /** JSDoc */


### PR DESCRIPTION
looks like I forgot to clean the imports in https://github.com/getsentry/sentry-javascript/pull/2057 🙈 

/cc @kamilogorek 