### PR TITLE
ref(ember): Improve sdk consistency with other sdk usage

### DIFF
--- a/packages/ember/addon/index.ts
+++ b/packages/ember/addon/index.ts
@@ -73,7 +73,12 @@ export const instrumentRoutePerformance = (BaseRoute: any) => {
   return {
     [BaseRoute.name]: class extends BaseRoute {
       beforeModel(...args: any[]) {
-        return instrumentFunction('ember.route.beforeModel', (<any>this).fullRouteName, super.beforeModel.bind(this), args);
+        return instrumentFunction(
+          'ember.route.beforeModel',
+          (<any>this).fullRouteName,
+          super.beforeModel.bind(this),
+          args,
+        );
       }
 
       async model(...args: any[]) {
@@ -81,7 +86,12 @@ export const instrumentRoutePerformance = (BaseRoute: any) => {
       }
 
       async afterModel(...args: any[]) {
-        return instrumentFunction('ember.route.afterModel', (<any>this).fullRouteName, super.afterModel.bind(this), args);
+        return instrumentFunction(
+          'ember.route.afterModel',
+          (<any>this).fullRouteName,
+          super.afterModel.bind(this),
+          args,
+        );
       }
 
       async setupController(...args: any[]) {
@@ -97,3 +107,6 @@ export const instrumentRoutePerformance = (BaseRoute: any) => {
 };
 
 export * from '@sentry/browser';
+
+// init is now the preferred way to call initialization for this addon.
+export const init = InitSentryForEmber;

--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -333,7 +333,8 @@ function _instrumentInitialLoad(config: EmberSentryConfig) {
 export async function instrumentForPerformance(appInstance: ApplicationInstance) {
   const config = getSentryConfig();
   const sentryConfig = config.sentry;
-  const browserTracingOptions = config.browserTracingOptions || {};
+  // Maintaining backwards compatibility with config.browserTracingOptions, but passing it with Sentry options is preferred.
+  const browserTracingOptions = config.browserTracingOptions || config.sentry.browserTracingOptions || {};
 
   const tracing = await import('@sentry/tracing');
 

--- a/packages/ember/addon/types.ts
+++ b/packages/ember/addon/types.ts
@@ -1,7 +1,7 @@
 import { BrowserOptions } from '@sentry/browser';
 
 export type EmberSentryConfig = {
-  sentry: BrowserOptions;
+  sentry: BrowserOptions & { browserTracingOptions: Object };
   transitionTimeout: number;
   ignoreEmberOnErrorWarning: boolean;
   disableInstrumentComponents: boolean;

--- a/packages/ember/tests/dummy/app/app.js
+++ b/packages/ember/tests/dummy/app/app.js
@@ -2,7 +2,7 @@ import Application from '@ember/application';
 import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
-import { InitSentryForEmber } from '@sentry/ember';
+import * as Sentry from '@sentry/ember';
 
 import { Transports } from '@sentry/browser';
 import Ember from 'ember';
@@ -20,7 +20,7 @@ class TestFetchTransport extends Transports.FetchTransport {
   }
 }
 
-InitSentryForEmber({
+Sentry.init({
   transport: TestFetchTransport,
 });
 

--- a/packages/ember/tests/dummy/config/environment.js
+++ b/packages/ember/tests/dummy/config/environment.js
@@ -27,9 +27,9 @@ module.exports = function(environment) {
     sentry: {
       tracesSampleRate: 1,
       dsn: process.env.SENTRY_DSN,
-    },
-    browserTracingOptions: {
-      tracingOrigins: ['localhost', 'doesntexist.example'],
+      browserTracingOptions: {
+        tracingOrigins: ['localhost', 'doesntexist.example'],
+      },
     },
     ignoreEmberOnErrorWarning: true,
     minimumRunloopQueueDuration: 5,


### PR DESCRIPTION
Considering how being able to pass Sentry config into the init function at runtime is now supported, this cleans up the way the Ember sdk works to be more in-line with our other sdk's (like Vue). This should primarily make our general docs more correct for Ember usage as we can shift to always recommending passing config to init (instead of a lot of special cases) as well as keep maintenance of the sdk simple.

- Switches to exporting an 'init' function (still exporting the old function for backwards compatibility)
- Allows passing browserTracingOptions in the Sentry config at runtime as well, since it's not really an addon option and we might need to pass functions like 'beforeNavigate', which Ember config doesn't really support.


