### PR TITLE
fix: Sync ScopeListeners

### DIFF
--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -440,12 +440,10 @@ export class Scope implements ScopeInterface {
   protected _notifyScopeListeners(): void {
     if (!this._notifyingListeners) {
       this._notifyingListeners = true;
-      setTimeout(() => {
-        this._scopeListeners.forEach(callback => {
-          callback(this);
-        });
-        this._notifyingListeners = false;
+      this._scopeListeners.forEach(callback => {
+        callback(this);
       });
+      this._notifyingListeners = false;
     }
   }
 


### PR DESCRIPTION
We have a race condition in the electron SDK where we set the user on the scope but since we call the notifies in `setTimeout` the user is not properly propagated to the main process.

So if you have this for example:
```js
configureScope(scope => {
    scope.setUser({ id: 'abc' }); // This invokes notify scope listeners
  });
}

captureException(new Error('test'));
```

On electron, we sync the scope across different processes via IPC calls.

The previous code resulted in:

IPC -> captureException
IPC -> Scope update

after the change, because we are removing the `setTimeout`

its:

IPC -> Scope update
IPC -> captureException