### PR TITLE
fix: Make sure that message exist before returning it in angular error handler

### DIFF
--- a/packages/angular/src/errorhandler.ts
+++ b/packages/angular/src/errorhandler.ts
@@ -109,7 +109,7 @@ class SentryErrorHandler implements AngularErrorHandler {
       }
 
       // ... or an`ErrorEvent`, which can provide us with the message but no stack...
-      if (error.error instanceof ErrorEvent) {
+      if (error.error instanceof ErrorEvent && error.error.message) {
         return error.error.message;
       }
 


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/2292#issuecomment-692494628