### PR TITLE
fix(node): Fix failing test

### DIFF
--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -308,7 +308,7 @@ describe('tracingHandler', () => {
     });
   });
 
-  it('lets all spans being finished before calling `finish` itself, despite being registered to `res.finish` event first', done => {
+  it('waits to finish transaction until all spans are finished, even though `transaction.finish()` is registered on `res.finish` event first', done => {
     const transaction = new Transaction({ name: 'mockTransaction' });
     transaction.initSpanRecorder();
     const span = transaction.startChild({
@@ -328,7 +328,7 @@ describe('tracingHandler', () => {
     setImmediate(() => {
       expect(finishSpan).toHaveBeenCalled();
       expect(finishTransaction).toHaveBeenCalled();
-      expect(span.endTimestamp).toBeLessThan(transaction.endTimestamp!);
+      expect(span.endTimestamp).toBeLessThanOrEqual(transaction.endTimestamp!);
       done();
     });
   });

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -309,7 +309,7 @@ describe('tracingHandler', () => {
   });
 
   it('waits to finish transaction until all spans are finished, even though `transaction.finish()` is registered on `res.finish` event first', done => {
-    const transaction = new Transaction({ name: 'mockTransaction' });
+    const transaction = new Transaction({ name: 'mockTransaction', sampled: true });
     transaction.initSpanRecorder();
     const span = transaction.startChild({
       description: 'reallyCoolHandler',
@@ -318,6 +318,11 @@ describe('tracingHandler', () => {
     jest.spyOn(sentryCore, 'startTransaction').mockReturnValue(transaction as TransactionType);
     const finishSpan = jest.spyOn(span, 'finish');
     const finishTransaction = jest.spyOn(transaction, 'finish');
+
+    let sentEvent: Event;
+    jest.spyOn((transaction as any)._hub, 'captureEvent').mockImplementation(event => {
+      sentEvent = event as Event;
+    });
 
     sentryTracingMiddleware(req, res, next);
     res.once('finish', () => {
@@ -329,6 +334,8 @@ describe('tracingHandler', () => {
       expect(finishSpan).toHaveBeenCalled();
       expect(finishTransaction).toHaveBeenCalled();
       expect(span.endTimestamp).toBeLessThanOrEqual(transaction.endTimestamp!);
+      expect(sentEvent.spans?.length).toEqual(1);
+      expect(sentEvent.spans?.[0].spanId).toEqual(span.spanId);
       done();
     });
   });


### PR DESCRIPTION
Depending on the precision of the clock you're using, timestamps might match even if event A happens before event B. The check for `span` being included in the transaction event ensures `span.finish()` must have happened before `transaction.finish()` - otherwise the latter would have [filtered `span` out](https://github.com/getsentry/sentry-javascript/blob/73b9bbd4c42efa5f95a7d5446b3390dd859f82fa/packages/tracing/src/transaction.ts#L90).

(I also did some tiny wordsmithing on the test title.)
