### PR TITLE
feat: Simplify shouldCreateSpanForRequest

### DIFF
--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -100,7 +100,14 @@ export function registerRequestInstrumentation(_options?: Partial<RequestInstrum
     return urlMap[url];
   };
 
-  const shouldCreateSpan = shouldCreateSpanForRequest || defaultShouldCreateSpan;
+  // We want that our users don't have to re-implement shouldCreateSpanForRequest themselves
+  // That's why we filter out already unwanted Spans from tracingOrigins
+  let shouldCreateSpan = defaultShouldCreateSpan;
+  if (typeof shouldCreateSpanForRequest === 'function') {
+    shouldCreateSpan = (url: string) => {
+      return defaultShouldCreateSpan(url) && shouldCreateSpanForRequest(url);
+    };
+  }
 
   const spans: Record<string, Span> = {};
 


### PR DESCRIPTION
I was writing docs on how users can filter out Spans and noticed that the API is very hard to use.
https://github.com/getsentry/sentry-docs/pull/2133

This change makes it so it works as expected.