### PR TITLE
feat: Require use of flag to send envelopes

### DIFF
--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -1,3 +1,4 @@
+import { getCurrentHub } from '@sentry/hub';
 import { Event } from '@sentry/types';
 
 import { API } from './api';
@@ -15,7 +16,9 @@ interface SentryRequest {
 
 /** Creates a SentryRequest from an event. */
 export function eventToSentryRequest(event: Event, api: API): SentryRequest {
-  const useEnvelope = event.type === 'transaction';
+  const client = getCurrentHub().getClient();
+  const experimentsOptions = (client && client.getOptions()._experiments) || {};
+  const useEnvelope = event.type === 'transaction' && experimentsOptions.useEnvelope;
 
   const req: SentryRequest = {
     body: JSON.stringify(event),


### PR DESCRIPTION
This gives us an easy kill-switch if we decide to revert back to the
store endpoint. Sending envelopes becomes opt-in.

Usage:

```js
Sentry.init({
  dsn: '...',
  integrations: [new Sentry.Integrations.Tracing()],
  tracesSampleRate: 1,
  _experiments: { useEnvelope: true },
});
```