### PR TITLE
ci: Remove dead config in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,6 @@ cache:
   directories:
     - node_modules
 
-stages:
-  - Test
-  - Deploy
-  - Saucelabs
-
 jobs:
   include:
     - stage: Test


### PR DESCRIPTION
There is no "Saucelabs" stage, and otherwise the "stages" entry just
serve to customize the order of the stages, which does not need to be
customized.