### PR TITLE
feat(dev): Add profile for debugging tests in @sentry/core in VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,6 +3,7 @@
   // Hover to view descriptions of existing attributes.
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
+  // TODO: these are all alike save the package, so figure out how to make that variable
   "configurations": [
     // @sentry/tracing - run a specific test file in watch mode
     // must have file in currently active tab when hitting the play button
@@ -41,6 +42,30 @@
         "--runInBand",
         "--config",
         "${workspaceFolder}/packages/node/package.json",
+        "--coverage",
+        "false", // coverage messes up the source maps
+        "${relativeFile}" // remove this to run all package tests
+      ],
+      "disableOptimisticBPs": true,
+      "sourceMaps": true,
+      "smartStep": true,
+      "console": "integratedTerminal", // otherwise it goes to the VSCode debug terminal, which can't read from stdin
+      "internalConsoleOptions": "neverOpen", // since we're not using it, don't automatically switch to it
+    },
+
+    // @sentry/core - run a specific test file in watch mode
+    // must have file in currently active tab when hitting the play button
+    {
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/packages/core",
+      "name": "Debug @sentry/core tests - just open file",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": [
+        "--watch",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/packages/core/package.json",
         "--coverage",
         "false", // coverage messes up the source maps
         "${relativeFile}" // remove this to run all package tests


### PR DESCRIPTION
Someday I'll make this work for all packages in the repo, but for now, this works.
