### PR TITLE
ref: Mark transactions as event.transaction in breadcrumbs

### DIFF
--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -317,7 +317,7 @@ function addSentryBreadcrumb(serializedData: string): void {
     const event = JSON.parse(serializedData);
     getCurrentHub().addBreadcrumb(
       {
-        category: 'sentry',
+        category: `sentry.${event.transaction ? 'transaction' : 'event'}`,
         event_id: event.event_id,
         level: event.level || Severity.fromString('error'),
         message: getEventDescription(event),

--- a/packages/browser/test/integration/common/init.js
+++ b/packages/browser/test/integration/common/init.js
@@ -48,7 +48,7 @@ function initSDK() {
       }
 
       // One of the tests use manually created breadcrumb without eventId and we want to let it through
-      if (breadcrumb.category === "sentry" && breadcrumb.event_id) {
+      if (breadcrumb.category.indexOf("sentry" === 0) && breadcrumb.event_id) {
         return null;
       }
 

--- a/packages/browser/test/integration/suites/breadcrumbs.js
+++ b/packages/browser/test/integration/suites/breadcrumbs.js
@@ -86,7 +86,7 @@ describe("breadcrumbs", function() {
 
   it(
     optional(
-      "should transform XMLHttpRequests to the Sentry store endpoint as sentry type breadcrumb",
+      "should transform XMLHttpRequests with events to the Sentry store endpoint as sentry.event type breadcrumb",
       IS_LOADER
     ),
     function() {
@@ -112,7 +112,44 @@ describe("breadcrumbs", function() {
           return;
         }
         assert.equal(summary.breadcrumbs.length, 1);
-        assert.equal(summary.breadcrumbs[0].category, "sentry");
+        assert.equal(summary.breadcrumbs[0].category, "sentry.event");
+        assert.equal(summary.breadcrumbs[0].level, "warning");
+        assert.equal(summary.breadcrumbs[0].message, "someMessage");
+      });
+    }
+  );
+
+  it(
+    optional(
+      "should transform XMLHttpRequests with transactions to the Sentry store endpoint as sentry.transaction type breadcrumb",
+      IS_LOADER
+    ),
+    function() {
+      return runInSandbox(sandbox, { manual: true }, function() {
+        var store =
+          document.location.protocol +
+          "//" +
+          document.location.hostname +
+          (document.location.port ? ":" + document.location.port : "") +
+          "/api/1/store/" +
+          "?sentry_key=1337";
+
+        var xhr = new XMLHttpRequest();
+        xhr.open("POST", store);
+        xhr.send(
+          '{"message":"someMessage","transaction":"wat","level":"warning"}'
+        );
+        waitForXHR(xhr, function() {
+          Sentry.captureMessage("test");
+          window.finalizeManualTest();
+        });
+      }).then(function(summary) {
+        // The async loader doesn't wrap XHR
+        if (IS_LOADER) {
+          return;
+        }
+        assert.equal(summary.breadcrumbs.length, 1);
+        assert.equal(summary.breadcrumbs[0].category, "sentry.transaction");
         assert.equal(summary.breadcrumbs[0].level, "warning");
         assert.equal(summary.breadcrumbs[0].message, "someMessage");
       });


### PR DESCRIPTION
Necessary UI change: https://github.com/getsentry/sentry/pull/17243