### PR TITLE
fix: Use proper type name for op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+- [apm] fix: Use proper type name for op #2584
+
 ## 5.16.0
 
 - [core] feat: Send transactions in envelopes (#2553)

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -493,8 +493,8 @@ export class Tracing implements Integration {
           case 'paint':
           case 'measure':
             const mark = transactionSpan.child({
-              description: `${entry.entryType} ${entry.name}`,
-              op: 'mark',
+              description: `${entry.name}`,
+              op: entry.entryType,
             });
             mark.startTimestamp = timeOrigin + startTime;
             mark.timestamp = mark.startTimestamp + duration;

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -493,7 +493,7 @@ export class Tracing implements Integration {
           case 'paint':
           case 'measure':
             const mark = transactionSpan.child({
-              description: `${entry.name}`,
+              description: entry.name,
               op: entry.entryType,
             });
             mark.startTimestamp = timeOrigin + startTime;


### PR DESCRIPTION
Use the name of type for `op` instead of always `mark`.