### PR TITLE
ref(gatsby): Default release to empty string

### DIFF
--- a/packages/gatsby/gatsby-node.js
+++ b/packages/gatsby/gatsby-node.js
@@ -11,7 +11,7 @@ const sentryRelease = JSON.stringify(
     process.env.ZEIT_GITHUB_COMMIT_SHA ||
     process.env.ZEIT_GITLAB_COMMIT_SHA ||
     process.env.ZEIT_BITBUCKET_COMMIT_SHA ||
-    '',
+    undefined,
 );
 
 const sentryDsn = JSON.stringify(process.env.SENTRY_DSN || '');

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -86,7 +86,10 @@
         "tsConfig": "./tsconfig.json",
         "diagnostics": false
       }
-    }
+    },
+    "setupFiles": [
+      "<rootDir>/test/setEnvVars.ts"
+    ]
   },
   "sideEffects": false
 }

--- a/packages/gatsby/test/gatsby-node.test.ts
+++ b/packages/gatsby/test/gatsby-node.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
 const { onCreateWebpackConfig } = require('../gatsby-node');
 
 describe('onCreateWebpackConfig', () => {
@@ -18,7 +17,7 @@ describe('onCreateWebpackConfig', () => {
     expect(plugins.define).toHaveBeenCalledTimes(1);
     expect(plugins.define).toHaveBeenLastCalledWith({
       __SENTRY_DSN__: expect.any(String),
-      __SENTRY_RELEASE__: undefined,
+      __SENTRY_RELEASE__: expect.any(String),
     });
 
     expect(actions.setWebpackConfig).toHaveBeenCalledTimes(1);

--- a/packages/gatsby/test/gatsby-node.test.ts
+++ b/packages/gatsby/test/gatsby-node.test.ts
@@ -18,7 +18,7 @@ describe('onCreateWebpackConfig', () => {
     expect(plugins.define).toHaveBeenCalledTimes(1);
     expect(plugins.define).toHaveBeenLastCalledWith({
       __SENTRY_DSN__: expect.any(String),
-      __SENTRY_RELEASE__: expect.any(String),
+      __SENTRY_RELEASE__: undefined,
     });
 
     expect(actions.setWebpackConfig).toHaveBeenCalledTimes(1);

--- a/packages/gatsby/test/setEnvVars.ts
+++ b/packages/gatsby/test/setEnvVars.ts
@@ -1,0 +1,2 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+process.env.SENTRY_RELEASE = '14abbb1678a2eb59d1a171ea33d630dd6c6eee70';

--- a/packages/gatsby/test/setEnvVars.ts
+++ b/packages/gatsby/test/setEnvVars.ts
@@ -1,2 +1,2 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
 process.env.SENTRY_RELEASE = '14abbb1678a2eb59d1a171ea33d630dd6c6eee70';


### PR DESCRIPTION
To make gatsby work better out of the box, we set the default for the release value to be undefined instead of an empty string.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
