### PR TITLE
ref(node): Update Node manual tests and test for sessionCount

### DIFF
--- a/packages/node/test/manual/release-health/single-session/caught-exception-errored-session.js
+++ b/packages/node/test/manual/release-health/single-session/caught-exception-errored-session.js
@@ -1,39 +1,35 @@
 const Sentry = require('../../../../dist');
-const { assertSessions, constructStrippedSessionObject, BaseDummyTransport } = require('../test-utils');
+const {
+  assertSessions,
+  constructStrippedSessionObject,
+  BaseDummyTransport,
+  validateSessionCountFunction,
+} = require('../test-utils');
 
-let sessionCounter = 0;
-process.on('exit', ()=> {
-  if (process.exitCode !== 1) {
-    console.log('SUCCESS: All application mode sessions were sent to node transport as expected');
-  }
-})
+const sessionCounts = {
+  sessionCounter: 0,
+  expectedSessions: 2,
+};
+
+validateSessionCountFunction(sessionCounts);
 
 class DummyTransport extends BaseDummyTransport {
   sendSession(session) {
-    sessionCounter++;
-    if (sessionCounter === 1) {
-      assertSessions(constructStrippedSessionObject(session),
-        {
-          init: true,
-          status: 'ok',
-          errors: 1,
-          release: '1.1'
-        }
-      )
-    }
-    else if (sessionCounter === 2) {
-      assertSessions(constructStrippedSessionObject(session),
-        {
-          init: false,
-          status: 'exited',
-          errors: 1,
-          release: '1.1'
-        }
-      )
-    }
-    else {
-      console.log('FAIL: Received way too many Sessions!');
-      process.exit(1);
+    sessionCounts.sessionCounter++;
+    if (sessionCounts.sessionCounter === 1) {
+      assertSessions(constructStrippedSessionObject(session), {
+        init: true,
+        status: 'ok',
+        errors: 1,
+        release: '1.1',
+      });
+    } else if (sessionCounts.sessionCounter === 2) {
+      assertSessions(constructStrippedSessionObject(session), {
+        init: false,
+        status: 'exited',
+        errors: 1,
+        release: '1.1',
+      });
     }
     return super.sendSession(session);
   }
@@ -43,7 +39,7 @@ Sentry.init({
   dsn: 'http://test@example.com/1337',
   release: '1.1',
   transport: DummyTransport,
-  autoSessionTracking: true
+  autoSessionTracking: true,
 });
 
 /**
@@ -54,8 +50,7 @@ Sentry.init({
  * `beforeExit` event which happens right before the process exits.
  */
 try {
-  throw new Error('hey there')
-}
-catch(e) {
+  throw new Error('hey there');
+} catch (e) {
   Sentry.captureException(e);
 }

--- a/packages/node/test/manual/release-health/single-session/healthy-session.js
+++ b/packages/node/test/manual/release-health/single-session/healthy-session.js
@@ -1,29 +1,28 @@
 const Sentry = require('../../../../dist');
-const { assertSessions, constructStrippedSessionObject, BaseDummyTransport } = require('../test-utils');
+const {
+  assertSessions,
+  constructStrippedSessionObject,
+  BaseDummyTransport,
+  validateSessionCountFunction,
+} = require('../test-utils');
 
-let sessionCounter = 0;
-process.on('exit', ()=> {
-  if (process.exitCode !== 1) {
-    console.log('SUCCESS: All application mode sessions were sent to node transport as expected');
-  }
-})
+const sessionCounts = {
+  sessionCounter: 0,
+  expectedSessions: 1,
+};
+
+validateSessionCountFunction(sessionCounts);
 
 class DummyTransport extends BaseDummyTransport {
   sendSession(session) {
-    sessionCounter++;
-    if (sessionCounter === 1) {
-      assertSessions(constructStrippedSessionObject(session),
-        {
-          init: true,
-          status: 'exited',
-          errors: 0,
-          release: '1.1'
-        }
-      )
-    }
-    else {
-      console.log('FAIL: Received way too many Sessions!');
-      process.exit(1);
+    sessionCounts.sessionCounter++;
+    if (sessionCounts.sessionCounter === 1) {
+      assertSessions(constructStrippedSessionObject(session), {
+        init: true,
+        status: 'exited',
+        errors: 0,
+        release: '1.1',
+      });
     }
     return super.sendSession(session);
   }
@@ -33,7 +32,7 @@ Sentry.init({
   dsn: 'http://test@example.com/1337',
   release: '1.1',
   transport: DummyTransport,
-  autoSessionTracking: true
+  autoSessionTracking: true,
 });
 
 /**

--- a/packages/node/test/manual/release-health/single-session/uncaught-exception-crashed-session.js
+++ b/packages/node/test/manual/release-health/single-session/uncaught-exception-crashed-session.js
@@ -1,22 +1,20 @@
 const Sentry = require('../../../../dist');
 const { assertSessions, constructStrippedSessionObject, BaseDummyTransport } = require('../test-utils');
 
-process.on('exit', ()=> {
-  if (process.exitCode !== 1) {
+process.on('exit', () => {
+  if (process.exitCode === 0) {
     console.log('SUCCESS: All application mode sessions were sent to node transport as expected');
   }
-})
+});
 
 class DummyTransport extends BaseDummyTransport {
   sendSession(session) {
-    assertSessions(constructStrippedSessionObject(session),
-      {
-        init: true,
-        status: 'crashed',
-        errors: 1,
-        release: '1.1'
-      }
-    )
+    assertSessions(constructStrippedSessionObject(session), {
+      init: true,
+      status: 'crashed',
+      errors: 1,
+      release: '1.1',
+    });
     process.exit(0);
   }
 }
@@ -25,7 +23,7 @@ Sentry.init({
   dsn: 'http://test@example.com/1337',
   release: '1.1',
   transport: DummyTransport,
-  autoSessionTracking: true
+  autoSessionTracking: true,
 });
 /**
  * The following code snippet will throw an exception of `mechanism.handled` equal to `false`, and so this session
@@ -34,4 +32,4 @@ Sentry.init({
  * extracts event data and uses it to update the Session and send it. No secondary session update in this case because
  * we explicitly exit the process in the onUncaughtException handler and so the `beforeExit` event is not fired.
  */
-throw new Error('test error')
+throw new Error('test error');

--- a/packages/node/test/manual/release-health/single-session/unhandled-rejection-crashed-session.js
+++ b/packages/node/test/manual/release-health/single-session/unhandled-rejection-crashed-session.js
@@ -1,32 +1,30 @@
 const Sentry = require('../../../../dist');
-const { assertSessions, constructStrippedSessionObject, BaseDummyTransport } = require('../test-utils');
+const {
+  assertSessions,
+  constructStrippedSessionObject,
+  BaseDummyTransport,
+  validateSessionCountFunction,
+} = require('../test-utils');
 
-let sessionCounter = 0;
-process.on('exit', () => {
-  if (process.exitCode !== 1) {
-    console.log('SUCCESS: All application mode sessions were sent to node transport as expected');
-  }
-})
+const sessionCounts = {
+  sessionCounter: 0,
+  expectedSessions: 1,
+};
+
+validateSessionCountFunction(sessionCounts);
 
 class DummyTransport extends BaseDummyTransport {
   sendSession(session) {
-    sessionCounter++;
+    sessionCounts.sessionCounter++;
 
-    if (sessionCounter === 1) {
-      assertSessions(constructStrippedSessionObject(session),
-        {
-          init: true,
-          status: 'crashed',
-          errors: 1,
-          release: '1.1'
-        }
-      )
+    if (sessionCounts.sessionCounter === 1) {
+      assertSessions(constructStrippedSessionObject(session), {
+        init: true,
+        status: 'crashed',
+        errors: 1,
+        release: '1.1',
+      });
     }
-    else {
-      console.log('FAIL: Received way too many Sessions!');
-      process.exit(1);
-    }
-
     return super.sendSession(session);
   }
 }
@@ -35,7 +33,7 @@ Sentry.init({
   dsn: 'http://test@example.com/1337',
   release: '1.1',
   transport: DummyTransport,
-  autoSessionTracking: true
+  autoSessionTracking: true,
 });
 
 /**


### PR DESCRIPTION
This PR cleans up Node manual tests to use refactored test util function + adds logic that actually tests for the session count rather than just the session body