### PR TITLE
fix: fetch errors do not have responses

### DIFF
--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -189,10 +189,7 @@ export class Breadcrumbs implements Integration {
       getCurrentHub().addBreadcrumb(
         {
           category: 'fetch',
-          data: {
-            ...handlerData.fetchData,
-            status_code: handlerData.response.status,
-          },
+          data: handlerData.fetchData,
           level: Severity.Error,
           type: 'http',
         },


### PR DESCRIPTION
> Originally I was going to file an issue, but I figured it'd be more useful to just PR the fix

<!-- Requirements: please go through this checklist before opening a new issue -->

- [X] Review the documentation: https://docs.sentry.io/
- [X] Search for existing issues: https://github.com/getsentry/sentry-javascript/issues
- [X] Use the latest release: https://github.com/getsentry/sentry-javascript/releases
- [ ] <strike>Provide a link to the affected event from your Sentry account</strike> **Not Applicable**

## Package + Version

- [x] `@sentry/browser`

### Version:

```
5.15.5
```

## Description

`fetch` breadcrumbs attempts to access a  non-existent `response` object. 

`fetch` treats all responses as a success, regardless of the HTTP status code. When `fetch` throws an error, it won't have a response.

## Details

To reproduce the error, you can use this small HTML file:

``` html
<!DOCTYPE html>
<script src="https://browser.sentry-cdn.com/5.15.5/bundle.min.js"></script>
<script>
Sentry.init({
    dsn: "YOUR_PUBLIC_DSN",
    debug: true,
});
fetch("https://some-domain-that.doesnt-exist.com");
</script>
```

### Explanation

The handlers for `fetch` do not add a `response` object when an error occurs (correctly, as one does not exist in this case):

https://github.com/getsentry/sentry-javascript/blob/03d9ef0feff883f8c1cad96743b3ead84d9aaf48/packages/utils/src/instrument.ts#L166-L173

However, in the code for adding the fetch breadcrumbs, there is an unconditional attempt to access the `response.status` property in the error case:

https://github.com/getsentry/sentry-javascript/blob/03d9ef0feff883f8c1cad96743b3ead84d9aaf48/packages/browser/src/integrations/breadcrumbs.ts#L188-L196

Which leads to the error shown:

![image](https://user-images.githubusercontent.com/96213/80647215-56a37080-8a2b-11ea-8651-70ae6a1c639c.png)
