### PR TITLE
feat[apm]: Add discardBackgroundSpans option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+- [apm] feat: Add `discardBackgroundSpans` to discard background spans by default
+
 ## 5.13.1
 
 - [node] fix: Restore engines back to `>= 6`


### PR DESCRIPTION
This PR discards spans/transactions (also does not add the `sentry-trace` header for xhr & fetch) if the tab is/gets moved to the background by using the visibility API https://developers.google.com/web/updates/2017/03/background_tabs#optimising_an_application_for_background

Timing in background is off, but the code comment for the option is explaining why it's there.