### PR TITLE
fix(options): Fix description of `maxBreadcrumb`

### DIFF
--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -67,7 +67,7 @@ export interface Options {
   dist?: string;
 
   /** 
-  * The maximum number of breadcrumbs sent with events. Defaults to 30.
+   * The maximum number of breadcrumbs sent with events. Defaults to 30.
    * Values over 100 will be ignored and 100 used instead.
    */
   maxBreadcrumbs?: number;

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -68,7 +68,7 @@ export interface Options {
 
   /** 
   * The maximum number of breadcrumbs sent with events. Defaults to 30.
-  * Values over 100 will be ignored and 100 used instead.
+   * Values over 100 will be ignored and 100 used instead.
    */
   maxBreadcrumbs?: number;
 

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -66,7 +66,10 @@ export interface Options {
   /** Sets the distribution for all events */
   dist?: string;
 
-  /** The maximum number of breadcrumbs sent with events. Defaults to 100. */
+  /** 
+  * The maximum number of breadcrumbs sent with events. Defaults to 30.
+  * Values over 100 will be ignored and 100 used instead.
+  */
   maxBreadcrumbs?: number;
 
   /** Console logging verbosity for the SDK Client. */

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -69,7 +69,7 @@ export interface Options {
   /** 
   * The maximum number of breadcrumbs sent with events. Defaults to 30.
   * Values over 100 will be ignored and 100 used instead.
-  */
+   */
   maxBreadcrumbs?: number;
 
   /** Console logging verbosity for the SDK Client. */


### PR DESCRIPTION
Make the description match the behavior described here:

https://github.com/getsentry/sentry-javascript/blob/1d8ebf96c07fa07ca350960af7f4115c3349623e/packages/hub/src/hub.ts#L38-L48

and implemented here:
https://github.com/getsentry/sentry-javascript/blob/1d8ebf96c07fa07ca350960af7f4115c3349623e/packages/hub/src/hub.ts#L226.

