### PR TITLE
fix: Fallback to empty string if req.baseUrl is empty

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -124,9 +124,7 @@ function extractExpressTransactionName(
 
   let path = '';
   if (req.route) {
-    // if the mountpoint is `/`, req.baseUrl is '' (not undefined), so it's safe to include it here
-    // see https://github.com/expressjs/express/blob/508936853a6e311099c9985d4c11a4b1b8f6af07/test/req.baseUrl.js#L7
-    path = `${req.baseUrl}${req.route.path}`;
+    path = `${req.baseUrl || ''}${req.route.path}`;
   } else if (req.originalUrl || req.url) {
     path = stripUrlQueryAndFragment(req.originalUrl || req.url || '');
   }


### PR DESCRIPTION
This comment (and link with the test) provide time and time that it's false. Even today during some of my tests:

![image](https://user-images.githubusercontent.com/1523305/111304424-04286e00-8656-11eb-964b-c9d0245e53cc.png)
