### PR TITLE
fix(core): Skip anonymous callbacks while searching frame URLs.

### DIFF
--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -1,5 +1,5 @@
 import { addGlobalEventProcessor, getCurrentHub } from '@sentry/hub';
-import { Event, Integration } from '@sentry/types';
+import { Event, Integration, StackFrame } from '@sentry/types';
 import { getEventDescription, isMatchingPattern, logger } from '@sentry/utils';
 
 // "Script error." is hard coded into browsers for errors that it can't read.
@@ -190,16 +190,29 @@ export class InboundFilters implements Integration {
   }
 
   /** JSDoc */
+  private _getLastUrl(frames: StackFrame[]): string | null {
+    for (let i = frames.length - 1; i >= 0; i--) {
+      const frame = frames[i];
+
+      if (frame?.filename !== '<anonymous>') {
+        return frame.filename || null;
+      }
+    }
+
+    return null;
+  }
+
+  /** JSDoc */
   private _getEventFilterUrl(event: Event): string | null {
     try {
       if (event.stacktrace) {
         const frames = event.stacktrace.frames;
-        return (frames && frames[frames.length - 1].filename) || null;
+        return frames ? this._getLastUrl(frames) : null;
       }
       if (event.exception) {
         const frames =
           event.exception.values && event.exception.values[0].stacktrace && event.exception.values[0].stacktrace.frames;
-        return (frames && frames[frames.length - 1].filename) || null;
+        return frames ? this._getLastUrl(frames) : null;
       }
       return null;
     } catch (oO) {

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -190,7 +190,7 @@ export class InboundFilters implements Integration {
   }
 
   /** JSDoc */
-  private _getLastUrl(frames: StackFrame[]): string | null {
+  private _getLastValidUrl(frames: StackFrame[] = []): string | null {
     for (let i = frames.length - 1; i >= 0; i--) {
       const frame = frames[i];
 
@@ -207,12 +207,12 @@ export class InboundFilters implements Integration {
     try {
       if (event.stacktrace) {
         const frames = event.stacktrace.frames;
-        return frames ? this._getLastUrl(frames) : null;
+        return this._getLastValidUrl(frames);
       }
       if (event.exception) {
         const frames =
           event.exception.values && event.exception.values[0].stacktrace && event.exception.values[0].stacktrace.frames;
-        return frames ? this._getLastUrl(frames) : null;
+        return this._getLastValidUrl(frames);
       }
       return null;
     } catch (oO) {

--- a/packages/core/test/lib/integrations/inboundfilters.test.ts
+++ b/packages/core/test/lib/integrations/inboundfilters.test.ts
@@ -456,5 +456,36 @@ describe('InboundFilters', () => {
         ),
       ).toBe(true);
     });
+
+    it('should search for script names when there is an anonymous callback at the last frame', () => {
+      const messageEvent = {
+        message: 'any',
+        stacktrace: {
+          frames: [
+            { filename: 'https://our-side.com/js/bundle.js' },
+            { filename: 'https://awesome-analytics.io/some/file.js' },
+            { filename: '<anonymous>' },
+          ],
+        },
+      };
+
+      expect(
+        inboundFilters._isAllowedUrl(
+          messageEvent,
+          inboundFilters._mergeOptions({
+            allowUrls: ['https://awesome-analytics.io/some/file.js'],
+          }),
+        ),
+      ).toBe(true);
+
+      expect(
+        inboundFilters._isDeniedUrl(
+          messageEvent,
+          inboundFilters._mergeOptions({
+            denyUrls: ['https://awesome-analytics.io/some/file.js'],
+          }),
+        ),
+      ).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
Fixes: #3800

Ideally, should be tested on different browsers/versions with real stack traces. Ref: #3841