### PR TITLE
fix(mongo): Remove `aggregate` from operations whose arguments get serialized

### DIFF
--- a/packages/tracing/src/integrations/mongo.ts
+++ b/packages/tracing/src/integrations/mongo.ts
@@ -47,7 +47,7 @@ const OPERATIONS = [
 const OPERATION_SIGNATURES: {
   [op in Operation]?: string[];
 } = {
-  aggregate: ['pipeline'],
+  // aggregate intentionally not included because `pipeline` arguments are too complex to serialize well
   bulkWrite: ['operations'],
   countDocuments: ['query'],
   createIndex: ['fieldOrSpec'],

--- a/packages/tracing/src/integrations/mongo.ts
+++ b/packages/tracing/src/integrations/mongo.ts
@@ -48,6 +48,7 @@ const OPERATION_SIGNATURES: {
   [op in Operation]?: string[];
 } = {
   // aggregate intentionally not included because `pipeline` arguments are too complex to serialize well
+  // see https://github.com/getsentry/sentry-javascript/pull/3102
   bulkWrite: ['operations'],
   countDocuments: ['query'],
   createIndex: ['fieldOrSpec'],


### PR DESCRIPTION
Removing `aggregate` as an operation whose arguments we serialize because `pipeline` values are complex nested objects which don't serialize well.

`aggregate` syntax: `db.collection.aggregate(pipeline, options)`
(see https://docs.mongodb.com/manual/reference/method/db.collection.aggregate/#db.collection.aggregate)

`pipeline` syntax: `[ <stage>, <...> ]`
(see https://docs.mongodb.com/manual/reference/operator/aggregation-pipeline/)

Example stage syntax: `{ $match: { <query> } }`
(see https://docs.mongodb.com/manual/reference/operator/aggregation/match/ and https://docs.mongodb.com/manual/reference/operator/aggregation/match/#equality-match)

Stages can even end up nested in other stages:
```
{ $facet:
   {
      <outputField1>: [ <stage1>, <stage2>, ... ],
      <outputField2>: [ <stage1>, <stage2>, ... ],
      ...
   }
}
```
(see https://docs.mongodb.com/manual/reference/operator/aggregation/facet/ and https://docs.mongodb.com/manual/reference/operator/aggregation/facet/#example)