### PR TITLE
fix(nextjs): Prevent webpack 5 from crashing server

### DIFF
--- a/packages/nextjs/src/utils/handlers.ts
+++ b/packages/nextjs/src/utils/handlers.ts
@@ -81,7 +81,11 @@ export const withSentry = (handler: NextApiHandler): WrappedNextApiHandler => {
 
         transaction.finish();
       }
-      await flush(2000);
+      try {
+        await flush(2000);
+      } catch (e) {
+        // no-empty
+      }
     }
   };
 };


### PR DESCRIPTION
Unblocks https://github.com/getsentry/sentry-javascript/issues/3636.

It seems that awaiting a flush() call is throwing errors in
Webpack 5. This crashes the server as the handler has already
sent a response at that point. This patch wraps the flush call
in a try, catch until we can figure out a better fix.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
