### PR TITLE
add "enableInExpoDevelopment" type definition

### DIFF
--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -110,4 +110,10 @@ export interface Options {
    * @returns The breadcrumb that will be added | null.
    */
   beforeBreadcrumb?(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): Breadcrumb | null;
+
+  /**
+   * Enable debug functionality in Expo(ReactNative) environment.
+   * Defaults to false.
+   */
+  enableInExpoDevelopment?: boolean;
 }


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-javascript/issues/2235

## What
Added `enableInExpoDevelopment` type definition.

## Why
In Expo(ReactNative) documents, it indicates we can use `enableInExpoDevelopment` props like below.
```
Sentry.init({
  dsn: 'DSN',
  enableInExpoDevelopment: true,
  debug: true
});
```

And it actually works with `"sentry-expo": "^2.0.0"`.

So we should add type definition of `enableInExpoDevelopment`.

## Refs
https://docs.expo.io/versions/latest/guides/using-sentry/