### PR TITLE
fix(nextjs): Fix incomplete merging of user config with Sentry config

### DIFF
--- a/packages/nextjs/src/utils/config.ts
+++ b/packages/nextjs/src/utils/config.ts
@@ -77,7 +77,13 @@ export function withSentryConfig(
     experimental: { ...(providedExports.experimental || {}), plugins: true },
     plugins: [...(providedExports.plugins || []), '@sentry/next-plugin-sentry'],
     productionBrowserSourceMaps: true,
-    webpack: (config, options) => {
+    webpack: (originalConfig, options) => {
+      let config = originalConfig;
+
+      if (typeof providedExports.webpack === 'function') {
+        config = providedExports.webpack(originalConfig, options);
+      }
+
       if (!options.dev) {
         // Ensure quality source maps in production. (Source maps aren't uploaded in dev, and besides, Next doesn't let
         // you change this is dev even if you want to - see
@@ -92,10 +98,6 @@ export function withSentryConfig(
           ...providedWebpackPluginOptions,
         }),
       );
-
-      if (typeof providedExports.webpack === 'function') {
-        return providedExports.webpack(config, options);
-      }
 
       return config;
     },

--- a/packages/nextjs/src/utils/config.ts
+++ b/packages/nextjs/src/utils/config.ts
@@ -73,11 +73,12 @@ export function withSentryConfig(
   }
 
   return {
-    experimental: { plugins: true },
+    ...providedExports,
+    experimental: { ...(providedExports.experimental || {}), plugins: true },
     plugins: [...(providedExports.plugins || []), '@sentry/next-plugin-sentry'],
     productionBrowserSourceMaps: true,
-    webpack: (config, { dev }) => {
-      if (!dev) {
+    webpack: (config, options) => {
+      if (!options.dev) {
         // Ensure quality source maps in production. (Source maps aren't uploaded in dev, and besides, Next doesn't let
         // you change this is dev even if you want to - see
         // https://github.com/vercel/next.js/blob/master/errors/improper-devtool.md.)
@@ -86,11 +87,16 @@ export function withSentryConfig(
       config.plugins.push(
         // TODO it's not clear how to do this better, but there *must* be a better way
         new ((SentryWebpackPlugin as unknown) as typeof defaultWebpackPlugin)({
-          dryRun: dev,
+          dryRun: options.dev,
           ...defaultWebpackPluginOptions,
           ...providedWebpackPluginOptions,
         }),
       );
+
+      if (typeof providedExports.webpack === 'function') {
+        return providedExports.webpack(config, options);
+      }
+
       return config;
     },
   };


### PR DESCRIPTION
Unless I'm misunderstanding something, it looks to me like the recommended way to use the `withSentryConfig` method will override most of the users custom `next.config.js` setup.

```javascript
// This file sets a custom webpack configuration to use your Next.js app
// with Sentry.
// https://nextjs.org/docs/api-reference/next.config.js/introduction
// https://docs.sentry.io/platforms/javascript/guides/nextjs/

const { withSentryConfig } = require("@sentry/nextjs");

const moduleExports = {
  // your existing module.exports
};

const SentryWebpackPluginOptions = {
  // Additional config options for the Sentry Webpack plugin. Keep in mind that
  // the following options are set automatically, and overriding them is not
  // recommended:
  //   release, url, org, project, authToken, configFile, stripPrefix,
  //   urlPrefix, include, ignore
  // For all available options, see:
  // https://github.com/getsentry/sentry-webpack-plugin#options.
};

// Make sure adding Sentry options is the last code to run before exporting, to
// ensure that your source maps include changes from all other Webpack plugins
module.exports = withSentryConfig(moduleExports, SentryWebpackPluginOptions);
```

So e.g. if my config looks like:

```javascript
const moduleExports = {
  experimental: {
    optimizeFonts: true
  },
  images: {
    domains: ['res.cloudinary.com']
  }
}
```

and if I then follow the recommended approach, none of my custom settings will be included (if I understand correctly, haven't actually checked).

So this PR attempts to solve this by allowing any custom setting from an existing `next.config.js` to be added to the one returned by `withSentryConfig`, as well as allowing custom `webpack` functions from the existing config to further mutate the returned config.

Fixes #3432 