### PR TITLE
fix: Revert express tracing integration type to use any

### DIFF
--- a/packages/tracing/src/integrations/express.ts
+++ b/packages/tracing/src/integrations/express.ts
@@ -29,7 +29,7 @@ type Method =
   | 'use';
 
 type Router = {
-  [method in Method]: (...args: unknown[]) => unknown;
+  [method in Method]: (...args: any) => any; // eslint-disable-line @typescript-eslint/no-explicit-any
 };
 
 interface ExpressResponse {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/3089