### PR TITLE
fix: Fix for if timestamp of last span is taken for end of transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 5.12.1
+
+- [apm] ref: If `maxTransactionTimeout` = `0` there is no timeout
+- [apm] fix: Make sure that the `maxTransactionTimeout` is always enforced on transaction events
+
 ## 5.12.0
 
 - [core] feat: Provide `normalizeDepth` option and sensible default for scope methods (#2404)

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -67,6 +67,7 @@ interface TracingOptions {
   /**
    * The maximum time a transaction can be before it will be dropped. This is for some edge cases where a browser
    * completely freezes the JS state and picks it up later. So after this timeout, the SDK will not send the event.
+   * If you want to have an unlimited timeout set it to 0.
    * Time is in ms.
    *
    * Default: 600000 = 10min
@@ -203,6 +204,7 @@ export class Tracing implements Integration {
       if (
         event.type === 'transaction' &&
         event.timestamp &&
+        Tracing.options.maxTransactionTimeout !== 0 &&
         timestampWithMs() > event.timestamp + Tracing.options.maxTransactionTimeout
       ) {
         return null;
@@ -300,7 +302,10 @@ export class Tracing implements Integration {
   public static finishIdleTransaction(): void {
     const active = Tracing._activeTransaction as SpanClass;
     if (active) {
-      if (timestampWithMs() > active.startTimestamp + Tracing.options.maxTransactionTimeout) {
+      if (
+        Tracing.options.maxTransactionTimeout !== 0 &&
+        timestampWithMs() > active.startTimestamp + Tracing.options.maxTransactionTimeout
+      ) {
         // If we reached the max timeout of the transaction, we will just not finish it and therefore discard it.
         Tracing._activeTransaction = undefined;
       } else {


### PR DESCRIPTION
This adds an `eventProcessor` to make sure to check on the finished transaction that it wasn't running for too long. 
Also added `0` to bail out of `maxTransactionTimeout`.