### PR TITLE
Remove the dynamicRequire hack to fix scope memory leak

### DIFF
--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -12,15 +12,7 @@ import {
   SpanContext,
   User,
 } from '@sentry/types';
-import {
-  consoleSandbox,
-  dynamicRequire,
-  getGlobalObject,
-  isNodeEnv,
-  logger,
-  timestampWithMs,
-  uuid4,
-} from '@sentry/utils';
+import { consoleSandbox, getGlobalObject, isNodeEnv, logger, timestampWithMs, uuid4 } from '@sentry/utils';
 
 import { Carrier, Layer } from './interfaces';
 import { Scope } from './scope';
@@ -462,10 +454,7 @@ export function getCurrentHub(): Hub {
  */
 function getHubFromActiveDomain(registry: Carrier): Hub {
   try {
-    // We need to use `dynamicRequire` because `require` on it's own will be optimized by webpack.
-    // We do not want this to happen, we need to try to `require` the domain node module and fail if we are in browser
-    // for example so we do not have to shim it and use `getCurrentHub` universally.
-    const domain = dynamicRequire(module, 'domain');
+    const domain = require('domain');
     const activeDomain = domain.active;
 
     // If there no active domain, just return global hub


### PR DESCRIPTION
That bug has been discussed in #1762. When bundling `@sentry/node` with webpack, it causes a sentry to leak memory.

The problem resides in the `dynamicRequire` function. This function expects the `module.require` function to exist, but when bundled with webpack it doesn't. When we use it to require the `domain` module, which is needed to clone the scope instance, it throws an error and sentry fallback to using the global scope instance.

Each incoming requests then use the same scope instance and attach a new event processor callback to it. Since those event processors are never unassigned and depend on the whole scope object to be garbage collected, their closure which capture a lot of stuff (like the request object) stays in memory.

**Recap**

dynamicRequire is used to load the `domain` module
![Screen Shot 2020-03-24 at 12 05 04](https://user-images.githubusercontent.com/2637675/77450802-2af8ef00-6dca-11ea-883e-32971dd3a853.png)

mod.require is undefined
![Screen Shot 2020-03-24 at 12 20 01](https://user-images.githubusercontent.com/2637675/77450815-30563980-6dca-11ea-9989-5bc8b2b329b0.png)

What the mod object looks like
![Screen Shot 2020-03-24 at 12 20 38](https://user-images.githubusercontent.com/2637675/77450830-36e4b100-6dca-11ea-9459-6ed801c7c0c2.png)

`dynamicRequire` is making the assumption that the `module` is the one from node, but when bundled by webpack it's an object provided by webpack that doesn't have the `Module` `__proto__`.

`dynamicRequire` throws an error since `mod.require` is undefined and `getHubFromActiveDomain` end up using `getHubFromCarrier(registry)` instead of `getHubFromCarrier(activeDomain)`
![Screen Shot 2020-03-24 at 12 21 22](https://user-images.githubusercontent.com/2637675/77450838-3a783800-6dca-11ea-8b4b-e20808042cd3.png)

I guess this might also cause bugs when processing an error since all the event processors previously added by previous requests will be called? 🤔 

To fix this issue I replaced `dynamicRequire` with `require`, and it now works, no more leak! 🎉 
I guess the `dynamicRequire` hack was only needed with older versions of webpack and now isn't needed anymore.