### PR TITLE
test(nextjs): Pin next v10 to integration tests

### DIFF
--- a/packages/nextjs/test/integration/package.json
+++ b/packages/nextjs/test/integration/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@sentry/nextjs": "file:../../",
-    "next": "latest",
+    "next": "10.1.3",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },

--- a/packages/nextjs/test/integration/package.json
+++ b/packages/nextjs/test/integration/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@sentry/nextjs": "file:../../",
-    "next": "10.1.3",
+    "next": "10.x",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },


### PR DESCRIPTION
To unblock broken master, we pin integration test deps.
Once we've tested more with next v11, we should come back
and update these tests to use a test matrix with varying
next versions.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
