### PR TITLE
Fix reading source file multiple times

### DIFF
--- a/packages/node/src/parsers.ts
+++ b/packages/node/src/parsers.ts
@@ -163,7 +163,7 @@ export function parseStack(stack: stacktrace.StackFrame[], options?: NodeOptions
     if (parsedFrame.filename) {
       parsedFrame.module = getModule(parsedFrame.filename);
 
-      if (!isInternal && linesOfContext > 0) {
+      if (!isInternal && linesOfContext > 0 && filesToRead.indexOf(parsedFrame.filename) === -1) {
         filesToRead.push(parsedFrame.filename);
       }
     }

--- a/packages/node/test/parsers.test.ts
+++ b/packages/node/test/parsers.test.ts
@@ -4,6 +4,7 @@ import * as Parsers from '../src/parsers';
 import * as stacktrace from '../src/stacktrace';
 
 import { getError } from './helper/error';
+import { StackFrame } from '../src/stacktrace';
 
 describe('parsers.ts', () => {
   let frames: stacktrace.StackFrame[];
@@ -68,6 +69,42 @@ describe('parsers.ts', () => {
         .then(null, () => {
           // no-empty
         });
+    });
+  });
+
+  test('parseStack with duplicate files', async () => {
+    expect.assertions(1);
+    const frames: StackFrame[] = [
+      {
+        columnNumber: 1,
+        fileName: '/var/task/index.js',
+        functionName: 'module.exports../src/index.ts.fxn1',
+        lineNumber: 1,
+        methodName: 'fxn1',
+        native: false,
+        typeName: 'module.exports../src/index.ts',
+      },
+      {
+        columnNumber: 2,
+        fileName: '/var/task/index.js',
+        functionName: 'module.exports../src/index.ts.fxn2',
+        lineNumber: 2,
+        methodName: 'fxn2',
+        native: false,
+        typeName: 'module.exports../src/index.ts',
+      },
+      {
+        columnNumber: 3,
+        fileName: '/var/task/index.js',
+        functionName: 'module.exports../src/index.ts.fxn3',
+        lineNumber: 3,
+        methodName: 'fxn3',
+        native: false,
+        typeName: 'module.exports../src/index.ts',
+      },
+    ];
+    return Parsers.parseStack(frames).then(_ => {
+      expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/node/test/parsers.test.ts
+++ b/packages/node/test/parsers.test.ts
@@ -4,7 +4,6 @@ import * as Parsers from '../src/parsers';
 import * as stacktrace from '../src/stacktrace';
 
 import { getError } from './helper/error';
-import { StackFrame } from '../src/stacktrace';
 
 describe('parsers.ts', () => {
   let frames: stacktrace.StackFrame[];
@@ -74,7 +73,7 @@ describe('parsers.ts', () => {
 
   test('parseStack with duplicate files', async () => {
     expect.assertions(1);
-    const frames: StackFrame[] = [
+    const framesWithDuplicateFiles: stacktrace.StackFrame[] = [
       {
         columnNumber: 1,
         fileName: '/var/task/index.js',
@@ -103,7 +102,7 @@ describe('parsers.ts', () => {
         typeName: 'module.exports../src/index.ts',
       },
     ];
-    return Parsers.parseStack(frames).then(_ => {
+    return Parsers.parseStack(framesWithDuplicateFiles).then(_ => {
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

`@sentry/node/parsers/readSourceFiles()` expects the list of source files to be deduplicated (https://github.com/getsentry/sentry-javascript/blob/8870389b2d56673cb233356d1cb1b589de28cce8/packages/node/src/parsers.ts#L71).  If `parseStack()` doesn't deduplicate the list then the same file is opened multiple times.  If the file is large (which can happen when using webpack) then this can waste enough memory to be a problem on a memory-constrained instance.

For example this stack:

```
[ { columnNumber: 11,
    fileName: '/var/task/index.js',
    functionName: null,
    lineNumber: 339944,
    methodName: null,
    native: false,
    typeName: 'Object' },
  { columnNumber: null,
    fileName: null,
    functionName: 'Generator.next',
    lineNumber: null,
    methodName: 'next',
    native: false,
    typeName: 'Generator' },
  { columnNumber: 67,
    fileName: '/var/task/index.js',
    functionName: null,
    lineNumber: 339920,
    methodName: null,
    native: false,
    typeName: null },
  { columnNumber: null,
    fileName: null,
    functionName: 'new Promise',
    lineNumber: null,
    methodName: null,
    native: false,
    typeName: null },
  { columnNumber: 10,
    fileName: '/var/task/index.js',
    functionName: 'module.exports../src/lambdas/rest/user/index.ts.__awaiter',
    lineNumber: 339899,
    methodName: '__awaiter',
    native: false,
    typeName: 'module.exports../src/lambdas/rest/user/index.ts' },
  { columnNumber: 47,
    fileName: '/var/task/index.js',
    functionName: 'Object.router.route.handler.evt [as handler]',
    lineNumber: 339943,
    methodName: 'evt [as handler]',
    native: false,
    typeName: 'Object.router.route.handler' },
  { columnNumber: 42,
    fileName: '/var/task/index.js',
    functionName: null,
    lineNumber: 13489,
    methodName: null,
    native: false,
    typeName: 'BuildableRoute' },
  { columnNumber: null,
    fileName: null,
    functionName: 'Generator.next',
    lineNumber: null,
    methodName: 'next',
    native: false,
    typeName: 'Generator' },
  { columnNumber: 67,
    fileName: '/var/task/index.js',
    functionName: null,
    lineNumber: 13429,
    methodName: null,
    native: false,
    typeName: null },
  { columnNumber: null,
    fileName: null,
    functionName: 'new Promise',
    lineNumber: null,
    methodName: null,
    native: false,
    typeName: null },
  { columnNumber: 10,
    fileName: '/var/task/index.js',
    functionName:
     'module.exports../node_modules/cassava/dist/routes/BuildableRoute.js.__awaiter',
    lineNumber: 13408,
    methodName: '__awaiter',
    native: false,
    typeName:
     'module.exports../node_modules/cassava/dist/routes/BuildableRoute.js' },
  { columnNumber: 12,
    fileName: '/var/task/index.js',
    functionName: 'BuildableRoute.handle',
    lineNumber: 13471,
    methodName: 'handle',
    native: false,
    typeName: 'BuildableRoute' },
  { columnNumber: 34,
    fileName: '/var/task/index.js',
    functionName: null,
    lineNumber: 12653,
    methodName: null,
    native: false,
    typeName: 'Router' },
  { columnNumber: null,
    fileName: null,
    functionName: 'Generator.next',
    lineNumber: null,
    methodName: 'next',
    native: false,
    typeName: 'Generator' },
  { columnNumber: 24,
    fileName: '/var/task/index.js',
    functionName: 'fulfilled',
    lineNumber: 12516,
    methodName: null,
    native: false,
    typeName: null },
  { columnNumber: 7,
    fileName: 'internal/process/next_tick.js',
    functionName: 'process._tickCallback',
    lineNumber: 68,
    methodName: '_tickCallback',
    native: false,
    typeName: 'process' } ]
```

generates filesToRead

```
[ '/var/task/index.js',
  '/var/task/index.js',
  '/var/task/index.js',
  '/var/task/index.js',
  '/var/task/index.js',
  '/var/task/index.js',
  '/var/task/index.js',
  '/var/task/index.js',
  '/var/task/index.js',
  '/var/task/index.js' ]
```