### PR TITLE
chore(dev): Use Node 14 for development work

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postpublish": "make publish-docs && lerna run --stream --concurrency 1 postpublish"
   },
   "volta": {
-    "node": "10.18.1",
+    "node": "14.17.0",
     "yarn": "1.22.5"
   },
   "workspaces": [


### PR DESCRIPTION
This PR bumps us from Node 10 to Node 14, primarily to get around issues in the VSCode debugger, which won't run under Node 10 anymore. 

The one danger in doing so would be that we might use a newer feature of Node which doesn't exist in older versions we're still supporting and doesn't get transpiled down, and not realize we're doing so until it breaks some customer's app. Fortunately, you [can tell TS](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#tsconfig-bases) what Node version you're targeting through the use of particular combinations of `tsconfig` settings. The oldest version for which they have a spec is [Node 10](https://www.npmjs.com/package/@tsconfig/node10), but that's what we've been using all along anyway. Fortunately, according to that list, all of our current settings already fulfill the requirements.