### PR TITLE
fix(ember): Fix ember tests on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           key: ${{ runner.os }}-${{ github.sha }}
       - run: yarn install
       - name: Unit Tests
-        run: yarn test --ignore="@sentry/ember"
+        run: yarn test
       - uses: codecov/codecov-action@v1
 
   job_browserstack_test:

--- a/packages/ember/config/ember-try.js
+++ b/packages/ember/config/ember-try.js
@@ -4,6 +4,7 @@ const getChannelURL = require('ember-source-channel-url');
 
 module.exports = async function() {
   return {
+    useYarn: true,
     scenarios: [
       {
         name: 'ember-lts-3.12',

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,7 +10,7 @@ if [[ "$(cut -d. -f1 <<< "$TRAVIS_NODE_VERSION")" -le 6 ]]; then
   yarn build --ignore="@sentry/ember" --ignore="@sentry/serverless"
   nvm use 6
   # browser can be tested only on Node >= v8 because Karma is not supporting anything older
-  yarn test --ignore="@sentry/tracing" --ignore="@sentry/react" --ignore="@sentry/gatsby" --ignore="@sentry/ember" --ignore="@sentry-internal/eslint-plugin-sdk" --ignore="@sentry-internal/eslint-config-sdk" --ignore="@sentry/serverless" --ignore="@sentry/browser" --ignore="@sentry/integrations"
+  yarn test --ignore="@sentry/tracing" --ignore="@sentry/react" --ignore="@sentry/gatsby" --ignore="@sentry/ember" --ignore="@sentry-internal/eslint-plugin-sdk" --ignore="@sentry-internal/eslint-config-sdk" --ignore="@sentry/serverless" --ignore="@sentry/browser" --ignore="@sentry/integrations" 
 elif [[ "$(cut -d. -f1 <<< "$TRAVIS_NODE_VERSION")" -le 8 ]]; then
   yarn install --ignore-engines --ignore-scripts
   # ember requires Node >= 10 to build
@@ -20,5 +20,5 @@ elif [[ "$(cut -d. -f1 <<< "$TRAVIS_NODE_VERSION")" -le 8 ]]; then
 else
   yarn install
   yarn build
-  yarn test --ignore="@sentry/ember"
+  yarn test
 fi


### PR DESCRIPTION
### Summary
Ember-try uses npm by default to modify the package.json to test different versions of Ember, switching to use yarn should fix the issues it had resolving on new releases.

Tested this on a branch locally by creating a new lerna version, so it should work now. Reverting the `disable ember tests` commit.


