### PR TITLE
feat(tracing): Handle incoming tracestate data, allow for third-party data

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { captureException, getCurrentHub, startTransaction, withScope } from '@sentry/core';
-import { extractTraceparentData, Span } from '@sentry/tracing';
+import { extractSentrytraceData, Span } from '@sentry/tracing';
 import { Event, ExtractedNodeRequestData, Transaction } from '@sentry/types';
 import { forget, isPlainObject, isString, logger, normalize, stripUrlQueryAndFragment } from '@sentry/utils';
 import * as cookie from 'cookie';
@@ -58,7 +58,7 @@ export function tracingHandler(): (
     // If there is a trace header set, we extract the data from it (parentSpanId, traceId, and sampling decision)
     let traceparentData;
     if (req.headers && isString(req.headers['sentry-trace'])) {
-      traceparentData = extractTraceparentData(req.headers['sentry-trace'] as string);
+      traceparentData = extractSentrytraceData(req.headers['sentry-trace'] as string);
     }
 
     const transaction = startTransaction(

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -69,7 +69,7 @@ export function tracingHandler(): (
         name: extractExpressTransactionName(req, { path: true, method: true }),
         op: 'http.server',
         ...traceparentData,
-        metadata: { tracestate: tracestateData },
+        ...(tracestateData && { metadata: { tracestate: tracestateData } }),
       },
       { request: extractRequestData(req) },
     );

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { captureException, getCurrentHub, startTransaction, withScope } from '@sentry/core';
-import { extractSentrytraceData, Span } from '@sentry/tracing';
+import { extractSentrytraceData, extractTracestateData, Span } from '@sentry/tracing';
 import { Event, ExtractedNodeRequestData, Transaction } from '@sentry/types';
 import { forget, isPlainObject, isString, logger, normalize, stripUrlQueryAndFragment } from '@sentry/utils';
 import * as cookie from 'cookie';
@@ -55,10 +55,13 @@ export function tracingHandler(): (
     res: http.ServerResponse,
     next: (error?: any) => void,
   ): void {
-    // If there is a trace header set, we extract the data from it (parentSpanId, traceId, and sampling decision)
-    let traceparentData;
-    if (req.headers && isString(req.headers['sentry-trace'])) {
+    // Extract data from trace headers
+    let traceparentData, tracestateData;
+    if (req.headers?.['sentry-trace']) {
       traceparentData = extractSentrytraceData(req.headers['sentry-trace'] as string);
+    }
+    if (req.headers?.tracestate) {
+      tracestateData = extractTracestateData(req.headers.tracestate as string);
     }
 
     const transaction = startTransaction(
@@ -66,6 +69,7 @@ export function tracingHandler(): (
         name: extractExpressTransactionName(req, { path: true, method: true }),
         op: 'http.server',
         ...traceparentData,
+        metadata: { tracestate: tracestateData },
       },
       { request: extractRequestData(req) },
     );

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -221,8 +221,11 @@ describe('tracingHandler', () => {
     expect(startTransaction).toHaveBeenCalled();
   });
 
-  it("pulls parent's data from tracing header on the request", () => {
-    req.headers = { 'sentry-trace': '12312012123120121231201212312012-1121201211212012-0' };
+  it('pulls data from tracing headers on the request', () => {
+    req.headers = {
+      'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
+      tracestate: 'sentry=doGsaREgReaT',
+    };
 
     sentryTracingMiddleware(req, res, next);
 
@@ -232,6 +235,7 @@ describe('tracingHandler', () => {
     expect(transaction.traceId).toEqual('12312012123120121231201212312012');
     expect(transaction.parentSpanId).toEqual('1121201211212012');
     expect(transaction.sampled).toEqual(false);
+    expect(transaction.metadata?.tracestate).toEqual({ sentry: 'sentry=doGsaREgReaT' });
   });
 
   it('extracts request data for sampling context', () => {

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -1,7 +1,7 @@
 import * as sentryCore from '@sentry/core';
 import { Hub } from '@sentry/hub';
 import * as hubModule from '@sentry/hub';
-import { addExtensionMethods, Span, TRACEPARENT_REGEXP, Transaction } from '@sentry/tracing';
+import { addExtensionMethods, SENTRY_TRACE_REGEX, Span, Transaction } from '@sentry/tracing';
 import * as http from 'http';
 import * as nock from 'nock';
 
@@ -77,7 +77,7 @@ describe('tracing', () => {
 
     expect(sentryTraceHeader).toBeDefined();
     expect(tracestateHeader).toBeDefined();
-    expect(TRACEPARENT_REGEXP.test(sentryTraceHeader as string)).toBe(true);
+    expect(SENTRY_TRACE_REGEX.test(sentryTraceHeader as string)).toBe(true);
   });
 
   it("doesn't attach tracing headers to outgoing sentry requests", () => {

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -9,9 +9,9 @@ import {
   withScope,
 } from '@sentry/node';
 import * as Sentry from '@sentry/node';
-import { extractTraceparentData } from '@sentry/tracing';
+import { extractSentrytraceData, extractTracestateData } from '@sentry/tracing';
 import { Integration } from '@sentry/types';
-import { isString, logger } from '@sentry/utils';
+import { logger } from '@sentry/utils';
 // NOTE: I have no idea how to fix this right now, and don't want to waste more time, as it builds just fine — Kamil
 // eslint-disable-next-line import/no-unresolved
 import { Context, Handler } from 'aws-lambda';
@@ -192,7 +192,7 @@ export function wrapHandler<TEvent, TResult>(
   };
   let timeoutWarningTimer: NodeJS.Timeout;
 
-  // AWSLambda is like Express. It makes a distinction about handlers based on it's last argument
+  // AWSLambda is like Express. It makes a distinction about handlers based on its last argument
   // async (event) => async handler
   // async (event, context) => async handler
   // (event, context, callback) => sync handler
@@ -243,16 +243,22 @@ export function wrapHandler<TEvent, TResult>(
       }, timeoutWarningDelay);
     }
 
-    // Applying `sentry-trace` to context
-    let traceparentData;
+    // Extract tracing data from headers
+    let traceparentData, tracestateData;
     const eventWithHeaders = event as { headers?: { [key: string]: string } };
-    if (eventWithHeaders.headers && isString(eventWithHeaders.headers['sentry-trace'])) {
-      traceparentData = extractTraceparentData(eventWithHeaders.headers['sentry-trace'] as string);
+
+    if (eventWithHeaders.headers?.['sentry-trace']) {
+      traceparentData = extractSentrytraceData(eventWithHeaders.headers['sentry-trace'] as string);
     }
+    if (eventWithHeaders.headers?.tracestate) {
+      tracestateData = extractTracestateData(eventWithHeaders.headers.tracestate as string);
+    }
+
     const transaction = startTransaction({
       name: context.functionName,
       op: 'awslambda.handler',
       ...traceparentData,
+      ...(tracestateData && { metadata: { tracestate: tracestateData } }),
     });
 
     const hub = getCurrentHub();

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -221,6 +221,35 @@ describe('AWSLambda', () => {
       await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
     });
 
+    test('incoming trace headers are correctly parsed and used', async () => {
+      expect.assertions(1);
+
+      fakeEvent.headers = {
+        'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
+        tracestate: 'sentry=doGsaREgReaT,maisey=silly,charlie=goofy',
+      };
+
+      const handler: Handler = (_event, _context, callback) => {
+        expect(Sentry.startTransaction).toBeCalledWith(
+          expect.objectContaining({
+            traceId: '12312012123120121231201212312012',
+            parentSpanId: '1121201211212012',
+            parentSampled: false,
+            metadata: {
+              tracestate: {
+                sentry: 'sentry=doGsaREgReaT',
+                thirdparty: 'maisey=silly,charlie=goofy',
+              },
+            },
+          }),
+        );
+
+        callback(undefined, { its: 'fine' });
+      };
+      const wrappedHandler = wrapHandler(handler);
+      await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
+    });
+
     test('capture error', async () => {
       expect.assertions(10);
 
@@ -278,6 +307,35 @@ describe('AWSLambda', () => {
       await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
     });
 
+    test('incoming trace headers are correctly parsed and used', async () => {
+      expect.assertions(1);
+
+      fakeEvent.headers = {
+        'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
+        tracestate: 'sentry=doGsaREgReaT,maisey=silly,charlie=goofy',
+      };
+
+      const handler: Handler = async (_event, _context, callback) => {
+        expect(Sentry.startTransaction).toBeCalledWith(
+          expect.objectContaining({
+            traceId: '12312012123120121231201212312012',
+            parentSpanId: '1121201211212012',
+            parentSampled: false,
+            metadata: {
+              tracestate: {
+                sentry: 'sentry=doGsaREgReaT',
+                thirdparty: 'maisey=silly,charlie=goofy',
+              },
+            },
+          }),
+        );
+
+        callback(undefined, { its: 'fine' });
+      };
+      const wrappedHandler = wrapHandler(handler);
+      await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
+    });
+
     test('capture error', async () => {
       expect.assertions(10);
 
@@ -323,6 +381,35 @@ describe('AWSLambda', () => {
       const handler: Handler = async (event, context, _callback) => {
         expect(event).toHaveProperty('fortySix');
         expect(context).toHaveProperty('ytho');
+      };
+      const wrappedHandler = wrapHandler(handler);
+      await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
+    });
+
+    test('incoming trace headers are correctly parsed and used', async () => {
+      expect.assertions(1);
+
+      fakeEvent.headers = {
+        'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
+        tracestate: 'sentry=doGsaREgReaT,maisey=silly,charlie=goofy',
+      };
+
+      const handler: Handler = async (_event, _context, callback) => {
+        expect(Sentry.startTransaction).toBeCalledWith(
+          expect.objectContaining({
+            traceId: '12312012123120121231201212312012',
+            parentSpanId: '1121201211212012',
+            parentSampled: false,
+            metadata: {
+              tracestate: {
+                sentry: 'sentry=doGsaREgReaT',
+                thirdparty: 'maisey=silly,charlie=goofy',
+              },
+            },
+          }),
+        );
+
+        callback(undefined, { its: 'fine' });
       };
       const wrappedHandler = wrapHandler(handler);
       await wrappedHandler(fakeEvent, fakeContext, fakeCallback);

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -5,7 +5,7 @@ import { getGlobalObject, logger } from '@sentry/utils';
 import { startIdleTransaction } from '../hubextensions';
 import { DEFAULT_IDLE_TIMEOUT, IdleTransaction } from '../idletransaction';
 import { SpanStatus } from '../spanstatus';
-import { extractTraceparentData, secToMs } from '../utils';
+import { extractSentrytraceData, secToMs } from '../utils';
 import { registerBackgroundTabDetection } from './backgroundtab';
 import { MetricsInstrumentation } from './metrics';
 import {
@@ -237,7 +237,7 @@ export class BrowserTracing implements Integration {
 export function getHeaderContext(): Partial<TransactionContext> | undefined {
   const header = getMetaContent('sentry-trace');
   if (header) {
-    return extractTraceparentData(header);
+    return extractSentrytraceData(header);
   }
 
   return undefined;

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -23,6 +23,7 @@ export { addExtensionMethods };
 
 export {
   extractSentrytraceData,
+  extractTracestateData,
   getActiveTransaction,
   hasTracingEnabled,
   SENTRY_TRACE_REGEX,

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -22,9 +22,9 @@ addExtensionMethods();
 export { addExtensionMethods };
 
 export {
-  extractTraceparentData,
+  extractSentrytraceData,
   getActiveTransaction,
   hasTracingEnabled,
+  SENTRY_TRACE_REGEX,
   stripUrlQueryAndFragment,
-  TRACEPARENT_REGEXP,
 } from './utils';

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -380,11 +380,11 @@ export class Span implements SpanInterface {
     // `dsn.publicKey` required and remove the `!`.
 
     return `sentry=${computeTracestateValue({
-      trace_id: this.traceId,
+      traceId: this.traceId,
       environment,
       release,
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      public_key: dsn.publicKey!,
+      publicKey: dsn.publicKey!,
     })}`;
   }
 }

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -251,20 +251,6 @@ export class Span implements SpanInterface {
   /**
    * @inheritDoc
    */
-  public toTracestate(): string | undefined {
-    const sentryTracestate = this.transaction?.metadata?.tracestate?.sentry || this._getNewTracestate();
-    let thirdpartyTracestate = this.transaction?.metadata?.tracestate?.thirdparty;
-
-    // if there's third-party data, add a leading comma; otherwise, convert from `undefined` to the empty string, so the
-    // end result doesn’t come out as `sentry=xxxxxundefined`
-    thirdpartyTracestate = thirdpartyTracestate ? `,${thirdpartyTracestate}` : '';
-
-    return `${sentryTracestate}${thirdpartyTracestate}`;
-  }
-
-  /**
-   * @inheritDoc
-   */
   public toContext(): SpanContext {
     return dropUndefinedKeys({
       data: this.data,
@@ -304,7 +290,7 @@ export class Span implements SpanInterface {
    * @inheritDoc
    */
   public getTraceHeaders(): TraceHeaders {
-    const tracestate = this.toTracestate();
+    const tracestate = this._toTracestate();
 
     return {
       'sentry-trace': this.toTraceparent(),
@@ -394,5 +380,19 @@ export class Span implements SpanInterface {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       publicKey: dsn.publicKey!,
     })}`;
+  }
+
+  /**
+   * Return a tracestate-compatible header string. Returns undefined if there is no client or no DSN.
+   */
+  private _toTracestate(): string | undefined {
+    const sentryTracestate = this.transaction?.metadata?.tracestate?.sentry || this._getNewTracestate();
+    let thirdpartyTracestate = this.transaction?.metadata?.tracestate?.thirdparty;
+
+    // if there's third-party data, add a leading comma; otherwise, convert from `undefined` to the empty string, so the
+    // end result doesn’t come out as `sentry=xxxxxundefined`
+    thirdpartyTracestate = thirdpartyTracestate ? `,${thirdpartyTracestate}` : '';
+
+    return `${sentryTracestate}${thirdpartyTracestate}`;
   }
 }

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -40,12 +40,13 @@ export class Transaction extends SpanClass implements TransactionInterface {
     }
 
     this.name = transactionContext.name || '';
-
+    this.metadata = transactionContext.metadata || {};
     this._trimEnd = transactionContext.trimEnd;
 
-    this.metadata = transactionContext.metadata || {};
-    this.metadata.tracestate = this.metadata.tracestate || {};
-    this.metadata.tracestate.sentry = this.metadata.tracestate.sentry || this._getNewTracestate(this._hub);
+    // create a new sentry tracestate value if we didn't inherit one
+    if (!this.metadata.tracestate?.sentry) {
+      this.metadata.tracestate = { ...this.metadata.tracestate, sentry: this._getNewTracestate(this._hub) };
+    }
 
     // this is because transactions are also spans, and spans have a transaction pointer
     this.transaction = this;

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -10,6 +10,36 @@ export const SENTRY_TRACE_REGEX = new RegExp(
     '[ \\t]*$', // whitespace
 );
 
+// This is a normal base64 regex, modified to reflect that fact that we strip the
+// trailing = or == off
+const base64Stripped =
+  // any of the characters in the base64 "alphabet", in multiples of 4
+  '([a-zA-Z0-9+/]{4})*' +
+  // either nothing or 2 or 3 base64-alphabet characters (see
+  // https://en.wikipedia.org/wiki/Base64#Decoding_Base64_without_padding
+  // forwhy there's never only 1 extra character)
+  '([a-zA-Z0-9+/]{2,3})?';
+
+// comma-delimited list of entries of the form `xxx=yyy`
+const tracestateEntry = '[^=]+=[^=]+';
+const TRACESTATE_ENTRIES_REGEX = new RegExp(
+  // one or more xxxxx=yyyy entries
+  `^(${tracestateEntry})+` +
+    // each entry except the last must be followed by a comma
+    '(,|$)',
+);
+
+// this doesn't check that the value is valid, just that there's something there of the form `sentry=xxxx`
+const SENTRY_TRACESTATE_ENTRY_REGEX = new RegExp(
+  // either sentry is the first entry or there's stuff immediately before it,
+  // ending in a commma (this prevents matching something like `coolsentry=xxx`)
+  '(?:^|.+,)' +
+    // sentry's part, not including the potential comma
+    '(sentry=[^,]*)' +
+    // either there's a comma and another vendor's entry or we end
+    '(?:,.+|$)',
+);
+
 /**
  * Determines if tracing is currently enabled.
  *
@@ -28,6 +58,7 @@ export function hasTracingEnabled(options: Options): boolean {
  */
 export function extractSentrytraceData(header: string): TraceparentData | undefined {
   const matches = header.match(SENTRY_TRACE_REGEX);
+
   if (matches) {
     let parentSampled: boolean | undefined;
     if (matches[3] === '1') {
@@ -41,7 +72,54 @@ export function extractSentrytraceData(header: string): TraceparentData | undefi
       parentSpanId: matches[2],
     };
   }
+
   return undefined;
+}
+
+type TracestateHeaderData = { sentry?: string; thirdparty?: string };
+
+/**
+ * Extract data from an incoming `tracestate` header
+ *
+ * @param header
+ * @returns Object containing data from the header
+ */
+export function extractTracestateData(header: string): TracestateHeaderData {
+  let sentryEntry, thirdPartyEntry;
+
+  if (header) {
+    let before, after;
+
+    // find sentry's entry, if any
+    const sentryMatch = SENTRY_TRACESTATE_ENTRY_REGEX.exec(header);
+
+    if (sentryMatch !== null) {
+      sentryEntry = sentryMatch[1];
+
+      // remove the commas after the split so we don't end up with `xxx=yyy,,zzz=qqq` (double commas) when we put them
+      // back together
+      [before, after] = header.split(sentryEntry).map(s => s.replace(/^,*|,*$/g, ''));
+
+      // extract sentry's value from its entry and test to make sure it's valid; if it isn't, discard the entire entry
+      // so that a new one will be created by the Transaction contrcutor
+      const sentryValue = sentryEntry.replace('sentry=', '');
+      if (!new RegExp(`^${base64Stripped}$`).test(sentryValue)) {
+        sentryEntry = undefined;
+      }
+    } else {
+      // this could just as well be `before`; we just need to get the thirdparty data into one or the other since
+      // there's no valid Sentry entry
+      after = header;
+    }
+
+    // if either thirdparty part is invalid or empty, remove it before gluing them together
+    const validThirdpartyEntries = [before, after].filter(x => TRACESTATE_ENTRIES_REGEX.test(x || ''));
+    if (validThirdpartyEntries.length) {
+      thirdPartyEntry = validThirdpartyEntries.join(',');
+    }
+  }
+
+  return { sentry: sentryEntry, thirdparty: thirdPartyEntry };
 }
 
 /** Grabs active transaction off scope, if any */

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -147,10 +147,10 @@ export function secToMs(time: number): number {
 export { stripUrlQueryAndFragment } from '@sentry/utils';
 
 type SentryTracestateData = {
-  trace_id: string;
+  traceId: string;
   environment: string | undefined | null;
   release: string | undefined | null;
-  public_key: string;
+  publicKey: string;
 };
 
 /**

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -2,7 +2,7 @@ import { getCurrentHub, Hub } from '@sentry/hub';
 import { Options, TraceparentData, Transaction } from '@sentry/types';
 import { SentryError, unicodeToBase64 } from '@sentry/utils';
 
-export const TRACEPARENT_REGEXP = new RegExp(
+export const SENTRY_TRACE_REGEX = new RegExp(
   '^[ \\t]*' + // whitespace
   '([0-9a-f]{32})?' + // trace_id
   '-?([0-9a-f]{16})?' + // span_id
@@ -22,12 +22,12 @@ export function hasTracingEnabled(options: Options): boolean {
 /**
  * Extract transaction context data from a `sentry-trace` header.
  *
- * @param traceparent Traceparent string
+ * @param header Traceparent string
  *
  * @returns Object containing data from the header, or undefined if traceparent string is malformed
  */
-export function extractTraceparentData(traceparent: string): TraceparentData | undefined {
-  const matches = traceparent.match(TRACEPARENT_REGEXP);
+export function extractSentrytraceData(header: string): TraceparentData | undefined {
+  const matches = header.match(SENTRY_TRACE_REGEX);
   if (matches) {
     let parentSampled: boolean | undefined;
     if (matches[3] === '1') {
@@ -68,7 +68,7 @@ export function secToMs(time: number): number {
 // so it can be used in manual instrumentation without necessitating a hard dependency on @sentry/utils
 export { stripUrlQueryAndFragment } from '@sentry/utils';
 
-type TracestateData = {
+type SentryTracestateData = {
   trace_id: string;
   environment: string | undefined | null;
   release: string | undefined | null;
@@ -81,7 +81,7 @@ type TracestateData = {
  * @throws SentryError (because using the logger creates a circular dependency)
  * @returns the base64-encoded header value
  */
-export function computeTracestateValue(data: TracestateData): string {
+export function computeTracestateValue(data: SentryTracestateData): string {
   // `JSON.stringify` will drop keys with undefined values, but not ones with null values
   data.environment = data.environment || null;
   data.release = data.release || null;

--- a/packages/tracing/test/browser/request.test.ts
+++ b/packages/tracing/test/browser/request.test.ts
@@ -241,7 +241,7 @@ describe('callbacks', () => {
 
       expect(setRequestHeader).toHaveBeenCalledWith(
         'sentry-trace',
-        expect.stringMatching(tracingUtils.TRACEPARENT_REGEXP),
+        expect.stringMatching(tracingUtils.SENTRY_TRACE_REGEX),
       );
       expect(setRequestHeader).toHaveBeenCalledWith('tracestate', expect.stringMatching(TRACESTATE_HEADER_REGEX));
     });

--- a/packages/tracing/test/hub.test.ts
+++ b/packages/tracing/test/hub.test.ts
@@ -9,7 +9,7 @@ import { logger } from '@sentry/utils';
 import { BrowserTracing } from '../src/browser/browsertracing';
 import { addExtensionMethods } from '../src/hubextensions';
 import { Transaction } from '../src/transaction';
-import { computeTracestateValue, extractTraceparentData, TRACEPARENT_REGEXP } from '../src/utils';
+import { computeTracestateValue, extractSentrytraceData, TRACEPARENT_REGEXP } from '../src/utils';
 import { addDOMPropertiesToGlobal, getSymbolObjectKeyByName, testOnlyIfNodeVersionAtLeast } from './testutils';
 
 addExtensionMethods();
@@ -409,7 +409,7 @@ describe('Hub', () => {
 
           // check that sampling decision is passed down correctly
           expect(transaction.sampled).toBe(true);
-          expect(extractTraceparentData(headers['sentry-trace'])!.parentSampled).toBe(true);
+          expect(extractSentrytraceData(headers['sentry-trace'])!.parentSampled).toBe(true);
         },
       );
 
@@ -451,7 +451,7 @@ describe('Hub', () => {
 
           // check that sampling decision is passed down correctly
           expect(transaction.sampled).toBe(false);
-          expect(extractTraceparentData(headers['sentry-trace'])!.parentSampled).toBe(false);
+          expect(extractSentrytraceData(headers['sentry-trace'])!.parentSampled).toBe(false);
         },
       );
 

--- a/packages/tracing/test/hub.test.ts
+++ b/packages/tracing/test/hub.test.ts
@@ -9,7 +9,7 @@ import { logger } from '@sentry/utils';
 import { BrowserTracing } from '../src/browser/browsertracing';
 import { addExtensionMethods } from '../src/hubextensions';
 import { Transaction } from '../src/transaction';
-import { computeTracestateValue, extractSentrytraceData, TRACEPARENT_REGEXP } from '../src/utils';
+import { computeTracestateValue, extractSentrytraceData, SENTRY_TRACE_REGEX } from '../src/utils';
 import { addDOMPropertiesToGlobal, getSymbolObjectKeyByName, testOnlyIfNodeVersionAtLeast } from './testutils';
 
 addExtensionMethods();
@@ -63,10 +63,10 @@ describe('Hub', () => {
       const transaction = hub.startTransaction({ name: 'FETCH /ball' });
 
       const b64Value = computeTracestateValue({
-        trace_id: transaction.traceId,
+        traceId: transaction.traceId,
         environment,
         release,
-        public_key: 'dogsarebadatkeepingsecrets',
+        publicKey: 'dogsarebadatkeepingsecrets',
       });
 
       expect(transaction.metadata?.tracestate?.sentry).toEqual(`sentry=${b64Value}`);
@@ -81,10 +81,10 @@ describe('Hub', () => {
       const transaction = getCurrentHub().startTransaction({ name: 'FETCH /ball' });
 
       const b64Value = computeTracestateValue({
-        trace_id: transaction.traceId,
+        traceId: transaction.traceId,
         environment: 'production',
         release,
-        public_key: 'dogsarebadatkeepingsecrets',
+        publicKey: 'dogsarebadatkeepingsecrets',
       });
 
       expect(transaction.metadata?.tracestate?.sentry).toEqual(`sentry=${b64Value}`);
@@ -404,7 +404,7 @@ describe('Hub', () => {
 
           // check that sentry-trace header is added to request
           expect(headers).toEqual(
-            expect.objectContaining({ 'sentry-trace': expect.stringMatching(TRACEPARENT_REGEXP) }),
+            expect.objectContaining({ 'sentry-trace': expect.stringMatching(SENTRY_TRACE_REGEX) }),
           );
 
           // check that sampling decision is passed down correctly
@@ -446,7 +446,7 @@ describe('Hub', () => {
 
           // check that sentry-trace header is added to request
           expect(headers).toEqual(
-            expect.objectContaining({ 'sentry-trace': expect.stringMatching(TRACEPARENT_REGEXP) }),
+            expect.objectContaining({ 'sentry-trace': expect.stringMatching(SENTRY_TRACE_REGEX) }),
           );
 
           // check that sampling decision is passed down correctly

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -95,10 +95,10 @@ describe('Span', () => {
 
   describe('toTraceparent', () => {
     test('simple', () => {
-      expect(new Span().toTraceparent()).toMatch(SENTRY_TRACE_REGEX);
+      expect(new Span().getTraceHeaders()['sentry-trace']).toMatch(SENTRY_TRACE_REGEX);
     });
     test('with sample', () => {
-      expect(new Span({ sampled: true }).toTraceparent()).toMatch(SENTRY_TRACE_REGEX);
+      expect(new Span({ sampled: true }).getTraceHeaders()['sentry-trace']).toMatch(SENTRY_TRACE_REGEX);
     });
   });
 
@@ -159,7 +159,7 @@ describe('Span', () => {
 
       const headers = span.getTraceHeaders();
 
-      expect(headers['sentry-trace']).toEqual(span.toTraceparent());
+      expect(headers['sentry-trace']).toEqual(`${span.traceId}-${span.spanId}-1`);
       expect(headers.tracestate).toEqual(transaction.metadata?.tracestate?.sentry);
     });
   });

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -2,7 +2,7 @@ import { BrowserClient } from '@sentry/browser';
 import { Hub, Scope } from '@sentry/hub';
 
 import { Span, SpanStatus, Transaction } from '../src';
-import { TRACEPARENT_REGEXP } from '../src/utils';
+import { SENTRY_TRACE_REGEX } from '../src/utils';
 
 describe('Span', () => {
   let hub: Hub;
@@ -94,10 +94,10 @@ describe('Span', () => {
 
   describe('toTraceparent', () => {
     test('simple', () => {
-      expect(new Span().toTraceparent()).toMatch(TRACEPARENT_REGEXP);
+      expect(new Span().toTraceparent()).toMatch(SENTRY_TRACE_REGEX);
     });
     test('with sample', () => {
-      expect(new Span({ sampled: true }).toTraceparent()).toMatch(TRACEPARENT_REGEXP);
+      expect(new Span({ sampled: true }).toTraceparent()).toMatch(SENTRY_TRACE_REGEX);
     });
   });
 

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -124,7 +124,7 @@ describe('Span', () => {
       const transaction = new Transaction({ name: 'FETCH /ball', traceId }, hub);
       const span = transaction.startChild({ op: 'dig.hole' });
 
-      expect(span.toTracestate()).toEqual(computedTracestate);
+      expect(span.getTraceHeaders().tracestate).toEqual(computedTracestate);
     });
 
     test('third-party data', () => {
@@ -132,7 +132,7 @@ describe('Span', () => {
       transaction.setMetadata({ tracestate: { sentry: computedTracestate, thirdparty: thirdpartyData } });
       const span = transaction.startChild({ op: 'dig.hole' });
 
-      expect(span.toTracestate()).toEqual(`${computedTracestate},${thirdpartyData}`);
+      expect(span.getTraceHeaders().tracestate).toEqual(`${computedTracestate},${thirdpartyData}`);
     });
 
     test('orphan span', () => {
@@ -140,7 +140,7 @@ describe('Span', () => {
       const span = new Span({ op: 'dig.hole' });
       span.traceId = traceId;
 
-      expect(span.toTracestate()).toEqual(computedTracestate);
+      expect(span.getTraceHeaders().tracestate).toEqual(computedTracestate);
     });
   });
 

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -93,6 +93,7 @@ describe('Span', () => {
     });
   });
 
+  // TODO Once toTraceparent is removed, we obv don't need these tests anymore
   describe('toTraceparent', () => {
     test('simple', () => {
       expect(new Span().getTraceHeaders()['sentry-trace']).toMatch(SENTRY_TRACE_REGEX);

--- a/packages/tracing/test/utils.test.ts
+++ b/packages/tracing/test/utils.test.ts
@@ -1,8 +1,8 @@
-import { extractTraceparentData } from '../src/utils';
+import { extractSentrytraceData } from '../src/utils';
 
-describe('extractTraceparentData', () => {
+describe('extractSentrytraceData', () => {
   test('no sample', () => {
-    const data = extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb') as any;
+    const data = extractSentrytraceData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb') as any;
 
     expect(data).toBeDefined();
     expect(data.parentSpanId).toEqual('bbbbbbbbbbbbbbbb');
@@ -11,21 +11,21 @@ describe('extractTraceparentData', () => {
   });
 
   test('sample true', () => {
-    const data = extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-1') as any;
+    const data = extractSentrytraceData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-1') as any;
 
     expect(data).toBeDefined();
     expect(data.parentSampled).toBeTruthy();
   });
 
   test('sample false', () => {
-    const data = extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-0') as any;
+    const data = extractSentrytraceData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-0') as any;
 
     expect(data).toBeDefined();
     expect(data.parentSampled).toBeFalsy();
   });
 
   test('just sample decision - false', () => {
-    const data = extractTraceparentData('0') as any;
+    const data = extractSentrytraceData('0') as any;
 
     expect(data).toBeDefined();
     expect(data.traceId).toBeUndefined();
@@ -34,7 +34,7 @@ describe('extractTraceparentData', () => {
   });
 
   test('just sample decision - true', () => {
-    const data = extractTraceparentData('1') as any;
+    const data = extractSentrytraceData('1') as any;
 
     expect(data).toBeDefined();
     expect(data.traceId).toBeUndefined();
@@ -44,21 +44,21 @@ describe('extractTraceparentData', () => {
 
   test('invalid', () => {
     // trace id wrong length
-    expect(extractTraceparentData('a-bbbbbbbbbbbbbbbb-1')).toBeUndefined();
+    expect(extractSentrytraceData('a-bbbbbbbbbbbbbbbb-1')).toBeUndefined();
 
     // parent span id wrong length
-    expect(extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-b-1')).toBeUndefined();
+    expect(extractSentrytraceData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-b-1')).toBeUndefined();
 
     // parent sampling decision wrong length
-    expect(extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-11')).toBeUndefined();
+    expect(extractSentrytraceData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-11')).toBeUndefined();
 
     // trace id invalid hex value
-    expect(extractTraceparentData('someStuffHereWhichIsNotAtAllHexy-bbbbbbbbbbbbbbbb-1')).toBeUndefined();
+    expect(extractSentrytraceData('someStuffHereWhichIsNotAtAllHexy-bbbbbbbbbbbbbbbb-1')).toBeUndefined();
 
     // parent span id invalid hex value
-    expect(extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-alsoNotSuperHexy-1')).toBeUndefined();
+    expect(extractSentrytraceData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-alsoNotSuperHexy-1')).toBeUndefined();
 
     // bogus sampling decision
-    expect(extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-x')).toBeUndefined();
+    expect(extractSentrytraceData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-x')).toBeUndefined();
   });
 });

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -149,11 +149,12 @@ export interface Span extends SpanContext {
    */
   isSuccess(): boolean;
 
-  /** Return a traceparent-compatible header string */
-  toTraceparent(): string;
-
-  /** Return a tracestate-compatible header string. Returns undefined if there is no client or no DSN. */
-  toTracestate(): string | undefined;
+  /**
+   * Return a traceparent-compatible header string
+   *
+   * NOTE: Do not use `span.toTraceparnt` directly. Use `span.getTraceHeaders` instead.
+   */
+  toTraceparent(): string; // TODO (kmclb) make this private
 
   /** Returns the current span properties as a `SpanContext` */
   toContext(): SpanContext;

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -149,8 +149,11 @@ export interface Span extends SpanContext {
    */
   isSuccess(): boolean;
 
-  /** Return a traceparent compatible header string */
+  /** Return a traceparent-compatible header string */
   toTraceparent(): string;
+
+  /** Return a tracestate-compatible header string. Returns undefined if there is no client or no DSN. */
+  toTracestate(): string | undefined;
 
   /** Returns the current span properties as a `SpanContext` */
   toContext(): SpanContext;

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -152,7 +152,7 @@ export interface Span extends SpanContext {
   /**
    * Return a traceparent-compatible header string
    *
-   * NOTE: Do not use `span.toTraceparnt` directly. Use `span.getTraceHeaders` instead.
+   * @deprecated Do not use `span.toTraceparnt` directly. Use `span.getTraceHeaders` instead.
    */
   toTraceparent(): string; // TODO (kmclb) make this private
 

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -122,8 +122,9 @@ export enum TransactionSamplingMethod {
 export interface TransactionMetadata {
   transactionSampling?: { rate?: number; method?: string };
 
-  /** The sentry half of a transaction's tracestate header, used for dynamic sampling */
+  /** The two halves (sentry and third-party) of a transaction's tracestate header, used for dynamic sampling */
   tracestate?: {
     sentry?: string;
+    thirdparty?: string;
   };
 }


### PR DESCRIPTION
This builds on previous dynamic sampling/tracestate PRs by (as the title says), consuming incoming `tracestate` headers and allowing for non-sentry data in both those and outgoing `tracestate` headers.

This should complete the initial implementation of `tracestate` on the JavaScript side.

Lingering issues to be dealt with in future:

- Because `Buffer` is mentioned in `utils/string.ts`, webpack will include the entire contents of node's `Buffer` module in your bundle when you include `@sentry/browser` or any of its derivatives in said bundle. (Rollup is smart enough to exclude it from our CDN bundles.) Before we GA this, we need to figure out a way around that. Holding off for now since all of the build tooling is changing in v7, and this likely won't GA until after v7 is released. (As to our dogfooding, @HazAT suggested seeing how much of an impact it actually has there before spending time dealing with it.)

- This initial proof of concept doesn't include any user data, which the final version will need to.

- This also doesn't handle weird edge cases in terms of third-party data in the headers (blank values, for instance), as detailed in the [official spec](https://www.w3.org/TR/trace-context/#tracestate-header-field-values).


