### PR TITLE
fix(dev): Allow ember-canary to fail

### DIFF
--- a/packages/ember/config/ember-try.js
+++ b/packages/ember/config/ember-try.js
@@ -40,6 +40,7 @@ module.exports = async function() {
       },
       {
         name: 'ember-canary',
+        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),


### PR DESCRIPTION
For a few days last week, a failure in the `ember-canary` tests was blocking the rest of our CI. It seems to have resolved itself over the weekend, but as a matter of principle we probably shouldn't block on someone else's not-yet-released code. This allows the `ember-canary` tests to fail without killing the process.

(As it happens, this is even suggested in the example code in the `ember-try` [README](https://github.com/ember-cli/ember-try#configuration-files).)