### PR TITLE
ref(offline integration): Move event listener setup from constructor to setupOnce

### DIFF
--- a/packages/integrations/src/offline.ts
+++ b/packages/integrations/src/offline.ts
@@ -51,6 +51,13 @@ export class Offline implements Integration {
     this.offlineEventStore = localForage.createInstance({
       name: 'sentry/offlineEventStore',
     });
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
+    this.hub = getCurrentHub();
 
     if ('addEventListener' in this.global) {
       this.global.addEventListener('online', () => {
@@ -59,13 +66,6 @@ export class Offline implements Integration {
         });
       });
     }
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    this.hub = getCurrentHub();
 
     addGlobalEventProcessor((event: Event) => {
       if (this.hub && this.hub.getIntegration(Offline)) {


### PR DESCRIPTION
Event listener should be set up after hub is set on instance (in `setupOnce` method) as event may be fired before hub is set (hub is used in `_sendEvents`).

IMHO it's bad practice to have business logic in constructor.
___
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).