### PR TITLE
ref: Deprecate top-level stacktrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- [browser] fix: Don't capture our own XHR events that somehow bubbled-up to global handler
+- [browser] fix: Don't capture our own XHR events that somehow bubbled-up to global handler (#2221)
+- [core] ref: Deprecate top-level stacktrace event attribute (#2214)
 
 ## 5.6.2
 

--- a/packages/browser/src/backend.ts
+++ b/packages/browser/src/backend.ts
@@ -151,9 +151,13 @@ export class BrowserBackend extends BaseBackend<BrowserOptions> {
     if (this._options.attachStacktrace && hint && hint.syntheticException) {
       const stacktrace = _computeStackTrace(hint.syntheticException);
       const frames = prepareFramesForEvent(stacktrace.stack);
-      event.stacktrace = {
-        frames,
-      };
+      event.threads = [
+        {
+          stacktrace: {
+            frames,
+          },
+        },
+      ];
     }
 
     return SyncPromise.resolve(event);

--- a/packages/browser/src/parsers.ts
+++ b/packages/browser/src/parsers.ts
@@ -45,9 +45,13 @@ export function eventFromPlainObject(exception: {}, syntheticException: Error | 
   if (syntheticException) {
     const stacktrace = _computeStackTrace(syntheticException);
     const frames = prepareFramesForEvent(stacktrace.stack);
-    event.stacktrace = {
-      frames,
-    };
+    event.threads = [
+      {
+        stacktrace: {
+          frames,
+        },
+      },
+    ];
   }
 
   return event;

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -161,6 +161,7 @@ export class InboundFilters implements Integration {
   /** JSDoc */
   private _getEventFilterUrl(event: Event): string | null {
     try {
+      // tslint:disable-next-line:deprecation
       if (event.stacktrace) {
         // tslint:disable:no-unsafe-any
         const frames = (event as any).stacktrace.frames;
@@ -169,6 +170,11 @@ export class InboundFilters implements Integration {
       if (event.exception) {
         // tslint:disable:no-unsafe-any
         const frames = (event as any).exception.values[0].stacktrace.frames;
+        return frames[frames.length - 1].filename;
+      }
+      if (event.threads) {
+        // tslint:disable:no-unsafe-any
+        const frames = (event as any).threads[0].stacktrace.frames;
         return frames[frames.length - 1].filename;
       }
       return null;

--- a/packages/integrations/src/dedupe.ts
+++ b/packages/integrations/src/dedupe.ts
@@ -1,5 +1,7 @@
 import { Event, EventProcessor, Exception, Hub, Integration, StackFrame } from '@sentry/types';
 
+import { getFramesFromEvent } from './helpers';
+
 /** Deduplication filter */
 export class Dedupe implements Integration {
   /**
@@ -87,26 +89,9 @@ export class Dedupe implements Integration {
   }
 
   /** JSDoc */
-  private _getFramesFromEvent(event: Event): StackFrame[] | undefined {
-    const exception = event.exception;
-
-    if (exception) {
-      try {
-        // @ts-ignore
-        return exception.values[0].stacktrace.frames;
-      } catch (_oO) {
-        return undefined;
-      }
-    } else if (event.stacktrace) {
-      return event.stacktrace.frames;
-    }
-    return undefined;
-  }
-
-  /** JSDoc */
   private _isSameStacktrace(currentEvent: Event, previousEvent: Event): boolean {
-    let currentFrames = this._getFramesFromEvent(currentEvent);
-    let previousFrames = this._getFramesFromEvent(previousEvent);
+    let currentFrames = getFramesFromEvent(currentEvent);
+    let previousFrames = getFramesFromEvent(previousEvent);
 
     // If no event has a fingerprint, they are assumed to be the same
     if (!currentFrames && !previousFrames) {

--- a/packages/integrations/src/helpers.ts
+++ b/packages/integrations/src/helpers.ts
@@ -1,0 +1,27 @@
+import { Event, StackFrame } from '@sentry/types';
+
+/**
+ * Extract frames from the Event, independent of it's shape
+ */
+export function getFramesFromEvent(event: Event): StackFrame[] | undefined {
+  if (event.exception) {
+    try {
+      // @ts-ignore
+      return event.exception.values[0].stacktrace.frames;
+    } catch (_oO) {
+      return undefined;
+    }
+    // tslint:disable:deprecation
+  } else if (event.stacktrace) {
+    return event.stacktrace.frames;
+    // tslint:enable:deprecation
+  } else if (event.threads) {
+    try {
+      // @ts-ignore
+      return event.threads[0].stacktrace.frames;
+    } catch (_oO) {
+      return undefined;
+    }
+  }
+  return undefined;
+}

--- a/packages/integrations/src/rewriteframes.ts
+++ b/packages/integrations/src/rewriteframes.ts
@@ -1,6 +1,8 @@
 import { Event, EventProcessor, Hub, Integration, StackFrame } from '@sentry/types';
 import { basename, relative } from '@sentry/utils';
 
+import { getFramesFromEvent } from './helpers';
+
 type StackFrameIteratee = (frame: StackFrame) => StackFrame;
 
 /** Rewrite event frames paths */
@@ -58,30 +60,11 @@ export class RewriteFrames implements Integration {
 
   /** JSDoc */
   public process(event: Event): Event {
-    const frames = this._getFramesFromEvent(event);
-    if (frames) {
-      for (const i in frames) {
-        // tslint:disable-next-line
-        frames[i] = this._iteratee(frames[i]);
-      }
+    const frames = getFramesFromEvent(event) || [];
+    for (const i in frames) {
+      // tslint:disable-next-line
+      frames[i] = this._iteratee(frames[i]);
     }
     return event;
-  }
-
-  /** JSDoc */
-  private _getFramesFromEvent(event: Event): StackFrame[] | undefined {
-    const exception = event.exception;
-
-    if (exception) {
-      try {
-        // tslint:disable-next-line:no-unsafe-any
-        return (exception as any).values[0].stacktrace.frames;
-      } catch (_oO) {
-        return undefined;
-      }
-    } else if (event.stacktrace) {
-      return event.stacktrace.frames;
-    }
-    return undefined;
   }
 }

--- a/packages/integrations/src/transaction.ts
+++ b/packages/integrations/src/transaction.ts
@@ -1,5 +1,7 @@
 import { Event, EventProcessor, Hub, Integration, StackFrame } from '@sentry/types';
 
+import { getFramesFromEvent } from './helpers';
+
 /** Add node transaction to the event */
 export class Transaction implements Integration {
   /**
@@ -28,7 +30,7 @@ export class Transaction implements Integration {
    * @inheritDoc
    */
   public process(event: Event): Event {
-    const frames = this._getFramesFromEvent(event);
+    const frames = getFramesFromEvent(event) || [];
 
     // use for loop so we don't have to reverse whole frames array
     for (let i = frames.length - 1; i >= 0; i--) {
@@ -41,12 +43,6 @@ export class Transaction implements Integration {
     }
 
     return event;
-  }
-
-  /** JSDoc */
-  private _getFramesFromEvent(event: Event): StackFrame[] {
-    const exception = event.exception && event.exception.values && event.exception.values[0];
-    return (exception && exception.stacktrace && exception.stacktrace.frames) || [];
   }
 
   /** JSDoc */

--- a/packages/integrations/test/helpers.test.ts
+++ b/packages/integrations/test/helpers.test.ts
@@ -1,0 +1,100 @@
+import { getFramesFromEvent } from '../src/helpers';
+
+describe('getFramesFromEvent', () => {
+  it('event.exception.values[0].stacktrace.frames', () => {
+    const frames = getFramesFromEvent({
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  filename: '/www/src/app/file1.js',
+                },
+                {
+                  filename: '/www/src/app/file2.js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+    expect(frames).toEqual([
+      {
+        filename: '/www/src/app/file1.js',
+      },
+      {
+        filename: '/www/src/app/file2.js',
+      },
+    ]);
+  });
+
+  it('event.stacktrace.frames', () => {
+    const frames = getFramesFromEvent({
+      stacktrace: {
+        frames: [
+          {
+            filename: '/www/src/app/file1.js',
+          },
+          {
+            filename: '/www/src/app/file2.js',
+          },
+        ],
+      },
+    });
+    expect(frames).toEqual([
+      {
+        filename: '/www/src/app/file1.js',
+      },
+      {
+        filename: '/www/src/app/file2.js',
+      },
+    ]);
+  });
+
+  it('event.threads[0].stacktrace.frames', () => {
+    const frames = getFramesFromEvent({
+      threads: [
+        {
+          stacktrace: {
+            frames: [
+              {
+                filename: '/www/src/app/file1.js',
+              },
+              {
+                filename: '/www/src/app/file2.js',
+              },
+            ],
+          },
+        },
+      ],
+    });
+    expect(frames).toEqual([
+      {
+        filename: '/www/src/app/file1.js',
+      },
+      {
+        filename: '/www/src/app/file2.js',
+      },
+    ]);
+  });
+
+  it('no frames', () => {
+    const frames = getFramesFromEvent({});
+    expect(frames).toEqual(undefined);
+  });
+
+  it('broken frames', () => {
+    const exceptionNoFrames = getFramesFromEvent({
+      exception: {
+        values: [],
+      },
+    });
+    const threadsNoFrames = getFramesFromEvent({
+      threads: [],
+    });
+    expect(exceptionNoFrames).toEqual(undefined);
+    expect(threadsNoFrames).toEqual(undefined);
+  });
+});

--- a/packages/node/src/backend.ts
+++ b/packages/node/src/backend.ts
@@ -130,9 +130,13 @@ export class NodeBackend extends BaseBackend<NodeOptions> {
       if (this._options.attachStacktrace && hint && hint.syntheticException) {
         const stack = hint.syntheticException ? extractStackFromError(hint.syntheticException) : [];
         parseStack(stack, this._options).then(frames => {
-          event.stacktrace = {
-            frames: prepareFramesForEvent(frames),
-          };
+          event.threads = [
+            {
+              stacktrace: {
+                frames: prepareFramesForEvent(frames),
+              },
+            },
+          ];
           resolve(event);
         });
       } else {

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -4,6 +4,7 @@ import { Request } from './request';
 import { SdkInfo } from './sdkinfo';
 import { Severity } from './severity';
 import { Stacktrace } from './stacktrace';
+import { Thread } from './thread';
 import { User } from './user';
 
 /** JSDoc */
@@ -26,6 +27,10 @@ export interface Event {
   exception?: {
     values?: Exception[];
   };
+  /**
+   * @deprecated Top-level `stacktrace` attribute has been deprecated. Use event.threads.0.stacktrace instead.
+   * See https://docs.sentry.io/development/sdk-dev/event-payloads/stacktrace/ for more informations.
+   */
   stacktrace?: Stacktrace;
   breadcrumbs?: Breadcrumb[];
   contexts?: { [key: string]: object };
@@ -33,6 +38,7 @@ export interface Event {
   extra?: { [key: string]: any };
   user?: User;
   type?: EventType;
+  threads?: Thread[];
 }
 
 /** JSDoc */


### PR DESCRIPTION
Reverted for now, as it's breaking change.

TBD: Fix one remaining integration test before merging.