### PR TITLE
build: Selectively run ember tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,9 +193,17 @@ jobs:
         with:
           path: ${{ env.CACHED_BUILD_PATHS }}
           key: ${{ env.BUILD_CACHE_KEY }}
+      - name: Check changed files
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v6.2
+        with:
+          files: .*packages\/(ember|browser|core|tracing|hub|minimal|types|utils)($|/.*)
+      # Only run ember tests if the files above have changed
       - name: Run Ember tests
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         run: yarn test --scope=@sentry/ember
       - name: Compute test coverage
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         uses: codecov/codecov-action@v1
 
   job_artifacts:

--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -13,8 +13,6 @@ import {
   User,
 } from '@sentry/types';
 
-// Test change
-
 /**
  * This calls a function on the current hub.
  * @param method function to call on hub.

--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -13,6 +13,8 @@ import {
   User,
 } from '@sentry/types';
 
+// Test change
+
 /**
  * This calls a function on the current hub.
  * @param method function to call on hub.


### PR DESCRIPTION
Only run ember tests if packages/ember or it's dependents have changed. 

Ran `yarn init -y && yarn add @sentry/ember && npm ls --depth 4 --parseable | grep "@sentry/"` to get dependents
```
ember-test-env/node_modules/@sentry/ember
ember-test-env/node_modules/@sentry/browser
ember-test-env/node_modules/@sentry/core
ember-test-env/node_modules/@sentry/tracing
ember-test-env/node_modules/@sentry/hub
ember-test-env/node_modules/@sentry/minimal
ember-test-env/node_modules/@sentry/types
ember-test-env/node_modules/@sentry/utils
```

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
