### PR TITLE
ref(ember): Allow initing Ember without config entry

### DIFF
--- a/packages/ember/addon/index.ts
+++ b/packages/ember/addon/index.ts
@@ -17,6 +17,11 @@ export function InitSentryForEmber(_runtimeConfig: BrowserOptions | undefined) {
   assert('Missing configuration.', config);
   assert('Missing configuration for Sentry.', config.sentry || _runtimeConfig);
 
+  if (!config.sentry) {
+    // If environment config is not specified but the above assertion passes, use runtime config.
+    config.sentry = { ..._runtimeConfig } as any;
+  }
+
   // Permanently merge options into config, preferring runtime config
   Object.assign(config.sentry, _runtimeConfig || {});
   const initConfig = Object.assign({}, config.sentry);


### PR DESCRIPTION
### Summary
Using the config is only necessary if you want to change specific addon options now, and the docs are going to be updated to reflect this. Passing a config object to  should work without a config entry for sentry.

