### PR TITLE
Move node version to runtime context

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,6 @@
   },
   "resolutions": {
     "**/agent-base": "5"
-  }
+  },
+  "version": "0.0.0"
 }

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -64,7 +64,7 @@ function extractTransaction(req: { [key: string]: any }, type: boolean | Transac
         stack: [
           {
             name: string;
-          },
+          }
         ];
       };
     };

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -64,7 +64,7 @@ function extractTransaction(req: { [key: string]: any }, type: boolean | Transac
         stack: [
           {
             name: string;
-          }
+          },
         ];
       };
     };
@@ -240,9 +240,12 @@ export function parseRequest(
   };
 
   if (options.version) {
-    event.extra = {
-      ...event.extra,
-      node: global.process.version,
+    event.contexts = {
+      ...event.contexts,
+      runtime: {
+        name: 'node',
+        version: global.process.version,
+      },
     };
   }
 

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -18,6 +18,25 @@ describe('parseRequest', () => {
     },
   };
 
+  describe('parseRequest.contexts runtime', () => {
+    test('runtime name must contain node', () => {
+      const parsedRequest: Event = parseRequest({}, mockReq);
+      expect(parsedRequest.contexts.runtime.name).toEqual('node');
+    });
+
+    test('runtime version must contain current node version', () => {
+      const parsedRequest: Event = parseRequest({}, mockReq);
+      expect(parsedRequest.contexts.runtime.version).toEqual(process.version);
+    });
+
+    test('runtime disbaled by options', () => {
+      const parsedRequest: Event = parseRequest({}, mockReq, {
+        version: false,
+      });
+      expect(parsedRequest).not.toHaveProperty('contexts.runtime');
+    });
+  });
+
   describe('parseRequest.user properties', () => {
     const DEFAULT_USER_KEYS = ['id', 'username', 'email'];
     const CUSTOM_USER_KEYS = ['custom_property'];


### PR DESCRIPTION
Hello, i moved the node runtime version from extra dictionary to contexts interface (https://docs.sentry.io/development/sdk-dev/event-payloads/contexts/#runtime-context)