### PR TITLE
fix(apm): Set `op` in node http.server transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [apm] fix: Use Performance API for timings when available, including Web Workers (#2492)
 - [apm] fix: Remove Performance references (#2495)
+- [apm] fix: Set `op` in node http.server transaction (#2496)
 
 ## 5.14.1
 

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -34,11 +34,14 @@ export function tracingHandler(): (
 
     const hub = getCurrentHub();
     const transaction = hub.startSpan({
-      transaction: `${reqMethod}|${reqUrl}`,
+      op: 'http.server',
+      transaction: `${reqMethod} ${reqUrl}`,
     });
+
     hub.configureScope(scope => {
       scope.setSpan(transaction);
     });
+
     res.once('finish', () => {
       transaction.setHttpStatus(res.statusCode);
       transaction.finish();


### PR DESCRIPTION
We need to set an `op` otherwise the transaction will be discarded.