### PR TITLE
Make @angular/common a peerDependency instead of dependency

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@angular/common: "^10.0.3"
+    "@angular/common": "^10.0.3"
   },
   "dependencies": {
     "@angular/core": "^10.0.3",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -17,10 +17,10 @@
   },
   "peerDependencies": {
     "@angular/common": "^10.0.3"
+    "@angular/core": "^10.0.3",
+    "@angular/router": "^10.0.3"
   },
   "dependencies": {
-    "@angular/core": "^10.0.3",
-    "@angular/router": "^10.0.3",
     "@sentry/browser": "5.25.0",
     "@sentry/types": "5.25.0",
     "@sentry/utils": "5.25.0",
@@ -28,6 +28,9 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
+    "@angular/common": "^10.0.3"
+    "@angular/core": "^10.0.3",
+    "@angular/router": "^10.0.3",
     "@sentry-internal/eslint-config-sdk": "5.25.0",
     "eslint": "7.6.0",
     "npm-run-all": "^4.1.2",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -15,8 +15,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "peerDependencies": {
+    "@angular/common: "^10.0.3"
+  },
   "dependencies": {
-    "@angular/common": "^10.0.3",
     "@angular/core": "^10.0.3",
     "@angular/router": "^10.0.3",
     "@sentry/browser": "5.25.0",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@angular/common": "^10.0.3"
+    "@angular/common": "^10.0.3",
     "@angular/core": "^10.0.3",
     "@angular/router": "^10.0.3"
   },
@@ -28,7 +28,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@angular/common": "^10.0.3"
+    "@angular/common": "^10.0.3",
     "@angular/core": "^10.0.3",
     "@angular/router": "^10.0.3",
     "@sentry-internal/eslint-config-sdk": "5.25.0",


### PR DESCRIPTION
Solves #2960

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
