### PR TITLE
ref(nextjs): Stop setting redundant `productionBrowserSourceMaps` in config

### DIFF
--- a/packages/nextjs/src/config/index.ts
+++ b/packages/nextjs/src/config/index.ts
@@ -12,21 +12,17 @@ export function withSentryConfig(
   userNextConfig: ExportedNextConfig = {},
   userSentryWebpackPluginOptions: Partial<SentryWebpackPluginOptions> = {},
 ): NextConfigFunction | NextConfigObject {
-  const partialConfig = {
-    // TODO When we add a way to disable the webpack plugin, doing so should turn this off, too
-    productionBrowserSourceMaps: true,
-    webpack: constructWebpackConfigFunction(userNextConfig, userSentryWebpackPluginOptions),
-  };
+  const newWebpackConfig = constructWebpackConfigFunction(userNextConfig, userSentryWebpackPluginOptions);
 
   // If the user has passed us a function, we need to return a function, so that we have access to `phase` and
   // `defaults` in order to pass them along to the user's function
   if (typeof userNextConfig === 'function') {
     return (phase: string, defaults: { defaultConfig: { [key: string]: unknown } }): NextConfigObject => ({
       ...userNextConfig(phase, defaults),
-      ...partialConfig,
+      webpack: newWebpackConfig,
     });
   }
 
   // Otherwise, we can just merge their config with ours and return an object.
-  return { ...userNextConfig, ...partialConfig };
+  return { ...userNextConfig, webpack: newWebpackConfig };
 }

--- a/packages/nextjs/test/config.test.ts
+++ b/packages/nextjs/test/config.test.ts
@@ -115,7 +115,6 @@ describe('withSentryConfig', () => {
 
     expect(finalConfig).toEqual(
       expect.objectContaining({
-        productionBrowserSourceMaps: true,
         webpack: expect.any(Function), // `webpack` is tested specifically elsewhere
       }),
     );
@@ -133,7 +132,6 @@ describe('withSentryConfig', () => {
     expect(finalConfig).toEqual(
       expect.objectContaining({
         ...userNextConfig,
-        productionBrowserSourceMaps: true,
         webpack: expect.any(Function), // `webpack` is tested specifically elsewhere
       }),
     );
@@ -147,7 +145,6 @@ describe('withSentryConfig', () => {
     expect(finalConfig).toEqual(
       expect.objectContaining({
         ...userNextConfigFunction(),
-        productionBrowserSourceMaps: true,
         webpack: expect.any(Function), // `webpack` is tested specifically elsewhere
       }),
     );


### PR DESCRIPTION
Currently, `withSentryConfig` both sets `productionBrowserSourceMaps` to `true` in the main `nextjs` config and sets `devtool` to `source-map` in the webpack config. 

It turns out, though, that the only thing the former change does is cause nextjs to [make the latter change](https://github.com/vercel/next.js/blob/fa138358e1df7ca6d1bab7da57e18031d5abbf27/packages/next/build/webpack/config/blocks/base.ts#L39-L43) itself. ([All other references](https://github.com/vercel/next.js/search?q=productionBrowserSourceMaps) to `productionBrowserSourceMaps` in the nextjs code are merely type annotations or instances of passing the value from one function to another. The linked code is the only place that value is actually used.) Therefore, since we're making the `devtool` config change ourselves, the `productionBrowserSourceMaps` config change is renundant, and can be removed.

(Of the two config changes, we want to remove this one and not the `devtool` one, since we want sourcemaps for both server and client builds. The `devtool` change affects both, whereas `productionBrowserSourceMaps` (as the name implies) only affects the client build.)