### PR TITLE
fix(ember): Add guards to ensure performance marks exist

### DIFF
--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -305,6 +305,12 @@ function _instrumentInitialLoad(config: EmberSentryConfig) {
   }
   const measureName = '@sentry/ember:initial-load';
 
+  const startMarkExists = performance.getEntriesByName(startName).length > 0;
+  const endMarkExists = performance.getEntriesByName(endName).length > 0;
+  if (!startMarkExists || !endMarkExists) {
+    return;
+  }
+
   performance.measure(measureName, startName, endName);
   const measures = performance.getEntriesByName(measureName);
   const measure = measures[0];


### PR DESCRIPTION
### Summary
This adds some guards before performing the initial load performance.measure to ensure that the performance marks exist. If the marks don't exist an error is thrown.

Refs #3391 