### PR TITLE
fix(nextjs): Catch exceptions when syncing plug-in's version

### DIFF
--- a/packages/nextjs/src/utils/config.ts
+++ b/packages/nextjs/src/utils/config.ts
@@ -107,5 +107,6 @@ export function withSentryConfig(
 try {
   syncPluginVersionWithNextVersion();
 } catch (error) {
-  logger.warn(`[next-plugin-sentry] Cannot sync plug-in and next versions. Plug-in may not work, versions must match`);
+  logger.warn(`[next-plugin-sentry] Cannot sync plug-in and next versions. Plug-in may not work, versions must match.`);
+  logger.warn('[next-plugin-sentry] A local project build should sync the versions, before deploying it.');
 }

--- a/packages/nextjs/src/utils/config.ts
+++ b/packages/nextjs/src/utils/config.ts
@@ -96,4 +96,8 @@ export function withSentryConfig(
   };
 }
 
-syncPluginVersionWithNextVersion();
+try {
+  syncPluginVersionWithNextVersion();
+} catch (error) {
+  logger.warn(`[next-plugin-sentry] Cannot sync plug-in and next versions. Plug-in may not work, versions must match`);
+}


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/3441
Vercel's file system is read-only, so it throws an exception when trying to rewrite the plugin's version. This happens in runtime in every request in serverless environments.

Users are supposed to build the app before deploying it to Vercel (where the file system isn't read-only), since the plugin version must still be sync-ed.