### PR TITLE
ref: Remove default http(s) import from http-module

### DIFF
--- a/packages/node/src/transports/base/http-module.ts
+++ b/packages/node/src/transports/base/http-module.ts
@@ -1,8 +1,8 @@
-import http, { IncomingHttpHeaders } from 'http';
-import https from 'https';
+import { IncomingHttpHeaders, RequestOptions as HTTPRequestOptions } from 'http';
+import { RequestOptions as HTTPSRequestOptions } from 'https';
 import { URL } from 'url';
 
-export type HTTPModuleRequestOptions = http.RequestOptions | https.RequestOptions | string | URL;
+export type HTTPModuleRequestOptions = HTTPRequestOptions | HTTPSRequestOptions | string | URL;
 
 /**
  * Cut version of http.IncomingMessage.


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/3679

It's not necessary for our needs, and fixing this on the client-side requires changing `allowSyntheticDefaultImports` config, which we don't want to enforce.