### PR TITLE
fix: Span fields when JSON-serialized

### DIFF
--- a/packages/apm/src/span.ts
+++ b/packages/apm/src/span.ts
@@ -278,9 +278,9 @@ export class Span implements SpanInterface, SpanContext {
     description?: string;
     op?: string;
     parent_span_id?: string;
-    sampled?: boolean;
     span_id: string;
     start_timestamp: number;
+    status?: string;
     tags?: { [key: string]: string };
     timestamp?: number;
     trace_id: string;

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -307,9 +307,9 @@ export class Span implements SpanInterface, SpanContext {
     description?: string;
     op?: string;
     parent_span_id?: string;
-    sampled?: boolean;
     span_id: string;
     start_timestamp: number;
+    status?: string;
     tags?: { [key: string]: string };
     timestamp?: number;
     trace_id: string;

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -158,9 +158,9 @@ export interface Span extends SpanContext {
     description?: string;
     op?: string;
     parent_span_id?: string;
-    sampled?: boolean;
     span_id: string;
     start_timestamp: number;
+    status?: string;
     tags?: { [key: string]: string };
     timestamp?: number;
     trace_id: string;


### PR DESCRIPTION
The 'status' field was not part of the type definition, even though we set
it, while the 'sampled' field should not be part of the JSON-serialized
span.

References:

- https://github.com/getsentry/relay/blob/a5d24ca07fcc115ad9729fc3dc49ba06c7ea5b8c/relay-general/src/protocol/span.rs#L7-L50
- https://develop.sentry.dev/sdk/event-payloads/span/