### PR TITLE
build: Lock in TypeScript to 3.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "lerna run --stream --concurrency 1 --sort build",
+    "build": "node ./scripts/verify-packages-versions.js && lerna run --stream --concurrency 1 --sort build",
     "build:es5": "lerna run --stream --concurrency 1 --sort build:es5",
     "build:esm": "lerna run --stream --concurrency 1 --sort build:esm",
     "build:watch": "lerna run build:watch --stream --no-sort --concurrency 9999",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "size-limit": "^4.5.5",
     "ts-jest": "^24.0.2",
     "typedoc": "^0.18.0",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "resolutions": {
     "**/agent-base": "5"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -31,7 +31,7 @@
     "npm-run-all": "^4.1.2",
     "prettier": "1.17.0",
     "rimraf": "^2.6.3",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "build": "run-p build:es5 build:esm",

--- a/packages/apm/package.json
+++ b/packages/apm/package.json
@@ -37,7 +37,7 @@
     "rollup-plugin-node-resolve": "^4.2.3",
     "rollup-plugin-terser": "^4.0.4",
     "rollup-plugin-typescript2": "^0.21.0",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "build": "run-p build:es5 build:esm build:bundle",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -51,7 +51,7 @@
     "rollup-plugin-terser": "^4.0.4",
     "rollup-plugin-typescript2": "^0.21.0",
     "sinon": "^7.3.2",
-    "typescript": "3.9.7",
+    "typescript": "3.7.5",
     "webpack": "^4.30.0"
   },
   "scripts": {

--- a/packages/browser/test/unit/transports/fetch.test.ts
+++ b/packages/browser/test/unit/transports/fetch.test.ts
@@ -18,7 +18,7 @@ let transport: Transports.BaseTransport;
 
 describe('FetchTransport', () => {
   beforeEach(() => {
-    fetch = stub(window, 'fetch');
+    fetch = (stub(window, 'fetch') as unknown) as SinonStub;
     transport = new Transports.FetchTransport({ dsn: testDsn });
   });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,7 @@
     "npm-run-all": "^4.1.2",
     "prettier": "1.17.0",
     "rimraf": "^2.6.3",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "build": "run-p build:es5 build:esm",

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -75,7 +75,7 @@
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "qunit-dom": "^1.2.0",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/packages/eslint-config-sdk/package.json
+++ b/packages/eslint-config-sdk/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "eslint": "7.6.0",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "link:yarn": "yarn link",

--- a/packages/eslint-plugin-sdk/package.json
+++ b/packages/eslint-plugin-sdk/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "mocha": "^6.2.0",
     "prettier": "1.17.0",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "link:yarn": "yarn link",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -41,7 +41,7 @@
     "prettier": "1.17.0",
     "react": "^16.13.1",
     "rimraf": "^2.6.3",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "build": "run-p build:es5 build:esm",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -27,7 +27,7 @@
     "npm-run-all": "^4.1.2",
     "prettier": "1.17.0",
     "rimraf": "^2.6.3",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "build": "run-p build:es5 build:esm",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -34,7 +34,7 @@
     "rollup-plugin-node-resolve": "^4.2.3",
     "rollup-plugin-terser": "^4.0.4",
     "rollup-plugin-typescript2": "^0.21.0",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "build": "run-p build:es5 build:esm build:bundle",

--- a/packages/minimal/package.json
+++ b/packages/minimal/package.json
@@ -27,7 +27,7 @@
     "npm-run-all": "^4.1.2",
     "prettier": "1.17.0",
     "rimraf": "^2.6.3",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "build": "run-p build:es5 build:esm",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -38,7 +38,7 @@
     "npm-run-all": "^4.1.2",
     "prettier": "1.17.0",
     "rimraf": "^2.6.3",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "build": "run-p build:es5 build:esm",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -55,7 +55,7 @@
     "react-test-renderer": "^16.13.1",
     "redux": "^4.0.5",
     "rimraf": "^2.6.3",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "build": "run-p build:es5 build:esm",

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -39,7 +39,7 @@
     "rollup-plugin-node-resolve": "^4.2.3",
     "rollup-plugin-terser": "^4.0.4",
     "rollup-plugin-typescript2": "^0.21.0",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "build": "run-p build:es5 build:esm build:bundle",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -20,7 +20,7 @@
     "eslint": "7.6.0",
     "npm-run-all": "^4.1.2",
     "prettier": "1.17.0",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "build": "run-p build:es5 build:esm",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "tslint": "5.16.0",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "link:yarn": "yarn link",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -27,7 +27,7 @@
     "npm-run-all": "^4.1.2",
     "prettier": "1.17.0",
     "rimraf": "^2.6.3",
-    "typescript": "3.9.7"
+    "typescript": "3.7.5"
   },
   "scripts": {
     "build": "run-p build:es5 build:esm",

--- a/scripts/verify-packages-versions.js
+++ b/scripts/verify-packages-versions.js
@@ -1,0 +1,27 @@
+const pkg = require('../package.json');
+
+const TYPESCRIPT_VERSION = '3.7.5';
+
+if (pkg.devDependencies.typescript !== TYPESCRIPT_VERSION) {
+  console.error(`
+[INCORRECT PACKAGE VERSION]: Expected TypeScript v${TYPESCRIPT_VERSION}, got v${pkg.devDependencies.typescript}
+
+Starting version 3.9, TypeScript emits module exports using \`Object.defineProperty\`,
+with \`configurable: false\`, instead of \`exports.thing = module.thing;\` as it always used to do.
+This means, that any object mutation after the initial compilation are impossible and makes
+the package slightly less open for modifications, and prevent users from experimenting with it,
+and from implementing some of their scenarios.
+
+If you REALLY know what you are doing, and you REALLY want to use a different version of TypeScript,
+modify \`TYPESCRIPT_VERSION\` constant at the top of this file.
+
+change: https://github.com/getsentry/sentry-javascript/pull/2848
+ref: https://github.com/getsentry/sentry-javascript/issues/2845
+ref: https://twitter.com/wesleytodd/status/1297974661574262784
+
+"Never upgrade a TypeScript version without a major package bump. Just don't." — Kamil
+`);
+  process.exit(1);
+}
+
+process.exit(0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -17930,10 +17930,10 @@ typescript-memoize@^1.0.0-alpha.3:
   dependencies:
     core-js "2.4.1"
 
-typescript@3.9.7:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@3.7.5:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
+  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
 
 ua-parser-js@^0.7.18:
   version "0.7.21"


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/2845

I wasn't able to compile `@sentry/ember` with any version of TypeScript 3.8, despite it working just with `3.7` and `3.9`, I don't even...
Version 3.8 doesn't add any features that we use anyway, so we can ignore it - https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html

The lesson for the future: **never upgrade a typescript version without major package bump, as they don't use semver**
(this should be a poster in every office)