### PR TITLE
chore(dev): Pin `nextjs` version in dev dependencies

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -29,7 +29,7 @@
     "@sentry/types": "6.4.0",
     "@types/webpack": "^5.28.0",
     "eslint": "7.20.0",
-    "next": "^10.1.3",
+    "next": "10.1.3",
     "rimraf": "3.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
In 10.1.4, `next` [started using](https://github.com/vercel/next.js/pull/24129/files#diff-92887a01f8cba75d0ff8fb92a56cf08495d49f0b9077b2e550a9517ca956cd52R2) the `import type` syntax which [TS introduced in 3.8](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/#type-only-imports-exports). They've since [thought better of it](https://github.com/vercel/next.js/pull/25145), but in the meantime, 10.1.4 and 10.2 break our builds, since we're only on TS 3.7.5.

This pins `next` at a compatible version until that fix is released.