### PR TITLE
fix(utils): Check for performance.now() when calculating browser timing

### DIFF
--- a/packages/utils/src/time.ts
+++ b/packages/utils/src/time.ts
@@ -141,7 +141,7 @@ export const browserPerformanceTimeOrigin = ((): number | undefined => {
   // data as reliable if they are within a reasonable threshold of the current time.
 
   const { performance } = getGlobalObject<Window>();
-  if (!performance) {
+  if (!performance || !performance.now) {
     _browserPerformanceTimeOriginMode = 'none';
     return undefined;
   }


### PR DESCRIPTION
We should guard against performance.now not being available
when calculating browserPerformanceTimeOrigin. We do a similar check
when for our wrapper around the native performance api implementation.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
