### PR TITLE
fix(apm): Check if performance.mark() exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - [gatsby] feat: Add @sentry/gatsby package (#2652)
 - [core] ref: Rename `whitelistUrls/blacklistUrls` to `allowUrls/denyUrls`
 - [react] ref: Refactor Profiler to account for update and render (#2677)
-- [tracing] feat: Add ability to get span from activity using `getActivitySpan` (#2677)
+- [apm] feat: Add ability to get span from activity using `getActivitySpan` (#2677)
+- [apm] fix: Check if `performance.mark` exists before calling it (#2680)
 
 ## 5.17.0
 

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -171,7 +171,9 @@ export class Tracing implements Integration {
    */
   public constructor(_options?: Partial<TracingOptions>) {
     if (global.performance) {
-      global.performance.mark('sentry-tracing-init');
+      if (global.performance.mark) {
+        global.performance.mark('sentry-tracing-init');
+      }
       Tracing._trackLCP();
     }
     const defaults = {


### PR DESCRIPTION
`performance.mark()` is not support by all the browsers we support, so we should check it exists before using it.

See: https://caniuse.com/#feat=mdn-api_performancemark