### PR TITLE
Wrap google cloud functions with a Proxy().

### DIFF
--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -20,6 +20,7 @@
     "@sentry/node": "5.27.3",
     "@sentry/types": "5.27.3",
     "@sentry/utils": "5.27.3",
+    "@types/aws-lambda": "^8.10.62",
     "@types/express": "^4.17.2",
     "tslib": "^1.9.3"
   },
@@ -29,7 +30,6 @@
     "@google-cloud/functions-framework": "^1.7.1",
     "@google-cloud/pubsub": "^2.5.0",
     "@sentry-internal/eslint-config-sdk": "5.27.3",
-    "@types/aws-lambda": "^8.10.62",
     "@types/node": "^14.6.4",
     "aws-sdk": "^2.765.0",
     "eslint": "7.6.0",

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -20,6 +20,7 @@
     "@sentry/node": "5.27.3",
     "@sentry/types": "5.27.3",
     "@sentry/utils": "5.27.3",
+    "@types/express": "^4.17.2",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/serverless/src/gcpfunction/general.ts
+++ b/packages/serverless/src/gcpfunction/general.ts
@@ -1,10 +1,47 @@
-// '@google-cloud/functions-framework/build/src/functions' import is expected to be type-only so it's erased in the final .js file.
-// When TypeScript compiler is upgraded, use `import type` syntax to explicitly assert that we don't want to load a module here.
-import { Context } from '@google-cloud/functions-framework/build/src/functions';
 import { Scope } from '@sentry/node';
 import { Context as SentryContext } from '@sentry/types';
-import * as domain from 'domain';
+import { Request, Response } from 'express'; // eslint-disable-line import/no-extraneous-dependencies
 import { hostname } from 'os';
+
+export interface HttpFunction {
+  (req: Request, res: Response): any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+export interface EventFunction {
+  (data: Record<string, any>, context: Context): any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+export interface EventFunctionWithCallback {
+  (data: Record<string, any>, context: Context, callback: Function): any; // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
+}
+
+export interface CloudEventFunction {
+  (cloudevent: CloudEventsContext): any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+export interface CloudEventFunctionWithCallback {
+  (cloudevent: CloudEventsContext, callback: Function): any; // eslint-disable-line @typescript-eslint/no-explicit-any, @typescript-eslint/ban-types
+}
+
+export interface CloudFunctionsContext {
+  eventId?: string;
+  timestamp?: string;
+  eventType?: string;
+  resource?: string;
+}
+
+export interface CloudEventsContext {
+  [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  type?: string;
+  specversion?: string;
+  source?: string;
+  id?: string;
+  time?: string;
+  schemaurl?: string;
+  contenttype?: string;
+}
+
+export type Context = CloudFunctionsContext | CloudEventsContext;
 
 export interface WrapperOptions {
   flushTimeout: number;
@@ -23,12 +60,4 @@ export function configureScopeWithContext(scope: Scope, context: Context): void 
   });
   scope.setTag('server_name', process.env.SENTRY_NAME || hostname());
   scope.setContext('gcp.function.context', { ...context } as SentryContext);
-}
-
-/**
- * @returns Current active domain with a correct type.
- */
-export function getActiveDomain(): domain.Domain {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-  return (domain as any).active as domain.Domain;
 }

--- a/packages/serverless/src/utils.ts
+++ b/packages/serverless/src/utils.ts
@@ -1,5 +1,6 @@
 import { Event, SDK_VERSION } from '@sentry/node';
 import { addExceptionMechanism } from '@sentry/utils';
+import * as domain from 'domain';
 
 /**
  * Event processor that will override SDK details to point to the serverless SDK instead of Node,
@@ -30,4 +31,58 @@ export function serverlessEventProcessor(integration: string): (event: Event) =>
 
     return event;
   };
+}
+
+/**
+ * @returns Current active domain with a correct type.
+ */
+export function getActiveDomain(): domain.Domain | null {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+  return (domain as any).active as domain.Domain | null;
+}
+
+/**
+ * @param fn function to run
+ * @returns function which runs in the newly created domain or in the existing one
+ */
+export function domainify<A extends unknown[], R>(fn: (...args: A) => R): (...args: A) => R {
+  return (...args) => {
+    if (getActiveDomain()) {
+      return fn(...args);
+    }
+    const dom = domain.create();
+    return dom.run(() => fn(...args));
+  };
+}
+
+/**
+ * @param source function to be wrapped
+ * @param wrap wrapping function that takes source and returns a wrapper
+ * @param overrides properties to override in the source
+ * @returns wrapped function
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function proxyFunction<A extends any[], R, F extends (...args: A) => R>(
+  source: F,
+  wrap: (source: F) => F,
+  overrides?: Record<PropertyKey, unknown>,
+): F {
+  const wrapper = wrap(source);
+  const handler: ProxyHandler<F> = {
+    apply: <T>(_target: F, thisArg: T, args: A) => {
+      return wrapper.apply(thisArg, args);
+    },
+  };
+
+  if (overrides) {
+    handler.get = (target, prop) => {
+      // eslint-disable-next-line no-prototype-builtins
+      if (overrides.hasOwnProperty(prop)) {
+        return overrides[prop as string];
+      }
+      return (target as Record<PropertyKey, unknown>)[prop as string];
+    };
+  }
+
+  return new Proxy(source, handler);
 }

--- a/packages/serverless/test/gcpfunction.test.ts
+++ b/packages/serverless/test/gcpfunction.test.ts
@@ -1,15 +1,17 @@
+import { Event } from '@sentry/types';
+import * as domain from 'domain';
+
+import * as Sentry from '../src';
+import { wrapCloudEventFunction, wrapEventFunction, wrapHttpFunction } from '../src/gcpfunction';
 import {
   CloudEventFunction,
   CloudEventFunctionWithCallback,
   EventFunction,
   EventFunctionWithCallback,
   HttpFunction,
-} from '@google-cloud/functions-framework/build/src/functions';
-import { Event } from '@sentry/types';
-import * as domain from 'domain';
-
-import * as Sentry from '../src';
-import { Request, Response, wrapCloudEventFunction, wrapEventFunction, wrapHttpFunction } from '../src/gcpfunction';
+  Request,
+  Response,
+} from '../src/gcpfunction/general';
 
 /**
  * Why @ts-ignore some Sentry.X calls


### PR DESCRIPTION
Firebase wrappers such as `onRequest`, `onCreate`, etc return callable handlers with some important additional data in properties which is being used by `firebase-cli` while deploying the functions.

So when we wrap such functions naively, these properties are not visible anymore. So I decided to circumvent it with a `new Proxy(fn, { apply: ... })` trick. This proxy object will redirect all property accesses to the original function but calling behavior will be re-defined.

Also added some workarounds for firebase emulator (`firebase emulators:start`)

- Need to wrap `fn.__emulator_func` too. See code comments.
- Need to create a new domain because unlike `functions-framework`, firebase emulator doesn't create a domain.

Fixes #3023.

Also this PR removes a dependency on `@google-cloud/functions-framework` package since it's used only for importing types but these types are also needed for TypeScript users and we cannot force them to install an entired functions-framework as a dependency. Instead, I moved all the types from it right in this package and also add a *runtime* dependency `@types/express`. Fixes #2997.