### PR TITLE
test: Replace Authorization with Accept header

### DIFF
--- a/packages/browser/test/unit/transports/fetch.test.ts
+++ b/packages/browser/test/unit/transports/fetch.test.ts
@@ -87,7 +87,7 @@ describe('FetchTransport', () => {
         {
           dsn: testDsn,
           headers: {
-            Authorization: 'Basic GVzdDp0ZXN0Cg==',
+            Accept: 'application/json',
           },
         },
         window.fetch,
@@ -103,7 +103,7 @@ describe('FetchTransport', () => {
         fetch.calledWith(storeUrl, {
           body: JSON.stringify(eventPayload),
           headers: {
-            Authorization: 'Basic GVzdDp0ZXN0Cg==',
+            Accept: 'application/json',
           },
           method: 'POST',
           referrerPolicy: 'origin',

--- a/packages/browser/test/unit/transports/xhr.test.ts
+++ b/packages/browser/test/unit/transports/xhr.test.ts
@@ -64,7 +64,7 @@ describe('XHRTransport', () => {
       transport = new Transports.XHRTransport({
         dsn: testDsn,
         headers: {
-          Authorization: 'Basic GVzdDp0ZXN0Cg==',
+          Accept: 'application/json',
         },
       });
 
@@ -74,8 +74,7 @@ describe('XHRTransport', () => {
 
       expect(res.status).equal(Status.Success);
       const requestHeaders: { [key: string]: string } = request.requestHeaders as { [key: string]: string };
-      const authHeaderLabel = 'Authorization';
-      expect(requestHeaders[authHeaderLabel]).equal('Basic GVzdDp0ZXN0Cg==');
+      expect(requestHeaders['Accept']).equal('application/json');
     });
 
     describe('Rate-limiting', () => {


### PR DESCRIPTION
The actual header doesn't matter for the test, so using something that
doesn't look like a leaked credential.

(see https://github.com/getsentry/sentry-javascript/pull/3400/checks?check_run_id=2355704679)