### PR TITLE
fix(core): Skip native frames while searching frame URLs.

### DIFF
--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -194,7 +194,7 @@ export class InboundFilters implements Integration {
     for (let i = frames.length - 1; i >= 0; i--) {
       const frame = frames[i];
 
-      if (frame?.filename !== '<anonymous>') {
+      if (frame?.filename !== '<anonymous>' && frame?.filename !== '[native code]') {
         return frame.filename || null;
       }
     }

--- a/packages/core/test/lib/integrations/inboundfilters.test.ts
+++ b/packages/core/test/lib/integrations/inboundfilters.test.ts
@@ -487,5 +487,36 @@ describe('InboundFilters', () => {
         ),
       ).toBe(true);
     });
+
+    it('should search for script names when the last frame is from native code', () => {
+      const messageEvent = {
+        message: 'any',
+        stacktrace: {
+          frames: [
+            { filename: 'https://our-side.com/js/bundle.js' },
+            { filename: 'https://awesome-analytics.io/some/file.js' },
+            { filename: '[native code]' },
+          ],
+        },
+      };
+
+      expect(
+        inboundFilters._isAllowedUrl(
+          messageEvent,
+          inboundFilters._mergeOptions({
+            allowUrls: ['https://awesome-analytics.io/some/file.js'],
+          }),
+        ),
+      ).toBe(true);
+
+      expect(
+        inboundFilters._isDeniedUrl(
+          messageEvent,
+          inboundFilters._mergeOptions({
+            denyUrls: ['https://awesome-analytics.io/some/file.js'],
+          }),
+        ),
+      ).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
When the exceptions are thrown from native code (see **To reproduce** below), `InboundFilters#_getLastValidUrl()` returns `[native code]` instead of a valid URL, causing `InboundFilters#_isAllowedUrl()` fail.

This PR skips native frames to solve the issue.

## Package + Version
@sentry/browser@6.11.0


## To reproduce
Visit https://codepen.io/luin/pen/qBmGgwv on Safari. It contains a regexp that Safari doesn't support. The error stack will show on the alert box. Notice that the first frame is `[native code]`.

----
- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
