### PR TITLE
ref: Add hub.startTransaction extension

### DIFF
--- a/packages/apm/src/hubextensions.ts
+++ b/packages/apm/src/hubextensions.ts
@@ -89,6 +89,7 @@ export function addExtensionMethods(): void {
       carrier.__SENTRY__.extensions.startTransaction = startTransaction;
     }
     if (!carrier.__SENTRY__.extensions.startSpan) {
+      // tslint:disable-next-line: deprecation
       carrier.__SENTRY__.extensions.startSpan = startSpan;
     }
     if (!carrier.__SENTRY__.extensions.traceHeaders) {

--- a/packages/apm/src/hubextensions.ts
+++ b/packages/apm/src/hubextensions.ts
@@ -1,6 +1,5 @@
 import { getMainCarrier, Hub } from '@sentry/hub';
 import { SpanContext, TransactionContext } from '@sentry/types';
-import { logger } from '@sentry/utils';
 
 import { Span } from './span';
 import { Transaction } from './transaction';
@@ -27,15 +26,6 @@ function traceHeaders(this: Hub): { [key: string]: string } {
  * @param context Properties with which the span should be created
  */
 function startSpan(this: Hub, context: SpanContext | TransactionContext): Transaction | Span {
-  // This is our safeguard so people always get a Transaction in return.
-  // We set `_isTransaction: true` in {@link Sentry.startTransaction} to have a runtime check
-  // if the user really wanted to create a Transaction.
-  if ((context as TransactionContext)._isTransaction && !(context as TransactionContext).name) {
-    logger.warn('You are trying to start a Transaction but forgot to provide a `name` property.');
-    logger.warn('Will fall back to <unlabeled transaction>, use `transaction.setName()` to change it.');
-    (context as TransactionContext).name = '<unlabeled transaction>';
-  }
-
   if ((context as TransactionContext).name) {
     // We are dealing with a Transaction
     const transaction = new Transaction(context as TransactionContext, this);

--- a/packages/apm/src/hubextensions.ts
+++ b/packages/apm/src/hubextensions.ts
@@ -1,5 +1,6 @@
 import { getMainCarrier, Hub } from '@sentry/hub';
 import { SpanContext, TransactionContext } from '@sentry/types';
+import { logger } from '@sentry/utils';
 
 import { Span } from './span';
 import { Transaction } from './transaction';
@@ -19,35 +20,49 @@ function traceHeaders(this: Hub): { [key: string]: string } {
 }
 
 /**
- * This functions starts a span. If there is already a `Span` on the Scope,
+ * Starts a Transaction. This is the entry point to do manual tracing. You can
+ * add child spans to transactions. Spans themselves can have children, building
+ * a tree structure. This function returns a Transaction and you need to keep
+ * track of the instance yourself. When you call `.finish()` on the transaction
+ * it will be sent to Sentry.
+ */
+function startTransaction(this: Hub, context: TransactionContext): Transaction {
+  const transaction = new Transaction(context, this);
+
+  const client = this.getClient();
+  // Roll the dice for sampling transaction, all child spans inherit the sampling decision.
+  if (transaction.sampled === undefined) {
+    const sampleRate = (client && client.getOptions().tracesSampleRate) || 0;
+    // if true = we want to have the transaction
+    // if false = we don't want to have it
+    // Math.random (inclusive of 0, but not 1)
+    transaction.sampled = Math.random() < sampleRate;
+  }
+
+  // We only want to create a span list if we sampled the transaction
+  // If sampled == false, we will discard the span anyway, so we can save memory by not storing child spans
+  if (transaction.sampled) {
+    const experimentsOptions = (client && client.getOptions()._experiments) || {};
+    transaction.initSpanRecorder(experimentsOptions.maxSpans as number);
+  }
+
+  return transaction;
+}
+
+/**
+ * This function starts a span. If there is already a `Span` on the Scope,
  * the created Span with the SpanContext will have a reference to it and become it's child.
- * Otherwise it'll crete a new `Span`.
+ * Otherwise it'll create a new `Span`.
  *
  * @param context Properties with which the span should be created
+ *
+ * @deprecated Use startTransaction to start transactions and Transaction.startChild to start spans.
  */
 function startSpan(this: Hub, context: SpanContext | TransactionContext): Transaction | Span {
+  logger.warn('Deprecated: Use startTransaction to start transactions and Transaction.startChild to start spans.');
+
   if ((context as TransactionContext).name) {
-    // We are dealing with a Transaction
-    const transaction = new Transaction(context as TransactionContext, this);
-
-    const client = this.getClient();
-    // We only roll the dice on sampling for root spans of transactions because all child spans inherit this state
-    if (transaction.sampled === undefined) {
-      const sampleRate = (client && client.getOptions().tracesSampleRate) || 0;
-      // if true = we want to have the transaction
-      // if false = we don't want to have it
-      // Math.random (inclusive of 0, but not 1)
-      transaction.sampled = Math.random() < sampleRate;
-    }
-
-    // We only want to create a span list if we sampled the transaction
-    // If sampled == false, we will discard the span anyway, so we can save memory by not storing child spans
-    if (transaction.sampled) {
-      const experimentsOptions = (client && client.getOptions()._experiments) || {};
-      transaction.initSpanRecorder(experimentsOptions.maxSpans as number);
-    }
-
-    return transaction;
+    return startTransaction(this, context as TransactionContext);
   }
 
   const scope = this.getScope();
@@ -70,6 +85,9 @@ export function addExtensionMethods(): void {
   const carrier = getMainCarrier();
   if (carrier.__SENTRY__) {
     carrier.__SENTRY__.extensions = carrier.__SENTRY__.extensions || {};
+    if (!carrier.__SENTRY__.extensions.startTransaction) {
+      carrier.__SENTRY__.extensions.startTransaction = startTransaction;
+    }
     if (!carrier.__SENTRY__.extensions.startSpan) {
       carrier.__SENTRY__.extensions.startSpan = startSpan;
     }

--- a/packages/apm/src/span.ts
+++ b/packages/apm/src/span.ts
@@ -77,7 +77,7 @@ export class Span implements SpanInterface, SpanContext {
   public spanRecorder?: SpanRecorder;
 
   /**
-   * You should never call the custructor manually, always use `hub.startSpan()`.
+   * You should never call the constructor manually, always use `hub.startSpan()`.
    * @internal
    * @hideconstructor
    * @hidden

--- a/packages/apm/src/transaction.ts
+++ b/packages/apm/src/transaction.ts
@@ -92,6 +92,11 @@ export class Transaction extends SpanClass {
       return undefined;
     }
 
+    if (!this.name) {
+      logger.warn('Transaction has no name, falling back to <unlabeled transaction>.');
+      this.name = '<unlabeled transaction>';
+    }
+
     super.finish(endTimestamp);
 
     if (this.sampled !== true) {

--- a/packages/apm/src/transaction.ts
+++ b/packages/apm/src/transaction.ts
@@ -93,7 +93,7 @@ export class Transaction extends SpanClass {
     }
 
     if (!this.name) {
-      logger.warn('Transaction has no name, falling back to <unlabeled transaction>.');
+      logger.warn('Transaction has no name, falling back to `<unlabeled transaction>`.');
       this.name = '<unlabeled transaction>';
     }
 

--- a/packages/apm/src/transaction.ts
+++ b/packages/apm/src/transaction.ts
@@ -46,7 +46,8 @@ export class Transaction extends SpanClass {
   private readonly _trimEnd?: boolean;
 
   /**
-   * This constructor should never be called manually. Those instrumenting tracing should use `Stentry.startTransaction()`, and internal methods should use `hub.startSpan()`.
+   * This constructor should never be called manually. Those instrumenting tracing should use
+   * `Sentry.startTransaction()`, and internal methods should use `hub.startTransaction()`.
    * @internal
    * @hideconstructor
    * @hidden

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -368,7 +368,14 @@ export class Hub implements HubInterface {
   /**
    * @inheritDoc
    */
-  public startSpan(context: SpanContext | TransactionContext): Transaction | Span {
+  public startSpan(context: SpanContext): Span {
+    return this._callExtensionMethod('startSpan', context);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public startTransaction(context: TransactionContext): Transaction {
     return this._callExtensionMethod('startSpan', context);
   }
 

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -376,7 +376,7 @@ export class Hub implements HubInterface {
    * @inheritDoc
    */
   public startTransaction(context: TransactionContext): Transaction {
-    return this._callExtensionMethod('startSpan', context);
+    return this._callExtensionMethod('startTransaction', context);
   }
 
   /**

--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -177,8 +177,7 @@ export function _callOnClient(method: string, ...args: any[]): void {
  */
 export function startTransaction(transactionContext: TransactionContext): Transaction {
   if (!transactionContext.name) {
-    logger.warn('You are trying to start a Transaction but forgot to provide a `name` property.');
-    logger.warn('Will fall back to <unlabeled transaction>, use `transaction.setName()` to change it.');
+    logger.warn('Transaction started without name, falling back to <unlabeled transaction>.');
     transactionContext.name = '<unlabeled transaction>';
   }
   return callOnHub<Transaction>('startSpan', transactionContext);

--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -1,6 +1,5 @@
 import { getCurrentHub, Hub, Scope } from '@sentry/hub';
 import { Breadcrumb, Event, Severity, Transaction, TransactionContext, User } from '@sentry/types';
-import { logger } from '@sentry/utils';
 
 /**
  * This calls a function on the current hub.
@@ -170,15 +169,12 @@ export function _callOnClient(method: string, ...args: any[]): void {
 }
 
 /**
- * This starts a Transaction and is considered the entry point to do manual tracing. You can add child spans
- * to a transactions. After that more children can be added to created spans to buld a tree structure.
- * This function returns a Transaction and you need to keep track of the instance yourself. When you call `.finsh()` on
- * a transaction it will be sent to Sentry.
+ * Starts a Transaction. This is the entry point to do manual tracing. You can
+ * add child spans to transactions. Spans themselves can have children, building
+ * a tree structure. This function returns a Transaction and you need to keep
+ * track of the instance yourself. When you call `.finish()` on the transaction
+ * it will be sent to Sentry.
  */
-export function startTransaction(transactionContext: TransactionContext): Transaction {
-  if (!transactionContext.name) {
-    logger.warn('Transaction started without name, falling back to <unlabeled transaction>.');
-    transactionContext.name = '<unlabeled transaction>';
-  }
-  return callOnHub<Transaction>('startSpan', transactionContext);
+export function startTransaction(context: TransactionContext): Transaction {
+  return callOnHub('startTransaction', context);
 }

--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -176,5 +176,5 @@ export function _callOnClient(method: string, ...args: any[]): void {
  * it will be sent to Sentry.
  */
 export function startTransaction(context: TransactionContext): Transaction {
-  return callOnHub('startTransaction', context);
+  return callOnHub('startTransaction', { ...context });
 }

--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -1,5 +1,6 @@
 import { getCurrentHub, Hub, Scope } from '@sentry/hub';
 import { Breadcrumb, Event, Severity, Transaction, TransactionContext, User } from '@sentry/types';
+import { logger } from '@sentry/utils';
 
 /**
  * This calls a function on the current hub.
@@ -175,8 +176,10 @@ export function _callOnClient(method: string, ...args: any[]): void {
  * a transaction it will be sent to Sentry.
  */
 export function startTransaction(transactionContext: TransactionContext): Transaction {
-  return callOnHub<Transaction>('startSpan', {
-    ...transactionContext,
-    _isTransaction: true,
-  });
+  if (!transactionContext.name) {
+    logger.warn('You are trying to start a Transaction but forgot to provide a `name` property.');
+    logger.warn('Will fall back to <unlabeled transaction>, use `transaction.setName()` to change it.');
+    transactionContext.name = '<unlabeled transaction>';
+  }
+  return callOnHub<Transaction>('startSpan', transactionContext);
 }

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -181,11 +181,19 @@ export interface Hub {
   startSpan(context: SpanContext): Span;
 
   /**
-   * Starts a Transaction.
-   * This is the entry point to do manual tracing. You can add child spans to transactions.
-   * Spans themselves can have children, building a tree structure.
-   * This function returns a Transaction and you need to keep track of the instance yourself.
-   * When you call `.finish()` on the transaction it will be sent to Sentry.
+   * Starts a new transaction and returns it. This is the entry point to manual
+   * tracing instrumentation.
+   *
+   * A tree structure can be built by adding child spans to the transaction, and
+   * child spans to other spans. To start a new child span within the transaction
+   * or any span, call the respective `.startChild()` method.
+   *
+   * Every child span must be finished before the transaction is finished,
+   * otherwise the unfinished spans are discarded.
+   *
+   * The transaction must be finished with a call to its `.finish()` method, at
+   * which point the transaction with all its finished child spans will be sent to
+   * Sentry.
    */
   startTransaction(context: TransactionContext): Transaction;
 }

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -174,10 +174,18 @@ export interface Hub {
   traceHeaders(): { [key: string]: string };
 
   /**
-   * This functions starts either a Span or a Transaction (depending on the argument passed).
-   * If there is a Span on the Scope we use the `trace_id` for all other created Transactions / Spans as a reference.
-   *
-   * @param context Properties with which the Transaction/Span should be created
+   * This function starts a span. If there is already a `Span` on the Scope,
+   * the created Span with the SpanContext will have a reference to it and become it's child.
+   * Otherwise it'll create a new `Span`.
    */
-  startSpan(context: SpanContext | TransactionContext): Transaction | Span;
+  startSpan(context: SpanContext): Span;
+
+  /**
+   * Starts a Transaction.
+   * This is the entry point to do manual tracing. You can add child spans to transactions.
+   * Spans themselves can have children, building a tree structure.
+   * This function returns a Transaction and you need to keep track of the instance yourself.
+   * When you call `.finish()` on the transaction it will be sent to Sentry.
+   */
+  startTransaction(context: TransactionContext): Transaction;
 }

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -12,13 +12,6 @@ export interface TransactionContext extends SpanContext {
    * transaction after a given "idle time" and we don't want this "idle time" to be part of the transaction.
    */
   trimEnd?: boolean;
-
-  /**
-   * This flag is internally used by {@link Sentry.startTransaction} and set there to determine this is really a
-   * Transaction. Since there is no type safety in JS we set it in the top level function to true to check later
-   * if the user really wanted to create a Transaction and we can log a warning if they forgot to set the name property.
-   */
-  _isTransaction?: boolean;
 }
 
 /**


### PR DESCRIPTION
This probably replaces #2625.

- Remove `Transaction._isTransaction` because the only way this was used is equivalent to calling `Hub.startTransaction`.
- Instead of warning of missing name when starting a transaction, move the warning to right before the transaction is sent to Sentry, because it is a valid use case to start without a name and set it later (e.g. when the final name is not known until after the transaction is started).
- Extract code that starts transactions from startSpan. The recommended way to start transactions is through `Sentry.startTransaction` or `Hub.startTransaction`, and to start spans call `Transaction.startChild`.