### PR TITLE
fix: allRoutes cannot triple equal a new array instance

### DIFF
--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -65,7 +65,7 @@ function createReactRouterInstrumentation(
   }
 
   function getTransactionName(pathname: string): string {
-    if (allRoutes === [] || !matchPath) {
+    if (allRoutes.length === 0 || !matchPath) {
       return pathname;
     }
 


### PR DESCRIPTION
Running `===` against a newly instantiated array will always return
false. Instead, we should check that `allRoutes` is empty.
