### PR TITLE
[ref] Add Angular 11 to possible peerDependencies list

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -16,9 +16,9 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@angular/common": "^10.0.3",
-    "@angular/core": "^10.0.3",
-    "@angular/router": "^10.0.3"
+    "@angular/common": "10.x || 11.x",
+    "@angular/core": "10.x || 11.x",
+    "@angular/router": "10.x || 11.x"
   },
   "dependencies": {
     "@sentry/browser": "6.0.2",


### PR DESCRIPTION
Resolve https://github.com/getsentry/sentry-javascript/issues/3145

Verified that Angular 11 compiles and works correctly with the current SDK implementation.