### PR TITLE
fix(utils): Prevent instrumentation handlers from being added multiple times

### DIFF
--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -85,40 +85,40 @@ export class Breadcrumbs implements Integration {
   public setupOnce(): void {
     if (this._options.console) {
       addInstrumentationHandler({
-        callback: (...args) => {
-          this._consoleBreadcrumb(...args);
+        callback: handlerData => {
+          this._consoleBreadcrumb(handlerData);
         },
         type: 'console',
       });
     }
     if (this._options.dom) {
       addInstrumentationHandler({
-        callback: (...args) => {
-          this._domBreadcrumb(...args);
+        callback: handlerData => {
+          this._domBreadcrumb(handlerData);
         },
         type: 'dom',
       });
     }
     if (this._options.xhr) {
       addInstrumentationHandler({
-        callback: (...args) => {
-          this._xhrBreadcrumb(...args);
+        callback: handlerData => {
+          this._xhrBreadcrumb(handlerData);
         },
         type: 'xhr',
       });
     }
     if (this._options.fetch) {
       addInstrumentationHandler({
-        callback: (...args) => {
-          this._fetchBreadcrumb(...args);
+        callback: handlerData => {
+          this._fetchBreadcrumb(handlerData);
         },
         type: 'fetch',
       });
     }
     if (this._options.history) {
       addInstrumentationHandler({
-        callback: (...args) => {
-          this._historyBreadcrumb(...args);
+        callback: handlerData => {
+          this._historyBreadcrumb(handlerData);
         },
         type: 'history',
       });


### PR DESCRIPTION
Adding an instrumentation handler consists of two steps:

1. Adding that handler to the list of handlers that will be triggered by the API being instrumented
2. Wrapping the native API so that the above triggering actually happens

In step 2, [we keep track](https://github.com/getsentry/sentry-javascript/blob/4a11356e3b4f4ff227ec3069f730ede5f7fcca72/packages/utils/src/instrument.ts#L42-L50) of which APIs have already been wrapped, so that we don't wrap an API twice. There's no such check in step 1, however. This adds that check. It can be used like so:

```js
const wrappedXHRCallback = (handlerData: XHRData): void => {
  request.xhrCallback(handlerData, shouldCreateSpan, spans);
};
wrappedXHRCallback.id = 'tracing.browser.request.xhrCallback';

addInstrumentationHandler({
  callback: wrappedXHRCallback,
  type: 'xhr',
});
```

Step 1 then compares the id of the new handler with those it already has, and bails if it's a duplicate. As a straightforward way to guarantee uniqueness, I propose that we adopt the convention of giving handlers the id of `<filepath relative to /packages>.<handler function name>` (with the small change that path segments would go from being slashes to being dots). You can see an example of that above. 

This PR doesn't retroactively give existing handlers an id; that can be handled in a follow-up. The one change it _does_ make (other than the ones to enable the above change, obviously) is to be more specific about the number of arguments passed to breadcrumb functions, since the `InstrumentHandlerCallback` signature went from being `(data: any) => void` to `(...args: any[]) => void` to accommodate the above usage (where the callback has multiple arguments) without explicit casting.


WIP because there are as yet no tests.