### PR TITLE
fix(nextjs): Add React as a peer dependency

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -33,7 +33,8 @@
     "rimraf": "3.0.2"
   },
   "peerDependencies": {
-    "next": "^10.0.8"
+    "next": "^10.0.8",
+    "react": "15.x || 16.x || 17.x"
   },
   "scripts": {
     "build": "run-p build:esm build:es5",


### PR DESCRIPTION
Adds React as a peer dependency of Next.js; same versions as in `@sentry/react`.

Fixes https://github.com/getsentry/sentry-javascript/issues/3509.