### PR TITLE
build: Make Sentry SDKs "Official"

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sentry/angular",
   "version": "6.2.5",
-  "description": "Offical Sentry SDK for Angular",
+  "description": "Official Sentry SDK for Angular",
   "repository": "git://github.com/getsentry/sentry-javascript.git",
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/angular",
   "author": "Sentry",

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sentry/ember",
   "version": "6.2.5",
-  "description": "Offical Sentry SDK for Ember.js",
+  "description": "Official Sentry SDK for Ember.js",
   "repository": "git://github.com/getsentry/sentry-javascript.git",
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/ember",
   "author": "Sentry",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sentry/gatsby",
   "version": "6.2.5",
-  "description": "Offical Sentry SDK for Gatsby.js",
+  "description": "Official Sentry SDK for Gatsby.js",
   "repository": "git://github.com/getsentry/sentry-javascript.git",
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/gatsby",
   "author": "Sentry",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sentry/react",
   "version": "6.2.5",
-  "description": "Offical Sentry SDK for React.js",
+  "description": "Official Sentry SDK for React.js",
   "repository": "git://github.com/getsentry/sentry-javascript.git",
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/react",
   "author": "Sentry",

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sentry/serverless",
   "version": "6.2.5",
-  "description": "Offical Sentry SDK for various serverless solutions",
+  "description": "Official Sentry SDK for various serverless solutions",
   "repository": "git://github.com/getsentry/sentry-javascript.git",
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/serverless",
   "author": "Sentry",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sentry/vue",
   "version": "6.2.5",
-  "description": "Offical Sentry SDK for Vue.js",
+  "description": "Official Sentry SDK for Vue.js",
   "repository": "git://github.com/getsentry/sentry-javascript.git",
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/vue",
   "author": "Sentry",


### PR DESCRIPTION
This fixes a typo in multiple `package.json` files.