### PR TITLE
feat(testing): Always run browser check before BrowserStack tests

### DIFF
--- a/packages/browser/scripts/checkbrowsers.js
+++ b/packages/browser/scripts/checkbrowsers.js
@@ -102,7 +102,9 @@ const checkLocalConfigsVsBrowserStack = (localConfigs, bsConfigs) => {
     }
     console.log(
       '\nPlease visit https://api.browserstack.com/5/browsers or https://api.browserstack.com/5/browsers?flat=true to choose new configurations.',
+      "\n\n(If you're sure one of the reported browsers is supported, check to make sure the local config contains all keys (even if they have a null value) and that the values match exactly the ones given by the API.)\n",
     );
+    process.exit(-1);
   } else {
     console.log('\nAll configurations supported!\n');
   }
@@ -119,9 +121,14 @@ const checkLocalConfigsVsBrowserStack = (localConfigs, bsConfigs) => {
 const findUnsupportedConfigs = localConfigs => {
   if (!hasCreds()) {
     console.warn(
-      'Unable to find API credentials in env. Please export them as BROWSERSTACK_USERNAME and BROWSERSTACK_ACCESS_KEY.',
+      'Unable to find API credentials in env. Please export them as BROWSERSTACK_USERNAME and BROWSERSTACK_ACCESS_KEY.\n',
     );
-    return;
+    process.exit(-1);
+  }
+
+  if (!localConfigs) {
+    console.warn('Unable to load local browser configurations.\n');
+    process.exit(-1);
   }
 
   fetchCurrentData(browserstackUsername, browserstackAccessKey)

--- a/packages/browser/test/integration/suites/loader-specific.js
+++ b/packages/browser/test/integration/suites/loader-specific.js
@@ -6,7 +6,7 @@ var loaderVariants = [
 for (var idx in loaderVariants) {
   (function() {
     describe(loaderVariants[idx], function() {
-      this.timeout(5000);
+      this.timeout(60000);
       this.retries(3);
 
       var sandbox;

--- a/packages/browser/test/integration/suites/shell.js
+++ b/packages/browser/test/integration/suites/shell.js
@@ -6,7 +6,7 @@ function runVariant(variant) {
   var IS_SYNC_LOADER = !!variant.match(/^loader-lazy-no$/);
 
   describe(variant, function() {
-    this.timeout(5000);
+    this.timeout(60000);
     this.retries(3);
 
     var sandbox;

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -429,7 +429,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
             originalException: reason as Error,
           });
           reject(
-            `Event processing pipeline threw an error, original event will not be sent. Details has been sent as a new event.\nReason: ${reason}`,
+            `Event processing pipeline threw an error, original event will not be sent. Details have been sent as a new event.\nReason: ${reason}`,
           );
         });
     });

--- a/scripts/browser-integration.sh
+++ b/scripts/browser-integration.sh
@@ -5,6 +5,6 @@ yarn
 # We have to build other packages first, as we use absolute packages import in TypeScript
 yarn build
 cd packages/browser
+yarn test:integration:checkbrowsers
 yarn test:integration
 yarn test:package
-


### PR DESCRIPTION
If we have an out-of-date, no-longer-supported browser in our BrowserStack browser list, integration tests are necessarily going to fail, so let's bail earlier rather than later. Tested locally and on Travis and seems to work in both locations:

![image](https://user-images.githubusercontent.com/14812505/75017202-daba0480-548c-11ea-83a1-cce07e81aa05.png)

![image](https://user-images.githubusercontent.com/14812505/75013750-36808f80-5485-11ea-911f-aac8aa2626cc.png)

This also increases the timeout so that the BS tests should hopefully be less brittle.

Oh, and it fixes a typo. :-)

Haven't discussed this with anyone yet, so open to feedback on whether or not this seems like a good idea.