### PR TITLE
fix: data is a string => string map?

### DIFF
--- a/packages/types/src/breadcrumb.ts
+++ b/packages/types/src/breadcrumb.ts
@@ -7,7 +7,7 @@ export interface Breadcrumb {
   event_id?: string;
   category?: string;
   message?: string;
-  data?: { [key: string]: any };
+  data?: Record<string, string>;
   timestamp?: number;
 }
 


### PR DESCRIPTION
According to https://docs.sentry.io/enriching-error-data/breadcrumbs/?platform=javascript the data map only allows strings. If it allows more indeed, can we update the docs instead?
