### PR TITLE
ref: Remove performance clear entry calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-- [apm] ref: Use `onresourcetimingbufferfull` and don't delete measurements
+- [apm] ref: Use `onresourcetimingbufferfull` and don't delete measurements (#2490)
 
 ## 5.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-- [apm] ref: Use `onresourcetimingbufferfull` and don't delete measurements (#2490)
+- [apm] ref: Remove performance clear entry calls (#2490)
 
 ## 5.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+- [apm] ref: Use `onresourcetimingbufferfull` and don't delete measurements
+
 ## 5.14.0
 
 - [apm] feat: Add a simple heartbeat check, if activities don't change in 3 beats, finish the transaction (#2478)

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -189,7 +189,7 @@ export class Tracing implements Integration {
       const oldCallback = performance.onresourcetimingbufferfull;
       performance.onresourcetimingbufferfull = function(_event: unknown): void {
         logger.warn('[Tracing]: Resource Timing Buffer is FULL! Increasing it to 300');
-        performance.setResourceTimingBufferSize(300);
+        performance.setResourceTimingBufferSize(Tracing._performanceCursor * 2);
         if (oldCallback) {
           oldCallback.apply(this, arguments);
         }

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -182,20 +182,6 @@ export class Tracing implements Integration {
   public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
     Tracing._getCurrentHub = getCurrentHub;
 
-    if (global.performance) {
-      // The Performance object has a limited buffer size, often 150 entries. At some point the buffer may overflow, in
-      // which case we would not be able to use it to create/update spans.
-      // https://developer.mozilla.org/en-US/docs/Web/API/Performance
-      const oldCallback = performance.onresourcetimingbufferfull;
-      performance.onresourcetimingbufferfull = function(_event: unknown): void {
-        logger.warn('[Tracing]: Resource Timing Buffer is FULL! Increasing it to 300');
-        performance.setResourceTimingBufferSize(Tracing._performanceCursor * 2);
-        if (oldCallback) {
-          oldCallback.apply(this, arguments);
-        }
-      };
-    }
-
     if (this._emitOptionsWarning) {
       logger.warn(
         '[Tracing] You need to define `tracingOrigins` in the options. Set an array of urls or patterns to trace.',


### PR DESCRIPTION
User code or other libraries may be using the performance entries, therefore we do not clear entries.

Note: there is a limit on the number of "resource timing" entries, we do not change that, leaving it up to the browser default.