### PR TITLE
fix(nextjs): Add `next` as a peer dependency

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -32,6 +32,9 @@
     "next": "^10.1.3",
     "rimraf": "3.0.2"
   },
+  "peerDependencies": {
+    "next": "^10.0.8"
+  },
   "scripts": {
     "build": "run-p build:esm build:es5",
     "build:esm": "tsc -p tsconfig.esm.json",


### PR DESCRIPTION
Since there are now a few different places in our code where we import things from `next`, it should be a dependency. That said, anyone using the SDK presumably already has `next` installed, so this PR makes it a peer dependency rather than a regular dependency.

Fixes https://github.com/getsentry/sentry-javascript/issues/3490.