### PR TITLE
fix: Normalized Event before caching.

### DIFF
--- a/packages/integrations/src/offline.ts
+++ b/packages/integrations/src/offline.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Event, EventProcessor, Hub, Integration } from '@sentry/types';
-import { getGlobalObject, logger, uuid4 } from '@sentry/utils';
+import { getGlobalObject, logger, normalize, uuid4 } from '@sentry/utils';
 import * as localForageType from 'localforage';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -98,7 +98,7 @@ export class Offline implements Integration {
    * @param event an event
    */
   private async _cacheEvent(event: Event): Promise<Event> {
-    return this.offlineEventStore.setItem<Event>(uuid4(), event);
+    return this.offlineEventStore.setItem<Event>(uuid4(), normalize(event));
   }
 
   /**


### PR DESCRIPTION
This fixes an issue with the Offline integration when caching events, that have Spans, in an IndexedDB. Spans have functions which cause the storage to fail. Fixed it by using the normalize function on the event beforehand.

I tried creating tests, however when attempting to use [fakeIndexedDB](https://github.com/dumbmatter/fakeIndexedDB) I could not figure out how to deal with its asynchronicity.