### PR TITLE
fix: Prevent scope from storing more than 100 breadcrumbs at the time

### DIFF
--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -43,12 +43,6 @@ export const API_VERSION = 4;
 const DEFAULT_BREADCRUMBS = 100;
 
 /**
- * Absolute maximum number of breadcrumbs added to an event. The
- * `maxBreadcrumbs` option cannot be higher than this value.
- */
-const MAX_BREADCRUMBS = 100;
-
-/**
  * A layer in the process stack.
  * @hidden
  */
@@ -289,7 +283,7 @@ export class Hub implements HubInterface {
 
     if (finalBreadcrumb === null) return;
 
-    scope.addBreadcrumb(finalBreadcrumb, Math.min(maxBreadcrumbs, MAX_BREADCRUMBS));
+    scope.addBreadcrumb(finalBreadcrumb, maxBreadcrumbs);
   }
 
   /**

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -63,8 +63,24 @@ describe('Scope', () => {
 
     test('addBreadcrumb', () => {
       const scope = new Scope();
-      scope.addBreadcrumb({ message: 'test' }, 100);
+      scope.addBreadcrumb({ message: 'test' });
       expect((scope as any)._breadcrumbs[0]).toHaveProperty('message', 'test');
+    });
+
+    test('addBreadcrumb can be limited to hold up to N breadcrumbs', () => {
+      const scope = new Scope();
+      for (let i = 0; i < 10; i++) {
+        scope.addBreadcrumb({ message: 'test' }, 5);
+      }
+      expect((scope as any)._breadcrumbs).toHaveLength(5);
+    });
+
+    test('addBreadcrumb cannot go over MAX_BREADCRUMBS value', () => {
+      const scope = new Scope();
+      for (let i = 0; i < 111; i++) {
+        scope.addBreadcrumb({ message: 'test' }, 111);
+      }
+      expect((scope as any)._breadcrumbs).toHaveLength(100);
     });
 
     test('setLevel', () => {
@@ -181,7 +197,7 @@ describe('Scope', () => {
       scope.setFingerprint(['abcd']);
       scope.setLevel(Severity.Warning);
       scope.setTransactionName('/abc');
-      scope.addBreadcrumb({ message: 'test' }, 100);
+      scope.addBreadcrumb({ message: 'test' });
       scope.setContext('os', { id: '1' });
       const event: Event = {};
       return scope.applyToEvent(event).then(processedEvent => {
@@ -203,7 +219,7 @@ describe('Scope', () => {
       scope.setTag('a', 'b');
       scope.setUser({ id: '1' });
       scope.setFingerprint(['abcd']);
-      scope.addBreadcrumb({ message: 'test' }, 100);
+      scope.addBreadcrumb({ message: 'test' });
       scope.setContext('server', { id: '2' });
       const event: Event = {
         breadcrumbs: [{ message: 'test1' }],
@@ -358,7 +374,7 @@ describe('Scope', () => {
     scope.setTag('a', 'b');
     scope.setUser({ id: '1' });
     scope.setFingerprint(['abcd']);
-    scope.addBreadcrumb({ message: 'test' }, 100);
+    scope.addBreadcrumb({ message: 'test' });
     scope.setRequestSession({ status: RequestSessionStatus.Ok });
     expect((scope as any)._extra).toEqual({ a: 2 });
     scope.clear();
@@ -368,7 +384,7 @@ describe('Scope', () => {
 
   test('clearBreadcrumbs', () => {
     const scope = new Scope();
-    scope.addBreadcrumb({ message: 'test' }, 100);
+    scope.addBreadcrumb({ message: 'test' });
     expect((scope as any)._breadcrumbs).toHaveLength(1);
     scope.clearBreadcrumbs();
     expect((scope as any)._breadcrumbs).toHaveLength(0);


### PR DESCRIPTION
```js
Sentry.configureScope(scope => {
  for (let i = 0; i < 1000; i++) {
    scope.addBreadcrumb({ message: 'hi' })
  }
})
```

This would store 1000 crumbs, despite having hard limit of 100, as this limit was stored in the Hub, and not Scope where it should. cc @timfish 

fixes https://github.com/getsentry/sentry-javascript/issues/2963
fixes https://github.com/getsentry/sentry-electron/issues/205
fixes https://github.com/getsentry/sentry-electron/issues/277