### PR TITLE
ref: Remove event from EventType type

### DIFF
--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -47,7 +47,7 @@ export interface Event {
 }
 
 /** JSDoc */
-export type EventType = 'event' | 'transaction';
+export type EventType = 'transaction';
 
 /** JSDoc */
 export interface EventHint {


### PR DESCRIPTION
https://develop.sentry.dev/sdk/event-payloads/types/#eventtype
https://develop.sentry.dev/sdk/envelopes/#data-model

```
EventType = "default" | "error" | "transaction"
ItemType = "event" | "transaction"
```

These are two different things apparently. 