### PR TITLE
Fix: Don't overwrite the transaction on an event if it's already been set.

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -203,7 +203,7 @@ export function parseRequest(
     };
   }
 
-  if (options.transaction) {
+  if (options.transaction && !event.transaction) {
     const transaction = extractTransaction(req, options.transaction);
     if (transaction) {
       event.transaction = transaction;


### PR DESCRIPTION
This PR prevents the transaction property being overwritten if it has already been set on the event.
[v5.2.0](https://github.com/getsentry/sentry-javascript/blob/master/CHANGELOG.md#520) saw the introduction of the `setTransaction` function on the scopes . The value set using this function in `@sentry/node` isn't being respected currently.

Setting the transaction in `@sentry/browser` works fine.

#### Example issue

When I inspect the current scope after I've used the `scope.setTransaction` call I can see the transaction is set correctly, however if I check the event in the `beforeSend` callback it's been changed.

#### Transaction value from the current scope before submitting an error

![Screenshot 2019-06-21 at 11 28 00](https://user-images.githubusercontent.com/7782211/59916670-ba2a3e00-9417-11e9-91a8-0561a6c72797.png)

#### Transaction value from `beforeSend`

![Screenshot 2019-06-21 at 11 28 08](https://user-images.githubusercontent.com/7782211/59916734-e5149200-9417-11e9-8aed-1e8ead2afe4c.png)

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
