### PR TITLE
fix(node): Disable autoSessionTracking by default

### DIFF
--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -104,7 +104,7 @@ export function init(options: NodeOptions = {}): void {
   }
 
   if (options.autoSessionTracking === undefined) {
-    options.autoSessionTracking = true;
+    options.autoSessionTracking = false;
   }
 
   if (options.environment === undefined && process.env.SENTRY_ENVIRONMENT) {

--- a/packages/node/test/manual/release-health/single-session/caught-exception-errored-session.js
+++ b/packages/node/test/manual/release-health/single-session/caught-exception-errored-session.js
@@ -43,6 +43,7 @@ Sentry.init({
   dsn: 'http://test@example.com/1337',
   release: '1.1',
   transport: DummyTransport,
+  autoSessionTracking: true
 });
 
 /**

--- a/packages/node/test/manual/release-health/single-session/healthy-session.js
+++ b/packages/node/test/manual/release-health/single-session/healthy-session.js
@@ -32,7 +32,8 @@ class DummyTransport extends BaseDummyTransport {
 Sentry.init({
   dsn: 'http://test@example.com/1337',
   release: '1.1',
-  transport: DummyTransport
+  transport: DummyTransport,
+  autoSessionTracking: true
 });
 
 /**

--- a/packages/node/test/manual/release-health/single-session/uncaught-exception-crashed-session.js
+++ b/packages/node/test/manual/release-health/single-session/uncaught-exception-crashed-session.js
@@ -24,7 +24,8 @@ class DummyTransport extends BaseDummyTransport {
 Sentry.init({
   dsn: 'http://test@example.com/1337',
   release: '1.1',
-  transport: DummyTransport
+  transport: DummyTransport,
+  autoSessionTracking: true
 });
 /**
  * The following code snippet will throw an exception of `mechanism.handled` equal to `false`, and so this session

--- a/packages/node/test/manual/release-health/single-session/unhandled-rejection-crashed-session.js
+++ b/packages/node/test/manual/release-health/single-session/unhandled-rejection-crashed-session.js
@@ -34,7 +34,8 @@ class DummyTransport extends BaseDummyTransport {
 Sentry.init({
   dsn: 'http://test@example.com/1337',
   release: '1.1',
-  transport: DummyTransport
+  transport: DummyTransport,
+  autoSessionTracking: true
 });
 
 /**


### PR DESCRIPTION
This PR
- Toggles `autoSessionTracking` to `false` by default -> We do this, for now, to be able to release version. We switch this back once we fully release everything wrt Release Health and Node