### PR TITLE
fix: Re-export all the things from @sentry/browser in @sentry/vue

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,23 +1,4 @@
-export {
-  addGlobalEventProcessor,
-  addBreadcrumb,
-  captureException,
-  captureEvent,
-  captureMessage,
-  configureScope,
-  getHubFromCarrier,
-  getCurrentHub,
-  Hub,
-  Scope,
-  setContext,
-  setExtra,
-  setExtras,
-  setTag,
-  setTags,
-  setUser,
-  startTransaction,
-  withScope,
-} from '@sentry/browser';
+export * from '@sentry/browser';
 
 export { init } from './sdk';
 export { vueRouterInstrumentation } from './vuerouter';


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/3383

We do this for `@sentry/angular` and `@sentry/react`. It was an obvious oversight.