### PR TITLE
fix: Don't override metadata

### DIFF
--- a/packages/react/src/sdk.ts
+++ b/packages/react/src/sdk.ts
@@ -5,7 +5,7 @@ import { BrowserOptions, init as browserInit, SDK_VERSION } from '@sentry/browse
  */
 export function init(options: BrowserOptions): void {
   options._metadata = options._metadata || {};
-  if (!options._metadata.sdk) {
+  if (options._metadata.sdk === undefined) {
     options._metadata.sdk = {
       name: 'sentry.javascript.react',
       packages: [

--- a/packages/react/src/sdk.ts
+++ b/packages/react/src/sdk.ts
@@ -5,15 +5,18 @@ import { BrowserOptions, init as browserInit, SDK_VERSION } from '@sentry/browse
  */
 export function init(options: BrowserOptions): void {
   options._metadata = options._metadata || {};
-  options._metadata.sdk = {
-    name: 'sentry.javascript.react',
-    packages: [
-      {
-        name: 'npm:@sentry/react',
-        version: SDK_VERSION,
-      },
-    ],
-    version: SDK_VERSION,
-  };
+  if (!options._metadata.sdk) {
+    options._metadata.sdk = {
+      name: 'sentry.javascript.react',
+      packages: [
+        {
+          name: 'npm:@sentry/react',
+          version: SDK_VERSION,
+        },
+      ],
+      version: SDK_VERSION,
+    };
+  }
+
   browserInit(options);
 }


### PR DESCRIPTION
When initializing the React SDK, overriding metadata won't allow other SDKs to use that info. This PR prevents that.