### PR TITLE
misc: Add yarn to make prepare-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 prepare-release:
+	yarn
 	yarn clean
 	yarn build
 	yarn lint


### PR DESCRIPTION
It is a necessary step to install dependencies.

Make it easier on contributors who can't memorize all individual commands that need to be run in the repo.