### PR TITLE
fix(react): Update peer dependencies for react and react-dom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
+- [react] feat: Update peer dependencies for `react` and `react-dom`
 
 ## 5.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
-- [react] feat: Update peer dependencies for `react` and `react-dom`
+- [react] feat: Update peer dependencies for `react` and `react-dom` (#2694)
 
 ## 5.18.0
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,8 +23,8 @@
     "tslib": "^1.9.3"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "15.x || 16.x",
+    "react-dom": "15.x || 16.x"
   },
   "devDependencies": {
     "@testing-library/react": "^10.0.6",


### PR DESCRIPTION
We support and test React 15.x and 16.x, so we should outline that in `@sentry/react`'s peer dependencies.