### PR TITLE
fix: Guard against invalid req.user input

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -1,7 +1,7 @@
 import { Span } from '@sentry/apm';
 import { captureException, getCurrentHub, withScope } from '@sentry/core';
 import { Event } from '@sentry/types';
-import { forget, isString, logger, normalize } from '@sentry/utils';
+import { forget, isPlainObject, isString, logger, normalize } from '@sentry/utils';
 import * as cookie from 'cookie';
 import * as domain from 'domain';
 import * as http from 'http';
@@ -256,7 +256,7 @@ export function parseRequest(
   }
 
   if (options.user) {
-    const extractedUser = req.user ? extractUserData(req.user, options.user) : {};
+    const extractedUser = req.user && isPlainObject(req.user) ? extractUserData(req.user, options.user) : {};
 
     if (Object.keys(extractedUser)) {
       event.user = {

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -30,7 +30,9 @@ export interface Event {
   };
   stacktrace?: Stacktrace;
   breadcrumbs?: Breadcrumb[];
-  contexts?: { [key: string]: object };
+  contexts?: {
+    [key: string]: object;
+  };
   tags?: { [key: string]: string };
   extra?: { [key: string]: any };
   user?: User;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,6 +13,7 @@ export { Options } from './options';
 export { Package } from './package';
 export { Request } from './request';
 export { Response } from './response';
+export { Runtime } from './runtime';
 export { Scope } from './scope';
 export { SdkInfo } from './sdkinfo';
 export { Severity } from './severity';


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/2275

Lint issues are fixed here https://github.com/getsentry/sentry-javascript/pull/2511