### PR TITLE
feat(nextjs): Add server-side request transactions

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -21,12 +21,12 @@
     "@sentry/integrations": "6.3.6",
     "@sentry/node": "6.3.6",
     "@sentry/react": "6.3.6",
+    "@sentry/tracing": "6.3.6",
     "@sentry/utils": "6.3.6",
     "@sentry/webpack-plugin": "1.15.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@sentry/tracing": "6.3.6",
     "@sentry/types": "6.3.6",
     "@types/webpack": "^5.28.0",
     "eslint": "7.20.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -26,6 +26,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
+    "@sentry/tracing": "6.3.6",
     "@sentry/types": "6.3.6",
     "@types/webpack": "^5.28.0",
     "eslint": "7.20.0",

--- a/packages/nextjs/src/utils/config.ts
+++ b/packages/nextjs/src/utils/config.ts
@@ -3,33 +3,36 @@ import { logger } from '@sentry/utils';
 import defaultWebpackPlugin, { SentryCliPluginOptions } from '@sentry/webpack-plugin';
 import * as SentryWebpackPlugin from '@sentry/webpack-plugin';
 
+const SENTRY_CLIENT_CONFIG_FILE = './sentry.client.config.js';
+const SENTRY_SERVER_CONFIG_FILE = './sentry.server.config.js';
+// this is where the transpiled/bundled version of `USER_SERVER_CONFIG_FILE` will end up
+export const SERVER_INIT_OUTPUT_LOCATION = 'sentry/serverInit';
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type PlainObject<T = any> = { [key: string]: T };
-
-// Man are these types hard to name well. "Entry" = an item in some collection of items, but in our case, one of the
-// things we're worried about here is property (entry) in an object called... entry. So henceforth, the specific
-// property we're modifying is going to be known as an EntryProperty.
 
 // The function which is ultimately going to be exported from `next.config.js` under the name `webpack`
 type WebpackExport = (config: WebpackConfig, options: WebpackOptions) => WebpackConfig;
 
 // The two arguments passed to the exported `webpack` function, as well as the thing it returns
-type WebpackConfig = { devtool: string; plugins: PlainObject[]; entry: EntryProperty };
+type WebpackConfig = { devtool: string; plugins: PlainObject[]; entry: EntryProperty; output: { path: string } };
 type WebpackOptions = { dev: boolean; isServer: boolean; buildId: string };
 
 // For our purposes, the value for `entry` is either an object, or a function which returns such an object
 type EntryProperty = (() => Promise<EntryPropertyObject>) | EntryPropertyObject;
-
 // Each value in that object is either a string representing a single entry point, an array of such strings, or an
 // object containing either of those, along with other configuration options. In that third case, the entry point(s) are
 // listed under the key `import`.
-type EntryPropertyObject = PlainObject<string | Array<string> | EntryPointObject>;
+type EntryPropertyObject = PlainObject<string> | PlainObject<Array<string>> | PlainObject<EntryPointObject>;
 type EntryPointObject = { import: string | Array<string> };
 
-const sentryClientConfig = './sentry.client.config.js';
-const sentryServerConfig = './sentry.server.config.js';
-
-/** Add a file (`injectee`) to a given element (`injectionPoint`) of the `entry` property */
+/**
+ * Add a file to a specific element of the given `entry` webpack config property.
+ *
+ * @param entryProperty The existing `entry` config object
+ * @param injectionPoint The key where the file should be injected
+ * @param injectee The path to the injected file
+ */
 const _injectFile = (entryProperty: EntryPropertyObject, injectionPoint: string, injectee: string): void => {
   // can be a string, array of strings, or object whose `import` property is one of those two
   let injectedInto = entryProperty[injectionPoint];
@@ -41,21 +44,19 @@ const _injectFile = (entryProperty: EntryPropertyObject, injectionPoint: string,
     return;
   }
 
-  // In case we inject our client config, we need to add it after the frontend code
-  // otherwise the runtime config isn't loaded. See: https://github.com/getsentry/sentry-javascript/issues/3485
-  const isClient = injectee === sentryClientConfig;
-
+  // We inject the user's client config file after the existing code so that the config file has access to
+  // `publicRuntimeConfig`. See https://github.com/getsentry/sentry-javascript/issues/3485
   if (typeof injectedInto === 'string') {
-    injectedInto = isClient ? [injectedInto, injectee] : [injectee, injectedInto];
+    injectedInto = [injectedInto, injectee];
   } else if (Array.isArray(injectedInto)) {
-    injectedInto = isClient ? [...injectedInto, injectee] : [injectee, ...injectedInto];
+    injectedInto = [...injectedInto, injectee];
   } else {
-    let importVal: string | string[] | EntryPointObject;
+    let importVal: string | string[];
+
     if (typeof injectedInto.import === 'string') {
-      importVal = isClient ? [injectedInto.import, injectee] : [injectee, injectedInto.import];
+      importVal = [injectedInto.import, injectee];
     } else {
-      // If it's not a string, the inner value is an array
-      importVal = isClient ? [...injectedInto.import, injectee] : [injectee, ...injectedInto.import];
+      importVal = [...injectedInto.import, injectee];
     }
 
     injectedInto = {
@@ -68,8 +69,6 @@ const _injectFile = (entryProperty: EntryPropertyObject, injectionPoint: string,
 };
 
 const injectSentry = async (origEntryProperty: EntryProperty, isServer: boolean): Promise<EntryProperty> => {
-  // Out of the box, nextjs uses the `() => Promise<EntryPropertyObject>)` flavor of EntryProperty, where the returned
-  // object has string arrays for values.
   // The `entry` entry in a webpack config can be a string, array of strings, object, or function. By default, nextjs
   // sets it to an async function which returns the promise of an object of string arrays. Because we don't know whether
   // someone else has come along before us and changed that, we need to check a few things along the way. The one thing
@@ -80,19 +79,19 @@ const injectSentry = async (origEntryProperty: EntryProperty, isServer: boolean)
     newEntryProperty = await origEntryProperty();
   }
   newEntryProperty = newEntryProperty as EntryPropertyObject;
-  // On the server, we need to inject the SDK into both into the base page (`_document`) and into individual API routes
-  // (which have no common base).
+  // Add a new element to the `entry` array, we force webpack to create a bundle out of the user's
+  // `sentry.server.config.js` file and output it to `SERVER_INIT_LOCATION`. (See
+  // https://webpack.js.org/guides/code-splitting/#entry-points.) We do this so that the user's config file is run
+  // through babel (and any other processors through which next runs the rest of the user-provided code - pages, API
+  // routes, etc.). Specifically, we need any ESM-style `import` code to get transpiled into ES5, so that we can call
+  // `require()` on the resulting file when we're instrumenting the sesrver. (We can't use a dynamic import there
+  // because that then forces the user into a particular TS config.)
   if (isServer) {
-    Object.keys(newEntryProperty).forEach(key => {
-      if (key === 'pages/_document' || key.includes('pages/api')) {
-        // for some reason, because we're now in a function, we have to cast again
-        _injectFile(newEntryProperty as EntryPropertyObject, key, sentryServerConfig);
-      }
-    });
+    newEntryProperty[SERVER_INIT_OUTPUT_LOCATION] = SENTRY_SERVER_CONFIG_FILE;
   }
   // On the client, it's sufficient to inject it into the `main` JS code, which is included in every browser page.
   else {
-    _injectFile(newEntryProperty, 'main', sentryClientConfig);
+    _injectFile(newEntryProperty, 'main', SENTRY_CLIENT_CONFIG_FILE);
   }
   // TODO: hack made necessary because the async-ness of this function turns our object back into a promise, meaning the
   // internal `next` code which should do this doesn't
@@ -109,11 +108,18 @@ type NextConfigExports = {
   webpack?: WebpackExport;
 };
 
+/**
+ * Add Sentry options to the config to be exported from the user's `next.config.js` file.
+ *
+ * @param providedExports The existing config to be exported ,prior to adding Sentry
+ * @param providedSentryWebpackPluginOptions Configuration for SentryWebpackPlugin
+ * @returns The modified config to be exported
+ */
 export function withSentryConfig(
   providedExports: NextConfigExports = {},
-  providedWebpackPluginOptions: Partial<SentryCliPluginOptions> = {},
+  providedSentryWebpackPluginOptions: Partial<SentryCliPluginOptions> = {},
 ): NextConfigExports {
-  const defaultWebpackPluginOptions = {
+  const defaultSentryWebpackPluginOptions = {
     url: process.env.SENTRY_URL,
     org: process.env.SENTRY_ORG,
     project: process.env.SENTRY_PROJECT,
@@ -122,17 +128,17 @@ export function withSentryConfig(
     stripPrefix: ['webpack://_N_E/'],
     urlPrefix: `~/_next`,
     include: '.next/',
-    ignore: ['node_modules', 'webpack.config.js'],
+    ignore: ['.next/cache', 'server/ssr-module-cache.js', 'static/*/_ssgManifest.js', 'static/*/_buildManifest.js'],
   };
 
   // warn if any of the default options for the webpack plugin are getting overridden
-  const webpackPluginOptionOverrides = Object.keys(defaultWebpackPluginOptions)
+  const sentryWebpackPluginOptionOverrides = Object.keys(defaultSentryWebpackPluginOptions)
     .concat('dryrun')
-    .filter(key => key in Object.keys(providedWebpackPluginOptions));
-  if (webpackPluginOptionOverrides.length > 0) {
+    .filter(key => key in Object.keys(providedSentryWebpackPluginOptions));
+  if (sentryWebpackPluginOptionOverrides.length > 0) {
     logger.warn(
       '[Sentry] You are overriding the following automatically-set SentryWebpackPlugin config options:\n' +
-        `\t${webpackPluginOptionOverrides.toString()},\n` +
+        `\t${sentryWebpackPluginOptionOverrides.toString()},\n` +
         "which has the possibility of breaking source map upload and application. This is only a good idea if you know what you're doing.",
     );
   }
@@ -161,8 +167,8 @@ export function withSentryConfig(
       new ((SentryWebpackPlugin as unknown) as typeof defaultWebpackPlugin)({
         dryRun: options.dev,
         release: getSentryRelease(options.buildId),
-        ...defaultWebpackPluginOptions,
-        ...providedWebpackPluginOptions,
+        ...defaultSentryWebpackPluginOptions,
+        ...providedSentryWebpackPluginOptions,
       }),
     );
 

--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -1,6 +1,10 @@
+import { deepReadDirSync } from '@sentry/node';
+import { hasTracingEnabled } from '@sentry/tracing';
+import { Transaction } from '@sentry/types';
 import { fill } from '@sentry/utils';
 import * as http from 'http';
 import { default as createNextServer } from 'next';
+import * as path from 'path';
 import * as url from 'url';
 
 import * as Sentry from '../index.server';
@@ -10,23 +14,33 @@ type PlainObject<T = any> = { [key: string]: T };
 
 interface NextServer {
   server: Server;
+  createServer: (options: PlainObject) => Server;
 }
 
 interface Server {
   dir: string;
+  publicDir: string;
+}
+
+interface NextRequest extends http.IncomingMessage {
+  cookies: Record<string, string>;
+  url: string;
+}
+
+interface NextResponse extends http.ServerResponse {
+  __sentry__: {
+    transaction?: Transaction;
+  };
 }
 
 type HandlerGetter = () => Promise<ReqHandler>;
-type ReqHandler = (
-  req: http.IncomingMessage,
-  res: http.ServerResponse,
-  parsedUrl?: url.UrlWithParsedQuery,
-) => Promise<void>;
+type ReqHandler = (req: NextRequest, res: NextResponse, parsedUrl?: url.UrlWithParsedQuery) => Promise<void>;
 type ErrorLogger = (err: Error) => void;
 
 // these aliases are purely to make the function signatures more easily understandable
 type WrappedHandlerGetter = HandlerGetter;
 type WrappedErrorLogger = ErrorLogger;
+type WrappedReqHandler = ReqHandler;
 
 // TODO is it necessary for this to be an object?
 const closure: PlainObject = {};
@@ -61,11 +75,15 @@ function makeWrappedHandlerGetter(origHandlerGetter: HandlerGetter): WrappedHand
   const wrappedHandlerGetter = async function(this: NextServer): Promise<ReqHandler> {
     if (!closure.wrappingComplete) {
       closure.projectRootDir = this.server.dir;
+      closure.server = this.server;
+      closure.publicDir = this.server.publicDir;
 
       const serverPrototype = Object.getPrototypeOf(this.server);
 
       // wrap the logger so we can capture errors in page-level functions like `getServerSideProps`
       fill(serverPrototype, 'logError', makeWrappedErrorLogger);
+
+      fill(serverPrototype, 'handleRequest', makeWrappedReqHandler);
 
       closure.wrappingComplete = true;
     }
@@ -88,4 +106,78 @@ function makeWrappedErrorLogger(origErrorLogger: ErrorLogger): WrappedErrorLogge
     Sentry.captureException(err);
     return origErrorLogger.call(this, err);
   };
+}
+
+/**
+ * Wrap the server's request handler to be able to create request transactions.
+ *
+ * @param origReqHandler The original request handler from the `Server` class
+ * @returns A wrapped version of that handler
+ */
+function makeWrappedReqHandler(origReqHandler: ReqHandler): WrappedReqHandler {
+  const liveServer = closure.server as Server;
+
+  // inspired by
+  // https://github.com/vercel/next.js/blob/4443d6f3d36b107e833376c2720c1e206eee720d/packages/next/next-server/server/next-server.ts#L1166
+  const publicDirFiles = new Set(
+    deepReadDirSync(liveServer.publicDir).map(p =>
+      encodeURI(
+        // switch any backslashes in the path to regular slashes
+        p.replace(/\\/g, '/'),
+      ),
+    ),
+  );
+
+  // add transaction start and stop to the normal request handling
+  const wrappedReqHandler = async function(
+    this: Server,
+    req: NextRequest,
+    res: NextResponse,
+    parsedUrl?: url.UrlWithParsedQuery,
+  ): Promise<void> {
+    // We only want to record page and API requests
+    if (hasTracingEnabled() && shouldTraceRequest(req.url, publicDirFiles)) {
+      const transaction = Sentry.startTransaction({
+        name: `${(req.method || 'GET').toUpperCase()} ${req.url}`,
+        op: 'http.server',
+      });
+      Sentry.getCurrentHub()
+        .getScope()
+        ?.setSpan(transaction);
+
+      res.__sentry__ = {};
+      res.__sentry__.transaction = transaction;
+    }
+
+    res.once('finish', () => {
+      const transaction = res.__sentry__?.transaction;
+      if (transaction) {
+        // Push `transaction.finish` to the next event loop so open spans have a chance to finish before the transaction
+        // closes
+        setImmediate(() => {
+          // TODO
+          // addExpressReqToTransaction(transaction, req);
+          transaction.setHttpStatus(res.statusCode);
+          transaction.finish();
+        });
+      }
+    });
+
+    return origReqHandler.call(this, req, res, parsedUrl);
+  };
+
+  return wrappedReqHandler;
+}
+
+/**
+ * Determine if the request should be traced, by filtering out requests for internal next files and static resources.
+ *
+ * @param url The URL of the request
+ * @param publicDirFiles A set containing relative paths to all available static resources (note that this does not
+ * include static *pages*, but rather images and the like)
+ * @returns false if the URL is for an internal or static resource
+ */
+function shouldTraceRequest(url: string, publicDirFiles: Set<string>): boolean {
+  // `static` is a deprecated but still-functional location for static resources
+  return !url.startsWith('/_next/') && !url.startsWith('/static/') && !publicDirFiles.has(url);
 }

--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -156,15 +156,14 @@ function makeWrappedErrorLogger(origErrorLogger: ErrorLogger): WrappedErrorLogge
 function makeWrappedReqHandler(origReqHandler: ReqHandler): WrappedReqHandler {
   const liveServer = closure.server as Server;
 
-  // inspired by
+  // inspired by next's public file routing; see
   // https://github.com/vercel/next.js/blob/4443d6f3d36b107e833376c2720c1e206eee720d/packages/next/next-server/server/next-server.ts#L1166
   const publicDirFiles = new Set(
-    deepReadDirSync(liveServer.publicDir).map(p =>
-      encodeURI(
-        // switch any backslashes in the path to regular slashes
-        p.replace(/\\/g, '/'),
-      ),
-    ),
+    // we need the paths here to match the format of a request url, which means they must:
+    // - start with a slash
+    // - use forward slashes rather than backslashes
+    // - be URL-encoded
+    deepReadDirSync(liveServer.publicDir).map(filepath => encodeURI(`/${filepath.replace(/\\/g, '/')}`)),
   );
 
   // add transaction start and stop to the normal request handling

--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -45,6 +45,8 @@ type WrappedReqHandler = ReqHandler;
 // TODO is it necessary for this to be an object?
 const closure: PlainObject = {};
 
+let sdkInitialized = false;
+
 /**
  * Do the monkeypatching and wrapping necessary to catch errors in page routes. Along the way, as a bonus, grab (and
  * return) the path of the project root, for use in `RewriteFrames`.
@@ -58,6 +60,10 @@ export function instrumentServer(): string {
   // wrap this getter because it runs before the request handler runs, which gives us a chance to wrap the logger before
   // it's called for the first time
   fill(nextServerPrototype, 'getServerRequestHandler', makeWrappedHandlerGetter);
+  if (!sdkInitialized) {
+    require(path.join(process.cwd(), 'sentry.server.config.js'));
+    sdkInitialized = true;
+  }
 
   return closure.projectRootDir;
 }

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -255,8 +255,11 @@ export function extractRequestData(
         if (method === 'GET' || method === 'HEAD') {
           break;
         }
-        // body data:
-        //   node, express, koa: req.body
+        // body data: express, koa: req.body
+
+        // when using node by itself, you have to read the incoming stream(see
+        // https://nodejs.dev/learn/get-http-request-body-data-using-nodejs); if a user is doing that, we can't know
+        // where they're going to store the final result, so they'll have to capture this data themselves
         if (req.body !== undefined) {
           requestData.data = isString(req.body) ? req.body : JSON.stringify(normalize(req.body));
         }

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -41,6 +41,7 @@ export {
 export { NodeBackend, NodeOptions } from './backend';
 export { NodeClient } from './client';
 export { defaultIntegrations, init, lastEventId, flush, close, getSentryRelease } from './sdk';
+export { deepReadDirSync } from './utils';
 export { SDK_NAME } from './version';
 
 import { Integrations as CoreIntegrations } from '@sentry/core';

--- a/packages/node/src/utils.ts
+++ b/packages/node/src/utils.ts
@@ -1,0 +1,26 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Recursively read the contents of a directory.
+ *
+ * @param targetDir The directory to scan. All returned paths will be relative to this directory.
+ * @param _paths Array to hold results, passed for purposes of recursion. Not meant to be provided by the caller.
+ * @returns Array holding all relative paths
+ */
+export function deepReadDirSync(targetDir: string, _paths?: string[]): string[] {
+  const paths = _paths || [];
+  const currentDirContents = fs.readdirSync(targetDir);
+
+  currentDirContents.forEach((fileOrDirName: string) => {
+    const fileOrDirAbsPath = path.join(targetDir, fileOrDirName);
+
+    if (fs.statSync(fileOrDirAbsPath).isDirectory()) {
+      deepReadDirSync(fileOrDirAbsPath, paths);
+      return;
+    }
+    paths.push(fileOrDirAbsPath.replace(targetDir, ''));
+  });
+
+  return paths;
+}

--- a/packages/node/test/fixtures/testDeepReadDirSync/cats/eddy.txt
+++ b/packages/node/test/fixtures/testDeepReadDirSync/cats/eddy.txt
@@ -1,0 +1,1 @@
+Lived to be almost 23. Named Eddy because she would sometimes just spin around and around and around, for no reason.

--- a/packages/node/test/fixtures/testDeepReadDirSync/cats/persephone.txt
+++ b/packages/node/test/fixtures/testDeepReadDirSync/cats/persephone.txt
@@ -1,0 +1,1 @@
+Originally a stray. Adopted the humans rather than vice-versa.

--- a/packages/node/test/fixtures/testDeepReadDirSync/cats/piper.txt
+++ b/packages/node/test/fixtures/testDeepReadDirSync/cats/piper.txt
@@ -1,0 +1,1 @@
+A polydactyl with an enormous fluffy tail.

--- a/packages/node/test/fixtures/testDeepReadDirSync/cats/sassafras.txt
+++ b/packages/node/test/fixtures/testDeepReadDirSync/cats/sassafras.txt
@@ -1,0 +1,1 @@
+All black. Once ran away for two weeks, but eventually came back.

--- a/packages/node/test/fixtures/testDeepReadDirSync/cats/teaberry.txt
+++ b/packages/node/test/fixtures/testDeepReadDirSync/cats/teaberry.txt
@@ -1,0 +1,1 @@
+Named by popular consensus, after the plant that makes wintergreen.

--- a/packages/node/test/fixtures/testDeepReadDirSync/debra.txt
+++ b/packages/node/test/fixtures/testDeepReadDirSync/debra.txt
@@ -1,0 +1,1 @@
+A black and white hooded rat, who loved to eat pizza crusts.

--- a/packages/node/test/fixtures/testDeepReadDirSync/dogs/theBigs/charlie.txt
+++ b/packages/node/test/fixtures/testDeepReadDirSync/dogs/theBigs/charlie.txt
@@ -1,0 +1,1 @@
+Named after the Charles River. A big dog who loves to play with tiny dogs.

--- a/packages/node/test/fixtures/testDeepReadDirSync/dogs/theBigs/maisey.txt
+++ b/packages/node/test/fixtures/testDeepReadDirSync/dogs/theBigs/maisey.txt
@@ -1,0 +1,1 @@
+Has fluff between her toes. Slow to warm, but incredibly loyal thereafter.

--- a/packages/node/test/fixtures/testDeepReadDirSync/dogs/theSmalls/bodhi.txt
+++ b/packages/node/test/fixtures/testDeepReadDirSync/dogs/theSmalls/bodhi.txt
@@ -1,0 +1,1 @@
+Loves to explore. Has spots on his tongue.

--- a/packages/node/test/fixtures/testDeepReadDirSync/dogs/theSmalls/cory.txt
+++ b/packages/node/test/fixtures/testDeepReadDirSync/dogs/theSmalls/cory.txt
@@ -1,0 +1,1 @@
+Resembles a small sheep. Sneezes when playing with another dog.

--- a/packages/node/test/utils.test.ts
+++ b/packages/node/test/utils.test.ts
@@ -1,0 +1,53 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { deepReadDirSync } from '../src/utils';
+
+// The parent directory for the new temporary directory
+
+describe('deepReadDirSync', () => {
+  it('handles nested files', () => {
+    // compare sets so that order doesn't matter
+    expect(new Set(deepReadDirSync('./test/fixtures/testDeepReadDirSync'))).toEqual(
+      new Set([
+        // root level
+        'debra.txt',
+        // one level deep
+        'cats/eddy.txt',
+        'cats/persephone.txt',
+        'cats/piper.txt',
+        'cats/sassafras.txt',
+        'cats/teaberry.txt',
+        // two levels deep
+        'dogs/theBigs/charlie.txt',
+        'dogs/theBigs/maisey.txt',
+        'dogs/theSmalls/bodhi.txt',
+        'dogs/theSmalls/cory.txt',
+      ]),
+    );
+  });
+
+  it('handles empty target directory', (done: (error?: Error) => void) => {
+    expect.assertions(1);
+    const tmpDir = os.tmpdir();
+
+    fs.mkdtemp(`${tmpDir}${path.sep}`, (err, dirPath) => {
+      if (err) throw err;
+      try {
+        expect(deepReadDirSync(dirPath)).toEqual([]);
+        done();
+      } catch (error) {
+        done(error);
+      }
+    });
+  });
+
+  it('errors if directory does not exist', () => {
+    expect(() => deepReadDirSync('./IDontExist')).toThrowError('Directory does not exist.');
+  });
+
+  it('errors if given path is not a directory', () => {
+    expect(() => deepReadDirSync('package.json')).toThrowError('it is not a directory');
+  });
+});


### PR DESCRIPTION
This PR adds tracing to requests for both page routes and API routes, by wrapping the server's main request handler. In order for the SDK to be initialized early enough for this to work, the logic for including the user's `sentry.server.config.js` file has changed in the following ways:

- It is no longer injected into `_document` nor into individual API routes.
- Instead, it's included as its own `entry` entry, which causes it to get output as a separate file, which we can then require earlier in the process.
- As a result, `_injectFile` can be simplified, since it's now only handling client-side injection.

Why is having webpack output a separate file any better than the separate file it already is? The answer is that doing it this way runs it through the same webpack processors as the rest of the code written by the user, which is a good idea in general (and is what was happening when we were injecting it into existing `entry` entries), and which is specifically necessary in this case because (warning: a trip down into the weeds ahead):
  - We need to import or require `sentry.server.config.js` for its side effect of starting up the SDK.
  - We need the relative path to it to be resolved with respect to the user's nextjs project folder, not relative to our SDK, so we need to do the importing/requiring dynamically.
  - In order to use a dynamic import, we need to have a specific value for `module` in our `tsconfig` - and not only do we have a different one for our ESM builds, we've all seen how well it goes when we try to force our users into a particular TS configuration (see: `localForage` and its numerous associated issues and PRs), so that feels like a non-starter.
  - We therefore have to use `require`, but you can't require something which is itself using ESM imports, which our users easily might do in their `sentry.server.config.js`.
  - So, as a result of all of that, we need that file to be Babel-ized, and running it through next's webpack processors will do that.

Note: If you pull this to test it, you have to watch out for the relative path vs yarn linking problem, otherwise your test app won't build.

TODO in this PR:
- [ ] Test this on Vercel (currently needs a beta release)
- [ ] ~Add tests~ UPDATE: There's too much to mock here, so we'll make an example app against which to test in a separate PR

TODO in future PRs:
- [ ] Use parameterized path for transaction name
- [ ] Add request data to transaction
- [ ] Deal with incoming sentry request headers (`sentry-trace` and `tracestate`)
- [ ] Wrap routing code in a span? (We do this for Express)
- [ ] Wrap Express middleware (which can be used with nextjs) in spans
- [ ] Figure out if our Express integration fully covers the use of an Express server (which is also possible) or if modifications need to be made