### PR TITLE
fix(ember): Fix runtime config options not being merged

### DIFF
--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -5,12 +5,16 @@ import * as Sentry from '@sentry/browser';
 import { Span, Transaction, Integration } from '@sentry/types';
 import { EmberRunQueues } from '@ember/runloop/-private/types';
 import { getActiveTransaction } from '..';
-import { browserPerformanceTimeOrigin, timestampWithMs } from '@sentry/utils';
+import { browserPerformanceTimeOrigin, getGlobalObject, timestampWithMs } from '@sentry/utils';
 import { macroCondition, isTesting, getOwnConfig } from '@embroider/macros';
-import { EmberSentryConfig, OwnConfig } from '../types';
+import { EmberSentryConfig, GlobalConfig, OwnConfig } from '../types';
 
 function getSentryConfig() {
-  return getOwnConfig<OwnConfig>().sentryConfig;
+  const _global = getGlobalObject<GlobalConfig>();
+  _global.__sentryEmberConfig = _global.__sentryEmberConfig ?? {};
+  const environmentConfig = getOwnConfig<OwnConfig>().sentryConfig;
+  Object.assign(environmentConfig.sentry, _global.__sentryEmberConfig);
+  return environmentConfig;
 }
 
 export function initialize(appInstance: ApplicationInstance): void {

--- a/packages/ember/addon/types.ts
+++ b/packages/ember/addon/types.ts
@@ -18,3 +18,7 @@ export type EmberSentryConfig = {
 export type OwnConfig = {
   sentryConfig: EmberSentryConfig;
 };
+
+export type GlobalConfig = {
+  __sentryEmberConfig: EmberSentryConfig['sentry'];
+};


### PR DESCRIPTION
### Summary
Runtime options can be ignored in production mode because of embroider macros differences between dev and production. Instead of relying on the config object reference being provided, we'll use a global instead to hold on to the merged config between the init call and the performance initializer code.

Aside: The code to pull the global is intentionally not DRY'd as to not export the function, which should be internal use only as it's an implementation detail. 

Refs #3785 (thanks @kiwi-josh for letting us know)
