### PR TITLE
fix(apm|tracing): Make sure Performance Observer takeRecords() is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
+- [apm/tracing] fix: Make sure Performance Observer takeRecords() is defined
 
 ## 5.21.1
 

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -760,7 +760,9 @@ export class Tracing implements Integration {
       });
 
       Tracing._forceLCP = (): void => {
-        po.takeRecords().forEach(updateLCP);
+        if (po.takeRecords) {
+          po.takeRecords().forEach(updateLCP);
+        }
       };
     } catch (e) {
       // Do nothing if the browser doesn't support this API.

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -170,7 +170,9 @@ export class MetricsInstrumentation {
       });
 
       this._forceLCP = () => {
-        po.takeRecords().forEach(updateLCP);
+        if (po.takeRecords) {
+          po.takeRecords().forEach(updateLCP);
+        }
       };
     } catch (e) {
       // Do nothing if the browser doesn't support this API.


### PR DESCRIPTION
In Safari 14.0 and below, `PerformanceObserver.takeRecords()` is not defined. We should defend against it by
checking for existance before usage. In the future, we may have to look for another way to track PO records
for these browsers.

Also an issue for IE 11.