### PR TITLE
fix: Adjust for timeOrigin shifts

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -400,11 +400,22 @@ export const crossPlatformPerformance: CrossPlatformPerformance = (() => {
   return getGlobalObject<Window>().performance || performanceFallback;
 })();
 
+let FIRST_CLOCK_READ: number | undefined;
+
+/**
+ * This returns a timestamp of the first time we look at the clock
+ */
+function getFirstClockRead(): number {
+  if (!FIRST_CLOCK_READ) {
+    FIRST_CLOCK_READ = crossPlatformPerformance.timeOrigin;
+  }
+  return FIRST_CLOCK_READ;
+}
 /**
  * Returns a timestamp in seconds with milliseconds precision since the UNIX epoch calculated with the monotonic clock.
  */
 export function timestampWithMs(): number {
-  return (crossPlatformPerformance.timeOrigin + crossPlatformPerformance.now()) / 1000;
+  return (getFirstClockRead() + crossPlatformPerformance.now()) / 1000;
 }
 
 // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string


### PR DESCRIPTION
The assumption here is that the Browser shifts `timeOrigin` and therefore it's not stable.
We internally store our first reading and base all future timestamps on the first reading instead of relying on the unstable `timeOrigin`.