### PR TITLE
fix: Bump minimal craft version

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,4 @@
-minVersion: '0.8.2'
+minVersion: '0.8.4'
 github:
   owner: getsentry
   repo: sentry-javascript


### PR DESCRIPTION
There was a bug in craft pre-0.8.4 that messed with GCS upload parameters.