### PR TITLE
feat(tracing): Send sample rate and type in transaction item header in envelope

### DIFF
--- a/packages/core/test/lib/request.test.ts
+++ b/packages/core/test/lib/request.test.ts
@@ -1,0 +1,40 @@
+import { Event } from '@sentry/types';
+
+import { API } from '../../src/api';
+import { eventToSentryRequest } from '../../src/request';
+
+describe('eventToSentryRequest', () => {
+  const api = new API('https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012');
+  const event: Event = {
+    contexts: { trace: { trace_id: '1231201211212012', span_id: '12261980', op: 'pageload' } },
+    environment: 'dogpark',
+    event_id: '0908201304152013',
+    release: 'off.leash.park',
+    spans: [],
+    transaction: '/dogs/are/great/',
+    type: 'transaction',
+    user: { id: '1121', username: 'CharlieDog', ip_address: '11.21.20.12' },
+  };
+
+  it('adds sampling information to transaction item header', () => {
+    event.tags = { __sentry_samplingMethod: 'client_rate', __sentry_sampleRate: '0.1121', dog: 'Charlie' };
+
+    const result = eventToSentryRequest(event as Event, api);
+
+    const [envelopeHeaderString, itemHeaderString, eventString] = result.body.split('\n');
+
+    const envelope = {
+      envelopeHeader: JSON.parse(envelopeHeaderString),
+      itemHeader: JSON.parse(itemHeaderString),
+      event: JSON.parse(eventString),
+    };
+
+    // the right stuff is added to the item header
+    expect(envelope.itemHeader).toEqual({ type: 'transaction', sample_rates: [{ id: 'client_rate', rate: '0.1121' }] });
+
+    // show that it pops the right tags and leaves the rest alone
+    expect('__sentry_samplingMethod' in envelope.event.tags).toBe(false);
+    expect('__sentry_sampleRate' in envelope.event.tags).toBe(false);
+    expect('dog' in envelope.event.tags).toBe(true);
+  });
+});

--- a/packages/core/test/lib/request.test.ts
+++ b/packages/core/test/lib/request.test.ts
@@ -1,4 +1,4 @@
-import { Event } from '@sentry/types';
+import { Event, TransactionSamplingMethod } from '@sentry/types';
 
 import { API } from '../../src/api';
 import { eventToSentryRequest } from '../../src/request';
@@ -16,25 +16,41 @@ describe('eventToSentryRequest', () => {
     user: { id: '1121', username: 'CharlieDog', ip_address: '11.21.20.12' },
   };
 
-  it('adds sampling information to transaction item header', () => {
-    event.tags = { __sentry_samplingMethod: 'client_rate', __sentry_sampleRate: '0.1121', dog: 'Charlie' };
+  [
+    { method: TransactionSamplingMethod.Rate, rate: '0.1121', dog: 'Charlie' },
+    { method: TransactionSamplingMethod.Sampler, rate: '0.1231', dog: 'Maisey' },
+    { method: TransactionSamplingMethod.Inheritance, dog: 'Cory' },
+    { method: TransactionSamplingMethod.Explicit, dog: 'Bodhi' },
 
-    const result = eventToSentryRequest(event as Event, api);
+    // this shouldn't ever happen (at least the method should always be included in tags), but good to know that things
+    // won't blow up if it does
+    { dog: 'Lucy' },
+  ].forEach(({ method, rate, dog }) => {
+    it(`adds transaction sampling information to item header - ${method}, ${rate}, ${dog}`, () => {
+      // TODO kmclb - once tag types are loosened, don't need to cast to string here
+      event.tags = { __sentry_samplingMethod: String(method), __sentry_sampleRate: String(rate), dog };
 
-    const [envelopeHeaderString, itemHeaderString, eventString] = result.body.split('\n');
+      const result = eventToSentryRequest(event as Event, api);
 
-    const envelope = {
-      envelopeHeader: JSON.parse(envelopeHeaderString),
-      itemHeader: JSON.parse(itemHeaderString),
-      event: JSON.parse(eventString),
-    };
+      const [envelopeHeaderString, itemHeaderString, eventString] = result.body.split('\n');
 
-    // the right stuff is added to the item header
-    expect(envelope.itemHeader).toEqual({ type: 'transaction', sample_rates: [{ id: 'client_rate', rate: '0.1121' }] });
+      const envelope = {
+        envelopeHeader: JSON.parse(envelopeHeaderString),
+        itemHeader: JSON.parse(itemHeaderString),
+        event: JSON.parse(eventString),
+      };
 
-    // show that it pops the right tags and leaves the rest alone
-    expect('__sentry_samplingMethod' in envelope.event.tags).toBe(false);
-    expect('__sentry_sampleRate' in envelope.event.tags).toBe(false);
-    expect('dog' in envelope.event.tags).toBe(true);
+      // the right stuff is added to the item header
+      expect(envelope.itemHeader).toEqual({
+        type: 'transaction',
+        // TODO kmclb - once tag types are loosened, don't need to cast to string here
+        sample_rates: [{ id: String(method), rate: String(rate) }],
+      });
+
+      // show that it pops the right tags and leaves the rest alone
+      expect('__sentry_samplingMethod' in envelope.event.tags).toBe(false);
+      expect('__sentry_sampleRate' in envelope.event.tags).toBe(false);
+      expect('dog' in envelope.event.tags).toBe(true);
+    });
   });
 });

--- a/packages/tracing/src/hubextensions.ts
+++ b/packages/tracing/src/hubextensions.ts
@@ -29,18 +29,6 @@ function traceHeaders(this: Hub): { [key: string]: string } {
 }
 
 /**
- * Implements sampling inheritance and falls back to user-provided static rate if no parent decision is available.
- *
- * @param parentSampled: The parent transaction's sampling decision, if any.
- * @param givenRate: The rate to use if no parental decision is available.
- *
- * @returns The parent's sampling decision (if one exists), or the provided static rate
- */
-function _inheritOrUseGivenRate(parentSampled: boolean | undefined, givenRate: unknown): boolean | unknown {
-  return parentSampled !== undefined ? parentSampled : givenRate;
-}
-
-/**
  * Makes a sampling decision for the given transaction and stores it on the transaction.
  *
  * Called every time a transaction is created. Only transactions which emerge with a `sampled` value of `true` will be
@@ -64,15 +52,33 @@ function sample<T extends Transaction>(hub: Hub, transaction: T, samplingContext
 
   // if the user has forced a sampling decision by passing a `sampled` value in their transaction context, go with that
   if (transaction.sampled !== undefined) {
+    transaction.tags = { ...transaction.tags, __sentry_samplingMethod: 'explicitly_set' };
     return transaction;
   }
 
   // we would have bailed already if neither `tracesSampler` nor `tracesSampleRate` were defined, so one of these should
   // work; prefer the hook if so
-  const sampleRate =
-    typeof options.tracesSampler === 'function'
-      ? options.tracesSampler(samplingContext)
-      : _inheritOrUseGivenRate(samplingContext.parentSampled, options.tracesSampleRate);
+  let sampleRate;
+  if (typeof options.tracesSampler === 'function') {
+    sampleRate = options.tracesSampler(samplingContext);
+    // cast the rate to a number first in case it's a boolean
+    transaction.tags = {
+      ...transaction.tags,
+      __sentry_samplingMethod: 'client_sampler',
+      __sentry_sampleRate: String(Number(sampleRate)),
+    };
+  } else if (samplingContext.parentSampled !== undefined) {
+    sampleRate = samplingContext.parentSampled;
+    transaction.tags = { ...transaction.tags, __sentry_samplingMethod: 'inheritance' };
+  } else {
+    sampleRate = options.tracesSampleRate;
+    // cast the rate to a number first in case it's a boolean
+    transaction.tags = {
+      ...transaction.tags,
+      __sentry_samplingMethod: 'client_rate',
+      __sentry_sampleRate: String(Number(sampleRate)),
+    };
+  }
 
   // Since this is coming from the user (or from a function provided by the user), who knows what we might get. (The
   // only valid values are booleans or numbers between 0 and 1.)
@@ -88,7 +94,7 @@ function sample<T extends Transaction>(hub: Hub, transaction: T, samplingContext
       `[Tracing] Discarding transaction because ${
         typeof options.tracesSampler === 'function'
           ? 'tracesSampler returned 0 or false'
-          : 'tracesSampleRate is set to 0'
+          : 'a negative sampling decision was inherited or tracesSampleRate is set to 0'
       }`,
     );
     transaction.sampled = false;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -32,6 +32,7 @@ export {
   TraceparentData,
   Transaction,
   TransactionContext,
+  TransactionSamplingMethod,
 } from './transaction';
 export { Thread } from './thread';
 export { Transport, TransportOptions, TransportClass } from './transport';

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -100,3 +100,10 @@ export interface SamplingContext extends CustomSamplingContext {
 }
 
 export type Measurements = Record<string, { value: number }>;
+
+export enum TransactionSamplingMethod {
+  Explicit = 'explicitly_set',
+  Sampler = 'client_sampler',
+  Rate = 'client_rate',
+  Inheritance = 'inheritance',
+}


### PR DESCRIPTION
Product asked for this data, to get a sense of what kinds of sample rates people are using. It also may help inform future dynamic sampling work in relay.

TODO:

- [ ] ~The spec didn't mention what should happen in either the case of sampling inheritance or of an explicitly set sampling decision, so I recorded it, but with no sample rate. Happy to change this to something else if anyone would prefer.~
- [ ] Make DACI re: propagating this information between SDKs
- [ ] Decide on protocol including propagated info
- [ ] Implement protocol
- [ ] Implement propagation
- [ ] Implement receiving and use of propagated info


EDIT: Agreed with @HazAT that we'll go with the simple version for now: sample rates sent if they come from either `traces_sampler` or -`traces_sample_rate`, but not other methods (inheritance and having the sampling decision explicitly set). The rest, listed above, we'll hold on until it's clear we need to do it.