### PR TITLE
feat: Provide normalizeDepth option and sensible default for scope methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Unreleased
 
+- [core] feat: Provide `normalizeDepth` option and sensible default for scope methods (#2404)
+- [browser] fix: Export `EventHint` type (#2407)
+
 ## 5.11.2
 
 - [apm] fix: Add new option to `Tracing` `maxTransactionTimeout` determines the max length of a transaction
 - [hub] ref: Always also set transaction name on the top span in the scope
-- [core] fix: Use event_id from hint given by top-level hub calls
+- [core] fix: Use `event_id` from hint given by top-level hub calls
 
 ## 5.11.1
 

--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -1,6 +1,6 @@
 import { captureException, withScope } from '@sentry/core';
 import { Event as SentryEvent, Mechanism, Scope, WrappedFunction } from '@sentry/types';
-import { addExceptionMechanism, addExceptionTypeValue, normalize } from '@sentry/utils';
+import { addExceptionMechanism, addExceptionTypeValue } from '@sentry/utils';
 
 let ignoreOnError: number = 0;
 
@@ -98,7 +98,7 @@ export function wrap(
 
           processedEvent.extra = {
             ...processedEvent.extra,
-            arguments: normalize(args, 3),
+            arguments: args,
           };
 
           return processedEvent;

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -6,7 +6,6 @@ import {
   getGlobalObject,
   htmlTreeAsString,
   logger,
-  normalize,
   parseUrl,
   safeJoin,
 } from '@sentry/utils';
@@ -75,9 +74,7 @@ export class Breadcrumbs implements Integration {
     const breadcrumb = {
       category: 'console',
       data: {
-        extra: {
-          arguments: normalize(handlerData.args, 3),
-        },
+        arguments: handlerData.args,
         logger: 'console',
       },
       level: Severity.fromString(handlerData.level),
@@ -87,7 +84,7 @@ export class Breadcrumbs implements Integration {
     if (handlerData.level === 'assert') {
       if (handlerData.args[0] === false) {
         breadcrumb.message = `Assertion failed: ${safeJoin(handlerData.args.slice(1), ' ') || 'console.assert'}`;
-        breadcrumb.data.extra.arguments = normalize(handlerData.args.slice(1), 3);
+        breadcrumb.data.arguments = handlerData.args.slice(1);
       } else {
         // Don't capture a breadcrumb for passed assertions
         return;

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -329,6 +329,143 @@ describe('BaseClient', () => {
       });
     });
 
+    test('normalizes event with default depth of 3', () => {
+      expect.assertions(1);
+      const client = new TestClient({ dsn: PUBLIC_DSN });
+      const fourLevelsObject = {
+        a: {
+          b: {
+            c: 'wat',
+            d: {
+              e: 'wat',
+            },
+          },
+        },
+      };
+      const normalizedObject = {
+        a: {
+          b: {
+            c: 'wat',
+            d: '[Object]',
+          },
+        },
+      };
+      const fourLevelBreadcrumb = {
+        data: fourLevelsObject,
+        message: 'wat',
+      };
+      const normalizedBreadcrumb = {
+        data: normalizedObject,
+        message: 'wat',
+      };
+      client.captureEvent({
+        breadcrumbs: [fourLevelBreadcrumb, fourLevelBreadcrumb, fourLevelBreadcrumb],
+        contexts: fourLevelsObject,
+        extra: fourLevelsObject,
+        user: fourLevelsObject,
+      });
+      expect(TestBackend.instance!.event!).toEqual({
+        breadcrumbs: [normalizedBreadcrumb, normalizedBreadcrumb, normalizedBreadcrumb],
+        contexts: normalizedObject,
+        event_id: '42',
+        extra: normalizedObject,
+        user: normalizedObject,
+      });
+    });
+
+    test('normalization respects `normalizeDepth` option', () => {
+      expect.assertions(1);
+      const client = new TestClient({
+        dsn: PUBLIC_DSN,
+        normalizeDepth: 2,
+      });
+      const fourLevelsObject = {
+        a: {
+          b: {
+            c: 'wat',
+            d: {
+              e: 'wat',
+            },
+          },
+        },
+      };
+      const normalizedObject = {
+        a: {
+          b: '[Object]',
+        },
+      };
+      const fourLevelBreadcrumb = {
+        data: fourLevelsObject,
+        message: 'wat',
+      };
+      const normalizedBreadcrumb = {
+        data: normalizedObject,
+        message: 'wat',
+      };
+      client.captureEvent({
+        breadcrumbs: [fourLevelBreadcrumb, fourLevelBreadcrumb, fourLevelBreadcrumb],
+        contexts: fourLevelsObject,
+        extra: fourLevelsObject,
+        user: fourLevelsObject,
+      });
+      expect(TestBackend.instance!.event!).toEqual({
+        breadcrumbs: [normalizedBreadcrumb, normalizedBreadcrumb, normalizedBreadcrumb],
+        contexts: normalizedObject,
+        event_id: '42',
+        extra: normalizedObject,
+        user: normalizedObject,
+      });
+    });
+
+    test('skips normalization when `normalizeDepth: 0`', () => {
+      expect.assertions(1);
+      const client = new TestClient({
+        dsn: PUBLIC_DSN,
+        normalizeDepth: 0,
+      });
+      const fourLevelsObject = {
+        a: {
+          b: {
+            c: 'wat',
+            d: {
+              e: 'wat',
+            },
+          },
+        },
+      };
+      const normalizedObject = {
+        a: {
+          b: {
+            c: 'wat',
+            d: {
+              e: 'wat',
+            },
+          },
+        },
+      };
+      const fourLevelBreadcrumb = {
+        data: fourLevelsObject,
+        message: 'wat',
+      };
+      const normalizedBreadcrumb = {
+        data: normalizedObject,
+        message: 'wat',
+      };
+      client.captureEvent({
+        breadcrumbs: [fourLevelBreadcrumb, fourLevelBreadcrumb, fourLevelBreadcrumb],
+        contexts: fourLevelsObject,
+        extra: fourLevelsObject,
+        user: fourLevelsObject,
+      });
+      expect(TestBackend.instance!.event!).toEqual({
+        breadcrumbs: [normalizedBreadcrumb, normalizedBreadcrumb, normalizedBreadcrumb],
+        contexts: normalizedObject,
+        event_id: '42',
+        extra: normalizedObject,
+        user: normalizedObject,
+      });
+    });
+
     test('calls beforeSend and uses original event without any changes', () => {
       expect.assertions(1);
       const beforeSend = jest.fn(event => event);

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -8,7 +8,7 @@ import {
   Span,
   User,
 } from '@sentry/types';
-import { getGlobalObject, isThenable, normalize, SyncPromise, timestampWithMs } from '@sentry/utils';
+import { getGlobalObject, isThenable, SyncPromise, timestampWithMs } from '@sentry/utils';
 
 /**
  * Holds additional event information. {@link Scope.applyToEvent} will be
@@ -115,7 +115,7 @@ export class Scope implements ScopeInterface {
    * @inheritDoc
    */
   public setUser(user: User | null): this {
-    this._user = normalize(user);
+    this._user = user || {};
     this._notifyScopeListeners();
     return this;
   }
@@ -126,7 +126,7 @@ export class Scope implements ScopeInterface {
   public setTags(tags: { [key: string]: string }): this {
     this._tags = {
       ...this._tags,
-      ...normalize(tags),
+      ...tags,
     };
     this._notifyScopeListeners();
     return this;
@@ -136,7 +136,7 @@ export class Scope implements ScopeInterface {
    * @inheritDoc
    */
   public setTag(key: string, value: string): this {
-    this._tags = { ...this._tags, [key]: normalize(value) };
+    this._tags = { ...this._tags, [key]: value };
     this._notifyScopeListeners();
     return this;
   }
@@ -144,10 +144,10 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public setExtras(extra: { [key: string]: any }): this {
+  public setExtras(extras: { [key: string]: any }): this {
     this._extra = {
       ...this._extra,
-      ...normalize(extra),
+      ...extras,
     };
     this._notifyScopeListeners();
     return this;
@@ -157,7 +157,7 @@ export class Scope implements ScopeInterface {
    * @inheritDoc
    */
   public setExtra(key: string, extra: any): this {
-    this._extra = { ...this._extra, [key]: normalize(extra) };
+    this._extra = { ...this._extra, [key]: extra };
     this._notifyScopeListeners();
     return this;
   }
@@ -166,7 +166,7 @@ export class Scope implements ScopeInterface {
    * @inheritDoc
    */
   public setFingerprint(fingerprint: string[]): this {
-    this._fingerprint = normalize(fingerprint);
+    this._fingerprint = fingerprint;
     this._notifyScopeListeners();
     return this;
   }
@@ -175,7 +175,7 @@ export class Scope implements ScopeInterface {
    * @inheritDoc
    */
   public setLevel(level: Severity): this {
-    this._level = normalize(level);
+    this._level = level;
     this._notifyScopeListeners();
     return this;
   }
@@ -195,8 +195,8 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public setContext(name: string, context: { [key: string]: any } | null): this {
-    this._context[name] = context ? normalize(context) : undefined;
+  public setContext(key: string, context: { [key: string]: any } | null): this {
+    this._context = { ...this._context, [key]: context };
     this._notifyScopeListeners();
     return this;
   }
@@ -260,13 +260,15 @@ export class Scope implements ScopeInterface {
    * @inheritDoc
    */
   public addBreadcrumb(breadcrumb: Breadcrumb, maxBreadcrumbs?: number): this {
-    const timestamp = timestampWithMs();
-    const mergedBreadcrumb = { timestamp, ...breadcrumb };
+    const mergedBreadcrumb = {
+      timestamp: timestampWithMs(),
+      ...breadcrumb,
+    };
 
     this._breadcrumbs =
       maxBreadcrumbs !== undefined && maxBreadcrumbs >= 0
-        ? [...this._breadcrumbs, normalize(mergedBreadcrumb)].slice(-maxBreadcrumbs)
-        : [...this._breadcrumbs, normalize(mergedBreadcrumb)];
+        ? [...this._breadcrumbs, mergedBreadcrumb].slice(-maxBreadcrumbs)
+        : [...this._breadcrumbs, mergedBreadcrumb];
     this._notifyScopeListeners();
     return this;
   }

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -35,7 +35,7 @@ describe('Scope', () => {
       const scope = new Scope();
       scope.setExtra('a', 1);
       scope.setExtras({ a: undefined });
-      expect((scope as any)._extra).toEqual({ a: '[undefined]' });
+      expect((scope as any)._extra).toEqual({ a: undefined });
     });
   });
 
@@ -63,7 +63,7 @@ describe('Scope', () => {
       const scope = new Scope();
       scope.setUser({ id: '1' });
       scope.setUser(null);
-      expect((scope as any)._user).toEqual(null);
+      expect((scope as any)._user).toEqual({});
     });
   });
 

--- a/packages/integrations/src/captureconsole.ts
+++ b/packages/integrations/src/captureconsole.ts
@@ -1,5 +1,5 @@
 import { EventProcessor, Hub, Integration, Severity } from '@sentry/types';
-import { fill, getGlobalObject, normalize, safeJoin } from '@sentry/utils';
+import { fill, getGlobalObject, safeJoin } from '@sentry/utils';
 
 const global = getGlobalObject<Window | NodeJS.Global>();
 
@@ -48,7 +48,7 @@ export class CaptureConsole implements Integration {
         if (hub.getIntegration(CaptureConsole)) {
           hub.withScope(scope => {
             scope.setLevel(Severity.fromString(level));
-            scope.setExtra('arguments', normalize(args, 3));
+            scope.setExtra('arguments', args);
             scope.addEventProcessor(event => {
               event.logger = 'console';
               return event;
@@ -58,7 +58,7 @@ export class CaptureConsole implements Integration {
             if (level === 'assert') {
               if (args[0] === false) {
                 message = `Assertion failed: ${safeJoin(args.slice(1), ' ') || 'console.assert'}`;
-                scope.setExtra('arguments', normalize(args.slice(1), 3));
+                scope.setExtra('arguments', args.slice(1));
                 hub.captureMessage(message);
               }
             } else {

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -88,6 +88,17 @@ export interface Options {
   maxValueLength?: number;
 
   /**
+   * Maximum number of levels that normalization algorithm will traverse in objects and arrays.
+   * Used when normalizing an event before sending, on all of the listed attributes:
+   * - `breadcrumbs.data`
+   * - `user`
+   * - `contexts`
+   * - `extra`
+   * Defaults to `3`. Set to `0` to disable.
+   */
+  normalizeDepth?: number;
+
+  /**
    * A callback invoked during event submission, allowing to optionally modify
    * the event before it is sent to Sentry.
    *


### PR DESCRIPTION
The initial issue wasn't with an incorrect circular algorithm implementation. It was with recursive references with a large payload, that were outgrowing the stack.

The most basic way to crash it:

```js
class C {
  constructor(count) {
    if (count > 1000) return;
    this.tail = new C(count + 1);
  }
  data = Array.from({ length: 1000 }).fill('A'.repeat(1000));
}

Sentry.normalize(new C(0)));
```

The only notable change here is a conflict with `ExtractErrorData` that keeps error details one level deeper than regular "scope data", eg. `contexts.errorName.data`, not `contexts.key` so it's own `depth` option will be effectively ignored when `normalizeDepth` value is smaller.

Similar thing would happen for console breadcrumbs integration, as it keeps the data in `breadcrumb.data.arguments`, but because I only normalize `breadcrumb.data`, it doesn't affect it.

Fixes https://github.com/getsentry/sentry-javascript/issues/2178 
Fixes https://github.com/getsentry/sentry-javascript/issues/2311
Fixes https://github.com/getsentry/sentry-javascript/issues/2359
Fixes https://github.com/getsentry/sentry-javascript/issues/2366
Fixes https://github.com/getsentry/sentry-javascript/issues/2375