### PR TITLE
ref: Change autoSessionTracking comment about its default state

### DIFF
--- a/packages/browser/src/backend.ts
+++ b/packages/browser/src/backend.ts
@@ -32,7 +32,7 @@ export interface BrowserOptions extends Options {
 
   /**
    * A flag enabling Sessions Tracking feature.
-   * By default Sessions Tracking is disabled.
+   * By default, Sessions Tracking is enabled.
    */
   autoSessionTracking?: boolean;
 }


### PR DESCRIPTION
`autoSessionTracking` is `enabled` by default, which makes the comment incorrect.