### PR TITLE
fix(ember): Fix rootURL breaking route recognition

### DIFF
--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -41,7 +41,7 @@ export function _instrumentEmberRouter(
   let activeTransaction: Transaction;
   let transitionSpan: Span;
 
-  const url = location && location.getURL && location.formatURL() && location.formatURL(location.getURL());
+  const url = location && location.getURL && location.formatURL && location.formatURL(location.getURL());
 
   if (macroCondition(isTesting())) {
     routerService._sentryInstrumented = true;

--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -41,7 +41,7 @@ export function _instrumentEmberRouter(
   let activeTransaction: Transaction;
   let transitionSpan: Span;
 
-  const url = location && location.getURL && location.getURL();
+  const url = location && location.getURL && location.formatURL() && location.formatURL(location.getURL());
 
   if (macroCondition(isTesting())) {
     routerService._sentryInstrumented = true;


### PR DESCRIPTION
### Summary
Mentioned in #2977, route recognition needs the url to be correctly formatted. Since there are different location types, using formatURL should get the correct URL out for use in recognition.

**Note:** Going to test this out a little more before merging in.