### PR TITLE
Build and test against Node 14 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,6 @@ jobs:
     - name: '@sentry/packages - build and test [node v12]'
       node_js: '12'
       script: scripts/test.sh
+    - name: '@sentry/packages - build and test [node v14]'
+      node_js: '14'
+      script: scripts/test.sh


### PR DESCRIPTION
👋 

Node 14 went LTS at the end of October, adding to travis. Alternatively, could add `lts/*` and/or `node` targets: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/