### PR TITLE
fix(node): Generate a Sentry Release string from env if its not provided 

### DIFF
--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -93,7 +93,10 @@ export function init(options: NodeOptions = {}): void {
   }
 
   if (options.release === undefined) {
-    options.release = getSentryRelease();
+    const detectedRelease = getSentryRelease();
+    if (detectedRelease !== undefined) {
+      options.release = detectedRelease;
+    }
   }
 
   if (options.environment === undefined && process.env.SENTRY_ENVIRONMENT) {
@@ -148,7 +151,7 @@ export async function close(timeout?: number): Promise<boolean> {
 /**
  * A function that returns a Sentry release string dynamically from env variables
  */
-function getSentryRelease(): string {
+function getSentryRelease(): string | undefined {
   // Always read first as Sentry takes this as precedence
   if (process.env.SENTRY_RELEASE) {
     return process.env.SENTRY_RELEASE;
@@ -170,7 +173,6 @@ function getSentryRelease(): string {
     // Zeit (now known as Vercel)
     process.env.ZEIT_GITHUB_COMMIT_SHA ||
     process.env.ZEIT_GITLAB_COMMIT_SHA ||
-    process.env.ZEIT_BITBUCKET_COMMIT_SHA ||
-    ''
+    process.env.ZEIT_BITBUCKET_COMMIT_SHA
   );
 }

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -148,7 +148,7 @@ export async function close(timeout?: number): Promise<boolean> {
 /**
  * A function that returns a Sentry release string dynamically from env variables
  */
-export function getSentryRelease(): string {
+function getSentryRelease(): string {
   // Always read first as Sentry takes this as precedence
   if (process.env.SENTRY_RELEASE) {
     return process.env.SENTRY_RELEASE;

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -161,7 +161,6 @@ export function getSentryRelease(): string {
   }
 
   return (
-    // This supports the variable that sentry-webpack-plugin injects
     // GitHub Actions - https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
     process.env.GITHUB_SHA ||
     // Netlify - https://docs.netlify.com/configure-builds/environment-variables/#build-metadata

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -149,29 +149,29 @@ export async function close(timeout?: number): Promise<boolean> {
  * A function that returns a Sentry release string dynamically from env variables
  */
 export function getSentryRelease(): string {
-  // Fetches the variable that sentry-webpack-plugin injects
-  const global = getGlobalObject<Window>();
-  let globalSentryRelease = undefined;
-  if (global.SENTRY_RELEASE && global.SENTRY_RELEASE.id) {
-    globalSentryRelease = global.SENTRY_RELEASE.id;
+  // Always read first as Sentry takes this as precedence
+  if (process.env.SENTRY_RELEASE) {
+    return process.env.SENTRY_RELEASE;
   }
 
-  const sentryRelease = JSON.stringify(
-    // Always read first as Sentry takes this as precedence
-    process.env.SENTRY_RELEASE ||
-      // This supports the variable that sentry-webpack-plugin injects
-      globalSentryRelease ||
-      // GitHub Actions - https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
-      process.env.GITHUB_SHA ||
-      // Netlify - https://docs.netlify.com/configure-builds/environment-variables/#build-metadata
-      process.env.COMMIT_REF ||
-      // Vercel - https://vercel.com/docs/v2/build-step#system-environment-variables
-      process.env.VERCEL_GIT_COMMIT_SHA ||
-      // Zeit (now known as Vercel)
-      process.env.ZEIT_GITHUB_COMMIT_SHA ||
-      process.env.ZEIT_GITLAB_COMMIT_SHA ||
-      process.env.ZEIT_BITBUCKET_COMMIT_SHA ||
-      '',
+  // This supports the variable that sentry-webpack-plugin injects
+  const global = getGlobalObject();
+  if (global.SENTRY_RELEASE && global.SENTRY_RELEASE.id) {
+    return global.SENTRY_RELEASE.id;
+  }
+
+  return (
+    // This supports the variable that sentry-webpack-plugin injects
+    // GitHub Actions - https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
+    process.env.GITHUB_SHA ||
+    // Netlify - https://docs.netlify.com/configure-builds/environment-variables/#build-metadata
+    process.env.COMMIT_REF ||
+    // Vercel - https://vercel.com/docs/v2/build-step#system-environment-variables
+    process.env.VERCEL_GIT_COMMIT_SHA ||
+    // Zeit (now known as Vercel)
+    process.env.ZEIT_GITHUB_COMMIT_SHA ||
+    process.env.ZEIT_GITLAB_COMMIT_SHA ||
+    process.env.ZEIT_BITBUCKET_COMMIT_SHA ||
+    ''
   );
-  return sentryRelease;
 }

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -281,7 +281,7 @@ describe('SentryNode initialization', () => {
   test('initialization proceeds as normal if global.SENTRY_RELEASE is not set', () => {
     // This is mostly a happy-path test to ensure that the initialization doesn't throw an error.
     init({ dsn });
-    expect(global.__SENTRY__.hub._stack[0].client.getOptions().release).toEqual('');
+    expect(global.__SENTRY__.hub._stack[0].client.getOptions().release).toBeUndefined();
   });
 
   describe('SDK metadata', () => {

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -278,11 +278,6 @@ describe('SentryNode initialization', () => {
     // Unsure if this is needed under jest.
     global.SENTRY_RELEASE = undefined;
   });
-  test('initialization proceeds as normal if global.SENTRY_RELEASE is not set', () => {
-    // This is mostly a happy-path test to ensure that the initialization doesn't throw an error.
-    init({ dsn });
-    expect(global.__SENTRY__.hub._stack[0].client.getOptions().release).toBeUndefined();
-  });
 
   describe('SDK metadata', () => {
     it('should set SDK data when Sentry.init() is called', () => {

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -281,7 +281,7 @@ describe('SentryNode initialization', () => {
   test('initialization proceeds as normal if global.SENTRY_RELEASE is not set', () => {
     // This is mostly a happy-path test to ensure that the initialization doesn't throw an error.
     init({ dsn });
-    expect(global.__SENTRY__.hub._stack[0].client.getOptions().release).toBeUndefined();
+    expect(global.__SENTRY__.hub._stack[0].client.getOptions().release).toEqual('');
   });
 
   describe('SDK metadata', () => {


### PR DESCRIPTION
This PR:
- Generates a Sentry Release string from env variables dynamically if its not provided on init