### PR TITLE
feat: Pick up sentry-trace in JS <meta/> tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+- [tracing] feat: Pick up sentry-trace in JS <meta/> tag (#2703)
+- [tracing] fix: Respect sample decision when continuing trace from header in node (#2703)
+
 ## 5.18.1
 
 - [react] feat: Update peer dependencies for `react` and `react-dom` (#2694)

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -298,10 +298,10 @@ export class Tracing implements Integration {
         traceId = span.traceId;
         parentSpanId = span.parentSpanId;
         sampled = span.sampled;
+        Tracing._log(
+          `[Tracing] found 'sentry-meta' '<meta />' continuing trace with: trace_id: ${traceId} span_id: ${parentSpanId}`,
+        );
       }
-      Tracing._log(
-        `[Tracing] found 'sentry-meta' '<meta />' continuing trace with: trace_id: ${traceId} span_id: ${parentSpanId}`,
-      );
     }
 
     return hub.startTransaction({
@@ -317,16 +317,8 @@ export class Tracing implements Integration {
    * Returns the value of a meta tag
    */
   private static _getMeta(metaName: string): string | null {
-    const metas = document.getElementsByTagName('meta');
-
-    // tslint:disable-next-line: prefer-for-of
-    for (let i = 0; i < metas.length; i++) {
-      if (metas[i].getAttribute('name') === metaName) {
-        return metas[i].getAttribute('content');
-      }
-    }
-
-    return null;
+    const el = document.querySelector(`meta[name=${metaName}]`);
+    return el ? el.getAttribute('content') : null;
   }
 
   /**

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -34,6 +34,7 @@ export function tracingHandler(): (
 
     let traceId;
     let parentSpanId;
+    let sampled;
 
     // If there is a trace header set, we extract the data from it and set the span on the scope
     // to be the origin an created transaction set the parent_span_id / trace_id
@@ -42,6 +43,7 @@ export function tracingHandler(): (
       if (span) {
         traceId = span.traceId;
         parentSpanId = span.parentSpanId;
+        sampled = span.sampled;
       }
     }
 
@@ -49,6 +51,7 @@ export function tracingHandler(): (
       name: `${reqMethod} ${reqUrl}`,
       op: 'http.server',
       parentSpanId,
+      sampled,
       traceId,
     });
 


### PR DESCRIPTION
Add functionality to `Tracing` integration to pick up `<meta name="sentry-trace" />` to continue a trace in the frontend.

The reason why it's a `<meta/>` tag is that a `<script/>` tag setting something on the window would block rendering.

Right now, only Laravel can provide this meta tag with this PR
https://github.com/getsentry/sentry-laravel/pull/358

This is for cases where the Trace is not started from the frontend but from the backend.
It can be also useful for other webframeworks that are not SPA and instead still render templates from backend -> frontend.