### PR TITLE
fix mismatching browser/node version 5.29.1

### DIFF
--- a/packages/browser/src/version.ts
+++ b/packages/browser/src/version.ts
@@ -1,2 +1,2 @@
 export const SDK_NAME = 'sentry.javascript.browser';
-export const SDK_VERSION = '5.29.0';
+export const SDK_VERSION = '5.29.1';

--- a/packages/node/src/version.ts
+++ b/packages/node/src/version.ts
@@ -1,2 +1,2 @@
 export const SDK_NAME = 'sentry.javascript.node';
-export const SDK_VERSION = '5.29.0';
+export const SDK_VERSION = '5.29.1';


### PR DESCRIPTION
I updated to the sentry/node, sentry/browser 5.29.1 package released yesterday.
However, the version stated within the source is 5.29.0.
I have modified the version.