### PR TITLE
next-plugin-sentry: moved dependencies

### DIFF
--- a/packages/next-plugin-sentry/package.json
+++ b/packages/next-plugin-sentry/package.json
@@ -13,11 +13,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "@sentry/integrations": "6.3.1",
-    "@sentry/nextjs": "6.3.1"
-  },
   "devDependencies": {
+    "@sentry/integrations": "6.3.1",
+    "@sentry/nextjs": "6.3.1",
     "eslint": "7.20.0",
     "rimraf": "3.0.2"
   },
@@ -26,6 +24,8 @@
     "required-env": []
   },
   "peerDependencies": {
+    "@sentry/integrations": "^6.3.1",
+    "@sentry/nextjs": "^6.3.1",
     "next": "*"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2634,17 +2634,7 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@sentry/browser@6.3.0-beta.3":
-  version "6.3.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.3.0-beta.3.tgz#9e425643bc55977d2fc6b1c7d00adbbb182a6ced"
-  integrity sha512-WNxCToVTWm14xuXa6fJSM3++r91EvwPrwAZYUqZnnyySxfWP9YE8rbKO/BCXPVK4G1P4ub4Cx6acr8s+n9S1Ew==
-  dependencies:
-    "@sentry/core" "6.3.0-beta.3"
-    "@sentry/types" "6.3.0-beta.3"
-    "@sentry/utils" "6.3.0-beta.3"
-    tslib "^1.9.3"
-
-"@sentry/cli@^1.52.4", "@sentry/cli@^1.63.1":
+"@sentry/cli@^1.63.1":
   version "1.64.0"
   resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.64.0.tgz#8eadb93118ad295b0ac49de55a80eeb5a682c403"
   integrity sha512-MHWHiYVBJaE0y/JVSziZIclBYhINiI4VsJ10r7rcJYAwDah3JYBPMrv0iwmuxBVWRFMSuAmSpivkzn67JS6sPg==
@@ -2656,139 +2646,12 @@
     progress "^2.0.3"
     proxy-from-env "^1.1.0"
 
-"@sentry/core@6.3.0-beta.3":
-  version "6.3.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.3.0-beta.3.tgz#d2b9525fbce877ce998cf881f874bb060c04fc27"
-  integrity sha512-jpAB5Btk2Kj/6kHBIDClqQ917TaPi50TU6Rg82Y0mtUH63LRy0/d1ET4FT8pnHREN0DoKLhPVkoLLgCXI5aCAQ==
-  dependencies:
-    "@sentry/hub" "6.3.0-beta.3"
-    "@sentry/minimal" "6.3.0-beta.3"
-    "@sentry/types" "6.3.0-beta.3"
-    "@sentry/utils" "6.3.0-beta.3"
-    tslib "^1.9.3"
-
-"@sentry/hub@6.3.0-beta.3":
-  version "6.3.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.3.0-beta.3.tgz#98aeafa4830ea2e73cbc8803174e6063b63818e6"
-  integrity sha512-uMCD0AHOmSJm1PT/hSs3vaWuUHSAcp1fL30fYUQmBe+WF8TQQICFNMWM67zd0BER366bKraY0MsKiXqtMCWVUQ==
-  dependencies:
-    "@sentry/types" "6.3.0-beta.3"
-    "@sentry/utils" "6.3.0-beta.3"
-    tslib "^1.9.3"
-
-"@sentry/integrations@6.3.0-beta.3":
-  version "6.3.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-6.3.0-beta.3.tgz#0ec8471c8b9a07ff7d64a2a194c2329222df3132"
-  integrity sha512-SLdarsq4rtmh3BXJ1abnRvmmOtGwfdXFTeoe7Hpqwu44B25zKGpxWJaMH+3rPu9HXlEFhSNOS8cIxZj8cJbSqA==
-  dependencies:
-    "@sentry/types" "6.3.0-beta.3"
-    "@sentry/utils" "6.3.0-beta.3"
-    localforage "^1.8.1"
-    tslib "^1.9.3"
-
-"@sentry/minimal@6.3.0-beta.3":
-  version "6.3.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.3.0-beta.3.tgz#f861fd90386107c682acf63b3b42bf54a44dd571"
-  integrity sha512-IbicT7RQzz0LBtjAhoH8Qof9tdZkmBQQKbfEhkCyLB4jkABbwR3YAyZLsYnfZH+eTMxHEQAvndckLDthS7nWQQ==
-  dependencies:
-    "@sentry/hub" "6.3.0-beta.3"
-    "@sentry/types" "6.3.0-beta.3"
-    tslib "^1.9.3"
-
-"@sentry/next-plugin-sentry@6.2.5", "@sentry/next-plugin-sentry@6.3.0-beta.3":
-  version "6.3.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/next-plugin-sentry/-/next-plugin-sentry-6.3.0-beta.3.tgz#e063a5b691d8658d4dd70d7e5757aa3c2859330c"
-  integrity sha512-ITec6nkxZ3M+c3zLmW2PojxI06c0C+KSSBscELC0w9LVOoYlS8i0/b1SIZo0ecvD8SO+SH59mdQMQuRnj9oxQg==
-  dependencies:
-    "@sentry/integrations" "6.3.0-beta.3"
-    "@sentry/nextjs" "6.3.0-beta.3"
-
-"@sentry/nextjs@6.3.0-beta.3":
-  version "6.3.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/nextjs/-/nextjs-6.3.0-beta.3.tgz#6041ea94a39d4aae585d4996e96f3e82835417d5"
-  integrity sha512-A3eXXnu/HfFmXobK84bnJ8G6nyEcg6qzxSNIY9wTj57UtCxDLQtZTTXKUqqHvDiw90kQ+BbYb3WC52uwYl576g==
-  dependencies:
-    "@sentry/core" "6.3.0-beta.3"
-    "@sentry/minimal" "6.3.0-beta.3"
-    "@sentry/next-plugin-sentry" "6.3.0-beta.3"
-    "@sentry/node" "6.3.0-beta.3"
-    "@sentry/react" "6.3.0-beta.3"
-    "@sentry/webpack-plugin" "^1.14.1"
-    "@sentry/wizard" "^1.2.1"
-
-"@sentry/node@6.3.0-beta.3":
-  version "6.3.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.3.0-beta.3.tgz#47e04ebdf374f65464793bfcf4f08b67d622751d"
-  integrity sha512-twbTle013E1SXGd/sren1J0fktIrPjnpR/Jk/DIwjeFzOtmU1r3ugn8pxgFdtwLfCOakhSDUK6SSg2kFGFOwMw==
-  dependencies:
-    "@sentry/core" "6.3.0-beta.3"
-    "@sentry/hub" "6.3.0-beta.3"
-    "@sentry/tracing" "6.3.0-beta.3"
-    "@sentry/types" "6.3.0-beta.3"
-    "@sentry/utils" "6.3.0-beta.3"
-    cookie "^0.4.1"
-    https-proxy-agent "^5.0.0"
-    lru_map "^0.3.3"
-    tslib "^1.9.3"
-
-"@sentry/react@6.3.0-beta.3":
-  version "6.3.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-6.3.0-beta.3.tgz#236e5edde8a81d7b51fe7fc1a1037fc6cb32ffad"
-  integrity sha512-vZcef4PrMY8V6L05VLhECHrpUjLM0HJdgeNmpZljHTHFnFpnA+aZSGSSm6a22kOeZhhCiooJHid+ORlF0Mo+bg==
-  dependencies:
-    "@sentry/browser" "6.3.0-beta.3"
-    "@sentry/minimal" "6.3.0-beta.3"
-    "@sentry/types" "6.3.0-beta.3"
-    "@sentry/utils" "6.3.0-beta.3"
-    hoist-non-react-statics "^3.3.2"
-    tslib "^1.9.3"
-
-"@sentry/tracing@6.3.0-beta.3":
-  version "6.3.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.3.0-beta.3.tgz#0481f962731de92bdc2b5411a8b6e9a74b113644"
-  integrity sha512-AYn3ZcfEGH7V5UrDXWxsGEvl2u2FpF6aRFfUmCaepgo9zgWsLrDss2+dRDuFTASYaLTtMcmoW7YBqN9PukumEQ==
-  dependencies:
-    "@sentry/hub" "6.3.0-beta.3"
-    "@sentry/minimal" "6.3.0-beta.3"
-    "@sentry/types" "6.3.0-beta.3"
-    "@sentry/utils" "6.3.0-beta.3"
-    tslib "^1.9.3"
-
-"@sentry/types@6.3.0-beta.3":
-  version "6.3.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.3.0-beta.3.tgz#494f5415a8da128516f94a65012c1dc827483943"
-  integrity sha512-jUyG2u5NdGaTiMztbYkA7Pt5o7vu1StyJRB2GGcp0m2mZNj5nYFRr6+PlAfmr7t873PRUGfaJOvpbo6VAr9nNw==
-
-"@sentry/utils@6.3.0-beta.3":
-  version "6.3.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.3.0-beta.3.tgz#4a3633350edab1b95fc2f555bde61a4763ca1a94"
-  integrity sha512-RS8iHiCoCEsTBRX78T9ufZE0rLUNLlWxFKqqSPxYvYcIA2FgJnYXKvX4XLILbvvVLdIeqQdHYahrlO7TDmZQRw==
-  dependencies:
-    "@sentry/types" "6.3.0-beta.3"
-    tslib "^1.9.3"
-
-"@sentry/webpack-plugin@1.15.0", "@sentry/webpack-plugin@^1.14.1":
+"@sentry/webpack-plugin@1.15.0":
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-1.15.0.tgz#c7f9eafbbace1929c3fb81bb720fc0d7e8b4f86d"
   integrity sha512-KHVug+xI+KH/xCL7otWcRRszw0rt6i/BCH5F8+6/njz2gCBrYQOzdMvzWm4GeXZUuw5ekgycYaUhDs1/6enjuQ==
   dependencies:
     "@sentry/cli" "^1.63.1"
-
-"@sentry/wizard@^1.2.1":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@sentry/wizard/-/wizard-1.2.5.tgz#061e9d60e08bba33241db6f93c1bb4aa704864fc"
-  integrity sha512-vR6aKJlmaOd8C7r6s2Aj6VFDtkBeA2MKgFrbRZSwBL6N2izQc3NqQm22ziXStElqM3hl3Poj0Qywl58AV69dlQ==
-  dependencies:
-    "@sentry/cli" "^1.52.4"
-    chalk "^2.4.1"
-    glob "^7.1.3"
-    inquirer "^6.2.0"
-    lodash "^4.17.15"
-    opn "^5.4.0"
-    r2 "^2.0.1"
-    read-env "^1.3.0"
-    xcode "2.0.0"
-    yargs "^12.0.2"
 
 "@simple-dom/interface@^1.4.0":
   version "1.4.0"
@@ -5298,7 +5161,7 @@ base64-js@0.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.2.tgz#024f0f72afa25b75f9c0ee73cd4f55ec1bed9784"
   integrity sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q=
 
-base64-js@^1.0.2, base64-js@^1.3.0, base64-js@^1.3.1, base64-js@^1.5.1:
+base64-js@^1.0.2, base64-js@^1.3.0, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -5351,11 +5214,6 @@ better-assert@~1.0.0:
   integrity sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=
   dependencies:
     callsite "1.0.0"
-
-big-integer@^1.6.44:
-  version "1.6.48"
-  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
-  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
 
 big.js@^5.2.2:
   version "5.2.2"
@@ -5488,20 +5346,6 @@ bower-endpoint-parser@0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz#00b565adbfab6f2d35addde977e97962acbcb3f6"
   integrity sha1-ALVlrb+rby01rd3pd+l5Yqy8s/Y=
-
-bplist-creator@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/bplist-creator/-/bplist-creator-0.0.8.tgz#56b2a6e79e9aec3fc33bf831d09347d73794e79c"
-  integrity sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==
-  dependencies:
-    stream-buffers "~2.2.0"
-
-bplist-parser@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.2.0.tgz#43a9d183e5bf9d545200ceac3e712f79ebbe8d0e"
-  integrity sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==
-  dependencies:
-    big-integer "^1.6.44"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -6480,11 +6324,6 @@ camelcase-keys@^6.2.2:
     map-obj "^4.0.0"
     quick-lru "^4.0.1"
 
-camelcase@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
-  integrity sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==
-
 camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
@@ -6547,7 +6386,7 @@ cardinal@^1.0.0:
     ansicolors "~0.2.1"
     redeyed "~1.0.0"
 
-caseless@^0.12.0, caseless@~0.12.0:
+caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
@@ -14669,7 +14508,7 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^2.0.0-alpha.8, node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -15154,13 +14993,6 @@ opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
-
-opn@^5.4.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-5.5.0.tgz#fc7164fab56d235904c51c3b27da6758ca3b9bfc"
-  integrity sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==
-  dependencies:
-    is-wsl "^1.1.0"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -15834,15 +15666,6 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
-
-plist@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.2.tgz#74bbf011124b90421c22d15779cee60060ba95bc"
-  integrity sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==
-  dependencies:
-    base64-js "^1.5.1"
-    xmlbuilder "^9.0.7"
-    xmldom "^0.5.0"
 
 plugin-error@^1.0.1:
   version "1.0.1"
@@ -16603,15 +16426,6 @@ qunit@^2.9.3:
     node-watch "0.7.1"
     tiny-glob "0.2.8"
 
-r2@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/r2/-/r2-2.0.1.tgz#94cd802ecfce9a622549c8182032d8e4a2b2e612"
-  integrity sha512-EEmxoxYCe3LHzAUhRIRxdCKERpeRNmlLj6KLUSORqnK6dWl/K5ShmDGZqM2lRZQeqJgF+wyqk0s1M7SWUveNOQ==
-  dependencies:
-    caseless "^0.12.0"
-    node-fetch "^2.0.0-alpha.8"
-    typedarray-to-buffer "^3.1.2"
-
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -16754,13 +16568,6 @@ read-cmd-shim@^1.0.1:
   integrity sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==
   dependencies:
     graceful-fs "^4.1.2"
-
-read-env@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/read-env/-/read-env-1.3.0.tgz#e26e1e446992b3216e9a3c6f6ac51064fe91fdff"
-  integrity sha512-DbCgZ8oHwZreK/E2E27RGk3EUPapMhYGSGIt02k9sX6R3tCFc4u4tkltKvkCvzEQ3SOLUaiYHAnGb+TdsnPp0A==
-  dependencies:
-    camelcase "5.0.0"
 
 "read-package-json@1 || 2", read-package-json@^2.0.0, read-package-json@^2.0.13:
   version "2.1.2"
@@ -17888,15 +17695,6 @@ simple-html-tokenizer@^0.5.10, simple-html-tokenizer@^0.5.8:
   resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz#4c5186083c164ba22a7b477b7687ac056ad6b1d9"
   integrity sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==
 
-simple-plist@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/simple-plist/-/simple-plist-1.1.1.tgz#54367ca28bc5996a982c325c1c4a4c1a05f4047c"
-  integrity sha512-pKMCVKvZbZTsqYR6RKgLfBHkh2cV89GXcA/0CVPje3sOiNOnXA8+rp/ciAMZ7JRaUdLzlEM6JFfUn+fS6Nt3hg==
-  dependencies:
-    bplist-creator "0.0.8"
-    bplist-parser "0.2.0"
-    plist "^3.0.1"
-
 simple-swizzle@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
@@ -18430,11 +18228,6 @@ stream-browserify@^2.0.1, stream-browserify@^2.0.2:
   dependencies:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
-
-stream-buffers@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-2.2.0.tgz#91d5f5130d1cef96dcfa7f726945188741d09ee4"
-  integrity sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ=
 
 stream-combiner@~0.0.4:
   version "0.0.4"
@@ -19507,7 +19300,7 @@ type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typedarray-to-buffer@^3.1.2, typedarray-to-buffer@^3.1.5:
+typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
@@ -20490,14 +20283,6 @@ ws@~3.3.1:
     safe-buffer "~5.1.0"
     ultron "~1.1.0"
 
-xcode@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/xcode/-/xcode-2.0.0.tgz#134f1f94c26fbfe8a9aaa9724bfb2772419da1a2"
-  integrity sha512-5xF6RCjAdDEiEsbbZaS/gBRt3jZ/177otZcpoLCjGN/u1LrfgH7/Sgeeavpr/jELpyDqN2im3AKosl2G2W8hfw==
-  dependencies:
-    simple-plist "^1.0.0"
-    uuid "^3.3.2"
-
 xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
@@ -20516,7 +20301,7 @@ xml2js@0.4.19:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
 
-xmlbuilder@^9.0.7, xmlbuilder@~9.0.1:
+xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
   integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
@@ -20530,11 +20315,6 @@ xmldom@^0.1.19:
   version "0.1.31"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
   integrity sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==
-
-xmldom@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
-  integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
 
 xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"
@@ -20640,7 +20420,7 @@ yargs@13.3.2, yargs@^13.3.0:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
-yargs@^12.0.1, yargs@^12.0.2:
+yargs@^12.0.1:
   version "12.0.5"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
   integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==


### PR DESCRIPTION
Hello!

I've noticed the issue with dependencies in the `next-plugin-sentry` which currently has `@sentry/nextjs` in its dependencies. This leads to the issue in my project:

<img width="830" alt="Screen Shot 2021-04-24 at 14 40 27" src="https://user-images.githubusercontent.com/10692413/115959200-58ebbe00-a50b-11eb-813b-9ef214660d5c.png">

As you can see from the screenshot, It uses the internal version of the `@sentry/nextjs` package instead of the one from the project. I think that it's not correct behavior, it seems to me that this package should not bring `@sentry/nextjs` package as dependency. That's why I moved it to `devDependencies` and `peerDependencies`. This looks like a correct approach, I think. I tested it in my project, the error disappears if I remove that nested `node_modules` folder. So this PR should help.

Please let me know what you think about it. Thanks!