### PR TITLE
fix(tracing): Remove undefined `tracestate` data rather than setting it to `null`

### DIFF
--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -378,6 +378,9 @@ export class Span implements SpanInterface {
 
     const { environment, release } = client.getOptions() || {};
 
+    // only define a `user` object if there's going to be something in it
+    const user = userId || userSegment ? { id: userId, segment: userSegment } : undefined;
+
     // TODO - the only reason we need the non-null assertion on `dsn.publicKey` (below) is because `dsn.publicKey` has
     // to be optional while we transition from `dsn.user` -> `dsn.publicKey`. Once `dsn.user` is removed, we can make
     // `dsn.publicKey` required and remove the `!`.
@@ -388,7 +391,7 @@ export class Span implements SpanInterface {
       release,
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       public_key: dsn.publicKey!,
-      user: { id: userId, segment: userSegment },
+      user,
     })}`;
   }
 

--- a/packages/tracing/test/httpheaders.test.ts
+++ b/packages/tracing/test/httpheaders.test.ts
@@ -166,14 +166,13 @@ describe('tracestate', () => {
 
     describe('mutibility', () => {
       it("won't include data set after transaction is created if there's an inherited value", () => {
-        expect.assertions(2);
+        expect.assertions(1);
 
         const inheritedTracestate = `sentry=${computeTracestateValue({
           trace_id: '12312012090820131231201209082013',
           environment: 'dogpark',
           release: 'off.leash.trail',
           public_key: 'dogsarebadatkeepingsecrets',
-          user: { id: undefined, segment: undefined },
         })}`;
 
         const transaction = new Transaction(
@@ -194,8 +193,7 @@ describe('tracestate', () => {
           const tracestateValue = (transaction as any)._toTracestate().replace('sentry=', '');
           const reinflatedTracestate = JSON.parse(base64ToUnicode(tracestateValue));
 
-          expect(reinflatedTracestate.user.id).toBeNull();
-          expect(reinflatedTracestate.user.segment).toBeNull();
+          expect(reinflatedTracestate.user).toBeUndefined();
         });
       });
 
@@ -221,7 +219,7 @@ describe('tracestate', () => {
       });
 
       it("won't include data set after first call to `getTraceHeaders`", () => {
-        expect.assertions(2);
+        expect.assertions(1);
 
         const transaction = new Transaction(
           {
@@ -238,8 +236,7 @@ describe('tracestate', () => {
           const tracestateValue = (transaction as any)._toTracestate().replace('sentry=', '');
           const reinflatedTracestate = JSON.parse(base64ToUnicode(tracestateValue));
 
-          expect(reinflatedTracestate.user.id).toBeNull();
-          expect(reinflatedTracestate.user.segment).toBeNull();
+          expect(reinflatedTracestate.user).toBeUndefined();
         });
       });
     });


### PR DESCRIPTION
The only two values guaranteed to be included in a transaction's `tracestate` are `trace_id` and `public_key`. The rest - `release`, `environment`, `user.id`, and `user.segment` - may or may not have values. Previously, any of these lacking a value were being set to `null` in the `tracestate` object. This changes it so the keys are removed instead.

The only snag I could foresee here is that if no user data is available, I've chosen to not send a `user` key at all, rather than sending `user: { }`. That means that on the relay end, asking for `user.id` will have to first include a check for `user`. If this is a problem, I can switch to sending an empty object.

NB: Currently this is a PR against another PR's branch, just so that only this PR's changes show up. Once that PR is merged, I'll rebase onto the main feature branch.
