### PR TITLE
misc: Fix Travis conditional build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ jobs:
     - name: '@sentry/browser - browserstack integration tests'
       node_js: '12'
       script: scripts/browser-integration.sh
-      if: env(TRAVIS_SECURE_ENV_VARS) = true
+      if: env(BROWSERSTACK_USERNAME)
     - stage: Deploy
       name: '@sentry/packages - pack and zeus upload'
       node_js: '12'

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ jobs:
     - name: '@sentry/browser - browserstack integration tests'
       node_js: '12'
       script: scripts/browser-integration.sh
-      if: env(BROWSERSTACK_USERNAME)
+      if: fork = false
     - stage: Deploy
       name: '@sentry/packages - pack and zeus upload'
       node_js: '12'


### PR DESCRIPTION
Not all environment variables that Travis set in build time are
available to conditional build evaluation.

Instead of using environment variables, we can condition on the `fork`
attribute, which is `false` for branches in the main repo, and `true`
for PRs sent from forks.

Reference:
https://docs.travis-ci.com/user/conditions-v1#integration