### PR TITLE
ref(node): Remove query strings from transaction and span names

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -3,7 +3,7 @@
 import { captureException, getCurrentHub, startTransaction, withScope } from '@sentry/core';
 import { Span } from '@sentry/tracing';
 import { Event } from '@sentry/types';
-import { forget, isPlainObject, isString, logger, normalize, stripUrlPath } from '@sentry/utils';
+import { forget, isPlainObject, isString, logger, normalize, stripUrlQueryAndFragment } from '@sentry/utils';
 import * as cookie from 'cookie';
 import * as domain from 'domain';
 import * as http from 'http';
@@ -32,7 +32,7 @@ export function tracingHandler(): (
     // TODO: At this point `req.route.path` (which we use in `extractTransaction`) is not available
     // but `req.path` or `req.url` should do the job as well. We could unify this here.
     const reqMethod = (req.method || '').toUpperCase();
-    const reqUrl = req.url && stripUrlPath(req.url);
+    const reqUrl = req.url && stripUrlQueryAndFragment(req.url);
 
     let traceId;
     let parentSpanId;

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -11,7 +11,7 @@ import * as os from 'os';
 import * as url from 'url';
 
 import { NodeClient } from './client';
-import { stripQueryString } from './integrations/http';
+import { stripUrlPath } from './integrations/http';
 import { flush } from './sdk';
 
 const DEFAULT_SHUTDOWN_TIMEOUT = 2000;
@@ -33,7 +33,7 @@ export function tracingHandler(): (
     // TODO: At this point `req.route.path` (which we use in `extractTransaction`) is not available
     // but `req.path` or `req.url` should do the job as well. We could unify this here.
     const reqMethod = (req.method || '').toUpperCase();
-    const reqUrl = req.url && stripQueryString(req.url);
+    const reqUrl = req.url && stripUrlPath(req.url);
 
     let traceId;
     let parentSpanId;

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -3,7 +3,7 @@
 import { captureException, getCurrentHub, startTransaction, withScope } from '@sentry/core';
 import { Span } from '@sentry/tracing';
 import { Event } from '@sentry/types';
-import { forget, isPlainObject, isString, logger, normalize } from '@sentry/utils';
+import { forget, isPlainObject, isString, logger, normalize, stripUrlPath } from '@sentry/utils';
 import * as cookie from 'cookie';
 import * as domain from 'domain';
 import * as http from 'http';
@@ -11,7 +11,6 @@ import * as os from 'os';
 import * as url from 'url';
 
 import { NodeClient } from './client';
-import { stripUrlPath } from './integrations/http';
 import { flush } from './sdk';
 
 const DEFAULT_SHUTDOWN_TIMEOUT = 2000;

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -11,6 +11,7 @@ import * as os from 'os';
 import * as url from 'url';
 
 import { NodeClient } from './client';
+import { stripQueryString } from './integrations/http';
 import { flush } from './sdk';
 
 const DEFAULT_SHUTDOWN_TIMEOUT = 2000;
@@ -32,7 +33,7 @@ export function tracingHandler(): (
     // TODO: At this point `req.route.path` (which we use in `extractTransaction`) is not available
     // but `req.path` or `req.url` should do the job as well. We could unify this here.
     const reqMethod = (req.method || '').toUpperCase();
-    const reqUrl = req.url;
+    const reqUrl = req.url && stripQueryString(req.url);
 
     let traceId;
     let parentSpanId;

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -1,6 +1,6 @@
 import { getCurrentHub } from '@sentry/core';
 import { Integration, Span, Transaction } from '@sentry/types';
-import { fill, parseSemver, stripUrlPath } from '@sentry/utils';
+import { fill, parseSemver, stripUrlQueryAndFragment } from '@sentry/utils';
 import * as http from 'http';
 import * as https from 'https';
 
@@ -154,13 +154,13 @@ function addRequestBreadcrumb(event: string, url: string, req: http.IncomingMess
  */
 export function extractUrl(requestArgs: string | http.ClientRequestArgs): string {
   if (typeof requestArgs === 'string') {
-    return stripUrlPath(requestArgs);
+    return stripUrlQueryAndFragment(requestArgs);
   }
   const protocol = requestArgs.protocol || '';
   const hostname = requestArgs.hostname || requestArgs.host || '';
   // Don't log standard :80 (http) and :443 (https) ports to reduce the noise
   const port = !requestArgs.port || requestArgs.port === 80 || requestArgs.port === 443 ? '' : `:${requestArgs.port}`;
-  const path = requestArgs.path ? stripUrlPath(requestArgs.path) : '/';
+  const path = requestArgs.path ? stripUrlQueryAndFragment(requestArgs.path) : '/';
 
   // internal routes end up with too many slashes
   return `${protocol}//${hostname}${port}${path}`.replace('///', '/');

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -164,7 +164,7 @@ export function stripQueryString(path: string): string {
  * @param options url that should be returned or an object containing it's parts.
  * @returns constructed url
  */
-function extractUrl(options: string | http.ClientRequestArgs): string {
+export function extractUrl(options: string | http.ClientRequestArgs): string {
   if (typeof options === 'string') {
     return stripQueryString(options);
   }

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -1,6 +1,6 @@
 import { getCurrentHub } from '@sentry/core';
 import { Integration, Span, Transaction } from '@sentry/types';
-import { fill, parseSemver } from '@sentry/utils';
+import { fill, parseSemver, stripUrlPath } from '@sentry/utils';
 import * as http from 'http';
 import * as https from 'https';
 
@@ -144,16 +144,6 @@ function addRequestBreadcrumb(event: string, url: string, req: http.IncomingMess
       response: res,
     },
   );
-}
-
-/**
- * Strip the query string and fragment off of a given URL or path (if present)
- *
- * @param urlPath Path including possible query string and/or fragment
- * @returns Path without query string or fragment
- */
-export function stripUrlPath(urlPath: string): string {
-  return urlPath.split(/[?#]/, 1)[0];
 }
 
 /**

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -153,13 +153,7 @@ function addRequestBreadcrumb(event: string, url: string, req: http.IncomingMess
  * @returns Path without query string or fragment
  */
 export function stripUrlPath(urlPath: string): string {
-  if (urlPath.includes('?') || urlPath.includes('#')) {
-    // in theory, the fragment should always come after the query string, but you never know, so make the # a ? so the
-    // split will always happen if either is there
-    return urlPath.replace('#', '?').split('?')[0];
-  }
-
-  return urlPath;
+  return urlPath.split(/[?#]/, 1)[0];
 }
 
 /**

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -190,7 +190,7 @@ function cleanDescription(
     try {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
       requestOptions.protocol = (response as any).agent.protocol;
-      span.description = extractUrl(requestOptions);
+      span.description = `${requestOptions.method || 'GET'} ${extractUrl(requestOptions)}`;
     } catch (error) {
       // well, we tried
     }

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -147,17 +147,19 @@ function addRequestBreadcrumb(event: string, url: string, req: http.IncomingMess
 }
 
 /**
- * Strip the query string off of a URL or path
+ * Strip the query string and fragment off of a given URL or path (if present)
  *
- * @param path Path including possible query string
- * @returns Path without query string
+ * @param urlPath Path including possible query string and/or fragment
+ * @returns Path without query string or fragment
  */
-export function stripQueryString(path: string): string {
-  if (path.includes('?')) {
-    return path.split('?')[0];
+export function stripUrlPath(urlPath: string): string {
+  if (urlPath.includes('?') || urlPath.includes('#')) {
+    // in theory, the fragment should always come after the query string, but you never know, so make the # a ? so the
+    // split will always happen if either is there
+    return urlPath.replace('#', '?').split('?')[0];
   }
 
-  return path;
+  return urlPath;
 }
 
 /**
@@ -168,7 +170,7 @@ export function stripQueryString(path: string): string {
  */
 export function extractUrl(requestArgs: string | http.ClientRequestArgs): string {
   if (typeof requestArgs === 'string') {
-    return stripQueryString(requestArgs);
+    return stripUrlPath(requestArgs);
   }
   const protocol = requestArgs.protocol || '';
   const hostname = requestArgs.hostname || requestArgs.host || '';

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -161,21 +161,21 @@ export function stripQueryString(path: string): string {
 }
 
 /**
- * Function that can combine together a url that'll be used for our breadcrumbs.
+ * Assemble a URL to be used for breadcrumbs and spans.
  *
- * @param options url that should be returned or an object containing it's parts.
- * @returns constructed url
+ * @param requestArgs URL string or object containing the component parts
+ * @returns Fully-formed URL
  */
-export function extractUrl(options: string | http.ClientRequestArgs): string {
-  if (typeof options === 'string') {
-    return stripQueryString(options);
+export function extractUrl(requestArgs: string | http.ClientRequestArgs): string {
+  if (typeof requestArgs === 'string') {
+    return stripQueryString(requestArgs);
   }
-  const protocol = options.protocol || '';
-  const hostname = options.hostname || options.host || '';
+  const protocol = requestArgs.protocol || '';
+  const hostname = requestArgs.hostname || requestArgs.host || '';
   // Don't log standard :80 (http) and :443 (https) ports to reduce the noise
-  const port = !options.port || options.port === 80 || options.port === 443 ? '' : `:${options.port}`;
+  const port = !requestArgs.port || requestArgs.port === 80 || requestArgs.port === 443 ? '' : `:${requestArgs.port}`;
+  const path = requestArgs.path ? stripQueryString(requestArgs.path) : '/';
   return `${protocol}//${hostname}${port}${path}`;
-  const path = options.path ? stripQueryString(options.path) : '/';
 }
 
 /**

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -145,6 +145,20 @@ function addRequestBreadcrumb(event: string, url: string, req: http.IncomingMess
 }
 
 /**
+ * Strip the query string off of a URL or path
+ *
+ * @param path Path including possible query string
+ * @returns Path without query string
+ */
+export function stripQueryString(path: string): string {
+  if (path.includes('?')) {
+    return path.split('?')[0];
+  }
+
+  return path;
+}
+
+/**
  * Function that can combine together a url that'll be used for our breadcrumbs.
  *
  * @param options url that should be returned or an object containing it's parts.
@@ -152,14 +166,14 @@ function addRequestBreadcrumb(event: string, url: string, req: http.IncomingMess
  */
 function extractUrl(options: string | http.ClientRequestArgs): string {
   if (typeof options === 'string') {
-    return options;
+    return stripQueryString(options);
   }
   const protocol = options.protocol || '';
   const hostname = options.hostname || options.host || '';
   // Don't log standard :80 (http) and :443 (https) ports to reduce the noise
   const port = !options.port || options.port === 80 || options.port === 443 ? '' : `:${options.port}`;
-  const path = options.path || '/';
   return `${protocol}//${hostname}${port}${path}`;
+  const path = options.path ? stripQueryString(options.path) : '/';
 }
 
 /**

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -12,6 +12,7 @@ describe('extractUrl()', () => {
     port: 1231,
   };
   const queryString = '?furry=yes&funny=very';
+  const fragment = '#adoptnotbuy';
 
   it('accepts a url string', () => {
     expect(extractUrl(urlString)).toBe(urlString);
@@ -29,5 +30,25 @@ describe('extractUrl()', () => {
   it('strips query string from path in http.RequestOptions object', () => {
     const urlPartsWithQueryString = { ...urlParts, path: `${urlParts.path}${queryString}` };
     expect(extractUrl(urlPartsWithQueryString)).toBe(urlString);
+  });
+
+  it('strips fragment from url string', () => {
+    const urlWithFragment = `${urlString}${fragment}`;
+    expect(extractUrl(urlWithFragment)).toBe(urlString);
+  });
+
+  it('strips fragment from path in http.RequestOptions object', () => {
+    const urlPartsWithFragment = { ...urlParts, path: `${urlParts.path}${fragment}` };
+    expect(extractUrl(urlPartsWithFragment)).toBe(urlString);
+  });
+
+  it('strips query string and fragment from url string', () => {
+    const urlWithQueryStringAndFragment = `${urlString}${queryString}${fragment}`;
+    expect(extractUrl(urlWithQueryStringAndFragment)).toBe(urlString);
+  });
+
+  it('strips query string and fragment from path in http.RequestOptions object', () => {
+    const urlPartsWithQueryStringAndFragment = { ...urlParts, path: `${urlParts.path}${queryString}${fragment}` };
+    expect(extractUrl(urlPartsWithQueryStringAndFragment)).toBe(urlString);
   });
 }); // end describe('extractUrl()')

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -1,0 +1,33 @@
+import { RequestOptions } from 'http';
+
+import { extractUrl } from './../../src/integrations/http';
+
+describe('extractUrl()', () => {
+  const urlString = 'http://dogs.are.great:1231/yay/';
+  const urlParts: RequestOptions = {
+    protocol: 'http:',
+    host: 'dogs.are.great',
+    method: 'GET',
+    path: '/yay/',
+    port: 1231,
+  };
+  const queryString = '?furry=yes&funny=very';
+
+  it('accepts a url string', () => {
+    expect(extractUrl(urlString)).toBe(urlString);
+  });
+
+  it('accepts a http.RequestOptions object and returns a string with everything in the right place', () => {
+    expect(extractUrl(urlParts)).toBe('http://dogs.are.great:1231/yay/');
+  });
+
+  it('strips query string from url string', () => {
+    const urlWithQueryString = `${urlString}${queryString}`;
+    expect(extractUrl(urlWithQueryString)).toBe(urlString);
+  });
+
+  it('strips query string from path in http.RequestOptions object', () => {
+    const urlPartsWithQueryString = { ...urlParts, path: `${urlParts.path}${queryString}` };
+    expect(extractUrl(urlPartsWithQueryString)).toBe(urlString);
+  });
+}); // end describe('extractUrl()')

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -510,3 +510,13 @@ export function addContextToFrame(lines: string[], frame: StackFrame, linesOfCon
     .slice(Math.min(sourceLine + 1, maxLines), sourceLine + 1 + linesOfContext)
     .map((line: string) => snipLine(line, 0));
 }
+
+/**
+ * Strip the query string and fragment off of a given URL or path (if present)
+ *
+ * @param urlPath Full URL or path, including possible query string and/or fragment
+ * @returns URL or path without query string or fragment
+ */
+export function stripUrlPath(urlPath: string): string {
+  return urlPath.split(/[?#]/, 1)[0];
+}

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -518,5 +518,6 @@ export function addContextToFrame(lines: string[], frame: StackFrame, linesOfCon
  * @returns URL or path without query string or fragment
  */
 export function stripUrlQueryAndFragment(urlPath: string): string {
-  return urlPath.split(/[?#]/, 1)[0];
+  // eslint-disable-next-line no-useless-escape
+  return urlPath.split(/[\?#]/, 1)[0];
 }

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -517,6 +517,6 @@ export function addContextToFrame(lines: string[], frame: StackFrame, linesOfCon
  * @param urlPath Full URL or path, including possible query string and/or fragment
  * @returns URL or path without query string or fragment
  */
-export function stripUrlPath(urlPath: string): string {
+export function stripUrlQueryAndFragment(urlPath: string): string {
   return urlPath.split(/[?#]/, 1)[0];
 }


### PR DESCRIPTION
Including query strings in the URLs we use to name transactions and spans has at least two drawbacks:

- It makes them harder to group effectively
- It exposes potentially sensitive data

This removes the query string from the URLs we use to name both transactions representing incoming requests and spans representing outgoing requests. It also fixes a special case in which some outgoing requests to external servers were missing the protocol, and adds tests not only for this behavior but for the tracing handler in general.

Before:

![image](https://user-images.githubusercontent.com/14812505/91885124-17d13180-ec3c-11ea-9b27-43b35b61b421.png)

After:

![image](https://user-images.githubusercontent.com/14812505/91884380-cb392680-ec3a-11ea-8b38-e1437015c186.png)
