### PR TITLE
Update package.json to include the repository key

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "postpublish": "make publish-docs && lerna run --stream --concurrency 1 postpublish",
     "circularDepCheck": "lerna run --parallel circularDepCheck"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/getsentry/sentry-javascript.git"
+  },
   "volta": {
     "node": "14.17.0",
     "yarn": "1.22.5"


### PR DESCRIPTION
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
*raven-js

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:
#### This is not a contributing change
- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
