### PR TITLE
Limit breadcrumb object depth

### DIFF
--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -262,8 +262,8 @@ export class Scope implements ScopeInterface {
 
     this._breadcrumbs =
       maxBreadcrumbs !== undefined && maxBreadcrumbs >= 0
-        ? [...this._breadcrumbs, normalize(mergedBreadcrumb)].slice(-maxBreadcrumbs)
-        : [...this._breadcrumbs, normalize(mergedBreadcrumb)];
+        ? [...this._breadcrumbs, normalize(mergedBreadcrumb, 3)].slice(-maxBreadcrumbs)
+        : [...this._breadcrumbs, normalize(mergedBreadcrumb, 3)];
     this._notifyScopeListeners();
     return this;
   }

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -431,4 +431,16 @@ describe('Scope', () => {
     expect(listener).toHaveBeenCalled();
     expect(listener.mock.calls[0][0]._extra).toEqual({ a: 2 });
   });
+
+  test('addBreadcrumb limit data depth', () => {
+    expect.assertions(2);
+    const scope = new Scope();
+
+    const deepObject = { a: { b: { c: { d: { e: 'f' } } } } };
+
+    scope.addBreadcrumb({ message: 'test', data: deepObject });
+    const breadcrumb = (scope as any)._breadcrumbs[0];
+    expect(breadcrumb).toHaveProperty('message', 'test');
+    expect(breadcrumb).toHaveProperty('data', { a: { b: '[Object]' } });
+  });
 });


### PR DESCRIPTION
Our use case: We send a breadcrumb each time there's a log message (we have our own logger). These messages usually look like `logger.info('msg', {some: 'data'})`. The logger then also invokes `Sentry.addBreadcrumb({message: 'msg', data: {some: 'data'}, ...})`. This has been working fine until we accidentally logged out a RxJS (v4) Observable object.

Basically:
```
# x is DistinctUntilChangedObservable {source: MapObservable, keyFn: undefined, comparer: ƒ}
Sentry.addBreadcrumb({message: 'msg', data: x})
```

I'm not sure why, but the object circular reference check using `memo` in Sentry doesn't work in this case. This caused `walk()` function to go to infinite loop which basically ended up with the browser freezing.

I wasn't able to figure out why the circular reference check did not work for this object. However, limiting the breadcrumb data depth also helped. I don't think the depth should be unlimited here anyway but I might be missing some details why it's set to infinity.


Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
