### PR TITLE
feat: Mongoose tracing support added to MongoDB

### DIFF
--- a/packages/tracing/src/integrations/mongo.ts
+++ b/packages/tracing/src/integrations/mongo.ts
@@ -100,7 +100,7 @@ export class Mongo implements Integration {
 
   private _operations: Operation[];
   private _describeOperations?: boolean | Operation[];
-  private _useMongoose: boolean
+  private _useMongoose: boolean;
 
   /**
    * @inheritDoc
@@ -110,7 +110,7 @@ export class Mongo implements Integration {
       ? options.operations
       : ((OPERATIONS as unknown) as Operation[]);
     this._describeOperations = 'describeOperations' in options ? options.describeOperations : true;
-    this._useMongoose = !!options.useMongoose
+    this._useMongoose = !!options.useMongoose;
   }
 
   /**
@@ -118,7 +118,7 @@ export class Mongo implements Integration {
    */
   public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
     let collection: MongoCollection;
-    const moduleName = this._useMongoose ? 'mongoose' : 'mongodb'
+    const moduleName = this._useMongoose ? 'mongoose' : 'mongodb';
     try {
       const mongodbModule = dynamicRequire(module, moduleName) as { Collection: MongoCollection };
       collection = mongodbModule.Collection;
@@ -169,7 +169,7 @@ export class Mongo implements Integration {
         }
 
         const span = parentSpan?.startChild(getSpanContext(this, operation, args.slice(0, -1)));
-        return orig.call(this, ...args.slice(0, -1), function (err: Error, result: unknown) {
+        return orig.call(this, ...args.slice(0, -1), function(err: Error, result: unknown) {
           span?.finish();
           lastArg(err, result);
         });

--- a/packages/tracing/src/integrations/mongo.ts
+++ b/packages/tracing/src/integrations/mongo.ts
@@ -83,6 +83,7 @@ interface MongoCollection {
 interface MongoOptions {
   operations?: Operation[];
   describeOperations?: boolean | Operation[];
+  useMongoose?: boolean;
 }
 
 /** Tracing integration for mongo package */
@@ -99,6 +100,7 @@ export class Mongo implements Integration {
 
   private _operations: Operation[];
   private _describeOperations?: boolean | Operation[];
+  private _useMongoose: boolean
 
   /**
    * @inheritDoc
@@ -108,6 +110,7 @@ export class Mongo implements Integration {
       ? options.operations
       : ((OPERATIONS as unknown) as Operation[]);
     this._describeOperations = 'describeOperations' in options ? options.describeOperations : true;
+    this._useMongoose = !!options.useMongoose
   }
 
   /**
@@ -115,12 +118,12 @@ export class Mongo implements Integration {
    */
   public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
     let collection: MongoCollection;
-
+    const moduleName = this._useMongoose ? 'mongoose' : 'mongodb'
     try {
-      const mongodbModule = dynamicRequire(module, 'mongodb') as { Collection: MongoCollection };
+      const mongodbModule = dynamicRequire(module, moduleName) as { Collection: MongoCollection };
       collection = mongodbModule.Collection;
     } catch (e) {
-      logger.error('Mongo Integration was unable to require `mongodb` package.');
+      logger.error(`Mongo Integration was unable to require \`${moduleName}\` package.`);
       return;
     }
 
@@ -166,7 +169,7 @@ export class Mongo implements Integration {
         }
 
         const span = parentSpan?.startChild(getSpanContext(this, operation, args.slice(0, -1)));
-        return orig.call(this, ...args.slice(0, -1), function(err: Error, result: unknown) {
+        return orig.call(this, ...args.slice(0, -1), function (err: Error, result: unknown) {
           span?.finish();
           lastArg(err, result);
         });


### PR DESCRIPTION
After this PR, Mongo tracing for projects using Mongoose should function as expected by initializing Sentry with the following:

```
Sentry.init({
  dsn: <DSN>,
  integrations: [new Tracing.Integrations.Mongo({useMongoose: true})],
  tracesSampleRate: 1.0,
})
```

This works because the `Collection` methods from `mongodb` are applied to `NativeCollection` on `mongoose` (which can be accessed at `mongoose.Collection`) See: https://github.com/Automattic/mongoose/blob/master/lib/drivers/node-mongodb-native/collection.js#L15-L22

Fixes https://github.com/getsentry/sentry-javascript/issues/3176