### PR TITLE
feat: Send transactions in envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+- [core] feat: Send transactions in envelopes (#2553)
+
 ## 5.15.5
 
 - [browser/node] Add missing `BreadcrumbHint` and `EventHint` types exports (#2545)

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -170,7 +170,7 @@ export class Breadcrumbs implements Integration {
     const client = getCurrentHub().getClient<BrowserClient>();
     const dsn = client && client.getDsn();
     if (this._options.sentry && dsn) {
-      const filterUrl = new API(dsn).getStoreEndpoint();
+      const filterUrl = new API(dsn).getBaseApiEndpoint();
       // if Sentry key appears in URL, don't capture it as a request
       // but rather as our own 'sentry' type breadcrumb
       if (

--- a/packages/browser/src/transports/base.ts
+++ b/packages/browser/src/transports/base.ts
@@ -5,15 +5,20 @@ import { PromiseBuffer, SentryError } from '@sentry/utils';
 /** Base Transport class implementation */
 export abstract class BaseTransport implements Transport {
   /**
-   * @inheritDoc
+   * @deprecated
    */
   public url: string;
+
+  /** Helper to get Sentry API endpoints. */
+  protected readonly _api: API;
 
   /** A simple buffer holding all requests. */
   protected readonly _buffer: PromiseBuffer<Response> = new PromiseBuffer(30);
 
   public constructor(public options: TransportOptions) {
-    this.url = new API(this.options.dsn).getStoreEndpointWithUrlEncodedAuth();
+    this._api = new API(this.options.dsn);
+    // tslint:disable-next-line:deprecation
+    this.url = this._api.getStoreEndpointWithUrlEncodedAuth();
   }
 
   /**

--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -23,7 +23,7 @@ export class FetchTransport extends BaseTransport {
       });
     }
 
-    const sentryReq = eventToSentryRequest(event, this._api);
+    const sentryReq = eventToSentryRequest(event, this._api, this.options.headers);
 
     const options: RequestInit = {
       body: sentryReq.body,
@@ -33,11 +33,8 @@ export class FetchTransport extends BaseTransport {
       // It doesn't. And it throw exception instead of ignoring this parameter...
       // REF: https://github.com/getsentry/raven-js/issues/1233
       referrerPolicy: (supportsReferrerPolicy() ? 'origin' : '') as ReferrerPolicy,
+      headers: sentryReq.headers,
     };
-
-    if (this.options.headers !== undefined) {
-      options.headers = this.options.headers;
-    }
 
     return this._buffer.add(
       new SyncPromise<Response>((resolve, reject) => {

--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -23,7 +23,7 @@ export class FetchTransport extends BaseTransport {
       });
     }
 
-    const sentryReq = eventToSentryRequest(event, this._api, this.options.headers);
+    const sentryReq = eventToSentryRequest(event, this._api);
 
     const options: RequestInit = {
       body: sentryReq.body,
@@ -33,8 +33,11 @@ export class FetchTransport extends BaseTransport {
       // It doesn't. And it throw exception instead of ignoring this parameter...
       // REF: https://github.com/getsentry/raven-js/issues/1233
       referrerPolicy: (supportsReferrerPolicy() ? 'origin' : '') as ReferrerPolicy,
-      headers: sentryReq.headers,
     };
+
+    if (this.options.headers !== undefined) {
+      options.headers = this.options.headers;
+    }
 
     return this._buffer.add(
       new SyncPromise<Response>((resolve, reject) => {

--- a/packages/browser/src/transports/xhr.ts
+++ b/packages/browser/src/transports/xhr.ts
@@ -1,3 +1,4 @@
+import { eventToSentryRequest } from '@sentry/core';
 import { Event, Response, Status } from '@sentry/types';
 import { logger, parseRetryAfterHeader, SyncPromise } from '@sentry/utils';
 
@@ -19,6 +20,8 @@ export class XHRTransport extends BaseTransport {
         status: 429,
       });
     }
+
+    const sentryReq = eventToSentryRequest(event, this._api);
 
     return this._buffer.add(
       new SyncPromise<Response>((resolve, reject) => {
@@ -45,13 +48,13 @@ export class XHRTransport extends BaseTransport {
           reject(request);
         };
 
-        request.open('POST', this.url);
+        request.open('POST', sentryReq.url);
         for (const header in this.options.headers) {
           if (this.options.headers.hasOwnProperty(header)) {
             request.setRequestHeader(header, this.options.headers[header]);
           }
         }
-        request.send(JSON.stringify(event));
+        request.send(sentryReq.body);
       }),
     );
   }

--- a/packages/browser/src/transports/xhr.ts
+++ b/packages/browser/src/transports/xhr.ts
@@ -21,7 +21,7 @@ export class XHRTransport extends BaseTransport {
       });
     }
 
-    const sentryReq = eventToSentryRequest(event, this._api);
+    const sentryReq = eventToSentryRequest(event, this._api, this.options.headers);
 
     return this._buffer.add(
       new SyncPromise<Response>((resolve, reject) => {
@@ -49,9 +49,9 @@ export class XHRTransport extends BaseTransport {
         };
 
         request.open('POST', sentryReq.url);
-        for (const header in this.options.headers) {
-          if (this.options.headers.hasOwnProperty(header)) {
-            request.setRequestHeader(header, this.options.headers[header]);
+        for (const header in sentryReq.headers) {
+          if (sentryReq.headers.hasOwnProperty(header)) {
+            request.setRequestHeader(header, sentryReq.headers[header]);
           }
         }
         request.send(sentryReq.body);

--- a/packages/browser/src/transports/xhr.ts
+++ b/packages/browser/src/transports/xhr.ts
@@ -21,7 +21,7 @@ export class XHRTransport extends BaseTransport {
       });
     }
 
-    const sentryReq = eventToSentryRequest(event, this._api, this.options.headers);
+    const sentryReq = eventToSentryRequest(event, this._api);
 
     return this._buffer.add(
       new SyncPromise<Response>((resolve, reject) => {
@@ -49,9 +49,9 @@ export class XHRTransport extends BaseTransport {
         };
 
         request.open('POST', sentryReq.url);
-        for (const header in sentryReq.headers) {
-          if (sentryReq.headers.hasOwnProperty(header)) {
-            request.setRequestHeader(header, sentryReq.headers[header]);
+        for (const header in this.options.headers) {
+          if (this.options.headers.hasOwnProperty(header)) {
+            request.setRequestHeader(header, this.options.headers[header]);
           }
         }
         request.send(sentryReq.body);

--- a/packages/browser/test/unit/transports/base.test.ts
+++ b/packages/browser/test/unit/transports/base.test.ts
@@ -19,6 +19,7 @@ describe('BaseTransport', () => {
 
   it('has correct endpoint url', () => {
     const transport = new SimpleTransport({ dsn: testDsn });
+    // tslint:disable-next-line:deprecation
     expect(transport.url).equal('https://sentry.io/api/42/store/?sentry_key=123&sentry_version=7');
   });
 });

--- a/packages/browser/test/unit/transports/fetch.test.ts
+++ b/packages/browser/test/unit/transports/fetch.test.ts
@@ -28,6 +28,7 @@ describe('FetchTransport', () => {
   });
 
   it('inherits composeEndpointUrl() implementation', () => {
+    // tslint:disable-next-line:deprecation
     expect(transport.url).equal(transportUrl);
   });
 

--- a/packages/browser/test/unit/transports/xhr.test.ts
+++ b/packages/browser/test/unit/transports/xhr.test.ts
@@ -28,6 +28,7 @@ describe('XHRTransport', () => {
   });
 
   it('inherits composeEndpointUrl() implementation', () => {
+    // tslint:disable-next-line:deprecation
     expect(transport.url).equal(transportUrl);
   });
 

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -17,29 +17,59 @@ export class API {
     return this._dsnObject;
   }
 
-  /** Returns a string with auth headers in the url to the store endpoint. */
-  public getStoreEndpoint(): string {
-    return `${this._getBaseUrl()}${this.getStoreEndpointPath()}`;
-  }
-
-  /** Returns the store endpoint with auth added in url encoded. */
-  public getStoreEndpointWithUrlEncodedAuth(): string {
-    const dsn = this._dsnObject;
-    const auth = {
-      sentry_key: dsn.user, // sentry_key is currently used in tracing integration to identify internal sentry requests
-      sentry_version: SENTRY_API_VERSION,
-    };
-    // Auth is intentionally sent as part of query string (NOT as custom HTTP header)
-    // to avoid preflight CORS requests
-    return `${this.getStoreEndpoint()}?${urlEncode(auth)}`;
-  }
-
-  /** Returns the base path of the url including the port. */
-  private _getBaseUrl(): string {
+  /** Returns the prefix to construct Sentry ingestion API endpoints. */
+  public getBaseApiEndpoint(): string {
     const dsn = this._dsnObject;
     const protocol = dsn.protocol ? `${dsn.protocol}:` : '';
     const port = dsn.port ? `:${dsn.port}` : '';
-    return `${protocol}//${dsn.host}${port}`;
+    return `${protocol}//${dsn.host}${port}${dsn.path ? `/${dsn.path}` : ''}/api/`;
+  }
+
+  /** Returns the store endpoint URL. */
+  public getStoreEndpoint(): string {
+    return this._getIngestEndpoint('store');
+  }
+
+  /** Returns the envelope endpoint URL. */
+  private _getEnvelopeEndpoint(): string {
+    return this._getIngestEndpoint('envelope');
+  }
+
+  /** Returns the ingest API endpoint for target. */
+  private _getIngestEndpoint(target: 'store' | 'envelope'): string {
+    const base = this.getBaseApiEndpoint();
+    const dsn = this._dsnObject;
+    return `${base}${dsn.projectId}/${target}/`;
+  }
+
+  /**
+   * Returns the store endpoint URL with auth in the query string.
+   *
+   * Sending auth as part of the query string and not as custom HTTP headers avoids CORS preflight requests.
+   */
+  public getStoreEndpointWithUrlEncodedAuth(): string {
+    return `${this.getStoreEndpoint()}?${this._encodedAuth()}`;
+  }
+
+  /**
+   * Returns the envelope endpoint URL with auth in the query string.
+   *
+   * Sending auth as part of the query string and not as custom HTTP headers avoids CORS preflight requests.
+   */
+  public getEnvelopeEndpointWithUrlEncodedAuth(): string {
+    return `${this._getEnvelopeEndpoint()}?${this._encodedAuth()}`;
+  }
+
+  /** Returns a URL-encoded string with auth config suitable for a query string. */
+  private _encodedAuth(): string {
+    const dsn = this._dsnObject;
+    const auth = {
+      // We send only the minimum set of required information. See
+      // https://github.com/getsentry/sentry-javascript/issues/2572.
+      sentry_key: dsn.user,
+      sentry_version: SENTRY_API_VERSION,
+    };
+    return urlEncode(auth);
   }
 
   /** Returns only the path component for the store endpoint. */
@@ -48,7 +78,11 @@ export class API {
     return `${dsn.path ? `/${dsn.path}` : ''}/api/${dsn.projectId}/store/`;
   }
 
-  /** Returns an object that can be used in request headers. */
+  /**
+   * Returns an object that can be used in request headers.
+   *
+   * @deprecated in favor of `getStoreEndpointWithUrlEncodedAuth` and `getEnvelopeEndpointWithUrlEncodedAuth`.
+   */
   public getRequestHeaders(clientName: string, clientVersion: string): { [key: string]: string } {
     const dsn = this._dsnObject;
     const header = [`Sentry sentry_version=${SENTRY_API_VERSION}`];
@@ -71,7 +105,7 @@ export class API {
     } = {},
   ): string {
     const dsn = this._dsnObject;
-    const endpoint = `${this._getBaseUrl()}${dsn.path ? `/${dsn.path}` : ''}/api/embed/error-page/`;
+    const endpoint = `${this.getBaseApiEndpoint()}embed/error-page/`;
 
     const encodedOptions = [];
     encodedOptions.push(`dsn=${dsn.toString()}`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export { addGlobalEventProcessor, getCurrentHub, getHubFromCarrier, Hub, Scope }
 export { API } from './api';
 export { BaseClient } from './baseclient';
 export { BackendClass, BaseBackend } from './basebackend';
+export { eventToSentryRequest } from './request';
 export { initAndBind, ClientClass } from './sdk';
 export { NoopTransport } from './transports/noop';
 

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -1,0 +1,61 @@
+import { Event } from '@sentry/types';
+
+import { API } from './api';
+
+/** A generic client request. */
+interface SentryRequest {
+  body: string;
+  url: string;
+  // headers would contain auth & content-type headers for @sentry/node, but
+  // since @sentry/browser avoids custom headers to prevent CORS preflight
+  // requests, we can use the same approach for @sentry/browser and @sentry/node
+  // for simplicity -- no headers involved.
+  // headers: { [key: string]: string };
+}
+
+/** Creates a SentryRequest from an event. */
+export function eventToSentryRequest(event: Event, api: API): SentryRequest {
+  const useEnvelope = event.type === 'transaction';
+
+  const req: SentryRequest = {
+    body: JSON.stringify(event),
+    url: useEnvelope ? api.getEnvelopeEndpointWithUrlEncodedAuth() : api.getStoreEndpointWithUrlEncodedAuth(),
+  };
+
+  // https://docs.sentry.io/development/sdk-dev/envelopes/
+
+  // Since we don't need to manipulate envelopes nor store them, there is no
+  // exported concept of an Envelope with operations including serialization and
+  // deserialization. Instead, we only implement a minimal subset of the spec to
+  // serialize events inline here.
+  if (useEnvelope) {
+    const envelopeHeaders = JSON.stringify({
+      event_id: event.event_id,
+      sent_at: new Date().toISOString(),
+    });
+    const itemHeaders = JSON.stringify({
+      type: event.type,
+      // The content-type is assumed to be 'application/json' and not part of
+      // the current spec for transaction items, so we don't bloat the request
+      // body with it.
+      //
+      // content_type: 'application/json',
+      //
+      // The length is optional. It must be the number of bytes in req.Body
+      // encoded as UTF-8. Since the server can figure this out and would
+      // otherwise refuse events that report the length incorrectly, we decided
+      // not to send the length to avoid problems related to reporting the wrong
+      // size and to reduce request body size.
+      //
+      // length: new TextEncoder().encode(req.body).length,
+    });
+    // The trailing newline is optional. We intentionally don't send it to avoid
+    // sending unnecessary bytes.
+    //
+    // const envelope = `${envelopeHeaders}\n${itemHeaders}\n${req.body}\n`;
+    const envelope = `${envelopeHeaders}\n${itemHeaders}\n${req.body}`;
+    req.body = envelope;
+  }
+
+  return req;
+}

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -22,7 +22,7 @@ export function eventToSentryRequest(event: Event, api: API): SentryRequest {
     url: useEnvelope ? api.getEnvelopeEndpointWithUrlEncodedAuth() : api.getStoreEndpointWithUrlEncodedAuth(),
   };
 
-  // https://docs.sentry.io/development/sdk-dev/envelopes/
+  // https://develop.sentry.dev/sdk/envelopes/
 
   // Since we don't need to manipulate envelopes nor store them, there is no
   // exported concept of an Envelope with operations including serialization and

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -4,38 +4,21 @@ import { API } from './api';
 
 /** A generic client request. */
 interface SentryRequest {
-  url: string;
-  headers: { [key: string]: string };
   body: string;
+  url: string;
+  // headers would contain auth & content-type headers for @sentry/node, but
+  // since @sentry/browser avoids custom headers to prevent CORS preflight
+  // requests, we can use the same approach for @sentry/browser and @sentry/node
+  // for simplicity -- no headers involved.
+  // headers: { [key: string]: string };
 }
 
 /** Creates a SentryRequest from an event. */
-export function eventToSentryRequest(event: Event, api: API, extraHeaders?: { [key: string]: string }): SentryRequest {
+export function eventToSentryRequest(event: Event, api: API): SentryRequest {
   const useEnvelope = event.type === 'transaction';
 
   const req: SentryRequest = {
     body: JSON.stringify(event),
-    headers: {
-      // To simplify maintenance, eventToSentryRequest is used by both
-      // @sentry/browser and @sentry/node.
-      //
-      // In @sentry/browser we want to avoid CORS preflight requests and thus we
-      // want to ensure outgoing requests are "simple requests" as explained in
-      // https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Simple_requests.
-      //
-      // Therefore, we do not include any custom headers (auth goes in the query
-      // string instead) and we are limited in the values of Content-Type. If we
-      // were to not set the Content-Type header, browsers fill it in as
-      // `text/plain`, which is rejected by Relay for envelopes. If we set it to
-      // the empty string, current versions of mainstream browsers seem to
-      // respect it and despite empty string not being in the list of accepted
-      // values for "simple requests", empirically browsers do not send
-      // preflight requests in that case.
-      //
-      // 'Content-Type': useEnvelope ? 'application/x-sentry-envelope' : 'application/json',
-      'Content-Type': '',
-      ...extraHeaders,
-    },
     url: useEnvelope ? api.getEnvelopeEndpointWithUrlEncodedAuth() : api.getStoreEndpointWithUrlEncodedAuth(),
   };
 

--- a/packages/core/test/lib/api.test.ts
+++ b/packages/core/test/lib/api.test.ts
@@ -16,11 +16,13 @@ describe('API', () => {
   });
 
   test('getRequestHeaders', () => {
+    // tslint:disable-next-line:deprecation
     expect(new API(dsnPublic).getRequestHeaders('a', '1.0')).toMatchObject({
       'Content-Type': 'application/json',
       'X-Sentry-Auth': expect.stringMatching(/^Sentry sentry_version=\d, sentry_client=a\/1\.0, sentry_key=abc$/),
     });
 
+    // tslint:disable-next-line:deprecation
     expect(new API(legacyDsn).getRequestHeaders('a', '1.0')).toMatchObject({
       'Content-Type': 'application/json',
       'X-Sentry-Auth': expect.stringMatching(

--- a/packages/node/src/transports/base.ts
+++ b/packages/node/src/transports/base.ts
@@ -57,13 +57,10 @@ export abstract class BaseTransport implements Transport {
   }
 
   /** Returns a build request option object used by request */
-  protected _getRequestOptions(uri: url.URL): http.RequestOptions | https.RequestOptions {
-    const headers = {
-      // The auth headers are not included because auth is done via query string to match @sentry/browser.
-      //
-      // ...this._api.getRequestHeaders(SDK_NAME, SDK_VERSION)
-      ...this.options.headers,
-    };
+  protected _getRequestOptions(
+    uri: url.URL,
+    headers: { [key: string]: string },
+  ): http.RequestOptions | https.RequestOptions {
     const { hostname, pathname, port, protocol, search } = uri;
     // See https://github.com/nodejs/node/blob/38146e717fed2fabe3aacb6540d839475e0ce1c6/lib/internal/url.js#L1268-L1290
     const path = `${pathname}${search}`;
@@ -93,8 +90,8 @@ export abstract class BaseTransport implements Transport {
     }
     return this._buffer.add(
       new Promise<Response>((resolve, reject) => {
-        const sentryReq = eventToSentryRequest(event, this._api);
-        const options = this._getRequestOptions(new url.URL(sentryReq.url));
+        const sentryReq = eventToSentryRequest(event, this._api, this.options.headers);
+        const options = this._getRequestOptions(new url.URL(sentryReq.url), sentryReq.headers);
 
         const req = httpModule.request(options, (res: http.IncomingMessage) => {
           const statusCode = res.statusCode || 500;

--- a/packages/node/test/transports/http.test.ts
+++ b/packages/node/test/transports/http.test.ts
@@ -6,6 +6,7 @@ import { HTTPTransport } from '../../src/transports/http';
 
 const mockSetEncoding = jest.fn();
 const dsn = 'http://9e9fd4523d784609a5fc0ebb1080592f@sentry.io:8989/mysubpath/50622';
+const transportPath = '/mysubpath/api/50622/store/?sentry_key=9e9fd4523d784609a5fc0ebb1080592f&sentry_version=7';
 let mockReturnCode = 200;
 let mockHeaders = {};
 
@@ -27,11 +28,9 @@ function createTransport(options: TransportOptions): HTTPTransport {
 }
 
 function assertBasicOptions(options: any): void {
-  expect(options.headers['X-Sentry-Auth']).toContain('sentry_version');
-  expect(options.headers['X-Sentry-Auth']).toContain('sentry_client');
-  expect(options.headers['X-Sentry-Auth']).toContain('sentry_key');
+  expect(options.headers).not.toContain('X-Sentry-Auth'); // auth is part of the query string
   expect(options.port).toEqual('8989');
-  expect(options.path).toEqual('/mysubpath/api/50622/store/');
+  expect(options.path).toEqual(transportPath);
   expect(options.hostname).toEqual('sentry.io');
 }
 

--- a/packages/node/test/transports/https.test.ts
+++ b/packages/node/test/transports/https.test.ts
@@ -6,6 +6,7 @@ import { HTTPSTransport } from '../../src/transports/https';
 
 const mockSetEncoding = jest.fn();
 const dsn = 'https://9e9fd4523d784609a5fc0ebb1080592f@sentry.io:8989/mysubpath/50622';
+const transportPath = '/mysubpath/api/50622/store/?sentry_key=9e9fd4523d784609a5fc0ebb1080592f&sentry_version=7';
 let mockReturnCode = 200;
 let mockHeaders = {};
 
@@ -33,11 +34,9 @@ function createTransport(options: TransportOptions): HTTPSTransport {
 }
 
 function assertBasicOptions(options: any): void {
-  expect(options.headers['X-Sentry-Auth']).toContain('sentry_version');
-  expect(options.headers['X-Sentry-Auth']).toContain('sentry_client');
-  expect(options.headers['X-Sentry-Auth']).toContain('sentry_key');
+  expect(options.headers).not.toContain('X-Sentry-Auth'); // auth is part of the query string
   expect(options.port).toEqual('8989');
-  expect(options.path).toEqual('/mysubpath/api/50622/store/');
+  expect(options.path).toEqual(transportPath);
   expect(options.hostname).toEqual('sentry.io');
 }
 


### PR DESCRIPTION
The new Envelope endpoint and format is what we want to use for transactions going forward.

Apart from transactions as Envelopes, we unify how `@sentry/browser` and `@sentry/node` authenticate requests for ease of maintenance. Now all requests include the public key as a query string.