### PR TITLE
fix: Wrap oldOnPopState.apply call in try/catch to prevent Firefox from crashing

### DIFF
--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -330,7 +330,14 @@ function instrumentHistory(): void {
       to,
     });
     if (oldOnPopState) {
-      return oldOnPopState.apply(this, args);
+      // Apparently this can throw in Firefox when incorrectly implemented plugin is installed.
+      // https://github.com/getsentry/sentry-javascript/issues/3344
+      // https://github.com/bugsnag/bugsnag-js/issues/469
+      try {
+        return oldOnPopState.apply(this, args);
+      } catch (_oO) {
+        // no-empty
+      }
     }
   };
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/3344

There's no clear root cause for this but has been reported in multiple places on GitHub.
Fix is very small, so we can safely include it here.