### PR TITLE
fix(tracing): Add manual DOMStringList typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
-- [tracing] fix: Add manual `DOMStringList` typing (#2706)
+- [tracing] fix: Add manual `DOMStringList` typing (#2718)
 
 ## 5.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
+- [tracing] fix: Add manual `DOMStringList` typing (#2706)
 
 ## 5.19.0
 

--- a/packages/apm/src/integrations/types.ts
+++ b/packages/apm/src/integrations/types.ts
@@ -1,4 +1,31 @@
 /**
+ * A type returned by some APIs which contains a list of DOMString (strings).
+ *
+ * Copy DOMStringList interface so that user's dont have to include dom typings with Tracing integration
+ * Based on https://github.com/microsoft/TypeScript/blob/4cf0afe2662980ebcd8d444dbd13d8f47d06fcd5/lib/lib.dom.d.ts#L4051
+ */
+interface DOMStringList {
+  /**
+   * Returns the number of strings in strings.
+   */
+  readonly length: number;
+  /**
+   * Returns true if strings contains string, and false otherwise.
+   */
+  contains(str: string): boolean;
+  /**
+   * Returns the string with index index from strings.
+   */
+  item(index: number): string | null;
+  [index: number]: string;
+}
+
+declare var DOMStringList: {
+  prototype: DOMStringList;
+  new (): DOMStringList;
+};
+
+/**
  * The location (URL) of the object it is linked to. Changes done on it are reflected on the object it relates to.
  * Both the Document and Window interface have such a linked Location, accessible via Document.location and Window.location respectively.
  *


### PR DESCRIPTION
Addresses https://github.com/getsentry/sentry-javascript/issues/2715.

Adds manual typing for DOMStringList.

