### PR TITLE
fix(apm): Sampling of traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-- [apm] fix: Sampling of traces (#2500)
+- [apm] fix: Sampling of traces work now only depending on the client option `tracesSampleRate` (#2500)
+- [apm] fix: Remove internal `makeRoot` parameter from `hub.startSpan` (#2500)
+- [apm] fix: Made constructor of `Span` internal, only use `hub.startSpan` or `Sentry.startSpan` in the future (#2500)
+- [apm] ref: Refactored SpanRecorder to work correctly when recording child spans (#2500)
+- [apm] feat: Now individual transaction can be sent without relying on the Scope (#2500)
 - [apm] ref: Remove status from tags in transaction (#2497)
 - [browser] fix: Respect breadcrumbs sentry:false option (#2499)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+- [apm] fix: Set sampled and op by default (#2500)
+- [apm] ref: Remove status from tags in transaction (#2497)
+- [browser] fix: Respect breadcrumbs sentry:false option (#2499)
+
 ## 5.14.2
 
 - [apm] fix: Use Performance API for timings when available, including Web Workers (#2492)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-- [apm] fix: Set sampled and op by default (#2500)
+- [apm] fix: Sampling of traces (#2500)
 - [apm] ref: Remove status from tags in transaction (#2497)
 - [browser] fix: Respect breadcrumbs sentry:false option (#2499)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,8 @@
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
 - [apm] fix: Sampling of traces work now only depending on the client option `tracesSampleRate` (#2500)
-- [apm] fix: Remove internal `makeRoot` parameter from `hub.startSpan` (#2500)
-- [apm] fix: Made constructor of `Span` internal, only use `hub.startSpan` or `Sentry.startSpan` in the future (#2500)
-- [apm] ref: Refactored SpanRecorder to work correctly when recording child spans (#2500)
-- [apm] feat: Now individual transaction can be sent without relying on the Scope (#2500)
+- [apm] fix: Remove internal `forceNoChild` parameter from `hub.startSpan` (#2500)
+- [apm] fix: Made constructor of `Span` internal, only use `hub.startSpan` (#2500)
 - [apm] ref: Remove status from tags in transaction (#2497)
 - [browser] fix: Respect breadcrumbs sentry:false option (#2499)
 

--- a/packages/apm/src/hubextensions.ts
+++ b/packages/apm/src/hubextensions.ts
@@ -33,7 +33,7 @@ function traceHeaders(): { [key: string]: string } {
  * and attach a `SpanRecorder`. If it's of type `SpanContext` and there is already a `Span` on the Scope,
  * the created Span will have a reference to it and become it's child. Otherwise it'll crete a new `Span`.
  *
- * @param span Already constructed span which should be started or properties with which the span should be created
+ * @param spanOrSpanContext Already constructed span which should be started or properties with which the span should be created
  * @param makeRoot This will just create the span as it is and will not attach it to the span on the scope (if there is one)
  */
 function startSpan(spanOrSpanContext?: Span | SpanContext, makeRoot: boolean = false): Span {

--- a/packages/apm/src/hubextensions.ts
+++ b/packages/apm/src/hubextensions.ts
@@ -64,11 +64,6 @@ function startSpan(spanOrSpanContext?: Span | SpanContext, forceNoChild: boolean
   const experimentsOptions = (client && client.getOptions()._experiments) || {};
   span.initFinishedSpans(experimentsOptions.maxSpans as number);
 
-  // If we do not have an op by now by default we set a name otherwise the server will discard the transaction/span
-  if (span.op === undefined) {
-    span.op = 'op';
-  }
-
   return span;
 }
 

--- a/packages/apm/src/hubextensions.ts
+++ b/packages/apm/src/hubextensions.ts
@@ -60,7 +60,9 @@ function startSpan(spanOrSpanContext?: Span | SpanContext, forceNoChild: boolean
     span.sampled = Math.random() < sampleRate;
   }
 
-  // We always want to record spans independent from the sample rate
+  // We always want to record spans independent from the sample rate.
+  // The Span tree should be built regardless and the top level sample rate shouldn't determine if we create
+  // child spans.
   const experimentsOptions = (client && client.getOptions()._experiments) || {};
   span.initFinishedSpans(experimentsOptions.maxSpans as number);
 

--- a/packages/apm/src/hubextensions.ts
+++ b/packages/apm/src/hubextensions.ts
@@ -34,21 +34,19 @@ function traceHeaders(): { [key: string]: string } {
  * the created Span will have a reference to it and become it's child. Otherwise it'll crete a new `Span`.
  *
  * @param span Already constructed span which should be started or properties with which the span should be created
+ * @param makeRoot This will just create the span as it is and will not attach it to the span on the scope (if there is one)
  */
-function startSpan(spanOrSpanContext?: Span | SpanContext, forceNoChild: boolean = false): Span {
+function startSpan(spanOrSpanContext?: Span | SpanContext, makeRoot: boolean = false): Span {
   // @ts-ignore
   const that = this as Hub;
   const scope = that.getScope();
   const client = that.getClient();
   let span;
 
-  if (!isSpanInstance(spanOrSpanContext) && !forceNoChild) {
+  if (!isSpanInstance(spanOrSpanContext) && !makeRoot) {
     if (scope) {
       const parentSpan = scope.getSpan() as Span;
-      // If we have a span on the scope, it means we want to create a child on this span
-      // but only if there is no timestamp set. This means that this span has already be finished.
-      // And it's not valid that you set another span as a child.
-      if (parentSpan && parentSpan.timestamp === undefined) {
+      if (parentSpan) {
         span = parentSpan.child(spanOrSpanContext);
       }
     }

--- a/packages/apm/src/hubextensions.ts
+++ b/packages/apm/src/hubextensions.ts
@@ -30,7 +30,7 @@ function traceHeaders(): { [key: string]: string } {
 
 /**
  * This functions starts a span. If argument passed is of type `Span`, it'll run sampling on it if configured
- * and attach a `SpanList`. If it's of type `SpanContext` and there is already a `Span` on the Scope,
+ * and attach a `SpanRecorder`. If it's of type `SpanContext` and there is already a `Span` on the Scope,
  * the created Span will have a reference to it and become it's child. Otherwise it'll crete a new `Span`.
  *
  * @param spanOrSpanContext Already constructed span or properties with which the span should be created
@@ -65,7 +65,7 @@ function startSpan(spanOrSpanContext?: Span | SpanContext, makeRoot: boolean = f
   // in case we will discard the span anyway because sampled == false, we safe memory and do not store child spans
   if (span.sampled) {
     const experimentsOptions = (client && client.getOptions()._experiments) || {};
-    span.initSpanList(experimentsOptions.maxSpans as number);
+    span.initSpanRecorder(experimentsOptions.maxSpans as number);
   }
 
   return span;

--- a/packages/apm/src/hubextensions.ts
+++ b/packages/apm/src/hubextensions.ts
@@ -60,9 +60,13 @@ function startSpan(spanOrSpanContext?: Span | SpanContext, forceNoChild: boolean
     span.sampled = Math.random() < sampleRate;
   }
 
-  if (span.sampled) {
-    const experimentsOptions = (client && client.getOptions()._experiments) || {};
-    span.initFinishedSpans(experimentsOptions.maxSpans as number);
+  // We always want to record spans independent from the sample rate
+  const experimentsOptions = (client && client.getOptions()._experiments) || {};
+  span.initFinishedSpans(experimentsOptions.maxSpans as number);
+
+  // If we do not have an op by now by default we set a name otherwise the server will discard the transaction/span
+  if (span.op === undefined) {
+    span.op = 'op';
   }
 
   return span;

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -371,13 +371,10 @@ export class Tracing implements Integration {
       return undefined;
     }
 
-    Tracing._activeTransaction = hub.startSpan(
-      {
-        ...spanContext,
-        transaction: name,
-      },
-      true,
-    );
+    Tracing._activeTransaction = hub.startSpan({
+      ...spanContext,
+      transaction: name,
+    });
 
     // We set the transaction on the scope so if there are any other spans started outside of this integration
     // we also add them to this transaction.

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -407,8 +407,8 @@ export class Tracing implements Integration {
 
     // tslint:disable-next-line: completed-docs
     function addSpan(span: SpanClass): void {
-      if (transactionSpan.spanRecorder) {
-        transactionSpan.spanRecorder.finishSpan(span);
+      if (transactionSpan.spanList) {
+        transactionSpan.spanList.finishSpan(span);
       }
     }
 
@@ -498,8 +498,8 @@ export class Tracing implements Integration {
             const resourceName = entry.name.replace(window.location.origin, '');
             if (entry.initiatorType === 'xmlhttprequest' || entry.initiatorType === 'fetch') {
               // We need to update existing spans with new timing info
-              if (transactionSpan.spanRecorder) {
-                transactionSpan.spanRecorder.finishedSpans.map((finishedSpan: SpanClass) => {
+              if (transactionSpan.spanList) {
+                transactionSpan.spanList.finishedSpans.map((finishedSpan: SpanClass) => {
                   if (finishedSpan.description && finishedSpan.description.indexOf(resourceName) !== -1) {
                     finishedSpan.startTimestamp = timeOrigin + startTime;
                     finishedSpan.timestamp = finishedSpan.startTimestamp + duration;

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -108,7 +108,7 @@ export class Tracing implements Integration {
    */
   private static _getCurrentHub?: () => Hub;
 
-  private static _activeTransaction?: SpanClass;
+  private static _activeTransaction?: Span;
 
   private static _currentIndex: number = 1;
 
@@ -363,13 +363,7 @@ export class Tracing implements Integration {
         transaction: name,
       },
       true,
-    ) as SpanClass;
-
-    // We need to do this workaround here and not use configureScope
-    // Reason being at the time we start the inital transaction we do not have a client bound on the hub yet
-    // therefore configureScope wouldn't be executed and we would miss setting the transaction
-    // tslint:disable-next-line: no-unsafe-any
-    (hub as any).getScope().setSpan(Tracing._activeTransaction);
+    );
 
     // The reason we do this here is because of cached responses
     // If we start and transaction without an activity it would never finish since there is no activity
@@ -634,7 +628,7 @@ export class Tracing implements Integration {
 
     if (activity) {
       logger.log(`[Tracing] popActivity ${activity.name}#${id}`);
-      const span = activity.span as SpanClass;
+      const span = activity.span as Span;
       if (span) {
         if (spanData) {
           Object.keys(spanData).forEach((key: string) => {

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -407,8 +407,8 @@ export class Tracing implements Integration {
 
     // tslint:disable-next-line: completed-docs
     function addSpan(span: SpanClass): void {
-      if (transactionSpan.spanList) {
-        transactionSpan.spanList.finishSpan(span);
+      if (transactionSpan.spanRecorder) {
+        transactionSpan.spanRecorder.finishSpan(span);
       }
     }
 
@@ -498,8 +498,8 @@ export class Tracing implements Integration {
             const resourceName = entry.name.replace(window.location.origin, '');
             if (entry.initiatorType === 'xmlhttprequest' || entry.initiatorType === 'fetch') {
               // We need to update existing spans with new timing info
-              if (transactionSpan.spanList) {
-                transactionSpan.spanList.finishedSpans.map((finishedSpan: SpanClass) => {
+              if (transactionSpan.spanRecorder) {
+                transactionSpan.spanRecorder.finishedSpans.map((finishedSpan: SpanClass) => {
                   if (finishedSpan.description && finishedSpan.description.indexOf(resourceName) !== -1) {
                     finishedSpan.startTimestamp = timeOrigin + startTime;
                     finishedSpan.timestamp = finishedSpan.startTimestamp + duration;

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -59,7 +59,7 @@ interface TracingOptions {
    * @deprecated Use tracesSampleRate in the SDK options
    * Sample to determine if the Integration should instrument anything. The decision will be taken once per load
    * on initalization.
-   * 0 = 0% chance of instrumenting
+   * 0 = 0% change of instrumenting
    * 1 = 100% change of instrumenting
    *
    * Default: 1

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -573,15 +573,15 @@ export class Tracing implements Integration {
       autoPopAfter?: number;
     },
   ): number {
-    if (!Tracing._activeTransaction) {
+    const activeTransaction = Tracing._activeTransaction;
+
+    if (!activeTransaction) {
       logger.log(`[Tracing] Not pushing activity ${name} since there is no active transaction`);
       return 0;
     }
 
     // We want to clear the timeout also here since we push a new activity
     clearTimeout(Tracing._debounce);
-
-    const activeTransaction = Tracing._activeTransaction;
 
     const _getCurrentHub = Tracing._getCurrentHub;
     if (spanContext && _getCurrentHub) {
@@ -628,7 +628,7 @@ export class Tracing implements Integration {
 
     if (activity) {
       logger.log(`[Tracing] popActivity ${activity.name}#${id}`);
-      const span = activity.span as Span;
+      const span = activity.span;
       if (span) {
         if (spanData) {
           Object.keys(spanData).forEach((key: string) => {

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -57,12 +57,7 @@ interface TracingOptions {
 
   /**
    * @deprecated Use tracesSampleRate in the SDK options
-   * Sample to determine if the Integration should instrument anything. The decision will be taken once per load
-   * on initalization.
-   * 0 = 0% change of instrumenting
-   * 1 = 100% change of instrumenting
-   *
-   * Default: 1
+   * This is a noop
    */
   tracesSampleRate?: number;
 

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -402,6 +402,8 @@ export class Tracing implements Integration {
 
     const span = hub.startSpan(
       {
+        op: 'operation',
+        sampled: true,
         ...spanContext,
         transaction: name,
       },

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -56,12 +56,6 @@ interface TracingOptions {
   startTransactionOnLocationChange: boolean;
 
   /**
-   * @deprecated Use tracesSampleRate in the SDK options
-   * This is a noop
-   */
-  tracesSampleRate?: number;
-
-  /**
    * The maximum duration of a transaction before it will be discarded. This is for some edge cases where a browser
    * completely freezes the JS state and picks it up later (background tabs).
    * So after this duration, the SDK will not send the event.
@@ -387,23 +381,6 @@ export class Tracing implements Integration {
     }, (Tracing.options && Tracing.options.idleTimeout) || 100);
 
     return span;
-  }
-
-  /**
-   * Update transaction
-   * @deprecated
-   */
-  public static updateTransactionName(name: string): void {
-    logger.log('[Tracing] DEPRECATED, use Sentry.configureScope => scope.setTransaction instead', name);
-    const _getCurrentHub = Tracing._getCurrentHub;
-    if (_getCurrentHub) {
-      const hub = _getCurrentHub();
-      if (hub) {
-        hub.configureScope(scope => {
-          scope.setTransaction(name);
-        });
-      }
-    }
   }
 
   /**

--- a/packages/apm/src/span.ts
+++ b/packages/apm/src/span.ts
@@ -117,6 +117,7 @@ export class Span implements SpanInterface, SpanContext {
    * You should never call the custructor manually, always use `hub.startSpan()`.
    * @internal
    * @hideconstructor
+   * @hidden
    */
   public constructor(spanContext?: SpanContext, hub?: Hub) {
     if (isInstanceOf(hub, Hub)) {

--- a/packages/apm/src/span.ts
+++ b/packages/apm/src/span.ts
@@ -21,9 +21,8 @@ class SpanRecorder {
   private _openSpanCount: number = 0;
   public finishedSpans: Span[] = [];
 
-  public constructor(maxlen?: number) {
-    // tslint:disable-next-line: strict-type-predicates
-    this._maxlen = typeof maxlen !== 'number' ? 1000 : maxlen;
+  public constructor(maxlen: number) {
+    this._maxlen = maxlen;
   }
 
   /**
@@ -178,7 +177,9 @@ export class Span implements SpanInterface, SpanContext {
   /**
    * @inheritDoc
    */
-  public child(spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId'>>): Span {
+  public child(
+    spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId' | 'sampled' | 'traceid' | 'parentSpanId'>>,
+  ): Span {
     const span = new Span({
       ...spanContext,
       parentSpanId: this._spanId,
@@ -204,7 +205,7 @@ export class Span implements SpanInterface, SpanContext {
    */
   public static fromTraceparent(
     traceparent: string,
-    spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId' | 'sampled' | 'traceid'>>,
+    spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId' | 'sampled' | 'traceid' | 'parentSpanId'>>,
   ): Span | undefined {
     const matches = traceparent.match(TRACEPARENT_REGEXP);
     if (matches) {

--- a/packages/apm/src/span.ts
+++ b/packages/apm/src/span.ts
@@ -290,7 +290,7 @@ export class Span implements SpanInterface, SpanContext {
 
     if (this.sampled !== true) {
       // At this point if `sampled !== true` we want to discard the transaction.
-      logger.warn('Discarding transaction Span because it was sampled == false || undefined');
+      logger.warn('Discarding transaction Span because it was span.sampled !== true');
       return undefined;
     }
 

--- a/packages/apm/src/span.ts
+++ b/packages/apm/src/span.ts
@@ -21,8 +21,9 @@ class SpanRecorder {
   private _openSpanCount: number = 0;
   public finishedSpans: Span[] = [];
 
-  public constructor(maxlen: number) {
-    this._maxlen = maxlen;
+  public constructor(maxlen?: number) {
+    // tslint:disable-next-line: strict-type-predicates
+    this._maxlen = typeof maxlen !== 'number' ? 1000 : maxlen;
   }
 
   /**

--- a/packages/apm/src/span.ts
+++ b/packages/apm/src/span.ts
@@ -287,11 +287,8 @@ export class Span implements SpanInterface, SpanContext {
       return undefined;
     }
 
-    if (this.sampled === undefined) {
-      // At this point a `sampled === undefined` should have already been
-      // resolved to a concrete decision. If `sampled` is `undefined`, it's
-      // likely that somebody used `Sentry.startSpan(...)` on a
-      // non-transaction span and later decided to make it a transaction.
+    if (this.sampled !== true) {
+      // At this point if `sampled !== true` we want to discard the transaction.
       logger.warn('Discarding transaction Span without sampling decision');
       return undefined;
     }

--- a/packages/apm/src/span.ts
+++ b/packages/apm/src/span.ts
@@ -178,7 +178,7 @@ export class Span implements SpanInterface, SpanContext {
    * @inheritDoc
    */
   public child(
-    spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId' | 'sampled' | 'traceid' | 'parentSpanId'>>,
+    spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId' | 'sampled' | 'traceId' | 'parentSpanId'>>,
   ): Span {
     const span = new Span({
       ...spanContext,
@@ -205,7 +205,7 @@ export class Span implements SpanInterface, SpanContext {
    */
   public static fromTraceparent(
     traceparent: string,
-    spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId' | 'sampled' | 'traceid' | 'parentSpanId'>>,
+    spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId' | 'sampled' | 'traceId' | 'parentSpanId'>>,
   ): Span | undefined {
     const matches = traceparent.match(TRACEPARENT_REGEXP);
     if (matches) {

--- a/packages/apm/src/span.ts
+++ b/packages/apm/src/span.ts
@@ -195,8 +195,8 @@ export class Span implements SpanInterface, SpanContext {
   /**
    * @inheritDoc
    */
-  public isChildSpan(): boolean {
-    return this._parentSpanId !== undefined;
+  public isRootSpan(): boolean {
+    return this._parentSpanId === undefined;
   }
 
   /**
@@ -283,6 +283,11 @@ export class Span implements SpanInterface, SpanContext {
 
     this.timestamp = timestampWithMs();
 
+    // We will not send any child spans
+    if (!this.isRootSpan()) {
+      return undefined;
+    }
+
     // This happens if a span was initiated outside of `hub.startSpan`
     // Also if the span was sampled (sampled = false) in `hub.startSpan` already
     if (this.spanRecorder === undefined) {
@@ -304,11 +309,6 @@ export class Span implements SpanInterface, SpanContext {
         }
         return prev;
       }).timestamp;
-    }
-
-    // We will not send any child spans
-    if (this.isChildSpan()) {
-      return undefined;
     }
 
     return this._hub.captureEvent({

--- a/packages/apm/src/span.ts
+++ b/packages/apm/src/span.ts
@@ -289,7 +289,7 @@ export class Span implements SpanInterface, SpanContext {
 
     if (this.sampled !== true) {
       // At this point if `sampled !== true` we want to discard the transaction.
-      logger.warn('Discarding transaction Span without sampling decision');
+      logger.warn('Discarding transaction Span because it was sampled == false || undefined');
       return undefined;
     }
 

--- a/packages/apm/src/span.ts
+++ b/packages/apm/src/span.ts
@@ -176,8 +176,7 @@ export class Span implements SpanInterface, SpanContext {
   }
 
   /**
-   * Creates a new `Span` while setting the current `Span.id` as `parentSpanId`.
-   * Also the `sampled` decision will be inherited.
+   * @inheritDoc
    */
   public child(spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId'>>): Span {
     const span = new Span({

--- a/packages/apm/test/hub.test.ts
+++ b/packages/apm/test/hub.test.ts
@@ -13,20 +13,26 @@ describe('Hub', () => {
 
   describe('spans', () => {
     describe('sampling', () => {
-      test('set tracesSampleRate 0', () => {
+      test('set tracesSampleRate 0 root span', () => {
         const hub = new Hub(new BrowserClient({ tracesSampleRate: 0 }));
         const span = hub.startSpan() as any;
-        expect(span.sampled).toBeUndefined();
+        expect(span.sampled).toBe(false);
       });
       test('set tracesSampleRate 0 on transaction', () => {
         const hub = new Hub(new BrowserClient({ tracesSampleRate: 0 }));
         const span = hub.startSpan({ transaction: 'foo' }) as any;
         expect(span.sampled).toBe(false);
       });
-      test('set tracesSampleRate 1', () => {
+      test('set tracesSampleRate 1 on transaction', () => {
         const hub = new Hub(new BrowserClient({ tracesSampleRate: 1 }));
         const span = hub.startSpan({ transaction: 'foo' }) as any;
         expect(span.sampled).toBeTruthy();
+      });
+      test('set tracesSampleRate should be propergated to children', () => {
+        const hub = new Hub(new BrowserClient({ tracesSampleRate: 0 }));
+        const span = hub.startSpan() as any;
+        const child = span.child({ op: 1 });
+        expect(child.sampled).toBeFalsy();
       });
     });
     describe('start', () => {

--- a/packages/apm/test/hub.test.ts
+++ b/packages/apm/test/hub.test.ts
@@ -35,6 +35,7 @@ describe('Hub', () => {
         expect(child.sampled).toBeFalsy();
       });
     });
+
     describe('start', () => {
       test('simple', () => {
         const hub = new Hub(new BrowserClient());

--- a/packages/apm/test/hub.test.ts
+++ b/packages/apm/test/hub.test.ts
@@ -1,9 +1,9 @@
+import { BrowserClient } from '@sentry/browser';
 import { Hub, Scope } from '@sentry/hub';
 
 import { addExtensionMethods } from '../src/hubextensions';
 
 addExtensionMethods();
-const clientFn: any = jest.fn();
 
 describe('Hub', () => {
   afterEach(() => {
@@ -12,16 +12,33 @@ describe('Hub', () => {
   });
 
   describe('spans', () => {
+    describe('sampling', () => {
+      test('set tracesSampleRate 0', () => {
+        const hub = new Hub(new BrowserClient({ tracesSampleRate: 0 }));
+        const span = hub.startSpan() as any;
+        expect(span.sampled).toBeUndefined();
+      });
+      test('set tracesSampleRate 0 on transaction', () => {
+        const hub = new Hub(new BrowserClient({ tracesSampleRate: 0 }));
+        const span = hub.startSpan({ transaction: 'foo' }) as any;
+        expect(span.sampled).toBe(false);
+      });
+      test('set tracesSampleRate 1', () => {
+        const hub = new Hub(new BrowserClient({ tracesSampleRate: 1 }));
+        const span = hub.startSpan({ transaction: 'foo' }) as any;
+        expect(span.sampled).toBeTruthy();
+      });
+    });
     describe('start', () => {
       test('simple', () => {
-        const hub = new Hub(clientFn);
+        const hub = new Hub(new BrowserClient());
         const span = hub.startSpan() as any;
         expect(span._spanId).toBeTruthy();
       });
 
       test('inherits from parent span', () => {
         const myScope = new Scope();
-        const hub = new Hub(clientFn, myScope);
+        const hub = new Hub(new BrowserClient(), myScope);
         const parentSpan = hub.startSpan({}) as any;
         expect(parentSpan._parentId).toBeFalsy();
         hub.configureScope(scope => {

--- a/packages/apm/test/span.test.ts
+++ b/packages/apm/test/span.test.ts
@@ -96,8 +96,8 @@ describe('Span', () => {
       const span2 = span.child();
       const span3 = span.child();
       span3.finish();
-      expect(span.spanList).toBe(span2.spanList);
-      expect(span.spanList).toBe(span3.spanList);
+      expect(span.spanRecorder).toBe(span2.spanRecorder);
+      expect(span.spanRecorder).toBe(span3.spanRecorder);
     });
   });
 
@@ -238,7 +238,7 @@ describe('Span', () => {
         spanTwo.finish();
 
         expect(spy).not.toHaveBeenCalled();
-        expect((spanOne as any).spanList.finishedSpans).toHaveLength(2);
+        expect((spanOne as any).spanRecorder.finishedSpans).toHaveLength(2);
       });
 
       test("finish a span with another one on the scope shouldn't override contexts.trace", () => {
@@ -291,7 +291,7 @@ describe('Span', () => {
           child.finish();
         }
         span.finish();
-        expect((span as any).spanList).toBeUndefined();
+        expect((span as any).spanRecorder).toBeUndefined();
         expect(spy).not.toHaveBeenCalled();
       });
     });

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -52,7 +52,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
   protected readonly _dsn?: Dsn;
 
   /** Array of used integrations. */
-  protected readonly _integrations: IntegrationIndex = {};
+  protected _integrations: IntegrationIndex = {};
 
   /** Is the client still processing a call? */
   protected _processing: boolean = false;
@@ -69,10 +69,6 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
 
     if (options.dsn) {
       this._dsn = new Dsn(options.dsn);
-    }
-
-    if (this._isEnabled()) {
-      this._integrations = setupIntegrations(this._options);
     }
   }
 
@@ -185,10 +181,12 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
   }
 
   /**
-   * @inheritDoc
+   * Sets up the integrations
    */
-  public getIntegrations(): IntegrationIndex {
-    return this._integrations || {};
+  public setupIntegrations(): void {
+    if (this._isEnabled()) {
+      this._integrations = setupIntegrations(this._options);
+    }
   }
 
   /**

--- a/packages/core/src/sdk.ts
+++ b/packages/core/src/sdk.ts
@@ -19,5 +19,4 @@ export function initAndBind<F extends Client, O extends Options>(clientClass: Cl
   const hub = getCurrentHub();
   const client = new clientClass(options);
   hub.bindClient(client);
-  client.setupIntegrations();
 }

--- a/packages/core/src/sdk.ts
+++ b/packages/core/src/sdk.ts
@@ -16,5 +16,8 @@ export function initAndBind<F extends Client, O extends Options>(clientClass: Cl
   if (options.debug === true) {
     logger.enable();
   }
-  getCurrentHub().bindClient(new clientClass(options));
+  const hub = getCurrentHub();
+  const client = new clientClass(options);
+  hub.bindClient(client);
+  client.setupIntegrations();
 }

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -8,6 +8,7 @@ import { TestIntegration } from '../mocks/integration';
 import { FakeTransport } from '../mocks/transport';
 
 const PUBLIC_DSN = 'https://username@domain/path';
+declare var global: any;
 
 jest.mock('@sentry/utils', () => {
   const original = jest.requireActual('@sentry/utils');
@@ -565,12 +566,17 @@ describe('BaseClient', () => {
   });
 
   describe('integrations', () => {
-    test('setup each one of them on ctor', () => {
+    beforeEach(() => {
+      global.__SENTRY__ = {};
+    });
+
+    test('setup each one of them on setupIntegration call', () => {
       expect.assertions(2);
       const client = new TestClient({
         dsn: PUBLIC_DSN,
         integrations: [new TestIntegration()],
       });
+      client.setupIntegrations();
       expect(Object.keys((client as any)._integrations).length).toBe(1);
       expect(client.getIntegration(TestIntegration)).toBeTruthy();
     });
@@ -580,6 +586,7 @@ describe('BaseClient', () => {
       const client = new TestClient({
         integrations: [new TestIntegration()],
       });
+      client.setupIntegrations();
       expect(Object.keys((client as any)._integrations).length).toBe(0);
       expect(client.getIntegration(TestIntegration)).toBeFalsy();
     });
@@ -591,6 +598,7 @@ describe('BaseClient', () => {
         enabled: false,
         integrations: [new TestIntegration()],
       });
+      client.setupIntegrations();
       expect(Object.keys((client as any)._integrations).length).toBe(0);
       expect(client.getIntegration(TestIntegration)).toBeFalsy();
     });

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -571,7 +571,7 @@ describe('BaseClient', () => {
         dsn: PUBLIC_DSN,
         integrations: [new TestIntegration()],
       });
-      expect(Object.keys(client.getIntegrations()).length).toBe(1);
+      expect(Object.keys((client as any)._integrations).length).toBe(1);
       expect(client.getIntegration(TestIntegration)).toBeTruthy();
     });
 
@@ -580,7 +580,7 @@ describe('BaseClient', () => {
       const client = new TestClient({
         integrations: [new TestIntegration()],
       });
-      expect(Object.keys(client.getIntegrations()).length).toBe(0);
+      expect(Object.keys((client as any)._integrations).length).toBe(0);
       expect(client.getIntegration(TestIntegration)).toBeFalsy();
     });
 
@@ -591,7 +591,7 @@ describe('BaseClient', () => {
         enabled: false,
         integrations: [new TestIntegration()],
       });
-      expect(Object.keys(client.getIntegrations()).length).toBe(0);
+      expect(Object.keys((client as any)._integrations).length).toBe(0);
       expect(client.getIntegration(TestIntegration)).toBeFalsy();
     });
   });

--- a/packages/core/test/lib/sdk.test.ts
+++ b/packages/core/test/lib/sdk.test.ts
@@ -10,14 +10,15 @@ const PUBLIC_DSN = 'https://username@domain/path';
 
 jest.mock('@sentry/hub', () => ({
   getCurrentHub(): {
-    bindClient(): boolean;
+    bindClient(client: any): boolean;
     getClient(): boolean;
   } {
     return {
       getClient(): boolean {
         return false;
       },
-      bindClient(): boolean {
+      bindClient(client: any): boolean {
+        client.setupIntegrations();
         return true;
       },
     };

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -105,7 +105,7 @@ export class Hub implements HubInterface {
   public bindClient(client?: Client): void {
     const top = this.getStackTop();
     top.client = client;
-    if (client) {
+    if (client && client.setupIntegrations) {
       client.setupIntegrations();
     }
   }

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -105,6 +105,9 @@ export class Hub implements HubInterface {
   public bindClient(client?: Client): void {
     const top = this.getStackTop();
     top.client = client;
+    if (client) {
+      client.setupIntegrations();
+    }
   }
 
   /**

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -81,7 +81,7 @@ function createHandlerWrapper(
       let span: Span;
       if (tracingEnabled) {
         span = getCurrentHub().startSpan({
-          description: `${typeof options === 'string' || !options.method ? 'GET' : options.method}|${requestUrl}`,
+          description: `${typeof options === 'string' || !options.method ? 'GET' : options.method} ${requestUrl}`,
           op: 'request',
         });
       }

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -70,4 +70,7 @@ export interface Client<O extends Options = Options> {
 
   /** Returns an array of installed integrations on the client. */
   getIntegration<T extends Integration>(integartion: IntegrationClass<T>): T | null;
+
+  /** This is an internal function to setup all integrations that should run on the client */
+  setupIntegrations(): void;
 }

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -174,7 +174,7 @@ export interface Hub {
 
   /**
    * This functions starts a span. If argument passed is of type `Span`, it'll run sampling on it if configured
-   * and attach a `SpanList`. If it's of type `SpanContext` and there is already a `Span` on the Scope,
+   * and attach a `SpanRecorder`. If it's of type `SpanContext` and there is already a `Span` on the Scope,
    * the created Span will have a reference to it and become it's child. Otherwise it'll crete a new `Span`.
    *
    * @param span Already constructed span which should be started or properties with which the span should be created

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -174,7 +174,7 @@ export interface Hub {
 
   /**
    * This functions starts a span. If argument passed is of type `Span`, it'll run sampling on it if configured
-   * and attach a `SpanRecorder`. If it's of type `SpanContext` and there is already a `Span` on the Scope,
+   * and attach a `SpanList`. If it's of type `SpanContext` and there is already a `Span` on the Scope,
    * the created Span will have a reference to it and become it's child. Otherwise it'll crete a new `Span`.
    *
    * @param span Already constructed span which should be started or properties with which the span should be created

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -78,7 +78,14 @@ export interface Options {
   /** A global sample rate to apply to all events (0 - 1). */
   sampleRate?: number;
 
-  /** A global sample rate to apply to all transactions (0 - 1). */
+  /**
+   * Sample rate to determine transaction/span sampling.
+   *
+   * 0 = 0% chance of instrumenting
+   * 1 = 100% change of instrumenting
+   *
+   * Default: 1
+   */
   tracesSampleRate?: number;
 
   /** Attaches stacktraces to pure capture message / log integrations */

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -39,6 +39,11 @@ export interface Span {
    * Determines whether span was successful (HTTP200)
    */
   isSuccess(): boolean;
+
+  /**
+   * Determines if the span is a child of another span
+   */
+  isChildSpan(): boolean;
 }
 
 /** Interface holder all properties that can be set on a Span on creation. */

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -70,9 +70,9 @@ export interface Span {
   isSuccess(): boolean;
 
   /**
-   * Determines if the span is a child of another span
+   * Determines if the span is transaction (root)
    */
-  isChildSpan(): boolean;
+  isRootSpan(): boolean;
 }
 
 /** Interface holder all properties that can be set on a Span on creation. */

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -36,6 +36,12 @@ export interface Span {
   setHttpStatus(httpStatus: number): this;
 
   /**
+   * Creates a new `Span` while setting the current `Span.id` as `parentSpanId`.
+   * Also the `sampled` decision will be inherited.
+   */
+  child(spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId'>>): Span;
+
+  /**
    * Determines whether span was successful (HTTP200)
    */
   isSuccess(): boolean;

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -5,9 +5,30 @@ export interface Span {
   /** Return a traceparent compatible header string */
   toTraceparent(): string;
   /** Convert the object to JSON for w. spans array info only */
-  getTraceContext(): object;
+  getTraceContext(): {
+    data?: { [key: string]: any };
+    description?: string;
+    op?: string;
+    parent_span_id?: string;
+    span_id: string;
+    status?: string;
+    tags?: { [key: string]: string };
+    trace_id: string;
+  };
   /** Convert the object to JSON */
-  toJSON(): object;
+  toJSON(): {
+    data?: { [key: string]: any };
+    description?: string;
+    op?: string;
+    parent_span_id?: string;
+    sampled?: boolean;
+    span_id: string;
+    start_timestamp: number;
+    tags?: { [key: string]: string };
+    timestamp?: number;
+    trace_id: string;
+    transaction?: string;
+  };
 
   /**
    * Sets the tag attribute on the current span
@@ -39,7 +60,9 @@ export interface Span {
    * Creates a new `Span` while setting the current `Span.id` as `parentSpanId`.
    * Also the `sampled` decision will be inherited.
    */
-  child(spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId' | 'sampled' | 'traceId' | 'parentSpanId'>>): Span;
+  child(
+    spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId' | 'sampled' | 'traceId' | 'parentSpanId'>>,
+  ): Span;
 
   /**
    * Determines whether span was successful (HTTP200)


### PR DESCRIPTION
Reworking the sampling decision, now everything is consistent with it was meant to be.

- fix sampling of traces work now only depending on the client option `tracesSampleRate`
- remove internal `forceNoChild` parameter from `hub.startSpan`
- make constructor of `Span` internal, only use `hub.startSpan`