### PR TITLE
fix(docs): Remove deprecated parameter from applyToEvent docstring

### DIFF
--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -311,7 +311,6 @@ export class Scope implements ScopeInterface {
    * Also if the event has already breadcrumbs on it, we do not merge them.
    * @param event Event
    * @param hint May contain additional informartion about the original exception.
-   * @param maxBreadcrumbs number of max breadcrumbs to merged into event.
    * @hidden
    */
   public applyToEvent(event: Event, hint?: EventHint): SyncPromise<Event | null> {


### PR DESCRIPTION
`maxBreadcrumbs` got removed [here](https://github.com/getsentry/sentry-javascript/commit/9e862abe8c2d144e1ec953c4c3c4b671b845b4d0#diff-9149adc4b7fd7b844f7874022e9d197dL234), but is still in the docstring*.

*what do you call docstrings in JS?