### PR TITLE
ref(gatsby): Make `@sentry/tracing` mandatory + add tests

### DIFF
--- a/packages/gatsby/.eslintrc.js
+++ b/packages/gatsby/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
   },
   parserOptions: {
     ecmaVersion: 2018,
+    jsx: true,
   },
   extends: ['@sentry-internal/sdk'],
   ignorePatterns: ['build/**', 'dist/**', 'esm/**', 'examples/**', 'scripts/**'],

--- a/packages/gatsby/README.md
+++ b/packages/gatsby/README.md
@@ -40,7 +40,7 @@ To automatically capture the `release` value on Vercel you will need to register
 
 ## Sentry Performance
 
-To enable Tracing support, supply the `tracesSampleRate` to the options and make sure you have installed the `@sentry/tracing` package.
+To enable Tracing support, supply the `tracesSampleRate` to the options and make sure you have installed the `@sentry/tracing` package. This will also turn on the `BrowserTracing` integration for automatic instrumentation of the browser.
 
 ```javascript
 {
@@ -51,6 +51,28 @@ To enable Tracing support, supply the `tracesSampleRate` to the options and make
       options: {
           dsn: process.env.SENTRY_DSN, // this is the default
           tracesSampleRate: 1, // this is just to test, you should lower this in production
+      }
+    },
+    // ...
+  ]
+}
+```
+
+If you want to supply options to the `BrowserTracing` integration, use the `browserTracingOptions` parameter.
+
+```javascript
+{
+  // ...
+  plugins: [
+    {
+      resolve: "@sentry/gatsby",
+      options: {
+          dsn: process.env.SENTRY_DSN, // this is the default
+          tracesSampleRate: 1, // this is just to test, you should lower this in production
+          browserTracingOptions: {
+            // disable creating spans for XHR requests
+            traceXHR: false,
+          }
       }
     },
     // ...

--- a/packages/gatsby/gatsby-browser.js
+++ b/packages/gatsby/gatsby-browser.js
@@ -1,31 +1,14 @@
 exports.onClientEntry = function(_, pluginParams) {
-  require.ensure(['@sentry/react'], function(require) {
+  require.ensure(['@sentry/react', '@sentry/tracing'], function(require) {
     const Sentry = require('@sentry/react');
-
-    let TracingIntegration = undefined;
-    let BrowserTracingIntegration = undefined;
-    try {
-      BrowserTracingIntegration = require('@sentry/tracing').Integrations.BrowserTracing;
-    } catch (_) {
-      /* no-empty */
-    }
-    try {
-      /** @deprecated Remove when @sentry/apm is no longer used */
-      TracingIntegration = require('@sentry/apm').Integrations.Tracing;
-    } catch (_) {
-      /* no-empty */
-    }
-
+    const Tracing = require('@sentry/tracing');
     const tracesSampleRate = pluginParams.tracesSampleRate !== undefined ? pluginParams.tracesSampleRate : 0;
     const integrations = [...(pluginParams.integrations || [])];
 
-    if (tracesSampleRate) {
-      if (BrowserTracingIntegration) {
-        integrations.push(new BrowserTracingIntegration());
-      } else if (TracingIntegration) {
-        integrations.push(new TracingIntegration());
-      }
+    if (tracesSampleRate && !integrations.some(ele => ele.id === 'BrowserTracing')) {
+      integrations.push(new Tracing.Integrations.BrowserTracing(pluginParams.browserTracingOptions));
     }
+    console.log(pluginParams);
 
     Sentry.init({
       environment: process.env.NODE_ENV || 'development',
@@ -33,10 +16,16 @@ exports.onClientEntry = function(_, pluginParams) {
       release: __SENTRY_RELEASE__,
       // eslint-disable-next-line no-undef
       dsn: __SENTRY_DSN__,
+      beforeSend: event => {
+        console.log(event);
+        return null;
+      },
       ...pluginParams,
       tracesSampleRate,
       integrations,
     });
+
+    Tracing.addExtensionMethods();
 
     Sentry.addGlobalEventProcessor(event => {
       event.sdk = {

--- a/packages/gatsby/gatsby-browser.js
+++ b/packages/gatsby/gatsby-browser.js
@@ -2,12 +2,18 @@ const Sentry = require('@sentry/react');
 const Tracing = require('@sentry/tracing');
 
 exports.onClientEntry = function(_, pluginParams) {
+  if (pluginParams === undefined) {
+    return;
+  }
+
   const tracesSampleRate = pluginParams.tracesSampleRate !== undefined ? pluginParams.tracesSampleRate : 0;
   const integrations = [...(pluginParams.integrations || [])];
 
-  if (tracesSampleRate && !integrations.some(ele => ele.id === 'BrowserTracing')) {
+  if (tracesSampleRate && !integrations.some(ele => ele.name === 'BrowserTracing')) {
     integrations.push(new Tracing.Integrations.BrowserTracing(pluginParams.browserTracingOptions));
   }
+
+  Tracing.addExtensionMethods();
 
   Sentry.init({
     environment: process.env.NODE_ENV || 'development',
@@ -19,8 +25,6 @@ exports.onClientEntry = function(_, pluginParams) {
     tracesSampleRate,
     integrations,
   });
-
-  Tracing.addExtensionMethods();
 
   Sentry.addGlobalEventProcessor(event => {
     event.sdk = {

--- a/packages/gatsby/gatsby-browser.js
+++ b/packages/gatsby/gatsby-browser.js
@@ -1,47 +1,41 @@
+const Sentry = require('@sentry/react');
+const Tracing = require('@sentry/tracing');
+
 exports.onClientEntry = function(_, pluginParams) {
-  require.ensure(['@sentry/react', '@sentry/tracing'], function(require) {
-    const Sentry = require('@sentry/react');
-    const Tracing = require('@sentry/tracing');
-    const tracesSampleRate = pluginParams.tracesSampleRate !== undefined ? pluginParams.tracesSampleRate : 0;
-    const integrations = [...(pluginParams.integrations || [])];
+  const tracesSampleRate = pluginParams.tracesSampleRate !== undefined ? pluginParams.tracesSampleRate : 0;
+  const integrations = [...(pluginParams.integrations || [])];
 
-    if (tracesSampleRate && !integrations.some(ele => ele.id === 'BrowserTracing')) {
-      integrations.push(new Tracing.Integrations.BrowserTracing(pluginParams.browserTracingOptions));
-    }
-    console.log(pluginParams);
+  if (tracesSampleRate && !integrations.some(ele => ele.id === 'BrowserTracing')) {
+    integrations.push(new Tracing.Integrations.BrowserTracing(pluginParams.browserTracingOptions));
+  }
 
-    Sentry.init({
-      environment: process.env.NODE_ENV || 'development',
-      // eslint-disable-next-line no-undef
-      release: __SENTRY_RELEASE__,
-      // eslint-disable-next-line no-undef
-      dsn: __SENTRY_DSN__,
-      beforeSend: event => {
-        console.log(event);
-        return null;
-      },
-      ...pluginParams,
-      tracesSampleRate,
-      integrations,
-    });
-
-    Tracing.addExtensionMethods();
-
-    Sentry.addGlobalEventProcessor(event => {
-      event.sdk = {
-        ...event.sdk,
-        name: 'sentry.javascript.gatsby',
-        packages: [
-          ...((event.sdk && event.sdk.packages) || []),
-          {
-            name: 'npm:@sentry/gatsby',
-            version: Sentry.SDK_VERSION,
-          },
-        ],
-        version: Sentry.SDK_VERSION,
-      };
-      return event;
-    });
-    window.Sentry = Sentry;
+  Sentry.init({
+    environment: process.env.NODE_ENV || 'development',
+    // eslint-disable-next-line no-undef
+    release: __SENTRY_RELEASE__,
+    // eslint-disable-next-line no-undef
+    dsn: __SENTRY_DSN__,
+    ...pluginParams,
+    tracesSampleRate,
+    integrations,
   });
+
+  Tracing.addExtensionMethods();
+
+  Sentry.addGlobalEventProcessor(event => {
+    event.sdk = {
+      ...event.sdk,
+      name: 'sentry.javascript.gatsby',
+      packages: [
+        ...((event.sdk && event.sdk.packages) || []),
+        {
+          name: 'npm:@sentry/gatsby',
+          version: Sentry.SDK_VERSION,
+        },
+      ],
+      version: Sentry.SDK_VERSION,
+    };
+    return event;
+  });
+  window.Sentry = Sentry;
 };

--- a/packages/gatsby/gatsby-node.js
+++ b/packages/gatsby/gatsby-node.js
@@ -1,24 +1,61 @@
+const Sentry = require('@sentry/node');
+
+const sentryRelease = JSON.stringify(
+  process.env.SENTRY_RELEASE ||
+    // GitHub Actions - https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
+    process.env.GITHUB_SHA ||
+    // Netlify - https://docs.netlify.com/configure-builds/environment-variables/#build-metadata
+    process.env.COMMIT_REF ||
+    // Vercel - https://vercel.com/docs/v2/build-step#system-environment-variables
+    process.env.VERCEL_GITHUB_COMMIT_SHA ||
+    process.env.VERCEL_GITLAB_COMMIT_SHA ||
+    process.env.VERCEL_BITBUCKET_COMMIT_SHA ||
+    // Zeit (now known as Vercel)
+    process.env.ZEIT_GITHUB_COMMIT_SHA ||
+    process.env.ZEIT_GITLAB_COMMIT_SHA ||
+    process.env.ZEIT_BITBUCKET_COMMIT_SHA ||
+    '',
+);
+
+const sentryDsn = JSON.stringify(process.env.SENTRY_DSN || '');
+
+exports.onPreBuild = (_, pluginParams) => {
+  if (!pluginParams || !pluginParams.trackBuild) {
+    return;
+  }
+
+  Sentry.init({
+    environment: process.env.NODE_ENV || 'development',
+    // eslint-disable-next-line no-undef
+    release: sentryRelease,
+    // eslint-disable-next-line no-undef
+    dsn: __SENTRY_DSN__,
+    ...pluginParams,
+  });
+
+  Sentry.addGlobalEventProcessor(event => {
+    event.sdk = {
+      ...event.sdk,
+      name: 'sentry.javascript.gatsby',
+      packages: [
+        ...((event.sdk && event.sdk.packages) || []),
+        {
+          name: 'npm:@sentry/gatsby',
+          version: Sentry.SDK_VERSION,
+        },
+      ],
+      version: Sentry.SDK_VERSION,
+    };
+    return event;
+  });
+};
+
 exports.onCreateWebpackConfig = ({ plugins, actions }) => {
   actions.setWebpackConfig({
     plugins: [
       plugins.define({
-        __SENTRY_RELEASE__: JSON.stringify(
-          process.env.SENTRY_RELEASE ||
-            // GitHub Actions - https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
-            process.env.GITHUB_SHA ||
-            // Netlify - https://docs.netlify.com/configure-builds/environment-variables/#build-metadata
-            process.env.COMMIT_REF ||
-            // Vercel - https://vercel.com/docs/v2/build-step#system-environment-variables
-            process.env.VERCEL_GITHUB_COMMIT_SHA ||
-            process.env.VERCEL_GITLAB_COMMIT_SHA ||
-            process.env.VERCEL_BITBUCKET_COMMIT_SHA ||
-            // Zeit (now known as Vercel)
-            process.env.ZEIT_GITHUB_COMMIT_SHA ||
-            process.env.ZEIT_GITLAB_COMMIT_SHA ||
-            process.env.ZEIT_BITBUCKET_COMMIT_SHA ||
-            '',
-        ),
-        __SENTRY_DSN__: JSON.stringify(process.env.SENTRY_DSN || ''),
+        __SENTRY_RELEASE__: sentryRelease,
+        __SENTRY_DSN__: sentryDsn,
       }),
     ],
   });

--- a/packages/gatsby/gatsby-node.js
+++ b/packages/gatsby/gatsby-node.js
@@ -1,6 +1,5 @@
-const Sentry = require('@sentry/node');
-
 const sentryRelease = JSON.stringify(
+  // Always read first as Sentry takes this as precedence
   process.env.SENTRY_RELEASE ||
     // GitHub Actions - https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
     process.env.GITHUB_SHA ||
@@ -18,37 +17,6 @@ const sentryRelease = JSON.stringify(
 );
 
 const sentryDsn = JSON.stringify(process.env.SENTRY_DSN || '');
-
-exports.onPreBuild = (_, pluginParams) => {
-  if (!pluginParams || !pluginParams.trackBuild) {
-    return;
-  }
-
-  Sentry.init({
-    environment: process.env.NODE_ENV || 'development',
-    // eslint-disable-next-line no-undef
-    release: sentryRelease,
-    // eslint-disable-next-line no-undef
-    dsn: __SENTRY_DSN__,
-    ...pluginParams,
-  });
-
-  Sentry.addGlobalEventProcessor(event => {
-    event.sdk = {
-      ...event.sdk,
-      name: 'sentry.javascript.gatsby',
-      packages: [
-        ...((event.sdk && event.sdk.packages) || []),
-        {
-          name: 'npm:@sentry/gatsby',
-          version: Sentry.SDK_VERSION,
-        },
-      ],
-      version: Sentry.SDK_VERSION,
-    };
-    return event;
-  });
-};
 
 exports.onCreateWebpackConfig = ({ plugins, actions }) => {
   actions.setWebpackConfig({

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -34,10 +34,12 @@
   },
   "devDependencies": {
     "@sentry-internal/eslint-config-sdk": "5.21.4",
+    "@testing-library/react": "^10.4.9",
     "eslint": "7.6.0",
     "jest": "^24.7.1",
     "npm-run-all": "^4.1.2",
     "prettier": "1.17.0",
+    "react": "^16.13.1",
     "rimraf": "^2.6.3",
     "typescript": "3.9.7"
   },

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@sentry/react": "5.21.4",
-    "@sentry/types": "5.21.4"
+    "@sentry/tracing": "5.21.4"
   },
   "peerDependencies": {
     "gatsby": "*"

--- a/packages/gatsby/test/gatsby-browser.test.ts
+++ b/packages/gatsby/test/gatsby-browser.test.ts
@@ -1,0 +1,132 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const { onClientEntry } = require('../gatsby-browser');
+
+(global as any).__SENTRY_RELEASE__ = '683f3a6ab819d47d23abfca9a914c81f0524d35b';
+(global as any).__SENTRY_DSN__ = 'https://examplePublicKey@o0.ingest.sentry.io/0';
+
+let sentryInit = jest.fn();
+let sentryProcessEvent: <T>(event: T) => T;
+jest.mock('@sentry/react', () => {
+  const original = jest.requireActual('@sentry/react');
+  return {
+    ...original,
+    init: (...args: any[]) => {
+      sentryInit(...args);
+    },
+    addGlobalEventProcessor: (callback: any) => {
+      sentryProcessEvent = callback;
+    },
+  };
+});
+
+let tracingAddExtensionMethods = jest.fn();
+jest.mock('@sentry/tracing', () => {
+  const original = jest.requireActual('@sentry/tracing');
+  return {
+    ...original,
+    addExtensionMethods: (...args: any[]) => {
+      tracingAddExtensionMethods(...args);
+    },
+  };
+});
+
+describe('onClientEntry', () => {
+  beforeEach(() => {
+    sentryInit = jest.fn();
+    tracingAddExtensionMethods = jest.fn();
+
+    // @ts-ignore need to set as undefined
+    sentryProcessEvent = undefined;
+  });
+
+  afterEach(() => {
+    (window as any).Sentry = undefined;
+  });
+
+  it('inits Sentry by default', () => {
+    onClientEntry(undefined, {});
+    expect(sentryInit).toHaveBeenCalledTimes(1);
+    expect(sentryInit).toHaveBeenLastCalledWith({
+      dsn: (global as any).__SENTRY_DSN__,
+      environment: process.env.NODE_ENV,
+      integrations: [],
+      release: (global as any).__SENTRY_RELEASE__,
+      tracesSampleRate: 0,
+    });
+  });
+
+  it('sets window.Sentry', () => {
+    onClientEntry(undefined, {});
+    expect((window as any).Sentry).not.toBeUndefined();
+  });
+
+  it('adds a global event processor', () => {
+    onClientEntry(undefined, {});
+    if (sentryProcessEvent) {
+      const changedEvent = sentryProcessEvent({});
+
+      expect(changedEvent).toEqual({
+        sdk: {
+          name: 'sentry.javascript.gatsby',
+          packages: [
+            {
+              name: 'npm:@sentry/gatsby',
+              version: expect.any(String),
+            },
+          ],
+          version: expect.any(String),
+        },
+      });
+    } else {
+      fail('process event not defined');
+    }
+  });
+
+  it('adds Tracing extension methods', () => {
+    onClientEntry(undefined, {});
+
+    expect(tracingAddExtensionMethods).toHaveBeenCalledTimes(1);
+    expect(tracingAddExtensionMethods).toHaveBeenLastCalledWith();
+  });
+
+  it('sets a tracesSampleRate if defined as option', () => {
+    onClientEntry(undefined, { tracesSampleRate: 0.5 });
+    expect(sentryInit).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        tracesSampleRate: 0.5,
+      }),
+    );
+  });
+
+  it('adds `BrowserTracing` integration if tracesSampleRate is defined', () => {
+    onClientEntry(undefined, { tracesSampleRate: 0.5 });
+    expect(sentryInit).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        integrations: [expect.objectContaining({ name: 'BrowserTracing' })],
+      }),
+    );
+  });
+
+  it('only defines a single `BrowserTracing` integration', () => {
+    const Tracing = jest.requireActual('@sentry/tracing');
+    const integrations = [new Tracing.Integrations.BrowserTracing()];
+    onClientEntry(undefined, { tracesSampleRate: 0.5, integrations });
+
+    expect(sentryInit).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        integrations: [expect.objectContaining({ name: 'BrowserTracing' })],
+      }),
+    );
+  });
+
+  // Run this last to check for any test side effects
+  it('does not run if plugin params are undefined', () => {
+    onClientEntry();
+    expect(sentryInit).toHaveBeenCalledTimes(0);
+    expect((window as any).Sentry).toBeUndefined();
+    expect(sentryProcessEvent).toBeUndefined();
+    expect(tracingAddExtensionMethods).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/gatsby/test/gatsby-node.test.ts
+++ b/packages/gatsby/test/gatsby-node.test.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const { onCreateWebpackConfig } = require('../gatsby-node');
+
+describe('onCreateWebpackConfig', () => {
+  it('sets a webpack config', () => {
+    const plugins = {
+      define: jest.fn(),
+    };
+
+    const actions = {
+      setWebpackConfig: jest.fn(),
+    };
+
+    onCreateWebpackConfig({ plugins, actions });
+
+    expect(plugins.define).toHaveBeenCalledTimes(1);
+    expect(plugins.define).toHaveBeenLastCalledWith({ __SENTRY_DSN__: '""', __SENTRY_RELEASE__: '""' });
+
+    expect(actions.setWebpackConfig).toHaveBeenCalledTimes(1);
+    expect(actions.setWebpackConfig).toHaveBeenLastCalledWith({ plugins: expect.any(Array) });
+  });
+});

--- a/packages/gatsby/test/gatsby-node.test.ts
+++ b/packages/gatsby/test/gatsby-node.test.ts
@@ -16,7 +16,10 @@ describe('onCreateWebpackConfig', () => {
     onCreateWebpackConfig({ plugins, actions });
 
     expect(plugins.define).toHaveBeenCalledTimes(1);
-    expect(plugins.define).toHaveBeenLastCalledWith({ __SENTRY_DSN__: '""', __SENTRY_RELEASE__: '""' });
+    expect(plugins.define).toHaveBeenLastCalledWith({
+      __SENTRY_DSN__: expect.any(String),
+      __SENTRY_RELEASE__: expect.any(String),
+    });
 
     expect(actions.setWebpackConfig).toHaveBeenCalledTimes(1);
     expect(actions.setWebpackConfig).toHaveBeenLastCalledWith({ plugins: expect.any(Array) });

--- a/packages/gatsby/test/integration.test.tsx
+++ b/packages/gatsby/test/integration.test.tsx
@@ -1,0 +1,39 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { render } from '@testing-library/react';
+import * as React from 'react';
+
+import { onClientEntry } from '../gatsby-browser';
+
+beforeAll(() => {
+  (global as any).__SENTRY_RELEASE__ = '683f3a6ab819d47d23abfca9a914c81f0524d35b';
+  (global as any).__SENTRY_DSN__ = 'https://examplePublicKey@o0.ingest.sentry.io/0';
+});
+
+describe('useEffect', () => {
+  it('captures error in use effect', () => {
+    let calls = 0;
+
+    onClientEntry(undefined, {
+      beforeSend: event => {
+        expect(event).not.toBeUndefined();
+        calls += 1;
+
+        return null;
+      },
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    function TestComponent() {
+      React.useEffect(() => {
+        const error = new Error('testing 123');
+        (window as any).Sentry.captureException(error);
+      });
+
+      return <div>Hello</div>;
+    }
+
+    render(<TestComponent />);
+
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/gatsby/tsconfig.build.json
+++ b/packages/gatsby/tsconfig.build.json
@@ -1,8 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "esModuleInterop": true,
     "baseUrl": ".",
-    "outDir": "dist"
+    "outDir": "dist",
+    "jsx": "react"
   },
   "include": ["src/**/*"]
 }

--- a/packages/gatsby/tsconfig.esm.json
+++ b/packages/gatsby/tsconfig.esm.json
@@ -1,8 +1,10 @@
 {
   "extends": "../../tsconfig.esm.json",
   "compilerOptions": {
+    "esModuleInterop": true,
     "baseUrl": ".",
     "outDir": "esm",
+    "jsx": "react"
   },
   "include": ["src/**/*"]
 }

--- a/packages/gatsby/tsconfig.json
+++ b/packages/gatsby/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "extends": "./tsconfig.build.json",
-  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "include": ["src/**/*.ts", "test/**/*.ts", "test/integration.test.tsx", "src/**/*.tsx", "test/**/*.tsx"],
   "exclude": ["dist"],
   "compilerOptions": {
     "rootDir": ".",
-    "types": ["node", "jest"]
+    "types": ["jest"]
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "@sentry-internal/eslint-config-sdk": "5.21.4",
-    "@testing-library/react": "^10.0.6",
+    "@testing-library/react": "^10.4.9",
     "@testing-library/react-hooks": "^3.3.0",
     "@types/history-4": "npm:@types/history@4.7.7",
     "@types/history-5": "npm:@types/history@4.7.7",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,13 +10,13 @@ if [[ "$(cut -d. -f1 <<< "$TRAVIS_NODE_VERSION")" -le 6 ]]; then
   yarn build --ignore="@sentry/ember"
   nvm use 6
   # browser can be tested only on Node >= v8 because Karma is not supporting anything older
-  yarn test --ignore="@sentry/browser" --ignore="@sentry/integrations" --ignore="@sentry/react" --ignore="@sentry/ember" --ignore="@sentry/tracing" --ignore="@sentry-internal/eslint-plugin-sdk" --ignore="@sentry-internal/eslint-config-sdk"
+  yarn test --ignore="@sentry/browser" --ignore="@sentry/integrations" --ignore="@sentry/react" --ignore="@sentry/gatsby" --ignore="@sentry/ember" --ignore="@sentry/tracing" --ignore="@sentry-internal/eslint-plugin-sdk" --ignore="@sentry-internal/eslint-config-sdk"
 elif [[ "$(cut -d. -f1 <<< "$TRAVIS_NODE_VERSION")" -le 8 ]]; then
   yarn install --ignore-engines --ignore-scripts
   # ember requires Node >= 10 to build
   yarn build --ignore="@sentry/ember"
   # tracing, ember and react work only on Node >= v10
-  yarn test --ignore="@sentry/tracing" --ignore="@sentry/react" --ignore="@sentry/ember" --ignore="@sentry-internal/eslint-plugin-sdk" --ignore="@sentry-internal/eslint-config-sdk"
+  yarn test --ignore="@sentry/tracing" --ignore="@sentry/react" --ignore="@sentry/gatsby" --ignore="@sentry/ember" --ignore="@sentry-internal/eslint-plugin-sdk" --ignore="@sentry-internal/eslint-config-sdk"
 else
   yarn install
   yarn build

--- a/yarn.lock
+++ b/yarn.lock
@@ -1538,15 +1538,16 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jest/types@^25.5.0":
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
-  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
+"@jest/types@^26.3.0":
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.3.0.tgz#97627bf4bdb72c55346eef98e3b3f7ddc4941f71"
+  integrity sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^1.1.1"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
     "@types/yargs" "^15.0.0"
-    chalk "^3.0.0"
+    chalk "^4.0.0"
 
 "@lerna/add@3.13.3":
   version "3.13.3"
@@ -2414,16 +2415,16 @@
   dependencies:
     highlight.js "^9.15.6"
 
-"@testing-library/dom@^7.17.1":
-  version "7.21.4"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.21.4.tgz#24b045f3161b7c91fdb35da7c001908cdc99b55b"
-  integrity sha512-IXjKRTAH31nQ+mx6q3IPw85RTLul8VlWBm1rxURoxDt7JI0HPlAAfbtrKTdeq83XYCYO7HSHogyV+OsD+6FX0Q==
+"@testing-library/dom@^7.22.3":
+  version "7.22.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.22.5.tgz#178fb0bfb52540538667f2f72d4b7fb406a49499"
+  integrity sha512-qALmosaNSny/JqQ+mDhdT0N5u1a76pEcOvfWFDpBQOchtkxDm/w/bCfe0J/K7nHrwJPHelFiAZksaBs//P9fsw==
   dependencies:
     "@babel/runtime" "^7.10.3"
     "@types/aria-query" "^4.2.0"
     aria-query "^4.2.2"
-    dom-accessibility-api "^0.4.6"
-    pretty-format "^25.5.0"
+    dom-accessibility-api "^0.5.1"
+    pretty-format "^26.4.2"
 
 "@testing-library/react-hooks@^3.3.0":
   version "3.4.0"
@@ -2433,13 +2434,13 @@
     "@babel/runtime" "^7.5.4"
     "@types/testing-library__react-hooks" "^3.3.0"
 
-"@testing-library/react@^10.0.6":
-  version "10.4.7"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.4.7.tgz#fc14847fb70a5e93576b8f7f0d1490ead02a9061"
-  integrity sha512-hUYbum3X2f1ZKusKfPaooKNYqE/GtPiQ+D2HJaJ4pkxeNJQFVUEvAvEh9+3QuLdBeTWkDMNY5NSijc5+pGdM4Q==
+"@testing-library/react@^10.4.9":
+  version "10.4.9"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.4.9.tgz#9faa29c6a1a217bf8bbb96a28bd29d7a847ca150"
+  integrity sha512-pHZKkqUy0tmiD81afs8xfiuseXfU/N7rAX3iKjeZYje86t9VaB0LrxYVa+OOsvkrveX5jCK3IjajVn2MbePvqA==
   dependencies:
     "@babel/runtime" "^7.10.3"
-    "@testing-library/dom" "^7.17.1"
+    "@testing-library/dom" "^7.22.3"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -2803,6 +2804,13 @@
   integrity sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
   dependencies:
     "@types/istanbul-lib-coverage" "*"
+    "@types/istanbul-lib-report" "*"
+
+"@types/istanbul-reports@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
+  integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
+  dependencies:
     "@types/istanbul-lib-report" "*"
 
 "@types/jest@^24.0.11":
@@ -7322,10 +7330,10 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.4.6:
-  version "0.4.6"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.4.6.tgz#f3f2af68aee01b1c862f37918d41841bb1aaf92a"
-  integrity sha512-qxFVFR/ymtfamEQT/AsYLe048sitxFCoCHiM+vuOdR3fE94i3so2SCFJxyz/RxV69PZ+9FgToYWOd7eqJqcbYw==
+dom-accessibility-api@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.1.tgz#152f5e88583d900977119223e3e76c2d93d23830"
+  integrity sha512-8DhtmKTYWXNpPiL/QOszbnkAbCGuPz9ieVwDrmWM1rNx4KRI3zqmvKANAD1PJdvvov3+eq1BPLXQkYTpqTrWng==
 
 dom-serialize@^2.2.0:
   version "2.2.1"
@@ -14894,12 +14902,12 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
-pretty-format@^25.5.0:
-  version "25.5.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
-  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
+pretty-format@^26.4.2:
+  version "26.4.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.4.2.tgz#d081d032b398e801e2012af2df1214ef75a81237"
+  integrity sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==
   dependencies:
-    "@jest/types" "^25.5.0"
+    "@jest/types" "^26.3.0"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
@@ -15301,7 +15309,7 @@ react-test-renderer@^16.13.1:
     react-is "^16.8.6"
     scheduler "^0.19.1"
 
-react@^16.0.0:
+react@^16.0.0, react@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==


### PR DESCRIPTION
A couple of changes here.

1) Add tests for `gatsby-browser` and `gatsby-node` 😎 

```
--------------------|----------|----------|----------|----------|-------------------|
File                |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
--------------------|----------|----------|----------|----------|-------------------|
All files           |      100 |    92.59 |      100 |      100 |                   |
 gatsby             |      100 |    92.59 |      100 |      100 |                   |
  gatsby-browser.js |      100 |    86.67 |      100 |      100 |             19,34 |
  gatsby-node.js    |      100 |      100 |      100 |      100 |                   |
 gatsby/src         |      100 |      100 |      100 |      100 |                   |
  index.ts          |      100 |      100 |      100 |      100 |                   |
--------------------|----------|----------|----------|----------|-------------------|
```

2) Refactor gatsby to add `@sentry/tracing` by default.

3) Remove the `require.ensure` call inside the `onClientEntry`, as that was causing a delay in initialization. This fixes https://github.com/getsentry/sentry-javascript/issues/2785.

Tested with unit tests and by checking in `develop` docs.