### PR TITLE
feat: Extract prototyped data in `extractUserData`

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -143,7 +143,7 @@ function extractUserData(req: { [key: string]: any }, keys: boolean | string[]):
   const attributes = Array.isArray(keys) ? keys : DEFAULT_USER_KEYS;
 
   attributes.forEach(key => {
-    if (key in req.user)) {
+    if (key in req.user) {
       user[key] = (req.user as { [key: string]: string })[key];
     }
   });

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -143,7 +143,7 @@ function extractUserData(req: { [key: string]: any }, keys: boolean | string[]):
   const attributes = Array.isArray(keys) ? keys : DEFAULT_USER_KEYS;
 
   attributes.forEach(key => {
-    if ({}.hasOwnProperty.call(req.user, key)) {
+    if (key in req.user)) {
       user[key] = (req.user as { [key: string]: string })[key];
     }
   });


### PR DESCRIPTION
I have a slightly unusual express server setup in which the client provides their user ID in the `req.user` field, then a middleware replaces this with the corresponding user entry from a database, thus populating `req.user.email` and `req.user.id`. Unfortunately, it turns out that sentry is unable to extract these fields automatically, because they are defined in the prototype of the `req.user` object, and thus are ignored by `hasOwnProperty`. Changing this to a simple `in` operator fixes this issue. I don't see a good reason why `hasOwnProperty` should be preferred to `in` here, as the extracted fields are configurable anyways.