### PR TITLE
feat: SessionTiming integration

### DIFF
--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -6,6 +6,7 @@ export { Ember } from './ember';
 export { ExtraErrorData } from './extraerrordata';
 export { ReportingObserver } from './reportingobserver';
 export { RewriteFrames } from './rewriteframes';
+export { SessionTiming } from './sessiontiming';
 export { Tracing } from './tracing';
 export { Transaction } from './transaction';
 export { Vue } from './vue';

--- a/packages/integrations/src/sessiontiming.ts
+++ b/packages/integrations/src/sessiontiming.ts
@@ -1,0 +1,46 @@
+import { Event, EventProcessor, Hub, Integration } from '@sentry/types';
+
+/** This function adds duration since Sentry was initialized till the time event was sent */
+export class SessionTiming implements Integration {
+  /**
+   * @inheritDoc
+   */
+  public name: string = SessionTiming.id;
+  /**
+   * @inheritDoc
+   */
+  public static id: string = 'SessionTiming';
+
+  /** Exact time Client was initialized expressed in milliseconds since Unix Epoch. */
+  protected readonly _startTime: number = Date.now();
+
+  /**
+   * @inheritDoc
+   */
+  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
+    addGlobalEventProcessor(event => {
+      const self = getCurrentHub().getIntegration(SessionTiming);
+      if (self) {
+        return self.process(event);
+      }
+      return event;
+    });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public process(event: Event): Event {
+    const now = Date.now();
+
+    return {
+      ...event,
+      extra: {
+        ...event.extra,
+        ['session:start']: this._startTime,
+        ['session:duration']: now - this._startTime,
+        ['session:end']: now,
+      },
+    };
+  }
+}

--- a/packages/integrations/test/sessiontiming.test.ts
+++ b/packages/integrations/test/sessiontiming.test.ts
@@ -1,0 +1,18 @@
+import { SessionTiming } from '../src/sessiontiming';
+
+const sessionTiming: SessionTiming = new SessionTiming();
+
+describe('SessionTiming', () => {
+  it('should work as expected', () => {
+    const event = sessionTiming.process({
+      extra: {
+        some: 'value',
+      },
+    });
+
+    expect(typeof event.extra!['session:start']).toBe('number');
+    expect(typeof event.extra!['session:duration']).toBe('number');
+    expect(typeof event.extra!['session:end']).toBe('number');
+    expect(event.extra!.some).toEqual('value');
+  });
+});


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-javascript/issues/1823

Usage:

```js
import { SessionTiming } from '@sentry/integration';

Sentry.init({
  integrations: [new SessionTiming()]
});
```