### PR TITLE
 fix(node): Sets mechanism handled to false when it is a crash

### DIFF
--- a/packages/node/src/backend.ts
+++ b/packages/node/src/backend.ts
@@ -53,7 +53,9 @@ export class NodeBackend extends BaseBackend<NodeOptions> {
   public eventFromException(exception: any, hint?: EventHint): PromiseLike<Event> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let ex: any = exception;
-    const mechanism: Mechanism = {
+    const providedMechanism: Mechanism | undefined =
+      hint && hint.data && (hint.data as { mechanism: Mechanism }).mechanism;
+    const mechanism: Mechanism = providedMechanism || {
       handled: true,
       type: 'generic',
     };

--- a/packages/node/src/integrations/onuncaughtexception.ts
+++ b/packages/node/src/integrations/onuncaughtexception.ts
@@ -78,7 +78,10 @@ export class OnUncaughtException implements Integration {
         if (hub.getIntegration(OnUncaughtException)) {
           hub.withScope((scope: Scope) => {
             scope.setLevel(Severity.Fatal);
-            hub.captureException(error, { originalException: error });
+            hub.captureException(error, {
+              originalException: error,
+              data: { mechanism: { handled: false, type: 'onuncaughtexception' } },
+            });
             if (!calledFatalError) {
               calledFatalError = true;
               onFatalError(error);

--- a/packages/node/src/integrations/onunhandledrejection.ts
+++ b/packages/node/src/integrations/onunhandledrejection.ts
@@ -69,7 +69,10 @@ export class OnUnhandledRejection implements Integration {
         scope.setExtras(context.extra);
       }
 
-      hub.captureException(reason, { originalException: promise });
+      hub.captureException(reason, {
+        originalException: promise,
+        data: { mechanism: { handled: false, type: 'onunhandledrejection' } },
+      });
     });
     /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 

--- a/packages/node/test/onuncaughtexception.test.ts
+++ b/packages/node/test/onuncaughtexception.test.ts
@@ -1,0 +1,34 @@
+import { Hub } from '@sentry/hub';
+
+import { OnUncaughtException } from '../src/integrations/onuncaughtexception';
+
+jest.mock('@sentry/hub', () => {
+  // we just want to short-circuit it, so dont worry about types
+  const original = jest.requireActual('@sentry/hub');
+  original.Hub.prototype.getIntegration = () => true;
+  return {
+    ...original,
+    getCurrentHub: () => new Hub(),
+  };
+});
+
+describe('uncaught exceptions', () => {
+  test('install global listener', () => {
+    const integration = new OnUncaughtException();
+    integration.setupOnce();
+    expect(process.listeners('uncaughtException')).toHaveLength(1);
+  });
+
+  test('sendUncaughtException', () => {
+    const integration = new OnUncaughtException({ onFatalError: jest.fn() });
+    integration.setupOnce();
+
+    const captureException = jest.spyOn(Hub.prototype, 'captureException');
+
+    integration.handler({ message: 'message', name: 'name' });
+
+    expect(captureException.mock.calls[0][1]?.data).toEqual({
+      mechanism: { handled: false, type: 'onuncaughtexception' },
+    });
+  });
+});

--- a/packages/node/test/onunhandledrejection.test.ts
+++ b/packages/node/test/onunhandledrejection.test.ts
@@ -42,6 +42,9 @@ describe('unhandled promises', () => {
 
     integration.sendUnhandledPromise('bla', promise);
 
+    expect(captureException.mock.calls[0][1]?.data).toEqual({
+      mechanism: { handled: false, type: 'onunhandledrejection' },
+    });
     expect(captureException.mock.calls[0][0]).toBe('bla');
     expect(setUser.mock.calls[0][0]).toEqual({ id: 1 });
     expect(setExtra.mock.calls[0]).toEqual(['unhandledPromiseRejection', true]);


### PR DESCRIPTION
This PR:
- Sets mechanism handled to false when error is triggered by an `onuncaughtexception` or `onunhandledrejection`.
Also, add the appropriate exception type to mechanism whether it is `onuncaughtexception` or `onunhandledrejection`.

