### PR TITLE
feat(nextjs): Add options to disable webpack plugin

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -9,6 +9,10 @@ export type ExportedNextConfig = NextConfigObject | NextConfigFunction;
 export type NextConfigObject = {
   // custom webpack options
   webpack?: WebpackConfigFunction;
+  sentry?: {
+    disableServerWebpackPlugin?: boolean;
+    disableClientWebpackPlugin?: boolean;
+  };
 } & {
   // other `next.config.js` options
   [key: string]: unknown;


### PR DESCRIPTION
Despite our strong encouragement, not everyone wants to use the `SentryWebpackPlugin` to upload sourcemaps. This PR introduces two new options, `disableServerWebpackPlugin` and `disableClientWebpackPlugin`, which can be used in `next.config.js` like this:

```
const { withSentryConfig } = require("@sentry/nextjs");

const moduleExports = {
  sentry: {
    disableServerWebpackPlugin: true,
    disableClientWebpackPlugin: true,
  },
};

// unnecessary if the webpack plugin is disabled for both server and client (in that case, can also safely 
// be omitted from the `withSentryConfig` call below)
const SentryWebpackPluginOptions = {
  // ...
};

module.exports = withSentryConfig(moduleExports, SentryWebpackPluginOptions);
```

Setting either of these options does two things in the relevant (server or client) config:

- prevents the SDK from forcing `webpack.devtool` to be `source-map` in production, and
- prevents the SDK from adding an instance of `SentryWebpackPlugin` to the webpack config.

These changes are documented in https://github.com/getsentry/sentry-docs/pull/3826.

Fixes https://github.com/getsentry/sentry-javascript/issues/3674