### PR TITLE
fix(nextjs): Correctly handle functional next config in `withSentryConfig`

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -4,7 +4,7 @@ export { SentryCliPluginOptions as SentryWebpackPluginOptions } from '@sentry/we
  * Overall Nextjs config
  */
 
-export type ExportedNextConfig = NextConfigObject;
+export type ExportedNextConfig = NextConfigObject | NextConfigFunction;
 
 export type NextConfigObject = {
   // whether or not next should create source maps for browser code
@@ -16,6 +16,11 @@ export type NextConfigObject = {
   // other `next.config.js` options
   [key: string]: unknown;
 };
+
+export type NextConfigFunction = (
+  phase: string,
+  defaults: { defaultConfig: { [key: string]: unknown } },
+) => NextConfigObject;
 
 /**
  * Webpack config

--- a/packages/nextjs/test/config.test.ts
+++ b/packages/nextjs/test/config.test.ts
@@ -62,7 +62,10 @@ function materializeFinalNextConfig(
   userNextConfig: ExportedNextConfig,
   userSentryWebpackPluginConfig: SentryWebpackPluginOptions,
 ): NextConfigObject {
-  const finalConfigValues = withSentryConfig(userNextConfig, userSentryWebpackPluginConfig);
+  const configFunction = withSentryConfig(userNextConfig, userSentryWebpackPluginConfig);
+  const finalConfigValues = configFunction('phase-production-build', {
+    defaultConfig: {},
+  });
 
   return finalConfigValues;
 }
@@ -123,6 +126,20 @@ describe('withSentryConfig', () => {
     expect(finalConfig).toEqual(
       expect.objectContaining({
         ...userNextConfig,
+        productionBrowserSourceMaps: true,
+        webpack: expect.any(Function), // `webpack` is tested specifically elsewhere
+      }),
+    );
+  });
+
+  it("works when user's overall config is a function", () => {
+    const userNextConfigFunction = () => userNextConfig;
+
+    const finalConfig = materializeFinalNextConfig(userNextConfigFunction, userSentryWebpackPluginConfig);
+
+    expect(finalConfig).toEqual(
+      expect.objectContaining({
+        ...userNextConfigFunction(),
         productionBrowserSourceMaps: true,
         webpack: expect.any(Function), // `webpack` is tested specifically elsewhere
       }),


### PR DESCRIPTION
To set up Sentry, we tell users to end their `next.config.js` files with

`module.exports = withSentryConfig(moduleExports, SentryWebpackPluginOptions);`,

where `moduleExports` is what was the user's `module.exports` before they added Sentry - in other words, all of their other config for their next app. 

According to [the next docs](https://nextjs.org/docs/api-reference/next.config.js/introduction), that config can take the form either of an object or a function which returns an object. We've been correctly handling the first case, but not the second. This fixes that by checking if `moduleExports` is a function, and if so, running that function before merging in the user config, so that in either case we know we're merging in an object.

Fixes https://github.com/getsentry/sentry-docs/issues/3723.
Fixes https://github.com/ricokahler/next-plugin-preval/issues/42.
