### PR TITLE
Apply crossorigin attribute with setAttribute tag

### DIFF
--- a/packages/browser/src/loader.js
+++ b/packages/browser/src/loader.js
@@ -61,7 +61,7 @@
     var _currentScriptTag = _document.getElementsByTagName(_script)[0];
     var _newScriptTag = _document.createElement(_script);
     _newScriptTag.src = _sdkBundleUrl;
-    _newScriptTag.crossorigin = 'anonymous';
+    _newScriptTag.setAttribute('crossorigin', 'anonymous');
 
     // Once our SDK is loaded
     _newScriptTag.addEventListener('load', function() {


### PR DESCRIPTION
The crossorigin attribute is not being applied to the script tag when the assignment `_newScriptTag.crossorigin = 'anonymous'` but using `setAttribute()` applies the attribute correctly.
