### PR TITLE
fix(nextjs): Fix ember tests on CI

### DIFF
--- a/packages/ember/tests/acceptance/sentry-performance-test.js
+++ b/packages/ember/tests/acceptance/sentry-performance-test.js
@@ -23,7 +23,11 @@ function assertSentryCall(assert, callNumber, options) {
   }
   if (options.spans) {
     assert.deepEqual(
-      event.spans.map(s => `${s.op} | ${s.description}`),
+      event.spans.map(s => {
+        // Normalize span descriptions for internal components so tests work on either side of updated Ember versions
+        const normalizedDescription = s.description === 'component:-link-to' ? 'component:link-to' : s.description;
+        return `${s.op} | ${normalizedDescription}`;
+      }),
       options.spans,
       `Has correct spans`,
     );


### PR DESCRIPTION
Ember tests are failing on CI. They've been fixed on master on https://github.com/getsentry/sentry-javascript/commit/defce6765dcca70d6874ff8f87d2160ad0808614, and this is the same fix for the Next.js branch.
