### PR TITLE
fix: Add a wrapper around performance for React Native

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -42,7 +42,7 @@ export function getGlobalObject<T>(): T & SentryGlobal {
  * Determines if running in react native
  */
 export function isReactNative(): boolean {
-  return navigator?.product === 'ReactNative';
+  return getGlobalObject<Window>().navigator?.product === 'ReactNative';
 }
 
 /**

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -39,6 +39,13 @@ export function getGlobalObject<T>(): T & SentryGlobal {
 }
 
 /**
+ * Determines if running in react native
+ */
+export function isReactNative(): boolean {
+  return navigator?.product === 'ReactNative';
+}
+
+/**
  * Extended Window interface that allows for Crypto API usage in IE browsers
  */
 interface MsCryptoWindow extends Window {
@@ -260,7 +267,26 @@ const performanceFallback: CrossPlatformPerformance = {
   timeOrigin: INITIAL_TIME,
 };
 
+/**
+ * Performance wrapper for react native as performance.now() has been found to start off with an unusual offset.
+ */
+function getReactNativePerformanceWrapper(): CrossPlatformPerformance {
+  const INITIAL_OFFSET = performance.now();
+
+  return {
+    now(): number {
+      return performance.now() - INITIAL_OFFSET;
+    },
+    timeOrigin: INITIAL_TIME,
+  };
+}
+
 export const crossPlatformPerformance: CrossPlatformPerformance = ((): CrossPlatformPerformance => {
+  // React Native's performance.now() starts with a gigantic offset, so we need to wrap it.
+  if (isReactNative()) {
+    return getReactNativePerformanceWrapper();
+  }
+
   if (isNodeEnv()) {
     try {
       const perfHooks = dynamicRequire(module, 'perf_hooks') as { performance: CrossPlatformPerformance };


### PR DESCRIPTION
Calling `performance.now()` in React Native seems to include some large offset even though it is relatively precise. This causes gigantic timestamp jumps in React Native, along with breadcrumbs being completely out of order.

This is solved by having a unique wrapper for performance on React Native. The initial offset is set at the start, and any subsequent calls to `performance.now()` will have the offset subtracted. This solution should work short of finding the source of this offset and submitting a PR to React Native; even if it does eventually get fixed, this solution should still work as the initial offset would then be 0 or close to 0.

https://sentry.slack.com/archives/C01354JB6ES/p1600273809119300

Related Issues:
https://github.com/getsentry/sentry-javascript/issues/2590
https://github.com/getsentry/sentry-react-native/issues/1004

Asana Task:
https://app.asana.com/0/1163978839534255/1193837000315289/f

