### PR TITLE
fix: Replace performance.timeOrigin in favour of browserPerformanceTimeOrigin

### DIFF
--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -5,7 +5,7 @@ import * as Sentry from '@sentry/browser';
 import { Span, Transaction, Integration } from '@sentry/types';
 import { EmberRunQueues } from '@ember/runloop/-private/types';
 import { getActiveTransaction } from '..';
-import { timestampWithMs } from '@sentry/utils';
+import { browserPerformanceTimeOrigin, timestampWithMs } from '@sentry/utils';
 import { macroCondition, isTesting, getOwnConfig } from '@embroider/macros';
 import { EmberSentryConfig, OwnConfig } from '../types';
 
@@ -299,7 +299,7 @@ function _instrumentInitialLoad(config: EmberSentryConfig) {
 
   // Split performance check in two so clearMarks still happens even if timeOrigin isn't available.
   const HAS_PERFORMANCE_TIMING =
-    performance.measure && performance.getEntriesByName && performance.timeOrigin !== undefined;
+    performance.measure && performance.getEntriesByName && browserPerformanceTimeOrigin !== undefined;
   if (!HAS_PERFORMANCE_TIMING) {
     return;
   }
@@ -309,7 +309,7 @@ function _instrumentInitialLoad(config: EmberSentryConfig) {
   const measures = performance.getEntriesByName(measureName);
   const measure = measures[0];
 
-  const startTimestamp = (measure.startTime + performance.timeOrigin) / 1000;
+  const startTimestamp = (measure.startTime + browserPerformanceTimeOrigin!) / 1000;
   const endTimestamp = startTimestamp + measure.duration / 1000;
 
   const transaction = getActiveTransaction();

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -236,11 +236,13 @@ export class MetricsInstrumentation {
         return;
       }
 
-      const timeOrigin = msToSec(performance.timeOrigin);
       const startTime = msToSec(entry.startTime as number);
       logger.log('[Measurements] Adding LCP');
       this._measurements['lcp'] = { value: metric.value };
-      this._measurements['mark.lcp'] = { value: timeOrigin + startTime };
+      if (browserPerformanceTimeOrigin !== undefined) {
+        const timeOrigin = msToSec(browserPerformanceTimeOrigin);
+        this._measurements['mark.lcp'] = { value: timeOrigin + startTime };
+      }
     });
   }
 
@@ -253,11 +255,13 @@ export class MetricsInstrumentation {
         return;
       }
 
-      const timeOrigin = msToSec(performance.timeOrigin);
       const startTime = msToSec(entry.startTime as number);
       logger.log('[Measurements] Adding FID');
       this._measurements['fid'] = { value: metric.value };
-      this._measurements['mark.fid'] = { value: timeOrigin + startTime };
+      if (browserPerformanceTimeOrigin !== undefined) {
+        const timeOrigin = msToSec(browserPerformanceTimeOrigin);
+        this._measurements['mark.fid'] = { value: timeOrigin + startTime };
+      }
     });
   }
 

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -236,13 +236,11 @@ export class MetricsInstrumentation {
         return;
       }
 
+      const timeOrigin = msToSec(browserPerformanceTimeOrigin as number);
       const startTime = msToSec(entry.startTime as number);
       logger.log('[Measurements] Adding LCP');
       this._measurements['lcp'] = { value: metric.value };
-      if (browserPerformanceTimeOrigin !== undefined) {
-        const timeOrigin = msToSec(browserPerformanceTimeOrigin);
-        this._measurements['mark.lcp'] = { value: timeOrigin + startTime };
-      }
+      this._measurements['mark.lcp'] = { value: timeOrigin + startTime };
     });
   }
 
@@ -255,13 +253,11 @@ export class MetricsInstrumentation {
         return;
       }
 
+      const timeOrigin = msToSec(browserPerformanceTimeOrigin as number);
       const startTime = msToSec(entry.startTime as number);
       logger.log('[Measurements] Adding FID');
       this._measurements['fid'] = { value: metric.value };
-      if (browserPerformanceTimeOrigin !== undefined) {
-        const timeOrigin = msToSec(browserPerformanceTimeOrigin);
-        this._measurements['mark.fid'] = { value: timeOrigin + startTime };
-      }
+      this._measurements['mark.fid'] = { value: timeOrigin + startTime };
     });
   }
 


### PR DESCRIPTION
Use `browserPerformanceTimeOrigin` in favour of `performance.timeOrigin` when generating timestamps for the LCP and FID web vitals.