### PR TITLE
fix: Use the more reliable timeOrigin

### DIFF
--- a/packages/utils/src/time.ts
+++ b/packages/utils/src/time.ts
@@ -165,9 +165,7 @@ export const browserPerformanceTimeOrigin = ((): number | undefined => {
   const navigationStart = performance.timing && performance.timing.navigationStart;
   const hasNavigationStart = typeof navigationStart === 'number';
   // if navigationStart isn't available set delta to threshold so it isn't used
-  const navigationStartDelta = hasNavigationStart
-    ? Math.abs(navigationStart + performanceNow - dateNow)
-    : threshold;
+  const navigationStartDelta = hasNavigationStart ? Math.abs(navigationStart + performanceNow - dateNow) : threshold;
   const navigationStartIsReliable = navigationStartDelta < threshold;
 
   if (timeOriginIsReliable || navigationStartIsReliable) {

--- a/packages/utils/src/time.ts
+++ b/packages/utils/src/time.ts
@@ -147,10 +147,12 @@ export const browserPerformanceTimeOrigin = ((): number | undefined => {
   }
 
   const threshold = 3600 * 1000;
+  const performanceNow = performance.now();
+  const dateNow = Date.now();
 
   // if timeOrigin isn't available set delta to threshold so it isn't used
   const timeOriginDelta = performance.timeOrigin
-    ? Math.abs(performance.timeOrigin + performance.now() - Date.now())
+    ? Math.abs(performance.timeOrigin + performanceNow - dateNow)
     : threshold;
   const timeOriginIsReliable = timeOriginDelta < threshold;
 
@@ -164,7 +166,7 @@ export const browserPerformanceTimeOrigin = ((): number | undefined => {
   const hasNavigationStart = typeof navigationStart === 'number';
   // if navigationStart isn't available set delta to threshold so it isn't used
   const navigationStartDelta = hasNavigationStart
-    ? Math.abs(navigationStart + performance.now() - Date.now())
+    ? Math.abs(navigationStart + performanceNow - dateNow)
     : threshold;
   const navigationStartIsReliable = navigationStartDelta < threshold;
 
@@ -181,5 +183,5 @@ export const browserPerformanceTimeOrigin = ((): number | undefined => {
 
   // Either both timeOrigin and navigationStart are skewed or neither is available, fallback to Date.
   _browserPerformanceTimeOriginMode = 'dateNow';
-  return Date.now();
+  return dateNow;
 })();


### PR DESCRIPTION
- We want to still avoid using date.now() if possible, but this way if
  either or both performance apis are reliable, we use the more reliable
  one instead of still defaulting to timeOrigin

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
