### PR TITLE
Revert "feat: Require use of flag to send envelopes (#2594)"

### DIFF
--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -1,4 +1,3 @@
-import { getCurrentHub } from '@sentry/hub';
 import { Event } from '@sentry/types';
 import { timestampWithMs } from '@sentry/utils';
 
@@ -17,9 +16,7 @@ interface SentryRequest {
 
 /** Creates a SentryRequest from an event. */
 export function eventToSentryRequest(event: Event, api: API): SentryRequest {
-  const client = getCurrentHub().getClient();
-  const experimentsOptions = (client && client.getOptions()._experiments) || {};
-  const useEnvelope = event.type === 'transaction' && experimentsOptions.useEnvelope;
+  const useEnvelope = event.type === 'transaction';
 
   const req: SentryRequest = {
     body: JSON.stringify(event),


### PR DESCRIPTION
This reverts commit 0d9725a4048f9b271521410b8839cea3938c76a4.

The endpoint works now and we should use it going forward, no option.