### PR TITLE
Fix read only property assign

### DIFF
--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -143,11 +143,14 @@ export function wrap(
 
   // Restore original function name (not all browsers allow that)
   try {
-    Object.defineProperty(sentryWrapped, 'name', {
-      get(): string {
-        return fn.name;
-      },
-    });
+    const descriptor = Object.getOwnPropertyDescriptor(sentryWrapped, 'name') as PropertyDescriptor;
+    if (descriptor.configurable) {
+      Object.defineProperty(sentryWrapped, 'name', {
+        get(): string {
+          return fn.name;
+        },
+      });
+    }
   } catch (_oO) {
     /*no-empty*/
   }

--- a/packages/browser/src/tracekit.ts
+++ b/packages/browser/src/tracekit.ts
@@ -275,7 +275,7 @@ TraceKit._report = (function reportModuleWrapper() {
     var stack = TraceKit._computeStackTrace(err);
     stack.mechanism = 'onunhandledrejection';
     if (!stack.message) {
-      stack.message = JSON.stringify(normalize(err))
+      stack.message = JSON.stringify(normalize(err));
     }
     _notifyHandlers(stack, true, err);
   }


### PR DESCRIPTION
This code has been causing errors on WebOS 2.0 (LG TVs). For some weird reason, the `Object.defineProperty` stopped raising an exception and was causing the application to crash. Check the log:

https://pastebin.com/aJcU5Bf6

This is the snippet that generated the log above:

```typescript
// Restore original function name (not all browsers allow that)
try {
    const descriptor = Object.getOwnPropertyDescriptor(sentryWrapped, 'name') as PropertyDescriptor
    console.log('Is Name configurable: ' + descriptor.configurable);
    Object.defineProperty(sentryWrapped, 'name', {
        get(): string {
            return fn.name;
        },
    });
} catch (_oO) {
    console.log('ERROR --------')
    /*no-empty*/
}
```

Notice that after some point, the catch does not execute anymore and the error pops out. But the property is still read-only.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
