### PR TITLE
ref(hub): Simplify getting hub from active domain

### DIFF
--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -22,7 +22,7 @@ import {
 } from '@sentry/types';
 import { consoleSandbox, dateTimestampInSeconds, getGlobalObject, isNodeEnv, logger, uuid4 } from '@sentry/utils';
 
-import { Carrier, Layer } from './interfaces';
+import { Carrier, DomainAsCarrier, Layer } from './interfaces';
 import { Scope } from './scope';
 import { Session } from './session';
 
@@ -469,6 +469,20 @@ export function getCurrentHub(): Hub {
   }
   // Return hub that lives on a global object
   return getHubFromCarrier(registry);
+}
+
+/**
+ * Returns the active domain, if one exists
+ * @deprecated No longer used; remove in v7
+ * @returns The domain, or undefined if there is no active domain
+ */
+// eslint-disable-next-line deprecation/deprecation
+export function getActiveDomain(): DomainAsCarrier | undefined {
+  logger.warn('Function `getActiveDomain` is deprecated and will be removed in a future version.');
+
+  const sentry = getMainCarrier().__SENTRY__;
+
+  return sentry && sentry.extensions && sentry.extensions.domain && sentry.extensions.domain.active;
 }
 
 /**

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -22,7 +22,7 @@ import {
 } from '@sentry/types';
 import { consoleSandbox, dateTimestampInSeconds, getGlobalObject, isNodeEnv, logger, uuid4 } from '@sentry/utils';
 
-import { Carrier, DomainAsCarrier, Layer } from './interfaces';
+import { Carrier, Layer } from './interfaces';
 import { Scope } from './scope';
 import { Session } from './session';
 
@@ -472,23 +472,12 @@ export function getCurrentHub(): Hub {
 }
 
 /**
- * Returns the active domain, if one exists
- *
- * @returns The domain, or undefined if there is no active domain
- */
-export function getActiveDomain(): DomainAsCarrier | undefined {
-  const sentry = getMainCarrier().__SENTRY__;
-
-  return sentry && sentry.extensions && sentry.extensions.domain && sentry.extensions.domain.active;
-}
-
-/**
  * Try to read the hub from an active domain, and fallback to the registry if one doesn't exist
  * @returns discovered hub
  */
 function getHubFromActiveDomain(registry: Carrier): Hub {
   try {
-    const activeDomain = getActiveDomain();
+    const activeDomain = getMainCarrier().__SENTRY__?.extensions?.domain?.active;
 
     // If there's no active domain, just return global hub
     if (!activeDomain) {

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -1,4 +1,14 @@
-export { Carrier, Layer } from './interfaces';
+// eslint-disable-next-line deprecation/deprecation
+export { Carrier, DomainAsCarrier, Layer } from './interfaces';
 export { addGlobalEventProcessor, Scope } from './scope';
 export { Session } from './session';
-export { getCurrentHub, getHubFromCarrier, getMainCarrier, Hub, makeMain, setHubOnCarrier } from './hub';
+export {
+  // eslint-disable-next-line deprecation/deprecation
+  getActiveDomain,
+  getCurrentHub,
+  getHubFromCarrier,
+  getMainCarrier,
+  Hub,
+  makeMain,
+  setHubOnCarrier,
+} from './hub';

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -1,12 +1,4 @@
-export { Carrier, DomainAsCarrier, Layer } from './interfaces';
+export { Carrier, Layer } from './interfaces';
 export { addGlobalEventProcessor, Scope } from './scope';
 export { Session } from './session';
-export {
-  getActiveDomain,
-  getCurrentHub,
-  getHubFromCarrier,
-  getMainCarrier,
-  Hub,
-  makeMain,
-  setHubOnCarrier,
-} from './hub';
+export { getCurrentHub, getHubFromCarrier, getMainCarrier, Hub, makeMain, setHubOnCarrier } from './hub';

--- a/packages/hub/src/interfaces.ts
+++ b/packages/hub/src/interfaces.ts
@@ -33,3 +33,12 @@ export interface Carrier {
     };
   };
 }
+
+/**
+ * @hidden
+ * @deprecated Can be removed once `Hub.getActiveDomain` is removed.
+ */
+export interface DomainAsCarrier extends Carrier {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  members: { [key: string]: any }[];
+}

--- a/packages/hub/src/interfaces.ts
+++ b/packages/hub/src/interfaces.ts
@@ -33,8 +33,3 @@ export interface Carrier {
     };
   };
 }
-
-export interface DomainAsCarrier extends Carrier {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  members: { [key: string]: any }[];
-}

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -94,8 +94,8 @@ export interface SamplingContext extends CustomSamplingContext {
   parentSampled?: boolean;
 
   /**
-   * Object representing the URL of the current page or worker script. Passed by default in a browser or service worker
-   * context.
+   * Object representing the URL of the current page or worker script. Passed by default when using the `BrowserTracing`
+   * integration.
    */
   location?: WorkerLocation;
 


### PR DESCRIPTION
`Hub.getActiveDomain` was factored out of `Hub.getHubFromActiveDomain` in https://github.com/getsentry/sentry-javascript/pull/2820 so it could be used in `getDefaultSamplingContext`, which no longer exists (as of https://github.com/getsentry/sentry-javascript/pull/3210). ~This is a follow up to that PR, which reverts the original factoring-out, and also gets rid of an interface which is unused as a result.~ This is a follow up to that PR, which reverts the original factoring-out and deprecates both the factored-out function and an interface which will be unused once the deprecated function is removed.