### PR TITLE
chore: Define type for Extra(s)

### DIFF
--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -17,6 +17,7 @@ import {
   User,
 } from '@sentry/types';
 import { consoleSandbox, getGlobalObject, isNodeEnv, logger, timestampWithMs, uuid4 } from '@sentry/utils';
+
 import { Carrier, Layer } from './interfaces';
 import { Scope } from './scope';
 

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -4,6 +4,8 @@ import {
   Client,
   Event,
   EventHint,
+  Extra,
+  Extras,
   Hub as HubInterface,
   Integration,
   IntegrationClass,
@@ -15,7 +17,6 @@ import {
   User,
 } from '@sentry/types';
 import { consoleSandbox, getGlobalObject, isNodeEnv, logger, timestampWithMs, uuid4 } from '@sentry/utils';
-
 import { Carrier, Layer } from './interfaces';
 import { Scope } from './scope';
 
@@ -287,7 +288,7 @@ export class Hub implements HubInterface {
   /**
    * @inheritDoc
    */
-  public setExtras(extras: { [key: string]: any }): void {
+  public setExtras(extras: Extras): void {
     const top = this.getStackTop();
     if (!top.scope) {
       return;
@@ -309,7 +310,7 @@ export class Hub implements HubInterface {
   /**
    * @inheritDoc
    */
-  public setExtra(key: string, extra: any): void {
+  public setExtra(key: string, extra: Extra): void {
     const top = this.getStackTop();
     if (!top.scope) {
       return;

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -4,6 +4,8 @@ import {
   Event,
   EventHint,
   EventProcessor,
+  Extra,
+  Extras,
   Scope as ScopeInterface,
   ScopeContext,
   Severity,
@@ -147,7 +149,7 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public setExtras(extras: { [key: string]: any }): this {
+  public setExtras(extras: Extras): this {
     this._extra = {
       ...this._extra,
       ...extras,
@@ -159,7 +161,7 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public setExtra(key: string, extra: any): this {
+  public setExtra(key: string, extra: Extra): this {
     this._extra = { ...this._extra, [key]: extra };
     this._notifyScopeListeners();
     return this;

--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -1,5 +1,15 @@
 import { getCurrentHub, Hub, Scope } from '@sentry/hub';
-import { Breadcrumb, CaptureContext, Event, Severity, Transaction, TransactionContext, User } from '@sentry/types';
+import {
+  Breadcrumb,
+  CaptureContext,
+  Event,
+  Extra,
+  Extras,
+  Severity,
+  Transaction,
+  TransactionContext,
+  User,
+} from '@sentry/types';
 
 /**
  * This calls a function on the current hub.
@@ -105,7 +115,7 @@ export function setContext(name: string, context: { [key: string]: any } | null)
  * Set an object that will be merged sent as extra data with the event.
  * @param extras Extras object to merge into current context.
  */
-export function setExtras(extras: { [key: string]: any }): void {
+export function setExtras(extras: Extras): void {
   callOnHub<void>('setExtras', extras);
 }
 
@@ -123,7 +133,7 @@ export function setTags(tags: { [key: string]: string }): void {
  * @param extra Any kind of data. This data will be normalized.
  */
 
-export function setExtra(key: string, extra: any): void {
+export function setExtra(key: string, extra: Extra): void {
   callOnHub<void>('setExtra', key, extra);
 }
 

--- a/packages/types/src/extra.ts
+++ b/packages/types/src/extra.ts
@@ -1,0 +1,2 @@
+export type Extra = unknown;
+export type Extras = Record<string, Extra>;

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -1,6 +1,7 @@
 import { Breadcrumb, BreadcrumbHint } from './breadcrumb';
 import { Client } from './client';
 import { Event, EventHint } from './event';
+import { Extra, Extras } from './extra';
 import { Integration, IntegrationClass } from './integration';
 import { Scope } from './scope';
 import { Severity } from './severity';
@@ -138,13 +139,13 @@ export interface Hub {
    * @param key String of extra
    * @param extra Any kind of data. This data will be normalized.
    */
-  setExtra(key: string, extra: any): void;
+  setExtra(key: string, extra: Extra): void;
 
   /**
    * Set an object that will be merged sent as extra data with the event.
    * @param extras Extras object to merge into current context.
    */
-  setExtras(extras: { [key: string]: any }): void;
+  setExtras(extras: Extras): void;
 
   /**
    * Sets context data with the given name.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -5,6 +5,7 @@ export { ExtendedError } from './error';
 export { Event, EventHint } from './event';
 export { EventProcessor } from './eventprocessor';
 export { Exception } from './exception';
+export { Extra, Extras } from './extra';
 export { Hub } from './hub';
 export { Integration, IntegrationClass } from './integration';
 export { LogLevel } from './loglevel';

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -1,5 +1,6 @@
 import { Breadcrumb } from './breadcrumb';
 import { EventProcessor } from './eventprocessor';
+import { Extra, Extras } from './extra';
 import { Severity } from './severity';
 import { Span } from './span';
 import { Transaction } from './transaction';
@@ -50,14 +51,14 @@ export interface Scope {
    * Set an object that will be merged sent as extra data with the event.
    * @param extras Extras object to merge into current context.
    */
-  setExtras(extras: { [key: string]: any }): this;
+  setExtras(extras: Extras): this;
 
   /**
    * Set key:value that will be sent as extra data with the event.
    * @param key String of extra
    * @param extra Any kind of data. This data will be normailzed.
    */
-  setExtra(key: string, extra: any): this;
+  setExtra(key: string, extra: Extra): this;
 
   /**
    * Sets the fingerprint on the scope to send with the events.


### PR DESCRIPTION
This PR introduces a type for `Extra` and `Extras` so developers can reference these types in their code

e.g.:

```ts
import { Extras } from '@sentry/types';

export class LogService {
  // ...

  public error(message: string, extras?: Extras): void {
    console.error(message, extras);
    this.message(/* ... */, extras);
  }

  // ...

  private message(/* ... */, extras: Extras = {}): void {
    // ...
    Sentry.setExtras(extras);
    // ...
  }
}
```