### PR TITLE
feat: initalScope in SDK Options

### DIFF
--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -179,6 +179,29 @@ describe('SentryBrowser initialization', () => {
     delete global.SENTRY_RELEASE;
   });
 
+  it('should use initalScope object', () => {
+    init({ dsn, initialScope: { tags: { a: 'b' } } });
+    expect(global.__SENTRY__.hub._stack[0].scope._tags).to.deep.equal({ a: 'b' });
+  });
+
+  it('should use initalScope Scope', () => {
+    const scope = new Scope();
+    scope.setTags({ a: 'b' });
+    init({ dsn, initialScope: scope });
+    expect(global.__SENTRY__.hub._stack[0].scope._tags).to.deep.equal({ a: 'b' });
+  });
+
+  it('should use initalScope callback', () => {
+    init({
+      dsn,
+      initialScope: scope => {
+        scope.setTags({ a: 'b' });
+        return scope;
+      },
+    });
+    expect(global.__SENTRY__.hub._stack[0].scope._tags).to.deep.equal({ a: 'b' });
+  });
+
   it('should have initialization proceed as normal if window.SENTRY_RELEASE is not set', () => {
     // This is mostly a happy-path test to ensure that the initialization doesn't throw an error.
     init({ dsn });

--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -179,7 +179,7 @@ describe('SentryBrowser initialization', () => {
     delete global.SENTRY_RELEASE;
   });
 
-  it('should use initalScope object', () => {
+  it('should use initialScope', () => {
     init({ dsn, initialScope: { tags: { a: 'b' } } });
     expect(global.__SENTRY__.hub._stack[0].scope._tags).to.deep.equal({ a: 'b' });
   });

--- a/packages/core/src/sdk.ts
+++ b/packages/core/src/sdk.ts
@@ -17,6 +17,7 @@ export function initAndBind<F extends Client, O extends Options>(clientClass: Cl
     logger.enable();
   }
   const hub = getCurrentHub();
+  hub.getScope()?.update(options.initialScope);
   const client = new clientClass(options);
   hub.bindClient(client);
 }

--- a/packages/core/test/lib/sdk.test.ts
+++ b/packages/core/test/lib/sdk.test.ts
@@ -3,6 +3,7 @@ import { Client, Integration } from '@sentry/types';
 import { installedIntegrations } from '../../src/integration';
 import { initAndBind } from '../../src/sdk';
 import { TestClient } from '../mocks/client';
+import { Scope } from '@sentry/hub';
 
 // eslint-disable-next-line no-var
 declare var global: any;
@@ -16,10 +17,14 @@ jest.mock('@sentry/hub', () => {
     getCurrentHub(): {
       bindClient(client: Client): boolean;
       getClient(): boolean;
+      getScope(): Scope;
     } {
       return {
         getClient(): boolean {
           return false;
+        },
+        getScope(): Scope {
+          return new Scope();
         },
         bindClient(client: Client): boolean {
           client.setupIntegrations();

--- a/packages/core/test/lib/sdk.test.ts
+++ b/packages/core/test/lib/sdk.test.ts
@@ -1,9 +1,9 @@
+import { Scope } from '@sentry/hub';
 import { Client, Integration } from '@sentry/types';
 
 import { installedIntegrations } from '../../src/integration';
 import { initAndBind } from '../../src/sdk';
 import { TestClient } from '../mocks/client';
-import { Scope } from '@sentry/hub';
 
 // eslint-disable-next-line no-var
 declare var global: any;

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -2,6 +2,7 @@ import { Breadcrumb, BreadcrumbHint } from './breadcrumb';
 import { Event, EventHint } from './event';
 import { Integration } from './integration';
 import { LogLevel } from './loglevel';
+import { CaptureContext } from './scope';
 import { SdkMetadata } from './sdkmetadata';
 import { SamplingContext } from './transaction';
 import { Transport, TransportClass, TransportOptions } from './transport';
@@ -123,6 +124,11 @@ export interface Options {
    * By default, Sessions Tracking is enabled.
    */
   autoSessionTracking?: boolean;
+
+  /**
+   * Set data to the inital scope
+   */
+  initialScope?: CaptureContext;
 
   /**
    * Set of metadata about the SDK that can be internally used to enhance envelopes and events,


### PR DESCRIPTION
This PR adds the options to `Sentry.init` to provide an initial Scope the SDK will be started with.

We need this for our Electron SDK to have a Scope already during SDK `init` (when the native crash handler starts). Potentially this is also going to be useful for dynamic sampling.