### PR TITLE
serverless: let reject in callbackWrapper call captureExceptionAsync with the error

### DIFF
--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -165,7 +165,8 @@ export const wrapHandler = <TEvent = any, TResult = any>(
         if (args[0] === null || args[0] === undefined) {
           resolve(callback(...args));
         } else {
-          captureExceptionAsync(args[0], context, options).finally(() => reject(callback(...args)));
+          callback(...args);
+          reject(args[0]);
         }
       };
     };

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -38,7 +38,7 @@ const fakeCallback: Callback = (err, result) => {
   if (err === null || err === undefined) {
     return result;
   }
-  return err;
+  return undefined;
 };
 
 describe('AWSLambda', () => {
@@ -157,7 +157,7 @@ describe('AWSLambda', () => {
     });
 
     test('unsuccessful execution', async () => {
-      expect.assertions(2);
+      expect.assertions(3);
 
       const error = new Error('sorry');
       const handler: Handler = (_event, _context, callback) => {
@@ -169,6 +169,7 @@ describe('AWSLambda', () => {
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       } catch (e) {
         expect(Sentry.captureException).toBeCalledWith(error);
+        expect(Sentry.captureException).toBeCalledTimes(1);
         expect(Sentry.flush).toBeCalledWith(2000);
       }
     });


### PR DESCRIPTION
Fixes #2956 

I modified `fakeCallback` to not return the supplied error. I don't think you can assume that callbacks will always do that. That exposes the bug in the existing test suites if we add a check:

```typescript
expect(Sentry.captureException).toBeCalledTimes(1);
``` 

Second commit fixes the issue by discarding the `callback` result and `reject`ing with the error instead.

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

