### PR TITLE
ref(node): Make naming of `http` method wrappers clearer

### DIFF
--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -75,10 +75,7 @@ type WrappedHandlerMaker = (originalHandler: OriginalHandler) => WrappedHandler;
  *
  * @returns A function which accepts the exiting handler and returns a wrapped handler
  */
-function _createWrappedHandlerMaker(
-  breadcrumbsEnabled: boolean,
-  tracingEnabled: boolean,
-): WrappedHandlerMaker {
+function _createWrappedHandlerMaker(breadcrumbsEnabled: boolean, tracingEnabled: boolean): WrappedHandlerMaker {
   return function wrappedHandlerMaker(originalHandler: OriginalHandler): WrappedHandler {
     return function wrappedHandler(
       this: typeof http | typeof https,


### PR DESCRIPTION
This PR is purely cosmetic, but hopefully will make the code easier to read.

Two issues here:

1) Typing a function which returns a function which takes a function and returns a function can get a little dizzying in TS, whether in the writing or the reading. Parentheses would help some, but Prettier removes them. Better to break up the endless chain of `( ): ( ) => ( ): ( ) => ( ): ( ) => ( ): ( ) => ( ): ( ) => ( ): ( ) => ( ): ( ) => ( ): ( ) => ( )` (I'm exaggerating, but you get the point) with some named types, both so it's clearer what belongs to what but also so it's more obvious what each bit is for.

2) The word "wrapper" in English is ambiguous, in that it can mean either the entity doing the wrapping or the outer layer which said entity applies to the wrapped item. To add to the confusion, we (English speakers) sometimes employ a synecdoche and refer to to the wrapped item as a "wrapper," because even though both wrapper and wrappee are there, you can only see the wrapper. Mad props to anyone who has to learn our ridiculous tongue.

The end result here is a tiny bit awkward-sounding, but hopefully easier to parse and harder to get misled by.