### PR TITLE
fix(nextjs): Fix duplicated extension when compiling `sentry.server.config.js`

### DIFF
--- a/packages/nextjs/src/utils/config.ts
+++ b/packages/nextjs/src/utils/config.ts
@@ -98,6 +98,8 @@ const injectSentry = async (origEntryProperty: EntryProperty, isServer: boolean)
   // `require()` on the resulting file when we're instrumenting the sesrver. (We can't use a dynamic import there
   // because that then forces the user into a particular TS config.)
   if (isServer) {
+    // slice off the final `.js` since webpack is going to add it back in for us, and we don't want to end up with
+    // `.js.js` as the extension
     newEntryProperty[SERVER_SDK_INIT_PATH.slice(0, -3)] = SENTRY_SERVER_CONFIG_FILE;
   }
   // On the client, it's sufficient to inject it into the `main` JS code, which is included in every browser page.

--- a/packages/nextjs/src/utils/config.ts
+++ b/packages/nextjs/src/utils/config.ts
@@ -98,7 +98,7 @@ const injectSentry = async (origEntryProperty: EntryProperty, isServer: boolean)
   // `require()` on the resulting file when we're instrumenting the sesrver. (We can't use a dynamic import there
   // because that then forces the user into a particular TS config.)
   if (isServer) {
-    newEntryProperty[SERVER_SDK_INIT_PATH] = SENTRY_SERVER_CONFIG_FILE;
+    newEntryProperty[SERVER_SDK_INIT_PATH.slice(0, -3)] = SENTRY_SERVER_CONFIG_FILE;
   }
   // On the client, it's sufficient to inject it into the `main` JS code, which is included in every browser page.
   else {


### PR DESCRIPTION
The files being output by webpack after it compiles `sentry.server.config.js` are currently coming out with a double extension (`.js.js`), because we include the `.js` even though webpack also adds one. This fixes that by removing our `.js` when passing the file to webpack. (The `.js` can't just be removed from the constant because it's needed elsewhere).
