### PR TITLE
fix: `options` typings

### DIFF
--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -131,6 +131,15 @@ export interface Options {
    * @returns The breadcrumb that will be added | null.
    */
   beforeBreadcrumb?(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): Breadcrumb | null;
+  
+  /**
+   * Controls how many milliseconds to wait before shutting down. The default is
+   * SDK-specific but typically around 2 seconds. Setting this too low can cause
+   * problems for sending events from command line applications. Setting it too
+   * high can cause the application to block for users with network connectivity
+   * problems.
+   */
+  shutdownTimeout?: number; 
 
   _experiments?: {
     [key: string]: any;


### PR DESCRIPTION
Include [`shutdownTimeout` option](https://docs.sentry.io/error-reporting/configuration/?platform=javascript#shutdown-timeout)

