### PR TITLE
Fix allowSentryBreadcrumbs to activate when appropriate

### DIFF
--- a/packages/browser/test/integration/common/init.js
+++ b/packages/browser/test/integration/common/init.js
@@ -43,7 +43,7 @@ function initSDK() {
 
       // One of the tests use manually created breadcrumb without eventId and we want to let it through
       if (
-        breadcrumb.category.indexOf("sentry" === 0) &&
+        breadcrumb.category.indexOf("sentry") === 0 &&
         breadcrumb.event_id &&
         !window.allowSentryBreadcrumbs
       ) {


### PR DESCRIPTION
The included test, to check for a breadcrumb category starting with "sentry", was improperly written.