### PR TITLE
fix(nextjs): Let `flush` finish in API routes

### DIFF
--- a/packages/nextjs/src/utils/handlers.ts
+++ b/packages/nextjs/src/utils/handlers.ts
@@ -5,8 +5,6 @@ import { addExceptionMechanism, isString, logger, stripUrlQueryAndFragment } fro
 import * as domain from 'domain';
 import { NextApiHandler, NextApiResponse } from 'next';
 
-import { addRequestDataToEvent, NextRequest } from './instrumentServer';
-
 const { parseRequest } = Handlers;
 
 // purely for clarity
@@ -35,7 +33,7 @@ export const withSentry = (handler: NextApiHandler): WrappedNextApiHandler => {
       const currentScope = getCurrentHub().getScope();
 
       if (currentScope) {
-        currentScope.addEventProcessor(event => addRequestDataToEvent(event, req as NextRequest));
+        currentScope.addEventProcessor(event => parseRequest(event, req));
 
         if (hasTracingEnabled()) {
           // If there is a trace header set, extract the data from it (parentSpanId, traceId, and sampling decision)
@@ -83,7 +81,7 @@ export const withSentry = (handler: NextApiHandler): WrappedNextApiHandler => {
             addExceptionMechanism(event, {
               handled: false,
             });
-            return parseRequest(event, req);
+            return event;
           });
           captureException(e);
         }

--- a/packages/nextjs/src/utils/handlers.ts
+++ b/packages/nextjs/src/utils/handlers.ts
@@ -84,9 +84,12 @@ export const withSentry = (handler: NextApiHandler): WrappedNextApiHandler => {
           transaction.finish();
         }
         try {
+          logger.log('Flushing events...');
           await flush(2000);
         } catch (e) {
-          // no-empty
+          logger.log(`Error while flushing events:\n${e}`);
+        } finally {
+          logger.log('Done flushing events');
         }
       }
     });

--- a/packages/nextjs/src/utils/handlers.ts
+++ b/packages/nextjs/src/utils/handlers.ts
@@ -1,4 +1,4 @@
-import { captureException, flush, getCurrentHub, Handlers, startTransaction, withScope } from '@sentry/node';
+import { captureException, flush, getCurrentHub, Handlers, startTransaction } from '@sentry/node';
 import { extractTraceparentData, hasTracingEnabled } from '@sentry/tracing';
 import { Transaction } from '@sentry/types';
 import { addExceptionMechanism, isString, logger, stripUrlQueryAndFragment } from '@sentry/utils';
@@ -78,15 +78,15 @@ export const withSentry = (handler: NextApiHandler): WrappedNextApiHandler => {
       try {
         return await handler(req, res); // Call original handler
       } catch (e) {
-        withScope(scope => {
-          scope.addEventProcessor(event => {
+        if (currentScope) {
+          currentScope.addEventProcessor(event => {
             addExceptionMechanism(event, {
               handled: false,
             });
             return parseRequest(event, req);
           });
           captureException(e);
-        });
+        }
         throw e;
       }
     });

--- a/packages/nextjs/src/utils/handlers.ts
+++ b/packages/nextjs/src/utils/handlers.ts
@@ -121,10 +121,9 @@ function wrapEndMethod(origEnd: ResponseEndMethod): WrappedResponseEndMethod {
     try {
       logger.log('Flushing events...');
       await flush(2000);
+      logger.log('Done flushing events');
     } catch (e) {
       logger.log(`Error while flushing events:\n${e}`);
-    } finally {
-      logger.log('Done flushing events');
     }
 
     return origEnd.call(this, ...args);

--- a/packages/nextjs/test/integration/test/runner.js
+++ b/packages/nextjs/test/integration/test/runner.js
@@ -52,7 +52,11 @@ const runScenario = async (scenario, execute, env) => {
 };
 
 const runScenarios = async (scenarios, execute, env) => {
-  return Promise.all(scenarios.map(scenario => runScenario(scenario, execute, env)));
+  return Promise.all(
+    scenarios.map(scenario => {
+      return runScenario(scenario, execute, env);
+    }),
+  );
 };
 
 module.exports.run = async ({

--- a/packages/nextjs/test/integration/test/server/errorApiEndpoint.js
+++ b/packages/nextjs/test/integration/test/server/errorApiEndpoint.js
@@ -3,7 +3,9 @@ const assert = require('assert');
 const { sleep } = require('../utils/common');
 const { getAsync, interceptEventRequest } = require('../utils/server');
 
-module.exports = async ({ url, argv }) => {
+module.exports = async ({ url: urlBase, argv }) => {
+  const url = `${urlBase}/api/error`;
+
   const capturedRequest = interceptEventRequest(
     {
       exception: {
@@ -18,7 +20,7 @@ module.exports = async ({ url, argv }) => {
         runtime: 'node',
       },
       request: {
-        url: `${url}/api/error`,
+        url,
         method: 'GET',
       },
       transaction: 'GET /api/error',
@@ -27,7 +29,7 @@ module.exports = async ({ url, argv }) => {
     'errorApiEndpoint',
   );
 
-  await getAsync(`${url}/api/error`);
+  await getAsync(url);
   await sleep(100);
 
   assert.ok(capturedRequest.isDone(), 'Did not intercept expected request');

--- a/packages/nextjs/test/integration/test/server/errorApiEndpoint.js
+++ b/packages/nextjs/test/integration/test/server/errorApiEndpoint.js
@@ -1,12 +1,12 @@
 const assert = require('assert');
 
 const { sleep } = require('../utils/common');
-const { getAsync, interceptEventRequest } = require('../utils/server');
+const { getAsync, interceptEventRequest, interceptTracingRequest } = require('../utils/server');
 
 module.exports = async ({ url: urlBase, argv }) => {
   const url = `${urlBase}/api/error`;
 
-  const capturedRequest = interceptEventRequest(
+  const capturedErrorRequest = interceptEventRequest(
     {
       exception: {
         values: [
@@ -29,8 +29,28 @@ module.exports = async ({ url: urlBase, argv }) => {
     'errorApiEndpoint',
   );
 
+  const capturedTransactionRequest = interceptTracingRequest(
+    {
+      contexts: {
+        trace: {
+          op: 'http.server',
+          status: 'internal_error',
+          tags: { 'http.status_code': '500' },
+        },
+      },
+      transaction: 'GET /api/error',
+      type: 'transaction',
+      request: {
+        url,
+      },
+    },
+    argv,
+    'errorApiEndpoint',
+  );
+
   await getAsync(url);
   await sleep(100);
 
-  assert.ok(capturedRequest.isDone(), 'Did not intercept expected request');
+  assert.ok(capturedErrorRequest.isDone(), 'Did not intercept expected error request');
+  assert.ok(capturedTransactionRequest.isDone(), 'Did not intercept expected transaction request');
 };

--- a/packages/nextjs/test/integration/test/server/errorServerSideProps.js
+++ b/packages/nextjs/test/integration/test/server/errorServerSideProps.js
@@ -3,7 +3,9 @@ const assert = require('assert');
 const { sleep } = require('../utils/common');
 const { getAsync, interceptEventRequest } = require('../utils/server');
 
-module.exports = async ({ url, argv }) => {
+module.exports = async ({ url: urlBase, argv }) => {
+  const url = `${urlBase}/withServerSideProps`;
+
   const capturedRequest = interceptEventRequest(
     {
       exception: {
@@ -18,7 +20,7 @@ module.exports = async ({ url, argv }) => {
         runtime: 'node',
       },
       request: {
-        url: '/withServerSideProps',
+        url,
         method: 'GET',
       },
     },
@@ -26,7 +28,7 @@ module.exports = async ({ url, argv }) => {
     'errorServerSideProps',
   );
 
-  await getAsync(`${url}/withServerSideProps`);
+  await getAsync(url);
   await sleep(100);
 
   assert.ok(capturedRequest.isDone(), 'Did not intercept expected request');

--- a/packages/nextjs/test/integration/test/server/tracing200.js
+++ b/packages/nextjs/test/integration/test/server/tracing200.js
@@ -3,7 +3,9 @@ const assert = require('assert');
 const { sleep } = require('../utils/common');
 const { getAsync, interceptTracingRequest } = require('../utils/server');
 
-module.exports = async ({ url, argv }) => {
+module.exports = async ({ url: urlBase, argv }) => {
+  const url = `${urlBase}/api/users`;
+
   const capturedRequest = interceptTracingRequest(
     {
       contexts: {
@@ -16,14 +18,14 @@ module.exports = async ({ url, argv }) => {
       transaction: 'GET /api/users',
       type: 'transaction',
       request: {
-        url: '/api/users',
+        url,
       },
     },
     argv,
     'tracing200',
   );
 
-  await getAsync(`${url}/api/users`);
+  await getAsync(url);
   await sleep(100);
 
   assert.ok(capturedRequest.isDone(), 'Did not intercept expected request');

--- a/packages/nextjs/test/integration/test/server/tracing500.js
+++ b/packages/nextjs/test/integration/test/server/tracing500.js
@@ -3,7 +3,8 @@ const assert = require('assert');
 const { sleep } = require('../utils/common');
 const { getAsync, interceptTracingRequest } = require('../utils/server');
 
-module.exports = async ({ url, argv }) => {
+module.exports = async ({ url: urlBase, argv }) => {
+  const url = `${urlBase}/api/broken`;
   const capturedRequest = interceptTracingRequest(
     {
       contexts: {
@@ -16,14 +17,14 @@ module.exports = async ({ url, argv }) => {
       transaction: 'GET /api/broken',
       type: 'transaction',
       request: {
-        url: '/api/broken',
+        url,
       },
     },
     argv,
     'tracing500',
   );
 
-  await getAsync(`${url}/api/broken`);
+  await getAsync(url);
   await sleep(100);
 
   assert.ok(capturedRequest.isDone(), 'Did not intercept expected request');

--- a/packages/nextjs/test/integration/test/server/tracingHttp.js
+++ b/packages/nextjs/test/integration/test/server/tracingHttp.js
@@ -5,7 +5,9 @@ const nock = require('nock');
 const { sleep } = require('../utils/common');
 const { getAsync, interceptTracingRequest } = require('../utils/server');
 
-module.exports = async ({ url, argv }) => {
+module.exports = async ({ url: urlBase, argv }) => {
+  const url = `${urlBase}/api/http`;
+
   nock('http://example.com')
     .get('/')
     .reply(200, 'ok');
@@ -30,14 +32,14 @@ module.exports = async ({ url, argv }) => {
       transaction: 'GET /api/http',
       type: 'transaction',
       request: {
-        url: '/api/http',
+        url,
       },
     },
     argv,
     'tracingHttp',
   );
 
-  await getAsync(`${url}/api/http`);
+  await getAsync(url);
   await sleep(100);
 
   assert.ok(capturedRequest.isDone(), 'Did not intercept expected request');


### PR DESCRIPTION
As discussed in more detail in the penultimate paragraph of [this PR](https://github.com/getsentry/sentry-javascript/pull/3786), when deployed to vercel, API route lambdas have been shutting down too soon for sentry events to get reliably sent to our servers (in spite of the use of `flush`). This fixes that by wrapping the response's `.end()` method (which is what triggers the lambda shutdown) such that it waits for flush to finish before emitting its `finished` signal. 

Logs from API routes now consistently look like this:

```
[GET] /api/hello

Sentry Logger [Log]: [Tracing] Starting http.server transaction - GET /api/hello
Sentry Logger [Log]: [Tracing] Finishing http.server transaction - GET /api/hello
Sentry Logger [Log]: Flushing events...
Sentry Logger [Log]: Done flushing events
```

Fixes https://github.com/getsentry/sentry-javascript/issues/3806.