### PR TITLE
ref: Update craft config file to support the new craft version

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -62,6 +62,8 @@ targets:
     includeNames: /^sentry-node-serverless-\d+(\.\d+)*\.zip$/
     layerName: SentryNodeServerlessSDK
     compatibleRuntimes:
-      - nodejs10.x
-      - nodejs12.x
+      - name: node
+        versions:
+          - nodejs10.x
+          - nodejs12.x
     license: MIT


### PR DESCRIPTION
The new Craft version requires a small change in the `.craft.yml` file, which is addressed here. Releases that don't use the same version will fail.