### PR TITLE
feat(utils): use `req.cookies` if available instead of parsing

### DIFF
--- a/packages/utils/src/node.ts
+++ b/packages/utils/src/node.ts
@@ -71,7 +71,7 @@ export function extractNodeRequestData(
   // url (including path and query string):
   //   node, express: req.originalUrl
   //   koa: req.url
-  const originalUrl = (req.originalUrl || req.url) as string;
+  const originalUrl = (req.originalUrl || req.url || '') as string;
   // absolute url
   const absoluteUrl = `${protocol}://${host}${originalUrl}`;
 
@@ -89,8 +89,9 @@ export function extractNodeRequestData(
       case 'cookies':
         // cookies:
         //   node, express, koa: req.headers.cookie
+        //   vercel, sails.js, express (w/ cookie middleware): req.cookies
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        requestData.cookies = dynamicRequire(module, 'cookie').parse(headers.cookie || '');
+        requestData.cookies = req.cookies || dynamicRequire(module, 'cookie').parse(headers.cookie || '');
         break;
       case 'query_string':
         // query string:

--- a/packages/utils/test/node.test.ts
+++ b/packages/utils/test/node.test.ts
@@ -1,0 +1,176 @@
+import { extractNodeRequestData } from '../src/node';
+
+describe('extractNodeRequestData()', () => {
+  describe('default behaviour', () => {
+    test('node', () => {
+      expect(
+        extractNodeRequestData({
+          headers: { host: 'example.com' },
+          method: 'GET',
+          secure: true,
+          originalUrl: '/',
+        }),
+      ).toEqual({
+        cookies: {},
+        headers: {
+          host: 'example.com',
+        },
+        method: 'GET',
+        query_string: null,
+        url: 'https://example.com/',
+      });
+    });
+
+    test('degrades gracefully without request data', () => {
+      expect(extractNodeRequestData({})).toEqual({
+        cookies: {},
+        headers: {},
+        method: undefined,
+        query_string: null,
+        url: 'http://<no host>',
+      });
+    });
+  });
+
+  describe('cookies', () => {
+    it('uses `req.cookies` if available', () => {
+      expect(
+        extractNodeRequestData(
+          {
+            cookies: { foo: 'bar' },
+          },
+          ['cookies'],
+        ),
+      ).toEqual({
+        cookies: { foo: 'bar' },
+      });
+    });
+
+    it('parses the cookie header', () => {
+      expect(
+        extractNodeRequestData(
+          {
+            headers: {
+              cookie: 'foo=bar;',
+            },
+          },
+          ['cookies'],
+        ),
+      ).toEqual({
+        cookies: { foo: 'bar' },
+      });
+    });
+
+    it('falls back if no cookies are defined', () => {
+      expect(extractNodeRequestData({}, ['cookies'])).toEqual({
+        cookies: {},
+      });
+    });
+  });
+
+  describe('data', () => {
+    it('includes data from `req.body` if available', () => {
+      expect(
+        extractNodeRequestData(
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: 'foo=bar',
+          },
+          ['data'],
+        ),
+      ).toEqual({
+        data: 'foo=bar',
+      });
+    });
+
+    it('encodes JSON body contents back to a string', () => {
+      expect(
+        extractNodeRequestData(
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: { foo: 'bar' },
+          },
+          ['data'],
+        ),
+      ).toEqual({
+        data: '{"foo":"bar"}',
+      });
+    });
+  });
+
+  describe('query_string', () => {
+    it('parses the query parms from the url', () => {
+      expect(
+        extractNodeRequestData(
+          {
+            headers: { host: 'example.com' },
+            secure: true,
+            originalUrl: '/?foo=bar',
+          },
+          ['query_string'],
+        ),
+      ).toEqual({
+        query_string: 'foo=bar',
+      });
+    });
+
+    it('gracefully degrades if url cannot be determined', () => {
+      expect(extractNodeRequestData({}, ['query_string'])).toEqual({
+        query_string: null,
+      });
+    });
+  });
+
+  describe('url', () => {
+    test('express/koa', () => {
+      expect(
+        extractNodeRequestData(
+          {
+            host: 'example.com',
+            protocol: 'https',
+            url: '/',
+          },
+          ['url'],
+        ),
+      ).toEqual({
+        url: 'https://example.com/',
+      });
+    });
+
+    test('node', () => {
+      expect(
+        extractNodeRequestData(
+          {
+            headers: { host: 'example.com' },
+            secure: true,
+            originalUrl: '/',
+          },
+          ['url'],
+        ),
+      ).toEqual({
+        url: 'https://example.com/',
+      });
+    });
+  });
+
+  describe('custom key', () => {
+    it('includes the custom key if present', () => {
+      expect(
+        extractNodeRequestData(
+          {
+            httpVersion: '1.1',
+          },
+          ['httpVersion'],
+        ),
+      ).toEqual({
+        httpVersion: '1.1',
+      });
+    });
+
+    it('gracefully degrades if the custom key is missing', () => {
+      expect(extractNodeRequestData({}, ['httpVersion'])).toEqual({});
+    });
+  });
+});


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

For some frameworks, `req.cookies` is already a parsed object representing all the cookies on a request. A couple examples include [any Node application deployed with Vercel](https://vercel.com/docs/runtimes#official-runtimes/node-js/node-js-request-and-response-objects/node-js-helpers), the [Sails.js framework](https://sailsjs.com/documentation/reference/request-req/req-cookies) and any Express server which has the cookies middleware installed.

I've simply modified the cookie logic to use `req.cookies` if it exists and to skip the parsing of `req.headers.cookies`. For any application that doesn't have this available, the existing logic is used.

In our case, we are deploying our Node applications through Vercel. Unfortunately the dynamic require line here ends up breaking inside of a Vercel deployment because the `cookies` dependency is missing (see [5.26.x behaviour](https://sentry-nft.vercel.app/api/5.26) vs [5.23.x behaviour](https://sentry-nft.vercel.app/api/5.23) in Vercel)

We've notified Vercel of the issue but since the extra parsing here is unnecessary on ours and other similar deployments, I figured I would send this out to you guys! 😄 

I noticed that the `extractNodeRequestData` method was entirely uncovered by tests. I've added tests for the specific cookie logic I introduced but also went ahead and added basic coverage for the rest of the properties that are parsed. I tried to keep the same structure and approach from your other tests but let me know if you'd like the tests rolled back to just the changes introduced here -- or would just like style changes in general.