### PR TITLE
ref: Enable Next.js SDK in development with `enableInDev`

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -9,6 +9,7 @@
   "engines": {
     "node": ">=6"
   },
+  "main": "./esm/node.js",
   "module": "./esm/node.js",
   "browser": "./esm/react.js",
   "types": "./esm/react.d.ts",

--- a/packages/nextjs/src/node.ts
+++ b/packages/nextjs/src/node.ts
@@ -24,6 +24,9 @@ export function init(options: NextjsOptions): any {
     // eslint-disable-next-line no-console
     console.warn('[Sentry] Detected a non-production environment. Not initializing Sentry.');
     // eslint-disable-next-line no-console
-    console.warn('[Sentry] To use Sentry also in development set `dev: true` in the options.');
+    console.warn(
+      '[Sentry] To use Sentry in development set `enableInDev: true` in next.config.js -> ' +
+        '`module.exports.publicRuntimeConfig.sentry` and `module.exports.serverRuntimeConfig.sentry`',
+    );
   }
 }

--- a/packages/nextjs/src/react.ts
+++ b/packages/nextjs/src/react.ts
@@ -20,6 +20,9 @@ export function init(options: NextjsOptions): any {
     // eslint-disable-next-line no-console
     console.warn('[Sentry] Detected a non-production environment. Not initializing Sentry.');
     // eslint-disable-next-line no-console
-    console.warn('[Sentry] To use Sentry also in development set `dev: true` in the options.');
+    console.warn(
+      '[Sentry] To use Sentry in development set `enableInDev: true` in next.config.js -> ' +
+        '`module.exports.publicRuntimeConfig.sentry` and `module.exports.serverRuntimeConfig.sentry`',
+    );
   }
 }

--- a/packages/nextjs/src/utils/initDecider.ts
+++ b/packages/nextjs/src/utils/initDecider.ts
@@ -10,8 +10,8 @@ export class InitDecider {
   /**
    * Returns a boolean representing whether the NextJS SDK should be initialised.
    *
-   * The SDK should be initialised if the `dev` option is set to true.
-   * `dev` is optional, so if it isn't set or is set to false, the SDK will only
+   * The SDK should be initialised if the `enableInDev` option is set to true.
+   * `enableInDev` is optional, so if it isn't set or is set to false, the SDK will only
    * be initialised in a production environment.
    */
   public shouldInitSentry(): boolean {
@@ -22,10 +22,10 @@ export class InitDecider {
   }
 
   /**
-   * Returns true if the option `dev` is true, and false otherwise.
+   * Returns true if the option `enableInDev` is true, and false otherwise.
    */
   private _isEnabledInDev(): boolean {
-    return this._options.dev || false;
+    return this._options.enableInDev || false;
   }
 
   /**

--- a/packages/nextjs/src/utils/nextjsOptions.ts
+++ b/packages/nextjs/src/utils/nextjsOptions.ts
@@ -8,5 +8,5 @@ export interface NextjsOptions extends Options, BrowserOptions, NodeOptions {
    * non-production environments. By default, the SDK is only initialised in
    * production.
    */
-  dev?: boolean;
+  enableInDev?: boolean;
 }

--- a/packages/nextjs/test/initDecider.test.ts
+++ b/packages/nextjs/test/initDecider.test.ts
@@ -14,11 +14,11 @@ function getEmptyOptions(): NextjsOptions {
 }
 
 function getDevTrueOptions(): NextjsOptions {
-  return { dev: true };
+  return { enableInDev: true };
 }
 
 function getDevFalseOptions(): NextjsOptions {
-  return { dev: false };
+  return { enableInDev: false };
 }
 
 describe('decide initialization in development', () => {


### PR DESCRIPTION
The Next.js SDK is enabled by default in production environments. To enable it in other environments (such as in development), a flag must be enabled. Before, the flag was `dev`; now, it's `enableInDev`.