### PR TITLE
fix: Schedule the execution of the finish to let all the spans being closed first

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -63,8 +63,11 @@ export function tracingHandler(): (
     (res as any).__sentry_transaction = transaction;
 
     res.once('finish', () => {
-      transaction.setHttpStatus(res.statusCode);
-      transaction.finish();
+      // We schedule the immediate execution of the `finish` to let all the spans being closed first.
+      setImmediate(() => {
+        transaction.setHttpStatus(res.statusCode);
+        transaction.finish();
+      });
     });
 
     next();


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/3001