### PR TITLE
feat(browser): Add `DOMException.code` as tag if it exists

### DIFF
--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -87,7 +87,9 @@ export function eventFromUnknownInput(
 
     event = eventFromString(message, syntheticException, options);
     addExceptionTypeValue(event, message);
-    event.tags = domException.code ? { ...event.tags, 'DOMException.code': String(domException.code) } : event.tags;
+    if ('code' in domException) {
+      event.tags = { ...event.tags, 'DOMException.code': `${domException.code}` }
+    }
 
     return event;
   }

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -78,7 +78,7 @@ export function eventFromUnknownInput(
   }
   if (isDOMError(exception as DOMError) || isDOMException(exception as DOMException)) {
     // If it is a DOMError or DOMException (which are legacy APIs, but still supported in some browsers)
-    // then we just extract the name and message, as they don't provide anything else
+    // then we just extract the name, code, and message, as they don't provide anything else
     // https://developer.mozilla.org/en-US/docs/Web/API/DOMError
     // https://developer.mozilla.org/en-US/docs/Web/API/DOMException
     const domException = exception as DOMException;
@@ -87,6 +87,8 @@ export function eventFromUnknownInput(
 
     event = eventFromString(message, syntheticException, options);
     addExceptionTypeValue(event, message);
+    event.tags = domException.code ? { ...event.tags, 'DOMException.code': String(domException.code) } : event.tags;
+
     return event;
   }
   if (isError(exception as Error)) {


### PR DESCRIPTION
Though `DOMException.code` is [long since deprecated](https://bugzilla.mozilla.org/show_bug.cgi?id=743574) in favor of `DOMException.name`, there are apparently still cases where it shows up. This adds the code as a tag in those cases.

Fixes https://github.com/getsentry/sentry-javascript/issues/3005.