### PR TITLE
ci: Run browserstack tests only if key is present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ jobs:
     - name: '@sentry/browser - browserstack integration tests'
       node_js: '12'
       script: scripts/browser-integration.sh
+      if: env(TRAVIS_SECURE_ENV_VARS) = true
     - stage: Deploy
       name: '@sentry/packages - pack and zeus upload'
       node_js: '12'


### PR DESCRIPTION
For PRs from external contributors, browserstack tests can never succeed
because they depend on secret env var keys that Travis do not provide to
untrusted builds.

This change disables running the tests altogether when the keys are not
available.

The browserstack tests are run anyway in master and release branches, no
changes.