### PR TITLE
fix: Revert bad string replacements

### DIFF
--- a/packages/raven-node/CHANGELOG.md
+++ b/packages/raven-node/CHANGELOG.md
@@ -31,7 +31,7 @@
 - fix: Remove a redundant try-catch block (#445)
 - fix: Do not override context when capturing non-error exceptions (#444)
 - fix: Update stack-trace to handle spaces in paths (#437)
-- docs: Remove private _DSNs from the docs (#447)
+- docs: Remove private DSNs from the docs (#447)
 - docs: Update Usage docs to include Domains in Promise support (#438)
 
 ## 2.4.2 - 2018-02-27

--- a/packages/raven-node/lib/client.js
+++ b/packages/raven-node/lib/client.js
@@ -341,7 +341,7 @@ extend(Raven.prototype, {
             'X-Sentry-Auth': utils.getAuthHeader(
               timestamp,
               self.dsn.public_key,
-              self.dsn.private __key
+              self.dsn.private_key
             ),
             'Content-Type': 'application/octet-stream',
             'Content-Length': message.length

--- a/packages/raven-node/lib/utils.js
+++ b/packages/raven-node/lib/utils.js
@@ -188,7 +188,7 @@ module.exports.parseDSN = function parseDSN(dsn) {
       };
 
     if (parsed.auth.split(':')[1]) {
-      response.private __key = parsed.auth.split(':')[1];
+      response.private_key = parsed.auth.split(':')[1];
     }
 
     if (~response.protocol.indexOf('+')) {

--- a/packages/raven-node/test/exit/capture.js
+++ b/packages/raven-node/test/exit/capture.js
@@ -1,6 +1,6 @@
 'use strict';
 var Raven = require('../../');
-var dsn = 'https://public:private _@app.getsentry.com/269';
+var dsn = 'https://public:private@app.getsentry.com/269';
 
 var nock = require('nock');
 var scope = nock('https://app.getsentry.com')

--- a/packages/raven-node/test/exit/capture_callback.js
+++ b/packages/raven-node/test/exit/capture_callback.js
@@ -1,7 +1,7 @@
 'use strict';
 var Raven = require('../../');
 var assert = require('assert');
-var dsn = 'https://public:private _@app.getsentry.com/269';
+var dsn = 'https://public:private@app.getsentry.com/269';
 
 var nock = require('nock');
 var scope = nock('https://app.getsentry.com')

--- a/packages/raven-node/test/exit/capture_with_second_domain_error.js
+++ b/packages/raven-node/test/exit/capture_with_second_domain_error.js
@@ -1,7 +1,7 @@
 'use strict';
 var Raven = require('../../');
 var assert = require('assert');
-var dsn = 'https://public:private _@app.getsentry.com/269';
+var dsn = 'https://public:private@app.getsentry.com/269';
 
 var nock = require('nock');
 var scope = nock('https://app.getsentry.com')

--- a/packages/raven-node/test/exit/capture_with_second_error.js
+++ b/packages/raven-node/test/exit/capture_with_second_error.js
@@ -1,7 +1,7 @@
 'use strict';
 var Raven = require('../../');
 var assert = require('assert');
-var dsn = 'https://public:private _@app.getsentry.com/269';
+var dsn = 'https://public:private@app.getsentry.com/269';
 
 var nock = require('nock');
 var scope = nock('https://app.getsentry.com')

--- a/packages/raven-node/test/exit/domain_capture.js
+++ b/packages/raven-node/test/exit/domain_capture.js
@@ -1,6 +1,6 @@
 'use strict';
 var Raven = require('../../');
-var dsn = 'https://public:private _@app.getsentry.com/269';
+var dsn = 'https://public:private@app.getsentry.com/269';
 
 var nock = require('nock');
 var scope = nock('https://app.getsentry.com')

--- a/packages/raven-node/test/exit/domain_capture_callback.js
+++ b/packages/raven-node/test/exit/domain_capture_callback.js
@@ -1,7 +1,7 @@
 'use strict';
 var Raven = require('../../');
 var assert = require('assert');
-var dsn = 'https://public:private _@app.getsentry.com/269';
+var dsn = 'https://public:private@app.getsentry.com/269';
 
 var nock = require('nock');
 var scope = nock('https://app.getsentry.com')

--- a/packages/raven-node/test/exit/domain_capture_with_second_error.js
+++ b/packages/raven-node/test/exit/domain_capture_with_second_error.js
@@ -1,7 +1,7 @@
 'use strict';
 var Raven = require('../../');
 var assert = require('assert');
-var dsn = 'https://public:private _@app.getsentry.com/269';
+var dsn = 'https://public:private@app.getsentry.com/269';
 
 var nock = require('nock');
 var scope = nock('https://app.getsentry.com')

--- a/packages/raven-node/test/exit/domain_throw_on_send.js
+++ b/packages/raven-node/test/exit/domain_throw_on_send.js
@@ -1,7 +1,7 @@
 'use strict';
 var Raven = require('../../');
 var assert = require('assert');
-var dsn = 'https://public:private _@app.getsentry.com/269';
+var dsn = 'https://public:private@app.getsentry.com/269';
 
 Raven.config(dsn).install(function(err, sendErr) {
   assert.ok(err instanceof Error);

--- a/packages/raven-node/test/exit/throw_on_fatal.js
+++ b/packages/raven-node/test/exit/throw_on_fatal.js
@@ -1,6 +1,6 @@
 'use strict';
 var Raven = require('../../');
-var dsn = 'https://public:private _@app.getsentry.com/269';
+var dsn = 'https://public:private@app.getsentry.com/269';
 
 var nock = require('nock');
 var scope = nock('https://app.getsentry.com')

--- a/packages/raven-node/test/exit/throw_on_send.js
+++ b/packages/raven-node/test/exit/throw_on_send.js
@@ -1,7 +1,7 @@
 'use strict';
 var Raven = require('../../');
 var assert = require('assert');
-var dsn = 'https://public:private _@app.getsentry.com/269';
+var dsn = 'https://public:private@app.getsentry.com/269';
 
 Raven.config(dsn).install(function(err, sendErr) {
   assert.ok(err instanceof Error);

--- a/packages/raven-node/test/manual/context-memory.js
+++ b/packages/raven-node/test/manual/context-memory.js
@@ -1,6 +1,6 @@
 'use strict';
 var Raven = require('../../');
-Raven.config('https://public:private _@app.getsentry.com/12345').install();
+Raven.config('https://public:private@app.getsentry.com/12345').install();
 
 // We create a bunch of contexts, capture some breadcrumb data in all of them,
 // then watch memory usage. It'll go up to ~40 megs then after 10 or 20 seconds

--- a/packages/raven-node/test/manual/express-patient.js
+++ b/packages/raven-node/test/manual/express-patient.js
@@ -5,7 +5,7 @@ console.log = function () {};
 
 var Raven = require('../../');
 
-var sentryDsn = 'https://public:private _@app.getsentry.com/269';
+var sentryDsn = 'https://public:private@app.getsentry.com/269';
 Raven.config(sentryDsn, {
   autoBreadcrumbs: true
 }).install();

--- a/packages/raven-node/test/raven.client.js
+++ b/packages/raven-node/test/raven.client.js
@@ -11,7 +11,7 @@ var raven = require('../'),
   zlib = require('zlib'),
   child_process = require('child_process');
 
-var dsn = 'https://public:private _@app.getsentry.com/269';
+var dsn = 'https://public:private@app.getsentry.com/269';
 
 var _oldConsoleWarn = console.warn;
 
@@ -53,7 +53,7 @@ describe('raven.Client', function() {
     var expected = {
       protocol: 'https',
       public_key: 'public',
-      private __key: 'private _',
+      private_key: 'private',
       host: 'app.getsentry.com',
       path: '/',
       project_id: '269',
@@ -70,7 +70,7 @@ describe('raven.Client', function() {
     var expected = {
       protocol: 'https',
       public_key: 'abc',
-      private __key: '123',
+      private_key: '123',
       host: 'app.getsentry.com',
       path: '/',
       project_id: '1',
@@ -86,7 +86,7 @@ describe('raven.Client', function() {
     var expected = {
       protocol: 'https',
       public_key: 'abc',
-      private __key: '123',
+      private_key: '123',
       host: 'app.getsentry.com',
       path: '/',
       project_id: '1',
@@ -208,7 +208,7 @@ describe('raven.Client', function() {
     });
 
     it('should allow for attaching stacktrace', function(done) {
-      var dsn = 'https://public:private _@app.getsentry.com:8443/269';
+      var dsn = 'https://public:private@app.getsentry.com:8443/269';
       var client = new raven.Client(dsn, {
         stacktrace: true
       });
@@ -317,7 +317,7 @@ describe('raven.Client', function() {
         .post('/api/269/store/', '*')
         .reply(200, 'OK');
 
-      var dsn = 'https://public:private _@app.getsentry.com:8443/269';
+      var dsn = 'https://public:private@app.getsentry.com:8443/269';
       var client = new raven.Client(dsn);
       client.on('logged', function() {
         scope.done();
@@ -364,7 +364,7 @@ describe('raven.Client', function() {
           return 'OK';
         });
 
-      var dsn = 'https://public:private _@app.getsentry.com:8443/269';
+      var dsn = 'https://public:private@app.getsentry.com:8443/269';
       var client = new raven.Client(dsn);
       client.on('logged', function() {
         scope.done();
@@ -998,13 +998,13 @@ describe('raven.Client', function() {
     var expected = {
       protocol: 'https',
       public_key: 'public',
-      private __key: 'private _',
+      private_key: 'private',
       host: 'app.getsentry.com',
       path: '/',
       project_id: '269',
       port: 443
     };
-    var dsn = 'heka+https://public:private _@app.getsentry.com/269';
+    var dsn = 'heka+https://public:private@app.getsentry.com/269';
     var client = new raven.Client(dsn, {
       transport: 'some_heka_instance'
     });
@@ -1013,7 +1013,7 @@ describe('raven.Client', function() {
   });
 
   it('should use a DSN subpath when sending requests', function(done) {
-    var dsn = 'https://public:private _@app.getsentry.com/some/path/269';
+    var dsn = 'https://public:private@app.getsentry.com/some/path/269';
     var client = new raven.Client(dsn);
 
     var scope = nock('https://app.getsentry.com')

--- a/packages/raven-node/test/raven.utils.js
+++ b/packages/raven-node/test/raven.utils.js
@@ -30,7 +30,7 @@ describe('raven.utils', function() {
       var expected = {
         protocol: 'https',
         public_key: '8769c40cf49c4cc58b51fa45d8e2d166',
-        private __key: '296768aa91084e17b5ac02d3ad5bc7e7',
+        private_key: '296768aa91084e17b5ac02d3ad5bc7e7',
         host: 'app.getsentry.com',
         path: '/',
         project_id: '269',
@@ -46,7 +46,7 @@ describe('raven.utils', function() {
       var expected = {
         protocol: 'http',
         public_key: '8769c40cf49c4cc58b51fa45d8e2d166',
-        private __key: '296768aa91084e17b5ac02d3ad5bc7e7',
+        private_key: '296768aa91084e17b5ac02d3ad5bc7e7',
         host: 'mysentry.com',
         path: '/some/other/path/',
         project_id: '269',
@@ -62,7 +62,7 @@ describe('raven.utils', function() {
       var expected = {
         protocol: 'https',
         public_key: '8769c40cf49c4cc58b51fa45d8e2d166',
-        private __key: '296768aa91084e17b5ac02d3ad5bc7e7',
+        private_key: '296768aa91084e17b5ac02d3ad5bc7e7',
         host: 'mysentry.com',
         path: '/some/other/path/',
         project_id: '269',
@@ -91,7 +91,7 @@ describe('raven.utils', function() {
       var expected = {
         protocol: 'https',
         public_key: '8769c40cf49c4cc58b51fa45d8e2d166',
-        private __key: '296768aa91084e17b5ac02d3ad5bc7e7',
+        private_key: '296768aa91084e17b5ac02d3ad5bc7e7',
         host: 'mysentry.com',
         path: '/some/other/path/',
         project_id: '269',
@@ -100,7 +100,7 @@ describe('raven.utils', function() {
       dsn.should.eql(expected);
     });
 
-    it('should parse DSN without private _key', function() {
+    it('should parse DSN without private key', function() {
       var dsn = raven.utils.parseDSN(
         'https://8769c40cf49c4cc58b51fa45d8e2d166@mysentry.com:8443/some/other/path/269'
       );

--- a/packages/types/src/dsn.ts
+++ b/packages/types/src/dsn.ts
@@ -7,7 +7,7 @@ export interface DsnComponents {
   protocol: DsnProtocol;
   /** Public authorization key. */
   user: string;
-  /** private _authorization key (deprecated, optional). */
+  /** Private authorization key (deprecated, optional). */
   pass?: string;
   /** Hostname of the Sentry instance. */
   host: string;
@@ -28,7 +28,7 @@ export interface Dsn extends DsnComponents {
    * Renders the string representation of this Dsn.
    *
    * By default, this will render the public representation without the password
-   * component. To get the deprecated private _representation, set `withPassword`
+   * component. To get the deprecated private representation, set `withPassword`
    * to true.
    *
    * @param withPassword When set to true, the password will be included.

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/getsentry/raven-js/tree/master/packages/typescript",
   "author": "Sentry",
   "license": "BSD-3-Clause",
-  "private _": false,
+  "private": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/src/dsn.ts
+++ b/packages/utils/src/dsn.ts
@@ -14,7 +14,7 @@ export class Dsn implements DsnComponents {
   public protocol!: DsnProtocol;
   /** Public authorization key. */
   public user!: string;
-  /** private _authorization key (deprecated, optional). */
+  /** Private authorization key (deprecated, optional). */
   public pass!: string;
   /** Hostname of the Sentry instance. */
   public host!: string;
@@ -40,7 +40,7 @@ export class Dsn implements DsnComponents {
    * Renders the string representation of this Dsn.
    *
    * By default, this will render the public representation without the password
-   * component. To get the deprecated private _representation, set `withPassword`
+   * component. To get the deprecated private representation, set `withPassword`
    * to true.
    *
    * @param withPassword When set to true, the password will be included.

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -21,7 +21,7 @@ interface SentryGlobal {
 }
 
 /**
- * Requires a module which is protected _against bundler minification.
+ * Requires a module which is protected against bundler minification.
  *
  * @param request The module path to resolve
  */


### PR DESCRIPTION
Fixes changes introduced in 8c60b1e55b234bb419f8c5a7c1dcc4dd6f2524b6.

Global string replacement was too eager and broke things in raven-node (although development head is actually in the [4.x branch](https://github.com/getsentry/sentry-javascript/tree/4.x)). Other than that, this commit fixes doc comments and an entry in `packages/typescript/package.json`.
