### PR TITLE
fix: Remove floating promise eslint issues

### DIFF
--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -132,7 +132,7 @@ export class FetchTransport extends BaseTransport {
 
     return this._buffer.add(
       new SyncPromise<Response>((resolve, reject) => {
-        this._fetch(sentryRequest.url, options)
+        void this._fetch(sentryRequest.url, options)
           .then(response => {
             const headers = {
               'x-sentry-rate-limits': response.headers.get('X-Sentry-Rate-Limits'),

--- a/packages/integrations/src/offline.ts
+++ b/packages/integrations/src/offline.ts
@@ -69,7 +69,7 @@ export class Offline implements Integration {
 
     if ('addEventListener' in this.global) {
       this.global.addEventListener('online', () => {
-        this._sendEvents().catch(() => {
+        void this._sendEvents().catch(() => {
           logger.warn('could not send cached events');
         });
       });
@@ -79,7 +79,7 @@ export class Offline implements Integration {
       if (this.hub && this.hub.getIntegration(Offline)) {
         // cache if we are positively offline
         if ('navigator' in this.global && 'onLine' in this.global.navigator && !this.global.navigator.onLine) {
-          this._cacheEvent(event)
+          void this._cacheEvent(event)
             .then((_event: Event): Promise<void> => this._enforceMaxEvents())
             .catch((_error): void => {
               logger.warn('could not cache event while offline');
@@ -95,7 +95,7 @@ export class Offline implements Integration {
 
     // if online now, send any events stored in a previous offline session
     if ('navigator' in this.global && 'onLine' in this.global.navigator && this.global.navigator.onLine) {
-      this._sendEvents().catch(() => {
+      void this._sendEvents().catch(() => {
         logger.warn('could not send cached events');
       });
     }
@@ -159,7 +159,7 @@ export class Offline implements Integration {
       if (this.hub) {
         this.hub.captureEvent(event);
 
-        this._purgeEvent(cacheKey).catch((_error): void => {
+        void this._purgeEvent(cacheKey).catch((_error): void => {
           logger.warn('could not purge event from cache');
         });
       } else {

--- a/packages/node/src/backend.ts
+++ b/packages/node/src/backend.ts
@@ -109,7 +109,7 @@ export class NodeBackend extends BaseBackend<NodeOptions> {
     return new SyncPromise<Event>(resolve => {
       if (this._options.attachStacktrace && hint && hint.syntheticException) {
         const stack = hint.syntheticException ? extractStackFromError(hint.syntheticException) : [];
-        parseStack(stack, this._options)
+        void parseStack(stack, this._options)
           .then(frames => {
             event.stacktrace = {
               frames: prepareFramesForEvent(frames),

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -397,7 +397,7 @@ export function requestHandler(
       // eslint-disable-next-line @typescript-eslint/unbound-method
       const _end = res.end;
       res.end = function(chunk?: any | (() => void), encoding?: string | (() => void), cb?: () => void): void {
-        flush(options.flushTimeout)
+        void flush(options.flushTimeout)
           .then(() => {
             _end.call(this, chunk, encoding, cb);
           })

--- a/packages/node/src/integrations/linkederrors.ts
+++ b/packages/node/src/integrations/linkederrors.ts
@@ -60,7 +60,7 @@ export class LinkedErrors implements Integration {
     }
 
     return new SyncPromise<Event>(resolve => {
-      this._walkErrorTree(hint.originalException as Error, this._key)
+      void this._walkErrorTree(hint.originalException as Error, this._key)
         .then((linkedErrors: Exception[]) => {
           if (event && event.exception && event.exception.values) {
             event.exception.values = [...linkedErrors, ...event.exception.values];
@@ -81,9 +81,9 @@ export class LinkedErrors implements Integration {
       return SyncPromise.resolve(stack);
     }
     return new SyncPromise<Exception[]>((resolve, reject) => {
-      getExceptionFromError(error[key])
+      void getExceptionFromError(error[key])
         .then((exception: Exception) => {
-          this._walkErrorTree(error[key], key, [exception, ...stack])
+          void this._walkErrorTree(error[key], key, [exception, ...stack])
             .then(resolve)
             .then(null, () => {
               reject();

--- a/packages/node/test/parsers.test.ts
+++ b/packages/node/test/parsers.test.ts
@@ -22,10 +22,10 @@ describe('parsers.ts', () => {
     test('parseStack with same file', done => {
       expect.assertions(1);
       let mockCalls = 0;
-      Parsers.parseStack(frames)
+      void Parsers.parseStack(frames)
         .then(_ => {
           mockCalls = spy.mock.calls.length;
-          Parsers.parseStack(frames)
+          void Parsers.parseStack(frames)
             .then(_1 => {
               // Calls to readFile shouldn't increase if there isn't a new error
               expect(spy).toHaveBeenCalledTimes(mockCalls);
@@ -63,14 +63,14 @@ describe('parsers.ts', () => {
       expect.assertions(2);
       let mockCalls = 0;
       let newErrorCalls = 0;
-      Parsers.parseStack(frames)
+      void Parsers.parseStack(frames)
         .then(_ => {
           mockCalls = spy.mock.calls.length;
-          Parsers.parseStack(stacktrace.parse(getError()))
+          void Parsers.parseStack(stacktrace.parse(getError()))
             .then(_1 => {
               newErrorCalls = spy.mock.calls.length;
               expect(newErrorCalls).toBeGreaterThan(mockCalls);
-              Parsers.parseStack(stacktrace.parse(getError()))
+              void Parsers.parseStack(stacktrace.parse(getError()))
                 .then(_2 => {
                   expect(spy).toHaveBeenCalledTimes(newErrorCalls);
                   done();

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -89,7 +89,7 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
       transaction.setHttpStatus(res.statusCode);
       transaction.finish();
 
-      flush(options.flushTimeout)
+      void flush(options.flushTimeout)
         .then(() => {
           _end.call(this, chunk, encoding, cb);
         })

--- a/packages/utils/src/async.ts
+++ b/packages/utils/src/async.ts
@@ -4,7 +4,7 @@
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function forget(promise: PromiseLike<any>): void {
-  promise.then(null, e => {
+  void promise.then(null, e => {
     // TODO: Use a better logging mechanism
     // eslint-disable-next-line no-console
     console.error(e);

--- a/packages/utils/src/promisebuffer.ts
+++ b/packages/utils/src/promisebuffer.ts
@@ -28,7 +28,7 @@ export class PromiseBuffer<T> {
     if (this._buffer.indexOf(task) === -1) {
       this._buffer.push(task);
     }
-    task
+    void task
       .then(() => this.remove(task))
       .then(null, () =>
         this.remove(task).then(null, () => {
@@ -70,7 +70,7 @@ export class PromiseBuffer<T> {
           resolve(false);
         }
       }, timeout);
-      SyncPromise.all(this._buffer)
+      void SyncPromise.all(this._buffer)
         .then(() => {
           clearTimeout(capturedSetTimeout);
           resolve(true);

--- a/packages/utils/src/syncpromise.ts
+++ b/packages/utils/src/syncpromise.ts
@@ -68,7 +68,7 @@ class SyncPromise<T> implements PromiseLike<T> {
       const resolvedCollection: U[] = [];
 
       collection.forEach((item, index) => {
-        SyncPromise.resolve(item)
+        void SyncPromise.resolve(item)
           .then(value => {
             resolvedCollection[index] = value;
             counter -= 1;
@@ -184,7 +184,7 @@ class SyncPromise<T> implements PromiseLike<T> {
     }
 
     if (isThenable(value)) {
-      (value as PromiseLike<T>).then(this._resolve, this._reject);
+      void (value as PromiseLike<T>).then(this._resolve, this._reject);
       return;
     }
 

--- a/packages/utils/test/syncpromise.test.ts
+++ b/packages/utils/test/syncpromise.test.ts
@@ -42,11 +42,13 @@ describe('SyncPromise', () => {
 
     const fp = async (s: PromiseLike<string>, prepend: string) =>
       new Promise<string>(resolve => {
-        s.then(val => {
-          resolve(prepend + val);
-        }).then(null, _ => {
-          // bla
-        });
+        void s
+          .then(val => {
+            resolve(prepend + val);
+          })
+          .then(null, _ => {
+            // bla
+          });
       });
 
     const res = await cp
@@ -70,11 +72,13 @@ describe('SyncPromise', () => {
 
     const f = (s: SyncPromise<string>, prepend: string) =>
       new SyncPromise<string>(resolve => {
-        s.then(val => {
-          resolve(prepend + val);
-        }).then(null, () => {
-          // no-empty
-        });
+        void s
+          .then(val => {
+            resolve(prepend + val);
+          })
+          .then(null, () => {
+            // no-empty
+          });
       });
 
     return (
@@ -103,7 +107,7 @@ describe('SyncPromise', () => {
     expect.assertions(2);
 
     return new SyncPromise<number>(done => {
-      new Promise<number>(resolve => {
+      void new Promise<number>(resolve => {
         expect(true).toBe(true);
         resolve(41);
       })
@@ -152,17 +156,21 @@ describe('SyncPromise', () => {
         resolve(2);
       }),
     );
-    qp.then(value => {
-      expect(value).toEqual(2);
-    }).then(null, () => {
-      // no-empty
-    });
+    void qp
+      .then(value => {
+        expect(value).toEqual(2);
+      })
+      .then(null, () => {
+        // no-empty
+      });
     expect(qp).not.toHaveProperty('_value');
-    qp.then(value => {
-      expect(value).toEqual(2);
-    }).then(null, () => {
-      // no-empty
-    });
+    void qp
+      .then(value => {
+        expect(value).toEqual(2);
+      })
+      .then(null, () => {
+        // no-empty
+      });
     jest.runAllTimers();
     expect(qp).toHaveProperty('_value');
   });


### PR DESCRIPTION
For some reason eslint is passing on master, but fails
after the yarn lock was updating when adding madge. This PR
cherry-picks a commit fixing the lint errors from the
abhi/circular-dep branch

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
