### PR TITLE
Add support for custom URL schemes to tracekit

### DIFF
--- a/packages/browser/src/tracekit.ts
+++ b/packages/browser/src/tracekit.ts
@@ -477,7 +477,7 @@ TraceKit._computeStackTrace = (function _computeStackTraceWrapper() {
     }
 
     // Chromium based browsers: Chrome, Brave, new Opera, new Edge
-    var chrome = /^\s*at (?:(.*?) ?\()?((?:file|https?|blob|chrome-extension|native|eval|webpack|<anonymous>|[a-z]:|\/).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i,
+    var chrome = /^\s*at (?:(.*?) ?\()?((?:file|https?|blob|chrome-extension|native|eval|webpack|<anonymous>|[a-z]:|[-a-z]+(?=:)|\/).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i,
       // gecko regex: `(?:bundle|\d+\.js)`: `bundle` is for react native, `\d+\.js` also but specifically for ram bundles because it
       // generates filenames without a prefix like `file://` the filenames in the stacktrace are just 42.js
       // We need this specific case for now because we want no other regex to match.

--- a/packages/browser/test/unit/tracekit/original.test.ts
+++ b/packages/browser/test/unit/tracekit/original.test.ts
@@ -38,6 +38,7 @@ import {
   SAFARI_7,
   SAFARI_8,
   SAFARI_8_EVAL,
+  CHROMIUM_EMBEDDED_FRAMEWORK_CUSTOM_SCHEME
 } from './originalfixtures';
 
 describe('Tracekit - Original Tests', () => {
@@ -1244,4 +1245,18 @@ describe('Tracekit - Original Tests', () => {
       context: null,
     });
   });
+
+  it('should parse Chromium Embedded Framework errors with custom schemes', () => {
+    const stackFrames = _computeStackTrace(CHROMIUM_EMBEDDED_FRAMEWORK_CUSTOM_SCHEME);
+    expect(stackFrames).to.be.ok;
+    expect(stackFrames.stack.length).to.equal(1);
+    expect(stackFrames.stack[0]).to.deep.equal({
+      url: 'examplescheme://examplehost/cd351f7250857e22ceaa.worker.js',
+      func: '?',
+      args: [],
+      line: 70179,
+      column: 15,
+      context: null,
+    });
+  })
 });

--- a/packages/browser/test/unit/tracekit/originalfixtures.ts
+++ b/packages/browser/test/unit/tracekit/originalfixtures.ts
@@ -482,3 +482,11 @@ export const ANDROID_REACT_NATIVE_PROD = {
     'value@index.android.bundle:29:927\n' +
     '[native code]',
 };
+
+export const CHROMIUM_EMBEDDED_FRAMEWORK_CUSTOM_SCHEME = {
+  message: 'message string',
+  name: 'Error',
+  stack:
+    'Error: message string\n' +
+    '    at examplescheme://examplehost/cd351f7250857e22ceaa.worker.js:70179:15'
+};


### PR DESCRIPTION
Chromium Embedded Frameworks supports having custom schemes to load
content. This would cause tracekit to not match those stacktraces, as
the scheme was not in the fixed list that is searched for.

To prevent mismatches, the clause for "any scheme" looks ahead to ensure
that it is followed by a colon.

I suspect this will also help with https://github.com/getsentry/sentry/issues/11019