### PR TITLE
fix(serverless): Handle incoming "sentry-trace" header

### DIFF
--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@sentry/minimal": "6.1.0",
     "@sentry/node": "6.1.0",
+    "@sentry/tracing": "6.1.0",
     "@sentry/types": "6.1.0",
     "@sentry/utils": "6.1.0",
     "@types/aws-lambda": "^8.10.62",

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -9,9 +9,9 @@ import {
   withScope,
 } from '@sentry/node';
 import * as Sentry from '@sentry/node';
-import { Integration } from '@sentry/types';
-import { logger, isString } from '@sentry/utils';
 import { extractTraceparentData } from '@sentry/tracing';
+import { Integration } from '@sentry/types';
+import { isString, logger } from '@sentry/utils';
 // NOTE: I have no idea how to fix this right now, and don't want to waste more time, as it builds just fine — Kamil
 // eslint-disable-next-line import/no-unresolved
 import { Context, Handler } from 'aws-lambda';

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -113,7 +113,7 @@ export function tryPatchHandler(taskRoot: string, handlerPath: string): void {
 
   let mod: HandlerBag;
   let functionName: string | undefined;
-  handlerName.split('.').forEach((name) => {
+  handlerName.split('.').forEach(name => {
     mod = obj;
     obj = obj && (obj as HandlerModule)[name];
     functionName = name;
@@ -236,7 +236,7 @@ export function wrapHandler<TEvent, TResult>(
       const timeoutWarningDelay = context.getRemainingTimeInMillis() - options.timeoutWarningLimit;
 
       timeoutWarningTimer = setTimeout(() => {
-        withScope((scope) => {
+        withScope(scope => {
           scope.setTag('timeout', humanReadableTimeout);
           captureMessage(`Possible function timeout: ${context.functionName}`, Severity.Warning);
         });

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -245,8 +245,9 @@ export function wrapHandler<TEvent, TResult>(
 
     // Applying `sentry-trace` to context
     let traceparentData;
-    if (event.headers && isString(event.headers['sentry-trace'])) {
-      traceparentData = extractTraceparentData(event.headers['sentry-trace'] as string);
+    const eventWithHeaders = event as { headers?: { [key: string]: string } };
+    if (eventWithHeaders.headers && isString(eventWithHeaders.headers['sentry-trace'])) {
+      traceparentData = extractTraceparentData(eventWithHeaders.headers['sentry-trace'] as string);
     }
     const transaction = startTransaction({
       name: context.functionName,

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -1,5 +1,6 @@
 import { captureException, flush, getCurrentHub, Handlers, startTransaction } from '@sentry/node';
-import { logger, stripUrlQueryAndFragment } from '@sentry/utils';
+import { logger, stripUrlQueryAndFragment, isString } from '@sentry/utils';
+import { extractTraceparentData } from '@sentry/tracing';
 
 import { domainify, getActiveDomain, proxyFunction } from './../utils';
 import { HttpFunction, WrapperOptions } from './general';
@@ -48,9 +49,16 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
     const reqMethod = (req.method || '').toUpperCase();
     const reqUrl = stripUrlQueryAndFragment(req.originalUrl || req.url || '');
 
+    // Applying `sentry-trace` to context
+    let traceparentData;
+    const reqWithHeaders = req as { headers?: { [key: string]: string } };
+    if (reqWithHeaders.headers && isString(reqWithHeaders.headers['sentry-trace'])) {
+      traceparentData = extractTraceparentData(reqWithHeaders.headers['sentry-trace'] as string);
+    }
     const transaction = startTransaction({
       name: `${reqMethod} ${reqUrl}`,
       op: 'gcp.function.http',
+      ...traceparentData,
     });
 
     // getCurrentHub() is expected to use current active domain as a carrier

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -1,6 +1,6 @@
 import { captureException, flush, getCurrentHub, Handlers, startTransaction } from '@sentry/node';
-import { logger, stripUrlQueryAndFragment, isString } from '@sentry/utils';
 import { extractTraceparentData } from '@sentry/tracing';
+import { isString, logger, stripUrlQueryAndFragment } from '@sentry/utils';
 
 import { domainify, getActiveDomain, proxyFunction } from './../utils';
 import { HttpFunction, WrapperOptions } from './general';

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -1,4 +1,3 @@
-import { Event } from '@sentry/types';
 // NOTE: I have no idea how to fix this right now, and don't want to waste more time, as it builds just fine — Kamil
 // eslint-disable-next-line import/no-unresolved
 import { Callback, Handler } from 'aws-lambda';

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -16,9 +16,7 @@ const { wrapHandler } = Sentry.AWSLambda;
 
 // Default `timeoutWarningLimit` is 500ms so leaving some space for it to trigger when necessary
 const DEFAULT_EXECUTION_TIME = 100;
-const fakeEvent = {
-  fortySix: 'o_O',
-};
+let fakeEvent: { [key: string]: unknown };
 const fakeContext = {
   callbackWaitsForEmptyEventLoop: false,
   functionName: 'functionName',
@@ -72,6 +70,12 @@ function expectScopeSettings() {
 }
 
 describe('AWSLambda', () => {
+  beforeEach(() => {
+    fakeEvent = {
+      fortySix: 'o_O',
+    };
+  });
+
   afterEach(() => {
     // @ts-ignore see "Why @ts-ignore" note
     Sentry.resetMocks();
@@ -228,9 +232,16 @@ describe('AWSLambda', () => {
       const wrappedHandler = wrapHandler(handler);
 
       try {
+        fakeEvent.headers = { 'sentry-trace': '12312012123120121231201212312012-1121201211212012-0' };
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       } catch (e) {
-        expect(Sentry.startTransaction).toBeCalledWith({ name: 'functionName', op: 'awslambda.handler' });
+        expect(Sentry.startTransaction).toBeCalledWith({
+          name: 'functionName',
+          op: 'awslambda.handler',
+          traceId: '12312012123120121231201212312012',
+          parentSpanId: '1121201211212012',
+          parentSampled: false,
+        });
         expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(e);
         // @ts-ignore see "Why @ts-ignore" note

--- a/packages/serverless/test/gcpfunction.test.ts
+++ b/packages/serverless/test/gcpfunction.test.ts
@@ -19,7 +19,6 @@ import {
  * A hack-ish way to contain everything related to mocks in the same __mocks__ file.
  * Thanks to this, we don't have to do more magic than necessary. Just add and export desired method and assert on it.
  */
-type objectOfStrings = { [key: string]: string };
 
 describe('GCPFunction', () => {
   afterEach(() => {
@@ -27,8 +26,8 @@ describe('GCPFunction', () => {
     Sentry.resetMocks();
   });
 
-  async function handleHttp(fn: HttpFunction, trace_headers: objectOfStrings | null = null): Promise<void> {
-    let headers: objectOfStrings = { host: 'hostname', 'content-type': 'application/json' };
+  async function handleHttp(fn: HttpFunction, trace_headers: { [key: string]: string } | null = null): Promise<void> {
+    let headers: { [key: string]: string } = { host: 'hostname', 'content-type': 'application/json' };
     if (trace_headers) {
       headers = { ...headers, ...trace_headers };
     }
@@ -130,7 +129,9 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapHttpFunction(handler);
 
-      const trace_headers: objectOfStrings = { 'sentry-trace': '12312012123120121231201212312012-1121201211212012-0' };
+      const trace_headers: { [key: string]: string } = {
+        'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
+      };
 
       await handleHttp(wrappedHandler, trace_headers);
       expect(Sentry.startTransaction).toBeCalledWith({


### PR DESCRIPTION
In AWS Lambda and in GCP function, `sentry-trace` header was not propagated. This meant transactions were not given a `parentTraceId`, `spanId`,  and `parentSampled` attributes

This PR:
- Injects the `sentry_trace` headers in transactions created in `wrapHandler` for AWS and `_wrapHttpFunction` for GCP

Fixes #3238