### PR TITLE
feat(tracing): Change resource span op name and add data

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,3 @@
+// This is an empty file so that danger works correctly
+{
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,0 @@
-// This is an empty file so that danger works correctly
-{
-}

--- a/packages/eslint-config-sdk/src/index.js
+++ b/packages/eslint-config-sdk/src/index.js
@@ -39,6 +39,10 @@ module.exports = {
         // Enforce type annotations to maintain consistency. This is especially important as
         // we have a public API, so we want changes to be very explicit.
         '@typescript-eslint/typedef': ['error', { arrowParameter: false }],
+
+        // Although for most codebases inferencing the return type is fine, we explicitly ask to annotate
+        // all functions with a return type. This is so that intent is as clear as possible. We are guarding against
+        // cases where you accidently refactor a function's return type to be the wrong type.
         '@typescript-eslint/explicit-function-return-type': ['error', { allowExpressions: true }],
 
         // Consistent ordering of fields, methods and constructors for classes should be enforced

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { SpanContext } from '@sentry/types';
 import { getGlobalObject, logger } from '@sentry/utils';
@@ -214,7 +215,7 @@ function addMeasureSpans(
 /** Create resource related spans */
 function addResourceSpans(
   transaction: Transaction,
-  entry: Record<string, any>,
+  entry: Record<string, unknown>,
   resourceName: string,
   startTime: number,
   duration: number,
@@ -226,14 +227,26 @@ function addResourceSpans(
     return undefined;
   }
 
+  const tags: Record<string, string> = {};
+  if (entry.transferSize) {
+    tags.transferSize = (entry.transferSize as number).toString();
+  }
+  if (entry.encodedBodySize) {
+    tags.encodedBodySize = (entry.encodedBodySize as number).toString();
+  }
+  if (entry.decodedBodySize) {
+    tags.decodedBodySize = (entry.decodedBodySize as number).toString();
+  }
+
   const startTimestamp = timeOrigin + startTime;
   const endTimestamp = startTimestamp + duration;
 
   _startChild(transaction, {
-    description: `${entry.initiatorType} ${resourceName}`,
+    description: resourceName,
     endTimestamp,
-    op: 'resource',
+    op: entry.initiatorType && entry.initiatorType !== '' ? `resource.${entry.initiatorType}` : 'resource',
     startTimestamp,
+    tags,
   });
 
   return endTimestamp;

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -236,13 +236,13 @@ export function addResourceSpans(
 
   const data: Record<string, any> = {};
   if ('transferSize' in entry) {
-    data.transferSize = entry.transferSize;
+    data['Transfer Size'] = entry.transferSize;
   }
   if ('encodedBodySize' in entry) {
-    data.encodedBodySize = entry.encodedBodySize;
+    data['Encoded Body Size'] = entry.encodedBodySize;
   }
   if ('decodedBodySize' in entry) {
-    data.decodedBodySize = entry.decodedBodySize;
+    data['Decoded Body Size'] = entry.decodedBodySize;
   }
 
   const startTimestamp = timeOrigin + startTime;

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -235,13 +235,13 @@ export function addResourceSpans(
   }
 
   const data: Record<string, any> = {};
-  if (entry.transferSize) {
+  if ('transferSize' in entry) {
     data.transferSize = entry.transferSize;
   }
-  if (entry.encodedBodySize) {
+  if ('encodedBodySize' in entry) {
     data.encodedBodySize = entry.encodedBodySize;
   }
-  if (entry.decodedBodySize) {
+  if ('decodedBodySize' in entry) {
     data.decodedBodySize = entry.decodedBodySize;
   }
 
@@ -251,7 +251,7 @@ export function addResourceSpans(
   _startChild(transaction, {
     description: resourceName,
     endTimestamp,
-    op: entry.initiatorType && entry.initiatorType !== '' ? `resource.${entry.initiatorType}` : 'resource',
+    op: entry.initiatorType ? `resource.${entry.initiatorType}` : 'resource',
     startTimestamp,
     data,
   });

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -212,10 +212,17 @@ function addMeasureSpans(
   return measureStartTimestamp;
 }
 
+export interface ResourceEntry extends Record<string, unknown> {
+  initiatorType?: string;
+  transferSize?: number;
+  encodedBodySize?: number;
+  decodedBodySize?: number;
+}
+
 /** Create resource related spans */
-function addResourceSpans(
+export function addResourceSpans(
   transaction: Transaction,
-  entry: Record<string, unknown>,
+  entry: ResourceEntry,
   resourceName: string,
   startTime: number,
   duration: number,
@@ -227,15 +234,15 @@ function addResourceSpans(
     return undefined;
   }
 
-  const tags: Record<string, string> = {};
+  const data: Record<string, any> = {};
   if (entry.transferSize) {
-    tags.transferSize = (entry.transferSize as number).toString();
+    data.transferSize = entry.transferSize;
   }
   if (entry.encodedBodySize) {
-    tags.encodedBodySize = (entry.encodedBodySize as number).toString();
+    data.encodedBodySize = entry.encodedBodySize;
   }
   if (entry.decodedBodySize) {
-    tags.decodedBodySize = (entry.decodedBodySize as number).toString();
+    data.decodedBodySize = entry.decodedBodySize;
   }
 
   const startTimestamp = timeOrigin + startTime;
@@ -246,7 +253,7 @@ function addResourceSpans(
     endTimestamp,
     op: entry.initiatorType && entry.initiatorType !== '' ? `resource.${entry.initiatorType}` : 'resource',
     startTimestamp,
-    tags,
+    data,
   });
 
   return endTimestamp;

--- a/packages/tracing/test/browser/metrics.test.ts
+++ b/packages/tracing/test/browser/metrics.test.ts
@@ -142,4 +142,28 @@ describe('addResourceSpans', () => {
       );
     }
   });
+
+  it('allows for enter size of 0', () => {
+    const entry: ResourceEntry = {
+      initiatorType: 'css',
+      transferSize: 0,
+      encodedBodySize: 0,
+      decodedBodySize: 0,
+    };
+
+    addResourceSpans(transaction, entry, '/assets/to/css', 100, 23, 345);
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(transaction.startChild).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(transaction.startChild).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: {
+          decodedBodySize: entry.decodedBodySize,
+          encodedBodySize: entry.encodedBodySize,
+          transferSize: entry.transferSize,
+        },
+      }),
+    );
+  });
 });

--- a/packages/tracing/test/browser/metrics.test.ts
+++ b/packages/tracing/test/browser/metrics.test.ts
@@ -91,9 +91,9 @@ describe('addResourceSpans', () => {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(transaction.startChild).toHaveBeenLastCalledWith({
       data: {
-        decodedBodySize: entry.decodedBodySize,
-        encodedBodySize: entry.encodedBodySize,
-        transferSize: entry.transferSize,
+        ['Decoded Body Size']: entry.decodedBodySize,
+        ['Encoded Body Size']: entry.encodedBodySize,
+        ['Transfer Size']: entry.transferSize,
       },
       description: '/assets/to/css',
       endTimestamp: timeOrigin + startTime + duration,
@@ -159,9 +159,9 @@ describe('addResourceSpans', () => {
     expect(transaction.startChild).toHaveBeenLastCalledWith(
       expect.objectContaining({
         data: {
-          decodedBodySize: entry.decodedBodySize,
-          encodedBodySize: entry.encodedBodySize,
-          transferSize: entry.transferSize,
+          ['Decoded Body Size']: entry.decodedBodySize,
+          ['Encoded Body Size']: entry.encodedBodySize,
+          ['Transfer Size']: entry.transferSize,
         },
       }),
     );


### PR DESCRIPTION
Add `transferSize`, `encodedBodySize`, and `decodedBodySize` metrics to resource spans and adjust resource op name to account for `initiatorType` (ex. `resource.css`, `resource.img`)

This ones for 🇨🇦 

![image](https://user-images.githubusercontent.com/18689448/90174539-28e0fe00-dd74-11ea-8310-d6914f8a5f03.png)

![image](https://user-images.githubusercontent.com/18689448/90174567-35655680-dd74-11ea-953b-4b3c99afe233.png)