### PR TITLE
fix: Provide better descriptions for the performance navigation timing spans

### DIFF
--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -287,9 +287,9 @@ function addNavigationSpans(transaction: Transaction, entry: Record<string, any>
   addPerformanceNavigationTiming({ transaction, entry, event: 'domContentLoadedEvent', timeOrigin });
   addPerformanceNavigationTiming({ transaction, entry, event: 'loadEvent', timeOrigin });
   addPerformanceNavigationTiming({ transaction, entry, event: 'connect', timeOrigin });
-  addPerformanceNavigationTiming({ transaction, entry, event: 'secureConnection', timeOrigin, eventEnd: 'connectEnd', description: 'secureConnection (TLS)' });
+  addPerformanceNavigationTiming({ transaction, entry, event: 'secureConnection', timeOrigin, eventEnd: 'connectEnd', description: 'TLS/SSL' });
   addPerformanceNavigationTiming({ transaction, entry, event: 'fetch', timeOrigin, eventEnd: 'domainLookupStart', description: 'cache' });
-  addPerformanceNavigationTiming({ transaction, entry, event: 'domainLookup', timeOrigin });
+  addPerformanceNavigationTiming({ transaction, entry, event: 'domainLookup', timeOrigin, description: 'DNS' });
   addRequest(transaction, entry, timeOrigin);
 }
 

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -287,8 +287,22 @@ function addNavigationSpans(transaction: Transaction, entry: Record<string, any>
   addPerformanceNavigationTiming({ transaction, entry, event: 'domContentLoadedEvent', timeOrigin });
   addPerformanceNavigationTiming({ transaction, entry, event: 'loadEvent', timeOrigin });
   addPerformanceNavigationTiming({ transaction, entry, event: 'connect', timeOrigin });
-  addPerformanceNavigationTiming({ transaction, entry, event: 'secureConnection', timeOrigin, eventEnd: 'connectEnd', description: 'TLS/SSL' });
-  addPerformanceNavigationTiming({ transaction, entry, event: 'fetch', timeOrigin, eventEnd: 'domainLookupStart', description: 'cache' });
+  addPerformanceNavigationTiming({
+    transaction,
+    entry,
+    event: 'secureConnection',
+    timeOrigin,
+    eventEnd: 'connectEnd',
+    description: 'TLS/SSL',
+  });
+  addPerformanceNavigationTiming({
+    transaction,
+    entry,
+    event: 'fetch',
+    timeOrigin,
+    eventEnd: 'domainLookupStart',
+    description: 'cache',
+  });
   addPerformanceNavigationTiming({ transaction, entry, event: 'domainLookup', timeOrigin, description: 'DNS' });
   addRequest(transaction, entry, timeOrigin);
 }

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -289,7 +289,7 @@ function addNavigationSpans(transaction: Transaction, entry: Record<string, any>
   addPerformanceNavigationTiming({ transaction, entry, event: 'connect', timeOrigin });
   addPerformanceNavigationTiming({ transaction, entry, event: 'secureConnection', timeOrigin, eventEnd: 'connectEnd', description: 'secureConnection (TLS)' });
   addPerformanceNavigationTiming({ transaction, entry, event: 'fetch', timeOrigin, eventEnd: 'domainLookupStart', description: 'cache' });
-  addPerformanceNavigationTiming({ transaction, entry, event: 'domainLookup', timeOrigin, description: 'DNS' });
+  addPerformanceNavigationTiming({ transaction, entry, event: 'domainLookup', timeOrigin });
   addRequest(transaction, entry, timeOrigin);
 }
 


### PR DESCRIPTION
Screenshot provided by Rodolfo B.:

<img width="463" alt="Screenshot 2021-02-09 at 14 57 35" src="https://user-images.githubusercontent.com/139499/107394153-8bb81580-6ac9-11eb-966f-14b605e3e77d.png">

Today performance navigation timing spans are created with descriptions that do not match the following diagram (specifically in regions outlined in magenta):

<img width="867" alt="Screen Shot 2021-02-09 at 11 22 57 AM" src="https://user-images.githubusercontent.com/139499/107394263-adb19800-6ac9-11eb-914d-7189ec8561dc.png">

The descriptions for these spans use the event name which may not be sufficient. Thus, we rename some as follows:

- "secureConnection" to "secureConnection (TLS)"
- "fetch" to "cache"
- "domainLookup" to "DNS"

-----

What it looks like:

<img width="1303" alt="Screen Shot 2021-02-18 at 3 55 19 PM" src="https://user-images.githubusercontent.com/139499/108420389-c0327c80-7201-11eb-867f-56f427a57ee5.png">

