### PR TITLE
fix: Prevent circular structure serialization in events

### DIFF
--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -85,17 +85,18 @@ export class GlobalHandlers implements Integration {
         }
 
         const client = currentHub.getClient();
-        const event = isPrimitive(error)
-          ? this._eventFromIncompleteOnError(data.msg, data.url, data.line, data.column)
-          : this._enhanceEventWithInitialFrame(
-              eventFromUnknownInput(error, undefined, {
-                attachStacktrace: client && client.getOptions().attachStacktrace,
-                rejection: false,
-              }),
-              data.url,
-              data.line,
-              data.column,
-            );
+        const event =
+          error === undefined && isString(data.msg)
+            ? this._eventFromIncompleteOnError(data.msg, data.url, data.line, data.column)
+            : this._enhanceEventWithInitialFrame(
+                eventFromUnknownInput(error || data.msg, undefined, {
+                  attachStacktrace: client && client.getOptions().attachStacktrace,
+                  rejection: false,
+                }),
+                data.url,
+                data.line,
+                data.column,
+              );
 
         addExceptionMechanism(event, {
           handled: false,
@@ -188,12 +189,10 @@ export class GlobalHandlers implements Integration {
     let message = isErrorEvent(msg) ? msg.message : msg;
     let name;
 
-    if (isString(message)) {
-      const groups = message.match(ERROR_TYPES_RE);
-      if (groups) {
-        name = groups[1];
-        message = groups[2];
-      }
+    const groups = message.match(ERROR_TYPES_RE);
+    if (groups) {
+      name = groups[1];
+      message = groups[2];
     }
 
     const event = {

--- a/packages/browser/test/integration/suites/onerror.js
+++ b/packages/browser/test/integration/suites/onerror.js
@@ -130,6 +130,25 @@ describe("window.onerror", function() {
     });
   });
 
+  it("should onerror calls with non-string first argument gracefully", function() {
+    return runInSandbox(sandbox, function() {
+      window.onerror({
+        type: "error",
+        otherKey: "hi",
+      });
+    }).then(function(summary) {
+      assert.equal(summary.events[0].exception.values[0].type, "Error");
+      assert.equal(
+        summary.events[0].exception.values[0].value,
+        "Non-Error exception captured with keys: otherKey, type"
+      );
+      assert.deepEqual(summary.events[0].extra.__serialized__, {
+        type: "error",
+        otherKey: "hi",
+      });
+    });
+  });
+
   it("should NOT catch an exception already caught [but rethrown] via Sentry.captureException", function() {
     return runInSandbox(sandbox, function() {
       try {


### PR DESCRIPTION
This will prevent SDK from failing to serialize an incorrect `onerror` call eg. `window.onerror(jqueryEvent)`. This is invalid JS code, as first argument should be a string message _or_ `ErrorEvent` object - https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror but we have to somehow handle it gracefully.

It'll utilize our known `Non-Error exception captured with keys: currentTarget, delegateTarget, isTrigger` message and `__serialied__` context field.

ref: https://github.com/getsentry/sentry-javascript/issues/2809 should fix some users issues, but cannot guarantee that all of them.