### PR TITLE
chore(ci): Make job names nicer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
         run: yarn lint
 
   job_unit_test:
-    name: Test
+    name: Test (Node ${{ matrix.node }})
     needs: job_build
     continue-on-error: true
     timeout-minutes: 30


### PR DESCRIPTION
This makes it so the jobs are named `Test (Node 6)`, `Test (Node 8)`, etc. rather than `Test (6)`, `Test (8)`.
