### PR TITLE
ref(docs): Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,22 +7,17 @@
 
 # Contributing
 
-This part of the documentation gives you a basic overview of how to help with the development of our `@sentry/*`
-packages contained in this repo.
+We welcome suggested improvements and bug fixes to the `@sentry/*` family of packages, in the form of pull requests on [`GitHub`](https://github.com/getsentry/sentry-javascript). The guide below will help you get started, but if you have further questions, please feel free to reach out on [Discord](https://discord.gg/Ww9hbqr).
 
-## Community
-
-The public-facing channels for support and development of Sentry SDKs can be found on [Discord](https://discord.gg/Ww9hbqr).
 
 ## Setting up an Environment
 
-To run the test suite and run our code linter, node.js and yarn are required.
+To run the test suite and our code linter, node.js and yarn are required.
 
-[`node`](https://nodejs.org/download) [`yarn`](https://yarnpkg.com/en/docs/install)
+[`node` download](https://nodejs.org/download) 
+[`yarn` download](https://yarnpkg.com/en/docs/install)
 
-Since this is a mono repo containing several packages, we use `lerna` to manage them.
-
-To get started, install all dependencies, bootstrap the workspace and perform initial build, so TypeScript can read all the linked type definitions from a monorepo.
+`sentry-javascript` is a monorepo containing several packages, and we use `lerna` to manage them. To get started, install all dependencies, use `lerna` to bootstrap the workspace, and then perform an initial build, so TypeScript can read all of the linked type definitions.
 
 ```
 $ yarn
@@ -30,31 +25,36 @@ $ yarn lerna bootstrap
 $ yarn build
 ```
 
-With that, the repo is fully setup and you are ready to run all commands.
+With that, the repo is fully set up and you are ready to run all commands.
 
-## Build
+## Building Packages
 
-Since we are using [`TypeScript`](https://www.typescriptlang.org/) you need to transpile the code to JavaScript to be
-able to use it. Every package has a `build` script which takes care of everything. You can also run `build` on every
-package by calling
+Since we are using [`TypeScript`](https://www.typescriptlang.org/), you need to transpile the code to JavaScript to be
+able to use it. Every package has a `build` script which takes care of everything. You can also run `build` on all of the
+packages at once by calling `yarn build` in the project root.
 
-```
-$ yarn build
-```
+## Adding Tests
 
-in the project root.
+**Any nontrivial fixes/features should include tests.** You'll find a `test` folder in each package. 
 
-## Running the Test Suite
+Note that _for the `browser` package only_, if you add a new file to the [integration test suite](https://github.com/getsentry/sentry-javascript/tree/master/packages/browser/test/integration/suites), you also need to add it to [the list in `shell.js`](https://github.com/getsentry/sentry-javascript/blob/b74e199254147fd984e7bb1ea24193aee70afa74/packages/browser/test/integration/suites/shell.js#L25) as well. Adding tests to existing files will work out of the box in all packages.
 
-You can run all test at once by calling `yarn test` in the project root or in individual sub packages. Note that you must run `yarn build` before the test command will work.
+## Running Tests
 
-## Lint
+Running tests works the same way as building - running `yarn test` at the project root will run tests for all packages, and running `yarn test` in a specific package will run tests for that package. There are also commands to run subsets of the tests in each location. Check out the `scripts` entry of the corresponding `package.json` for details.
 
-You can run all test at once by calling `yarn lint` in the project root or in individual sub packages. Note that you must run `yarn build` before the lint command will work.
+Note: you must run `yarn build` before `yarn test` will work.
 
-## Contributing Back Code
+## Linting
 
-Please, send over suggestions and bug fixes in the form of pull requests on
-[`GitHub`](https://github.com/getsentry/sentry-javascript). Any nontrivial fixes/features should include tests. Do not
-bump version numbers yourself. For new features and improvements consider contributing to our new SDKs instead,
-`raven-js` and `raven-node` will still be supported but are in maintenance mode and will only receive bug fixes.
+Similar to building and testing, linting can be done in the project root or in individual packages by calling `yarn lint`.
+
+Note: you must run `yarn build` before `yarn lint` will work.
+
+## Final Notes
+
+When contributing to the codebase, please make note of the following:
+
+- Non-trivial PRs will not be accepted without tests (see above).
+- Please do not bump version numbers yourself. 
+- `raven-js` and `raven-node` are deprecated, and only bug and security fix PRs will be accepted. Any new features and improvements should be to our new SDKs (`browser` and `node`) and the packages (`core`, `hub`, `integrations`, and the like) which support them.


### PR DESCRIPTION
Originally intended as just an additional note about adding test files to `browser`. But once a copyeditor, always a copyeditor... 😬 

Other than the note mentioned above, no content has been changed, but the doc has been heavily wordsmithed and reorganized. Since it's hard to get an overall sense of the end result based on the diff, here's what it would look like after these changes:

![image](https://user-images.githubusercontent.com/14812505/74461976-a7c1b080-4e8f-11ea-89a7-4d58b0df3122.png)

I am very open to feedback here, since I know I got a little over-enthusiastic. 😄 