### PR TITLE
fix: Dont capture our own XHR events that somehow bubbled-up to global handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- This slot is waiting for you
+- [browser] fix: Don't capture our own XHR events that somehow bubbled-up to global handler
 
 ## 5.6.2
 

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -56,7 +56,8 @@ export class GlobalHandlers implements Integration {
     Error.stackTraceLimit = 50;
 
     _subscribe((stack: TraceKitStackTrace, _: boolean, error: any) => {
-      if (shouldIgnoreOnError()) {
+      const isFailedOwnDelivery = error && error.__sentry_own_request__ === true;
+      if (shouldIgnoreOnError() || isFailedOwnDelivery) {
         return;
       }
       const self = getCurrentHub().getIntegration(GlobalHandlers);

--- a/packages/browser/test/integration/suites/builtins.js
+++ b/packages/browser/test/integration/suites/builtins.js
@@ -304,6 +304,26 @@ describe("wrapped built-ins", function() {
         }
       });
     });
+
+    it("should skip our own failed requests that somehow bubbled-up to unhandledrejection handler", function() {
+      return runInSandbox(sandbox, function() {
+        if (isChrome()) {
+          Promise.reject({
+            __sentry_own_request__: true,
+          });
+          Promise.reject({
+            __sentry_own_request__: false,
+          });
+          Promise.reject({});
+        } else {
+          window.resolveTest({ window: window });
+        }
+      }).then(function(summary) {
+        if (summary.window.isChrome()) {
+          assert.equal(summary.events.length, 2);
+        }
+      });
+    });
   });
 
   it("should capture exceptions inside setTimeout", function() {


### PR DESCRIPTION
It can only happen with some odd combination of `Promise` and `Fetch` polyfills not playing nice together. We do have a code that should guard us against failed deliveries: https://github.com/getsentry/sentry-javascript/blob/master/packages/core/src/basebackend.ts#L95-L99 but apparently some polyfill break promise chain somewhere and it goes up to global error handler.