### PR TITLE
chore(build): Increase limits on size check

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -3,24 +3,24 @@ module.exports = [
     name: '@sentry/browser - CDN Bundle (gzipped)',
     path: 'packages/browser/build/bundle.min.js',
     gzip: true,
-    limit: '18 KB',
+    limit: '21 KB',
   },
   {
     name: '@sentry/browser - Webpack',
     path: 'packages/browser/esm/index.js',
     import: '{ init }',
-    limit: '19 KB',
+    limit: '22 KB',
   },
   {
     name: '@sentry/react - Webpack',
     path: 'packages/react/esm/index.js',
     import: '{ init }',
-    limit: '19 KB',
+    limit: '22 KB',
   },
   {
     name: '@sentry/browser + @sentry/tracing - CDN Bundle (gzipped)',
     path: 'packages/tracing/build/bundle.tracing.min.js',
     gzip: true,
-    limit: '25 KB',
+    limit: '28 KB',
   },
 ];


### PR DESCRIPTION
`newLimit = Math.ceil(currentSize) + 1;`

(So we can keep track but aren't perma-red.)
