### PR TITLE
fix(metrics): Check for cls entry sources

### DIFF
--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -214,7 +214,8 @@ export class MetricsInstrumentation {
       transaction.setTag('lcp.size', this._lcpEntry.size);
     }
 
-    if (this._clsEntry) {
+    // See: https://developer.mozilla.org/en-US/docs/Web/API/LayoutShift
+    if (this._clsEntry && this._clsEntry.sources) {
       logger.log('[Measurements] Adding CLS Data');
       this._clsEntry.sources.map((source, index) =>
         transaction.setTag(`cls.source.${index + 1}`, htmlTreeAsString(source.node)),


### PR DESCRIPTION
The LayoutShift.sources field may not exist in certain browsers, even if
the LayoutShift API is there. This PR patches logic that adds CLS data
to make sure that `._clsEntry.sources` exists.

Ref: https://developer.mozilla.org/en-US/docs/Web/API/LayoutShift

See Sentry issue: https://sentry.io/share/issue/ebd52ddcc2c64a91b61e7a5486ec71bc/