### PR TITLE
Pass scope data for transactions in serverless

### DIFF
--- a/packages/serverless/src/gcpfunction/general.ts
+++ b/packages/serverless/src/gcpfunction/general.ts
@@ -1,9 +1,8 @@
 // '@google-cloud/functions-framework/build/src/functions' import is expected to be type-only so it's erased in the final .js file.
 // When TypeScript compiler is upgraded, use `import type` syntax to explicitly assert that we don't want to load a module here.
 import { Context } from '@google-cloud/functions-framework/build/src/functions';
-import { captureException, Scope, SDK_VERSION, withScope } from '@sentry/node';
+import { Scope } from '@sentry/node';
 import { Context as SentryContext } from '@sentry/types';
-import { addExceptionMechanism } from '@sentry/utils';
 import * as domain from 'domain';
 import { hostname } from 'os';
 
@@ -12,52 +11,18 @@ export interface WrapperOptions {
 }
 
 /**
- * Capture exception with additional event information.
+ * Enhances the scope with additional event information.
  *
- * @param e exception to be captured
+ * @param scope scope
  * @param context event context
  */
-export function captureEventError(e: unknown, context: Context): void {
-  withScope(scope => {
-    addServerlessEventProcessor(scope);
-    scope.setContext('runtime', {
-      name: 'node',
-      version: global.process.version,
-    });
-    scope.setTag('server_name', process.env.SENTRY_NAME || hostname());
-    scope.setContext('gcp.function.context', { ...context } as SentryContext);
-    captureException(e);
+export function configureScopeWithContext(scope: Scope, context: Context): void {
+  scope.setContext('runtime', {
+    name: 'node',
+    version: global.process.version,
   });
-}
-
-/**
- * Add event processor that will override SDK details to point to the serverless SDK instead of Node,
- * as well as set correct mechanism type, which should be set to `handled: false`.
- * We do it like this, so that we don't introduce any side-effects in this module, which makes it tree-shakeable.
- * @param scope Scope that processor should be added to
- */
-export function addServerlessEventProcessor(scope: Scope): void {
-  scope.addEventProcessor(event => {
-    event.sdk = {
-      ...event.sdk,
-      name: 'sentry.javascript.serverless',
-      integrations: [...((event.sdk && event.sdk.integrations) || []), 'GCPFunction'],
-      packages: [
-        ...((event.sdk && event.sdk.packages) || []),
-        {
-          name: 'npm:@sentry/serverless',
-          version: SDK_VERSION,
-        },
-      ],
-      version: SDK_VERSION,
-    };
-
-    addExceptionMechanism(event, {
-      handled: false,
-    });
-
-    return event;
-  });
+  scope.setTag('server_name', process.env.SENTRY_NAME || hostname());
+  scope.setContext('gcp.function.context', { ...context } as SentryContext);
 }
 
 /**

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -1,10 +1,10 @@
 // '@google-cloud/functions-framework/build/src/functions' import is expected to be type-only so it's erased in the final .js file.
 // When TypeScript compiler is upgraded, use `import type` syntax to explicitly assert that we don't want to load a module here.
 import { HttpFunction } from '@google-cloud/functions-framework/build/src/functions';
-import { captureException, flush, getCurrentHub, Handlers, startTransaction, withScope } from '@sentry/node';
+import { captureException, flush, getCurrentHub, Handlers, startTransaction } from '@sentry/node';
 import { logger, stripUrlQueryAndFragment } from '@sentry/utils';
 
-import { addServerlessEventProcessor, getActiveDomain, WrapperOptions } from './general';
+import { getActiveDomain, WrapperOptions } from './general';
 
 type Request = Parameters<HttpFunction>[0];
 type Response = Parameters<HttpFunction>[1];
@@ -17,21 +17,6 @@ export interface HttpFunctionWrapperOptions extends WrapperOptions {
 export { Request, Response };
 
 const { parseRequest } = Handlers;
-
-/**
- * Capture exception with additional request information.
- *
- * @param e exception to be captured
- * @param req incoming request
- * @param options request capture options
- */
-function captureRequestError(e: unknown, req: Request, options: ParseRequestOptions): void {
-  withScope(scope => {
-    addServerlessEventProcessor(scope);
-    scope.addEventProcessor(event => parseRequest(event, req, options));
-    captureException(e);
-  });
-}
 
 /**
  * Wraps an HTTP function handler adding it error capture and tracing capabilities.
@@ -58,8 +43,12 @@ export function wrapHttpFunction(
       op: 'gcp.function.http',
     });
 
-    // We put the transaction on the scope so users can attach children to it
+    // getCurrentHub() is expected to use current active domain as a carrier
+    // since functions-framework creates a domain for each incoming request.
+    // So adding of event processors every time should not lead to memory bloat.
     getCurrentHub().configureScope(scope => {
+      scope.addEventProcessor(event => parseRequest(event, req, options.parseRequestOptions));
+      // We put the transaction on the scope so users can attach children to it
       scope.setSpan(transaction);
     });
 
@@ -71,7 +60,7 @@ export function wrapHttpFunction(
     // functions-framework creates a domain for each incoming request so we take advantage of this fact and add an error handler.
     // BTW this is the only way to catch any exception occured during request lifecycle.
     getActiveDomain().on('error', err => {
-      captureRequestError(err, req, options.parseRequestOptions);
+      captureException(err);
     });
 
     // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/packages/serverless/src/gcpfunction/index.ts
+++ b/packages/serverless/src/gcpfunction/index.ts
@@ -1,4 +1,15 @@
+import * as Sentry from '@sentry/node';
+
+import { serverlessEventProcessor } from '../utils';
+
 export * from './http';
 export * from './events';
 export * from './cloud_events';
-export { init } from '@sentry/node';
+
+/**
+ * @see {@link Sentry.init}
+ */
+export function init(options: Sentry.NodeOptions = {}): void {
+  Sentry.init(options);
+  Sentry.addGlobalEventProcessor(serverlessEventProcessor('GCPFunction'));
+}

--- a/packages/serverless/src/utils.ts
+++ b/packages/serverless/src/utils.ts
@@ -1,0 +1,33 @@
+import { Event, SDK_VERSION } from '@sentry/node';
+import { addExceptionMechanism } from '@sentry/utils';
+
+/**
+ * Event processor that will override SDK details to point to the serverless SDK instead of Node,
+ * as well as set correct mechanism type, which should be set to `handled: false`.
+ * We do it like this, so that we don't introduce any side-effects in this module, which makes it tree-shakeable.
+ * @param event Event
+ * @param integration Name of the serverless integration ('AWSLambda', 'GCPFunction', etc)
+ */
+export function serverlessEventProcessor(integration: string): (event: Event) => Event {
+  return event => {
+    event.sdk = {
+      ...event.sdk,
+      name: 'sentry.javascript.serverless',
+      integrations: [...((event.sdk && event.sdk.integrations) || []), integration],
+      packages: [
+        ...((event.sdk && event.sdk.packages) || []),
+        {
+          name: 'npm:@sentry/serverless',
+          version: SDK_VERSION,
+        },
+      ],
+      version: SDK_VERSION,
+    };
+
+    addExceptionMechanism(event, {
+      handled: false,
+    });
+
+    return event;
+  };
+}

--- a/packages/serverless/test/__mocks__/@sentry/node.ts
+++ b/packages/serverless/test/__mocks__/@sentry/node.ts
@@ -27,6 +27,8 @@ export const fakeTransaction = {
   setHttpStatus: jest.fn(),
   startChild: jest.fn(() => fakeSpan),
 };
+export const init = jest.fn();
+export const addGlobalEventProcessor = jest.fn();
 export const getCurrentHub = jest.fn(() => fakeHub);
 export const startTransaction = jest.fn(_ => fakeTransaction);
 export const captureException = jest.fn();
@@ -51,6 +53,8 @@ export const resetMocks = (): void => {
   fakeScope.setSpan.mockClear();
   fakeScope.getTransaction.mockClear();
 
+  init.mockClear();
+  addGlobalEventProcessor.mockClear();
   getCurrentHub.mockClear();
   startTransaction.mockClear();
   captureException.mockClear();

--- a/packages/serverless/test/__mocks__/@sentry/node.ts
+++ b/packages/serverless/test/__mocks__/@sentry/node.ts
@@ -5,19 +5,19 @@ export const SDK_VERSION = '6.6.6';
 export const Severity = {
   Warning: 'warning',
 };
-export const fakeParentScope = {
-  setSpan: jest.fn(),
-  getTransaction: jest.fn(() => fakeTransaction),
-};
 export const fakeHub = {
-  configureScope: jest.fn((fn: (arg: any) => any) => fn(fakeParentScope)),
-  getScope: jest.fn(() => fakeParentScope),
+  configureScope: jest.fn((fn: (arg: any) => any) => fn(fakeScope)),
+  pushScope: jest.fn(() => fakeScope),
+  popScope: jest.fn(),
+  getScope: jest.fn(() => fakeScope),
 };
 export const fakeScope = {
   addEventProcessor: jest.fn(),
   setTransactionName: jest.fn(),
   setTag: jest.fn(),
   setContext: jest.fn(),
+  setSpan: jest.fn(),
+  getTransaction: jest.fn(() => fakeTransaction),
 };
 export const fakeSpan = {
   finish: jest.fn(),
@@ -39,15 +39,17 @@ export const resetMocks = (): void => {
   fakeTransaction.finish.mockClear();
   fakeTransaction.startChild.mockClear();
   fakeSpan.finish.mockClear();
-  fakeParentScope.setSpan.mockClear();
-  fakeParentScope.getTransaction.mockClear();
   fakeHub.configureScope.mockClear();
+  fakeHub.pushScope.mockClear();
+  fakeHub.popScope.mockClear();
   fakeHub.getScope.mockClear();
 
   fakeScope.addEventProcessor.mockClear();
   fakeScope.setTransactionName.mockClear();
   fakeScope.setTag.mockClear();
   fakeScope.setContext.mockClear();
+  fakeScope.setSpan.mockClear();
+  fakeScope.getTransaction.mockClear();
 
   getCurrentHub.mockClear();
   startTransaction.mockClear();

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -41,6 +41,36 @@ const fakeCallback: Callback = (err, result) => {
   return err;
 };
 
+function expectScopeSettings() {
+  // @ts-ignore see "Why @ts-ignore" note
+  expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+  // @ts-ignore see "Why @ts-ignore" note
+  expect(Sentry.fakeScope.setTag).toBeCalledWith('server_name', expect.anything());
+  // @ts-ignore see "Why @ts-ignore" note
+  expect(Sentry.fakeScope.setTag).toBeCalledWith('url', 'awslambda:///functionName');
+  // @ts-ignore see "Why @ts-ignore" note
+  expect(Sentry.fakeScope.setContext).toBeCalledWith('runtime', { name: 'node', version: expect.anything() });
+  // @ts-ignore see "Why @ts-ignore" note
+  expect(Sentry.fakeScope.setContext).toBeCalledWith(
+    'aws.lambda',
+    expect.objectContaining({
+      aws_request_id: 'awsRequestId',
+      function_name: 'functionName',
+      function_version: 'functionVersion',
+      invoked_function_arn: 'invokedFunctionArn',
+      remaining_time_in_millis: 100,
+    }),
+  );
+  // @ts-ignore see "Why @ts-ignore" note
+  expect(Sentry.fakeScope.setContext).toBeCalledWith(
+    'aws.cloudwatch.logs',
+    expect.objectContaining({
+      log_group: 'logGroupName',
+      log_stream: 'logStreamName',
+    }),
+  );
+}
+
 describe('AWSLambda', () => {
   afterEach(() => {
     // @ts-ignore see "Why @ts-ignore" note
@@ -140,7 +170,7 @@ describe('AWSLambda', () => {
 
   describe('wrapHandler() on sync handler', () => {
     test('successful execution', async () => {
-      expect.assertions(5);
+      expect.assertions(10);
 
       const handler: Handler = (_event, _context, callback) => {
         callback(null, 42);
@@ -149,15 +179,14 @@ describe('AWSLambda', () => {
       const rv = await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       expect(rv).toStrictEqual(42);
       expect(Sentry.startTransaction).toBeCalledWith({ name: 'functionName', op: 'awslambda.handler' });
-      // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeParentScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      expectScopeSettings();
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
       expect(Sentry.flush).toBeCalledWith(2000);
     });
 
     test('unsuccessful execution', async () => {
-      expect.assertions(5);
+      expect.assertions(10);
 
       const error = new Error('sorry');
       const handler: Handler = (_event, _context, callback) => {
@@ -169,8 +198,7 @@ describe('AWSLambda', () => {
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       } catch (e) {
         expect(Sentry.startTransaction).toBeCalledWith({ name: 'functionName', op: 'awslambda.handler' });
-        // @ts-ignore see "Why @ts-ignore" note
-        expect(Sentry.fakeParentScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+        expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(error);
         // @ts-ignore see "Why @ts-ignore" note
         expect(Sentry.fakeTransaction.finish).toBeCalled();
@@ -191,7 +219,7 @@ describe('AWSLambda', () => {
     });
 
     test('capture error', async () => {
-      expect.assertions(5);
+      expect.assertions(10);
 
       const error = new Error('wat');
       const handler: Handler = (_event, _context, _callback) => {
@@ -203,8 +231,7 @@ describe('AWSLambda', () => {
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       } catch (e) {
         expect(Sentry.startTransaction).toBeCalledWith({ name: 'functionName', op: 'awslambda.handler' });
-        // @ts-ignore see "Why @ts-ignore" note
-        expect(Sentry.fakeParentScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+        expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(e);
         // @ts-ignore see "Why @ts-ignore" note
         expect(Sentry.fakeTransaction.finish).toBeCalled();
@@ -215,7 +242,7 @@ describe('AWSLambda', () => {
 
   describe('wrapHandler() on async handler', () => {
     test('successful execution', async () => {
-      expect.assertions(5);
+      expect.assertions(10);
 
       const handler: Handler = async (_event, _context) => {
         return 42;
@@ -224,8 +251,7 @@ describe('AWSLambda', () => {
       const rv = await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       expect(rv).toStrictEqual(42);
       expect(Sentry.startTransaction).toBeCalledWith({ name: 'functionName', op: 'awslambda.handler' });
-      // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeParentScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      expectScopeSettings();
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
       expect(Sentry.flush).toBeCalled();
@@ -243,7 +269,7 @@ describe('AWSLambda', () => {
     });
 
     test('capture error', async () => {
-      expect.assertions(5);
+      expect.assertions(10);
 
       const error = new Error('wat');
       const handler: Handler = async (_event, _context) => {
@@ -255,8 +281,7 @@ describe('AWSLambda', () => {
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       } catch (e) {
         expect(Sentry.startTransaction).toBeCalledWith({ name: 'functionName', op: 'awslambda.handler' });
-        // @ts-ignore see "Why @ts-ignore" note
-        expect(Sentry.fakeParentScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+        expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(error);
         // @ts-ignore see "Why @ts-ignore" note
         expect(Sentry.fakeTransaction.finish).toBeCalled();
@@ -267,7 +292,7 @@ describe('AWSLambda', () => {
 
   describe('wrapHandler() on async handler with a callback method (aka incorrect usage)', () => {
     test('successful execution', async () => {
-      expect.assertions(5);
+      expect.assertions(10);
 
       const handler: Handler = async (_event, _context, _callback) => {
         return 42;
@@ -276,8 +301,7 @@ describe('AWSLambda', () => {
       const rv = await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       expect(rv).toStrictEqual(42);
       expect(Sentry.startTransaction).toBeCalledWith({ name: 'functionName', op: 'awslambda.handler' });
-      // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeParentScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      expectScopeSettings();
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
       expect(Sentry.flush).toBeCalled();
@@ -295,7 +319,7 @@ describe('AWSLambda', () => {
     });
 
     test('capture error', async () => {
-      expect.assertions(5);
+      expect.assertions(10);
 
       const error = new Error('wat');
       const handler: Handler = async (_event, _context, _callback) => {
@@ -307,8 +331,7 @@ describe('AWSLambda', () => {
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       } catch (e) {
         expect(Sentry.startTransaction).toBeCalledWith({ name: 'functionName', op: 'awslambda.handler' });
-        // @ts-ignore see "Why @ts-ignore" note
-        expect(Sentry.fakeParentScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+        expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(error);
         // @ts-ignore see "Why @ts-ignore" note
         expect(Sentry.fakeTransaction.finish).toBeCalled();


### PR DESCRIPTION
In #2945 I added transaction support in a way that it doesn't capture any context info for transaction events :(
Though it captures exception events context just fine, it misses the context for transaction events. This PR aims to fix it.