### PR TITLE
Require https-proxy-agent only when actually needed

### DIFF
--- a/packages/node/src/transports/http.ts
+++ b/packages/node/src/transports/http.ts
@@ -1,7 +1,6 @@
 import { Event, Response, TransportOptions } from '@sentry/types';
 import { SentryError } from '@sentry/utils';
 import * as http from 'http';
-import * as HttpsProxyAgent from 'https-proxy-agent';
 
 import { BaseTransport } from './base';
 
@@ -12,10 +11,12 @@ export class HTTPTransport extends BaseTransport {
     super(options);
     this.module = http;
     const proxy = options.httpProxy || process.env.http_proxy;
-    this.client = proxy
-      ? // tslint:disable-next-line:no-unsafe-any
-        (new HttpsProxyAgent(proxy) as http.Agent)
-      : new http.Agent({ keepAlive: false, maxSockets: 30, timeout: 2000 });
+    if(proxy){
+      const HttpsProxyAgent = require('https-proxy-agent');
+      this.client = (new HttpsProxyAgent(proxy) as http.Agent);
+    } else {
+      this.client = new http.Agent({ keepAlive: false, maxSockets: 30, timeout: 2000 });
+    }
   }
 
   /**

--- a/packages/node/src/transports/https.ts
+++ b/packages/node/src/transports/https.ts
@@ -1,7 +1,6 @@
 import { Event, Response, TransportOptions } from '@sentry/types';
 import { SentryError } from '@sentry/utils';
 import * as https from 'https';
-import * as HttpsProxyAgent from 'https-proxy-agent';
 
 import { BaseTransport } from './base';
 
@@ -12,10 +11,12 @@ export class HTTPSTransport extends BaseTransport {
     super(options);
     this.module = https;
     const proxy = options.httpsProxy || options.httpProxy || process.env.https_proxy || process.env.http_proxy;
-    this.client = proxy
-      ? // tslint:disable-next-line:no-unsafe-any
-        (new HttpsProxyAgent(proxy) as https.Agent)
-      : new https.Agent({ keepAlive: false, maxSockets: 30, timeout: 2000 });
+    if(proxy){
+      const HttpsProxyAgent = require('https-proxy-agent');
+      this.client = (new HttpsProxyAgent(proxy) as https.Agent);
+    } else {
+      this.client = new http.Agent({ keepAlive: false, maxSockets: 30, timeout: 2000 });
+    }
   }
 
   /**

--- a/packages/node/src/transports/https.ts
+++ b/packages/node/src/transports/https.ts
@@ -15,7 +15,7 @@ export class HTTPSTransport extends BaseTransport {
       const HttpsProxyAgent = require('https-proxy-agent');
       this.client = (new HttpsProxyAgent(proxy) as https.Agent);
     } else {
-      this.client = new http.Agent({ keepAlive: false, maxSockets: 30, timeout: 2000 });
+      this.client = new https.Agent({ keepAlive: false, maxSockets: 30, timeout: 2000 });
     }
   }
 


### PR DESCRIPTION
`https-proxy-agent` patches core Node methods in `https` for whatever reason, and that breaks unrelated code. In our app we don't use proxy, and the mere fact that `sentry-javascript` requires the proxy package, it breaks other code.

See TooTallNate/node-agent-base#35 and sindresorhus/got#951