### PR TITLE
feat(eslint): Create no-eq-empty rule

### DIFF
--- a/packages/eslint-config-sdk/src/index.js
+++ b/packages/eslint-config-sdk/src/index.js
@@ -20,6 +20,9 @@ module.exports = {
       plugins: ['@typescript-eslint', 'jsdoc', 'deprecation'],
       parser: '@typescript-eslint/parser',
       rules: {
+        // We want to guard against using the equality operator with empty arrays
+        '@sentry-internal/sdk/no-eq-empty': 'error',
+
         // Unused variables should be removed unless they are marked with and underscore (ex. _varName).
         '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
 

--- a/packages/eslint-plugin-sdk/src/index.js
+++ b/packages/eslint-plugin-sdk/src/index.js
@@ -11,5 +11,6 @@
 module.exports = {
   rules: {
     'no-async-await': require('./rules/no-async-await'),
+    'no-eq-empty': require('./rules/no-eq-empty'),
   },
 };

--- a/packages/eslint-plugin-sdk/src/rules/no-eq-empty.js
+++ b/packages/eslint-plugin-sdk/src/rules/no-eq-empty.js
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Rule to disallow using the equality operator with empty arrays or objects
+ * @author Abhijeet Prasad
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow using the equality operator with empty arrays or objects',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      equality: 'Do not apply the equality operator on an empty {{ name }}.{{ fix }}',
+    },
+  },
+  create: function(context) {
+    // variables should be defined here
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    // any helper functions should go here or else delete this section
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      BinaryExpression(node) {
+        if (node.operator === '==' || node.operator === '===') {
+          if (node.left.type !== 'ArrayExpression' && node.right.type === 'ArrayExpression') {
+            context.report({
+              node,
+              messageId: 'equality',
+              data: {
+                name: 'array',
+                fix: ' Use .length or Array.isArray instead.',
+              },
+            });
+          } else if (node.left.type !== 'ObjectExpression' && node.right.type === 'ObjectExpression') {
+            context.report({
+              node,
+              messageId: 'equality',
+              data: {
+                name: 'object',
+                fix: '',
+              },
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-sdk/test/lib/rules/no-async-await.js
+++ b/packages/eslint-plugin-sdk/test/lib/rules/no-async-await.js
@@ -8,9 +8,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var rule = require('../../../src/rules/no-async-await'),
-  path = require('path'),
-  RuleTester = require('eslint').RuleTester;
+const rule = require('../../../src/rules/no-async-await');
+const RuleTester = require('eslint').RuleTester;
 
 //------------------------------------------------------------------------------
 // Tests
@@ -21,7 +20,7 @@ RuleTester.setDefaultConfig({
     ecmaVersion: 8,
   },
 });
-var ruleTester = new RuleTester();
+const ruleTester = new RuleTester();
 
 ruleTester.run('no-async-await', rule, {
   valid: [],

--- a/packages/eslint-plugin-sdk/test/lib/rules/no-eq-empty.js
+++ b/packages/eslint-plugin-sdk/test/lib/rules/no-eq-empty.js
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview Rule to disallow using the equality operator with empty array
+ * @author Abhijeet Prasad
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../src/rules/no-eq-empty');
+const RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 8,
+  },
+});
+const ruleTester = new RuleTester();
+
+const arrayMessage = 'Do not apply the equality operator on an empty array. Use .length or Array.isArray instead.';
+const objectMessage = 'Do not apply the equality operator on an empty object.';
+
+ruleTester.run('no-eq-empty', rule, {
+  valid: [
+    {
+      code: 'const hey = [] === []',
+    },
+    {
+      code: 'const hey = [] == []',
+    },
+    {
+      code: 'const hey = {} === {}',
+    },
+    {
+      code: 'const hey = {} == {}',
+    },
+  ],
+  invalid: [
+    {
+      code: 'empty === []',
+      errors: [
+        {
+          message: arrayMessage,
+          type: 'BinaryExpression',
+        },
+      ],
+    },
+    {
+      code: 'empty == []',
+      errors: [
+        {
+          message: arrayMessage,
+          type: 'BinaryExpression',
+        },
+      ],
+    },
+    {
+      code: 'const hey = function() {}() === []',
+      errors: [
+        {
+          message: arrayMessage,
+          type: 'BinaryExpression',
+        },
+      ],
+    },
+    {
+      code: 'empty === {}',
+      errors: [
+        {
+          message: objectMessage,
+          type: 'BinaryExpression',
+        },
+      ],
+    },
+    {
+      code: 'empty == {}',
+      errors: [
+        {
+          message: objectMessage,
+          type: 'BinaryExpression',
+        },
+      ],
+    },
+    {
+      code: 'const hey = function(){}() === {}',
+      errors: [
+        {
+          message: objectMessage,
+          type: 'BinaryExpression',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Make sure we guard against using equality operator with an empty array or object.

This is to prevent cases like https://github.com/getsentry/sentry-javascript/pull/3779 which we missed in the initial code review.

Adding eslint rules is pretty easy + very quick to dev, we should aggressively leverage them to make code reviews easier. 