### PR TITLE
fix(nextjs): Inject Sentry into `main.js` entry.

### DIFF
--- a/packages/nextjs/src/utils/config.ts
+++ b/packages/nextjs/src/utils/config.ts
@@ -106,6 +106,12 @@ const injectSentry = async (origEntryProperty: EntryProperty, isServer: boolean)
   // On the client, it's sufficient to inject it into the `main` JS code, which is included in every browser page.
   else {
     _injectFile(newEntryProperty, 'main', SENTRY_CLIENT_CONFIG_FILE);
+
+    // next-pwa inserts its register script to 'main.js' entry. In this case, both `main` and `main.js` exist.
+    // As in: https://github.com/getsentry/sentry-javascript/issues/3538
+    if ('main.js' in newEntryProperty) {
+      _injectFile(newEntryProperty, 'main.js', SENTRY_CLIENT_CONFIG_FILE);
+    }
   }
 
   return newEntryProperty;


### PR DESCRIPTION
Fixes: #3538 

[`next-pwa`](https://github.com/shadowwalker/next-pwa) explicitly [inserts](https://github.com/shadowwalker/next-pwa/blob/d0d03f965c3239a9d57af0aa6db08ef2b283275f/index.js#L88) its registration script to `main.js` entry. In this case, Sentry should also be injected into it.