### PR TITLE
ref: Remove circular dependency in @sentry/node

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -3,17 +3,14 @@
 import { captureException, getCurrentHub, startTransaction, withScope } from '@sentry/core';
 import { extractTraceparentData, Span } from '@sentry/tracing';
 import { Event, ExtractedNodeRequestData, Transaction } from '@sentry/types';
-import { forget, isPlainObject, isString, logger, normalize, stripUrlQueryAndFragment } from '@sentry/utils';
+import { isPlainObject, isString, logger, normalize, stripUrlQueryAndFragment } from '@sentry/utils';
 import * as cookie from 'cookie';
 import * as domain from 'domain';
 import * as http from 'http';
 import * as os from 'os';
 import * as url from 'url';
 
-import { NodeClient } from './client';
 import { flush } from './sdk';
-
-const DEFAULT_SHUTDOWN_TIMEOUT = 2000;
 
 export interface ExpressRequest {
   baseUrl?: string;
@@ -472,33 +469,4 @@ export function errorHandler(options?: {
 
     next(error);
   };
-}
-
-/**
- * @hidden
- */
-export function logAndExitProcess(error: Error): void {
-  // eslint-disable-next-line no-console
-  console.error(error && error.stack ? error.stack : error);
-
-  const client = getCurrentHub().getClient<NodeClient>();
-
-  if (client === undefined) {
-    logger.warn('No NodeClient was defined, we are exiting the process now.');
-    global.process.exit(1);
-    return;
-  }
-
-  const options = client.getOptions();
-  const timeout =
-    (options && options.shutdownTimeout && options.shutdownTimeout > 0 && options.shutdownTimeout) ||
-    DEFAULT_SHUTDOWN_TIMEOUT;
-  forget(
-    client.close(timeout).then((result: boolean) => {
-      if (!result) {
-        logger.warn('We reached the timeout for emptying the request buffer, still exiting now!');
-      }
-      global.process.exit(1);
-    }),
-  );
 }

--- a/packages/node/src/integrations/onuncaughtexception.ts
+++ b/packages/node/src/integrations/onuncaughtexception.ts
@@ -3,7 +3,7 @@ import { Integration, Severity } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import { NodeClient } from '../client';
-import { logAndExitProcess } from '../handlers';
+import { logAndExitProcess } from './utils/errorhandling';
 
 /** Global Promise Rejection handler */
 export class OnUncaughtException implements Integration {

--- a/packages/node/src/integrations/onunhandledrejection.ts
+++ b/packages/node/src/integrations/onunhandledrejection.ts
@@ -2,7 +2,7 @@ import { getCurrentHub, Scope } from '@sentry/core';
 import { Integration } from '@sentry/types';
 import { consoleSandbox } from '@sentry/utils';
 
-import { logAndExitProcess } from '../handlers';
+import { logAndExitProcess } from './utils/errorhandling';
 
 type UnhandledRejectionMode = 'none' | 'warn' | 'strict';
 

--- a/packages/node/src/integrations/utils/errorhandling.ts
+++ b/packages/node/src/integrations/utils/errorhandling.ts
@@ -1,0 +1,35 @@
+import { getCurrentHub } from '@sentry/core';
+import { forget, logger } from '@sentry/utils';
+
+import { NodeClient } from '../../client';
+
+const DEFAULT_SHUTDOWN_TIMEOUT = 2000;
+
+/**
+ * @hidden
+ */
+export function logAndExitProcess(error: Error): void {
+  // eslint-disable-next-line no-console
+  console.error(error && error.stack ? error.stack : error);
+
+  const client = getCurrentHub().getClient<NodeClient>();
+
+  if (client === undefined) {
+    logger.warn('No NodeClient was defined, we are exiting the process now.');
+    global.process.exit(1);
+    return;
+  }
+
+  const options = client.getOptions();
+  const timeout =
+    (options && options.shutdownTimeout && options.shutdownTimeout > 0 && options.shutdownTimeout) ||
+    DEFAULT_SHUTDOWN_TIMEOUT;
+  forget(
+    client.close(timeout).then((result: boolean) => {
+      if (!result) {
+        logger.warn('We reached the timeout for emptying the request buffer, still exiting now!');
+      }
+      global.process.exit(1);
+    }),
+  );
+}


### PR DESCRIPTION
When rolluping code that uses sentry, I got a warning for circular references in `@sentry/node`. Here’s a summary of what references what:
```
File                                       Member                                       Exported from package as
------------------------------------------+--------------------------------------------+--------------------------------
src/sdk.ts                                 export const defaultIntegrations             defaultIntegrations
`src/integrations/index.ts                 export OnUncaughtException                   Integrations.OnUncaughtException
 `src/integrations/onuncaughtexception.ts  export class OnUncaughtException             Integrations.OnUncaughtException
  `src/handlers.ts                         export function logAndExitProcess (@hidden)  (Handlers.logAndExitProcess)
   
   src/handlers.ts                         export function requestHandler               Handlers.requestHandler
   `src/sdk.ts                             export async function flush                  flush
```

This could be resolved by extracting either `flush` or `logAndExitProcess` to a lower-level module. I opted to move `logAndExitProcess` because it is not public and because it seems neat that a function that is only called from `integrations` is placed inside that directory, not above it.