### PR TITLE
feat(web-vitals): Capture extra information from LCP and CLS web vitals.

### DIFF
--- a/packages/tracing/src/browser/web-vitals/getCLS.ts
+++ b/packages/tracing/src/browser/web-vitals/getCLS.ts
@@ -21,9 +21,18 @@ import { onHidden } from './lib/onHidden';
 import { ReportHandler } from './types';
 
 // https://wicg.github.io/layout-instability/#sec-layout-shift
-interface LayoutShift extends PerformanceEntry {
+export interface LayoutShift extends PerformanceEntry {
   value: number;
   hadRecentInput: boolean;
+  lastInputTime: DOMHighResTimeStamp;
+  sources: Array<LayoutShiftAttribution>;
+  toJSON(): Record<string, unknown>;
+}
+
+export interface LayoutShiftAttribution {
+  node?: Node;
+  previousRect: DOMRectReadOnly;
+  currentRect: DOMRectReadOnly;
 }
 
 export const getCLS = (onReport: ReportHandler, reportAllChanges = false): void => {

--- a/packages/tracing/src/browser/web-vitals/getLCP.ts
+++ b/packages/tracing/src/browser/web-vitals/getLCP.ts
@@ -22,13 +22,24 @@ import { onHidden } from './lib/onHidden';
 import { whenInput } from './lib/whenInput';
 import { ReportHandler } from './types';
 
+// https://wicg.github.io/largest-contentful-paint/#sec-largest-contentful-paint-interface
+export interface LargestContentfulPaint extends PerformanceEntry {
+  renderTime: DOMHighResTimeStamp;
+  loadTime: DOMHighResTimeStamp;
+  size: number;
+  id: string;
+  url: string;
+  element?: Element;
+  toJSON(): Record<string, unknown>;
+}
+
 export const getLCP = (onReport: ReportHandler, reportAllChanges = false): void => {
   const metric = initMetric('LCP');
   const firstHidden = getFirstHidden();
 
   let report: ReturnType<typeof bindReporter>;
 
-  const entryHandler = (entry: PerformanceEntry): void => {
+  const entryHandler = (entry: LargestContentfulPaint): void => {
     // The startTime attribute returns the value of the renderTime if it is not 0,
     // and the value of the loadTime otherwise.
     const value = entry.startTime;
@@ -45,7 +56,7 @@ export const getLCP = (onReport: ReportHandler, reportAllChanges = false): void 
     report();
   };
 
-  const po = observe('largest-contentful-paint', entryHandler);
+  const po = observe('largest-contentful-paint', entryHandler as PerformanceEntryHandler);
 
   if (po) {
     report = bindReporter(onReport, metric, po, reportAllChanges);


### PR DESCRIPTION
Be able to capture extra information from LCP and CLS web vitals.

For LCP, we'd like to know the element (or image) that contributed the largest contentful paint:
- https://wicg.github.io/largest-contentful-paint/#sec-largest-contentful-paint-interface
- https://developer.mozilla.org/en-US/docs/Web/API/LargestContentfulPaint#Properties

For CLS, we'd like to know the top 5 DOM nodes contributing the the CLS scores:
- https://wicg.github.io/layout-instability/#layoutshiftattribution
- https://wicg.github.io/layout-instability/#source-attribution

These will be surfaced in the product to indicate source of poor LCP or CLS scores.

<img width="1323" alt="Screen Shot 2020-10-27 at 4 14 07 PM" src="https://user-images.githubusercontent.com/139499/97357975-f3c35280-1870-11eb-8937-292473f68901.png">

<img width="1311" alt="Screen Shot 2020-10-27 at 5 17 11 PM" src="https://user-images.githubusercontent.com/139499/97364451-78669e80-187a-11eb-89c6-84d67ed56308.png">

## TODO

- [ ] add DOM element source for FID
