### PR TITLE
feat: export type CaptureContext from @sentry/types in @sentry/browser

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -9,6 +9,7 @@ export {
   Exception,
   Response,
   Severity,
+  ScopeContext,
   StackFrame,
   Stacktrace,
   Status,

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -1,6 +1,7 @@
 export {
   Breadcrumb,
   BreadcrumbHint,
+  CaptureContext,
   Request,
   SdkInfo,
   Event,


### PR DESCRIPTION
We need to use the types CaptureContext and ScopeContext to make a custom captureSentryException. We can add @sentry/types in dependencies just for this, but it would be better to have it directly from @sentry/browser :)

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
