### PR TITLE
deps: Allow for LocalForage >=1.8.1

### DIFF
--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@sentry/types": "6.0.2",
     "@sentry/utils": "6.0.2",
-    "localforage": "1.8.1",
+    "localforage": "^1.8.1",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14006,10 +14006,10 @@ loader.js@^4.7.0:
   resolved "https://registry.yarnpkg.com/loader.js/-/loader.js-4.7.0.tgz#a1a52902001c83631efde9688b8ab3799325ef1f"
   integrity sha512-9M2KvGT6duzGMgkOcTkWb+PR/Q2Oe54df/tLgHGVmFpAmtqJ553xJh6N63iFYI2yjo2PeJXbS5skHi/QpJq4vA==
 
-localforage@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.8.1.tgz#f6c0a24b41ab33b10e4dc84342dd696f6f3e3433"
-  integrity sha512-azSSJJfc7h4bVpi0PGi+SmLQKJl2/8NErI+LhJsrORNikMZnhaQ7rv9fHj+ofwgSHrKRlsDCL/639a6nECIKuQ==
+localforage@^1.8.1:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/localforage/-/localforage-1.9.0.tgz#f3e4d32a8300b362b4634cc4e066d9d00d2f09d1"
+  integrity sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==
   dependencies:
     lie "3.1.1"
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/3132

We use `^1.8.1` because we need _at least_ `1.8.1` due to it's fix in this specific version (see: https://github.com/localForage/localForage/blob/master/CHANGELOG.md), but anything higher in `1.x` will work as well, as there were no breaking changes introduced (yay semver).