### PR TITLE
build(typedoc): Ignore React docs

### DIFF
--- a/typedoc.js
+++ b/typedoc.js
@@ -11,6 +11,8 @@ module.exports = {
     '**/build/**/*',
     '**/packages/typescript/**/*',
     '**/dangerfile.ts',
+    // TODO: Don't exclude React
+    '**/packages/react/**/*',
   ],
   mode: 'modules',
   excludeExternals: true,


### PR DESCRIPTION
For now, we have to ignore React docs so that we can publish type docs.

I will investigate further into getting this working.