### PR TITLE
feat: No longer debounce IdleTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [apm] feat: Introduce `Sentry.startTransaction` and `Transaction.startChild` #2600
 - [apm] feat: Transactions no longer go through `beforeSend` #2600
 - [browser] fix: Emit Sentry Request breadcrumbs from inside the client (#2615)
+- [apm] fix: No longer debounce IdleTransaction #2618
 
 ## 5.15.5
 

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -460,7 +460,7 @@ export class Tracing implements Integration {
           const keepSpan = finishedSpan.startTimestamp < Tracing._idleTransactionEndTimestamp + timeout;
           if (!keepSpan) {
             Tracing._log(
-              '[Tracing] discarding span since this happens after Transaction was flushed',
+              '[Tracing] discarding Span since it happened after Transaction was finished',
               finishedSpan.toJSON(),
             );
           }


### PR DESCRIPTION
Right now we debouce a `setTimeout` every time an activity is popped.
This resulted in sometimes the `IdleTransaction` never finishing because there was constantly an activity blocking flushing the Transaction.

This PR changes the behavior that once all activities are done the `setTimeout` is triggered and will fire regardless.
In addition we discard any Spans that might have been recorded after the Transaction was marked for flushing. This fixes a bug where we had very long Transactions recorded because they weren't flushed + we recorded Spans at the very end -> resulting in absurdly long Transactions.