### PR TITLE
fix: Prevent InboundFilters mergeOptions method from breaking users code

### DIFF
--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -17,6 +17,12 @@ const terserInstance = terser({
     reserved: ['captureException', 'captureMessage', 'sentryWrapped'],
     properties: {
       regex: /^_[^_]/,
+      // This exclusion prevents most of the occurences of the bug linked below:
+      // https://github.com/getsentry/sentry-javascript/issues/2622
+      // The bug is caused by multiple SDK instances, where one is minified and one is using non-mangled code.
+      // Unfortunatelly we cannot fix it reliably (thus `typeof` check in the `InboundFilters` code),
+      // as we cannot force people using multiple instances in their apps to sync SDK versions.
+      reserved: ['_mergeOptions'],
     },
   },
 });

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -17,7 +17,7 @@ const terserInstance = terser({
     reserved: ['captureException', 'captureMessage', 'sentryWrapped'],
     properties: {
       regex: /^_[^_]/,
-      // This exclusion prevents most of the occurences of the bug linked below:
+      // This exclusion prevents most of the occurrences of the bug linked below:
       // https://github.com/getsentry/sentry-javascript/issues/2622
       // The bug is caused by multiple SDK instances, where one is minified and one is using non-mangled code.
       // Unfortunatelly we cannot fix it reliably (thus `typeof` check in the `InboundFilters` code),

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -46,10 +46,10 @@ export class InboundFilters implements Integration {
       if (self) {
         const client = hub.getClient();
         const clientOptions = client ? client.getOptions() : {};
-        // This checks prevents most of the occurences of the bug linked below:
+        // This checks prevents most of the occurrences of the bug linked below:
         // https://github.com/getsentry/sentry-javascript/issues/2622
         // The bug is caused by multiple SDK instances, where one is minified and one is using non-mangled code.
-        // Unfortunatelly we cannot fix it reliably (thus reserved property in rollups terser config),
+        // Unfortunatelly we cannot fix it reliably (thus reserved property in rollup's terser config),
         // as we cannot force people using multiple instances in their apps to sync SDK versions.
         const options = typeof self._mergeOptions === 'function' ? self._mergeOptions(clientOptions) : {};
         if (typeof self._shouldDropEvent !== 'function') {

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -46,10 +46,16 @@ export class InboundFilters implements Integration {
       if (self) {
         const client = hub.getClient();
         const clientOptions = client ? client.getOptions() : {};
-        const options = self._mergeOptions(clientOptions);
-        if (self._shouldDropEvent(event, options)) {
-          return null;
+        // This checks prevents most of the occurences of the bug linked below:
+        // https://github.com/getsentry/sentry-javascript/issues/2622
+        // The bug is caused by multiple SDK instances, where one is minified and one is using non-mangled code.
+        // Unfortunatelly we cannot fix it reliably (thus reserved property in rollups terser config),
+        // as we cannot force people using multiple instances in their apps to sync SDK versions.
+        const options = typeof self._mergeOptions === 'function' ? self._mergeOptions(clientOptions) : {};
+        if (typeof self._shouldDropEvent !== 'function') {
+          return event;
         }
+        return self._shouldDropEvent(event, options) ? null : event;
       }
       return event;
     });


### PR DESCRIPTION
See code comment for an explanation.

Fixes https://github.com/getsentry/sentry-javascript/issues/2622