### PR TITLE
fix(vue): Make Router.name type optional to match VueRouter

### DIFF
--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -11,7 +11,7 @@ export type VueRouterInstrumentation = <T extends Transaction>(
 type Route = {
   params: any;
   query: any;
-  name: any;
+  name?: any;
   path: any;
   matched: any[];
 };


### PR DESCRIPTION
ref: https://github.com/vuejs/vue-router/blob/73459565c4c64bfe9b41341875a84c87bc8b931c/types/router.d.ts#L201
fixes: https://github.com/getsentry/sentry-javascript/pull/3804#issuecomment-885199653