### PR TITLE
fix(react): Remove unnecessary `null` in `FallbackRender`'s `error` type

### DIFF
--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -4,8 +4,8 @@ import * as React from 'react';
 
 export const UNKNOWN_COMPONENT = 'unknown';
 
-export type FallbackRender = (fallback: {
-  error: Error | null;
+export type FallbackRender = (errorData: {
+  error: Error;
   componentStack: string | null;
   eventId: string | null;
   resetError(): void;


### PR DESCRIPTION
We already know `error` exists because of the `if (error)` check.

Fixes https://github.com/getsentry/sentry-javascript/issues/2892.