### PR TITLE
test(breadcrumb): Add test case for creating breadcrumbs for requests to the envelope endpoint

### DIFF
--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -313,18 +313,38 @@ export class Breadcrumbs implements Integration {
 function addSentryBreadcrumb(serializedData: string): void {
   // There's always something that can go wrong with deserialization...
   try {
-    const event = JSON.parse(serializedData);
-    getCurrentHub().addBreadcrumb(
-      {
-        category: `sentry.${event.type === 'transaction' ? 'transaction' : 'event'}`,
-        event_id: event.event_id,
-        level: event.level || Severity.fromString('error'),
-        message: getEventDescription(event),
-      },
-      {
-        event,
-      },
-    );
+    try {
+      const event = JSON.parse(serializedData);
+      getCurrentHub().addBreadcrumb(
+        {
+          category: `sentry.${event.type === 'transaction' ? 'transaction' : 'event'}`,
+          event_id: event.event_id,
+          level: event.level || Severity.fromString('error'),
+          message: getEventDescription(event),
+        },
+        {
+          event,
+        },
+      );
+    } catch (_oO) {
+      // We are dealing with an envelope here
+      // For simplicity we only deal with transactions
+      const envelopeLines = serializedData.split('\n');
+      const envelopeHeader = JSON.parse(envelopeLines[0]);
+      const itemHeader = JSON.parse(envelopeLines[1]);
+      const item = JSON.parse(envelopeLines[2]);
+      getCurrentHub().addBreadcrumb(
+        {
+          category: `sentry.${itemHeader.type}`,
+          event_id: envelopeHeader.event_id,
+          level: item.level,
+          message: getEventDescription(item),
+        },
+        {
+          item,
+        },
+      );
+    }
   } catch (_oO) {
     logger.error('Error while adding sentry type breadcrumb');
   }

--- a/packages/browser/test/integration/karma.conf.js
+++ b/packages/browser/test/integration/karma.conf.js
@@ -73,6 +73,7 @@ module.exports = config => {
       "/base/variants/123": "/base/subjects/123",
       // Supresses warnings
       "/api/1/store/": "/",
+      "/api/1/envelope/": "/",
     },
     frameworks: ["mocha", "chai", "sinon"],
     files,

--- a/packages/browser/test/integration/suites/breadcrumbs.js
+++ b/packages/browser/test/integration/suites/breadcrumbs.js
@@ -174,20 +174,7 @@ describe("breadcrumbs", function() {
         var xhr = new XMLHttpRequest();
         xhr.open("POST", envelope);
         xhr.send(
-          `
-{
-  "event_id": "aa3ff046696b4bc6b609ce6d28fde9e2",
-  "sent_at": "2020-05-19T15:44:49.028Z"
-}
-{
-  "type": "transaction"
-}
-{
-  "message":"someMessage",
-  "transaction":"wat",
-  "level":"warning",
-}
-          `.trim()
+          '{"event_id": "aa3ff046696b4bc6b609ce6d28fde9e2","sent_at": "2020-05-19T15:44:49.028Z"}\n{"type": "transaction"}\n{"message":"someMessage","transaction":"wat","level":"warning"}'
         );
         waitForXHR(xhr, function() {
           Sentry.captureMessage("test");

--- a/packages/browser/test/integration/suites/breadcrumbs.js
+++ b/packages/browser/test/integration/suites/breadcrumbs.js
@@ -158,6 +158,56 @@ describe("breadcrumbs", function() {
 
   it(
     optional(
+      "should transform XMLHttpRequests with transactions type to the Sentry envelope endpoint as sentry.transaction type breadcrumb",
+      IS_LOADER
+    ),
+    function() {
+      return runInSandbox(sandbox, { manual: true }, function() {
+        var envelope =
+          document.location.protocol +
+          "//" +
+          document.location.hostname +
+          (document.location.port ? ":" + document.location.port : "") +
+          "/api/1/envelope/" +
+          "?sentry_key=1337";
+
+        var xhr = new XMLHttpRequest();
+        xhr.open("POST", envelope);
+        xhr.send(
+          `
+{
+  "event_id": "aa3ff046696b4bc6b609ce6d28fde9e2",
+  "sent_at": "2020-05-19T15:44:49.028Z"
+}
+{
+  "type": "transaction"
+}
+{
+  "message":"someMessage",
+  "transaction":"wat",
+  "level":"warning",
+}
+          `.trim()
+        );
+        waitForXHR(xhr, function() {
+          Sentry.captureMessage("test");
+          window.finalizeManualTest();
+        });
+      }).then(function(summary) {
+        // The async loader doesn't wrap XHR
+        if (IS_LOADER) {
+          return;
+        }
+        assert.equal(summary.breadcrumbs.length, 1);
+        assert.equal(summary.breadcrumbs[0].category, "sentry.transaction");
+        assert.equal(summary.breadcrumbs[0].level, "warning");
+        assert.equal(summary.breadcrumbs[0].message, "someMessage");
+      });
+    }
+  );
+
+  it(
+    optional(
       "should not transform XMLHttpRequests with transactions attribute to the Sentry store endpoint as sentry.transaction type breadcrumb",
       IS_LOADER
     ),


### PR DESCRIPTION
This adds a test case for creating breadcrumbs whenever an event is sent to the envelope endpoint.

This fails for now until https://github.com/getsentry/sentry-javascript/issues/2602 is resolved. 