### PR TITLE
feat(nextjs): Continue trace using incoming `sentry-trace` header

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -65,6 +65,7 @@ export function tracingHandler(): (
         op: 'http.server',
         ...traceparentData,
       },
+      // extra context passed to the tracesSampler
       { request: extractRequestData(req) },
     );
 


### PR DESCRIPTION
**NB:** This is a draft not because it's not done but because it needs to be rebased before merging.

This PR adds support for continuing a trace started in another service, by reading and applying the `sentry-trace` header on incoming requests. It also passes the request as extra context in the `tracesSampler`.