### PR TITLE
feat: Remove normalization of contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 - [react] feat: Add @sentry/react package (#2631)
+- [core] feat: Remove normalization of contexts (#2649)
 
 ## 5.16.1
 

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -289,7 +289,6 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    * Normalized keys:
    * - `breadcrumbs.data`
    * - `user`
-   * - `contexts`
    * - `extra`
    * @param event Event
    * @returns Normalized event
@@ -312,9 +311,6 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
       }),
       ...(event.user && {
         user: normalize(event.user, depth),
-      }),
-      ...(event.contexts && {
-        contexts: normalize(event.contexts, depth),
       }),
       ...(event.extra && {
         extra: normalize(event.extra, depth),

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -467,7 +467,7 @@ describe('BaseClient', () => {
       });
       expect(TestBackend.instance!.event!).toEqual({
         breadcrumbs: [normalizedBreadcrumb, normalizedBreadcrumb, normalizedBreadcrumb],
-        contexts: normalizedObject,
+        contexts: fourLevelsObject,
         event_id: '42',
         extra: normalizedObject,
         timestamp: 2020,
@@ -512,7 +512,7 @@ describe('BaseClient', () => {
       });
       expect(TestBackend.instance!.event!).toEqual({
         breadcrumbs: [normalizedBreadcrumb, normalizedBreadcrumb, normalizedBreadcrumb],
-        contexts: normalizedObject,
+        contexts: fourLevelsObject,
         event_id: '42',
         extra: normalizedObject,
         timestamp: 2020,


### PR DESCRIPTION
All of the context types documented in [1] are flat objects.

The more recent addition contexts.trace is the only context type that
may have nested objects under contexts.trace.data. That value holds the
data for the Transaction Span and matches spans[].data for invidual
Spans.

Removing normalization is one solution to the inconsistency in which
data in Transactions is heavily limited, while data in Span is ignored
by normalization.

This is the simplest to implement fix to #2646, thus what we implement
here to evaluate. We expect that no other key under contexts will be
affected negatively by this change.

[1]: https://develop.sentry.dev/sdk/event-payloads/contexts/

Fixes #2646