### PR TITLE
ref: Add tests for breadcrumbs

### DIFF
--- a/packages/browser/examples/app.js
+++ b/packages/browser/examples/app.js
@@ -25,9 +25,9 @@ class HappyTransport extends Sentry.Transports.BaseTransport {
       event,
     );
 
-    return {
+    return Promise.resolve({
       status: 'success',
-    };
+    });
   }
 }
 

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -74,11 +74,9 @@ export class BrowserClient extends BaseClient<BrowserBackend, BrowserOptions> {
    * @inheritDoc
    */
   protected _sendEvent(event: Event): void {
-    if (event) {
-      const integration = this.getIntegration(Breadcrumbs);
-      if (integration) {
-        integration.addSentryBreadcrumb(event);
-      }
+    const integration = this.getIntegration(Breadcrumbs);
+    if (integration) {
+      integration.addSentryBreadcrumb(event);
     }
     super._sendEvent(event);
   }

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -73,30 +73,14 @@ export class BrowserClient extends BaseClient<BrowserBackend, BrowserOptions> {
   /**
    * @inheritDoc
    */
-  public captureEvent(event: Event, hint?: EventHint, scope?: Scope): string | undefined {
-    let eventId: string | undefined = hint && hint.event_id;
-    this._processing = true;
-
-    this._processEvent(event, hint, scope)
-      .then(finalEvent => {
-        // We need to check for finalEvent in case beforeSend returned null
-        // We do this here to not parse any requests if they are outgoing to Sentry
-        // We log breadcrumbs if the integration has them enabled
-        if (finalEvent) {
-          eventId = finalEvent.event_id;
-          const integration = this.getIntegration(Breadcrumbs);
-          if (integration) {
-            integration.addSentryBreadcrumb(finalEvent);
-          }
-        }
-        this._processing = false;
-      })
-      .then(null, reason => {
-        logger.error(reason);
-        this._processing = false;
-      });
-
-    return eventId;
+  protected _sendEvent(event: Event): void {
+    if (event) {
+      const integration = this.getIntegration(Breadcrumbs);
+      if (integration) {
+        integration.addSentryBreadcrumb(event);
+      }
+    }
+    super._sendEvent(event);
   }
 
   /**

--- a/packages/browser/test/integration/common/init.js
+++ b/packages/browser/test/integration/common/init.js
@@ -51,7 +51,11 @@ function initSDK() {
       }
 
       // One of the tests use manually created breadcrumb without eventId and we want to let it through
-      if (breadcrumb.category.indexOf("sentry" === 0) && breadcrumb.event_id) {
+      if (
+        breadcrumb.category.indexOf("sentry" === 0) &&
+        breadcrumb.event_id &&
+        !window.allowSentryBreadcrumbs
+      ) {
         return null;
       }
 

--- a/packages/browser/test/integration/karma.conf.js
+++ b/packages/browser/test/integration/karma.conf.js
@@ -73,6 +73,7 @@ module.exports = config => {
       "/base/variants/123": "/base/subjects/123",
       // Supresses warnings
       "/api/1/store/": "/",
+      "/api/1/envelope/": "/",
     },
     frameworks: ["mocha", "chai", "sinon"],
     files,

--- a/packages/browser/test/integration/suites/api.js
+++ b/packages/browser/test/integration/suites/api.js
@@ -26,6 +26,56 @@ describe("API", function() {
     });
   });
 
+  it("should capture Sentry internal event as breadcrumbs for the following event sent", function() {
+    return runInSandbox(sandbox, { manual: true }, function() {
+      window.allowSentryBreadcrumbs = true;
+      Sentry.captureMessage("a");
+      Sentry.captureMessage("b");
+      // For the loader
+      Sentry.flush && Sentry.flush(2000);
+      window.finalizeManualTest();
+    }).then(function(summary) {
+      assert.equal(summary.events.length, 2);
+      assert.equal(summary.breadcrumbs.length, 2);
+      assert.equal(summary.events[1].breadcrumbs[0].category, "sentry.event");
+      assert.equal(
+        summary.events[1].breadcrumbs[0].event_id,
+        summary.events[0].event_id
+      );
+      assert.equal(
+        summary.events[1].breadcrumbs[0].level,
+        summary.events[0].level
+      );
+    });
+  });
+
+  it("should capture Sentry internal transaction as breadcrumbs for the following event sent", function() {
+    return runInSandbox(sandbox, { manual: true }, function() {
+      window.allowSentryBreadcrumbs = true;
+      Sentry.captureEvent({
+        event_id: "aa3ff046696b4bc6b609ce6d28fde9e2",
+        message: "someMessage",
+        transaction: "wat",
+        type: "transaction",
+      });
+      Sentry.captureMessage("c");
+      // For the loader
+      Sentry.flush && Sentry.flush(2000);
+      window.finalizeManualTest();
+    }).then(function(summary) {
+      // We have a length of one here since transactions don't go through beforeSend
+      // and we add events to summary in beforeSend
+      assert.equal(summary.events.length, 1);
+      assert.equal(summary.breadcrumbs.length, 2);
+      assert.equal(
+        summary.events[0].breadcrumbs[0].category,
+        "sentry.transaction"
+      );
+      assert.isNotEmpty(summary.events[0].breadcrumbs[0].event_id);
+      assert.isUndefined(summary.events[0].breadcrumbs[0].level);
+    });
+  });
+
   it("should generate a synthetic trace for captureException w/ non-errors", function() {
     return runInSandbox(sandbox, function() {
       throwNonError();


### PR DESCRIPTION
This adds tests for adding Sentry internal breadcrumbs.

This is a follow up from #2615.