### PR TITLE
feat(nextjs): Add body data to transaction `request` context

### DIFF
--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -31,6 +31,7 @@ export interface NextRequest extends http.IncomingMessage {
   url: string;
   query: { [key: string]: string };
   headers: { [key: string]: string };
+  body: string | { [key: string]: unknown };
 }
 type NextResponse = http.ServerResponse;
 
@@ -309,9 +310,11 @@ function shouldTraceRequest(url: string, publicDirFiles: Set<string>): boolean {
  * @returns The modified event
  */
 export function addRequestDataToEvent(event: SentryEvent, req: NextRequest): SentryEvent {
+  // TODO (breaking change): Replace all calls to this function with `parseRequest(event, req, { transaction: false })`
+  // (this is breaking because doing so will change `event.request.url` from a path into an absolute URL)
   event.request = {
     ...event.request,
-    // TODO body/data
+    data: req.body,
     url: req.url.split('?')[0],
     cookies: req.cookies,
     headers: req.headers,

--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -311,7 +311,8 @@ function shouldTraceRequest(url: string, publicDirFiles: Set<string>): boolean {
  */
 export function addRequestDataToEvent(event: SentryEvent, req: NextRequest): SentryEvent {
   // TODO (breaking change): Replace all calls to this function with `parseRequest(event, req, { transaction: false })`
-  // (this is breaking because doing so will change `event.request.url` from a path into an absolute URL)
+  // (this is breaking because doing so will change `event.request.url` from a path into an absolute URL, which might
+  // mess up various automations in the Sentry web app - alert rules, auto assignment, saved searches, etc)
   event.request = {
     ...event.request,
     data: req.body,


### PR DESCRIPTION
This PR adds data from the request body to the `request` context data on server-side transactions. 

This data is already being collected for errors (because in that case we use the [`parseRequest`](https://github.com/getsentry/sentry-javascript/blob/482ca021592fb5c9152b7980986ab4ea53e358ac/packages/node/src/handlers.ts#L299) function from `@sentry/node`, which collects body data), but for transactions we haven't been (there we use [`addRequestDataToEvent`](https://github.com/getsentry/sentry-javascript/blob/482ca021592fb5c9152b7980986ab4ea53e358ac/packages/nextjs/src/utils/instrumentServer.ts#L311), which collects similar data, but has had body data as a `TODO`). 

My first version of this PR simply swapped `addRequestDataToEvent` out in favor of `parseRequest`, which both fixes the missing body data and gets rid of some redundancy in the code. Unfortunately, the new end-to-end tests revealed that that would in fact be a breaking change, since in the `url` field `parseRequest` sends a full URL whereas `addRequestDataToEvent` sends only the path. Because `request.url` gets copied over as a tag during ingest, and various features in Sentry's web app (alert rules, auto assignment, saved searches, etc) can rely on matching a certain tag value, the format change probably needs to wait for at least a minor bump, if not a major one.

Therefore, the final version of this change simply adds body data collection to `addRequestDataToEvent`, and leaves a `TODO` about switching to `parseRequest` in the future. Also, as part of my first attempt, I modified `parseRequest` slightly to adapt it for `nextjs` use, and since none of those changes affect any other platform, I left them in, so that the eventual swap is as easy as possible.
