### PR TITLE
feat(apm|tracing): Remove express typing

### DIFF
--- a/packages/apm/src/integrations/express.ts
+++ b/packages/apm/src/integrations/express.ts
@@ -1,7 +1,20 @@
 import { Integration, Transaction } from '@sentry/types';
 import { logger } from '@sentry/utils';
-// tslint:disable-next-line:no-implicit-dependencies
-import { Application, ErrorRequestHandler, NextFunction, Request, RequestHandler, Response } from 'express';
+
+// tslint:disable: completed-docs
+// Have to manually set types because we are using package-alias
+interface Application {
+  use(...args: any): any;
+}
+
+type ErrorRequestHandler = (...args: any) => any;
+type RequestHandler = (...args: any) => any;
+type NextFunction = (...args: any) => any;
+
+interface Response {
+  once(name: string, callback: () => void): void;
+}
+// tslint:enable: completed-docs
 
 /**
  * Internal helper for `__sentry_transaction`
@@ -167,6 +180,7 @@ function wrapUseArgs(args: IArguments): unknown[] {
  * Patches original app.use to utilize our tracing functionality
  */
 function instrumentMiddlewares(app: Application): Application {
+  // tslint:disable-next-line: no-unbound-method
   const originalAppUse = app.use;
   app.use = function(): any {
     return originalAppUse.apply(this, wrapUseArgs(arguments));

--- a/packages/tracing/src/integrations/express.ts
+++ b/packages/tracing/src/integrations/express.ts
@@ -1,7 +1,20 @@
 import { Integration, Transaction } from '@sentry/types';
 import { logger } from '@sentry/utils';
-// tslint:disable-next-line:no-implicit-dependencies
-import { Application, ErrorRequestHandler, NextFunction, Request, RequestHandler, Response } from 'express';
+
+// tslint:disable: completed-docs
+// Have to manually set types because we are using package-alias
+interface Application {
+  use(...args: any): any;
+}
+
+type ErrorRequestHandler = (...args: any) => any;
+type RequestHandler = (...args: any) => any;
+type NextFunction = (...args: any) => any;
+
+interface Response {
+  once(name: string, callback: () => void): void;
+}
+// tslint:enable: completed-docs
 
 /**
  * Internal helper for `__sentry_transaction`
@@ -167,6 +180,7 @@ function wrapUseArgs(args: IArguments): unknown[] {
  * Patches original app.use to utilize our tracing functionality
  */
 function instrumentMiddlewares(app: Application): Application {
+  // tslint:disable-next-line: no-unbound-method
   const originalAppUse = app.use;
   app.use = function(): any {
     return originalAppUse.apply(this, wrapUseArgs(arguments));


### PR DESCRIPTION
Manually set types so that users don't complain about importing typscript types for express.