### PR TITLE
chore(utils): Split browser/node compatibility utils into separate module

### DIFF
--- a/packages/utils/src/compat.ts
+++ b/packages/utils/src/compat.ts
@@ -1,0 +1,44 @@
+import { Integration } from '@sentry/types';
+
+/**
+ * Checks whether we're in the Node.js or Browser environment
+ *
+ * @returns Answer to given question
+ */
+export function isNodeEnv(): boolean {
+  return Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';
+}
+
+/** Internal */
+interface SentryGlobal {
+  Sentry?: {
+    Integrations?: Integration[];
+  };
+  SENTRY_ENVIRONMENT?: string;
+  SENTRY_DSN?: string;
+  SENTRY_RELEASE?: {
+    id?: string;
+  };
+  __SENTRY__: {
+    globalEventProcessors: any;
+    hub: any;
+    logger: any;
+  };
+}
+
+const fallbackGlobalObject = {};
+
+/**
+ * Safely get global scope object
+ *
+ * @returns Global scope object
+ */
+export function getGlobalObject<T>(): T & SentryGlobal {
+  return (isNodeEnv()
+    ? global
+    : typeof window !== 'undefined'
+    ? window
+    : typeof self !== 'undefined'
+    ? self
+    : fallbackGlobalObject) as T & SentryGlobal;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,6 @@
 export * from './async';
 export * from './browser';
+export * from './compat';
 export * from './dsn';
 export * from './error';
 export * from './instrument';

--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -2,9 +2,9 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { WrappedFunction } from '@sentry/types';
 
+import { getGlobalObject } from './compat';
 import { isInstanceOf, isString } from './is';
 import { logger } from './logger';
-import { getGlobalObject } from './misc';
 import { fill } from './object';
 import { getFunctionName } from './stacktrace';
 import { supportsHistory, supportsNativeFetch } from './supports';

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { consoleSandbox, getGlobalObject } from './misc';
+import { getGlobalObject } from './compat';
+import { consoleSandbox } from './misc';
 
 // TODO: Implement different loggers for different environments
 const global = getGlobalObject<Window | NodeJS.Global>();

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -1,42 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Event, Integration, StackFrame, WrappedFunction } from '@sentry/types';
+import { Event, StackFrame, WrappedFunction } from '@sentry/types';
 
-import { isNodeEnv } from './node';
+import { getGlobalObject } from './compat';
 import { snipLine } from './string';
-
-/** Internal */
-interface SentryGlobal {
-  Sentry?: {
-    Integrations?: Integration[];
-  };
-  SENTRY_ENVIRONMENT?: string;
-  SENTRY_DSN?: string;
-  SENTRY_RELEASE?: {
-    id?: string;
-  };
-  __SENTRY__: {
-    globalEventProcessors: any;
-    hub: any;
-    logger: any;
-  };
-}
-
-const fallbackGlobalObject = {};
-
-/**
- * Safely get global scope object
- *
- * @returns Global scope object
- */
-export function getGlobalObject<T>(): T & SentryGlobal {
-  return (isNodeEnv()
-    ? global
-    : typeof window !== 'undefined'
-    ? window
-    : typeof self !== 'undefined'
-    ? self
-    : fallbackGlobalObject) as T & SentryGlobal;
-}
 
 /**
  * Extended Window interface that allows for Crypto API usage in IE browsers

--- a/packages/utils/src/node.ts
+++ b/packages/utils/src/node.ts
@@ -1,17 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ExtractedNodeRequestData } from '@sentry/types';
 
+import { isNodeEnv } from './compat';
 import { isString } from './is';
 import { normalize } from './object';
-
-/**
- * Checks whether we're in the Node.js or Browser environment
- *
- * @returns Answer to given question
- */
-export function isNodeEnv(): boolean {
-  return Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';
-}
 
 /**
  * Requires a module which is protected against bundler minification.

--- a/packages/utils/src/supports.ts
+++ b/packages/utils/src/supports.ts
@@ -1,5 +1,5 @@
+import { getGlobalObject } from './compat';
 import { logger } from './logger';
-import { getGlobalObject } from './misc';
 
 /**
  * Tells whether current environment supports ErrorEvent objects

--- a/packages/utils/src/time.ts
+++ b/packages/utils/src/time.ts
@@ -1,5 +1,5 @@
-import { getGlobalObject } from './misc';
-import { dynamicRequire, isNodeEnv } from './node';
+import { getGlobalObject, isNodeEnv } from './compat';
+import { dynamicRequire } from './node';
 
 /**
  * An object that can return the current timestamp in seconds since the UNIX epoch.

--- a/packages/utils/test/misc.test.ts
+++ b/packages/utils/test/misc.test.ts
@@ -1,12 +1,7 @@
 import { StackFrame } from '@sentry/types';
 
-import {
-  addContextToFrame,
-  getEventDescription,
-  getGlobalObject,
-  parseRetryAfterHeader,
-  stripUrlQueryAndFragment,
-} from '../src/misc';
+import { getGlobalObject } from '../src/compat';
+import { addContextToFrame, getEventDescription, parseRetryAfterHeader, stripUrlQueryAndFragment } from '../src/misc';
 
 describe('getEventDescription()', () => {
   test('message event', () => {


### PR DESCRIPTION
This eliminates a future circular dependency, in an upcoming PR.
