### PR TITLE
ci: Add continue-on-error for browserstack job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,6 +141,7 @@ jobs:
     needs: job_build
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    continue-on-error: true
     if: "github.ref == 'refs/heads/master'"
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error