### PR TITLE
feat(nextjs): Allow for TypeScript user config files

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -43,7 +43,7 @@ export type WebpackConfigObject = {
 };
 
 // Information about the current build environment
-export type BuildContext = { dev: boolean; isServer: boolean; buildId: string };
+export type BuildContext = { dev: boolean; isServer: boolean; buildId: string; dir: string };
 
 /**
  * Webpack `entry` config

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -153,7 +153,7 @@ async function addSentryToEntryProperty(
  * @param platform Either "server" or "client", so that we know which file to look for
  * @returns The name of the relevant file. If no file is found, this method throws an error.
  */
-function getUserConfigFile(projectDir: string, platform: 'server' | 'client'): string {
+export function getUserConfigFile(projectDir: string, platform: 'server' | 'client'): string {
   let configFile;
 
   const possibilities = [`sentry.${platform}.config.ts`, `sentry.${platform}.config.js`];

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -1,6 +1,8 @@
 import { getSentryRelease } from '@sentry/node';
 import { dropUndefinedKeys, logger } from '@sentry/utils';
 import * as SentryWebpackPlugin from '@sentry/webpack-plugin';
+import * as fs from 'fs';
+import * as path from 'path';
 
 import {
   BuildContext,
@@ -18,9 +20,6 @@ export { SentryWebpackPlugin };
 // TODO: merge default SentryWebpackPlugin ignore with their SentryWebpackPlugin ignore or ignoreFile
 // TODO: merge default SentryWebpackPlugin include with their SentryWebpackPlugin include
 // TODO: drop merged keys from override check? `includeDefaults` option?
-
-export const CLIENT_SDK_CONFIG_FILE = './sentry.client.config.js';
-export const SERVER_SDK_CONFIG_FILE = './sentry.server.config.js';
 
 const defaultSentryWebpackPluginOptions = dropUndefinedKeys({
   url: process.env.SENTRY_URL,
@@ -132,15 +131,45 @@ async function addSentryToEntryProperty(
   const newEntryProperty =
     typeof currentEntryProperty === 'function' ? await currentEntryProperty() : { ...currentEntryProperty };
 
-  const userConfigFile = buildContext.isServer ? SERVER_SDK_CONFIG_FILE : CLIENT_SDK_CONFIG_FILE;
+  const userConfigFile = buildContext.isServer
+    ? getUserConfigFile(buildContext.dir, 'server')
+    : getUserConfigFile(buildContext.dir, 'client');
 
   for (const entryPointName in newEntryProperty) {
     if (entryPointName === 'pages/_app' || entryPointName.includes('pages/api')) {
-      addFileToExistingEntryPoint(newEntryProperty, entryPointName, userConfigFile);
+      // we need to turn the filename into a path so webpack can find it
+      addFileToExistingEntryPoint(newEntryProperty, entryPointName, `./${userConfigFile}`);
     }
   }
 
   return newEntryProperty;
+}
+
+/**
+ * Search the project directory for a valid user config file for the given platform, allowing for it to be either a
+ * TypeScript or JavaScript file.
+ *
+ * @param projectDir The root directory of the project, where the file should be located
+ * @param platform Either "server" or "client", so that we know which file to look for
+ * @returns The name of the relevant file. If no file is found, this method throws an error.
+ */
+function getUserConfigFile(projectDir: string, platform: 'server' | 'client'): string {
+  let configFile;
+
+  const possibilities = [`sentry.${platform}.config.ts`, `sentry.${platform}.config.js`];
+
+  for (const filename of possibilities) {
+    if (fs.existsSync(path.resolve(projectDir, filename))) {
+      configFile = filename;
+      break;
+    }
+  }
+
+  if (!configFile) {
+    throw new Error(`Cannot find '${possibilities[0]}' or '${possibilities[1]}' in '${projectDir}'.`);
+  }
+
+  return configFile;
 }
 
 /**

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -154,22 +154,15 @@ async function addSentryToEntryProperty(
  * @returns The name of the relevant file. If no file is found, this method throws an error.
  */
 export function getUserConfigFile(projectDir: string, platform: 'server' | 'client'): string {
-  let configFile;
-
   const possibilities = [`sentry.${platform}.config.ts`, `sentry.${platform}.config.js`];
 
   for (const filename of possibilities) {
     if (fs.existsSync(path.resolve(projectDir, filename))) {
-      configFile = filename;
-      break;
+      return filename;
     }
   }
 
-  if (!configFile) {
-    throw new Error(`Cannot find '${possibilities[0]}' or '${possibilities[1]}' in '${projectDir}'.`);
-  }
-
-  return configFile;
+  throw new Error(`Cannot find '${possibilities[0]}' or '${possibilities[1]}' in '${projectDir}'.`);
 }
 
 /**


### PR DESCRIPTION
Now that we're [no longer dynamically requiring](https://github.com/getsentry/sentry-javascript/pull/3786) the user's SDK server config file and instead injecting it into the relevant bundles using webpack, there's no requirement that it be in vanilla JS, because injecting it directly into the bundles means that it will go through the full transpilation process right along with all the rest of the user's code.

This PR changes the config code to look for either a TS or JS config file, for both server and client config. (In other words, instead of just looking for `sentry.server.config.js` and `sentry.client.config.js`, we now also can find `sentry.server.config.ts` and `sentry.client.config.ts` if they're present instead.)

Fixes https://github.com/getsentry/sentry-javascript/issues/3500