### PR TITLE
Fix import of hoist-non-react-statics

### DIFF
--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -1,5 +1,5 @@
 import { captureException, ReportDialogOptions, Scope, showReportDialog, withScope } from '@sentry/browser';
-import * as hoistNonReactStatic from 'hoist-non-react-statics';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
 
 export const UNKNOWN_COMPONENT = 'unknown';
@@ -142,7 +142,7 @@ function withErrorBoundary<P extends object>(
 
   // Copy over static methods from Wrapped component to Profiler HOC
   // See: https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over
-  hoistNonReactStatic(Wrapped, WrappedComponent);
+  hoistNonReactStatics(Wrapped, WrappedComponent);
   return Wrapped;
 }
 

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -1,7 +1,7 @@
 import { getCurrentHub, Hub } from '@sentry/browser';
 import { Integration, IntegrationClass, Span, Transaction } from '@sentry/types';
 import { timestampWithMs } from '@sentry/utils';
-import * as hoistNonReactStatic from 'hoist-non-react-statics';
+import hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
 
 export const UNKNOWN_COMPONENT = 'unknown';
@@ -209,7 +209,7 @@ function withProfiler<P extends object>(
 
   // Copy over static methods from Wrapped component to Profiler HOC
   // See: https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over
-  hoistNonReactStatic(Wrapped, WrappedComponent);
+  hoistNonReactStatics(Wrapped, WrappedComponent);
   return Wrapped;
 }
 

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -4,6 +4,7 @@
     "declaration": true,
     "declarationMap": true,
     "downlevelIteration": true,
+    "esModuleInterop": true,
     "inlineSources": true,
     "importHelpers": true,
     "lib": ["es6", "dom"],


### PR DESCRIPTION
The module uses a default export, so the star import is technically incorrect form: https://github.com/mridgway/hoist-non-react-statics/blob/f3de655212b47f20b9c6a27e89a60d23f358925a/src/index.js#L91

As a side effect, this causes build errors with Rollup: `(!) Cannot call a namespace ('hoistNonReactStatic')`

I think esModuleInterop is needed as well, but I'm going to see if CI passes without that first, as it might just be my local setup that's the issue.