### PR TITLE
misc: Document where to find raven SDKs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,4 +57,4 @@ When contributing to the codebase, please make note of the following:
 
 - Non-trivial PRs will not be accepted without tests (see above).
 - Please do not bump version numbers yourself. 
-- `raven-js` and `raven-node` are deprecated, and only bug and security fix PRs will be accepted. Any new features and improvements should be to our new SDKs (`browser` and `node`) and the packages (`core`, `hub`, `integrations`, and the like) which support them.
+- [`raven-js`](https://github.com/getsentry/sentry-javascript/tree/3.x/packages/raven-js) and [`raven-node`](https://github.com/getsentry/sentry-javascript/tree/3.x/packages/raven-node) are deprecated, and only bug and security fix PRs will be accepted targeting the [3.x branch](https://github.com/getsentry/sentry-javascript/tree/3.x). Any new features and improvements should be to our new SDKs (`browser` and `node`) and the packages (`core`, `hub`, `integrations`, and the like) which support them.

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ package. Please refer to the README and instructions of those SDKs for more deta
 - [`@sentry/electron`](https://github.com/getsentry/sentry-electron): SDK for Electron with support for native crashes
 - [`sentry-cordova`](https://github.com/getsentry/sentry-cordova): SDK for Cordova Apps and Ionic with support for
   native crashes
-- [`raven-js`](https://github.com/getsentry/sentry-javascript/tree/master/packages/raven-js): Our old stable JavaScript
+- [`raven-js`](https://github.com/getsentry/sentry-javascript/tree/3.x/packages/raven-js): Our old stable JavaScript
   SDK, we still support and release bug fixes for the SDK but all new features will be implemented in `@sentry/browser`
   which is the successor.
-- [`raven`](https://github.com/getsentry/sentry-javascript/tree/master/packages/raven-node): Our old stable Node SDK,
+- [`raven`](https://github.com/getsentry/sentry-javascript/tree/3.x/packages/raven-node): Our old stable Node SDK,
   same as for `raven-js` we still support and release bug fixes for the SDK but all new features will be implemented in
   `@sentry/node` which is the successor.
 


### PR DESCRIPTION
The v3.x series of JavaScript SDKs are maintained (only important security fixes) from a separate branch, and not from master.

As per conversation with @HazAT, I've created a new branch [`3.x`](https://github.com/getsentry/sentry-javascript/tree/3.x) pointing at the same [commit](https://github.com/getsentry/sentry-javascript/tree/7b664ff3a828fe59e32ccc182d5b4bb449dc9402) as `4.x` to avoid confusion. The v4.x series of SDKs is `@sentry/browser` and `@sentry/node`.

This paves the way to remove raven packages from master (#2604).