### PR TITLE
fix(tracing): Add check for document.scripts in metrics

### DIFF
--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -46,14 +46,14 @@ export class MetricsInstrumentation {
     const timeOrigin = msToSec(browserPerformanceTimeOrigin);
     let entryScriptSrc: string | undefined;
 
-    if (global.document) {
+    if (global.document && global.document.scripts) {
       // eslint-disable-next-line @typescript-eslint/prefer-for-of
-      for (let i = 0; i < document.scripts.length; i++) {
+      for (let i = 0; i < global.document.scripts.length; i++) {
         // We go through all scripts on the page and look for 'data-entry'
         // We remember the name and measure the time between this script finished loading and
         // our mark 'sentry-tracing-init'
-        if (document.scripts[i].dataset.entry === 'true') {
-          entryScriptSrc = document.scripts[i].src;
+        if (global.document.scripts[i].dataset.entry === 'true') {
+          entryScriptSrc = global.document.scripts[i].src;
           break;
         }
       }


### PR DESCRIPTION
Fixes #3705

Supersedes #3707

We should check if document.scripts exists as it does not exist in some browser environments. This patch also refactors the document logic to rely on `global.document` instead of `document`.
