### PR TITLE
ref(tracing): Make `metadata` property on `Transaction` class public

### DIFF
--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -1,18 +1,20 @@
 import { getCurrentHub, Hub } from '@sentry/hub';
-import { Event, Measurements, Transaction as TransactionInterface, TransactionContext } from '@sentry/types';
+import {
+  Event,
+  Measurements,
+  Transaction as TransactionInterface,
+  TransactionContext,
+  TransactionMetadata,
+} from '@sentry/types';
 import { dropUndefinedKeys, isInstanceOf, logger } from '@sentry/utils';
 
 import { Span as SpanClass, SpanRecorder } from './span';
-
-interface TransactionMetadata {
-  transactionSampling?: { [key: string]: string | number };
-}
 
 /** JSDoc */
 export class Transaction extends SpanClass implements TransactionInterface {
   public name: string;
 
-  private _metadata: TransactionMetadata = {};
+  public metadata: TransactionMetadata;
 
   private _measurements: Measurements = {};
 
@@ -39,6 +41,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
 
     this.name = transactionContext.name || '';
 
+    this.metadata = transactionContext.metadata || {};
     this._trimEnd = transactionContext.trimEnd;
 
     // this is because transactions are also spans, and spans have a transaction pointer
@@ -76,7 +79,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
    * @hidden
    */
   public setMetadata(newMetadata: TransactionMetadata): void {
-    this._metadata = { ...this._metadata, ...newMetadata };
+    this.metadata = { ...this.metadata, ...newMetadata };
   }
 
   /**
@@ -123,7 +126,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
       timestamp: this.endTimestamp,
       transaction: this.name,
       type: 'transaction',
-      debug_meta: this._metadata,
+      debug_meta: this.metadata,
     };
 
     const hasMeasurements = Object.keys(this._measurements).length > 0;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -43,6 +43,7 @@ export {
   TraceparentData,
   Transaction,
   TransactionContext,
+  TransactionMetadata,
   TransactionSamplingMethod,
 } from './transaction';
 export { Thread } from './thread';

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -22,6 +22,11 @@ export interface TransactionContext extends SpanContext {
    * If this transaction has a parent, the parent's sampling decision
    */
   parentSampled?: boolean;
+
+  /**
+   * Metadata associated with the transaction, for internal SDK use.
+   */
+  metadata?: TransactionMetadata;
 }
 
 /**
@@ -57,6 +62,11 @@ export interface Transaction extends TransactionContext, Span {
    * @inheritDoc
    */
   data: { [key: string]: any };
+
+  /**
+   * Metadata about the transaction
+   */
+  metadata: TransactionMetadata;
 
   /**
    * Set the name of the transaction
@@ -112,4 +122,14 @@ export enum TransactionSamplingMethod {
   Sampler = 'client_sampler',
   Rate = 'client_rate',
   Inheritance = 'inheritance',
+}
+
+export interface TransactionMetadata {
+  transactionSampling?: { rate?: number; method?: string };
+
+  /** The two halves (sentry and third-party) of a transaction's tracestate header, used for dynamic sampling */
+  tracestate?: {
+    sentry?: string;
+    thirdparty?: string;
+  };
 }


### PR DESCRIPTION
Pulling this in from https://github.com/getsentry/sentry-javascript/tree/kmclb-dynamic-sampling-data-in-envelopes. It makes the `metadata` property on the `Transaction` class public, and allows it to be passed in at transaction creation time, which at this moment would be helpful for nextjs tracing work.
