### PR TITLE
ref: Use esm imports with localforage and add esModuleInterop

### DIFF
--- a/packages/integrations/src/offline.ts
+++ b/packages/integrations/src/offline.ts
@@ -1,10 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Event, EventProcessor, Hub, Integration } from '@sentry/types';
 import { getGlobalObject, logger, normalize, uuid4 } from '@sentry/utils';
-import * as localForageType from 'localforage';
+import localForage from 'localforage';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const localForage = require('localforage');
 /**
  * cache offline errors and send when connected
  */
@@ -38,7 +36,7 @@ export class Offline implements Integration {
   /**
    * event cache
    */
-  public offlineEventStore: typeof localForageType; // type imported from localforage
+  public offlineEventStore: typeof localForage;
 
   /**
    * @inheritDoc

--- a/packages/integrations/tsconfig.build.json
+++ b/packages/integrations/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "declarationMap": false,
+    "esModuleInterop": true,
     "baseUrl": ".",
     "outDir": "dist",
     "types": ["node"]

--- a/packages/integrations/tsconfig.esm.json
+++ b/packages/integrations/tsconfig.esm.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.esm.json",
   "compilerOptions": {
     "declarationMap": false,
+    "esModuleInterop": true,
     "baseUrl": ".",
     "outDir": "esm",
     "types": ["node"]

--- a/packages/integrations/tsconfig.json
+++ b/packages/integrations/tsconfig.json
@@ -3,7 +3,6 @@
   "include": ["src/**/*.ts", "test/**/*.ts"],
   "exclude": ["dist"],
   "compilerOptions": {
-    "esModuleInterop": true,
     "declarationMap": false,
     "rootDir": ".",
     "types": ["node", "jest"]


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/pull/3101
Fixes https://github.com/getsentry/sentry-javascript/issues/3401
Closes https://github.com/getsentry/sentry-javascript/pull/3294

`esModuleInterop` is recommended by TS Team - https://www.typescriptlang.org/tsconfig#esModuleInterop and we already use it in other packages.