### PR TITLE
fix(node): Enable autoSessionTracking correctly

### DIFF
--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -110,10 +110,6 @@ export function init(options: NodeOptions = {}): void {
     }
   }
 
-  if (options.autoSessionTracking === undefined) {
-    options.autoSessionTracking = false;
-  }
-
   if (options.environment === undefined && process.env.SENTRY_ENVIRONMENT) {
     options.environment = process.env.SENTRY_ENVIRONMENT;
   }


### PR DESCRIPTION
Fixes #3754.

If the autoSessionTracking option is undefined, we should be setting it to be true, not false.
