### PR TITLE
fix(apm): check if performance.getEntries() exists

### DIFF
--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -561,7 +561,7 @@ export class Tracing implements Integration {
    * @param transactionSpan The transaction span
    */
   private static _addPerformanceEntries(transactionSpan: SpanClass): void {
-    if (!global.performance) {
+    if (!global.performance || !global.performance.getEntries) {
       // Gatekeeper if performance API not available
       return;
     }


### PR DESCRIPTION
`performance.getEntries()` is not supported by some browsers, so we need to check that it is exists before you use it.
see: https://caniuse.com/#feat=mdn-api_performance_getentries

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
