### PR TITLE
feat(web-vitals): Upgrade to web-vitals v1.1.2

### DIFF
--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -34,6 +34,7 @@ export class MetricsInstrumentation {
   }
 
   /** Add performance related spans to a transaction */
+  // eslint-disable-next-line complexity
   public addPerformanceEntries(transaction: Transaction): void {
     if (!global || !global.performance || !global.performance.getEntries || !browserPerformanceTimeOrigin) {
       // Gatekeeper if performance API not available
@@ -188,7 +189,7 @@ export class MetricsInstrumentation {
 
       transaction.setMeasurements(this._measurements);
 
-      if (this._lcpEntry) {
+      if (this._lcpEntry && this._lcpEntry !== undefined) {
         logger.log('[Measurements] Adding LCP Data');
         // Capture Properties of the LCP element that contributes to the LCP.
 

--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -6,11 +6,11 @@ import { browserPerformanceTimeOrigin, getGlobalObject, htmlTreeAsString, isNode
 import { Span } from '../span';
 import { Transaction } from '../transaction';
 import { msToSec } from '../utils';
+import { NavigatorDeviceMemory, NavigatorNetworkInformation } from './types';
 import { getCLS } from './web-vitals/getCLS';
 import { getFID } from './web-vitals/getFID';
 import { getLCP, LargestContentfulPaint } from './web-vitals/getLCP';
 import { getFirstHidden } from './web-vitals/lib/getFirstHidden';
-import { NavigatorDeviceMemory, NavigatorNetworkInformation } from './web-vitals/types';
 
 const global = getGlobalObject<Window>();
 

--- a/packages/tracing/src/browser/types.ts
+++ b/packages/tracing/src/browser/types.ts
@@ -1,0 +1,49 @@
+// http://wicg.github.io/netinfo/#navigatornetworkinformation-interface
+export interface NavigatorNetworkInformation {
+  readonly connection?: NetworkInformation;
+}
+
+// http://wicg.github.io/netinfo/#connection-types
+type ConnectionType = 'bluetooth' | 'cellular' | 'ethernet' | 'mixed' | 'none' | 'other' | 'unknown' | 'wifi' | 'wimax';
+
+// http://wicg.github.io/netinfo/#effectiveconnectiontype-enum
+type EffectiveConnectionType = '2g' | '3g' | '4g' | 'slow-2g';
+
+// http://wicg.github.io/netinfo/#dom-megabit
+type Megabit = number;
+// http://wicg.github.io/netinfo/#dom-millisecond
+type Millisecond = number;
+
+// http://wicg.github.io/netinfo/#networkinformation-interface
+interface NetworkInformation extends EventTarget {
+  // http://wicg.github.io/netinfo/#type-attribute
+  readonly type?: ConnectionType;
+  // http://wicg.github.io/netinfo/#effectivetype-attribute
+  readonly effectiveType?: EffectiveConnectionType;
+  // http://wicg.github.io/netinfo/#downlinkmax-attribute
+  readonly downlinkMax?: Megabit;
+  // http://wicg.github.io/netinfo/#downlink-attribute
+  readonly downlink?: Megabit;
+  // http://wicg.github.io/netinfo/#rtt-attribute
+  readonly rtt?: Millisecond;
+  // http://wicg.github.io/netinfo/#savedata-attribute
+  readonly saveData?: boolean;
+  // http://wicg.github.io/netinfo/#handling-changes-to-the-underlying-connection
+  onchange?: EventListener;
+}
+
+// https://w3c.github.io/device-memory/#sec-device-memory-js-api
+export interface NavigatorDeviceMemory {
+  readonly deviceMemory?: number;
+}
+
+export type NavigationTimingPolyfillEntry = Omit<
+  PerformanceNavigationTiming,
+  | 'initiatorType'
+  | 'nextHopProtocol'
+  | 'redirectCount'
+  | 'transferSize'
+  | 'encodedBodySize'
+  | 'decodedBodySize'
+  | 'toJSON'
+>;

--- a/packages/tracing/src/browser/web-vitals/README.md
+++ b/packages/tracing/src/browser/web-vitals/README.md
@@ -4,9 +4,9 @@
 
 This was vendored from: https://github.com/GoogleChrome/web-vitals
 
-The commit SHA used is: [56c736b7c4e80f295bc8a98017671c95231fa225](https://github.com/GoogleChrome/web-vitals/tree/56c736b7c4e80f295bc8a98017671c95231fa225)
+Current vendored version: 1.2.2
 
-Current vendored version: 0.2.4
+The commit SHA used is: [d51aa10f68eda421ed90f2a966c3e9e2611d6d57](https://github.com/GoogleChrome/web-vitals/tree/d51aa10f68eda421ed90f2a966c3e9e2611d6d57)
 
 Current vendored web vitals are:
 
@@ -17,6 +17,10 @@ Current vendored web vitals are:
 ## License
 
 [Apache 2.0](https://github.com/GoogleChrome/web-vitals/blob/master/LICENSE)
+
+## Notable differences from `web-vitals` library
+
+- Currently we do not grab metrics information from bfcache events (ex. `onBFCacheRestore`)
 
 ## CHANGELOG
 

--- a/packages/tracing/src/browser/web-vitals/README.md
+++ b/packages/tracing/src/browser/web-vitals/README.md
@@ -6,11 +6,25 @@ This was vendored from: https://github.com/GoogleChrome/web-vitals
 
 The commit SHA used is: [56c736b7c4e80f295bc8a98017671c95231fa225](https://github.com/GoogleChrome/web-vitals/tree/56c736b7c4e80f295bc8a98017671c95231fa225)
 
+Current vendored version: 0.2.4
+
 Current vendored web vitals are:
 
 - LCP (Largest Contentful Paint)
 - FID (First Input Delay)
+- CLS (Cumulative Layout Shift)
 
-# License
+## License
 
 [Apache 2.0](https://github.com/GoogleChrome/web-vitals/blob/master/LICENSE)
+
+## CHANGELOG
+
+https://github.com/getsentry/sentry-javascript/pull/3515
+- Remove support for Time to First Byte (TTFB)
+
+https://github.com/getsentry/sentry-javascript/pull/2964
+- Added support for Cumulative Layout Shift (CLS) and Time to First Byte (TTFB)
+
+https://github.com/getsentry/sentry-javascript/pull/2909
+- Added support for FID (First Input Delay) and LCP (Largest Contentful Paint)

--- a/packages/tracing/src/browser/web-vitals/README.md
+++ b/packages/tracing/src/browser/web-vitals/README.md
@@ -20,8 +20,9 @@ Current vendored web vitals are:
 
 ## Notable differences from `web-vitals` library
 
-- Currently we do not grab metrics information from bfcache events (ex. `onBFCacheRestore`)
-
+<!---
+TODO(abhi): Uhh I gotta figure this out lol, it's def something with polyfilled func
+-->
 ## CHANGELOG
 
 https://github.com/getsentry/sentry-javascript/pull/3515

--- a/packages/tracing/src/browser/web-vitals/getCLS.ts
+++ b/packages/tracing/src/browser/web-vitals/getCLS.ts
@@ -27,7 +27,7 @@ interface LayoutShift extends PerformanceEntry {
   hadRecentInput: boolean;
 }
 
-export const getCLS = (onReport: ReportHandler, reportAllChanges = false): void => {
+export const getCLS = (onReport: ReportHandler, reportAllChanges?: boolean): void => {
   let metric = initMetric('CLS', 0);
   let report: ReturnType<typeof bindReporter>;
 

--- a/packages/tracing/src/browser/web-vitals/getFID.ts
+++ b/packages/tracing/src/browser/web-vitals/getFID.ts
@@ -72,6 +72,7 @@ export const getFID = (onReport: ReportHandler, reportAllChanges?: boolean): voi
       });
     }
   } else {
+    resetFirstInputPolyfill();
     firstInputPolyfill(entryHandler as FirstInputPolyfillCallback);
   }
 };

--- a/packages/tracing/src/browser/web-vitals/getFID.ts
+++ b/packages/tracing/src/browser/web-vitals/getFID.ts
@@ -38,7 +38,7 @@ declare global {
   }
 }
 
-export const getFID = (onReport: ReportHandler, reportAllChanges = false): void => {
+export const getFID = (onReport: ReportHandler, reportAllChanges?: boolean): void => {
   let metric = initMetric('FID');
   const firstHidden = getFirstHidden();
 

--- a/packages/tracing/src/browser/web-vitals/getLCP.ts
+++ b/packages/tracing/src/browser/web-vitals/getLCP.ts
@@ -34,7 +34,7 @@ export interface LargestContentfulPaint extends PerformanceEntry {
   toJSON(): Record<string, string>;
 }
 
-export const getLCP = (onReport: ReportHandler, reportAllChanges = false): void => {
+export const getLCP = (onReport: ReportHandler, reportAllChanges?: boolean): void => {
   let metric = initMetric('LCP');
   const firstHidden = getFirstHidden();
 

--- a/packages/tracing/src/browser/web-vitals/lib/bindReporter.ts
+++ b/packages/tracing/src/browser/web-vitals/lib/bindReporter.ts
@@ -15,29 +15,22 @@
  */
 
 import { Metric, ReportHandler } from '../types';
+import { finalMetrics } from './finalMetrics';
 
-export const bindReporter = (
-  callback: ReportHandler,
-  metric: Metric,
-  po: PerformanceObserver | undefined,
-  observeAllUpdates?: boolean,
-): (() => void) => {
+export const bindReporter = (callback: ReportHandler, metric: Metric, reportAllChanges?: boolean): (() => void) => {
   let prevValue: number;
   return () => {
-    if (po && metric.isFinal) {
-      po.disconnect();
-    }
     if (metric.value >= 0) {
-      if (observeAllUpdates || metric.isFinal || document.visibilityState === 'hidden') {
+      if (reportAllChanges || finalMetrics.has(metric) || document.visibilityState === 'hidden') {
         metric.delta = metric.value - (prevValue || 0);
 
         // Report the metric if there's a non-zero delta, if the metric is
         // final, or if no previous value exists (which can happen in the case
         // of the document becoming hidden when the metric value is 0).
         // See: https://github.com/GoogleChrome/web-vitals/issues/14
-        if (metric.delta || metric.isFinal || prevValue === undefined) {
-          callback(metric);
+        if (metric.delta || prevValue === undefined) {
           prevValue = metric.value;
+          callback(metric);
         }
       }
     }

--- a/packages/tracing/src/browser/web-vitals/lib/finalMetrics.ts
+++ b/packages/tracing/src/browser/web-vitals/lib/finalMetrics.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Metric } from '../types';
+
+export const finalMetrics: WeakSet<Metric> | Set<Metric> = typeof WeakSet === 'function' ? new WeakSet() : new Set();

--- a/packages/tracing/src/browser/web-vitals/lib/generateUniqueID.ts
+++ b/packages/tracing/src/browser/web-vitals/lib/generateUniqueID.ts
@@ -15,10 +15,10 @@
  */
 
 /**
- * Performantly generate a unique, 27-char string by combining the current
- * timestamp with a 13-digit random number.
+ * Performantly generate a unique, 30-char string by combining a version
+ * number, the current timestamp with a 13-digit number integer.
  * @return {string}
  */
 export const generateUniqueID = (): string => {
-  return `${Date.now()}-${Math.floor(Math.random() * (9e12 - 1)) + 1e12}`;
+  return `v1-${Date.now()}-${Math.floor(Math.random() * (9e12 - 1)) + 1e12}`;
 };

--- a/packages/tracing/src/browser/web-vitals/lib/initMetric.ts
+++ b/packages/tracing/src/browser/web-vitals/lib/initMetric.ts
@@ -17,13 +17,12 @@
 import { Metric } from '../types';
 import { generateUniqueID } from './generateUniqueID';
 
-export const initMetric = (name: Metric['name'], value = -1): Metric => {
+export const initMetric = (name: Metric['name'], value?: number): Metric => {
   return {
     name,
-    value,
+    value: typeof value === 'undefined' ? -1 : value,
     delta: 0,
     entries: [],
     id: generateUniqueID(),
-    isFinal: false,
   };
 };

--- a/packages/tracing/src/browser/web-vitals/lib/observe.ts
+++ b/packages/tracing/src/browser/web-vitals/lib/observe.ts
@@ -29,6 +29,12 @@ export interface PerformanceEntryHandler {
 export const observe = (type: string, callback: PerformanceEntryHandler): PerformanceObserver | undefined => {
   try {
     if (PerformanceObserver.supportedEntryTypes.includes(type)) {
+      // More extensive feature detect needed for Firefox due to:
+      // https://github.com/GoogleChrome/web-vitals/issues/142
+      if (type === 'first-input' && !('PerformanceEventTiming' in self)) {
+        return;
+      }
+
       const po: PerformanceObserver = new PerformanceObserver(l => l.getEntries().map(callback));
 
       po.observe({ type, buffered: true });

--- a/packages/tracing/src/browser/web-vitals/lib/onBFCacheRestore.ts
+++ b/packages/tracing/src/browser/web-vitals/lib/onBFCacheRestore.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+interface onBFCacheRestoreCallback {
+  (event: PageTransitionEvent): void;
+}
+
+export const onBFCacheRestore = (cb: onBFCacheRestoreCallback): void => {
+  addEventListener(
+    'pageshow',
+    event => {
+      if (event.persisted) {
+        cb(event);
+      }
+    },
+    true,
+  );
+};

--- a/packages/tracing/src/browser/web-vitals/lib/polyfills/firstInputPolyfill.ts
+++ b/packages/tracing/src/browser/web-vitals/lib/polyfills/firstInputPolyfill.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FirstInputPolyfillCallback, FirstInputPolyfillEntry } from '../../types';
+
+type addOrRemoveEventListener = typeof addEventListener | typeof removeEventListener;
+
+let firstInputEvent: Event | null;
+let firstInputDelay: number;
+let firstInputTimeStamp: Date;
+let callbacks: FirstInputPolyfillCallback[];
+
+const listenerOpts: AddEventListenerOptions = { passive: true, capture: true };
+const startTimeStamp: Date = new Date();
+
+/**
+ * Accepts a callback to be invoked once the first input delay and event
+ * are known.
+ */
+export const firstInputPolyfill = (onFirstInput: FirstInputPolyfillCallback): void => {
+  callbacks.push(onFirstInput);
+  reportFirstInputDelayIfRecordedAndValid();
+};
+
+export const resetFirstInputPolyfill = (): void => {
+  callbacks = [];
+  firstInputDelay = -1;
+  firstInputEvent = null;
+  eachEventType(addEventListener);
+};
+
+/**
+ * Records the first input delay and event, so subsequent events can be
+ * ignored. All added event listeners are then removed.
+ */
+const recordFirstInputDelay = (delay: number, event: Event): void => {
+  if (!firstInputEvent) {
+    firstInputEvent = event;
+    firstInputDelay = delay;
+    firstInputTimeStamp = new Date();
+
+    eachEventType(removeEventListener);
+    reportFirstInputDelayIfRecordedAndValid();
+  }
+};
+
+/**
+ * Reports the first input delay and event (if they're recorded and valid)
+ * by running the array of callback functions.
+ */
+const reportFirstInputDelayIfRecordedAndValid = (): void => {
+  // In some cases the recorded delay is clearly wrong, e.g. it's negative
+  // or it's larger than the delta between now and initialization.
+  // - https://github.com/GoogleChromeLabs/first-input-delay/issues/4
+  // - https://github.com/GoogleChromeLabs/first-input-delay/issues/6
+  // - https://github.com/GoogleChromeLabs/first-input-delay/issues/7
+  if (
+    firstInputDelay >= 0 &&
+    // @ts-ignore (subtracting two dates always returns a number)
+    firstInputDelay < firstInputTimeStamp - startTimeStamp
+  ) {
+    const entry = {
+      entryType: 'first-input',
+      /* eslint-disable @typescript-eslint/no-non-null-assertion */
+      name: firstInputEvent!.type,
+      target: firstInputEvent!.target,
+      cancelable: firstInputEvent!.cancelable,
+      startTime: firstInputEvent!.timeStamp,
+      processingStart: firstInputEvent!.timeStamp + firstInputDelay,
+      /* eslint-enable @typescript-eslint/no-non-null-assertion */
+    } as FirstInputPolyfillEntry;
+    callbacks.forEach(function(callback: FirstInputPolyfillCallback) {
+      callback(entry);
+    });
+    callbacks = [];
+  }
+};
+
+/**
+ * Handles pointer down events, which are a special case.
+ * Pointer events can trigger main or compositor thread behavior.
+ * We differentiate these cases based on whether or not we see a
+ * 'pointercancel' event, which are fired when we scroll. If we're scrolling
+ * we don't need to report input delay since FID excludes scrolling and
+ * pinch/zooming.
+ */
+const onPointerDown = (delay: number, event: Event): void => {
+  /**
+   * Responds to 'pointerup' events and records a delay. If a pointer up event
+   * is the next event after a pointerdown event, then it's not a scroll or
+   * a pinch/zoom.
+   */
+  const onPointerUp = (): void => {
+    recordFirstInputDelay(delay, event);
+    removePointerEventListeners();
+  };
+
+  /**
+   * Responds to 'pointercancel' events and removes pointer listeners.
+   * If a 'pointercancel' is the next event to fire after a pointerdown event,
+   * it means this is a scroll or pinch/zoom interaction.
+   */
+  const onPointerCancel = (): void => {
+    removePointerEventListeners();
+  };
+
+  /**
+   * Removes added pointer event listeners.
+   */
+  const removePointerEventListeners = (): void => {
+    removeEventListener('pointerup', onPointerUp, listenerOpts);
+    removeEventListener('pointercancel', onPointerCancel, listenerOpts);
+  };
+
+  addEventListener('pointerup', onPointerUp, listenerOpts);
+  addEventListener('pointercancel', onPointerCancel, listenerOpts);
+};
+
+/**
+ * Handles all input events and records the time between when the event
+ * was received by the operating system and when it's JavaScript listeners
+ * were able to run.
+ */
+const onInput = (event: Event): void => {
+  // Only count cancelable events, which should trigger behavior
+  // important to the user.
+  if (event.cancelable) {
+    // In some browsers `event.timeStamp` returns a `DOMTimeStamp` value
+    // (epoch time) instead of the newer `DOMHighResTimeStamp`
+    // (document-origin time). To check for that we assume any timestamp
+    // greater than 1 trillion is a `DOMTimeStamp`, and compare it using
+    // the `Date` object rather than `performance.now()`.
+    // - https://github.com/GoogleChromeLabs/first-input-delay/issues/4
+    const isEpochTime = event.timeStamp > 1e12;
+    const now = isEpochTime ? new Date() : performance.now();
+
+    // Input delay is the delta between when the system received the event
+    // (e.g. event.timeStamp) and when it could run the callback (e.g. `now`).
+    const delay = (now as number) - event.timeStamp;
+
+    if (event.type == 'pointerdown') {
+      onPointerDown(delay, event);
+    } else {
+      recordFirstInputDelay(delay, event);
+    }
+  }
+};
+
+/**
+ * Invokes the passed callback const for =  each event type with t =>he
+ * `onInput` const and =  `listenerOpts =>`.
+ */
+const eachEventType = (callback: addOrRemoveEventListener): void => {
+  const eventTypes = ['mousedown', 'keydown', 'touchstart', 'pointerdown'];
+  eventTypes.forEach(type => callback(type, onInput, listenerOpts));
+};

--- a/packages/tracing/src/browser/web-vitals/types.ts
+++ b/packages/tracing/src/browser/web-vitals/types.ts
@@ -31,10 +31,6 @@ export interface Metric {
   // together and calculate a total.
   id: string;
 
-  // `false` if the value of the metric may change in the future,
-  // for the current page.
-  isFinal: boolean;
-
   // Any performance entries used in the metric value calculation.
   // Note, entries will be added to the array as the value changes.
   entries: PerformanceEntry[];
@@ -43,53 +39,3 @@ export interface Metric {
 export interface ReportHandler {
   (metric: Metric): void;
 }
-
-// http://wicg.github.io/netinfo/#navigatornetworkinformation-interface
-export interface NavigatorNetworkInformation {
-  readonly connection?: NetworkInformation;
-}
-
-// http://wicg.github.io/netinfo/#connection-types
-type ConnectionType = 'bluetooth' | 'cellular' | 'ethernet' | 'mixed' | 'none' | 'other' | 'unknown' | 'wifi' | 'wimax';
-
-// http://wicg.github.io/netinfo/#effectiveconnectiontype-enum
-type EffectiveConnectionType = '2g' | '3g' | '4g' | 'slow-2g';
-
-// http://wicg.github.io/netinfo/#dom-megabit
-type Megabit = number;
-// http://wicg.github.io/netinfo/#dom-millisecond
-type Millisecond = number;
-
-// http://wicg.github.io/netinfo/#networkinformation-interface
-interface NetworkInformation extends EventTarget {
-  // http://wicg.github.io/netinfo/#type-attribute
-  readonly type?: ConnectionType;
-  // http://wicg.github.io/netinfo/#effectivetype-attribute
-  readonly effectiveType?: EffectiveConnectionType;
-  // http://wicg.github.io/netinfo/#downlinkmax-attribute
-  readonly downlinkMax?: Megabit;
-  // http://wicg.github.io/netinfo/#downlink-attribute
-  readonly downlink?: Megabit;
-  // http://wicg.github.io/netinfo/#rtt-attribute
-  readonly rtt?: Millisecond;
-  // http://wicg.github.io/netinfo/#savedata-attribute
-  readonly saveData?: boolean;
-  // http://wicg.github.io/netinfo/#handling-changes-to-the-underlying-connection
-  onchange?: EventListener;
-}
-
-// https://w3c.github.io/device-memory/#sec-device-memory-js-api
-export interface NavigatorDeviceMemory {
-  readonly deviceMemory?: number;
-}
-
-export type NavigationTimingPolyfillEntry = Omit<
-  PerformanceNavigationTiming,
-  | 'initiatorType'
-  | 'nextHopProtocol'
-  | 'redirectCount'
-  | 'transferSize'
-  | 'encodedBodySize'
-  | 'decodedBodySize'
-  | 'toJSON'
->;

--- a/packages/tracing/src/browser/web-vitals/types.ts
+++ b/packages/tracing/src/browser/web-vitals/types.ts
@@ -39,3 +39,18 @@ export interface Metric {
 export interface ReportHandler {
   (metric: Metric): void;
 }
+
+// https://wicg.github.io/event-timing/#sec-performance-event-timing
+export interface PerformanceEventTiming extends PerformanceEntry {
+  processingStart: DOMHighResTimeStamp;
+  processingEnd: DOMHighResTimeStamp;
+  duration: DOMHighResTimeStamp;
+  cancelable?: boolean;
+  target?: Element;
+}
+
+export type FirstInputPolyfillEntry = Omit<PerformanceEventTiming, 'processingEnd' | 'toJSON'>;
+
+export interface FirstInputPolyfillCallback {
+  (entry: FirstInputPolyfillEntry): void;
+}


### PR DESCRIPTION
# 🚧 WIP 🏗️ 

Bumps web-vitals to v1.1.2. I'm pretty sure I'm closing this one in favour of a PR with cleaner README + commits, but wanted to get this one out so y'all can spend your weekend thinking about vitals :)))

These are scary changes so there is still a lot to do before we can make this ready to review. Also my first time touching this stuff so apologies if I'm missing something here.

- Port over the `web-vitals` tests. Def write some tests myself also
- Do some extensive testing on Sentry instance with multiple browsers
- Figure out if the bug fixes/breaking changes may result in large changes/discrepencies and how we can communicate that (either docs or heads up to support)
- Figure out the polyfill stuff (need some help with that)
- Figure out if we wanna support `onBFCacheRestore`: https://web.dev/bfcache/. 

For more reference for the last 2, see: https://github.com/GoogleChrome/web-vitals/pull/87

Also I might end up closing this PR and doing this upgrade later as v2 is pretty close to come out (and we can just bite the bullet that way).
