### PR TITLE
doc: fix outdated docstring on Span constructor

### DIFF
--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -105,7 +105,8 @@ export class Span implements SpanInterface {
   public transaction?: Transaction;
 
   /**
-   * You should never call the constructor manually, always use `hub.startSpan()`.
+   * You should never call the constructor manually, always use `Sentry.startTransaction()`
+   * or call `startChild()` on an existing span.
    * @internal
    * @hideconstructor
    * @hidden


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
