### PR TITLE
feat(tracing): Add user data to `tracestate` header

### DIFF
--- a/packages/core/test/lib/request.test.ts
+++ b/packages/core/test/lib/request.test.ts
@@ -28,7 +28,7 @@ describe('eventToSentryRequest', () => {
     environment: 'dogpark',
     event_id: '0908201304152013',
     release: 'off.leash.park',
-    user: { id: '1121', username: 'CharlieDog', ip_address: '11.21.20.12' },
+    user: { id: '1121', username: 'CharlieDog', ip_address: '11.21.20.12', segment: 'bigs' },
   };
 
   describe('error/message events', () => {
@@ -65,13 +65,15 @@ describe('eventToSentryRequest', () => {
           // computeTracestateValue({
           //   trace_id: '1231201211212012',
           //   environment: 'dogpark',
-          //   release: 'off.leash.park',
           //   public_key: 'dogsarebadatkeepingsecrets',
+          //   release: 'off.leash.park',
+          //   user: { id: '1121', segment: 'bigs' },
           // }),
           tracestate: {
             sentry:
-              'sentry=eyJ0cmFjZV9pZCI6IjEyMzEyMDEyMTEyMTIwMTIiLCJlbnZpcm9ubWVudCI6ImRvZ3BhcmsiLCJyZWxlYXNlIjoib2ZmLmxlYXNo' +
-              'LnBhcmsiLCJwdWJsaWNfa2V5IjoiZG9nc2FyZWJhZGF0a2VlcGluZ3NlY3JldHMifQ',
+              'sentry=eyJ0cmFjZV9pZCI6IjEyMzEyMDEyMTEyMTIwMTIiLCJlbnZpcm9ubWVudCI6ImRvZ3BhcmsiLCJwdWJsaWNfa2V5Ijo' +
+              'iZG9nc2FyZWJhZGF0a2VlcGluZ3NlY3JldHMiLCJyZWxlYXNlIjoib2ZmLmxlYXNoLnBhcmsiLCJ1c2VyIjp7ImlkIjoiMTEyM' +
+              'SIsInNlZ21lbnQiOiJiaWdzIn19',
           },
         },
         spans: [],
@@ -160,10 +162,11 @@ describe('eventToSentryRequest', () => {
 
           expect(envelope.envelopeHeader.trace).toBeDefined();
           expect(envelope.envelopeHeader.trace).toEqual({
+            trace_id: '1231201211212012',
             environment: 'dogpark',
             public_key: 'dogsarebadatkeepingsecrets',
             release: 'off.leash.park',
-            trace_id: '1231201211212012',
+            user: { id: '1121', segment: 'bigs' },
           });
         });
       });

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
-import { getCurrentHub } from '@sentry/hub';
-import { Hub, Primitive, Span as SpanInterface, SpanContext, TraceHeaders, Transaction } from '@sentry/types';
+import { getCurrentHub, Hub } from '@sentry/hub';
+import { Primitive, Span as SpanInterface, SpanContext, TraceHeaders, Transaction } from '@sentry/types';
 import { dropUndefinedKeys, logger, timestampWithMs, uuid4 } from '@sentry/utils';
 
 import { SpanStatus } from './spanstatus';
@@ -367,6 +367,7 @@ export class Span implements SpanInterface {
    */
   protected _getNewTracestate(hub: Hub = getCurrentHub()): string | undefined {
     const client = hub.getClient();
+    const { id: userId, segment: userSegment } = hub.getScope()?.getUser() || {};
     const dsn = client?.getDsn();
 
     if (!client || !dsn) {
@@ -385,6 +386,8 @@ export class Span implements SpanInterface {
       release,
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       publicKey: dsn.publicKey!,
+      userId,
+      userSegment,
     })}`;
   }
 

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -408,7 +408,7 @@ export class Span implements SpanInterface {
    * undefined if there is no client or no DSN.
    */
   private _toTracestate(): string | undefined {
-    // if this is an orphan span, crate a new tracestate value
+    // if this is an orphan span, create a new tracestate value
     const sentryTracestate = this.transaction?.metadata?.tracestate?.sentry || this._getNewTracestate();
     let thirdpartyTracestate = this.transaction?.metadata?.tracestate?.thirdparty;
 

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -365,7 +365,9 @@ export class Span implements SpanInterface {
    *
    * @returns The new Sentry tracestate entry, or undefined if there's no client or no dsn
    */
-  protected _getNewTracestate(hub: Hub = getCurrentHub()): string | undefined {
+  protected _getNewTracestate(): string | undefined {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    const hub = ((this.transaction as any)?._hub as Hub) || getCurrentHub();
     const client = hub.getClient();
     const { id: userId, segment: userSegment } = hub.getScope()?.getUser() || {};
     const dsn = client?.getDsn();

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -383,13 +383,12 @@ export class Span implements SpanInterface {
     // `dsn.publicKey` required and remove the `!`.
 
     return `sentry=${computeTracestateValue({
-      traceId: this.traceId,
+      trace_id: this.traceId,
       environment,
       release,
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      publicKey: dsn.publicKey!,
-      userId,
-      userSegment,
+      public_key: dsn.publicKey!,
+      user: { id: userId, segment: userSegment },
     })}`;
   }
 

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -40,11 +40,6 @@ export class Transaction extends SpanClass implements TransactionInterface {
     this._trimEnd = transactionContext.trimEnd;
     this._hub = hub || getCurrentHub();
 
-    // create a new sentry tracestate value if we didn't inherit one
-    if (!this.metadata.tracestate?.sentry) {
-      this.metadata.tracestate = { ...this.metadata.tracestate, sentry: this._getNewTracestate(this._hub) };
-    }
-
     // this is because transactions are also spans, and spans have a transaction pointer
     this.transaction = this;
   }
@@ -115,6 +110,11 @@ export class Transaction extends SpanClass implements TransactionInterface {
         }
         return prev;
       }).endTimestamp;
+    }
+
+    // ensure that we have a tracestate to attach to the envelope header
+    if (!this.metadata.tracestate?.sentry) {
+      this.metadata.tracestate = { ...this.metadata.tracestate, sentry: this._getNewTracestate() };
     }
 
     const transaction: Event = {

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -149,6 +149,8 @@ type SentryTracestateData = {
   environment: string | undefined | null;
   release: string | undefined | null;
   publicKey: string;
+  userId: string | undefined | null;
+  userSegment: string | undefined | null;
 };
 
 /**
@@ -159,9 +161,11 @@ type SentryTracestateData = {
  */
 export function computeTracestateValue(data: SentryTracestateData): string {
   // `JSON.stringify` will drop keys with undefined values, but not ones with null values, so this prevents
-  // `environment` and `release` from being dropped if they haven't been set by `Sentry.init`
+  // these values from being dropped if they haven't been set by `Sentry.init`
   data.environment = data.environment || null;
   data.release = data.release || null;
+  data.userId = data.userId || null;
+  data.userSegment = data.userSegment || null;
 
   // See https://www.w3.org/TR/trace-context/#tracestate-header-field-values
   // The spec for tracestate header values calls for a string of the form

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -144,13 +144,12 @@ export function secToMs(time: number): number {
 // so it can be used in manual instrumentation without necessitating a hard dependency on @sentry/utils
 export { stripUrlQueryAndFragment } from '@sentry/utils';
 
-export type SentryTracestateData = {
-  traceId: string;
+type SentryTracestateData = {
+  trace_id: string;
   environment: string | undefined | null;
   release: string | undefined | null;
-  publicKey: string;
-  userId: string | undefined | null;
-  userSegment: string | undefined | null;
+  public_key: string;
+  user: { id: string | undefined | null; segment: string | undefined | null };
 };
 
 /**
@@ -164,8 +163,8 @@ export function computeTracestateValue(data: SentryTracestateData): string {
   // these values from being dropped if they haven't been set by `Sentry.init`
   data.environment = data.environment || null;
   data.release = data.release || null;
-  data.userId = data.userId || null;
-  data.userSegment = data.userSegment || null;
+  data.user.id = data.user.id || null;
+  data.user.segment = data.user.segment || null;
 
   // See https://www.w3.org/TR/trace-context/#tracestate-header-field-values
   // The spec for tracestate header values calls for a string of the form

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -144,7 +144,7 @@ export function secToMs(time: number): number {
 // so it can be used in manual instrumentation without necessitating a hard dependency on @sentry/utils
 export { stripUrlQueryAndFragment } from '@sentry/utils';
 
-type SentryTracestateData = {
+export type SentryTracestateData = {
   traceId: string;
   environment: string | undefined | null;
   release: string | undefined | null;

--- a/packages/tracing/test/httpheaders.test.ts
+++ b/packages/tracing/test/httpheaders.test.ts
@@ -7,7 +7,7 @@ import { base64ToUnicode } from '@sentry/utils';
 
 import { Span } from '../src/span';
 import { Transaction } from '../src/transaction';
-import { computeTracestateValue, SentryTracestateData } from '../src/utils';
+import { computeTracestateValue } from '../src/utils';
 
 // TODO gather sentry-trace and tracestate tests here
 
@@ -169,11 +169,12 @@ describe('tracestate', () => {
         expect.assertions(2);
 
         const inheritedTracestate = `sentry=${computeTracestateValue({
-          traceId: '12312012090820131231201209082013',
+          trace_id: '12312012090820131231201209082013',
           environment: 'dogpark',
           release: 'off.leash.trail',
-          publicKey: 'dogsarebadatkeepingsecrets',
-        } as SentryTracestateData)}`;
+          public_key: 'dogsarebadatkeepingsecrets',
+          user: { id: undefined, segment: undefined },
+        })}`;
 
         const transaction = new Transaction(
           {
@@ -193,8 +194,8 @@ describe('tracestate', () => {
           const tracestateValue = (transaction as any)._toTracestate().replace('sentry=', '');
           const reinflatedTracestate = JSON.parse(base64ToUnicode(tracestateValue));
 
-          expect(reinflatedTracestate.userId).toBeNull();
-          expect(reinflatedTracestate.userSegment).toBeNull();
+          expect(reinflatedTracestate.user.id).toBeNull();
+          expect(reinflatedTracestate.user.segment).toBeNull();
         });
       });
 
@@ -214,8 +215,8 @@ describe('tracestate', () => {
           const tracestateValue = (transaction as any)._toTracestate().replace('sentry=', '');
           const reinflatedTracestate = JSON.parse(base64ToUnicode(tracestateValue));
 
-          expect(reinflatedTracestate.userId).toEqual('1121');
-          expect(reinflatedTracestate.userSegment).toEqual('bigs');
+          expect(reinflatedTracestate.user.id).toEqual('1121');
+          expect(reinflatedTracestate.user.segment).toEqual('bigs');
         });
       });
 
@@ -237,8 +238,8 @@ describe('tracestate', () => {
           const tracestateValue = (transaction as any)._toTracestate().replace('sentry=', '');
           const reinflatedTracestate = JSON.parse(base64ToUnicode(tracestateValue));
 
-          expect(reinflatedTracestate.userId).toBeNull();
-          expect(reinflatedTracestate.userSegment).toBeNull();
+          expect(reinflatedTracestate.user.id).toBeNull();
+          expect(reinflatedTracestate.user.segment).toBeNull();
         });
       });
     });

--- a/packages/tracing/test/httpheaders.test.ts
+++ b/packages/tracing/test/httpheaders.test.ts
@@ -1,0 +1,250 @@
+import * as sentryCore from '@sentry/core';
+import { API } from '@sentry/core';
+import { Hub } from '@sentry/hub';
+import { SentryRequest } from '@sentry/types';
+import * as utilsPackage from '@sentry/utils';
+import { base64ToUnicode } from '@sentry/utils';
+
+import { Span } from '../src/span';
+import { Transaction } from '../src/transaction';
+import { computeTracestateValue, SentryTracestateData } from '../src/utils';
+
+// TODO gather sentry-trace and tracestate tests here
+
+function parseEnvelopeRequest(request: SentryRequest): any {
+  const [envelopeHeaderString, itemHeaderString, eventString] = request.body.split('\n');
+
+  return {
+    envelopeHeader: JSON.parse(envelopeHeaderString),
+    itemHeader: JSON.parse(itemHeaderString),
+    event: JSON.parse(eventString),
+  };
+}
+
+describe('sentry-trace', () => {
+  // TODO gather relevant tests here
+});
+
+describe('tracestate', () => {
+  // grab these this way rather than importing them individually to get around TS's guards against instantiating
+  // abstract classes (using the real classes would create a circulr dependency)
+  const { BaseClient, BaseBackend } = sentryCore as any;
+
+  const dsn = 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012';
+  const environment = 'dogpark';
+  const release = 'off.leash.trail';
+  const hub = new Hub(
+    new BaseClient(BaseBackend, {
+      dsn,
+      environment,
+      release,
+    }),
+  );
+
+  describe('sentry tracestate', () => {
+    describe('lazy creation', () => {
+      const getNewTracestate = jest
+        .spyOn(Span.prototype as any, '_getNewTracestate')
+        .mockReturnValue('sentry=doGsaREgReaT');
+
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      afterAll(() => {
+        jest.restoreAllMocks();
+      });
+
+      describe('when creating a transaction', () => {
+        it('uses sentry tracestate passed to the transaction constructor rather than creating a new one', () => {
+          const transaction = new Transaction({
+            name: 'FETCH /ball',
+            metadata: { tracestate: { sentry: 'sentry=doGsaREgReaT' } },
+          });
+
+          expect(getNewTracestate).not.toHaveBeenCalled();
+          expect(transaction.metadata.tracestate?.sentry).toEqual('sentry=doGsaREgReaT');
+        });
+
+        it("doesn't create new sentry tracestate on transaction creation if none provided", () => {
+          const transaction = new Transaction({
+            name: 'FETCH /ball',
+          });
+
+          expect(transaction.metadata.tracestate?.sentry).toBeUndefined();
+          expect(getNewTracestate).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('when getting outgoing request headers', () => {
+        it('uses existing sentry tracestate when getting tracing headers rather than creating new one', () => {
+          const transaction = new Transaction({
+            name: 'FETCH /ball',
+            metadata: { tracestate: { sentry: 'sentry=doGsaREgReaT' } },
+          });
+
+          expect(transaction.getTraceHeaders().tracestate).toEqual('sentry=doGsaREgReaT');
+          expect(getNewTracestate).not.toHaveBeenCalled();
+        });
+
+        it('creates and stores new sentry tracestate when getting tracing headers if none exists', () => {
+          const transaction = new Transaction({
+            name: 'FETCH /ball',
+          });
+
+          expect(transaction.metadata.tracestate?.sentry).toBeUndefined();
+
+          transaction.getTraceHeaders();
+
+          expect(getNewTracestate).toHaveBeenCalled();
+          expect(transaction.metadata.tracestate?.sentry).toEqual('sentry=doGsaREgReaT');
+          expect(transaction.getTraceHeaders().tracestate).toEqual('sentry=doGsaREgReaT');
+        });
+      });
+
+      describe('when getting envelope headers', () => {
+        // In real life, `transaction.finish()` calls `captureEvent()`, which eventually calls `eventToSentryRequest()`,
+        // which in turn calls `base64ToUnicode`. Here we're short circuiting that process a little, to avoid having to
+        // mock out more of the intermediate pieces.
+        jest
+          .spyOn(utilsPackage, 'base64ToUnicode')
+          .mockImplementation(base64 =>
+            base64 === 'doGsaREgReaT' ? '{"all the":"right stuff here"}' : '{"nope nope nope":"wrong"}',
+          );
+        jest.spyOn(hub, 'captureEvent').mockImplementation(event => {
+          expect(event).toEqual(
+            expect.objectContaining({ debug_meta: { tracestate: { sentry: 'sentry=doGsaREgReaT' } } }),
+          );
+
+          const envelope = parseEnvelopeRequest(sentryCore.eventToSentryRequest(event, new API(dsn)));
+          expect(envelope.envelopeHeader).toEqual(
+            expect.objectContaining({ trace: { 'all the': 'right stuff here' } }),
+          );
+
+          // `captureEvent` normally returns the event id
+          return '11212012041520131231201209082013'; //
+        });
+
+        it('uses existing sentry tracestate in envelope headers rather than creating a new one', () => {
+          // one here, and two inside the `captureEvent` implementation above
+          expect.assertions(3);
+
+          const transaction = new Transaction(
+            {
+              name: 'FETCH /ball',
+              metadata: { tracestate: { sentry: 'sentry=doGsaREgReaT' } },
+              sampled: true,
+            },
+            hub,
+          );
+
+          transaction.finish();
+
+          expect(getNewTracestate).not.toHaveBeenCalled();
+        });
+
+        it('creates new sentry tracestate for envelope header if none exists', () => {
+          // two here, and two inside the `captureEvent` implementation above
+          expect.assertions(4);
+
+          const transaction = new Transaction(
+            {
+              name: 'FETCH /ball',
+              sampled: true,
+            },
+            hub,
+          );
+
+          expect(transaction.metadata.tracestate?.sentry).toBeUndefined();
+
+          transaction.finish();
+
+          expect(getNewTracestate).toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('mutibility', () => {
+      it("won't include data set after transaction is created if there's an inherited value", () => {
+        expect.assertions(2);
+
+        const inheritedTracestate = `sentry=${computeTracestateValue({
+          traceId: '12312012090820131231201209082013',
+          environment: 'dogpark',
+          release: 'off.leash.trail',
+          publicKey: 'dogsarebadatkeepingsecrets',
+        } as SentryTracestateData)}`;
+
+        const transaction = new Transaction(
+          {
+            name: 'FETCH /ball',
+            metadata: {
+              tracestate: {
+                sentry: inheritedTracestate,
+              },
+            },
+          },
+          hub,
+        );
+
+        hub.withScope(scope => {
+          scope.setUser({ id: '1121', username: 'CharlieDog', ip_address: '11.21.20.12', segment: 'bigs' });
+
+          const tracestateValue = (transaction as any)._toTracestate().replace('sentry=', '');
+          const reinflatedTracestate = JSON.parse(base64ToUnicode(tracestateValue));
+
+          expect(reinflatedTracestate.userId).toBeNull();
+          expect(reinflatedTracestate.userSegment).toBeNull();
+        });
+      });
+
+      it("will include data set after transaction is created if there's no inherited value and `getTraceHeaders` hasn't been called", () => {
+        expect.assertions(2);
+
+        const transaction = new Transaction(
+          {
+            name: 'FETCH /ball',
+          },
+          hub,
+        );
+
+        hub.withScope(scope => {
+          scope.setUser({ id: '1121', username: 'CharlieDog', ip_address: '11.21.20.12', segment: 'bigs' });
+
+          const tracestateValue = (transaction as any)._toTracestate().replace('sentry=', '');
+          const reinflatedTracestate = JSON.parse(base64ToUnicode(tracestateValue));
+
+          expect(reinflatedTracestate.userId).toEqual('1121');
+          expect(reinflatedTracestate.userSegment).toEqual('bigs');
+        });
+      });
+
+      it("won't include data set after first call to `getTraceHeaders`", () => {
+        expect.assertions(2);
+
+        const transaction = new Transaction(
+          {
+            name: 'FETCH /ball',
+          },
+          hub,
+        );
+
+        transaction.getTraceHeaders();
+
+        hub.withScope(scope => {
+          scope.setUser({ id: '1121', username: 'CharlieDog', ip_address: '11.21.20.12', segment: 'bigs' });
+
+          const tracestateValue = (transaction as any)._toTracestate().replace('sentry=', '');
+          const reinflatedTracestate = JSON.parse(base64ToUnicode(tracestateValue));
+
+          expect(reinflatedTracestate.userId).toBeNull();
+          expect(reinflatedTracestate.userSegment).toBeNull();
+        });
+      });
+    });
+  });
+
+  describe('third-party tracestate', () => {
+    // TODO gather relevant tests here
+  });
+});

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -110,7 +110,13 @@ describe('Span', () => {
     const traceId = '12312012123120121231201212312012';
     const user = { id: '1121', segment: 'bigs' };
 
-    const computedTracestate = `sentry=${computeTracestateValue({ traceId, environment, release, publicKey })}`;
+    const computedTracestate = `sentry=${computeTracestateValue({
+      trace_id: traceId,
+      environment,
+      release,
+      public_key: publicKey,
+      user,
+    })}`;
     const thirdpartyData = 'maisey=silly,charlie=goofy';
 
     const hub = new Hub(

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -108,6 +108,7 @@ describe('Span', () => {
     const release = 'off.leash.trail';
     const environment = 'dogpark';
     const traceId = '12312012123120121231201212312012';
+    const user = { id: '1121', segment: 'bigs' };
 
     const computedTracestate = `sentry=${computeTracestateValue({ traceId, environment, release, publicKey })}`;
     const thirdpartyData = 'maisey=silly,charlie=goofy';
@@ -120,6 +121,10 @@ describe('Span', () => {
         environment,
       }),
     );
+
+    hub.configureScope(scope => {
+      scope.setUser(user);
+    });
 
     test('no third-party data', () => {
       const transaction = new Transaction({ name: 'FETCH /ball', traceId }, hub);

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -64,6 +64,11 @@ export interface Transaction extends TransactionContext, Span {
   data: { [key: string]: any };
 
   /**
+   * Metadata about the transaction
+   */
+  metadata: TransactionMetadata;
+
+  /**
    * Set the name of the transaction
    */
   setName(name: string): void;

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -5,4 +5,5 @@ export interface User {
   ip_address?: string;
   email?: string;
   username?: string;
+  segment?: string;
 }


### PR DESCRIPTION
As the title says...

Specific things to note:

- User data is included as an object, with the keys `id` and `segment`. For now, the id is sent un-hashed (until we can figure out exactly how we want to handle hashing in a way which is repeatable across platforms).
- The sentry part of the `tracestate` header is now computed lazily, to increase the chances user data will make it in (since it often isn't know at transaction start time):
  - If a sentry `tracestate` value is passed in at transaction creation time, as when it's inherited, that value is used and no amount of setting user data (or any other data, for that matter) after the fact will affect it. (This is not a change.)
  - If no value is passed to the constructor, the property remains undefined until it's needed. (This is a change.)
  - The first time it might be needed is to be used in headers on an outgoing request. Therefore, `getTraceHeaders` is now a get-or-create method with respect to the sentry` tracestate` value. Once it's been set in that method once, it is immutable. (This is also a change.)
  - The second time it might be needed is for use in envelope headers for transaction events. If no sentry `tracestate` value is passed to the transaction constructor and no XHR requests are made during the transaction, the transaction will close without a sentry `tracestate` value. In this case, `transaction.finish` will compute the value as it's capturing the event. (This, too, is a change.)