### PR TITLE
fix(react): Require ReactElement in ErrorBoundary props and render

### DIFF
--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -8,7 +8,7 @@ import {
   withScope,
 } from '@sentry/browser';
 import { Event } from '@sentry/types';
-import { parseSemver } from '@sentry/utils';
+import { logger, parseSemver } from '@sentry/utils';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
 
@@ -169,6 +169,10 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
 
       if (React.isValidElement(element)) {
         return element;
+      }
+
+      if (fallback) {
+        logger.warn('fallback did not produce a valid ReactElement');
       }
 
       // Fail gracefully if no fallback provided or is not valid

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -21,7 +21,7 @@ export type FallbackRender = (errorData: {
   componentStack: string | null;
   eventId: string | null;
   resetError(): void;
-}) => React.ReactNode;
+}) => React.ReactElement;
 
 export type ErrorBoundaryProps = {
   /** If a Sentry report dialog should be rendered on error */
@@ -39,7 +39,7 @@ export type ErrorBoundaryProps = {
    * the error, the component stack, and an function that resets the error boundary on error.
    *
    */
-  fallback?: React.ReactNode | FallbackRender;
+  fallback?: React.ReactElement | FallbackRender;
   /** Called with the error boundary encounters an error */
   onError?(error: Error, componentStack: string, eventId: string): void;
   /** Called on componentDidMount() */
@@ -160,14 +160,22 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
     const { error, componentStack, eventId } = this.state;
 
     if (error) {
-      if (React.isValidElement(fallback)) {
-        return fallback;
-      }
+      let element: React.ReactElement | undefined = undefined;
       if (typeof fallback === 'function') {
-        return fallback({ error, componentStack, resetError: this.resetErrorBoundary, eventId }) as FallbackRender;
+        element = fallback({ error, componentStack, resetError: this.resetErrorBoundary, eventId });
+      } else {
+        element = fallback;
       }
 
-      // Fail gracefully if no fallback provided
+      if (React.isValidElement(element)) {
+        return element;
+      }
+
+      if (fallback) {
+        console.log('ErrorBoundary: fallback did not produce a ReactElement');
+      }
+
+      // Fail gracefully if no fallback provided or is not valid
       return null;
     }
 

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -171,10 +171,6 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
         return element;
       }
 
-      if (fallback) {
-        console.log('ErrorBoundary: fallback did not produce a ReactElement');
-      }
-
       // Fail gracefully if no fallback provided or is not valid
       return null;
     }

--- a/packages/react/test/errorboundary.test.tsx
+++ b/packages/react/test/errorboundary.test.tsx
@@ -80,7 +80,17 @@ describe('ErrorBoundary', () => {
 
   it('renders null if not given a valid `fallback` prop', () => {
     const { container } = render(
-      <ErrorBoundary fallback={new Error('true')}>
+      <ErrorBoundary fallback="Not a ReactElement">
+        <Bam />
+      </ErrorBoundary>,
+    );
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders null if not given a valid `fallback` prop function', () => {
+    const { container } = render(
+      <ErrorBoundary fallback={() => 'Not a ReactElement'}>
         <Bam />
       </ErrorBoundary>,
     );


### PR DESCRIPTION
Updates the ErrorBoundary fallback type in @sentry/react to require a ReactElement. This addresses the inconsistency in https://github.com/getsentry/sentry-javascript/issues/3828

Open question: in the case where the fallback prop is not a valid element, I wanted to include some sort of console warning so that the developer can get feedback (really only matters for js). This would have saved us an hour of debugging and sifting through the SDK source code. However, the linter doesn't allow console.log statements -- what's the preferred approach? We can ignore the linter for that line, leave it out entirely, or follow some warning convention if it exists in the codebase.

---

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
