### PR TITLE
fix(tracing): Pop transaction (or descendant) off scope when finished

### DIFF
--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -118,7 +118,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
     const currentScope = this._hub.getScope();
     const spanOnScope = currentScope?.getSpan();
     if (currentScope && spanOnScope?.transaction === this) {
-      currentScope!.setSpan(undefined);
+      currentScope.setSpan(undefined);
     }
 
     const transaction: Event = {

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -113,6 +113,14 @@ export class Transaction extends SpanClass implements TransactionInterface {
       }).endTimestamp;
     }
 
+    // if this transaction (or any of its descendants) is currently set on the scope, pop it off so that no future
+    // errors or spans get associated with it
+    const currentScope = this._hub.getScope();
+    const spanOnScope = currentScope?.getSpan();
+    if (currentScope && spanOnScope?.transaction === this) {
+      currentScope!.setSpan(undefined);
+    }
+
     const transaction: Event = {
       contexts: {
         trace: this.getTraceContext(),

--- a/packages/tracing/test/idletransaction.test.ts
+++ b/packages/tracing/test/idletransaction.test.ts
@@ -30,20 +30,9 @@ describe('IdleTransaction', () => {
       });
     });
 
-    it('removes sampled transaction from scope on finish if onScope is true', () => {
-      const transaction = new IdleTransaction({ name: 'foo' }, hub, 1000, true);
+    it('removes sampled transaction from scope on finish', () => {
+      const transaction = new IdleTransaction({ name: 'foo', sampled: true }, hub, 1000, true);
       transaction.initSpanRecorder(10);
-
-      transaction.finish();
-      jest.runAllTimers();
-
-      hub.configureScope(s => {
-        expect(s.getTransaction()).toBe(undefined);
-      });
-    });
-
-    it('removes unsampled transaction from scope on finish if onScope is true', () => {
-      const transaction = new IdleTransaction({ name: 'foo', sampled: false }, hub, 1000, true);
 
       transaction.finish();
       jest.runAllTimers();

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -382,3 +382,38 @@ describe('Span', () => {
     });
   });
 });
+
+// TODO pull this and other transaction-related tests into their own file
+describe('Transaction', () => {
+  it('pops finished transaction off of scope', () => {
+    const scope = new Scope();
+    const transaction = new Transaction({ name: 'dogpark' });
+    scope.setSpan(transaction);
+
+    expect(scope.getSpan()).toBe(transaction);
+    transaction.finish();
+    expect(scope.getSpan()).toBeUndefined;
+  });
+
+  it("pops finished transaction's descendant off of scope", () => {
+    const scope = new Scope();
+    const transaction = new Transaction({ name: 'dogpark' });
+    const childSpan = transaction.startChild();
+    scope.setSpan(childSpan);
+
+    expect(scope.getSpan()).toBe(childSpan);
+    transaction.finish();
+    expect(scope.getSpan()).toBeUndefined;
+  });
+
+  it('does not pop other transactions off of scope', () => {
+    const scope = new Scope();
+    const dogparkTransaction = new Transaction({ name: 'dogpark' });
+    const fetchBallTransaction = new Transaction({ name: 'FETCH /ball' });
+    scope.setSpan(fetchBallTransaction);
+
+    expect(scope.getSpan()).toBe(fetchBallTransaction);
+    dogparkTransaction.finish();
+    expect(scope.getSpan()).toBe(fetchBallTransaction);
+  });
+});


### PR DESCRIPTION
Currently, when a transaction on the scope is finished, we leave it on the scope. This is a problem because:

a) future error events can get associated with the finished transaction, even if they occur long after the transaction is closed
b) any code which checks for a transaction on the scope and creates a child span if it finds one will similarly be associating the closed transaction with events (in this case whatever created the span) which happen at a totally separate time.

This fixes the bug, so that when a transaction finishes, if it or any of its descendants is on the scope, it gets removed.