### PR TITLE
fix(sessions): Do not track sessions if not enabled

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -153,7 +153,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    */
   public captureSession(session: Session): void {
     if (!this._isEnabled()) {
-      logger.warn('SDK not enabled, will not send session.');
+      logger.warn('SDK not enabled, will not capture session.');
       return;
     }
 
@@ -490,7 +490,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
     const { beforeSend, sampleRate } = this.getOptions();
 
     if (!this._isEnabled()) {
-      return SyncPromise.reject(new SentryError('SDK not enabled, will not send event.'));
+      return SyncPromise.reject(new SentryError('SDK not enabled, will not capture event.'));
     }
 
     const isTransaction = event.type === 'transaction';

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -152,6 +152,11 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    * @inheritDoc
    */
   public captureSession(session: Session): void {
+    if (!this._isEnabled()) {
+      logger.warn('SDK not enabled, will not send session.');
+      return;
+    }
+
     if (!(typeof session.release === 'string')) {
       logger.warn('Discarded session because of missing or non-string release');
     } else {

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -1,4 +1,4 @@
-import { Hub, Scope } from '@sentry/hub';
+import { Hub, Scope, Session } from '@sentry/hub';
 import { Event, Severity, Span } from '@sentry/types';
 import { logger, SentryError, SyncPromise } from '@sentry/utils';
 
@@ -962,6 +962,24 @@ describe('BaseClient', () => {
           expect(true).toEqual(true);
         }),
       ]);
+    });
+  });
+
+  describe('captureSession()', () => {
+    test('sends sessions to the backend', () => {
+      expect.assertions(1);
+      const client = new TestClient({ dsn: PUBLIC_DSN });
+      const session = new Session({ release: 'test' });
+      client.captureSession(session);
+      expect(TestBackend.instance!.session).toEqual(session);
+    });
+
+    test('skips when disabled', () => {
+      expect.assertions(1);
+      const client = new TestClient({ enabled: false, dsn: PUBLIC_DSN });
+      const session = new Session({ release: 'test' });
+      client.captureSession(session);
+      expect(TestBackend.instance!.session).toBeUndefined();
     });
   });
 });

--- a/packages/core/test/mocks/backend.ts
+++ b/packages/core/test/mocks/backend.ts
@@ -1,3 +1,4 @@
+import { Session } from '@sentry/hub';
 import { Event, Options, Severity, Transport } from '@sentry/types';
 import { SyncPromise } from '@sentry/utils';
 
@@ -14,6 +15,7 @@ export class TestBackend extends BaseBackend<TestOptions> {
   public static sendEventCalled?: (event: Event) => void;
 
   public event?: Event;
+  public session?: Session;
 
   public constructor(protected readonly _options: TestOptions) {
     super(_options);
@@ -48,6 +50,10 @@ export class TestBackend extends BaseBackend<TestOptions> {
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     TestBackend.sendEventCalled && TestBackend.sendEventCalled(event);
+  }
+
+  public sendSession(session: Session): void {
+    this.session = session;
   }
 
   protected _setupTransport(): Transport {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/3685

The patch updates the @sentry/core baseClient to not send sessions
to Sentry if it is disabled. This makes sessions match the behaviour
of events and integrations (both of which get disabled when the
enabled option is set to false).

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
