### PR TITLE
ref(ember): Add type definitions for Ember

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "lerna run --stream --concurrency 1 --sort test",
     "codecov": "codecov",
     "pack:changed": "lerna run pack --since",
-    "postpublish": "make publish-docs"
+    "prepublishOnly": "lerna run --stream --concurrency 1 prepublishOnly",
+    "postpublish": "make publish-docs && lerna run --stream --concurrency 1 postpublish"
   },
   "volta": {
     "node": "10.18.1",

--- a/packages/ember/tsconfig.json
+++ b/packages/ember/tsconfig.json
@@ -24,5 +24,5 @@
       "*": ["types/*"]
     }
   },
-  "include": ["app/**/*", "addon/**/*", "tests/**/*", "types/**/*", "test-support/**/*", "addon-test-support/**/*"]
+  "include": ["app/**/*", "addon/**/*", "types/**/*", "addon-test-support/**/*"]
 }


### PR DESCRIPTION
### Summary
Since we aren't running 'prepublishOnly' via Lerna, Ember-cli-typescript's precompile wasn't getting called. A pre and post publish call will temporarily create the definitions for publishing and remove them afterwards. This is required since .ts files can't be included in the app folder in Ember since they get merged as-is into a project file structure.

**Note:** Can someone from sdk confirm that prepublishOnly will get called before our release script is run? 

Refs https://github.com/getsentry/sentry-javascript/issues/3516