### PR TITLE
fix: Dont require transaction to be on the scope to be delivered correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-Coming soon...
+- [apm] fix: Always attach `contexts.trace` to finished transaction (#2353)
 
 ## 5.10.2
 

--- a/packages/apm/src/span.ts
+++ b/packages/apm/src/span.ts
@@ -287,6 +287,9 @@ export class Span implements SpanInterface, SpanContext {
     }
 
     return this._hub.captureEvent({
+      contexts: {
+        trace: this.getTraceContext(),
+      },
       spans: finishedSpans,
       start_timestamp: this.startTimestamp,
       tags: this.tags,

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -327,10 +327,6 @@ export class Scope implements ScopeInterface {
     if (this._transaction) {
       event.transaction = this._transaction;
     }
-    if (this._span) {
-      event.contexts = event.contexts || {};
-      event.contexts.trace = this._span.getTraceContext();
-    }
 
     this._applyFingerprint(event);
 


### PR DESCRIPTION
Without this, every transaction has to be attached to the scope in order for this block to be called:

https://github.com/getsentry/sentry-javascript/blob/ef7b3b2dd02af063138f7453f8c7d92e033365b8/packages/hub/src/scope.ts#L330-L333

Sending manually created transaction would end up with: `Error while sending event: SentryError: HTTP Error (400): invalid transaction event: trace context hard-required for transaction events`