### PR TITLE
feat(perf): Capture time spent redirecting before loading the current page

### DIFF
--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -248,6 +248,7 @@ export class MetricsInstrumentation {
 /** Instrument navigation entries */
 function addNavigationSpans(transaction: Transaction, entry: Record<string, any>, timeOrigin: number): void {
   addPerformanceNavigationTiming(transaction, entry, 'unloadEvent', timeOrigin);
+  addPerformanceNavigationTiming(transaction, entry, 'redirect', timeOrigin);
   addPerformanceNavigationTiming(transaction, entry, 'domContentLoadedEvent', timeOrigin);
   addPerformanceNavigationTiming(transaction, entry, 'loadEvent', timeOrigin);
   addPerformanceNavigationTiming(transaction, entry, 'connect', timeOrigin);


### PR DESCRIPTION
Ref:
- https://www.w3.org/TR/navigation-timing/#dom-performancetiming-redirectstart
- https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming/redirectStart
- https://developer.mozilla.org/en-US/docs/Web/API/PerformanceTiming/redirectEnd

 If there is no redirect, or if one of the redirect is not of the same origin, then values for either `redirectStart` or `redirectEnd` is `0`, and thus, no span is created. 

This can reveal any server or CDN configuration issues that can add any unnecessary time to the page load time. 