### PR TITLE
ref(tracing): Rework tracestate internals to allow for third-party data

### DIFF
--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -79,7 +79,11 @@ export function transactionToSentryRequest(event: Event, api: API): SentryReques
   // so we have to decode and reinflate it
   let reinflatedTracestate;
   try {
-    const encodedSentryValue = (tracestate?.sentry as string).replace('sentry=', '');
+    // Because transaction metadata passes through a number of locations (transactionContext, transaction, event during
+    // processing, event as sent), each with different requirements, all of the parts are typed as optional. That said,
+    // if we get to this point and either `tracestate` or `tracestate.sentry` are undefined, something's gone very wrong.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const encodedSentryValue = tracestate!.sentry!.replace('sentry=', '');
     reinflatedTracestate = JSON.parse(base64ToUnicode(encodedSentryValue));
   } catch (err) {
     logger.warn(err);

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -67,7 +67,7 @@ export function eventToSentryRequest(event: Event, api: API): SentryRequest {
 export function transactionToSentryRequest(event: Event, api: API): SentryRequest {
   const sdkInfo = getSdkMetadataForEnvelopeHeader(api);
 
-  const { transactionSampling, tracestate: encodedTracestate, ...metadata } = event.debug_meta || {};
+  const { transactionSampling, tracestate, ...metadata } = event.debug_meta || {};
   const { method: samplingMethod, rate: sampleRate } = transactionSampling || {};
   if (Object.keys(metadata).length === 0) {
     delete event.debug_meta;
@@ -77,9 +77,10 @@ export function transactionToSentryRequest(event: Event, api: API): SentryReques
 
   // the tracestate is stored in bas64-encoded JSON, but envelope header values are expected to be full JS values,
   // so we have to decode and reinflate it
-  let tracestate;
+  let reinflatedTracestate;
   try {
-    tracestate = JSON.parse(base64ToUnicode(encodedTracestate as string));
+    const encodedSentryValue = (tracestate?.sentry as string).replace('sentry=', '');
+    reinflatedTracestate = JSON.parse(base64ToUnicode(encodedSentryValue));
   } catch (err) {
     logger.warn(err);
   }
@@ -88,7 +89,7 @@ export function transactionToSentryRequest(event: Event, api: API): SentryReques
     event_id: event.event_id,
     sent_at: new Date().toISOString(),
     ...(sdkInfo && { sdk: sdkInfo }),
-    ...(tracestate && { trace: tracestate }), // trace context for dynamic sampling on relay
+    ...(reinflatedTracestate && { trace: reinflatedTracestate }), // trace context for dynamic sampling on relay
   });
 
   const itemHeaders = JSON.stringify({

--- a/packages/core/test/lib/request.test.ts
+++ b/packages/core/test/lib/request.test.ts
@@ -68,9 +68,11 @@ describe('eventToSentryRequest', () => {
           //   release: 'off.leash.park',
           //   public_key: 'dogsarebadatkeepingsecrets',
           // }),
-          tracestate:
-            'eyJ0cmFjZV9pZCI6IjEyMzEyMDEyMTEyMTIwMTIiLCJlbnZpcm9ubWVudCI6ImRvZ3BhcmsiLCJyZWxlYXNlIjoib2ZmLmxlYXNo' +
-            'LnBhcmsiLCJwdWJsaWNfa2V5IjoiZG9nc2FyZWJhZGF0a2VlcGluZ3NlY3JldHMifQ',
+          tracestate: {
+            sentry:
+              'sentry=eyJ0cmFjZV9pZCI6IjEyMzEyMDEyMTEyMTIwMTIiLCJlbnZpcm9ubWVudCI6ImRvZ3BhcmsiLCJyZWxlYXNlIjoib2ZmLmxlYXNo' +
+              'LnBhcmsiLCJwdWJsaWNfa2V5IjoiZG9nc2FyZWJhZGF0a2VlcGluZ3NlY3JldHMifQ',
+          },
         },
         spans: [],
         transaction: '/dogs/are/great/',

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -1,7 +1,7 @@
 import { getCurrentHub } from '@sentry/hub';
+import { Span } from '@sentry/types';
 import { addInstrumentationHandler, isInstanceOf, isMatchingPattern } from '@sentry/utils';
 
-import { Span } from '../span';
 import { getActiveTransaction, hasTracingEnabled } from '../utils';
 
 export const DEFAULT_TRACING_ORIGINS = ['localhost', /^\//];

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -291,7 +291,7 @@ export class Span implements SpanInterface {
    */
   public getTraceHeaders(): TraceHeaders {
     // tracestates live on the transaction, so if this is a free-floating span, there won't be one
-    const tracestate = this.transaction && `sentry=${this.transaction.tracestate}`; // TODO kmclb
+    const tracestate = this.transaction && `sentry=${this.transaction.metadata?.tracestate?.sentry}`;
 
     return {
       'sentry-trace': this.toTraceparent(),

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -291,7 +291,12 @@ export class Span implements SpanInterface {
    */
   public getTraceHeaders(): TraceHeaders {
     // tracestates live on the transaction, so if this is a free-floating span, there won't be one
-    const tracestate = this.transaction && `sentry=${this.transaction.metadata?.tracestate?.sentry}`;
+    let tracestate;
+    if (this.transaction) {
+      tracestate = this.transaction.metadata?.tracestate?.sentry;
+    } else {
+      tracestate = this._getNewTracestate();
+    }
 
     return {
       'sentry-trace': this.toTraceparent(),

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -10,11 +10,9 @@ import { dropUndefinedKeys, isInstanceOf, logger } from '@sentry/utils';
 
 import { Span as SpanClass, SpanRecorder } from './span';
 
-
 /** JSDoc */
 export class Transaction extends SpanClass implements TransactionInterface {
   public name: string;
-
 
   public metadata: TransactionMetadata;
 
@@ -121,7 +119,6 @@ export class Transaction extends SpanClass implements TransactionInterface {
       }).endTimestamp;
     }
 
-
     const transaction: Event = {
       contexts: {
         trace: this.getTraceContext(),
@@ -170,9 +167,4 @@ export class Transaction extends SpanClass implements TransactionInterface {
 
     return this;
   }
-
-
-
-
-
 }

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -1,11 +1,16 @@
 import { getCurrentHub, Hub } from '@sentry/hub';
-import { DebugMeta, Event, Measurements, Transaction as TransactionInterface, TransactionContext } from '@sentry/types';
+import {
+  Event,
+  Measurements,
+  Transaction as TransactionInterface,
+  TransactionContext,
+  TransactionMetadata,
+} from '@sentry/types';
 import { dropUndefinedKeys, isInstanceOf, logger } from '@sentry/utils';
 
 import { Span as SpanClass, SpanRecorder } from './span';
 import { computeTracestateValue } from './utils';
 
-type TransactionMetadata = Pick<DebugMeta, 'transactionSampling' | 'tracestate'>;
 
 /** JSDoc */
 export class Transaction extends SpanClass implements TransactionInterface {

--- a/packages/tracing/test/hub.test.ts
+++ b/packages/tracing/test/hub.test.ts
@@ -35,12 +35,19 @@ describe('Hub', () => {
         name: 'dogpark',
         traceId: '12312012123120121231201212312012',
         parentSpanId: '1121201211212012',
-        tracestate: 'doGsaREgReaT',
+        metadata: { tracestate: { sentry: 'doGsaREgReaT' } },
       };
       const hub = new Hub(new BrowserClient({ tracesSampleRate: 1 }));
       const transaction = hub.startTransaction(transactionContext);
 
-      expect(transaction).toEqual(expect.objectContaining(transactionContext));
+      expect(transaction).toEqual(
+        expect.objectContaining({
+          name: 'dogpark',
+          traceId: '12312012123120121231201212312012',
+          parentSpanId: '1121201211212012',
+          metadata: expect.objectContaining({ tracestate: { sentry: 'doGsaREgReaT' } }),
+        }),
+      );
     });
 
     it('creates a new tracestate value if not given one in transaction context', () => {
@@ -62,7 +69,7 @@ describe('Hub', () => {
         public_key: 'dogsarebadatkeepingsecrets',
       });
 
-      expect(transaction.tracestate).toEqual(b64Value);
+      expect(transaction.metadata?.tracestate?.sentry).toEqual(`sentry=${b64Value}`);
     });
 
     it('uses default environment if none given', () => {
@@ -80,7 +87,7 @@ describe('Hub', () => {
         public_key: 'dogsarebadatkeepingsecrets',
       });
 
-      expect(transaction.tracestate).toEqual(b64Value);
+      expect(transaction.metadata?.tracestate?.sentry).toEqual(`sentry=${b64Value}`);
     });
   });
 

--- a/packages/tracing/test/hub.test.ts
+++ b/packages/tracing/test/hub.test.ts
@@ -35,7 +35,7 @@ describe('Hub', () => {
         name: 'dogpark',
         traceId: '12312012123120121231201212312012',
         parentSpanId: '1121201211212012',
-        metadata: { tracestate: { sentry: 'doGsaREgReaT' } },
+        metadata: { tracestate: { sentry: 'sentry=doGsaREgReaT' } },
       };
       const hub = new Hub(new BrowserClient({ tracesSampleRate: 1 }));
       const transaction = hub.startTransaction(transactionContext);
@@ -45,7 +45,7 @@ describe('Hub', () => {
           name: 'dogpark',
           traceId: '12312012123120121231201212312012',
           parentSpanId: '1121201211212012',
-          metadata: expect.objectContaining({ tracestate: { sentry: 'doGsaREgReaT' } }),
+          metadata: expect.objectContaining({ tracestate: { sentry: 'sentry=doGsaREgReaT' } }),
         }),
       );
     });

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -117,7 +117,7 @@ describe('Span', () => {
       const headers = span.getTraceHeaders();
 
       expect(headers['sentry-trace']).toEqual(span.toTraceparent());
-      expect(headers.tracestate).toEqual(transaction.tracestate);
+      expect(headers.tracestate).toEqual(transaction.metadata?.tracestate?.sentry);
     });
   });
 

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -117,7 +117,7 @@ describe('Span', () => {
       const headers = span.getTraceHeaders();
 
       expect(headers['sentry-trace']).toEqual(span.toTraceparent());
-      expect(headers.tracestate).toEqual(`sentry=${transaction.tracestate}`);
+      expect(headers.tracestate).toEqual(transaction.tracestate);
     });
   });
 

--- a/packages/types/src/debugMeta.ts
+++ b/packages/types/src/debugMeta.ts
@@ -5,7 +5,6 @@ import { TransactionMetadata } from './transaction';
  **/
 export type DebugMeta = {
   images?: Array<DebugImage>;
-
 } & TransactionMetadata;
 
 /**

--- a/packages/types/src/debugMeta.ts
+++ b/packages/types/src/debugMeta.ts
@@ -1,13 +1,12 @@
+import { TransactionMetadata } from './transaction';
+
 /**
  * Holds meta information to customize the behavior of sentry's event processing.
  **/
-export interface DebugMeta {
+export type DebugMeta = {
   images?: Array<DebugImage>;
-  transactionSampling?: { rate?: number; method?: string };
 
-  /** The Sentry portion of a transaction's tracestate header, used for dynamic sampling */
-  tracestate?: string;
-}
+} & TransactionMetadata;
 
 /**
  * Possible choices for debug images.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -34,6 +34,7 @@ export {
   TraceparentData,
   Transaction,
   TransactionContext,
+  TransactionMetadata,
   TransactionSamplingMethod,
 } from './transaction';
 export { Thread } from './thread';

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -119,3 +119,12 @@ export enum TransactionSamplingMethod {
   Rate = 'client_rate',
   Inheritance = 'inheritance',
 }
+
+export interface TransactionMetadata {
+  transactionSampling?: { rate?: number; method?: string };
+
+  /** The sentry half of a transaction's tracestate header, used for dynamic sampling */
+  tracestate?: {
+    sentry?: string;
+  };
+}

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -24,10 +24,9 @@ export interface TransactionContext extends SpanContext {
   parentSampled?: boolean;
 
   /**
-   * The tracestate header value associated with this transaction, potentially inherited from a parent transaction,
-   * which will be propagated across services to all child transactions
+   * Metadata associated with the transaction, for internal SDK use.
    */
-  tracestate?: string;
+  metadata?: TransactionMetadata;
 }
 
 /**


### PR DESCRIPTION
There's no behavior change here - just a bunch of shifting things around so that

1) tracestate data lives inside the new (since the previous PR's inception) `metadata` property on the `Transaction` class rather than directly on the transaction,

2) the data is stored as an object rather than a string, so there will be somewhere to put other vendors' data,

3) the value stored includes the `sentry=` (rather than just being the value) because that will match the may the third-party data is stored, and

4) orphan spans can generate `tracestate` headers, too.
