### PR TITLE
fix(dev): Use less popular ports for node manual testing

### DIFF
--- a/packages/node/test/manual/apm-transaction/main.js
+++ b/packages/node/test/manual/apm-transaction/main.js
@@ -105,8 +105,8 @@ app.get('/trace', async (_req, res, next) => {
 app.use(Tracing.finish());
 app.use(Sentry.Handlers.errorHandler());
 
-const server = app.listen(3000, () => {
-  http.get('http://localhost:3000/trace', res => {
+const server = app.listen(1231, () => {
+  http.get('http://localhost:1231/trace', res => {
     server.close();
   });
 });

--- a/packages/node/test/manual/express-scope-separation/start.js
+++ b/packages/node/test/manual/express-scope-separation/start.js
@@ -83,8 +83,8 @@ app.get('/baz', req => {
 
 app.use(Sentry.Handlers.errorHandler());
 
-app.listen(3000);
+app.listen(1121);
 
-http.get('http://localhost:3000/foo');
-http.get('http://localhost:3000/bar');
-http.get('http://localhost:3000/baz');
+http.get('http://localhost:1121/foo');
+http.get('http://localhost:1121/bar');
+http.get('http://localhost:1121/baz');

--- a/packages/node/test/manual/memory-leak/express-patient.js
+++ b/packages/node/test/manual/memory-leak/express-patient.js
@@ -146,7 +146,7 @@ app.use((err, req, res, next) => {
   return res.status(500).send('oh no there was an error: ' + err.message);
 });
 
-const server = app.listen(3000, () => {
-  process._rawDebug('patient is waiting to be poked on port 3000');
+const server = app.listen(5140, () => {
+  process._rawDebug('patient is waiting to be poked on port 5140');
   memwatch.gc();
 });


### PR DESCRIPTION
Port `3000` is the default port for (at minimum) Rails, Express, and Next.js. It's also the port we've been using in our scripts which do manual testing in the node SDK. This means if you're running a local server from any of the above, and try to run tests in the node SDK, it hangs (and with no error message, either, which is kind of annoying - see https://github.com/nodejs/node/issues/35937). 

This PR changes the port used by each of the manual test scripts to ones which hopefully are much less likely to already be in use locally.
