### PR TITLE
fix(react-router-v3): makes normalizeTransactionName take a callback function

### DIFF
--- a/packages/react/src/reactrouterv3.ts
+++ b/packages/react/src/reactrouterv3.ts
@@ -105,7 +105,8 @@ function normalizeTransactionName(
         return callback(name);
       }
 
-      return callback(routePath);
+      name = routePath;
+      return callback(name);
     },
   );
 }

--- a/packages/react/src/reactrouterv3.ts
+++ b/packages/react/src/reactrouterv3.ts
@@ -44,14 +44,15 @@ export function reactRouterV3Instrumentation(
 
     // Have to use global.location because history.location might not be defined.
     if (startTransactionOnPageLoad && global && global.location) {
-      prevName = normalizeTransactionName(routes, (global.location as unknown) as Location, match);
-
-      activeTransaction = startTransaction({
-        name: prevName,
-        op: 'pageload',
-        tags: {
-          'routing.instrumentation': 'react-router-v3',
-        },
+      normalizeTransactionName(routes, (global.location as unknown) as Location, match, (localName: string) => {
+        prevName = localName;
+        activeTransaction = startTransaction({
+          name: prevName,
+          op: 'pageload',
+          tags: {
+            'routing.instrumentation': 'react-router-v3',
+          },
+        });
       });
     }
 
@@ -65,11 +66,13 @@ export function reactRouterV3Instrumentation(
           if (prevName) {
             tags.from = prevName;
           }
-          prevName = normalizeTransactionName(routes, location, match);
-          activeTransaction = startTransaction({
-            name: prevName,
-            op: 'navigation',
-            tags,
+          normalizeTransactionName(routes, location, match, (localName: string) => {
+            prevName = localName;
+            activeTransaction = startTransaction({
+              name: prevName,
+              op: 'navigation',
+              tags,
+            });
           });
         }
       });
@@ -80,7 +83,12 @@ export function reactRouterV3Instrumentation(
 /**
  * Normalize transaction names using `Router.match`
  */
-function normalizeTransactionName(appRoutes: Route[], location: Location, match: Match): string {
+function normalizeTransactionName(
+  appRoutes: Route[],
+  location: Location,
+  match: Match,
+  callback: (pathname: string) => void,
+): void {
   let name = location.pathname;
   match(
     {
@@ -89,19 +97,17 @@ function normalizeTransactionName(appRoutes: Route[], location: Location, match:
     },
     (error, _redirectLocation, renderProps) => {
       if (error || !renderProps) {
-        return name;
+        return callback(name);
       }
 
       const routePath = getRouteStringFromRoutes(renderProps.routes || []);
       if (routePath.length === 0 || routePath === '/*') {
-        return name;
+        return callback(name);
       }
 
-      name = routePath;
-      return name;
+      return callback(routePath);
     },
   );
-  return name;
 }
 
 /**


### PR DESCRIPTION
This PR converts the `normalizeTransactionName` to a function that takes a callback instead of returning a value. This is to fix a bug where `normalizeTransactionName` returns a value before the callback passed to `match` is called. In that case, we end up returning the wrong value and the transaction name is incorrect. We see this in Sentry where we get a transaction for `/settings/sentry/integrations/` instead of `/settings/:orgId/integrations/`. This happens because the callback passed to `match` might be called asynchronously (https://github.com/ReactTraining/react-router/blob/42fe32d8f4ebec170a6d980badbc702ab88b5897/modules/matchRoutes.js#L249). So we need a callback here as well to get the proper behavior.

I tried to test this with Sentry but I think version `5.25.0-beta.2` introduces some breaking changes compared to `5.24.2` which is what we currently use.