### PR TITLE
ref: Convert React and Vue Tracing to use active transaction

### DIFF
--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -1,80 +1,10 @@
-import { getCurrentHub } from '@sentry/browser';
-import { Integration, IntegrationClass, Span } from '@sentry/types';
-import { logger, timestampWithMs } from '@sentry/utils';
+import { getCurrentHub, Hub } from '@sentry/browser';
+import { Span, Transaction } from '@sentry/types';
+import { timestampWithMs } from '@sentry/utils';
 import * as hoistNonReactStatic from 'hoist-non-react-statics';
 import * as React from 'react';
 
 export const UNKNOWN_COMPONENT = 'unknown';
-
-const TRACING_GETTER = ({
-  id: 'Tracing',
-} as any) as IntegrationClass<Integration>;
-
-let globalTracingIntegration: Integration | null = null;
-const getTracingIntegration = () => {
-  if (globalTracingIntegration) {
-    return globalTracingIntegration;
-  }
-
-  globalTracingIntegration = getCurrentHub().getIntegration(TRACING_GETTER);
-  return globalTracingIntegration;
-};
-
-/**
- * Warn if tracing integration not configured. Will only warn once.
- */
-function warnAboutTracing(name: string): void {
-  if (globalTracingIntegration === null) {
-    logger.warn(
-      `Unable to profile component ${name} due to invalid Tracing Integration. Please make sure the Tracing integration is setup properly.`,
-    );
-  }
-}
-
-/**
- * pushActivity creates an new react activity.
- * Is a no-op if Tracing integration is not valid
- * @param name displayName of component that started activity
- */
-function pushActivity(name: string, op: string): number | null {
-  if (globalTracingIntegration === null) {
-    return null;
-  }
-
-  // tslint:disable-next-line:no-unsafe-any
-  return (globalTracingIntegration as any).constructor.pushActivity(name, {
-    description: `<${name}>`,
-    op: `react.${op}`,
-  });
-}
-
-/**
- * popActivity removes a React activity.
- * Is a no-op if Tracing integration is not valid.
- * @param activity id of activity that is being popped
- */
-function popActivity(activity: number | null): void {
-  if (activity === null || globalTracingIntegration === null) {
-    return;
-  }
-
-  // tslint:disable-next-line:no-unsafe-any
-  (globalTracingIntegration as any).constructor.popActivity(activity);
-}
-
-/**
- * Obtain a span given an activity id.
- * Is a no-op if Tracing integration is not valid.
- * @param activity activity id associated with obtained span
- */
-function getActivitySpan(activity: number | null): Span | undefined {
-  if (activity === null || globalTracingIntegration === null) {
-    return undefined;
-  }
-
-  // tslint:disable-next-line:no-unsafe-any
-  return (globalTracingIntegration as any).constructor.getActivitySpan(activity) as Span | undefined;
-}
 
 export type ProfilerProps = {
   // The name of the component being profiled.
@@ -95,12 +25,8 @@ export type ProfilerProps = {
  * spans based on component lifecycles.
  */
 class Profiler extends React.Component<ProfilerProps> {
-  // The activity representing how long it takes to mount a component.
-  public mountActivity: number | null = null;
-  // The span of the mount activity
+  // The span representing how long it takes to mount a component
   public mountSpan: Span | undefined = undefined;
-  // The span of the render
-  public renderSpan: Span | undefined = undefined;
 
   public static defaultProps: Partial<ProfilerProps> = {
     disabled: false,
@@ -116,18 +42,20 @@ class Profiler extends React.Component<ProfilerProps> {
       return;
     }
 
-    if (getTracingIntegration()) {
-      this.mountActivity = pushActivity(name, 'mount');
-    } else {
-      warnAboutTracing(name);
+    const activeTransaction = getActiveTransaction();
+    if (activeTransaction) {
+      this.mountSpan = activeTransaction.startChild({
+        description: `<${name}>`,
+        op: 'react.mount',
+      });
     }
   }
 
   // If a component mounted, we can finish the mount activity.
   public componentDidMount(): void {
-    this.mountSpan = getActivitySpan(this.mountActivity);
-    popActivity(this.mountActivity);
-    this.mountActivity = null;
+    if (this.mountSpan) {
+      this.mountSpan.finish();
+    }
   }
 
   public componentDidUpdate({ updateProps, includeUpdates = true }: ProfilerProps): void {
@@ -221,22 +149,26 @@ function useProfiler(
     hasRenderSpan: true,
   },
 ): void {
-  const [mountActivity] = React.useState(() => {
+  const [mountSpan] = React.useState(() => {
     if (options && options.disabled) {
-      return null;
+      return undefined;
     }
 
-    if (getTracingIntegration()) {
-      return pushActivity(name, 'mount');
+    const activeTransaction = getActiveTransaction();
+    if (activeTransaction) {
+      return activeTransaction.startChild({
+        description: `<${name}>`,
+        op: 'react.mount',
+      });
     }
 
-    warnAboutTracing(name);
-    return null;
+    return undefined;
   });
 
   React.useEffect(() => {
-    const mountSpan = getActivitySpan(mountActivity);
-    popActivity(mountActivity);
+    if (mountSpan) {
+      mountSpan.finish();
+    }
 
     return () => {
       if (mountSpan && options.hasRenderSpan) {
@@ -252,3 +184,15 @@ function useProfiler(
 }
 
 export { withProfiler, Profiler, useProfiler };
+
+/** Grabs active transaction off scope */
+export function getActiveTransaction<T extends Transaction>(hub: Hub = getCurrentHub()): T | undefined {
+  if (hub) {
+    const scope = hub.getScope();
+    if (scope) {
+      return scope.getTransaction() as T | undefined;
+    }
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
Last PR before https://github.com/getsentry/sentry-javascript/pull/2719 is ready :)

This one changes both React and Vue to add children to the current active transaction instead of pushing and popping activities.

This is a change in behaviour, as if the components no longer add/remove activities, the 0 activity point is reached more quickly by the `Tracing` integration, but I figured if we are looking to move past it, we should just do this.

I updated the react tests and tested on Sentry and everything seems good.