### PR TITLE
fix: Correctly limit Buffer requests

### DIFF
--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -133,23 +133,24 @@ export class FetchTransport extends BaseTransport {
     }
 
     return this._buffer.add(
-      new SyncPromise<Response>((resolve, reject) => {
-        void this._fetch(sentryRequest.url, options)
-          .then(response => {
-            const headers = {
-              'x-sentry-rate-limits': response.headers.get('X-Sentry-Rate-Limits'),
-              'retry-after': response.headers.get('Retry-After'),
-            };
-            this._handleResponse({
-              requestType: sentryRequest.type,
-              response,
-              headers,
-              resolve,
-              reject,
-            });
-          })
-          .catch(reject);
-      }),
+      () =>
+        new SyncPromise<Response>((resolve, reject) => {
+          void this._fetch(sentryRequest.url, options)
+            .then(response => {
+              const headers = {
+                'x-sentry-rate-limits': response.headers.get('X-Sentry-Rate-Limits'),
+                'retry-after': response.headers.get('Retry-After'),
+              };
+              this._handleResponse({
+                requestType: sentryRequest.type,
+                response,
+                headers,
+                resolve,
+                reject,
+              });
+            })
+            .catch(reject);
+        }),
     );
   }
 }

--- a/packages/browser/src/transports/xhr.ts
+++ b/packages/browser/src/transports/xhr.ts
@@ -37,27 +37,28 @@ export class XHRTransport extends BaseTransport {
     }
 
     return this._buffer.add(
-      new SyncPromise<Response>((resolve, reject) => {
-        const request = new XMLHttpRequest();
+      () =>
+        new SyncPromise<Response>((resolve, reject) => {
+          const request = new XMLHttpRequest();
 
-        request.onreadystatechange = (): void => {
-          if (request.readyState === 4) {
-            const headers = {
-              'x-sentry-rate-limits': request.getResponseHeader('X-Sentry-Rate-Limits'),
-              'retry-after': request.getResponseHeader('Retry-After'),
-            };
-            this._handleResponse({ requestType: sentryRequest.type, response: request, headers, resolve, reject });
-          }
-        };
+          request.onreadystatechange = (): void => {
+            if (request.readyState === 4) {
+              const headers = {
+                'x-sentry-rate-limits': request.getResponseHeader('X-Sentry-Rate-Limits'),
+                'retry-after': request.getResponseHeader('Retry-After'),
+              };
+              this._handleResponse({ requestType: sentryRequest.type, response: request, headers, resolve, reject });
+            }
+          };
 
-        request.open('POST', sentryRequest.url);
-        for (const header in this.options.headers) {
-          if (this.options.headers.hasOwnProperty(header)) {
-            request.setRequestHeader(header, this.options.headers[header]);
+          request.open('POST', sentryRequest.url);
+          for (const header in this.options.headers) {
+            if (this.options.headers.hasOwnProperty(header)) {
+              request.setRequestHeader(header, this.options.headers[header]);
+            }
           }
-        }
-        request.send(sentryRequest.body);
-      }),
+          request.send(sentryRequest.body);
+        }),
     );
   }
 }

--- a/packages/browser/test/unit/mocks/simpletransport.ts
+++ b/packages/browser/test/unit/mocks/simpletransport.ts
@@ -5,7 +5,7 @@ import { BaseTransport } from '../../../src/transports';
 
 export class SimpleTransport extends BaseTransport {
   public sendEvent(_: Event): PromiseLike<Response> {
-    return this._buffer.add(
+    return this._buffer.add(() =>
       SyncPromise.resolve({
         status: Status.fromHttpCode(200),
       }),

--- a/packages/core/test/mocks/transport.ts
+++ b/packages/core/test/mocks/transport.ts
@@ -16,11 +16,12 @@ export class FakeTransport implements Transport {
   public sendEvent(_event: Event): PromiseLike<Response> {
     this.sendCalled += 1;
     return this._buffer.add(
-      new SyncPromise(async res => {
-        await sleep(this.delay);
-        this.sentCount += 1;
-        res({ status: Status.Success });
-      }),
+      () =>
+        new SyncPromise(async res => {
+          await sleep(this.delay);
+          this.sentCount += 1;
+          res({ status: Status.Success });
+        }),
     );
   }
 

--- a/packages/utils/src/promisebuffer.ts
+++ b/packages/utils/src/promisebuffer.ts
@@ -21,7 +21,7 @@ export class PromiseBuffer<T> {
   /**
    * Add a promise to the queue.
    *
-   * @param taskProducer A function producing any PromiseLike<T>
+   * @param taskProducer A function producing any PromiseLike<T>; In previous versions is used to be `@param task: PromiseLike<T>`, however, Promises were instantly created on the call-site, making them fell through the buffer limit.
    * @returns The original promise.
    */
   public add(taskProducer: PromiseLike<T> | TaskProducer<T>): PromiseLike<T> {

--- a/packages/utils/src/promisebuffer.ts
+++ b/packages/utils/src/promisebuffer.ts
@@ -21,7 +21,7 @@ export class PromiseBuffer<T> {
   /**
    * Add a promise to the queue.
    *
-   * @param taskProducer A function producing any PromiseLike<T>; In previous versions is used to be `@param task: PromiseLike<T>`, however, Promises were instantly created on the call-site, making them fell through the buffer limit.
+   * @param taskProducer A function producing any PromiseLike<T>; In previous versions this used to be `@param task: PromiseLike<T>`, however, Promises were instantly created on the call-site, making them fall through the buffer limit.
    * @returns The original promise.
    */
   public add(taskProducer: PromiseLike<T> | TaskProducer<T>): PromiseLike<T> {

--- a/packages/utils/test/promisebuffer.test.ts
+++ b/packages/utils/test/promisebuffer.test.ts
@@ -10,20 +10,28 @@ describe('PromiseBuffer', () => {
   describe('add()', () => {
     test('no limit', () => {
       const q = new PromiseBuffer<void>();
-      const p = new SyncPromise<void>(resolve => setTimeout(resolve, 1));
+      const p = jest.fn(
+        () => new SyncPromise<void>(resolve => setTimeout(resolve, 1)),
+      );
       q.add(p);
       expect(q.length()).toBe(1);
     });
+
     test('with limit', () => {
       const q = new PromiseBuffer<void>(1);
-      const p = new SyncPromise<void>(resolve => setTimeout(resolve, 1));
-      expect(q.add(p)).toEqual(p);
-      expect(
-        q.add(
-          new SyncPromise<void>(resolve => setTimeout(resolve, 1)),
-        ),
-      ).rejects.toThrowError();
+      let t1;
+      const p1 = jest.fn(() => {
+        t1 = new SyncPromise<void>(resolve => setTimeout(resolve, 1));
+        return t1;
+      });
+      const p2 = jest.fn(
+        () => new SyncPromise<void>(resolve => setTimeout(resolve, 1)),
+      );
+      expect(q.add(p1)).toEqual(t1);
+      expect(q.add(p2)).rejects.toThrowError();
       expect(q.length()).toBe(1);
+      expect(p1).toHaveBeenCalled();
+      expect(p2).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
I'd prefer to have `add(taskProducer: TaskProducer<T>): PromiseLike<T>` signature, but the problem is that we might break custom transports that use `Buffer` implementation. Not even sure if there are _any_ in the wild, so it _might_ be worth playing it not safe and just go for a valid implementation already? fwiw the current implementation is basically broken, so I think it's better to implement it correctly and actually force people to update their custom transports if they have any.

For reviewers: You can skip all `transport/file.ts` changes. They only add `() =>` before each `new Promise`, but indentations make it look like a lot of changes (noting this as not everyone is using `hide whitespace changes` in GitHub UI).

Fixes https://github.com/getsentry/sentry-javascript/issues/3725