### PR TITLE
feat(nextjs): Add non-serializable browser config options

### DIFF
--- a/packages/nextjs/src/node.ts
+++ b/packages/nextjs/src/node.ts
@@ -27,3 +27,8 @@ export function init(options: NextjsOptions): any {
     console.warn('[Sentry] To use Sentry also in development set `dev: true` in the options.');
   }
 }
+
+/** Does nothing, added for compatibility reasons. */
+export function addBrowserConfig(_options: any): void {
+  // NOOP
+}

--- a/packages/nextjs/src/react.ts
+++ b/packages/nextjs/src/react.ts
@@ -3,16 +3,25 @@ import { configureScope, init as reactInit } from '@sentry/react';
 import { InitDecider } from './utils/initDecider';
 import { MetadataBuilder } from './utils/metadataBuilder';
 import { NextjsOptions } from './utils/nextjsOptions';
+import * as optionsHandler from './utils/optionsHandler';
 
 export * from '@sentry/react';
 
 /** Inits the Sentry NextJS SDK on the browser with the React SDK. */
-export function init(options: NextjsOptions): any {
+export function init(options: NextjsOptions): void {
   const metadataBuilder = new MetadataBuilder(options, ['nextjs', 'react']);
   metadataBuilder.addSdkMetadata();
   const initDecider = new InitDecider(options);
   if (initDecider.shouldInitSentry()) {
-    reactInit(options);
+    let allOptions = {};
+    if (optionsHandler.areAddedBrowserOptions()) {
+      allOptions = { ...options, ...optionsHandler.getBrowserOptions() };
+      optionsHandler.removeBrowserOptions();
+    } else {
+      allOptions = options;
+    }
+    reactInit(allOptions);
+
     configureScope(scope => {
       scope.setTag('runtime', 'browser');
     });
@@ -22,4 +31,9 @@ export function init(options: NextjsOptions): any {
     // eslint-disable-next-line no-console
     console.warn('[Sentry] To use Sentry also in development set `dev: true` in the options.');
   }
+}
+
+/** Adds the config that couldnt be added to the init. */
+export function addBrowserConfig(options: any): void {
+  optionsHandler.addBrowserOptions(options);
 }

--- a/packages/nextjs/src/utils/optionsHandler.ts
+++ b/packages/nextjs/src/utils/optionsHandler.ts
@@ -1,14 +1,6 @@
 declare global {
   interface Window {
     __SENTRY__: {
-      // Where actual SDK options are
-      hub: {
-        getClient: () => {
-          _backend: {
-            _options: unknown;
-          };
-        };
-      };
       // Where tmp options are
       // Options for Next.js SDK are defined before the SDK can be initialized,
       // so they are stored in a tmp global variable, where the SDK can take them.

--- a/packages/nextjs/src/utils/optionsHandler.ts
+++ b/packages/nextjs/src/utils/optionsHandler.ts
@@ -1,0 +1,61 @@
+declare global {
+  interface Window {
+    __SENTRY__: {
+      // Where actual SDK options are
+      hub: {
+        getClient: () => {
+          _backend: {
+            _options: unknown;
+          };
+        };
+      };
+      // Where tmp options are
+      // Options for Next.js SDK are defined before the SDK can be initialized,
+      // so they are stored in a tmp global variable, where the SDK can take them.
+      _tmp: {
+        nextjs: {
+          _options: {
+            browser: any;
+          };
+        };
+      };
+    };
+  }
+}
+
+/**
+ * Creates the required objects to store tmp data.
+ */
+function createTmpOptions(): void {
+  window.__SENTRY__._tmp = {
+    nextjs: {
+      _options: {
+        browser: {},
+      },
+    },
+  };
+}
+createTmpOptions();
+
+const SDK_TMP_OPTIONS = window.__SENTRY__._tmp.nextjs._options;
+SDK_TMP_OPTIONS.browser = {};
+
+/**
+ * Adds the given options to the browser options.
+ * Note that options are added (appended), not set (overwritten).
+ */
+export function addBrowserOptions(browserOptions: any): void {
+  SDK_TMP_OPTIONS.browser = { ...SDK_TMP_OPTIONS.browser, ...browserOptions };
+}
+
+export function removeBrowserOptions(): void {
+  SDK_TMP_OPTIONS.browser = {};
+}
+
+export function areAddedBrowserOptions(): boolean {
+  return Object.keys(SDK_TMP_OPTIONS.browser).length > 0;
+}
+
+export function getBrowserOptions(): any {
+  return SDK_TMP_OPTIONS.browser;
+}


### PR DESCRIPTION
Currently, serializable options are configured in `next.config.js` and there's no way to set non-serializable options. This PR adds the `addBrowserConfig` function to the SDK, which allows users to set non-serializable config options for the browser. 

The SDK is initialized at a later stage the user sets config options, but they need to be available when the SDK is initialized. The `optionsHandler`, managed by the public `addBrowserConfig` function, handles the temporary storage of the options, keeping them in the `__SENTRY__` object of the browser. When the SDK is being initialized, checks whether such options exist and retrieves them.