### PR TITLE
fix(types): Vendor minimal type for `localforage` in `Offline` integration

### DIFF
--- a/packages/integrations/src/offline.ts
+++ b/packages/integrations/src/offline.ts
@@ -1,7 +1,17 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Event, EventProcessor, Hub, Integration } from '@sentry/types';
 import { getGlobalObject, logger, normalize, uuid4 } from '@sentry/utils';
 import localForage from 'localforage';
+
+type LocalForage = {
+  setItem<T>(key: string, value: T, callback?: (err: any, value: T) => void): Promise<T>;
+  iterate<T, U>(
+    iteratee: (value: T, key: string, iterationNumber: number) => U,
+    callback?: (err: any, result: U) => void,
+  ): Promise<U>;
+  removeItem(key: string, callback?: (err: any) => void): Promise<void>;
+};
 
 /**
  * cache offline errors and send when connected
@@ -36,7 +46,7 @@ export class Offline implements Integration {
   /**
    * event cache
    */
-  public offlineEventStore: typeof localForage;
+  public offlineEventStore: LocalForage;
 
   /**
    * @inheritDoc


### PR DESCRIPTION
The `localforage` package (upon which our `Offline` integration depends) uses commonJS-style exports. This means that in order for our SDK to build successfully, and in order for any project using both us and Typescript to build successfully, either we have to `require` it or use `esModuleInterop` in our `tsconfig`, and force our users to do the same. 

Since this has been an issue multiple times over, seemingly no matter which way we (or others) try to fix it*, this PR bypasses the types supplied by `localforage` and uses a custom type.

So, hopefully for the last time:
Fixes https://github.com/getsentry/sentry-javascript/issues/2853
Fixes https://github.com/getsentry/sentry-javascript/issues/3091
Fixes https://github.com/getsentry/sentry-javascript/issues/3401

\*See https://github.com/getsentry/sentry-javascript/pull/2856, https://github.com/getsentry/sentry-javascript/pull/2864, https://github.com/getsentry/sentry-javascript/pull/2861, https://github.com/getsentry/sentry-javascript/pull/3101, https://github.com/getsentry/sentry-javascript/pull/3294, https://github.com/dualinventive/sentry-javascript/pull/1, and https://github.com/getsentry/sentry-javascript/pull/3403. Not to mention this PR.


