### PR TITLE
ref: Revert the usage of globalThis for getGlobalObject util

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -48,14 +48,14 @@ const fallbackGlobalObject = {};
  *
  * @returns Global scope object
  */
-export function getGlobalObject<T>(): T & typeof globalThis & SentryGlobal {
+export function getGlobalObject<T>(): T & SentryGlobal {
   return (isNodeEnv()
     ? global
     : typeof window !== 'undefined'
     ? window
     : typeof self !== 'undefined'
     ? self
-    : fallbackGlobalObject) as T & typeof globalThis & SentryGlobal;
+    : fallbackGlobalObject) as T & SentryGlobal;
 }
 
 /**


### PR DESCRIPTION
It has been introduced in TypeScript `3.4`, but some older frameworks are still pinned to the older compilers.

![image](https://user-images.githubusercontent.com/1523305/91422981-327c6280-e858-11ea-8d14-f8f91d97fa2c.png)
