### PR TITLE
Add `optional` parameter to AWSServices integration

### DIFF
--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -44,7 +44,7 @@ export interface WrapperOptions {
   timeoutWarningLimit: number;
 }
 
-export const defaultIntegrations: Integration[] = [...Sentry.defaultIntegrations, new AWSServices()];
+export const defaultIntegrations: Integration[] = [...Sentry.defaultIntegrations, new AWSServices({ optional: true })];
 
 /**
  * @see {@link Sentry.init}


### PR DESCRIPTION
Initially, I thought there's no need to catch the error of `require('aws-sdk/global')` because this package is always available on AWS Lambda and even in the `sam local` emulator.

However, in some environments it could be missing. Examples of such environments is netlify dev or it could be simply a unit-test environment without any packages.

Fixes #3000.