### PR TITLE
fix(nextjs): Fix conflict with other libraries modifying webpack `entry` property

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -54,10 +54,13 @@ export type WebpackEntryProperty = EntryPropertyObject | EntryPropertyFunction;
 // Each value in that object is either a string representing a single entry point, an array of such strings, or an
 // object containing either of those, along with other configuration options. In that third case, the entry point(s) are
 // listed under the key `import`.
-export type EntryPropertyObject =
-  | { [key: string]: string }
-  | { [key: string]: Array<string> }
-  | { [key: string]: EntryPointObject }; // only in webpack 5
+export type EntryPropertyObject = {
+  [key: string]:
+    | string
+    | Array<string>
+    // only in webpack 5
+    | EntryPointObject;
+};
 
 export type EntryPropertyFunction = () => Promise<EntryPropertyObject>;
 

--- a/packages/nextjs/test/config.test.ts
+++ b/packages/nextjs/test/config.test.ts
@@ -212,7 +212,27 @@ describe('webpack config', () => {
       });
 
       expect(finalWebpackConfig.entry).toEqual(
-        expect.objectContaining({ main: expect.arrayContaining(['./sentry.client.config.js']) }),
+        expect.objectContaining({ main: ['./src/index.ts', './sentry.client.config.js'] }),
+      );
+    });
+
+    // see https://github.com/getsentry/sentry-javascript/pull/3696#issuecomment-863363803
+    it('handles non-empty `main.js` entry point', async () => {
+      const finalWebpackConfig = await materializeFinalWebpackConfig({
+        userNextConfig,
+        userSentryWebpackPluginConfig,
+        incomingWebpackConfig: {
+          ...clientWebpackConfig,
+          entry: () => Promise.resolve({ main: './src/index.ts', 'main.js': ['sitLieDownRollOver.config.js'] }),
+        },
+        incomingWebpackBuildContext: { ...buildContext, isServer: false },
+      });
+
+      expect(finalWebpackConfig.entry).toEqual(
+        expect.objectContaining({
+          main: ['sitLieDownRollOver.config.js', './src/index.ts', './sentry.client.config.js'],
+          'main.js': [],
+        }),
       );
     });
   });


### PR DESCRIPTION
In order to include the user's `sentry.client.config.js` code (which is where `Sentry.init()` is called) in the browser bundle, we modify the `entry` webpack configuration so that the `main` entry point includes that file in addition to the core nextjs browser code.

At some point in the past, that same entry point was called `main.js`, and next maintains code to [preserve backwards compatibility](https://github.com/vercel/next.js/blob/4f3674cc37b1e3bc19ecf4f4e606543f2ce03d8b/packages/next/build/webpack-config.ts#L1728-L1754) with anything which still uses that name for it. In that code, anything in `main.js` is copied over to `main` before `main.js` is deleted. Should be fine, right?

It would be, except that instead of copying the `main.js` stuff into the current value of `main` (which by that point includes `sentry.client.config.js`), it instead uses the original `main` value (which doesn't include our code). Luckily for us, this only happens if there's anything actually _in_ `main.js`, so as long as we can guarantee that it's empty, we're good.

In most cases there's nothing to do, because [it's empty by default](https://github.com/vercel/next.js/blob/4f3674cc37b1e3bc19ecf4f4e606543f2ce03d8b/packages/next/build/webpack-config.ts#L304). But currently, if another library has added something to it, it triggers next's copying over and the Sentry code is lost. This fixes that by doing the copying ourselves, and then emptying `main.js` before next can get ahold of it.

Fixing this also exposed a mistake in our types, so that's fixed here as well.

Fixes https://github.com/getsentry/sentry-javascript/issues/3538.