### PR TITLE
fix(serverless): wrapEventFunction does not await for async code

### DIFF
--- a/packages/serverless/src/gcpfunction/cloud_events.ts
+++ b/packages/serverless/src/gcpfunction/cloud_events.ts
@@ -76,10 +76,10 @@ function _wrapCloudEventFunction(
       .then(() => (fn as CloudEventFunction)(context))
       .then(
         result => {
-          newCallback(null, result);
+          return newCallback(null, result);
         },
         err => {
-          newCallback(err, undefined);
+          return newCallback(err, undefined);
         },
       );
   };

--- a/packages/serverless/src/gcpfunction/cloud_events.ts
+++ b/packages/serverless/src/gcpfunction/cloud_events.ts
@@ -59,7 +59,7 @@ function _wrapCloudEventFunction(
       }
       transaction.finish();
 
-      flush(options.flushTimeout)
+      void flush(options.flushTimeout)
         .then(() => {
           callback(...args);
         })

--- a/packages/serverless/src/gcpfunction/cloud_events.ts
+++ b/packages/serverless/src/gcpfunction/cloud_events.ts
@@ -59,7 +59,7 @@ function _wrapCloudEventFunction(
       }
       transaction.finish();
 
-      void flush(options.flushTimeout)
+      flush(options.flushTimeout)
         .then(() => {
           callback(...args);
         })
@@ -72,7 +72,7 @@ function _wrapCloudEventFunction(
       return (fn as CloudEventFunctionWithCallback)(context, newCallback);
     }
 
-    void Promise.resolve()
+    return Promise.resolve()
       .then(() => (fn as CloudEventFunction)(context))
       .then(
         result => {

--- a/packages/serverless/src/gcpfunction/cloud_events.ts
+++ b/packages/serverless/src/gcpfunction/cloud_events.ts
@@ -75,12 +75,8 @@ function _wrapCloudEventFunction(
     return Promise.resolve()
       .then(() => (fn as CloudEventFunction)(context))
       .then(
-        result => {
-          return newCallback(null, result);
-        },
-        err => {
-          return newCallback(err, undefined);
-        },
+        result => newCallback(null, result),
+        err => newCallback(err, undefined),
       );
   };
 }

--- a/packages/serverless/src/gcpfunction/events.ts
+++ b/packages/serverless/src/gcpfunction/events.ts
@@ -29,7 +29,7 @@ function _wrapEventFunction(
     flushTimeout: 2000,
     ...wrapOptions,
   };
-  return async (data, context, callback) => {
+  return (data, context, callback) => {
     const transaction = startTransaction({
       name: context.eventType,
       op: 'gcp.function.event',
@@ -54,7 +54,7 @@ function _wrapEventFunction(
       }
       transaction.finish();
 
-      void flush(options.flushTimeout)
+      flush(options.flushTimeout)
         .then(() => {
           callback(...args);
         })
@@ -67,7 +67,7 @@ function _wrapEventFunction(
       return (fn as EventFunctionWithCallback)(data, context, newCallback);
     }
 
-    await Promise.resolve()
+    return Promise.resolve()
       .then(() => (fn as EventFunction)(data, context))
       .then(
         result => {

--- a/packages/serverless/src/gcpfunction/events.ts
+++ b/packages/serverless/src/gcpfunction/events.ts
@@ -71,10 +71,10 @@ function _wrapEventFunction(
       .then(() => (fn as EventFunction)(data, context))
       .then(
         result => {
-          newCallback(null, result);
+          return newCallback(null, result);
         },
         err => {
-          newCallback(err, undefined);
+          return newCallback(err, undefined);
         },
       );
   };

--- a/packages/serverless/src/gcpfunction/events.ts
+++ b/packages/serverless/src/gcpfunction/events.ts
@@ -70,12 +70,8 @@ function _wrapEventFunction(
     return Promise.resolve()
       .then(() => (fn as EventFunction)(data, context))
       .then(
-        result => {
-          return newCallback(null, result);
-        },
-        err => {
-          return newCallback(err, undefined);
-        },
+        result => newCallback(null, result),
+        err => newCallback(err, undefined),
       );
   };
 }

--- a/packages/serverless/src/gcpfunction/events.ts
+++ b/packages/serverless/src/gcpfunction/events.ts
@@ -54,7 +54,7 @@ function _wrapEventFunction(
       }
       transaction.finish();
 
-      flush(options.flushTimeout)
+      void flush(options.flushTimeout)
         .then(() => {
           callback(...args);
         })

--- a/packages/serverless/src/gcpfunction/events.ts
+++ b/packages/serverless/src/gcpfunction/events.ts
@@ -29,7 +29,7 @@ function _wrapEventFunction(
     flushTimeout: 2000,
     ...wrapOptions,
   };
-  return (data, context, callback) => {
+  return async (data, context, callback) => {
     const transaction = startTransaction({
       name: context.eventType,
       op: 'gcp.function.event',
@@ -67,7 +67,7 @@ function _wrapEventFunction(
       return (fn as EventFunctionWithCallback)(data, context, newCallback);
     }
 
-    void Promise.resolve()
+    await Promise.resolve()
       .then(() => (fn as EventFunction)(data, context))
       .then(
         result => {


### PR DESCRIPTION
This PR:-
- Awaits async code in GCP functions `wrapEventFunction` because google cloud expects us to either await async code or return a promise 

> When working with asynchronous tasks that involve callbacks or Promise objects, you must explicitly inform the runtime that your function has finished executing these tasks

Ref: https://cloud.google.com/functions/docs/concepts/nodejs-runtime#signal-termination

fixes: #3325 