### PR TITLE
fix(nextjs): Add missing changes from #3462

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "packages/integrations",
     "packages/minimal",
     "packages/nextjs",
-    "packages/next-plugin-sentry",
     "packages/node",
     "packages/react",
     "packages/serverless",

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -1,5 +1,6 @@
 import { configureScope, init as nodeInit } from '@sentry/node';
 
+import { instrumentServer } from './utils/instrumentServer';
 import { MetadataBuilder } from './utils/metadataBuilder';
 import { NextjsOptions } from './utils/nextjsOptions';
 import { defaultRewriteFrames, getFinalServerIntegrations } from './utils/serverIntegrations';
@@ -28,3 +29,6 @@ export function init(options: NextjsOptions): void {
 
 export { withSentryConfig } from './utils/config';
 export { withSentry } from './utils/handlers';
+
+// TODO capture project root (which this returns) for RewriteFrames?
+instrumentServer();

--- a/packages/nextjs/src/utils/config.ts
+++ b/packages/nextjs/src/utils/config.ts
@@ -115,7 +115,7 @@ export function withSentryConfig(
     .map(key => key in Object.keys(providedWebpackPluginOptions));
   if (webpackPluginOptionOverrides.length > 0) {
     logger.warn(
-      '[next-plugin-sentry] You are overriding the following automatically-set SentryWebpackPlugin config options:\n' +
+      '[Sentry] You are overriding the following automatically-set SentryWebpackPlugin config options:\n' +
         `\t${webpackPluginOptionOverrides.toString()},\n` +
         "which has the possibility of breaking source map upload and application. This is only a good idea if you know what you're doing.",
     );

--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -1,0 +1,91 @@
+import { fill } from '@sentry/utils';
+import * as http from 'http';
+import { default as createNextServer } from 'next';
+import * as url from 'url';
+
+import * as Sentry from '../index.server';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type PlainObject<T = any> = { [key: string]: T };
+
+interface NextServer {
+  server: Server;
+}
+
+interface Server {
+  dir: string;
+}
+
+type HandlerGetter = () => Promise<ReqHandler>;
+type ReqHandler = (
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  parsedUrl?: url.UrlWithParsedQuery,
+) => Promise<void>;
+type ErrorLogger = (err: Error) => void;
+
+// these aliases are purely to make the function signatures more easily understandable
+type WrappedHandlerGetter = HandlerGetter;
+type WrappedErrorLogger = ErrorLogger;
+
+// TODO is it necessary for this to be an object?
+const closure: PlainObject = {};
+
+/**
+ * Do the monkeypatching and wrapping necessary to catch errors in page routes. Along the way, as a bonus, grab (and
+ * return) the path of the project root, for use in `RewriteFrames`.
+ *
+ * @returns The absolute path of the project root directory
+ *
+ */
+export function instrumentServer(): string {
+  const nextServerPrototype = Object.getPrototypeOf(createNextServer({}));
+
+  // wrap this getter because it runs before the request handler runs, which gives us a chance to wrap the logger before
+  // it's called for the first time
+  fill(nextServerPrototype, 'getServerRequestHandler', makeWrappedHandlerGetter);
+
+  return closure.projectRootDir;
+}
+
+/**
+ * Create a wrapped version of Nextjs's `NextServer.getServerRequestHandler` method, as a way to access the running
+ * `Server` instance and monkeypatch its prototype.
+ *
+ * @param origHandlerGetter Nextjs's `NextServer.getServerRequestHandler` method
+ * @returns A wrapped version of the same method, to monkeypatch in at server startup
+ */
+function makeWrappedHandlerGetter(origHandlerGetter: HandlerGetter): WrappedHandlerGetter {
+  // We wrap this purely in order to be able to grab data and do further monkeypatching the first time it runs.
+  // Otherwise, it's just a pass-through to the original method.
+  const wrappedHandlerGetter = async function(this: NextServer): Promise<ReqHandler> {
+    if (!closure.wrappingComplete) {
+      closure.projectRootDir = this.server.dir;
+
+      const serverPrototype = Object.getPrototypeOf(this.server);
+
+      // wrap the logger so we can capture errors in page-level functions like `getServerSideProps`
+      fill(serverPrototype, 'logError', makeWrappedErrorLogger);
+
+      closure.wrappingComplete = true;
+    }
+
+    return origHandlerGetter.call(this);
+  };
+
+  return wrappedHandlerGetter;
+}
+
+/**
+ * Wrap the error logger used by the server to capture exceptions which arise from functions like `getServerSideProps`.
+ *
+ * @param origErrorLogger The original logger from the `Server` class
+ * @returns A wrapped version of that logger
+ */
+function makeWrappedErrorLogger(origErrorLogger: ErrorLogger): WrappedErrorLogger {
+  return (err: Error): void => {
+    // TODO add context data here
+    Sentry.captureException(err);
+    return origErrorLogger(err);
+  };
+}


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/pull/3462 accidentally got merged in an incomplete state. This adds in the remaining changes it should have included. See its PR description for a full accounting of what the combined changes entail.