### PR TITLE
fix: Missing BreadcrumbHint and EventHint exports are added to node and browser sub-packages

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -1,5 +1,6 @@
 export {
   Breadcrumb,
+  BreadcrumbHint,
   Request,
   SdkInfo,
   Event,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,8 +1,10 @@
 export {
   Breadcrumb,
+  BreadcrumbHint,
   Request,
   SdkInfo,
   Event,
+  EventHint,
   Exception,
   Response,
   Severity,


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [X] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Since I am only using the `browser` and `node` sub-packages, I modified only those folders. If other packages also needs to be updated, let me know. 