### PR TITLE
fixes crash for react native instrumenting fetch

### DIFF
--- a/packages/utils/src/supports.ts
+++ b/packages/utils/src/supports.ts
@@ -106,7 +106,7 @@ export function supportsNativeFetch(): boolean {
   // so create a "pure" iframe to see if that has native fetch
   let result = false;
   const doc = global.document;
-  if (doc) {
+  if (doc && typeof doc.createElement === 'function') {
     try {
       const sandbox = doc.createElement('iframe');
       sandbox.hidden = true;


### PR DESCRIPTION
This PR fixes a crash in @sentry/react-native v1.3.3 on startup, caused by assuming `global.document.createElement` exists (hence assuming web context).

This PR just makes sure `global.document.createElement` is a function before actually calling it.

- React native uses JavascriptCore and Hermes, `global.document` in those environments *only* contains `addEventListener` and `removeEventListener` and nothing else.
- In the following [commit](https://github.com/getsentry/sentry-react-native/commit/01d646558c9f3aafbbaaf76e521a0a8f57c70725#diff-e82ba8ff14f16e95ad5a786210a512e6) in @sentry/react-native, line 46 of sdk.ts, `fetch:false` was removed. `fetch:false` prevented the crash from happening by bypassing the fetch instrumentation. Hence the mentioned commit triggered an existing bug within sentry-javascript. This bug appeared for us when we upgraded @sentry/react-native from v1.2.1 to v1.3.3