### PR TITLE
fix(@sentry/gatsby): Specify gatsby peer dep

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -30,7 +30,7 @@
     "@sentry/tracing": "6.2.5"
   },
   "peerDependencies": {
-    "gatsby": "*"
+    "gatsby": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "@sentry-internal/eslint-config-sdk": "6.2.5",


### PR DESCRIPTION
Hello, Gatsby maintainer here 👋 

While looking at the Gatsby plugin I noticed that the `peerDependency` on `gatsby` is set incorrectly. We're in the process of providing more helpful information on the `/plugins` page of our website and for that we need plugins to set their `peerDependencies` correctly/more specific.

At the moment you say that _any_ version (v3, v4, v5, v6, etc.) will work with this even when in between we'd introduce breaking changes.

Making it more explicit is the safer choice (in the future you'll be able to mark breaking changes with explicit version ranges) and will allow us to display the plugin as compatible to versions X, Y, Z.

Using Git blame I found this comment: https://github.com/getsentry/sentry-javascript/pull/2652#discussion_r436780853
The APIs the plugin uses are safe to use on v2 and v3 of Gatsby :)

Thanks!
