### PR TITLE
fix(utils/object): fix normalizing error from null

### DIFF
--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -211,7 +211,7 @@ function serializeValue(value: any): any {
  */
 // tslint:disable-next-line:cyclomatic-complexity
 function normalizeValue<T>(value: T, key?: any): T | string {
-  if (key === 'domain' && typeof value === 'object' && ((value as unknown) as { _events: any })._events) {
+  if (key === 'domain' && value && typeof value === 'object' && ((value as unknown) as { _events: any })._events) {
     return '[Domain]';
   }
 


### PR DESCRIPTION
Fix sentry captured extra serialization

```js
require('@sentry/utils/dist/object').normalize({ domain: null })
```

got `**non-serializable**`，because of `Cannot read property '_events' of null`