### PR TITLE
fix(nextjs): Add environment automatically

### DIFF
--- a/packages/nextjs/src/index.client.ts
+++ b/packages/nextjs/src/index.client.ts
@@ -9,6 +9,7 @@ export * from '@sentry/react';
 export function init(options: NextjsOptions): void {
   const metadataBuilder = new MetadataBuilder(options, ['nextjs', 'react']);
   metadataBuilder.addSdkMetadata();
+  options.environment = options.environment || process.env.NODE_ENV;
   reactInit(options);
   configureScope(scope => {
     scope.setTag('runtime', 'browser');

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -15,6 +15,7 @@ export { ErrorBoundary, withErrorBoundary } from '@sentry/react';
 export function init(options: NextjsOptions): void {
   const metadataBuilder = new MetadataBuilder(options, ['nextjs', 'node']);
   metadataBuilder.addSdkMetadata();
+  options.environment = options.environment || process.env.NODE_ENV;
   if (options.integrations) {
     options.integrations = getFinalServerIntegrations(options.integrations);
   } else {


### PR DESCRIPTION
Specifying no [environment](https://docs.sentry.io/platforms/javascript/configuration/environments/) leads events to be marked as production environments. This PR adds the `environment` from `process.env.NODE_ENV` by default, without keeping users from setting their own environment.