### PR TITLE
fix: Make APM optional in gatsby package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 - [react] feat: Export `createReduxEnhancer` to log redux actions as breadcrumbs, and attach state as an extra. (#2717)
 - [tracing] feat: `Add @sentry/tracing` (#2719)
-- [gatsby] fix: Make APM optional in gatsby package
-- [tracing] ref: Use idleTimout if no activities occur in idle transaction
+- [gatsby] fix: Make APM optional in gatsby package (#2752)
+- [tracing] ref: Use idleTimout if no activities occur in idle transaction (#2752)
 
 ## 5.19.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 - [react] feat: Export `createReduxEnhancer` to log redux actions as breadcrumbs, and attach state as an extra. (#2717)
 - [tracing] feat: `Add @sentry/tracing` (#2719)
+- [gatsby] fix: Make APM optional in gatsby package
 
 ## 5.19.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [react] feat: Export `createReduxEnhancer` to log redux actions as breadcrumbs, and attach state as an extra. (#2717)
 - [tracing] feat: `Add @sentry/tracing` (#2719)
 - [gatsby] fix: Make APM optional in gatsby package
+- [tracing] ref: Use idleTimout if no activities occur in idle transaction
 
 ## 5.19.2
 

--- a/packages/gatsby/README.md
+++ b/packages/gatsby/README.md
@@ -24,7 +24,7 @@ Register the package as a plugin in `gastby-config.js`:
 }
 ```
 
-Options will be passed directly to `Sentry.init`. The `environment` value defaults to `NODE_ENV` (or `development` if not set).
+Options will be passed directly to `Sentry.init`. See all available options in [our docs](https://docs.sentry.io/error-reporting/configuration/?platform=javascript). The `environment` value defaults to `NODE_ENV` (or `development` if not set).
 
 ## GitHub Actions
 
@@ -37,6 +37,26 @@ The `release` value is inferred from `COMMIT_REF`.
 ## Vercel
 
 To automatically capture the `release` value on Vercel you will need to register appropriate [system environment variable](https://vercel.com/docs/v2/build-step#system-environment-variables) (e.g. `VERCEL_GITHUB_COMMIT_SHA`) in your project.
+
+## Sentry Performance
+
+To enable Tracing support, supply the `tracesSampleRate` to the options and make sure you have installed the `@sentry/tracing` package.
+
+```javascript
+{
+  // ...
+  plugins: [
+    {
+      resolve: "@sentry/gatsby",
+      options: {
+          dsn: process.env.SENTRY_DSN, // this is the default
+          tracesSampleRate: 1, // this is just to test, you should lower this in production
+      }
+    },
+    // ...
+  ]
+}
+```
 
 ## Links
 


### PR DESCRIPTION
This PR has two changes after I did some testing with gatsby (https://github.com/getsentry/develop)

1. `fix: Make APM optional in gatsby package`

If a user has `@sentry/apm` or `@sentry/tracing`, we will use it, otherwise just fallback to normal.

![image](https://user-images.githubusercontent.com/18689448/87807664-8726c980-c826-11ea-9f05-1b673cf605cf.png)

2. `ref: Use idleTimout if no activities occur in idle transaction`

If idleTransaction does not get any activities pushed in the `idleTimeout` specified we finish the transaction (it most likely points to a simple page with no requests going to happen).

We do this by setting a timeout on idle transaction creation. The moment we push an activity, we cancel this timeout and instead rely on the activity system to end the transaction. This is behaviour that was in `@sentry/apm` where it would fake push and pop an activity when creating an idle transaction.

![image](https://user-images.githubusercontent.com/18689448/87807703-986fd600-c826-11ea-8ee2-1dd7cb458d35.png)
