### PR TITLE
feat: Add instrumentation for React Router v3

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,10 +28,13 @@
     "react-dom": "15.x || 16.x"
   },
   "devDependencies": {
+    "@sentry/tracing": "5.19.2",
     "@testing-library/react": "^10.0.6",
     "@testing-library/react-hooks": "^3.3.0",
+    "@types/history": "^4.7.6",
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/react": "^16.9.35",
+    "@types/react-router-3": "npm:@types/react-router@3.0.20",
     "jest": "^24.7.1",
     "jsdom": "^16.2.2",
     "npm-run-all": "^4.1.2",
@@ -39,6 +42,7 @@
     "prettier-check": "^2.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
+    "react-router-3": "npm:react-router@3.2.0",
     "react-test-renderer": "^16.13.1",
     "redux": "^4.0.5",
     "rimraf": "^2.6.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,13 +28,11 @@
     "react-dom": "15.x || 16.x"
   },
   "devDependencies": {
-    "@sentry/tracing": "5.19.2",
     "@testing-library/react": "^10.0.6",
     "@testing-library/react-hooks": "^3.3.0",
-    "@types/history": "^4.7.6",
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/react": "^16.9.35",
-    "@types/react-router-3": "npm:@types/react-router@3.0.20",
+    "@types/react-router-3": "npm:@types/react-router@^3.2.0",
     "jest": "^24.7.1",
     "jsdom": "^16.2.2",
     "npm-run-all": "^4.1.2",
@@ -42,7 +40,7 @@
     "prettier-check": "^2.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "react-router-3": "npm:react-router@3.2.0",
+    "react-router-3": "npm:react-router@^3.2.0",
     "react-test-renderer": "^16.13.1",
     "redux": "^4.0.5",
     "rimraf": "^2.6.3",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -26,6 +26,6 @@ export * from '@sentry/browser';
 export { Profiler, withProfiler, useProfiler } from './profiler';
 export { ErrorBoundary, withErrorBoundary } from './errorboundary';
 export { createReduxEnhancer } from './redux';
-export { reactRouterV3Instrumenation } from './reactrouter';
+export { reactRouterV3Instrumentation } from './reactrouter';
 
 createReactEventProcessor();

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -26,5 +26,6 @@ export * from '@sentry/browser';
 export { Profiler, withProfiler, useProfiler } from './profiler';
 export { ErrorBoundary, withErrorBoundary } from './errorboundary';
 export { createReduxEnhancer } from './redux';
+export { reactRouterV3Instrumenation } from './reactrouter';
 
 createReactEventProcessor();

--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -1,70 +1,81 @@
 import { Transaction, TransactionContext } from '@sentry/types';
+import { getGlobalObject } from '@sentry/utils';
 
-type routingInstrumentation = (
-  startTransaction: (context: TransactionContext) => Transaction,
+type ReactRouterInstrumentation = <T extends Transaction>(
+  startTransaction: (context: TransactionContext) => T | undefined,
   startTransactionOnPageLoad?: boolean,
   startTransactionOnLocationChange?: boolean,
 ) => void;
 
-// Many of the types below had to be mocked out to lower bundle size.
-type PlainRoute = { path: string; childRoutes: PlainRoute[] };
+// Many of the types below had to be mocked out to prevent typescript issues
+// these types are required for correct functionality.
 
-type Match = (
-  props: { location: Location; routes: PlainRoute[] },
-  cb: (error?: Error, _redirectLocation?: Location, renderProps?: { routes?: PlainRoute[] }) => void,
+export type Route = { path?: string; childRoutes?: Route[] };
+
+export type Match = (
+  props: { location: Location; routes: Route[] },
+  cb: (error?: Error, _redirectLocation?: Location, renderProps?: { routes?: Route[] }) => void,
 ) => void;
 
 type Location = {
   pathname: string;
-  action: 'PUSH' | 'REPLACE' | 'POP';
-  key: string;
+  action?: 'PUSH' | 'REPLACE' | 'POP';
 } & Record<string, any>;
 
 type History = {
-  location: Location;
-  listen(cb: (location: Location) => void): void;
+  location?: Location;
+  listen?(cb: (location: Location) => void): void;
 } & Record<string, any>;
+
+const global = getGlobalObject<Window>();
 
 /**
  * Creates routing instrumentation for React Router v3
+ * Works for React Router >= 3.2.0 and < 4.0.0
  *
  * @param history object from the `history` library
  * @param routes a list of all routes, should be
  * @param match `Router.match` utility
  */
-export function reactRouterV3Instrumenation(
+export function reactRouterV3Instrumentation(
   history: History,
-  routes: PlainRoute[],
+  routes: Route[],
   match: Match,
-): routingInstrumentation {
+): ReactRouterInstrumentation {
   return (
     startTransaction: (context: TransactionContext) => Transaction | undefined,
     startTransactionOnPageLoad: boolean = true,
     startTransactionOnLocationChange: boolean = true,
   ) => {
     let activeTransaction: Transaction | undefined;
-    let name = normalizeTransactionName(routes, history.location, match);
-    if (startTransactionOnPageLoad) {
+    let prevName: string | undefined;
+
+    if (startTransactionOnPageLoad && global && global.location) {
+      // Have to use global.location because history.location might not be defined.
+      prevName = normalizeTransactionName(routes, global.location, match);
       activeTransaction = startTransaction({
-        name,
+        name: prevName,
         op: 'pageload',
         tags: {
-          from: name,
-          routingInstrumentation: 'react-router-v3',
+          'routing.instrumentation': 'react-router-v3',
         },
       });
     }
 
-    if (startTransactionOnLocationChange) {
+    if (startTransactionOnLocationChange && history.listen) {
       history.listen(location => {
         if (location.action === 'PUSH') {
           if (activeTransaction) {
             activeTransaction.finish();
           }
-          const tags = { from: name, routingInstrumentation: 'react-router-v3' };
-          name = normalizeTransactionName(routes, history.location, match);
+          const tags: Record<string, string> = { 'routing.instrumentation': 'react-router-v3' };
+          if (prevName) {
+            tags.from = prevName;
+          }
+
+          prevName = normalizeTransactionName(routes, location, match);
           activeTransaction = startTransaction({
-            name,
+            name: prevName,
             op: 'navigation',
             tags,
           });
@@ -74,41 +85,47 @@ export function reactRouterV3Instrumenation(
   };
 }
 
-export function normalizeTransactionName(appRoutes: PlainRoute[], location: Location, match: Match): string {
-  const defaultName = location.pathname;
+/**
+ * Normalize transaction names using `Router.match`
+ */
+function normalizeTransactionName(appRoutes: Route[], location: Location, match: Match): string {
+  let name = location.pathname;
   match(
     {
       location,
       routes: appRoutes,
     },
-    (error?: Error, _redirectLocation?: Location, renderProps?: { routes?: PlainRoute[] }) => {
+    (error, _redirectLocation, renderProps) => {
       if (error || !renderProps) {
-        return defaultName;
+        return name;
       }
 
       const routePath = getRouteStringFromRoutes(renderProps.routes || []);
-
       if (routePath.length === 0 || routePath === '/*') {
-        return defaultName;
+        return name;
       }
 
-      return routePath;
+      name = routePath;
+      return name;
     },
   );
-
-  return defaultName;
+  return name;
 }
 
-function getRouteStringFromRoutes(routes: PlainRoute[]): string {
-  if (!Array.isArray(routes)) {
+/**
+ * Generate route name from array of routes
+ */
+function getRouteStringFromRoutes(routes: Route[]): string {
+  if (!Array.isArray(routes) || routes.length === 0) {
     return '';
   }
 
-  const routesWithPaths: PlainRoute[] = routes.filter((route: PlainRoute) => !!route.path);
+  const routesWithPaths: Route[] = routes.filter((route: Route) => !!route.path);
 
   let index = -1;
-  for (let x = routesWithPaths.length; x >= 0; x--) {
-    if (routesWithPaths[x].path.startsWith('/')) {
+  for (let x = routesWithPaths.length - 1; x >= 0; x--) {
+    const route = routesWithPaths[x];
+    if (route.path && route.path.startsWith('/')) {
       index = x;
       break;
     }

--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -1,0 +1,122 @@
+import { Transaction, TransactionContext } from '@sentry/types';
+
+type routingInstrumentation = (
+  startTransaction: (context: TransactionContext) => Transaction,
+  startTransactionOnPageLoad?: boolean,
+  startTransactionOnLocationChange?: boolean,
+) => void;
+
+// Many of the types below had to be mocked out to lower bundle size.
+type PlainRoute = { path: string; childRoutes: PlainRoute[] };
+
+type Match = (
+  props: { location: Location; routes: PlainRoute[] },
+  cb: (error?: Error, _redirectLocation?: Location, renderProps?: { routes?: PlainRoute[] }) => void,
+) => void;
+
+type Location = {
+  pathname: string;
+  action: 'PUSH' | 'REPLACE' | 'POP';
+  key: string;
+} & Record<string, any>;
+
+type History = {
+  location: Location;
+  listen(cb: (location: Location) => void): void;
+} & Record<string, any>;
+
+/**
+ * Creates routing instrumentation for React Router v3
+ *
+ * @param history object from the `history` library
+ * @param routes a list of all routes, should be
+ * @param match `Router.match` utility
+ */
+export function reactRouterV3Instrumenation(
+  history: History,
+  routes: PlainRoute[],
+  match: Match,
+): routingInstrumentation {
+  return (
+    startTransaction: (context: TransactionContext) => Transaction | undefined,
+    startTransactionOnPageLoad: boolean = true,
+    startTransactionOnLocationChange: boolean = true,
+  ) => {
+    let activeTransaction: Transaction | undefined;
+    let name = normalizeTransactionName(routes, history.location, match);
+    if (startTransactionOnPageLoad) {
+      activeTransaction = startTransaction({
+        name,
+        op: 'pageload',
+        tags: {
+          from: name,
+          routingInstrumentation: 'react-router-v3',
+        },
+      });
+    }
+
+    if (startTransactionOnLocationChange) {
+      history.listen(location => {
+        if (location.action === 'PUSH') {
+          if (activeTransaction) {
+            activeTransaction.finish();
+          }
+          const tags = { from: name, routingInstrumentation: 'react-router-v3' };
+          name = normalizeTransactionName(routes, history.location, match);
+          activeTransaction = startTransaction({
+            name,
+            op: 'navigation',
+            tags,
+          });
+        }
+      });
+    }
+  };
+}
+
+export function normalizeTransactionName(appRoutes: PlainRoute[], location: Location, match: Match): string {
+  const defaultName = location.pathname;
+  match(
+    {
+      location,
+      routes: appRoutes,
+    },
+    (error?: Error, _redirectLocation?: Location, renderProps?: { routes?: PlainRoute[] }) => {
+      if (error || !renderProps) {
+        return defaultName;
+      }
+
+      const routePath = getRouteStringFromRoutes(renderProps.routes || []);
+
+      if (routePath.length === 0 || routePath === '/*') {
+        return defaultName;
+      }
+
+      return routePath;
+    },
+  );
+
+  return defaultName;
+}
+
+function getRouteStringFromRoutes(routes: PlainRoute[]): string {
+  if (!Array.isArray(routes)) {
+    return '';
+  }
+
+  const routesWithPaths: PlainRoute[] = routes.filter((route: PlainRoute) => !!route.path);
+
+  let index = -1;
+  for (let x = routesWithPaths.length; x >= 0; x--) {
+    if (routesWithPaths[x].path.startsWith('/')) {
+      index = x;
+      break;
+    }
+  }
+
+  return routesWithPaths
+    .slice(index)
+    .filter(({ path }) => !!path)
+    .map(({ path }) => path)
+    .join('');
+}

--- a/packages/react/test/reactrouter.test.tsx
+++ b/packages/react/test/reactrouter.test.tsx
@@ -1,0 +1,6 @@
+import { browserHistory } from 'react-router-3';
+import { routes } from './routes';
+
+describe('React Router V3', () => {
+  it('works', () => {});
+});

--- a/packages/react/test/reactrouter.test.tsx
+++ b/packages/react/test/reactrouter.test.tsx
@@ -1,6 +1,0 @@
-import { browserHistory } from 'react-router-3';
-import { routes } from './routes';
-
-describe('React Router V3', () => {
-  it('works', () => {});
-});

--- a/packages/react/test/reactrouterv3.test.tsx
+++ b/packages/react/test/reactrouterv3.test.tsx
@@ -1,0 +1,132 @@
+import { render } from '@testing-library/react';
+import * as React from 'react';
+import { createMemoryHistory, createRoutes, IndexRoute, match, Route, Router } from 'react-router-3';
+
+import { Match, reactRouterV3Instrumentation, Route as RouteType } from '../src/reactrouter';
+
+// Have to manually set types because we are using package-alias
+declare module 'react-router-3' {
+  type History = { replace: Function; push: Function };
+  export function createMemoryHistory(): History;
+  export const Router: React.ComponentType<{ history: History }>;
+  export const Route: React.ComponentType<{ path: string; component: React.ComponentType<any> }>;
+  export const IndexRoute: React.ComponentType<{ component: React.ComponentType<any> }>;
+  export const match: Match;
+  export const createRoutes: (routes: any) => RouteType[];
+}
+
+const App: React.FC = ({ children }) => <div>{children}</div>;
+
+function Home(): JSX.Element {
+  return <div>Home</div>;
+}
+
+function About(): JSX.Element {
+  return <div>About</div>;
+}
+
+function Features(): JSX.Element {
+  return <div>Features</div>;
+}
+
+function Users({ params }: { params: Record<string, string> }): JSX.Element {
+  return <div>{params.userid}</div>;
+}
+
+describe('React Router V3', () => {
+  const routes = (
+    <Route path="/" component={App}>
+      <IndexRoute component={Home} />
+      <Route path="about" component={About} />
+      <Route path="features" component={Features} />
+      <Route path="users/:userid" component={Users} />
+    </Route>
+  );
+  const history = createMemoryHistory();
+
+  const instrumentationRoutes = createRoutes(routes);
+  const instrumentation = reactRouterV3Instrumentation(history, instrumentationRoutes, match);
+
+  it('starts a pageload transaction when instrumentation is started', () => {
+    const mockStartTransaction = jest.fn();
+    instrumentation(mockStartTransaction);
+    expect(mockStartTransaction).toHaveBeenCalledTimes(1);
+    expect(mockStartTransaction).toHaveBeenLastCalledWith({
+      name: '/',
+      op: 'pageload',
+      tags: { 'routing.instrumentation': 'react-router-v3' },
+    });
+  });
+
+  it('does not start pageload transaction if option is false', () => {
+    const mockStartTransaction = jest.fn();
+    instrumentation(mockStartTransaction, false);
+    expect(mockStartTransaction).toHaveBeenCalledTimes(0);
+  });
+
+  it('starts a navigation transaction', () => {
+    const mockStartTransaction = jest.fn();
+    instrumentation(mockStartTransaction);
+    render(<Router history={history}>{routes}</Router>);
+
+    history.push('/about');
+    expect(mockStartTransaction).toHaveBeenCalledTimes(2);
+    expect(mockStartTransaction).toHaveBeenLastCalledWith({
+      name: '/about',
+      op: 'navigation',
+      tags: { from: '/', 'routing.instrumentation': 'react-router-v3' },
+    });
+
+    history.push('/features');
+    expect(mockStartTransaction).toHaveBeenCalledTimes(3);
+    expect(mockStartTransaction).toHaveBeenLastCalledWith({
+      name: '/features',
+      op: 'navigation',
+      tags: { from: '/about', 'routing.instrumentation': 'react-router-v3' },
+    });
+  });
+
+  it('does not start a transaction if option is false', () => {
+    const mockStartTransaction = jest.fn();
+    instrumentation(mockStartTransaction, true, false);
+    render(<Router history={history}>{routes}</Router>);
+    expect(mockStartTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('only starts a navigation transaction on push', () => {
+    const mockStartTransaction = jest.fn();
+    instrumentation(mockStartTransaction);
+    render(<Router history={history}>{routes}</Router>);
+
+    history.replace('hello');
+    expect(mockStartTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('finishes a transaction on navigation', () => {
+    const mockFinish = jest.fn();
+    const mockStartTransaction = jest.fn().mockReturnValue({ finish: mockFinish });
+    instrumentation(mockStartTransaction);
+    render(<Router history={history}>{routes}</Router>);
+    expect(mockStartTransaction).toHaveBeenCalledTimes(1);
+
+    history.push('/features');
+    expect(mockFinish).toHaveBeenCalledTimes(1);
+    expect(mockStartTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('normalizes transaction names', () => {
+    const mockStartTransaction = jest.fn();
+    instrumentation(mockStartTransaction);
+    const { container } = render(<Router history={history}>{routes}</Router>);
+
+    history.push('/users/123');
+    expect(container.innerHTML).toContain('123');
+
+    expect(mockStartTransaction).toHaveBeenCalledTimes(2);
+    expect(mockStartTransaction).toHaveBeenLastCalledWith({
+      name: '/users/:userid',
+      op: 'navigation',
+      tags: { from: '/', 'routing.instrumentation': 'react-router-v3' },
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1458,11 +1458,6 @@
   resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.4.tgz#8c3496bd1b50cc04aeefd691140aa571d4dbfa34"
   integrity sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==
 
-"@types/history@*", "@types/history@^4.7.6":
-  version "4.7.6"
-  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.6.tgz#ed8fc802c45b8e8f54419c2d054e55c9ea344356"
-  integrity sha512-GRTZLeLJ8ia00ZH8mxMO8t0aC9M1N9bN461Z2eaRurJo6Fpa+utgCwLzI4jQHcrdzuzp5WPN9jRwpsCQ1VhJ5w==
-
 "@types/history@^3":
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-3.2.4.tgz#0b6c62240d1fac020853aa5608758991d9f6ef3d"
@@ -1604,20 +1599,12 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
-"@types/react-router-3@npm:@types/react-router@3.0.20":
+"@types/react-router-3@npm:@types/react-router@^3.2.0":
   version "3.0.20"
   resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-3.0.20.tgz#a711682475ccef70ad9ad9e459859380221e6ee6"
   integrity sha512-0sx2ThGYgblXPf8we/c+umFzP3RCbBp1bbFmd3pO1UaOYnTDno82iql3MQTVqB09rhopKORNfakDU/9xZ4QR6g==
   dependencies:
     "@types/history" "^3"
-    "@types/react" "*"
-
-"@types/react-router@^5.1.8":
-  version "5.1.8"
-  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.8.tgz#4614e5ba7559657438e17766bb95ef6ed6acc3fa"
-  integrity sha512-HzOyJb+wFmyEhyfp4D4NYrumi+LQgQL/68HvJO+q6XtuHSDvw6Aqov7sCAhjbNq3bUPgPqbdvjXC5HeB2oEAPg==
-  dependencies:
-    "@types/history" "*"
     "@types/react" "*"
 
 "@types/react-test-renderer@*":
@@ -6417,11 +6404,6 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
-  integrity sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=
-
 hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
@@ -10623,7 +10605,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.5.6, prop-types@^15.6.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -10861,22 +10843,23 @@ react-dom@^16.0.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
+react-is@^16.12.0, react-is@^16.13.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-"react-router-3@npm:react-router@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.2.0.tgz#62b6279d589b70b34e265113e4c0a9261a02ed36"
-  integrity sha512-sXlLOg0TRCqnjCVskqBHGjzNjcJKUqXEKnDSuxMYJSPJNq9hROE9VsiIW2kfIq7Ev+20Iz0nxayekXyv0XNmsg==
+"react-router-3@npm:react-router@^3.2.0":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.2.6.tgz#cad202796a7bba3efc2100da453b3379c9d4aeb4"
+  integrity sha512-nlxtQE8B22hb/JxdaslI1tfZacxFU8x8BJryXOnR2RxB4vc01zuHYAHAIgmBkdk1kzXaA25hZxK6KAH/+CXArw==
   dependencies:
     create-react-class "^15.5.1"
     history "^3.0.0"
-    hoist-non-react-statics "^1.2.0"
+    hoist-non-react-statics "^3.3.2"
     invariant "^2.2.1"
     loose-envify "^1.2.0"
-    prop-types "^15.5.6"
+    prop-types "^15.7.2"
+    react-is "^16.13.0"
     warning "^3.0.0"
 
 react-test-renderer@^16.13.1:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1458,6 +1458,16 @@
   resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.4.tgz#8c3496bd1b50cc04aeefd691140aa571d4dbfa34"
   integrity sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==
 
+"@types/history@*", "@types/history@^4.7.6":
+  version "4.7.6"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.6.tgz#ed8fc802c45b8e8f54419c2d054e55c9ea344356"
+  integrity sha512-GRTZLeLJ8ia00ZH8mxMO8t0aC9M1N9bN461Z2eaRurJo6Fpa+utgCwLzI4jQHcrdzuzp5WPN9jRwpsCQ1VhJ5w==
+
+"@types/history@^3":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-3.2.4.tgz#0b6c62240d1fac020853aa5608758991d9f6ef3d"
+  integrity sha512-q7x8QeCRk2T6DR2UznwYW//mpN5uNlyajkewH2xd1s1ozCS4oHFRg2WMusxwLFlE57EkUYsd/gCapLBYzV3ffg==
+
 "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -1593,6 +1603,22 @@
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/react-router-3@npm:@types/react-router@3.0.20":
+  version "3.0.20"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-3.0.20.tgz#a711682475ccef70ad9ad9e459859380221e6ee6"
+  integrity sha512-0sx2ThGYgblXPf8we/c+umFzP3RCbBp1bbFmd3pO1UaOYnTDno82iql3MQTVqB09rhopKORNfakDU/9xZ4QR6g==
+  dependencies:
+    "@types/history" "^3"
+    "@types/react" "*"
+
+"@types/react-router@^5.1.8":
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.8.tgz#4614e5ba7559657438e17766bb95ef6ed6acc3fa"
+  integrity sha512-HzOyJb+wFmyEhyfp4D4NYrumi+LQgQL/68HvJO+q6XtuHSDvw6Aqov7sCAhjbNq3bUPgPqbdvjXC5HeB2oEAPg==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
 
 "@types/react-test-renderer@*":
   version "16.9.2"
@@ -1942,10 +1968,31 @@ after@0.8.2:
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
   integrity sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
 
-agent-base@4, agent-base@5, agent-base@6, agent-base@^4.3.0, agent-base@~4.2.1:
+agent-base@4, agent-base@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
+  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
+  dependencies:
+    es6-promisify "^5.0.0"
+
+agent-base@5:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
   integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
+
+agent-base@6:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.1.tgz#808007e4e5867decb0ab6ab2f928fbdb5a596db4"
+  integrity sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==
+  dependencies:
+    debug "4"
+
+agent-base@~4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
+  integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
+  dependencies:
+    es6-promisify "^5.0.0"
 
 agentkeepalive@^3.4.1:
   version "3.5.2"
@@ -2225,7 +2272,7 @@ arrify@^2.0.0, arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
-asap@^2.0.0:
+asap@^2.0.0, asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -4172,6 +4219,11 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
   integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
 
+core-js@^1.0.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
+
 core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.5:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
@@ -4240,6 +4292,15 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-react-class@^15.5.1:
+  version "15.6.3"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
+  integrity sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 cross-spawn-async@^2.1.1:
   version "2.2.5"
@@ -5122,6 +5183,18 @@ es6-object-assign@^1.1.0:
   resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
   integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
 
+es6-promise@^4.0.3:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
+  dependencies:
+    es6-promise "^4.0.3"
+
 escalade@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.0.2.tgz#6a580d70edb87880f22b4c91d0d56078df6962c4"
@@ -5512,6 +5585,19 @@ fb-watchman@^2.0.0:
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
+
+fbjs@^0.8.9:
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
+  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
 
 fd-slicer@~1.1.0:
   version "1.1.0"
@@ -6312,6 +6398,16 @@ highlight.js@^9.13.1, highlight.js@^9.15.6:
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
   integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
 
+history@^3.0.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-3.3.0.tgz#fcedcce8f12975371545d735461033579a6dae9c"
+  integrity sha1-/O3M6PEpdTcVRdc1RhAzV5ptrpw=
+  dependencies:
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    query-string "^4.2.2"
+    warning "^3.0.0"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -6320,6 +6416,11 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
+
+hoist-non-react-statics@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+  integrity sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=
 
 hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
@@ -6700,7 +6801,7 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -7041,7 +7142,7 @@ is-stream-ended@^0.1.4:
   resolved "https://registry.yarnpkg.com/is-stream-ended/-/is-stream-ended-0.1.4.tgz#f50224e95e06bce0e356d440a4827cd35b267eda"
   integrity sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw==
 
-is-stream@^1.0.0, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -7142,6 +7243,14 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
+isomorphic-fetch@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 isstream@0.1.2, isstream@~0.1.2:
   version "0.1.2"
@@ -8362,7 +8471,7 @@ longest@^1.0.1:
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
   integrity sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -9082,6 +9191,14 @@ node-fetch-npm@^2.0.2:
     encoding "^0.1.11"
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
+
+node-fetch@^1.0.1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
 
 node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.6.0:
   version "2.6.0"
@@ -10484,6 +10601,13 @@ promise-retry@^1.1.1:
     err-code "^1.0.0"
     retry "^0.10.0"
 
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
+  dependencies:
+    asap "~2.0.3"
+
 prompts@^2.0.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.3.2.tgz#480572d89ecf39566d2bd3fe2c9fccb7c4c0b068"
@@ -10499,7 +10623,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.6.2:
+prop-types@^15.5.6, prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -10650,6 +10774,14 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+query-string@^4.2.2:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.3.4.tgz#bbb693b9ca915c232515b228b1a02b609043dbeb"
+  integrity sha1-u7aTucqRXCMlFbIosaArYJBD2+s=
+  dependencies:
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
 querystring-es3@^0.2.0, querystring-es3@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -10733,6 +10865,19 @@ react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-i
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+"react-router-3@npm:react-router@3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.2.0.tgz#62b6279d589b70b34e265113e4c0a9261a02ed36"
+  integrity sha512-sXlLOg0TRCqnjCVskqBHGjzNjcJKUqXEKnDSuxMYJSPJNq9hROE9VsiIW2kfIq7Ev+20Iz0nxayekXyv0XNmsg==
+  dependencies:
+    create-react-class "^15.5.1"
+    history "^3.0.0"
+    hoist-non-react-statics "^1.2.0"
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    prop-types "^15.5.6"
+    warning "^3.0.0"
 
 react-test-renderer@^16.13.1:
   version "16.13.1"
@@ -11580,7 +11725,7 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4:
+setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -12064,6 +12209,11 @@ streamroller@^1.0.6:
     debug "^3.2.6"
     fs-extra "^7.0.1"
     lodash "^4.17.14"
+
+strict-uri-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+  integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
 string-length@^2.0.0:
   version "2.0.0"
@@ -12869,6 +13019,11 @@ typescript@3.4.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
   integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
 
+ua-parser-js@^0.7.18:
+  version "0.7.21"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
+  integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
+
 uglify-js@^2.6:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
@@ -13244,6 +13399,13 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.x"
 
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  integrity sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=
+  dependencies:
+    loose-envify "^1.0.0"
+
 watchpack-chokidar2@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz#9948a1866cbbd6cb824dea13a7ed691f6c8ddff0"
@@ -13346,6 +13508,11 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@>=0.10.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.2.0.tgz#8e134f701f0a4ab5fda82626f113e2b647fd16dc"
+  integrity sha512-SdGPoQMMnzVYThUbSrEvqTlkvC1Ux27NehaJ/GUHBfNrh5Mjg+1/uRyFMwVnxO2MrikMWvWAqUGgQOfVU4hT7w==
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Just making my contribution to what will soon be the biggest `yarn.lock` file ever 😎 

This PR adds instrumentation support for `react-router` v3. This is based entirely on the excellent `getsentry/sentry` implementation. To see how it works, see below:

```jsx
// Must be `react-router` >= v3.2.0 and < 4.0.0
import * as Router from 'react-router';
import { reactRouterV3Instrumentation  } from '@sentry/react';

// Rendered below
const routes = (
  <Route />
  <Route />
  <Route />
);

// Have to generate PlainRoutes from routes
const appRoutes = Router.createRoutes(routes);

Sentry.init({
  tracesSampleRate: 1,
  integrations: [
    new Integrations.BrowserTracing({
      routingInstrumentation: reactRouterV3Instrumentation(Router.browserHistory, appRoutes, Router.match),
    });
  ]
});
```

If you notice, we make the user pass in a `history`, `routes` and `Router.match`. This is so that is is easier to test, can accommodate various history settings (hashRouting, browserRouting) and we don't make any assumptions on dependencies.

This is tested on Sentry and unit tested.

File             |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-----------------|----------|----------|----------|----------|-------------------|
All files        |    93.18 |    89.19 |      100 |     92.5 |                   |
 reactrouter.tsx |    93.18 |    89.19 |      100 |     92.5 |       100,105,119 |
