### PR TITLE
feat: Export addExtensionMethods for SDKs to use

### DIFF
--- a/packages/apm/src/index.bundle.ts
+++ b/packages/apm/src/index.bundle.ts
@@ -78,3 +78,5 @@ export { INTEGRATIONS as Integrations };
 
 // We are patching the global object with our hub extension methods
 addExtensionMethods();
+
+export { addExtensionMethods };

--- a/packages/apm/src/index.ts
+++ b/packages/apm/src/index.ts
@@ -9,3 +9,5 @@ export { SpanStatus } from './spanstatus';
 
 // We are patching the global object with our hub extension methods
 addExtensionMethods();
+
+export { addExtensionMethods };

--- a/packages/tracing/src/index.bundle.ts
+++ b/packages/tracing/src/index.bundle.ts
@@ -78,3 +78,5 @@ export { INTEGRATIONS as Integrations };
 
 // We are patching the global object with our hub extension methods
 addExtensionMethods();
+
+export { addExtensionMethods };

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -13,3 +13,5 @@ export { SpanStatus } from './spanstatus';
 
 // We are patching the global object with our hub extension methods
 addExtensionMethods();
+
+export { addExtensionMethods };


### PR DESCRIPTION
In case a user for some reason cannot access the side effect, let's let them import and call it themselves.

This can also be used by SDKs like `react-native`/`electron` etc. to call the extensions themselves.