### PR TITLE
fix: Clear activeTransaction from the scope and always start idle timers

### DIFF
--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -208,6 +208,8 @@ export class BrowserTracing implements Integration {
       logger.log(`[Tracing] Will not send ${finalContext.op} transaction because of beforeNavigate.`);
     }
 
+    logger.log(`[Tracing] Starting ${finalContext.op} transaction on scope`);
+
     const hub = this._getCurrentHub();
     const { location } = getGlobalObject() as WindowOrWorkerGlobalScope & { location: Location };
 
@@ -218,7 +220,6 @@ export class BrowserTracing implements Integration {
       true,
       { location }, // for use in the tracesSampler
     );
-    logger.log(`[Tracing] Starting ${finalContext.op} transaction on scope`);
     idleTransaction.registerBeforeFinishCallback((transaction, endTimestamp) => {
       this._metrics.addPerformanceEntries(transaction);
       adjustTransactionDuration(secToMs(maxTransactionDuration), transaction, endTimestamp);

--- a/packages/tracing/test/idletransaction.test.ts
+++ b/packages/tracing/test/idletransaction.test.ts
@@ -30,9 +30,20 @@ describe('IdleTransaction', () => {
       });
     });
 
-    it('removes transaction from scope on finish if onScope is true', () => {
+    it('removes sampled transaction from scope on finish if onScope is true', () => {
       const transaction = new IdleTransaction({ name: 'foo' }, hub, 1000, true);
       transaction.initSpanRecorder(10);
+
+      transaction.finish();
+      jest.runAllTimers();
+
+      hub.configureScope(s => {
+        expect(s.getTransaction()).toBe(undefined);
+      });
+    });
+
+    it('removes unsampled transaction from scope on finish if onScope is true', () => {
+      const transaction = new IdleTransaction({ name: 'foo', sampled: false }, hub, 1000, true);
 
       transaction.finish();
       jest.runAllTimers();

--- a/packages/tracing/test/idletransaction.test.ts
+++ b/packages/tracing/test/idletransaction.test.ts
@@ -165,7 +165,7 @@ describe('IdleTransaction', () => {
   });
 
   describe('heartbeat', () => {
-    it('does not start heartbeat if there is no span recorder', () => {
+    it('does not mark transaction as `DeadlineExceeded` if idle timeout has not been reached', () => {
       const HEARTBEAT_INTERVAL = 5000;
       // 20s to exceed 3 heartbeats
       const transaction = new IdleTransaction({ name: 'foo' }, hub, 20000);


### PR DESCRIPTION
This makes sure, that after sampling a transaction, all future transactions are still captured correctly.