### PR TITLE
fix(nextjs): User server types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+## 6.3.3
+
+- [nextjs] fix: User server types #3471
+
 ## 6.3.2
 
 - [nextjs] ref: Remove next.js plugin (#3462)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## 6.3.3
 
-- [nextjs] fix: User server types #3471
+- [nextjs] fix: User server types (#3471)
 
 ## 6.3.2
 

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -12,7 +12,7 @@
   "main": "./dist/index.server.js",
   "module": "./esm/index.server.js",
   "browser": "./esm/index.client.js",
-  "types": "./esm/index.client.d.ts",
+  "types": "./esm/index.server.d.ts",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
In order to use `withSentry`, the types must be from the server instead of the client.