### PR TITLE
ref: Prevent instantiating unnecessary Date objects

### DIFF
--- a/packages/node/test/transports/http.test.ts
+++ b/packages/node/test/transports/http.test.ts
@@ -98,9 +98,11 @@ describe('HTTPTransport', () => {
     const now = Date.now();
     const mock = jest
       .spyOn(Date, 'now')
+      // Initialize _disabledUntil attribute
+      .mockReturnValueOnce(now)
       // Check for first event
       .mockReturnValueOnce(now)
-      // Setting disableUntil
+      // Setting disabledUntil
       .mockReturnValueOnce(now)
       // Check for second event
       .mockReturnValueOnce(now + (retryAfterSeconds / 2) * 1000)

--- a/packages/node/test/transports/https.test.ts
+++ b/packages/node/test/transports/https.test.ts
@@ -104,9 +104,11 @@ describe('HTTPSTransport', () => {
     const now = Date.now();
     const mock = jest
       .spyOn(Date, 'now')
+      // Initialize _disabledUntil attribute
+      .mockReturnValueOnce(now)
       // Check for first event
       .mockReturnValueOnce(now)
-      // Setting disableUntil
+      // Setting disabledUntil
       .mockReturnValueOnce(now)
       // Check for second event
       .mockReturnValueOnce(now + (retryAfterSeconds / 2) * 1000)

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -350,7 +350,7 @@ function _htmlElementAsString(el: unknown): string {
  * Returns a timestamp in seconds with milliseconds precision.
  */
 export function timestampWithMs(): number {
-  return new Date().getTime() / 1000;
+  return Date.now() / 1000;
 }
 
 // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string


### PR DESCRIPTION
Resources:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now