### PR TITLE
feat(rum): Capture browser navigator information

### DIFF
--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -176,12 +176,10 @@ export class MetricsInstrumentation {
 
       if (isMeasurementValue(connection.rtt)) {
         this._measurements['connection.rtt'] = { value: connection.rtt };
-        transaction.setTag('connection.rtt', String(connection.rtt));
       }
 
       if (isMeasurementValue(connection.downlink)) {
         this._measurements['connection.downlink'] = { value: connection.downlink };
-        transaction.setTag('connection.downlink', String(connection.downlink));
       }
     }
 

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -138,9 +138,10 @@ export class MetricsInstrumentation {
 
     this._performanceCursor = Math.max(performance.getEntries().length - 1, 0);
 
+    this._trackNavigator(transaction);
+
     // Measurements are only available for pageload transactions
     if (transaction.op === 'pageload') {
-      this._trackNavigator();
       transaction.setContexts({ browser: this._browserContext });
       transaction.setMeasurements(this._measurements);
     }
@@ -163,7 +164,7 @@ export class MetricsInstrumentation {
   /**
    * Capture the information of the user agent.
    */
-  private _trackNavigator(): void {
+  private _trackNavigator(transaction: Transaction): void {
     const navigator = global.navigator as null | (Navigator & NavigatorNetworkInformation & NavigatorDeviceMemory);
 
     if(!navigator) {

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -177,6 +177,11 @@ export class MetricsInstrumentation {
     if (connection) {
       if (connection.effectiveType) {
         this._browserContext.effectiveConnectionType = connection.effectiveType;
+        transaction.setTag('effectiveConnectionType', connection.effectiveType);
+      }
+
+      if (connection.type) {
+        transaction.setTag('connectionType', connection.type);
       }
 
       if (isMeasurementValue(connection.rtt)) {

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -158,7 +158,7 @@ export class MetricsInstrumentation {
   private _trackNavigator(transaction: Transaction): void {
     const navigator = global.navigator as null | (Navigator & NavigatorNetworkInformation & NavigatorDeviceMemory);
 
-    if(!navigator) {
+    if (!navigator) {
       return;
     }
 

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -376,6 +376,9 @@ export function _startChild(transaction: Transaction, { startTimestamp, ...ctx }
   });
 }
 
-function isMeasurementValue(measurement: any): measurement is number {
-  return typeof measurement === 'number' && isFinite(measurement);
+/**
+ * Checks if a given value is a valid measurement value.
+ */
+function isMeasurementValue(value: any): value is number {
+  return typeof value === 'number' && isFinite(value);
 }

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -179,23 +179,23 @@ export class MetricsInstrumentation {
         this._browserContext.effectiveConnectionType = connection.effectiveType;
       }
 
-      if (typeof connection.rtt === 'number') {
+      if (isMeasurementValue(connection.rtt)) {
         this._measurements['connection.rtt'] = { value: connection.rtt };
         transaction.setTag('connection.rtt', String(connection.rtt));
       }
 
-      if (typeof connection.downlink === 'number') {
+      if (isMeasurementValue(connection.downlink)) {
         this._measurements['connection.downlink'] = { value: connection.downlink };
         transaction.setTag('connection.downlink', String(connection.downlink));
       }
     }
 
-    if (typeof navigator?.deviceMemory === 'number') {
+    if (isMeasurementValue(navigator.deviceMemory)) {
       this._browserContext.deviceMemory = navigator.deviceMemory;
       transaction.setTag('deviceMemory', String(navigator.deviceMemory));
     }
 
-    if (typeof navigator?.hardwareConcurrency === 'number') {
+    if (isMeasurementValue(navigator.hardwareConcurrency)) {
       this._browserContext.hardwareConcurrency = navigator.hardwareConcurrency;
       transaction.setTag('hardwareConcurrency', String(navigator.hardwareConcurrency));
     }
@@ -383,4 +383,8 @@ export function _startChild(transaction: Transaction, { startTimestamp, ...ctx }
     startTimestamp,
     ...ctx,
   });
+}
+
+function isMeasurementValue(measurement: any): measurement is number {
+  return typeof measurement === 'number' && isFinite(measurement);
 }

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -181,19 +181,23 @@ export class MetricsInstrumentation {
 
       if (typeof connection.rtt === 'number') {
         this._measurements['connection.rtt'] = { value: connection.rtt };
+        transaction.setTag('connection.rtt', String(connection.rtt));
       }
 
       if (typeof connection.downlink === 'number') {
         this._measurements['connection.downlink'] = { value: connection.downlink };
+        transaction.setTag('connection.downlink', String(connection.downlink));
       }
     }
 
     if (typeof navigator?.deviceMemory === 'number') {
       this._browserContext.deviceMemory = navigator.deviceMemory;
+      transaction.setTag('deviceMemory', String(navigator.deviceMemory));
     }
 
     if (typeof navigator?.hardwareConcurrency === 'number') {
       this._browserContext.hardwareConcurrency = navigator.hardwareConcurrency;
+      transaction.setTag('hardwareConcurrency', String(navigator.hardwareConcurrency));
     }
   }
 

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -165,11 +165,15 @@ export class MetricsInstrumentation {
    * Capture the information of the user agent.
    */
   private _trackNavigator(): void {
-    const navigator = window.navigator as null | (Navigator & NavigatorNetworkInformation & NavigatorDeviceMemory);
+    const navigator = global.navigator as null | (Navigator & NavigatorNetworkInformation & NavigatorDeviceMemory);
+
+    if(!navigator) {
+      return;
+    }
 
     // track network connectivity
 
-    const connection = navigator?.connection;
+    const connection = navigator.connection;
     if (connection) {
       if (connection.effectiveType) {
         this._browserContext.effectiveConnectionType = connection.effectiveType;

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -15,17 +15,9 @@ import { NavigatorDeviceMemory, NavigatorNetworkInformation } from './web-vitals
 
 const global = getGlobalObject<Window>();
 
-type BrowserContext = {
-  effectiveConnectionType?: string;
-  deviceMemory?: number;
-  // number of CPUs
-  hardwareConcurrency?: number;
-};
-
 /** Class tracking metrics  */
 export class MetricsInstrumentation {
   private _measurements: Measurements = {};
-  private _browserContext: BrowserContext = {};
 
   private _performanceCursor: number = 0;
 
@@ -142,7 +134,6 @@ export class MetricsInstrumentation {
 
     // Measurements are only available for pageload transactions
     if (transaction.op === 'pageload') {
-      transaction.setContexts({ browser: this._browserContext });
       transaction.setMeasurements(this._measurements);
     }
   }
@@ -176,7 +167,6 @@ export class MetricsInstrumentation {
     const connection = navigator.connection;
     if (connection) {
       if (connection.effectiveType) {
-        this._browserContext.effectiveConnectionType = connection.effectiveType;
         transaction.setTag('effectiveConnectionType', connection.effectiveType);
       }
 
@@ -196,12 +186,10 @@ export class MetricsInstrumentation {
     }
 
     if (isMeasurementValue(navigator.deviceMemory)) {
-      this._browserContext.deviceMemory = navigator.deviceMemory;
       transaction.setTag('deviceMemory', String(navigator.deviceMemory));
     }
 
     if (isMeasurementValue(navigator.hardwareConcurrency)) {
-      this._browserContext.hardwareConcurrency = navigator.hardwareConcurrency;
       transaction.setTag('hardwareConcurrency', String(navigator.hardwareConcurrency));
     }
   }

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -175,11 +175,11 @@ export class MetricsInstrumentation {
       }
 
       if (isMeasurementValue(connection.rtt)) {
-        this._measurements['connection.rtt'] = { value: connection.rtt };
+        this._measurements['connection.rtt'] = { value: connection.rtt as number };
       }
 
       if (isMeasurementValue(connection.downlink)) {
-        this._measurements['connection.downlink'] = { value: connection.downlink };
+        this._measurements['connection.downlink'] = { value: connection.downlink as number };
       }
     }
 
@@ -379,6 +379,6 @@ export function _startChild(transaction: Transaction, { startTimestamp, ...ctx }
 /**
  * Checks if a given value is a valid measurement value.
  */
-function isMeasurementValue(value: any): value is number {
+function isMeasurementValue(value: any): boolean {
   return typeof value === 'number' && isFinite(value);
 }

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -15,8 +15,6 @@ import { NavigatorDeviceMemory, NavigatorNetworkInformation } from './web-vitals
 
 const global = getGlobalObject<Window>();
 
-type FooNavigator = Navigator & NavigatorNetworkInformation & NavigatorDeviceMemory;
-
 type BrowserContext = {
   effectiveConnectionType?: string;
   deviceMemory?: number;
@@ -167,7 +165,7 @@ export class MetricsInstrumentation {
    * Capture the information of the user agent.
    */
   private _trackNavigator(): void {
-    const navigator = window.navigator as null | FooNavigator;
+    const navigator = window.navigator as null | (Navigator & NavigatorNetworkInformation & NavigatorDeviceMemory);
 
     // track network connectivity
 

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -39,7 +39,6 @@ export class MetricsInstrumentation {
       this._trackLCP();
       this._trackFID();
       this._trackTTFB();
-      this._trackNavigator();
     }
   }
 

--- a/packages/tracing/src/browser/web-vitals/types.ts
+++ b/packages/tracing/src/browser/web-vitals/types.ts
@@ -43,3 +43,42 @@ export interface Metric {
 export interface ReportHandler {
   (metric: Metric): void;
 }
+
+// http://wicg.github.io/netinfo/#navigatornetworkinformation-interface
+export interface NavigatorNetworkInformation {
+  readonly connection?: NetworkInformation;
+}
+
+// http://wicg.github.io/netinfo/#connection-types
+type ConnectionType = 'bluetooth' | 'cellular' | 'ethernet' | 'mixed' | 'none' | 'other' | 'unknown' | 'wifi' | 'wimax';
+
+// http://wicg.github.io/netinfo/#effectiveconnectiontype-enum
+type EffectiveConnectionType = '2g' | '3g' | '4g' | 'slow-2g';
+
+// http://wicg.github.io/netinfo/#dom-megabit
+type Megabit = number;
+// http://wicg.github.io/netinfo/#dom-millisecond
+type Millisecond = number;
+
+// http://wicg.github.io/netinfo/#networkinformation-interface
+interface NetworkInformation extends EventTarget {
+  // http://wicg.github.io/netinfo/#type-attribute
+  readonly type?: ConnectionType;
+  // http://wicg.github.io/netinfo/#effectivetype-attribute
+  readonly effectiveType?: EffectiveConnectionType;
+  // http://wicg.github.io/netinfo/#downlinkmax-attribute
+  readonly downlinkMax?: Megabit;
+  // http://wicg.github.io/netinfo/#downlink-attribute
+  readonly downlink?: Megabit;
+  // http://wicg.github.io/netinfo/#rtt-attribute
+  readonly rtt?: Millisecond;
+  // http://wicg.github.io/netinfo/#savedata-attribute
+  readonly saveData?: boolean;
+  // http://wicg.github.io/netinfo/#handling-changes-to-the-underlying-connection
+  onchange?: EventListener;
+}
+
+// https://w3c.github.io/device-memory/#sec-device-memory-js-api
+export interface NavigatorDeviceMemory {
+  readonly deviceMemory?: number;
+}

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -1,5 +1,5 @@
 import { getCurrentHub, Hub } from '@sentry/hub';
-import { Event, Measurements, Transaction as TransactionInterface, TransactionContext } from '@sentry/types';
+import { Contexts, Event, Measurements, Transaction as TransactionInterface, TransactionContext } from '@sentry/types';
 import { isInstanceOf, logger } from '@sentry/utils';
 
 import { Span as SpanClass, SpanRecorder } from './span';
@@ -8,6 +8,7 @@ import { Span as SpanClass, SpanRecorder } from './span';
 export class Transaction extends SpanClass implements TransactionInterface {
   public name: string;
   private _measurements: Measurements = {};
+  private _contexts: Contexts = {};
 
   /**
    * The reference to the current hub.
@@ -65,6 +66,13 @@ export class Transaction extends SpanClass implements TransactionInterface {
   }
 
   /**
+   *
+   */
+  public setContexts(contexts: Contexts): void {
+    this._contexts = contexts;
+  }
+
+  /**
    * @inheritDoc
    */
   public finish(endTimestamp?: number): string | undefined {
@@ -100,6 +108,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
 
     const transaction: Event = {
       contexts: {
+        ...this._contexts,
         trace: this.getTraceContext(),
       },
       spans: finishedSpans,

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -1,5 +1,5 @@
 import { getCurrentHub, Hub } from '@sentry/hub';
-import { Contexts, Event, Measurements, Transaction as TransactionInterface, TransactionContext } from '@sentry/types';
+import { Event, Measurements, Transaction as TransactionInterface, TransactionContext } from '@sentry/types';
 import { isInstanceOf, logger } from '@sentry/utils';
 
 import { Span as SpanClass, SpanRecorder } from './span';
@@ -8,7 +8,6 @@ import { Span as SpanClass, SpanRecorder } from './span';
 export class Transaction extends SpanClass implements TransactionInterface {
   public name: string;
   private _measurements: Measurements = {};
-  private _contexts: Contexts = {};
 
   /**
    * The reference to the current hub.
@@ -66,13 +65,6 @@ export class Transaction extends SpanClass implements TransactionInterface {
   }
 
   /**
-   *
-   */
-  public setContexts(contexts: Contexts): void {
-    this._contexts = contexts;
-  }
-
-  /**
    * @inheritDoc
    */
   public finish(endTimestamp?: number): string | undefined {
@@ -108,7 +100,6 @@ export class Transaction extends SpanClass implements TransactionInterface {
 
     const transaction: Event = {
       contexts: {
-        ...this._contexts,
         trace: this.getTraceContext(),
       },
       spans: finishedSpans,


### PR DESCRIPTION
We capture information from `window.navigator` that can provide insights into the browser (user agent) environment: https://developer.mozilla.org/en-US/docs/Web/API/Navigator

Capture network connectivity information (http://wicg.github.io/netinfo/) such as:
- `rtt` - effective round-trip time estimate in milliseconds
- `downlink` - the effective bandwidth estimate in megabits per second, rounded to nearest multiple of 25 kilobits per second
- Connection type - https://wicg.github.io/netinfo/#connectiontype-enum
- Effective connection type - https://wicg.github.io/netinfo/#dfn-effective-connection-type

Device information such as:
- device memory in gigabytes - https://developer.mozilla.org/en-US/docs/Web/API/Navigator/deviceMemory
- number of CPU - https://developer.mozilla.org/en-US/docs/Web/API/NavigatorConcurrentHardware/hardwareConcurrency


These properties provide insights into why some transactions are longer than they typically are (e.g. someone is accessing Sentry using a poor Internet connection).

