### PR TITLE
fix: A bunch of typos

### DIFF
--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -64,7 +64,7 @@ import { createErrorHandler } from '@sentry/angular';
 export class AppModule {}
 ```
 
-Additionally, `createErrorHandler` accepts a set of options that allows you to configure its behaviour. For more details
+Additionally, `createErrorHandler` accepts a set of options that allows you to configure its behavior. For more details
 see `ErrorHandlerOptions` interface in `src/errorhandler.ts`.
 
 ### Tracing
@@ -76,9 +76,9 @@ components initializations.
 
 #### Install
 
-Registering a Trace Service is a 3 steps process.
+Registering a Trace Service is a 3-step process.
 
-1. Register and configure `@sentry/tracing` `BrowserTracing` integration, including custom Angular routing
+1. Register and configure the `BrowserTracing` integration from `@sentry/tracing`, including custom Angular routing
    instrumentation:
 
 ```javascript
@@ -117,7 +117,7 @@ import { TraceService } from '@sentry/angular';
 export class AppModule {}
 ```
 
-3. Either require the `TraceService` from inside `AppModule` or use `APP_INITIALIZER` to force instantiate Tracing.
+3. Either require the `TraceService` from inside `AppModule` or use `APP_INITIALIZER` to force-instantiate Tracing.
 
 ```javascript
 @NgModule({

--- a/packages/angular/src/errorhandler.ts
+++ b/packages/angular/src/errorhandler.ts
@@ -3,7 +3,7 @@ import { ErrorHandler as AngularErrorHandler, Injectable } from '@angular/core';
 import * as Sentry from '@sentry/browser';
 
 /**
- * Options used to configure the behaviour of the Angular ErrorHandler.
+ * Options used to configure the behavior of the Angular ErrorHandler.
  */
 export interface ErrorHandlerOptions {
   logErrors?: boolean;

--- a/packages/gatsby/README.md
+++ b/packages/gatsby/README.md
@@ -24,7 +24,7 @@ Register the package as a plugin in `gastby-config.js`:
 }
 ```
 
-Options will be passed directly to `Sentry.init`. See all available options in [our docs](https://docs.sentry.io/error-reporting/configuration/?platform=javascript). The `environment` value defaults to `NODE_ENV` (or `development` if not set).
+Options will be passed directly to `Sentry.init`. See all available options in [our docs](https://docs.sentry.io/error-reporting/configuration/?platform=javascript). The `environment` value defaults to `NODE_ENV` (or `'development'` if `NODE_ENV` is not set).
 
 ## GitHub Actions
 

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -25,8 +25,8 @@ import { Scope } from './scope';
 /**
  * API compatibility version of this hub.
  *
- * WARNING: This number should only be incresed when the global interface
- * changes a and new methods are introduced.
+ * WARNING: This number should only be increased when the global interface
+ * changes and new methods are introduced.
  *
  * @hidden
  */
@@ -457,7 +457,7 @@ export function getCurrentHub(): Hub {
 }
 
 /**
- * Try to read the hub from an active domain, fallback to the registry if one doesnt exist
+ * Try to read the hub from an active domain, and fallback to the registry if one doesn't exist
  * @returns discovered hub
  */
 function getHubFromActiveDomain(registry: Carrier): Hub {
@@ -473,12 +473,12 @@ function getHubFromActiveDomain(registry: Carrier): Hub {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const activeDomain = domain.active;
 
-    // If there no active domain, just return global hub
+    // If there's no active domain, just return global hub
     if (!activeDomain) {
       return getHubFromCarrier(registry);
     }
 
-    // If there's no hub on current domain, or its an old API, assign a new one
+    // If there's no hub on current domain, or it's an old API, assign a new one
     if (!hasHubOnCarrier(activeDomain) || getHubFromCarrier(activeDomain).isOlderThan(API_VERSION)) {
       const registryHubTopStack = getHubFromCarrier(registry).getStackTop();
       setHubOnCarrier(activeDomain, new Hub(registryHubTopStack.client, Scope.clone(registryHubTopStack.scope)));

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -16,7 +16,7 @@ import { flush } from './sdk';
 const DEFAULT_SHUTDOWN_TIMEOUT = 2000;
 
 /**
- * Express compatible tracing handler.
+ * Express-compatible tracing handler.
  * @see Exposed as `Handlers.tracingHandler`
  */
 export function tracingHandler(): (
@@ -29,7 +29,7 @@ export function tracingHandler(): (
     res: http.ServerResponse,
     next: (error?: any) => void,
   ): void {
-    // TODO: At this point req.route.path we use in `extractTransaction` is not available
+    // TODO: At this point `req.route.path` (which we use in `extractTransaction`) is not available
     // but `req.path` or `req.url` should do the job as well. We could unify this here.
     const reqMethod = (req.method || '').toUpperCase();
     const reqUrl = req.url;
@@ -38,8 +38,7 @@ export function tracingHandler(): (
     let parentSpanId;
     let sampled;
 
-    // If there is a trace header set, we extract the data from it and set the span on the scope
-    // to be the origin an created transaction set the parent_span_id / trace_id
+    // If there is a trace header set, we extract the data from it (parentSpanId, traceId, and sampling decision)
     if (req.headers && isString(req.headers['sentry-trace'])) {
       const span = Span.fromTraceparent(req.headers['sentry-trace'] as string);
       if (span) {

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -63,7 +63,7 @@ export interface BrowserTracingOptions extends RequestInstrumentationOptions {
 
   /**
    * beforeNavigate is called before a pageload/navigation transaction is created and allows for users
-   * to set custom transaction context. Defaults behaviour is to return `window.location.pathname`.
+   * to set custom transaction context. Default behavior is to return `window.location.pathname`.
    *
    * If undefined is returned, a pageload/navigation transaction will not be created.
    */

--- a/packages/tracing/src/browser/router.ts
+++ b/packages/tracing/src/browser/router.ts
@@ -30,9 +30,9 @@ export function defaultRoutingInstrumentation<T extends TransactionType>(
         /**
          * This early return is there to account for some cases where navigation transaction
          * starts right after long running pageload. We make sure that if `from` is undefined
-         * and that a valid `startingURL` exists, we don't uncessarily create a navigation transaction.
+         * and that a valid `startingURL` exists, we don't unnecessarily create a navigation transaction.
          *
-         * This was hard to duplicate, but this behaviour stopped as soon as this fix
+         * This was hard to duplicate, but this behavior stopped as soon as this fix
          * was applied. This issue might also only be caused in certain development environments
          * where the usage of a hot module reloader is causing errors.
          */

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -72,7 +72,7 @@ export class Transaction extends SpanClass {
 
     if (this.sampled !== true) {
       // At this point if `sampled !== true` we want to discard the transaction.
-      logger.warn('Discarding transaction because it was not chosen to be sampled.');
+      logger.log('Discarding transaction because its trace was not chosen to be sampled.');
       return undefined;
     }
 

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -72,7 +72,7 @@ export class Transaction extends SpanClass {
 
     if (this.sampled !== true) {
       // At this point if `sampled !== true` we want to discard the transaction.
-      logger.log('Discarding transaction because its trace was not chosen to be sampled.');
+      logger.log('[Tracing] Discarding transaction because its trace was not chosen to be sampled.');
       return undefined;
     }
 

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -81,8 +81,8 @@ export interface Options {
   /**
    * Sample rate to determine trace sampling.
    *
-   * 0.0 = 0% chance of instrumenting
-   * 1.0 = 100% chance of instrumenting
+   * 0.0 = 0% chance of a given trace being sent (send no traces)
+   * 1.0 = 100% chance of a given trace being sent (send all traces)
    *
    * Default: 0.0
    */

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -1,7 +1,7 @@
 import { Span, SpanContext } from './span';
 
 /**
- * Interface holding Transaction specific properties
+ * Interface holding Transaction-specific properties
  */
 export interface TransactionContext extends SpanContext {
   name: string;


### PR DESCRIPTION
Some of the changes are extracted from #2820 (changes that are unrelated to the main work in the PR -- thanks @lobsterkatie), while some are new fixes, like `behaviour` -> `behavior` (we use US spelling).