### PR TITLE
ref: Skip body parsing for GET/HEAD requests

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -148,19 +148,14 @@ function extractRequestData(req: { [key: string]: any }, keys: boolean | string[
         request.query_string = url.parse(originalUrl || '', false).query;
         break;
       case 'data':
+        if (method === 'GET' || method === 'HEAD') {
+          break;
+        }
         // body data:
         //   node, express, koa: req.body
-        let data = req.body;
-        if (method === 'GET' || method === 'HEAD') {
-          if (typeof data === 'undefined') {
-            data = '<unavailable>';
-          }
+        if (req.body !== undefined) {
+          request.data = isString(req.body) ? req.body : JSON.stringify(normalize(req.body));
         }
-        if (data && !isString(data)) {
-          // Make sure the request body is a string
-          data = JSON.stringify(normalize(data));
-        }
-        request.data = data;
         break;
       default:
         if ({}.hasOwnProperty.call(req, key)) {

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -3,12 +3,12 @@ import { parseRequest } from '../src/handlers';
 
 describe('parseRequest', () => {
   const mockReq = {
-    body: '',
+    body: 'foo',
     cookies: { test: 'test' },
     headers: {
       host: 'mattrobenolt.com',
     },
-    method: 'GET',
+    method: 'POST',
     url: '/some/path?key=value',
     user: {
       custom_property: 'foo',
@@ -72,8 +72,8 @@ describe('parseRequest', () => {
   describe('parseRequest.request properties', () => {
     test('parseRequest.request only contains the default set of properties from the request', () => {
       const DEFAULT_REQUEST_PROPERTIES = ['cookies', 'data', 'headers', 'method', 'query_string', 'url'];
-      const parsedRequest: Event = parseRequest({}, mockReq, {});
-      expect(Object.keys(parsedRequest.request as any[])).toEqual(DEFAULT_REQUEST_PROPERTIES);
+      const parsedRequest: Event = parseRequest({}, mockReq);
+      expect(Object.keys(parsedRequest.request as {})).toEqual(DEFAULT_REQUEST_PROPERTIES);
     });
 
     test('parseRequest.request only contains the specified properties in the options.request array', () => {
@@ -81,7 +81,13 @@ describe('parseRequest', () => {
       const parsedRequest: Event = parseRequest({}, mockReq, {
         request: INCLUDED_PROPERTIES,
       });
-      expect(Object.keys(parsedRequest.request as any[])).toEqual(['data', 'headers', 'query_string', 'url']);
+      expect(Object.keys(parsedRequest.request as {})).toEqual(INCLUDED_PROPERTIES);
+    });
+
+    test('parseRequest.request skips `body` property for GET and HEAD requests', () => {
+      expect(parseRequest({}, mockReq, {}).request).toHaveProperty('data');
+      expect(parseRequest({}, { ...mockReq, method: 'GET' }, {}).request).not.toHaveProperty('data');
+      expect(parseRequest({}, { ...mockReq, method: 'HEAD' }, {}).request).not.toHaveProperty('data');
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/2502