### PR TITLE
rfc(volta): Update to use extends

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -50,5 +50,8 @@
     "fix:eslint": "eslint . --format stylish --fix",
     "pack": "npm pack"
   },
+  "volta": {
+    "extends": "../../package.json"
+  },
   "sideEffects": false
 }

--- a/packages/apm/package.json
+++ b/packages/apm/package.json
@@ -60,6 +60,9 @@
     "test:watch": "jest --watch",
     "pack": "npm pack"
   },
+  "volta": {
+    "extends": "../../package.json"
+  },
   "jest": {
     "collectCoverage": true,
     "transform": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -84,5 +84,8 @@
     "version": "node ../../scripts/versionbump.js src/version.ts",
     "pack": "npm pack"
   },
+  "volta": {
+    "extends": "../../package.json"
+  },
   "sideEffects": false
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,9 @@
     "test:watch": "jest --watch",
     "pack": "npm pack"
   },
+  "volta": {
+    "extends": "../../package.json"
+  },
   "jest": {
     "collectCoverage": true,
     "transform": {

--- a/packages/eslint-config-sdk/package.json
+++ b/packages/eslint-config-sdk/package.json
@@ -41,5 +41,8 @@
     "lint": "prettier --check \"**/*.js\"",
     "fix": "prettier --write \"**/*.js\"",
     "pack": "npm pack"
+  },
+  "volta": {
+    "extends": "../../package.json"
   }
 }

--- a/packages/eslint-plugin-sdk/package.json
+++ b/packages/eslint-plugin-sdk/package.json
@@ -32,5 +32,8 @@
     "fix": "prettier --write \"{src,test}/**/*.js\"",
     "test": "mocha test --recursive",
     "pack": "npm pack"
+  },
+  "volta": {
+    "extends": "../../package.json"
   }
 }

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -62,6 +62,9 @@
     "test:watch": "jest --watch",
     "pack": "npm pack"
   },
+  "volta": {
+    "extends": "../../package.json"
+  },
   "jest": {
     "collectCoverage": true,
     "transform": {

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -48,6 +48,9 @@
     "test:watch": "jest --watch",
     "pack": "npm pack"
   },
+  "volta": {
+    "extends": "../../package.json"
+  },
   "jest": {
     "collectCoverage": true,
     "transform": {

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -56,6 +56,9 @@
     "test:watch": "jest --watch",
     "pack": "npm pack"
   },
+  "volta": {
+    "extends": "../../package.json"
+  },
   "jest": {
     "collectCoverage": true,
     "transform": {

--- a/packages/minimal/package.json
+++ b/packages/minimal/package.json
@@ -48,6 +48,9 @@
     "test:watch": "jest --watch",
     "pack": "npm pack"
   },
+  "volta": {
+    "extends": "../../package.json"
+  },
   "jest": {
     "collectCoverage": true,
     "transform": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -63,6 +63,9 @@
     "version": "node ../../scripts/versionbump.js src/version.ts",
     "pack": "npm pack"
   },
+  "volta": {
+    "extends": "../../package.json"
+  },
   "jest": {
     "collectCoverage": true,
     "transform": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -76,6 +76,9 @@
     "test:watch": "jest --watch",
     "pack": "npm pack"
   },
+  "volta": {
+    "extends": "../../package.json"
+  },
   "jest": {
     "collectCoverage": true,
     "transform": {

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -52,6 +52,9 @@
     "test:watch": "jest --watch --passWithNoTests",
     "pack": "npm pack"
   },
+  "volta": {
+    "extends": "../../package.json"
+  },
   "sideEffects": false,
   "jest": {
     "collectCoverage": true,

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -62,6 +62,9 @@
     "test:watch": "jest --watch",
     "pack": "npm pack"
   },
+  "volta": {
+    "extends": "../../package.json"
+  },
   "jest": {
     "collectCoverage": true,
     "transform": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -38,5 +38,8 @@
     "fix:eslint": "eslint . --format stylish --fix",
     "pack": "npm pack"
   },
+  "volta": {
+    "extends": "../../package.json"
+  },
   "sideEffects": false
 }

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -21,5 +21,8 @@
   "scripts": {
     "link:yarn": "yarn link",
     "pack": "npm pack"
+  },
+  "volta": {
+    "extends": "../../package.json"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -48,6 +48,9 @@
     "test:watch": "jest --watch",
     "pack": "npm pack"
   },
+  "volta": {
+    "extends": "../../package.json"
+  },
   "jest": {
     "collectCoverage": true,
     "transform": {


### PR DESCRIPTION
When I was in the different packages I noticed that my node version would change.

As of Volta 0.8.2 you can use 'extends' for monorepo support, which helps pin node versions in all the packages (except where we need to special case it). Might be nice to have all of volta deps explicitly pinned.