### PR TITLE
fix: Correctly attach installed integrations to sdkinfo

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -434,10 +434,10 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    * @param event The event that will be filled with all integrations.
    */
   protected _applyIntegrationsMetadata(event: Event): void {
-    const sdkInfo = event.sdk;
     const integrationsArray = Object.keys(this._integrations);
-    if (sdkInfo && integrationsArray.length > 0) {
-      sdkInfo.integrations = integrationsArray;
+    if (integrationsArray.length > 0) {
+      event.sdk = event.sdk || {};
+      event.sdk.integrations = [...(event.sdk.integrations || []), ...integrationsArray];
     }
   }
 

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -19,11 +19,7 @@ function enhanceEventWithSdkInfo(event: Event, sdkInfo?: SdkInfo): Event {
   if (!sdkInfo) {
     return event;
   }
-
-  event.sdk = event.sdk || {
-    name: sdkInfo.name,
-    version: sdkInfo.version,
-  };
+  event.sdk = event.sdk || {};
   event.sdk.name = event.sdk.name || sdkInfo.name;
   event.sdk.version = event.sdk.version || sdkInfo.version;
   event.sdk.integrations = [...(event.sdk.integrations || []), ...(sdkInfo.integrations || [])];

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -477,6 +477,15 @@ describe('BaseClient', () => {
       });
     });
 
+    test('adds installed integrations to sdk info', () => {
+      const client = new TestClient({ dsn: PUBLIC_DSN, integrations: [new TestIntegration()] });
+      client.setupIntegrations();
+      client.captureEvent({ message: 'message' });
+      expect(TestBackend.instance!.event!.sdk).toEqual({
+        integrations: ['TestIntegration'],
+      });
+    });
+
     test('normalizes event with default depth of 3', () => {
       expect.assertions(1);
       const client = new TestClient({ dsn: PUBLIC_DSN });

--- a/packages/react/src/sdk.ts
+++ b/packages/react/src/sdk.ts
@@ -5,18 +5,15 @@ import { BrowserOptions, init as browserInit, SDK_VERSION } from '@sentry/browse
  */
 export function init(options: BrowserOptions): void {
   options._metadata = options._metadata || {};
-  if (options._metadata.sdk === undefined) {
-    options._metadata.sdk = {
-      name: 'sentry.javascript.react',
-      packages: [
-        {
-          name: 'npm:@sentry/react',
-          version: SDK_VERSION,
-        },
-      ],
-      version: SDK_VERSION,
-    };
-  }
-
+  options._metadata.sdk = options._metadata.sdk || {
+    name: 'sentry.javascript.react',
+    packages: [
+      {
+        name: 'npm:@sentry/react',
+        version: SDK_VERSION,
+      },
+    ],
+    version: SDK_VERSION,
+  };
   browserInit(options);
 }

--- a/packages/types/src/sdkinfo.ts
+++ b/packages/types/src/sdkinfo.ts
@@ -1,8 +1,8 @@
 import { Package } from './package';
 
 export interface SdkInfo {
-  name: string;
-  version: string;
+  name?: string;
+  version?: string;
   integrations?: string[];
   packages?: Package[];
 }


### PR DESCRIPTION
I also changed `SdkInfo` type, because we attach different parts of the information at different times, which is reasonable, but that type did not allow that. It's misc information anyway, so we don't need to be that strict here.