### PR TITLE
feat: Add ensureNoCircularStructures experiment to help debug serialization bugs

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -389,6 +389,12 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       normalized.contexts.trace = event.contexts.trace;
     }
+
+    const { _experiments = {} } = this.getOptions();
+    if (_experiments.ensureNoCircularStructures) {
+      return normalize(normalized);
+    }
+
     return normalized;
   }
 


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry-javascript/issues/2809

We don't want to expose this publicly, as it may be costly to normalize every event in its entirety (keep in mind that it defaults to infinite depth, _but_ will break recursive cycles) but should be useful to expose what is triggering serialization issues in some cases.