### PR TITLE
Feat: Allow node stackwalk in Electron renderer

### DIFF
--- a/packages/node/src/backend.ts
+++ b/packages/node/src/backend.ts
@@ -16,15 +16,15 @@ export class NodeBackend extends BaseBackend<NodeOptions> {
    * @inheritDoc
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-  public eventFromException(exception: any, hint?: EventHint | undefined): PromiseLike<Event> {
-    return eventFromException(this._options, exception, readFile, hint);
+  public eventFromException(exception: any, hint?: EventHint): PromiseLike<Event> {
+    return eventFromException(this._options, exception, hint, readFile);
   }
 
   /**
    * @inheritDoc
    */
   public eventFromMessage(message: string, level: Severity = Severity.Info, hint?: EventHint): PromiseLike<Event> {
-    return eventFromMessage(this._options, message, level, readFile, hint);
+    return eventFromMessage(this._options, message, level, hint, readFile);
   }
 
   /**

--- a/packages/node/src/backend.ts
+++ b/packages/node/src/backend.ts
@@ -1,17 +1,9 @@
-import { BaseBackend, getCurrentHub } from '@sentry/core';
-import { Event, EventHint, Mechanism, Severity, Transport, TransportOptions } from '@sentry/types';
-import {
-  addExceptionMechanism,
-  addExceptionTypeValue,
-  Dsn,
-  extractExceptionKeysForMessage,
-  isError,
-  isPlainObject,
-  normalizeToSize,
-  SyncPromise,
-} from '@sentry/utils';
+import { BaseBackend } from '@sentry/core';
+import { Event, EventHint, Severity, Transport, TransportOptions } from '@sentry/types';
+import { Dsn } from '@sentry/utils';
+import { readFile } from 'fs';
 
-import { extractStackFromError, parseError, parseStack, prepareFramesForEvent } from './parsers';
+import { eventFromException, eventFromMessage } from './eventbuilder';
 import { HTTPSTransport, HTTPTransport } from './transports';
 import { NodeOptions } from './types';
 
@@ -24,79 +16,15 @@ export class NodeBackend extends BaseBackend<NodeOptions> {
    * @inheritDoc
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-  public eventFromException(exception: any, hint?: EventHint): PromiseLike<Event> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let ex: any = exception;
-    const providedMechanism: Mechanism | undefined =
-      hint && hint.data && (hint.data as { mechanism: Mechanism }).mechanism;
-    const mechanism: Mechanism = providedMechanism || {
-      handled: true,
-      type: 'generic',
-    };
-
-    if (!isError(exception)) {
-      if (isPlainObject(exception)) {
-        // This will allow us to group events based on top-level keys
-        // which is much better than creating new group when any key/value change
-        const message = `Non-Error exception captured with keys: ${extractExceptionKeysForMessage(exception)}`;
-
-        getCurrentHub().configureScope(scope => {
-          scope.setExtra('__serialized__', normalizeToSize(exception as Record<string, unknown>));
-        });
-
-        ex = (hint && hint.syntheticException) || new Error(message);
-        (ex as Error).message = message;
-      } else {
-        // This handles when someone does: `throw "something awesome";`
-        // We use synthesized Error here so we can extract a (rough) stack trace.
-        ex = (hint && hint.syntheticException) || new Error(exception as string);
-        (ex as Error).message = exception;
-      }
-      mechanism.synthetic = true;
-    }
-
-    return new SyncPromise<Event>((resolve, reject) =>
-      parseError(ex as Error, this._options)
-        .then(event => {
-          addExceptionTypeValue(event, undefined, undefined);
-          addExceptionMechanism(event, mechanism);
-
-          resolve({
-            ...event,
-            event_id: hint && hint.event_id,
-          });
-        })
-        .then(null, reject),
-    );
+  public eventFromException(exception: any, hint?: EventHint | undefined): PromiseLike<Event> {
+    return eventFromException(this._options, exception, readFile, hint);
   }
 
   /**
    * @inheritDoc
    */
   public eventFromMessage(message: string, level: Severity = Severity.Info, hint?: EventHint): PromiseLike<Event> {
-    const event: Event = {
-      event_id: hint && hint.event_id,
-      level,
-      message,
-    };
-
-    return new SyncPromise<Event>(resolve => {
-      if (this._options.attachStacktrace && hint && hint.syntheticException) {
-        const stack = hint.syntheticException ? extractStackFromError(hint.syntheticException) : [];
-        void parseStack(stack, this._options)
-          .then(frames => {
-            event.stacktrace = {
-              frames: prepareFramesForEvent(frames),
-            };
-            resolve(event);
-          })
-          .then(null, () => {
-            resolve(event);
-          });
-      } else {
-        resolve(event);
-      }
-    });
+    return eventFromMessage(this._options, message, level, readFile, hint);
   }
 
   /**

--- a/packages/node/src/backend.ts
+++ b/packages/node/src/backend.ts
@@ -1,9 +1,9 @@
 import { BaseBackend } from '@sentry/core';
 import { Event, EventHint, Severity, Transport, TransportOptions } from '@sentry/types';
 import { Dsn } from '@sentry/utils';
-import { readFile } from 'fs';
 
 import { eventFromException, eventFromMessage } from './eventbuilder';
+import { readFilesAddPrePostContext } from './sources';
 import { HTTPSTransport, HTTPTransport } from './transports';
 import { NodeOptions } from './types';
 
@@ -17,14 +17,14 @@ export class NodeBackend extends BaseBackend<NodeOptions> {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   public eventFromException(exception: any, hint?: EventHint): PromiseLike<Event> {
-    return eventFromException(this._options, exception, hint, readFile);
+    return eventFromException(this._options, exception, hint, readFilesAddPrePostContext);
   }
 
   /**
    * @inheritDoc
    */
   public eventFromMessage(message: string, level: Severity = Severity.Info, hint?: EventHint): PromiseLike<Event> {
-    return eventFromMessage(this._options, message, level, hint, readFile);
+    return eventFromMessage(this._options, message, level, hint, readFilesAddPrePostContext);
   }
 
   /**

--- a/packages/node/src/eventbuilder.ts
+++ b/packages/node/src/eventbuilder.ts
@@ -1,0 +1,106 @@
+import { getCurrentHub } from '@sentry/core';
+import { Event, EventHint, Mechanism, Severity } from '@sentry/types';
+import {
+  addExceptionMechanism,
+  addExceptionTypeValue,
+  extractExceptionKeysForMessage,
+  isError,
+  isPlainObject,
+  normalizeToSize,
+  SyncPromise,
+} from '@sentry/utils';
+
+import { extractStackFromError, parseError, parseStack, prepareFramesForEvent, ReadFileFn } from './parsers';
+import { NodeOptions } from './types';
+
+/**
+ * Builds and Event from a Exception
+ * @hidden
+ */
+export function eventFromException(
+  options: NodeOptions,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
+  exception: any,
+  readFile?: ReadFileFn,
+  hint?: EventHint,
+): PromiseLike<Event> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let ex: any = exception;
+  const providedMechanism: Mechanism | undefined =
+    hint && hint.data && (hint.data as { mechanism: Mechanism }).mechanism;
+  const mechanism: Mechanism = providedMechanism || {
+    handled: true,
+    type: 'generic',
+  };
+
+  if (!isError(exception)) {
+    if (isPlainObject(exception)) {
+      // This will allow us to group events based on top-level keys
+      // which is much better than creating new group when any key/value change
+      const message = `Non-Error exception captured with keys: ${extractExceptionKeysForMessage(exception)}`;
+
+      getCurrentHub().configureScope(scope => {
+        scope.setExtra('__serialized__', normalizeToSize(exception as Record<string, unknown>));
+      });
+
+      ex = (hint && hint.syntheticException) || new Error(message);
+      (ex as Error).message = message;
+    } else {
+      // This handles when someone does: `throw "something awesome";`
+      // We use synthesized Error here so we can extract a (rough) stack trace.
+      ex = (hint && hint.syntheticException) || new Error(exception as string);
+      (ex as Error).message = exception;
+    }
+    mechanism.synthetic = true;
+  }
+
+  return new SyncPromise<Event>((resolve, reject) =>
+    parseError(ex as Error, readFile, options)
+      .then(event => {
+        addExceptionTypeValue(event, undefined, undefined);
+        addExceptionMechanism(event, mechanism);
+
+        resolve({
+          ...event,
+          event_id: hint && hint.event_id,
+        });
+      })
+      .then(null, reject),
+  );
+}
+
+/**
+ * Builds and Event from a Message
+ * @hidden
+ */
+export function eventFromMessage(
+  options: NodeOptions,
+  message: string,
+  level: Severity = Severity.Info,
+  readFile?: ReadFileFn,
+  hint?: EventHint,
+): PromiseLike<Event> {
+  const event: Event = {
+    event_id: hint && hint.event_id,
+    level,
+    message,
+  };
+
+  return new SyncPromise<Event>(resolve => {
+    if (options.attachStacktrace && hint && hint.syntheticException) {
+      const stack = hint.syntheticException ? extractStackFromError(hint.syntheticException) : [];
+      void parseStack(stack, readFile, options)
+        .then(frames => {
+          event.stacktrace = {
+            frames: prepareFramesForEvent(frames),
+          };
+          resolve(event);
+        })
+        .then(null, () => {
+          resolve(event);
+        });
+    } else {
+      resolve(event);
+    }
+  });
+}

--- a/packages/node/src/eventbuilder.ts
+++ b/packages/node/src/eventbuilder.ts
@@ -21,8 +21,8 @@ export function eventFromException(
   options: NodeOptions,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   exception: any,
-  readFile?: ReadFileFn,
   hint?: EventHint,
+  readFile?: ReadFileFn,
 ): PromiseLike<Event> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let ex: any = exception;
@@ -77,8 +77,8 @@ export function eventFromMessage(
   options: NodeOptions,
   message: string,
   level: Severity = Severity.Info,
-  readFile?: ReadFileFn,
   hint?: EventHint,
+  readFile?: ReadFileFn,
 ): PromiseLike<Event> {
   const event: Event = {
     event_id: hint && hint.event_id,

--- a/packages/node/src/eventbuilder.ts
+++ b/packages/node/src/eventbuilder.ts
@@ -10,7 +10,7 @@ import {
   SyncPromise,
 } from '@sentry/utils';
 
-import { extractStackFromError, parseError, parseStack, prepareFramesForEvent, ReadFileFn } from './parsers';
+import { extractStackFromError, parseError, parseStack, prepareFramesForEvent, ReadFilesFn } from './parsers';
 import { NodeOptions } from './types';
 
 /**
@@ -22,7 +22,7 @@ export function eventFromException(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   exception: any,
   hint?: EventHint,
-  readFile?: ReadFileFn,
+  readFiles?: ReadFilesFn,
 ): PromiseLike<Event> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let ex: any = exception;
@@ -55,7 +55,7 @@ export function eventFromException(
   }
 
   return new SyncPromise<Event>((resolve, reject) =>
-    parseError(ex as Error, readFile, options)
+    parseError(ex as Error, readFiles, options)
       .then(event => {
         addExceptionTypeValue(event, undefined, undefined);
         addExceptionMechanism(event, mechanism);
@@ -78,7 +78,7 @@ export function eventFromMessage(
   message: string,
   level: Severity = Severity.Info,
   hint?: EventHint,
-  readFile?: ReadFileFn,
+  readFiles?: ReadFilesFn,
 ): PromiseLike<Event> {
   const event: Event = {
     event_id: hint && hint.event_id,
@@ -89,7 +89,7 @@ export function eventFromMessage(
   return new SyncPromise<Event>(resolve => {
     if (options.attachStacktrace && hint && hint.syntheticException) {
       const stack = hint.syntheticException ? extractStackFromError(hint.syntheticException) : [];
-      void parseStack(stack, readFile, options)
+      void parseStack(stack, readFiles, options)
         .then(frames => {
           event.stacktrace = {
             frames: prepareFramesForEvent(frames),

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -42,6 +42,7 @@ export { NodeOptions } from './types';
 export { NodeBackend } from './backend';
 export { NodeClient } from './client';
 export { defaultIntegrations, init, lastEventId, flush, close, getSentryRelease } from './sdk';
+export { eventFromException, eventFromMessage } from './eventbuilder';
 export { deepReadDirSync } from './utils';
 export { SDK_NAME } from './version';
 

--- a/packages/node/src/sources.ts
+++ b/packages/node/src/sources.ts
@@ -1,0 +1,105 @@
+import { StackFrame } from '@sentry/types';
+import { addContextToFrame, SyncPromise } from '@sentry/utils';
+import { readFile } from 'fs';
+import { LRUMap } from 'lru_map';
+
+const FILE_CONTENT_CACHE = new LRUMap<string, string | null>(100);
+
+/**
+ * Resets the file cache. Exists for testing purposes.
+ * @hidden
+ */
+export function resetFileContentCache(): void {
+  FILE_CONTENT_CACHE.clear();
+}
+
+/**
+ * This function tries to read the source files + adding pre and post context (source code)
+ * to a frame.
+ * @param filesToRead string[] of filepaths
+ * @param frames StackFrame[] containg all frames
+ */
+export function readFilesAddPrePostContext(
+  filesToRead: string[],
+  frames: StackFrame[],
+  linesOfContext: number,
+): PromiseLike<StackFrame[]> {
+  return new SyncPromise<StackFrame[]>(resolve =>
+    readSourceFiles(filesToRead).then(sourceFiles => {
+      const result = frames.map(frame => {
+        if (frame.filename && sourceFiles[frame.filename]) {
+          try {
+            const lines = (sourceFiles[frame.filename] as string).split('\n');
+
+            addContextToFrame(lines, frame, linesOfContext);
+          } catch (e) {
+            // anomaly, being defensive in case
+            // unlikely to ever happen in practice but can definitely happen in theory
+          }
+        }
+        return frame;
+      });
+
+      resolve(result);
+    }),
+  );
+}
+
+/**
+ * This function reads file contents and caches them in a global LRU cache.
+ * Returns a Promise filepath => content array for all files that we were able to read.
+ *
+ * @param filenames Array of filepaths to read content from.
+ */
+function readSourceFiles(filenames: string[]): PromiseLike<{ [key: string]: string | null }> {
+  // we're relying on filenames being de-duped already
+  if (filenames.length === 0) {
+    return SyncPromise.resolve({});
+  }
+
+  return new SyncPromise<{
+    [key: string]: string | null;
+  }>(resolve => {
+    const sourceFiles: {
+      [key: string]: string | null;
+    } = {};
+
+    let count = 0;
+    // eslint-disable-next-line @typescript-eslint/prefer-for-of
+    for (let i = 0; i < filenames.length; i++) {
+      const filename = filenames[i];
+
+      const cache = FILE_CONTENT_CACHE.get(filename);
+      // We have a cache hit
+      if (cache !== undefined) {
+        // If it's not null (which means we found a file and have a content)
+        // we set the content and return it later.
+        if (cache !== null) {
+          sourceFiles[filename] = cache;
+        }
+        // eslint-disable-next-line no-plusplus
+        count++;
+        // In any case we want to skip here then since we have a content already or we couldn't
+        // read the file and don't want to try again.
+        if (count === filenames.length) {
+          resolve(sourceFiles);
+        }
+        continue;
+      }
+
+      readFile(filename, (err: Error | null, data: Buffer) => {
+        const content = err ? null : data.toString();
+        sourceFiles[filename] = content;
+
+        // We always want to set the cache, even to null which means there was an error reading the file.
+        // We do not want to try to read the file again.
+        FILE_CONTENT_CACHE.set(filename, content);
+        // eslint-disable-next-line no-plusplus
+        count++;
+        if (count === filenames.length) {
+          resolve(sourceFiles);
+        }
+      });
+    }
+  });
+}

--- a/packages/node/test/parsers.test.ts
+++ b/packages/node/test/parsers.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 
 import * as Parsers from '../src/parsers';
+import * as Sources from '../src/sources';
 import * as stacktrace from '../src/stacktrace';
 import { getError } from './helper/error';
 
@@ -11,7 +12,7 @@ describe('parsers.ts', () => {
   beforeEach(() => {
     spy = jest.spyOn(fs, 'readFile');
     frames = stacktrace.parse(new Error('test'));
-    Parsers.resetFileContentCache();
+    Sources.resetFileContentCache();
   });
 
   afterEach(() => {
@@ -22,10 +23,10 @@ describe('parsers.ts', () => {
     test('parseStack with same file', done => {
       expect.assertions(1);
       let mockCalls = 0;
-      void Parsers.parseStack(frames, fs.readFile)
+      void Parsers.parseStack(frames, Sources.readFilesAddPrePostContext)
         .then(_ => {
           mockCalls = spy.mock.calls.length;
-          void Parsers.parseStack(frames, fs.readFile)
+          void Parsers.parseStack(frames, Sources.readFilesAddPrePostContext)
             .then(_1 => {
               // Calls to readFile shouldn't increase if there isn't a new error
               expect(spy).toHaveBeenCalledTimes(mockCalls);
@@ -54,7 +55,7 @@ describe('parsers.ts', () => {
           typeName: 'module.exports../src/index.ts',
         },
       ];
-      return Parsers.parseStack(framesWithFilePath, fs.readFile).then(_ => {
+      return Parsers.parseStack(framesWithFilePath, Sources.readFilesAddPrePostContext).then(_ => {
         expect(spy).toHaveBeenCalledTimes(1);
       });
     });
@@ -63,14 +64,14 @@ describe('parsers.ts', () => {
       expect.assertions(2);
       let mockCalls = 0;
       let newErrorCalls = 0;
-      void Parsers.parseStack(frames, fs.readFile)
+      void Parsers.parseStack(frames, Sources.readFilesAddPrePostContext)
         .then(_ => {
           mockCalls = spy.mock.calls.length;
-          void Parsers.parseStack(stacktrace.parse(getError()), fs.readFile)
+          void Parsers.parseStack(stacktrace.parse(getError()), Sources.readFilesAddPrePostContext)
             .then(_1 => {
               newErrorCalls = spy.mock.calls.length;
               expect(newErrorCalls).toBeGreaterThan(mockCalls);
-              void Parsers.parseStack(stacktrace.parse(getError()), fs.readFile)
+              void Parsers.parseStack(stacktrace.parse(getError()), Sources.readFilesAddPrePostContext)
                 .then(_2 => {
                   expect(spy).toHaveBeenCalledTimes(newErrorCalls);
                   done();
@@ -120,14 +121,14 @@ describe('parsers.ts', () => {
         typeName: 'module.exports../src/index.ts',
       },
     ];
-    return Parsers.parseStack(framesWithDuplicateFiles, fs.readFile).then(_ => {
+    return Parsers.parseStack(framesWithDuplicateFiles, Sources.readFilesAddPrePostContext).then(_ => {
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 
   test('parseStack with no context', async () => {
     expect.assertions(1);
-    return Parsers.parseStack(frames, fs.readFile, { frameContextLines: 0 }).then(_ => {
+    return Parsers.parseStack(frames, Sources.readFilesAddPrePostContext, { frameContextLines: 0 }).then(_ => {
       expect(spy).toHaveBeenCalledTimes(0);
     });
   });

--- a/packages/node/test/parsers.test.ts
+++ b/packages/node/test/parsers.test.ts
@@ -22,10 +22,10 @@ describe('parsers.ts', () => {
     test('parseStack with same file', done => {
       expect.assertions(1);
       let mockCalls = 0;
-      void Parsers.parseStack(frames)
+      void Parsers.parseStack(frames, fs.readFile)
         .then(_ => {
           mockCalls = spy.mock.calls.length;
-          void Parsers.parseStack(frames)
+          void Parsers.parseStack(frames, fs.readFile)
             .then(_1 => {
               // Calls to readFile shouldn't increase if there isn't a new error
               expect(spy).toHaveBeenCalledTimes(mockCalls);
@@ -54,7 +54,7 @@ describe('parsers.ts', () => {
           typeName: 'module.exports../src/index.ts',
         },
       ];
-      return Parsers.parseStack(framesWithFilePath).then(_ => {
+      return Parsers.parseStack(framesWithFilePath, fs.readFile).then(_ => {
         expect(spy).toHaveBeenCalledTimes(1);
       });
     });
@@ -63,14 +63,14 @@ describe('parsers.ts', () => {
       expect.assertions(2);
       let mockCalls = 0;
       let newErrorCalls = 0;
-      void Parsers.parseStack(frames)
+      void Parsers.parseStack(frames, fs.readFile)
         .then(_ => {
           mockCalls = spy.mock.calls.length;
-          void Parsers.parseStack(stacktrace.parse(getError()))
+          void Parsers.parseStack(stacktrace.parse(getError()), fs.readFile)
             .then(_1 => {
               newErrorCalls = spy.mock.calls.length;
               expect(newErrorCalls).toBeGreaterThan(mockCalls);
-              void Parsers.parseStack(stacktrace.parse(getError()))
+              void Parsers.parseStack(stacktrace.parse(getError()), fs.readFile)
                 .then(_2 => {
                   expect(spy).toHaveBeenCalledTimes(newErrorCalls);
                   done();
@@ -120,14 +120,14 @@ describe('parsers.ts', () => {
         typeName: 'module.exports../src/index.ts',
       },
     ];
-    return Parsers.parseStack(framesWithDuplicateFiles).then(_ => {
+    return Parsers.parseStack(framesWithDuplicateFiles, fs.readFile).then(_ => {
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });
 
   test('parseStack with no context', async () => {
     expect.assertions(1);
-    return Parsers.parseStack(frames, { frameContextLines: 0 }).then(_ => {
+    return Parsers.parseStack(frames, fs.readFile, { frameContextLines: 0 }).then(_ => {
       expect(spy).toHaveBeenCalledTimes(0);
     });
   });


### PR DESCRIPTION
Related to: https://github.com/getsentry/sentry-electron/issues/308

This PR:
- Moves `@sentry/node` functions `eventFromException` and `eventFromMessage` out of backend and into their own file [much like in the browser SDK](https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/eventbuilder.ts). 
- Re-exports them for use in `@sentry/electron`
- Adds `readFile` as a parameter in the parser functions

Why is this funky `readFile` stuff required?

The Electron renderer may or may not have access to node functionality. If `nodeIntegration` is enabled, full node is available.  If `nodeIntegration` is disabled and a bundler is being used, it will complain that `fs` cannot be found/is unavailable. With this PR we would just not pass `readFile` when the stack parser is called from the Electron renderer and no source files will be read.

What are the alternatives?
- Have different entry points in `@sentry/electron` depending on `nodeIntegration` (ie. `init` and `initWithNode`)
- Inform those using bundlers that they need to add `fs` to `externals`
- Add a `NodeIntegration` sentry integration that "patches" in this functionality? 
- Any other ideas?