### PR TITLE
fix(apm): Use Performance API for timings when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+- [apm] fix: Use Performance API for timings when available, including Web Workers (#2492)
+
 ## 5.14.1
 
 - [apm] fix: Check for performance.timing in webworkers (#2491)

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -378,19 +378,11 @@ export const crossPlatformPerformance: Pick<Performance, 'now' | 'timeOrigin'> =
     // is not as widely supported. Namely, performance.timeOrigin is undefined in Safari as of writing.
     // tslint:disable-next-line:strict-type-predicates
     if (performance.timeOrigin === undefined) {
-      // For webworkers it could mean we don't have performance.timing then we fallback
-      // tslint:disable-next-line:deprecation
-      if (!performance.timing) {
-        return performanceFallback;
-      }
-      // tslint:disable-next-line:deprecation
-      if (!performance.timing.navigationStart) {
-        return performanceFallback;
-      }
-
+      // As of writing, performance.timing is not available in Web Workers in mainstream browsers, so it is not always a
+      // valid fallback. In the absence of a initial time provided by the browser, fallback to INITIAL_TIME.
       // @ts-ignore
       // tslint:disable-next-line:deprecation
-      performance.timeOrigin = performance.timing.navigationStart;
+      performance.timeOrigin = (performance.timing && performance.timing.navigationStart) || INITIAL_TIME;
     }
   }
 


### PR DESCRIPTION
Instead of downgrading to use the dumb performanceFallback, in the
absence of a timeOrigin we can use INITIAL_TIME.

This should give better timings in Safari Web Workers.