### PR TITLE
Allow filtering Transactions in beforeSend callback function via separate option

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -482,7 +482,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    */
   protected _processEvent(event: Event, hint?: EventHint, scope?: Scope): PromiseLike<Event> {
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    const { beforeSend, sampleRate } = this.getOptions();
+    const { beforeSend, sampleRate, passTransactionsToBeforeSend } = this.getOptions();
 
     if (!this._isEnabled()) {
       return SyncPromise.reject(new SentryError('SDK not enabled, will not send event.'));
@@ -507,7 +507,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
         }
 
         const isInternalException = hint && hint.data && (hint.data as { __sentry__: boolean }).__sentry__ === true;
-        if (isInternalException || isTransaction || !beforeSend) {
+        if (isInternalException || (!passTransactionsToBeforeSend && isTransaction) || !beforeSend) {
           return prepared;
         }
 

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -118,6 +118,12 @@ export interface Options {
    */
   tracesSampleRate?: number;
 
+  /** Enable passing transactions to beforeSend callback.
+   *
+   * Without this option only exception events are passed, excluding regular transactions.
+   */
+  passTransactionsToBeforeSend?: boolean;
+
   /**
    * Set of metadata about the SDK that can be internally used to enhance envelopes and events,
    * and provide additional data about every request.


### PR DESCRIPTION
At now `beforeSend()` function accepts all events, excluding transactions, because of this line of code:
https://github.com/getsentry/sentry-javascript/blob/438ed91bd457f897da89c7728fd074bbef0a0ce1/packages/core/src/baseclient.ts#L510

But there are no reasons described why the Transactions are excluded, but they are sometimes very much needed to filter.

Because of there is no way to do this via core code, I make the PR that adds the new boolean option `passTransactionsToBeforeSend` to options, that enables passing Transactions to `beforeSend()` callback.

Please lookup it and give feedback if something done wrong, or the reasons why this feature is disabled and can't be enabled. Thanks!