### PR TITLE
ci: Stop testing with Node.js v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,20 @@ stages:
 jobs:
   include:
     - stage: Test
-      name: '@sentry/packages - build + lint + test + codecov + danger [node v8]'
-      node_js: '8'
+      name: '@sentry/packages - build + lint + test + codecov + danger [node v12]'
+      node_js: '12'
       script: scripts/danger.sh
+    - name: '@sentry/packages - build and test [node v8]'
+      node_js: '8'
+      script: scripts/test.sh
     - name: '@sentry/packages - build and test [node v10]'
       node_js: '10'
       script: scripts/test.sh
+    - name: '@sentry/packages - build and test [node v12]'
+      node_js: '12'
+      script: scripts/test.sh
     - name: '@sentry/browser - browserstack integration tests'
-      node_js: '10'
+      node_js: '12'
       script: scripts/browser-integration.sh
     - stage: Deploy
       name: '@sentry/packages - pack and zeus upload'

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,6 @@ jobs:
       name: '@sentry/packages - build + lint + test + codecov + danger [node v8]'
       node_js: '8'
       script: scripts/danger.sh
-    - name: '@sentry/packages - build and test [node v6]'
-      node_js: '6'
-      script: scripts/test.sh
     - name: '@sentry/packages - build and test [node v10]'
       node_js: '10'
       script: scripts/test.sh

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "dist/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION
Node.js v6 is old and lacks features we require to implement new SDK
features.