### PR TITLE
ref(core): Prevent redundant setup work

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -207,7 +207,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    * Sets up the integrations
    */
   public setupIntegrations(): void {
-    if (this._isEnabled()) {
+    if (this._isEnabled() && !this._integrations.initialized) {
       this._integrations = setupIntegrations(this._options);
     }
   }

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -5,9 +5,9 @@ import { logger } from '@sentry/utils';
 export const installedIntegrations: string[] = [];
 
 /** Map of integrations assigned to a client */
-export interface IntegrationIndex {
+export type IntegrationIndex = {
   [key: string]: Integration;
-}
+} & { initialized?: boolean };
 
 /**
  * @private
@@ -74,5 +74,9 @@ export function setupIntegrations<O extends Options>(options: O): IntegrationInd
     integrations[integration.name] = integration;
     setupIntegration(integration);
   });
+  // set the `initialized` flag so we don't run through the process again unecessarily; use `Object.defineProperty`
+  // because by default it creates a property which is nonenumerable, which we want since `initialized` shouldn't be
+  // considered a member of the index the way the actual integrations are
+  Object.defineProperty(integrations, 'initialized', { value: true });
   return integrations;
 }

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -103,7 +103,9 @@ export class Hub implements HubInterface {
    */
   public constructor(client?: Client, scope: Scope = new Scope(), private readonly _version: number = API_VERSION) {
     this.getStackTop().scope = scope;
-    this.bindClient(client);
+    if (client) {
+      this.bindClient(client);
+    }
   }
 
   /**


### PR DESCRIPTION
This PR fixes two places where we do work unnecessarily:

1) When creating a new `Hub` instance we call `bindClient`, even if there's no client to bind.

2) When calling `Client.setupIntegrations()` (as we do when binding a client to a hub), we run through the whole integration-setup process, even if the client has already had its integrations set up.

(The latter situation comes up, among other places, any time we create a domain: each new domain gets its own hub, which then is bound to the current client, meaning we currently call `setupIntegrations()` for every incoming request handled by either our Express integration or our nextjs SDK.)

To prevent this, we now (as of this change) check a) if there's a client to bind to the new hub, and b) if the client having its integrations set up has already had that done.


