### PR TITLE
ref(nextjs): Move config code to SDK and fix `next` version bug

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -22,6 +22,7 @@
     "@sentry/next-plugin-sentry": "6.2.5",
     "@sentry/node": "6.2.5",
     "@sentry/react": "6.2.5",
+    "@sentry/utils": "6.2.5",
     "@sentry/webpack-plugin": "1.15.0"
   },
   "devDependencies": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -9,6 +9,7 @@
   "engines": {
     "node": ">=6"
   },
+  "main": "./dist/index.server.js",
   "module": "./esm/index.server.js",
   "browser": "./esm/index.client.js",
   "types": "./esm/index.client.d.ts",
@@ -31,8 +32,10 @@
   "scripts": {
     "build": "run-p build:esm",
     "build:esm": "tsc -p tsconfig.esm.json",
-    "build:watch": "run-p build:watch:esm",
+    "build:es5": "tsc -p tsconfig.build.json",
+    "build:watch": "run-p build:watch:esm build:watch:es5",
     "build:watch:esm": "tsc -p tsconfig.esm.json -w --preserveWatchOutput",
+    "build:watch:es5": "tsc -p tsconfig.build.json -w --preserveWatchOutput",
     "clean": "rimraf dist esm coverage *.js *.js.map *.d.ts",
     "link:yarn": "yarn link",
     "lint": "run-s lint:prettier lint:eslint",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@sentry/types": "6.2.5",
+    "@types/webpack": "^5.28.0",
     "eslint": "7.20.0",
     "rimraf": "3.0.2"
   },

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -32,7 +32,7 @@
     "rimraf": "3.0.2"
   },
   "scripts": {
-    "build": "run-p build:esm",
+    "build": "run-p build:esm build:es5",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:es5": "tsc -p tsconfig.build.json",
     "build:watch": "run-p build:watch:esm build:watch:es5",

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -25,3 +25,5 @@ export function init(options: NextjsOptions): void {
     scope.setTag('runtime', 'node');
   });
 }
+
+export { withSentryConfig } from './utils/config';

--- a/packages/nextjs/src/utils/config.ts
+++ b/packages/nextjs/src/utils/config.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// import { version as nextVersion } from './node_modules/next/package.json';
+import { getSentryRelease } from '@sentry/node';
+import { logger } from '@sentry/utils';
+import defaultWebpackPlugin, { SentryCliPluginOptions } from '@sentry/webpack-plugin';
+import * as SentryWebpackPlugin from '@sentry/webpack-plugin';
+import * as fs from 'fs';
+
+/**
+ * Next requires that plugins be tagged with the same version number as the currently-running `next.js` package, so
+ * modify our `package.json` to trick it into thinking we comply. Run before the plugin is loaded at server startup.
+ */
+export function syncPluginVersionWithNextVersion(): void {
+  // TODO Once we get at least to TS 2.9, we can use `"resolveJsonModule": true` in our `compilerOptions` and we'll be
+  // able to do:
+  // import { version as nextVersion } from './node_modules/next/package.json';
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-member-access
+  const nextVersion = (require('../../../../next/package.json') as any).version;
+  if (!nextVersion) {
+    logger.error('[next-plugin-sentry] Cannot read next.js version. Plug-in will not work.');
+    return;
+  }
+
+  const pluginPackageDotJsonPath = `../../../next-plugin-sentry/package.json`;
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const pluginPackageDotJson = require(pluginPackageDotJsonPath); // see TODO above
+  if (!pluginPackageDotJson) {
+    logger.error(`[next-plugin-sentry] Cannot read ${pluginPackageDotJsonPath}. Plug-in will not work.`);
+    return;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  (pluginPackageDotJson as any).version = nextVersion;
+  // interestingly, the `require` calls above seem to resolve from a different starting point than `fs` does here, which
+  // is why we can't just use `pluginPackageDotJsonPath` again
+  fs.writeFileSync('./node_modules/@sentry/next-plugin-sentry/package.json', JSON.stringify(pluginPackageDotJson));
+}
+
+type WebpackConfig = { devtool: string; plugins: Array<{ [key: string]: any }> };
+type NextConfigExports = {
+  experimental?: { plugins: boolean };
+  plugins?: string[];
+  productionBrowserSourceMaps?: boolean;
+  webpack?: (config: WebpackConfig, { dev }: { dev: boolean }) => WebpackConfig;
+};
+
+export function withSentryConfig(
+  providedExports: NextConfigExports = {},
+  providedWebpackPluginOptions: Partial<SentryCliPluginOptions> = {},
+): NextConfigExports {
+  const defaultWebpackPluginOptions = {
+    release: getSentryRelease(),
+    url: process.env.SENTRY_URL,
+    org: process.env.SENTRY_ORG,
+    project: process.env.SENTRY_PROJECT,
+    authToken: process.env.SENTRY_AUTH_TOKEN,
+    configFile: 'sentry.properties',
+    stripPrefix: ['webpack://_N_E/'],
+    urlPrefix: `~/_next`,
+    include: '.next/',
+    ignore: ['node_modules', 'webpack.config.js'],
+  };
+  const webpackPluginOptionOverrides = Object.keys(defaultWebpackPluginOptions)
+    .concat('dryrun')
+    .map(key => key in Object.keys(providedWebpackPluginOptions));
+  if (webpackPluginOptionOverrides.length > 0) {
+    logger.warn(
+      '[next-plugin-sentry] You are overriding the following automatically-set SentryWebpackPlugin config options:\n' +
+        `\t${webpackPluginOptionOverrides.toString()},\n` +
+        "which has the possibility of breaking source map upload and application. This is only a good idea if you know what you're doing.",
+    );
+  }
+
+  return {
+    experimental: { plugins: true },
+    plugins: [...(providedExports.plugins || []), '@sentry/next-plugin-sentry'],
+    productionBrowserSourceMaps: true,
+    webpack: (config, { dev }) => {
+      if (!dev) {
+        // Ensure quality source maps in production. (Source maps aren't uploaded in dev, and besides, Next doesn't let
+        // you change this is dev even if you want to - see
+        // https://github.com/vercel/next.js/blob/master/errors/improper-devtool.md.)
+        config.devtool = 'source-map';
+      }
+      config.plugins.push(
+        // TODO it's not clear how to do this better, but there *must* be a better way
+        new ((SentryWebpackPlugin as unknown) as typeof defaultWebpackPlugin)({
+          dryRun: dev,
+          ...defaultWebpackPluginOptions,
+          ...providedWebpackPluginOptions,
+        }),
+      );
+      return config;
+    },
+  };
+}
+
+syncPluginVersionWithNextVersion();

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -40,7 +40,7 @@ export {
 
 export { NodeBackend, NodeOptions } from './backend';
 export { NodeClient } from './client';
-export { defaultIntegrations, init, lastEventId, flush, close } from './sdk';
+export { defaultIntegrations, init, lastEventId, flush, close, getSentryRelease } from './sdk';
 export { SDK_NAME } from './version';
 
 import { Integrations as CoreIntegrations } from '@sentry/core';

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -151,7 +151,7 @@ export async function close(timeout?: number): Promise<boolean> {
 /**
  * A function that returns a Sentry release string dynamically from env variables
  */
-function getSentryRelease(): string | undefined {
+export function getSentryRelease(): string | undefined {
   // Always read first as Sentry takes this as precedence
   if (process.env.SENTRY_RELEASE) {
     return process.env.SENTRY_RELEASE;
@@ -170,6 +170,9 @@ function getSentryRelease(): string | undefined {
     process.env.COMMIT_REF ||
     // Vercel - https://vercel.com/docs/v2/build-step#system-environment-variables
     process.env.VERCEL_GIT_COMMIT_SHA ||
+    process.env.VERCEL_GITHUB_COMMIT_SHA ||
+    process.env.VERCEL_GITLAB_COMMIT_SHA ||
+    process.env.VERCEL_BITBUCKET_COMMIT_SHA ||
     // Zeit (now known as Vercel)
     process.env.ZEIT_GITHUB_COMMIT_SHA ||
     process.env.ZEIT_GITLAB_COMMIT_SHA ||


### PR DESCRIPTION
Two changes here:

- Cramer reported running into trouble because he hadn't specified the `next` version in his project's `package.json` exactly, and as a result, the version we copy over to our plugin didn't match what `next` was expecting. (`'^10.1.3' didn't match ''10.1.3'`, and neither did `10.x`.) To avoid such problems, the version number we copy over is now drawn from the `version` value in `next`'s `package.json` rather than the `dependencies.next` value in the project's `package.json`.

- He also mentioned it would be nice to abstract away as much of the boilerplate config code as we could, and since this was something we as a team had already identified as something we'd like to do, I went ahead and did it. Also, in order for it to be possible to use SDK code in `next.config.js` (which is vanilla JS), it was necessary to add an ES5 build and a `main` entry in `package.json`. 

A word of caution when testing this - if you pull the branch and use your linked packages in a test app, it will fail, because the relative paths will anchor themselves in your repo rather than your test app. My solution has been to leave everything linked, and then `mv node_modules/@sentry node_modules/@sentry-linked && cp -r node_modules/@sentry-linked node_modules/@sentry`, which will create non-sym-linked versions of all of the packages. (Fun fact, using `Duplicate` in the Finder - I know, I know, it's sacrilege, but I got lazy - just gives you another set of sym-links, not a copy of those links' targets.)

This PR is in coordination with [this PR](https://github.com/getsentry/sentry-wizard/pull/102) in the wizard and [this commit](https://github.com/getsentry/sentry-docs/pull/3319/commits/06ac0bed2982b1b31a1715e4bbecf285fae2d118) in docs.