### PR TITLE
ref: Make SpanStatus.Ok default of span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+- [apm] ref: Make `SpanStatus.Ok` default value (#2516)
+
 ## 5.15.0
 
 - [apm] fix: Sampling of traces work now only depending on the client option `tracesSampleRate` (#2500)

--- a/packages/apm/src/span.ts
+++ b/packages/apm/src/span.ts
@@ -66,7 +66,7 @@ export class Span implements SpanInterface, SpanContext {
   /**
    * Internal keeper of the status
    */
-  private _status?: SpanStatus;
+  private _status?: SpanStatus = SpanStatus.Ok;
 
   /**
    * @inheritDoc

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -13,7 +13,6 @@ export { Options } from './options';
 export { Package } from './package';
 export { Request } from './request';
 export { Response } from './response';
-export { Runtime } from './runtime';
 export { Scope } from './scope';
 export { SdkInfo } from './sdkinfo';
 export { Severity } from './severity';


### PR DESCRIPTION
Make SpanStatus.ok the default value to be the same as Python.
We set the transaction and spans to another status in case an error happens.

https://sentry.io/organizations/sentry/performance/summary/?project=1&transaction=%2Fapi%2F0%2Fissues%7Cgroups%2F%7Bissue_id%7D%2F
