### PR TITLE
chore(build): Upgrade prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lerna": "3.13.4",
     "mocha": "^6.1.4",
     "npm-run-all": "^4.1.2",
-    "prettier": "1.17.0",
+    "prettier": "1.19.0",
     "replace-in-file": "^4.0.0",
     "rimraf": "^2.6.3",
     "sinon": "^7.3.2",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -29,7 +29,7 @@
     "@sentry-internal/eslint-config-sdk": "5.21.4",
     "eslint": "7.6.0",
     "npm-run-all": "^4.1.2",
-    "prettier": "1.17.0",
+    "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "typescript": "3.7.5"
   },

--- a/packages/apm/package.json
+++ b/packages/apm/package.json
@@ -29,7 +29,7 @@
     "eslint": "7.6.0",
     "jest": "^24.7.1",
     "npm-run-all": "^4.1.2",
-    "prettier": "1.17.0",
+    "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",

--- a/packages/apm/src/integrations/tracing.ts
+++ b/packages/apm/src/integrations/tracing.ts
@@ -510,9 +510,7 @@ export class Tracing implements Integration {
       if (Tracing._heartbeatCounter >= 3) {
         if (Tracing._activeTransaction) {
           Tracing._log(
-            `[Tracing] Transaction: ${
-              SpanStatus.Cancelled
-            } -> Heartbeat safeguard kicked in since content hasn't changed for 3 beats`,
+            `[Tracing] Transaction: ${SpanStatus.Cancelled} -> Heartbeat safeguard kicked in since content hasn't changed for 3 beats`,
           );
           Tracing._activeTransaction.setStatus(SpanStatus.DeadlineExceeded);
           Tracing._activeTransaction.setTag('heartbeat', 'failed');

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -42,7 +42,7 @@
     "karma-typescript-es6-transform": "^4.0.0",
     "node-fetch": "^2.6.0",
     "npm-run-all": "^4.1.2",
-    "prettier": "1.17.0",
+    "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
     "eslint": "7.6.0",
     "jest": "^24.7.1",
     "npm-run-all": "^4.1.2",
-    "prettier": "1.17.0",
+    "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "typescript": "3.7.5"
   },

--- a/packages/eslint-plugin-sdk/package.json
+++ b/packages/eslint-plugin-sdk/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "mocha": "^6.2.0",
-    "prettier": "1.17.0",
+    "prettier": "1.19.0",
     "typescript": "3.7.5"
   },
   "scripts": {

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -38,7 +38,7 @@
     "eslint": "7.6.0",
     "jest": "^24.7.1",
     "npm-run-all": "^4.1.2",
-    "prettier": "1.17.0",
+    "prettier": "1.19.0",
     "react": "^16.13.1",
     "rimraf": "^2.6.3",
     "typescript": "3.7.5"

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -25,7 +25,7 @@
     "eslint": "7.6.0",
     "jest": "^24.7.1",
     "npm-run-all": "^4.1.2",
-    "prettier": "1.17.0",
+    "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "typescript": "3.7.5"
   },

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -27,7 +27,7 @@
     "eslint": "7.6.0",
     "jest": "^24.7.1",
     "npm-run-all": "^4.1.2",
-    "prettier": "1.17.0",
+    "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",

--- a/packages/integrations/src/ember.ts
+++ b/packages/integrations/src/ember.ts
@@ -53,22 +53,19 @@ export class Ember implements Integration {
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this._Ember.RSVP.on(
-      'error',
-      (reason: unknown): void => {
-        if (getCurrentHub().getIntegration(Ember)) {
-          getCurrentHub().withScope(scope => {
-            if (isInstanceOf(reason, Error)) {
-              scope.setExtra('context', 'Unhandled Promise error detected');
-              getCurrentHub().captureException(reason, { originalException: reason as Error });
-            } else {
-              scope.setExtra('reason', reason);
-              getCurrentHub().captureMessage('Unhandled Promise error detected');
-            }
-          });
-        }
-      },
-    );
+    this._Ember.RSVP.on('error', (reason: unknown): void => {
+      if (getCurrentHub().getIntegration(Ember)) {
+        getCurrentHub().withScope(scope => {
+          if (isInstanceOf(reason, Error)) {
+            scope.setExtra('context', 'Unhandled Promise error detected');
+            getCurrentHub().captureException(reason, { originalException: reason as Error });
+          } else {
+            scope.setExtra('reason', reason);
+            getCurrentHub().captureMessage('Unhandled Promise error detected');
+          }
+        });
+      }
+    });
   }
   /* eslint-enable @typescript-eslint/no-unsafe-member-access */
 }

--- a/packages/integrations/src/offline.ts
+++ b/packages/integrations/src/offline.ts
@@ -68,11 +68,9 @@ export class Offline implements Integration {
         if ('navigator' in this.global && 'onLine' in this.global.navigator && !this.global.navigator.onLine) {
           this._cacheEvent(event)
             .then((_event: Event): Promise<void> => this._enforceMaxEvents())
-            .catch(
-              (_error): void => {
-                logger.warn('could not cache event while offline');
-              },
-            );
+            .catch((_error): void => {
+              logger.warn('could not cache event while offline');
+            });
 
           // return null on success or failure, because being offline will still result in an error
           return null;
@@ -105,12 +103,10 @@ export class Offline implements Integration {
     const events: Array<{ event: Event; cacheKey: string }> = [];
 
     return this.offlineEventStore
-      .iterate<Event, void>(
-        (event: Event, cacheKey: string, _index: number): void => {
-          // aggregate events
-          events.push({ cacheKey, event });
-        },
-      )
+      .iterate<Event, void>((event: Event, cacheKey: string, _index: number): void => {
+        // aggregate events
+        events.push({ cacheKey, event });
+      })
       .then(
         (): Promise<void> =>
           // this promise resolves when the iteration is finished
@@ -122,11 +118,9 @@ export class Offline implements Integration {
               .map(event => event.cacheKey),
           ),
       )
-      .catch(
-        (_error): void => {
-          logger.warn('could not enforce max events');
-        },
-      );
+      .catch((_error): void => {
+        logger.warn('could not enforce max events');
+      });
   }
 
   /**
@@ -148,22 +142,18 @@ export class Offline implements Integration {
    * send all events
    */
   private async _sendEvents(): Promise<void> {
-    return this.offlineEventStore.iterate<Event, void>(
-      (event: Event, cacheKey: string, _index: number): void => {
-        if (this.hub) {
-          const newEventId = this.hub.captureEvent(event);
+    return this.offlineEventStore.iterate<Event, void>((event: Event, cacheKey: string, _index: number): void => {
+      if (this.hub) {
+        const newEventId = this.hub.captureEvent(event);
 
-          if (newEventId) {
-            this._purgeEvent(cacheKey).catch(
-              (_error): void => {
-                logger.warn('could not purge event from cache');
-              },
-            );
-          }
-        } else {
-          logger.warn('no hub found - could not send cached event');
+        if (newEventId) {
+          this._purgeEvent(cacheKey).catch((_error): void => {
+            logger.warn('could not purge event from cache');
+          });
         }
-      },
-    );
+      } else {
+        logger.warn('no hub found - could not send cached event');
+      }
+    });
   }
 }

--- a/packages/integrations/src/reportingobserver.ts
+++ b/packages/integrations/src/reportingobserver.ts
@@ -90,7 +90,7 @@ export class ReportingObserver implements Integration {
     this._getCurrentHub = getCurrentHub;
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    const observer = new (getGlobalObject<any>()).ReportingObserver(this.handler.bind(this), {
+    const observer = new (getGlobalObject<any>().ReportingObserver)(this.handler.bind(this), {
       buffered: true,
       types: this._options.types,
     });

--- a/packages/minimal/package.json
+++ b/packages/minimal/package.json
@@ -25,7 +25,7 @@
     "eslint": "7.6.0",
     "jest": "^24.7.1",
     "npm-run-all": "^4.1.2",
-    "prettier": "1.17.0",
+    "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "typescript": "3.7.5"
   },

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -36,7 +36,7 @@
     "express": "^4.17.1",
     "jest": "^24.7.1",
     "npm-run-all": "^4.1.2",
-    "prettier": "1.17.0",
+    "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "typescript": "3.7.5"
   },

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -90,7 +90,7 @@ function extractTransaction(req: { [key: string]: any }, type: boolean | Transac
         stack: [
           {
             name: string;
-          }
+          },
         ];
       };
     };

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,7 +46,7 @@
     "jest": "^24.7.1",
     "jsdom": "^16.2.2",
     "npm-run-all": "^4.1.2",
-    "prettier": "1.17.0",
+    "prettier": "1.19.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-router-3": "npm:react-router@3.2.0",

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -31,7 +31,7 @@
     "jest": "^24.7.1",
     "jsdom": "^16.2.2",
     "npm-run-all": "^4.1.2",
-    "prettier": "1.17.0",
+    "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",

--- a/packages/tracing/src/browser/backgroundtab.ts
+++ b/packages/tracing/src/browser/backgroundtab.ts
@@ -16,9 +16,7 @@ export function registerBackgroundTabDetection(): void {
       const activeTransaction = getActiveTransaction() as IdleTransaction;
       if (global.document.hidden && activeTransaction) {
         logger.log(
-          `[Tracing] Transaction: ${SpanStatus.Cancelled} -> since tab moved to the background, op: ${
-            activeTransaction.op
-          }`,
+          `[Tracing] Transaction: ${SpanStatus.Cancelled} -> since tab moved to the background, op: ${activeTransaction.op}`,
         );
         // We should not set status if it is already set, this prevent important statuses like
         // error or data loss from being overwritten on transaction.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -19,7 +19,7 @@
     "@sentry-internal/eslint-config-sdk": "5.21.4",
     "eslint": "7.6.0",
     "npm-run-all": "^4.1.2",
-    "prettier": "1.17.0",
+    "prettier": "1.19.0",
     "typescript": "3.7.5"
   },
   "scripts": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,7 +25,7 @@
     "eslint": "7.6.0",
     "jest": "^24.7.1",
     "npm-run-all": "^4.1.2",
-    "prettier": "1.17.0",
+    "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "typescript": "3.7.5"
   },

--- a/packages/utils/src/path.ts
+++ b/packages/utils/src/path.ts
@@ -63,7 +63,10 @@ export function resolve(...args: string[]): string {
   // handle relative paths to be safe (might happen when process.cwd() fails)
 
   // Normalize the path
-  resolvedPath = normalizeArray(resolvedPath.split('/').filter(p => !!p), !resolvedAbsolute).join('/');
+  resolvedPath = normalizeArray(
+    resolvedPath.split('/').filter(p => !!p),
+    !resolvedAbsolute,
+  ).join('/');
 
   return (resolvedAbsolute ? '/' : '') + resolvedPath || '.';
 }
@@ -129,7 +132,10 @@ export function normalizePath(path: string): string {
   const trailingSlash = path.substr(-1) === '/';
 
   // Normalize the path
-  let normalizedPath = normalizeArray(path.split('/').filter(p => !!p), !isPathAbsolute).join('/');
+  let normalizedPath = normalizeArray(
+    path.split('/').filter(p => !!p),
+    !isPathAbsolute,
+  ).join('/');
 
   if (!normalizedPath && !isPathAbsolute) {
     normalizedPath = '.';

--- a/packages/utils/test/object.test.ts
+++ b/packages/utils/test/object.test.ts
@@ -193,7 +193,10 @@ describe('normalize()', () => {
       obj.children[1].self = obj.children[1];
       expect(normalize(obj)).toEqual({
         name: 'Alice',
-        children: [{ name: 'Bob', self: '[Circular ~]' }, { name: 'Eve', self: '[Circular ~]' }],
+        children: [
+          { name: 'Bob', self: '[Circular ~]' },
+          { name: 'Eve', self: '[Circular ~]' },
+        ],
       });
     });
 
@@ -210,7 +213,10 @@ describe('normalize()', () => {
       const obj: object[] = [];
       obj.push({ name: 'Alice', self: obj });
       obj.push({ name: 'Bob', self: obj });
-      expect(normalize(obj)).toEqual([{ name: 'Alice', self: '[Circular ~]' }, { name: 'Bob', self: '[Circular ~]' }]);
+      expect(normalize(obj)).toEqual([
+        { name: 'Alice', self: '[Circular ~]' },
+        { name: 'Bob', self: '[Circular ~]' },
+      ]);
     });
 
     test('repeated objects in objects', () => {

--- a/packages/utils/test/promisebuffer.test.ts
+++ b/packages/utils/test/promisebuffer.test.ts
@@ -18,7 +18,11 @@ describe('PromiseBuffer', () => {
       const q = new PromiseBuffer<void>(1);
       const p = new SyncPromise<void>(resolve => setTimeout(resolve, 1));
       expect(q.add(p)).toEqual(p);
-      expect(q.add(new SyncPromise<void>(resolve => setTimeout(resolve, 1)))).rejects.toThrowError();
+      expect(
+        q.add(
+          new SyncPromise<void>(resolve => setTimeout(resolve, 1)),
+        ),
+      ).rejects.toThrowError();
       expect(q.length()).toBe(1);
     });
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "types": ["node"],
     "paths": {
       "@sentry/*": ["*/src"]
-    }
+    },
+    "noErrorTruncation": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14906,10 +14906,10 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@1.17.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
-  integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==
+prettier@1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.0.tgz#3bec4489d5eebcd52b95ddd2c22467b5c852fde1"
+  integrity sha512-GlAIjk6DjkNT6u/Bw5QCWrbzh9YlLKwwmJT//1YiCR3WDpZDnyss64aXHQZgF8VKeGlWnX6+tGsKSVxsZT/gtA==
 
 pretty-format@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
Versions of `prettier` prior to `1.19.0` didn't include support for new features introduced in TS 3.7 like optional chaining. So that using those features doesn't break CI builds, this upgrades `prettier` to that version. (We probably want to consider upgrading further, but for the moment this is an easy change which will unblock PRs.)

No breaking changes are listed in either the [1.18.0 release notes](https://prettier.io/blog/2019/06/06/1.18.0.html) or the [1.19.0 release notes](https://prettier.io/blog/2019/11/09/1.19.0.html), and I have confirmed that after running `yarn fix` for the whole repo, `yarn lint`, `yarn build`, and `yarn test` all run with no errors.