### PR TITLE
build(nextjs): Remove Wizard

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -21,8 +21,7 @@
     "@sentry/next-plugin-sentry": "6.2.1",
     "@sentry/node": "6.2.5",
     "@sentry/react": "6.2.5",
-    "@sentry/webpack-plugin": "^1.14.1",
-    "@sentry/wizard": "^1.2.3"
+    "@sentry/webpack-plugin": "^1.14.1"
   },
   "devDependencies": {
     "@sentry/types": "6.2.5",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -21,7 +21,7 @@
     "@sentry/next-plugin-sentry": "6.2.1",
     "@sentry/node": "6.2.5",
     "@sentry/react": "6.2.5",
-    "@sentry/webpack-plugin": "^1.14.1"
+    "@sentry/webpack-plugin": "1.15.0"
   },
   "devDependencies": {
     "@sentry/types": "6.2.5",


### PR DESCRIPTION
The Wizard is only supposed to be executed once, to configure a Next.js app to use Sentry. Users who want to use it will find the package useless after setting up their projects (but consuming space); and those who don't want to, from the very beginning. Thus, removing the package as an SDK dependency is beneficial for everyone.

> By default, npx will check whether \<command\> exists in $PATH, or in the local project binaries, and execute that. If \<command\> is not found, it will be installed prior to execution.

From [`npx` description](https://www.npmjs.com/package/npx#description). Removing the Wizard will still allow users who want to use it actually use it (not anymore with `yarn`, though).

What does it change?

- Smaller SDK size.
- Executing the package (if it isn't already installed, which is supposed it isn't) will take longer since it has to be installed first.

Conclusion: taking a few more seconds for users to set up their projects is more beneficial than having the Wizard installed without using it.

The [Webpack plugin](https://github.com/getsentry/sentry-webpack-plugin) has also been updated to the latest version, `1.15.0`.