### PR TITLE
feat(browser): Envelope tunnel support for browser

### DIFF
--- a/packages/browser/src/backend.ts
+++ b/packages/browser/src/backend.ts
@@ -24,13 +24,6 @@ export interface BrowserOptions extends Options {
    */
   denyUrls?: Array<string | RegExp>;
 
-  /**
-   * A URL to an envelope tunnel endpoint.  An envelope tunnel is an HTTP endpoint
-   * that accepts Sentry envelopes for forwarding.  This can be used to force data
-   * through a custom server independent of the type of data.
-   */
-  envelopeTunnel?: string;
-
   /** @deprecated use {@link Options.allowUrls} instead. */
   whitelistUrls?: Array<string | RegExp>;
 

--- a/packages/browser/src/backend.ts
+++ b/packages/browser/src/backend.ts
@@ -24,6 +24,13 @@ export interface BrowserOptions extends Options {
    */
   denyUrls?: Array<string | RegExp>;
 
+  /**
+   * A URL to an envelope tunnel endpoint.  An envelope tunnel is an HTTP endpoint
+   * that accepts Sentry envelopes for forwarding.  This can be used to force data
+   * through a custom server independent of the type of data.
+   */
+  envelopeTunnel?: string;
+
   /** @deprecated use {@link Options.allowUrls} instead. */
   whitelistUrls?: Array<string | RegExp>;
 
@@ -61,6 +68,7 @@ export class BrowserBackend extends BaseBackend<BrowserOptions> {
     const transportOptions = {
       ...this._options.transportOptions,
       dsn: this._options.dsn,
+      envelopeTunnel: this._options.envelopeTunnel,
       _metadata: this._options._metadata,
     };
 

--- a/packages/browser/src/backend.ts
+++ b/packages/browser/src/backend.ts
@@ -61,7 +61,7 @@ export class BrowserBackend extends BaseBackend<BrowserOptions> {
     const transportOptions = {
       ...this._options.transportOptions,
       dsn: this._options.dsn,
-      envelopeTunnel: this._options.envelopeTunnel,
+      tunnel: this._options.tunnel,
       _metadata: this._options._metadata,
     };
 

--- a/packages/browser/src/transports/base.ts
+++ b/packages/browser/src/transports/base.ts
@@ -35,7 +35,7 @@ export abstract class BaseTransport implements Transport {
   protected readonly _rateLimits: Record<string, Date> = {};
 
   public constructor(public options: TransportOptions) {
-    this._api = new API(options.dsn, options._metadata, options.envelopeTunnel);
+    this._api = new API(options.dsn, options._metadata, options.tunnel);
     // eslint-disable-next-line deprecation/deprecation
     this.url = this._api.getStoreEndpointWithUrlEncodedAuth();
   }

--- a/packages/browser/src/transports/base.ts
+++ b/packages/browser/src/transports/base.ts
@@ -35,7 +35,7 @@ export abstract class BaseTransport implements Transport {
   protected readonly _rateLimits: Record<string, Date> = {};
 
   public constructor(public options: TransportOptions) {
-    this._api = new API(options.dsn, options._metadata);
+    this._api = new API(options.dsn, options._metadata, options.envelopeTunnel);
     // eslint-disable-next-line deprecation/deprecation
     this.url = this._api.getStoreEndpointWithUrlEncodedAuth();
   }

--- a/packages/browser/test/unit/transports/fetch.test.ts
+++ b/packages/browser/test/unit/transports/fetch.test.ts
@@ -5,6 +5,7 @@ import { Event, Status, Transports } from '../../../src';
 
 const testDsn = 'https://123@sentry.io/42';
 const storeUrl = 'https://sentry.io/api/42/store/?sentry_key=123&sentry_version=7';
+const envelopeTunnel = 'https://hello.com/world';
 const eventPayload: Event = {
   event_id: '1337',
 };
@@ -48,6 +49,15 @@ describe('FetchTransport', () => {
           referrerPolicy: 'origin',
         }),
       ).equal(true);
+    });
+
+    it('sends a request to envelopeTunnel if configured', async () => {
+      transport = new Transports.FetchTransport({ dsn: testDsn, envelopeTunnel }, window.fetch);
+      fetch.returns(Promise.resolve({ status: 200, headers: new Headers() }));
+
+      await transport.sendEvent(eventPayload);
+
+      expect(fetch.calledWith(envelopeTunnel)).equal(true);
     });
 
     it('rejects with non-200 status code', async () => {

--- a/packages/browser/test/unit/transports/fetch.test.ts
+++ b/packages/browser/test/unit/transports/fetch.test.ts
@@ -5,7 +5,7 @@ import { Event, Status, Transports } from '../../../src';
 
 const testDsn = 'https://123@sentry.io/42';
 const storeUrl = 'https://sentry.io/api/42/store/?sentry_key=123&sentry_version=7';
-const envelopeTunnel = 'https://hello.com/world';
+const tunnel = 'https://hello.com/world';
 const eventPayload: Event = {
   event_id: '1337',
 };
@@ -51,13 +51,13 @@ describe('FetchTransport', () => {
       ).equal(true);
     });
 
-    it('sends a request to envelopeTunnel if configured', async () => {
-      transport = new Transports.FetchTransport({ dsn: testDsn, envelopeTunnel }, window.fetch);
+    it('sends a request to tunnel if configured', async () => {
+      transport = new Transports.FetchTransport({ dsn: testDsn, tunnel }, window.fetch);
       fetch.returns(Promise.resolve({ status: 200, headers: new Headers() }));
 
       await transport.sendEvent(eventPayload);
 
-      expect(fetch.calledWith(envelopeTunnel)).equal(true);
+      expect(fetch.calledWith(tunnel)).equal(true);
     });
 
     it('rejects with non-200 status code', async () => {

--- a/packages/browser/test/unit/transports/xhr.test.ts
+++ b/packages/browser/test/unit/transports/xhr.test.ts
@@ -6,6 +6,7 @@ import { Event, Status, Transports } from '../../../src';
 const testDsn = 'https://123@sentry.io/42';
 const storeUrl = 'https://sentry.io/api/42/store/?sentry_key=123&sentry_version=7';
 const envelopeUrl = 'https://sentry.io/api/42/envelope/?sentry_key=123&sentry_version=7';
+const envelopeTunnel = 'https://hello.com/world';
 const eventPayload: Event = {
   event_id: '1337',
 };
@@ -44,6 +45,15 @@ describe('XHRTransport', () => {
       expect(server.requests.length).equal(1);
       expect(request.method).equal('POST');
       expect(JSON.parse(request.requestBody)).deep.equal(eventPayload);
+    });
+
+    it('sends a request to envelopeTunnel if configured', async () => {
+      transport = new Transports.XHRTransport({ dsn: testDsn, envelopeTunnel });
+      server.respondWith('POST', envelopeTunnel, [200, {}, '']);
+
+      await transport.sendEvent(eventPayload);
+
+      expect(server.requests[0].url).equal(envelopeTunnel);
     });
 
     it('rejects with non-200 status code', async () => {

--- a/packages/browser/test/unit/transports/xhr.test.ts
+++ b/packages/browser/test/unit/transports/xhr.test.ts
@@ -6,7 +6,7 @@ import { Event, Status, Transports } from '../../../src';
 const testDsn = 'https://123@sentry.io/42';
 const storeUrl = 'https://sentry.io/api/42/store/?sentry_key=123&sentry_version=7';
 const envelopeUrl = 'https://sentry.io/api/42/envelope/?sentry_key=123&sentry_version=7';
-const envelopeTunnel = 'https://hello.com/world';
+const tunnel = 'https://hello.com/world';
 const eventPayload: Event = {
   event_id: '1337',
 };
@@ -47,13 +47,13 @@ describe('XHRTransport', () => {
       expect(JSON.parse(request.requestBody)).deep.equal(eventPayload);
     });
 
-    it('sends a request to envelopeTunnel if configured', async () => {
-      transport = new Transports.XHRTransport({ dsn: testDsn, envelopeTunnel });
-      server.respondWith('POST', envelopeTunnel, [200, {}, '']);
+    it('sends a request to tunnel if configured', async () => {
+      transport = new Transports.XHRTransport({ dsn: testDsn, tunnel });
+      server.respondWith('POST', tunnel, [200, {}, '']);
 
       await transport.sendEvent(eventPayload);
 
-      expect(server.requests[0].url).equal(envelopeTunnel);
+      expect(server.requests[0].url).equal(tunnel);
     });
 
     it('rejects with non-200 status code', async () => {

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -19,14 +19,14 @@ export class API {
   private readonly _dsnObject: Dsn;
 
   /** The envelope tunnel to use. */
-  private envelopeTunnel?: string;
+  private readonly _envelopeTunnel?: string;
 
   /** Create a new instance of API */
   public constructor(dsn: DsnLike, metadata: SdkMetadata = {}, envelopeTunnel?: string) {
     this.dsn = dsn;
     this._dsnObject = new Dsn(dsn);
     this.metadata = metadata;
-    this.envelopeTunnel = envelopeTunnel;
+    this._envelopeTunnel = envelopeTunnel;
   }
 
   /** Returns the Dsn object. */
@@ -35,13 +35,13 @@ export class API {
   }
 
   /** Does this transport force envelopes? */
-  public forcesEnvelopes(): boolean {
-    return !!this.envelopeTunnel;
+  public forceEnvelope(): boolean {
+    return !!this._envelopeTunnel;
   }
 
   /** Returns the prefix to construct Sentry ingestion API endpoints. */
   public getBaseApiEndpoint(): string {
-    const dsn = this._dsnObject;
+    const dsn = this.getDsn();
     const protocol = dsn.protocol ? `${dsn.protocol}:` : '';
     const port = dsn.port ? `:${dsn.port}` : '';
     return `${protocol}//${dsn.host}${port}${dsn.path ? `/${dsn.path}` : ''}/api/`;
@@ -67,12 +67,16 @@ export class API {
    * Sending auth as part of the query string and not as custom HTTP headers avoids CORS preflight requests.
    */
   public getEnvelopeEndpointWithUrlEncodedAuth(): string {
+    if (this.forceEnvelope()) {
+      return this._envelopeTunnel as string;
+    }
+
     return `${this._getEnvelopeEndpoint()}?${this._encodedAuth()}`;
   }
 
   /** Returns only the path component for the store endpoint. */
   public getStoreEndpointPath(): string {
-    const dsn = this._dsnObject;
+    const dsn = this.getDsn();
     return `${dsn.path ? `/${dsn.path}` : ''}/api/${dsn.projectId}/store/`;
   }
 
@@ -82,7 +86,7 @@ export class API {
    */
   public getRequestHeaders(clientName: string, clientVersion: string): { [key: string]: string } {
     // CHANGE THIS to use metadata but keep clientName and clientVersion compatible
-    const dsn = this._dsnObject;
+    const dsn = this.getDsn();
     const header = [`Sentry sentry_version=${SENTRY_API_VERSION}`];
     header.push(`sentry_client=${clientName}/${clientVersion}`);
     header.push(`sentry_key=${dsn.publicKey}`);
@@ -103,7 +107,7 @@ export class API {
       user?: { name?: string; email?: string };
     } = {},
   ): string {
-    const dsn = this._dsnObject;
+    const dsn = this.getDsn();
     const endpoint = `${this.getBaseApiEndpoint()}embed/error-page/`;
 
     const encodedOptions = [];
@@ -141,20 +145,17 @@ export class API {
 
   /** Returns the ingest API endpoint for target. */
   private _getIngestEndpoint(target: 'store' | 'envelope'): string {
-    if (this.envelopeTunnel) {
-      return this.envelopeTunnel;
+    if (this._envelopeTunnel) {
+      return this._envelopeTunnel;
     }
     const base = this.getBaseApiEndpoint();
-    const dsn = this._dsnObject;
+    const dsn = this.getDsn();
     return `${base}${dsn.projectId}/${target}/`;
   }
 
   /** Returns a URL-encoded string with auth config suitable for a query string. */
   private _encodedAuth(): string {
-    if (this.envelopeTunnel) {
-      return '';
-    }
-    const dsn = this._dsnObject;
+    const dsn = this.getDsn();
     const auth = {
       // We send only the minimum set of required information. See
       // https://github.com/getsentry/sentry-javascript/issues/2572.

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -18,16 +18,25 @@ export class API {
   /** The internally used Dsn object. */
   private readonly _dsnObject: Dsn;
 
+  /** The envelope tunnel to use. */
+  private envelopeTunnel?: string;
+
   /** Create a new instance of API */
-  public constructor(dsn: DsnLike, metadata: SdkMetadata = {}) {
+  public constructor(dsn: DsnLike, metadata: SdkMetadata = {}, envelopeTunnel?: string) {
     this.dsn = dsn;
     this._dsnObject = new Dsn(dsn);
     this.metadata = metadata;
+    this.envelopeTunnel = envelopeTunnel;
   }
 
   /** Returns the Dsn object. */
   public getDsn(): Dsn {
     return this._dsnObject;
+  }
+
+  /** Does this transport force envelopes? */
+  public forcesEnvelopes(): boolean {
+    return !!this.envelopeTunnel;
   }
 
   /** Returns the prefix to construct Sentry ingestion API endpoints. */
@@ -132,6 +141,9 @@ export class API {
 
   /** Returns the ingest API endpoint for target. */
   private _getIngestEndpoint(target: 'store' | 'envelope'): string {
+    if (this.envelopeTunnel) {
+      return this.envelopeTunnel;
+    }
     const base = this.getBaseApiEndpoint();
     const dsn = this._dsnObject;
     return `${base}${dsn.projectId}/${target}/`;
@@ -139,6 +151,9 @@ export class API {
 
   /** Returns a URL-encoded string with auth config suitable for a query string. */
   private _encodedAuth(): string {
+    if (this.envelopeTunnel) {
+      return '';
+    }
     const dsn = this._dsnObject;
     const auth = {
       // We send only the minimum set of required information. See

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -19,14 +19,14 @@ export class API {
   private readonly _dsnObject: Dsn;
 
   /** The envelope tunnel to use. */
-  private readonly _envelopeTunnel?: string;
+  private readonly _tunnel?: string;
 
   /** Create a new instance of API */
-  public constructor(dsn: DsnLike, metadata: SdkMetadata = {}, envelopeTunnel?: string) {
+  public constructor(dsn: DsnLike, metadata: SdkMetadata = {}, tunnel?: string) {
     this.dsn = dsn;
     this._dsnObject = new Dsn(dsn);
     this.metadata = metadata;
-    this._envelopeTunnel = envelopeTunnel;
+    this._tunnel = tunnel;
   }
 
   /** Returns the Dsn object. */
@@ -36,7 +36,7 @@ export class API {
 
   /** Does this transport force envelopes? */
   public forceEnvelope(): boolean {
-    return !!this._envelopeTunnel;
+    return !!this._tunnel;
   }
 
   /** Returns the prefix to construct Sentry ingestion API endpoints. */
@@ -68,7 +68,7 @@ export class API {
    */
   public getEnvelopeEndpointWithUrlEncodedAuth(): string {
     if (this.forceEnvelope()) {
-      return this._envelopeTunnel as string;
+      return this._tunnel as string;
     }
 
     return `${this._getEnvelopeEndpoint()}?${this._encodedAuth()}`;
@@ -145,8 +145,8 @@ export class API {
 
   /** Returns the ingest API endpoint for target. */
   private _getIngestEndpoint(target: 'store' | 'envelope'): string {
-    if (this._envelopeTunnel) {
-      return this._envelopeTunnel;
+    if (this._tunnel) {
+      return this._tunnel;
     }
     const base = this.getBaseApiEndpoint();
     const dsn = this.getDsn();

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -51,7 +51,7 @@ export function sessionToSentryRequest(session: Session | SessionAggregates, api
 export function eventToSentryRequest(event: Event, api: API): SentryRequest {
   const sdkInfo = getSdkMetadataForEnvelopeHeader(api);
   const eventType = event.type || 'event';
-  const useEnvelope = eventType === 'transaction' || api.forcesEnvelopes();
+  const useEnvelope = eventType === 'transaction' || api.forceEnvelope();
 
   const { transactionSampling, ...metadata } = event.debug_meta || {};
   const { method: samplingMethod, rate: sampleRate } = transactionSampling || {};
@@ -78,6 +78,7 @@ export function eventToSentryRequest(event: Event, api: API): SentryRequest {
       event_id: event.event_id,
       sent_at: new Date().toISOString(),
       ...(sdkInfo && { sdk: sdkInfo }),
+      ...(api.forceEnvelope() && { dsn: api.getDsn().toString() }),
     });
     const itemHeaders = JSON.stringify({
       type: event.type,

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -51,7 +51,7 @@ export function sessionToSentryRequest(session: Session | SessionAggregates, api
 export function eventToSentryRequest(event: Event, api: API): SentryRequest {
   const sdkInfo = getSdkMetadataForEnvelopeHeader(api);
   const eventType = event.type || 'event';
-  const useEnvelope = eventType === 'transaction';
+  const useEnvelope = eventType === 'transaction' || api.forcesEnvelopes();
 
   const { transactionSampling, ...metadata } = event.debug_meta || {};
   const { method: samplingMethod, rate: sampleRate } = transactionSampling || {};

--- a/packages/core/test/lib/api.test.ts
+++ b/packages/core/test/lib/api.test.ts
@@ -5,6 +5,7 @@ import { API } from '../../src/api';
 const ingestDsn = 'https://abc@xxxx.ingest.sentry.io:1234/subpath/123';
 const dsnPublic = 'https://abc@sentry.io:1234/subpath/123';
 const legacyDsn = 'https://abc:123@sentry.io:1234/subpath/123';
+const envelopeTunnel = 'https://hello.com/world';
 
 describe('API', () => {
   test('getStoreEndpoint', () => {
@@ -13,6 +14,13 @@ describe('API', () => {
     );
     expect(new API(dsnPublic).getStoreEndpoint()).toEqual('https://sentry.io:1234/subpath/api/123/store/');
     expect(new API(ingestDsn).getStoreEndpoint()).toEqual('https://xxxx.ingest.sentry.io:1234/subpath/api/123/store/');
+  });
+
+  test('getEnvelopeEndpoint', () => {
+    expect(new API(dsnPublic).getEnvelopeEndpointWithUrlEncodedAuth()).toEqual(
+      'https://sentry.io:1234/subpath/api/123/envelope/?sentry_key=abc&sentry_version=7',
+    );
+    expect(new API(dsnPublic, {}, envelopeTunnel).getEnvelopeEndpointWithUrlEncodedAuth()).toEqual(envelopeTunnel);
   });
 
   test('getRequestHeaders', () => {

--- a/packages/core/test/lib/api.test.ts
+++ b/packages/core/test/lib/api.test.ts
@@ -5,7 +5,7 @@ import { API } from '../../src/api';
 const ingestDsn = 'https://abc@xxxx.ingest.sentry.io:1234/subpath/123';
 const dsnPublic = 'https://abc@sentry.io:1234/subpath/123';
 const legacyDsn = 'https://abc:123@sentry.io:1234/subpath/123';
-const envelopeTunnel = 'https://hello.com/world';
+const tunnel = 'https://hello.com/world';
 
 describe('API', () => {
   test('getStoreEndpoint', () => {
@@ -20,7 +20,7 @@ describe('API', () => {
     expect(new API(dsnPublic).getEnvelopeEndpointWithUrlEncodedAuth()).toEqual(
       'https://sentry.io:1234/subpath/api/123/envelope/?sentry_key=abc&sentry_version=7',
     );
-    expect(new API(dsnPublic, {}, envelopeTunnel).getEnvelopeEndpointWithUrlEncodedAuth()).toEqual(envelopeTunnel);
+    expect(new API(dsnPublic, {}, tunnel).getEnvelopeEndpointWithUrlEncodedAuth()).toEqual(tunnel);
   });
 
   test('getRequestHeaders', () => {

--- a/packages/core/test/lib/request.test.ts
+++ b/packages/core/test/lib/request.test.ts
@@ -13,7 +13,7 @@ const api = new API('https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.s
 });
 
 const ingestDsn = 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012';
-const envelopeTunnel = 'https://hello.com/world';
+const tunnel = 'https://hello.com/world';
 
 function parseEnvelopeRequest(request: SentryRequest): any {
   const [envelopeHeaderString, itemHeaderString, eventString] = request.body.split('\n');
@@ -139,16 +139,16 @@ describe('eventToSentryRequest', () => {
     );
   });
 
-  it('uses envelopeTunnel as the url if it is configured', () => {
-    api = new API(ingestDsn, {}, envelopeTunnel);
+  it('uses tunnel as the url if it is configured', () => {
+    api = new API(ingestDsn, {}, tunnel);
 
     const result = eventToSentryRequest(event, api);
 
-    expect(result.url).toEqual(envelopeTunnel);
+    expect(result.url).toEqual(tunnel);
   });
 
-  it('adds dsn to envelope header if envelopeTunnel is configured', () => {
-    api = new API(ingestDsn, {}, envelopeTunnel);
+  it('adds dsn to envelope header if tunnel is configured', () => {
+    api = new API(ingestDsn, {}, tunnel);
 
     const result = eventToSentryRequest(event, api);
     const envelope = parseEnvelopeRequest(result);

--- a/packages/core/test/lib/request.test.ts
+++ b/packages/core/test/lib/request.test.ts
@@ -12,19 +12,33 @@ const api = new API('https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.s
   },
 });
 
-describe('eventToSentryRequest', () => {
-  let event: Event;
-  function parseEnvelopeRequest(request: SentryRequest): any {
-    const [envelopeHeaderString, itemHeaderString, eventString] = request.body.split('\n');
+const ingestDsn = 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012';
+const envelopeTunnel = 'https://hello.com/world';
 
-    return {
-      envelopeHeader: JSON.parse(envelopeHeaderString),
-      itemHeader: JSON.parse(itemHeaderString),
-      event: JSON.parse(eventString),
-    };
-  }
+function parseEnvelopeRequest(request: SentryRequest): any {
+  const [envelopeHeaderString, itemHeaderString, eventString] = request.body.split('\n');
+
+  return {
+    envelopeHeader: JSON.parse(envelopeHeaderString),
+    itemHeader: JSON.parse(itemHeaderString),
+    event: JSON.parse(eventString),
+  };
+}
+
+describe('eventToSentryRequest', () => {
+  let api: API;
+  let event: Event;
 
   beforeEach(() => {
+    api = new API(ingestDsn, {
+      sdk: {
+        integrations: ['AWSLambda'],
+        name: 'sentry.javascript.browser',
+        version: `12.31.12`,
+        packages: [{ name: 'npm:@sentry/browser', version: `12.31.12` }],
+      },
+    });
+
     event = {
       contexts: { trace: { trace_id: '1231201211212012', span_id: '12261980', op: 'pageload' } },
       environment: 'dogpark',
@@ -37,7 +51,7 @@ describe('eventToSentryRequest', () => {
     };
   });
 
-  it(`adds transaction sampling information to item header`, () => {
+  it('adds transaction sampling information to item header', () => {
     event.debug_meta = { transactionSampling: { method: TransactionSamplingMethod.Rate, rate: 0.1121 } };
 
     const result = eventToSentryRequest(event, api);
@@ -121,6 +135,27 @@ describe('eventToSentryRequest', () => {
           ],
           version: '1337',
         },
+      }),
+    );
+  });
+
+  it('uses envelopeTunnel as the url if it is configured', () => {
+    api = new API(ingestDsn, {}, envelopeTunnel);
+
+    const result = eventToSentryRequest(event, api);
+
+    expect(result.url).toEqual(envelopeTunnel);
+  });
+
+  it('adds dsn to envelope header if envelopeTunnel is configured', () => {
+    api = new API(ingestDsn, {}, envelopeTunnel);
+
+    const result = eventToSentryRequest(event, api);
+    const envelope = parseEnvelopeRequest(result);
+
+    expect(envelope.envelopeHeader).toEqual(
+      expect.objectContaining({
+        dsn: ingestDsn,
       }),
     );
   });

--- a/packages/node/src/backend.ts
+++ b/packages/node/src/backend.ts
@@ -116,7 +116,7 @@ export class NodeBackend extends BaseBackend<NodeOptions> {
       ...(this._options.httpsProxy && { httpsProxy: this._options.httpsProxy }),
       ...(this._options.caCerts && { caCerts: this._options.caCerts }),
       dsn: this._options.dsn,
-      envelopeTunnel: this._options.envelopeTunnel,
+      tunnel: this._options.tunnel,
       _metadata: this._options._metadata,
     };
 

--- a/packages/node/src/backend.ts
+++ b/packages/node/src/backend.ts
@@ -116,6 +116,7 @@ export class NodeBackend extends BaseBackend<NodeOptions> {
       ...(this._options.httpsProxy && { httpsProxy: this._options.httpsProxy }),
       ...(this._options.caCerts && { caCerts: this._options.caCerts }),
       dsn: this._options.dsn,
+      envelopeTunnel: this._options.envelopeTunnel,
       _metadata: this._options._metadata,
     };
 

--- a/packages/node/src/transports/base/index.ts
+++ b/packages/node/src/transports/base/index.ts
@@ -51,7 +51,7 @@ export abstract class BaseTransport implements Transport {
 
   /** Create instance and set this.dsn */
   public constructor(public options: TransportOptions) {
-    this._api = new API(options.dsn, options._metadata);
+    this._api = new API(options.dsn, options._metadata, options.envelopeTunnel);
   }
 
   /** Default function used to parse URLs */

--- a/packages/node/src/transports/base/index.ts
+++ b/packages/node/src/transports/base/index.ts
@@ -51,7 +51,7 @@ export abstract class BaseTransport implements Transport {
 
   /** Create instance and set this.dsn */
   public constructor(public options: TransportOptions) {
-    this._api = new API(options.dsn, options._metadata, options.envelopeTunnel);
+    this._api = new API(options.dsn, options._metadata, options.tunnel);
   }
 
   /** Default function used to parse URLs */

--- a/packages/node/test/transports/http.test.ts
+++ b/packages/node/test/transports/http.test.ts
@@ -10,6 +10,7 @@ const mockSetEncoding = jest.fn();
 const dsn = 'http://9e9fd4523d784609a5fc0ebb1080592f@sentry.io:8989/mysubpath/50622';
 const storePath = '/mysubpath/api/50622/store/';
 const envelopePath = '/mysubpath/api/50622/envelope/';
+const envelopeTunnel = 'https://hello.com/world';
 const eventPayload: Event = {
   event_id: '1337',
 };
@@ -157,6 +158,19 @@ describe('HTTPTransport', () => {
       assertBasicOptions(requestOptions);
       expect(e).toEqual(new SentryError(`HTTP Error (${mockReturnCode}): test-failed`));
     }
+  });
+
+  test('sends a request to envelopeTunnel if configured', async () => {
+    const transport = createTransport({ dsn, envelopeTunnel });
+
+    await transport.sendEvent({
+      message: 'test',
+    });
+
+    const requestOptions = (transport.module!.request as jest.Mock).mock.calls[0][0];
+    expect(requestOptions.protocol).toEqual('https:');
+    expect(requestOptions.hostname).toEqual('hello.com');
+    expect(requestOptions.path).toEqual('/world');
   });
 
   test('back-off using retry-after header', async () => {

--- a/packages/node/test/transports/http.test.ts
+++ b/packages/node/test/transports/http.test.ts
@@ -10,7 +10,7 @@ const mockSetEncoding = jest.fn();
 const dsn = 'http://9e9fd4523d784609a5fc0ebb1080592f@sentry.io:8989/mysubpath/50622';
 const storePath = '/mysubpath/api/50622/store/';
 const envelopePath = '/mysubpath/api/50622/envelope/';
-const envelopeTunnel = 'https://hello.com/world';
+const tunnel = 'https://hello.com/world';
 const eventPayload: Event = {
   event_id: '1337',
 };
@@ -160,8 +160,8 @@ describe('HTTPTransport', () => {
     }
   });
 
-  test('sends a request to envelopeTunnel if configured', async () => {
-    const transport = createTransport({ dsn, envelopeTunnel });
+  test('sends a request to tunnel if configured', async () => {
+    const transport = createTransport({ dsn, tunnel });
 
     await transport.sendEvent({
       message: 'test',

--- a/packages/node/test/transports/https.test.ts
+++ b/packages/node/test/transports/https.test.ts
@@ -10,7 +10,7 @@ const mockSetEncoding = jest.fn();
 const dsn = 'https://9e9fd4523d784609a5fc0ebb1080592f@sentry.io:8989/mysubpath/50622';
 const storePath = '/mysubpath/api/50622/store/';
 const envelopePath = '/mysubpath/api/50622/envelope/';
-const envelopeTunnel = 'https://hello.com/world';
+const tunnel = 'https://hello.com/world';
 const sessionsPayload: SessionAggregates = {
   attrs: { environment: 'test', release: '1.0' },
   aggregates: [{ started: '2021-03-17T16:00:00.000Z', exited: 1 }],
@@ -145,8 +145,8 @@ describe('HTTPSTransport', () => {
     }
   });
 
-  test('sends a request to envelopeTunnel if configured', async () => {
-    const transport = createTransport({ dsn, envelopeTunnel });
+  test('sends a request to tunnel if configured', async () => {
+    const transport = createTransport({ dsn, tunnel });
 
     await transport.sendEvent({
       message: 'test',

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -62,7 +62,7 @@ export interface Options {
    * that accepts Sentry envelopes for forwarding. This can be used to force data
    * through a custom server independent of the type of data.
    */
-  envelopeTunnel?: string;
+  tunnel?: string;
 
   /**
    * The release identifier used when uploading respective source maps. Specify

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -58,6 +58,13 @@ export interface Options {
   transportOptions?: TransportOptions;
 
   /**
+   * A URL to an envelope tunnel endpoint. An envelope tunnel is an HTTP endpoint
+   * that accepts Sentry envelopes for forwarding. This can be used to force data
+   * through a custom server independent of the type of data.
+   */
+  envelopeTunnel?: string;
+
+  /**
    * The release identifier used when uploading respective source maps. Specify
    * this value to allow Sentry to resolve the correct source maps when
    * processing events.

--- a/packages/types/src/transport.ts
+++ b/packages/types/src/transport.ts
@@ -45,6 +45,8 @@ export interface TransportOptions {
   caCerts?: string;
   /** Fetch API init parameters */
   fetchParameters?: { [key: string]: string };
+  /** An optional envelope tunnel URL */
+  envelopeTunnel?: string;
   /**
    * Set of metadata about the SDK that can be internally used to enhance envelopes and events,
    * and provide additional data about every request.

--- a/packages/types/src/transport.ts
+++ b/packages/types/src/transport.ts
@@ -45,7 +45,7 @@ export interface TransportOptions {
   caCerts?: string;
   /** Fetch API init parameters */
   fetchParameters?: { [key: string]: string };
-  /** An optional envelope tunnel URL */
+  /** The envelope tunnel to use. */
   envelopeTunnel?: string;
   /**
    * Set of metadata about the SDK that can be internally used to enhance envelopes and events,

--- a/packages/types/src/transport.ts
+++ b/packages/types/src/transport.ts
@@ -46,7 +46,7 @@ export interface TransportOptions {
   /** Fetch API init parameters */
   fetchParameters?: { [key: string]: string };
   /** The envelope tunnel to use. */
-  envelopeTunnel?: string;
+  tunnel?: string;
   /**
    * Set of metadata about the SDK that can be internally used to enhance envelopes and events,
    * and provide additional data about every request.


### PR DESCRIPTION
This is a non working WIP implementation of adding a mode to the JavaScript SDK to work around ad blockers blocking traffic.

The idea is that if a URL is configured with `envelopeTunnel` the transport forces all events to be sent as envelopes (with embedded auth), no url parameters are configured and the submission URL is the given tunnel URL instead of the regular one.

This is intended to address https://github.com/getsentry/sentry/issues/25607