### PR TITLE
export event hint type from browser

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -3,6 +3,7 @@ export {
   Request,
   SdkInfo,
   Event,
+  EventHint,
   Exception,
   Response,
   Severity,


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

---

`EventHint` type is missing from the exported types; required to properly declare, for instance, a `beforeSend` callback.