### PR TITLE
fix: Allow Integration<T> constructor to have arguments

### DIFF
--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -3,7 +3,7 @@ import { Hub } from './hub';
 
 /** Integration Class Interface */
 export interface IntegrationClass<T> {
-  new (): T;
+  new (...args: any[]): T;
   /**
    * Property that holds the integration name
    */


### PR DESCRIPTION
Relax the constructor signature so it may have arguments. Someone might wanna do:

```typescript
class MyCustomIntegration implements Integration {
    public static id = 'MyCustomIntegration';
    public name = MyCustomIntegration.id;

    constructor(public options: {patterns: RegExp[]}) {
    }

    public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
        addGlobalEventProcessor((event: Event) => {
            const self = getCurrentHub().getIntegration(MyCustomIntegration);

            if (self && self.options.patterns.some(rx => rx.test(/* ... */)) {
                return null;
            }

            return event;
        });
    }
}
```

But `getIntegration(MyCustomIntegration)` complains, that `MyCustomIntegration` doesn't match the signature, as arguments in the constructor aren't allowed.