### PR TITLE
fix: Re-add TraceContext for all events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 - [react] feat: Add @sentry/react package (#2631)
 - [browser] Change XHR instrumentation order to handle `onreadystatechange` breadcrumbs correctly (#2643)
+- [apm] fix: Re-add TraceContext for all events (#2656)
 
 ## 5.16.1
 

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -1,4 +1,4 @@
-import { Hub } from '@sentry/hub';
+import { Hub, Scope } from '@sentry/hub';
 import { Event, EventProcessor, Integration, Severity, Span, SpanContext, TransactionContext } from '@sentry/types';
 import {
   addInstrumentationHandler,
@@ -435,6 +435,9 @@ export class Tracing implements Integration {
       trimEnd: true,
       ...transactionContext,
     }) as Transaction;
+
+    // We set the transaction here on the scope so error events pick up the trace context and attach it to the error
+    hub.configureScope(scope => scope.setSpan(Tracing._activeTransaction));
 
     // The reason we do this here is because of cached responses
     // If we start and transaction without an activity it would never finish since there is no activity

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -1,4 +1,4 @@
-import { Hub, Scope } from '@sentry/hub';
+import { Hub } from '@sentry/hub';
 import { Event, EventProcessor, Integration, Severity, Span, SpanContext, TransactionContext } from '@sentry/types';
 import {
   addInstrumentationHandler,

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -377,6 +377,12 @@ export class Scope implements ScopeInterface {
     if (this._transaction) {
       event.transaction = this._transaction;
     }
+    // We want to set the trace context for normal events only if there isn't already
+    // a trace context on the event. There is a product feature in place where we link
+    // errors with transaction and it relys on that.
+    if (this._span) {
+      event.contexts = { trace: this._span.getTraceContext(), ...event.contexts };
+    }
 
     this._applyFingerprint(event);
 

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -265,6 +265,38 @@ describe('Scope', () => {
     });
   });
 
+  test('applyToEvent trace context', async () => {
+    expect.assertions(1);
+    const scope = new Scope();
+    const span = {
+      fake: 'span',
+      getTraceContext: () => ({ a: 'b' }),
+    } as any;
+    scope.setSpan(span);
+    const event: Event = {};
+    return scope.applyToEvent(event).then(processedEvent => {
+      expect((processedEvent!.contexts!.trace as any).a).toEqual('b');
+    });
+  });
+
+  test('applyToEvent existing trace context in event should be stronger', async () => {
+    expect.assertions(1);
+    const scope = new Scope();
+    const span = {
+      fake: 'span',
+      getTraceContext: () => ({ a: 'b' }),
+    } as any;
+    scope.setSpan(span);
+    const event: Event = {
+      contexts: {
+        trace: { a: 'c' },
+      },
+    };
+    return scope.applyToEvent(event).then(processedEvent => {
+      expect((processedEvent!.contexts!.trace as any).a).toEqual('c');
+    });
+  });
+
   test('clear', () => {
     const scope = new Scope();
     scope.setExtra('a', 2);


### PR DESCRIPTION
We want that normal error events to also receive the `trace` context. 
This is a product feature we rely on to connect error with transactions.