### PR TITLE
ref(nextjs): Use current hub by default when checking if tracing is enabled

### DIFF
--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -1,4 +1,3 @@
-import { getCurrentHub } from '@sentry/hub';
 import { addInstrumentationHandler, isInstanceOf, isMatchingPattern } from '@sentry/utils';
 
 import { Span } from '../span';
@@ -145,13 +144,7 @@ export function fetchCallback(
   shouldCreateSpan: (url: string) => boolean,
   spans: Record<string, Span>,
 ): void {
-  const currentClientOptions = getCurrentHub()
-    .getClient()
-    ?.getOptions();
-  if (
-    !(currentClientOptions && hasTracingEnabled(currentClientOptions)) ||
-    !(handlerData.fetchData && shouldCreateSpan(handlerData.fetchData.url))
-  ) {
+  if (!hasTracingEnabled() || !(handlerData.fetchData && shouldCreateSpan(handlerData.fetchData.url))) {
     return;
   }
 
@@ -219,13 +212,10 @@ export function xhrCallback(
   shouldCreateSpan: (url: string) => boolean,
   spans: Record<string, Span>,
 ): void {
-  const currentClientOptions = getCurrentHub()
-    .getClient()
-    ?.getOptions();
   if (
-    !(currentClientOptions && hasTracingEnabled(currentClientOptions)) ||
-    !(handlerData.xhr && handlerData.xhr.__sentry_xhr__ && shouldCreateSpan(handlerData.xhr.__sentry_xhr__.url)) ||
-    handlerData.xhr.__sentry_own_request__
+    !hasTracingEnabled() ||
+    handlerData.xhr?.__sentry_own_request__ ||
+    !(handlerData.xhr?.__sentry_xhr__ && shouldCreateSpan(handlerData.xhr.__sentry_xhr__.url))
   ) {
     return;
   }

--- a/packages/tracing/src/hubextensions.ts
+++ b/packages/tracing/src/hubextensions.ts
@@ -43,7 +43,7 @@ function traceHeaders(this: Hub): { [key: string]: string } {
  */
 function sample<T extends Transaction>(transaction: T, options: Options, samplingContext: SamplingContext): T {
   // nothing to do if tracing is not enabled
-  if (!hasTracingEnabled(options)) {
+  if (!hasTracingEnabled()) {
     transaction.sampled = false;
     return transaction;
   }

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -14,7 +14,14 @@ export const TRACEPARENT_REGEXP = new RegExp(
  *
  * Tracing is enabled when at least one of `tracesSampleRate` and `tracesSampler` is defined in the SDK config.
  */
-export function hasTracingEnabled(options: Options): boolean {
+export function hasTracingEnabled(
+  options: Options | undefined = getCurrentHub()
+    .getClient()
+    ?.getOptions(),
+): boolean {
+  if (!options) {
+    return false;
+  }
   return 'tracesSampleRate' in options || 'tracesSampler' in options;
 }
 

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -1,5 +1,5 @@
 import { BrowserClient } from '@sentry/browser';
-import { Hub, Scope } from '@sentry/hub';
+import { Hub, makeMain, Scope } from '@sentry/hub';
 
 import { Span, SpanStatus, Transaction } from '../src';
 import { TRACEPARENT_REGEXP } from '../src/utils';
@@ -10,6 +10,7 @@ describe('Span', () => {
   beforeEach(() => {
     const myScope = new Scope();
     hub = new Hub(new BrowserClient({ tracesSampleRate: 1 }), myScope);
+    makeMain(hub);
   });
 
   describe('new Span', () => {


### PR DESCRIPTION
This just saves us having to call `getCurrentHub()?.getOptions()` and checking for the existence of options immediately before every `hasTracingEnabled()` call.