### PR TITLE
Change close/flushes to return false on failure

### DIFF
--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -150,7 +150,7 @@ export async function flush(timeout?: number): Promise<boolean> {
   if (client) {
     return client.flush(timeout);
   }
-  return Promise.reject(false);
+  return false;
 }
 
 /**
@@ -164,7 +164,7 @@ export async function close(timeout?: number): Promise<boolean> {
   if (client) {
     return client.close(timeout);
   }
-  return Promise.reject(false);
+  return false;
 }
 
 /**


### PR DESCRIPTION
This matches the comment, and currently rejecting a promise will cause an uncaught promise exception which doesn't get caught and the causes the application to crash. Additionally, rejecting a promise with a boolean doesn't cause a stack trace which made this hard to diagnose. If keeping the rejection is preferred, then it should instead reject with an error object, not just a boolean.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
