### PR TITLE
[stash] feat(node): Add `shouldCreateSpanForRequest` option to node tracing

### DIFF
--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -101,6 +101,9 @@ function _createWrappedHandlerMaker(
         return originalHandler.apply(this, arguments);
       }
 
+      // TODO(kmclb): The cache below mirrors the one on the browser side, but in a node context it may actually break
+      // things, so figure that out and consider removing it
+
       // apply user-provided filter (if any) and cache result for next time
       const spanDecisionCache: { [key: string]: boolean } = {};
       const shouldStartSpan = (url: string): boolean => {

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -234,7 +234,8 @@ function cleanDescription(
 }
 
 /**
- * Checks whether given url points to Sentry server
+ * Checks whether given url points to a Sentry server by comparing it with the host in the DSN.
+ *
  * @param url url to verify
  */
 function isSentryRequest(url: string): boolean {

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -1,10 +1,21 @@
-import { RequestOptions } from 'http';
+import * as sentryCore from '@sentry/core';
+import { Hub } from '@sentry/hub';
+import * as dsn from 'dns';
+import * as http from 'http';
+import * as net from 'net';
 
-import { extractUrl } from './../../src/integrations/http';
+import { NodeClient } from '../../src';
+import { extractUrl, Http as httpIntegration } from './../../src/integrations/http';
+
+// callng `http.request(url)` triggers a live DNS lookup, which we don't want
+jest.spyOn(dsn, 'lookup').mockImplementation(() => {
+  // we know our url is fake, so don't bother trying to do any DNS resolution - it'll just lead to errors
+  return;
+});
 
 describe('extractUrl()', () => {
   const urlString = 'http://dogs.are.great:1231/yay/';
-  const urlParts: RequestOptions = {
+  const urlParts: http.RequestOptions = {
     protocol: 'http:',
     host: 'dogs.are.great',
     method: 'GET',
@@ -51,4 +62,126 @@ describe('extractUrl()', () => {
     const urlPartsWithQueryStringAndFragment = { ...urlParts, path: `${urlParts.path}${queryString}${fragment}` };
     expect(extractUrl(urlPartsWithQueryStringAndFragment)).toBe(urlString);
   });
-}); // end describe('extractUrl()')
+});
+
+describe('options', () => {
+  // TODO (kmclb): In addition to having a few as-yet-unimplemented tests, this suffers from the problem of an
+  // integration only going through the `setupOnce` process... once. If it bakes its options into whatever it sets up,
+  // later instances will never have their options applied (since `setupOnce` won't run again), and they'll be stuck
+  // with the first instances choices. Find a workaround or fix the original behavior.
+
+  const url = 'http://sit.shake.rollover/good/dog';
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it.only('should capture breadcrumbs by default', () => {
+    const hub = new Hub(
+      new NodeClient({
+        dsn: 'https://1231@dogs.are.great/1121',
+        integrations: [new httpIntegration()],
+      }),
+    );
+    jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
+
+    const req = http.request(url);
+    req.emit('response');
+
+    const breadcrumbs = (hub.getScope() as any)._breadcrumbs;
+    expect(breadcrumbs).toEqual(
+      expect.arrayContaining([expect.objectContaining({ category: 'http', data: expect.objectContaining({ url }) })]),
+    );
+  });
+
+  it.only('should not capture breadcrumbs if told not to', () => {
+    const hub = new Hub(
+      new NodeClient({
+        dsn: 'https://1231@dogs.are.great/1121',
+        integrations: [new httpIntegration({ breadcrumbs: false })],
+      }),
+    );
+    jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
+
+    const req = http.request(url);
+    req.emit('response');
+
+    const breadcrumbs = (hub.getScope() as any)._breadcrumbs;
+    expect(breadcrumbs.length).toBe(0);
+  });
+
+  it('should ignore Sentry requests when creating breadcrumbs', () => {
+    const hub = new Hub(
+      new NodeClient({
+        dsn: 'https://1231@dogs.are.great/1121',
+        integrations: [new httpIntegration()],
+      }),
+    );
+    jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
+
+    const req = http.request('http://dogs.are.great');
+    req.emit('response');
+
+    const breadcrumbs = (hub.getScope() as any)._breadcrumbs;
+    expect(breadcrumbs.length).toBe(0);
+  });
+
+  it('should not capture spans by default', () => {
+    const hub = new Hub(
+      new NodeClient({
+        dsn: 'https://1231@dogs.are.great/1121',
+        integrations: [new httpIntegration()],
+      }),
+    );
+    const transaction = hub.startTransaction({ name: 'dogpark' });
+
+    jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
+    const startChild = jest.spyOn(transaction, 'startChild');
+
+    const req = http.request(url);
+    req.emit('response');
+
+    expect(startChild).not.toHaveBeenCalled();
+  });
+
+  // TODO (kmclb): This isn't yet working or complete. Need to figure out how to tie a mock response in. (Why are the
+  // datatypes on the params in `.once('response', function callback(param1, param2) {...})` seemingly backwards?)
+  it('should capture spans if told to do so', () => {
+    const hub = new Hub(
+      new NodeClient({
+        dsn: 'https://1231@dogs.are.great/1121',
+        integrations: [new httpIntegration({ tracing: true })],
+      }),
+    );
+    jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
+
+    const transaction = hub.startTransaction({ name: 'dogpark', sampled: true });
+    hub.getScope()?.setSpan(transaction);
+
+    const startChild = jest.spyOn(transaction, 'startChild');
+
+    const req = http.request(url);
+
+    const res = new http.ServerResponse(new http.IncomingMessage(new net.Socket()));
+    req.emit('response', res); // datatypes in callback?
+
+    expect(startChild).toHaveBeenCalled();
+    // expect transaction to have a span corresponding to this request
+  });
+
+  it('should apply given shouldCreateSpanForRequest', () => {
+    // pass
+  });
+
+  it('should create a span if shouldCreateSpanForRequest says it should', () => {
+    // pass
+  });
+
+  it("shouldn't create a span if shouldCreateSpanForRequest says not to", () => {
+    // pass
+  });
+
+  it('should ignore Sentry requests when creating spans', () => {
+    // pass
+  });
+});

--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -20,7 +20,7 @@ export interface Integration {
 
   /**
    * Sets the integration up only once.
-   * This takes no options on purpose, options should be passed in the constructor
+   * This intentionally takes no options. Options should be passed in the constructor.
    */
   setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void;
 }


### PR DESCRIPTION
It's not clear whether we want to specifically add `shouldCreateSpanFor*Request*` or whether we want to add a more generic `shouldCreateSpan`.

Tabling further work here until that decision is made, which leaves this very much a WIP. 
