### PR TITLE
fix(types): Remove redundant implementee

### DIFF
--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -37,7 +37,7 @@ export class SpanRecorder {
 /**
  * Span contains all data about a span
  */
-export class Span implements SpanInterface, SpanContext {
+export class Span implements SpanInterface {
   /**
    * @inheritDoc
    */


### PR DESCRIPTION
The `Span` interface [extends](https://github.com/getsentry/sentry-javascript/blob/e39c754e64626ec83c138159dd33b4d4127decaa/packages/types/src/span.ts#L61) the `SpanContext` interface, so anything in the latter is definitely in the former. Therefore, implementing the "superset" interface is sufficient.