### PR TITLE
fix(tracing): Expose `startTransaction` in CDN bundle

### DIFF
--- a/packages/tracing/src/index.bundle.ts
+++ b/packages/tracing/src/index.bundle.ts
@@ -30,6 +30,7 @@ export {
   setTag,
   setTags,
   setUser,
+  startTransaction,
   Transports,
   withScope,
 } from '@sentry/browser';


### PR DESCRIPTION
Much like https://github.com/getsentry/sentry-javascript/pull/2726. 

We're correctly putting `startTransaction` onto `__SENTRY__`, but missed putting it in `Sentry`.