### PR TITLE
fix(nextjs): Fix error logging

### DIFF
--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -83,11 +83,10 @@ function makeWrappedHandlerGetter(origHandlerGetter: HandlerGetter): WrappedHand
  * @returns A wrapped version of that logger
  */
 function makeWrappedErrorLogger(origErrorLogger: ErrorLogger): WrappedErrorLogger {
-  return (err: Error): void => {
+  return function(this: Server, err: Error): void {
     // TODO add context data here
     Sentry.captureException(err);
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    return origErrorLogger.bind(this, err);
+    debugger;
+    return origErrorLogger.call(this, err);
   };
 }

--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -86,7 +86,6 @@ function makeWrappedErrorLogger(origErrorLogger: ErrorLogger): WrappedErrorLogge
   return function(this: Server, err: Error): void {
     // TODO add context data here
     Sentry.captureException(err);
-    debugger;
     return origErrorLogger.call(this, err);
   };
 }

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -8,12 +8,14 @@ import { getFunctionName } from './stacktrace';
 import { truncate } from './string';
 
 /**
- * Wrap a given object method with a higher-order function
+ * Replace a method in an object with a wrapped version of itself.
  *
  * @param source An object that contains a method to be wrapped.
- * @param name A name of method to be wrapped.
- * @param replacementFactory A function that should be used to wrap a given method, returning the wrapped method which
- * will be substituted in for `source[name]`.
+ * @param name The name of the method to be wrapped.
+ * @param replacementFactory A higher-order function that takes the original version of the given method and returns a
+ * wrapped verstion. Note: The function returned by `replacementFactory` needs to be a non-arrow function, in order to
+ * preserve the correct value of `this`, and the original method must be called using `origMethod.call(this, <other
+ * args>)` or `origMethod.apply(this, [<other args>])` (rather than being called directly), again to preserve `this`.
  * @returns void
  */
 export function fill(source: { [key: string]: any }, name: string, replacementFactory: (...args: any[]) => any): void {


### PR DESCRIPTION
This PR makes two changes to the function which wraps the native error logger:

- Calls the original method rather than returning a bound copy of it
- Refactors it to be a real (non-arrow) function, so that the original `this` (a `Server` instance) isn't overwritten by the `this` (`global`) present when the function is defined