### PR TITLE
ref: Remove dom references from utils for old TS and env interop

### DIFF
--- a/packages/utils/src/is.ts
+++ b/packages/utils/src/is.ts
@@ -1,5 +1,3 @@
-/// <reference lib="dom" />
-
 /**
  * Checks whether given value's type is one of a few Error or Error-like
  * {@link isError}.
@@ -93,7 +91,7 @@ export function isPlainObject(wat: any): boolean {
  * @param wat A value to be checked.
  * @returns A boolean representing the result.
  */
-export function isEvent(wat: any): wat is Event {
+export function isEvent(wat: any): boolean {
   // tslint:disable-next-line:strict-type-predicates
   return typeof Event !== 'undefined' && wat instanceof Event;
 }
@@ -105,7 +103,7 @@ export function isEvent(wat: any): wat is Event {
  * @param wat A value to be checked.
  * @returns A boolean representing the result.
  */
-export function isElement(wat: any): wat is Element {
+export function isElement(wat: any): boolean {
   // tslint:disable-next-line:strict-type-predicates
   return typeof Element !== 'undefined' && wat instanceof Element;
 }

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -99,37 +99,49 @@ function getWalkSource(
   }
 
   if (isEvent(value)) {
+    /**
+     * Event-like interface that's usable in browser and node
+     */
+    interface SimpleEvent {
+      [key: string]: unknown;
+      type: string;
+      target?: unknown;
+      currentTarget?: unknown;
+    }
+
+    const event = value as SimpleEvent;
+
     const source: {
       [key: string]: any;
     } = {};
 
-    source.type = value.type;
+    source.type = event.type;
 
     // Accessing event.target can throw (see getsentry/raven-js#838, #768)
     try {
-      source.target = isElement(value.target)
-        ? htmlTreeAsString(value.target)
-        : Object.prototype.toString.call(value.target);
+      source.target = isElement(event.target)
+        ? htmlTreeAsString(event.target)
+        : Object.prototype.toString.call(event.target);
     } catch (_oO) {
       source.target = '<unknown>';
     }
 
     try {
-      source.currentTarget = isElement(value.currentTarget)
-        ? htmlTreeAsString(value.currentTarget)
-        : Object.prototype.toString.call(value.currentTarget);
+      source.currentTarget = isElement(event.currentTarget)
+        ? htmlTreeAsString(event.currentTarget)
+        : Object.prototype.toString.call(event.currentTarget);
     } catch (_oO) {
       source.currentTarget = '<unknown>';
     }
 
     // tslint:disable-next-line:strict-type-predicates
     if (typeof CustomEvent !== 'undefined' && value instanceof CustomEvent) {
-      source.detail = value.detail;
+      source.detail = event.detail;
     }
 
-    for (const i in value) {
-      if (Object.prototype.hasOwnProperty.call(value, i)) {
-        source[i] = (value as { [key: string]: any })[i];
+    for (const i in event) {
+      if (Object.prototype.hasOwnProperty.call(event, i)) {
+        source[i] = event;
       }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-javascript/issues/2280
Fixes: https://github.com/getsentry/sentry-javascript/issues/2287