### PR TITLE
fix(nextjs): Add `api/` to BrowserTracing tracingOrigins

### DIFF
--- a/packages/nextjs/src/index.client.ts
+++ b/packages/nextjs/src/index.client.ts
@@ -1,5 +1,5 @@
 import { configureScope, init as reactInit } from '@sentry/react';
-import { Integrations } from '@sentry/tracing';
+import { defaultRequestInstrumentationOptions, Integrations } from '@sentry/tracing';
 
 import { nextRouterInstrumentation } from './performance/client';
 import { MetadataBuilder } from './utils/metadataBuilder';
@@ -33,6 +33,7 @@ export function init(options: NextjsOptions): void {
 }
 
 const defaultBrowserTracingIntegration = new BrowserTracing({
+  tracingOrigins: [...defaultRequestInstrumentationOptions.tracingOrigins, /^(api\/)/],
   routingInstrumentation: nextRouterInstrumentation,
 });
 


### PR DESCRIPTION
Update default tracingOrigins for NextJS BrowserTracing to
include api routes so we can add sentry-trace header correctly.

![image](https://user-images.githubusercontent.com/18689448/119833409-1718b380-becd-11eb-9bd0-e01d645cbd45.png)


Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
