### PR TITLE
fix(build): Increase size limit for browser+tracing bundle

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -21,6 +21,6 @@ module.exports = [
     name: '@sentry/browser + @sentry/tracing - CDN Bundle (gzipped)',
     path: 'packages/tracing/build/bundle.tracing.min.js',
     gzip: true,
-    limit: '23 KB',
+    limit: '25 KB',
   },
 ];


### PR DESCRIPTION
Bumped to 25K because we're already over 24K, but probably would want to know if we go much higher than that.