### PR TITLE
fix: Update stray raven reference in wrapping comment

### DIFF
--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -75,8 +75,8 @@ export function wrap(
     try {
       // Attempt to invoke user-land function
       // NOTE: If you are a Sentry user, and you are seeing this stack frame, it
-      //       means Raven caught an error invoking your application code. This is
-      //       expected behavior and NOT indicative of a bug with Raven.js.
+      //       means the sentry.javascript SDK caught an error invoking your application code. This
+      //       is expected behavior and NOT indicative of a bug with sentry.javascript.
       const wrappedArguments = args.map((arg: any) => wrap(arg, options));
 
       if (fn.handleEvent) {


### PR DESCRIPTION
I assume this is just a leftover from the raven days.

(If this wording works, I can also make the change [here](https://github.com/getsentry/sentry-javascript/blob/bd3f72ec062abf16e92e2d18e12baeb72d199a76/packages/browser/src/integrations/helpers.ts#L75-L78).)