### PR TITLE
Fix maxBreadcrumbs doc comment to note the proper default

### DIFF
--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -68,7 +68,7 @@ export interface Options {
   dist?: string;
 
   /**
-   * The maximum number of breadcrumbs sent with events. Defaults to 30.
+   * The maximum number of breadcrumbs sent with events. Defaults to 100.
    * Values over 100 will be ignored and 100 used instead.
    */
   maxBreadcrumbs?: number;


### PR DESCRIPTION
Consistent with DEFAULT_BREADCRUMBS of src/hub.ts
https://github.com/getsentry/sentry-javascript/blob/e9bad4792b80bc3de21bb6fcd806f31b2123602a/packages/hub/src/hub.ts#L38-L42