### PR TITLE
ref(ember): Fix tests to be forward compatible with component changes

### DIFF
--- a/packages/ember/tests/acceptance/sentry-performance-test.js
+++ b/packages/ember/tests/acceptance/sentry-performance-test.js
@@ -23,7 +23,11 @@ function assertSentryCall(assert, callNumber, options) {
   }
   if (options.spans) {
     assert.deepEqual(
-      event.spans.map(s => `${s.op} | ${s.description}`),
+      event.spans.map(s => {
+        // Normalize span descriptions for internal components so tests work on either side of updated Ember versions
+        const normalizedDescription = s.description === 'component:-link-to' ? 'component:link-to' : s.description;
+        `${s.op} | ${normalizedDescription}`;
+      }),
       options.spans,
       `Has correct spans`,
     );

--- a/packages/ember/tests/acceptance/sentry-performance-test.js
+++ b/packages/ember/tests/acceptance/sentry-performance-test.js
@@ -26,7 +26,7 @@ function assertSentryCall(assert, callNumber, options) {
       event.spans.map(s => {
         // Normalize span descriptions for internal components so tests work on either side of updated Ember versions
         const normalizedDescription = s.description === 'component:-link-to' ? 'component:link-to' : s.description;
-        `${s.op} | ${normalizedDescription}`;
+        return `${s.op} | ${normalizedDescription}`;
       }),
       options.spans,
       `Has correct spans`,


### PR DESCRIPTION
### Summary
One of the frameworks provided components, link-to, had a change to it's internal name. It's not really relevant to the functionality of the test, so normalizing the description should work across the version changes.

This should reduce failures for Ember compatibility suite on master. 

