### PR TITLE
feat: Async support for beforeBreadcrumb

### DIFF
--- a/packages/browser/examples/app.js
+++ b/packages/browser/examples/app.js
@@ -85,6 +85,13 @@ Sentry.init({
         breadcrumb.message = `User clicked on a button with label "${label}"`;
       }
     }
+
+    // if we get back a failed fetch, add a breadcrumb with the error code.
+    if (breadcrumb.category === 'fetch') {
+      if (hint && hint.response && hint.response.body) {
+        return hint.response.body().then(({ errorCode }) => ({ ...breadcrumb, errorCode }));
+      }
+    }
     console.log(breadcrumb);
     return breadcrumb;
   },

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -106,5 +106,5 @@ export interface Options {
    * @param breadcrumb The breadcrumb as created by the SDK.
    * @returns The breadcrumb that will be added | null.
    */
-  beforeBreadcrumb?(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): Breadcrumb | null;
+  beforeBreadcrumb?(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): PromiseLike<Breadcrumb | null> | Breadcrumb | null;
 }

--- a/packages/utils/src/is.ts
+++ b/packages/utils/src/is.ts
@@ -99,7 +99,7 @@ export function isRegExp(wat: any): boolean {
  * Checks whether given value has a then function.
  * @param wat A value to be checked.
  */
-export function isThenable(wat: any): boolean {
+export function isThenable<T>(wat: any): wat is PromiseLike<T> {
   // tslint:disable:no-unsafe-any
   return Boolean(wat && wat.then && typeof wat.then === 'function');
   // tslint:enable:no-unsafe-any


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

We have two use cases I have found for wanting to asynchronously add context to a breadcrumb:
1: Sometimes the response of a failed api request gives context for what lead to an error.  So we need to parse the body before adding the breadcrumb.
2: With synthetic events in react, the event is not always fully created before being passed into the hint.  For example this component: https://github.com/airbnb/lunar/blob/master/packages/core/src/components/TrackingBoundary/index.tsx
We add `trackingContext` to the event in the component tree.  This is added after the addBreadcrumb is called on the same click event.  So we need to set a callback to after the event has propagated before sending up the breadcrumb.

Alternatives considered:
Currently, we are using the workaround of cancelling these breadcrumbs, and then manually adding a breadcrumb, but this seems like a workaround, not a long term solution.
