### PR TITLE
fix: Make sure that getSession exists before calling it

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -522,7 +522,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
           throw new SentryError('`beforeSend` returned `null`, will not send event.');
         }
 
-        const session = scope && scope.getSession();
+        const session = scope && scope.getSession && scope.getSession();
         if (!isTransaction && session) {
           this._updateSessionFromEvent(session, processedEvent);
         }

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -384,7 +384,7 @@ export class Hub implements HubInterface {
     const { scope, client } = this.getStackTop();
     if (!scope) return;
 
-    const session = scope.getSession();
+    const session = scope.getSession && scope.getSession();
     if (session) {
       session.close();
       if (client && client.captureSession) {


### PR DESCRIPTION
This can happen when malformed node_modules are using older version of `hub`, but `core` wants to call that method. Or when there are 2 versions of Sentry living next to each other for some unknown reason. Fix is straightforward enough that I'm fine to include it, and we already got 2 customers reporting this issue.