### PR TITLE
fix(apm/tracing): update pageload op transaction start timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 - [react] feat: Add instrumentation for React Router v3 (#2759)
 - [apm/tracing] fix: Make sure fetch requests are being timed correctly (#2772)
+- [apm/tracing] fix: Make sure pageload transactions start timestamps are correctly generated (#2773)
 
 ## 5.20.0
 

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -1049,7 +1049,7 @@ function historyCallback(_: { [key: string]: any }): void {
 
 /**
  * Helper function to start child on transactions. This function will make sure that the transaction will
- * will use the start timestamp of the created child span if it is earlier than the transactions actual
+ * use the start timestamp of the created child span if it is earlier than the transactions actual
  * start timestamp.
  */
 export function _startChild(parent: Span, { startTimestamp, ...ctx }: SpanContext): Span {

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -581,7 +581,7 @@ export class Tracing implements Integration {
 
     // tslint:disable-next-line: completed-docs
     function addPerformanceNavigationTiming(parent: Span, entry: { [key: string]: number }, event: string): void {
-      parent.startChild({
+      _startChild(parent, {
         description: event,
         endTimestamp: timeOrigin + Tracing._msToSec(entry[`${event}End`]),
         op: 'browser',
@@ -591,14 +591,14 @@ export class Tracing implements Integration {
 
     // tslint:disable-next-line: completed-docs
     function addRequest(parent: Span, entry: { [key: string]: number }): void {
-      parent.startChild({
+      _startChild(parent, {
         description: 'request',
         endTimestamp: timeOrigin + Tracing._msToSec(entry.responseEnd),
         op: 'browser',
         startTimestamp: timeOrigin + Tracing._msToSec(entry.requestStart),
       });
 
-      parent.startChild({
+      _startChild(parent, {
         description: 'response',
         endTimestamp: timeOrigin + Tracing._msToSec(entry.responseEnd),
         op: 'browser',
@@ -648,12 +648,12 @@ export class Tracing implements Integration {
           case 'mark':
           case 'paint':
           case 'measure':
-            const mark = transactionSpan.startChild({
+            const mark = _startChild(transactionSpan, {
               description: entry.name,
+              endTimestamp: timeOrigin + startTime + duration,
               op: entry.entryType,
+              startTimestamp: timeOrigin + startTime,
             });
-            mark.startTimestamp = timeOrigin + startTime;
-            mark.endTimestamp = mark.startTimestamp + duration;
             if (tracingInitMarkStartTime === undefined && entry.name === 'sentry-tracing-init') {
               tracingInitMarkStartTime = mark.startTimestamp;
             }
@@ -663,12 +663,12 @@ export class Tracing implements Integration {
             // we already instrument based on fetch and xhr, so we don't need to
             // duplicate spans here.
             if (entry.initiatorType !== 'xmlhttprequest' && entry.initiatorType !== 'fetch') {
-              const resource = transactionSpan.startChild({
+              const resource = _startChild(transactionSpan, {
                 description: `${entry.initiatorType} ${resourceName}`,
+                endTimestamp: timeOrigin + startTime + duration,
                 op: `resource`,
+                startTimestamp: timeOrigin + startTime,
               });
-              resource.startTimestamp = timeOrigin + startTime;
-              resource.endTimestamp = resource.startTimestamp + duration;
               // We remember the entry script end time to calculate the difference to the first init mark
               if (entryScriptStartEndTime === undefined && (entryScriptSrc || '').indexOf(resourceName) > -1) {
                 entryScriptStartEndTime = resource.endTimestamp;
@@ -681,7 +681,7 @@ export class Tracing implements Integration {
       });
 
     if (entryScriptStartEndTime !== undefined && tracingInitMarkStartTime !== undefined) {
-      transactionSpan.startChild({
+      _startChild(transactionSpan, {
         description: 'evaluation',
         endTimestamp: tracingInitMarkStartTime,
         op: `script`,
@@ -1045,4 +1045,20 @@ function historyCallback(_: { [key: string]: any }): void {
       op: 'navigation',
     });
   }
+}
+
+/**
+ * Helper function to start child on transactions. This function will make sure that the transaction will
+ * will use the start timestamp of the created child span if it is earlier than the transactions actual
+ * start timestamp.
+ */
+export function _startChild(parent: Span, { startTimestamp, ...ctx }: SpanContext): Span {
+  if (startTimestamp && parent.startTimestamp > startTimestamp) {
+    parent.startTimestamp = startTimestamp;
+  }
+
+  return parent.startChild({
+    startTimestamp,
+    ...ctx,
+  });
 }

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -1,6 +1,7 @@
 import { SpanContext } from '@sentry/types';
 import { getGlobalObject, logger } from '@sentry/utils';
 
+import { Span } from '../span';
 import { Transaction } from '../transaction';
 
 import { msToSec } from './utils';
@@ -273,7 +274,7 @@ function addRequest(transaction: Transaction, entry: Record<string, any>, timeOr
 
 /**
  * Helper function to start child on transactions. This function will make sure that the transaction will
- * will use the start timestamp of the created child span if it is earlier than the transactions actual
+ * use the start timestamp of the created child span if it is earlier than the transactions actual
  * start timestamp.
  */
 export function _startChild(transaction: Transaction, { startTimestamp, ...ctx }: SpanContext): Span {

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -1,9 +1,9 @@
+import { SpanContext } from '@sentry/types';
 import { getGlobalObject, logger } from '@sentry/utils';
 
 import { Transaction } from '../transaction';
 
 import { msToSec } from './utils';
-import { TransactionContext, SpanContext } from '@sentry/types';
 
 const global = getGlobalObject<Window>();
 

--- a/packages/tracing/test/browser/metrics.test.ts
+++ b/packages/tracing/test/browser/metrics.test.ts
@@ -1,0 +1,40 @@
+import { Span, Transaction } from '../../src';
+import { _startChild } from '../../src/browser/metrics';
+
+describe('_startChild()', () => {
+  it('creates a span with given properties', () => {
+    const transaction = new Transaction({ name: 'test' });
+    const span = _startChild(transaction, {
+      description: 'evaluation',
+      op: 'script',
+    });
+
+    expect(span).toBeInstanceOf(Span);
+    expect(span.description).toBe('evaluation');
+    expect(span.op).toBe('script');
+  });
+
+  it('adjusts the start timestamp if child span starts before transaction', () => {
+    const transaction = new Transaction({ name: 'test', startTimestamp: 123 });
+    const span = _startChild(transaction, {
+      description: 'script.js',
+      op: 'resource',
+      startTimestamp: 100,
+    });
+
+    expect(transaction.startTimestamp).toEqual(span.startTimestamp);
+    expect(transaction.startTimestamp).toEqual(100);
+  });
+
+  it('does not adjust start timestamp if child span starts after transaction', () => {
+    const transaction = new Transaction({ name: 'test', startTimestamp: 123 });
+    const span = _startChild(transaction, {
+      description: 'script.js',
+      op: 'resource',
+      startTimestamp: 150,
+    });
+
+    expect(transaction.startTimestamp).not.toEqual(span.startTimestamp);
+    expect(transaction.startTimestamp).toEqual(123);
+  });
+});


### PR DESCRIPTION
## Background

When I was testing my react router integration, I found an issue where the duration of pageload transactions in the performance view was different than the duration shown in the span view. Note: The **pageload** transactions that I am referring to are the one's automatically generated by the `@sentry/apm` or `@sentry/tracing` Tracing integration.

The transaction duration in the performance view is computed straight from the transaction payload, `end_timestamp` - `start_timestamp` of the transaction. Meanwhile, the transaction duration in the span view is actually adjusted with some helper functions in the UI itself. This was to make sure that things were normalized so that strange traces would not be rendered in the UI. See the helpers here: https://github.com/getsentry/sentry/blob/master/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx#L500-L530

This meant there were cases where pageload transactions had a computed duration of something like `140 ms`, but the span view would show a duration of `300ms`. This also meant that if a user got alerted by a metric alert for average duration, they would see a different number in the individual transaction view (as metric alerts rely on transaction duration computed from snuba - `end_timestamp` - `start_timestamp` from event payload).

As this issue was only occurring in a) automatically created transactions from browser b) pageload transactions, my first instinct was to check the performance spans we add to transactions. It turns out that was causing the issue.

## The Issue

The problem was caused by the fact that when we add performance spans (`resource`, `script` etc.), we do not adjust transaction start time. When you add certain performance related spans, they might have a start timestamp that is before the transaction's initial start time (they occured before `sentry-tracing-init`). This means that the transaction duration becomes much smaller than the duration of it's child spans.

The helpers in the Sentry UI were automatically checking to make sure that if this was the case, that the span UI would render a transaction that had the `start_timestamp` of the earliest child span.

In the example below, `sentry-tracing-init` only occurs 5000ms after all the performance related spans. This means that before the change in this PR, the computed duration in from the transaction payload would be `5000ms` less than what actually is.

![image](https://user-images.githubusercontent.com/18689448/88393422-97d9c100-cd8b-11ea-9c4e-59dce9f929da.png)

## Fix

This is fixed by adjusting the performance spans to adjust transaction start time accordingly. See the helper function `_startChild` for more details. This fix was made to both `@sentry/apm` and `@sentry/tracing`.

This was tested with unit tests in `@sentry/tracing` and verified on Sentry master.

## Notes

It's important to note that these changes may break existing users alerts, because naturally pageload durations will rise as it now accounts for these extra spans.
