### PR TITLE
Fix absent method `now` on window.Performance

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -382,22 +382,26 @@ export const crossPlatformPerformance: CrossPlatformPerformance = (() => {
     }
   }
 
-  if (getGlobalObject<Window>().performance) {
-    // Polyfill for performance.timeOrigin.
-    //
-    // While performance.timing.navigationStart is deprecated in favor of performance.timeOrigin, performance.timeOrigin
-    // is not as widely supported. Namely, performance.timeOrigin is undefined in Safari as of writing.
-    // tslint:disable-next-line:strict-type-predicates
-    if (performance.timeOrigin === undefined) {
-      // As of writing, performance.timing is not available in Web Workers in mainstream browsers, so it is not always a
-      // valid fallback. In the absence of a initial time provided by the browser, fallback to INITIAL_TIME.
-      // @ts-ignore
-      // tslint:disable-next-line:deprecation
-      performance.timeOrigin = (performance.timing && performance.timing.navigationStart) || INITIAL_TIME;
-    }
+  const { performance } = getGlobalObject<Window>();
+
+  if (!performance || !performance.now) {
+    return performanceFallback;
   }
 
-  return getGlobalObject<Window>().performance || performanceFallback;
+  // Polyfill for performance.timeOrigin.
+  //
+  // While performance.timing.navigationStart is deprecated in favor of performance.timeOrigin, performance.timeOrigin
+  // is not as widely supported. Namely, performance.timeOrigin is undefined in Safari as of writing.
+  // tslint:disable-next-line:strict-type-predicates
+  if (performance.timeOrigin === undefined) {
+    // As of writing, performance.timing is not available in Web Workers in mainstream browsers, so it is not always a
+    // valid fallback. In the absence of a initial time provided by the browser, fallback to INITIAL_TIME.
+    // @ts-ignore
+    // tslint:disable-next-line:deprecation
+    performance.timeOrigin = (performance.timing && performance.timing.navigationStart) || INITIAL_TIME;
+  }
+
+  return performance;
 })();
 
 /**


### PR DESCRIPTION
We have an issue in our self-hosted sentry `Object [object Performance] has no method 'now'`

It shows `Sentry.addBreadcrumb` as the source of the error.

It seems that some browsers can have global performance object without `now` method.

50% of all events from Chrome 22.0.1229 - I know that it's pretty old - but the fix seems trivial