### PR TITLE
fix: Use event_id from hint given by top-level hub calls

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -143,6 +143,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
         logger.error(reason);
         this._processing = false;
       });
+
     return eventId;
   }
 
@@ -284,7 +285,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
     }
 
     if (prepared.event_id === undefined) {
-      prepared.event_id = uuid4();
+      prepared.event_id = hint && hint.event_id ? hint.event_id : uuid4();
     }
 
     this._addIntegrations(prepared.sdk);

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -234,6 +234,17 @@ describe('BaseClient', () => {
       });
     });
 
+    test('adds event_id from hint if available', () => {
+      expect.assertions(1);
+      const client = new TestClient({ dsn: PUBLIC_DSN });
+      const scope = new Scope();
+      client.captureEvent({ message: 'message' }, { event_id: 'wat' }, scope);
+      expect(TestBackend.instance!.event!).toEqual({
+        event_id: 'wat',
+        message: 'message',
+      });
+    });
+
     test('adds the configured environment', () => {
       expect.assertions(1);
       const client = new TestClient({


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/1940