### PR TITLE
ref: Disable node session for next.js

### DIFF
--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -23,9 +23,7 @@ export function init(options: NextjsOptions): void {
   }
 
   // Right now we only capture frontend sessions for Next.js
-  if (options.autoSessionTracking === undefined) {
-    options.autoSessionTracking = false;
-  }
+  options.autoSessionTracking = false;
 
   nodeInit(options);
   configureScope(scope => {

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -22,6 +22,11 @@ export function init(options: NextjsOptions): void {
     options.integrations = [defaultRewriteFrames];
   }
 
+  // Right now we only capture frontend sessions for Next.js
+  if (options.autoSessionTracking === undefined) {
+    options.autoSessionTracking = false;
+  }
+
   nodeInit(options);
   configureScope(scope => {
     scope.setTag('runtime', 'node');


### PR DESCRIPTION
For now, we disable server sessions for next.js since the request mode is not working yet. Currently, we continue to capture frontend sessions.