### PR TITLE
fix(tracing): Add transaction name as tag on error events

### DIFF
--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -392,6 +392,10 @@ export class Scope implements ScopeInterface {
     // errors with transaction and it relys on that.
     if (this._span) {
       event.contexts = { trace: this._span.getTraceContext(), ...event.contexts };
+      const transactionName = this._span.transaction?.name;
+      if (transactionName) {
+        event.tags = { transaction: transactionName, ...event.tags };
+      }
     }
 
     this._applyFingerprint(event);

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -297,6 +297,38 @@ describe('Scope', () => {
     });
   });
 
+  test('applyToEvent transaction name tag when transaction on scope', async () => {
+    expect.assertions(1);
+    const scope = new Scope();
+    const transaction = {
+      fake: 'span',
+      getTraceContext: () => ({ a: 'b' }),
+      name: 'fake transaction',
+    } as any;
+    transaction.transaction = transaction; // because this is a transaction, its transaction pointer points to itself
+    scope.setSpan(transaction);
+    const event: Event = {};
+    return scope.applyToEvent(event).then(processedEvent => {
+      expect(processedEvent!.tags!.transaction).toEqual('fake transaction');
+    });
+  });
+
+  test('applyToEvent transaction name tag when span on scope', async () => {
+    expect.assertions(1);
+    const scope = new Scope();
+    const transaction = { name: 'fake transaction' };
+    const span = {
+      fake: 'span',
+      getTraceContext: () => ({ a: 'b' }),
+      transaction,
+    } as any;
+    scope.setSpan(span);
+    const event: Event = {};
+    return scope.applyToEvent(event).then(processedEvent => {
+      expect(processedEvent!.tags!.transaction).toEqual('fake transaction');
+    });
+  });
+
   test('clear', () => {
     const scope = new Scope();
     scope.setExtra('a', 2);


### PR DESCRIPTION
Somewhere along the way, the JS SDK stopped sending transaction name as a tag. This restores that behavior, upon which the "Related Issues" feature on transactions depends.

![image](https://user-images.githubusercontent.com/14812505/97945756-51f2a880-1d3d-11eb-8c8f-74e77b0a66a6.png)
