### PR TITLE
Fix raven.js so that `setTagsContext` doesn't fail on react-native if you call it after intialization

### DIFF
--- a/packages/raven-js/src/raven.js
+++ b/packages/raven-js/src/raven.js
@@ -2277,6 +2277,10 @@ Raven.prototype = {
     if (isUndefined(context)) {
       delete this._globalContext[key];
     } else {
+      // if the destination object is frozen, clone it first.
+      if (this._globalContext[key] && objectFrozen(this._globalContext[key])) {
+        this._globalContext[key] = objectMerge({}, this._globalContext)
+      }
       this._globalContext[key] = objectMerge(this._globalContext[key] || {}, context);
     }
   }


### PR DESCRIPTION
Newer versions of react-native will call `Object.freeze` on objects that get sent
over the bridge to native, so that you don't mutate them by mistake.
raven-js's context objects are sent over the bridge by react-native-sentry.

This adds a check for frozen-ness, cloning the context object first if needed.

Test Plan:
In a react-native app, call `Sentry.setTagsContext` in response to a user action. You should not see an error about mutating a frozen object.