### PR TITLE
Support Windows-style path in RewriteFrame's default iteratee

### DIFF
--- a/packages/integrations/src/rewriteframes.ts
+++ b/packages/integrations/src/rewriteframes.ts
@@ -24,8 +24,12 @@ export class RewriteFrames implements Integration {
    * @inheritDoc
    */
   private readonly _iteratee: StackFrameIteratee = (frame: StackFrame) => {
-    if (frame.filename && frame.filename.startsWith('/')) {
-      const base = this._root ? relative(this._root, frame.filename) : basename(frame.filename);
+    // Check if the frame filename begins with `/` or a Windows-style prefix such as `C:\\`
+    if (frame.filename && /^(\/|[A-Z]:\\)/.test(frame.filename)) {
+      const filename = frame.filename
+        .replace(/^[A-Z]:/, '') // remove Windows-style prefix
+        .replace(/\\/g, '/'); // replace all `\\` instances with `/`
+      const base = this._root ? relative(this._root, filename) : basename(filename);
       frame.filename = `app:///${base}`;
     }
     return frame;

--- a/packages/integrations/test/rewriteframes.test.ts
+++ b/packages/integrations/test/rewriteframes.test.ts
@@ -5,6 +5,7 @@ import { RewriteFrames } from '../src/rewriteframes';
 let rewriteFrames: RewriteFrames;
 let messageEvent: Event;
 let exceptionEvent: Event;
+let windowsExceptionEvent: Event;
 
 describe('RewriteFrames', () => {
   beforeEach(() => {
@@ -38,6 +39,24 @@ describe('RewriteFrames', () => {
         ],
       },
     };
+    windowsExceptionEvent = {
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  filename: 'C:\\www\\src\\app\\file1.js',
+                },
+                {
+                  filename: 'C:\\www\\src\\app\\file2.js',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
   });
 
   describe('default iteratee appends basename to `app:///` if frame starts with `/`', () => {
@@ -58,6 +77,18 @@ describe('RewriteFrames', () => {
     });
   });
 
+  describe('default iteratee appends basename to `app:///` if frame starts with `C:\\`', () => {
+    beforeEach(() => {
+      rewriteFrames = new RewriteFrames();
+    });
+
+    it('trasforms windowsExceptionEvent frames', () => {
+      const event = rewriteFrames.process(windowsExceptionEvent);
+      expect(event.exception!.values![0].stacktrace!.frames![0].filename).toEqual('app:///file1.js');
+      expect(event.exception!.values![0].stacktrace!.frames![1].filename).toEqual('app:///file2.js');
+    });
+  });
+
   describe('can use custom root to perform `relative` on filepaths', () => {
     beforeEach(() => {
       rewriteFrames = new RewriteFrames({
@@ -73,6 +104,12 @@ describe('RewriteFrames', () => {
 
     it('transforms exceptionEvent frames', () => {
       const event = rewriteFrames.process(exceptionEvent);
+      expect(event.exception!.values![0].stacktrace!.frames![0].filename).toEqual('app:///src/app/file1.js');
+      expect(event.exception!.values![0].stacktrace!.frames![1].filename).toEqual('app:///src/app/file2.js');
+    });
+
+    it('trasforms windowsExceptionEvent frames', () => {
+      const event = rewriteFrames.process(windowsExceptionEvent);
       expect(event.exception!.values![0].stacktrace!.frames![0].filename).toEqual('app:///src/app/file1.js');
       expect(event.exception!.values![0].stacktrace!.frames![1].filename).toEqual('app:///src/app/file2.js');
     });


### PR DESCRIPTION
The previous default iteratee does not work in Windows because it only detects paths that begin with `/`. This change ensures paths that begin with `C:\\` are also accounted for.