### PR TITLE
fix(nextjs): Do not start a navigation if from url is the same

### DIFF
--- a/packages/nextjs/src/performance/client.ts
+++ b/packages/nextjs/src/performance/client.ts
@@ -86,7 +86,9 @@ function changeStateWrapper(originalChangeStateWrapper: RouterChangeState): Wrap
     // internal API.
     ...args: any[]
   ): Promise<boolean> {
-    if (startTransaction !== undefined) {
+    const newTransactionName = stripUrlQueryAndFragment(url);
+    // do not start a transaction if it's from the same page
+    if (startTransaction !== undefined && prevTransactionName !== newTransactionName) {
       if (activeTransaction) {
         activeTransaction.finish();
       }
@@ -98,7 +100,7 @@ function changeStateWrapper(originalChangeStateWrapper: RouterChangeState): Wrap
       if (prevTransactionName) {
         tags.from = prevTransactionName;
       }
-      prevTransactionName = stripUrlQueryAndFragment(url);
+      prevTransactionName = newTransactionName;
       activeTransaction = startTransaction({
         name: prevTransactionName,
         op: 'navigation',


### PR DESCRIPTION
Right now in certain cases (like with SSR), the router change state
triggers twice for a single pageload. This means that a pageload will
end early and start a transaction with the same name.

See logic: https://github.com/vercel/next.js/blob/e89b8e466aad110f8af3f60ef7d8292f6064a245/packages/next/client/index.tsx#L204

This patch adds a check to make sure that navigation transactions are
only created if the route URL is different.

Fixes https://github.com/getsentry/sentry-javascript/issues/3803
