### PR TITLE
fix(node/browser): Set SDK info in client constructor

### DIFF
--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -1,4 +1,4 @@
-import { BaseClient, Scope } from '@sentry/core';
+import { BaseClient, Scope, SDK_VERSION } from '@sentry/core';
 import { Event, EventHint } from '@sentry/types';
 import { getGlobalObject, logger } from '@sentry/utils';
 
@@ -19,6 +19,18 @@ export class BrowserClient extends BaseClient<BrowserBackend, BrowserOptions> {
    * @param options Configuration options for this SDK.
    */
   public constructor(options: BrowserOptions = {}) {
+    options._metadata = options._metadata || {};
+    options._metadata.sdk = options._metadata.sdk || {
+      name: 'sentry.javascript.browser',
+      packages: [
+        {
+          name: 'npm:@sentry/browser',
+          version: SDK_VERSION,
+        },
+      ],
+      version: SDK_VERSION,
+    };
+
     super(BrowserBackend, options);
   }
 

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub, initAndBind, Integrations as CoreIntegrations, SDK_VERSION } from '@sentry/core';
+import { getCurrentHub, initAndBind, Integrations as CoreIntegrations } from '@sentry/core';
 import { addInstrumentationHandler, getGlobalObject, logger, SyncPromise } from '@sentry/utils';
 
 import { BrowserOptions } from './backend';
@@ -87,18 +87,6 @@ export function init(options: BrowserOptions = {}): void {
   if (options.autoSessionTracking === undefined) {
     options.autoSessionTracking = true;
   }
-
-  options._metadata = options._metadata || {};
-  options._metadata.sdk = {
-    name: 'sentry.javascript.browser',
-    packages: [
-      {
-        name: 'npm:@sentry/browser',
-        version: SDK_VERSION,
-      },
-    ],
-    version: SDK_VERSION,
-  };
 
   initAndBind(BrowserClient, options);
 

--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -1,3 +1,4 @@
+import { SDK_VERSION } from '@sentry/core';
 import { expect } from 'chai';
 import { SinonSpy, spy } from 'sinon';
 
@@ -177,10 +178,66 @@ describe('SentryBrowser initialization', () => {
     expect(global.__SENTRY__.hub._stack[0].client.getOptions().release).to.equal('foobar');
     delete global.SENTRY_RELEASE;
   });
+
   it('should have initialization proceed as normal if window.SENTRY_RELEASE is not set', () => {
     // This is mostly a happy-path test to ensure that the initialization doesn't throw an error.
     init({ dsn });
     expect(global.__SENTRY__.hub._stack[0].client.getOptions().release).to.be.undefined;
+  });
+
+  describe('SDK metadata', () => {
+    it('should set SDK data when Sentry.init() is called', () => {
+      init({ dsn });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const sdkData = (getCurrentHub().getClient() as any)._backend._transport._api.metadata?.sdk;
+
+      expect(sdkData.name).to.equal('sentry.javascript.browser');
+      expect(sdkData.packages[0].name).to.equal('npm:@sentry/browser');
+      expect(sdkData.packages[0].version).to.equal(SDK_VERSION);
+      expect(sdkData.version).to.equal(SDK_VERSION);
+    });
+
+    it('should set SDK data when instantiating a client directly', () => {
+      const client = new BrowserClient({ dsn });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const sdkData = (client as any)._backend._transport._api.metadata?.sdk;
+
+      expect(sdkData.name).to.equal('sentry.javascript.browser');
+      expect(sdkData.packages[0].name).to.equal('npm:@sentry/browser');
+      expect(sdkData.packages[0].version).to.equal(SDK_VERSION);
+      expect(sdkData.version).to.equal(SDK_VERSION);
+    });
+
+    // wrapper packages (like @sentry/angular and @sentry/react) set their SDK data in their `init` methods, which are
+    // called before the client is instantiated, and we don't want to clobber that data
+    it("shouldn't overwrite SDK data that's already there", () => {
+      init({
+        dsn,
+        // this would normally be set by the wrapper SDK in init()
+        _metadata: {
+          sdk: {
+            name: 'sentry.javascript.angular',
+            packages: [
+              {
+                name: 'npm:@sentry/angular',
+                version: SDK_VERSION,
+              },
+            ],
+            version: SDK_VERSION,
+          },
+        },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const sdkData = (getCurrentHub().getClient() as any)._backend._transport._api.metadata?.sdk;
+
+      expect(sdkData.name).to.equal('sentry.javascript.angular');
+      expect(sdkData.packages[0].name).to.equal('npm:@sentry/angular');
+      expect(sdkData.packages[0].version).to.equal(SDK_VERSION);
+      expect(sdkData.version).to.equal(SDK_VERSION);
+    });
   });
 });
 

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -1,4 +1,4 @@
-import { BaseClient, Scope } from '@sentry/core';
+import { BaseClient, Scope, SDK_VERSION } from '@sentry/core';
 import { Event, EventHint } from '@sentry/types';
 
 import { NodeBackend, NodeOptions } from './backend';
@@ -15,6 +15,18 @@ export class NodeClient extends BaseClient<NodeBackend, NodeOptions> {
    * @param options Configuration options for this SDK.
    */
   public constructor(options: NodeOptions) {
+    options._metadata = options._metadata || {};
+    options._metadata.sdk = options._metadata.sdk || {
+      name: 'sentry.javascript.node',
+      packages: [
+        {
+          name: 'npm:@sentry/node',
+          version: SDK_VERSION,
+        },
+      ],
+      version: SDK_VERSION,
+    };
+
     super(NodeBackend, options);
   }
 

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub, initAndBind, Integrations as CoreIntegrations, SDK_VERSION } from '@sentry/core';
+import { getCurrentHub, initAndBind, Integrations as CoreIntegrations } from '@sentry/core';
 import { getMainCarrier, setHubOnCarrier } from '@sentry/hub';
 import { getGlobalObject } from '@sentry/utils';
 import * as domain from 'domain';
@@ -107,18 +107,6 @@ export function init(options: NodeOptions = {}): void {
   if (options.environment === undefined && process.env.SENTRY_ENVIRONMENT) {
     options.environment = process.env.SENTRY_ENVIRONMENT;
   }
-
-  options._metadata = options._metadata || {};
-  options._metadata.sdk = {
-    name: 'sentry.javascript.node',
-    packages: [
-      {
-        name: 'npm:@sentry/node',
-        version: SDK_VERSION,
-      },
-    ],
-    version: SDK_VERSION,
-  };
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
   if ((domain as any).active) {


### PR DESCRIPTION
Since https://github.com/getsentry/sentry-javascript/pull/3177, SDK metadata (version, package name, etc) is set in `Sentry.init()`. This works great, except when you instantiate a client directly, as we tell people to do [here](https://docs.sentry.io/platforms/javascript/troubleshooting/#using-a-client-directly). In that case, the data never gets set.

This moves that data-setting into the constructors of `BrowserClient` and `NodeClient`. That way, if anyone creates a client themselves, they get the data. To protect the data that's set in wrapper classes like `@sentry/react` and `@sentry/serverless` (data which continues to be set in `.init()`), the client constructors only set their data if there isn't already data there.
