### PR TITLE
Fix _processing flag in BaseClient.

### DIFF
--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -1,6 +1,6 @@
 import { Hub, Scope } from '@sentry/hub';
 import { Event, Severity, Span } from '@sentry/types';
-import { SentryError } from '@sentry/utils';
+import { SentryError, SyncPromise } from '@sentry/utils';
 
 import { TestBackend } from '../mocks/backend';
 import { TestClient } from '../mocks/client';
@@ -780,6 +780,37 @@ describe('BaseClient', () => {
       await client.flush(delay);
       expect(transportInstance.sentCount).toEqual(1);
       expect(transportInstance.sendCalled).toEqual(1);
+    });
+
+    test('flush with some events being processed async', async () => {
+      jest.useRealTimers();
+      expect.assertions(5);
+      const client = new TestClient({
+        dsn: PUBLIC_DSN,
+        enableSend: true,
+        transport: FakeTransport,
+      });
+
+      const delay = 300;
+      const spy = jest.spyOn(TestBackend.instance!, 'eventFromMessage');
+      spy.mockImplementationOnce(
+        (message, level) =>
+          new SyncPromise((resolve, _reject) => {
+            setTimeout(() => resolve({ message, level }), 150);
+          }),
+      );
+      const transportInstance = (client as any)._getBackend().getTransport() as FakeTransport;
+      transportInstance.delay = delay;
+
+      client.captureMessage('test async');
+      client.captureMessage('test non-async');
+      expect(transportInstance).toBeInstanceOf(FakeTransport);
+      expect(transportInstance.sendCalled).toEqual(1);
+      expect(transportInstance.sentCount).toEqual(0);
+      await client.flush(delay);
+      expect(transportInstance.sentCount).toEqual(2);
+      expect(transportInstance.sendCalled).toEqual(2);
+      spy.mockRestore();
     });
 
     test('close', async () => {


### PR DESCRIPTION
I had experienced some problems with `flush()` in a following scenario:

```javascript
captureException(error); // Sets _processing=true. Internally, this one is asynchronous because of file I/O
captureMessage('foo');   // Sets _processing=true and immediately sets _processing=false because it's synchronous.
await flush(2000);       // Then, flush doesn't wait for captured error because _processing=false but the message is not even in a buffer yet.
os.exit();               // Finally, I miss that exception in Sentry.
```

I tried to change `fs.readFile` to `fs.readFileSync` in `packages/node/src/parsers.ts` but file I/O is not the only issue. `beforeSend` callback could result in asynchronous execution too.

So my proposal is to change `_processing` from `boolean` to `number` counter. Another option would be to introduce another `PromiseBuffer` and just `drain` it. What do you think?