### PR TITLE
chore(nextjs): Generalized server-side performance cleanup

### DIFF
--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -17,6 +17,7 @@ export function init(options: NextjsOptions): void {
   const metadataBuilder = new MetadataBuilder(options, ['nextjs', 'node']);
   metadataBuilder.addSdkMetadata();
   options.environment = options.environment || process.env.NODE_ENV;
+  // TODO capture project root and store in an env var for RewriteFrames?
   addServerIntegrations(options);
   // Right now we only capture frontend sessions for Next.js
   options.autoSessionTracking = false;
@@ -47,5 +48,5 @@ function addServerIntegrations(options: NextjsOptions): void {
 export { withSentryConfig } from './utils/config';
 export { withSentry } from './utils/handlers';
 
-// TODO capture project root (which this returns) for RewriteFrames?
+// wrap various server methods to enable error monitoring and tracing
 instrumentServer();

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -116,7 +116,9 @@ function _createWrappedRequestMethodFactory(
           });
 
           const sentryTraceHeader = span.toTraceparent();
-          logger.log(`[Tracing] Adding sentry-trace header to outgoing request: ${sentryTraceHeader}`);
+          logger.log(
+            `[Tracing] Adding sentry-trace header ${sentryTraceHeader} to outgoing request to ${requestUrl}: `,
+          );
           requestOptions.headers = { ...requestOptions.headers, 'sentry-trace': sentryTraceHeader };
         }
       }


### PR DESCRIPTION
Just a bunch of random housekeeping.

- No longer return project root directory from `instrumentServer` since it's not yet defined at that point.
- No longer store transaction on `res`, since our new use of domains means that `getActiveTransaction` is safe. As a result, change `NextResponse` from an interface to a type which is purely an alias.
- Store a pointer to the live `Server` instance directly on the top scope rather than in an object, and get rid of the other stuff being stored in that object (`closure`) since it can all be gotten off of the aforementioned `Server` instance.
- Fix/expand/tweak various docstrings and comments.
- Improve log message when tracing an outgoing HTTP request.
