### PR TITLE
ref(tracing): Export utility function from tracing

### DIFF
--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -41,3 +41,6 @@ export function extractTraceparentData(traceparent: string): TraceparentData | u
   }
   return undefined;
 }
+
+// so it can be used in manual instrumentation without necessitating a hard dependency on @sentry/utils
+export { stripUrlQueryAndFragment } from '@sentry/utils';


### PR DESCRIPTION
The `stripUrlQueryAndFragment` function from `@sentry/utils` is nice to have for manual tracing instrumentation. This makes it available in the `@sentry/tracing` namespace.