### PR TITLE
fix: Add SentryRequestType to RateLimitingCategory mapping

### DIFF
--- a/packages/browser/src/transports/base.ts
+++ b/packages/browser/src/transports/base.ts
@@ -9,6 +9,14 @@ import {
 } from '@sentry/types';
 import { logger, parseRetryAfterHeader, PromiseBuffer, SentryError } from '@sentry/utils';
 
+const CATEGORY_MAPPING: {
+  [key in SentryRequestType]: string;
+} = {
+  event: 'error',
+  transaction: 'transaction',
+  session: 'session',
+};
+
 /** Base Transport class implementation */
 export abstract class BaseTransport implements Transport {
   /**
@@ -80,15 +88,16 @@ export abstract class BaseTransport implements Transport {
   /**
    * Gets the time that given category is disabled until for rate limiting
    */
-  protected _disabledUntil(category: string): Date {
+  protected _disabledUntil(requestType: SentryRequestType): Date {
+    const category = CATEGORY_MAPPING[requestType];
     return this._rateLimits[category] || this._rateLimits.all;
   }
 
   /**
    * Checks if a category is rate limited
    */
-  protected _isRateLimited(category: string): boolean {
-    return this._disabledUntil(category) > new Date(Date.now());
+  protected _isRateLimited(requestType: SentryRequestType): boolean {
+    return this._disabledUntil(requestType) > new Date(Date.now());
   }
 
   /**

--- a/packages/browser/test/unit/transports/fetch.test.ts
+++ b/packages/browser/test/unit/transports/fetch.test.ts
@@ -290,7 +290,7 @@ describe('FetchTransport', () => {
           .returns(afterLimit);
 
         const headers = new Headers();
-        headers.set('X-Sentry-Rate-Limits', `${retryAfterSeconds}:event;transaction:scope`);
+        headers.set('X-Sentry-Rate-Limits', `${retryAfterSeconds}:error;transaction:scope`);
         fetch.returns(Promise.resolve({ status: 429, headers }));
 
         try {
@@ -366,7 +366,7 @@ describe('FetchTransport', () => {
           .returns(afterLimit);
 
         const headers = new Headers();
-        headers.set('X-Sentry-Rate-Limits', `${retryAfterSeconds}:event;transaction:scope`);
+        headers.set('X-Sentry-Rate-Limits', `${retryAfterSeconds}:error;transaction:scope`);
         fetch.returns(Promise.resolve({ status: 429, headers }));
 
         try {
@@ -433,7 +433,7 @@ describe('FetchTransport', () => {
           .returns(afterLimit);
 
         const headers = new Headers();
-        headers.set('X-Sentry-Rate-Limits', `${retryAfterSeconds}:event;transaction:scope`);
+        headers.set('X-Sentry-Rate-Limits', `${retryAfterSeconds}:error;transaction:scope`);
         fetch.returns(Promise.resolve({ status: 200, headers }));
 
         let eventRes = await transport.sendEvent(eventPayload);

--- a/packages/browser/test/unit/transports/fetch.test.ts
+++ b/packages/browser/test/unit/transports/fetch.test.ts
@@ -223,7 +223,7 @@ describe('FetchTransport', () => {
           .returns(afterLimit);
 
         const headers = new Headers();
-        headers.set('X-Sentry-Rate-Limits', `${retryAfterSeconds}:event:scope`);
+        headers.set('X-Sentry-Rate-Limits', `${retryAfterSeconds}:error:scope`);
         fetch.returns(Promise.resolve({ status: 429, headers }));
 
         try {

--- a/packages/browser/test/unit/transports/xhr.test.ts
+++ b/packages/browser/test/unit/transports/xhr.test.ts
@@ -202,7 +202,7 @@ describe('XHRTransport', () => {
 
         server.respondWith('POST', storeUrl, [
           429,
-          { 'X-Sentry-Rate-Limits': `${retryAfterSeconds}:event;transaction:scope` },
+          { 'X-Sentry-Rate-Limits': `${retryAfterSeconds}:error;transaction:scope` },
           '',
         ]);
         server.respondWith('POST', envelopeUrl, [200, {}, '']);

--- a/packages/browser/test/unit/transports/xhr.test.ts
+++ b/packages/browser/test/unit/transports/xhr.test.ts
@@ -137,7 +137,7 @@ describe('XHRTransport', () => {
         const withinLimit = beforeLimit + (retryAfterSeconds / 2) * 1000;
         const afterLimit = beforeLimit + retryAfterSeconds * 1000;
 
-        server.respondWith('POST', storeUrl, [429, { 'X-Sentry-Rate-Limits': `${retryAfterSeconds}:event:scope` }, '']);
+        server.respondWith('POST', storeUrl, [429, { 'X-Sentry-Rate-Limits': `${retryAfterSeconds}:error:scope` }, '']);
         server.respondWith('POST', envelopeUrl, [200, {}, '']);
 
         const dateStub = stub(Date, 'now')
@@ -356,7 +356,7 @@ describe('XHRTransport', () => {
         const withinLimit = beforeLimit + (retryAfterSeconds / 2) * 1000;
         const afterLimit = beforeLimit + retryAfterSeconds * 1000;
 
-        server.respondWith('POST', storeUrl, [200, { 'X-Sentry-Rate-Limits': `${retryAfterSeconds}:event:scope` }, '']);
+        server.respondWith('POST', storeUrl, [200, { 'X-Sentry-Rate-Limits': `${retryAfterSeconds}:error:scope` }, '']);
 
         const dateStub = stub(Date, 'now')
           // 1st event - _isRateLimited - false


### PR DESCRIPTION
Fixes a limiting of error-based only events.