### PR TITLE
ref(nextjs): Export `BrowserTracing` integration directly from `@sentry/nextjs`

### DIFF
--- a/packages/nextjs/src/index.client.ts
+++ b/packages/nextjs/src/index.client.ts
@@ -1,5 +1,5 @@
-import { configureScope, init as reactInit } from '@sentry/react';
-import { defaultRequestInstrumentationOptions, Integrations } from '@sentry/tracing';
+import { configureScope, init as reactInit, Integrations as BrowserIntegrations } from '@sentry/react';
+import { defaultRequestInstrumentationOptions, Integrations as TracingIntegrations } from '@sentry/tracing';
 
 import { nextRouterInstrumentation } from './performance/client';
 import { MetadataBuilder } from './utils/metadataBuilder';
@@ -9,7 +9,8 @@ import { addIntegration, UserIntegrations } from './utils/userIntegrations';
 export * from '@sentry/react';
 export { nextRouterInstrumentation } from './performance/client';
 
-const { BrowserTracing } = Integrations;
+const { BrowserTracing } = TracingIntegrations;
+export const Integrations = { ...BrowserIntegrations, BrowserTracing };
 
 /** Inits the Sentry NextJS SDK on the browser with the React SDK. */
 export function init(options: NextjsOptions): void {


### PR DESCRIPTION
This adds `BrowserTracing` to the `Integrations` object exported from the browser half of `@sentry/nextjs`, so that if users need to change any of the default options (which would necessitate them importing it), they don’t have to get it from `@sentry/tracing`, which they may not have in their dependencies. (`@sentry/tracing` is one of `@sentry/nextjs`'s dependencies, of course, so importing from it would definitely work, but depending on their project settings, it has the potential to tick off their linter.)

(In the process of testing this, the SDK version in `yarn.lock` got bumped, so that's included here, too, just 'cause.)
