### PR TITLE
feat(nextjs): Parameterize server-side transaction names and harvest request data

### DIFF
--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -31,6 +31,7 @@ interface NextRequest extends http.IncomingMessage {
   cookies: Record<string, string>;
   url: string;
   query: { [key: string]: string };
+  headers: { [key: string]: string };
 }
 
 interface NextResponse extends http.ServerResponse {
@@ -290,7 +291,7 @@ function addRequestDataToEvent(event: SentryEvent, req: NextRequest): SentryEven
     // TODO body/data
     url: req.url.split('?')[0],
     cookies: req.cookies,
-    headers: req.headers as { [key: string]: string },
+    headers: req.headers,
     method: req.method,
     query_string: req.query,
   };

--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -288,6 +288,7 @@ function shouldTraceRequest(url: string, publicDirFiles: Set<string>): boolean {
 
 function addRequestDataToEvent(event: SentryEvent, req: NextRequest): SentryEvent {
   event.request = {
+    ...event.request,
     // TODO body/data
     url: req.url.split('?')[0],
     cookies: req.cookies,

--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -215,7 +215,7 @@ function makeWrappedReqHandler(origReqHandler: ReqHandler): WrappedReqHandler {
           const transaction = Sentry.startTransaction({
             name: `${namePrefix}${reqPath}`,
             op: 'http.server',
-            metadata: { request: req },
+            metadata: { requestPath: req.url.split('?')[0] },
           });
 
           currentScope.setSpan(transaction);
@@ -227,7 +227,7 @@ function makeWrappedReqHandler(origReqHandler: ReqHandler): WrappedReqHandler {
 
               // we'll collect this data in a more targeted way in the event processor we added above,
               // `addRequestDataToEvent`
-              delete transaction.metadata.request;
+              delete transaction.metadata.requestPath;
 
               // Push `transaction.finish` to the next event loop so open spans have a chance to finish before the
               // transaction closes
@@ -261,9 +261,8 @@ function makeWrappedMethodForGettingParameterizedPath(
     const transaction = getActiveTransaction();
 
     // replace specific URL with parameterized version
-    if (transaction && transaction.metadata.request) {
-      // strip query string, if any
-      const origPath = transaction.metadata.request.url.split('?')[0];
+    if (transaction && transaction.metadata.requestPath) {
+      const origPath = transaction.metadata.requestPath;
       transaction.name = transaction.name.replace(origPath, parameterizedPath);
     }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -15,7 +15,7 @@ export { Mechanism } from './mechanism';
 export { ExtractedNodeRequestData, Primitive, WorkerLocation } from './misc';
 export { Options } from './options';
 export { Package } from './package';
-export { Request, SentryRequest, SentryRequestType } from './request';
+export { QueryParams, Request, SentryRequest, SentryRequestType } from './request';
 export { Response } from './response';
 export { Runtime } from './runtime';
 export { CaptureContext, Scope, ScopeContext } from './scope';

--- a/packages/types/src/request.ts
+++ b/packages/types/src/request.ts
@@ -13,7 +13,7 @@ export interface Request {
   url?: string;
   method?: string;
   data?: any;
-  query_string?: string;
+  query_string?: string | { [key: string]: string };
   cookies?: { [key: string]: string };
   env?: { [key: string]: string };
   headers?: { [key: string]: string };

--- a/packages/types/src/request.ts
+++ b/packages/types/src/request.ts
@@ -13,8 +13,10 @@ export interface Request {
   url?: string;
   method?: string;
   data?: any;
-  query_string?: string | { [key: string]: string };
+  query_string?: QueryParams;
   cookies?: { [key: string]: string };
   env?: { [key: string]: string };
   headers?: { [key: string]: string };
 }
+
+export type QueryParams = string | { [key: string]: string } | Array<[string, string]>;

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -132,4 +132,10 @@ export interface TransactionMetadata {
     sentry?: string;
     thirdparty?: string;
   };
+
+  /** For transactions tracing server-side request handling, the request being tracked. */
+  request?: {
+    [key: string]: any;
+    url: string;
+  };
 }

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -133,9 +133,6 @@ export interface TransactionMetadata {
     thirdparty?: string;
   };
 
-  /** For transactions tracing server-side request handling, the request being tracked. */
-  request?: {
-    [key: string]: any;
-    url: string;
-  };
+  /** For transactions tracing server-side request handling, the path of the request being tracked. */
+  requestPath?: string;
 }


### PR DESCRIPTION
This PR does two things:

1) It wraps two more methods on `next`'s `Server` class, one of which is called on every API request, and the other of which is called on every page request. Both methods are passed a parameterized version of the path, which our wrappers grab and use to modify the name of the currently active transaction.

2) It adds an event processor which pulls data off of the request and adds it to the event. This runs whether or not tracing is enabled, in order to add data to both error and transaction events.

The only other thing of minor interest is that the type for `Event.request.query_string` is expanded to include objects, which is okay [according to the dev docs](https://develop.sentry.dev/sdk/event-payloads/request/#attributes).
