### PR TITLE
fix: Make sure fetch requests are being timed correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 - [react] feat: Add instrumentation for React Router v3 (#2759)
+- [apm/tracing] fix: Make sure fetch requests are being timed correctly (#2772)
 
 ## 5.20.0
 

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -661,15 +661,7 @@ export class Tracing implements Integration {
           case 'resource':
             const resourceName = entry.name.replace(window.location.origin, '');
             if (entry.initiatorType === 'xmlhttprequest' || entry.initiatorType === 'fetch') {
-              // We need to update existing spans with new timing info
-              if (transactionSpan.spanRecorder) {
-                transactionSpan.spanRecorder.spans.map((finishedSpan: Span) => {
-                  if (finishedSpan.description && finishedSpan.description.indexOf(resourceName) !== -1) {
-                    finishedSpan.startTimestamp = timeOrigin + startTime;
-                    finishedSpan.endTimestamp = finishedSpan.startTimestamp + duration;
-                  }
-                });
-              }
+              // do nothing, we can't adjust timings just based on urls
             } else {
               const resource = transactionSpan.startChild({
                 description: `${entry.initiatorType} ${resourceName}`,

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -660,9 +660,9 @@ export class Tracing implements Integration {
             break;
           case 'resource':
             const resourceName = entry.name.replace(window.location.origin, '');
-            if (entry.initiatorType === 'xmlhttprequest' || entry.initiatorType === 'fetch') {
-              // do nothing, we can't adjust timings just based on urls
-            } else {
+            // we already instrument based on fetch and xhr, so we don't need to
+            // duplicate spans here.
+            if (entry.initiatorType !== 'xmlhttprequest' && entry.initiatorType !== 'fetch') {
               const resource = transactionSpan.startChild({
                 description: `${entry.initiatorType} ${resourceName}`,
                 op: `resource`,

--- a/packages/tracing/src/browser/backgroundtab.ts
+++ b/packages/tracing/src/browser/backgroundtab.ts
@@ -19,7 +19,11 @@ export function registerBackgroundTabDetection(): void {
         logger.log(
           `[Tracing] Transaction: ${SpanStatus.Cancelled} -> since tab moved to the background, op: ${activeTransaction.op}`,
         );
-        activeTransaction.setStatus(SpanStatus.Cancelled);
+        // We should not set status if it is already set, this prevent important statuses like
+        // error or data loss from being overwritten on transaction.
+        if (!activeTransaction.status) {
+          activeTransaction.setStatus(SpanStatus.Cancelled);
+        }
         activeTransaction.setTag('visibilitychange', 'document.hidden');
         activeTransaction.finish();
       }

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -1,6 +1,5 @@
 import { getGlobalObject, logger } from '@sentry/utils';
 
-import { Span } from '../span';
 import { Transaction } from '../transaction';
 
 import { msToSec } from './utils';
@@ -216,30 +215,20 @@ function addResourceSpans(
   timeOrigin: number,
 ): number | undefined {
   if (entry.initiatorType === 'xmlhttprequest' || entry.initiatorType === 'fetch') {
-    // We need to update existing spans with new timing info
-    if (transaction.spanRecorder) {
-      transaction.spanRecorder.spans.map((finishedSpan: Span) => {
-        if (finishedSpan.description && finishedSpan.description.indexOf(resourceName) !== -1) {
-          finishedSpan.startTimestamp = timeOrigin + startTime;
-          finishedSpan.endTimestamp = finishedSpan.startTimestamp + duration;
-        }
-      });
-    }
-  } else {
-    const startTimestamp = timeOrigin + startTime;
-    const endTimestamp = startTimestamp + duration;
-
-    transaction.startChild({
-      description: `${entry.initiatorType} ${resourceName}`,
-      endTimestamp,
-      op: 'resource',
-      startTimestamp,
-    });
-
-    return endTimestamp;
+    return undefined;
   }
 
-  return undefined;
+  const startTimestamp = timeOrigin + startTime;
+  const endTimestamp = startTimestamp + duration;
+
+  transaction.startChild({
+    description: `${entry.initiatorType} ${resourceName}`,
+    endTimestamp,
+    op: 'resource',
+    startTimestamp,
+  });
+
+  return endTimestamp;
 }
 
 /** Create performance navigation related spans */

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -214,6 +214,8 @@ function addResourceSpans(
   duration: number,
   timeOrigin: number,
 ): number | undefined {
+  // we already instrument based on fetch and xhr, so we don't need to
+  // duplicate spans here.
   if (entry.initiatorType === 'xmlhttprequest' || entry.initiatorType === 'fetch') {
     return undefined;
   }

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -104,7 +104,7 @@ export function registerRequestInstrumentation(_options?: Partial<RequestInstrum
   if (traceFetch) {
     addInstrumentationHandler({
       callback: (handlerData: FetchData) => {
-        fetchCallback(handlerData, shouldCreateSpan, spans);
+        _fetchCallback(handlerData, shouldCreateSpan, spans);
       },
       type: 'fetch',
     });
@@ -123,7 +123,7 @@ export function registerRequestInstrumentation(_options?: Partial<RequestInstrum
 /**
  * Create and track fetch request spans
  */
-export function fetchCallback(
+export function _fetchCallback(
   handlerData: FetchData,
   shouldCreateSpan: (url: string) => boolean,
   spans: Record<string, Span>,

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -40,9 +40,9 @@ export interface RequestInstrumentationOptions {
 }
 
 /** Data returned from fetch callback */
-interface FetchData {
+export interface FetchData {
   args: any[];
-  fetchData: {
+  fetchData?: {
     method: string;
     url: string;
     // span_id
@@ -123,12 +123,12 @@ export function registerRequestInstrumentation(_options?: Partial<RequestInstrum
 /**
  * Create and track fetch request spans
  */
-function fetchCallback(
+export function fetchCallback(
   handlerData: FetchData,
   shouldCreateSpan: (url: string) => boolean,
   spans: Record<string, Span>,
 ): void {
-  if (!shouldCreateSpan(handlerData.fetchData.url) || !handlerData.fetchData) {
+  if (!handlerData.fetchData || !shouldCreateSpan(handlerData.fetchData.url)) {
     return;
   }
 
@@ -154,6 +154,7 @@ function fetchCallback(
       op: 'http',
     });
 
+    handlerData.fetchData.__span = span.spanId;
     spans[span.spanId] = span;
 
     const request = (handlerData.args[0] = handlerData.args[0] as string | Request);

--- a/packages/tracing/src/idletransaction.ts
+++ b/packages/tracing/src/idletransaction.ts
@@ -118,9 +118,7 @@ export class IdleTransaction extends Transaction {
     this._prevHeartbeatString = heartbeatString;
 
     if (this._heartbeatCounter >= 3) {
-      logger.log(
-        `[Tracing] Transaction: ${SpanStatus.DeadlineExceeded} -> Heartbeat safeguard kicked in since content hasn't changed for 3 beats`,
-      );
+      logger.log(`[Tracing] Transaction finished because of no change for 3 heart beats`);
       this.setStatus(SpanStatus.DeadlineExceeded);
       this.setTag('heartbeat', 'failed');
       this.finish();

--- a/packages/tracing/src/idletransaction.ts
+++ b/packages/tracing/src/idletransaction.ts
@@ -63,7 +63,7 @@ export class IdleTransaction extends Transaction {
   private _prevHeartbeatString: string | undefined;
 
   // Amount of times heartbeat has counted. Will cause transaction to finish after 3 beats.
-  private _heartbeatCounter: number = 1;
+  private _heartbeatCounter: number = 0;
 
   // We should not use heartbeat if we finished a transaction
   private _finished: boolean = false;
@@ -119,7 +119,7 @@ export class IdleTransaction extends Transaction {
 
     if (this._heartbeatCounter >= 3) {
       logger.log(
-        `[Tracing] Transaction: ${SpanStatus.Cancelled} -> Heartbeat safeguard kicked in since content hasn't changed for 3 beats`,
+        `[Tracing] Transaction: ${SpanStatus.DeadlineExceeded} -> Heartbeat safeguard kicked in since content hasn't changed for 3 beats`,
       );
       this.setStatus(SpanStatus.DeadlineExceeded);
       this.setTag('heartbeat', 'failed');

--- a/packages/tracing/test/browser/request.test.ts
+++ b/packages/tracing/test/browser/request.test.ts
@@ -1,4 +1,25 @@
-import { registerRequestInstrumentation } from '../../src/browser/request';
+import { BrowserClient } from '@sentry/browser';
+import { Hub, makeMain } from '@sentry/hub';
+
+import { Span, Transaction } from '../../src';
+import { fetchCallback, FetchData, registerRequestInstrumentation } from '../../src/browser/request';
+import { addExtensionMethods } from '../../src/hubextensions';
+
+declare global {
+  namespace NodeJS {
+    // tslint:disable-next-line: completed-docs
+    interface Global {
+      // Have to mock out Request because it is not defined in jest environment
+      Request: Request;
+    }
+  }
+}
+
+beforeAll(() => {
+  addExtensionMethods();
+  // @ts-ignore
+  global.Request = {};
+});
 
 const mockAddInstrumentationHandler = jest.fn();
 let mockFetchCallback = jest.fn();
@@ -45,5 +66,97 @@ describe('registerRequestInstrumentation', () => {
     registerRequestInstrumentation({ traceXHR: false });
     expect(mockAddInstrumentationHandler).toHaveBeenCalledTimes(1);
     expect(mockXHRCallback()).toBe(undefined);
+  });
+});
+
+describe('fetchCallback', () => {
+  let hub: Hub;
+  let transaction: Transaction;
+  beforeEach(() => {
+    hub = new Hub(new BrowserClient({ tracesSampleRate: 1 }));
+    makeMain(hub);
+    transaction = hub.startTransaction({ name: 'organizations/users/:userid', op: 'pageload' }) as Transaction;
+    hub.configureScope(scope => scope.setSpan(transaction));
+  });
+
+  afterEach(() => {
+    if (transaction) {
+      transaction.finish();
+    }
+    hub.configureScope(scope => scope.setSpan(undefined));
+  });
+
+  it('does not create span if it should not be created', () => {
+    const shouldCreateSpan = (url: string): boolean => url === '/organizations';
+    const data: FetchData = {
+      args: ['/users'],
+      fetchData: {
+        method: 'GET',
+        url: '/users',
+      },
+      startTimestamp: 1595509730275,
+    };
+    const spans = {};
+
+    fetchCallback(data, shouldCreateSpan, spans);
+    expect(spans).toEqual({});
+  });
+
+  it('does not create span if there is no fetch data', () => {
+    const shouldCreateSpan = (_: string): boolean => true;
+    const data: FetchData = {
+      args: [],
+      startTimestamp: 1595509730275,
+    };
+    const spans = {};
+
+    fetchCallback(data, shouldCreateSpan, spans);
+    expect(spans).toEqual({});
+  });
+
+  it('creates and finishes fetch span on active transaction', () => {
+    const shouldCreateSpan = (_: string): boolean => true;
+    const data: FetchData = {
+      args: ['/users'],
+      fetchData: {
+        method: 'GET',
+        url: '/users',
+      },
+      startTimestamp: 1595509730275,
+    };
+    const spans: Record<string, Span> = {};
+
+    // Start fetch request
+    fetchCallback(data, shouldCreateSpan, spans);
+    const spanKey = Object.keys(spans)[0];
+
+    const fetchSpan = spans[spanKey];
+    expect(fetchSpan).toBeInstanceOf(Span);
+    expect(fetchSpan.data).toEqual({
+      method: 'GET',
+      type: 'fetch',
+      url: '/users',
+    });
+    expect(fetchSpan.description).toBe('GET /users');
+    expect(fetchSpan.op).toBe('http');
+    if (data.fetchData) {
+      expect(data.fetchData.__span).toBeDefined();
+    } else {
+      fail('Fetch data does not exist');
+    }
+
+    const newData = {
+      ...data,
+      endTimestamp: data.startTimestamp + 12343234,
+    };
+
+    // End fetch request
+    fetchCallback(newData, shouldCreateSpan, spans);
+    expect(spans).toEqual({});
+    if (transaction.spanRecorder) {
+      expect(transaction.spanRecorder.spans[1].endTimestamp).toBeDefined();
+    } else {
+      fail('Transaction does not have span recorder');
+    }
   });
 });


### PR DESCRIPTION
### Motivation

Earlier today, Daniel raised up some concerns about incorrect timings for fetch spans. This PR splits up each of those concerns into actionable items, and aims to address them.

### Implementation

First it takes a look at an issue where `fetch` spans were being doubled in `@sentry/tracing`. This happens because we did not store the span correctly, so there was no span to finish. I have fixed this and added tests.

`handlerData.fetchData.__span = span.spanId` was added for the fix.

Second, we took a look at an issue affecting both `@sentry/apm` and `@sentry/tracing` where the end timing for spans with the same description ended up being the same. This was because we have logic in `performance` to adjust `fetch` and `xhr` span timestamps based on description.

Because we could not figure out a good way to keep this while recognizing unique URLs, we decided to delete this code as our tracking of spans should be enough to ensure accurate timestamps.