### PR TITLE
fix(ember): Fix backwards compatibility with Embroider changes

### DIFF
--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -16,6 +16,21 @@ module.exports = {
     },
   },
 
+  getAddonConfig(app) {
+    const config = require(app.options.configPath)(app.env);
+    return config['@sentry/ember'] || {};
+  },
+
+  included() {
+    this._super.included.apply(this, arguments);
+    const app = this._findHost(this);
+    if (!('@embroider/core' in app.dependencies())) {
+      const addonConfig = this.getAddonConfig(app);
+      const options = Object.assign({}, addonConfig);
+      this.options['@embroider/macros'].setOwnConfig.sentryConfig = options;
+    }
+  },
+
   contentFor(type, config) {
     const addonConfig = config['@sentry/ember'] || {};
     const app = this._findHost(this);

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -17,7 +17,12 @@ module.exports = {
   },
 
   getAddonConfig(app) {
-    const config = require(app.options.configPath)(app.env);
+    let config = {};
+    try {
+      config = require(app.options.configPath)(app.env);
+    } catch(_) {
+      // Config not found
+    }
     return config['@sentry/ember'] || {};
   },
 

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -45,8 +45,6 @@
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",
     "@embroider/compat": "^0.35.1",
-    "@embroider/core": "^0.35.1",
-    "@embroider/webpack": "^0.35.1",
     "@glimmer/component": "^1.0.0",
     "@glimmer/tracking": "^1.0.0",
     "@sentry-internal/eslint-config-sdk": "6.0.4",


### PR DESCRIPTION
### Summary
Switching from ember-get-config to macros introduced a regression (#3181) for the classic build system, since Embroider injects runtime config differently depending on whether the app is using embroider for it's build system or not. This will grab the config and make it available to embroider/macros if embroider/core is not detected.
