### PR TITLE
ref(nextjs): Stop reinitializing the server SDK unnecessarily

### DIFF
--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -1,5 +1,6 @@
 import { RewriteFrames } from '@sentry/integrations';
-import { configureScope, init as nodeInit, Integrations } from '@sentry/node';
+import { configureScope, getCurrentHub, init as nodeInit, Integrations } from '@sentry/node';
+import { logger } from '@sentry/utils';
 
 import { instrumentServer } from './utils/instrumentServer';
 import { MetadataBuilder } from './utils/metadataBuilder';
@@ -14,6 +15,17 @@ export { ErrorBoundary, withErrorBoundary } from '@sentry/react';
 
 /** Inits the Sentry NextJS SDK on node. */
 export function init(options: NextjsOptions): void {
+  if (options.debug) {
+    logger.enable();
+  }
+
+  logger.log('Initializing SDK...');
+
+  if (sdkAlreadyInitialized()) {
+    logger.log('SDK already initialized');
+    return;
+  }
+
   const metadataBuilder = new MetadataBuilder(options, ['nextjs', 'node']);
   metadataBuilder.addSdkMetadata();
   options.environment = options.environment || process.env.NODE_ENV;
@@ -26,6 +38,13 @@ export function init(options: NextjsOptions): void {
   configureScope(scope => {
     scope.setTag('runtime', 'node');
   });
+
+  logger.log('SDK successfully initialized');
+}
+
+function sdkAlreadyInitialized(): boolean {
+  const hub = getCurrentHub();
+  return !!hub.getClient();
 }
 
 const SOURCEMAP_FILENAME_REGEX = /^.*\/\.next\//;


### PR DESCRIPTION
In the nextjs SDK, we bundle the user's `Sentry.init()` code with every API route and with the `_app` page, which is the basis of all user-provided pages. This is necessary because, when deployed on Vercel, each API route (and optionally each individual page) is turned into its own serverless function, so each one has to independently be able to start up the SDK.

That said, a) not all nextjs apps are deployed to Vercel, and b) even those that are sometimes have multiple serverless API routes combined into a single serverless function. As a result, `Sentry.init()` can end up getting called over and over again, as different routes are hit on the same running server process. While we manage hubs and clients and scopes in such a way that this doesn't break anything, it's also a total waste of time - the startup code that we bundle with each route comes from a single source (`sentry.server.config.js`) and therefore is the same for every route; once the SDK is started with the given options, it's started. No reason to do it multiple times. 

This PR thus introduces a check when calling the server-side `Sentry.init()`: if there is a client already defined on the current hub, it means the startup process has already run, and so it bails. 

The above change itself should be straightforward to review, but the test changes might be slightly more complicated to look at. TL;DR, because I needed the real `init()` from the node SDK to run (in order to create an already-initialized client to check), I switched the mocking of `@sentry/node` from a direct mock to a pair of spies. I further did two renamings - `s/mockInit/nodeInit`, to make it clear which `init()` function we're talking about, and `s/reactInitOptions/nodeInitOptions`, since this is the backend initialization we're testing rather than the front end.

