### PR TITLE
feat: Add getScope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- [minimal] feat: Add `getScope` returns the current Scope and an empty new one if there is no current hub.
+
 ## 5.3.1
 
 - [integrations] fix: Tracing integration CDN build.

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -23,6 +23,7 @@ export {
   withScope,
   getHubFromCarrier,
   getCurrentHub,
+  getScope,
   Hub,
   Scope,
 } from '@sentry/core';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export {
   captureEvent,
   captureMessage,
   configureScope,
+  getScope,
   withScope,
 } from '@sentry/minimal';
 export { addGlobalEventProcessor, getCurrentHub, Hub, getHubFromCarrier, Scope } from '@sentry/hub';

--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -101,6 +101,14 @@ export function withScope(callback: (scope: Scope) => void): void {
   callOnHub<void>('withScope', callback);
 }
 
+
+/**
+ * Returns the current top Scope on the hub or an empty new Scope if there is is none on the hub.
+ */
+export function getScope(): Scope {
+  return callOnHub<Scope | undefined>('getScope') || new Scope();
+}
+
 /**
  * Calls a function on the latest client. Use this with caution, it's meant as
  * in "internal" helper so we don't need to expose every possible function in

--- a/packages/minimal/test/lib/minimal.test.ts
+++ b/packages/minimal/test/lib/minimal.test.ts
@@ -1,6 +1,14 @@
 import { getCurrentHub, getHubFromCarrier, Scope } from '@sentry/hub';
 import { Severity } from '@sentry/types';
-import { _callOnClient, captureEvent, captureException, captureMessage, configureScope, withScope } from '../../src';
+import {
+  _callOnClient,
+  captureEvent,
+  captureException,
+  captureMessage,
+  configureScope,
+  getScope,
+  withScope,
+} from '../../src';
 import { init, TestClient, TestClient2 } from '../mocks/client';
 
 declare var global: any;
@@ -207,5 +215,11 @@ describe('Minimal', () => {
       expect(global.__SENTRY__.hub._stack).toHaveLength(2);
     });
     expect(global.__SENTRY__.hub._stack).toHaveLength(1);
+  });
+
+  test('getScope', () => {
+    const scope = getScope();
+    scope.setTag('a', 'b');
+    expect(global.__SENTRY__.hub._stack[0].scope).toEqual(scope);
   });
 });

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -22,6 +22,7 @@ export {
   configureScope,
   getCurrentHub,
   getHubFromCarrier,
+  getScope,
   Hub,
   Scope,
   withScope,


### PR DESCRIPTION
This exposes a new "global" function called `getScope` 

This enables users to do something like this:

```js
Sentry.getScope().setTags({a: 'b'});
Sentry.getScope().setContext('os', {name: 'mac'});

// vs. 

Sentry.configureScope(scope => {
  scope.setTags({a: 'b'});
  scope.setContext('os', {name: 'mac'});
});
```

It returns an empty `Scope` in case there is no current hub.

The motivation for this change is:
- Users don't need to fully understand the concept of a scope for the simplest use case there is e.g:  setting tags `Sentry.getScope().setTags({a: 'b'});`
- Exposing all scope functions globally like `Sentry.setTag`, `Sentry.setContext` ... increases bundle size significantly and is way harder to maintain since we would always need to sync global API with scope API (thinking about moving towards tracing API), `Sentry.getScope()` is a good compromise
- This should provide users an easier path to migrate their old SDK codebase to the new one: _string replace_:
```js
Raven.setTagsContext({a: 'b'}); 
// ->
Sentry.getScope().setTags({a: 'b'});
```

`getScope` vs. `configureScope`

`configureScope` works differently in a way that in case there is no active client on the hub, the `configureScope` callback will not be invoked at all, meaning if there are expensive operations this is better than `getScope`. This is the main difference between these two functions. 