### PR TITLE
ref(nextjs): Use resolved paths for `require` calls in config code

### DIFF
--- a/packages/next-plugin-sentry/package.json
+++ b/packages/next-plugin-sentry/package.json
@@ -9,7 +9,7 @@
   "engines": {
     "node": ">=6"
   },
-  "main": "index.js",
+  "main": "./src/on-init-server.js",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/nextjs/src/utils/config.ts
+++ b/packages/nextjs/src/utils/config.ts
@@ -13,21 +13,28 @@ import * as path from 'path';
  *
  * @param startPath The location from which to start the search.
  * @param searchFile The file to search for
- * @returns The absolute path of the file, if it's found, or undefined if it's not.
+ * @returns The absolute path of the file, if it's found, or undefined if it's not
  */
 function findUp(startPath: string, searchFile: string): string | undefined {
   if (!fs.existsSync(startPath)) {
     throw new Error(`The given \`startPath\` value (${startPath}) does not exist.`);
   }
 
+  // if the last segment of `startPath` is a file, trim it off so that we start looking in its parent directory
   let currentDir = fs.statSync(startPath).isFile() ? path.dirname(startPath) : startPath;
-  while (currentDir !== '/') {
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
     const possiblePath = path.join(currentDir, searchFile);
     if (fs.existsSync(possiblePath)) {
       return possiblePath;
     }
 
-    currentDir = path.join(currentDir, '..');
+    const parentDir = path.resolve(currentDir, '..');
+    // this means we've gotten to the root
+    if (currentDir === parentDir) {
+      break;
+    }
+    currentDir = parentDir;
   }
 
   return undefined;


### PR DESCRIPTION
Currently, we use relative paths for the `require` calls in `syncPluginVersionWithNextVersion`. Though this works most of the time, it depends on the particular structure of the user's `node_modules` directory, which is mostly predictable but not guaranteed. This PR therefore switches to using a combination of `require.resolve` and a recursive search up the file hierarchy to find the `package.json` files we need.

Fixes https://github.com/getsentry/sentry-javascript/issues/3424.
Fixes https://github.com/getsentry/sentry-javascript/issues/3430.