### PR TITLE
fix(ember): Fixing fetching config during build step

### DIFF
--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -16,32 +16,15 @@ module.exports = {
     },
   },
 
-  getAddonConfig(app) {
-    let config = {};
-    try {
-      config = require(app.options.configPath)(app.env);
-    } catch(_) {
-      // Config not found
-    }
-    return config['@sentry/ember'] || {};
-  },
-
-  included() {
-    this._super.included.apply(this, arguments);
-    const app = this._findHost(this);
-    if (!('@embroider/core' in app.dependencies())) {
-      const addonConfig = this.getAddonConfig(app);
-      const options = Object.assign({}, addonConfig);
-      this.options['@embroider/macros'].setOwnConfig.sentryConfig = options;
-    }
+  config(_, appConfig) {
+    const addonConfig = appConfig['@sentry/ember'];
+    const options = Object.assign({}, addonConfig);
+    this.options['@embroider/macros'].setOwnConfig.sentryConfig = options;
+    return this._super(...arguments);
   },
 
   contentFor(type, config) {
     const addonConfig = config['@sentry/ember'] || {};
-    const app = this._findHost(this);
-    this.app = app;
-    const options = Object.assign({}, addonConfig);
-    this.options['@embroider/macros'].setOwnConfig.sentryConfig = options;
 
     const { disablePerformance, disableInitialLoadInstrumentation } = addonConfig;
     if (disablePerformance || disableInitialLoadInstrumentation) {

--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -18,8 +18,7 @@ module.exports = {
 
   config(_, appConfig) {
     const addonConfig = appConfig['@sentry/ember'];
-    const options = Object.assign({}, addonConfig);
-    this.options['@embroider/macros'].setOwnConfig.sentryConfig = options;
+    this.options['@embroider/macros'].setOwnConfig.sentryConfig = { ...addonConfig };
     return this._super(...arguments);
   },
 


### PR DESCRIPTION
### Summary
As mentioned in #3230, this is still causing problems for build systems. Pulled out the logic that makes the addon config available via an embroider macro to the 'config' hook for the addon, which gets rid of the conditional logic as well as pulling configPath which could be undefined. Tested (using the dummy app) on both sides of using Embroider and the existing build system and the macros appear to be populated now, so this should work.
