### PR TITLE
fix[tracing]: fetch headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [tracing] feat: Pick up sentry-trace in JS <meta/> tag (#2703)
 - [tracing] fix: Respect sample decision when continuing trace from header in node (#2703)
 - [gatsby] fix: Package gatsby files properly (#2711)
+- [tracing] fix: All options of adding fetch headers (#2712)
 
 ## 5.18.1
 

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -1021,13 +1021,12 @@ function fetchCallback(handlerData: { [key: string]: any }): void {
       if (span) {
         const options = (handlerData.args[1] = (handlerData.args[1] as { [key: string]: any }) || {});
         if (options.headers) {
-          if (Array.isArray(options.headers)) {
-            options.headers = [...options.headers, { 'sentry-trace': span.toTraceparent() }];
+          if (typeof options.headers.append === 'function') {
+            options.headers.append('sentry-trace', span.toTraceparent());
+          } else if (Array.isArray(options.headers)) {
+            options.headers = [...options.headers, ['sentry-trace', span.toTraceparent()]];
           } else {
-            options.headers = {
-              ...options.headers,
-              'sentry-trace': span.toTraceparent(),
-            };
+            options.headers = { ...options.headers, 'sentry-trace': span.toTraceparent() };
           }
         } else {
           options.headers = { 'sentry-trace': span.toTraceparent() };


### PR DESCRIPTION
Fixes #2685

The cases I tested

```js
  await fetch('/?1', { headers: {'content-type': 'application/json'} });
  await fetch('/?2', { headers: new Headers({ 'content-type': 'application/json' }) });
  await fetch('/?3', { headers: [['content-type', 'application/json']] });
  await fetch('/?4');
```

@AbhiPrasad We need to add tests for this in `@sentry/tracing`