### PR TITLE
ref(node): Don't strip query strings or fragments from span descriptions

### DIFF
--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -1,6 +1,6 @@
 import { getCurrentHub } from '@sentry/core';
 import { Integration, Span, Transaction } from '@sentry/types';
-import { fill, parseSemver, stripUrlQueryAndFragment } from '@sentry/utils';
+import { fill, parseSemver } from '@sentry/utils';
 import * as http from 'http';
 import * as https from 'https';
 
@@ -159,20 +159,17 @@ function addRequestBreadcrumb(event: string, url: string, req: http.IncomingMess
  * Assemble a URL to be used for breadcrumbs and spans.
  *
  * @param url URL string or object containing the component parts
- * @param strip Whether or not to strip querystring and fragment. Defaults to false.
- *
  * @returns Fully-formed URL
  */
-export function extractUrl(url: string | http.ClientRequestArgs, strip: boolean = false): string {
+export function extractUrl(url: string | http.ClientRequestArgs): string {
   if (typeof url === 'string') {
-    return strip ? stripUrlQueryAndFragment(url) : url;
+    return url;
   }
-
   const protocol = url.protocol || '';
   const hostname = url.hostname || url.host || '';
   // Don't log standard :80 (http) and :443 (https) ports to reduce the noise
   const port = !url.port || url.port === 80 || url.port === 443 ? '' : `:${url.port}`;
-  const path = url.path ? (strip ? stripUrlQueryAndFragment(url.path) : url.path) : '/';
+  const path = url.path ? url.path : '/';
 
   // internal routes end up with too many slashes
   return `${protocol}//${hostname}${port}${path}`.replace('///', '/');

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -158,18 +158,21 @@ function addRequestBreadcrumb(event: string, url: string, req: http.IncomingMess
 /**
  * Assemble a URL to be used for breadcrumbs and spans.
  *
- * @param requestArgs URL string or object containing the component parts
+ * @param url URL string or object containing the component parts
+ * @param strip Whether or not to strip querystring and fragment. Defaults to false.
+ *
  * @returns Fully-formed URL
  */
-export function extractUrl(requestArgs: string | http.ClientRequestArgs): string {
-  if (typeof requestArgs === 'string') {
-    return stripUrlQueryAndFragment(requestArgs);
+export function extractUrl(url: string | http.ClientRequestArgs, strip: boolean = false): string {
+  if (typeof url === 'string') {
+    return strip ? stripUrlQueryAndFragment(url) : url;
   }
-  const protocol = requestArgs.protocol || '';
-  const hostname = requestArgs.hostname || requestArgs.host || '';
+
+  const protocol = url.protocol || '';
+  const hostname = url.hostname || url.host || '';
   // Don't log standard :80 (http) and :443 (https) ports to reduce the noise
-  const port = !requestArgs.port || requestArgs.port === 80 || requestArgs.port === 443 ? '' : `:${requestArgs.port}`;
-  const path = requestArgs.path ? stripUrlQueryAndFragment(requestArgs.path) : '/';
+  const port = !url.port || url.port === 80 || url.port === 443 ? '' : `:${url.port}`;
+  const path = url.path ? (strip ? stripUrlQueryAndFragment(url.path) : url.path) : '/';
 
   // internal routes end up with too many slashes
   return `${protocol}//${hostname}${port}${path}`.replace('///', '/');

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -22,33 +22,69 @@ describe('extractUrl()', () => {
     expect(extractUrl(urlParts)).toBe('http://dogs.are.great:1231/yay/');
   });
 
-  it('strips query string from url string', () => {
+  it("by default doesn't strip query string from url string", () => {
     const urlWithQueryString = `${urlString}${queryString}`;
-    expect(extractUrl(urlWithQueryString)).toBe(urlString);
+    expect(extractUrl(urlWithQueryString)).toBe(urlWithQueryString);
   });
 
-  it('strips query string from path in http.RequestOptions object', () => {
+  it("by default doesn't strip query string from path in http.RequestOptions object", () => {
     const urlPartsWithQueryString = { ...urlParts, path: `${urlParts.path}${queryString}` };
-    expect(extractUrl(urlPartsWithQueryString)).toBe(urlString);
+    const urlWithQueryString = `${urlString}${queryString}`;
+
+    expect(extractUrl(urlPartsWithQueryString)).toBe(urlWithQueryString);
   });
 
-  it('strips fragment from url string', () => {
+  it("by default doesn't strip fragment from url string", () => {
     const urlWithFragment = `${urlString}${fragment}`;
-    expect(extractUrl(urlWithFragment)).toBe(urlString);
+    expect(extractUrl(urlWithFragment)).toBe(urlWithFragment);
   });
 
-  it('strips fragment from path in http.RequestOptions object', () => {
+  it("by default doesn't strip fragment from path in http.RequestOptions object", () => {
     const urlPartsWithFragment = { ...urlParts, path: `${urlParts.path}${fragment}` };
-    expect(extractUrl(urlPartsWithFragment)).toBe(urlString);
+    const urlWithFragment = `${urlString}${fragment}`;
+
+    expect(extractUrl(urlPartsWithFragment)).toBe(urlWithFragment);
   });
 
-  it('strips query string and fragment from url string', () => {
+  it("by default doesn't strip query string and fragment from url string", () => {
     const urlWithQueryStringAndFragment = `${urlString}${queryString}${fragment}`;
-    expect(extractUrl(urlWithQueryStringAndFragment)).toBe(urlString);
+    expect(extractUrl(urlWithQueryStringAndFragment)).toBe(urlWithQueryStringAndFragment);
   });
 
-  it('strips query string and fragment from path in http.RequestOptions object', () => {
+  it("by default doesn't strip query string and fragment from path in http.RequestOptions object", () => {
     const urlPartsWithQueryStringAndFragment = { ...urlParts, path: `${urlParts.path}${queryString}${fragment}` };
-    expect(extractUrl(urlPartsWithQueryStringAndFragment)).toBe(urlString);
+    const urlWithQueryStringAndFragment = `${urlString}${queryString}${fragment}`;
+
+    expect(extractUrl(urlPartsWithQueryStringAndFragment)).toBe(urlWithQueryStringAndFragment);
+  });
+
+  it('strips query string from url string when asked', () => {
+    const urlWithQueryString = `${urlString}${queryString}`;
+    expect(extractUrl(urlWithQueryString, true)).toBe(urlString);
+  });
+
+  it('strips query string from path in http.RequestOptions object when asked', () => {
+    const urlPartsWithQueryString = { ...urlParts, path: `${urlParts.path}${queryString}` };
+    expect(extractUrl(urlPartsWithQueryString, true)).toBe(urlString);
+  });
+
+  it('strips fragment from url string when asked', () => {
+    const urlWithFragment = `${urlString}${fragment}`;
+    expect(extractUrl(urlWithFragment, true)).toBe(urlString);
+  });
+
+  it('strips fragment from path in http.RequestOptions object when asked', () => {
+    const urlPartsWithFragment = { ...urlParts, path: `${urlParts.path}${fragment}` };
+    expect(extractUrl(urlPartsWithFragment, true)).toBe(urlString);
+  });
+
+  it('strips query string and fragment from url string when asked', () => {
+    const urlWithQueryStringAndFragment = `${urlString}${queryString}${fragment}`;
+    expect(extractUrl(urlWithQueryStringAndFragment, true)).toBe(urlString);
+  });
+
+  it('strips query string and fragment from path in http.RequestOptions object when asked', () => {
+    const urlPartsWithQueryStringAndFragment = { ...urlParts, path: `${urlParts.path}${queryString}${fragment}` };
+    expect(extractUrl(urlPartsWithQueryStringAndFragment, true)).toBe(urlString);
   });
 }); // end describe('extractUrl()')

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -11,80 +11,12 @@ describe('extractUrl()', () => {
     path: '/yay/',
     port: 1231,
   };
-  const queryString = '?furry=yes&funny=very';
-  const fragment = '#adoptnotbuy';
 
   it('accepts a url string', () => {
     expect(extractUrl(urlString)).toBe(urlString);
   });
 
   it('accepts a http.RequestOptions object and returns a string with everything in the right place', () => {
-    expect(extractUrl(urlParts)).toBe('http://dogs.are.great:1231/yay/');
+    expect(extractUrl(urlParts)).toBe(urlString);
   });
-
-  it("by default doesn't strip query string from url string", () => {
-    const urlWithQueryString = `${urlString}${queryString}`;
-    expect(extractUrl(urlWithQueryString)).toBe(urlWithQueryString);
-  });
-
-  it("by default doesn't strip query string from path in http.RequestOptions object", () => {
-    const urlPartsWithQueryString = { ...urlParts, path: `${urlParts.path}${queryString}` };
-    const urlWithQueryString = `${urlString}${queryString}`;
-
-    expect(extractUrl(urlPartsWithQueryString)).toBe(urlWithQueryString);
-  });
-
-  it("by default doesn't strip fragment from url string", () => {
-    const urlWithFragment = `${urlString}${fragment}`;
-    expect(extractUrl(urlWithFragment)).toBe(urlWithFragment);
-  });
-
-  it("by default doesn't strip fragment from path in http.RequestOptions object", () => {
-    const urlPartsWithFragment = { ...urlParts, path: `${urlParts.path}${fragment}` };
-    const urlWithFragment = `${urlString}${fragment}`;
-
-    expect(extractUrl(urlPartsWithFragment)).toBe(urlWithFragment);
-  });
-
-  it("by default doesn't strip query string and fragment from url string", () => {
-    const urlWithQueryStringAndFragment = `${urlString}${queryString}${fragment}`;
-    expect(extractUrl(urlWithQueryStringAndFragment)).toBe(urlWithQueryStringAndFragment);
-  });
-
-  it("by default doesn't strip query string and fragment from path in http.RequestOptions object", () => {
-    const urlPartsWithQueryStringAndFragment = { ...urlParts, path: `${urlParts.path}${queryString}${fragment}` };
-    const urlWithQueryStringAndFragment = `${urlString}${queryString}${fragment}`;
-
-    expect(extractUrl(urlPartsWithQueryStringAndFragment)).toBe(urlWithQueryStringAndFragment);
-  });
-
-  it('strips query string from url string when asked', () => {
-    const urlWithQueryString = `${urlString}${queryString}`;
-    expect(extractUrl(urlWithQueryString, true)).toBe(urlString);
-  });
-
-  it('strips query string from path in http.RequestOptions object when asked', () => {
-    const urlPartsWithQueryString = { ...urlParts, path: `${urlParts.path}${queryString}` };
-    expect(extractUrl(urlPartsWithQueryString, true)).toBe(urlString);
-  });
-
-  it('strips fragment from url string when asked', () => {
-    const urlWithFragment = `${urlString}${fragment}`;
-    expect(extractUrl(urlWithFragment, true)).toBe(urlString);
-  });
-
-  it('strips fragment from path in http.RequestOptions object when asked', () => {
-    const urlPartsWithFragment = { ...urlParts, path: `${urlParts.path}${fragment}` };
-    expect(extractUrl(urlPartsWithFragment, true)).toBe(urlString);
-  });
-
-  it('strips query string and fragment from url string when asked', () => {
-    const urlWithQueryStringAndFragment = `${urlString}${queryString}${fragment}`;
-    expect(extractUrl(urlWithQueryStringAndFragment, true)).toBe(urlString);
-  });
-
-  it('strips query string and fragment from path in http.RequestOptions object when asked', () => {
-    const urlPartsWithQueryStringAndFragment = { ...urlParts, path: `${urlParts.path}${queryString}${fragment}` };
-    expect(extractUrl(urlPartsWithQueryStringAndFragment, true)).toBe(urlString);
-  });
-}); // end describe('extractUrl()')
+});

--- a/packages/utils/test/misc.test.ts
+++ b/packages/utils/test/misc.test.ts
@@ -1,6 +1,12 @@
 import { StackFrame } from '@sentry/types';
 
-import { addContextToFrame, getEventDescription, getGlobalObject, parseRetryAfterHeader } from '../src/misc';
+import {
+  addContextToFrame,
+  getEventDescription,
+  getGlobalObject,
+  parseRetryAfterHeader,
+  stripUrlQueryAndFragment,
+} from '../src/misc';
 
 describe('getEventDescription()', () => {
   test('message event', () => {
@@ -208,5 +214,26 @@ describe('addContextToFrame', () => {
     expect(frame.pre_context).toEqual(['10: j', '11: k', '12: l', '13: m', '14: n']);
     expect(frame.context_line).toEqual('14: n');
     expect(frame.post_context).toEqual([]);
+  });
+});
+
+describe('stripQueryStringAndFragment', () => {
+  const urlString = 'http://dogs.are.great:1231/yay/';
+  const queryString = '?furry=yes&funny=very';
+  const fragment = '#adoptnotbuy';
+
+  it('strips query string from url', () => {
+    const urlWithQueryString = `${urlString}${queryString}`;
+    expect(stripUrlQueryAndFragment(urlWithQueryString)).toBe(urlString);
+  });
+
+  it('strips fragment from url', () => {
+    const urlWithFragment = `${urlString}${fragment}`;
+    expect(stripUrlQueryAndFragment(urlWithFragment)).toBe(urlString);
+  });
+
+  it('strips query string and fragment from url', () => {
+    const urlWithQueryStringAndFragment = `${urlString}${queryString}${fragment}`;
+    expect(stripUrlQueryAndFragment(urlWithQueryStringAndFragment)).toBe(urlString);
   });
 });


### PR DESCRIPTION
Reverts the `span` half of https://github.com/getsentry/sentry-javascript/pull/2857.