### PR TITLE
Don't add sdk event processor if running in React Native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
+- [react] feat: Don't add sdk event processor if running in React Native (#2762)
 
 ## 5.20.0
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,7 +1,11 @@
 import { addGlobalEventProcessor, SDK_VERSION } from '@sentry/browser';
 
 function createReactEventProcessor(): void {
-  if (addGlobalEventProcessor) {
+  // Only add the event processor if not running in React Native.
+  // tslint:disable-next-line: strict-type-predicates
+  const isReactNative = typeof navigator !== 'undefined' && navigator.product === 'ReactNative';
+
+  if (addGlobalEventProcessor && !isReactNative) {
     addGlobalEventProcessor(event => {
       event.sdk = {
         ...event.sdk,


### PR DESCRIPTION
Don't add the global event processor that sets the sdk info on the event if running in React Native. To determine that it's running in React Native it checks `navigator.product` : https://github.com/facebook/react-native/commit/3c65e62183ce05893be0822da217cb803b121c61

This check is needed as we're moving to use `@sentry/react` in `@sentry/react-native` and this event processor overwrites the react native sdk info.

- [ ] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
