### PR TITLE
Extra integration: filter fingerprint property

### DIFF
--- a/packages/integrations/src/extraerrordata.ts
+++ b/packages/integrations/src/extraerrordata.ts
@@ -78,7 +78,17 @@ export class ExtraErrorData implements Integration {
     let result = null;
     // We are trying to enhance already existing event, so no harm done if it won't succeed
     try {
-      const nativeKeys = ['name', 'message', 'stack', 'line', 'column', 'fileName', 'lineNumber', 'columnNumber'];
+      const nativeKeys = [
+        'name',
+        'message',
+        'stack',
+        'line',
+        'column',
+        'fileName',
+        'lineNumber',
+        'columnNumber',
+        'fingerprint',
+      ];
       const errorKeys = Object.getOwnPropertyNames(error).filter(key => nativeKeys.indexOf(key) === -1);
 
       if (errorKeys.length) {


### PR DESCRIPTION
Sentry handles [custom fingerprinting](https://docs.sentry.io/data-management/event-grouping/sdk-fingerprinting/) by adding a `fingerprint` property to the error/event object. I think we might don't want to keep this info into the extra event context so we can add it to the native key filter list here.
With this in the extra context, we could think "Oh we have that info too, but we don't need it, let's remove it" and we break the custom fingerprint grouping system. Since this property is used by Sentry itself, this context is not a good place for it IMHO.
What do you think?