### PR TITLE
fix: Guard truncate from unexpected input

### DIFF
--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -8,7 +8,8 @@ import { isRegExp } from './is';
  * @returns string Encoded
  */
 export function truncate(str: string, max: number = 0): string {
-  if (max === 0) {
+  // tslint:disable-next-line:strict-type-predicates
+  if (typeof str !== 'string' || max === 0) {
     return str;
   }
   return str.length <= max ? str : `${str.substr(0, max)}...`;

--- a/packages/utils/test/string.test.ts
+++ b/packages/utils/test/string.test.ts
@@ -2,6 +2,7 @@ import { keysToEventMessage, truncate } from '../src/string';
 
 describe('truncate()', () => {
   test('it works as expected', () => {
+    expect(truncate(null, 3)).toEqual(null);
     expect(truncate('lolol', 3)).toEqual('lol...');
     expect(truncate('lolol', 10)).toEqual('lolol');
     expect(truncate('1'.repeat(1000), 300)).toHaveLength(303);


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/2070

"And that Kids is why you shouldn't trust statically to dynamically typed transpiled languages."