### PR TITLE
fix(types): Add default instance type for `IntegrationClass` interface

### DIFF
--- a/packages/integrations/src/vue.ts
+++ b/packages/integrations/src/vue.ts
@@ -10,14 +10,14 @@ import { basename, getGlobalObject, logger, timestampWithMs } from '@sentry/util
  */
 const TRACING_GETTER = ({
   id: 'Tracing',
-} as any) as IntegrationClass<Integration>;
+} as any) as IntegrationClass;
 
 /**
  * Used to extract BrowserTracing integration from @sentry/tracing
  */
 const BROWSER_TRACING_GETTER = ({
   id: 'BrowserTracing',
-} as any) as IntegrationClass<Integration>;
+} as any) as IntegrationClass;
 
 /** Global Vue object limited to the methods/attributes we require */
 interface VueInstance {

--- a/packages/nextjs/src/index.client.ts
+++ b/packages/nextjs/src/index.client.ts
@@ -1,5 +1,6 @@
 import { configureScope, init as reactInit, Integrations as BrowserIntegrations } from '@sentry/react';
 import { defaultRequestInstrumentationOptions, Integrations as TracingIntegrations } from '@sentry/tracing';
+import { IntegrationClass } from '@sentry/types';
 
 import { nextRouterInstrumentation } from './performance/client';
 import { MetadataBuilder } from './utils/metadataBuilder';
@@ -10,7 +11,7 @@ export * from '@sentry/react';
 export { nextRouterInstrumentation } from './performance/client';
 
 const { BrowserTracing } = TracingIntegrations;
-export const Integrations = { ...BrowserIntegrations, BrowserTracing };
+export const Integrations: { [key: string]: IntegrationClass } = { ...BrowserIntegrations, BrowserTracing };
 
 /** Inits the Sentry NextJS SDK on the browser with the React SDK. */
 export function init(options: NextjsOptions): void {

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -9,7 +9,7 @@ export const UNKNOWN_COMPONENT = 'unknown';
 
 const TRACING_GETTER = ({
   id: 'Tracing',
-} as any) as IntegrationClass<Integration>;
+} as any) as IntegrationClass;
 
 let globalTracingIntegration: Integration | null = null;
 /** @deprecated remove when @sentry/apm no longer used */

--- a/packages/tracing/src/hubextensions.ts
+++ b/packages/tracing/src/hubextensions.ts
@@ -232,20 +232,20 @@ function _autoloadDatabaseIntegrations(): void {
 
   const packageToIntegrationMapping: Record<string, () => Integration> = {
     mongodb() {
-      const integration = dynamicRequire(module, './integrations/mongo') as { Mongo: IntegrationClass<Integration> };
+      const integration = dynamicRequire(module, './integrations/mongo') as { Mongo: IntegrationClass };
       return new integration.Mongo();
     },
     mongoose() {
-      const integration = dynamicRequire(module, './integrations/mongo') as { Mongo: IntegrationClass<Integration> };
+      const integration = dynamicRequire(module, './integrations/mongo') as { Mongo: IntegrationClass };
       return new integration.Mongo({ mongoose: true });
     },
     mysql() {
-      const integration = dynamicRequire(module, './integrations/mysql') as { Mysql: IntegrationClass<Integration> };
+      const integration = dynamicRequire(module, './integrations/mysql') as { Mysql: IntegrationClass };
       return new integration.Mysql();
     },
     pg() {
       const integration = dynamicRequire(module, './integrations/postgres') as {
-        Postgres: IntegrationClass<Integration>;
+        Postgres: IntegrationClass;
       };
       return new integration.Postgres();
     },

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -1,8 +1,10 @@
+import { IntegrationClass } from '@sentry/types';
+
 import { BrowserTracing } from './browser';
 import { addExtensionMethods } from './hubextensions';
 import * as TracingIntegrations from './integrations';
 
-const Integrations = { ...TracingIntegrations, BrowserTracing };
+const Integrations: { [key: string]: IntegrationClass } = { ...TracingIntegrations, BrowserTracing };
 
 export { Integrations };
 export { Span } from './span';

--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -1,7 +1,10 @@
 import { EventProcessor } from './eventprocessor';
 import { Hub } from './hub';
 
-/** Integration Class Interface */
+/**
+ * Integration class interface. Note that this is separate from the {@link Integration} interface, which is for
+ * instances of the class described by this interface.
+ */
 export interface IntegrationClass<T = Integration> {
   /**
    * Property that holds the integration name
@@ -11,7 +14,10 @@ export interface IntegrationClass<T = Integration> {
   new (...args: any[]): T;
 }
 
-/** Integration interface */
+/**
+ * Interface for instances of the `Integration` class. Note that this is separate from the {@link IntegrationClass}
+ * interface.
+ */
 export interface Integration {
   /**
    * Returns {@link IntegrationClass.id}

--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -2,7 +2,7 @@ import { EventProcessor } from './eventprocessor';
 import { Hub } from './hub';
 
 /** Integration Class Interface */
-export interface IntegrationClass<T> {
+export interface IntegrationClass<T = Integration> {
   /**
    * Property that holds the integration name
    */


### PR DESCRIPTION
This adds a default type to the generic type parameter in `IntegrationClass`, so we don't have to specify everywhere. It also adds types to two exported integration arrays (which change was the inspiration for the main one here). Finally, it adds to the docstrings for both the `Integration` and `IntegrationClass` interfaces in order to clarify the distinction between them. 
