### PR TITLE
feat(rum): Add more web vitals: CLS and TTFB

### DIFF
--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -9,6 +9,7 @@ import { msToSec } from '../utils';
 import { getCLS } from './web-vitals/getCLS';
 import { getFID } from './web-vitals/getFID';
 import { getLCP } from './web-vitals/getLCP';
+import { getTTFB } from './web-vitals/getTTFB';
 
 const global = getGlobalObject<Window>();
 
@@ -27,6 +28,7 @@ export class MetricsInstrumentation {
       this._trackCLS();
       this._trackLCP();
       this._trackFID();
+      this._trackTTFB();
     }
   }
 
@@ -173,6 +175,24 @@ export class MetricsInstrumentation {
       logger.log('[Measurements] Adding FID');
       this._measurements['fid'] = { value: metric.value };
       this._measurements['mark.fid'] = { value: timeOrigin + startTime };
+    });
+  }
+
+  /** Starts tracking the Time to First Byte on the current page. */
+  private _trackTTFB(): void {
+    getTTFB(metric => {
+      const entry = metric.entries.pop();
+
+      if (!entry) {
+        return;
+      }
+
+      logger.log('[Measurements] Adding TTFB');
+      this._measurements['ttfb'] = { value: metric.value };
+
+      // Capture the time spent making the request and receiving the first byte of the response
+      const requestTime = metric.value - (metric.entries[0] as PerformanceNavigationTiming).requestStart;
+      this._measurements['ttfb.requestTime'] = { value: requestTime };
     });
   }
 }

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -191,7 +191,7 @@ export class MetricsInstrumentation {
       this._measurements['ttfb'] = { value: metric.value };
 
       // Capture the time spent making the request and receiving the first byte of the response
-      const requestTime = metric.value - (metric.entries[0] as PerformanceNavigationTiming).requestStart;
+      const requestTime = metric.value - ((metric.entries[0] ?? entry) as PerformanceNavigationTiming).requestStart;
       this._measurements['ttfb.requestTime'] = { value: requestTime };
     });
   }

--- a/packages/tracing/src/browser/web-vitals/getCLS.ts
+++ b/packages/tracing/src/browser/web-vitals/getCLS.ts
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-import {bindReporter} from './lib/bindReporter';
-import {initMetric} from './lib/initMetric';
-import {observe, PerformanceEntryHandler} from './lib/observe';
-import {onHidden} from './lib/onHidden';
-import {ReportHandler} from './types';
-
+import { bindReporter } from './lib/bindReporter';
+import { initMetric } from './lib/initMetric';
+import { observe, PerformanceEntryHandler } from './lib/observe';
+import { onHidden } from './lib/onHidden';
+import { ReportHandler } from './types';
 
 // https://wicg.github.io/layout-instability/#sec-layout-shift
 interface LayoutShift extends PerformanceEntry {
@@ -45,7 +44,7 @@ export const getCLS = (onReport: ReportHandler, reportAllChanges = false): void 
   if (po) {
     report = bindReporter(onReport, metric, po, reportAllChanges);
 
-    onHidden(({isUnloading}) => {
+    onHidden(({ isUnloading }) => {
       po.takeRecords().map(entryHandler as PerformanceEntryHandler);
 
       if (isUnloading) {

--- a/packages/tracing/src/browser/web-vitals/getCLS.ts
+++ b/packages/tracing/src/browser/web-vitals/getCLS.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {bindReporter} from './lib/bindReporter';
+import {initMetric} from './lib/initMetric';
+import {observe, PerformanceEntryHandler} from './lib/observe';
+import {onHidden} from './lib/onHidden';
+import {ReportHandler} from './types';
+
+
+// https://wicg.github.io/layout-instability/#sec-layout-shift
+interface LayoutShift extends PerformanceEntry {
+  value: number;
+  hadRecentInput: boolean;
+}
+
+export const getCLS = (onReport: ReportHandler, reportAllChanges = false): void => {
+  const metric = initMetric('CLS', 0);
+
+  let report: ReturnType<typeof bindReporter>;
+
+  const entryHandler = (entry: LayoutShift): void => {
+    // Only count layout shifts without recent user input.
+    if (!entry.hadRecentInput) {
+      (metric.value as number) += entry.value;
+      metric.entries.push(entry);
+      report();
+    }
+  };
+
+  const po = observe('layout-shift', entryHandler as PerformanceEntryHandler);
+  if (po) {
+    report = bindReporter(onReport, metric, po, reportAllChanges);
+
+    onHidden(({isUnloading}) => {
+      po.takeRecords().map(entryHandler as PerformanceEntryHandler);
+
+      if (isUnloading) {
+        metric.isFinal = true;
+      }
+      report();
+    });
+  }
+};

--- a/packages/tracing/src/browser/web-vitals/getTTFB.ts
+++ b/packages/tracing/src/browser/web-vitals/getTTFB.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-import {initMetric} from './lib/initMetric';
-import {ReportHandler} from './types';
-
+import { initMetric } from './lib/initMetric';
+import { ReportHandler } from './types';
 
 interface NavigationEntryShim {
   // From `PerformanceNavigationTimingEntry`.
@@ -46,25 +45,25 @@ interface NavigationEntryShim {
 }
 
 type PerformanceTimingKeys =
-    'connectEnd' |
-    'connectStart' |
-    'domComplete' |
-    'domContentLoadedEventEnd' |
-    'domContentLoadedEventStart' |
-    'domInteractive' |
-    'domainLookupEnd' |
-    'domainLookupStart' |
-    'fetchStart' |
-    'loadEventEnd' |
-    'loadEventStart' |
-    'redirectEnd' |
-    'redirectStart' |
-    'requestStart' |
-    'responseEnd' |
-    'responseStart' |
-    'secureConnectionStart' |
-    'unloadEventEnd' |
-    'unloadEventStart';
+  | 'connectEnd'
+  | 'connectStart'
+  | 'domComplete'
+  | 'domContentLoadedEventEnd'
+  | 'domContentLoadedEventStart'
+  | 'domInteractive'
+  | 'domainLookupEnd'
+  | 'domainLookupStart'
+  | 'fetchStart'
+  | 'loadEventEnd'
+  | 'loadEventStart'
+  | 'redirectEnd'
+  | 'redirectStart'
+  | 'requestStart'
+  | 'responseEnd'
+  | 'responseStart'
+  | 'secureConnectionStart'
+  | 'unloadEventEnd'
+  | 'unloadEventStart';
 
 const afterLoad = (callback: () => void): void => {
   if (document.readyState === 'complete') {
@@ -74,7 +73,7 @@ const afterLoad = (callback: () => void): void => {
     // Use `pageshow` so the callback runs after `loadEventEnd`.
     addEventListener('pageshow', callback);
   }
-}
+};
 
 const getNavigationEntryFromPerformanceTiming = (): PerformanceNavigationTiming => {
   // Really annoying that TypeScript errors when using `PerformanceTiming`.
@@ -91,7 +90,9 @@ const getNavigationEntryFromPerformanceTiming = (): PerformanceNavigationTiming 
   for (const key in timing) {
     if (key !== 'navigationStart' && key !== 'toJSON') {
       navigationEntry[key as PerformanceTimingKeys] = Math.max(
-          timing[key as PerformanceTimingKeys] - timing.navigationStart, 0);
+        timing[key as PerformanceTimingKeys] - timing.navigationStart,
+        0,
+      );
     }
   }
   return navigationEntry as PerformanceNavigationTiming;
@@ -103,11 +104,10 @@ export const getTTFB = (onReport: ReportHandler): void => {
   afterLoad(() => {
     try {
       // Use the NavigationTiming L2 entry if available.
-      const navigationEntry = performance.getEntriesByType('navigation')[0] ||
-          getNavigationEntryFromPerformanceTiming();
+      const navigationEntry =
+        performance.getEntriesByType('navigation')[0] || getNavigationEntryFromPerformanceTiming();
 
-      metric.value = metric.delta =
-          (navigationEntry as PerformanceNavigationTiming).responseStart;
+      metric.value = metric.delta = (navigationEntry as PerformanceNavigationTiming).responseStart;
 
       metric.entries = [navigationEntry];
       metric.isFinal = true;

--- a/packages/tracing/src/browser/web-vitals/getTTFB.ts
+++ b/packages/tracing/src/browser/web-vitals/getTTFB.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {initMetric} from './lib/initMetric';
+import {ReportHandler} from './types';
+
+
+interface NavigationEntryShim {
+  // From `PerformanceNavigationTimingEntry`.
+  entryType: string;
+  startTime: number;
+
+  // From `performance.timing`.
+  connectEnd?: number;
+  connectStart?: number;
+  domComplete?: number;
+  domContentLoadedEventEnd?: number;
+  domContentLoadedEventStart?: number;
+  domInteractive?: number;
+  domainLookupEnd?: number;
+  domainLookupStart?: number;
+  fetchStart?: number;
+  loadEventEnd?: number;
+  loadEventStart?: number;
+  redirectEnd?: number;
+  redirectStart?: number;
+  requestStart?: number;
+  responseEnd?: number;
+  responseStart?: number;
+  secureConnectionStart?: number;
+  unloadEventEnd?: number;
+  unloadEventStart?: number;
+}
+
+type PerformanceTimingKeys =
+    'connectEnd' |
+    'connectStart' |
+    'domComplete' |
+    'domContentLoadedEventEnd' |
+    'domContentLoadedEventStart' |
+    'domInteractive' |
+    'domainLookupEnd' |
+    'domainLookupStart' |
+    'fetchStart' |
+    'loadEventEnd' |
+    'loadEventStart' |
+    'redirectEnd' |
+    'redirectStart' |
+    'requestStart' |
+    'responseEnd' |
+    'responseStart' |
+    'secureConnectionStart' |
+    'unloadEventEnd' |
+    'unloadEventStart';
+
+const afterLoad = (callback: () => void): void => {
+  if (document.readyState === 'complete') {
+    // Queue a task so the callback runs after `loadEventEnd`.
+    setTimeout(callback, 0);
+  } else {
+    // Use `pageshow` so the callback runs after `loadEventEnd`.
+    addEventListener('pageshow', callback);
+  }
+}
+
+const getNavigationEntryFromPerformanceTiming = (): PerformanceNavigationTiming => {
+  // Really annoying that TypeScript errors when using `PerformanceTiming`.
+  // Note: browsers that do not support navigation entries will fall back to using performance.timing
+  // (with the timestamps converted from epoch time to DOMHighResTimeStamp).
+  // eslint-disable-next-line deprecation/deprecation
+  const timing = performance.timing;
+
+  const navigationEntry: NavigationEntryShim = {
+    entryType: 'navigation',
+    startTime: 0,
+  };
+
+  for (const key in timing) {
+    if (key !== 'navigationStart' && key !== 'toJSON') {
+      navigationEntry[key as PerformanceTimingKeys] = Math.max(
+          timing[key as PerformanceTimingKeys] - timing.navigationStart, 0);
+    }
+  }
+  return navigationEntry as PerformanceNavigationTiming;
+};
+
+export const getTTFB = (onReport: ReportHandler): void => {
+  const metric = initMetric('TTFB');
+
+  afterLoad(() => {
+    try {
+      // Use the NavigationTiming L2 entry if available.
+      const navigationEntry = performance.getEntriesByType('navigation')[0] ||
+          getNavigationEntryFromPerformanceTiming();
+
+      metric.value = metric.delta =
+          (navigationEntry as PerformanceNavigationTiming).responseStart;
+
+      metric.entries = [navigationEntry];
+      metric.isFinal = true;
+
+      onReport(metric);
+    } catch (error) {
+      // Do nothing.
+    }
+  });
+};


### PR DESCRIPTION
Continuation from https://github.com/getsentry/sentry-javascript/pull/2909.

------

Add the rest of the available web vitals, specifically:

- Cumulative Layout Shift (CLS) (`measurements.cls`) - https://web.dev/cls/
- Time to First Byte (TTFB) (`measurements.ttfb`) - https://web.dev/time-to-first-byte/
- Also added `measurements.ttfb.requestTime`, which measures the time spent making the request and receiving the first byte of the response.

Sourced from: https://github.com/GoogleChrome/web-vitals specifically [56c736b7c4e80f295bc8a98017671c95231fa225](https://github.com/GoogleChrome/web-vitals/tree/56c736b7c4e80f295bc8a98017671c95231fa225). This is already on the vendored web-vitals README file.

 