### PR TITLE
feat: Add autopop parameter, Add debug loggings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [node] ref: Drop Node v6, add Node v12 to test matrix, move all scripts to Node v12 (#2455)
 - [apm] fix: Use monotonic clock to compute durations (#2441)
 - [utils] ref: Prevent instantiating unnecessary Date objects in `timestampWithMs` (#2442)
-- [apm] feat: Add `autoPopAfterMs` parameter to `pushActivity` to prevent never ending spans (#2459)
+- [apm] feat: Add `options.autoPopAfterMs` parameter to `pushActivity` to prevent never ending spans (#2459)
 - [browser] fix: Mark transactions as event.transaction in breadcrumbs correctly
 
 ## 5.12.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [node] ref: Drop Node v6, add Node v12 to test matrix, move all scripts to Node v12 (#2455)
 - [apm] fix: Use monotonic clock to compute durations (#2441)
 - [utils] ref: Prevent instantiating unnecessary Date objects in `timestampWithMs` (#2442)
-- [apm] feat: Add `options.autoPopAfterMs` parameter to `pushActivity` to prevent never ending spans (#2459)
+- [apm] feat: Add `options.autoPopAfter` parameter to `pushActivity` to prevent never ending spans (#2459)
 - [browser] fix: Mark transactions as event.transaction in breadcrumbs correctly
 
 ## 5.12.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - [node] ref: Drop Node v6, add Node v12 to test matrix, move all scripts to Node v12 (#2455)
 - [apm] fix: Use monotonic clock to compute durations (#2441)
 - [utils] ref: Prevent instantiating unnecessary Date objects in `timestampWithMs` (#2442)
+- [apm] feat: Add `autoPopAfterMs` parameter to `pushActivity` to prevent never ending spans (#2459)
+- [browser] fix: Mark transactions as event.transaction in breadcrumbs correctly
 
 ## 5.12.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [node] ref: Drop Node v6, add Node v12 to test matrix, move all scripts to Node v12 (#2455)
 - [apm] fix: Use monotonic clock to compute durations (#2441)
 - [utils] ref: Prevent instantiating unnecessary Date objects in `timestampWithMs` (#2442)
-- [apm] feat: Add `options.autoPopAfter` parameter to `pushActivity` to prevent never ending spans (#2459)
+- [apm] feat: Add `options.autoPopAfter` parameter to `pushActivity` to prevent never-ending spans (#2459)
 - [browser] fix: Mark transactions as event.transaction in breadcrumbs correctly
 
 ## 5.12.5

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -378,7 +378,7 @@ export class Tracing implements Integration {
       setTimeout(() => {
         Tracing.popActivity(index, {
           autopop: true,
-          status: SpanStatus.ResourceExhausted,
+          status: SpanStatus.DeadlineExceeded,
         });
       }, options.autoPopAfter);
     }

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -335,8 +335,12 @@ export class Tracing implements Integration {
 
   /**
    * Starts tracking for a specifc activity
+   *
+   * @param name Name of the activity, can be any string (Only used internally to identify the activity)
+   * @param spanContext If provided a Span with the SpanContext will be created.
+   * @param autoPopAfter Time in ms, if provided the activity will be popped automatically after this timeout. This can be helpful in cases where you cannot gurantee your application knows the state and calls `popActivity` for sure.
    */
-  public static pushActivity(name: string, spanContext?: SpanContext, autoPopAfterMs?: number): number {
+  public static pushActivity(name: string, spanContext?: SpanContext, autoPopAfter?: number): number {
     if (!Tracing._isEnabled()) {
       // Tracing is not enabled
       return 0;
@@ -362,15 +366,15 @@ export class Tracing implements Integration {
 
     logger.log(`[Tracing] pushActivity: ${name}#${Tracing._currentIndex}`);
     logger.log('[Tracing] activies count', Object.keys(Tracing._activities).length);
-    if (autoPopAfterMs) {
-      logger.log(`[Tracing] auto pop of: ${name}#${Tracing._currentIndex} in ${autoPopAfterMs}ms`);
+    if (autoPopAfter) {
+      logger.log(`[Tracing] auto pop of: ${name}#${Tracing._currentIndex} in ${autoPopAfter}ms`);
       const index = Tracing._currentIndex;
       setTimeout(() => {
         Tracing.popActivity(index, {
           autopop: true,
           status: SpanStatus.ResourceExhausted,
         });
-      }, autoPopAfterMs);
+      }, autoPopAfter);
     }
     return Tracing._currentIndex++;
   }

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -3,7 +3,6 @@ import {
   addInstrumentationHandler,
   getGlobalObject,
   isMatchingPattern,
-  isNumber,
   logger,
   supportsNativeFetch,
 } from '@sentry/utils';
@@ -373,7 +372,7 @@ export class Tracing implements Integration {
 
     logger.log(`[Tracing] pushActivity: ${name}#${Tracing._currentIndex}`);
     logger.log('[Tracing] activies count', Object.keys(Tracing._activities).length);
-    if (options && options.autoPopAfter !== undefined && !isNaN(options.autoPopAfter)) {
+    if (options && typeof options.autoPopAfter === 'number') {
       logger.log(`[Tracing] auto pop of: ${name}#${Tracing._currentIndex} in ${options.autoPopAfter}ms`);
       const index = Tracing._currentIndex;
       setTimeout(() => {

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -338,9 +338,15 @@ export class Tracing implements Integration {
    *
    * @param name Name of the activity, can be any string (Only used internally to identify the activity)
    * @param spanContext If provided a Span with the SpanContext will be created.
-   * @param autoPopAfter Time in ms, if provided the activity will be popped automatically after this timeout. This can be helpful in cases where you cannot gurantee your application knows the state and calls `popActivity` for sure.
+   * @param options _autoPopAfter_ | Time in ms, if provided the activity will be popped automatically after this timeout. This can be helpful in cases where you cannot gurantee your application knows the state and calls `popActivity` for sure.
    */
-  public static pushActivity(name: string, spanContext?: SpanContext, autoPopAfter?: number): number {
+  public static pushActivity(
+    name: string,
+    spanContext?: SpanContext,
+    options?: {
+      autoPopAfter?: number;
+    },
+  ): number {
     if (!Tracing._isEnabled()) {
       // Tracing is not enabled
       return 0;
@@ -366,15 +372,15 @@ export class Tracing implements Integration {
 
     logger.log(`[Tracing] pushActivity: ${name}#${Tracing._currentIndex}`);
     logger.log('[Tracing] activies count', Object.keys(Tracing._activities).length);
-    if (autoPopAfter) {
-      logger.log(`[Tracing] auto pop of: ${name}#${Tracing._currentIndex} in ${autoPopAfter}ms`);
+    if (options && options.autoPopAfter) {
+      logger.log(`[Tracing] auto pop of: ${name}#${Tracing._currentIndex} in ${options.autoPopAfter}ms`);
       const index = Tracing._currentIndex;
       setTimeout(() => {
         Tracing.popActivity(index, {
           autopop: true,
           status: SpanStatus.ResourceExhausted,
         });
-      }, autoPopAfter);
+      }, options.autoPopAfter);
     }
     return Tracing._currentIndex++;
   }

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -3,6 +3,7 @@ import {
   addInstrumentationHandler,
   getGlobalObject,
   isMatchingPattern,
+  isNumber,
   logger,
   supportsNativeFetch,
 } from '@sentry/utils';
@@ -372,12 +373,12 @@ export class Tracing implements Integration {
 
     logger.log(`[Tracing] pushActivity: ${name}#${Tracing._currentIndex}`);
     logger.log('[Tracing] activies count', Object.keys(Tracing._activities).length);
-    if (options && options.autoPopAfter) {
+    if (options && options.autoPopAfter !== undefined && !isNaN(options.autoPopAfter)) {
       logger.log(`[Tracing] auto pop of: ${name}#${Tracing._currentIndex} in ${options.autoPopAfter}ms`);
       const index = Tracing._currentIndex;
       setTimeout(() => {
         Tracing.popActivity(index, {
-          autopop: true,
+          autoPop: true,
           status: SpanStatus.DeadlineExceeded,
         });
       }, options.autoPopAfter);

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -317,7 +317,7 @@ function addSentryBreadcrumb(serializedData: string): void {
     const event = JSON.parse(serializedData);
     getCurrentHub().addBreadcrumb(
       {
-        category: `sentry.${event.transaction ? 'transaction' : 'event'}`,
+        category: `sentry.${event.type === 'transaction' ? 'transaction' : 'event'}`,
         event_id: event.event_id,
         level: event.level || Severity.fromString('error'),
         message: getEventDescription(event),


### PR DESCRIPTION
This PR adds a new parameter to `pushActivity` as a fallback to auto finish never finishing spans.

If someone starts an activity (span) and it never finishes, the transaction will never be flushed unless a navigation change happens. By providing the `autoPopAfterMs` parameter in `pushActivity` we have an idle timeout to finish the span regardless.
If this timeout kicks in, we mark the span with `DeadlineExceeded` status so it's clear this is an error in the users application and the span was never finished.

This happens on sentry.io in our React Profiler for measuring rendering times, sometimes it happens that `finishProfile` is never called and therefore we never pop the activity (finish the span).

Debug logging example: 
![image](https://user-images.githubusercontent.com/363802/75524518-59272100-5a0e-11ea-95f2-1d74c843ecf2.png)
