### PR TITLE
fix: SDK name for serverless

### DIFF
--- a/packages/serverless/src/gcpfunction/general.ts
+++ b/packages/serverless/src/gcpfunction/general.ts
@@ -1,7 +1,7 @@
 // '@google-cloud/functions-framework/build/src/functions' import is expected to be type-only so it's erased in the final .js file.
 // When TypeScript compiler is upgraded, use `import type` syntax to explicitly assert that we don't want to load a module here.
 import { Context } from '@google-cloud/functions-framework/build/src/functions';
-import { captureException, Scope, SDK_VERSION, withScope } from '@sentry/node';
+import { addGlobalEventProcessor, captureException, Scope, SDK_VERSION, withScope } from '@sentry/node';
 import { Context as SentryContext } from '@sentry/types';
 import { addExceptionMechanism } from '@sentry/utils';
 import * as domain from 'domain';
@@ -31,6 +31,27 @@ export function captureEventError(e: unknown, context: Context): void {
 }
 
 /**
+ * Add SDK info
+ */
+addGlobalEventProcessor(event => {
+  event.sdk = {
+    ...event.sdk,
+    name: 'sentry.javascript.serverless',
+    integrations: [...((event.sdk && event.sdk.integrations) || []), 'GCPFunction'],
+    packages: [
+      ...((event.sdk && event.sdk.packages) || []),
+      {
+        name: 'npm:@sentry/serverless',
+        version: SDK_VERSION,
+      },
+    ],
+    version: SDK_VERSION,
+  };
+
+  return event;
+});
+
+/**
  * Add event processor that will override SDK details to point to the serverless SDK instead of Node,
  * as well as set correct mechanism type, which should be set to `handled: false`.
  * We do it like this, so that we don't introduce any side-effects in this module, which makes it tree-shakeable.
@@ -38,20 +59,6 @@ export function captureEventError(e: unknown, context: Context): void {
  */
 export function addServerlessEventProcessor(scope: Scope): void {
   scope.addEventProcessor(event => {
-    event.sdk = {
-      ...event.sdk,
-      name: 'sentry.javascript.serverless',
-      integrations: [...((event.sdk && event.sdk.integrations) || []), 'GCPFunction'],
-      packages: [
-        ...((event.sdk && event.sdk.packages) || []),
-        {
-          name: 'npm:@sentry/serverless',
-          version: SDK_VERSION,
-        },
-      ],
-      version: SDK_VERSION,
-    };
-
     addExceptionMechanism(event, {
       handled: false,
     });


### PR DESCRIPTION
Transactions have the wrong SDK name since the event handler will not be added. We need to use GlobalEventhandler to always set the SDK name correctly.

![image](https://user-images.githubusercontent.com/363802/96112373-cd9dca00-0ee2-11eb-9f3a-8260b5159102.png)
