### PR TITLE
ref(types): Loosen tag types, create new `Primitive` type

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -92,7 +92,7 @@ We realized how annoying it is to set a whole object using `setExtra`, that's wh
 `Scope`.
 
 ```typescript
-setTags(tags: { [key: string]: string }): this;
+setTags(tags: { [key: string]: string | number | boolean | undefined }): this;
 setExtras(extras: { [key: string]: any }): this;
 clearBreadcrumbs(): this;
 ```

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -88,11 +88,11 @@ like this:
 
 ## New Scope functions
 
-We realized how annoying it is to set a whole object using `setExtra`, that's why there are now a few new methods on the
+We realized how annoying it is to set a whole object using `setExtra`, so there are now a few new methods on the
 `Scope`.
 
 ```typescript
-setTags(tags: { [key: string]: string | number | boolean | undefined }): this;
+setTags(tags: { [key: string]: string | number | boolean | bigint| symbol| null | undefined }): this;
 setExtras(extras: { [key: string]: any }): this;
 clearBreadcrumbs(): this;
 ```

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -92,7 +92,7 @@ We realized how annoying it is to set a whole object using `setExtra`, so there 
 `Scope`.
 
 ```typescript
-setTags(tags: { [key: string]: string | number | boolean | bigint| symbol| null | undefined }): this;
+setTags(tags: { [key: string]: string | number | boolean | null | undefined }): this;
 setExtras(extras: { [key: string]: any }): this;
 clearBreadcrumbs(): this;
 ```

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -216,7 +216,6 @@ export class GlobalHandlers implements Integration {
    * @param reason: The `reason` property of the promise rejection
    * @returns An Event object with an appropriate `exception` value
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _eventFromRejectionWithPrimitive(reason: Primitive): Event {
     return {
       exception: {

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -119,7 +119,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
     let eventId: string | undefined = hint && hint.event_id;
 
     const promisedEvent = isPrimitive(message)
-      ? this._getBackend().eventFromMessage(`${message}`, level, hint)
+      ? this._getBackend().eventFromMessage(String(message), level, hint)
       : this._getBackend().eventFromException(message, hint);
 
     this._process(

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -261,7 +261,7 @@ export class Hub implements HubInterface {
   /**
    * @inheritDoc
    */
-  public setTags(tags: { [key: string]: string }): void {
+  public setTags(tags: { [key: string]: string | number | boolean | undefined }): void {
     const scope = this.getScope();
     if (scope) scope.setTags(tags);
   }
@@ -277,7 +277,7 @@ export class Hub implements HubInterface {
   /**
    * @inheritDoc
    */
-  public setTag(key: string, value: string): void {
+  public setTag(key: string, value: string | number | boolean | undefined): void {
     const scope = this.getScope();
     if (scope) scope.setTag(key, value);
   }

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -11,6 +11,7 @@ import {
   Hub as HubInterface,
   Integration,
   IntegrationClass,
+  Primitive,
   SessionContext,
   Severity,
   Span,
@@ -261,7 +262,7 @@ export class Hub implements HubInterface {
   /**
    * @inheritDoc
    */
-  public setTags(tags: { [key: string]: string | number | boolean | undefined }): void {
+  public setTags(tags: { [key: string]: Primitive }): void {
     const scope = this.getScope();
     if (scope) scope.setTags(tags);
   }
@@ -277,7 +278,7 @@ export class Hub implements HubInterface {
   /**
    * @inheritDoc
    */
-  public setTag(key: string, value: string | number | boolean | undefined): void {
+  public setTag(key: string, value: Primitive): void {
     const scope = this.getScope();
     if (scope) scope.setTag(key, value);
   }

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -41,7 +41,7 @@ export class Scope implements ScopeInterface {
   protected _user: User = {};
 
   /** Tags */
-  protected _tags: { [key: string]: string } = {};
+  protected _tags: { [key: string]: string | number | boolean | undefined } = {};
 
   /** Extra */
   protected _extra: Extras = {};
@@ -124,7 +124,7 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public setTags(tags: { [key: string]: string }): this {
+  public setTags(tags: { [key: string]: string | number | boolean | undefined }): this {
     this._tags = {
       ...this._tags,
       ...tags,
@@ -136,7 +136,7 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public setTag(key: string, value: string): this {
+  public setTag(key: string, value: string | number | boolean | undefined): this {
     this._tags = { ...this._tags, [key]: value };
     this._notifyScopeListeners();
     return this;

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -9,6 +9,7 @@ import {
   EventProcessor,
   Extra,
   Extras,
+  Primitive,
   Scope as ScopeInterface,
   ScopeContext,
   Severity,
@@ -41,7 +42,7 @@ export class Scope implements ScopeInterface {
   protected _user: User = {};
 
   /** Tags */
-  protected _tags: { [key: string]: string | number | boolean | undefined } = {};
+  protected _tags: { [key: string]: Primitive } = {};
 
   /** Extra */
   protected _extra: Extras = {};
@@ -124,7 +125,7 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public setTags(tags: { [key: string]: string | number | boolean | undefined }): this {
+  public setTags(tags: { [key: string]: Primitive }): this {
     this._tags = {
       ...this._tags,
       ...tags,
@@ -136,7 +137,7 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public setTag(key: string, value: string | number | boolean | undefined): this {
+  public setTag(key: string, value: Primitive): this {
     this._tags = { ...this._tags, [key]: value };
     this._notifyScopeListeners();
     return this;

--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -6,6 +6,7 @@ import {
   Event,
   Extra,
   Extras,
+  Primitive,
   Severity,
   Transaction,
   TransactionContext,
@@ -127,7 +128,7 @@ export function setExtras(extras: Extras): void {
  * Set an object that will be merged sent as tags data with the event.
  * @param tags Tags context object to merge into current context.
  */
-export function setTags(tags: { [key: string]: string | number | boolean | undefined }): void {
+export function setTags(tags: { [key: string]: Primitive }): void {
   callOnHub<void>('setTags', tags);
 }
 
@@ -148,7 +149,7 @@ export function setExtra(key: string, extra: Extra): void {
  * @param key String key of tag
  * @param value Value of tag
  */
-export function setTag(key: string, value: string | number | boolean | undefined): void {
+export function setTag(key: string, value: Primitive): void {
   callOnHub<void>('setTag', key, value);
 }
 

--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -127,7 +127,7 @@ export function setExtras(extras: Extras): void {
  * Set an object that will be merged sent as tags data with the event.
  * @param tags Tags context object to merge into current context.
  */
-export function setTags(tags: { [key: string]: string }): void {
+export function setTags(tags: { [key: string]: string | number | boolean | undefined }): void {
   callOnHub<void>('setTags', tags);
 }
 
@@ -142,10 +142,13 @@ export function setExtra(key: string, extra: Extra): void {
 
 /**
  * Set key:value that will be sent as tags data with the event.
+ *
+ * Can also be used to unset a tag, by passing `undefined`.
+ *
  * @param key String key of tag
- * @param value String value of tag
+ * @param value Value of tag
  */
-export function setTag(key: string, value: string): void {
+export function setTag(key: string, value: string | number | boolean | undefined): void {
   callOnHub<void>('setTag', key, value);
 }
 

--- a/packages/react/src/reactrouterv3.ts
+++ b/packages/react/src/reactrouterv3.ts
@@ -62,7 +62,9 @@ export function reactRouterV3Instrumentation(
           if (activeTransaction) {
             activeTransaction.finish();
           }
-          const tags: Record<string, string> = { 'routing.instrumentation': 'react-router-v3' };
+          const tags: Record<string, string | number | boolean | undefined> = {
+            'routing.instrumentation': 'react-router-v3',
+          };
           if (prevName) {
             tags.from = prevName;
           }

--- a/packages/react/src/reactrouterv3.ts
+++ b/packages/react/src/reactrouterv3.ts
@@ -1,4 +1,4 @@
-import { Transaction, TransactionContext } from '@sentry/types';
+import { Primitive, Transaction, TransactionContext } from '@sentry/types';
 import { getGlobalObject } from '@sentry/utils';
 
 import { Location, ReactRouterInstrumentation } from './types';
@@ -62,7 +62,7 @@ export function reactRouterV3Instrumentation(
           if (activeTransaction) {
             activeTransaction.finish();
           }
-          const tags: Record<string, string | number | boolean | undefined> = {
+          const tags: Record<string, Primitive> = {
             'routing.instrumentation': 'react-router-v3',
           };
           if (prevName) {

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -86,7 +86,7 @@ export class Span implements SpanInterface {
   /**
    * @inheritDoc
    */
-  public tags: { [key: string]: string } = {};
+  public tags: { [key: string]: string | number | boolean | undefined } = {};
 
   /**
    * @inheritDoc
@@ -187,7 +187,7 @@ export class Span implements SpanInterface {
   /**
    * @inheritDoc
    */
-  public setTag(key: string, value: string): this {
+  public setTag(key: string, value: string | number | boolean | undefined): this {
     this.tags = { ...this.tags, [key]: value };
     return this;
   }
@@ -257,7 +257,7 @@ export class Span implements SpanInterface {
     parent_span_id?: string;
     span_id: string;
     status?: string;
-    tags?: { [key: string]: string };
+    tags?: { [key: string]: string | number | boolean | undefined };
     trace_id: string;
   } {
     return dropUndefinedKeys({
@@ -284,7 +284,7 @@ export class Span implements SpanInterface {
     span_id: string;
     start_timestamp: number;
     status?: string;
-    tags?: { [key: string]: string };
+    tags?: { [key: string]: string | number | boolean | undefined };
     timestamp?: number;
     trace_id: string;
   } {

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { Span as SpanInterface, SpanContext, Transaction } from '@sentry/types';
+import { Primitive, Span as SpanInterface, SpanContext, Transaction } from '@sentry/types';
 import { dropUndefinedKeys, timestampWithMs, uuid4 } from '@sentry/utils';
 
 import { SpanStatus } from './spanstatus';
@@ -86,7 +86,7 @@ export class Span implements SpanInterface {
   /**
    * @inheritDoc
    */
-  public tags: { [key: string]: string | number | boolean | undefined } = {};
+  public tags: { [key: string]: Primitive } = {};
 
   /**
    * @inheritDoc
@@ -187,7 +187,7 @@ export class Span implements SpanInterface {
   /**
    * @inheritDoc
    */
-  public setTag(key: string, value: string | number | boolean | undefined): this {
+  public setTag(key: string, value: Primitive): this {
     this.tags = { ...this.tags, [key]: value };
     return this;
   }
@@ -257,7 +257,7 @@ export class Span implements SpanInterface {
     parent_span_id?: string;
     span_id: string;
     status?: string;
-    tags?: { [key: string]: string | number | boolean | undefined };
+    tags?: { [key: string]: Primitive };
     trace_id: string;
   } {
     return dropUndefinedKeys({
@@ -284,7 +284,7 @@ export class Span implements SpanInterface {
     span_id: string;
     start_timestamp: number;
     status?: string;
-    tags?: { [key: string]: string | number | boolean | undefined };
+    tags?: { [key: string]: Primitive };
     timestamp?: number;
     trace_id: string;
   } {

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -35,7 +35,7 @@ export interface Event {
   stacktrace?: Stacktrace;
   breadcrumbs?: Breadcrumb[];
   contexts?: Contexts;
-  tags?: { [key: string]: string };
+  tags?: { [key: string]: string | number | boolean | undefined };
   extra?: Extras;
   user?: User;
   type?: EventType;

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -2,6 +2,7 @@ import { Breadcrumb } from './breadcrumb';
 import { Contexts } from './context';
 import { Exception } from './exception';
 import { Extras } from './extra';
+import { Primitive } from './misc';
 import { Request } from './request';
 import { CaptureContext } from './scope';
 import { SdkInfo } from './sdkinfo';
@@ -35,7 +36,7 @@ export interface Event {
   stacktrace?: Stacktrace;
   breadcrumbs?: Breadcrumb[];
   contexts?: Contexts;
-  tags?: { [key: string]: string | number | boolean | undefined };
+  tags?: { [key: string]: Primitive };
   extra?: Extras;
   user?: User;
   type?: EventType;

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -124,16 +124,20 @@ export interface Hub {
 
   /**
    * Set an object that will be merged sent as tags data with the event.
+   *
    * @param tags Tags context object to merge into current context.
    */
-  setTags(tags: { [key: string]: string }): void;
+  setTags(tags: { [key: string]: string | number | boolean | undefined }): void;
 
   /**
    * Set key:value that will be sent as tags data with the event.
+   *
+   * Can also be used to unset a tag, by passing `undefined`.
+   *
    * @param key String key of tag
-   * @param value String value of tag
+   * @param value Value of tag
    */
-  setTag(key: string, value: string): void;
+  setTag(key: string, value: string | number | boolean | undefined): void;
 
   /**
    * Set key:value that will be sent as extra data with the event.

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -3,6 +3,7 @@ import { Client } from './client';
 import { Event, EventHint } from './event';
 import { Extra, Extras } from './extra';
 import { Integration, IntegrationClass } from './integration';
+import { Primitive } from './misc';
 import { Scope } from './scope';
 import { Session, SessionContext } from './session';
 import { Severity } from './severity';
@@ -127,7 +128,7 @@ export interface Hub {
    *
    * @param tags Tags context object to merge into current context.
    */
-  setTags(tags: { [key: string]: string | number | boolean | undefined }): void;
+  setTags(tags: { [key: string]: Primitive }): void;
 
   /**
    * Set key:value that will be sent as tags data with the event.
@@ -137,7 +138,7 @@ export interface Hub {
    * @param key String key of tag
    * @param value Value of tag
    */
-  setTag(key: string, value: string | number | boolean | undefined): void;
+  setTag(key: string, value: Primitive): void;
 
   /**
    * Set key:value that will be sent as extra data with the event.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -11,7 +11,7 @@ export { Hub } from './hub';
 export { Integration, IntegrationClass } from './integration';
 export { LogLevel } from './loglevel';
 export { Mechanism } from './mechanism';
-export { ExtractedNodeRequestData, WorkerLocation } from './misc';
+export { ExtractedNodeRequestData, NonPrimitive, Primitive, WorkerLocation } from './misc';
 export { Options } from './options';
 export { Package } from './package';
 export { Request, SentryRequest, SentryRequestType } from './request';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -11,7 +11,7 @@ export { Hub } from './hub';
 export { Integration, IntegrationClass } from './integration';
 export { LogLevel } from './loglevel';
 export { Mechanism } from './mechanism';
-export { ExtractedNodeRequestData, NonPrimitive, Primitive, WorkerLocation } from './misc';
+export { ExtractedNodeRequestData, Primitive, WorkerLocation } from './misc';
 export { Options } from './options';
 export { Package } from './package';
 export { Request, SentryRequest, SentryRequestType } from './request';

--- a/packages/types/src/misc.ts
+++ b/packages/types/src/misc.ts
@@ -59,3 +59,8 @@ export interface WorkerLocation {
   /** Synonym for `href` attribute */
   toString(): string;
 }
+
+export type Primitive = number | string | boolean | bigint | symbol | null | undefined;
+
+// at eslint's suggestion, not using 'object' because https://github.com/microsoft/TypeScript/issues/21732 is still open
+export type NonPrimitive = Record<string, unknown>;

--- a/packages/types/src/misc.ts
+++ b/packages/types/src/misc.ts
@@ -61,6 +61,3 @@ export interface WorkerLocation {
 }
 
 export type Primitive = number | string | boolean | bigint | symbol | null | undefined;
-
-// at eslint's suggestion, not using 'object' because https://github.com/microsoft/TypeScript/issues/21732 is still open
-export type NonPrimitive = Record<string, unknown>;

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -17,7 +17,7 @@ export interface ScopeContext {
   level: Severity;
   extra: Extras;
   contexts: Contexts;
-  tags: { [key: string]: string };
+  tags: { [key: string]: string | number | boolean | undefined };
   fingerprint: string[];
 }
 
@@ -45,14 +45,17 @@ export interface Scope {
    * Set an object that will be merged sent as tags data with the event.
    * @param tags Tags context object to merge into current context.
    */
-  setTags(tags: { [key: string]: string }): this;
+  setTags(tags: { [key: string]: string | number | boolean | undefined }): this;
 
   /**
    * Set key:value that will be sent as tags data with the event.
+   *
+   * Can also be used to unset a tag by passing `undefined`.
+   *
    * @param key String key of tag
-   * @param value String value of tag
+   * @param value Value of tag
    */
-  setTag(key: string, value: string): this;
+  setTag(key: string, value: string | number | boolean | undefined): this;
 
   /**
    * Set an object that will be merged sent as extra data with the event.

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -2,6 +2,7 @@ import { Breadcrumb } from './breadcrumb';
 import { Context, Contexts } from './context';
 import { EventProcessor } from './eventprocessor';
 import { Extra, Extras } from './extra';
+import { Primitive } from './misc';
 import { Session } from './session';
 import { Severity } from './severity';
 import { Span } from './span';
@@ -17,7 +18,7 @@ export interface ScopeContext {
   level: Severity;
   extra: Extras;
   contexts: Contexts;
-  tags: { [key: string]: string | number | boolean | undefined };
+  tags: { [key: string]: Primitive };
   fingerprint: string[];
 }
 
@@ -45,7 +46,7 @@ export interface Scope {
    * Set an object that will be merged sent as tags data with the event.
    * @param tags Tags context object to merge into current context.
    */
-  setTags(tags: { [key: string]: string | number | boolean | undefined }): this;
+  setTags(tags: { [key: string]: Primitive }): this;
 
   /**
    * Set key:value that will be sent as tags data with the event.
@@ -55,7 +56,7 @@ export interface Scope {
    * @param key String key of tag
    * @param value Value of tag
    */
-  setTag(key: string, value: string | number | boolean | undefined): this;
+  setTag(key: string, value: Primitive): this;
 
   /**
    * Set an object that will be merged sent as extra data with the event.

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -1,3 +1,4 @@
+import { Primitive } from './misc';
 import { Transaction } from './transaction';
 
 /** Interface holding all properties that can be set on a Span on creation. */
@@ -41,7 +42,7 @@ export interface SpanContext {
   /**
    * Tags of the Span.
    */
-  tags?: { [key: string]: string | number | boolean | undefined };
+  tags?: { [key: string]: Primitive };
 
   /**
    * Data of the Span.
@@ -79,7 +80,7 @@ export interface Span extends SpanContext {
   /**
    * @inheritDoc
    */
-  tags: { [key: string]: string | number | boolean | undefined };
+  tags: { [key: string]: Primitive };
 
   /**
    * @inheritDoc
@@ -105,7 +106,7 @@ export interface Span extends SpanContext {
    * @param key Tag key
    * @param value Tag value
    */
-  setTag(key: string, value: string | number | boolean | undefined): this;
+  setTag(key: string, value: Primitive): this;
 
   /**
    * Sets the data attribute on the current span
@@ -159,7 +160,7 @@ export interface Span extends SpanContext {
     parent_span_id?: string;
     span_id: string;
     status?: string;
-    tags?: { [key: string]: string | number | boolean | undefined };
+    tags?: { [key: string]: Primitive };
     trace_id: string;
   };
   /** Convert the object to JSON */
@@ -171,7 +172,7 @@ export interface Span extends SpanContext {
     span_id: string;
     start_timestamp: number;
     status?: string;
-    tags?: { [key: string]: string | number | boolean | undefined };
+    tags?: { [key: string]: Primitive };
     timestamp?: number;
     trace_id: string;
   };

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -41,7 +41,7 @@ export interface SpanContext {
   /**
    * Tags of the Span.
    */
-  tags?: { [key: string]: string };
+  tags?: { [key: string]: string | number | boolean | undefined };
 
   /**
    * Data of the Span.
@@ -79,7 +79,7 @@ export interface Span extends SpanContext {
   /**
    * @inheritDoc
    */
-  tags: { [key: string]: string };
+  tags: { [key: string]: string | number | boolean | undefined };
 
   /**
    * @inheritDoc
@@ -98,11 +98,14 @@ export interface Span extends SpanContext {
   finish(endTimestamp?: number): void;
 
   /**
-   * Sets the tag attribute on the current span
+   * Sets the tag attribute on the current span.
+   *
+   * Can also be used to unset a tag, by passing `undefined`.
+   *
    * @param key Tag key
    * @param value Tag value
    */
-  setTag(key: string, value: string): this;
+  setTag(key: string, value: string | number | boolean | undefined): this;
 
   /**
    * Sets the data attribute on the current span
@@ -156,7 +159,7 @@ export interface Span extends SpanContext {
     parent_span_id?: string;
     span_id: string;
     status?: string;
-    tags?: { [key: string]: string };
+    tags?: { [key: string]: string | number | boolean | undefined };
     trace_id: string;
   };
   /** Convert the object to JSON */
@@ -168,7 +171,7 @@ export interface Span extends SpanContext {
     span_id: string;
     start_timestamp: number;
     status?: string;
-    tags?: { [key: string]: string };
+    tags?: { [key: string]: string | number | boolean | undefined };
     timestamp?: number;
     trace_id: string;
   };

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -51,7 +51,7 @@ export interface Transaction extends TransactionContext, Span {
   /**
    * @inheritDoc
    */
-  tags: { [key: string]: string };
+  tags: { [key: string]: string | number | boolean | undefined };
 
   /**
    * @inheritDoc

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -1,4 +1,4 @@
-import { ExtractedNodeRequestData, WorkerLocation } from './misc';
+import { ExtractedNodeRequestData, Primitive, WorkerLocation } from './misc';
 import { Span, SpanContext } from './span';
 
 /**
@@ -51,7 +51,7 @@ export interface Transaction extends TransactionContext, Span {
   /**
    * @inheritDoc
    */
-  tags: { [key: string]: string | number | boolean | undefined };
+  tags: { [key: string]: Primitive };
 
   /**
    * @inheritDoc

--- a/packages/utils/src/is.ts
+++ b/packages/utils/src/is.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+
+import { Primitive } from '@sentry/types';
 /**
  * Checks whether given value's type is one of a few Error or Error-like
  * {@link isError}.
@@ -65,13 +67,13 @@ export function isString(wat: any): boolean {
 }
 
 /**
- * Checks whether given value's is a primitive (undefined, null, number, boolean, string)
+ * Checks whether given value's is a primitive (undefined, null, number, boolean, string, bigint, symbol)
  * {@link isPrimitive}.
  *
  * @param wat A value to be checked.
  * @returns A boolean representing the result.
  */
-export function isPrimitive(wat: any): boolean {
+export function isPrimitive(wat: any): wat is Primitive {
   return wat === null || (typeof wat !== 'object' && typeof wat !== 'function');
 }
 

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -170,7 +170,13 @@ export function normalizeToSize<T>(
   return serialized as T;
 }
 
-/** Transforms any input value into a string form, either primitive value or a type of the input */
+/**
+ * Transform any non-primitive or Symbol-type value into a string. Acts as a no-op on non-Symbol primitives.
+ *
+ * @param value The value to stringify
+ * @returns For non-primitive and Symbol-type values, a string denoting the value's type, or in the case of a Symbol,
+ * its type and description. For non-Symbol primitives, the original value, unchanged.
+ */
 function serializeValue(value: any): any {
   const type = Object.prototype.toString.call(value);
 
@@ -234,6 +240,10 @@ function normalizeValue<T>(value: T, key?: any): T | string {
 
   if (typeof value === 'function') {
     return `[Function: ${getFunctionName(value)}]`;
+  }
+
+  if (typeof value === 'symbol') {
+    return `[${String(value)}]`;
   }
 
   return value;

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -171,11 +171,13 @@ export function normalizeToSize<T>(
 }
 
 /**
- * Transform any non-primitive or Symbol-type value into a string. Acts as a no-op on non-Symbol primitives.
+ * Transform any non-primitive, BigInt, or Symbol-type value into a string. Acts as a no-op on strings, numbers,
+ * booleans, null, and undefined.
  *
  * @param value The value to stringify
- * @returns For non-primitive and Symbol-type values, a string denoting the value's type, or in the case of a Symbol,
- * its type and description. For non-Symbol primitives, the original value, unchanged.
+ * @returns For non-primitive, BigInt, and Symbol-type values, a string denoting the value's type, type and value, or
+ *  type and `description` property, respectively. For non-BigInt, non-Symbol primitives, returns the original value,
+ *  unchanged.
  */
 function serializeValue(value: any): any {
   const type = Object.prototype.toString.call(value);
@@ -242,8 +244,14 @@ function normalizeValue<T>(value: T, key?: any): T | string {
     return `[Function: ${getFunctionName(value)}]`;
   }
 
+  // symbols and bigints are considered primitives by TS, but aren't natively JSON-serilaizable
+
   if (typeof value === 'symbol') {
     return `[${String(value)}]`;
+  }
+
+  if (typeof value === 'bigint') {
+    return `[BigInt: ${String(value)}]`;
   }
 
   return value;


### PR DESCRIPTION
The only thing we do with tags is serialize/JSONify them, and any primitive* can handle that. And since we do that, relay isn't an issue, because all it ever sees from us is strings anyway.

This loosens the type requirements for tags to include all members of a new union type called `Primitive`. It also adds a note to the `setTag` docstring pointing out that a tag can be unset by passing `undefined`. Finally, it refactors `isPrimitive()` into a type guard, and uses that type guard where possible.

Doesn't fully answer the request in https://github.com/getsentry/sentry-javascript/issues/2218, but at least it will stop people's linters from freaking out when they pass `undefined`, as we ourselves suggest. 

\*Actually, symbols apparently [don't let themselves be automatically cast to their string representation](https://developer.mozilla.org/en-US/docs/Glossary/Symbol) (EDIT: apparently [BigInts don't either](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt#Use_within_JSON)), so those are handled separately, in the `normalizeValue` function.