### PR TITLE
feat(browser): Allow mechanism to be provided as a hint. Update `angular` exception mechanism.

### DIFF
--- a/packages/angular/src/errorhandler.ts
+++ b/packages/angular/src/errorhandler.ts
@@ -1,6 +1,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { ErrorHandler as AngularErrorHandler, Inject, Injectable } from '@angular/core';
 import * as Sentry from '@sentry/browser';
+import { getCurrentHub } from '@sentry/browser';
 
 import { runOutsideAngular } from './zone';
 
@@ -40,7 +41,9 @@ class SentryErrorHandler implements AngularErrorHandler {
     const extractedError = this._extractError(error) || 'Handled unknown error';
 
     // Capture handled exception and send it to Sentry.
-    const eventId = runOutsideAngular(() => Sentry.captureException(extractedError));
+    const eventId = runOutsideAngular(() =>
+      getCurrentHub().captureException(extractedError, { data: { mechanism: { type: 'angular', handled: false } } }),
+    );
 
     // When in development mode, log the error to console for immediate feedback.
     if (this._options.logErrors) {

--- a/packages/angular/test/errorhandler.test.ts
+++ b/packages/angular/test/errorhandler.test.ts
@@ -1,0 +1,124 @@
+import { createErrorHandler, SentryErrorHandler } from '../src/errorhandler';
+
+import * as SentryBrowser from '@sentry/browser';
+import * as SentryUtils from '@sentry/utils';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Scope } from '@sentry/browser';
+
+const FakeScope = new Scope();
+
+jest.mock('@sentry/browser', () => {
+  const original = jest.requireActual('@sentry/browser');
+  return {
+    ...original,
+    captureException: (err: unknown, cb: (arg0?: unknown) => unknown) => {
+      cb(FakeScope);
+      return original.captureException(err, cb);
+    },
+  };
+});
+
+const captureExceptionSpy = jest.spyOn(SentryBrowser, 'captureException');
+
+jest.spyOn(console, 'error').mockImplementation();
+
+describe('SentryErrorHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('`createErrorHandler `creates a SentryErrorHandler with an empty config', () => {
+    const errorHandler = createErrorHandler();
+
+    expect(errorHandler).toBeInstanceOf(SentryErrorHandler);
+  });
+
+  it('handleError method assigns the correct mechanism', () => {
+    const addEventProcessorSpy = jest.spyOn(FakeScope, 'addEventProcessor').mockImplementationOnce(callback => {
+      callback({}, { event_id: 'fake-event-id' });
+      return FakeScope;
+    });
+
+    const addExceptionMechanismSpy = jest.spyOn(SentryUtils, 'addExceptionMechanism');
+
+    const errorHandler = createErrorHandler();
+    errorHandler.handleError(new Error('test'));
+
+    expect(addEventProcessorSpy).toBeCalledTimes(1);
+    expect(addExceptionMechanismSpy).toBeCalledTimes(1);
+    expect(addExceptionMechanismSpy).toBeCalledWith({}, { handled: false, type: 'angular' });
+  });
+
+  it('handleError method extracts `null` error', () => {
+    createErrorHandler().handleError(null);
+
+    expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+    expect(captureExceptionSpy).toHaveBeenCalledWith('Handled unknown error', expect.any(Function));
+  });
+
+  it('handleError method extracts `undefined` error', () => {
+    createErrorHandler().handleError(undefined);
+
+    expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+    expect(captureExceptionSpy).toHaveBeenCalledWith('Handled unknown error', expect.any(Function));
+  });
+
+  it('handleError method extracts a string', () => {
+    const str = 'sentry-test';
+    createErrorHandler().handleError(str);
+
+    expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+    expect(captureExceptionSpy).toHaveBeenCalledWith(str, expect.any(Function));
+  });
+
+  it('handleError method extracts an empty Error', () => {
+    const err = new Error();
+    createErrorHandler().handleError(err);
+
+    expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+    expect(captureExceptionSpy).toHaveBeenCalledWith(err, expect.any(Function));
+  });
+
+  it('handleError method extracts an Error with `ngOriginalError`', () => {
+    const ngErr = new Error('sentry-ng-test');
+    const err = {
+      ngOriginalError: ngErr,
+    };
+
+    createErrorHandler().handleError(err);
+
+    expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+    expect(captureExceptionSpy).toHaveBeenCalledWith(ngErr, expect.any(Function));
+  });
+
+  it('handleError method extracts an `HttpErrorResponse` with `Error`', () => {
+    const httpErr = new Error('sentry-http-test');
+    const err = new HttpErrorResponse({ error: httpErr });
+
+    createErrorHandler().handleError(err);
+
+    expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+    expect(captureExceptionSpy).toHaveBeenCalledWith(httpErr, expect.any(Function));
+  });
+
+  it('handleError method extracts an `HttpErrorResponse` with `ErrorEvent`', () => {
+    const httpErr = new ErrorEvent('http', { message: 'sentry-http-test' });
+    const err = new HttpErrorResponse({ error: httpErr });
+
+    createErrorHandler().handleError(err);
+
+    expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+    expect(captureExceptionSpy).toHaveBeenCalledWith('sentry-http-test', expect.any(Function));
+  });
+
+  it('handleError method extracts an `HttpErrorResponse` with string', () => {
+    const err = new HttpErrorResponse({ error: 'sentry-http-test' });
+    createErrorHandler().handleError(err);
+
+    expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+    expect(captureExceptionSpy).toHaveBeenCalledWith(
+      'Server returned code 0 with body "sentry-http-test"',
+      expect.any(Function),
+    );
+  });
+});

--- a/packages/angular/test/errorhandler.test.ts
+++ b/packages/angular/test/errorhandler.test.ts
@@ -1,9 +1,9 @@
-import { createErrorHandler, SentryErrorHandler } from '../src/errorhandler';
-
-import * as SentryBrowser from '@sentry/browser';
-import * as SentryUtils from '@sentry/utils';
 import { HttpErrorResponse } from '@angular/common/http';
+import * as SentryBrowser from '@sentry/browser';
 import { Scope } from '@sentry/browser';
+import * as SentryUtils from '@sentry/utils';
+
+import { createErrorHandler, SentryErrorHandler } from '../src/errorhandler';
 
 const FakeScope = new Scope();
 

--- a/packages/angular/test/errorhandler.test.ts
+++ b/packages/angular/test/errorhandler.test.ts
@@ -35,7 +35,7 @@ describe('SentryErrorHandler', () => {
 
   it('handleError method assigns the correct mechanism', () => {
     const addEventProcessorSpy = jest.spyOn(FakeScope, 'addEventProcessor').mockImplementationOnce(callback => {
-      callback({}, { event_id: 'fake-event-id' });
+      void callback({}, { event_id: 'fake-event-id' });
       return FakeScope;
     });
 

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -1,4 +1,13 @@
-import { Event, EventHint, Exception, Severity, SeverityLevel, StackFrame, StackParser } from '@sentry/types';
+import {
+  Event,
+  EventHint,
+  Exception,
+  Mechanism,
+  Severity,
+  SeverityLevel,
+  StackFrame,
+  StackParser,
+} from '@sentry/types';
 import {
   addExceptionMechanism,
   addExceptionTypeValue,
@@ -149,8 +158,17 @@ export function eventFromException(
 ): PromiseLike<Event> {
   const syntheticException = (hint && hint.syntheticException) || undefined;
   const event = eventFromUnknownInput(stackParser, exception, syntheticException, attachStacktrace);
-  addExceptionMechanism(event); // defaults to { type: 'generic', handled: true }
+  const providedMechanism: Mechanism | undefined =
+    hint && hint.data && (hint.data as { mechanism: Mechanism }).mechanism;
+  const mechanism: Mechanism = providedMechanism || {
+    handled: true,
+    type: 'generic',
+  };
+
+  addExceptionMechanism(event, mechanism);
+
   event.level = 'error';
+
   if (hint && hint.event_id) {
     event.event_id = hint.event_id;
   }

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -1,13 +1,4 @@
-import {
-  Event,
-  EventHint,
-  Exception,
-  Mechanism,
-  Severity,
-  SeverityLevel,
-  StackFrame,
-  StackParser,
-} from '@sentry/types';
+import { Event, EventHint, Exception, Severity, SeverityLevel, StackFrame, StackParser } from '@sentry/types';
 import {
   addExceptionMechanism,
   addExceptionTypeValue,
@@ -158,13 +149,8 @@ export function eventFromException(
 ): PromiseLike<Event> {
   const syntheticException = (hint && hint.syntheticException) || undefined;
   const event = eventFromUnknownInput(stackParser, exception, syntheticException, attachStacktrace);
-  const providedMechanism: Mechanism | undefined =
-    hint && hint.data && (hint.data as { mechanism: Mechanism }).mechanism;
-
-  addExceptionMechanism(event, providedMechanism);
-
+  addExceptionMechanism(event); // defaults to { type: 'generic', handled: true }
   event.level = 'error';
-
   if (hint && hint.event_id) {
     event.event_id = hint.event_id;
   }

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -160,12 +160,8 @@ export function eventFromException(
   const event = eventFromUnknownInput(stackParser, exception, syntheticException, attachStacktrace);
   const providedMechanism: Mechanism | undefined =
     hint && hint.data && (hint.data as { mechanism: Mechanism }).mechanism;
-  const mechanism: Mechanism = providedMechanism || {
-    handled: true,
-    type: 'generic',
-  };
 
-  addExceptionMechanism(event, mechanism);
+  addExceptionMechanism(event, providedMechanism);
 
   event.level = 'error';
 


### PR DESCRIPTION
Fixes: #3836
Used the approach from node implementation to allow setting custom mechanisms:
https://github.com/getsentry/sentry-javascript/blob/0acf10cf9dcc7f9548c3bcbbf3818f2d7340e05b/packages/node/src/backend.ts#L30-L35

`eventbuilder.ts` does not have tests, so I haven't added a test for this update. I can open a spin-off PR for testing it as whole if you find that useful.