### PR TITLE
ref: Better UnhandledRejection messages

### DIFF
--- a/packages/browser/src/tracekit.ts
+++ b/packages/browser/src/tracekit.ts
@@ -1,6 +1,6 @@
 // tslint:disable
 
-import { getGlobalObject, isError, isErrorEvent, normalize } from '@sentry/utils';
+import { getGlobalObject, isError, isErrorEvent } from '@sentry/utils';
 
 /**
  * @hidden
@@ -29,6 +29,7 @@ export interface StackTrace {
   stack: StackFrame[];
   useragent: string;
   original?: string;
+  incomplete?: boolean;
 }
 
 interface ComputeStackTrace {
@@ -271,12 +272,9 @@ TraceKit._report = (function reportModuleWrapper() {
    * @see https://developer.mozilla.org/en-US/docs/Web/API/PromiseRejectionEvent
    */
   function _traceKitWindowOnUnhandledRejection(e: any) {
-    var err = (e && (e.detail ? e.detail.reason : e.reason)) || e;
+    var err = e && typeof e.reason !== 'undefined' ? e.reason : e;
     var stack = TraceKit._computeStackTrace(err);
     stack.mechanism = 'onunhandledrejection';
-    if (!stack.message) {
-      stack.message = JSON.stringify(normalize(err));
-    }
     _notifyHandlers(stack, true, err);
   }
 

--- a/packages/browser/test/integration/suites/builtins.js
+++ b/packages/browser/test/integration/suites/builtins.js
@@ -80,7 +80,10 @@ describe("wrapped built-ins", function() {
     }).then(function(summary) {
       if (summary.window.isChrome()) {
         // non-error rejections doesnt provide stacktraces so we can skip the assertion
-        assert.equal(summary.events[0].exception.values[0].value, '"test"');
+        assert.equal(
+          summary.events[0].exception.values[0].value,
+          "Non-Error promise rejection captured with value: test"
+        );
         assert.equal(
           summary.events[0].exception.values[0].type,
           "UnhandledRejection"
@@ -92,6 +95,10 @@ describe("wrapped built-ins", function() {
         assert.equal(
           summary.events[0].exception.values[0].mechanism.type,
           "onunhandledrejection"
+        );
+        assert.equal(
+          summary.events[0].exception.values[0].mechanism.data.incomplete,
+          true
         );
       }
     });
@@ -108,6 +115,10 @@ describe("wrapped built-ins", function() {
       if (summary.window.isChrome()) {
         // non-error rejections doesnt provide stacktraces so we can skip the assertion
         assert.equal(summary.events[0].exception.values[0].value.length, 253);
+        assert.include(
+          summary.events[0].exception.values[0].value,
+          "Non-Error promise rejection captured with value: "
+        );
         assert.equal(
           summary.events[0].exception.values[0].type,
           "UnhandledRejection"
@@ -119,6 +130,10 @@ describe("wrapped built-ins", function() {
         assert.equal(
           summary.events[0].exception.values[0].mechanism.type,
           "onunhandledrejection"
+        );
+        assert.equal(
+          summary.events[0].exception.values[0].mechanism.data.incomplete,
+          true
         );
       }
     });
@@ -127,14 +142,17 @@ describe("wrapped built-ins", function() {
   it("should capture unhandledrejection with an object", function() {
     return runInSandbox(sandbox, function() {
       if (isChrome()) {
-        Promise.reject({ a: "b" });
+        Promise.reject({ a: "b", b: "c", c: "d" });
       } else {
         window.resolveTest({ window: window });
       }
     }).then(function(summary) {
       if (summary.window.isChrome()) {
         // non-error rejections doesnt provide stacktraces so we can skip the assertion
-        assert.equal(summary.events[0].exception.values[0].value, '{"a":"b"}');
+        assert.equal(
+          summary.events[0].exception.values[0].value,
+          "Non-Error promise rejection captured with keys: a, b, c"
+        );
         assert.equal(
           summary.events[0].exception.values[0].type,
           "UnhandledRejection"
@@ -146,6 +164,10 @@ describe("wrapped built-ins", function() {
         assert.equal(
           summary.events[0].exception.values[0].mechanism.type,
           "onunhandledrejection"
+        );
+        assert.equal(
+          summary.events[0].exception.values[0].mechanism.data.incomplete,
+          true
         );
       }
     });
@@ -168,7 +190,10 @@ describe("wrapped built-ins", function() {
     }).then(function(summary) {
       if (summary.window.isChrome()) {
         // non-error rejections doesnt provide stacktraces so we can skip the assertion
-        assert.equal(summary.events[0].exception.values[0].value.length, 253);
+        assert.equal(
+          summary.events[0].exception.values[0].value,
+          "Non-Error promise rejection captured with keys: a, b, c, d, e"
+        );
         assert.equal(
           summary.events[0].exception.values[0].type,
           "UnhandledRejection"
@@ -180,6 +205,10 @@ describe("wrapped built-ins", function() {
         assert.equal(
           summary.events[0].exception.values[0].mechanism.type,
           "onunhandledrejection"
+        );
+        assert.equal(
+          summary.events[0].exception.values[0].mechanism.data.incomplete,
+          true
         );
       }
     });

--- a/packages/types/src/mechanism.ts
+++ b/packages/types/src/mechanism.ts
@@ -3,7 +3,7 @@ export interface Mechanism {
   type: string;
   handled: boolean;
   data?: {
-    [key: string]: string;
+    [key: string]: string | boolean;
   };
   synthetic?: boolean;
 }


### PR DESCRIPTION
Unfortunately, SyntheticExceptions are no-go, as promises just don't provide stack traces, even when Error objects manually create after the fact. It'll capture Tracekit global handler only, not original calls.

This change will most likely cause some events to re-appear with better messages for some of the clients.

---

Setup:

<img width="369" alt="Screenshot 2019-07-31 at 13 24 32" src="https://user-images.githubusercontent.com/1523305/62208864-5260fe80-b398-11e9-8e6d-6c068e3d86f6.png">

---

Before:

<img width="803" alt="Screenshot 2019-07-31 at 13 33 31" src="https://user-images.githubusercontent.com/1523305/62208912-699fec00-b398-11e9-8efb-71dd2faa3bc7.png">
<img width="806" alt="Screenshot 2019-07-31 at 13 33 39" src="https://user-images.githubusercontent.com/1523305/62208917-6b69af80-b398-11e9-8025-150cbf0d39a6.png">

---

After:

<img width="532" alt="Screenshot 2019-07-31 at 13 35 46" src="https://user-images.githubusercontent.com/1523305/62208924-6efd3680-b398-11e9-97d1-7dd5c15d1cb8.png">
<img width="497" alt="Screenshot 2019-07-31 at 13 35 52" src="https://user-images.githubusercontent.com/1523305/62208933-7290bd80-b398-11e9-96eb-65f854a73caa.png">

---

It'd be nice to be able to show users some info regarding using `Error` objects for rejections, but I'm almost certain we shouldn't do this in the SDK. We already have all the data we need to do this in the UI (`mechanism.type` and `mechanism.data.incomplete`). Not sure about this change yet though, we can iterate.