### PR TITLE
Update import path in ember instance-initializer

### DIFF
--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -1,7 +1,7 @@
 import ApplicationInstance from '@ember/application/instance';
 import Ember from 'ember';
 import { run } from '@ember/runloop';
-import * as Sentry from '@sentry/browser';
+import * as Sentry from '@sentry/ember';
 import { Span, Transaction, Integration } from '@sentry/types';
 import { EmberRunQueues } from '@ember/runloop/-private/types';
 import { getActiveTransaction } from '..';


### PR DESCRIPTION
Import Sentry from the @sentry/ember package (rather than @sentry/browser) in the the ember instance-initializer, otherwise any existing client that gets created by the app author gets overridden by this one when [init is called](https://github.com/getsentry/sentry-javascript/blob/master/packages/ember/addon/instance-initializers/sentry-performance.ts#L363) - and loses any app specific `BrowserOptions` config that isn't defined directly in the `config/environment.js`
