### PR TITLE
fix(ember): Use correct import from `@sentry/browser`

### DIFF
--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -2,7 +2,7 @@ import ApplicationInstance from '@ember/application/instance';
 import Ember from 'ember';
 import { run } from '@ember/runloop';
 import environmentConfig from 'ember-get-config';
-import Sentry from '@sentry/browser';
+import * as Sentry from '@sentry/browser';
 import { Span, Transaction, Integration } from '@sentry/types';
 import { EmberRunQueues } from '@ember/runloop/-private/types';
 import { getActiveTransaction } from '..';


### PR DESCRIPTION
The current code `import Sentry from '@sentry/browser';` seems to work but is not actually correct, as `@sentry/browser` has no default export. I noticed this when trying out using embroider to build our app, where it warned me about this.