### PR TITLE
build(ci): Make ember test runs more restrictive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,7 +233,7 @@ jobs:
         id: changed-files-specific
         uses: tj-actions/changed-files@v6.2
         with:
-          files: .*packages\/(ember|browser|core|tracing|hub|minimal|types|utils)($|/.*)
+          files: .*packages\/ember($|/.*)
       # Only run ember tests if the files above have changed
       - name: Run Ember tests
         if: steps.changed-files-specific.outputs.any_changed == 'true' || github.event_name == 'push'


### PR DESCRIPTION
Only run ember tests if the ember package has been changed. Previously
we would run ember tests if ember or any of it's dependencies changed
(like hub, core, types etc.)