### PR TITLE
feat(nextjs): Add options to disable webpack entry

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -15,6 +15,8 @@ export type NextConfigObject = {
   // whether to build serverless functions for all pages, not just API routes
   target?: 'server' | 'experimental-serverless-trace';
   sentry?: {
+    disableServerWebpackEntry?: boolean;
+    disableClientWebpackEntry?: boolean;
     disableServerWebpackPlugin?: boolean;
     disableClientWebpackPlugin?: boolean;
   };

--- a/packages/nextjs/test/config.test.ts
+++ b/packages/nextjs/test/config.test.ts
@@ -312,6 +312,46 @@ describe('webpack config', () => {
         }),
       );
     });
+
+    it('allows webpack entry modification to be turned off for client code', async () => {
+      const clientOriginalWebpackConfig = userNextConfig.webpack(clientWebpackConfig, clientBuildContext);
+      const clientFinalNextConfig = materializeFinalNextConfig({
+        ...userNextConfig,
+        sentry: { disableClientWebpackEntry: true },
+      });
+      const clientFinalWebpackConfig = clientFinalNextConfig.webpack?.(clientWebpackConfig, clientBuildContext);
+
+      const serverOriginalWebpackConfig = userNextConfig.webpack(serverWebpackConfig, serverBuildContext);
+      const serverFinalNextConfig = materializeFinalNextConfig(userNextConfig, userSentryWebpackPluginConfig);
+      const serverFinalWebpackConfig = serverFinalNextConfig.webpack?.(serverWebpackConfig, serverBuildContext);
+
+      expect(await clientOriginalWebpackConfig.entry()).toEqual(
+        typeof clientFinalWebpackConfig?.entry === 'function' && (await clientFinalWebpackConfig.entry()),
+      );
+      expect(await serverOriginalWebpackConfig.entry()).not.toEqual(
+        typeof serverFinalWebpackConfig?.entry === 'function' && (await serverFinalWebpackConfig.entry()),
+      );
+    });
+
+    it('allows SentryWebpackPlugin to be turned off for server code', async () => {
+      const serverOriginalWebpackConfig = userNextConfig.webpack(serverWebpackConfig, serverBuildContext);
+      const serverFinalNextConfig = materializeFinalNextConfig({
+        ...userNextConfig,
+        sentry: { disableServerWebpackEntry: true },
+      });
+      const serverFinalWebpackConfig = serverFinalNextConfig.webpack?.(serverWebpackConfig, serverBuildContext);
+
+      const clientOriginalWebpackConfig = userNextConfig.webpack(clientWebpackConfig, clientBuildContext);
+      const clientFinalNextConfig = materializeFinalNextConfig(userNextConfig, userSentryWebpackPluginConfig);
+      const clientFinalWebpackConfig = clientFinalNextConfig.webpack?.(clientWebpackConfig, clientBuildContext);
+
+      expect(await clientOriginalWebpackConfig.entry()).not.toEqual(
+        typeof clientFinalWebpackConfig?.entry === 'function' && (await clientFinalWebpackConfig.entry()),
+      );
+      expect(await serverOriginalWebpackConfig.entry()).toEqual(
+        typeof serverFinalWebpackConfig?.entry === 'function' && (await serverFinalWebpackConfig.entry()),
+      );
+    });
   });
 });
 


### PR DESCRIPTION
In some case, I wanted to disable the webpack entry modification by `@sentry/nextjs`. I wanted to initialize Sentry at my own, without adding `sentry.client.config.js`, `sentry.server.config.js` files.

This PR make user to opt-out webpack entry modification by adding two new options, `disableServerWebpackEntry` and `disableClientWebpackEntry`.

Below simple `next.config.js` example:

```js
const { withSentryConfig } = require("@sentry/nextjs");

const nextConfig = {
  sentry: {
    disableServerWebpackEntry: true,
    disableClientWebpackEntry: true,
  },
};

const sentryWebpackPluginOptions = {
  // ...
};

module.exports = withSentryConfig(nextConfig, sentryWebpackPluginOptions);
```

It does below.
- Prevent webpack `entry` property being modified
- Prevent loading `sentry.client.config.js` and `sentry.server.config.js`
