### PR TITLE
fix: fetch headers if array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.4.1
+
+- [integrations] fix: Tracing integration fetch headers bug.
+
 ## 5.4.0
 
 - [global] feat: Exposed new simplified scope API. `Sentry.setTag`, `Sentry.setTags`, `Sentry.setExtra`, `Sentry.setExtras`, `Sentry.setUser`, `Sentry.setContext`

--- a/packages/integrations/src/tracing.ts
+++ b/packages/integrations/src/tracing.ts
@@ -162,10 +162,14 @@ export class Tracing implements Integration {
 
           if (options && whiteListed) {
             if (options.headers) {
-              options.headers = {
-                ...options.headers,
-                ...getCurrentHub().traceHeaders(),
-              };
+              if (Array.isArray(options.headers)) {
+                options.headers = [...options.headers, ...Object.entries(getCurrentHub().traceHeaders())];
+              } else {
+                options.headers = {
+                  ...options.headers,
+                  ...getCurrentHub().traceHeaders(),
+                };
+              }
             } else {
               options.headers = getCurrentHub().traceHeaders();
             }


### PR DESCRIPTION
Fixed a bug in how headers are sent with fetch requests.