### PR TITLE
Update HTTPModule request method options type

### DIFF
--- a/packages/node/src/transports/base.ts
+++ b/packages/node/src/transports/base.ts
@@ -30,7 +30,7 @@ export interface HTTPModule {
    * @param callback Callback when request is finished
    */
   request(
-    options: http.RequestOptions | https.RequestOptions | string | url.URL,
+    options: http.RequestOptions | https.RequestOptions,
     callback?: (res: http.IncomingMessage) => void,
   ): http.ClientRequest;
 


### PR DESCRIPTION
It looks like the request type is not up-to-date. At least, I can see that it's different from the type returned by `_getRequestOptions`.