### PR TITLE
feat: Vue performance monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- [integrations/vue] feat: Vue performance monitoring (#2571)
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
 ## 5.15.5

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -16,7 +16,6 @@
   "module": "esm/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@sentry/apm": "5.15.5",
     "@sentry/types": "5.15.5",
     "@sentry/utils": "5.15.5",
     "tslib": "^1.9.3"

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -16,6 +16,7 @@
   "module": "esm/index.js",
   "types": "dist/index.d.ts",
   "dependencies": {
+    "@sentry/apm": "5.15.5",
     "@sentry/types": "5.15.5",
     "@sentry/utils": "5.15.5",
     "tslib": "^1.9.3"

--- a/packages/integrations/src/vue.ts
+++ b/packages/integrations/src/vue.ts
@@ -1,17 +1,36 @@
+import { Integrations as APMIntegrations, Span as SpanClass } from '@sentry/apm';
 import { EventProcessor, Hub, Integration } from '@sentry/types';
 import { basename, getGlobalObject, logger, timestampWithMs } from '@sentry/utils';
-import { Integrations as APMIntegrations, Span as SpanClass } from '@sentry/apm';
 
+/** Global Vue object limited to the methods/attributes we require */
 interface VueInstance {
   config?: {
-    errorHandler(error: Error, vm?: ViewModel, info?: string): void;
+    errorHandler?(error: Error, vm?: ViewModel, info?: string): void; // tslint:disable-line:completed-docs
   };
-  mixin(opts: { [key: string]: () => void }): void;
+  mixin(hooks: { [key: string]: () => void }): void; // tslint:disable-line:completed-docs
   util: {
-    warn(...input: any): void;
+    warn(...input: any): void; // tslint:disable-line:completed-docs
   };
 }
 
+/** Representation of Vue component internals */
+interface ViewModel {
+  [key: string]: any;
+  $root: object;
+  $options: {
+    [key: string]: any;
+    name?: string;
+    propsData?: { [key: string]: any };
+    _componentTag?: string;
+    __file?: string;
+    $_sentryPerfHook?: boolean;
+  };
+  $once(hook: string, cb: () => void): void; // tslint:disable-line:completed-docs
+}
+
+// tslint:enable:completed-docs
+
+/** Vue Integration configuration */
 interface IntegrationOptions {
   /** Vue instance to be used inside the integration */
   Vue: VueInstance;
@@ -41,30 +60,17 @@ interface TracingOptions {
    * Can be either set to `boolean` to enable/disable tracking for all of them.
    * Or to an array of specific component names (case-sensitive).
    */
-  trackComponents: boolean | Array<string>;
+  trackComponents: boolean | string[];
   /** How long to wait until the tracked root activity is marked as finished and sent of to Sentry */
   timeout: number;
   /**
    * List of hooks to keep track of during component lifecycle.
    * Available hooks: https://vuejs.org/v2/api/#Options-Lifecycle-Hooks
    */
-  hooks: Array<Hook>;
+  hooks: Hook[];
 }
 
-interface ViewModel {
-  [key: string]: any;
-  $root: object;
-  $options: {
-    [key: string]: any;
-    name?: string;
-    propsData?: { [key: string]: any };
-    _componentTag?: string;
-    __file?: string;
-    $_sentryPerfHook?: boolean;
-  };
-  $once: (hook: string, cb: () => void) => void;
-}
-
+/** Optional metadata attached to Sentry Event */
 interface Metadata {
   [key: string]: any;
   componentName?: string;
@@ -74,32 +80,32 @@ interface Metadata {
 
 // https://vuejs.org/v2/api/#Options-Lifecycle-Hooks
 type Hook =
-  | 'beforeCreate'
-  | 'created'
-  | 'beforeMount'
-  | 'mounted'
-  | 'beforeUpdate'
-  | 'updated'
   | 'activated'
-  | 'deactivated'
+  | 'beforeCreate'
   | 'beforeDestroy'
-  | 'destroyed';
+  | 'beforeMount'
+  | 'beforeUpdate'
+  | 'created'
+  | 'deactivated'
+  | 'destroyed'
+  | 'mounted'
+  | 'updated';
 
-type Operation = 'create' | 'mount' | 'update' | 'activate' | 'destroy';
+type Operation = 'activate' | 'create' | 'destroy' | 'mount' | 'update';
 
 // Mappings from lifecycle hook to corresponding operation,
 // used to track already started measurements.
 const OPERATIONS: { [key in Hook]: Operation } = {
-  beforeCreate: 'create',
-  created: 'create',
-  beforeMount: 'mount',
-  mounted: 'mount',
-  beforeUpdate: 'update',
-  updated: 'update',
   activated: 'activate',
-  deactivated: 'activate',
+  beforeCreate: 'create',
   beforeDestroy: 'destroy',
+  beforeMount: 'mount',
+  beforeUpdate: 'update',
+  created: 'create',
+  deactivated: 'activate',
   destroyed: 'destroy',
+  mounted: 'mount',
+  updated: 'update',
 };
 
 const COMPONENT_NAME_REGEXP = /(?:^|[-_/])(\w)/g;
@@ -118,36 +124,39 @@ export class Vue implements Integration {
    */
   public static id: string = 'Vue';
 
-  private _options: IntegrationOptions;
+  private readonly _options: IntegrationOptions;
 
   /**
    * Cache holding already processed component names
    */
-  private componentsCache = Object.create(null);
-  private rootSpan?: SpanClass;
-  private rootSpanTimer?: ReturnType<typeof setTimeout>;
-  private tracingActivity?: number;
+  private readonly _componentsCache: { [key: string]: string } = {};
+  private _rootSpan?: SpanClass;
+  private _rootSpanTimer?: ReturnType<typeof setTimeout>;
+  private _tracingActivity?: number;
 
   /**
    * @inheritDoc
    */
   public constructor(options: Partial<IntegrationOptions>) {
     this._options = {
-      Vue: getGlobalObject<any>().Vue,
+      Vue: getGlobalObject<any>().Vue, // tslint:disable-line:no-unsafe-any
       attachProps: true,
       logErrors: false,
       tracing: false,
       ...options,
       tracingOptions: {
-        trackComponents: false,
         hooks: ['beforeMount', 'mounted', 'beforeUpdate', 'updated'],
         timeout: 2000,
+        trackComponents: false,
         ...options.tracingOptions,
       },
     };
   }
 
-  private getComponentName(vm: ViewModel): string {
+  /**
+   * Extract component name from the ViewModel
+   */
+  private _getComponentName(vm: ViewModel): string {
     // Such level of granularity is most likely not necessary, but better safe than sorry. — Kamil
     if (!vm) {
       return ANONYMOUS_COMPONENT_NAME;
@@ -174,22 +183,27 @@ export class Vue implements Integration {
       const unifiedFile = vm.$options.__file.replace(/^[a-zA-Z]:/, '').replace(/\\/g, '/');
       const filename = basename(unifiedFile, '.vue');
       return (
-        this.componentsCache[filename] ||
-        (this.componentsCache[filename] = filename.replace(COMPONENT_NAME_REGEXP, (_, c) => (c ? c.toUpperCase() : '')))
+        this._componentsCache[filename] ||
+        (this._componentsCache[filename] = filename.replace(COMPONENT_NAME_REGEXP, (_, c: string) =>
+          c ? c.toUpperCase() : '',
+        ))
       );
     }
 
     return ANONYMOUS_COMPONENT_NAME;
   }
 
-  private applyTracingHooks(vm: ViewModel, getCurrentHub: () => Hub): void {
+  /** Keep it as attribute function, to keep correct `this` binding inside the hooks callbacks  */
+  private readonly _applyTracingHooks = (vm: ViewModel, getCurrentHub: () => Hub) => {
     // Don't attach twice, just in case
-    if (vm.$options.$_sentryPerfHook) return;
+    if (vm.$options.$_sentryPerfHook) {
+      return;
+    }
     vm.$options.$_sentryPerfHook = true;
 
-    const name = this.getComponentName(vm);
+    const name = this._getComponentName(vm);
     const rootMount = name === ROOT_COMPONENT_NAME;
-    const spans: { [key: string]: any } = {};
+    const spans: { [key: string]: SpanClass } = {};
 
     // Render hook starts after once event is emitted,
     // but it ends before the second event of the same type.
@@ -201,14 +215,14 @@ export class Vue implements Integration {
 
       // On the first handler call (before), it'll be undefined, as `$once` will add it in the future.
       // However, on the second call (after), it'll be already in place.
-      if (this.rootSpan) {
-        this.finishRootSpan(now);
+      if (this._rootSpan) {
+        this._finishRootSpan(now);
       } else {
         vm.$once(`hook:${hook}`, () => {
           // Create an activity on the first event call. There'll be no second call, as rootSpan will be in place,
           // thus new event handler won't be attached.
-          this.tracingActivity = APMIntegrations.Tracing.pushActivity('Vue Application Render');
-          this.rootSpan = getCurrentHub().startSpan({
+          this._tracingActivity = APMIntegrations.Tracing.pushActivity('Vue Application Render');
+          this._rootSpan = getCurrentHub().startSpan({
             description: 'Application Render',
             op: 'Vue',
           }) as SpanClass;
@@ -222,7 +236,7 @@ export class Vue implements Integration {
         ? this._options.tracingOptions.trackComponents.includes(name)
         : this._options.tracingOptions.trackComponents;
 
-      if (!this.rootSpan || !shouldTrack) {
+      if (!this._rootSpan || !shouldTrack) {
         return;
       }
 
@@ -234,11 +248,11 @@ export class Vue implements Integration {
       // However, on the second call (after), it'll be already in place.
       if (span) {
         span.finish();
-        this.finishRootSpan(now);
+        this._finishRootSpan(now);
       } else {
         vm.$once(`hook:${hook}`, () => {
-          if (this.rootSpan) {
-            spans[op] = this.rootSpan.child({
+          if (this._rootSpan) {
+            spans[op] = this._rootSpan.child({
               description: `Vue <${name}>`,
               op,
             });
@@ -260,28 +274,30 @@ export class Vue implements Integration {
         vm.$options[hook] = [handler];
       }
     });
-  }
+  };
 
-  private finishRootSpan(timestamp: number): void {
-    if (this.rootSpanTimer) {
-      clearTimeout(this.rootSpanTimer);
+  /** Finish top-level span and activity with a debounce configured using `timeout` option */
+  private _finishRootSpan(timestamp: number): void {
+    if (this._rootSpanTimer) {
+      clearTimeout(this._rootSpanTimer);
     }
 
-    this.rootSpanTimer = setTimeout(() => {
-      if (this.rootSpan) {
-        this.rootSpan.timestamp = timestamp;
+    this._rootSpanTimer = setTimeout(() => {
+      if (this._rootSpan) {
+        this._rootSpan.timestamp = timestamp;
       }
-      if (this.tracingActivity) {
-        APMIntegrations.Tracing.popActivity(this.tracingActivity);
+      if (this._tracingActivity) {
+        APMIntegrations.Tracing.popActivity(this._tracingActivity);
       }
     }, this._options.tracingOptions.timeout);
   }
 
-  private startTracing(getCurrentHub: () => Hub): void {
-    const applyTracingHooks = this.applyTracingHooks.bind(this);
+  /** Inject configured tracing hooks into Vue's component lifecycles */
+  private _startTracing(getCurrentHub: () => Hub): void {
+    const applyTracingHooks = this._applyTracingHooks;
 
     this._options.Vue.mixin({
-      beforeCreate() {
+      beforeCreate(this: ViewModel): void {
         // TODO: Move this check to `setupOnce` when we rework integrations initialization in v6
         if (getCurrentHub().getIntegration(APMIntegrations.Tracing)) {
           // `this` points to currently rendered component
@@ -293,19 +309,21 @@ export class Vue implements Integration {
     });
   }
 
-  private attachErrorHandler(getCurrentHub: () => Hub): void {
+  /** Inject Sentry's handler into owns Vue's error handler  */
+  private _attachErrorHandler(getCurrentHub: () => Hub): void {
     if (!this._options.Vue.config) {
-      return logger.error('Vue instance is missing required `config` attribute');
+      logger.error('Vue instance is missing required `config` attribute');
+      return;
     }
 
-    const currentErrorHandler = this._options.Vue.config.errorHandler;
+    const currentErrorHandler = this._options.Vue.config.errorHandler; // tslint:disable-line:no-unbound-method
 
     this._options.Vue.config.errorHandler = (error: Error, vm?: ViewModel, info?: string): void => {
       const metadata: Metadata = {};
 
       if (vm) {
         try {
-          metadata.componentName = this.getComponentName(vm);
+          metadata.componentName = this._getComponentName(vm);
 
           if (this._options.attachProps) {
             metadata.propsData = vm.$options.propsData;
@@ -345,13 +363,14 @@ export class Vue implements Integration {
    */
   public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
     if (!this._options.Vue) {
-      return logger.error('Vue integration is missing a Vue instance');
+      logger.error('Vue integration is missing a Vue instance');
+      return;
     }
 
-    this.attachErrorHandler(getCurrentHub);
+    this._attachErrorHandler(getCurrentHub);
 
     if (this._options.tracing) {
-      this.startTracing(getCurrentHub);
+      this._startTracing(getCurrentHub);
     }
   }
 }

--- a/packages/integrations/src/vue.ts
+++ b/packages/integrations/src/vue.ts
@@ -1,15 +1,82 @@
 import { EventProcessor, Hub, Integration } from '@sentry/types';
-import { getGlobalObject, isPlainObject, logger } from '@sentry/utils';
+import { basename, getGlobalObject, logger, timestampWithMs } from '@sentry/utils';
+import { Integrations as APMIntegrations, Span as SpanClass } from '@sentry/apm';
+
+interface IntegrationOptions {
+  Vue: any;
+  /**
+   * When set to false, Sentry will suppress reporting of all props data
+   * from your Vue components for privacy concerns.
+   */
+  attachProps: boolean;
+  /**
+   * When set to true, original Vue's `logError` will be called as well.
+   * https://github.com/vuejs/vue/blob/c2b1cfe9ccd08835f2d99f6ce60f67b4de55187f/src/core/util/error.js#L38-L48
+   */
+  logErrors: boolean;
+  tracing: boolean;
+  tracingOptions: TracingOptions;
+}
+
+interface TracingOptions {
+  track: boolean | Array<string>;
+  timeout: number;
+  hooks: Array<Hook>;
+}
+
+interface ViewModel {
+  [key: string]: any;
+  $root: object;
+  $options: {
+    [key: string]: any;
+    name?: string;
+    propsData?: { [key: string]: any };
+    _componentTag?: string;
+    __file?: string;
+    $_sentryPerfHook?: boolean;
+  };
+  $once: (hook: string, cb: () => void) => void;
+}
 
 /** JSDoc */
 interface Metadata {
   [key: string]: any;
   componentName?: string;
-  propsData?: {
-    [key: string]: any;
-  };
+  propsData?: { [key: string]: any };
   lifecycleHook?: string;
 }
+
+// https://vuejs.org/v2/api/#Options-Lifecycle-Hooks
+type Hook =
+  | 'beforeCreate'
+  | 'created'
+  | 'beforeMount'
+  | 'mounted'
+  | 'beforeUpdate'
+  | 'updated'
+  | 'activated'
+  | 'deactivated'
+  | 'beforeDestroy'
+  | 'destroyed';
+
+// Mappings from lifecycle hook to corresponding operation,
+// used to track already started measurements.
+const OPERATIONS = {
+  beforeCreate: 'create',
+  created: 'create',
+  beforeMount: 'mount',
+  mounted: 'mount',
+  beforeUpdate: 'update',
+  updated: 'update',
+  activated: 'activate',
+  deactivated: 'activate',
+  beforeDestroy: 'destroy',
+  destroyed: 'destroy',
+};
+
+const COMPONENT_NAME_REGEXP = /(?:^|[-_/])(\w)/g;
+const ROOT_COMPONENT_NAME = 'root';
+const ANONYMOUS_COMPONENT_NAME = 'anonymous component';
 
 /** JSDoc */
 export class Vue implements Integration {
@@ -17,87 +84,215 @@ export class Vue implements Integration {
    * @inheritDoc
    */
   public name: string = Vue.id;
+
   /**
    * @inheritDoc
    */
   public static id: string = 'Vue';
 
-  /**
-   * @inheritDoc
-   */
-  private readonly _Vue: any; // tslint:disable-line:variable-name
+  private _options: IntegrationOptions;
 
   /**
-   * When set to false, Sentry will suppress reporting all props data
-   * from your Vue components for privacy concerns.
+   * Cache holding already processed component names
    */
-  private readonly _attachProps: boolean = true;
-
-  /**
-   * When set to true, original Vue's `logError` will be called as well.
-   * https://github.com/vuejs/vue/blob/c2b1cfe9ccd08835f2d99f6ce60f67b4de55187f/src/core/util/error.js#L38-L48
-   */
-  private readonly _logErrors: boolean = false;
+  private componentsCache = Object.create(null);
+  private rootSpan?: SpanClass;
+  private rootSpanTimer?: ReturnType<typeof setTimeout>;
+  private tracingActivity?: number;
 
   /**
    * @inheritDoc
    */
-  public constructor(options: { Vue?: any; attachProps?: boolean; logErrors?: boolean } = {}) {
-    // tslint:disable-next-line: no-unsafe-any
-    this._Vue = options.Vue || getGlobalObject<any>().Vue;
-
-    if (options.logErrors !== undefined) {
-      this._logErrors = options.logErrors;
-    }
-    if (options.attachProps === false) {
-      this._attachProps = false;
-    }
+  public constructor(options: Partial<IntegrationOptions>) {
+    this._options = {
+      Vue: getGlobalObject<any>().Vue,
+      attachProps: true,
+      logErrors: false,
+      tracing: false,
+      ...options,
+      tracingOptions: {
+        track: false,
+        hooks: ['beforeMount', 'mounted', 'beforeUpdate', 'updated'],
+        timeout: 2000,
+        ...options.tracingOptions,
+      },
+    };
   }
 
-  /** JSDoc */
-  private _formatComponentName(vm: any): string {
-    // tslint:disable:no-unsafe-any
+  private getComponentName(vm: ViewModel): string {
+    // Such level of granularity is most likely not necessary, but better safe than sorry. — Kamil
+    if (!vm) {
+      return ANONYMOUS_COMPONENT_NAME;
+    }
 
     if (vm.$root === vm) {
-      return 'root instance';
+      return ROOT_COMPONENT_NAME;
     }
-    const name = vm._isVue ? vm.$options.name || vm.$options._componentTag : vm.name;
-    return (
-      (name ? `component <${name}>` : 'anonymous component') +
-      (vm._isVue && vm.$options.__file ? ` at ${vm.$options.__file}` : '')
-    );
+
+    if (!vm.$options) {
+      return ANONYMOUS_COMPONENT_NAME;
+    }
+
+    if (vm.$options.name) {
+      return vm.$options.name;
+    }
+
+    if (vm.$options._componentTag) {
+      return vm.$options._componentTag;
+    }
+
+    // injected by vue-loader
+    if (vm.$options.__file) {
+      const unifiedFile = vm.$options.__file.replace(/^[a-zA-Z]:/, '').replace(/\\/g, '/');
+      const filename = basename(unifiedFile, '.vue');
+      return (
+        this.componentsCache[filename] ||
+        (this.componentsCache[filename] = filename.replace(COMPONENT_NAME_REGEXP, (_, c) => (c ? c.toUpperCase() : '')))
+      );
+    }
+
+    return ANONYMOUS_COMPONENT_NAME;
   }
 
-  /**
-   * @inheritDoc
-   */
-  public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    // tslint:disable:no-unsafe-any
+  private applyTracingHooks(vm: ViewModel, getCurrentHub: () => Hub): void {
+    // Don't attach twice, just in case
+    if (vm.$options.$_sentryPerfHook) return;
+    vm.$options.$_sentryPerfHook = true;
 
-    if (!this._Vue || !this._Vue.config) {
-      logger.error('VueIntegration is missing a Vue instance');
-      return;
+    const name = this.getComponentName(vm);
+    const rootMount = name === ROOT_COMPONENT_NAME;
+    const spans: { [key: string]: any } = {};
+
+    // Render hook starts after once event is emitted,
+    // but it ends before the second event of the same type.
+    //
+    // Because of this, we start measuring inside the first event,
+    // but finish it before it triggers, to skip the event emitter timing itself.
+    const rootHandler = (hook: Hook) => {
+      const now = timestampWithMs();
+
+      // On the first handler call (before), it'll be undefined, as `$once` will add it in the future.
+      // However, on the second call (after), it'll be already in place.
+      if (this.rootSpan) {
+        this.finishRootSpan(now);
+      } else {
+        vm.$once(`hook:${hook}`, () => {
+          // Create an activity on the first event call. There'll be no second call, as rootSpan will be in place,
+          // thus new event handler won't be attached.
+          this.tracingActivity = APMIntegrations.Tracing.pushActivity('Vue Application Render');
+          this.rootSpan = getCurrentHub().startSpan({
+            description: 'Application Render',
+            op: 'Vue',
+          }) as SpanClass;
+        });
+      }
+    };
+
+    const childHandler = (hook: Hook) => {
+      // Skip components that we don't want to track to minimize the noise and give a more granular control to the user
+      const shouldTrack = Array.isArray(this._options.tracingOptions.track)
+        ? this._options.tracingOptions.track.includes(name)
+        : this._options.tracingOptions.track;
+
+      if (!this.rootSpan || !shouldTrack) {
+        return;
+      }
+
+      const now = timestampWithMs();
+      const op = OPERATIONS[hook];
+      const span = spans[op];
+
+      // On the first handler call (before), it'll be undefined, as `$once` will add it in the future.
+      // However, on the second call (after), it'll be already in place.
+      if (span) {
+        span.finish();
+        this.finishRootSpan(now);
+      } else {
+        vm.$once(`hook:${hook}`, () => {
+          if (this.rootSpan) {
+            spans[op] = this.rootSpan.child({
+              description: `Vue <${name}>`,
+              op,
+            });
+          }
+        });
+      }
+    };
+
+    // Each compomnent has it's own scope, so all activities are only related to one of them
+    this._options.tracingOptions.hooks.forEach(hook => {
+      const handler = rootMount ? rootHandler.bind(this, hook) : childHandler.bind(this, hook);
+      const currentValue = vm.$options[hook];
+
+      if (Array.isArray(currentValue)) {
+        vm.$options[hook] = [handler, ...currentValue];
+      } else if (typeof currentValue === 'function') {
+        vm.$options[hook] = [handler, currentValue];
+      } else {
+        vm.$options[hook] = [handler];
+      }
+    });
+  }
+
+  private finishRootSpan(timestamp: number): void {
+    if (this.rootSpanTimer) {
+      clearTimeout(this.rootSpanTimer);
     }
 
-    const oldOnError = this._Vue.config.errorHandler;
+    this.rootSpanTimer = setTimeout(() => {
+      if (this.rootSpan) {
+        this.rootSpan.timestamp = timestamp;
+      }
+      if (this.tracingActivity) {
+        APMIntegrations.Tracing.popActivity(this.tracingActivity);
+      }
+    }, this._options.tracingOptions.timeout);
+  }
 
-    this._Vue.config.errorHandler = (error: Error, vm: { [key: string]: any }, info: string): void => {
+  private startTracing(getCurrentHub: () => Hub): void {
+    const applyTracingHooks = this.applyTracingHooks.bind(this);
+
+    this._options.Vue.mixin({
+      beforeCreate() {
+        // TODO: Move this check to `setupOnce` when we rework integrations initialization in v6
+        if (getCurrentHub().getIntegration(APMIntegrations.Tracing)) {
+          // `this` points to currently rendered component
+          applyTracingHooks(this, getCurrentHub);
+        } else {
+          logger.error('Vue integration has tracing enabled, but Tracing integration is not configured');
+        }
+      },
+    });
+  }
+
+  private attachErrorHandler(getCurrentHub: () => Hub): void {
+    if (!this._options.Vue.config) {
+      return logger.error('Vue instance is missing required `config` attribute');
+    }
+
+    const currentErrorHandler = this._options.Vue.config.errorHandler;
+
+    this._options.Vue.config.errorHandler = (error: Error, vm: ViewModel, info: string): void => {
       const metadata: Metadata = {};
 
-      if (isPlainObject(vm)) {
-        metadata.componentName = this._formatComponentName(vm);
+      if (vm) {
+        try {
+          metadata.componentName = this.getComponentName(vm);
 
-        if (this._attachProps) {
-          metadata.propsData = vm.$options.propsData;
+          if (this._options.attachProps) {
+            metadata.propsData = vm.$options.propsData;
+          }
+        } catch (_oO) {
+          logger.warn('Unable to extract metadata from Vue component.');
         }
       }
 
-      if (info !== void 0) {
+      if (info) {
         metadata.lifecycleHook = info;
       }
 
       if (getCurrentHub().getIntegration(Vue)) {
-        // This timeout makes sure that any breadcrumbs are recorded before sending it off the sentry
+        // Capture exception in the next event loop, to make sure that all breadcrumbs are recorded in time.
         setTimeout(() => {
           getCurrentHub().withScope(scope => {
             scope.setContext('vue', metadata);
@@ -106,15 +301,29 @@ export class Vue implements Integration {
         });
       }
 
-      if (typeof oldOnError === 'function') {
-        oldOnError.call(this._Vue, error, vm, info);
+      if (typeof currentErrorHandler === 'function') {
+        currentErrorHandler.call(this._options.Vue, error, vm, info);
       }
 
-      if (this._logErrors) {
-        this._Vue.util.warn(`Error in ${info}: "${error.toString()}"`, vm);
-        // tslint:disable-next-line:no-console
-        console.error(error);
+      if (this._options.logErrors) {
+        this._options.Vue.util.warn(`Error in ${info}: "${error.toString()}"`, vm);
+        console.error(error); // tslint:disable-line:no-console
       }
     };
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
+    if (!this._options.Vue) {
+      return logger.error('Vue integration is missing a Vue instance');
+    }
+
+    this.attachErrorHandler(getCurrentHub);
+
+    if (this._options.tracing) {
+      this.startTracing(getCurrentHub);
+    }
   }
 }


### PR DESCRIPTION
Example usage (minimal):

```js
import * as Sentry from "@sentry/browser";
import { Vue as VueIntegration } from "@sentry/integrations";
import { Integrations } from "@sentry/apm";

import Vue from "vue";

Sentry.init({
  dsn: "https://lol@nope.ingest.sentry.io/1337",
  integrations: [
    new Integrations.Tracing({
      tracingOrigins: [/localhost/]
    }),
    new VueIntegration({ Vue })
  ],
  tracesSampleRate: 1
});
```

Example usage (w. components tracking):

```js
import * as Sentry from "@sentry/browser";
import { Vue as VueIntegration } from "@sentry/integrations";
import { Integrations } from "@sentry/apm";
import Vue from "vue";

Sentry.init({
  dsn: "https://lol@nope.ingest.sentry.io/1337",
  integrations: [
    new Integrations.Tracing({
      tracingOrigins: [/localhost/]
    }),
    new VueIntegration({
      Vue,
      tracingOptions: {
        trackComponents: ["App", "home", "RwvArticleList", "Pagination", "RwvHeader", "RwvFooter"]
      }
    })
  ],
  tracesSampleRate: 1
});
```

https://github.com/getsentry/sentry-vue-perf can be used to verify the implementation locally (just swap the implementation in there, for the one showcased above).