### PR TITLE
fix(node): Fix for manual tests in node

### DIFF
--- a/packages/node/test/manual/apm-transaction/main.js
+++ b/packages/node/test/manual/apm-transaction/main.js
@@ -105,8 +105,9 @@ app.get('/trace', async (_req, res, next) => {
 app.use(Tracing.finish());
 app.use(Sentry.Handlers.errorHandler());
 
-const server = app.listen(1231, () => {
-  http.get('http://localhost:1231/trace', res => {
+const server = app.listen(0, () => {
+  const port = server.address().port;
+  http.get(`http://localhost:${port}/trace`, res => {
     server.close();
   });
 });

--- a/packages/node/test/manual/express-scope-separation/start.js
+++ b/packages/node/test/manual/express-scope-separation/start.js
@@ -18,6 +18,7 @@ class DummyTransport {
 
     if (!remaining) {
       console.error('SUCCESS: All scopes contain correct tags');
+      server.close();
       process.exit(0);
     }
 
@@ -83,8 +84,9 @@ app.get('/baz', req => {
 
 app.use(Sentry.Handlers.errorHandler());
 
-app.listen(1121);
-
-http.get('http://localhost:1121/foo');
-http.get('http://localhost:1121/bar');
-http.get('http://localhost:1121/baz');
+const server = app.listen(0, () => {
+  const port = server.address().port;
+  http.get(`http://localhost:${port}/foo`);
+  http.get(`http://localhost:${port}/bar`);
+  http.get(`http://localhost:${port}/baz`);
+});

--- a/packages/node/test/manual/memory-leak/express-patient.js
+++ b/packages/node/test/manual/memory-leak/express-patient.js
@@ -146,7 +146,8 @@ app.use((err, req, res, next) => {
   return res.status(500).send('oh no there was an error: ' + err.message);
 });
 
-const server = app.listen(5140, () => {
-  process._rawDebug('patient is waiting to be poked on port 5140');
+const server = app.listen(0, () => {
+  const port = server.address().port;
+  process._rawDebug(`patient is waiting to be poked on port ${port}`);
   memwatch.gc();
 });


### PR DESCRIPTION
This PR:
- Set port to 0 for servers in node manual tests so that an empty port is assigned rather then explicitly picking a port that might be taken.  
- Add explicit server close statement to ensure that server is closed
