### PR TITLE
fix(ember): Ensure initial page load is captured for Ember

### DIFF
--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -58,6 +58,11 @@ export function _instrumentEmberRouter(
         'routing.instrumentation': '@sentry/ember',
       },
     });
+
+    transitionSpan = activeTransaction.startChild({
+      op: 'ember.transition',
+      description: `route:undefined -> route:${routeInfo.name}`,
+    });
   }
 
   const finishActiveTransaction = function(_: any, nextInstance: any) {


### PR DESCRIPTION
This PR ensures that when running performance tracing for the initial page load, it works as expected.
That is hard to test, sadly.. But I noticed this behavior in a real-life app:

1. I open an initial page. This code runs and creates an initial `activeTransaction`:  https://github.com/getsentry/sentry-javascript/blob/4a11356e3b4f4ff227ec3069f730ede5f7fcca72/packages/ember/addon/instance-initializers/sentry-performance.ts#L52
2. `routerService.on('routeWillChange')` is not triggered for the initial page load, probably because it is already in-flight
3. `routerService.on('routeDidChange')` is triggered, but does nothing due to the condition https://github.com/getsentry/sentry-javascript/blob/4a11356e3b4f4ff227ec3069f730ede5f7fcca72/packages/ember/addon/instance-initializers/sentry-performance.ts#L90 because no` transitionSpan` exists yet

So this PR makes sure to add an initial `transitionSpan` - otherwise, the first time a user transitions to another page we get vastly wrong performance metrics.
