### PR TITLE
feat(scope): Add client to scope

### DIFF
--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -118,6 +118,8 @@ export class Hub implements HubInterface {
    */
   public bindClient(client?: Client): void {
     const top = this.getStackTop();
+    // TODO: Only bind client to scope, don't store in stack
+    if (top.scope) top.scope.bindClient(client);
     top.client = client;
     if (client && client.setupIntegrations) {
       client.setupIntegrations();

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -2,6 +2,7 @@
 import {
   Breadcrumb,
   CaptureContext,
+  Client,
   Context,
   Contexts,
   Event,
@@ -75,6 +76,9 @@ export class Scope implements ScopeInterface {
   /** Request Mode Session Status */
   protected _requestSession?: RequestSession;
 
+  /** Client */
+  protected _client?: Client;
+
   /**
    * Inherit values from the parent scope.
    * @param scope to clone.
@@ -94,6 +98,7 @@ export class Scope implements ScopeInterface {
       newScope._fingerprint = scope._fingerprint;
       newScope._eventProcessors = [...scope._eventProcessors];
       newScope._requestSession = scope._requestSession;
+      newScope._client = scope._client;
     }
     return newScope;
   }
@@ -396,6 +401,20 @@ export class Scope implements ScopeInterface {
     this._breadcrumbs = [];
     this._notifyScopeListeners();
     return this;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public getClient(): Client | undefined {
+    return this._client;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public bindClient(client?: Client): void {
+    this._client = client;
   }
 
   /**

--- a/packages/hub/test/hub.test.ts
+++ b/packages/hub/test/hub.test.ts
@@ -39,6 +39,14 @@ describe('Hub', () => {
     expect(hub.isOlderThan(0)).toBeFalsy();
   });
 
+  test('binds client to scope', () => {
+    const testClient: any = { bla: 'a' };
+    const hub = new Hub(testClient);
+
+    expect(hub.getScope()?.getClient()).toEqual(testClient);
+    expect(hub.getScope()?.getClient()).toEqual(hub.getClient());
+  });
+
   describe('pushScope', () => {
     test('simple', () => {
       const localScope = new Scope();

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -1,4 +1,4 @@
-import { Event, EventHint, RequestSessionStatus, Severity } from '@sentry/types';
+import { Client, Event, EventHint, RequestSessionStatus, Severity } from '@sentry/types';
 import { getGlobalObject } from '@sentry/utils';
 
 import { addGlobalEventProcessor, Scope } from '../src';
@@ -135,6 +135,22 @@ describe('Scope', () => {
       expect((scope as any)._level).toEqual(Severity.Critical);
       expect((scope as any)._user).toEqual({ id: '1' });
     });
+
+    test('getClient with no client', () => {
+      const scope = new Scope();
+      const client = scope.getClient();
+      expect(client).toBeUndefined();
+    });
+
+    test('bindClient', () => {
+      const scope = new Scope();
+      const client = {
+        captureEvent: (_: Event) => undefined,
+      } as Client;
+
+      scope.bindClient(client);
+      expect(scope.getClient()).toEqual(client);
+    });
   });
 
   describe('clone', () => {
@@ -184,6 +200,17 @@ describe('Scope', () => {
 
       expect(parentScope.getRequestSession()).toEqual({ status: RequestSessionStatus.Ok });
       expect(scope.getRequestSession()).toEqual({ status: RequestSessionStatus.Ok });
+    });
+
+    test('client', () => {
+      const parentScope = new Scope();
+      const client = {
+        captureEvent: (_: Event) => undefined,
+      } as Client;
+      parentScope.bindClient(client);
+
+      const newScope = Scope.clone(parentScope);
+      expect(newScope.getClient()).toEqual(client);
     });
   });
 

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -1,4 +1,5 @@
 import { Breadcrumb } from './breadcrumb';
+import { Client } from './client';
 import { Context, Contexts } from './context';
 import { EventProcessor } from './eventprocessor';
 import { Extra, Extras } from './extra';
@@ -155,4 +156,14 @@ export interface Scope {
    * Clears all currently set Breadcrumbs.
    */
   clearBreadcrumbs(): this;
+
+  /**
+   * Returns the client binded to the scope
+   */
+  getClient(): Client | undefined;
+
+  /**
+   * Binds a client to the scope
+   */
+  bindClient(client: Client): void;
 }


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/3751

As we move toward introducing a scope manager, we want to remove the idea of a stack of scopes and clients. As a replacement, the client now goes onto the scope. This enables patterns like:

```ts
Sentry.withScope((scope) => {
  scope.bindClient(TeamAClient);
  // any operations will use team A's client
});
```

By propagating the client through the scope, it becomes easier to devs to leverage multiple clients on the same page or process. This does mean that to capture events and messages, the hub will have to reach into the scope to access the client.

Temporarily, we store the client reference in both the hub stack and in the scope. This is to have backwards compatibility while we talk through the patterns and edit tests.