### PR TITLE
ref: Use allowSyntheticDefaultImports for integrations to fix localforage …

### DIFF
--- a/packages/integrations/src/offline.ts
+++ b/packages/integrations/src/offline.ts
@@ -1,10 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Event, EventProcessor, Hub, Integration } from '@sentry/types';
 import { getGlobalObject, logger, uuid4 } from '@sentry/utils';
-import * as localForageType from 'localforage';
-
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const localForage = require('localforage');
+import localForage from 'localforage';
 /**
  * cache offline errors and send when connected
  */
@@ -38,7 +35,7 @@ export class Offline implements Integration {
   /**
    * event cache
    */
-  public offlineEventStore: typeof localForageType; // type imported from localforage
+  public offlineEventStore: LocalForage; // type imported from localforage
 
   /**
    * @inheritDoc

--- a/packages/integrations/tsconfig.build.json
+++ b/packages/integrations/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "declarationMap": false,
     "baseUrl": ".",
     "outDir": "dist",

--- a/packages/integrations/tsconfig.esm.json
+++ b/packages/integrations/tsconfig.esm.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.esm.json",
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
     "declarationMap": false,
     "baseUrl": ".",
     "outDir": "esm",


### PR DESCRIPTION
Fixes #3101

Redo of #3180.

I think this fix should work. In #2853 the real issue seems to be the inclusion of // @ts-ignore: Module '"localforage"' has no default export.. Using allowSyntheticDefaultImports makes that @ts-ignore unnecessary.