### PR TITLE
Add logger message on transaction finishing

### DIFF
--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -132,7 +132,8 @@ export class Transaction extends SpanClass implements TransactionInterface {
       logger.log('[Measurements] Adding measurements to transaction', JSON.stringify(this._measurements, undefined, 2));
       transaction.measurements = this._measurements;
     }
-    logger.log(`[Tracing] finishing ${this.op} transaction - ${this.name}`);
+
+    logger.log(`[Tracing] Finishing ${this.op} transaction: ${this.name}.`);
 
     return this._hub.captureEvent(transaction);
   }

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -132,6 +132,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
       logger.log('[Measurements] Adding measurements to transaction', JSON.stringify(this._measurements, undefined, 2));
       transaction.measurements = this._measurements;
     }
+    logger.log(`[Tracing] finishing ${this.op} transaction - ${this.name}`);
 
     return this._hub.captureEvent(transaction);
   }


### PR DESCRIPTION
For some incomprehensible reasons the Sentry logger didn't log the transaction finishing events, but this is very useful info for debugging! This PR adds the log record output on `transaction.finish()` event:
```
Sentry Logger [Log]: [Tracing] finishing <op> transaction - <name>
```
If there is any other way to log transaction finish events already exists, please describe.