### PR TITLE
fix: Prevent isMatchingPattern from failing and add tests

### DIFF
--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -1,4 +1,4 @@
-import { isRegExp } from './is';
+import { isRegExp, isString } from './is';
 
 /**
  * Truncates given string to the maximum characters count
@@ -89,6 +89,10 @@ export function safeJoin(input: any[], delimiter?: string): string {
  * @param pattern Either a regex or a string that must be contained in value
  */
 export function isMatchingPattern(value: string, pattern: RegExp | string): boolean {
+  if (!isString(value)) {
+    return false;
+  }
+
   if (isRegExp(pattern)) {
     return (pattern as RegExp).test(value);
   }

--- a/packages/utils/test/string.test.ts
+++ b/packages/utils/test/string.test.ts
@@ -1,4 +1,4 @@
-import { truncate } from '../src/string';
+import { isMatchingPattern, truncate } from '../src/string';
 
 describe('truncate()', () => {
   test('it works as expected', () => {
@@ -8,5 +8,34 @@ describe('truncate()', () => {
     expect(truncate('1'.repeat(1000), 300)).toHaveLength(303);
     expect(truncate(new Array(1000).join('f'), 0)).toEqual(new Array(1000).join('f'));
     expect(truncate(new Array(1000).join('f'), 0)).toEqual(new Array(1000).join('f'));
+  });
+});
+
+describe('isMatchingPattern()', () => {
+  test('match using string substring', () => {
+    expect(isMatchingPattern('foobar', 'foobar')).toEqual(true);
+    expect(isMatchingPattern('foobar', 'foo')).toEqual(true);
+    expect(isMatchingPattern('foobar', 'bar')).toEqual(true);
+    expect(isMatchingPattern('foobar', 'nope')).toEqual(false);
+  });
+
+  test('match using regexp test', () => {
+    expect(isMatchingPattern('foobar', /^foo/)).toEqual(true);
+    expect(isMatchingPattern('foobar', /foo/)).toEqual(true);
+    expect(isMatchingPattern('foobar', /b.{1}r/)).toEqual(true);
+    expect(isMatchingPattern('foobar', /^foo$/)).toEqual(false);
+  });
+
+  test('should match empty pattern as true', () => {
+    expect(isMatchingPattern('foo', '')).toEqual(true);
+    expect(isMatchingPattern('bar', '')).toEqual(true);
+    expect(isMatchingPattern('', '')).toEqual(true);
+  });
+
+  test('should bail out with false when given non-string value', () => {
+    expect(isMatchingPattern(null, 'foo')).toEqual(false);
+    expect(isMatchingPattern(undefined, 'foo')).toEqual(false);
+    expect(isMatchingPattern({}, 'foo')).toEqual(false);
+    expect(isMatchingPattern([], 'foo')).toEqual(false);
   });
 });


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/2538