### PR TITLE
feat(react): Make _mountSpan protected in the profiler for RN to access

### DIFF
--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -86,10 +86,14 @@ export type ProfilerProps = {
  * spans based on component lifecycles.
  */
 class Profiler extends React.Component<ProfilerProps> {
+  /**
+   * The span of the mount activity
+   * Made protected for the React Native SDK to access
+   */
+  protected _mountSpan: Span | undefined = undefined;
+
   // The activity representing how long it takes to mount a component.
   private _mountActivity: number | null = null;
-  // The span of the mount activity
-  private _mountSpan: Span | undefined = undefined;
 
   // eslint-disable-next-line @typescript-eslint/member-ordering
   public static defaultProps: Partial<ProfilerProps> = {


### PR DESCRIPTION
The React Native SDK would extend the `Profiler` into `ReactNativeProfiler` and would need to access `_mountSpan` in https://github.com/getsentry/sentry-react-native/pull/1728. So this PR makes it protected instead of private.

--

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
