### PR TITLE
docs(vue): Document supported version range

### DIFF
--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -17,6 +17,8 @@
 This package is a wrapper around `@sentry/browser`, with added functionality related to Vue.js. All methods available in
 `@sentry/browser` can be imported from `@sentry/vue`.
 
+It targets Vue version `2.x`. Support for `3.x` is tracked by [GitHub issue #2925](https://github.com/getsentry/sentry-javascript/issues/2925).
+
 To use this SDK, call `Sentry.init(options)` before you create a new Vue instance.
 
 ```javascript


### PR DESCRIPTION
Complements https://github.com/getsentry/sentry-docs/pull/3704 (wizard) and https://github.com/getsentry/sentry-docs/pull/3716 (main Vue docs).

To avoid confusion, this PR adds a note the README that shows up both in https://github.com/getsentry/sentry-javascript/tree/master/packages/vue and https://www.npmjs.com/package/@sentry/vue.