### PR TITLE
ci: Add Node v16 to test matrix

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -67,4 +67,5 @@ targets:
           - nodejs10.x
           - nodejs12.x
           - nodejs14.x
+          - nodejs16.x
     license: MIT

--- a/.craft.yml
+++ b/.craft.yml
@@ -67,5 +67,4 @@ targets:
           - nodejs10.x
           - nodejs12.x
           - nodejs14.x
-          - nodejs16.x
     license: MIT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [6, 8, 10, 12, 14]
+        node: [6, 8, 10, 12, 14, 16]
     steps:
       - name: Check out current commit (${{ github.sha }})
         uses: actions/checkout@v2


### PR DESCRIPTION
https://nodejs.medium.com/node-js-16-available-now-7f5099a97e70