### PR TITLE
Fix tracingOrigins to work against any api path

### DIFF
--- a/packages/nextjs/src/index.client.ts
+++ b/packages/nextjs/src/index.client.ts
@@ -34,7 +34,7 @@ export function init(options: NextjsOptions): void {
 }
 
 const defaultBrowserTracingIntegration = new BrowserTracing({
-  tracingOrigins: [...defaultRequestInstrumentationOptions.tracingOrigins, /^(api\/)/],
+  tracingOrigins: [...defaultRequestInstrumentationOptions.tracingOrigins, /(api\/)/],
   routingInstrumentation: nextRouterInstrumentation,
 });
 


### PR DESCRIPTION
Fixes the regular expression to be more loose since ^ implies the start of the string the only urls that would have match would start with api, api is not an http protocol so nothing would match.

This changes `/^(api\/)/` to `/(api\/)/` as `/^(api\/)/` would only match a domain in the format of `api` where-as api is the start of the url (So nothing would ever match). Since https://docs.sentry.io/platforms/javascript/performance/instrumentation/automatic-instrumentation/#tracingorigins states:

> The tracingOrigins option matches against the whole request URL, not just the domain. Using stricter regex to match certain parts of the URL ensures that requests do not unnecessarily have the sentry-trace header attached.

**Note** This shouldn't require any test changes