### PR TITLE
feat(nextjs): Change not to dependent on @sentry/tracing

### DIFF
--- a/packages/nextjs/src/index.client.ts
+++ b/packages/nextjs/src/index.client.ts
@@ -9,7 +9,7 @@ import { addIntegration, UserIntegrations } from './utils/userIntegrations';
 export * from '@sentry/react';
 export { nextRouterInstrumentation } from './performance/client';
 
-const { BrowserTracing } = TracingIntegrations;
+const { BrowserTracing } = TracingIntegrations || {};
 export const Integrations = { ...BrowserIntegrations, BrowserTracing };
 
 /** Inits the Sentry NextJS SDK on the browser with the React SDK. */
@@ -33,12 +33,12 @@ export function init(options: NextjsOptions): void {
   });
 }
 
-const defaultBrowserTracingIntegration = new BrowserTracing({
-  tracingOrigins: [...defaultRequestInstrumentationOptions.tracingOrigins, /^(api\/)/],
-  routingInstrumentation: nextRouterInstrumentation,
-});
-
 function createClientIntegrations(integrations?: UserIntegrations): UserIntegrations {
+  const defaultBrowserTracingIntegration = new BrowserTracing({
+    tracingOrigins: [...defaultRequestInstrumentationOptions.tracingOrigins, /^(api\/)/],
+    routingInstrumentation: nextRouterInstrumentation,
+  });
+
   if (integrations) {
     return addIntegration(defaultBrowserTracingIntegration, integrations, {
       BrowserTracing: { keyPath: 'options.routingInstrumentation', value: nextRouterInstrumentation },


### PR DESCRIPTION
In some project, `@sentry/tracing` with `@sentry/hub` is too heavy for browser bundle size. (~9kB) I wanted to remove `@sentry/tracing` from `index.client.ts` since I do not use tracing/performance, but it was really hard.

This PR make `@sentry/tracing` as an optional dependency if the project wants. With this change, user can easily opt-out `@sentry/tracing` like below.

```javascript
// next.config.js
const { withSentryConfig } = require("@sentry/nextjs");

module.exports = withSentryConfig({
  webpack: (config, options) => {
    // Removes tracing from client bundle
    if (!options.isServer) {
      config.resolve.alias['@sentry/tracing'] = false;
    }
  }
})
```

I had to mock `@sentry/next.js/dist/index.client.js` to remove `@sentry/tracing` from bundle without this PR changes. It will be great if there exists any other better, or simpler solutions :)