### PR TITLE
fix(ember): resolve config path from app root

### DIFF
--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -19,7 +19,7 @@ module.exports = {
   getAddonConfig(app) {
     let config = {};
     try {
-      config = require(app.options.configPath)(app.env);
+      config = require(app.project.configPath())(app.env);
     } catch(_) {
       // Config not found
     }


### PR DESCRIPTION
This should aid in resolving the app configuration from the right location. Previously, it was calling `require` with a relative path from the `index.js` file of the Sentry addon itself. This broke trying to actually load the configuration file in _other_ addons that might include this as a dependency.

By resolving the config path relative to the app root first, we can correctly load the file even when `@sentry/ember` is used within another addon.

***

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
