### PR TITLE
feat(browser): Use scope data in report dialog

### DIFF
--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -102,10 +102,19 @@ export function init(options: BrowserOptions = {}): void {
  * @param options Everything is optional, we try to fetch all info need from the global scope.
  */
 export function showReportDialog(options: ReportDialogOptions = {}): void {
-  if (!options.eventId) {
-    options.eventId = getCurrentHub().lastEventId();
+  const hub = getCurrentHub();
+  const scope = hub.getScope();
+  if (scope) {
+    options.user = {
+      ...scope.getUser(),
+      ...options.user,
+    };
   }
-  const client = getCurrentHub().getClient<BrowserClient>();
+
+  if (!options.eventId) {
+    options.eventId = hub.lastEventId();
+  }
+  const client = hub.getClient<BrowserClient>();
   if (client) {
     client.showReportDialog(options);
   }

--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -15,6 +15,7 @@ import {
   init,
   Integrations,
   Scope,
+  showReportDialog,
   wrap,
 } from '../../src';
 import { SimpleTransport } from './mocks/simpletransport';
@@ -69,6 +70,39 @@ describe('SentryBrowser', () => {
       });
       expect(global.__SENTRY__.hub._stack[1].scope._user).to.deep.equal({
         id: 'def',
+      });
+    });
+  });
+
+  describe('showReportDialog', () => {
+    describe.only('user', () => {
+      const EX_USER = { email: 'test@example.com' };
+      const client = new BrowserClient({ dsn });
+      spy(client, 'showReportDialog');
+
+      it('uses the user on the scope', () => {
+        configureScope(scope => {
+          scope.setUser(EX_USER);
+        });
+        getCurrentHub().bindClient(client);
+
+        showReportDialog();
+
+        expect((client.showReportDialog as SinonSpy).called).to.be.true;
+        expect((client.showReportDialog as SinonSpy).lastCall.args[0].user.email).to.eq(EX_USER.email);
+      });
+
+      it('prioritizes options user over scope user', () => {
+        configureScope(scope => {
+          scope.setUser(EX_USER);
+        });
+        getCurrentHub().bindClient(client);
+
+        const DIALOG_OPTION_USER = { email: 'option@example.com' };
+        showReportDialog({ user: DIALOG_OPTION_USER });
+
+        expect((client.showReportDialog as SinonSpy).called).to.be.true;
+        expect((client.showReportDialog as SinonSpy).lastCall.args[0].user.email).to.eq(DIALOG_OPTION_USER.email);
       });
     });
   });

--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -75,7 +75,7 @@ describe('SentryBrowser', () => {
   });
 
   describe('showReportDialog', () => {
-    describe.only('user', () => {
+    describe('user', () => {
       const EX_USER = { email: 'test@example.com' };
       const client = new BrowserClient({ dsn });
       spy(client, 'showReportDialog');


### PR DESCRIPTION
If user is set on the scope, we set that user in report dialog options.
If a user is already set in the report dialog options, it takes
precedence over the user object in the scope.

Fixes #2607
