### PR TITLE
Add `tracestate` header to outgoing requests

### DIFF
--- a/packages/core/test/lib/request.test.ts
+++ b/packages/core/test/lib/request.test.ts
@@ -58,7 +58,20 @@ describe('eventToSentryRequest', () => {
     beforeEach(() => {
       transactionEvent = {
         ...eventBase,
-        debug_meta: { transactionSampling: { method: TransactionSamplingMethod.Rate, rate: 0.1121 } },
+        debug_meta: {
+          transactionSampling: { method: TransactionSamplingMethod.Rate, rate: 0.1121 },
+          // This value is hardcoded in its base64 form to avoid a dependency on @sentry/tracing, where the method to
+          // compute the value lives. It's equivalent to
+          // computeTracestateValue({
+          //   trace_id: '1231201211212012',
+          //   environment: 'dogpark',
+          //   release: 'off.leash.park',
+          //   public_key: 'dogsarebadatkeepingsecrets',
+          // }),
+          tracestate:
+            'eyJ0cmFjZV9pZCI6IjEyMzEyMDEyMTEyMTIwMTIiLCJlbnZpcm9ubWVudCI6ImRvZ3BhcmsiLCJyZWxlYXNlIjoib2ZmLmxlYXNo' +
+            'LnBhcmsiLCJwdWJsaWNfa2V5IjoiZG9nc2FyZWJhZGF0a2VlcGluZ3NlY3JldHMifQ',
+        },
         spans: [],
         transaction: '/dogs/are/great/',
         type: 'transaction',
@@ -77,7 +90,7 @@ describe('eventToSentryRequest', () => {
     });
 
     describe('envelope header', () => {
-      it('adds correct data to envelope header', () => {
+      it('adds correct entries to envelope header', () => {
         jest.spyOn(Date.prototype, 'toISOString').mockReturnValueOnce('2012-12-31T09:08:13.000Z');
 
         const result = eventToSentryRequest(transactionEvent, api);
@@ -155,7 +168,7 @@ describe('eventToSentryRequest', () => {
     });
 
     describe('item header', () => {
-      it('adds correct data to item header', () => {
+      it('adds correct entries to item header', () => {
         const result = eventToSentryRequest(transactionEvent, api);
         const envelope = parseEnvelopeRequest(result);
 

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -1,5 +1,5 @@
 import { getCurrentHub } from '@sentry/core';
-import { Integration, Span } from '@sentry/types';
+import { Integration, Span, TraceHeaders } from '@sentry/types';
 import { fill, logger, parseSemver } from '@sentry/utils';
 import * as http from 'http';
 import * as https from 'https';
@@ -115,9 +115,9 @@ function _createWrappedRequestMethodFactory(
             op: 'request',
           });
 
-          const sentryTraceHeader = span.toTraceparent();
-          logger.log(`[Tracing] Adding sentry-trace header to outgoing request: ${sentryTraceHeader}`);
-          requestOptions.headers = { ...requestOptions.headers, 'sentry-trace': sentryTraceHeader };
+          const traceHeaders = span.getTraceHeaders();
+          logger.log(`[Tracing] Adding sentry-trace and tracestate headers to outgoing request.`);
+          requestOptions.headers = { ...requestOptions.headers, ...(traceHeaders as TraceHeaders) };
         }
       }
 

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -64,7 +64,7 @@ describe('tracing', () => {
     expect((spans[0] as Transaction).name).toEqual('dogpark');
   });
 
-  it('attaches the sentry-trace header to outgoing non-sentry requests', async () => {
+  it('attaches tracing headers to outgoing non-sentry requests', async () => {
     nock('http://dogs.are.great')
       .get('/')
       .reply(200);
@@ -72,13 +72,15 @@ describe('tracing', () => {
     createTransactionOnScope();
 
     const request = http.get('http://dogs.are.great/');
-    const sentryTraceHeader = request.getHeader('sentry-trace') as string;
+    const sentryTraceHeader = request.getHeader('sentry-trace');
+    const tracestateHeader = request.getHeader('tracestate');
 
     expect(sentryTraceHeader).toBeDefined();
-    expect(TRACEPARENT_REGEXP.test(sentryTraceHeader)).toBe(true);
+    expect(tracestateHeader).toBeDefined();
+    expect(TRACEPARENT_REGEXP.test(sentryTraceHeader as string)).toBe(true);
   });
 
-  it("doesn't attach the sentry-trace header to outgoing sentry requests", () => {
+  it("doesn't attach tracing headers to outgoing sentry requests", () => {
     nock('http://squirrelchasers.ingest.sentry.io')
       .get('/api/12312012/store/')
       .reply(200);
@@ -87,7 +89,9 @@ describe('tracing', () => {
 
     const request = http.get('http://squirrelchasers.ingest.sentry.io/api/12312012/store/');
     const sentryTraceHeader = request.getHeader('sentry-trace');
+    const tracestateHeader = request.getHeader('tracestate');
 
     expect(sentryTraceHeader).not.toBeDefined();
+    expect(tracestateHeader).not.toBeDefined();
   });
 });

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -195,14 +195,14 @@ export function fetchCallback(
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (typeof headers.append === 'function') {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        headers.append('sentry-trace', span.toTraceparent());
+        headers.append(Object.entries(span.getTraceHeaders()));
       } else if (Array.isArray(headers)) {
-        headers = [...headers, ['sentry-trace', span.toTraceparent()]];
+        headers = [...headers, ...Object.entries(span.getTraceHeaders())];
       } else {
-        headers = { ...headers, 'sentry-trace': span.toTraceparent() };
+        headers = { ...headers, ...span.getTraceHeaders() };
       }
     } else {
-      headers = { 'sentry-trace': span.toTraceparent() };
+      headers = span.getTraceHeaders();
     }
     options.headers = headers;
   }
@@ -261,7 +261,11 @@ export function xhrCallback(
 
     if (handlerData.xhr.setRequestHeader) {
       try {
-        handlerData.xhr.setRequestHeader('sentry-trace', span.toTraceparent());
+        const sentryHeaders = span.getTraceHeaders();
+        handlerData.xhr.setRequestHeader('sentry-trace', sentryHeaders['sentry-trace']);
+        if (sentryHeaders.tracestate) {
+          handlerData.xhr.setRequestHeader('tracestate', sentryHeaders.tracestate);
+        }
       } catch (_) {
         // Error: InvalidStateError: Failed to execute 'setRequestHeader' on 'XMLHttpRequest': The object's state must be OPENED.
       }

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { Primitive, Span as SpanInterface, SpanContext, Transaction } from '@sentry/types';
+import { Primitive, Span as SpanInterface, SpanContext, TraceHeaders, Transaction } from '@sentry/types';
 import { dropUndefinedKeys, timestampWithMs, uuid4 } from '@sentry/utils';
 
 import { SpanStatus } from './spanstatus';
@@ -282,6 +282,19 @@ export class Span implements SpanInterface {
     this.traceId = spanContext.traceId ?? this.traceId;
 
     return this;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public getTraceHeaders(): TraceHeaders {
+    // tracestates live on the transaction, so if this is a free-floating span, there won't be one
+    const tracestate = this.transaction && `sentry=${this.transaction.tracestate}`; // TODO kmclb
+
+    return {
+      'sentry-trace': this.toTraceparent(),
+      ...(tracestate && { tracestate }),
+    };
   }
 
   /**

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -1,13 +1,11 @@
 import { getCurrentHub, Hub } from '@sentry/hub';
-import { Event, Measurements, Transaction as TransactionInterface, TransactionContext } from '@sentry/types';
+import { DebugMeta, Event, Measurements, Transaction as TransactionInterface, TransactionContext } from '@sentry/types';
 import { dropUndefinedKeys, isInstanceOf, logger } from '@sentry/utils';
 
 import { Span as SpanClass, SpanRecorder } from './span';
 import { computeTracestateValue } from './utils';
 
-interface TransactionMetadata {
-  transactionSampling?: { [key: string]: string | number };
-}
+type TransactionMetadata = Pick<DebugMeta, 'transactionSampling' | 'tracestate'>;
 
 /** JSDoc */
 export class Transaction extends SpanClass implements TransactionInterface {
@@ -119,6 +117,8 @@ export class Transaction extends SpanClass implements TransactionInterface {
         return prev;
       }).endTimestamp;
     }
+
+    this._metadata.tracestate = this.tracestate;
 
     const transaction: Event = {
       contexts: {

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -3,6 +3,7 @@ import { Event, Measurements, Transaction as TransactionInterface, TransactionCo
 import { dropUndefinedKeys, isInstanceOf, logger } from '@sentry/utils';
 
 import { Span as SpanClass, SpanRecorder } from './span';
+import { computeTracestateValue } from './utils';
 
 interface TransactionMetadata {
   transactionSampling?: { [key: string]: string | number };
@@ -11,6 +12,8 @@ interface TransactionMetadata {
 /** JSDoc */
 export class Transaction extends SpanClass implements TransactionInterface {
   public name: string;
+
+  public readonly tracestate: string;
 
   private _metadata: TransactionMetadata = {};
 
@@ -40,6 +43,10 @@ export class Transaction extends SpanClass implements TransactionInterface {
     this.name = transactionContext.name || '';
 
     this._trimEnd = transactionContext.trimEnd;
+
+    // _getNewTracestate only returns undefined in the absence of a client or dsn, in which case it doesn't matter what
+    // the header values are - nothing can be sent anyway - so the third alternative here is just to make TS happy
+    this.tracestate = transactionContext.tracestate || this._getNewTracestate() || 'things are broken';
 
     // this is because transactions are also spans, and spans have a transaction pointer
     this.transaction = this;
@@ -160,5 +167,28 @@ export class Transaction extends SpanClass implements TransactionInterface {
     this._trimEnd = transactionContext.trimEnd;
 
     return this;
+  }
+
+  /**
+   * Create a new tracestate header value
+   *
+   * @returns The new tracestate value, or undefined if there's no client or no dsn
+   */
+  private _getNewTracestate(): string | undefined {
+    const client = this._hub.getClient();
+    const dsn = client?.getDsn();
+
+    if (!client || !dsn) {
+      return;
+    }
+
+    const { environment, release } = client.getOptions() || {};
+
+    // TODO - the only reason we need the non-null assertion on `dsn.publicKey` (below) is because `dsn.publicKey` has
+    // to be optional while we transition from `dsn.user` -> `dsn.publicKey`. Once `dsn.user` is removed, we can make
+    // `dsn.publicKey` required and remove the `!`.
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return computeTracestateValue({ trace_id: this.traceId, environment, release, public_key: dsn.publicKey! });
   }
 }

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -1,5 +1,6 @@
 import { getCurrentHub, Hub } from '@sentry/hub';
 import { Options, TraceparentData, Transaction } from '@sentry/types';
+import { SentryError, unicodeToBase64 } from '@sentry/utils';
 
 export const TRACEPARENT_REGEXP = new RegExp(
   '^[ \\t]*' + // whitespace
@@ -66,3 +67,35 @@ export function secToMs(time: number): number {
 
 // so it can be used in manual instrumentation without necessitating a hard dependency on @sentry/utils
 export { stripUrlQueryAndFragment } from '@sentry/utils';
+
+/**
+ * Compute the value of a tracestate header.
+ *
+ * @throws SentryError (because using the logger creates a circular dependency)
+ * @returns the base64-encoded header value
+ */
+// Note: this is here instead of in the tracing package since @sentry/core tests rely on it
+export function computeTracestateValue(tracestateData: {
+  trace_id: string;
+  environment: string | undefined | null;
+  release: string | undefined | null;
+  public_key: string;
+}): string {
+  // `JSON.stringify` will drop keys with undefined values, but not ones with null values
+  tracestateData.environment = tracestateData.environment || null;
+  tracestateData.release = tracestateData.release || null;
+
+  // See https://www.w3.org/TR/trace-context/#tracestate-header-field-values
+  // The spec for tracestate header values calls for a string of the form
+  //
+  //    identifier1=value1,identifier2=value2,...
+  //
+  // which means the value can't include any equals signs, since they already have meaning. Equals signs are commonly
+  // used to pad the end of base64 values though, so to avoid confusion, we strip them off. (Most languages' base64
+  // decoding functions (including those in JS) are able to function without the padding.)
+  try {
+    return unicodeToBase64(JSON.stringify(tracestateData)).replace(/={1,2}$/, '');
+  } catch (err) {
+    throw new SentryError(`[Tracing] Error creating tracestate header: ${err}`);
+  }
+}

--- a/packages/tracing/test/browser/request.test.ts
+++ b/packages/tracing/test/browser/request.test.ts
@@ -13,6 +13,14 @@ import {
 import { addExtensionMethods } from '../../src/hubextensions';
 import * as tracingUtils from '../../src/utils';
 
+// This is a normal base64 regex, modified to reflect that fact that we strip the trailing = or == off
+const stripped_base64 = '([a-zA-Z0-9+/]{4})*([a-zA-Z0-9+/]{2,3})?';
+
+const TRACESTATE_HEADER_REGEX = new RegExp(
+  `sentry=(${stripped_base64})` +  // our part of the header - should be the only part or at least the first part
+    `(,\\w+=\\w+)*`, // any number of copies of a comma followed by `name=value`
+);
+
 beforeAll(() => {
   addExtensionMethods();
   // @ts-ignore need to override global Request because it's not in the jest environment (even with an
@@ -63,7 +71,7 @@ describe('callbacks', () => {
   const fetchHandlerData: FetchData = {
     args: ['http://dogs.are.great/', {}],
     fetchData: { url: 'http://dogs.are.great/', method: 'GET' },
-    startTimestamp: 1356996072000,
+    startTimestamp: 2012112120121231,
   };
   const xhrHandlerData: XHRData = {
     xhr: {
@@ -78,18 +86,27 @@ describe('callbacks', () => {
       // setRequestHeader: XMLHttpRequest.prototype.setRequestHeader,
       setRequestHeader,
     },
-    startTimestamp: 1353501072000,
+    startTimestamp: 2012112120121231,
   };
-  const endTimestamp = 1356996072000;
+  const endTimestamp = 2013041520130908;
 
   beforeAll(() => {
-    hub = new Hub(new BrowserClient({ tracesSampleRate: 1 }));
+    hub = new Hub(
+      new BrowserClient({
+        dsn: 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012',
+        environment: 'dogpark',
+        release: 'off.leash.park',
+
+        tracesSampleRate: 1,
+      }),
+    );
     makeMain(hub);
   });
 
   beforeEach(() => {
-    transaction = hub.startTransaction({ name: 'organizations/users/:userid', op: 'pageload' }) as Transaction;
+    transaction = hub.startTransaction({ name: 'meetNewDogFriend', op: 'wag.tail' }) as Transaction;
     hub.configureScope(scope => scope.setSpan(transaction));
+    jest.clearAllMocks();
   });
 
   describe('fetchCallback()', () => {
@@ -117,20 +134,17 @@ describe('callbacks', () => {
       expect(spans).toEqual({});
     });
 
-    it('does not add fetch request headers if tracing is disabled', () => {
+    it('does not add tracing headers if tracing is disabled', () => {
       hasTracingEnabled.mockReturnValueOnce(false);
 
       // make a local copy so the global one doesn't get mutated
-      const handlerData: FetchData = {
-        args: ['http://dogs.are.great/', {}],
-        fetchData: { url: 'http://dogs.are.great/', method: 'GET' },
-        startTimestamp: 1353501072000,
-      };
+      const handlerData = { ...fetchHandlerData };
 
       fetchCallback(handlerData, alwaysCreateSpan, {});
 
       const headers = (handlerData.args[1].headers as Record<string, string>) || {};
       expect(headers['sentry-trace']).not.toBeDefined();
+      expect(headers['tracestate']).not.toBeDefined();
     });
 
     it('creates and finishes fetch span on active transaction', () => {
@@ -185,8 +199,15 @@ describe('callbacks', () => {
       expect(newSpan!.status).toBe(SpanStatus.fromHttpCode(404));
     });
 
-    it('adds sentry-trace header to fetch requests', () => {
-      // TODO
+    it('adds tracing headers to fetch requests', () => {
+      // make a local copy so the global one doesn't get mutated
+      const handlerData = { ...fetchHandlerData };
+
+      fetchCallback(handlerData, alwaysCreateSpan, {});
+
+      const headers = (handlerData.args[1].headers as Record<string, string>) || {};
+      expect(headers['sentry-trace']).toBeDefined();
+      expect(headers['tracestate']).toBeDefined();
     });
   });
 
@@ -207,7 +228,7 @@ describe('callbacks', () => {
       expect(spans).toEqual({});
     });
 
-    it('does not add xhr request headers if tracing is disabled', () => {
+    it('does not add tracing headers if tracing is disabled', () => {
       hasTracingEnabled.mockReturnValueOnce(false);
 
       xhrCallback(xhrHandlerData, alwaysCreateSpan, {});
@@ -215,13 +236,14 @@ describe('callbacks', () => {
       expect(setRequestHeader).not.toHaveBeenCalled();
     });
 
-    it('adds sentry-trace header to XHR requests', () => {
+    it('adds tracing headers to XHR requests', () => {
       xhrCallback(xhrHandlerData, alwaysCreateSpan, {});
 
       expect(setRequestHeader).toHaveBeenCalledWith(
         'sentry-trace',
         expect.stringMatching(tracingUtils.TRACEPARENT_REGEXP),
       );
+      expect(setRequestHeader).toHaveBeenCalledWith('tracestate', expect.stringMatching(TRACESTATE_HEADER_REGEX));
     });
 
     it('creates and finishes XHR span on active transaction', () => {

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -101,6 +101,26 @@ describe('Span', () => {
     });
   });
 
+  describe('getTraceHeaders', () => {
+    it('returns correct headers', () => {
+      const hub = new Hub(
+        new BrowserClient({
+          dsn: 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012',
+          tracesSampleRate: 1,
+          release: 'off.leash.park',
+          environment: 'dogpark',
+        }),
+      );
+      const transaction = hub.startTransaction({ name: 'FETCH /ball' });
+      const span = transaction.startChild({ op: 'dig.hole' });
+
+      const headers = span.getTraceHeaders();
+
+      expect(headers['sentry-trace']).toEqual(span.toTraceparent());
+      expect(headers.tracestate).toEqual(`sentry=${transaction.tracestate}`);
+    });
+  });
+
   describe('toJSON', () => {
     test('simple', () => {
       const span = JSON.parse(

--- a/packages/types/src/debugMeta.ts
+++ b/packages/types/src/debugMeta.ts
@@ -4,6 +4,9 @@
 export interface DebugMeta {
   images?: Array<DebugImage>;
   transactionSampling?: { rate?: number; method?: string };
+
+  /** The Sentry portion of a transaction's tracestate header, used for dynamic sampling */
+  tracestate?: string;
 }
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -23,7 +23,7 @@ export { SdkInfo } from './sdkinfo';
 export { SdkMetadata } from './sdkmetadata';
 export { Session, SessionContext, SessionStatus } from './session';
 export { Severity } from './severity';
-export { Span, SpanContext } from './span';
+export { Span, SpanContext, TraceHeaders } from './span';
 export { StackFrame } from './stackframe';
 export { Stacktrace } from './stacktrace';
 export { Status } from './status';

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -158,6 +158,13 @@ export interface Span extends SpanContext {
   /** Updates the current span with a new `SpanContext` */
   updateWithContext(spanContext: SpanContext): this;
 
+  /**
+   * Get headers to attach to any outgoing requests made by the operation corresponding to the current span
+   *
+   * @returns An object containing the headers
+   */
+  getTraceHeaders(): TraceHeaders;
+
   /** Convert the object to JSON for w. spans array info only */
   getTraceContext(): {
     data?: { [key: string]: any };
@@ -169,6 +176,7 @@ export interface Span extends SpanContext {
     tags?: { [key: string]: Primitive };
     trace_id: string;
   };
+
   /** Convert the object to JSON */
   toJSON(): {
     data?: { [key: string]: any };
@@ -183,3 +191,8 @@ export interface Span extends SpanContext {
     trace_id: string;
   };
 }
+
+export type TraceHeaders = {
+  'sentry-trace': string;
+  tracestate?: string;
+};

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -22,6 +22,12 @@ export interface TransactionContext extends SpanContext {
    * If this transaction has a parent, the parent's sampling decision
    */
   parentSampled?: boolean;
+
+  /**
+   * The tracestate header value associated with this transaction, potentially inherited from a parent transaction,
+   * which will be propagated across services to all child transactions
+   */
+  tracestate?: string;
 }
 
 /**


### PR DESCRIPTION
This adds the `tracestate` header to outgoing requests in both browser (`XHR` and `fetch`) and node (`http`).

Major components:

- A new `tracestate` property on the `Transaction` class
	- Either passed in the `transactionContext` or computed when the transaction is created
    - Equal to a JSONified, base64-encoded version of an object containing `trace_id`, `release`, `environment`, and `public_key`, with any `=` padding on the end removed
    - Used both to provide a header value for outgoing requests and an envelope header value for transaction events
  
- Inclusion of a `tracestate` header on all outgoing requests

- Use of the already-calculated value for `trace` envelope header

- Tests for all of the above

Reading and using incoming `tracestate` header values (including accounting for other vendors' data which might also be present, as well as multiple `tracestate` headers) will be handled in a later PR.

