### PR TITLE
misc: Change size-limit to 100kb for tracking purposes only

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -3,24 +3,24 @@ module.exports = [
     name: '@sentry/browser - CDN Bundle (gzipped)',
     path: 'packages/browser/build/bundle.min.js',
     gzip: true,
-    limit: '21 KB',
+    limit: '100 KB',
   },
   {
     name: '@sentry/browser - Webpack',
     path: 'packages/browser/esm/index.js',
     import: '{ init }',
-    limit: '22 KB',
+    limit: '100 KB',
   },
   {
     name: '@sentry/react - Webpack',
     path: 'packages/react/esm/index.js',
     import: '{ init }',
-    limit: '22 KB',
+    limit: '100 KB',
   },
   {
     name: '@sentry/browser + @sentry/tracing - CDN Bundle (gzipped)',
     path: 'packages/tracing/build/bundle.tracing.min.js',
     gzip: true,
-    limit: '28 KB',
+    limit: '100 KB',
   },
 ];


### PR DESCRIPTION
We only want to track the size, not fail builds because of it.