### PR TITLE
fix(browser): Make sure handler exists for LinkedErrors Integration

### DIFF
--- a/packages/browser/src/integrations/linkederrors.ts
+++ b/packages/browser/src/integrations/linkederrors.ts
@@ -45,7 +45,8 @@ export class LinkedErrors implements Integration {
     addGlobalEventProcessor((event: Event, hint?: EventHint) => {
       const self = getCurrentHub().getIntegration(LinkedErrors);
       if (self) {
-        return self._handler(event, hint);
+        const handler = self._handler && self._handler.bind(self);
+        return typeof handler === 'function' ? handler(event, hint) : event;
       }
       return event;
     });


### PR DESCRIPTION
We should port the fixes done in the Node SDK in https://github.com/getsentry/sentry-javascript/pull/2742 to the browser SDK.

This makes sure that the handler class method is defined in the linked errors integration.

See Sentry issue: https://sentry.io/share/issue/c654e9998c8e447d92d93e0da3222366/