### PR TITLE
fix: Run rewriting for both Exaption and Stacktrace events

### DIFF
--- a/packages/integrations/src/rewriteframes.ts
+++ b/packages/integrations/src/rewriteframes.ts
@@ -54,16 +54,18 @@ export class RewriteFrames implements Integration {
   }
 
   /** JSDoc */
-  public process(event: Event): Event {
-    if (event.exception && Array.isArray(event.exception.values)) {
-      event = this._processExceptionsEvent(event);
+  public process(originalEvent: Event): Event {
+    let processedEvent = originalEvent;
+
+    if (originalEvent.exception && Array.isArray(originalEvent.exception.values)) {
+      processedEvent = this._processExceptionsEvent(processedEvent);
     }
 
-    if (event.stacktrace) {
-      event = this._processStacktraceEvent(event);
+    if (originalEvent.stacktrace) {
+      processedEvent = this._processStacktraceEvent(processedEvent);
     }
 
-    return event;
+    return processedEvent;
   }
 
   /**

--- a/packages/integrations/src/rewriteframes.ts
+++ b/packages/integrations/src/rewriteframes.ts
@@ -56,11 +56,11 @@ export class RewriteFrames implements Integration {
   /** JSDoc */
   public process(event: Event): Event {
     if (event.exception && Array.isArray(event.exception.values)) {
-      return this._processExceptionsEvent(event);
+      event = this._processExceptionsEvent(event);
     }
 
     if (event.stacktrace) {
-      return this._processStacktraceEvent(event);
+      event = this._processStacktraceEvent(event);
     }
 
     return event;


### PR DESCRIPTION
fix https://github.com/getsentry/sentry-javascript/issues/3652

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
