### PR TITLE
build: Run Zeus for release/ branches only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
     name: BrowserStack
     needs: job_build
     runs-on: ubuntu-latest
-    if: "'refs/heads/master' == github.ref || startsWith(github.ref, 'refs/tags/')"
+    if: "github.ref == 'refs/heads/master'"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -122,6 +122,7 @@ jobs:
     name: Zeus
     needs: job_build
     runs-on: ubuntu-latest
+    if: "contains(github.ref, 'release/')"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -157,6 +158,7 @@ jobs:
     name: Artifacts Upload
     needs: job_build
     runs-on: ubuntu-latest
+    if: "contains(github.ref, 'release/')"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1


### PR DESCRIPTION
- run Zeus for release/ branches only
- move artifacts upload higher on the list so that conditional steps are always last

1) Why do we run upload artifacts at all anyway? Do we need it every time?
2) Should we use the same `if` check for BrowserStack? Not sure why we use `tag` there