### PR TITLE
fix(node): save string exception as message of synthetic

### DIFF
--- a/packages/node/src/backend.ts
+++ b/packages/node/src/backend.ts
@@ -74,6 +74,7 @@ export class NodeBackend extends BaseBackend<NodeOptions> {
         // This handles when someone does: `throw "something awesome";`
         // We use synthesized Error here so we can extract a (rough) stack trace.
         ex = (hint && hint.syntheticException) || new Error(exception as string);
+        (ex as Error).message = exception;
       }
       mechanism.synthetic = true;
     }

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -102,7 +102,7 @@ describe('SentryNode', () => {
     });
 
     test('capture an exception', done => {
-      expect.assertions(5);
+      expect.assertions(6);
       getCurrentHub().bindClient(
         new NodeClient({
           beforeSend: (event: Event) => {
@@ -111,6 +111,7 @@ describe('SentryNode', () => {
             expect(event.exception!.values![0]).not.toBeUndefined();
             expect(event.exception!.values![0].stacktrace!).not.toBeUndefined();
             expect(event.exception!.values![0].stacktrace!.frames![2]).not.toBeUndefined();
+            expect(event.exception!.values![0].value).toEqual('test');
             done();
             return null;
           },
@@ -122,6 +123,33 @@ describe('SentryNode', () => {
       });
       try {
         throw new Error('test');
+      } catch (e) {
+        captureException(e);
+      }
+    });
+
+    test('capture a string exception', done => {
+      expect.assertions(6);
+      getCurrentHub().bindClient(
+        new NodeClient({
+          beforeSend: (event: Event) => {
+            expect(event.tags).toEqual({ test: '1' });
+            expect(event.exception).not.toBeUndefined();
+            expect(event.exception!.values![0]).not.toBeUndefined();
+            expect(event.exception!.values![0].stacktrace!).not.toBeUndefined();
+            expect(event.exception!.values![0].stacktrace!.frames![2]).not.toBeUndefined();
+            expect(event.exception!.values![0].value).toEqual('test string exception');
+            done();
+            return null;
+          },
+          dsn,
+        }),
+      );
+      configureScope((scope: Scope) => {
+        scope.setTag('test', '1');
+      });
+      try {
+        throw 'test string exception';
       } catch (e) {
         captureException(e);
       }


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/2830
Throwing a string in node causes the exception to appear as 'Sentry syntheticException'
in Sentry UI. This saves the string as a message of the syntheticException
so that the correct message is reported.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
