### PR TITLE
Change XHR instrumentation ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 - [react] feat: Add @sentry/react package (#2631)
+- [browser] Change XHR instrumentation order to handle `onreadystatechange` breadcrumbs correctly (#2643)
 
 ## 5.16.1
 


### PR DESCRIPTION
Fixes issue where 3rd party libraries like Axios are attaching their own handler before ours, resulting in missing breadcrumb in the consecutive error event. 

Ref: https://github.com/getsentry/sentry-javascript/issues/1333#issuecomment-638329421