### PR TITLE
chore: replace several instances of any

### DIFF
--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -1,5 +1,5 @@
 import { captureException, getCurrentHub, withScope } from '@sentry/core';
-import { Event as SentryEvent, Mechanism, WrappedFunction } from '@sentry/types';
+import { Event as SentryEvent, Mechanism, Scope, WrappedFunction } from '@sentry/types';
 import { addExceptionMechanism, addExceptionTypeValue, htmlTreeAsString, normalize } from '@sentry/utils';
 
 const debounceDuration: number = 1000;
@@ -40,7 +40,7 @@ export function wrap(
     capture?: boolean;
   } = {},
   before?: WrappedFunction,
-): any {
+): Function {
   // tslint:disable-next-line:strict-type-predicates
   if (typeof fn !== 'function') {
     return fn;
@@ -92,7 +92,7 @@ export function wrap(
     } catch (ex) {
       ignoreNextOnError();
 
-      withScope(scope => {
+      withScope((scope: Scope) => {
         scope.addEventProcessor((event: SentryEvent) => {
           const processedEvent = { ...event };
 

--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -40,7 +40,7 @@ export function wrap(
     capture?: boolean;
   } = {},
   before?: WrappedFunction,
-): Function {
+): any {
   // tslint:disable-next-line:strict-type-predicates
   if (typeof fn !== 'function') {
     return fn;

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -466,7 +466,7 @@ export class Breadcrumbs implements Integration {
           });
 
           if ('onreadystatechange' in xhr && typeof xhr.onreadystatechange === 'function') {
-            fill(xhr, 'onreadystatechange', function(original: () => void): void {
+            fill(xhr, 'onreadystatechange', function(original: () => void): Function {
               return wrap(
                 original,
                 {

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -163,6 +163,5 @@ export function close(timeout?: number): Promise<boolean> {
  * @returns The result of wrapped function call.
  */
 export function wrap(fn: Function): any {
-  // tslint:disable-next-line: no-unsafe-any
   return internalWrap(fn)();
 }

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -359,7 +359,8 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
             }
 
             const beforeSendResult = beforeSend(prepared, hint);
-            if ((typeof beforeSendResult as any) === 'undefined') {
+            // tslint:disable-next-line:strict-type-predicates
+            if (typeof beforeSendResult === 'undefined') {
               logger.error('`beforeSend` method has to return `null` or a valid event.');
             } else if (isThenable(beforeSendResult)) {
               this._handleAsyncBeforeSend(beforeSendResult as Promise<Event | null>, resolve, reject);

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -87,8 +87,7 @@ export class InboundFilters implements Integration {
     }
 
     try {
-      // tslint:disable-next-line:no-unsafe-any
-      return (event as any).exception.values[0].type === 'SentryError';
+      return event && event.exception && event.exception.values && event.exception.values[0] && event.exception.values[0].type === 'SentryError' || false;
     } catch (_oO) {
       return false;
     }
@@ -147,8 +146,7 @@ export class InboundFilters implements Integration {
     }
     if (event.exception) {
       try {
-        // tslint:disable-next-line:no-unsafe-any
-        const { type, value } = (event as any).exception.values[0];
+        const { type, value } = event.exception.values && event.exception.values[0] || {};
         return [`${value}`, `${type}: ${value}`];
       } catch (oO) {
         logger.error(`Cannot extract message for event ${getEventDescription(event)}`);
@@ -162,14 +160,12 @@ export class InboundFilters implements Integration {
   private _getEventFilterUrl(event: Event): string | null {
     try {
       if (event.stacktrace) {
-        // tslint:disable:no-unsafe-any
-        const frames = (event as any).stacktrace.frames;
-        return frames[frames.length - 1].filename;
+        const { frames } = event.stacktrace;
+        return frames && frames[frames.length - 1].filename || null;
       }
       if (event.exception) {
-        // tslint:disable:no-unsafe-any
-        const frames = (event as any).exception.values[0].stacktrace.frames;
-        return frames[frames.length - 1].filename;
+        const { frames } = event.exception.values && event.exception.values[0].stacktrace || {};
+        return frames && frames[frames.length - 1].filename || null;
       }
       return null;
     } catch (oO) {

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -146,7 +146,7 @@ export class InboundFilters implements Integration {
     }
     if (event.exception) {
       try {
-        const { type, value } = event.exception.values && event.exception.values[0] || {};
+        const { type = '', value = '' } = event.exception.values && event.exception.values[0] || {};
         return [`${value}`, `${type}: ${value}`];
       } catch (oO) {
         logger.error(`Cannot extract message for event ${getEventDescription(event)}`);
@@ -160,11 +160,11 @@ export class InboundFilters implements Integration {
   private _getEventFilterUrl(event: Event): string | null {
     try {
       if (event.stacktrace) {
-        const { frames } = event.stacktrace;
+        const frames = event.stacktrace.frames;
         return frames && frames[frames.length - 1].filename || null;
       }
       if (event.exception) {
-        const { frames } = event.exception.values && event.exception.values[0].stacktrace || {};
+        const frames = event.exception.values && event.exception.values[0].stacktrace && event.exception.values[0].stacktrace.frames;
         return frames && frames[frames.length - 1].filename || null;
       }
       return null;

--- a/packages/integrations/src/rewriteframes.ts
+++ b/packages/integrations/src/rewriteframes.ts
@@ -74,8 +74,7 @@ export class RewriteFrames implements Integration {
 
     if (exception) {
       try {
-        // tslint:disable-next-line:no-unsafe-any
-        return (exception as any).values[0].stacktrace.frames;
+        return exception.values && exception.values[0].stacktrace && exception.values[0].stacktrace.frames;
       } catch (_oO) {
         return undefined;
       }


### PR DESCRIPTION
- Rpeplace any in several places with the actual types
- Improve checks of event / exception to prevent TypeErrors (this was needed to be able to rewrite `(event as any)` to just `event`)

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
