### PR TITLE
feat(integrations): add prefix support for RewriteFrames

### DIFF
--- a/packages/integrations/src/rewriteframes.ts
+++ b/packages/integrations/src/rewriteframes.ts
@@ -23,9 +23,17 @@ export class RewriteFrames implements Integration {
   /**
    * @inheritDoc
    */
-  public constructor(options: { root?: string; iteratee?: StackFrameIteratee } = {}) {
+  private readonly _prefix: string = 'app:///';
+
+  /**
+   * @inheritDoc
+   */
+  public constructor(options: { root?: string; prefix?: string; iteratee?: StackFrameIteratee } = {}) {
     if (options.root) {
       this._root = options.root;
+    }
+    if (options.prefix) {
+      this._prefix = options.prefix;
     }
     if (options.iteratee) {
       this._iteratee = options.iteratee;
@@ -75,7 +83,7 @@ export class RewriteFrames implements Integration {
             .replace(/\\/g, '/') // replace all `\\` instances with `/`
         : frame.filename;
       const base = this._root ? relative(this._root, filename) : basename(filename);
-      frame.filename = `app:///${base}`;
+      frame.filename = `${this._prefix}${base}`;
     }
     return frame;
   };

--- a/packages/integrations/test/rewriteframes.test.ts
+++ b/packages/integrations/test/rewriteframes.test.ts
@@ -78,12 +78,32 @@ describe('RewriteFrames', () => {
     });
   });
 
+  describe('default iteratee prepends custom prefix to basename if frame starts with `/`', () => {
+    beforeEach(() => {
+      rewriteFrames = new RewriteFrames({
+        prefix: 'foobar/',
+      });
+    });
+
+    it('transforms messageEvent frames', () => {
+      const event = rewriteFrames.process(messageEvent);
+      expect(event.stacktrace!.frames![0].filename).toEqual('foobar/file1.js');
+      expect(event.stacktrace!.frames![1].filename).toEqual('foobar/file2.js');
+    });
+
+    it('transforms exceptionEvent frames', () => {
+      const event = rewriteFrames.process(exceptionEvent);
+      expect(event.exception!.values![0].stacktrace!.frames![0].filename).toEqual('foobar/file1.js');
+      expect(event.exception!.values![0].stacktrace!.frames![1].filename).toEqual('foobar/file2.js');
+    });
+  });
+
   describe('default iteratee appends basename to `app:///` if frame starts with `C:\\`', () => {
     beforeEach(() => {
       rewriteFrames = new RewriteFrames();
     });
 
-    it('trasforms windowsExceptionEvent frames', () => {
+    it('transforms windowsExceptionEvent frames', () => {
       const event = rewriteFrames.process(windowsExceptionEvent);
       expect(event.exception!.values![0].stacktrace!.frames![0].filename).toEqual('app:///file1.js');
       expect(event.exception!.values![0].stacktrace!.frames![1].filename).toEqual('app:///file2.js');


### PR DESCRIPTION
Closes getsentry/sentry-javascript#3406

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [X] If you've added code that should be tested, please add tests.
- [X] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

As discussed in #3406, this PR allow the end user to specify a custom prefix that will be used by the default iteratee. If the user do not pass a prefix, it falls back to `app:///` (current behavior); thus this is not a breaking change.

Example:

```typescript
const rewriteFrames = new RewriteFrames({
  prefix: '@foobar/',
});

// /www/src/app/file1.js will be mapped to @foobar/file1.js
```

Additional tests were written in `packages/integrations/test/rewriteframes.test.ts`.
