### PR TITLE
fix(tracing): Normalize transaction names for express methods to match those of other SDKs

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -113,7 +113,7 @@ function extractTransaction(req: { [key: string]: any }, type: boolean | Transac
       case 'methodPath':
       default: {
         const method = request.method.toUpperCase();
-        return `${method}|${routePath}`;
+        return `${method} ${routePath}`;
       }
     }
   } catch (_oO) {

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -138,20 +138,20 @@ describe('parseRequest', () => {
   describe('parseRequest.transaction property', () => {
     test('extracts method and full route path by default from `originalUrl`', () => {
       const parsedRequest: Event = parseRequest({}, mockReq);
-      expect(parsedRequest.transaction).toEqual('POST|/some/originalUrl');
+      expect(parsedRequest.transaction).toEqual('POST /some/originalUrl');
     });
 
     test('extracts method and full route path by default from `url` if `originalUrl` is not present', () => {
       delete mockReq.originalUrl;
       const parsedRequest: Event = parseRequest({}, mockReq);
-      expect(parsedRequest.transaction).toEqual('POST|/some/url');
+      expect(parsedRequest.transaction).toEqual('POST /some/url');
     });
 
     test('fallback to method and `route.path` if previous attempts failed', () => {
       delete mockReq.originalUrl;
       delete mockReq.url;
       const parsedRequest: Event = parseRequest({}, mockReq);
-      expect(parsedRequest.transaction).toEqual('POST|/path');
+      expect(parsedRequest.transaction).toEqual('POST /path');
     });
 
     test('can extract path only instead if configured', () => {


### PR DESCRIPTION
In the Sentry product, and in particular, the Performance transaction summary page, we rely on transaction names (i.e. `transaction` tag) to find other things like Issues.

We normalize the transaction name by dropping the `|` character for the Express tracing integration library.  