### PR TITLE
feat: Add runtime tags to errors

### DIFF
--- a/packages/next-plugin-sentry/src/on-error-client.js
+++ b/packages/next-plugin-sentry/src/on-error-client.js
@@ -1,14 +1,7 @@
 import { withScope, captureException } from '@sentry/nextjs';
 
-export default async function onErrorClient({ err, errorInfo, renderErrorProps, data, version }) {
-  // TODO: Extract some useful metadata from the router and other arguments — Kamil
-
+export default async function onErrorClient({ err }) {
   withScope(scope => {
-    if (typeof errorInfo?.componentStack === 'string') {
-      scope.setContext('react', {
-        componentStack: errorInfo.componentStack.trim(),
-      });
-    }
     captureException(err);
   });
 }

--- a/packages/next-plugin-sentry/src/on-error-client.js
+++ b/packages/next-plugin-sentry/src/on-error-client.js
@@ -1,7 +1,11 @@
-import { withScope, captureException } from '@sentry/nextjs';
+import { withScope, captureException, captureMessage } from '@sentry/nextjs';
 
 export default async function onErrorClient({ err }) {
   withScope(scope => {
-    captureException(err);
+    if (err instanceof Error) {
+      captureException(toCapture);
+    } else {
+      captureMessage(err.message);
+    }
   });
 }

--- a/packages/next-plugin-sentry/src/on-error-client.js
+++ b/packages/next-plugin-sentry/src/on-error-client.js
@@ -3,7 +3,7 @@ import { withScope, captureException, captureMessage } from '@sentry/nextjs';
 export default async function onErrorClient({ err }) {
   withScope(scope => {
     if (err instanceof Error) {
-      captureException(toCapture);
+      captureException(err);
     } else {
       captureMessage(err.message);
     }

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -17,12 +17,11 @@
   },
   "dependencies": {
     "@sentry/core": "6.2.1",
-    "@sentry/minimal": "6.2.1",
+    "@sentry/next-plugin-sentry": "6.2.1",
     "@sentry/node": "6.2.1",
     "@sentry/react": "6.2.1",
-    "@sentry/next-plugin-sentry": "6.2.1",
-    "@sentry/wizard": "^1.2.1",
-    "@sentry/webpack-plugin": "^1.14.1"
+    "@sentry/webpack-plugin": "^1.14.1",
+    "@sentry/wizard": "^1.2.1"
   },
   "devDependencies": {
     "@sentry/types": "6.2.1",

--- a/packages/nextjs/src/node.ts
+++ b/packages/nextjs/src/node.ts
@@ -1,4 +1,4 @@
-import { init as nodeInit } from '@sentry/node';
+import { configureScope, init as nodeInit } from '@sentry/node';
 
 import { InitDecider } from './utils/initDecider';
 import { MetadataBuilder } from './utils/metadataBuilder';
@@ -17,6 +17,9 @@ export function init(options: NextjsOptions): any {
   const initDecider = new InitDecider(options);
   if (initDecider.shouldInitSentry()) {
     nodeInit(options);
+    configureScope(scope => {
+      scope.setTag('runtime', 'node');
+    });
   } else {
     // eslint-disable-next-line no-console
     console.warn('[Sentry] Detected a non-production environment. Not initializing Sentry.');

--- a/packages/nextjs/src/react.ts
+++ b/packages/nextjs/src/react.ts
@@ -1,4 +1,4 @@
-import { init as reactInit } from '@sentry/react';
+import { configureScope, init as reactInit } from '@sentry/react';
 
 import { InitDecider } from './utils/initDecider';
 import { MetadataBuilder } from './utils/metadataBuilder';
@@ -13,6 +13,9 @@ export function init(options: NextjsOptions): any {
   const initDecider = new InitDecider(options);
   if (initDecider.shouldInitSentry()) {
     reactInit(options);
+    configureScope(scope => {
+      scope.setTag('runtime', 'browser');
+    });
   } else {
     // eslint-disable-next-line no-console
     console.warn('[Sentry] Detected a non-production environment. Not initializing Sentry.');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3276,16 +3276,6 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@sentry/browser@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.2.1.tgz#f9f277e6f8cad0c7efd1a01726095d63a47a1c16"
-  integrity sha512-OAikFZ9EimD3noxMp8tA6Cf6qJcQ2U8k5QSgTPwdx+09nZOGJzbRFteK7WWmrS93ZJdzN61lpSQbg5v+bmmfbQ==
-  dependencies:
-    "@sentry/core" "6.2.1"
-    "@sentry/types" "6.2.1"
-    "@sentry/utils" "6.2.1"
-    tslib "^1.9.3"
-
 "@sentry/cli@^1.52.4", "@sentry/cli@^1.58.0":
   version "1.63.0"
   resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.63.0.tgz#e69f05e2abab3c68a68958b55556618067e1dea9"
@@ -3296,96 +3286,6 @@
     node-fetch "^2.6.0"
     progress "^2.0.3"
     proxy-from-env "^1.1.0"
-
-"@sentry/core@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.2.1.tgz#8b177e9bf591e2e7ddcb04f0b1403de3f5aa8755"
-  integrity sha512-jPqQEtafxxDtLONhCbTHh/Uq8mZRhsfbwJTSVYfPVEe/ELfFZLQK7tP6rOh7zEWKbTkE0mE6XcaoH3ZRAhgrqg==
-  dependencies:
-    "@sentry/hub" "6.2.1"
-    "@sentry/minimal" "6.2.1"
-    "@sentry/types" "6.2.1"
-    "@sentry/utils" "6.2.1"
-    tslib "^1.9.3"
-
-"@sentry/hub@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.2.1.tgz#35bc6bf841a93f4354b3a17592c938b3dba20b73"
-  integrity sha512-pG7wCQeRpzeP6t0bT4T0X029R19dbDS3/qswF8BL6bg0AI3afjfjBAZm/fqn1Uwe/uBoMHVVdbxgJDZeQ5d4rQ==
-  dependencies:
-    "@sentry/types" "6.2.1"
-    "@sentry/utils" "6.2.1"
-    tslib "^1.9.3"
-
-"@sentry/integrations@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-6.2.1.tgz#caa9b49de29523698668d45827633be86b2268ff"
-  integrity sha512-UBvuil/b9M5HGH6aBDzTiIVRsmpC/wqwDKy28IO05XLdalmKgJ9C1EQhoyN6xw+1lINpXXFtfq4NhfgZgWbc7Q==
-  dependencies:
-    "@sentry/types" "6.2.1"
-    "@sentry/utils" "6.2.1"
-    localforage "^1.8.1"
-    tslib "^1.9.3"
-
-"@sentry/minimal@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.2.1.tgz#8f01480e1b56bc7dd54adf925e5317f233e19384"
-  integrity sha512-wuSXB4Ayxv9rBEQ4pm7fnG4UU2ZPtPnnChoEfd4/mw1UthXSvmPFEn6O4pdo2G8fTkl8eqm6wT/Q7uIXMEmw+A==
-  dependencies:
-    "@sentry/hub" "6.2.1"
-    "@sentry/types" "6.2.1"
-    tslib "^1.9.3"
-
-"@sentry/node@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.2.1.tgz#111418d2cc2245512bc5e46786c373d7d5202525"
-  integrity sha512-JlixtJHS6xMzh2G4Pz7oMM8Nd40mGUALQYtuGMwW2QE3IduOaaGsn1+eVpN6PwZetMnvRIn6VVFOc2UmFIzWpA==
-  dependencies:
-    "@sentry/core" "6.2.1"
-    "@sentry/hub" "6.2.1"
-    "@sentry/tracing" "6.2.1"
-    "@sentry/types" "6.2.1"
-    "@sentry/utils" "6.2.1"
-    cookie "^0.4.1"
-    https-proxy-agent "^5.0.0"
-    lru_map "^0.3.3"
-    tslib "^1.9.3"
-
-"@sentry/react@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-6.2.1.tgz#26587f3f47e9699003b04ac558d8aa8a2b7416d7"
-  integrity sha512-emJnYVASM2hej2f8eSjqiDRMljwLsDJDSwa6kVc5HUOs9gnVrE4MR+vSywraACf5tKZbH1YI+NUXCmR++fIB0g==
-  dependencies:
-    "@sentry/browser" "6.2.1"
-    "@sentry/minimal" "6.2.1"
-    "@sentry/types" "6.2.1"
-    "@sentry/utils" "6.2.1"
-    hoist-non-react-statics "^3.3.2"
-    tslib "^1.9.3"
-
-"@sentry/tracing@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.2.1.tgz#61c18c43c5390c348b35dafe73947ab379252d8f"
-  integrity sha512-bvStY1SnL08wkSeVK3j9K5rivQQJdKFCPR2VYRFOCaUoleZ6ChPUnBvxQ/E2LXc0hk/y/wo1q4r5B0dfCCY+bQ==
-  dependencies:
-    "@sentry/hub" "6.2.1"
-    "@sentry/minimal" "6.2.1"
-    "@sentry/types" "6.2.1"
-    "@sentry/utils" "6.2.1"
-    tslib "^1.9.3"
-
-"@sentry/types@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.2.1.tgz#28c946230b2023f72307b65606d32052ad9e5353"
-  integrity sha512-h0OV1QT+fv5ojfK5/+iEXClu33HirmvbjcQC2jf05IHj9yXIOWy6EB10S8nBjuLiiFqQiAQYj3FN9Ip4eN8NJA==
-
-"@sentry/utils@6.2.1":
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.2.1.tgz#bfcb12c20d44bf2aeb0073b1264703c11c179ebd"
-  integrity sha512-6kQgM/yBPdXu+3qbJnI6HBcWztN9QfiMkH++ZiKk4ERhg9d2LYWlze478uTU5Fyo/JQYcp+McpjtjpR9QIrr0g==
-  dependencies:
-    "@sentry/types" "6.2.1"
-    tslib "^1.9.3"
 
 "@sentry/webpack-plugin@^1.14.1":
   version "1.14.1"


### PR DESCRIPTION
Add a new tag `runtime` on the frontend with the value `browser` and the backend with the value `node`. 

Other minor changes:
- Some errors captured by the plugin are not actual errors and contain unuseful and/or misleading data. To avoid this, only actual errors are captured as exceptions, and the others are captured as messages.
- Remove unused `@sentry/minimal` package.
- Remove undefined args from `on-error-client` in the plugin.

The tags are added to help users identify where errors are happening, from a high-level perspective (frontend, `browser`; or backend, `node`).

`on-error-client`, in the plugin, only captures exceptions if the error is an actual `Error`. Some errors are launched with missing data (for example, no stack trace), and what users see in the issue is misleading. In those cases, instead of capturing the exception itself, what's being captured (as a message) is the error message, so that it still reaches the issue list but doesn't contain random data.