### PR TITLE
ref: Add captureSession guard for startSessionTracking method

### DIFF
--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -189,23 +189,25 @@ function startSessionTracking(): void {
 
   const hub = getCurrentHub();
 
-  if ('startSession' in hub) {
-    // The only way for this to be false is for there to be a version mismatch between @sentry/browser (>= 6.0.0) and
-    // @sentry/hub (< 5.27.0). In the simple case, there won't ever be such a mismatch, because the two packages are
-    // pinned at the same version in package.json, but there are edge cases where it's possible'. See
-    // https://github.com/getsentry/sentry-javascript/issues/3234 and
-    // https://github.com/getsentry/sentry-javascript/issues/3207.
-
-    hub.startSession();
-    hub.captureSession();
-
-    // We want to create a session for every navigation as well
-    addInstrumentationHandler({
-      callback: () => {
-        hub.startSession();
-        hub.captureSession();
-      },
-      type: 'history',
-    });
+  // The only way for this to be false is for there to be a version mismatch between @sentry/browser (>= 6.0.0) and
+  // @sentry/hub (< 5.27.0). In the simple case, there won't ever be such a mismatch, because the two packages are
+  // pinned at the same version in package.json, but there are edge cases where it's possible'. See
+  // https://github.com/getsentry/sentry-javascript/issues/3207 and
+  // https://github.com/getsentry/sentry-javascript/issues/3234 and
+  // https://github.com/getsentry/sentry-javascript/issues/3278.
+  if (typeof hub.startSession !== 'function' || typeof hub.captureSession !== 'function') {
+    return;
   }
+
+  hub.startSession();
+  hub.captureSession();
+
+  // We want to create a session for every navigation as well
+  addInstrumentationHandler({
+    callback: () => {
+      hub.startSession();
+      hub.captureSession();
+    },
+    type: 'history',
+  });
 }

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -191,7 +191,7 @@ function startSessionTracking(): void {
 
   // The only way for this to be false is for there to be a version mismatch between @sentry/browser (>= 6.0.0) and
   // @sentry/hub (< 5.27.0). In the simple case, there won't ever be such a mismatch, because the two packages are
-  // pinned at the same version in package.json, but there are edge cases where it's possible'. See
+  // pinned at the same version in package.json, but there are edge cases where it's possible. See
   // https://github.com/getsentry/sentry-javascript/issues/3207 and
   // https://github.com/getsentry/sentry-javascript/issues/3234 and
   // https://github.com/getsentry/sentry-javascript/issues/3278.


### PR DESCRIPTION
I have no clue why or how it happens, but apparently, it somehow does. This should prevent it https://github.com/getsentry/sentry-javascript/issues/3278#issuecomment-817853471