### PR TITLE
feat: Add typedocs build to gh actions

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -34,6 +34,7 @@ targets:
         onlyIfPresent: /^sentry-wasm-.*\.tgz$/
       'npm:@sentry/nextjs':
         onlyIfPresent: /^sentry-nextjs-.*\.tgz$/
+  - name: gh-pages
   - name: aws-lambda-layer
     includeNames: /^sentry-node-serverless-\d+(\.\d+)*\.zip$/
     layerName: SentryNodeServerlessSDK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ env:
   # DEPENDENCY_CACHE_KEY: can't be set here because we don't have access to yarn.lock
 
   CACHED_BUILD_PATHS: |
+    ${{ github.workspace }}/gh-pages.zip
     ${{ github.workspace }}/packages/**/build
     ${{ github.workspace }}/packages/**/dist
     ${{ github.workspace }}/packages/**/esm
@@ -140,6 +141,31 @@ jobs:
           key: ${{ env.BUILD_CACHE_KEY }}
       - name: Run linter
         run: yarn lint
+
+  job_typedocs:
+    name: Typedocs
+    needs: job_build
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out current commit (${{ github.sha }})
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v1
+      - name: Check dependency cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
+          key: ${{ needs.job_build.outputs.dependency_cache_key }}
+      - name: Check build cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.CACHED_BUILD_PATHS }}
+          key: ${{ env.BUILD_CACHE_KEY }}
+      - name: Build docs
+        run: make build-docs
+      - name: ZIP docs
+        run: zip -r gh-pages ./docs/
 
   job_circular_dep_check:
     name: Circular Dependency Check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,11 @@ jobs:
       - name: Run prepublishOnly script
         if: startsWith(github.ref, 'refs/heads/release/')
         run: yarn prepublishOnly
+      - name: Build docs
+        run: make build-docs
+      - name: ZIP docs
+        run: zip -r gh-pages ./docs/
+
     outputs:
       # this needs to be passed on, because the `needs` context only looks at direct ancestors (so steps which depend on
       # `job_build` can't see `job_install_deps` and what it returned)
@@ -141,31 +146,6 @@ jobs:
           key: ${{ env.BUILD_CACHE_KEY }}
       - name: Run linter
         run: yarn lint
-
-  job_typedocs:
-    name: Typedocs
-    needs: job_build
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@v2
-      - name: Set up Node
-        uses: actions/setup-node@v1
-      - name: Check dependency cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
-          key: ${{ needs.job_build.outputs.dependency_cache_key }}
-      - name: Check build cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.CACHED_BUILD_PATHS }}
-          key: ${{ env.BUILD_CACHE_KEY }}
-      - name: Build docs
-        run: make build-docs
-      - name: ZIP docs
-        run: zip -r gh-pages ./docs/
 
   job_circular_dep_check:
     name: Circular Dependency Check

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "sinon": "^7.3.2",
     "size-limit": "^4.5.5",
     "ts-jest": "^24.0.2",
-    "typedoc": "^0.18.0",
+    "typedoc": "0.18.0",
     "typescript": "3.7.5"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "codecov": "codecov",
     "pack:changed": "lerna run pack --since",
     "prepublishOnly": "lerna run --stream --concurrency 1 prepublishOnly",
-    "postpublish": "make publish-docs && lerna run --stream --concurrency 1 postpublish",
     "circularDepCheck": "lerna run --parallel circularDepCheck"
   },
   "volta": {

--- a/typedoc.js
+++ b/typedoc.js
@@ -5,12 +5,19 @@ module.exports = {
   includes: './',
   exclude: [
     '**/test/**/*',
+    '**/tests/**/*',
     '**/*.js',
     '**/dist/**/*',
     '**/esm/**/*',
     '**/build/**/*',
+    '**/node_modules/**/*',
     '**/packages/typescript/**/*',
     '**/packages/eslint-*/**/*',
+
+    // These are special cased because I don't know how to resolve type issues
+    '**/packages/react/src/errorboundary.tsx',
+    '**/packages/react/src/profiler.tsx',
+    '**/packages/react/src/reactrouter.tsx',
   ],
   mode: 'modules',
   excludeExternals: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11225,9 +11225,9 @@ hex-color-regex@^1.1.0:
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
 highlight.js@^10.0.0:
-  version "10.7.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.1.tgz#a8ec4152db24ea630c90927d6cae2a45f8ecb955"
-  integrity sha512-S6G97tHGqJ/U8DsXcEdnACbirtbx58Bx9CzIVeYli8OuswCfYI/LsXH2EiGcoGio1KAC3x4mmUwulOllJ2ZyRA==
+  version "10.7.3"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
+  integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
 
 highlight.js@^9.15.6:
   version "9.18.5"
@@ -14110,10 +14110,10 @@ markdown-it@^8.3.1:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
-marked@^1.1.1:
-  version "1.2.9"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.9.tgz#53786f8b05d4c01a2a5a76b7d1ec9943d29d72dc"
-  integrity sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==
+marked@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.0.0.tgz#d35784245a04871e5988a491e28867362e941693"
+  integrity sha512-Wo+L1pWTVibfrSr+TTtMuiMfNzmZWiOPeO7rZsQUY5bgsxpHesBEcIWJloWVTFnrMXnf/TL30eTFSGJddmQAng==
 
 matcher-collection@^1.0.0, matcher-collection@^1.1.1:
   version "1.1.2"
@@ -19827,28 +19827,28 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typedoc-default-themes@^0.10.2:
+typedoc-default-themes@^0.10.1:
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz#743380a80afe62c5ef92ca1bd4abe2ac596be4d2"
   integrity sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==
   dependencies:
     lunr "^2.3.8"
 
-typedoc@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.18.0.tgz#8bf53ddd7df5b8966b52c946929a09549d78682b"
-  integrity sha512-UgDQwapCGQCCdYhEQzQ+kGutmcedklilgUGf62Vw6RdI29u6FcfAXFQfRTiJEbf16aK3YnkB20ctQK1JusCRbA==
+typedoc@0.17.7:
+  version "0.17.7"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.17.7.tgz#70797401140403a5f91589ed3f4f24c03841bf7a"
+  integrity sha512-PEnzjwQAGjb0O8a6VDE0lxyLAadqNujN5LltsTUhZETolRMiIJv6Ox+Toa8h0XhKHqAOh8MOmB0eBVcWz6nuAw==
   dependencies:
-    fs-extra "^9.0.1"
+    fs-extra "^8.1.0"
     handlebars "^4.7.6"
     highlight.js "^10.0.0"
     lodash "^4.17.15"
     lunr "^2.3.8"
-    marked "^1.1.1"
+    marked "1.0.0"
     minimatch "^3.0.0"
     progress "^2.0.3"
     shelljs "^0.8.4"
-    typedoc-default-themes "^0.10.2"
+    typedoc-default-themes "^0.10.1"
 
 typescript-memoize@^1.0.0-alpha.3:
   version "1.0.0"


### PR DESCRIPTION
This re-adds the GH pages target to craft

- [ ] Upgrade typescript
- [ ] (optional) Fix react imports

ref: https://github.com/getsentry/sentry-javascript/issues/3871