### PR TITLE
feat(node): Add option to increase number of stacktrace frames

### DIFF
--- a/packages/node/src/backend.ts
+++ b/packages/node/src/backend.ts
@@ -37,6 +37,9 @@ export interface NodeOptions extends Options {
   /** Sets the number of context lines for each frame when loading a file. */
   frameContextLines?: number;
 
+  /** The maximum number of frames to include in a stacktrace. The Node default is 10. */
+  maxStacktraceFrames?: number;
+
   /** Callback that is executed when a fatal global error occurs. */
   onFatalError?(error: Error): void;
 }

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -132,6 +132,11 @@ export function init(options: NodeOptions = {}): void {
   if (options.autoSessionTracking) {
     startSessionTracking();
   }
+
+  // TODO: Right now, unless the user sets this option, this is a no-op, since 10 is Node's default value. Written this
+  // way so that it's easy to bump it if and when we choose to do so (would be a breaking change since it would likely
+  // have an effect on grouping)
+  Error.stackTraceLimit = typeof options.maxStacktraceFrames === 'number' ? options.maxStacktraceFrames : 10;
 }
 
 /**


### PR DESCRIPTION
Under Node's default settings, [only 10 stacktrace frames are shown with every error](https://nodejs.org/api/errors.html#errors_error_stacktracelimit). This adds an option to increase that number. If no value is passed in `Sentry.init()`, the default of 10 is used.

In future we may want to consider increasing this default, but given that such a change would likely affect grouping, we'd probably need to wait for a major bump in order to do so. Therefore, for the moment the option to capture more frames is strictly opt-in.
