### PR TITLE
fix(vue): Add `vue-router` to peer dependencies

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -24,7 +24,8 @@
     "tslib": "^1.9.3"
   },
   "peerDependencies": {
-    "vue": "2.x"
+    "vue": "2.x",
+    "vue-router": "3.x"
   },
   "devDependencies": {
     "@sentry-internal/eslint-config-sdk": "6.0.2",


### PR DESCRIPTION
We use `vue-router` in our router instrumentation for Vue. Presumably if you're using our Vue router instrumentation, you already have `vue-router` installed, but just to dot our I's and cross our T's, let's say out loud that it's necessary.