### PR TITLE
Add cookies as an optional property in the request handler

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -26,7 +26,7 @@ function extractTransaction(req: { [key: string]: any }, type: boolean | Transac
         stack: [
           {
             name: string;
-          }
+          },
         ];
       };
     };
@@ -51,7 +51,7 @@ function extractTransaction(req: { [key: string]: any }, type: boolean | Transac
 }
 
 /** JSDoc */
-function extractRequestData(req: { [key: string]: any }): { [key: string]: string } {
+function extractRequestData(req: { [key: string]: any }, keys: boolean | string[]): { [key: string]: string } {
   // headers:
   //   node, express: req.headers
   //   koa: req.header
@@ -112,6 +112,17 @@ function extractRequestData(req: { [key: string]: any }): { [key: string]: strin
     url: absoluteUrl,
   };
 
+  const attributes = Array.isArray(keys) ? keys : [];
+
+  if (attributes.length) {
+    Object.keys(request).forEach(key => {
+      /** Remove any of the unspecified keys in the options from the request interface */
+      if (!attributes.includes(key)) {
+        delete request[key];
+      }
+    });
+  }
+
   return request;
 }
 
@@ -161,8 +172,7 @@ export function parseRequest(
     [key: string]: any;
   },
   options?: {
-    cookies?: boolean;
-    request?: boolean;
+    request?: boolean | string[];
     serverName?: boolean;
     transaction?: boolean | TransactionTypes;
     user?: boolean | string[];
@@ -171,7 +181,6 @@ export function parseRequest(
 ): Event {
   // tslint:disable-next-line:no-parameter-reassignment
   options = {
-    cookies: true,
     request: true,
     serverName: true,
     transaction: true,
@@ -190,12 +199,8 @@ export function parseRequest(
   if (options.request) {
     event.request = {
       ...event.request,
-      ...extractRequestData(req),
+      ...extractRequestData(req, options.request),
     };
-
-    if (!options.cookies) {
-      delete event.request.cookies;
-    }
   }
 
   if (options.serverName) {

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -161,6 +161,7 @@ export function parseRequest(
     [key: string]: any;
   },
   options?: {
+    cookies?: boolean;
     request?: boolean;
     serverName?: boolean;
     transaction?: boolean | TransactionTypes;
@@ -170,6 +171,7 @@ export function parseRequest(
 ): Event {
   // tslint:disable-next-line:no-parameter-reassignment
   options = {
+    cookies: true,
     request: true,
     serverName: true,
     transaction: true,
@@ -190,6 +192,10 @@ export function parseRequest(
       ...event.request,
       ...extractRequestData(req),
     };
+
+    if (!options.cookies) {
+      delete event.request.cookies;
+    }
   }
 
   if (options.serverName) {

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -1,0 +1,73 @@
+import { parseRequest } from '../src/handlers';
+import { Event } from '../src';
+
+describe('parseRequest', () => {
+  const mockReq = {
+    method: 'GET',
+    url: '/some/path?key=value',
+    headers: {
+      host: 'mattrobenolt.com',
+    },
+    cookies: { test: 'test' },
+    body: '',
+    user: {
+      id: 123,
+      username: 'tobias',
+      email: 'tobias@mail.com',
+      custom_property: 'foo',
+    },
+  };
+
+  describe('parseRequest.user properties', () => {
+    const DEFAULT_USER_KEYS = ['id', 'username', 'email'];
+    const CUSTOM_USER_KEYS = ['custom_property'];
+
+    test('parseRequest.user only contains the default properties from the user', done => {
+      const fakeEvent: Event = {};
+      const parsedRequest: Event = parseRequest(fakeEvent, mockReq);
+      const userKeys = Object.keys(parsedRequest.user);
+
+      expect(userKeys).toEqual(DEFAULT_USER_KEYS);
+      expect(userKeys).not.toEqual(expect.arrayContaining(CUSTOM_USER_KEYS));
+      done();
+    });
+
+    test('parseRequest.user only contains the custom properties specified in the options.user array', done => {
+      const options = {
+        user: CUSTOM_USER_KEYS,
+      };
+      const fakeEvent: Event = {};
+      const parsedRequest: Event = parseRequest(fakeEvent, mockReq, options);
+      const userKeys = Object.keys(parsedRequest.user);
+
+      expect(userKeys).toEqual(CUSTOM_USER_KEYS);
+      expect(userKeys).not.toEqual(expect.arrayContaining(DEFAULT_USER_KEYS));
+      done();
+    });
+  });
+
+  describe('parseRequest.request properties', () => {
+    test('parseRequest.request only contains the default set of properties from the request', done => {
+      const DEFAULT_REQUEST_PROPERTIES = ['cookies', 'data', 'headers', 'method', 'query_string', 'url'];
+      const fakeEvent: Event = {};
+      const parsedRequest: Event = parseRequest(fakeEvent, mockReq, {});
+      expect(Object.keys(parsedRequest.request)).toEqual(DEFAULT_REQUEST_PROPERTIES);
+      done();
+    });
+
+    test('parseRequest.request only contains the specified properties in the options.request array', done => {
+      const EXCLUDED_PROPERTIES = ['cookies', 'method'];
+      const INCLUDED_PROPERTIES = ['data', 'headers', 'query_string', 'url'];
+      const options = {
+        request: INCLUDED_PROPERTIES,
+      };
+      const fakeEvent: Event = {};
+      const parsedRequest: Event = parseRequest(fakeEvent, mockReq, options);
+      const requestKeys = Object.keys(parsedRequest.request);
+
+      expect(requestKeys).toEqual(INCLUDED_PROPERTIES);
+      expect(requestKeys).not.toEqual(expect.arrayContaining(EXCLUDED_PROPERTIES));
+      done();
+    });
+  });
+});


### PR DESCRIPTION
We are using the `requestHandler` in our express application but we don't want cookies to be added to all of our errors as some cookies contain personal data.
We have used the settings in the Sentry UI to set `cookies` as a sensitive field and we also have a `beforeSend` block that deletes cookies from the error event. 
Neither of these have prevented the cookies being added to our errors.

This PR allows users to configure if they want cookies to be added to the request data. It feels like a reasonable configuration option to provide given the likelihood of cookies containing some personal data.

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
