### PR TITLE
test: Check for specific values in auth header

### DIFF
--- a/packages/node/test/transports/http.test.ts
+++ b/packages/node/test/transports/http.test.ts
@@ -28,7 +28,9 @@ function createTransport(options: TransportOptions): HTTPTransport {
 }
 
 function assertBasicOptions(options: any): void {
-  expect(options.headers['X-Sentry-Auth']).toBeTruthy();
+  expect(options.headers['X-Sentry-Auth']).toContain('sentry_version');
+  expect(options.headers['X-Sentry-Auth']).toContain('sentry_client');
+  expect(options.headers['X-Sentry-Auth']).toContain('sentry_key');
   expect(options.port).toEqual('8989');
   expect(options.path).toEqual(transportPath);
   expect(options.hostname).toEqual('sentry.io');

--- a/packages/node/test/transports/https.test.ts
+++ b/packages/node/test/transports/https.test.ts
@@ -34,7 +34,9 @@ function createTransport(options: TransportOptions): HTTPSTransport {
 }
 
 function assertBasicOptions(options: any): void {
-  expect(options.headers['X-Sentry-Auth']).toBeTruthy();
+  expect(options.headers['X-Sentry-Auth']).toContain('sentry_version');
+  expect(options.headers['X-Sentry-Auth']).toContain('sentry_client');
+  expect(options.headers['X-Sentry-Auth']).toContain('sentry_key');
   expect(options.port).toEqual('8989');
   expect(options.path).toEqual(transportPath);
   expect(options.hostname).toEqual('sentry.io');


### PR DESCRIPTION
The tests changed in 8958f61ca6663122094e1991c37a63dcf771b5cf and then partly reverted in 9c525ff277f0a18bd0bd63a30f5b762f6b37f0f8. This commit brings back the original checks.