### PR TITLE
fix(tracing): Make sure BrowserTracing is exported in CDN correctly

### DIFF
--- a/packages/tracing/src/index.bundle.ts
+++ b/packages/tracing/src/index.bundle.ts
@@ -68,7 +68,7 @@ if (_window.Sentry && _window.Sentry.Integrations) {
 const INTEGRATIONS = {
   ...windowIntegrations,
   ...BrowserIntegrations,
-  ...BrowserTracing,
+  BrowserTracing,
 };
 
 export { INTEGRATIONS as Integrations };

--- a/packages/tracing/test/index.bundle.test.ts
+++ b/packages/tracing/test/index.bundle.test.ts
@@ -1,0 +1,9 @@
+import { Integrations } from '../src/index.bundle';
+
+describe('Integrations export', () => {
+  it('is exported correctly', () => {
+    Object.values(Integrations).forEach(integration => {
+      expect(integration.id).toStrictEqual(expect.any(String));
+    });
+  });
+});


### PR DESCRIPTION
We were incorrectly exporting `BrowserTracing` in the CDN before.