### PR TITLE
fix(web-vitals): Check for valid entry in updatedCLS

### DIFF
--- a/packages/tracing/src/browser/web-vitals/getCLS.ts
+++ b/packages/tracing/src/browser/web-vitals/getCLS.ts
@@ -39,7 +39,7 @@ export const getCLS = (onReport: ReportHandler, reportAllChanges?: boolean): voi
   let report: ReturnType<typeof bindReporter>;
 
   const entryHandler = (entry: LayoutShift): void => {
-    if (!entry.hadRecentInput) {
+    if (entry && !entry.hadRecentInput) {
       (metric.value as number) += entry.value;
       metric.entries.push(entry);
       if (report) {

--- a/packages/tracing/src/browser/web-vitals/getUpdatedCLS.ts
+++ b/packages/tracing/src/browser/web-vitals/getUpdatedCLS.ts
@@ -43,7 +43,8 @@ export const getUpdatedCLS = (onReport: ReportHandler, reportAllChanges?: boolea
 
   const entryHandler = (entry: LayoutShift): void => {
     // Only count layout shifts without recent user input.
-    if (!entry.hadRecentInput) {
+    // TODO: Figure out why entry can be undefined
+    if (entry && !entry.hadRecentInput) {
       const firstSessionEntry = sessionEntries[0];
       const lastSessionEntry = sessionEntries[sessionEntries.length - 1];
 

--- a/packages/tracing/src/browser/web-vitals/getUpdatedCLS.ts
+++ b/packages/tracing/src/browser/web-vitals/getUpdatedCLS.ts
@@ -53,6 +53,7 @@ export const getUpdatedCLS = (onReport: ReportHandler, reportAllChanges?: boolea
       // entry in the current session. Otherwise, start a new session.
       if (
         sessionValue &&
+        sessionEntries.length !== 0 &&
         entry.startTime - lastSessionEntry.startTime < 1000 &&
         entry.startTime - firstSessionEntry.startTime < 5000
       ) {


### PR DESCRIPTION
As per comment in https://github.com/getsentry/sentry-javascript/issues/2925#issuecomment-881578478

Still not sure why this happens, but would like to continue to test on Sentry.
