### PR TITLE
docs: Remove broken link

### DIFF
--- a/packages/browser/src/integrations/useragent.ts
+++ b/packages/browser/src/integrations/useragent.ts
@@ -26,7 +26,6 @@ export class UserAgent implements Integration {
           return event;
         }
 
-        // Request Interface: https://docs.sentry.io/development/sdk-dev/event-payloads/request/
         const request = event.request || {};
         request.url = request.url || global.location.href;
         request.headers = request.headers || {};


### PR DESCRIPTION
The last change was fixing the broken link. Instead of constantly
updating the link, I think we're better off without the comment
altogether.

For the record, this is the new location:

https://develop.sentry.dev/sdk/event-payloads/request/