### PR TITLE
fix: Return type `any` from createReduxEnhancer to avoid type conflicts

### DIFF
--- a/packages/react/src/redux.ts
+++ b/packages/react/src/redux.ts
@@ -39,10 +39,6 @@ type PreloadedState<S> = Required<S> extends {
     : never
   : { [K in keyof S]: S[K] extends string | number | boolean | symbol ? S[K] : PreloadedState<S[K]> };
 
-type StoreEnhancer<Ext = Record<string, unknown>, StateExt = never> = (
-  next: StoreEnhancerStoreCreator<Ext, StateExt>,
-) => StoreEnhancerStoreCreator<Ext, StateExt>;
-
 type StoreEnhancerStoreCreator<Ext = Record<string, unknown>, StateExt = never> = <
   S = any,
   A extends Action = AnyAction
@@ -84,7 +80,8 @@ const defaultOptions: SentryEnhancerOptions = {
  *
  * @param enhancerOptions Options to pass to the enhancer
  */
-function createReduxEnhancer(enhancerOptions?: Partial<SentryEnhancerOptions>): StoreEnhancer {
+function createReduxEnhancer(enhancerOptions?: Partial<SentryEnhancerOptions>): any {
+  // Note: We return an any type as to not have type conflicts.
   const options = {
     ...defaultOptions,
     ...enhancerOptions,


### PR DESCRIPTION
Return an `any` type instead for `Sentry.createReduxEnhancer` exported from `@sentry/redux` to avoid type conflicts.

Fixes https://github.com/getsentry/sentry-javascript/issues/2829