### PR TITLE
fix(ember): Restrict compatibility tests to CI

### DIFF
--- a/packages/ember/config/ember-try.js
+++ b/packages/ember/config/ember-try.js
@@ -10,41 +10,41 @@ module.exports = async function() {
         name: 'ember-lts-3.12',
         npm: {
           devDependencies: {
-            'ember-source': '~3.12.0'
-          }
-        }
+            'ember-source': '~3.12.0',
+          },
+        },
       },
       {
         name: 'ember-lts-3.16',
         npm: {
           devDependencies: {
-            'ember-source': '~3.16.0'
-          }
-        }
+            'ember-source': '~3.16.0',
+          },
+        },
       },
       {
         name: 'ember-release',
         npm: {
           devDependencies: {
-            'ember-source': await getChannelURL('release')
-          }
-        }
+            'ember-source': await getChannelURL('release'),
+          },
+        },
       },
       {
         name: 'ember-beta',
         npm: {
           devDependencies: {
-            'ember-source': await getChannelURL('beta')
-          }
-        }
+            'ember-source': await getChannelURL('beta'),
+          },
+        },
       },
       {
         name: 'ember-canary',
         npm: {
           devDependencies: {
-            'ember-source': await getChannelURL('canary')
-          }
-        }
+            'ember-source': await getChannelURL('canary'),
+          },
+        },
       },
       // The default `.travis.yml` runs this scenario via `npm test`,
       // not via `ember try`. It's still included here so that running
@@ -53,21 +53,21 @@ module.exports = async function() {
       {
         name: 'ember-default',
         npm: {
-          devDependencies: {}
-        }
+          devDependencies: {},
+        },
       },
       {
         name: 'ember-default-with-jquery',
         env: {
           EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'jquery-integration': true
-          })
+            'jquery-integration': true,
+          }),
         },
         npm: {
           devDependencies: {
-            '@ember/jquery': '^0.5.1'
-          }
-        }
+            '@ember/jquery': '^0.5.1',
+          },
+        },
       },
       {
         name: 'ember-classic',
@@ -75,15 +75,15 @@ module.exports = async function() {
           EMBER_OPTIONAL_FEATURES: JSON.stringify({
             'application-template-wrapper': true,
             'default-async-observers': false,
-            'template-only-glimmer-components': false
-          })
+            'template-only-glimmer-components': false,
+          }),
         },
         npm: {
           ember: {
-            edition: 'classic'
-          }
-        }
-      }
-    ]
+            edition: 'classic',
+          },
+        },
+      },
+    ],
   };
 };

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -23,7 +23,7 @@
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint . --cache --cache-location '../../eslintcache/'",
     "start": "ember serve",
-    "test": "npm-run-all lint:* test:*",
+    "test": "bash ./scripts/run_tests.sh",
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each",
     "prepublishOnly": "ember ts:precompile",

--- a/packages/ember/scripts/run_tests.sh
+++ b/packages/ember/scripts/run_tests.sh
@@ -1,0 +1,10 @@
+# running compatibilty tests takes ~15 min on a 2019 2.6 GHz 6-Core Intel i7 16" MacBook Pro w 32 GB of RAM, vs ~25 sec
+# for the regular tests
+
+if [[ $TRAVIS || $GITHUB_ACTIONS ]]; then
+  echo "In CI - running tests against multiple versions of Ember"
+  yarn npm-run-all lint:* test:*
+else
+  echo "Tests running locally - will only run tests against default version of Ember"
+  yarn npm-run-all lint:* test:ember
+fi


### PR DESCRIPTION
This implements a check before running ember tests, to see whether we're in a CI environment or not, and skips running tests against multiple versions of ember if we aren't (under the assumption that while we like the security of doing ALL of the checks in CI, testing against one ember version locally should be enough to let us know whether or not we broke something).

Doing this speeds up local ember tests by a factor of 25x-30x. 

~WIP because bash is mysterious.~
EDIT: Leaving a note here rather than just deleting the above WIP comment on the off chance it helps one of us in the future. The issue was that in ubuntu, though the login shell is `bash`, the default shell is `dash`, and `dash` doesn't have the `[[ logical-test ]]` construct. Therefore calling my script with `. <script>` wasn't enough - I had to specifically ask for `bash`, as in `bash <script>`.