### PR TITLE
ref: Log which request type has been limited

### DIFF
--- a/packages/browser/src/transports/base.ts
+++ b/packages/browser/src/transports/base.ts
@@ -76,7 +76,8 @@ export abstract class BaseTransport implements Transport {
      * https://developer.mozilla.org/en-US/docs/Web/API/Headers/get
      */
     const limited = this._handleRateLimit(headers);
-    if (limited) logger.warn(`Too many requests, backing off until: ${this._disabledUntil(requestType)}`);
+    if (limited)
+      logger.warn(`Too many ${requestType} requests, backing off until: ${this._disabledUntil(requestType)}`);
 
     if (status === Status.Success) {
       resolve({ status });

--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -109,7 +109,9 @@ export class FetchTransport extends BaseTransport {
       return Promise.reject({
         event: originalPayload,
         type: sentryRequest.type,
-        reason: `Transport locked till ${this._disabledUntil(sentryRequest.type)} due to too many requests.`,
+        reason: `Transport for ${sentryRequest.type} requests locked till ${this._disabledUntil(
+          sentryRequest.type,
+        )} due to too many requests.`,
         status: 429,
       });
     }

--- a/packages/browser/src/transports/xhr.ts
+++ b/packages/browser/src/transports/xhr.ts
@@ -29,7 +29,9 @@ export class XHRTransport extends BaseTransport {
       return Promise.reject({
         event: originalPayload,
         type: sentryRequest.type,
-        reason: `Transport locked till ${this._disabledUntil(sentryRequest.type)} due to too many requests.`,
+        reason: `Transport for ${sentryRequest.type} requests locked till ${this._disabledUntil(
+          sentryRequest.type,
+        )} due to too many requests.`,
         status: 429,
       });
     }

--- a/packages/browser/test/unit/transports/fetch.test.ts
+++ b/packages/browser/test/unit/transports/fetch.test.ts
@@ -190,7 +190,9 @@ describe('FetchTransport', () => {
           throw new Error('unreachable!');
         } catch (res) {
           expect(res.status).equal(429);
-          expect(res.reason).equal(`Transport locked till ${new Date(afterLimit)} due to too many requests.`);
+          expect(res.reason).equal(
+            `Transport for event requests locked till ${new Date(afterLimit)} due to too many requests.`,
+          );
           expect(fetch.calledOnce).equal(true);
         }
 
@@ -256,7 +258,9 @@ describe('FetchTransport', () => {
           throw new Error('unreachable!');
         } catch (res) {
           expect(res.status).equal(429);
-          expect(res.reason).equal(`Transport locked till ${new Date(afterLimit)} due to too many requests.`);
+          expect(res.reason).equal(
+            `Transport for event requests locked till ${new Date(afterLimit)} due to too many requests.`,
+          );
           expect(fetch.calledTwice).equal(true);
         }
 
@@ -317,7 +321,9 @@ describe('FetchTransport', () => {
           throw new Error('unreachable!');
         } catch (res) {
           expect(res.status).equal(429);
-          expect(res.reason).equal(`Transport locked till ${new Date(afterLimit)} due to too many requests.`);
+          expect(res.reason).equal(
+            `Transport for event requests locked till ${new Date(afterLimit)} due to too many requests.`,
+          );
           expect(fetch.calledOnce).equal(true);
         }
 
@@ -326,7 +332,9 @@ describe('FetchTransport', () => {
           throw new Error('unreachable!');
         } catch (res) {
           expect(res.status).equal(429);
-          expect(res.reason).equal(`Transport locked till ${new Date(afterLimit)} due to too many requests.`);
+          expect(res.reason).equal(
+            `Transport for transaction requests locked till ${new Date(afterLimit)} due to too many requests.`,
+          );
           expect(fetch.calledOnce).equal(true);
         }
 
@@ -393,7 +401,9 @@ describe('FetchTransport', () => {
           throw new Error('unreachable!');
         } catch (res) {
           expect(res.status).equal(429);
-          expect(res.reason).equal(`Transport locked till ${new Date(afterLimit)} due to too many requests.`);
+          expect(res.reason).equal(
+            `Transport for event requests locked till ${new Date(afterLimit)} due to too many requests.`,
+          );
           expect(fetch.calledOnce).equal(true);
         }
 
@@ -402,7 +412,9 @@ describe('FetchTransport', () => {
           throw new Error('unreachable!');
         } catch (res) {
           expect(res.status).equal(429);
-          expect(res.reason).equal(`Transport locked till ${new Date(afterLimit)} due to too many requests.`);
+          expect(res.reason).equal(
+            `Transport for transaction requests locked till ${new Date(afterLimit)} due to too many requests.`,
+          );
           expect(fetch.calledOnce).equal(true);
         }
 
@@ -455,7 +467,9 @@ describe('FetchTransport', () => {
           throw new Error('unreachable!');
         } catch (res) {
           expect(res.status).equal(429);
-          expect(res.reason).equal(`Transport locked till ${new Date(afterLimit)} due to too many requests.`);
+          expect(res.reason).equal(
+            `Transport for event requests locked till ${new Date(afterLimit)} due to too many requests.`,
+          );
           expect(fetch.calledOnce).equal(true);
         }
 

--- a/packages/browser/test/unit/transports/xhr.test.ts
+++ b/packages/browser/test/unit/transports/xhr.test.ts
@@ -127,7 +127,9 @@ describe('XHRTransport', () => {
           throw new Error('unreachable!');
         } catch (res) {
           expect(res.status).equal(429);
-          expect(res.reason).equal(`Transport locked till ${new Date(afterLimit)} due to too many requests.`);
+          expect(res.reason).equal(
+            `Transport for event requests locked till ${new Date(afterLimit)} due to too many requests.`,
+          );
           expect(server.requests.length).equal(1);
         }
 
@@ -190,7 +192,9 @@ describe('XHRTransport', () => {
           throw new Error('unreachable!');
         } catch (res) {
           expect(res.status).equal(429);
-          expect(res.reason).equal(`Transport locked till ${new Date(afterLimit)} due to too many requests.`);
+          expect(res.reason).equal(
+            `Transport for event requests locked till ${new Date(afterLimit)} due to too many requests.`,
+          );
           expect(server.requests.length).equal(2);
         }
 
@@ -256,7 +260,9 @@ describe('XHRTransport', () => {
           throw new Error('unreachable!');
         } catch (res) {
           expect(res.status).equal(429);
-          expect(res.reason).equal(`Transport locked till ${new Date(afterLimit)} due to too many requests.`);
+          expect(res.reason).equal(
+            `Transport for event requests locked till ${new Date(afterLimit)} due to too many requests.`,
+          );
           expect(server.requests.length).equal(1);
         }
 
@@ -265,7 +271,9 @@ describe('XHRTransport', () => {
           throw new Error('unreachable!');
         } catch (res) {
           expect(res.status).equal(429);
-          expect(res.reason).equal(`Transport locked till ${new Date(afterLimit)} due to too many requests.`);
+          expect(res.reason).equal(
+            `Transport for transaction requests locked till ${new Date(afterLimit)} due to too many requests.`,
+          );
           expect(server.requests.length).equal(1);
         }
 
@@ -332,7 +340,9 @@ describe('XHRTransport', () => {
           throw new Error('unreachable!');
         } catch (res) {
           expect(res.status).equal(429);
-          expect(res.reason).equal(`Transport locked till ${new Date(afterLimit)} due to too many requests.`);
+          expect(res.reason).equal(
+            `Transport for event requests locked till ${new Date(afterLimit)} due to too many requests.`,
+          );
           expect(server.requests.length).equal(1);
         }
 
@@ -341,7 +351,9 @@ describe('XHRTransport', () => {
           throw new Error('unreachable!');
         } catch (res) {
           expect(res.status).equal(429);
-          expect(res.reason).equal(`Transport locked till ${new Date(afterLimit)} due to too many requests.`);
+          expect(res.reason).equal(
+            `Transport for transaction requests locked till ${new Date(afterLimit)} due to too many requests.`,
+          );
           expect(server.requests.length).equal(1);
         }
 
@@ -393,7 +405,9 @@ describe('XHRTransport', () => {
           throw new Error('unreachable!');
         } catch (res) {
           expect(res.status).equal(429);
-          expect(res.reason).equal(`Transport locked till ${new Date(afterLimit)} due to too many requests.`);
+          expect(res.reason).equal(
+            `Transport for event requests locked till ${new Date(afterLimit)} due to too many requests.`,
+          );
           expect(server.requests.length).equal(1);
         }
 

--- a/packages/node/test/transports/http.test.ts
+++ b/packages/node/test/transports/http.test.ts
@@ -204,7 +204,9 @@ describe('HTTPTransport', () => {
     } catch (e) {
       expect(e.status).toEqual(429);
       expect(e.reason).toEqual(
-        `Transport locked till ${new Date(now + retryAfterSeconds * 1000)} due to too many requests.`,
+        `Transport for event requests locked till ${new Date(
+          now + retryAfterSeconds * 1000,
+        )} due to too many requests.`,
       );
       expect(e.payload.message).toEqual('test');
       expect(e.type).toEqual('event');
@@ -257,7 +259,9 @@ describe('HTTPTransport', () => {
     } catch (e) {
       expect(e.status).toEqual(429);
       expect(e.reason).toEqual(
-        `Transport locked till ${new Date(now + retryAfterSeconds * 1000)} due to too many requests.`,
+        `Transport for event requests locked till ${new Date(
+          now + retryAfterSeconds * 1000,
+        )} due to too many requests.`,
       );
       expect(e.payload).toEqual(eventPayload);
       expect(e.type).toEqual('event');
@@ -268,7 +272,9 @@ describe('HTTPTransport', () => {
     } catch (e) {
       expect(e.status).toEqual(429);
       expect(e.reason).toEqual(
-        `Transport locked till ${new Date(now + retryAfterSeconds * 1000)} due to too many requests.`,
+        `Transport for transaction requests locked till ${new Date(
+          now + retryAfterSeconds * 1000,
+        )} due to too many requests.`,
       );
       expect(e.payload).toEqual(transactionPayload);
       expect(e.type).toEqual('transaction');
@@ -335,7 +341,9 @@ describe('HTTPTransport', () => {
     } catch (e) {
       expect(e.status).toEqual(429);
       expect(e.reason).toEqual(
-        `Transport locked till ${new Date(now + retryAfterSeconds * 1000)} due to too many requests.`,
+        `Transport for event requests locked till ${new Date(
+          now + retryAfterSeconds * 1000,
+        )} due to too many requests.`,
       );
       expect(e.payload).toEqual(eventPayload);
       expect(e.type).toEqual('event');
@@ -391,7 +399,9 @@ describe('HTTPTransport', () => {
     } catch (e) {
       expect(e.status).toEqual(429);
       expect(e.reason).toEqual(
-        `Transport locked till ${new Date(now + retryAfterSeconds * 1000)} due to too many requests.`,
+        `Transport for event requests locked till ${new Date(
+          now + retryAfterSeconds * 1000,
+        )} due to too many requests.`,
       );
       expect(e.payload).toEqual(eventPayload);
       expect(e.type).toEqual('event');
@@ -402,7 +412,9 @@ describe('HTTPTransport', () => {
     } catch (e) {
       expect(e.status).toEqual(429);
       expect(e.reason).toEqual(
-        `Transport locked till ${new Date(now + retryAfterSeconds * 1000)} due to too many requests.`,
+        `Transport for session requests locked till ${new Date(
+          now + retryAfterSeconds * 1000,
+        )} due to too many requests.`,
       );
       expect(e.payload.environment).toEqual(sessionPayload.environment);
       expect(e.payload.release).toEqual(sessionPayload.release);
@@ -415,7 +427,9 @@ describe('HTTPTransport', () => {
     } catch (e) {
       expect(e.status).toEqual(429);
       expect(e.reason).toEqual(
-        `Transport locked till ${new Date(now + retryAfterSeconds * 1000)} due to too many requests.`,
+        `Transport for transaction requests locked till ${new Date(
+          now + retryAfterSeconds * 1000,
+        )} due to too many requests.`,
       );
       expect(e.payload).toEqual(transactionPayload);
       expect(e.type).toEqual('transaction');
@@ -474,7 +488,9 @@ describe('HTTPTransport', () => {
     } catch (e) {
       expect(e.status).toEqual(429);
       expect(e.reason).toEqual(
-        `Transport locked till ${new Date(now + retryAfterSeconds * 1000)} due to too many requests.`,
+        `Transport for event requests locked till ${new Date(
+          now + retryAfterSeconds * 1000,
+        )} due to too many requests.`,
       );
       expect(e.payload).toEqual(eventPayload);
       expect(e.type).toEqual('event');
@@ -485,7 +501,9 @@ describe('HTTPTransport', () => {
     } catch (e) {
       expect(e.status).toEqual(429);
       expect(e.reason).toEqual(
-        `Transport locked till ${new Date(now + retryAfterSeconds * 1000)} due to too many requests.`,
+        `Transport for transaction requests locked till ${new Date(
+          now + retryAfterSeconds * 1000,
+        )} due to too many requests.`,
       );
       expect(e.payload).toEqual(transactionPayload);
       expect(e.type).toEqual('transaction');
@@ -539,7 +557,9 @@ describe('HTTPTransport', () => {
     } catch (e) {
       expect(e.status).toEqual(429);
       expect(e.reason).toEqual(
-        `Transport locked till ${new Date(now + retryAfterSeconds * 1000)} due to too many requests.`,
+        `Transport for event requests locked till ${new Date(
+          now + retryAfterSeconds * 1000,
+        )} due to too many requests.`,
       );
       expect(e.payload).toEqual(eventPayload);
       expect(e.type).toEqual('event');
@@ -586,7 +606,9 @@ describe('HTTPTransport', () => {
     } catch (e) {
       expect(e.status).toEqual(429);
       expect(e.reason).toEqual(
-        `Transport locked till ${new Date(now + retryAfterSeconds * 1000)} due to too many requests.`,
+        `Transport for event requests locked till ${new Date(
+          now + retryAfterSeconds * 1000,
+        )} due to too many requests.`,
       );
       expect(e.payload).toEqual(eventPayload);
       expect(e.type).toEqual('event');

--- a/packages/node/test/transports/https.test.ts
+++ b/packages/node/test/transports/https.test.ts
@@ -189,7 +189,9 @@ describe('HTTPSTransport', () => {
     } catch (e) {
       expect(e.status).toEqual(429);
       expect(e.reason).toEqual(
-        `Transport locked till ${new Date(now + retryAfterSeconds * 1000)} due to too many requests.`,
+        `Transport for event requests locked till ${new Date(
+          now + retryAfterSeconds * 1000,
+        )} due to too many requests.`,
       );
       expect(e.payload.message).toEqual('test');
       expect(e.type).toEqual('event');


### PR DESCRIPTION
No logical changes, just updated logging and unified variables naming.