### PR TITLE
fix(build): Don't build packages we're not going to test

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -7,14 +7,14 @@ if [[ "$(cut -d. -f1 <<< "$TRAVIS_NODE_VERSION")" -le 6 ]]; then
   nvm use 8
   yarn install --ignore-engines --ignore-scripts
   # ember requires Node >= 10 to build
-  yarn build --ignore="@sentry/ember" --ignore="@sentry/serverless"
+  yarn build --ignore="@sentry/ember" --ignore="@sentry/serverless" --ignore="@sentry/gatsby" --ignore="@sentry/react"
   nvm use 6
   # browser can be tested only on Node >= v8 because Karma is not supporting anything older
   yarn test --ignore="@sentry/tracing" --ignore="@sentry/react" --ignore="@sentry/gatsby" --ignore="@sentry/ember" --ignore="@sentry-internal/eslint-plugin-sdk" --ignore="@sentry-internal/eslint-config-sdk" --ignore="@sentry/serverless" --ignore="@sentry/browser" --ignore="@sentry/integrations" 
 elif [[ "$(cut -d. -f1 <<< "$TRAVIS_NODE_VERSION")" -le 8 ]]; then
   yarn install --ignore-engines --ignore-scripts
   # ember requires Node >= 10 to build
-  yarn build --ignore="@sentry/ember" --ignore="@sentry/serverless"
+  yarn build --ignore="@sentry/ember" --ignore="@sentry/serverless" --ignore="@sentry/gatsby" --ignore="@sentry/react"
   # serverless, tracing, ember and react work only on Node >= v10
   yarn test --ignore="@sentry/tracing" --ignore="@sentry/react" --ignore="@sentry/gatsby" --ignore="@sentry/ember" --ignore="@sentry-internal/eslint-plugin-sdk" --ignore="@sentry-internal/eslint-config-sdk" --ignore="@sentry/serverless"
 else


### PR DESCRIPTION
When testing against Node 6 and 8, we only test a subset of our packages. This PR adds to the list of packages we therefore skip building. (We can't skip all of the ones we don't test, because some of the ones we do test depend on them, but these are both untested and have no dependencies.)

Probably not a huge time savings, but can't hurt.