### PR TITLE
feat(react): Allow for scope to be accessed before error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 - [react] feat: Export `createReduxEnhancer` to log redux actions as breadcrumbs, and attach state as an extra. (#2717)
 - [tracing] feat: `Add @sentry/tracing` (#2719)
+- [react] feat: Add `beforeSend` option to ErrorBoundary
 
 ## 5.19.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 - [react] feat: Export `createReduxEnhancer` to log redux actions as breadcrumbs, and attach state as an extra. (#2717)
 - [tracing] feat: `Add @sentry/tracing` (#2719)
-- [react] feat: Add `beforeSend` option to ErrorBoundary
+- [react] feat: Add `beforeCapture` option to ErrorBoundary (#2753)
 
 ## 5.19.2
 

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -1,4 +1,4 @@
-import * as Sentry from '@sentry/browser';
+import { captureException, ReportDialogOptions, Scope, showReportDialog, withScope } from '@sentry/browser';
 import * as hoistNonReactStatic from 'hoist-non-react-statics';
 import * as React from 'react';
 
@@ -18,7 +18,7 @@ export type ErrorBoundaryProps = {
    * Options to be passed into the Sentry report dialog.
    * No-op if {@link showDialog} is false.
    */
-  dialogOptions?: Sentry.ReportDialogOptions;
+  dialogOptions?: ReportDialogOptions;
   // tslint:disable no-null-undefined-union
   /**
    * A fallback component that gets rendered when the error boundary encounters an error.
@@ -38,6 +38,8 @@ export type ErrorBoundaryProps = {
   onReset?(error: Error | null, componentStack: string | null, eventId: string | null): void;
   /** Called on componentWillUnmount() */
   onUnmount?(error: Error | null, componentStack: string | null, eventId: string | null): void;
+  /** Called before error is sent to Sentry, allows for you to add tags or context using the scope */
+  beforeSend?(scope: Scope, error: Error | null, componentStack: string | null): void;
 };
 
 type ErrorBoundaryState = {
@@ -60,18 +62,24 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
   public state: ErrorBoundaryState = INITIAL_STATE;
 
   public componentDidCatch(error: Error, { componentStack }: React.ErrorInfo): void {
-    const eventId = Sentry.captureException(error, { contexts: { react: { componentStack } } });
-    const { onError, showDialog, dialogOptions } = this.props;
-    if (onError) {
-      onError(error, componentStack, eventId);
-    }
-    if (showDialog) {
-      Sentry.showReportDialog({ ...dialogOptions, eventId });
-    }
+    const { beforeSend, onError, showDialog, dialogOptions } = this.props;
 
-    // componentDidCatch is used over getDerivedStateFromError
-    // so that componentStack is accessible through state.
-    this.setState({ error, componentStack, eventId });
+    withScope(scope => {
+      if (beforeSend) {
+        beforeSend(scope, error, componentStack);
+      }
+      const eventId = captureException(error, { contexts: { react: { componentStack } } });
+      if (onError) {
+        onError(error, componentStack, eventId);
+      }
+      if (showDialog) {
+        showReportDialog({ ...dialogOptions, eventId });
+      }
+
+      // componentDidCatch is used over getDerivedStateFromError
+      // so that componentStack is accessible through state.
+      this.setState({ error, componentStack, eventId });
+    });
   }
 
   public componentDidMount(): void {

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -38,7 +38,7 @@ export type ErrorBoundaryProps = {
   onReset?(error: Error | null, componentStack: string | null, eventId: string | null): void;
   /** Called on componentWillUnmount() */
   onUnmount?(error: Error | null, componentStack: string | null, eventId: string | null): void;
-  /** Called before error is sent to Sentry, allows for you to add tags or context using the scope */
+  /** Called before the error is captured by Sentry, allows for you to add tags or context using the scope */
   beforeCapture?(scope: Scope, error: Error | null, componentStack: string | null): void;
 };
 

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -39,7 +39,7 @@ export type ErrorBoundaryProps = {
   /** Called on componentWillUnmount() */
   onUnmount?(error: Error | null, componentStack: string | null, eventId: string | null): void;
   /** Called before error is sent to Sentry, allows for you to add tags or context using the scope */
-  beforeSend?(scope: Scope, error: Error | null, componentStack: string | null): void;
+  beforeCapture?(scope: Scope, error: Error | null, componentStack: string | null): void;
 };
 
 type ErrorBoundaryState = {
@@ -62,11 +62,11 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
   public state: ErrorBoundaryState = INITIAL_STATE;
 
   public componentDidCatch(error: Error, { componentStack }: React.ErrorInfo): void {
-    const { beforeSend, onError, showDialog, dialogOptions } = this.props;
+    const { beforeCapture, onError, showDialog, dialogOptions } = this.props;
 
     withScope(scope => {
-      if (beforeSend) {
-        beforeSend(scope, error, componentStack);
+      if (beforeCapture) {
+        beforeCapture(scope, error, componentStack);
       }
       const eventId = captureException(error, { contexts: { react: { componentStack } } });
       if (onError) {

--- a/packages/react/test/errorboundary.test.tsx
+++ b/packages/react/test/errorboundary.test.tsx
@@ -1,3 +1,4 @@
+import { Scope } from '@sentry/browser';
 import { fireEvent, render, screen } from '@testing-library/react';
 import * as React from 'react';
 
@@ -7,15 +8,19 @@ const mockCaptureException = jest.fn();
 const mockShowReportDialog = jest.fn();
 const EVENT_ID = 'test-id-123';
 
-jest.mock('@sentry/browser', () => ({
-  captureException: (err: any, ctx: any) => {
-    mockCaptureException(err, ctx);
-    return EVENT_ID;
-  },
-  showReportDialog: (options: any) => {
-    mockShowReportDialog(options);
-  },
-}));
+jest.mock('@sentry/browser', () => {
+  const actual = jest.requireActual('@sentry/browser');
+  return {
+    ...actual,
+    captureException: (err: any, ctx: any) => {
+      mockCaptureException(err, ctx);
+      return EVENT_ID;
+    },
+    showReportDialog: (options: any) => {
+      mockShowReportDialog(options);
+    },
+  };
+});
 
 const TestApp: React.FC<ErrorBoundaryProps> = ({ children, ...props }) => {
   const [isError, setError] = React.useState(false);
@@ -195,6 +200,31 @@ describe('ErrorBoundary', () => {
       expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error), {
         contexts: { react: { componentStack: expect.any(String) } },
       });
+    });
+
+    it('calls `beforeSend()` when an error occurs', () => {
+      const mockBeforeSend = jest.fn();
+
+      const testBeforeSend = (...args: any[]) => {
+        expect(mockCaptureException).toHaveBeenCalledTimes(0);
+        mockBeforeSend(...args);
+      };
+
+      render(
+        <TestApp fallback={<p>You have hit an error</p>} beforeSend={testBeforeSend}>
+          <h1>children</h1>
+        </TestApp>,
+      );
+
+      expect(mockBeforeSend).toHaveBeenCalledTimes(0);
+      expect(mockCaptureException).toHaveBeenCalledTimes(0);
+
+      const btn = screen.getByTestId('errorBtn');
+      fireEvent.click(btn);
+
+      expect(mockBeforeSend).toHaveBeenCalledTimes(1);
+      expect(mockBeforeSend).toHaveBeenLastCalledWith(expect.any(Scope), expect.any(Error), expect.any(String));
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
     });
 
     it('shows a Sentry Report Dialog with correct options', () => {

--- a/packages/react/test/errorboundary.test.tsx
+++ b/packages/react/test/errorboundary.test.tsx
@@ -202,28 +202,28 @@ describe('ErrorBoundary', () => {
       });
     });
 
-    it('calls `beforeSend()` when an error occurs', () => {
-      const mockBeforeSend = jest.fn();
+    it('calls `beforeCapture()` when an error occurs', () => {
+      const mockBeforeCapture = jest.fn();
 
-      const testBeforeSend = (...args: any[]) => {
+      const testBeforeCapture = (...args: any[]) => {
         expect(mockCaptureException).toHaveBeenCalledTimes(0);
-        mockBeforeSend(...args);
+        mockBeforeCapture(...args);
       };
 
       render(
-        <TestApp fallback={<p>You have hit an error</p>} beforeSend={testBeforeSend}>
+        <TestApp fallback={<p>You have hit an error</p>} beforeCapture={testBeforeCapture}>
           <h1>children</h1>
         </TestApp>,
       );
 
-      expect(mockBeforeSend).toHaveBeenCalledTimes(0);
+      expect(mockBeforeCapture).toHaveBeenCalledTimes(0);
       expect(mockCaptureException).toHaveBeenCalledTimes(0);
 
       const btn = screen.getByTestId('errorBtn');
       fireEvent.click(btn);
 
-      expect(mockBeforeSend).toHaveBeenCalledTimes(1);
-      expect(mockBeforeSend).toHaveBeenLastCalledWith(expect.any(Scope), expect.any(Error), expect.any(String));
+      expect(mockBeforeCapture).toHaveBeenCalledTimes(1);
+      expect(mockBeforeCapture).toHaveBeenLastCalledWith(expect.any(Scope), expect.any(Error), expect.any(String));
       expect(mockCaptureException).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
This change allows users to update the scope before the error boundary sends an error to Sentry.

This was requested so that users can add specific tags or fingerprints before an error is sent to Sentry based on the error and componentStack.
