### PR TITLE
fix: Typo in constant name in @sentry/tracing

### DIFF
--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -9,7 +9,7 @@ import { extractTraceparentData, secToMs } from '../utils';
 import { registerBackgroundTabDetection } from './backgroundtab';
 import { MetricsInstrumentation } from './metrics';
 import {
-  defaultRequestInstrumentionOptions,
+  defaultRequestInstrumentationOptions,
   registerRequestInstrumentation,
   RequestInstrumentationOptions,
 } from './request';
@@ -90,7 +90,7 @@ const DEFAULT_BROWSER_TRACING_OPTIONS = {
   routingInstrumentation: defaultRoutingInstrumentation,
   startTransactionOnLocationChange: true,
   startTransactionOnPageLoad: true,
-  ...defaultRequestInstrumentionOptions,
+  ...defaultRequestInstrumentationOptions,
 };
 
 /**
@@ -121,7 +121,7 @@ export class BrowserTracing implements Integration {
   private readonly _emitOptionsWarning: boolean = false;
 
   public constructor(_options?: Partial<BrowserTracingOptions>) {
-    let tracingOrigins = defaultRequestInstrumentionOptions.tracingOrigins;
+    let tracingOrigins = defaultRequestInstrumentationOptions.tracingOrigins;
     // NOTE: Logger doesn't work in constructors, as it's initialized after integrations instances
     if (
       _options &&
@@ -152,7 +152,7 @@ export class BrowserTracing implements Integration {
         '[Tracing] You need to define `tracingOrigins` in the options. Set an array of urls or patterns to trace.',
       );
       logger.warn(
-        `[Tracing] We added a reasonable default for you: ${defaultRequestInstrumentionOptions.tracingOrigins}`,
+        `[Tracing] We added a reasonable default for you: ${defaultRequestInstrumentationOptions.tracingOrigins}`,
       );
     }
 

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -76,7 +76,7 @@ export interface XHRData {
   endTimestamp?: number;
 }
 
-export const defaultRequestInstrumentionOptions: RequestInstrumentationOptions = {
+export const defaultRequestInstrumentationOptions: RequestInstrumentationOptions = {
   traceFetch: true,
   traceXHR: true,
   tracingOrigins: DEFAULT_TRACING_ORIGINS,
@@ -86,7 +86,7 @@ export const defaultRequestInstrumentionOptions: RequestInstrumentationOptions =
 export function registerRequestInstrumentation(_options?: Partial<RequestInstrumentationOptions>): void {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const { traceFetch, traceXHR, tracingOrigins, shouldCreateSpanForRequest } = {
-    ...defaultRequestInstrumentionOptions,
+    ...defaultRequestInstrumentationOptions,
     ..._options,
   };
 

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -10,7 +10,7 @@ import {
   getHeaderContext,
   getMetaContent,
 } from '../../src/browser/browsertracing';
-import { defaultRequestInstrumentionOptions } from '../../src/browser/request';
+import { defaultRequestInstrumentationOptions } from '../../src/browser/request';
 import { defaultRoutingInstrumentation } from '../../src/browser/router';
 import * as hubExtensions from '../../src/hubextensions';
 import { DEFAULT_IDLE_TIMEOUT, IdleTransaction } from '../../src/idletransaction';
@@ -84,7 +84,7 @@ describe('BrowserTracing', () => {
       routingInstrumentation: defaultRoutingInstrumentation,
       startTransactionOnLocationChange: true,
       startTransactionOnPageLoad: true,
-      ...defaultRequestInstrumentionOptions,
+      ...defaultRequestInstrumentationOptions,
     });
   });
 
@@ -131,7 +131,7 @@ describe('BrowserTracing', () => {
         });
 
         expect(warnSpy).toHaveBeenCalledTimes(2);
-        expect(inst.options.tracingOrigins).toEqual(defaultRequestInstrumentionOptions.tracingOrigins);
+        expect(inst.options.tracingOrigins).toEqual(defaultRequestInstrumentationOptions.tracingOrigins);
       });
 
       it('warns and uses default tracing origins if empty array given', () => {
@@ -141,7 +141,7 @@ describe('BrowserTracing', () => {
         });
 
         expect(warnSpy).toHaveBeenCalledTimes(2);
-        expect(inst.options.tracingOrigins).toEqual(defaultRequestInstrumentionOptions.tracingOrigins);
+        expect(inst.options.tracingOrigins).toEqual(defaultRequestInstrumentationOptions.tracingOrigins);
       });
 
       it('warns and uses default tracing origins if tracing origins are not defined', () => {
@@ -151,7 +151,7 @@ describe('BrowserTracing', () => {
         });
 
         expect(warnSpy).toHaveBeenCalledTimes(2);
-        expect(inst.options.tracingOrigins).toEqual(defaultRequestInstrumentionOptions.tracingOrigins);
+        expect(inst.options.tracingOrigins).toEqual(defaultRequestInstrumentationOptions.tracingOrigins);
       });
 
       it('sets tracing origins if provided and does not warn', () => {


### PR DESCRIPTION
defaultRequestInstrumentionOptions => defaultRequestInstrumentationOptions

Despite being exported, the old name is not documented and not part of
what is considered public API, therefore we remove the old name
altogether.