### PR TITLE
fix: Always trigger default browser onerror handler

### DIFF
--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -92,7 +92,7 @@ export class GlobalHandlers implements Integration {
         if (self._oldOnErrorHandler) {
           return self._oldOnErrorHandler.apply(this, arguments);
         }
-        return true;
+        return false;
       }
 
       const client = currentHub.getClient();
@@ -121,7 +121,7 @@ export class GlobalHandlers implements Integration {
         return self._oldOnErrorHandler.apply(this, arguments);
       }
 
-      return true;
+      return false;
     };
 
     this._onErrorHandlerInstalled = true;


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/1600
Fixes https://github.com/getsentry/sentry-javascript/issues/2336

"Because browsers..."

https://html.spec.whatwg.org/multipage/webappapis.html#the-event-handler-processing-algorithm

> If special error event handling is true
> If return value is true, then set event's canceled flag.
> 
> Otherwise
> If return value is false, then set event's canceled flag.

but

> There are two exceptions in the platform, for historical reasons:
> The onerror handlers on global objects, where returning true cancels the event