### PR TITLE
fix: sent_at for envelope headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
 - [apm] fix: Use proper type name for op #2584
-- [core[ fix: sent_at for envelope headers to use same clock #2597
+- [core] fix: sent_at for envelope headers to use same clock #2597
 
 ## 5.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
 - [apm] fix: Use proper type name for op #2584
+- [core[ fix: sent_at for envelope headers to use same clock #2597
 
 ## 5.16.0
 

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -35,7 +35,7 @@ export function eventToSentryRequest(event: Event, api: API): SentryRequest {
   if (useEnvelope) {
     const envelopeHeaders = JSON.stringify({
       event_id: event.event_id,
-      // We need to add * 1000 since we devide it by 1000 by default but JS works with ms precision
+      // We need to add * 1000 since we divide it by 1000 by default but JS works with ms precision
       // The reason we use timestampWithMs here is that all clocks across the SDK use the same clock
       sent_at: new Date(timestampWithMs() * 1000).toISOString(),
     });

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -1,5 +1,6 @@
 import { getCurrentHub } from '@sentry/hub';
 import { Event } from '@sentry/types';
+import { timestampWithMs } from '@sentry/utils';
 
 import { API } from './api';
 
@@ -34,7 +35,9 @@ export function eventToSentryRequest(event: Event, api: API): SentryRequest {
   if (useEnvelope) {
     const envelopeHeaders = JSON.stringify({
       event_id: event.event_id,
-      sent_at: new Date().toISOString(),
+      // We need to add * 1000 since we devide it by 1000 by default but JS works with ms precision
+      // The reason we use timestampWithMs here is that all clocks across the SDK use the same clock
+      sent_at: new Date(timestampWithMs() * 1000).toISOString(),
     });
     const itemHeaders = JSON.stringify({
       type: event.type,


### PR DESCRIPTION
Fixes `sent_at` header in the envelope to use the same clock as everywhere else.