### PR TITLE
chore(nextjs): Cosmetic changes ahead of API route fix

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -52,18 +52,14 @@ export type BuildContext = { dev: boolean; isServer: boolean; buildId: string };
 // For our purposes, the value for `entry` is either an object, or an async function which returns such an object
 export type WebpackEntryProperty = EntryPropertyObject | EntryPropertyFunction;
 
-// Each value in that object is either a string representing a single entry point, an array of such strings, or an
-// object containing either of those, along with other configuration options. In that third case, the entry point(s) are
-// listed under the key `import`.
 export type EntryPropertyObject = {
-  [key: string]:
-    | string
-    | Array<string>
-    // only in webpack 5
-    | EntryPointObject;
+  [key: string]: EntryPointValue;
 };
 
 export type EntryPropertyFunction = () => Promise<EntryPropertyObject>;
 
-// An object with options for a single entry point, potentially one of many in the webpack `entry` property
+// Each value in that object is either a string representing a single entry point, an array of such strings, or an
+// object containing either of those, along with other configuration options. In that third case, the entry point(s) are
+// listed under the key `import`.
+export type EntryPointValue = string | Array<string> | EntryPointObject;
 export type EntryPointObject = { import: string | Array<string> };

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -59,7 +59,6 @@ export function constructWebpackConfigFunction(
   // we're building server or client, whether we're in dev, what version of webpack we're using, etc). Note that
   // `currentWebpackConfig` and `buildContext` are referred to as `config` and `options` in the nextjs docs.
   const newWebpackFunction = (incomingConfig: WebpackConfigObject, buildContext: BuildContext): WebpackConfigObject => {
-    // clone to avoid mutability issues
     let newConfig = { ...incomingConfig };
 
     // if we're building server code, store the webpack output path as an env variable, so we know where to look for the
@@ -208,7 +207,9 @@ function addFileToExistingEntryPoint(
     newEntryPoint = [currentEntryPoint, filepath];
   } else if (Array.isArray(currentEntryPoint)) {
     newEntryPoint = [...currentEntryPoint, filepath];
-  } else {
+  }
+  // descriptor object (webpack 5+)
+  else {
     const currentImportValue = currentEntryPoint.import;
     let newImportValue: string | string[];
 

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -125,13 +125,13 @@ export function constructWebpackConfigFunction(
  * Modify the webpack `entry` property so that the code in `sentry.server.config.js` and `sentry.client.config.js` is
  * included in the the necessary bundles.
  *
- * @param origEntryProperty The value of the property before Sentry code has been injected
+ * @param currentEntryProperty The value of the property before Sentry code has been injected
  * @param buildContext Object passed by nextjs containing metadata about the build
  * @returns The value which the new `entry` property (which will be a function) will return (TODO: this should return
  * the function, rather than the function's return value)
  */
 async function addSentryToEntryProperty(
-  origEntryProperty: WebpackEntryProperty,
+  currentEntryProperty: WebpackEntryProperty,
   buildContext: BuildContext,
 ): Promise<EntryPropertyObject> {
   // The `entry` entry in a webpack config can be a string, array of strings, object, or function. By default, nextjs
@@ -140,9 +140,9 @@ async function addSentryToEntryProperty(
   // we know is that it won't have gotten *simpler* in form, so we only need to worry about the object and function
   // options. See https://webpack.js.org/configuration/entry-context/#entry.
 
-  let newEntryProperty = origEntryProperty;
-  if (typeof origEntryProperty === 'function') {
-    newEntryProperty = await origEntryProperty();
+  let newEntryProperty = currentEntryProperty;
+  if (typeof currentEntryProperty === 'function') {
+    newEntryProperty = await currentEntryProperty();
   }
   newEntryProperty = newEntryProperty as EntryPropertyObject;
 

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -54,9 +54,12 @@ export function constructWebpackConfigFunction(
   userNextConfig: NextConfigObject = {},
   userSentryWebpackPluginOptions: Partial<SentryWebpackPluginOptions> = {},
 ): WebpackConfigFunction {
-  const newWebpackFunction = (config: WebpackConfigObject, buildContext: BuildContext): WebpackConfigObject => {
+  // Will be called by nextjs and passed its default webpack configuration and context data about the build (whether
+  // we're building server or client, whether we're in dev, what version of webpack we're using, etc). Note that
+  // `currentWebpackConfig` and `buildContext` are referred to as `config` and `options` in the nextjs docs.
+  const newWebpackFunction = (incomingConfig: WebpackConfigObject, buildContext: BuildContext): WebpackConfigObject => {
     // clone to avoid mutability issues
-    let newConfig = { ...config };
+    let newConfig = { ...incomingConfig };
 
     // if we're building server code, store the webpack output path as an env variable, so we know where to look for the
     // webpack-processed version of `sentry.server.config.js` when we need it

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -140,11 +140,8 @@ async function addSentryToEntryProperty(
   // we know is that it won't have gotten *simpler* in form, so we only need to worry about the object and function
   // options. See https://webpack.js.org/configuration/entry-context/#entry.
 
-  let newEntryProperty = currentEntryProperty;
-  if (typeof currentEntryProperty === 'function') {
-    newEntryProperty = await currentEntryProperty();
-  }
-  newEntryProperty = newEntryProperty as EntryPropertyObject;
+  const newEntryProperty =
+    typeof currentEntryProperty === 'function' ? await currentEntryProperty() : { ...currentEntryProperty };
 
   // Add a new element to the `entry` array, we force webpack to create a bundle out of the user's
   // `sentry.server.config.js` file and output it to `SERVER_INIT_LOCATION`. (See

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -208,17 +208,17 @@ function addFileToExistingEntryPoint(
   } else if (Array.isArray(injectedInto)) {
     injectedInto = [...injectedInto, filepath];
   } else {
-    let importVal: string | string[];
+    let newImportValue: string | string[];
 
     if (typeof injectedInto.import === 'string') {
-      importVal = [injectedInto.import, filepath];
+      newImportValue = [injectedInto.import, filepath];
     } else {
-      importVal = [...injectedInto.import, filepath];
+      newImportValue = [...injectedInto.import, filepath];
     }
 
     injectedInto = {
       ...injectedInto,
-      import: importVal,
+      import: newImportValue,
     };
   }
 

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -13,8 +13,6 @@ import {
   WebpackEntryProperty,
 } from './types';
 import {
-  SENTRY_CLIENT_CONFIG_FILE,
-  SENTRY_SERVER_CONFIG_FILE,
   SERVER_SDK_INIT_PATH,
   storeServerConfigFileLocation,
 } from './utils';
@@ -24,6 +22,9 @@ export { SentryWebpackPlugin };
 // TODO: merge default SentryWebpackPlugin ignore with their SentryWebpackPlugin ignore or ignoreFile
 // TODO: merge default SentryWebpackPlugin include with their SentryWebpackPlugin include
 // TODO: drop merged keys from override check? `includeDefaults` option?
+
+const CLIENT_SDK_CONFIG_FILE = './sentry.client.config.js';
+const SERVER_SDK_CONFIG_FILE = './sentry.server.config.js';
 
 const defaultSentryWebpackPluginOptions = dropUndefinedKeys({
   url: process.env.SENTRY_URL,
@@ -155,11 +156,11 @@ async function addSentryToEntryProperty(
   if (isServer) {
     // slice off the final `.js` since webpack is going to add it back in for us, and we don't want to end up with
     // `.js.js` as the extension
-    newEntryProperty[SERVER_SDK_INIT_PATH.slice(0, -3)] = SENTRY_SERVER_CONFIG_FILE;
+    newEntryProperty[SERVER_SDK_INIT_PATH.slice(0, -3)] = SERVER_SDK_CONFIG_FILE;
   }
   // On the client, it's sufficient to inject it into the `main` JS code, which is included in every browser page.
   else {
-    addFileToExistingEntryPoint(newEntryProperty, 'main', SENTRY_CLIENT_CONFIG_FILE);
+    addFileToExistingEntryPoint(newEntryProperty, 'main', CLIENT_SDK_CONFIG_FILE);
 
     // To work around a bug in nextjs, we need to ensure that the `main.js` entry is empty (otherwise it'll choose that
     // over `main` and we'll lose the change we just made). In case some other library has put something into it, copy

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -207,12 +207,13 @@ function addFileToExistingEntryPoint(
   } else if (Array.isArray(newEntryPoint)) {
     newEntryPoint = [...newEntryPoint, filepath];
   } else {
+    const currentImportValue = newEntryPoint.import;
     let newImportValue: string | string[];
 
-    if (typeof newEntryPoint.import === 'string') {
-      newImportValue = [newEntryPoint.import, filepath];
+    if (typeof currentImportValue === 'string') {
+      newImportValue = [currentImportValue, filepath];
     } else {
-      newImportValue = [...newEntryPoint.import, filepath];
+      newImportValue = [...currentImportValue, filepath];
     }
 
     newEntryPoint = {

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -198,13 +198,6 @@ function addFileToExistingEntryPoint(
   // can be a string, array of strings, or object whose `import` property is one of those two
   let injectedInto = entryProperty[entryPointName];
 
-  // Sometimes especially for older next.js versions it happens we don't have an entry point
-  if (!injectedInto) {
-    // eslint-disable-next-line no-console
-    console.error(`[Sentry] Can't inject ${filepath}, no entrypoint is defined.`);
-    return;
-  }
-
   // We inject the user's client config file after the existing code so that the config file has access to
   // `publicRuntimeConfig`. See https://github.com/getsentry/sentry-javascript/issues/3485
   if (typeof injectedInto === 'string') {

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -5,6 +5,7 @@ import * as SentryWebpackPlugin from '@sentry/webpack-plugin';
 import {
   BuildContext,
   EntryPointObject,
+  EntryPointValue,
   EntryPropertyObject,
   NextConfigObject,
   SentryWebpackPluginOptions,
@@ -198,16 +199,17 @@ function addFileToExistingEntryPoint(
   filepath: string,
 ): void {
   // can be a string, array of strings, or object whose `import` property is one of those two
-  let newEntryPoint = entryProperty[entryPointName];
+  const currentEntryPoint = entryProperty[entryPointName];
+  let newEntryPoint: EntryPointValue;
 
   // We inject the user's client config file after the existing code so that the config file has access to
   // `publicRuntimeConfig`. See https://github.com/getsentry/sentry-javascript/issues/3485
-  if (typeof newEntryPoint === 'string') {
-    newEntryPoint = [newEntryPoint, filepath];
-  } else if (Array.isArray(newEntryPoint)) {
-    newEntryPoint = [...newEntryPoint, filepath];
+  if (typeof currentEntryPoint === 'string') {
+    newEntryPoint = [currentEntryPoint, filepath];
+  } else if (Array.isArray(currentEntryPoint)) {
+    newEntryPoint = [...currentEntryPoint, filepath];
   } else {
-    const currentImportValue = newEntryPoint.import;
+    const currentImportValue = currentEntryPoint.import;
     let newImportValue: string | string[];
 
     if (typeof currentImportValue === 'string') {
@@ -217,7 +219,7 @@ function addFileToExistingEntryPoint(
     }
 
     newEntryPoint = {
-      ...newEntryPoint,
+      ...currentEntryPoint,
       import: newImportValue,
     };
   }

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -199,30 +199,30 @@ function addFileToExistingEntryPoint(
   filepath: string,
 ): void {
   // can be a string, array of strings, or object whose `import` property is one of those two
-  let injectedInto = entryProperty[entryPointName];
+  let newEntryPoint = entryProperty[entryPointName];
 
   // We inject the user's client config file after the existing code so that the config file has access to
   // `publicRuntimeConfig`. See https://github.com/getsentry/sentry-javascript/issues/3485
-  if (typeof injectedInto === 'string') {
-    injectedInto = [injectedInto, filepath];
-  } else if (Array.isArray(injectedInto)) {
-    injectedInto = [...injectedInto, filepath];
+  if (typeof newEntryPoint === 'string') {
+    newEntryPoint = [newEntryPoint, filepath];
+  } else if (Array.isArray(newEntryPoint)) {
+    newEntryPoint = [...newEntryPoint, filepath];
   } else {
     let newImportValue: string | string[];
 
-    if (typeof injectedInto.import === 'string') {
-      newImportValue = [injectedInto.import, filepath];
+    if (typeof newEntryPoint.import === 'string') {
+      newImportValue = [newEntryPoint.import, filepath];
     } else {
-      newImportValue = [...injectedInto.import, filepath];
+      newImportValue = [...newEntryPoint.import, filepath];
     }
 
-    injectedInto = {
-      ...injectedInto,
+    newEntryPoint = {
+      ...newEntryPoint,
       import: newImportValue,
     };
   }
 
-  entryProperty[entryPointName] = injectedInto;
+  entryProperty[entryPointName] = newEntryPoint;
 }
 
 /**

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -13,10 +13,7 @@ import {
   WebpackConfigObject,
   WebpackEntryProperty,
 } from './types';
-import {
-  SERVER_SDK_INIT_PATH,
-  storeServerConfigFileLocation,
-} from './utils';
+import { SERVER_SDK_INIT_PATH, storeServerConfigFileLocation } from './utils';
 
 export { SentryWebpackPlugin };
 

--- a/packages/nextjs/src/utils/handlers.ts
+++ b/packages/nextjs/src/utils/handlers.ts
@@ -71,7 +71,6 @@ export const withSentry = (handler: NextApiHandler): WrappedNextApiHandler => {
       if (transaction) {
         transaction.setHttpStatus(res.statusCode);
 
-
         transaction.finish();
       }
       try {


### PR DESCRIPTION
Nothing substantive here - just a bunch of changes pulled out of an upcoming PR fixing API route monitoring in nextjs, to make that one easier to review.

Major themes:
- Standardize naming
- Split current and new values into separate variables
- Remove old code
  - Check for entry point existence (moot given our minimum supported nextjs version)
  - Unnecessary stuff which came along when tracing code was copied from `instrumentServer.js`