### PR TITLE
fix: Make sure that body is not exposed in the breadcrumb by default

### DIFF
--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -11,19 +11,6 @@ import {
   safeJoin,
 } from '@sentry/utils';
 
-/**
- * @hidden
- */
-export interface SentryWrappedXMLHttpRequest extends XMLHttpRequest {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
-  __sentry_xhr__?: {
-    method?: string;
-    url?: string;
-    status_code?: number;
-  };
-}
-
 /** JSDoc */
 interface BreadcrumbsOptions {
   console: boolean;
@@ -212,15 +199,21 @@ export class Breadcrumbs implements Integration {
         return;
       }
 
+      const { method, url, status_code, body } = handlerData.xhr.__sentry_xhr__ || {};
+
       getCurrentHub().addBreadcrumb(
         {
           category: 'xhr',
-          data: handlerData.xhr.__sentry_xhr__,
+          data: {
+            method,
+            url,
+            status_code,
+          },
           type: 'http',
         },
         {
           xhr: handlerData.xhr,
-          ...(handlerData.xhr.__sentry_xhr__.body && { input: handlerData.xhr.__sentry_xhr__.body }),
+          input: body,
         },
       );
 

--- a/packages/browser/test/integration/suites/breadcrumbs.js
+++ b/packages/browser/test/integration/suites/breadcrumbs.js
@@ -80,6 +80,7 @@ describe("breadcrumbs", function() {
         assert.equal(summary.breadcrumbs[0].type, "http");
         assert.equal(summary.breadcrumbs[0].category, "xhr");
         assert.equal(summary.breadcrumbs[0].data.method, "GET");
+        assert.isUndefined(summary.breadcrumbs[0].data.input);
         // To make sure that we are not providing this key for non-post requests
         assert.equal(summary.breadcrumbHints[0].input, undefined);
       });
@@ -109,6 +110,7 @@ describe("breadcrumbs", function() {
         assert.equal(summary.breadcrumbs[0].type, "http");
         assert.equal(summary.breadcrumbs[0].category, "xhr");
         assert.equal(summary.breadcrumbs[0].data.method, "POST");
+        assert.isUndefined(summary.breadcrumbs[0].data.input);
         assert.equal(summary.breadcrumbHints[0].input, '{"foo":"bar"}');
       });
     }


### PR DESCRIPTION
This way it's unified with fetch integration, as well as we don't don't risk eexposing any PII 