### PR TITLE
Fix: Add `attachment` to `SentryRequestType`

### DIFF
--- a/packages/browser/src/transports/base.ts
+++ b/packages/browser/src/transports/base.ts
@@ -15,6 +15,7 @@ const CATEGORY_MAPPING: {
   event: 'error',
   transaction: 'transaction',
   session: 'session',
+  attachment: 'attachment',
 };
 
 /** Base Transport class implementation */

--- a/packages/node/src/transports/base.ts
+++ b/packages/node/src/transports/base.ts
@@ -51,6 +51,7 @@ const CATEGORY_MAPPING: {
   event: 'error',
   transaction: 'transaction',
   session: 'session',
+  attachment: 'attachment',
 };
 
 /** Base Transport class implementation */

--- a/packages/types/src/request.ts
+++ b/packages/types/src/request.ts
@@ -1,5 +1,5 @@
 /** Possible SentryRequest types that can be used to make a distinction between Sentry features */
-export type SentryRequestType = 'event' | 'transaction' | 'session';
+export type SentryRequestType = 'event' | 'transaction' | 'session' | 'attachment';
 
 /** A generic client request. */
 export interface SentryRequest {


### PR DESCRIPTION
On upgrading the Electron SDK to Sentry JavaScript @6.4.0 I found that `SentryRequestType` has been added and its missing `attachment` type.
