### PR TITLE
fix(node/browser): Stringify options release if release is passed as an object rather than a string

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -152,8 +152,8 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    * @inheritDoc
    */
   public captureSession(session: Session): void {
-    if (!session.release) {
-      logger.warn('Discarded session because of missing release');
+    if (!(typeof session.release === 'string')) {
+      logger.warn('Discarded session because of missing or non-string release');
     } else {
       this._sendSession(session);
       // After sending, we set init false to inidcate it's not the first occurence


### PR DESCRIPTION
This PR fixes:
- Sending release as an object to the Server when release is set on SDK initialisation as an object. 

Expected Behaviour:
- Release should be sent to the server as a string 

Ref:
https://sentry.my.sentry.io/organizations/sentry/issues/286540/events/769bff308563499d8f807b67e787faf2/?project=4

