### PR TITLE
build: Add @sentry/react and @sentry/gatsby to release registry

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -29,3 +29,13 @@ targets:
     onlyIfPresent: /^sentry-node-.*\.tgz$/
     config:
       canonical: 'npm:@sentry/node'
+  - name: registry
+    type: sdk
+    onlyIfPresent: /^sentry-react-.*\.tgz$/
+    config:
+      canonical: 'npm:@sentry/react'
+  - name: registry
+    type: sdk
+    onlyIfPresent: /^sentry-gatsby-.*\.tgz$/
+    config:
+      canonical: 'npm:@sentry/gatsby'


### PR DESCRIPTION
Packages that report themselves as SDKs shall be part of the registry:

https://github.com/getsentry/sentry-release-registry/