### PR TITLE
fix: Add event type to item header when envelopes are forced

### DIFF
--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -81,7 +81,7 @@ export function eventToSentryRequest(event: Event, api: API): SentryRequest {
       ...(api.forceEnvelope() && { dsn: api.getDsn().toString() }),
     });
     const itemHeaders = JSON.stringify({
-      type: event.type,
+      type: eventType,
 
       // TODO: Right now, sampleRate may or may not be defined (it won't be in the cases of inheritance and
       // explicitly-set sampling decisions). Are we good with that?

--- a/packages/core/test/lib/request.test.ts
+++ b/packages/core/test/lib/request.test.ts
@@ -159,6 +159,20 @@ describe('eventToSentryRequest', () => {
       }),
     );
   });
+
+  it('adds default "event" item type to item header if tunnel is configured', () => {
+    api = new API(ingestDsn, {}, tunnel);
+    delete event.type;
+
+    const result = eventToSentryRequest(event, api);
+    const envelope = parseEnvelopeRequest(result);
+
+    expect(envelope.itemHeader).toEqual(
+      expect.objectContaining({
+        type: 'event',
+      }),
+    );
+  });
 });
 
 describe('sessionToSentryRequest', () => {

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -47,7 +47,7 @@ export interface Event {
 }
 
 /** JSDoc */
-export type EventType = 'transaction';
+export type EventType = 'event' | 'transaction';
 
 /** JSDoc */
 export interface EventHint {


### PR DESCRIPTION
An oversight that prevents `tunnel` from working correctly. In the times when there was only a single event type, we didn't specify `event.type === 'event'` because it was redundant. Now it's not.