### PR TITLE
ref: Rewrite React Profiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [gatsby] feat: Add @sentry/gatsby package (#2652)
 - [core] ref: Rename `whitelistUrls/blacklistUrls` to `allowUrls/denyUrls`
 - [react] ref: Refactor Profiler to account for update and render (#2677)
+- [tracing] feat: Add ability to get span from activity using `getActivitySpan` (#2677)
 
 ## 5.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [core] fix: Call `bindClient` when creating new `Hub` to make integrations work automatically (#2665)
 - [gatsby] feat: Add @sentry/gatsby package (#2652)
 - [core] ref: Rename `whitelistUrls/blacklistUrls` to `allowUrls/denyUrls`
+- [react] ref: Refactor Profiler to account for update and render (#2677)
 
 ## 5.17.0
 

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -770,15 +770,13 @@ export class Tracing implements Integration {
    * @param name Name of the activity, can be any string (Only used internally to identify the activity)
    * @param spanContext If provided a Span with the SpanContext will be created.
    * @param options _autoPopAfter_ | Time in ms, if provided the activity will be popped automatically after this timeout. This can be helpful in cases where you cannot gurantee your application knows the state and calls `popActivity` for sure.
-   * @param options _parentSpanId_ | Set a custom parent span id for the activity's span.
    */
   public static pushActivity(
     name: string,
     spanContext?: SpanContext,
     options?: {
       autoPopAfter?: number;
-      parentSpanId?: string;
-    },
+    },∂
   ): number {
     const activeTransaction = Tracing._activeTransaction;
 
@@ -792,9 +790,6 @@ export class Tracing implements Integration {
       const hub = _getCurrentHub();
       if (hub) {
         const span = activeTransaction.startChild(spanContext);
-        if (options && options.parentSpanId) {
-          span.parentSpanId = options.parentSpanId;
-        }
         Tracing._activities[Tracing._currentIndex] = {
           name,
           span,

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -879,14 +879,9 @@ export class Tracing implements Integration {
     if (!id) {
       return undefined;
     }
-    if (Tracing._getCurrentHub) {
-      const hub = Tracing._getCurrentHub();
-      if (hub) {
-        const activity = Tracing._activities[id];
-        if (activity) {
-          return activity.span;
-        }
-      }
+    const activity = Tracing._activities[id];
+    if (activity) {
+      return activity.span;
     }
     return undefined;
   }

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -820,7 +820,6 @@ export class Tracing implements Integration {
    * Removes activity and finishes the span in case there is one
    * @param id the id of the activity being removed
    * @param spanData span data that can be updated
-   * @param finish if a span should be finished after the activity is removed
    *
    */
   public static popActivity(id: number, spanData?: { [key: string]: any }): void {

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -1,3 +1,4 @@
+// tslint:disable: max-file-line-count
 import { Hub } from '@sentry/hub';
 import { Event, EventProcessor, Integration, Severity, Span, SpanContext, TransactionContext } from '@sentry/types';
 import {
@@ -827,7 +828,7 @@ export class Tracing implements Integration {
    * @param finish if a span should be finished after the activity is removed
    *
    */
-  public static popActivity(id: number, spanData?: { [key: string]: any }, finish: boolean = true): void {
+  public static popActivity(id: number, spanData?: { [key: string]: any }): void {
     // The !id is on purpose to also fail with 0
     // Since 0 is returned by push activity in case there is no active transaction
     if (!id) {
@@ -854,9 +855,7 @@ export class Tracing implements Integration {
         if (Tracing.options && Tracing.options.debug && Tracing.options.debug.spanDebugTimingInfo) {
           Tracing._addSpanDebugInfo(span);
         }
-        if (finish) {
-          span.finish();
-        }
+        span.finish();
       }
       // tslint:disable-next-line: no-dynamic-delete
       delete Tracing._activities[id];
@@ -888,7 +887,10 @@ export class Tracing implements Integration {
     if (Tracing._getCurrentHub) {
       const hub = Tracing._getCurrentHub();
       if (hub) {
-        return Tracing._activities[id].span;
+        const activity = Tracing._activities[id];
+        if (activity) {
+          return activity.span;
+        }
       }
     }
     return undefined;

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -776,7 +776,7 @@ export class Tracing implements Integration {
     spanContext?: SpanContext,
     options?: {
       autoPopAfter?: number;
-    },∂
+    },
   ): number {
     const activeTransaction = Tracing._activeTransaction;
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,22 +1,24 @@
 import { addGlobalEventProcessor, SDK_VERSION } from '@sentry/browser';
 
 function createReactEventProcessor(): void {
-  addGlobalEventProcessor(event => {
-    event.sdk = {
-      ...event.sdk,
-      name: 'sentry.javascript.react',
-      packages: [
-        ...((event.sdk && event.sdk.packages) || []),
-        {
-          name: 'npm:@sentry/react',
-          version: SDK_VERSION,
-        },
-      ],
-      version: SDK_VERSION,
-    };
+  if (addGlobalEventProcessor) {
+    addGlobalEventProcessor(event => {
+      event.sdk = {
+        ...event.sdk,
+        name: 'sentry.javascript.react',
+        packages: [
+          ...((event.sdk && event.sdk.packages) || []),
+          {
+            name: 'npm:@sentry/react',
+            version: SDK_VERSION,
+          },
+        ],
+        version: SDK_VERSION,
+      };
 
-    return event;
-  });
+      return event;
+    });
+  }
 }
 
 export * from '@sentry/browser';

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -50,7 +50,7 @@ function pushActivity(name: string, op: string): number | null {
 
 /**
  * popActivity removes a React activity.
- * Is a no-op if invalid Tracing integration or invalid activity id.
+ * Is a no-op if Tracing integration is not valid.
  * @param activity id of activity that is being popped
  */
 function popActivity(activity: number | null): void {
@@ -64,11 +64,11 @@ function popActivity(activity: number | null): void {
 
 /**
  * Obtain a span given an activity id.
- * Is a no-op if invalid Tracing integration.
+ * Is a no-op if Tracing integration is not valid.
  * @param activity activity id associated with obtained span
  */
 function getActivitySpan(activity: number | null): Span | undefined {
-  if (globalTracingIntegration === null) {
+  if (activity === null || globalTracingIntegration === null) {
     return undefined;
   }
 

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -36,27 +36,16 @@ function warnAboutTracing(name: string): void {
  * Is a no-op if Tracing integration is not valid
  * @param name displayName of component that started activity
  */
-function pushActivity(
-  name: string,
-  op: string,
-  options?: {
-    autoPopAfter?: number;
-    parentSpanId?: string;
-  },
-): number | null {
+function pushActivity(name: string, op: string): number | null {
   if (globalTracingIntegration === null) {
     return null;
   }
 
   // tslint:disable-next-line:no-unsafe-any
-  return (globalTracingIntegration as any).constructor.pushActivity(
-    name,
-    {
-      description: `<${name}>`,
-      op: `react.${op}`,
-    },
-    options,
-  );
+  return (globalTracingIntegration as any).constructor.pushActivity(name, {
+    description: `<${name}>`,
+    op: `react.${op}`,
+  });
 }
 
 /**

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -52,7 +52,6 @@ function pushActivity(name: string, op: string): number | null {
  * popActivity removes a React activity.
  * Is a no-op if invalid Tracing integration or invalid activity id.
  * @param activity id of activity that is being popped
- * @param finish if a span should be finished after the activity is removed
  */
 function popActivity(activity: number | null): void {
   if (activity === null || globalTracingIntegration === null) {

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -71,7 +71,7 @@ function popActivity(activity: number | null): void {
   }
 
   // tslint:disable-next-line:no-unsafe-any
-  (globalTracingIntegration as any).constructor.popActivity(activity, undefined);
+  (globalTracingIntegration as any).constructor.popActivity(activity);
 }
 
 /**
@@ -201,15 +201,14 @@ class Profiler extends React.Component<ProfilerProps> {
  */
 function withProfiler<P extends object>(
   WrappedComponent: React.ComponentType<P>,
-  // We do not want to have `updateProps` given in options, it is instead filled through
-  // the HOC.
+  // We do not want to have `updateProps` given in options, it is instead filled through the HOC.
   options?: Pick<Partial<ProfilerProps>, Exclude<keyof ProfilerProps, 'updateProps'>>,
 ): React.FC<P> {
   const componentDisplayName =
     (options && options.name) || WrappedComponent.displayName || WrappedComponent.name || UNKNOWN_COMPONENT;
 
   const Wrapped: React.FC<P> = (props: P) => (
-    <Profiler name={componentDisplayName} disabled={options && options.disabled} updateProps={props}>
+    <Profiler {...options} name={componentDisplayName} updateProps={props}>
       <WrappedComponent {...props} />
     </Profiler>
   );

--- a/packages/react/test/profiler.test.tsx
+++ b/packages/react/test/profiler.test.tsx
@@ -98,14 +98,10 @@ describe('withProfiler', () => {
       render(<ProfiledComponent />);
 
       expect(mockPushActivity).toHaveBeenCalledTimes(1);
-      expect(mockPushActivity).toHaveBeenLastCalledWith(
-        UNKNOWN_COMPONENT,
-        {
-          description: `<${UNKNOWN_COMPONENT}>`,
-          op: 'react.mount',
-        },
-        undefined,
-      );
+      expect(mockPushActivity).toHaveBeenLastCalledWith(UNKNOWN_COMPONENT, {
+        description: `<${UNKNOWN_COMPONENT}>`,
+        op: 'react.mount',
+      });
       expect(mockGetActivitySpan).toHaveBeenCalledTimes(1);
       expect(mockGetActivitySpan).toHaveBeenLastCalledWith(1);
 
@@ -198,14 +194,10 @@ describe('useProfiler()', () => {
       renderHook(() => useProfiler('Example'));
 
       expect(mockPushActivity).toHaveBeenCalledTimes(1);
-      expect(mockPushActivity).toHaveBeenLastCalledWith(
-        'Example',
-        {
-          description: '<Example>',
-          op: 'react.mount',
-        },
-        undefined,
-      );
+      expect(mockPushActivity).toHaveBeenLastCalledWith('Example', {
+        description: '<Example>',
+        op: 'react.mount',
+      });
       expect(mockGetActivitySpan).toHaveBeenCalledTimes(1);
       expect(mockGetActivitySpan).toHaveBeenLastCalledWith(1);
 

--- a/packages/react/test/profiler.test.tsx
+++ b/packages/react/test/profiler.test.tsx
@@ -4,24 +4,18 @@ import { renderHook } from '@testing-library/react-hooks';
 import * as React from 'react';
 
 import { UNKNOWN_COMPONENT, useProfiler, withProfiler } from '../src/profiler';
-/*(
-for key in SENTRY_FEATURES:
-	SENTRY_FEATURES[key] = True
 
-SENTRY_APM_SAMPLING = 1
-)*/
 const TEST_SPAN_ID = '518999beeceb49af';
+const TEST_TIMESTAMP = '123456';
 
 const mockStartChild = jest.fn((spanArgs: SpanContext) => ({ ...spanArgs }));
-const TEST_SPAN = {
-  spanId: TEST_SPAN_ID,
-  startChild: mockStartChild,
-};
-const TEST_TIMESTAMP = '123456';
 const mockPushActivity = jest.fn().mockReturnValue(1);
 const mockPopActivity = jest.fn();
 const mockLoggerWarn = jest.fn();
-const mockGetActivitySpan = jest.fn().mockReturnValue(TEST_SPAN);
+const mockGetActivitySpan = jest.fn().mockReturnValue({
+  spanId: TEST_SPAN_ID,
+  startChild: mockStartChild,
+});
 
 jest.mock('@sentry/utils', () => ({
   logger: {


### PR DESCRIPTION
I rewrote the `Profiler`, it's much more useful now.

### Motivation

After the meeting for performance last Wednesday, I re-evaluated our React Profiler, and decided it wasn't meeting the idea of, "is this useful?"

In my eyes, the Profiler should be looking at three primary things.
1. How long does it take/when does a component mount on a page
2. How long does a component stay on a page (visible/rendered)?
3. How many times did a component update, and why?

It's important to keep in mind that the questions the Profiler is trying to answer should be as lightweight as possible. The React profiler is not aiming to replace dev tools and dev debugging, but instead is used to clue in users about where things are inefficient, or why certain spans happened the way they did.

### Implementation

We now recommend only the HOC `withProfiler` as the way to use the Profiler. This is so the user can pass in the necessary options, and we can correctly intercept the props for the `react.update`   spans.

We now create 3 different spans from a react component, each trying to answer the respective question from above.

1. `react.mount` - the time between component constructor and it mounting on a page.

If this span was not created, it will not create the following spans. This is the only span that is required, the other one's can be turned off using options passed into the Profiler.

2. `react.render` - the time a component is on a page. 

Only will show up if a component unmounted while the transaction was still occurring. This is a child span to the `react.mount` span.

3. `react.update` - if the props had changed in a component during a transaction, we create a span for it. 

This will list the `changedProps` as data on the span. This is a child span to the `react.mount` span (**but I'm not sure if it should be**). It is important to note that the `useProfiler` hook does not generate this span as it cannot access component props (maybe we should allow users to pass it in?).

### Results

![image](https://user-images.githubusercontent.com/18689448/84923831-b9150680-b095-11ea-84ad-2714b88ad91c.png)

![image](https://user-images.githubusercontent.com/18689448/84923859-c8944f80-b095-11ea-93be-5f5f094a5a57.png)

### Testing

This was tested on getsentry using https://github.com/getsentry/sentry/pull/19366 as well as unit tests were updated to account for new functionality.

### Future

We are ready to :shipit: 
