### PR TITLE
ref:  Move global error handler+ promise rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+- [browser] ref: Move global error handler + unhandled promise rejection to instrument
+
 ## 5.13.2
 
 - [apm] feat: Add `discardBackgroundSpans` to discard background spans by default

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -211,6 +211,27 @@ export class Tracing implements Integration {
       });
     }
 
+    /**
+     * If an error or unhandled promise occurs, we mark the active transaction as failed
+     */
+    // tslint:disable-next-line: completed-docs
+    function errorCallback(): void {
+      if (Tracing._activeTransaction) {
+        logger.log(`[Tracing] Global error occured, setting status in transaction: ${SpanStatus.InternalError}`);
+        (Tracing._activeTransaction as SpanClass).setStatus(SpanStatus.InternalError);
+      }
+    }
+
+    addInstrumentationHandler({
+      callback: errorCallback,
+      type: 'error',
+    });
+
+    addInstrumentationHandler({
+      callback: errorCallback,
+      type: 'unhandledrejection',
+    });
+
     if (Tracing.options.discardBackgroundSpans && global.document) {
       document.addEventListener('visibilitychange', () => {
         if (document.hidden && Tracing._activeTransaction) {


### PR DESCRIPTION
We need this to mark a transaction as failed if a global unhandled error occurs.

I couldn't move to `addEventListener` since it doesn't work well with the loader.