### PR TITLE
Optimize supportsNativeFetch() with a fast path that avoids DOM I/O

### DIFF
--- a/packages/utils/src/supports.ts
+++ b/packages/utils/src/supports.ts
@@ -179,4 +179,3 @@ export function supportsHistory(): boolean {
 
   return !isChromePackagedApp && hasHistoryApi;
 }
-3


### PR DESCRIPTION
This fixes https://github.com/getsentry/sentry-javascript/issues/2324 by adding a fast path for the scenario where the browser supports `fetch` and `window.fetch` hasn't been wrapped or polyfilled (which should be very common on modern browsers)

This avoids expensive DOM I/O in the critical path during the initial load.

Fallbacking to the expensive iframe check, if necessary.

## Note

The new `isNativeFetch()` check is also more robust than the previous implementation, which could yield false positives (since it only checked if the function's body contained `native`).