### PR TITLE
chore(tracing): Clean-up work from removing `startSpan`

### DIFF
--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -229,35 +229,6 @@ describe('Span', () => {
         expect(spy).not.toHaveBeenCalled();
       });
 
-      test('mixing hub.startSpan(transaction) + span.startChild + maxSpans', () => {
-        const _hub = new Hub(
-          new BrowserClient({
-            _experiments: { maxSpans: 2 },
-            tracesSampleRate: 1,
-          }),
-        );
-        const spy = jest.spyOn(_hub as any, 'captureEvent') as any;
-
-        const transaction = _hub.startTransaction({ name: 'test' });
-        const childSpanOne = transaction.startChild({ op: '1' });
-        childSpanOne.finish();
-
-        _hub.configureScope(scope => {
-          scope.setSpan(transaction);
-        });
-
-        const spanTwo = transaction.startChild({ op: '2' });
-        spanTwo.finish();
-
-        const spanThree = transaction.startChild({ op: '3' });
-        spanThree.finish();
-
-        transaction.finish();
-
-        expect(spy).toHaveBeenCalled();
-        expect(spy.mock.calls[0][0].spans).toHaveLength(2);
-      });
-
       test('tree structure of spans should be correct when mixing it with span on scope', () => {
         const spy = jest.spyOn(hub as any, 'captureEvent') as any;
 

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -176,10 +176,7 @@ export interface Hub {
   traceHeaders(): { [key: string]: string };
 
   /**
-   * Starts a new `Span` and returns it. If there is a `Span` on the `Scope`,
-   * the new `Span` will be a child of the existing `Span`.
-   *
-   * @param context Properties of the new `Span`.
+   * @deprecated No longer does anything. Use use {@link Transaction.startChild} instead.
    */
   startSpan(context: SpanContext): Span;
 


### PR DESCRIPTION
[`startSpan` is no longer a thing](https://github.com/getsentry/sentry-javascript/blob/master/CHANGELOG.md#5160). This does a little clean up work which didn't get done at the time - removes a test and marks the method as deprecated, so we'll know to remove it in v6. 