### PR TITLE
fix: Capture only failed console.assert calls

### DIFF
--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -98,13 +98,17 @@ export class Breadcrumbs implements Integration {
             if (args[0] === false) {
               breadcrumbData.message = `Assertion failed: ${safeJoin(args.slice(1), ' ') || 'console.assert'}`;
               breadcrumbData.data.extra.arguments = normalize(args.slice(1), 3);
+              Breadcrumbs.addBreadcrumb(breadcrumbData, {
+                input: args,
+                level,
+              });
             }
+          } else {
+            Breadcrumbs.addBreadcrumb(breadcrumbData, {
+              input: args,
+              level,
+            });
           }
-
-          Breadcrumbs.addBreadcrumb(breadcrumbData, {
-            input: args,
-            level,
-          });
 
           // this fails for some browsers. :(
           if (originalConsoleLevel) {

--- a/packages/browser/test/integration/subjects/console-logs.js
+++ b/packages/browser/test/integration/subjects/console-logs.js
@@ -1,6 +1,12 @@
 console.log("One");
 console.warn("Two", { a: 1 });
 console.error("Error 2", { b: { c: [] } });
+
+// Passed assertions _should not_ be captured
+console.assert(1 + 1 === 2, "math works");
+// Failed assertions _should_ be captured
+console.assert(1 + 1 === 3, "math broke");
+
 function a() {
   throw new Error("Error thrown 3");
 }

--- a/packages/browser/test/integration/suites/breadcrumbs.js
+++ b/packages/browser/test/integration/suites/breadcrumbs.js
@@ -712,7 +712,7 @@ describe("breadcrumbs", function() {
     }
   );
 
-  it("should add breadcrumbs on thrown errors", function() {
+  it("should capture console breadcrumbs", function() {
     return runInSandbox(sandbox, { manual: true }, function() {
       window.allowConsoleBreadcrumbs = true;
       var logs = document.createElement("script");
@@ -726,8 +726,15 @@ describe("breadcrumbs", function() {
         // The async loader doesn't capture breadcrumbs, but we should receive the event without them
         assert.lengthOf(summary.events, 1);
       } else {
-        assert.ok(summary.breadcrumbs);
-        assert.lengthOf(summary.breadcrumbs, 3);
+        if ("assert" in console) {
+          assert.lengthOf(summary.breadcrumbs, 4);
+          assert.deepEqual(summary.breadcrumbs[3].data.extra.arguments, [
+            "math broke",
+          ]);
+        } else {
+          assert.lengthOf(summary.breadcrumbs, 3);
+        }
+
         assert.deepEqual(summary.breadcrumbs[0].data.extra.arguments, ["One"]);
         assert.deepEqual(summary.breadcrumbs[1].data.extra.arguments, [
           "Two",


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/2211

We have this implemented correctly in `CaptureConsole` integration :<
https://github.com/getsentry/sentry-javascript/blob/ec571ffbc64edf77203e9c69fb057735d0a6a3c6/packages/integrations/src/captureconsole.ts#L58-L66