### PR TITLE
feat: Explicit Scope for captureException and captureMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
+- [minimal/core] feat: Allow for explicit scope through 2nd argument to `captureException/captureMessage` (#2627)
 
 ## 5.16.0
 
@@ -12,15 +13,15 @@
 - [browser] fix: Call wrapped `RequestAnimationFrame` with correct context (#2570)
 - [node] fix: Prevent reading the same source file multiple times (#2569)
 - [integrations] feat: Vue performance monitoring (#2571)
-- [apm] fix: Use proper type name for op #2584
-- [core] fix: sent_at for envelope headers to use same clock #2597
-- [apm] fix: Improve bundle size by moving span status to @sentry/apm #2589
-- [apm] feat: No longer discard transactions instead mark them deadline exceeded #2588
-- [apm] feat: Introduce `Sentry.startTransaction` and `Transaction.startChild` #2600
-- [apm] feat: Transactions no longer go through `beforeSend` #2600
+- [apm] fix: Use proper type name for op (#2584)
+- [core] fix: sent_at for envelope headers to use same clock (#2597)
+- [apm] fix: Improve bundle size by moving span status to @sentry/apm (#2589)
+- [apm] feat: No longer discard transactions instead mark them deadline exceeded (#2588)
+- [apm] feat: Introduce `Sentry.startTransaction` and `Transaction.startChild` (#2600)
+- [apm] feat: Transactions no longer go through `beforeSend` (#2600)
 - [browser] fix: Emit Sentry Request breadcrumbs from inside the client (#2615)
-- [apm] fix: No longer debounce IdleTransaction #2618
-- [apm] feat: Add pageload transaction option + fixes #2623
+- [apm] fix: No longer debounce IdleTransaction (#2618)
+- [apm] feat: Add pageload transaction option + fixes (#2623)
 
 ## 5.15.5
 

--- a/packages/browser/test/package/test-code.js
+++ b/packages/browser/test/package/test-code.js
@@ -50,7 +50,19 @@ Sentry.addBreadcrumb({
 
 // Capture methods
 Sentry.captureException(new Error('foo'));
+Sentry.captureException(new Error('foo'), {
+  tags: {
+    foo: 1,
+  },
+});
+Sentry.captureException(new Error('foo'), scope => scope);
 Sentry.captureMessage('bar');
+Sentry.captureMessage('bar', {
+  tags: {
+    foo: 1,
+  },
+});
+Sentry.captureMessage('bar', scope => scope);
 
 // Scope behavior
 Sentry.withScope(scope => {

--- a/packages/core/test/mocks/backend.ts
+++ b/packages/core/test/mocks/backend.ts
@@ -1,4 +1,4 @@
-import { Event, Options, Transport } from '@sentry/types';
+import { Event, Options, Severity, Transport } from '@sentry/types';
 import { SyncPromise } from '@sentry/utils';
 
 import { BaseBackend } from '../../src/basebackend';
@@ -50,8 +50,8 @@ export class TestBackend extends BaseBackend<TestOptions> {
     });
   }
 
-  public eventFromMessage(message: string): PromiseLike<Event> {
-    return SyncPromise.resolve({ message });
+  public eventFromMessage(message: string, level: Severity = Severity.Info): PromiseLike<Event> {
+    return SyncPromise.resolve({ message, level });
   }
 
   public sendEvent(event: Event): void {

--- a/packages/hub/test/hub.test.ts
+++ b/packages/hub/test/hub.test.ts
@@ -136,22 +136,20 @@ describe('Hub', () => {
   });
 
   describe('configureScope', () => {
-    test('no client, should not invoke configureScope', () => {
-      expect.assertions(0);
-      const hub = new Hub();
-      hub.configureScope(_ => {
-        expect(true).toBeFalsy();
-      });
-    });
-
-    test('no client, should not invoke configureScope', () => {
-      expect.assertions(1);
+    test('should have an access to provide scope', () => {
       const localScope = new Scope();
       localScope.setExtra('a', 'b');
-      const hub = new Hub({ a: 'b' } as any, localScope);
-      hub.configureScope(confScope => {
-        expect((confScope as any)._extra).toEqual({ a: 'b' });
-      });
+      const hub = new Hub({} as any, localScope);
+      const cb = jest.fn();
+      hub.configureScope(cb);
+      expect(cb).toHaveBeenCalledWith(localScope);
+    });
+
+    test('should not invoke without client and scope', () => {
+      const hub = new Hub();
+      const cb = jest.fn();
+      hub.configureScope(cb);
+      expect(cb).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -10,238 +10,258 @@ describe('Scope', () => {
     getGlobalObject<any>().__SENTRY__.globalEventProcessors = undefined;
   });
 
-  describe('fingerprint', () => {
-    test('set', () => {
+  describe('attributes modification', () => {
+    test('setFingerprint', () => {
       const scope = new Scope();
       scope.setFingerprint(['abcd']);
       expect((scope as any)._fingerprint).toEqual(['abcd']);
     });
-  });
 
-  describe('extra', () => {
-    test('set key value', () => {
+    test('setExtra', () => {
       const scope = new Scope();
       scope.setExtra('a', 1);
       expect((scope as any)._extra).toEqual({ a: 1 });
     });
 
-    test('set object', () => {
+    test('setExtras', () => {
       const scope = new Scope();
       scope.setExtras({ a: 1 });
       expect((scope as any)._extra).toEqual({ a: 1 });
     });
 
-    test('set undefined', () => {
+    test('setExtras with undefined overrides the value', () => {
       const scope = new Scope();
       scope.setExtra('a', 1);
       scope.setExtras({ a: undefined });
       expect((scope as any)._extra).toEqual({ a: undefined });
     });
-  });
 
-  describe('tags', () => {
-    test('set key value', () => {
+    test('setTag', () => {
       const scope = new Scope();
       scope.setTag('a', 'b');
       expect((scope as any)._tags).toEqual({ a: 'b' });
     });
 
-    test('set object', () => {
+    test('setTags', () => {
       const scope = new Scope();
       scope.setTags({ a: 'b' });
       expect((scope as any)._tags).toEqual({ a: 'b' });
     });
-  });
 
-  describe('user', () => {
-    test('set', () => {
+    test('setUser', () => {
       const scope = new Scope();
       scope.setUser({ id: '1' });
       expect((scope as any)._user).toEqual({ id: '1' });
     });
-    test('unset', () => {
+
+    test('setUser with null unsets the user', () => {
       const scope = new Scope();
       scope.setUser({ id: '1' });
       scope.setUser(null);
       expect((scope as any)._user).toEqual({});
     });
-  });
 
-  describe('level', () => {
-    test('add', () => {
+    test('addBreadcrumb', () => {
       const scope = new Scope();
       scope.addBreadcrumb({ message: 'test' }, 100);
       expect((scope as any)._breadcrumbs[0]).toHaveProperty('message', 'test');
     });
-    test('set', () => {
+
+    test('setLevel', () => {
       const scope = new Scope();
       scope.setLevel(Severity.Critical);
       expect((scope as any)._level).toEqual(Severity.Critical);
     });
-  });
 
-  describe('transaction', () => {
-    test('set', () => {
+    test('setTransaction', () => {
       const scope = new Scope();
       scope.setTransaction('/abc');
       expect((scope as any)._transaction).toEqual('/abc');
     });
-    test('unset', () => {
+
+    test('setTransaction with no value unsets it', () => {
       const scope = new Scope();
       scope.setTransaction('/abc');
       scope.setTransaction();
       expect((scope as any)._transaction).toBeUndefined();
     });
-  });
 
-  describe('context', () => {
-    test('set', () => {
+    test('setContext', () => {
       const scope = new Scope();
       scope.setContext('os', { id: '1' });
-      expect((scope as any)._context.os).toEqual({ id: '1' });
+      expect((scope as any)._contexts.os).toEqual({ id: '1' });
     });
-    test('unset', () => {
+
+    test('setContext with null unsets it', () => {
       const scope = new Scope();
       scope.setContext('os', { id: '1' });
       scope.setContext('os', null);
       expect((scope as any)._user).toEqual({});
     });
-  });
 
-  describe('span', () => {
-    test('set', () => {
+    test('setSpan', () => {
       const scope = new Scope();
       const span = { fake: 'span' } as any;
       scope.setSpan(span);
       expect((scope as any)._span).toEqual(span);
     });
-    test('unset', () => {
+
+    test('setSpan with no value unsets it', () => {
       const scope = new Scope();
       scope.setSpan({ fake: 'span' } as any);
       scope.setSpan();
       expect((scope as any)._span).toEqual(undefined);
     });
-  });
 
-  test('chaining', () => {
-    const scope = new Scope();
-    scope.setLevel(Severity.Critical).setUser({ id: '1' });
-    expect((scope as any)._level).toEqual(Severity.Critical);
-    expect((scope as any)._user).toEqual({ id: '1' });
-  });
-
-  test('basic inheritance', () => {
-    const parentScope = new Scope();
-    parentScope.setExtra('a', 1);
-    const scope = Scope.clone(parentScope);
-    expect((parentScope as any)._extra).toEqual((scope as any)._extra);
-  });
-
-  test('parent changed inheritance', () => {
-    const parentScope = new Scope();
-    const scope = Scope.clone(parentScope);
-    parentScope.setExtra('a', 2);
-    expect((scope as any)._extra).toEqual({});
-    expect((parentScope as any)._extra).toEqual({ a: 2 });
-  });
-
-  test('child override inheritance', () => {
-    const parentScope = new Scope();
-    parentScope.setExtra('a', 1);
-
-    const scope = Scope.clone(parentScope);
-    scope.setExtra('a', 2);
-    expect((parentScope as any)._extra).toEqual({ a: 1 });
-    expect((scope as any)._extra).toEqual({ a: 2 });
-  });
-
-  test('applyToEvent', () => {
-    expect.assertions(8);
-    const scope = new Scope();
-    scope.setExtra('a', 2);
-    scope.setTag('a', 'b');
-    scope.setUser({ id: '1' });
-    scope.setFingerprint(['abcd']);
-    scope.setLevel(Severity.Warning);
-    scope.setTransaction('/abc');
-    scope.addBreadcrumb({ message: 'test' }, 100);
-    scope.setContext('os', { id: '1' });
-    const event: Event = {};
-    return scope.applyToEvent(event).then(processedEvent => {
-      expect(processedEvent!.extra).toEqual({ a: 2 });
-      expect(processedEvent!.tags).toEqual({ a: 'b' });
-      expect(processedEvent!.user).toEqual({ id: '1' });
-      expect(processedEvent!.fingerprint).toEqual(['abcd']);
-      expect(processedEvent!.level).toEqual('warning');
-      expect(processedEvent!.transaction).toEqual('/abc');
-      expect(processedEvent!.breadcrumbs![0]).toHaveProperty('message', 'test');
-      expect(processedEvent!.contexts).toEqual({ os: { id: '1' } });
+    test('chaining', () => {
+      const scope = new Scope();
+      scope.setLevel(Severity.Critical).setUser({ id: '1' });
+      expect((scope as any)._level).toEqual(Severity.Critical);
+      expect((scope as any)._user).toEqual({ id: '1' });
     });
   });
 
-  test('applyToEvent merge', () => {
-    expect.assertions(8);
-    const scope = new Scope();
-    scope.setExtra('a', 2);
-    scope.setTag('a', 'b');
-    scope.setUser({ id: '1' });
-    scope.setFingerprint(['abcd']);
-    scope.addBreadcrumb({ message: 'test' }, 100);
-    scope.setContext('server', { id: '2' });
-    const event: Event = {
-      breadcrumbs: [{ message: 'test1' }],
-      contexts: { os: { id: '1' } },
-      extra: { b: 3 },
-      fingerprint: ['efgh'],
-      tags: { b: 'c' },
-      user: { id: '3' },
-    };
-    return scope.applyToEvent(event).then(processedEvent => {
-      expect(processedEvent!.extra).toEqual({ a: 2, b: 3 });
-      expect(processedEvent!.tags).toEqual({ a: 'b', b: 'c' });
-      expect(processedEvent!.user).toEqual({ id: '3' });
-      expect(processedEvent!.fingerprint).toEqual(['efgh', 'abcd']);
-      expect(processedEvent!.breadcrumbs).toHaveLength(2);
-      expect(processedEvent!.breadcrumbs![0]).toHaveProperty('message', 'test1');
-      expect(processedEvent!.breadcrumbs![1]).toHaveProperty('message', 'test');
-      expect(processedEvent!.contexts).toEqual({
-        os: { id: '1' },
-        server: { id: '2' },
+  describe('clone', () => {
+    test('basic inheritance', () => {
+      const parentScope = new Scope();
+      parentScope.setExtra('a', 1);
+      const scope = Scope.clone(parentScope);
+      expect((parentScope as any)._extra).toEqual((scope as any)._extra);
+    });
+
+    test('parent changed inheritance', () => {
+      const parentScope = new Scope();
+      const scope = Scope.clone(parentScope);
+      parentScope.setExtra('a', 2);
+      expect((scope as any)._extra).toEqual({});
+      expect((parentScope as any)._extra).toEqual({ a: 2 });
+    });
+
+    test('child override inheritance', () => {
+      const parentScope = new Scope();
+      parentScope.setExtra('a', 1);
+
+      const scope = Scope.clone(parentScope);
+      scope.setExtra('a', 2);
+      expect((parentScope as any)._extra).toEqual({ a: 1 });
+      expect((scope as any)._extra).toEqual({ a: 2 });
+    });
+  });
+
+  describe('applyToEvent', () => {
+    test('basic usage', () => {
+      expect.assertions(8);
+      const scope = new Scope();
+      scope.setExtra('a', 2);
+      scope.setTag('a', 'b');
+      scope.setUser({ id: '1' });
+      scope.setFingerprint(['abcd']);
+      scope.setLevel(Severity.Warning);
+      scope.setTransaction('/abc');
+      scope.addBreadcrumb({ message: 'test' }, 100);
+      scope.setContext('os', { id: '1' });
+      const event: Event = {};
+      return scope.applyToEvent(event).then(processedEvent => {
+        expect(processedEvent!.extra).toEqual({ a: 2 });
+        expect(processedEvent!.tags).toEqual({ a: 'b' });
+        expect(processedEvent!.user).toEqual({ id: '1' });
+        expect(processedEvent!.fingerprint).toEqual(['abcd']);
+        expect(processedEvent!.level).toEqual('warning');
+        expect(processedEvent!.transaction).toEqual('/abc');
+        expect(processedEvent!.breadcrumbs![0]).toHaveProperty('message', 'test');
+        expect(processedEvent!.contexts).toEqual({ os: { id: '1' } });
       });
     });
-  });
 
-  test('applyToEvent message fingerprint', async () => {
-    expect.assertions(1);
-    const scope = new Scope();
-    const event: Event = {
-      fingerprint: ['bar'],
-      message: 'foo',
-    };
-    return scope.applyToEvent(event).then(processedEvent => {
-      expect(processedEvent!.fingerprint).toEqual(['bar']);
+    test('merge with existing event data', () => {
+      expect.assertions(8);
+      const scope = new Scope();
+      scope.setExtra('a', 2);
+      scope.setTag('a', 'b');
+      scope.setUser({ id: '1' });
+      scope.setFingerprint(['abcd']);
+      scope.addBreadcrumb({ message: 'test' }, 100);
+      scope.setContext('server', { id: '2' });
+      const event: Event = {
+        breadcrumbs: [{ message: 'test1' }],
+        contexts: { os: { id: '1' } },
+        extra: { b: 3 },
+        fingerprint: ['efgh'],
+        tags: { b: 'c' },
+        user: { id: '3' },
+      };
+      return scope.applyToEvent(event).then(processedEvent => {
+        expect(processedEvent!.extra).toEqual({ a: 2, b: 3 });
+        expect(processedEvent!.tags).toEqual({ a: 'b', b: 'c' });
+        expect(processedEvent!.user).toEqual({ id: '3' });
+        expect(processedEvent!.fingerprint).toEqual(['efgh', 'abcd']);
+        expect(processedEvent!.breadcrumbs).toHaveLength(2);
+        expect(processedEvent!.breadcrumbs![0]).toHaveProperty('message', 'test1');
+        expect(processedEvent!.breadcrumbs![1]).toHaveProperty('message', 'test');
+        expect(processedEvent!.contexts).toEqual({
+          os: { id: '1' },
+          server: { id: '2' },
+        });
+      });
     });
-  });
 
-  test('applyToEvent scope level should be stronger', () => {
-    expect.assertions(1);
-    const scope = new Scope();
-    scope.setLevel(Severity.Warning);
-    const event: Event = {};
-    event.level = Severity.Critical;
-    return scope.applyToEvent(event).then(processedEvent => {
-      expect(processedEvent!.level).toEqual('warning');
+    test('should make sure that fingerprint is always array', async () => {
+      const scope = new Scope();
+      const event: Event = {};
+
+      // @ts-ignore
+      event.fingerprint = 'foo';
+      await scope.applyToEvent(event).then(processedEvent => {
+        expect(processedEvent!.fingerprint).toEqual(['foo']);
+      });
+
+      // @ts-ignore
+      event.fingerprint = 'bar';
+      await scope.applyToEvent(event).then(processedEvent => {
+        expect(processedEvent!.fingerprint).toEqual(['bar']);
+      });
     });
-  });
 
-  test('applyToEvent scope transaction should be stronger', () => {
-    expect.assertions(1);
-    const scope = new Scope();
-    scope.setTransaction('/abc');
-    const event: Event = {};
-    event.transaction = '/cdf';
-    return scope.applyToEvent(event).then(processedEvent => {
-      expect(processedEvent!.transaction).toEqual('/abc');
+    test('should merge fingerprint from event and scope', async () => {
+      const scope = new Scope();
+      scope.setFingerprint(['foo']);
+      const event: Event = {
+        fingerprint: ['bar'],
+      };
+
+      await scope.applyToEvent(event).then(processedEvent => {
+        expect(processedEvent!.fingerprint).toEqual(['bar', 'foo']);
+      });
+    });
+
+    test('should remove default empty fingerprint array if theres no data available', async () => {
+      const scope = new Scope();
+      const event: Event = {};
+      await scope.applyToEvent(event).then(processedEvent => {
+        expect(processedEvent!.fingerprint).toEqual(undefined);
+      });
+    });
+
+    test('scope level should have priority over event level', () => {
+      expect.assertions(1);
+      const scope = new Scope();
+      scope.setLevel(Severity.Warning);
+      const event: Event = {};
+      event.level = Severity.Critical;
+      return scope.applyToEvent(event).then(processedEvent => {
+        expect(processedEvent!.level).toEqual('warning');
+      });
+    });
+
+    test('scope transaction should have priority over event transaction', () => {
+      expect.assertions(1);
+      const scope = new Scope();
+      scope.setTransaction('/abc');
+      const event: Event = {};
+      event.transaction = '/cdf';
+      return scope.applyToEvent(event).then(processedEvent => {
+        expect(processedEvent!.transaction).toEqual('/abc');
+      });
     });
   });
 
@@ -265,170 +285,286 @@ describe('Scope', () => {
     expect((scope as any)._breadcrumbs).toHaveLength(0);
   });
 
-  test('addEventProcessor', () => {
-    expect.assertions(3);
-    const event: Event = {
-      extra: { b: 3 },
-    };
-    const localScope = new Scope();
-    localScope.setExtra('a', 'b');
-    localScope.addEventProcessor((processedEvent: Event) => {
-      expect(processedEvent.extra).toEqual({ a: 'b', b: 3 });
-      return processedEvent;
-    });
-    localScope.addEventProcessor((processedEvent: Event) => {
-      processedEvent.dist = '1';
-      return processedEvent;
-    });
-    localScope.addEventProcessor((processedEvent: Event) => {
-      expect(processedEvent.dist).toEqual('1');
-      return processedEvent;
+  describe('update', () => {
+    let scope: Scope;
+
+    beforeEach(() => {
+      scope = new Scope();
+      scope.setTags({ foo: '1', bar: '2' });
+      scope.setExtras({ foo: '1', bar: '2' });
+      scope.setContext('foo', { id: '1' });
+      scope.setContext('bar', { id: '2' });
+      scope.setUser({ id: '1337' });
+      scope.setLevel(Severity.Info);
+      scope.setFingerprint(['foo']);
     });
 
-    return localScope.applyToEvent(event).then(final => {
-      expect(final!.dist).toEqual('1');
+    test('given no data, returns the original scope', () => {
+      const updatedScope = scope.update();
+      expect(updatedScope).toEqual(scope);
+    });
+
+    test('given neither function, Scope or plain object, returns original scope', () => {
+      // @ts-ignore
+      const updatedScope = scope.update('wat');
+      expect(updatedScope).toEqual(scope);
+    });
+
+    test('given callback function, pass it the scope and returns original or modified scope', () => {
+      const cb = jest
+        .fn()
+        .mockImplementationOnce(v => v)
+        .mockImplementationOnce(v => {
+          v.setTag('foo', 'bar');
+          return v;
+        });
+
+      let updatedScope = scope.update(cb);
+      expect(cb).toHaveBeenNthCalledWith(1, scope);
+      expect(updatedScope).toEqual(scope);
+
+      updatedScope = scope.update(cb);
+      expect(cb).toHaveBeenNthCalledWith(2, scope);
+      expect(updatedScope).toEqual(scope);
+    });
+
+    test('given callback function, when it doesnt return instanceof Scope, ignore it and return original scope', () => {
+      const cb = jest.fn().mockImplementationOnce(v => 'wat');
+      const updatedScope = scope.update(cb);
+      expect(cb).toHaveBeenCalledWith(scope);
+      expect(updatedScope).toEqual(scope);
+    });
+
+    test('given another instance of Scope, it should merge two together, with the passed scope having priority', () => {
+      const localScope = new Scope();
+      localScope.setTags({ bar: '3', baz: '4' });
+      localScope.setExtras({ bar: '3', baz: '4' });
+      localScope.setContext('bar', { id: '3' });
+      localScope.setContext('baz', { id: '4' });
+      localScope.setUser({ id: '42' });
+      localScope.setLevel(Severity.Warning);
+      localScope.setFingerprint(['bar']);
+
+      const updatedScope = scope.update(localScope) as any;
+
+      expect(updatedScope._tags).toEqual({
+        bar: '3',
+        baz: '4',
+        foo: '1',
+      });
+      expect(updatedScope._extra).toEqual({
+        bar: '3',
+        baz: '4',
+        foo: '1',
+      });
+      expect(updatedScope._contexts).toEqual({
+        bar: { id: '3' },
+        baz: { id: '4' },
+        foo: { id: '1' },
+      });
+      expect(updatedScope._user).toEqual({ id: '42' });
+      expect(updatedScope._level).toEqual(Severity.Warning);
+      expect(updatedScope._fingerprint).toEqual(['bar']);
+    });
+
+    test('given a plain object, it should merge two together, with the passed object having priority', () => {
+      const localAttributes = {
+        contexts: { bar: { id: '3' }, baz: { id: '4' } },
+        extra: { bar: '3', baz: '4' },
+        fingerprint: ['bar'],
+        level: Severity.Warning,
+        tags: { bar: '3', baz: '4' },
+        user: { id: '42' },
+      };
+      const updatedScope = scope.update(localAttributes) as any;
+
+      expect(updatedScope._tags).toEqual({
+        bar: '3',
+        baz: '4',
+        foo: '1',
+      });
+      expect(updatedScope._extra).toEqual({
+        bar: '3',
+        baz: '4',
+        foo: '1',
+      });
+      expect(updatedScope._contexts).toEqual({
+        bar: { id: '3' },
+        baz: { id: '4' },
+        foo: { id: '1' },
+      });
+      expect(updatedScope._user).toEqual({ id: '42' });
+      expect(updatedScope._level).toEqual(Severity.Warning);
+      expect(updatedScope._fingerprint).toEqual(['bar']);
     });
   });
 
-  test('addEventProcessor + global', () => {
-    expect.assertions(3);
-    const event: Event = {
-      extra: { b: 3 },
-    };
-    const localScope = new Scope();
-    localScope.setExtra('a', 'b');
+  describe('addEventProcessor', () => {
+    test('should allow for basic event manipulation', () => {
+      expect.assertions(3);
+      const event: Event = {
+        extra: { b: 3 },
+      };
+      const localScope = new Scope();
+      localScope.setExtra('a', 'b');
+      localScope.addEventProcessor((processedEvent: Event) => {
+        expect(processedEvent.extra).toEqual({ a: 'b', b: 3 });
+        return processedEvent;
+      });
+      localScope.addEventProcessor((processedEvent: Event) => {
+        processedEvent.dist = '1';
+        return processedEvent;
+      });
+      localScope.addEventProcessor((processedEvent: Event) => {
+        expect(processedEvent.dist).toEqual('1');
+        return processedEvent;
+      });
 
-    addGlobalEventProcessor((processedEvent: Event) => {
-      processedEvent.dist = '1';
-      return processedEvent;
-    });
-
-    localScope.addEventProcessor((processedEvent: Event) => {
-      expect(processedEvent.extra).toEqual({ a: 'b', b: 3 });
-      return processedEvent;
-    });
-
-    localScope.addEventProcessor((processedEvent: Event) => {
-      expect(processedEvent.dist).toEqual('1');
-      return processedEvent;
-    });
-
-    return localScope.applyToEvent(event).then(final => {
-      expect(final!.dist).toEqual('1');
-    });
-  });
-
-  test('addEventProcessor async', async () => {
-    jest.useFakeTimers();
-    expect.assertions(6);
-    const event: Event = {
-      extra: { b: 3 },
-    };
-    const localScope = new Scope();
-    localScope.setExtra('a', 'b');
-    const callCounter = jest.fn();
-    localScope.addEventProcessor((processedEvent: Event) => {
-      callCounter(1);
-      expect(processedEvent.extra).toEqual({ a: 'b', b: 3 });
-      return processedEvent;
-    });
-    localScope.addEventProcessor(
-      async (processedEvent: Event) =>
-        new Promise<Event>(resolve => {
-          callCounter(2);
-          setTimeout(() => {
-            callCounter(3);
-            processedEvent.dist = '1';
-            resolve(processedEvent);
-          }, 1);
-          jest.runAllTimers();
-        }),
-    );
-    localScope.addEventProcessor((processedEvent: Event) => {
-      callCounter(4);
-      return processedEvent;
+      return localScope.applyToEvent(event).then(final => {
+        expect(final!.dist).toEqual('1');
+      });
     });
 
-    return localScope.applyToEvent(event).then(processedEvent => {
-      expect(callCounter.mock.calls[0][0]).toBe(1);
-      expect(callCounter.mock.calls[1][0]).toBe(2);
-      expect(callCounter.mock.calls[2][0]).toBe(3);
-      expect(callCounter.mock.calls[3][0]).toBe(4);
-      expect(processedEvent!.dist).toEqual('1');
-    });
-  });
+    test('should work alongside global event processors', () => {
+      expect.assertions(3);
+      const event: Event = {
+        extra: { b: 3 },
+      };
+      const localScope = new Scope();
+      localScope.setExtra('a', 'b');
 
-  test('addEventProcessor async with reject', async () => {
-    jest.useFakeTimers();
-    expect.assertions(2);
-    const event: Event = {
-      extra: { b: 3 },
-    };
-    const localScope = new Scope();
-    localScope.setExtra('a', 'b');
-    const callCounter = jest.fn();
-    localScope.addEventProcessor((processedEvent: Event) => {
-      callCounter(1);
-      expect(processedEvent.extra).toEqual({ a: 'b', b: 3 });
-      return processedEvent;
-    });
-    localScope.addEventProcessor(
-      async (_processedEvent: Event) =>
-        new Promise<Event>((_, reject) => {
-          setTimeout(() => {
-            reject('bla');
-          }, 1);
-          jest.runAllTimers();
-        }),
-    );
-    localScope.addEventProcessor((processedEvent: Event) => {
-      callCounter(4);
-      return processedEvent;
+      addGlobalEventProcessor((processedEvent: Event) => {
+        processedEvent.dist = '1';
+        return processedEvent;
+      });
+
+      localScope.addEventProcessor((processedEvent: Event) => {
+        expect(processedEvent.extra).toEqual({ a: 'b', b: 3 });
+        return processedEvent;
+      });
+
+      localScope.addEventProcessor((processedEvent: Event) => {
+        expect(processedEvent.dist).toEqual('1');
+        return processedEvent;
+      });
+
+      return localScope.applyToEvent(event).then(final => {
+        expect(final!.dist).toEqual('1');
+      });
     });
 
-    return localScope.applyToEvent(event).then(null, reason => {
-      expect(reason).toEqual('bla');
-    });
-  });
+    test('should allow for async callbacks', async () => {
+      jest.useFakeTimers();
+      expect.assertions(6);
+      const event: Event = {
+        extra: { b: 3 },
+      };
+      const localScope = new Scope();
+      localScope.setExtra('a', 'b');
+      const callCounter = jest.fn();
+      localScope.addEventProcessor((processedEvent: Event) => {
+        callCounter(1);
+        expect(processedEvent.extra).toEqual({ a: 'b', b: 3 });
+        return processedEvent;
+      });
+      localScope.addEventProcessor(
+        async (processedEvent: Event) =>
+          new Promise<Event>(resolve => {
+            callCounter(2);
+            setTimeout(() => {
+              callCounter(3);
+              processedEvent.dist = '1';
+              resolve(processedEvent);
+            }, 1);
+            jest.runAllTimers();
+          }),
+      );
+      localScope.addEventProcessor((processedEvent: Event) => {
+        callCounter(4);
+        return processedEvent;
+      });
 
-  test('addEventProcessor return null', () => {
-    expect.assertions(1);
-    const event: Event = {
-      extra: { b: 3 },
-    };
-    const localScope = new Scope();
-    localScope.setExtra('a', 'b');
-    localScope.addEventProcessor(async (_: Event) => null);
-    return localScope.applyToEvent(event).then(processedEvent => {
-      expect(processedEvent).toBeNull();
+      return localScope.applyToEvent(event).then(processedEvent => {
+        expect(callCounter.mock.calls[0][0]).toBe(1);
+        expect(callCounter.mock.calls[1][0]).toBe(2);
+        expect(callCounter.mock.calls[2][0]).toBe(3);
+        expect(callCounter.mock.calls[3][0]).toBe(4);
+        expect(processedEvent!.dist).toEqual('1');
+      });
     });
-  });
 
-  test('addEventProcessor pass along hint', () => {
-    expect.assertions(3);
-    const event: Event = {
-      extra: { b: 3 },
-    };
-    const localScope = new Scope();
-    localScope.setExtra('a', 'b');
-    localScope.addEventProcessor(async (internalEvent: Event, hint?: EventHint) => {
-      expect(hint).toBeTruthy();
-      expect(hint!.syntheticException).toBeTruthy();
-      return internalEvent;
-    });
-    return localScope.applyToEvent(event, { syntheticException: new Error('what') }).then(processedEvent => {
-      expect(processedEvent).toEqual(event);
-    });
-  });
+    test('should correctly handle async rejections', async () => {
+      jest.useFakeTimers();
+      expect.assertions(2);
+      const event: Event = {
+        extra: { b: 3 },
+      };
+      const localScope = new Scope();
+      localScope.setExtra('a', 'b');
+      const callCounter = jest.fn();
+      localScope.addEventProcessor((processedEvent: Event) => {
+        callCounter(1);
+        expect(processedEvent.extra).toEqual({ a: 'b', b: 3 });
+        return processedEvent;
+      });
+      localScope.addEventProcessor(
+        async (_processedEvent: Event) =>
+          new Promise<Event>((_, reject) => {
+            setTimeout(() => {
+              reject('bla');
+            }, 1);
+            jest.runAllTimers();
+          }),
+      );
+      localScope.addEventProcessor((processedEvent: Event) => {
+        callCounter(4);
+        return processedEvent;
+      });
 
-  test('listeners', () => {
-    jest.useFakeTimers();
-    const scope = new Scope();
-    const listener = jest.fn();
-    scope.addScopeListener(listener);
-    scope.setExtra('a', 2);
-    jest.runAllTimers();
-    expect(listener).toHaveBeenCalled();
-    expect(listener.mock.calls[0][0]._extra).toEqual({ a: 2 });
+      return localScope.applyToEvent(event).then(null, reason => {
+        expect(reason).toEqual('bla');
+      });
+    });
+
+    test('should drop an event when any of processors return null', () => {
+      expect.assertions(1);
+      const event: Event = {
+        extra: { b: 3 },
+      };
+      const localScope = new Scope();
+      localScope.setExtra('a', 'b');
+      localScope.addEventProcessor(async (_: Event) => null);
+      return localScope.applyToEvent(event).then(processedEvent => {
+        expect(processedEvent).toBeNull();
+      });
+    });
+
+    test('should have an access to the EventHint', () => {
+      expect.assertions(3);
+      const event: Event = {
+        extra: { b: 3 },
+      };
+      const localScope = new Scope();
+      localScope.setExtra('a', 'b');
+      localScope.addEventProcessor(async (internalEvent: Event, hint?: EventHint) => {
+        expect(hint).toBeTruthy();
+        expect(hint!.syntheticException).toBeTruthy();
+        return internalEvent;
+      });
+      return localScope.applyToEvent(event, { syntheticException: new Error('what') }).then(processedEvent => {
+        expect(processedEvent).toEqual(event);
+      });
+    });
+
+    test('should notify all the listeners about the changes', () => {
+      jest.useFakeTimers();
+      const scope = new Scope();
+      const listener = jest.fn();
+      scope.addScopeListener(listener);
+      scope.setExtra('a', 2);
+      jest.runAllTimers();
+      expect(listener).toHaveBeenCalled();
+      expect(listener.mock.calls[0][0]._extra).toEqual({ a: 2 });
+    });
   });
 });

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -1,6 +1,7 @@
 import { Breadcrumb } from './breadcrumb';
 import { Exception } from './exception';
 import { Request } from './request';
+import { CaptureContext } from './scope';
 import { SdkInfo } from './sdkinfo';
 import { Severity } from './severity';
 import { Span } from './span';
@@ -46,6 +47,7 @@ export type EventType = 'transaction';
 /** JSDoc */
 export interface EventHint {
   event_id?: string;
+  captureContext?: CaptureContext;
   syntheticException?: Error | null;
   originalException?: Error | string | null;
   data?: any;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -14,7 +14,7 @@ export { Package } from './package';
 export { Request } from './request';
 export { Response } from './response';
 export { Runtime } from './runtime';
-export { Scope } from './scope';
+export { CaptureContext, Scope, ScopeContext } from './scope';
 export { SdkInfo } from './sdkinfo';
 export { Severity } from './severity';
 export { Span, SpanContext } from './span';

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -92,9 +92,9 @@ export interface Scope {
   /**
    * Updates the scope with provided data. Can work in three variations:
    * - plain object containing updatable attributes
-   * - Span instance that'll extract the attributes from
+   * - Scope instance that'll extract the attributes from
    * - callback function that'll receive the current scope as an argument and allow for modifications
-   * @param captureContext span modifier to be used
+   * @param captureContext scope modifier to be used
    */
   update(captureContext?: CaptureContext): this;
 

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -4,6 +4,19 @@ import { Severity } from './severity';
 import { Span } from './span';
 import { User } from './user';
 
+/** JSDocs */
+export type CaptureContext = Scope | Partial<ScopeContext> | ((scope: Scope) => Scope);
+
+/** JSDocs */
+export interface ScopeContext {
+  user: User;
+  level: Severity;
+  extra: { [key: string]: any };
+  contexts: { [key: string]: any };
+  tags: { [key: string]: string };
+  fingerprint: string[];
+}
+
 /**
  * Holds additional event information. {@link Scope.applyToEvent} will be
  * called by the client before an event will be sent.

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -89,6 +89,15 @@ export interface Scope {
    */
   setSpan(span?: Span): this;
 
+  /**
+   * Updates the scope with provided data. Can work in three variations:
+   * - plain object containing updatable attributes
+   * - Span instance that'll extract the attributes from
+   * - callback function that'll receive the current scope as an argument and allow for modifications
+   * @param captureContext span modifier to be used
+   */
+  update(captureContext?: CaptureContext): this;
+
   /** Clears the current scope and resets its properties. */
   clear(): this;
 


### PR DESCRIPTION
This PR introduces a second, optional argument to `captureException` and `captureMessage` methods, that allows to provide _some_ custom data directly to the scope.

Provided data will be merged with what's already on the scope, unless explicitly cleared using a callback method.

It works in three variations:
- plain object containing updatable attributes
- `Scope` instance that'll extract the attributes from
- callback function that'll receive the current scope as an argument and allow for modifications

List of allowed keys:
```
tags
extra
contexts
user
level
fingerprint
```

Example usages:

```js
Sentry.captureException(new Error("wat"), {
  tags: {
    wat: "ok",
  }
});
```

```js
Sentry.captureMessage("hey", {
  user: {
    id: 1337
  }
});
```

```js
// Explicitly clear what has been already stored on the scope
Sentry.captureException(new Error("clean as never"), scope => {
  scope.clear();
  scope.setTag("clean", "slate");
  return scope;
});
```

```js
// Use Scope instance to store the data (it'll still merge with the global scope)
const scope = new Sentry.Scope();
scope.setTag("idontknow", "whattodo");
Sentry.captureException(new Error("mkey"), scope);
```

```js
// Use Scope instance to store the data and ignore global one completely
const scope = new Sentry.Scope();
scope.setTag("idontknow", "whattodo");
Sentry.captureException(new Error("mkey"), () => scope);
```

Ref: https://github.com/getsentry/sentry-javascript/issues/1607
Notion: https://www.notion.so/sentry/Explicit-Scope-797e8b674010494d8854001281cf8769#8be8a9f0b4064842904d3e649bfac407
Asana: https://app.asana.com/0/1169125731075107/1175779896688409

![image](https://user-images.githubusercontent.com/1523305/83259986-48c34580-a1b9-11ea-9402-4772631fc60c.png)
