### PR TITLE
fix(sampling): Remove stray sampling data tags

### DIFF
--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -51,13 +51,17 @@ export function sessionToSentryRequest(session: Session, api: API): SentryReques
 
 /** Creates a SentryRequest from an event. */
 export function eventToSentryRequest(event: Event, api: API): SentryRequest {
-  // since JS has no Object.prototype.pop()
-  const { __sentry_samplingMethod: samplingMethod, __sentry_sampleRate: sampleRate, ...otherTags } = event.tags || {};
-  event.tags = otherTags;
-
   const sdkInfo = getSdkMetadataForEnvelopeHeader(api);
   const eventType = event.type || 'event';
   const useEnvelope = eventType === 'transaction';
+
+  const { transactionSampling, ...metadata } = event.debug_meta || {};
+  const { method: samplingMethod, rate: sampleRate } = transactionSampling || {};
+  if (Object.keys(metadata).length === 0) {
+    delete event.debug_meta;
+  } else {
+    event.debug_meta = metadata;
+  }
 
   const req: SentryRequest = {
     body: JSON.stringify(sdkInfo ? enhanceEventWithSdkInfo(event, api.metadata.sdk) : event),

--- a/packages/core/test/lib/request.test.ts
+++ b/packages/core/test/lib/request.test.ts
@@ -1,21 +1,30 @@
-import { Event, TransactionSamplingMethod } from '@sentry/types';
+import { DebugMeta, Event, SentryRequest, TransactionSamplingMethod } from '@sentry/types';
 
 import { API } from '../../src/api';
 import { eventToSentryRequest } from '../../src/request';
 
 describe('eventToSentryRequest', () => {
-  let api: API;
+  function parseEnvelopeRequest(request: SentryRequest): any {
+    const [envelopeHeaderString, itemHeaderString, eventString] = request.body.split('\n');
+
+    return {
+      envelopeHeader: JSON.parse(envelopeHeaderString),
+      itemHeader: JSON.parse(itemHeaderString),
+      event: JSON.parse(eventString),
+    };
+  }
+
+  const api = new API('https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012', {
+    sdk: {
+      integrations: ['AWSLambda'],
+      name: 'sentry.javascript.browser',
+      version: `12.31.12`,
+      packages: [{ name: 'npm:@sentry/browser', version: `12.31.12` }],
+    },
+  });
   let event: Event;
 
   beforeEach(() => {
-    api = new API('https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012', {
-      sdk: {
-        integrations: ['AWSLambda'],
-        name: 'sentry.javascript.browser',
-        version: `12.31.12`,
-        packages: [{ name: 'npm:@sentry/browser', version: `6.6.6` }],
-      },
-    });
     event = {
       contexts: { trace: { trace_id: '1231201211212012', span_id: '12261980', op: 'pageload' } },
       environment: 'dogpark',
@@ -28,68 +37,63 @@ describe('eventToSentryRequest', () => {
     };
   });
 
-  [
-    { method: TransactionSamplingMethod.Rate, rate: '0.1121', dog: 'Charlie' },
-    { method: TransactionSamplingMethod.Sampler, rate: '0.1231', dog: 'Maisey' },
-    { method: TransactionSamplingMethod.Inheritance, dog: 'Cory' },
-    { method: TransactionSamplingMethod.Explicit, dog: 'Bodhi' },
+  it(`adds transaction sampling information to item header`, () => {
+    event.debug_meta = { transactionSampling: { method: TransactionSamplingMethod.Rate, rate: 0.1121 } };
 
-    // this shouldn't ever happen (at least the method should always be included in tags), but good to know that things
-    // won't blow up if it does
-    { dog: 'Lucy' },
-  ].forEach(({ method, rate, dog }) => {
-    it(`adds transaction sampling information to item header - ${method}, ${rate}, ${dog}`, () => {
-      // TODO kmclb - once tag types are loosened, don't need to cast to string here
-      event.tags = { __sentry_samplingMethod: String(method), __sentry_sampleRate: String(rate), dog };
+    const result = eventToSentryRequest(event, api);
+    const envelope = parseEnvelopeRequest(result);
 
-      const result = eventToSentryRequest(event, api);
+    expect(envelope.itemHeader).toEqual(
+      expect.objectContaining({
+        sample_rates: [{ id: TransactionSamplingMethod.Rate, rate: 0.1121 }],
+      }),
+    );
+  });
 
-      const [envelopeHeaderString, itemHeaderString, eventString] = result.body.split('\n');
+  it('removes transaction sampling information (and only that) from debug_meta', () => {
+    event.debug_meta = {
+      transactionSampling: { method: TransactionSamplingMethod.Sampler, rate: 0.1121 },
+      dog: 'Charlie',
+    } as DebugMeta;
 
-      const envelope = {
-        envelopeHeader: JSON.parse(envelopeHeaderString),
-        itemHeader: JSON.parse(itemHeaderString),
-        event: JSON.parse(eventString),
-      };
+    const result = eventToSentryRequest(event, api);
+    const envelope = parseEnvelopeRequest(result);
 
-      // the right stuff is added to the item header
-      expect(envelope.itemHeader).toEqual({
-        type: 'transaction',
-        // TODO kmclb - once tag types are loosened, don't need to cast to string here
-        sample_rates: [{ id: String(method), rate: String(rate) }],
-      });
+    expect('transactionSampling' in envelope.event.debug_meta).toBe(false);
+    expect('dog' in envelope.event.debug_meta).toBe(true);
+  });
 
-      // show that it pops the right tags and leaves the rest alone
-      expect('__sentry_samplingMethod' in envelope.event.tags).toBe(false);
-      expect('__sentry_sampleRate' in envelope.event.tags).toBe(false);
-      expect('dog' in envelope.event.tags).toBe(true);
-    });
+  it('removes debug_meta entirely if it ends up empty', () => {
+    event.debug_meta = {
+      transactionSampling: { method: TransactionSamplingMethod.Rate, rate: 0.1121 },
+    } as DebugMeta;
+
+    const result = eventToSentryRequest(event, api);
+    const envelope = parseEnvelopeRequest(result);
+
+    expect('debug_meta' in envelope.event).toBe(false);
   });
 
   it('adds sdk info to envelope header', () => {
     const result = eventToSentryRequest(event, api);
+    const envelope = parseEnvelopeRequest(result);
 
-    const envelopeHeaderString = result.body.split('\n')[0];
-    const parsedHeader = JSON.parse(envelopeHeaderString);
-
-    expect(parsedHeader).toEqual(
+    expect(envelope.envelopeHeader).toEqual(
       expect.objectContaining({ sdk: { name: 'sentry.javascript.browser', version: '12.31.12' } }),
     );
   });
 
   it('adds sdk info to event body', () => {
     const result = eventToSentryRequest(event, api);
+    const envelope = parseEnvelopeRequest(result);
 
-    const eventString = result.body.split('\n')[2];
-    const parsedEvent = JSON.parse(eventString);
-
-    expect(parsedEvent).toEqual(
+    expect(envelope.event).toEqual(
       expect.objectContaining({
         sdk: {
           integrations: ['AWSLambda'],
           name: 'sentry.javascript.browser',
           version: `12.31.12`,
-          packages: [{ name: 'npm:@sentry/browser', version: `6.6.6` }],
+          packages: [{ name: 'npm:@sentry/browser', version: `12.31.12` }],
         },
       }),
     );
@@ -99,22 +103,21 @@ describe('eventToSentryRequest', () => {
     event.sdk = {
       integrations: ['Clojure'],
       name: 'foo',
-      packages: [{ name: 'npm:@sentry/clj', version: `6.6.6` }],
+      packages: [{ name: 'npm:@sentry/clj', version: `12.31.12` }],
       version: '1337',
     };
+
     const result = eventToSentryRequest(event, api);
+    const envelope = parseEnvelopeRequest(result);
 
-    const eventString = result.body.split('\n')[2];
-    const parsedEvent = JSON.parse(eventString);
-
-    expect(parsedEvent).toEqual(
+    expect(envelope.event).toEqual(
       expect.objectContaining({
         sdk: {
           integrations: ['Clojure', 'AWSLambda'],
           name: 'foo',
           packages: [
-            { name: 'npm:@sentry/clj', version: `6.6.6` },
-            { name: 'npm:@sentry/browser', version: `6.6.6` },
+            { name: 'npm:@sentry/clj', version: `12.31.12` },
+            { name: 'npm:@sentry/browser', version: `12.31.12` },
           ],
           version: '1337',
         },

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -7,6 +7,10 @@ import { Span as SpanClass, SpanRecorder } from './span';
 /** JSDoc */
 export class Transaction extends SpanClass implements TransactionInterface {
   public name: string;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private _metadata: { [key: string]: any } = {};
+
   private _measurements: Measurements = {};
 
   /**
@@ -65,6 +69,15 @@ export class Transaction extends SpanClass implements TransactionInterface {
   }
 
   /**
+   * Set metadata for this transaction.
+   * @hidden
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public setMetadata(newMetadata: { [key: string]: any }): void {
+    this._metadata = { ...this._metadata, ...newMetadata };
+  }
+
+  /**
    * @inheritDoc
    */
   public finish(endTimestamp?: number): string | undefined {
@@ -108,6 +121,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
       timestamp: this.endTimestamp,
       transaction: this.name,
       type: 'transaction',
+      debug_meta: this._metadata,
     };
 
     const hasMeasurements = Object.keys(this._measurements).length > 0;

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -4,12 +4,15 @@ import { dropUndefinedKeys, isInstanceOf, logger } from '@sentry/utils';
 
 import { Span as SpanClass, SpanRecorder } from './span';
 
+interface TransactionMetadata {
+  transactionSampling?: { [key: string]: string | number };
+}
+
 /** JSDoc */
 export class Transaction extends SpanClass implements TransactionInterface {
   public name: string;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private _metadata: { [key: string]: any } = {};
+  private _metadata: TransactionMetadata = {};
 
   private _measurements: Measurements = {};
 
@@ -72,8 +75,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
    * Set metadata for this transaction.
    * @hidden
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public setMetadata(newMetadata: { [key: string]: any }): void {
+  public setMetadata(newMetadata: TransactionMetadata): void {
     this._metadata = { ...this._metadata, ...newMetadata };
   }
 

--- a/packages/types/src/debugMeta.ts
+++ b/packages/types/src/debugMeta.ts
@@ -3,6 +3,7 @@
  **/
 export interface DebugMeta {
   images?: Array<DebugImage>;
+  transactionSampling?: { rate?: number; method?: string };
 }
 
 /**


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry-javascript/pull/3068.

In that PR, tags were used as a temporary way to get data through the event processors to the point where envelope headers are created. Once used, they were deleted from `event.tags`. Unfortunately, by that point they'd already been copied into `contexts.trace`, from which they weren't being deleted, causing them to show up in the UI.

This PR fixes that by using `debug_meta` instead of `tags` (which means that even if something goes wrong, it's only visible in the event JSON, not the UI) and adds a test to ensure that the data isn't where it shouldn't be. (It also does some cleanup work in that test suite to simplify things.)