### PR TITLE
ref(ember): Allow other integration options for default integration

### DIFF
--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -333,6 +333,7 @@ function _instrumentInitialLoad(config: EmberSentryConfig) {
 export async function instrumentForPerformance(appInstance: ApplicationInstance) {
   const config = getSentryConfig();
   const sentryConfig = config.sentry;
+  const browserTracingOptions = config.browserTracingOptions || {};
 
   const tracing = await import('@sentry/tracing');
 
@@ -349,6 +350,7 @@ export async function instrumentForPerformance(appInstance: ApplicationInstance)
         _instrumentEmberRouter(routerService, routerMain, config, customStartTransaction, startTransactionOnPageLoad);
       },
       idleTimeout,
+      ...browserTracingOptions,
     }),
   ];
 

--- a/packages/ember/addon/types.ts
+++ b/packages/ember/addon/types.ts
@@ -12,6 +12,7 @@ export type EmberSentryConfig = {
   enableComponentDefinitions: boolean;
   minimumRunloopQueueDuration: number;
   minimumComponentRenderDuration: number;
+  browserTracingOptions: Object;
 };
 
 export type OwnConfig = {

--- a/packages/ember/tests/dummy/config/environment.js
+++ b/packages/ember/tests/dummy/config/environment.js
@@ -28,6 +28,9 @@ module.exports = function(environment) {
       tracesSampleRate: 1,
       dsn: process.env.SENTRY_DSN,
     },
+    browserTracingOptions: {
+      tracingOrigins: ['localhost', 'doesntexist.example'],
+    },
     ignoreEmberOnErrorWarning: true,
     minimumRunloopQueueDuration: 5,
     minimumComponentRenderDuration: 2,


### PR DESCRIPTION
### Summary
This will allow users to pass additional configuration (like 'tracingOrigins') to the default instrumented browser tracing integration.

