### PR TITLE
fix(react): Use history object for init transaction name

### DIFF
--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -52,6 +52,18 @@ function createReactRouterInstrumentation(
   allRoutes: RouteConfig[] = [],
   matchPath?: MatchPath,
 ): ReactRouterInstrumentation {
+  function getInitPathName(): string | undefined {
+    if (history && history.location) {
+      return history.location.pathname;
+    }
+
+    if (global && global.location) {
+      return global.location.pathname;
+    }
+
+    return undefined;
+  }
+
   function getTransactionName(pathname: string): string {
     if (allRoutes === [] || !matchPath) {
       return pathname;
@@ -69,9 +81,10 @@ function createReactRouterInstrumentation(
   }
 
   return (customStartTransaction, startTransactionOnPageLoad = true, startTransactionOnLocationChange = true): void => {
-    if (startTransactionOnPageLoad && global && global.location) {
+    const initPathName = getInitPathName();
+    if (startTransactionOnPageLoad && initPathName) {
       activeTransaction = customStartTransaction({
-        name: getTransactionName(global.location.pathname),
+        name: getTransactionName(initPathName),
         op: 'pageload',
         tags: {
           'routing.instrumentation': name,


### PR DESCRIPTION
When creating pageload transactions the current react
router v4/v5 relies on global.location.pathname (global
is the current window instance), which can produce
inconsistent basenames. This can cause pageload transctions
to be not paramaterized correctly.

This patch fixes this by using history.location.pathname
to generate pageload transaction names. This was tested locally
to confirm changes.

Closes #3595 #3107

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
