### PR TITLE
ref(ember): Update scenarios and remove a few to speed up tests

### DIFF
--- a/packages/ember/config/ember-try.js
+++ b/packages/ember/config/ember-try.js
@@ -8,18 +8,10 @@ module.exports = async function() {
     useYarn: true,
     scenarios: [
       {
-        name: 'ember-lts-3.12',
+        name: 'ember-lts-3.20',
         npm: {
           devDependencies: {
-            'ember-source': '~3.12.0',
-          },
-        },
-      },
-      {
-        name: 'ember-lts-3.16',
-        npm: {
-          devDependencies: {
-            'ember-source': '~3.16.0',
+            'ember-source': '~3.20.0',
           },
         },
       },
@@ -39,39 +31,7 @@ module.exports = async function() {
           },
         },
       },
-      {
-        name: 'ember-canary',
-        allowedToFail: true,
-        npm: {
-          devDependencies: {
-            'ember-source': await getChannelURL('canary'),
-          },
-        },
-      },
       embroiderSafe(),
-      // The default `.travis.yml` runs this scenario via `npm test`,
-      // not via `ember try`. It's still included here so that running
-      // `ember try:each` manually or from a customized CI config will run it
-      // along with all the other scenarios.
-      {
-        name: 'ember-default',
-        npm: {
-          devDependencies: {},
-        },
-      },
-      {
-        name: 'ember-default-with-jquery',
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            'jquery-integration': true,
-          }),
-        },
-        npm: {
-          devDependencies: {
-            '@ember/jquery': '^0.5.1',
-          },
-        },
-      },
       {
         name: 'ember-classic',
         env: {


### PR DESCRIPTION
### Summary
Tests are pretty slow running all the variations in Ember scenarios, and a few LTS were out of date. Just picking the oldest supported LTS and removed a couple other default tests that shouldn't really check anything we don't cover in 'release'.

