### PR TITLE
ref: Use 'production' as default value for environment key

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -396,10 +396,11 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    * @param event event instance to be enhanced
    */
   protected _applyClientOptions(event: Event): void {
-    const { environment, release, dist, maxValueLength = 250 } = this.getOptions();
+    const options = this.getOptions();
+    const { environment, release, dist, maxValueLength = 250 } = options;
 
-    if (event.environment === undefined && environment !== undefined) {
-      event.environment = environment;
+    if (!('environment' in event)) {
+      event.environment = 'environment' in options ? environment : 'production';
     }
 
     if (event.release === undefined && release !== undefined) {

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -176,6 +176,7 @@ describe('BaseClient', () => {
       const client = new TestClient({ dsn: PUBLIC_DSN });
       client.captureException(new Error('test exception'));
       expect(TestBackend.instance!.event).toEqual({
+        environment: 'production',
         event_id: '42',
         exception: {
           values: [
@@ -244,6 +245,7 @@ describe('BaseClient', () => {
       const client = new TestClient({ dsn: PUBLIC_DSN });
       client.captureMessage('test message');
       expect(TestBackend.instance!.event).toEqual({
+        environment: 'production',
         event_id: '42',
         level: 'info',
         message: 'test message',
@@ -319,6 +321,7 @@ describe('BaseClient', () => {
       client.captureEvent({ message: 'message' }, undefined, scope);
       expect(TestBackend.instance!.event!.message).toBe('message');
       expect(TestBackend.instance!.event).toEqual({
+        environment: 'production',
         event_id: '42',
         message: 'message',
         timestamp: 2020,
@@ -332,6 +335,7 @@ describe('BaseClient', () => {
       client.captureEvent({ message: 'message', timestamp: 1234 }, undefined, scope);
       expect(TestBackend.instance!.event!.message).toBe('message');
       expect(TestBackend.instance!.event).toEqual({
+        environment: 'production',
         event_id: '42',
         message: 'message',
         timestamp: 1234,
@@ -344,7 +348,23 @@ describe('BaseClient', () => {
       const scope = new Scope();
       client.captureEvent({ message: 'message' }, { event_id: 'wat' }, scope);
       expect(TestBackend.instance!.event!).toEqual({
+        environment: 'production',
         event_id: 'wat',
+        message: 'message',
+        timestamp: 2020,
+      });
+    });
+
+    test('sets default environment to `production` it none provided', () => {
+      expect.assertions(1);
+      const client = new TestClient({
+        dsn: PUBLIC_DSN,
+      });
+      const scope = new Scope();
+      client.captureEvent({ message: 'message' }, undefined, scope);
+      expect(TestBackend.instance!.event!).toEqual({
+        environment: 'production',
+        event_id: '42',
         message: 'message',
         timestamp: 2020,
       });
@@ -366,6 +386,22 @@ describe('BaseClient', () => {
       });
     });
 
+    test('allows for environment to be explicitly set to falsy value', () => {
+      expect.assertions(1);
+      const client = new TestClient({
+        dsn: PUBLIC_DSN,
+        environment: undefined,
+      });
+      const scope = new Scope();
+      client.captureEvent({ message: 'message' }, undefined, scope);
+      expect(TestBackend.instance!.event!).toEqual({
+        environment: undefined,
+        event_id: '42',
+        message: 'message',
+        timestamp: 2020,
+      });
+    });
+
     test('adds the configured release', () => {
       expect.assertions(1);
       const client = new TestClient({
@@ -375,6 +411,7 @@ describe('BaseClient', () => {
       const scope = new Scope();
       client.captureEvent({ message: 'message' }, undefined, scope);
       expect(TestBackend.instance!.event!).toEqual({
+        environment: 'production',
         event_id: '42',
         message: 'message',
         release: 'v1.0.0',
@@ -415,6 +452,7 @@ describe('BaseClient', () => {
       scope.setUser({ id: 'user' });
       client.captureEvent({ message: 'message' }, undefined, scope);
       expect(TestBackend.instance!.event!).toEqual({
+        environment: 'production',
         event_id: '42',
         extra: { b: 'b' },
         message: 'message',
@@ -431,6 +469,7 @@ describe('BaseClient', () => {
       scope.setFingerprint(['abcd']);
       client.captureEvent({ message: 'message' }, undefined, scope);
       expect(TestBackend.instance!.event!).toEqual({
+        environment: 'production',
         event_id: '42',
         fingerprint: ['abcd'],
         message: 'message',
@@ -476,6 +515,7 @@ describe('BaseClient', () => {
       expect(TestBackend.instance!.event!).toEqual({
         breadcrumbs: [normalizedBreadcrumb, normalizedBreadcrumb, normalizedBreadcrumb],
         contexts: normalizedObject,
+        environment: 'production',
         event_id: '42',
         extra: normalizedObject,
         timestamp: 2020,
@@ -521,6 +561,7 @@ describe('BaseClient', () => {
       expect(TestBackend.instance!.event!).toEqual({
         breadcrumbs: [normalizedBreadcrumb, normalizedBreadcrumb, normalizedBreadcrumb],
         contexts: normalizedObject,
+        environment: 'production',
         event_id: '42',
         extra: normalizedObject,
         timestamp: 2020,
@@ -571,6 +612,7 @@ describe('BaseClient', () => {
       expect(TestBackend.instance!.event!).toEqual({
         breadcrumbs: [normalizedBreadcrumb, normalizedBreadcrumb, normalizedBreadcrumb],
         contexts: normalizedObject,
+        environment: 'production',
         event_id: '42',
         extra: normalizedObject,
         timestamp: 2020,
@@ -590,6 +632,7 @@ describe('BaseClient', () => {
             trace_id: '86f39e84263a4de99c326acab3bfe3bd',
           },
         },
+        environment: 'production',
         event_id: '972f45b826a248bba98e990878a177e1',
         spans: [
           ({


### PR DESCRIPTION
Per recent SDK dev docs change - https://develop.sentry.dev/sdk/overview/#writing-an-sdk

> Send an environment on each event. If none was detected or set by the user, production should be used.

