### PR TITLE
build(hub): Remove unnecessary include from tsconfig

### DIFF
--- a/packages/hub/tsconfig.json
+++ b/packages/hub/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.build.json",
-  "include": ["src/**/*.ts", "test/**/*.ts", "../apm/test/span.test.ts"],
+  "include": ["src/**/*.ts", "test/**/*.ts"],
   "exclude": ["dist"],
   "compilerOptions": {
     "rootDir": ".",


### PR DESCRIPTION
This has been bothering my vscode for a while.