### PR TITLE
fix: Normalize Transaction and Span consistently

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -300,7 +300,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
     }
 
     // tslint:disable:no-unsafe-any
-    return {
+    const normalized = {
       ...event,
       ...(event.breadcrumbs && {
         breadcrumbs: event.breadcrumbs.map(b => ({
@@ -320,6 +320,17 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
         extra: normalize(event.extra, depth),
       }),
     };
+    // event.contexts.trace stores information about a Transaction. Similarly,
+    // event.spans[] stores information about child Spans. Given that a
+    // Transaction is conceptually a Span, normalization should apply to both
+    // Transactions and Spans consistently.
+    // For now the decision is to skip normalization of Transactions and Spans,
+    // so this block overwrites the normalized event to add back the original
+    // Transaction information prior to normalization.
+    if (event.contexts && event.contexts.trace) {
+      normalized.contexts.trace = event.contexts.trace;
+    }
+    return normalized;
   }
 
   /**


### PR DESCRIPTION
This is such that setting data on a Transaction behaves the same as setting data on a Span.

Fixes #2646.

---

## BEFORE

![image](https://user-images.githubusercontent.com/88819/84026217-3604f980-a98d-11ea-8e0e-f60db95c0b68.png)


## AFTER

![image](https://user-images.githubusercontent.com/88819/84026171-238ac000-a98d-11ea-847a-5265bccf43e1.png)
