### PR TITLE
feat: Add span creators to @sentry/tracing package

### DIFF
--- a/packages/tracing/src/browser/backgroundtab.ts
+++ b/packages/tracing/src/browser/backgroundtab.ts
@@ -16,7 +16,11 @@ export function registerBackgroundTabDetection(): void {
     global.document.addEventListener('visibilitychange', () => {
       const activeTransaction = getActiveTransaction() as IdleTransaction;
       if (global.document.hidden && activeTransaction) {
-        logger.log(`[Tracing] Transaction: ${SpanStatus.Cancelled} -> since tab moved to the background`);
+        logger.log(
+          `[Tracing] Transaction: ${SpanStatus.Cancelled} -> since tab moved to the background, op: ${
+            activeTransaction.op
+          }`,
+        );
         activeTransaction.setStatus(SpanStatus.Cancelled);
         activeTransaction.setTag('visibilitychange', 'document.hidden');
         activeTransaction.finish();

--- a/packages/tracing/src/browser/backgroundtab.ts
+++ b/packages/tracing/src/browser/backgroundtab.ts
@@ -1,0 +1,28 @@
+import { getGlobalObject, logger } from '@sentry/utils';
+
+import { IdleTransaction } from '../idletransaction';
+import { SpanStatus } from '../spanstatus';
+
+import { getActiveTransaction } from './utils';
+
+const global = getGlobalObject<Window>();
+
+/**
+ * Add a listener that cancels and finishes a transaction when the global
+ * document is hidden.
+ */
+export function registerBackgroundTabDetection(): void {
+  if (global && global.document) {
+    global.document.addEventListener('visibilitychange', () => {
+      const activeTransaction = getActiveTransaction() as IdleTransaction;
+      if (global.document.hidden && activeTransaction) {
+        logger.log(`[Tracing] Transaction: ${SpanStatus.Cancelled} -> since tab moved to the background`);
+        activeTransaction.setStatus(SpanStatus.Cancelled);
+        activeTransaction.setTag('visibilitychange', 'document.hidden');
+        activeTransaction.finish();
+      }
+    });
+  } else {
+    logger.warn('[Tracing] Could not set up background tab detection due to lack of global document');
+  }
+}

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -185,6 +185,7 @@ export class BrowserTracing implements Integration {
     const ctx = beforeNavigate({
       ...context,
       ...getHeaderContext(),
+      trimEnd: true,
     });
 
     if (ctx === undefined) {
@@ -193,7 +194,7 @@ export class BrowserTracing implements Integration {
     }
 
     const hub = this._getCurrentHub();
-    logger.log(`[Tracing] starting ${ctx.op} idleTransaction on scope with context:`, ctx);
+    logger.log(`[Tracing] starting ${ctx.op} idleTransaction on scope`);
     const idleTransaction = startIdleTransaction(hub, ctx, idleTimeout, true);
     idleTransaction.registerBeforeFinishCallback(adjustTransactionDuration(secToMs(maxTransactionDuration)));
     idleTransaction.registerBeforeFinishCallback(transaction => {

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -18,7 +18,7 @@ import {
 import { defaultBeforeNavigate, defaultRoutingInstrumentation } from './router';
 import { secToMs } from './utils';
 
-export const DEFAULT_MAX_TRANSACTION_DURATION__SECONDS = 600;
+export const DEFAULT_MAX_TRANSACTION_DURATION_SECONDS = 600;
 
 /** Options for Browser Tracing integration */
 export interface BrowserTracingOptions extends RequestInstrumentationOptions {
@@ -100,7 +100,7 @@ export class BrowserTracing implements Integration {
     beforeNavigate: defaultBeforeNavigate,
     idleTimeout: DEFAULT_IDLE_TIMEOUT,
     markBackgroundTransactions: true,
-    maxTransactionDuration: DEFAULT_MAX_TRANSACTION_DURATION__SECONDS,
+    maxTransactionDuration: DEFAULT_MAX_TRANSACTION_DURATION_SECONDS,
     routingInstrumentation: defaultRoutingInstrumentation,
     startTransactionOnLocationChange: true,
     startTransactionOnPageLoad: true,

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -74,8 +74,8 @@ export interface BrowserTracingOptions extends RequestInstrumentationOptions {
 
   /**
    * Flag Transactions where tabs moved to background with "cancelled". Browser background tab timing is
-   * not suited towards doing precise measurements of operations. Background transaction can mess up your
-   * statistics in non deterministic ways that's why we by default recommend leaving this opition enabled.
+   * not suited towards doing precise measurements of operations. By default, we recommend that this option
+   * be enabled as background transactions can mess up your statistics in nondeterministic ways.
    *
    * Default: true
    */
@@ -119,14 +119,23 @@ export class BrowserTracing implements Integration {
   private readonly _emitOptionsWarning: boolean = false;
 
   public constructor(_options?: Partial<BrowserTracingOptions>) {
-    // NOTE: Logger doesn't work in contructors, as it's initialized after integrations instances
-    if (!_options || !Array.isArray(_options.tracingOrigins) || _options.tracingOrigins.length === 0) {
+    let tracingOrigins = defaultRequestInstrumentionOptions.tracingOrigins;
+    // NOTE: Logger doesn't work in constructors, as it's initialized after integrations instances
+    if (
+      _options &&
+      _options.tracingOrigins &&
+      Array.isArray(_options.tracingOrigins) &&
+      _options.tracingOrigins.length !== 0
+    ) {
+      tracingOrigins = _options.tracingOrigins;
+    } else {
       this._emitOptionsWarning = true;
     }
 
     this.options = {
       ...this.options,
       ..._options,
+      tracingOrigins,
     };
   }
 

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -6,6 +6,7 @@ import { startIdleTransaction } from '../hubextensions';
 import { DEFAULT_IDLE_TIMEOUT } from '../idletransaction';
 import { Span } from '../span';
 
+import { registerErrorInstrumentation } from './errors';
 import { defaultBeforeNavigate, defaultRoutingInstrumentation } from './router';
 
 /** Options for Browser Tracing integration */
@@ -103,6 +104,9 @@ export class BrowserTracing implements Integration {
       startTransactionOnPageLoad,
       startTransactionOnLocationChange,
     );
+
+    // TODO: Should this be default behaviour?
+    registerErrorInstrumentation();
   }
 
   /** Create routing idle transaction. */

--- a/packages/tracing/src/browser/errors.ts
+++ b/packages/tracing/src/browser/errors.ts
@@ -1,0 +1,30 @@
+import { addInstrumentationHandler, logger } from '@sentry/utils';
+
+import { SpanStatus } from '../spanstatus';
+
+import { getActiveTransaction } from './utils';
+
+/**
+ * Configures global error listeners
+ */
+export function registerErrorInstrumentation(): void {
+  addInstrumentationHandler({
+    callback: errorCallback,
+    type: 'error',
+  });
+  addInstrumentationHandler({
+    callback: errorCallback,
+    type: 'unhandledrejection',
+  });
+}
+
+/**
+ * If an error or unhandled promise occurs, we mark the active transaction as failed
+ */
+function errorCallback(): void {
+  const activeTransaction = getActiveTransaction();
+  if (activeTransaction) {
+    logger.log(`[Tracing] Transaction: ${SpanStatus.InternalError} -> Global error occured`);
+    activeTransaction.setStatus(SpanStatus.InternalError);
+  }
+}

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -66,6 +66,7 @@ export class MetricsInstrumentation {
       // i.e. entries that occurred before calling `observe()` below.
       po.observe({
         buffered: true,
+        // @ts-ignore
         type: 'largest-contentful-paint',
       });
 
@@ -164,7 +165,7 @@ export class MetricsInstrumentation {
       transaction.startChild({
         description: 'evaluation',
         endTimestamp: tracingInitMarkStartTime,
-        op: `script`,
+        op: 'script',
         startTimestamp: entryScriptStartEndTime,
       });
     }
@@ -230,7 +231,7 @@ function addResourceSpans(
     transaction.startChild({
       description: `${entry.initiatorType} ${resourceName}`,
       endTimestamp,
-      op: `resource`,
+      op: 'resource',
       startTimestamp,
     });
 

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -123,7 +123,7 @@ export class MetricsInstrumentation {
       }
     }
 
-    let entryScriptStartEndTime: number | undefined;
+    let entryScriptStartTimestamp: number | undefined;
     let tracingInitMarkStartTime: number | undefined;
 
     global.performance
@@ -153,8 +153,8 @@ export class MetricsInstrumentation {
             const resourceName = (entry.name as string).replace(window.location.origin, '');
             const endTimestamp = addResourceSpans(transaction, entry, resourceName, startTime, duration, timeOrigin);
             // We remember the entry script end time to calculate the difference to the first init mark
-            if (entryScriptStartEndTime === undefined && (entryScriptSrc || '').indexOf(resourceName) > -1) {
-              entryScriptStartEndTime = endTimestamp;
+            if (entryScriptStartTimestamp === undefined && (entryScriptSrc || '').indexOf(resourceName) > -1) {
+              entryScriptStartTimestamp = endTimestamp;
             }
             break;
           default:
@@ -162,12 +162,12 @@ export class MetricsInstrumentation {
         }
       });
 
-    if (entryScriptStartEndTime !== undefined && tracingInitMarkStartTime !== undefined) {
+    if (entryScriptStartTimestamp !== undefined && tracingInitMarkStartTime !== undefined) {
       transaction.startChild({
         description: 'evaluation',
         endTimestamp: tracingInitMarkStartTime,
         op: 'script',
-        startTimestamp: entryScriptStartEndTime,
+        startTimestamp: entryScriptStartTimestamp,
       });
     }
 

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -161,6 +161,7 @@ export class MetricsInstrumentation {
           // Ignore other entry types.
         }
       });
+
     if (entryScriptStartEndTime !== undefined && tracingInitMarkStartTime !== undefined) {
       transaction.startChild({
         description: 'evaluation',

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -1,0 +1,278 @@
+import { getGlobalObject, logger } from '@sentry/utils';
+
+import { Span } from '../span';
+import { Transaction } from '../transaction';
+
+import { msToSec } from './utils';
+
+const global = getGlobalObject<Window>();
+
+/** Class tracking metrics  */
+export class MetricsInstrumentation {
+  private _lcp: Record<string, any> = {};
+
+  private _performanceCursor: number = 0;
+
+  private _forceLCP = () => {
+    /* No-op, replaced later if LCP API is available. */
+    return;
+  };
+
+  /** Starts tracking the Largest Contentful Paint on the current page. */
+  private _trackLCP(): void {
+    // Based on reference implementation from https://web.dev/lcp/#measure-lcp-in-javascript.
+    // Use a try/catch instead of feature detecting `largest-contentful-paint`
+    // support, since some browsers throw when using the new `type` option.
+    // https://bugs.webkit.org/show_bug.cgi?id=209216
+    try {
+      // Keep track of whether (and when) the page was first hidden, see:
+      // https://github.com/w3c/page-visibility/issues/29
+      // NOTE: ideally this check would be performed in the document <head>
+      // to avoid cases where the visibility state changes before this code runs.
+      let firstHiddenTime = document.visibilityState === 'hidden' ? 0 : Infinity;
+      document.addEventListener(
+        'visibilitychange',
+        event => {
+          firstHiddenTime = Math.min(firstHiddenTime, event.timeStamp);
+        },
+        { once: true },
+      );
+
+      const updateLCP = (entry: PerformanceEntry) => {
+        // Only include an LCP entry if the page wasn't hidden prior to
+        // the entry being dispatched. This typically happens when a page is
+        // loaded in a background tab.
+        if (entry.startTime < firstHiddenTime) {
+          // NOTE: the `startTime` value is a getter that returns the entry's
+          // `renderTime` value, if available, or its `loadTime` value otherwise.
+          // The `renderTime` value may not be available if the element is an image
+          // that's loaded cross-origin without the `Timing-Allow-Origin` header.
+          this._lcp = {
+            // @ts-ignore
+            ...(entry.id && { elementId: entry.id }),
+            // @ts-ignore
+            ...(entry.size && { elementSize: entry.size }),
+            value: entry.startTime,
+          };
+        }
+      };
+
+      // Create a PerformanceObserver that calls `updateLCP` for each entry.
+      const po = new PerformanceObserver(entryList => {
+        entryList.getEntries().forEach(updateLCP);
+      });
+
+      // Observe entries of type `largest-contentful-paint`, including buffered entries,
+      // i.e. entries that occurred before calling `observe()` below.
+      po.observe({
+        buffered: true,
+        type: 'largest-contentful-paint',
+      });
+
+      this._forceLCP = () => {
+        po.takeRecords().forEach(updateLCP);
+      };
+    } catch (e) {
+      // Do nothing if the browser doesn't support this API.
+    }
+  }
+
+  public constructor() {
+    if (global && global.performance) {
+      if (global.performance.mark) {
+        global.performance.mark('sentry-tracing-init');
+      }
+
+      this._trackLCP();
+    }
+  }
+
+  /** Add performance related spans to a transaction */
+  public addPerformanceEntires(transaction: Transaction): void {
+    if (!global || !global.performance || !global.performance.getEntries) {
+      // Gatekeeper if performance API not available
+      return;
+    }
+
+    logger.log('[Tracing] Adding & adjusting spans using Performance API');
+
+    // TODO(fixme): depending on the 'op' directly is brittle.
+    if (transaction.op === 'pageload') {
+      // Force any pending records to be dispatched.
+      this._forceLCP();
+      if (this._lcp) {
+        // Set the last observed LCP score.
+        transaction.setData('_sentry_web_vitals', { LCP: this._lcp });
+      }
+    }
+
+    const timeOrigin = msToSec(performance.timeOrigin);
+    let entryScriptSrc: string | undefined;
+
+    if (global.document) {
+      // tslint:disable-next-line: prefer-for-of
+      for (let i = 0; i < document.scripts.length; i++) {
+        // We go through all scripts on the page and look for 'data-entry'
+        // We remember the name and measure the time between this script finished loading and
+        // our mark 'sentry-tracing-init'
+        if (document.scripts[i].dataset.entry === 'true') {
+          entryScriptSrc = document.scripts[i].src;
+          break;
+        }
+      }
+    }
+
+    let entryScriptStartEndTime: number | undefined;
+    let tracingInitMarkStartTime: number | undefined;
+
+    global.performance
+      .getEntries()
+      .slice(this._performanceCursor)
+      .forEach((entry: Record<string, any>) => {
+        const startTime = msToSec(entry.startTime as number);
+        const duration = msToSec(entry.duration as number);
+
+        if (transaction.op === 'navigation' && timeOrigin + startTime < transaction.startTimestamp) {
+          return;
+        }
+
+        switch (entry.entryType) {
+          case 'navigation':
+            addNavigationSpans(transaction, entry, timeOrigin);
+            break;
+          case 'mark':
+          case 'paint':
+          case 'measure':
+            const startTimestamp = addMeasureSpans(transaction, entry, startTime, duration, timeOrigin);
+            if (tracingInitMarkStartTime === undefined && entry.name === 'sentry-tracing-init') {
+              tracingInitMarkStartTime = startTimestamp;
+            }
+            break;
+          case 'resource':
+            const resourceName = (entry.name as string).replace(window.location.origin, '');
+            const endTimestamp = addResourceSpans(transaction, entry, resourceName, startTime, duration, timeOrigin);
+            // We remember the entry script end time to calculate the difference to the first init mark
+            if (entryScriptStartEndTime === undefined && (entryScriptSrc || '').indexOf(resourceName) > -1) {
+              entryScriptStartEndTime = endTimestamp;
+            }
+            break;
+          default:
+          // Ignore other entry types.
+        }
+      });
+    if (entryScriptStartEndTime !== undefined && tracingInitMarkStartTime !== undefined) {
+      transaction.startChild({
+        description: 'evaluation',
+        endTimestamp: tracingInitMarkStartTime,
+        op: `script`,
+        startTimestamp: entryScriptStartEndTime,
+      });
+    }
+
+    this._performanceCursor = Math.max(performance.getEntries().length - 1, 0);
+  }
+}
+
+/** Instrument navigation entries */
+function addNavigationSpans(transaction: Transaction, entry: Record<string, any>, timeOrigin: number): void {
+  addPerformanceNavigationTiming(transaction, entry, 'unloadEvent', timeOrigin);
+  addPerformanceNavigationTiming(transaction, entry, 'domContentLoadedEvent', timeOrigin);
+  addPerformanceNavigationTiming(transaction, entry, 'loadEvent', timeOrigin);
+  addPerformanceNavigationTiming(transaction, entry, 'connect', timeOrigin);
+  addPerformanceNavigationTiming(transaction, entry, 'domainLookup', timeOrigin);
+  addRequest(transaction, entry, timeOrigin);
+}
+
+/** Create measure related spans */
+function addMeasureSpans(
+  transaction: Transaction,
+  entry: Record<string, any>,
+  startTime: number,
+  duration: number,
+  timeOrigin: number,
+): number {
+  const measureStartTimestamp = timeOrigin + startTime;
+  const measureEndTimestamp = measureStartTimestamp + duration;
+
+  transaction.startChild({
+    description: entry.name as string,
+    endTimestamp: measureEndTimestamp,
+    op: entry.entryType as string,
+    startTimestamp: measureStartTimestamp,
+  });
+
+  return measureStartTimestamp;
+}
+
+/** Create resource related spans */
+function addResourceSpans(
+  transaction: Transaction,
+  entry: Record<string, any>,
+  resourceName: string,
+  startTime: number,
+  duration: number,
+  timeOrigin: number,
+): number | undefined {
+  if (entry.initiatorType === 'xmlhttprequest' || entry.initiatorType === 'fetch') {
+    // We need to update existing spans with new timing info
+    if (transaction.spanRecorder) {
+      transaction.spanRecorder.spans.map((finishedSpan: Span) => {
+        if (finishedSpan.description && finishedSpan.description.indexOf(resourceName) !== -1) {
+          finishedSpan.startTimestamp = timeOrigin + startTime;
+          finishedSpan.endTimestamp = finishedSpan.startTimestamp + duration;
+        }
+      });
+    }
+  } else {
+    const startTimestamp = timeOrigin + startTime;
+    const endTimestamp = startTimestamp + duration;
+
+    transaction.startChild({
+      description: `${entry.initiatorType} ${resourceName}`,
+      endTimestamp,
+      op: `resource`,
+      startTimestamp,
+    });
+
+    return endTimestamp;
+  }
+
+  return undefined;
+}
+
+/** Create performance navigation related spans */
+function addPerformanceNavigationTiming(
+  transaction: Transaction,
+  entry: Record<string, any>,
+  event: string,
+  timeOrigin: number,
+): void {
+  const end = entry[`${event}End`] as number | undefined;
+  const start = entry[`${event}Start`] as number | undefined;
+  if (!start || !end) {
+    return;
+  }
+  transaction.startChild({
+    description: event,
+    endTimestamp: end + timeOrigin,
+    op: 'browser',
+    startTimestamp: start + timeOrigin,
+  });
+}
+
+/** Create request and response related spans */
+function addRequest(transaction: Transaction, entry: Record<string, any>, timeOrigin: number): void {
+  transaction.startChild({
+    description: 'request',
+    endTimestamp: timeOrigin + msToSec(entry.responseEnd as number),
+    op: 'browser',
+    startTimestamp: timeOrigin + msToSec(entry.requestStart as number),
+  });
+
+  transaction.startChild({
+    description: 'response',
+    endTimestamp: timeOrigin + msToSec(entry.responseEnd as number),
+    op: 'browser',
+    startTimestamp: timeOrigin + msToSec(entry.responseStart as number),
+  });
+}

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -76,7 +76,7 @@ export const defaultRequestInstrumentionOptions: RequestInstrumentationOptions =
 };
 
 /** Registers span creators for xhr and fetch requests  */
-export function registerRequestInstrumentation(_options: Partial<RequestInstrumentationOptions>): void {
+export function registerRequestInstrumentation(_options?: Partial<RequestInstrumentationOptions>): void {
   const { traceFetch, traceXHR, tracingOrigins, shouldCreateSpanForRequest } = {
     ...defaultRequestInstrumentionOptions,
     ..._options,
@@ -198,6 +198,8 @@ function xhrCallback(
   if (handlerData.xhr.__sentry_own_request__) {
     return;
   }
+
+  // logger.log('XHR', JSON.stringify(handlerData));
 
   if (handlerData.endTimestamp && handlerData.xhr.__sentry_xhr_span_id__) {
     const span = spans[handlerData.xhr.__sentry_xhr_span_id__];

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -1,0 +1,235 @@
+import { addInstrumentationHandler, isInstanceOf, isMatchingPattern } from '@sentry/utils';
+
+import { Span } from '../span';
+
+import { getActiveTransaction } from './utils';
+
+export const DEFAULT_TRACING_ORIGINS = ['localhost', /^\//];
+
+/** Options for Request Instrumentation */
+export interface RequestInstrumentationOptions {
+  /**
+   * List of strings / regex where the integration should create Spans out of. Additionally this will be used
+   * to define which outgoing requests the `sentry-trace` header will be attached to.
+   *
+   * Default: ['localhost', /^\//] {@see DEFAULT_TRACING_ORIGINS}
+   */
+  tracingOrigins: Array<string | RegExp>;
+
+  /**
+   * Flag to disable patching all together for fetch requests.
+   *
+   * Default: true
+   */
+  traceFetch: boolean;
+
+  /**
+   * Flag to disable patching all together for xhr requests.
+   *
+   * Default: true
+   */
+  traceXHR: boolean;
+
+  /**
+   * This function will be called before creating a span for a request with the given url.
+   * Return false if you don't want a span for the given url.
+   *
+   * By default it uses the `tracingOrigins` options as a url match.
+   */
+  shouldCreateSpanForRequest?(url: string): boolean;
+}
+
+/** Data returned from fetch callback */
+interface FetchData {
+  args: any[];
+  fetchData: {
+    method: string;
+    url: string;
+    // span_id
+    __span?: string;
+  };
+  startTimestamp: number;
+  endTimestamp?: number;
+}
+
+/** Data returned from XHR request */
+interface XHRData {
+  xhr?: {
+    __sentry_xhr__?: {
+      method: string;
+      url: string;
+      status_code: number;
+      data: Record<string, any>;
+    };
+    __sentry_xhr_span_id__?: string;
+    __sentry_own_request__: boolean;
+    setRequestHeader?: Function;
+  };
+  startTimestamp: number;
+  endTimestamp?: number;
+}
+
+export const defaultRequestInstrumentionOptions: RequestInstrumentationOptions = {
+  traceFetch: true,
+  traceXHR: true,
+  tracingOrigins: DEFAULT_TRACING_ORIGINS,
+};
+
+/** Registers span creators for xhr and fetch requests  */
+export function registerRequestInstrumentation(_options: Partial<RequestInstrumentationOptions>): void {
+  const { traceFetch, traceXHR, tracingOrigins, shouldCreateSpanForRequest } = {
+    ...defaultRequestInstrumentionOptions,
+    ..._options,
+  };
+
+  // We should cache url -> decision so that we don't have to compute
+  // regexp everytime we create a request.
+  const urlMap: Record<string, boolean> = {};
+
+  const shouldCreateSpan = shouldCreateSpanForRequest
+    ? shouldCreateSpanForRequest
+    : (url: string) => {
+        if (urlMap[url]) {
+          return urlMap[url];
+        }
+        const origins = tracingOrigins;
+        const decision =
+          origins.some((origin: string | RegExp) => isMatchingPattern(url, origin)) &&
+          !isMatchingPattern(url, 'sentry_key');
+        urlMap[url] = decision;
+        return urlMap[url];
+      };
+
+  const spans: Record<string, Span | undefined> = {};
+
+  if (traceFetch) {
+    addInstrumentationHandler({
+      callback: (handlerData: FetchData) => {
+        fetchCallback(handlerData, shouldCreateSpan, spans);
+      },
+      type: 'fetch',
+    });
+  }
+
+  if (traceXHR) {
+    addInstrumentationHandler({
+      callback: (handlerData: XHRData) => {
+        xhrCallback(handlerData, shouldCreateSpan, spans);
+      },
+      type: 'xhr',
+    });
+  }
+}
+
+/**
+ * Create and track fetch request spans
+ */
+function fetchCallback(
+  handlerData: FetchData,
+  shouldCreateSpan: (url: string) => boolean,
+  spans: Record<string, Span | undefined>,
+): void {
+  if (!shouldCreateSpan(handlerData.fetchData.url)) {
+    return;
+  }
+
+  if (handlerData.endTimestamp && handlerData.fetchData.__span) {
+    const span = spans[handlerData.fetchData.__span];
+    if (span) {
+      span.finish();
+    }
+    return;
+  }
+
+  const activeTransaction = getActiveTransaction();
+  if (activeTransaction) {
+    const span = activeTransaction.startChild({
+      data: {
+        ...handlerData.fetchData,
+        type: 'fetch',
+      },
+      description: `${handlerData.fetchData.method} ${handlerData.fetchData.url}`,
+      op: 'http',
+    });
+
+    spans[span.spanId] = span;
+
+    const request = (handlerData.args[0] = handlerData.args[0] as string | Request);
+    const options = (handlerData.args[1] = (handlerData.args[1] as { [key: string]: any }) || {});
+    let headers = options.headers;
+    if (isInstanceOf(request, Request)) {
+      headers = (request as Request).headers;
+    }
+    if (headers) {
+      // tslint:disable-next-line: no-unsafe-any
+      if (typeof headers.append === 'function') {
+        // tslint:disable-next-line: no-unsafe-any
+        headers.append('sentry-trace', span.toTraceparent());
+      } else if (Array.isArray(headers)) {
+        headers = [...headers, ['sentry-trace', span.toTraceparent()]];
+      } else {
+        headers = { ...headers, 'sentry-trace': span.toTraceparent() };
+      }
+    } else {
+      headers = { 'sentry-trace': span.toTraceparent() };
+    }
+    options.headers = headers;
+  }
+}
+
+/**
+ * Create and track xhr request spans
+ */
+function xhrCallback(
+  handlerData: XHRData,
+  shouldCreateSpan: (url: string) => boolean,
+  spans: Record<string, Span | undefined>,
+): void {
+  if (!handlerData || !handlerData.xhr || !handlerData.xhr.__sentry_xhr__) {
+    return;
+  }
+
+  const xhr = handlerData.xhr.__sentry_xhr__;
+  if (!shouldCreateSpan(xhr.url)) {
+    return;
+  }
+
+  // We only capture complete, non-sentry requests
+  if (handlerData.xhr.__sentry_own_request__) {
+    return;
+  }
+
+  if (handlerData.endTimestamp && handlerData.xhr.__sentry_xhr_span_id__) {
+    const span = spans[handlerData.xhr.__sentry_xhr_span_id__];
+    if (span) {
+      span.setData('url', xhr.url);
+      span.setData('method', xhr.method);
+      span.setHttpStatus(xhr.status_code);
+      span.finish();
+    }
+    return;
+  }
+
+  const activeTransaction = getActiveTransaction();
+  if (activeTransaction) {
+    const span = activeTransaction.startChild({
+      data: {
+        ...xhr.data,
+        type: 'xhr',
+      },
+      description: `${xhr.method} ${xhr.url}`,
+      op: 'http',
+    });
+
+    handlerData.xhr.__sentry_xhr_span_id__ = span.spanId;
+    spans[handlerData.xhr.__sentry_xhr_span_id__] = span;
+
+    if (handlerData.xhr.setRequestHeader) {
+      try {
+        handlerData.xhr.setRequestHeader('sentry-trace', span.toTraceparent());
+      } catch (_) {
+        // Error: InvalidStateError: Failed to execute 'setRequestHeader' on 'XMLHttpRequest': The object's state must be OPENED.
+      }
+    }
+  }
+}

--- a/packages/tracing/src/browser/router.ts
+++ b/packages/tracing/src/browser/router.ts
@@ -43,6 +43,7 @@ export function defaultRoutingInstrumentation<T extends TransactionType>(
         if (from !== to) {
           startingUrl = undefined;
           if (activeTransaction) {
+            logger.log(`[Tracing] finishing current idleTransaction with op: ${activeTransaction.op}`);
             // We want to finish all current ongoing idle transactions as we
             // are navigating to a new page.
             activeTransaction.finish();

--- a/packages/tracing/src/browser/utils.ts
+++ b/packages/tracing/src/browser/utils.ts
@@ -20,3 +20,11 @@ export function getActiveTransaction<T extends Transaction>(hub: Hub = getCurren
 export function msToSec(time: number): number {
   return time / 1000;
 }
+
+/**
+ * Converts from seconds to milliseconds
+ * @param time time in seconds
+ */
+export function secToMs(time: number): number {
+  return time * 1000;
+}

--- a/packages/tracing/src/browser/utils.ts
+++ b/packages/tracing/src/browser/utils.ts
@@ -1,0 +1,22 @@
+import { getCurrentHub, Hub } from '@sentry/hub';
+import { Transaction } from '@sentry/types';
+
+/** Grabs active transaction off scope */
+export function getActiveTransaction<T extends Transaction>(hub: Hub = getCurrentHub()): T | undefined {
+  if (hub) {
+    const scope = hub.getScope();
+    if (scope) {
+      return scope.getTransaction() as T | undefined;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Converts from milliseconds to seconds
+ * @param time time in ms
+ */
+export function msToSec(time: number): number {
+  return time / 1000;
+}

--- a/packages/tracing/src/idletransaction.ts
+++ b/packages/tracing/src/idletransaction.ts
@@ -45,7 +45,7 @@ export class IdleTransactionSpanRecorder extends SpanRecorder {
   }
 }
 
-export type BeforeFinishCallback = (transactionSpan: IdleTransaction) => void;
+export type BeforeFinishCallback = (transactionSpan: IdleTransaction, endTimestamp: number) => void;
 
 /**
  * An IdleTransaction is a transaction that automatically finishes. It does this by tracking child spans as activities.
@@ -143,7 +143,7 @@ export class IdleTransaction extends Transaction {
       logger.log('[Tracing] finishing IdleTransaction', new Date(endTimestamp * 1000).toISOString(), this.op);
 
       for (const callback of this._beforeFinishCallbacks) {
-        callback(this);
+        callback(this, endTimestamp);
       }
 
       this.spanRecorder.spans = this.spanRecorder.spans.filter((span: Span) => {

--- a/packages/tracing/src/idletransaction.ts
+++ b/packages/tracing/src/idletransaction.ts
@@ -139,6 +139,9 @@ export class IdleTransaction extends Transaction {
 
   /** {@inheritDoc} */
   public finish(endTimestamp: number = timestampWithMs()): string | undefined {
+    this._finished = true;
+    this.activities = {};
+
     if (this.spanRecorder) {
       logger.log('[Tracing] finishing IdleTransaction', new Date(endTimestamp * 1000).toISOString(), this.op);
 
@@ -169,8 +172,6 @@ export class IdleTransaction extends Transaction {
         return keepSpan;
       });
 
-      this._finished = true;
-      this.activities = {};
       // this._onScope is true if the transaction was previously on the scope.
       if (this._onScope) {
         clearActiveTransaction(this._idleHub);
@@ -213,7 +214,9 @@ export class IdleTransaction extends Transaction {
       const end = timestampWithMs() + timeout / 1000;
 
       setTimeout(() => {
-        this.finish(end);
+        if (!this._finished) {
+          this.finish(end);
+        }
       }, timeout);
     }
   }

--- a/packages/tracing/test/browser/backgroundtab.test.ts
+++ b/packages/tracing/test/browser/backgroundtab.test.ts
@@ -1,0 +1,57 @@
+import { BrowserClient } from '@sentry/browser';
+import { Hub, makeMain } from '@sentry/hub';
+// tslint:disable-next-line: no-implicit-dependencies
+import { JSDOM } from 'jsdom';
+
+import { SpanStatus } from '../../src';
+import { registerBackgroundTabDetection } from '../../src/browser/backgroundtab';
+
+describe('registerBackgroundTabDetection', () => {
+  let events: Record<string, any> = {};
+  let hub: Hub;
+  beforeEach(() => {
+    const dom = new JSDOM();
+    // @ts-ignore
+    global.document = dom.window.document;
+
+    hub = new Hub(new BrowserClient({ tracesSampleRate: 1 }));
+    makeMain(hub);
+
+    // @ts-ignore
+    global.document.addEventListener = jest.fn((event, callback) => {
+      events[event] = callback;
+    });
+  });
+
+  afterEach(() => {
+    events = {};
+    hub.configureScope(scope => scope.setSpan(undefined));
+  });
+
+  it('does not creates an event listener if global document is undefined', () => {
+    // @ts-ignore;
+    global.document = undefined;
+    registerBackgroundTabDetection();
+    expect(events).toMatchObject({});
+  });
+
+  it('creates an event listener', () => {
+    registerBackgroundTabDetection();
+    expect(events).toMatchObject({ visibilitychange: expect.any(Function) });
+  });
+
+  it('finishes a transaction on visibility change', () => {
+    registerBackgroundTabDetection();
+    const transaction = hub.startTransaction({ name: 'test' });
+    hub.configureScope(scope => scope.setSpan(transaction));
+
+    // Simulate document visibility hidden event
+    // @ts-ignore
+    global.document.hidden = true;
+    events.visibilitychange();
+
+    expect(transaction.status).toBe(SpanStatus.Cancelled);
+    expect(transaction.tags.visibilitychange).toBe('document.hidden');
+    expect(transaction.endTimestamp).toBeDefined();
+  });
+});

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -7,7 +7,7 @@ import { SpanStatus } from '../../src';
 import {
   BrowserTracing,
   BrowserTracingOptions,
-  DEFAULT_MAX_TRANSACTION_DURATION__SECONDS,
+  DEFAULT_MAX_TRANSACTION_DURATION_SECONDS,
   getMetaContent,
 } from '../../src/browser/browsertracing';
 import { defaultRequestInstrumentionOptions } from '../../src/browser/request';
@@ -81,7 +81,7 @@ describe('BrowserTracing', () => {
       beforeNavigate: expect.any(Function),
       idleTimeout: DEFAULT_IDLE_TIMEOUT,
       markBackgroundTransactions: true,
-      maxTransactionDuration: DEFAULT_MAX_TRANSACTION_DURATION__SECONDS,
+      maxTransactionDuration: DEFAULT_MAX_TRANSACTION_DURATION_SECONDS,
       routingInstrumentation: defaultRoutingInstrumentation,
       startTransactionOnLocationChange: true,
       startTransactionOnPageLoad: true,
@@ -254,7 +254,7 @@ describe('BrowserTracing', () => {
       it('cancels a transaction if exceeded', () => {
         createBrowserTracing(true, { routingInstrumentation: customRoutingInstrumentation });
         const transaction = getActiveTransaction(hub) as IdleTransaction;
-        transaction.finish(transaction.startTimestamp + secToMs(DEFAULT_MAX_TRANSACTION_DURATION__SECONDS) + 1);
+        transaction.finish(transaction.startTimestamp + secToMs(DEFAULT_MAX_TRANSACTION_DURATION_SECONDS) + 1);
 
         expect(transaction.status).toBe(SpanStatus.DeadlineExceeded);
         expect(transaction.tags.maxTransactionDurationExceeded).toBeDefined();
@@ -263,7 +263,7 @@ describe('BrowserTracing', () => {
       it('does not cancel a transaction if not exceeded', () => {
         createBrowserTracing(true, { routingInstrumentation: customRoutingInstrumentation });
         const transaction = getActiveTransaction(hub) as IdleTransaction;
-        transaction.finish(transaction.startTimestamp + secToMs(DEFAULT_MAX_TRANSACTION_DURATION__SECONDS));
+        transaction.finish(transaction.startTimestamp + secToMs(DEFAULT_MAX_TRANSACTION_DURATION_SECONDS));
 
         expect(transaction.status).toBe(undefined);
         expect(transaction.tags.maxTransactionDurationExceeded).not.toBeDefined();
@@ -272,7 +272,7 @@ describe('BrowserTracing', () => {
       it('can have a custom value', () => {
         const customMaxTransactionDuration = 700;
         // Test to make sure default duration is less than tested custom value.
-        expect(DEFAULT_MAX_TRANSACTION_DURATION__SECONDS < customMaxTransactionDuration).toBe(true);
+        expect(DEFAULT_MAX_TRANSACTION_DURATION_SECONDS < customMaxTransactionDuration).toBe(true);
         createBrowserTracing(true, {
           maxTransactionDuration: customMaxTransactionDuration,
           routingInstrumentation: customRoutingInstrumentation,

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -256,7 +256,7 @@ describe('BrowserTracing', () => {
         const transaction = getActiveTransaction(hub) as IdleTransaction;
         transaction.finish(transaction.startTimestamp + secToMs(DEFAULT_MAX_TRANSACTION_DURATION__SECONDS) + 1);
 
-        expect(transaction.status).toBe(SpanStatus.Cancelled);
+        expect(transaction.status).toBe(SpanStatus.DeadlineExceeded);
         expect(transaction.tags.maxTransactionDurationExceeded).toBeDefined();
       });
 

--- a/packages/tracing/test/browser/errors.test.ts
+++ b/packages/tracing/test/browser/errors.test.ts
@@ -1,0 +1,88 @@
+import { BrowserClient } from '@sentry/browser';
+import { Hub, makeMain } from '@sentry/hub';
+
+import { SpanStatus } from '../../src';
+import { registerErrorInstrumentation } from '../../src/browser/errors';
+import { addExtensionMethods } from '../../src/hubextensions';
+
+const mockAddInstrumentationHandler = jest.fn();
+let mockErrorCallback: () => void = () => undefined;
+let mockUnhandledRejectionCallback: () => void = () => undefined;
+jest.mock('@sentry/utils', () => {
+  const actual = jest.requireActual('@sentry/utils');
+  return {
+    ...actual,
+    addInstrumentationHandler: ({ callback, type }: any) => {
+      if (type === 'error') {
+        mockErrorCallback = callback;
+      }
+      if (type === 'unhandledrejection') {
+        mockUnhandledRejectionCallback = callback;
+      }
+      return mockAddInstrumentationHandler({ callback, type });
+    },
+  };
+});
+
+beforeAll(() => {
+  addExtensionMethods();
+});
+
+describe('registerErrorHandlers()', () => {
+  let hub: Hub;
+  beforeEach(() => {
+    mockAddInstrumentationHandler.mockClear();
+    hub = new Hub(new BrowserClient({ tracesSampleRate: 1 }));
+    makeMain(hub);
+  });
+
+  afterEach(() => {
+    hub.configureScope(scope => scope.setSpan(undefined));
+  });
+
+  it('registers error instrumentation', () => {
+    registerErrorInstrumentation();
+    expect(mockAddInstrumentationHandler).toHaveBeenCalledTimes(2);
+    expect(mockAddInstrumentationHandler).toHaveBeenNthCalledWith(1, { callback: expect.any(Function), type: 'error' });
+    expect(mockAddInstrumentationHandler).toHaveBeenNthCalledWith(2, {
+      callback: expect.any(Function),
+      type: 'unhandledrejection',
+    });
+  });
+
+  it('does not set status if transaction is not on scope', () => {
+    registerErrorInstrumentation();
+    const transaction = hub.startTransaction({ name: 'test' });
+    expect(transaction.status).toBe(undefined);
+
+    mockErrorCallback();
+    expect(transaction.status).toBe(undefined);
+
+    mockUnhandledRejectionCallback();
+    expect(transaction.status).toBe(undefined);
+    transaction.finish();
+  });
+
+  it('sets status for transaction on scope on error', () => {
+    registerErrorInstrumentation();
+    const transaction = hub.startTransaction({ name: 'test' });
+    hub.configureScope(scope => scope.setSpan(transaction));
+
+    mockErrorCallback();
+    expect(transaction.status).toBe(SpanStatus.InternalError);
+
+    // mockUnhandledRejectionCallback();
+    // expect(transaction.status).toBe(undefined);
+    transaction.finish();
+  });
+
+  it('sets status for transaction on scope on unhandledrejection', () => {
+    registerErrorInstrumentation();
+    const transaction = hub.startTransaction({ name: 'test' });
+    hub.configureScope(scope => scope.setSpan(transaction));
+
+    mockUnhandledRejectionCallback();
+    expect(transaction.status).toBe(SpanStatus.InternalError);
+    transaction.finish();
+  });
+});

--- a/packages/tracing/test/browser/errors.test.ts
+++ b/packages/tracing/test/browser/errors.test.ts
@@ -71,8 +71,6 @@ describe('registerErrorHandlers()', () => {
     mockErrorCallback();
     expect(transaction.status).toBe(SpanStatus.InternalError);
 
-    // mockUnhandledRejectionCallback();
-    // expect(transaction.status).toBe(undefined);
     transaction.finish();
   });
 

--- a/packages/tracing/test/browser/metrics.test.ts
+++ b/packages/tracing/test/browser/metrics.test.ts
@@ -1,0 +1,1 @@
+import { performance } from 'perf_hooks';

--- a/packages/tracing/test/browser/metrics.test.ts
+++ b/packages/tracing/test/browser/metrics.test.ts
@@ -1,1 +1,0 @@
-import { performance } from 'perf_hooks';

--- a/packages/tracing/test/browser/request.test.ts
+++ b/packages/tracing/test/browser/request.test.ts
@@ -21,9 +21,9 @@ jest.mock('@sentry/utils', () => {
 
 describe('registerRequestInstrumentation', () => {
   beforeEach(() => {
-    mockFetchCallback.mockClear();
-    mockXHRCallback.mockClear();
-    mockAddInstrumentationHandler.mockClear();
+    mockFetchCallback.mockReset();
+    mockXHRCallback.mockReset();
+    mockAddInstrumentationHandler.mockReset();
   });
 
   it('tracks fetch and xhr requests', () => {

--- a/packages/tracing/test/browser/request.test.ts
+++ b/packages/tracing/test/browser/request.test.ts
@@ -1,0 +1,49 @@
+import { registerRequestInstrumentation } from '../../src/browser/request';
+
+const mockAddInstrumentationHandler = jest.fn();
+let mockFetchCallback = jest.fn();
+let mockXHRCallback = jest.fn();
+jest.mock('@sentry/utils', () => {
+  const actual = jest.requireActual('@sentry/utils');
+  return {
+    ...actual,
+    addInstrumentationHandler: ({ callback, type }: any) => {
+      if (type === 'fetch') {
+        mockFetchCallback = jest.fn(callback);
+      }
+      if (type === 'xhr') {
+        mockXHRCallback = jest.fn(callback);
+      }
+      return mockAddInstrumentationHandler({ callback, type });
+    },
+  };
+});
+
+describe('registerRequestInstrumentation', () => {
+  beforeEach(() => {
+    mockFetchCallback.mockClear();
+    mockXHRCallback.mockClear();
+    mockAddInstrumentationHandler.mockClear();
+  });
+
+  it('tracks fetch and xhr requests', () => {
+    registerRequestInstrumentation();
+    expect(mockAddInstrumentationHandler).toHaveBeenCalledTimes(2);
+    // fetch
+    expect(mockAddInstrumentationHandler).toHaveBeenNthCalledWith(1, { callback: expect.any(Function), type: 'fetch' });
+    // xhr
+    expect(mockAddInstrumentationHandler).toHaveBeenNthCalledWith(2, { callback: expect.any(Function), type: 'xhr' });
+  });
+
+  it('does not add fetch requests spans if traceFetch is false', () => {
+    registerRequestInstrumentation({ traceFetch: false });
+    expect(mockAddInstrumentationHandler).toHaveBeenCalledTimes(1);
+    expect(mockFetchCallback()).toBe(undefined);
+  });
+
+  it('does not add xhr requests spans if traceXHR is false', () => {
+    registerRequestInstrumentation({ traceXHR: false });
+    expect(mockAddInstrumentationHandler).toHaveBeenCalledTimes(1);
+    expect(mockXHRCallback()).toBe(undefined);
+  });
+});

--- a/packages/tracing/test/idletransaction.test.ts
+++ b/packages/tracing/test/idletransaction.test.ts
@@ -107,9 +107,9 @@ describe('IdleTransaction', () => {
 
     jest.runOnlyPendingTimers();
     expect(mockCallback1).toHaveBeenCalledTimes(1);
-    expect(mockCallback1).toHaveBeenLastCalledWith(transaction);
+    expect(mockCallback1).toHaveBeenLastCalledWith(transaction, expect.any(Number));
     expect(mockCallback2).toHaveBeenCalledTimes(1);
-    expect(mockCallback2).toHaveBeenLastCalledWith(transaction);
+    expect(mockCallback2).toHaveBeenLastCalledWith(transaction, expect.any(Number));
   });
 
   it('filters spans on finish', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1847,31 +1847,10 @@ after@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
 
-agent-base@4, agent-base@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
-  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
-  dependencies:
-    es6-promisify "^5.0.0"
-
-agent-base@5:
+agent-base@4, agent-base@5, agent-base@6, agent-base@^4.3.0, agent-base@~4.2.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
   integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
-
-agent-base@6:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.1.tgz#808007e4e5867decb0ab6ab2f928fbdb5a596db4"
-  integrity sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==
-  dependencies:
-    debug "4"
-
-agent-base@~4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
-  integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
-  dependencies:
-    es6-promisify "^5.0.0"
 
 agentkeepalive@^3.4.1:
   version "3.5.2"
@@ -4632,18 +4611,6 @@ es-to-primitive@^1.1.1, es-to-primitive@^1.2.0:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
-
-es6-promise@^4.0.3:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
-  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
-
-es6-promisify@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
-  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
-  dependencies:
-    es6-promise "^4.0.3"
 
 escape-html@~1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Continuing from https://github.com/getsentry/sentry-javascript/pull/2723, This PR adds span creators to `@sentry/tracing`.

During the integration setup, we add three new functions to register this functionality.
```ts
// From browser/errors.ts
// If an error occurs, adds span status cancelled
// should this be default behaviour?
registerErrorInstrumentation();

// From browser/backgroundtab.ts
// If document becomes hidden. cancels and ends the active transaction.
if (markBackgroundTransactions) {
  registerBackgroundTabDetection();
}

// From browser/request.ts
// Adds spans for fetch and XHR requests.
registerRequestInstrumentation({ traceFetch, traceXHR, tracingOrigins, shouldCreateSpanForRequest });
```

We also use a separate `MetricsInstrumentation` class (in `browser/metrics.ts`) to track metrics data. That way we can easily swap it out if we want to expose the option in the future.

<img width="300" src="https://user-images.githubusercontent.com/18689448/87095594-fee56a80-c20e-11ea-8950-080a67aa0ee3.png" alt="transaction-view-tracing" />

I didn't do full tests due to the large size of this PR, but I figured it was something we can get back to.
