### PR TITLE
Ember | Fix TypeScript error on `InitSentryForEmber`

### DIFF
--- a/packages/ember/addon/index.ts
+++ b/packages/ember/addon/index.ts
@@ -18,7 +18,7 @@ function _getSentryInitConfig() {
   return _global.__sentryEmberConfig;
 }
 
-export function InitSentryForEmber(_runtimeConfig: BrowserOptions | undefined) {
+export function InitSentryForEmber(_runtimeConfig?: BrowserOptions) {
   const environmentConfig = getOwnConfig<OwnConfig>().sentryConfig;
 
   assert('Missing configuration.', environmentConfig);


### PR DESCRIPTION
Hey there,

Thank you for the hard work fixing the types publications with the Ember addon.
While testing `6.9.0`, I found a new bug which was (I think) easy to address, so here is a PR for this.

```
// in app/app.ts
import Application from '@ember/application';
import Resolver from 'ember-resolver';
import loadInitializers from 'ember-load-initializers';
import config from 'search/config/environment';
import { InitSentryForEmber } from '@sentry/ember';

InitSentryForEmber();

export default class App extends Application {
// ...
}
```

TypeScript is reporting the following error:
```
app/app.ts:7:1 - error TS2554: Expected 1 arguments, but got 0.

7 InitSentryForEmber();
  ~~~~~~~~~~~~~~~~~~~~

node_modules/@sentry/ember/index.d.ts:5:44
    5 export declare function InitSentryForEmber(_runtimeConfig: BrowserOptions | undefined): void;
                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
An argument for '_runtimeConfig' was not provided.

Found 1 error.
```

The other option is to explicitly pass `undefined` as the first argument.
Let me know if there is anything else I can help with!
