### PR TITLE
fix: Make Vue tracing options optional

### DIFF
--- a/packages/integrations/src/vue.ts
+++ b/packages/integrations/src/vue.ts
@@ -151,7 +151,9 @@ export class Vue implements Integration {
   /**
    * @inheritDoc
    */
-  public constructor(options: Partial<IntegrationOptions>) {
+  public constructor(
+    options: Partial<Omit<IntegrationOptions, 'tracingOptions'> & { tracingOptions: Partial<TracingOptions> }>,
+  ) {
     this._options = {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       Vue: getGlobalObject<any>().Vue,

--- a/packages/integrations/src/vue.ts
+++ b/packages/integrations/src/vue.ts
@@ -313,7 +313,7 @@ export class Vue implements Integration {
       }
     };
 
-    // Each compomnent has it's own scope, so all activities are only related to one of them
+    // Each component has it's own scope, so all activities are only related to one of them
     this._options.tracingOptions.hooks.forEach(operation => {
       // Retrieve corresponding hooks from Vue lifecycle.
       // eg. mount => ['beforeMount', 'mounted']


### PR DESCRIPTION
Currently, when setting Vue integration [`tracingOptions`](https://github.com/getsentry/sentry-javascript/blob/15465a8feb91df3c435e0822ad3f67661154c425/packages/integrations/src/vue.ts#L72), a developer must provide all properties even though [defaults are set](https://github.com/getsentry/sentry-javascript/blob/15465a8feb91df3c435e0822ad3f67661154c425/packages/integrations/src/vue.ts#L162-L167).

This change makes all `tracingOptions` optional.