### PR TITLE
feat(tracing): Add beforeNavigate option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@
 - [react] ref: Refactor Profiler to account for update and render (#2677)
 - [apm] feat: Add ability to get span from activity using `getActivitySpan` (#2677)
 - [apm] fix: Check if `performance.mark` exists before calling it (#2680)
-- [tracing] feat: Add `setNavigationTransactionName` option
-- [tracing] ref: Create navigation transactions using `window.location.pathname` instead of `window.location.href`
+- [tracing] feat: Add `setNavigationTransactionName` option (#2691)
+- [tracing] ref: Create navigation transactions using `window.location.pathname` instead of `window.location.href` (#2691)
 
 ## 5.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - [react] ref: Refactor Profiler to account for update and render (#2677)
 - [apm] feat: Add ability to get span from activity using `getActivitySpan` (#2677)
 - [apm] fix: Check if `performance.mark` exists before calling it (#2680)
+- [tracing] feat: Add `setNavigationTransactionName` option
+- [tracing] ref: Create navigation transactions using `window.location.pathname` instead of `window.location.href`
 
 ## 5.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [react] ref: Refactor Profiler to account for update and render (#2677)
 - [apm] feat: Add ability to get span from activity using `getActivitySpan` (#2677)
 - [apm] fix: Check if `performance.mark` exists before calling it (#2680)
-- [tracing] feat: Add `setNavigationTransactionName` option (#2691)
+- [tracing] feat: Add `beforeNavigate` option (#2691)
 - [tracing] ref: Create navigation transactions using `window.location.pathname` instead of `window.location.href` (#2691)
 
 ## 5.17.0

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -233,8 +233,7 @@ export class Tracing implements Integration {
     }
 
     // Starting pageload transaction
-    if (global.location && global.location.href && Tracing.options && Tracing.options.startTransactionOnPageLoad) {
-      // Use `${global.location.href}` as transaction name
+    if (global.location && Tracing.options && Tracing.options.startTransactionOnPageLoad) {
       Tracing.startIdleTransaction({
         name: Tracing.options.beforeNavigate(window.location),
         op: 'pageload',


### PR DESCRIPTION
This PR adds a `beforeNavigate` option to the Tracing integration. It allows for users of the integration to change the transaction name before a navigation/pageload transaction has been created.

Currently it defaults to setting the transaction name to `location.pathname` (changed from `location.href` because we don't want to include query params). 

Not sure if `beforeNavigate` is the best name here, so open to alternatives. 