### PR TITLE
fix: Mark side effects for tracing hub extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 - [ember] feat: Add `@sentry/ember` (#2739)
+- [apm/tracing] fix: Mark side effects for tracing hub extensions (#2788)
 
 ## 5.20.1
 

--- a/packages/apm/package.json
+++ b/packages/apm/package.json
@@ -80,5 +80,7 @@
       }
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "./src/index.ts"
+  ]
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -91,5 +91,7 @@
       }
     }
   },
-  "sideEffects": false
+  "sideEffects": [
+    "./src/index.ts"
+  ]
 }

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -82,5 +82,7 @@
       }
     }
   },
-  "sideEffects": true
+  "sideEffects": [
+    "./src/index.ts"
+  ]
 }


### PR DESCRIPTION
This tells webpack or other bundlers that the index file has side effects.
