### PR TITLE
fix: Add missing event to EventHint in breadcrumbs integration

### DIFF
--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -122,7 +122,7 @@ export class Breadcrumbs implements Integration {
         message: target,
       },
       {
-        event,
+        event: handlerData.event,
         name: handlerData.name,
       },
     );


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/2464
That's embarrassing :| 