### PR TITLE
fix: missing license plugin in es6 rollup configuration

### DIFF
--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -109,7 +109,7 @@ export default [
         },
         include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
       }),
-      ...plugins.slice(1),
+      ...plugins.slice(1).concat(bundleConfig.plugins.slice(-1)),
     ],
   },
   {


### PR DESCRIPTION
License plugin was missing in es6 non minified rollup configuration which result in a bundle.es6.js without license at the top :
https://browser.sentry-cdn.com/5.19.0/bundle.es6.js