### PR TITLE
ref: Remove process.env.NODE_ENV from Vue integration

### DIFF
--- a/packages/integrations/src/vue.ts
+++ b/packages/integrations/src/vue.ts
@@ -111,9 +111,7 @@ export class Vue implements Integration {
       }
 
       if (this._logErrors) {
-        if (process && process.env && process.env.NODE_ENV !== 'production') {
-          this._Vue.util.warn(`Error in ${info}: "${error.toString()}"`, vm);
-        }
+        this._Vue.util.warn(`Error in ${info}: "${error.toString()}"`, vm);
         // tslint:disable-next-line:no-console
         console.error(error);
       }


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/2250

We can do this because `_logErrors` already allows for behavior modification _and_ CDN version of Vue doesn't contain this line and which makes it impossible to trigger the log.