### PR TITLE
feat(tracing): Add initial `tracestate` header handling

### DIFF
--- a/.jest/dom-environment.js
+++ b/.jest/dom-environment.js
@@ -1,0 +1,17 @@
+const JSDOMEnvironment = require('jest-environment-jsdom');
+
+// TODO Node >= 8.3 includes the same TextEncoder and TextDecoder as exist in the browser, but they haven't yet been
+// added to jsdom. Until they are, we can do it ourselves. Once they do, this file can go away.
+
+// see https://github.com/jsdom/jsdom/issues/2524 and https://nodejs.org/api/util.html#util_class_util_textencoder
+
+module.exports = class DOMEnvironment extends JSDOMEnvironment {
+  async setup() {
+    await super.setup();
+    if (typeof this.global.TextEncoder === 'undefined') {
+      const { TextEncoder, TextDecoder } = require('util');
+      this.global.TextEncoder = TextEncoder;
+      this.global.TextDecoder = TextDecoder;
+    }
+  }
+};

--- a/packages/browser/test/unit/string.test.ts
+++ b/packages/browser/test/unit/string.test.ts
@@ -17,14 +17,9 @@ describe('base64ToUnicode/unicodeToBase64', () => {
     expect(BASE64_REGEX.test(unicodeToBase64(unicodeString))).to.be.true;
   });
 
-  it('works as expected', () => {
+  it('works as expected (and conversion functions are inverses)', () => {
     expect(unicodeToBase64(unicodeString)).to.equal(base64String);
     expect(base64ToUnicode(base64String)).to.equal(unicodeString);
-  });
-
-  it('conversion functions are inverses', () => {
-    expect(base64ToUnicode(unicodeToBase64(unicodeString))).to.equal(unicodeString);
-    expect(unicodeToBase64(base64ToUnicode(base64String))).to.equal(base64String);
   });
 
   it('can handle and preserve multi-byte characters in original string', () => {
@@ -56,9 +51,9 @@ describe('base64ToUnicode/unicodeToBase64', () => {
     expect(() => {
       base64ToUnicode({} as any);
     }).to.throw('Unable to convert from base64');
-
-    // Note that by design, in node base64 encoding and decoding will accept any string, whether or not it's valid
-    // base64, by ignoring all invalid characters, including whitespace. Therefore, no wacky strings have been included
-    // here because they don't actually error.
+    expect(() => {
+      // the exclamation point makes this invalid base64
+      base64ToUnicode('Dogs are great!');
+    }).to.throw('Unable to convert from base64');
   });
 });

--- a/packages/browser/test/unit/string.test.ts
+++ b/packages/browser/test/unit/string.test.ts
@@ -1,0 +1,64 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { base64ToUnicode, unicodeToBase64 } from '@sentry/utils';
+import { expect } from 'chai';
+
+// See https://tools.ietf.org/html/rfc4648#section-4 for base64 spec
+// eslint-disable-next-line no-useless-escape
+const BASE64_REGEX = /([a-zA-Z0-9+/]{4})*(|([a-zA-Z0-9+/]{3}=)|([a-zA-Z0-9+/]{2}==))/;
+
+// NOTE: These tests are copied (and adapted for chai syntax) from `string.test.ts` in `@sentry/utils`. The
+// base64-conversion functions have a different implementation in browser and node, so they're copied here to prove they
+// work in a real live browser. If you make changes here, make sure to also port them over to that copy.
+describe('base64ToUnicode/unicodeToBase64', () => {
+  const unicodeString = 'Dogs are great!';
+  const base64String = 'RG9ncyBhcmUgZ3JlYXQh';
+
+  it('converts to valid base64', () => {
+    expect(BASE64_REGEX.test(unicodeToBase64(unicodeString))).to.be.true;
+  });
+
+  it('works as expected', () => {
+    expect(unicodeToBase64(unicodeString)).to.equal(base64String);
+    expect(base64ToUnicode(base64String)).to.equal(unicodeString);
+  });
+
+  it('conversion functions are inverses', () => {
+    expect(base64ToUnicode(unicodeToBase64(unicodeString))).to.equal(unicodeString);
+    expect(unicodeToBase64(base64ToUnicode(base64String))).to.equal(base64String);
+  });
+
+  it('can handle and preserve multi-byte characters in original string', () => {
+    ['🐶', 'Καλό κορίτσι, Μάιζεϊ!', 'Of margir hundar! Ég geri ráð fyrir að ég þurfi stærra rúm.'].forEach(orig => {
+      expect(() => {
+        unicodeToBase64(orig);
+      }).not.to.throw;
+      expect(base64ToUnicode(unicodeToBase64(orig))).to.equal(orig);
+    });
+  });
+
+  it('throws an error when given invalid input', () => {
+    expect(() => {
+      unicodeToBase64(null as any);
+    }).to.throw('Unable to convert to base64');
+    expect(() => {
+      unicodeToBase64(undefined as any);
+    }).to.throw('Unable to convert to base64');
+    expect(() => {
+      unicodeToBase64({} as any);
+    }).to.throw('Unable to convert to base64');
+
+    expect(() => {
+      base64ToUnicode(null as any);
+    }).to.throw('Unable to convert from base64');
+    expect(() => {
+      base64ToUnicode(undefined as any);
+    }).to.throw('Unable to convert from base64');
+    expect(() => {
+      base64ToUnicode({} as any);
+    }).to.throw('Unable to convert from base64');
+
+    // Note that by design, in node base64 encoding and decoding will accept any string, whether or not it's valid
+    // base64, by ignoring all invalid characters, including whitespace. Therefore, no wacky strings have been included
+    // here because they don't actually error.
+  });
+});

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -417,8 +417,8 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
     const options = this.getOptions();
     const { environment, release, dist, maxValueLength = 250 } = options;
 
-    if (!('environment' in event)) {
-      event.environment = 'environment' in options ? environment : 'production';
+    if (event.environment === undefined && environment !== undefined) {
+      event.environment = environment;
     }
 
     if (event.release === undefined && release !== undefined) {

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -61,12 +61,9 @@ export function eventToSentryRequest(event: Event, api: API): SentryRequest {
     url: useEnvelope ? api.getEnvelopeEndpointWithUrlEncodedAuth() : api.getStoreEndpointWithUrlEncodedAuth(),
   };
 
-  // https://develop.sentry.dev/sdk/envelopes/
-
-  // Since we don't need to manipulate envelopes nor store them, there is no
-  // exported concept of an Envelope with operations including serialization and
-  // deserialization. Instead, we only implement a minimal subset of the spec to
-  // serialize events inline here.
+  // Since we don't need to manipulate envelopes nor store them, there is no exported concept of an Envelope with
+  // operations including serialization and deserialization. Instead, we only implement a minimal subset of the spec to
+  // serialize events inline here. See https://develop.sentry.dev/sdk/envelopes/.
   if (useEnvelope) {
     // Extract header information from event
     const { transactionSampling, tracestate, ...metadata } = event.debug_meta || {};
@@ -101,19 +98,17 @@ export function eventToSentryRequest(event: Event, api: API): SentryRequest {
     const itemHeaderEntries: { [key: string]: unknown } = {
       type: eventType,
 
-      // The content-type is assumed to be 'application/json' and not part of
-      // the current spec for transaction items, so we don't bloat the request
-      // body with it.
+      // Note: as mentioned above, `content_type` and `length` were left out on purpose.
       //
-      // content_type: 'application/json',
+      // `content_type`:
+      // Assumed to be 'application/json' and not part of the current spec for transaction items. No point in bloating the
+      // request body with it. (Would be `content_type: 'application/json'`.)
       //
-      // The length is optional. It must be the number of bytes in req.Body
-      // encoded as UTF-8. Since the server can figure this out and would
-      // otherwise refuse events that report the length incorrectly, we decided
-      // not to send the length to avoid problems related to reporting the wrong
-      // size and to reduce request body size.
-      //
-      // length: new TextEncoder().encode(req.body).length,
+      // `length`:
+      // Optional and equal to the number of bytes in `req.Body` encoded as UTF-8. Since the server can figure this out
+      // and will refuse events that report the length incorrectly, we decided not to send the length to reduce request
+      // body size and to avoid problems related to reporting the wrong size.(Would be
+      // `length: new TextEncoder().encode(req.body).length`.)
     };
 
     if (eventType === 'transaction') {
@@ -123,10 +118,8 @@ export function eventToSentryRequest(event: Event, api: API): SentryRequest {
 
     const itemHeaders = JSON.stringify(itemHeaderEntries);
 
-    // The trailing newline is optional. We intentionally don't send it to avoid
-    // sending unnecessary bytes.
-    //
-    // const envelope = `${envelopeHeaders}\n${itemHeaders}\n${req.body}\n`;
+    // The trailing newline is optional; leave it off to avoid sending unnecessary bytes. (Would be
+    // `const envelope = `${envelopeHeaders}\n${itemHeaders}\n${req.body}\n`;`.)
     const envelope = `${envelopeHeaders}\n${itemHeaders}\n${req.body}`;
     req.body = envelope;
   }

--- a/packages/core/src/sdk.ts
+++ b/packages/core/src/sdk.ts
@@ -16,6 +16,7 @@ export function initAndBind<F extends Client, O extends Options>(clientClass: Cl
   if (options.debug === true) {
     logger.enable();
   }
+  options.environment = options.environment || 'production';
   const hub = getCurrentHub();
   hub.getScope()?.update(options.initialScope);
   const client = new clientClass(options);

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -177,7 +177,6 @@ describe('BaseClient', () => {
       const client = new TestClient({ dsn: PUBLIC_DSN });
       client.captureException(new Error('test exception'));
       expect(TestBackend.instance!.event).toEqual({
-        environment: 'production',
         event_id: '42',
         exception: {
           values: [
@@ -246,7 +245,6 @@ describe('BaseClient', () => {
       const client = new TestClient({ dsn: PUBLIC_DSN });
       client.captureMessage('test message');
       expect(TestBackend.instance!.event).toEqual({
-        environment: 'production',
         event_id: '42',
         level: 'info',
         message: 'test message',
@@ -322,7 +320,6 @@ describe('BaseClient', () => {
       client.captureEvent({ message: 'message' }, undefined, scope);
       expect(TestBackend.instance!.event!.message).toBe('message');
       expect(TestBackend.instance!.event).toEqual({
-        environment: 'production',
         event_id: '42',
         message: 'message',
         timestamp: 2020,
@@ -336,7 +333,6 @@ describe('BaseClient', () => {
       client.captureEvent({ message: 'message', timestamp: 1234 }, undefined, scope);
       expect(TestBackend.instance!.event!.message).toBe('message');
       expect(TestBackend.instance!.event).toEqual({
-        environment: 'production',
         event_id: '42',
         message: 'message',
         timestamp: 1234,
@@ -349,23 +345,7 @@ describe('BaseClient', () => {
       const scope = new Scope();
       client.captureEvent({ message: 'message' }, { event_id: 'wat' }, scope);
       expect(TestBackend.instance!.event!).toEqual({
-        environment: 'production',
         event_id: 'wat',
-        message: 'message',
-        timestamp: 2020,
-      });
-    });
-
-    test('sets default environment to `production` it none provided', () => {
-      expect.assertions(1);
-      const client = new TestClient({
-        dsn: PUBLIC_DSN,
-      });
-      const scope = new Scope();
-      client.captureEvent({ message: 'message' }, undefined, scope);
-      expect(TestBackend.instance!.event!).toEqual({
-        environment: 'production',
-        event_id: '42',
         message: 'message',
         timestamp: 2020,
       });
@@ -412,7 +392,6 @@ describe('BaseClient', () => {
       const scope = new Scope();
       client.captureEvent({ message: 'message' }, undefined, scope);
       expect(TestBackend.instance!.event!).toEqual({
-        environment: 'production',
         event_id: '42',
         message: 'message',
         release: 'v1.0.0',
@@ -453,7 +432,6 @@ describe('BaseClient', () => {
       scope.setUser({ id: 'user' });
       client.captureEvent({ message: 'message' }, undefined, scope);
       expect(TestBackend.instance!.event!).toEqual({
-        environment: 'production',
         event_id: '42',
         extra: { b: 'b' },
         message: 'message',
@@ -470,7 +448,6 @@ describe('BaseClient', () => {
       scope.setFingerprint(['abcd']);
       client.captureEvent({ message: 'message' }, undefined, scope);
       expect(TestBackend.instance!.event!).toEqual({
-        environment: 'production',
         event_id: '42',
         fingerprint: ['abcd'],
         message: 'message',
@@ -525,7 +502,6 @@ describe('BaseClient', () => {
       expect(TestBackend.instance!.event!).toEqual({
         breadcrumbs: [normalizedBreadcrumb, normalizedBreadcrumb, normalizedBreadcrumb],
         contexts: normalizedObject,
-        environment: 'production',
         event_id: '42',
         extra: normalizedObject,
         timestamp: 2020,
@@ -571,7 +547,6 @@ describe('BaseClient', () => {
       expect(TestBackend.instance!.event!).toEqual({
         breadcrumbs: [normalizedBreadcrumb, normalizedBreadcrumb, normalizedBreadcrumb],
         contexts: normalizedObject,
-        environment: 'production',
         event_id: '42',
         extra: normalizedObject,
         timestamp: 2020,
@@ -622,7 +597,6 @@ describe('BaseClient', () => {
       expect(TestBackend.instance!.event!).toEqual({
         breadcrumbs: [normalizedBreadcrumb, normalizedBreadcrumb, normalizedBreadcrumb],
         contexts: normalizedObject,
-        environment: 'production',
         event_id: '42',
         extra: normalizedObject,
         timestamp: 2020,

--- a/packages/core/test/lib/request.test.ts
+++ b/packages/core/test/lib/request.test.ts
@@ -1,20 +1,27 @@
-import { DebugMeta, Event, SentryRequest, TransactionSamplingMethod } from '@sentry/types';
+import { Event, SentryRequest, Session, TransactionSamplingMethod } from '@sentry/types';
 
 import { API } from '../../src/api';
 import { eventToSentryRequest, sessionToSentryRequest } from '../../src/request';
 
-const ingestDsn = 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012';
-const ingestUrl =
-  'https://squirrelchasers.ingest.sentry.io/api/12312012/envelope/?sentry_key=dogsarebadatkeepingsecrets&sentry_version=7';
-const tunnel = 'https://hello.com/world';
+const timestamp = '2012-12-31T09:08:13.000Z';
+jest.spyOn(Date.prototype, 'toISOString').mockReturnValue(timestamp);
 
-const api = new API(ingestDsn, {
-  sdk: {
-    integrations: ['AWSLambda'],
-    name: 'sentry.javascript.browser',
-    version: `12.31.12`,
-    packages: [{ name: 'npm:@sentry/browser', version: `12.31.12` }],
-  },
+const squirrelChasersDSN = 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012';
+const storeUrl =
+  'https://squirrelchasers.ingest.sentry.io/api/12312012/store/?sentry_key=dogsarebadatkeepingsecrets&sentry_version=7';
+const envelopeUrl =
+  'https://squirrelchasers.ingest.sentry.io/api/12312012/envelope/?sentry_key=dogsarebadatkeepingsecrets&sentry_version=7';
+const tunnelUrl = 'https://sit.stay.rollover/good/dog/';
+
+const sdkInfo = {
+  integrations: ['AWSLambda'],
+  name: 'sentry.javascript.browser',
+  version: `12.31.12`,
+  packages: [{ name: 'npm:@sentry/browser', version: `12.31.12` }],
+};
+
+const api = new API(squirrelChasersDSN, {
+  sdk: sdkInfo,
 });
 
 function parseEnvelopeRequest(request: SentryRequest): any {
@@ -28,186 +35,312 @@ function parseEnvelopeRequest(request: SentryRequest): any {
 }
 
 describe('eventToSentryRequest', () => {
-  let event: Event;
+  const eventBase = {
+    contexts: { trace: { trace_id: '1231201211212012', span_id: '12261980', op: 'pageload' } },
+    environment: 'dogpark',
+    event_id: '0908201304152013',
+    release: 'off.leash.park',
+    user: { id: '1121', username: 'CharlieDog', ip_address: '11.21.20.12', segment: 'bigs' },
+  };
 
-  beforeEach(() => {
-    event = {
-      contexts: { trace: { trace_id: '1231201211212012', span_id: '12261980', op: 'pageload' } },
-      environment: 'dogpark',
-      event_id: '0908201304152013',
-      release: 'off.leash.park',
-      spans: [],
-      transaction: '/dogs/are/great/',
-      type: 'transaction',
-      user: { id: '1121', username: 'CharlieDog', ip_address: '11.21.20.12' },
-    };
+  describe('error/message events', () => {
+    let errorEvent: Event;
+
+    beforeEach(() => {
+      errorEvent = {
+        ...eventBase,
+        exception: { values: [{ type: 'PuppyProblemsError', value: 'Charlie ate the flip-flops :-(' }] },
+      };
+    });
+
+    it('adds correct type, url, and event data', () => {
+      const result = eventToSentryRequest(errorEvent, api);
+
+      expect(result.type).toEqual('event');
+      expect(result.url).toEqual(storeUrl);
+      expect(result.body).toEqual(JSON.stringify(errorEvent));
+    });
+
+    it('uses an envelope if a tunnel is configured', () => {
+      const result = eventToSentryRequest(errorEvent, new API(squirrelChasersDSN, {}, tunnelUrl));
+
+      expect(() => {
+        // this will barf if the request body isn't of the form "<bunch-of-JSON>\n<bunch-of-JSON>\n<bunch-of-JSON>"
+        parseEnvelopeRequest(result);
+      }).not.toThrowError();
+    });
   });
 
-  it('adds transaction sampling information to item header', () => {
-    event.debug_meta = { transactionSampling: { method: TransactionSamplingMethod.Rate, rate: 0.1121 } };
+  describe('transaction events', () => {
+    let transactionEvent: Event;
 
-    const result = eventToSentryRequest(event, api);
-    const envelope = parseEnvelopeRequest(result);
-
-    expect(envelope.itemHeader).toEqual(
-      expect.objectContaining({
-        sample_rates: [{ id: TransactionSamplingMethod.Rate, rate: 0.1121 }],
-      }),
-    );
-  });
-
-  it('removes transaction sampling information (and only that) from debug_meta', () => {
-    event.debug_meta = {
-      transactionSampling: { method: TransactionSamplingMethod.Sampler, rate: 0.1121 },
-      dog: 'Charlie',
-    } as DebugMeta;
-
-    const result = eventToSentryRequest(event, api);
-    const envelope = parseEnvelopeRequest(result);
-
-    expect('transactionSampling' in envelope.event.debug_meta).toBe(false);
-    expect('dog' in envelope.event.debug_meta).toBe(true);
-  });
-
-  it('removes debug_meta entirely if it ends up empty', () => {
-    event.debug_meta = {
-      transactionSampling: { method: TransactionSamplingMethod.Rate, rate: 0.1121 },
-    } as DebugMeta;
-
-    const result = eventToSentryRequest(event, api);
-    const envelope = parseEnvelopeRequest(result);
-
-    expect('debug_meta' in envelope.event).toBe(false);
-  });
-
-  it('adds sdk info to envelope header', () => {
-    const result = eventToSentryRequest(event, api);
-    const envelope = parseEnvelopeRequest(result);
-
-    expect(envelope.envelopeHeader).toEqual(
-      expect.objectContaining({ sdk: { name: 'sentry.javascript.browser', version: '12.31.12' } }),
-    );
-  });
-
-  it('adds sdk info to event body', () => {
-    const result = eventToSentryRequest(event, api);
-    const envelope = parseEnvelopeRequest(result);
-
-    expect(envelope.event).toEqual(
-      expect.objectContaining({
-        sdk: {
-          integrations: ['AWSLambda'],
-          name: 'sentry.javascript.browser',
-          version: `12.31.12`,
-          packages: [{ name: 'npm:@sentry/browser', version: `12.31.12` }],
+    beforeEach(() => {
+      transactionEvent = {
+        ...eventBase,
+        debug_meta: {
+          transactionSampling: { method: TransactionSamplingMethod.Rate, rate: 0.1121 },
+          // This value is hardcoded in its base64 form to avoid a dependency on @sentry/tracing, where the method to
+          // compute the value lives. It's equivalent to
+          // computeTracestateValue({
+          //   trace_id: '1231201211212012',
+          //   environment: 'dogpark',
+          //   public_key: 'dogsarebadatkeepingsecrets',
+          //   release: 'off.leash.park',
+          //   user: { id: '1121', segment: 'bigs' },
+          // }),
+          tracestate: {
+            sentry:
+              'sentry=eyJ0cmFjZV9pZCI6IjEyMzEyMDEyMTEyMTIwMTIiLCJlbnZpcm9ubWVudCI6ImRvZ3BhcmsiLCJwdWJsaWNfa2V5Ijo' +
+              'iZG9nc2FyZWJhZGF0a2VlcGluZ3NlY3JldHMiLCJyZWxlYXNlIjoib2ZmLmxlYXNoLnBhcmsiLCJ1c2VyIjp7ImlkIjoiMTEyM' +
+              'SIsInNlZ21lbnQiOiJiaWdzIn19',
+          },
         },
-      }),
-    );
+        spans: [],
+        transaction: '/dogs/are/great/',
+        type: 'transaction',
+      };
+    });
+
+    it('adds correct type, url, and event data', () => {
+      const result = eventToSentryRequest(transactionEvent, api);
+      const envelope = parseEnvelopeRequest(result);
+
+      expect(result.type).toEqual('transaction');
+      expect(result.url).toEqual(envelopeUrl);
+      expect(envelope.event).toEqual(transactionEvent);
+    });
+
+    describe('envelope header', () => {
+      it('adds correct entries to envelope header', () => {
+        const result = eventToSentryRequest(transactionEvent, api);
+        const envelope = parseEnvelopeRequest(result);
+
+        expect(envelope.envelopeHeader).toEqual({
+          event_id: eventBase.event_id,
+          sent_at: timestamp,
+          sdk: { name: 'sentry.javascript.browser', version: '12.31.12' },
+          // the value for `trace` is tested separately
+          trace: expect.any(Object),
+        });
+      });
+
+      it('adds tracestate data to envelope header', () => {
+        const result = eventToSentryRequest(transactionEvent, api);
+        const envelope = parseEnvelopeRequest(result);
+
+        expect(envelope.envelopeHeader.trace).toBeDefined();
+        expect(envelope.envelopeHeader.trace).toEqual({
+          trace_id: '1231201211212012',
+          environment: 'dogpark',
+          public_key: 'dogsarebadatkeepingsecrets',
+          release: 'off.leash.park',
+          user: { id: '1121', segment: 'bigs' },
+        });
+      });
+    });
+
+    describe('item header', () => {
+      it('adds correct entries to item header', () => {
+        const result = eventToSentryRequest(transactionEvent, api);
+        const envelope = parseEnvelopeRequest(result);
+
+        expect(envelope.itemHeader).toEqual({
+          type: 'transaction',
+          // the value for `sample_rates` is tested separately
+          sample_rates: expect.any(Object),
+        });
+      });
+
+      it('adds transaction sampling information to item header', () => {
+        const result = eventToSentryRequest(transactionEvent, api);
+        const envelope = parseEnvelopeRequest(result);
+
+        expect(envelope.itemHeader).toEqual(
+          expect.objectContaining({
+            sample_rates: [{ id: TransactionSamplingMethod.Rate, rate: 0.1121 }],
+          }),
+        );
+      });
+    });
+
+    describe('debug_meta', () => {
+      it('removes transaction sampling and tracestate information from debug_meta', () => {
+        (transactionEvent.debug_meta as any).dog = 'Charlie';
+
+        const result = eventToSentryRequest(transactionEvent, api);
+        const envelope = parseEnvelopeRequest(result);
+
+        expect('transactionSampling' in envelope.event.debug_meta).toBe(false);
+        expect('tracestate' in envelope.event.debug_meta).toBe(false);
+        expect('dog' in envelope.event.debug_meta).toBe(true);
+      });
+
+      it('removes debug_meta entirely if it ends up empty', () => {
+        const result = eventToSentryRequest(transactionEvent, api);
+        const envelope = parseEnvelopeRequest(result);
+
+        expect('debug_meta' in envelope.event).toBe(false);
+      });
+    });
   });
 
-  it('merges existing sdk info if one is present on the event body', () => {
-    event.sdk = {
-      integrations: ['Clojure'],
-      name: 'foo',
-      packages: [{ name: 'npm:@sentry/clj', version: `12.31.12` }],
-      version: '1337',
-    };
+  describe('SDK metadata', () => {
+    it('adds sdk info to event body', () => {
+      const event = { ...eventBase };
+      const result = eventToSentryRequest(event, api);
 
-    const result = eventToSentryRequest(event, api);
-    const envelope = parseEnvelopeRequest(result);
+      expect(JSON.parse(result.body).sdk).toEqual(sdkInfo);
+    });
 
-    expect(envelope.event).toEqual(
-      expect.objectContaining({
+    it('merges sdk info if sdk data already exists on the event body', () => {
+      const event = {
+        ...eventBase,
         sdk: {
-          integrations: ['Clojure', 'AWSLambda'],
-          name: 'foo',
-          packages: [
-            { name: 'npm:@sentry/clj', version: `12.31.12` },
-            { name: 'npm:@sentry/browser', version: `12.31.12` },
-          ],
-          version: '1337',
+          integrations: ['Ball Fetching'],
+          name: 'sentry.dog.tricks',
+          packages: [{ name: 'npm:@sentry/dogtricks', version: `11.21.12` }],
+          version: '11.21.12',
         },
-      }),
-    );
+      };
+
+      const result = eventToSentryRequest(event, api);
+
+      expect(JSON.parse(result.body).sdk).toEqual({
+        integrations: ['Ball Fetching', 'AWSLambda'],
+        name: 'sentry.dog.tricks',
+        packages: [
+          { name: 'npm:@sentry/dogtricks', version: `11.21.12` },
+          { name: 'npm:@sentry/browser', version: `12.31.12` },
+        ],
+        version: '11.21.12',
+      });
+    });
   });
 
-  it('uses tunnel as the url if it is configured', () => {
-    const tunnelRequest = eventToSentryRequest(event, new API(ingestDsn, {}, tunnel));
-    expect(tunnelRequest.url).toEqual(tunnel);
+  describe('using a tunnel', () => {
+    let event: Event;
 
-    const defaultRequest = eventToSentryRequest(event, new API(ingestDsn, {}));
-    expect(defaultRequest.url).toEqual(ingestUrl);
-  });
+    beforeEach(() => {
+      event = { ...eventBase };
+    });
 
-  it('adds dsn to envelope header if tunnel is configured', () => {
-    const result = eventToSentryRequest(event, new API(ingestDsn, {}, tunnel));
-    const envelope = parseEnvelopeRequest(result);
+    it('uses the tunnel URL', () => {
+      const tunnelRequest = eventToSentryRequest(event, new API(squirrelChasersDSN, {}, tunnelUrl));
+      expect(tunnelRequest.url).toEqual(tunnelUrl);
+    });
 
-    expect(envelope.envelopeHeader).toEqual(
-      expect.objectContaining({
-        dsn: ingestDsn,
-      }),
-    );
-  });
+    it('adds dsn to envelope header', () => {
+      const result = eventToSentryRequest(event, new API(squirrelChasersDSN, {}, tunnelUrl));
+      const envelope = parseEnvelopeRequest(result);
 
-  it('adds default "event" item type to item header if tunnel is configured', () => {
-    delete event.type;
+      expect(envelope.envelopeHeader).toEqual(
+        expect.objectContaining({
+          dsn: squirrelChasersDSN,
+        }),
+      );
+    });
 
-    const result = eventToSentryRequest(event, new API(ingestDsn, {}, tunnel));
-    const envelope = parseEnvelopeRequest(result);
+    it('defaults `type` to "event" in item header if `type` missing from event', () => {
+      const result = eventToSentryRequest(event, new API(squirrelChasersDSN, {}, tunnelUrl));
+      const envelope = parseEnvelopeRequest(result);
 
-    expect(envelope.itemHeader).toEqual(
-      expect.objectContaining({
-        type: 'event',
-      }),
-    );
+      expect(envelope.itemHeader).toEqual(
+        expect.objectContaining({
+          type: 'event',
+        }),
+      );
+    });
+
+    it('uses `type` value from event in item header if present', () => {
+      // this is obviously not a valid event type, but the only valid one is "transaction", and that requires a whole
+      // bunch of metadata which is beside the point here
+      (event as any).type = 'dogEvent';
+
+      const result = eventToSentryRequest(event, new API(squirrelChasersDSN, {}, tunnelUrl));
+      const envelope = parseEnvelopeRequest(result);
+
+      expect(envelope.itemHeader).toEqual(
+        expect.objectContaining({
+          type: 'dogEvent',
+        }),
+      );
+    });
   });
 });
 
 describe('sessionToSentryRequest', () => {
-  it('test envelope creation for aggregateSessions', () => {
-    const aggregatedSession = {
-      attrs: { release: '1.0.x', environment: 'prod' },
-      aggregates: [{ started: '2021-04-08T12:18:00.000Z', exited: 2 }],
-    };
-    const result = sessionToSentryRequest(aggregatedSession, api);
+  //   { "sent_at": "2021-08-19T20:47:04.474Z", "sdk": { "name": "sentry.javascript.browser", "version": "6.11.0" } }
+  // {"type":"session"}
+  const sessionEvent = ({
+    sid: '0908201304152013',
+    init: true,
+    started: timestamp,
+    timestamp,
+    status: 'ok',
+    errors: 0,
+    attrs: {
+      release: 'off.leash.park',
+      environment: 'dogpark',
+    },
+  } as unknown) as Session;
 
-    const [envelopeHeaderString, itemHeaderString, sessionString] = result.body.split('\n');
+  const sessionAggregatesEvent = {
+    attrs: { release: 'off.leash.park', environment: 'dogpark' },
+    aggregates: [{ started: timestamp, exited: 2 }],
+  };
 
-    expect(JSON.parse(envelopeHeaderString)).toEqual(
-      expect.objectContaining({
-        sdk: { name: 'sentry.javascript.browser', version: '12.31.12' },
-      }),
-    );
-    expect(JSON.parse(itemHeaderString)).toEqual(
-      expect.objectContaining({
-        type: 'sessions',
-      }),
-    );
-    expect(JSON.parse(sessionString)).toEqual(
-      expect.objectContaining({
-        attrs: { release: '1.0.x', environment: 'prod' },
-        aggregates: [{ started: '2021-04-08T12:18:00.000Z', exited: 2 }],
-      }),
-    );
-  });
-
-  it('uses tunnel as the url if it is configured', () => {
-    const tunnelRequest = sessionToSentryRequest({ aggregates: [] }, new API(ingestDsn, {}, tunnel));
-    expect(tunnelRequest.url).toEqual(tunnel);
-
-    const defaultRequest = sessionToSentryRequest({ aggregates: [] }, new API(ingestDsn, {}));
-    expect(defaultRequest.url).toEqual(ingestUrl);
-  });
-
-  it('adds dsn to envelope header if tunnel is configured', () => {
-    const result = sessionToSentryRequest({ aggregates: [] }, new API(ingestDsn, {}, tunnel));
+  it('adds correct type, url, and event data to session events', () => {
+    const result = sessionToSentryRequest(sessionEvent, api);
     const envelope = parseEnvelopeRequest(result);
 
-    expect(envelope.envelopeHeader).toEqual(
-      expect.objectContaining({
-        dsn: ingestDsn,
-      }),
-    );
+    expect(result.type).toEqual('session');
+    expect(result.url).toEqual(envelopeUrl);
+    expect(envelope.event).toEqual(sessionEvent);
+  });
+
+  it('adds correct type, url, and event data to session aggregates events', () => {
+    const result = sessionToSentryRequest(sessionAggregatesEvent, api);
+    const envelope = parseEnvelopeRequest(result);
+
+    expect(result.type).toEqual('sessions');
+    expect(result.url).toEqual(envelopeUrl);
+    expect(envelope.event).toEqual(sessionAggregatesEvent);
+  });
+
+  it('adds correct entries to envelope header', () => {
+    const result = sessionToSentryRequest(sessionEvent, api);
+    const envelope = parseEnvelopeRequest(result);
+
+    expect(envelope.envelopeHeader).toEqual({
+      sent_at: timestamp,
+      sdk: { name: 'sentry.javascript.browser', version: '12.31.12' },
+    });
+  });
+
+  it('adds correct entries to item header', () => {
+    const result = sessionToSentryRequest(sessionEvent, api);
+    const envelope = parseEnvelopeRequest(result);
+
+    expect(envelope.itemHeader).toEqual({
+      type: 'session',
+    });
+  });
+
+  describe('using a tunnel', () => {
+    it('uses the tunnel URL', () => {
+      const tunnelRequest = sessionToSentryRequest(sessionEvent, new API(squirrelChasersDSN, {}, tunnelUrl));
+      expect(tunnelRequest.url).toEqual(tunnelUrl);
+    });
+
+    it('adds dsn to envelope header', () => {
+      const result = sessionToSentryRequest(sessionEvent, new API(squirrelChasersDSN, {}, tunnelUrl));
+      const envelope = parseEnvelopeRequest(result);
+
+      expect(envelope.envelopeHeader).toEqual(
+        expect.objectContaining({
+          dsn: squirrelChasersDSN,
+        }),
+      );
+    });
   });
 });

--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -28,14 +28,14 @@ export function initialize(appInstance: ApplicationInstance): void {
   }
 }
 
-function getBackburner() {
+function getBackburner(): typeof _backburner {
   if (run.backburner) {
     return run.backburner;
   }
   return _backburner;
 }
 
-function getTransitionInformation(transition: any, router: any) {
+function getTransitionInformation(transition: any, router: any): { [key: string]: any } {
   const fromRoute = transition?.from?.name;
   const toRoute = transition && transition.to ? transition.to.name : router.currentRouteName;
   return {

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -76,7 +76,7 @@
       "ts",
       "tsx"
     ],
-    "testEnvironment": "jsdom",
+    "testEnvironment": "../../.jest/dom-environment",
     "testMatch": [
       "**/*.test.ts",
       "**/*.test.tsx"

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -390,13 +390,6 @@ export class Hub implements HubInterface {
   /**
    * @inheritDoc
    */
-  public traceHeaders(): { [key: string]: string } {
-    return this._callExtensionMethod<{ [key: string]: string }>('traceHeaders');
-  }
-
-  /**
-   * @inheritDoc
-   */
   public captureSession(endSession: boolean = false): void {
     // both send the update and pull the session from the scope
     if (endSession) {

--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -1,5 +1,5 @@
 import { captureException, deepReadDirSync, getCurrentHub, Handlers, startTransaction } from '@sentry/node';
-import { extractTraceparentData, getActiveTransaction, hasTracingEnabled } from '@sentry/tracing';
+import { extractSentrytraceData, getActiveTransaction, hasTracingEnabled } from '@sentry/tracing';
 import { fill, isString, logger, stripUrlQueryAndFragment } from '@sentry/utils';
 import * as domain from 'domain';
 import * as http from 'http';
@@ -201,7 +201,7 @@ function makeWrappedReqHandler(origReqHandler: ReqHandler): WrappedReqHandler {
           // If there is a trace header set, extract the data from it (parentSpanId, traceId, and sampling decision)
           let traceparentData;
           if (req.headers && isString(req.headers['sentry-trace'])) {
-            traceparentData = extractTraceparentData(req.headers['sentry-trace'] as string);
+            traceparentData = extractSentrytraceData(req.headers['sentry-trace'] as string);
             logger.log(`[Tracing] Continuing trace ${traceparentData?.traceId}.`);
           }
 

--- a/packages/nextjs/src/utils/withSentry.ts
+++ b/packages/nextjs/src/utils/withSentry.ts
@@ -1,5 +1,5 @@
 import { captureException, flush, getCurrentHub, Handlers, startTransaction } from '@sentry/node';
-import { extractTraceparentData, hasTracingEnabled } from '@sentry/tracing';
+import { extractSentrytraceData, hasTracingEnabled } from '@sentry/tracing';
 import { Transaction } from '@sentry/types';
 import { addExceptionMechanism, isString, logger, stripUrlQueryAndFragment } from '@sentry/utils';
 import * as domain from 'domain';
@@ -39,7 +39,7 @@ export const withSentry = (handler: NextApiHandler): WrappedNextApiHandler => {
           // If there is a trace header set, extract the data from it (parentSpanId, traceId, and sampling decision)
           let traceparentData;
           if (req.headers && isString(req.headers['sentry-trace'])) {
-            traceparentData = extractTraceparentData(req.headers['sentry-trace'] as string);
+            traceparentData = extractSentrytraceData(req.headers['sentry-trace'] as string);
             logger.log(`[Tracing] Continuing trace ${traceparentData?.traceId}.`);
           }
 

--- a/packages/nextjs/src/utils/withSentry.ts
+++ b/packages/nextjs/src/utils/withSentry.ts
@@ -1,7 +1,7 @@
 import { captureException, flush, getCurrentHub, Handlers, startTransaction } from '@sentry/node';
-import { extractSentrytraceData, hasTracingEnabled } from '@sentry/tracing';
+import { extractSentrytraceData, extractTracestateData, hasTracingEnabled } from '@sentry/tracing';
 import { Transaction } from '@sentry/types';
-import { addExceptionMechanism, isString, logger, stripUrlQueryAndFragment } from '@sentry/utils';
+import { addExceptionMechanism, logger, stripUrlQueryAndFragment } from '@sentry/utils';
 import * as domain from 'domain';
 import { NextApiHandler, NextApiResponse } from 'next';
 
@@ -36,11 +36,14 @@ export const withSentry = (handler: NextApiHandler): WrappedNextApiHandler => {
         currentScope.addEventProcessor(event => parseRequest(event, req));
 
         if (hasTracingEnabled()) {
-          // If there is a trace header set, extract the data from it (parentSpanId, traceId, and sampling decision)
-          let traceparentData;
-          if (req.headers && isString(req.headers['sentry-trace'])) {
-            traceparentData = extractSentrytraceData(req.headers['sentry-trace'] as string);
-            logger.log(`[Tracing] Continuing trace ${traceparentData?.traceId}.`);
+          // Extract data from trace headers
+          let sentrytraceData, tracestateData;
+          if (req.headers?.['sentry-trace']) {
+            sentrytraceData = extractSentrytraceData(req.headers['sentry-trace'] as string);
+            logger.log(`[Tracing] Continuing trace ${sentrytraceData?.traceId}.`);
+          }
+          if (req.headers?.tracestate) {
+            tracestateData = extractTracestateData(req.headers.tracestate as string);
           }
 
           const url = `${req.url}`;
@@ -60,7 +63,8 @@ export const withSentry = (handler: NextApiHandler): WrappedNextApiHandler => {
             {
               name: `${reqMethod}${reqPath}`,
               op: 'http.server',
-              ...traceparentData,
+              ...sentrytraceData,
+              ...(tracestateData && { metadata: { tracestate: tracestateData } }),
             },
             // extra context passed to the `tracesSampler`
             { request: req },

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -54,16 +54,16 @@ export function tracingHandler(): (
     next: (error?: any) => void,
   ): void {
     // If there is a trace header set, we extract the data from it (parentSpanId, traceId, and sampling decision)
-    let traceparentData;
+    let sentrytraceData;
     if (req.headers && isString(req.headers['sentry-trace'])) {
-      traceparentData = extractSentrytraceData(req.headers['sentry-trace'] as string);
+      sentrytraceData = extractSentrytraceData(req.headers['sentry-trace'] as string);
     }
 
     const transaction = startTransaction(
       {
         name: extractExpressTransactionName(req, { path: true, method: true }),
         op: 'http.server',
-        ...traceparentData,
+        ...sentrytraceData,
       },
       // extra context passed to the tracesSampler
       { request: extractRequestData(req) },

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { captureException, getCurrentHub, startTransaction, withScope } from '@sentry/core';
-import { extractTraceparentData, Span } from '@sentry/tracing';
+import { extractSentrytraceData, Span } from '@sentry/tracing';
 import { Event, ExtractedNodeRequestData, RequestSessionStatus, Transaction } from '@sentry/types';
 import { isPlainObject, isString, logger, normalize, stripUrlQueryAndFragment } from '@sentry/utils';
 import * as cookie from 'cookie';
@@ -56,7 +56,7 @@ export function tracingHandler(): (
     // If there is a trace header set, we extract the data from it (parentSpanId, traceId, and sampling decision)
     let traceparentData;
     if (req.headers && isString(req.headers['sentry-trace'])) {
-      traceparentData = extractTraceparentData(req.headers['sentry-trace'] as string);
+      traceparentData = extractSentrytraceData(req.headers['sentry-trace'] as string);
     }
 
     const transaction = startTransaction(

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -1,5 +1,5 @@
 import { getCurrentHub } from '@sentry/core';
-import { Integration, Span } from '@sentry/types';
+import { Integration, Span, TraceHeaders } from '@sentry/types';
 import { fill, logger, parseSemver } from '@sentry/utils';
 import * as http from 'http';
 import * as https from 'https';
@@ -115,11 +115,9 @@ function _createWrappedRequestMethodFactory(
             op: 'request',
           });
 
-          const sentryTraceHeader = span.toTraceparent();
-          logger.log(
-            `[Tracing] Adding sentry-trace header ${sentryTraceHeader} to outgoing request to ${requestUrl}: `,
-          );
-          requestOptions.headers = { ...requestOptions.headers, 'sentry-trace': sentryTraceHeader };
+          const traceHeaders = span.getTraceHeaders();
+          logger.log(`[Tracing] Adding sentry-trace and tracestate headers to outgoing request to ${requestUrl}.`);
+          requestOptions.headers = { ...requestOptions.headers, ...(traceHeaders as TraceHeaders) };
         }
       }
 

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -325,8 +325,11 @@ describe('tracingHandler', () => {
     expect(startTransaction).toHaveBeenCalled();
   });
 
-  it("pulls parent's data from tracing header on the request", () => {
-    req.headers = { 'sentry-trace': '12312012123120121231201212312012-1121201211212012-0' };
+  it('pulls data from tracing headers on the request', () => {
+    req.headers = {
+      'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
+      tracestate: 'sentry=doGsaREgReaT',
+    };
 
     sentryTracingMiddleware(req, res, next);
 
@@ -336,6 +339,7 @@ describe('tracingHandler', () => {
     expect(transaction.traceId).toEqual('12312012123120121231201212312012');
     expect(transaction.parentSpanId).toEqual('1121201211212012');
     expect(transaction.sampled).toEqual(false);
+    expect(transaction.metadata?.tracestate).toEqual({ sentry: 'sentry=doGsaREgReaT' });
   });
 
   it('extracts request data for sampling context', () => {

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -1,7 +1,7 @@
 import * as sentryCore from '@sentry/core';
 import { Hub } from '@sentry/hub';
 import * as hubModule from '@sentry/hub';
-import { addExtensionMethods, Span, TRACEPARENT_REGEXP, Transaction } from '@sentry/tracing';
+import { addExtensionMethods, SENTRY_TRACE_REGEX, Span, Transaction } from '@sentry/tracing';
 import * as http from 'http';
 import * as nock from 'nock';
 
@@ -75,7 +75,7 @@ describe('tracing', () => {
     const sentryTraceHeader = request.getHeader('sentry-trace') as string;
 
     expect(sentryTraceHeader).toBeDefined();
-    expect(TRACEPARENT_REGEXP.test(sentryTraceHeader)).toBe(true);
+    expect(SENTRY_TRACE_REGEX.test(sentryTraceHeader)).toBe(true);
   });
 
   it("doesn't attach the sentry-trace header to outgoing sentry requests", () => {

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -9,7 +9,7 @@ import { NodeClient } from '../../src/client';
 import { Http as HttpIntegration } from '../../src/integrations/http';
 
 describe('tracing', () => {
-  function createTransactionOnScope() {
+  function createTransactionOnScope(): Transaction {
     const hub = new Hub(
       new NodeClient({
         dsn: 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012',
@@ -24,7 +24,10 @@ describe('tracing', () => {
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
     jest.spyOn(hubModule, 'getCurrentHub').mockReturnValue(hub);
 
-    const transaction = hub.startTransaction({ name: 'dogpark' });
+    // we have to cast this to a Transaction (the class) because hub.startTransaction only returns a Transaction (the
+    // interface, which doesn't have things like spanRecorder) (and because @sentry/hub can't depend on @sentry/tracing,
+    // we can't fix that)
+    const transaction = hub.startTransaction({ name: 'dogpark' }) as Transaction;
     hub.getScope()?.setSpan(transaction);
 
     return transaction;
@@ -36,7 +39,7 @@ describe('tracing', () => {
       .reply(200);
 
     const transaction = createTransactionOnScope();
-    const spans = (transaction as Span).spanRecorder?.spans as Span[];
+    const spans = transaction.spanRecorder?.spans as Span[];
 
     http.get('http://dogs.are.great/');
 
@@ -55,7 +58,7 @@ describe('tracing', () => {
       .reply(200);
 
     const transaction = createTransactionOnScope();
-    const spans = (transaction as Span).spanRecorder?.spans as Span[];
+    const spans = transaction.spanRecorder?.spans as Span[];
 
     http.get('http://squirrelchasers.ingest.sentry.io/api/12312012/store/');
 
@@ -64,7 +67,7 @@ describe('tracing', () => {
     expect((spans[0] as Transaction).name).toEqual('dogpark');
   });
 
-  it('attaches the sentry-trace header to outgoing non-sentry requests', async () => {
+  it('attaches tracing headers to outgoing non-sentry requests', async () => {
     nock('http://dogs.are.great')
       .get('/')
       .reply(200);
@@ -72,13 +75,15 @@ describe('tracing', () => {
     createTransactionOnScope();
 
     const request = http.get('http://dogs.are.great/');
-    const sentryTraceHeader = request.getHeader('sentry-trace') as string;
+    const sentryTraceHeader = request.getHeader('sentry-trace');
+    const tracestateHeader = request.getHeader('tracestate');
 
     expect(sentryTraceHeader).toBeDefined();
-    expect(SENTRY_TRACE_REGEX.test(sentryTraceHeader)).toBe(true);
+    expect(tracestateHeader).toBeDefined();
+    expect(SENTRY_TRACE_REGEX.test(sentryTraceHeader as string)).toBe(true);
   });
 
-  it("doesn't attach the sentry-trace header to outgoing sentry requests", () => {
+  it("doesn't attach tracing headers to outgoing sentry requests", () => {
     nock('http://squirrelchasers.ingest.sentry.io')
       .get('/api/12312012/store/')
       .reply(200);
@@ -87,7 +92,9 @@ describe('tracing', () => {
 
     const request = http.get('http://squirrelchasers.ingest.sentry.io/api/12312012/store/');
     const sentryTraceHeader = request.getHeader('sentry-trace');
+    const tracestateHeader = request.getHeader('tracestate');
 
     expect(sentryTraceHeader).not.toBeDefined();
+    expect(tracestateHeader).not.toBeDefined();
   });
 });

--- a/packages/node/test/manual/release-health/session-aggregates/aggregates-disable-single-session.js
+++ b/packages/node/test/manual/release-health/session-aggregates/aggregates-disable-single-session.js
@@ -30,7 +30,7 @@ function assertSessionAggregates(session, expected) {
 class DummyTransport extends BaseDummyTransport {
   sendSession(session) {
     assertSessionAggregates(session, {
-      attrs: { release: '1.1' },
+      attrs: { release: '1.1', environment: 'production' },
       aggregates: [{ crashed: 2, errored: 1, exited: 1 }],
     });
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -89,7 +89,7 @@
       "ts",
       "tsx"
     ],
-    "testEnvironment": "jsdom",
+    "testEnvironment": "../../.jest/dom-environment",
     "testMatch": [
       "**/*.test.ts",
       "**/*.test.tsx"

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -253,15 +253,15 @@ export function wrapHandler<TEvent, TResult>(
     }
 
     // Applying `sentry-trace` to context
-    let traceparentData;
+    let sentrytraceData;
     const eventWithHeaders = event as { headers?: { [key: string]: string } };
     if (eventWithHeaders.headers && isString(eventWithHeaders.headers['sentry-trace'])) {
-      traceparentData = extractSentrytraceData(eventWithHeaders.headers['sentry-trace'] as string);
+      sentrytraceData = extractSentrytraceData(eventWithHeaders.headers['sentry-trace'] as string);
     }
     const transaction = startTransaction({
       name: context.functionName,
       op: 'awslambda.handler',
-      ...traceparentData,
+      ...sentrytraceData,
     });
 
     const hub = getCurrentHub();

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -9,7 +9,7 @@ import {
   withScope,
 } from '@sentry/node';
 import * as Sentry from '@sentry/node';
-import { extractTraceparentData } from '@sentry/tracing';
+import { extractSentrytraceData } from '@sentry/tracing';
 import { Integration } from '@sentry/types';
 import { isString, logger } from '@sentry/utils';
 // NOTE: I have no idea how to fix this right now, and don't want to waste more time, as it builds just fine — Kamil
@@ -256,7 +256,7 @@ export function wrapHandler<TEvent, TResult>(
     let traceparentData;
     const eventWithHeaders = event as { headers?: { [key: string]: string } };
     if (eventWithHeaders.headers && isString(eventWithHeaders.headers['sentry-trace'])) {
-      traceparentData = extractTraceparentData(eventWithHeaders.headers['sentry-trace'] as string);
+      traceparentData = extractSentrytraceData(eventWithHeaders.headers['sentry-trace'] as string);
     }
     const transaction = startTransaction({
       name: context.functionName,

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -50,15 +50,15 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
     const reqUrl = stripUrlQueryAndFragment(req.originalUrl || req.url || '');
 
     // Applying `sentry-trace` to context
-    let traceparentData;
+    let sentrytraceData;
     const reqWithHeaders = req as { headers?: { [key: string]: string } };
     if (reqWithHeaders.headers && isString(reqWithHeaders.headers['sentry-trace'])) {
-      traceparentData = extractSentrytraceData(reqWithHeaders.headers['sentry-trace'] as string);
+      sentrytraceData = extractSentrytraceData(reqWithHeaders.headers['sentry-trace'] as string);
     }
     const transaction = startTransaction({
       name: `${reqMethod} ${reqUrl}`,
       op: 'gcp.function.http',
-      ...traceparentData,
+      ...sentrytraceData,
     });
 
     // getCurrentHub() is expected to use current active domain as a carrier

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -1,5 +1,5 @@
 import { captureException, flush, getCurrentHub, Handlers, startTransaction } from '@sentry/node';
-import { extractTraceparentData } from '@sentry/tracing';
+import { extractSentrytraceData } from '@sentry/tracing';
 import { isString, logger, stripUrlQueryAndFragment } from '@sentry/utils';
 
 import { domainify, getActiveDomain, proxyFunction } from './../utils';
@@ -53,7 +53,7 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
     let traceparentData;
     const reqWithHeaders = req as { headers?: { [key: string]: string } };
     if (reqWithHeaders.headers && isString(reqWithHeaders.headers['sentry-trace'])) {
-      traceparentData = extractTraceparentData(reqWithHeaders.headers['sentry-trace'] as string);
+      traceparentData = extractSentrytraceData(reqWithHeaders.headers['sentry-trace'] as string);
     }
     const transaction = startTransaction({
       name: `${reqMethod} ${reqUrl}`,

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -1,6 +1,6 @@
 import { captureException, flush, getCurrentHub, Handlers, startTransaction } from '@sentry/node';
-import { extractSentrytraceData } from '@sentry/tracing';
-import { isString, logger, stripUrlQueryAndFragment } from '@sentry/utils';
+import { extractSentrytraceData, extractTracestateData } from '@sentry/tracing';
+import { logger, stripUrlQueryAndFragment } from '@sentry/utils';
 
 import { domainify, getActiveDomain, proxyFunction } from './../utils';
 import { HttpFunction, WrapperOptions } from './general';
@@ -49,16 +49,22 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
     const reqMethod = (req.method || '').toUpperCase();
     const reqUrl = stripUrlQueryAndFragment(req.originalUrl || req.url || '');
 
-    // Applying `sentry-trace` to context
-    let sentrytraceData;
+    // Extract tracing data from headers
+    let sentrytraceData, tracestateData;
     const reqWithHeaders = req as { headers?: { [key: string]: string } };
-    if (reqWithHeaders.headers && isString(reqWithHeaders.headers['sentry-trace'])) {
+
+    if (reqWithHeaders.headers?.['sentry-trace']) {
       sentrytraceData = extractSentrytraceData(reqWithHeaders.headers['sentry-trace'] as string);
     }
+    if (reqWithHeaders.headers?.tracestate) {
+      tracestateData = extractTracestateData(reqWithHeaders.headers.tracestate as string);
+    }
+
     const transaction = startTransaction({
       name: `${reqMethod} ${reqUrl}`,
       op: 'gcp.function.http',
       ...sentrytraceData,
+      ...(tracestateData && { metadata: { tracestate: tracestateData } }),
     });
 
     // getCurrentHub() is expected to use current active domain as a carrier

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -221,6 +221,35 @@ describe('AWSLambda', () => {
       await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
     });
 
+    test('incoming trace headers are correctly parsed and used', async () => {
+      expect.assertions(1);
+
+      fakeEvent.headers = {
+        'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
+        tracestate: 'sentry=doGsaREgReaT,maisey=silly,charlie=goofy',
+      };
+
+      const handler: Handler = (_event, _context, callback) => {
+        expect(Sentry.startTransaction).toBeCalledWith(
+          expect.objectContaining({
+            traceId: '12312012123120121231201212312012',
+            parentSpanId: '1121201211212012',
+            parentSampled: false,
+            metadata: {
+              tracestate: {
+                sentry: 'sentry=doGsaREgReaT',
+                thirdparty: 'maisey=silly,charlie=goofy',
+              },
+            },
+          }),
+        );
+
+        callback(undefined, { its: 'fine' });
+      };
+      const wrappedHandler = wrapHandler(handler);
+      await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
+    });
+
     test('capture error', async () => {
       expect.assertions(10);
 
@@ -278,6 +307,35 @@ describe('AWSLambda', () => {
       await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
     });
 
+    test('incoming trace headers are correctly parsed and used', async () => {
+      expect.assertions(1);
+
+      fakeEvent.headers = {
+        'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
+        tracestate: 'sentry=doGsaREgReaT,maisey=silly,charlie=goofy',
+      };
+
+      const handler: Handler = async (_event, _context, callback) => {
+        expect(Sentry.startTransaction).toBeCalledWith(
+          expect.objectContaining({
+            traceId: '12312012123120121231201212312012',
+            parentSpanId: '1121201211212012',
+            parentSampled: false,
+            metadata: {
+              tracestate: {
+                sentry: 'sentry=doGsaREgReaT',
+                thirdparty: 'maisey=silly,charlie=goofy',
+              },
+            },
+          }),
+        );
+
+        callback(undefined, { its: 'fine' });
+      };
+      const wrappedHandler = wrapHandler(handler);
+      await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
+    });
+
     test('capture error', async () => {
       expect.assertions(10);
 
@@ -323,6 +381,35 @@ describe('AWSLambda', () => {
       const handler: Handler = async (event, context, _callback) => {
         expect(event).toHaveProperty('fortySix');
         expect(context).toHaveProperty('ytho');
+      };
+      const wrappedHandler = wrapHandler(handler);
+      await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
+    });
+
+    test('incoming trace headers are correctly parsed and used', async () => {
+      expect.assertions(1);
+
+      fakeEvent.headers = {
+        'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
+        tracestate: 'sentry=doGsaREgReaT,maisey=silly,charlie=goofy',
+      };
+
+      const handler: Handler = async (_event, _context, callback) => {
+        expect(Sentry.startTransaction).toBeCalledWith(
+          expect.objectContaining({
+            traceId: '12312012123120121231201212312012',
+            parentSpanId: '1121201211212012',
+            parentSampled: false,
+            metadata: {
+              tracestate: {
+                sentry: 'sentry=doGsaREgReaT',
+                thirdparty: 'maisey=silly,charlie=goofy',
+              },
+            },
+          }),
+        );
+
+        callback(undefined, { its: 'fine' });
       };
       const wrappedHandler = wrapHandler(handler);
       await wrappedHandler(fakeEvent, fakeContext, fakeCallback);

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -5,7 +5,7 @@ import { getGlobalObject, logger } from '@sentry/utils';
 import { startIdleTransaction } from '../hubextensions';
 import { DEFAULT_IDLE_TIMEOUT, IdleTransaction } from '../idletransaction';
 import { SpanStatus } from '../spanstatus';
-import { extractTraceparentData, secToMs } from '../utils';
+import { extractSentrytraceData, secToMs } from '../utils';
 import { registerBackgroundTabDetection } from './backgroundtab';
 import { MetricsInstrumentation } from './metrics';
 import {
@@ -237,7 +237,7 @@ export class BrowserTracing implements Integration {
 export function getHeaderContext(): Partial<TransactionContext> | undefined {
   const header = getMetaContent('sentry-trace');
   if (header) {
-    return extractTraceparentData(header);
+    return extractSentrytraceData(header);
   }
 
   return undefined;

--- a/packages/tracing/src/hubextensions.ts
+++ b/packages/tracing/src/hubextensions.ts
@@ -15,20 +15,6 @@ import { IdleTransaction } from './idletransaction';
 import { Transaction } from './transaction';
 import { hasTracingEnabled } from './utils';
 
-/** Returns all trace headers that are currently on the top scope. */
-function traceHeaders(this: Hub): { [key: string]: string } {
-  const scope = this.getScope();
-  if (scope) {
-    const span = scope.getSpan();
-    if (span) {
-      return {
-        'sentry-trace': span.toTraceparent(),
-      };
-    }
-  }
-  return {};
-}
-
 /**
  * Makes a sampling decision for the given transaction and stores it on the transaction.
  *
@@ -215,9 +201,6 @@ export function _addTracingExtensions(): void {
   carrier.__SENTRY__.extensions = carrier.__SENTRY__.extensions || {};
   if (!carrier.__SENTRY__.extensions.startTransaction) {
     carrier.__SENTRY__.extensions.startTransaction = _startTransaction;
-  }
-  if (!carrier.__SENTRY__.extensions.traceHeaders) {
-    carrier.__SENTRY__.extensions.traceHeaders = traceHeaders;
   }
 }
 

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -26,6 +26,6 @@ export {
   extractTraceparentData,
   getActiveTransaction,
   hasTracingEnabled,
+  SENTRY_TRACE_REGEX,
   stripUrlQueryAndFragment,
-  TRACEPARENT_REGEXP,
 } from './utils';

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -23,7 +23,7 @@ addExtensionMethods();
 export { addExtensionMethods };
 
 export {
-  extractTraceparentData,
+  extractSentrytraceData,
   getActiveTransaction,
   hasTracingEnabled,
   SENTRY_TRACE_REGEX,

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -24,6 +24,7 @@ export { addExtensionMethods };
 
 export {
   extractSentrytraceData,
+  extractTracestateData,
   getActiveTransaction,
   hasTracingEnabled,
   SENTRY_TRACE_REGEX,

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -1,8 +1,10 @@
 /* eslint-disable max-lines */
-import { Primitive, Span as SpanInterface, SpanContext, Transaction } from '@sentry/types';
-import { dropUndefinedKeys, timestampWithMs, uuid4 } from '@sentry/utils';
+import { getCurrentHub, Hub } from '@sentry/hub';
+import { Primitive, Span as SpanInterface, SpanContext, TraceHeaders, Transaction } from '@sentry/types';
+import { dropUndefinedKeys, logger, timestampWithMs, uuid4 } from '@sentry/utils';
 
 import { SpanStatus } from './spanstatus';
+import { computeTracestateValue } from './utils';
 
 /**
  * Keeps track of finished spans for a given transaction
@@ -287,6 +289,26 @@ export class Span implements SpanInterface {
   /**
    * @inheritDoc
    */
+  public getTraceHeaders(): TraceHeaders {
+    // if this span is part of a transaction, but that transaction doesn't yet have a tracestate value, create one
+    if (this.transaction && !this.transaction?.metadata.tracestate?.sentry) {
+      this.transaction.metadata.tracestate = {
+        ...this.transaction.metadata.tracestate,
+        sentry: this._getNewTracestate(),
+      };
+    }
+
+    const tracestate = this._toTracestate();
+
+    return {
+      'sentry-trace': this._toSentrytrace(),
+      ...(tracestate && { tracestate }),
+    };
+  }
+
+  /**
+   * @inheritDoc
+   */
   public getTraceContext(): {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     data?: { [key: string]: any };
@@ -338,5 +360,68 @@ export class Span implements SpanInterface {
       timestamp: this.endTimestamp,
       trace_id: this.traceId,
     });
+  }
+
+  /**
+   * Create a new Sentry tracestate header entry (i.e. `sentry=xxxxxx`)
+   *
+   * @returns The new Sentry tracestate entry, or undefined if there's no client or no dsn
+   */
+  protected _getNewTracestate(): string | undefined {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    const hub = ((this.transaction as any)?._hub as Hub) || getCurrentHub();
+    const client = hub.getClient();
+    const { id: userId, segment: userSegment } = hub.getScope()?.getUser() || {};
+    const dsn = client?.getDsn();
+
+    if (!client || !dsn) {
+      return;
+    }
+
+    const { environment, release } = client.getOptions() || {};
+
+    // only define a `user` object if there's going to be something in it (note: prettier insists on removing the
+    // parentheses, but since it's easy to misinterpret this, imagine `()` around `userId || userSegment`)
+    const user = userId || userSegment ? { id: userId, segment: userSegment } : undefined;
+
+    // TODO - the only reason we need the non-null assertion on `dsn.publicKey` (below) is because `dsn.publicKey` has
+    // to be optional while we transition from `dsn.user` -> `dsn.publicKey`. Once `dsn.user` is removed, we can make
+    // `dsn.publicKey` required and remove the `!`.
+
+    return `sentry=${computeTracestateValue({
+      trace_id: this.traceId,
+      environment,
+      release,
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      public_key: dsn.publicKey!,
+      user,
+    })}`;
+  }
+
+  /**
+   * Return a traceparent-compatible header string.
+   */
+  private _toSentrytrace(): string {
+    let sampledString = '';
+    if (this.sampled !== undefined) {
+      sampledString = this.sampled ? '-1' : '-0';
+    }
+    return `${this.traceId}-${this.spanId}${sampledString}`;
+  }
+
+  /**
+   * Return a tracestate-compatible header string, including both sentry and third-party data (if any). Returns
+   * undefined if there is no client or no DSN.
+   */
+  private _toTracestate(): string | undefined {
+    // if this is an orphan span, create a new tracestate value
+    const sentryTracestate = this.transaction?.metadata?.tracestate?.sentry || this._getNewTracestate();
+    let thirdpartyTracestate = this.transaction?.metadata?.tracestate?.thirdparty;
+
+    // if there's third-party data, add a leading comma; otherwise, convert from `undefined` to the empty string, so the
+    // end result doesn’t come out as `sentry=xxxxxundefined`
+    thirdpartyTracestate = thirdpartyTracestate ? `,${thirdpartyTracestate}` : '';
+
+    return `${sentryTracestate}${thirdpartyTracestate}`;
   }
 }

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -126,7 +126,7 @@ export class Span implements SpanInterface {
     if (spanContext.parentSpanId) {
       this.parentSpanId = spanContext.parentSpanId;
     }
-    // We want to include booleans as well here
+    // check this way instead of the normal way to make sure we don't miss cases where sampled = false
     if ('sampled' in spanContext) {
       this.sampled = spanContext.sampled;
     }
@@ -241,11 +241,9 @@ export class Span implements SpanInterface {
    * @inheritDoc
    */
   public toTraceparent(): string {
-    let sampledString = '';
-    if (this.sampled !== undefined) {
-      sampledString = this.sampled ? '-1' : '-0';
-    }
-    return `${this.traceId}-${this.spanId}${sampledString}`;
+    logger.warn('Direct use of `span.toTraceparent` is deprecated. Use `span.getTraceHeaders` instead.');
+
+    return this._toSentrytrace();
   }
 
   /**

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -6,7 +6,7 @@ import {
   TransactionContext,
   TransactionMetadata,
 } from '@sentry/types';
-import { dropUndefinedKeys, isInstanceOf, logger } from '@sentry/utils';
+import { dropUndefinedKeys, logger } from '@sentry/utils';
 
 import { Span as SpanClass, SpanRecorder } from './span';
 
@@ -21,7 +21,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
   /**
    * The reference to the current hub.
    */
-  private readonly _hub: Hub = (getCurrentHub() as unknown) as Hub;
+  private readonly _hub: Hub;
 
   private _trimEnd?: boolean;
 
@@ -35,16 +35,14 @@ export class Transaction extends SpanClass implements TransactionInterface {
   public constructor(transactionContext: TransactionContext, hub?: Hub) {
     super(transactionContext);
 
-    if (isInstanceOf(hub, Hub)) {
-      this._hub = hub as Hub;
-    }
-
     this.name = transactionContext.name || '';
-
     this.metadata = transactionContext.metadata || {};
     this._trimEnd = transactionContext.trimEnd;
+    this._hub = hub || getCurrentHub();
 
-    // this is because transactions are also spans, and spans have a transaction pointer
+    // this is because transactions are also spans, and spans have a transaction pointer (it doesn't get set in `super`
+    // because theoretically you can create a span without a transaction, though at the moment it doesn't do you much
+    // good)
     this.transaction = this;
   }
 

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -116,6 +116,11 @@ export class Transaction extends SpanClass implements TransactionInterface {
       }).endTimestamp;
     }
 
+    // ensure that we have a tracestate to attach to the envelope header
+    if (!this.metadata.tracestate?.sentry) {
+      this.metadata.tracestate = { ...this.metadata.tracestate, sentry: this._getNewTracestate() };
+    }
+
     const transaction: Event = {
       contexts: {
         trace: this.getTraceContext(),

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -10,6 +10,40 @@ export const SENTRY_TRACE_REGEX = new RegExp(
     '[ \\t]*$', // whitespace
 );
 
+// This is a normal base64 regex, modified to reflect that fact that we strip the trailing = or == off
+const BASE64_STRIPPED_REGEX = new RegExp(
+  // for our purposes, we want to test against the entire string, so enforce that there's nothing before the main regex
+  `^` +
+    // any of the characters in the base64 "alphabet", in multiples of 4
+    '([a-zA-Z0-9+/]{4})*' +
+    // either nothing or 2 or 3 base64-alphabet characters (see
+    // https://en.wikipedia.org/wiki/Base64#Decoding_Base64_without_padding
+    // for why there's never only 1 extra character)
+    '([a-zA-Z0-9+/]{2,3})?' +
+    // see above re: matching entire string
+    `$`,
+);
+
+// comma-delimited list of entries of the form `xxx=yyy`
+const tracestateEntry = '[^=]+=[^=]+';
+const TRACESTATE_ENTRIES_REGEX = new RegExp(
+  // one or more xxxxx=yyyy entries
+  `^(${tracestateEntry})+` +
+    // each entry except the last must be followed by a comma
+    '(,|$)',
+);
+
+// this doesn't check that the value is valid, just that there's something there of the form `sentry=xxxx`
+const SENTRY_TRACESTATE_ENTRY_REGEX = new RegExp(
+  // either sentry is the first entry or there's stuff immediately before it, ending in a commma (this prevents matching
+  // something like `coolsentry=xxx`)
+  '(?:^|.+,)' +
+    // sentry's part, not including the potential comma
+    '(sentry=[^,]*)' +
+    // either there's a comma and another vendor's entry or we end
+    '(?:,.+|$)',
+);
+
 /**
  * Determines if tracing is currently enabled.
  *
@@ -51,6 +85,46 @@ export function extractSentrytraceData(header: string): TraceparentData | undefi
   }
 
   return undefined;
+}
+
+/**
+ * Extract data from an incoming `tracestate` header
+ *
+ * @param header
+ * @returns Object containing data from the header
+ */
+export function extractTracestateData(header: string): { sentry?: string; thirdparty?: string } {
+  let sentryEntry, thirdPartyEntry, before, after;
+
+  // find sentry's entry, if any
+  const sentryMatch = SENTRY_TRACESTATE_ENTRY_REGEX.exec(header);
+
+  if (sentryMatch !== null) {
+    sentryEntry = sentryMatch[1];
+
+    // remove the commas after the split so we don't end up with `xxx=yyy,,zzz=qqq` (double commas) when we put them
+    // back together
+    [before, after] = header.split(sentryEntry).map(s => s.replace(/^,*|,*$/g, ''));
+
+    // extract sentry's value from its entry and test to make sure it's valid; if it isn't, discard the entire entry
+    // so that a new one will be created by the Transaction constructor
+    const sentryValue = sentryEntry.replace('sentry=', '');
+    if (!BASE64_STRIPPED_REGEX.test(sentryValue)) {
+      sentryEntry = undefined;
+    }
+  } else {
+    // this could just as well be `before`; we just need to get the thirdparty data into one or the other since
+    // there's no valid Sentry entry
+    after = header;
+  }
+
+  // if either thirdparty part is invalid or empty, remove it before gluing them together
+  const validThirdpartyEntries = [before, after].filter(x => TRACESTATE_ENTRIES_REGEX.test(x || ''));
+  if (validThirdpartyEntries.length) {
+    thirdPartyEntry = validThirdpartyEntries.join(',');
+  }
+
+  return { sentry: sentryEntry, thirdparty: thirdPartyEntry };
 }
 
 /** Grabs active transaction off scope, if any */

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -32,7 +32,7 @@ export function hasTracingEnabled(
  *
  * @returns Object containing data from the header, or undefined if traceparent string is malformed
  */
-export function extractTraceparentData(traceparent: string): TraceparentData | undefined {
+export function extractSentrytraceData(traceparent: string): TraceparentData | undefined {
   const matches = traceparent.match(SENTRY_TRACE_REGEX);
   if (matches) {
     let parentSampled: boolean | undefined;

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -1,7 +1,7 @@
 import { getCurrentHub, Hub } from '@sentry/hub';
 import { Options, TraceparentData, Transaction } from '@sentry/types';
 
-export const TRACEPARENT_REGEXP = new RegExp(
+export const SENTRY_TRACE_REGEX = new RegExp(
   '^[ \\t]*' + // whitespace
   '([0-9a-f]{32})?' + // trace_id
   '-?([0-9a-f]{16})?' + // span_id
@@ -33,7 +33,7 @@ export function hasTracingEnabled(
  * @returns Object containing data from the header, or undefined if traceparent string is malformed
  */
 export function extractTraceparentData(traceparent: string): TraceparentData | undefined {
-  const matches = traceparent.match(TRACEPARENT_REGEXP);
+  const matches = traceparent.match(SENTRY_TRACE_REGEX);
   if (matches) {
     let parentSampled: boolean | undefined;
     if (matches[3] === '1') {

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -28,12 +28,13 @@ export function hasTracingEnabled(
 /**
  * Extract transaction context data from a `sentry-trace` header.
  *
- * @param traceparent Traceparent string
+ * @param header Traceparent string
  *
  * @returns Object containing data from the header, or undefined if traceparent string is malformed
  */
-export function extractSentrytraceData(traceparent: string): TraceparentData | undefined {
-  const matches = traceparent.match(SENTRY_TRACE_REGEX);
+export function extractSentrytraceData(header: string): TraceparentData | undefined {
+  const matches = header.match(SENTRY_TRACE_REGEX);
+
   if (matches) {
     let parentSampled: boolean | undefined;
     if (matches[3] === '1') {
@@ -47,6 +48,7 @@ export function extractSentrytraceData(traceparent: string): TraceparentData | u
       parentSpanId: matches[2],
     };
   }
+
   return undefined;
 }
 

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -8,7 +8,7 @@ import {
   BrowserTracing,
   BrowserTracingOptions,
   DEFAULT_MAX_TRANSACTION_DURATION_SECONDS,
-  getHeaderContext,
+  extractTraceDataFromMetaTags,
   getMetaContent,
 } from '../../src/browser/browsertracing';
 import { defaultRequestInstrumentationOptions } from '../../src/browser/request';
@@ -209,20 +209,23 @@ describe('BrowserTracing', () => {
       });
     });
 
-    it('sets transaction context from sentry-trace header', () => {
-      const name = 'sentry-trace';
-      const content = '126de09502ae4e0fb26c6967190756a4-b6e54397b12a2a0f-1';
-      document.head.innerHTML = `<meta name="${name}" content="${content}">`;
+    it('sets transaction context from <meta> tag data', () => {
+      document.head.innerHTML =
+        `<meta name="sentry-trace" content="12312012123120121231201212312012-1121201211212012-0"> ` +
+        `<meta name="tracestate" content="sentry=doGsaREgReaT,maisey=silly,charlie=goofy">`;
+
       const startIdleTransaction = jest.spyOn(hubExtensions, 'startIdleTransaction');
 
       createBrowserTracing(true, { routingInstrumentation: customInstrumentRouting });
 
       expect(startIdleTransaction).toHaveBeenCalledWith(
+        // because `startIdleTransaction` uses positional arguments, we have to include placeholders for all of them
         expect.any(Object),
         expect.objectContaining({
-          traceId: '126de09502ae4e0fb26c6967190756a4',
-          parentSpanId: 'b6e54397b12a2a0f',
-          parentSampled: true,
+          traceId: '12312012123120121231201212312012',
+          parentSpanId: '1121201211212012',
+          parentSampled: false,
+          metadata: { tracestate: { sentry: 'sentry=doGsaREgReaT', thirdparty: 'maisey=silly,charlie=goofy' } },
         }),
         expect.any(Number),
         expect.any(Boolean),
@@ -354,7 +357,7 @@ describe('BrowserTracing', () => {
     });
   });
 
-  describe('sentry-trace <meta> element', () => {
+  describe('sentry-trace/tracestate <meta> tags', () => {
     describe('getMetaContent', () => {
       it('finds the specified tag and extracts the value', () => {
         const name = 'sentry-trace';
@@ -384,39 +387,37 @@ describe('BrowserTracing', () => {
       });
     });
 
-    describe('getHeaderContext', () => {
-      it('correctly parses a valid sentry-trace meta header', () => {
-        document.head.innerHTML = `<meta name="sentry-trace" content="12312012123120121231201212312012-1121201211212012-0">`;
+    describe('extractTraceDataFromMetaTags', () => {
+      it('correctly captures both sentry-trace and tracestate data', () => {
+        document.head.innerHTML =
+          `<meta name="sentry-trace" content="12312012123120121231201212312012-1121201211212012-0"> ` +
+          `<meta name="tracestate" content="sentry=doGsaREgReaT,maisey=silly,charlie=goofy">`;
 
-        const headerContext = getHeaderContext();
+        const headerContext = extractTraceDataFromMetaTags();
 
-        expect(headerContext).toBeDefined();
-        expect(headerContext!.traceId).toEqual('12312012123120121231201212312012');
-        expect(headerContext!.parentSpanId).toEqual('1121201211212012');
-        expect(headerContext!.parentSampled).toEqual(false);
+        expect(headerContext).toEqual({
+          traceId: '12312012123120121231201212312012',
+          parentSpanId: '1121201211212012',
+          parentSampled: false,
+          metadata: { tracestate: { sentry: 'sentry=doGsaREgReaT', thirdparty: 'maisey=silly,charlie=goofy' } },
+        });
       });
 
-      it('returns undefined if the header is malformed', () => {
-        document.head.innerHTML = `<meta name="sentry-trace" content="12312012-112120121-0">`;
+      it('returns undefined if neither tag is there', () => {
+        document.head.innerHTML = `<meta name="cory" content="loyal"> <meta name="bodhi" content="floppy">`;
 
-        const headerContext = getHeaderContext();
-
-        expect(headerContext).toBeUndefined();
-      });
-
-      it("returns undefined if the header isn't there", () => {
-        document.head.innerHTML = `<meta name="dogs" content="12312012123120121231201212312012-1121201211212012-0">`;
-
-        const headerContext = getHeaderContext();
+        const headerContext = extractTraceDataFromMetaTags();
 
         expect(headerContext).toBeUndefined();
       });
     });
 
-    describe('using the data', () => {
+    describe('using <meta> tag data', () => {
       it('uses the data for pageload transactions', () => {
         // make sampled false here, so we can see that it's being used rather than the tracesSampleRate-dictated one
-        document.head.innerHTML = `<meta name="sentry-trace" content="12312012123120121231201212312012-1121201211212012-0">`;
+        document.head.innerHTML =
+          `<meta name="sentry-trace" content="12312012123120121231201212312012-1121201211212012-0"> ` +
+          `<meta name="tracestate" content="sentry=doGsaREgReaT,maisey=silly,charlie=goofy">`;
 
         // pageload transactions are created as part of the BrowserTracing integration's initialization
         createBrowserTracing(true);
@@ -427,11 +428,20 @@ describe('BrowserTracing', () => {
         expect(transaction.traceId).toEqual('12312012123120121231201212312012');
         expect(transaction.parentSpanId).toEqual('1121201211212012');
         expect(transaction.sampled).toBe(false);
+        expect(transaction.metadata?.tracestate).toEqual({
+          sentry: 'sentry=doGsaREgReaT',
+          thirdparty: 'maisey=silly,charlie=goofy',
+        });
       });
 
+      // navigation transactions happen on the same page as generated a pageload transaction (with <metat> tags still
+      // possibly present) but they start their own trace and therefore shouldn't contain the pageload transaction's
+      // trace data
       it('ignores the data for navigation transactions', () => {
         mockChangeHistory = () => undefined;
-        document.head.innerHTML = `<meta name="sentry-trace" content="12312012123120121231201212312012-1121201211212012-0">`;
+        document.head.innerHTML =
+          `<meta name="sentry-trace" content="12312012123120121231201212312012-1121201211212012-0"> ` +
+          `<meta name="tracestate" content="sentry=doGsaREgReaT,maisey=silly,charlie=goofy">`;
 
         createBrowserTracing(true);
 
@@ -442,6 +452,9 @@ describe('BrowserTracing', () => {
         expect(transaction.op).toBe('navigation');
         expect(transaction.traceId).not.toEqual('12312012123120121231201212312012');
         expect(transaction.parentSpanId).toBeUndefined();
+        expect(transaction.sampled).toBe(true);
+        expect(transaction.metadata?.tracestate?.sentry).not.toEqual('sentry=doGsaREgReaT');
+        expect(transaction.metadata?.tracestate?.thirdparty).toBeUndefined();
       });
     });
   });

--- a/packages/tracing/test/browser/request.test.ts
+++ b/packages/tracing/test/browser/request.test.ts
@@ -214,7 +214,7 @@ describe('callbacks', () => {
 
       expect(setRequestHeader).toHaveBeenCalledWith(
         'sentry-trace',
-        expect.stringMatching(tracingUtils.TRACEPARENT_REGEXP),
+        expect.stringMatching(tracingUtils.SENTRY_TRACE_REGEX),
       );
     });
 

--- a/packages/tracing/test/browser/request.test.ts
+++ b/packages/tracing/test/browser/request.test.ts
@@ -6,12 +6,41 @@ import { Span, SpanStatus, Transaction } from '../../src';
 import { fetchCallback, FetchData, instrumentOutgoingRequests, xhrCallback, XHRData } from '../../src/browser/request';
 import { addExtensionMethods } from '../../src/hubextensions';
 import * as tracingUtils from '../../src/utils';
+import { objectFromEntries } from '../testutils';
+
+// This is a normal base64 regex, modified to reflect that fact that we strip the trailing = or == off
+const stripped_base64 = '([a-zA-Z0-9+/]{4})*([a-zA-Z0-9+/]{2,3})?';
+
+const TRACESTATE_HEADER_REGEX = new RegExp(
+  `sentry=(${stripped_base64})` +  // our part of the header - should be the only part or at least the first part
+    `(,\\w+=\\w+)*`, // any number of copies of a comma followed by `name=value`
+);
 
 beforeAll(() => {
   addExtensionMethods();
-  // @ts-ignore need to override global Request because it's not in the jest environment (even with an
-  // `@jest-environment jsdom` directive, for some reason)
-  global.Request = {};
+
+  // Add Request to the global scope (necessary because for some reason Request isn't in the jest environment, even with
+  // an `@jest-environment jsdom` directive)
+
+  type MockHeaders = {
+    [key: string]: any;
+    append: (key: string, value: string) => void;
+  };
+
+  class Request {
+    public headers: MockHeaders;
+    constructor() {
+      // We need our headers to act like an object for key-lookup purposes, but also have an append method that adds
+      // items as its siblings. This hack precludes a key named `append`, of course, but for our purposes it's enough.
+      const headers = {} as MockHeaders;
+      headers.append = (key: string, value: any): void => {
+        headers[key] = value;
+      };
+      this.headers = headers;
+    }
+  }
+
+  (global as any).Request = Request;
 });
 
 const hasTracingEnabled = jest.spyOn(tracingUtils, 'hasTracingEnabled');
@@ -49,7 +78,7 @@ describe('instrumentOutgoingRequests', () => {
   });
 });
 
-describe('callbacks', () => {
+describe('fetch and xhr callbacks', () => {
   let hub: Hub;
   let transaction: Transaction;
   const alwaysCreateSpan = () => true;
@@ -57,7 +86,7 @@ describe('callbacks', () => {
   const fetchHandlerData: FetchData = {
     args: ['http://dogs.are.great/', {}],
     fetchData: { url: 'http://dogs.are.great/', method: 'GET' },
-    startTimestamp: 1356996072000,
+    startTimestamp: 2012112120121231,
   };
   const xhrHandlerData: XHRData = {
     xhr: {
@@ -72,18 +101,27 @@ describe('callbacks', () => {
       // setRequestHeader: XMLHttpRequest.prototype.setRequestHeader,
       setRequestHeader,
     },
-    startTimestamp: 1353501072000,
+    startTimestamp: 2012112120121231,
   };
-  const endTimestamp = 1356996072000;
+  const endTimestamp = 2013041520130908;
 
   beforeAll(() => {
-    hub = new Hub(new BrowserClient({ tracesSampleRate: 1 }));
+    hub = new Hub(
+      new BrowserClient({
+        dsn: 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012',
+        environment: 'dogpark',
+        release: 'off.leash.park',
+
+        tracesSampleRate: 1,
+      }),
+    );
     makeMain(hub);
   });
 
   beforeEach(() => {
-    transaction = hub.startTransaction({ name: 'organizations/users/:userid', op: 'pageload' }) as Transaction;
+    transaction = hub.startTransaction({ name: 'meetNewDogFriend', op: 'wag.tail' }) as Transaction;
     hub.configureScope(scope => scope.setSpan(transaction));
+    jest.clearAllMocks();
   });
 
   describe('fetchCallback()', () => {
@@ -111,20 +149,17 @@ describe('callbacks', () => {
       expect(spans).toEqual({});
     });
 
-    it('does not add fetch request headers if tracing is disabled', () => {
+    it('does not add tracing headers if tracing is disabled', () => {
       hasTracingEnabled.mockReturnValueOnce(false);
 
       // make a local copy so the global one doesn't get mutated
-      const handlerData: FetchData = {
-        args: ['http://dogs.are.great/', {}],
-        fetchData: { url: 'http://dogs.are.great/', method: 'GET' },
-        startTimestamp: 1353501072000,
-      };
+      const handlerData = { ...fetchHandlerData };
 
       fetchCallback(handlerData, alwaysCreateSpan, {});
 
       const headers = (handlerData.args[1].headers as Record<string, string>) || {};
       expect(headers['sentry-trace']).not.toBeDefined();
+      expect(headers['tracestate']).not.toBeDefined();
     });
 
     it('creates and finishes fetch span on active transaction', () => {
@@ -179,8 +214,67 @@ describe('callbacks', () => {
       expect(newSpan!.status).toBe(SpanStatus.fromHttpCode(404));
     });
 
-    it('adds sentry-trace header to fetch requests', () => {
-      // TODO
+    describe('adding tracing headers to fetch requests', () => {
+      it('can handle headers added with an `append` method', () => {
+        const handlerData: FetchData = { ...fetchHandlerData, args: [new Request('http://dogs.are.great'), {}] };
+
+        fetchCallback(handlerData, alwaysCreateSpan, {});
+
+        const headers = handlerData.args[1].headers;
+        expect(headers['sentry-trace']).toBeDefined();
+        expect(headers['tracestate']).toBeDefined();
+      });
+
+      it('can handle existing headers in array form', () => {
+        const handlerData = {
+          ...fetchHandlerData,
+          args: [
+            'http://dogs.are.great/',
+            {
+              headers: [
+                ['GREETING_PROTOCOL', 'mutual butt sniffing'],
+                ['TAIL_ACTION', 'wagging'],
+              ],
+            },
+          ],
+        };
+
+        fetchCallback(handlerData, alwaysCreateSpan, {});
+
+        const headers = objectFromEntries((handlerData.args[1] as any).headers);
+        expect(headers['sentry-trace']).toBeDefined();
+        expect(headers['tracestate']).toBeDefined();
+      });
+
+      it('can handle existing headers in object form', () => {
+        const handlerData = {
+          ...fetchHandlerData,
+          args: [
+            'http://dogs.are.great/',
+            {
+              headers: { GREETING_PROTOCOL: 'mutual butt sniffing', TAIL_ACTION: 'wagging' },
+            },
+          ],
+        };
+
+        fetchCallback(handlerData, alwaysCreateSpan, {});
+
+        const headers = (handlerData.args[1] as any).headers;
+        expect(headers['sentry-trace']).toBeDefined();
+        expect(headers['tracestate']).toBeDefined();
+      });
+
+      it('can handle there being no existing headers', () => {
+        // override the value of `args`, even though we're overriding it with the same data, as a means of deep copying
+        // the one part which gets mutated
+        const handlerData = { ...fetchHandlerData, args: ['http://dogs.are.great/', {}] };
+
+        fetchCallback(handlerData, alwaysCreateSpan, {});
+
+        const headers = (handlerData.args[1] as any).headers;
+        expect(headers['sentry-trace']).toBeDefined();
+        expect(headers['tracestate']).toBeDefined();
+      });
     });
   });
 
@@ -201,7 +295,7 @@ describe('callbacks', () => {
       expect(spans).toEqual({});
     });
 
-    it('does not add xhr request headers if tracing is disabled', () => {
+    it('does not add tracing headers if tracing is disabled', () => {
       hasTracingEnabled.mockReturnValueOnce(false);
 
       xhrCallback(xhrHandlerData, alwaysCreateSpan, {});
@@ -209,13 +303,14 @@ describe('callbacks', () => {
       expect(setRequestHeader).not.toHaveBeenCalled();
     });
 
-    it('adds sentry-trace header to XHR requests', () => {
+    it('adds tracing headers to XHR requests', () => {
       xhrCallback(xhrHandlerData, alwaysCreateSpan, {});
 
       expect(setRequestHeader).toHaveBeenCalledWith(
         'sentry-trace',
         expect.stringMatching(tracingUtils.SENTRY_TRACE_REGEX),
       );
+      expect(setRequestHeader).toHaveBeenCalledWith('tracestate', expect.stringMatching(TRACESTATE_HEADER_REGEX));
     });
 
     it('creates and finishes XHR span on active transaction', () => {

--- a/packages/tracing/test/httpheaders.test.ts
+++ b/packages/tracing/test/httpheaders.test.ts
@@ -1,0 +1,248 @@
+import * as sentryCore from '@sentry/core';
+import { API } from '@sentry/core';
+import { Hub } from '@sentry/hub';
+import { SentryRequest } from '@sentry/types';
+import * as utilsPackage from '@sentry/utils';
+import { base64ToUnicode } from '@sentry/utils';
+
+import { Span } from '../src/span';
+import { Transaction } from '../src/transaction';
+import { computeTracestateValue } from '../src/utils';
+
+// TODO gather sentry-trace and tracestate tests here
+
+function parseEnvelopeRequest(request: SentryRequest): any {
+  const [envelopeHeaderString, itemHeaderString, eventString] = request.body.split('\n');
+
+  return {
+    envelopeHeader: JSON.parse(envelopeHeaderString),
+    itemHeader: JSON.parse(itemHeaderString),
+    event: JSON.parse(eventString),
+  };
+}
+
+describe('sentry-trace', () => {
+  // TODO gather relevant tests here
+});
+
+describe('tracestate', () => {
+  // grab these this way rather than importing them individually to get around TS's guards against instantiating
+  // abstract classes (using non-abstract classes would create a circular dependency)
+  const { BaseClient, BaseBackend } = sentryCore as any;
+
+  const dsn = 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012';
+  const environment = 'dogpark';
+  const release = 'off.leash.trail';
+  const hub = new Hub(
+    new BaseClient(BaseBackend, {
+      dsn,
+      environment,
+      release,
+    }),
+  );
+
+  describe('sentry tracestate', () => {
+    describe('lazy creation', () => {
+      const getNewTracestate = jest
+        .spyOn(Span.prototype as any, '_getNewTracestate')
+        .mockReturnValue('sentry=doGsaREgReaT');
+
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      afterAll(() => {
+        jest.restoreAllMocks();
+      });
+
+      describe('when creating a transaction', () => {
+        it('uses sentry tracestate passed to the transaction constructor rather than creating a new one', () => {
+          const transaction = new Transaction({
+            name: 'FETCH /ball',
+            metadata: { tracestate: { sentry: 'sentry=doGsaREgReaT' } },
+          });
+
+          expect(getNewTracestate).not.toHaveBeenCalled();
+          expect(transaction.metadata.tracestate?.sentry).toEqual('sentry=doGsaREgReaT');
+        });
+
+        it("doesn't create new sentry tracestate on transaction creation if none provided", () => {
+          const transaction = new Transaction({
+            name: 'FETCH /ball',
+          });
+
+          expect(transaction.metadata.tracestate?.sentry).toBeUndefined();
+          expect(getNewTracestate).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('when getting outgoing request headers', () => {
+        it('uses existing sentry tracestate when getting tracing headers rather than creating new one', () => {
+          const transaction = new Transaction({
+            name: 'FETCH /ball',
+            metadata: { tracestate: { sentry: 'sentry=doGsaREgReaT' } },
+          });
+
+          expect(transaction.getTraceHeaders().tracestate).toEqual('sentry=doGsaREgReaT');
+          expect(getNewTracestate).not.toHaveBeenCalled();
+        });
+
+        it('creates and stores new sentry tracestate when getting tracing headers if none exists', () => {
+          const transaction = new Transaction({
+            name: 'FETCH /ball',
+          });
+
+          expect(transaction.metadata.tracestate?.sentry).toBeUndefined();
+
+          transaction.getTraceHeaders();
+
+          expect(getNewTracestate).toHaveBeenCalled();
+          expect(transaction.metadata.tracestate?.sentry).toEqual('sentry=doGsaREgReaT');
+          expect(transaction.getTraceHeaders().tracestate).toEqual('sentry=doGsaREgReaT');
+        });
+      });
+
+      describe('when getting envelope headers', () => {
+        // In real life, `transaction.finish()` calls `captureEvent()`, which eventually calls `eventToSentryRequest()`,
+        // which in turn calls `base64ToUnicode`. Here we're short circuiting that process a little, to avoid having to
+        // mock out more of the intermediate pieces.
+        jest
+          .spyOn(utilsPackage, 'base64ToUnicode')
+          .mockImplementation(base64 =>
+            base64 === 'doGsaREgReaT' ? '{"all the":"right stuff here"}' : '{"nope nope nope":"wrong"}',
+          );
+        jest.spyOn(hub, 'captureEvent').mockImplementation(event => {
+          expect(event).toEqual(
+            expect.objectContaining({ debug_meta: { tracestate: { sentry: 'sentry=doGsaREgReaT' } } }),
+          );
+
+          const envelope = parseEnvelopeRequest(sentryCore.eventToSentryRequest(event, new API(dsn)));
+          expect(envelope.envelopeHeader).toEqual(
+            expect.objectContaining({ trace: { 'all the': 'right stuff here' } }),
+          );
+
+          // `captureEvent` normally returns the event id
+          return '11212012041520131231201209082013'; //
+        });
+
+        it('uses existing sentry tracestate in envelope headers rather than creating a new one', () => {
+          // one here, and two inside the `captureEvent` implementation above
+          expect.assertions(3);
+
+          const transaction = new Transaction(
+            {
+              name: 'FETCH /ball',
+              metadata: { tracestate: { sentry: 'sentry=doGsaREgReaT' } },
+              sampled: true,
+            },
+            hub,
+          );
+
+          transaction.finish();
+
+          expect(getNewTracestate).not.toHaveBeenCalled();
+        });
+
+        it('creates new sentry tracestate for envelope header if none exists', () => {
+          // two here, and two inside the `captureEvent` implementation above
+          expect.assertions(4);
+
+          const transaction = new Transaction(
+            {
+              name: 'FETCH /ball',
+              sampled: true,
+            },
+            hub,
+          );
+
+          expect(transaction.metadata.tracestate?.sentry).toBeUndefined();
+
+          transaction.finish();
+
+          expect(getNewTracestate).toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('mutibility', () => {
+      it("won't include data set after transaction is created if there's an inherited value", () => {
+        expect.assertions(1);
+
+        const inheritedTracestate = `sentry=${computeTracestateValue({
+          trace_id: '12312012090820131231201209082013',
+          environment: 'dogpark',
+          release: 'off.leash.trail',
+          public_key: 'dogsarebadatkeepingsecrets',
+        })}`;
+
+        const transaction = new Transaction(
+          {
+            name: 'FETCH /ball',
+            metadata: {
+              tracestate: {
+                sentry: inheritedTracestate,
+              },
+            },
+          },
+          hub,
+        );
+
+        hub.withScope(scope => {
+          scope.setUser({ id: '1121', username: 'CharlieDog', ip_address: '11.21.20.12', segment: 'bigs' });
+
+          const tracestateValue = (transaction as any)._toTracestate().replace('sentry=', '');
+          const reinflatedTracestate = JSON.parse(base64ToUnicode(tracestateValue));
+
+          expect(reinflatedTracestate.user).toBeUndefined();
+        });
+      });
+
+      it("will include data set after transaction is created if there's no inherited value and `getTraceHeaders` hasn't been called", () => {
+        expect.assertions(2);
+
+        const transaction = new Transaction(
+          {
+            name: 'FETCH /ball',
+          },
+          hub,
+        );
+
+        hub.withScope(scope => {
+          scope.setUser({ id: '1121', username: 'CharlieDog', ip_address: '11.21.20.12', segment: 'bigs' });
+
+          const tracestateValue = (transaction as any)._toTracestate().replace('sentry=', '');
+          const reinflatedTracestate = JSON.parse(base64ToUnicode(tracestateValue));
+
+          expect(reinflatedTracestate.user.id).toEqual('1121');
+          expect(reinflatedTracestate.user.segment).toEqual('bigs');
+        });
+      });
+
+      it("won't include data set after first call to `getTraceHeaders`", () => {
+        expect.assertions(1);
+
+        const transaction = new Transaction(
+          {
+            name: 'FETCH /ball',
+          },
+          hub,
+        );
+
+        transaction.getTraceHeaders();
+
+        hub.withScope(scope => {
+          scope.setUser({ id: '1121', username: 'CharlieDog', ip_address: '11.21.20.12', segment: 'bigs' });
+
+          const tracestateValue = (transaction as any)._toTracestate().replace('sentry=', '');
+          const reinflatedTracestate = JSON.parse(base64ToUnicode(tracestateValue));
+
+          expect(reinflatedTracestate.user).toBeUndefined();
+        });
+      });
+    });
+  });
+
+  describe('third-party tracestate', () => {
+    // TODO gather relevant tests here
+  });
+});

--- a/packages/tracing/test/hub.test.ts
+++ b/packages/tracing/test/hub.test.ts
@@ -8,7 +8,7 @@ import { logger } from '@sentry/utils';
 import { BrowserTracing } from '../src/browser/browsertracing';
 import { addExtensionMethods } from '../src/hubextensions';
 import { Transaction } from '../src/transaction';
-import { extractTraceparentData, SENTRY_TRACE_REGEX } from '../src/utils';
+import { extractSentrytraceData, SENTRY_TRACE_REGEX } from '../src/utils';
 import { addDOMPropertiesToGlobal, getSymbolObjectKeyByName, testOnlyIfNodeVersionAtLeast } from './testutils';
 
 addExtensionMethods();
@@ -376,7 +376,7 @@ describe('Hub', () => {
 
           // check that sampling decision is passed down correctly
           expect(transaction.sampled).toBe(true);
-          expect(extractTraceparentData(headers['sentry-trace'])!.parentSampled).toBe(true);
+          expect(extractSentrytraceData(headers['sentry-trace'])!.parentSampled).toBe(true);
         },
       );
 
@@ -418,7 +418,7 @@ describe('Hub', () => {
 
           // check that sampling decision is passed down correctly
           expect(transaction.sampled).toBe(false);
-          expect(extractTraceparentData(headers['sentry-trace'])!.parentSampled).toBe(false);
+          expect(extractSentrytraceData(headers['sentry-trace'])!.parentSampled).toBe(false);
         },
       );
 

--- a/packages/tracing/test/hub.test.ts
+++ b/packages/tracing/test/hub.test.ts
@@ -28,6 +28,29 @@ describe('Hub', () => {
     jest.clearAllMocks();
   });
 
+  describe('transaction creation', () => {
+    const hub = new Hub(
+      new BrowserClient({
+        dsn: 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012',
+        environment: 'dogpark',
+        release: 'off.leash.trail',
+      }),
+    );
+
+    it('uses inherited values when given in transaction context', () => {
+      const transactionContext = {
+        name: 'FETCH /ball',
+        traceId: '12312012123120121231201212312012',
+        parentSpanId: '1121201211212012',
+        metadata: { tracestate: { sentry: 'sentry=doGsaREgReaT', thirdparty: 'maisey=silly;charlie=goofy' } },
+      };
+
+      const transaction = hub.startTransaction(transactionContext);
+
+      expect(transaction).toEqual(expect.objectContaining(transactionContext));
+    });
+  });
+
   describe('getTransaction()', () => {
     it('should find a transaction which has been set on the scope if sampled = true', () => {
       const hub = new Hub(new BrowserClient({ tracesSampleRate: 1 }));

--- a/packages/tracing/test/hub.test.ts
+++ b/packages/tracing/test/hub.test.ts
@@ -8,7 +8,7 @@ import { logger } from '@sentry/utils';
 import { BrowserTracing } from '../src/browser/browsertracing';
 import { addExtensionMethods } from '../src/hubextensions';
 import { Transaction } from '../src/transaction';
-import { extractTraceparentData, TRACEPARENT_REGEXP } from '../src/utils';
+import { extractTraceparentData, SENTRY_TRACE_REGEX } from '../src/utils';
 import { addDOMPropertiesToGlobal, getSymbolObjectKeyByName, testOnlyIfNodeVersionAtLeast } from './testutils';
 
 addExtensionMethods();
@@ -371,7 +371,7 @@ describe('Hub', () => {
 
           // check that sentry-trace header is added to request
           expect(headers).toEqual(
-            expect.objectContaining({ 'sentry-trace': expect.stringMatching(TRACEPARENT_REGEXP) }),
+            expect.objectContaining({ 'sentry-trace': expect.stringMatching(SENTRY_TRACE_REGEX) }),
           );
 
           // check that sampling decision is passed down correctly
@@ -413,7 +413,7 @@ describe('Hub', () => {
 
           // check that sentry-trace header is added to request
           expect(headers).toEqual(
-            expect.objectContaining({ 'sentry-trace': expect.stringMatching(TRACEPARENT_REGEXP) }),
+            expect.objectContaining({ 'sentry-trace': expect.stringMatching(SENTRY_TRACE_REGEX) }),
           );
 
           // check that sampling decision is passed down correctly

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -2,7 +2,7 @@ import { BrowserClient } from '@sentry/browser';
 import { Hub, makeMain, Scope } from '@sentry/hub';
 
 import { Span, SpanStatus, Transaction } from '../src';
-import { TRACEPARENT_REGEXP } from '../src/utils';
+import { SENTRY_TRACE_REGEX } from '../src/utils';
 
 describe('Span', () => {
   let hub: Hub;
@@ -95,10 +95,10 @@ describe('Span', () => {
 
   describe('toTraceparent', () => {
     test('simple', () => {
-      expect(new Span().toTraceparent()).toMatch(TRACEPARENT_REGEXP);
+      expect(new Span().toTraceparent()).toMatch(SENTRY_TRACE_REGEX);
     });
     test('with sample', () => {
-      expect(new Span({ sampled: true }).toTraceparent()).toMatch(TRACEPARENT_REGEXP);
+      expect(new Span({ sampled: true }).toTraceparent()).toMatch(SENTRY_TRACE_REGEX);
     });
   });
 

--- a/packages/tracing/test/testutils.ts
+++ b/packages/tracing/test/testutils.ts
@@ -56,3 +56,16 @@ export const testOnlyIfNodeVersionAtLeast = (minVersion: number): jest.It => {
 
   return it;
 };
+
+/** Polyfill for `Object.fromEntries`, for Node < 12 */
+export const objectFromEntries =
+  'fromEntries' in Object
+    ? (Object as { fromEntries: any }).fromEntries
+    : (entries: Array<[string, any]>): Record<string, any> => {
+        const result: Record<string, any> = {};
+        entries.forEach(entry => {
+          const [key, value] = entry;
+          result[key] = value;
+        });
+        return result;
+      };

--- a/packages/tracing/test/utils.test.ts
+++ b/packages/tracing/test/utils.test.ts
@@ -1,8 +1,8 @@
-import { extractTraceparentData } from '../src/utils';
+import { extractSentrytraceData } from '../src/utils';
 
-describe('extractTraceparentData', () => {
+describe('extractSentrytraceData', () => {
   test('no sample', () => {
-    const data = extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb') as any;
+    const data = extractSentrytraceData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb') as any;
 
     expect(data).toBeDefined();
     expect(data.parentSpanId).toEqual('bbbbbbbbbbbbbbbb');
@@ -11,21 +11,21 @@ describe('extractTraceparentData', () => {
   });
 
   test('sample true', () => {
-    const data = extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-1') as any;
+    const data = extractSentrytraceData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-1') as any;
 
     expect(data).toBeDefined();
     expect(data.parentSampled).toBeTruthy();
   });
 
   test('sample false', () => {
-    const data = extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-0') as any;
+    const data = extractSentrytraceData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-0') as any;
 
     expect(data).toBeDefined();
     expect(data.parentSampled).toBeFalsy();
   });
 
   test('just sample decision - false', () => {
-    const data = extractTraceparentData('0') as any;
+    const data = extractSentrytraceData('0') as any;
 
     expect(data).toBeDefined();
     expect(data.traceId).toBeUndefined();
@@ -34,7 +34,7 @@ describe('extractTraceparentData', () => {
   });
 
   test('just sample decision - true', () => {
-    const data = extractTraceparentData('1') as any;
+    const data = extractSentrytraceData('1') as any;
 
     expect(data).toBeDefined();
     expect(data.traceId).toBeUndefined();
@@ -44,21 +44,21 @@ describe('extractTraceparentData', () => {
 
   test('invalid', () => {
     // trace id wrong length
-    expect(extractTraceparentData('a-bbbbbbbbbbbbbbbb-1')).toBeUndefined();
+    expect(extractSentrytraceData('a-bbbbbbbbbbbbbbbb-1')).toBeUndefined();
 
     // parent span id wrong length
-    expect(extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-b-1')).toBeUndefined();
+    expect(extractSentrytraceData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-b-1')).toBeUndefined();
 
     // parent sampling decision wrong length
-    expect(extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-11')).toBeUndefined();
+    expect(extractSentrytraceData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-11')).toBeUndefined();
 
     // trace id invalid hex value
-    expect(extractTraceparentData('someStuffHereWhichIsNotAtAllHexy-bbbbbbbbbbbbbbbb-1')).toBeUndefined();
+    expect(extractSentrytraceData('someStuffHereWhichIsNotAtAllHexy-bbbbbbbbbbbbbbbb-1')).toBeUndefined();
 
     // parent span id invalid hex value
-    expect(extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-alsoNotSuperHexy-1')).toBeUndefined();
+    expect(extractSentrytraceData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-alsoNotSuperHexy-1')).toBeUndefined();
 
     // bogus sampling decision
-    expect(extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-x')).toBeUndefined();
+    expect(extractSentrytraceData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-x')).toBeUndefined();
   });
 });

--- a/packages/types/src/debugMeta.ts
+++ b/packages/types/src/debugMeta.ts
@@ -1,10 +1,11 @@
+import { TransactionMetadata } from './transaction';
+
 /**
  * Holds meta information to customize the behavior of sentry's event processing.
  **/
-export interface DebugMeta {
+export type DebugMeta = {
   images?: Array<DebugImage>;
-  transactionSampling?: { rate?: number; method?: string };
-}
+} & TransactionMetadata;
 
 /**
  * Possible choices for debug images.

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -177,9 +177,6 @@ export interface Hub {
   /** Returns the integration if installed on the current client. */
   getIntegration<T extends Integration>(integration: IntegrationClass<T>): T | null;
 
-  /** Returns all trace headers that are currently on the top scope. */
-  traceHeaders(): { [key: string]: string };
-
   /**
    * @deprecated No longer does anything. Use use {@link Transaction.startChild} instead.
    */

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -32,7 +32,7 @@ export {
   SessionFlusherLike,
 } from './session';
 export { Severity } from './severity';
-export { Span, SpanContext } from './span';
+export { Span, SpanContext, TraceHeaders } from './span';
 export { StackFrame } from './stackframe';
 export { Stacktrace } from './stacktrace';
 export { Status } from './status';

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -149,8 +149,12 @@ export interface Span extends SpanContext {
    */
   isSuccess(): boolean;
 
-  /** Return a traceparent compatible header string */
-  toTraceparent(): string;
+  /**
+   * Return a traceparent-compatible header string
+   *
+   * @deprecated Do not use `span.toTraceparnt` directly. Use `span.getTraceHeaders` instead.
+   */
+  toTraceparent(): string; // TODO (kmclb) make this private
 
   /** Returns the current span properties as a `SpanContext` */
   toContext(): SpanContext;

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -158,6 +158,13 @@ export interface Span extends SpanContext {
   /** Updates the current span with a new `SpanContext` */
   updateWithContext(spanContext: SpanContext): this;
 
+  /**
+   * Get headers to attach to any outgoing requests made by the operation corresponding to the current span
+   *
+   * @returns An object containing the headers
+   */
+  getTraceHeaders(): TraceHeaders;
+
   /** Convert the object to JSON for w. spans array info only */
   getTraceContext(): {
     data?: { [key: string]: any };
@@ -169,6 +176,7 @@ export interface Span extends SpanContext {
     tags?: { [key: string]: Primitive };
     trace_id: string;
   };
+
   /** Convert the object to JSON */
   toJSON(): {
     data?: { [key: string]: any };
@@ -183,3 +191,8 @@ export interface Span extends SpanContext {
     trace_id: string;
   };
 }
+
+export type TraceHeaders = {
+  'sentry-trace': string;
+  tracestate?: string;
+};

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -5,4 +5,5 @@ export interface User {
   ip_address?: string;
   email?: string;
   username?: string;
+  segment?: string;
 }

--- a/packages/utils/src/crossplatform.ts
+++ b/packages/utils/src/crossplatform.ts
@@ -1,0 +1,44 @@
+import { Integration } from '@sentry/types';
+
+/**
+ * Checks whether we're in the Node.js or Browser environment
+ *
+ * @returns Answer to given question
+ */
+export function isNodeEnv(): boolean {
+  return Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';
+}
+
+/** Internal */
+interface SentryGlobal {
+  Sentry?: {
+    Integrations?: Integration[];
+  };
+  SENTRY_ENVIRONMENT?: string;
+  SENTRY_DSN?: string;
+  SENTRY_RELEASE?: {
+    id?: string;
+  };
+  __SENTRY__: {
+    globalEventProcessors: any;
+    hub: any;
+    logger: any;
+  };
+}
+
+const fallbackGlobalObject = {};
+
+/**
+ * Safely get global scope object
+ *
+ * @returns Global scope object
+ */
+export function getGlobalObject<T>(): T & SentryGlobal {
+  return (isNodeEnv()
+    ? global
+    : typeof window !== 'undefined'
+    ? window
+    : typeof self !== 'undefined'
+    ? self
+    : fallbackGlobalObject) as T & SentryGlobal;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,5 +1,6 @@
 export * from './async';
 export * from './browser';
+export * from './crossplatform';
 export * from './dsn';
 export * from './error';
 export * from './instrument';

--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -2,9 +2,9 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { WrappedFunction } from '@sentry/types';
 
+import { getGlobalObject } from './crossplatform';
 import { isInstanceOf, isString } from './is';
 import { logger } from './logger';
-import { getGlobalObject } from './misc';
 import { fill } from './object';
 import { getFunctionName } from './stacktrace';
 import { supportsHistory, supportsNativeFetch } from './supports';

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { consoleSandbox, getGlobalObject } from './misc';
+import { getGlobalObject } from './crossplatform';
+import { consoleSandbox } from './misc';
 
 // TODO: Implement different loggers for different environments
 const global = getGlobalObject<Window | NodeJS.Global>();

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -217,6 +217,7 @@ interface SemVer {
 /**
  * Parses input into a SemVer interface
  * @param input string representation of a semver version
+ * @returns A object containing each part of the version string as a separate entry
  */
 export function parseSemver(input: string): SemVer {
   const match = input.match(SEMVER_REGEXP) || [];

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -1,42 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Event, Integration, StackFrame, WrappedFunction } from '@sentry/types';
+import { Event, StackFrame, WrappedFunction } from '@sentry/types';
 
-import { isNodeEnv } from './node';
+import { getGlobalObject } from './crossplatform';
 import { snipLine } from './string';
-
-/** Internal */
-interface SentryGlobal {
-  Sentry?: {
-    Integrations?: Integration[];
-  };
-  SENTRY_ENVIRONMENT?: string;
-  SENTRY_DSN?: string;
-  SENTRY_RELEASE?: {
-    id?: string;
-  };
-  __SENTRY__: {
-    globalEventProcessors: any;
-    hub: any;
-    logger: any;
-  };
-}
-
-const fallbackGlobalObject = {};
-
-/**
- * Safely get global scope object
- *
- * @returns Global scope object
- */
-export function getGlobalObject<T>(): T & SentryGlobal {
-  return (isNodeEnv()
-    ? global
-    : typeof window !== 'undefined'
-    ? window
-    : typeof self !== 'undefined'
-    ? self
-    : fallbackGlobalObject) as T & SentryGlobal;
-}
 
 /**
  * Extended Window interface that allows for Crypto API usage in IE browsers

--- a/packages/utils/src/node.ts
+++ b/packages/utils/src/node.ts
@@ -1,13 +1,4 @@
 /**
- * Checks whether we're in the Node.js or Browser environment
- *
- * @returns Answer to given question
- */
-export function isNodeEnv(): boolean {
-  return Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';
-}
-
-/**
  * Requires a module which is protected against bundler minification.
  *
  * @param request The module path to resolve

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -1,3 +1,5 @@
+import { getGlobalObject } from './misc';
+import { SentryError } from './error';
 import { isRegExp, isString } from './is';
 
 /**
@@ -100,4 +102,118 @@ export function isMatchingPattern(value: string, pattern: RegExp | string): bool
     return value.indexOf(pattern) !== -1;
   }
   return false;
+}
+
+type GlobalWithBase64Helpers = {
+  // browser
+  atob?: (base64String: string) => string;
+  btoa?: (utf8String: string) => string;
+  // Node
+  Buffer?: { from: (input: string, encoding: string) => { toString: (encoding: string) => string } };
+};
+
+/**
+ * Convert a Unicode string to a base64 string.
+ *
+ * @param plaintext The string to base64-encode
+ * @throws SentryError (because using the logger creates a circular dependency)
+ * @returns A base64-encoded version of the string
+ */
+export function unicodeToBase64(plaintext: string): string {
+  const globalObject = getGlobalObject<GlobalWithBase64Helpers>();
+
+  // To account for the fact that different platforms use different character encodings natively, our `tracestate`
+  // spec calls for all jsonified data to be encoded in UTF-8 bytes before being passed to the base64 encoder.
+  try {
+    if (typeof plaintext !== 'string') {
+      throw new Error(`Input must be a string. Received input of type '${typeof plaintext}'.`);
+    }
+
+    // browser
+    if ('btoa' in globalObject) {
+      // encode using UTF-8
+      const bytes = new TextEncoder().encode(plaintext);
+
+      // decode using UTF-16 (JS's native encoding) since `btoa` requires string input
+      const bytesAsString = String.fromCharCode(...bytes);
+
+      // TODO: if TS ever learns about "in", we can get rid of the non-null assertion
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return globalObject.btoa!(bytesAsString);
+    }
+
+    // Node
+    if ('Buffer' in globalObject) {
+      // encode using UTF-8
+      // TODO: if TS ever learns about "in", we can get rid of the non-null assertion
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const bytes = globalObject.Buffer!.from(plaintext, 'utf-8');
+
+      // unlike the browser, Node can go straight from bytes to base64
+      return bytes.toString('base64');
+    }
+
+    // we shouldn't ever get here, because one of `btoa` and `Buffer` should exist, but just in case...
+    throw new SentryError('Neither `window.btoa` nor `global.Buffer` is defined.');
+  } catch (err) {
+    // Cast to a string just in case we're given something else
+    const stringifiedInput = JSON.stringify(plaintext);
+    const errMsg = `Unable to convert to base64: ${
+      stringifiedInput?.length > 256 ? `${stringifiedInput.slice(0, 256)}...` : stringifiedInput
+    }.`;
+    throw new SentryError(`${errMsg}\nGot error: ${err}`);
+  }
+}
+
+/**
+ * Convert a base64 string to a Unicode string.
+ *
+ * @param base64String The string to decode
+ * @throws SentryError (because using the logger creates a circular dependency)
+ * @returns A Unicode string
+ */
+export function base64ToUnicode(base64String: string): string {
+  const globalObject = getGlobalObject<GlobalWithBase64Helpers>();
+
+  // To account for the fact that different platforms use different character encodings natively, our `tracestate` spec
+  // calls for all jsonified data to be encoded in UTF-8 bytes before being passed to the base64 encoder. So to reverse
+  // the process, decode from base64 to bytes, then feed those bytes to a UTF-8 decoder.
+  try {
+    if (typeof base64String !== 'string') {
+      throw new Error(`Input must be a string. Received input of type '${typeof base64String}'.`);
+    }
+
+    // browser
+    if ('atob' in globalObject) {
+      // `atob` returns a string rather than bytes, so we first need to encode using the native encoding (UTF-16)
+      // TODO: if TS ever learns about "in", we can get rid of the non-null assertion
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const bytesAsString = globalObject.atob!(base64String);
+      const bytes = [...bytesAsString].map(char => char.charCodeAt(0));
+
+      // decode using UTF-8 (cast the `bytes` arry to a Uint8Array just because that's the format `decode()` expects)
+      return new TextDecoder().decode(Uint8Array.from(bytes));
+    }
+
+    // Node
+    if ('Buffer' in globalObject) {
+      // unlike the browser, Node can go straight from base64 to bytes
+      // TODO: if TS ever learns about "in", we can get rid of the non-null assertion
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const bytes = globalObject.Buffer!.from(base64String, 'base64');
+
+      // decode using UTF-8
+      return bytes.toString('utf-8');
+    }
+
+    // we shouldn't ever get here, because one of `atob` and `Buffer` should exist, but just in case...
+    throw new SentryError('Neither `window.atob` nor `global.Buffer` is defined.');
+  } catch (err) {
+    // we cast to a string just in case we're given something else
+    const stringifiedInput = JSON.stringify(base64String);
+    const errMsg = `Unable to convert from base64: ${
+      stringifiedInput?.length > 256 ? `${stringifiedInput.slice(0, 256)}...` : stringifiedInput
+    }.`;
+    throw new SentryError(`${errMsg}\nGot error: ${err}`);
+  }
 }

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -1,4 +1,4 @@
-import { getGlobalObject } from './misc';
+import { getGlobalObject } from './crossplatform';
 import { SentryError } from './error';
 import { isRegExp, isString } from './is';
 

--- a/packages/utils/src/supports.ts
+++ b/packages/utils/src/supports.ts
@@ -1,5 +1,5 @@
+import { getGlobalObject } from './crossplatform';
 import { logger } from './logger';
-import { getGlobalObject } from './misc';
 
 /**
  * Tells whether current environment supports ErrorEvent objects

--- a/packages/utils/src/time.ts
+++ b/packages/utils/src/time.ts
@@ -1,5 +1,5 @@
-import { getGlobalObject } from './misc';
-import { dynamicRequire, isNodeEnv } from './node';
+import { getGlobalObject, isNodeEnv } from './crossplatform';
+import { dynamicRequire } from './node';
 
 /**
  * An object that can return the current timestamp in seconds since the UNIX epoch.

--- a/packages/utils/test/misc.test.ts
+++ b/packages/utils/test/misc.test.ts
@@ -1,12 +1,7 @@
 import { StackFrame } from '@sentry/types';
 
-import {
-  addContextToFrame,
-  getEventDescription,
-  getGlobalObject,
-  parseRetryAfterHeader,
-  stripUrlQueryAndFragment,
-} from '../src/misc';
+import { getGlobalObject } from '../src/crossplatform';
+import { addContextToFrame, getEventDescription, parseRetryAfterHeader, stripUrlQueryAndFragment } from '../src/misc';
 
 describe('getEventDescription()', () => {
   test('message event', () => {

--- a/packages/utils/test/string.test.ts
+++ b/packages/utils/test/string.test.ts
@@ -61,14 +61,9 @@ describe('base64ToUnicode/unicodeToBase64', () => {
     expect(BASE64_REGEX.test(unicodeToBase64(unicodeString))).toBe(true);
   });
 
-  test('works as expected', () => {
+  test('works as expected (and conversion functions are inverses)', () => {
     expect(unicodeToBase64(unicodeString)).toEqual(base64String);
     expect(base64ToUnicode(base64String)).toEqual(unicodeString);
-  });
-
-  test('conversion functions are inverses', () => {
-    expect(base64ToUnicode(unicodeToBase64(unicodeString))).toEqual(unicodeString);
-    expect(unicodeToBase64(base64ToUnicode(base64String))).toEqual(base64String);
   });
 
   test('can handle and preserve multi-byte characters in original string', () => {

--- a/packages/utils/test/string.test.ts
+++ b/packages/utils/test/string.test.ts
@@ -1,4 +1,8 @@
-import { isMatchingPattern, truncate } from '../src/string';
+import { base64ToUnicode, isMatchingPattern, truncate, unicodeToBase64 } from '../src/string';
+
+// See https://tools.ietf.org/html/rfc4648#section-4 for base64 spec
+// eslint-disable-next-line no-useless-escape
+const BASE64_REGEX = /([a-zA-Z0-9+/]{4})*(|([a-zA-Z0-9+/]{3}=)|([a-zA-Z0-9+/]{2}==))/;
 
 describe('truncate()', () => {
   test('it works as expected', () => {
@@ -43,5 +47,62 @@ describe('isMatchingPattern()', () => {
     expect(isMatchingPattern(undefined as any, 'foo')).toEqual(false);
     expect(isMatchingPattern({} as any, 'foo')).toEqual(false);
     expect(isMatchingPattern([] as any, 'foo')).toEqual(false);
+  });
+});
+
+// NOTE: These tests are copied (and adapted for chai syntax) to `string.test.ts` in `@sentry/browser`. The
+// base64-conversion functions have a different implementation in browser and node, so they're copied there to prove
+// they work in a real live browser. If you make changes here, make sure to also port them over to that copy.
+describe('base64ToUnicode/unicodeToBase64', () => {
+  const unicodeString = 'Dogs are great!';
+  const base64String = 'RG9ncyBhcmUgZ3JlYXQh';
+
+  test('converts to valid base64', () => {
+    expect(BASE64_REGEX.test(unicodeToBase64(unicodeString))).toBe(true);
+  });
+
+  test('works as expected', () => {
+    expect(unicodeToBase64(unicodeString)).toEqual(base64String);
+    expect(base64ToUnicode(base64String)).toEqual(unicodeString);
+  });
+
+  test('conversion functions are inverses', () => {
+    expect(base64ToUnicode(unicodeToBase64(unicodeString))).toEqual(unicodeString);
+    expect(unicodeToBase64(base64ToUnicode(base64String))).toEqual(base64String);
+  });
+
+  test('can handle and preserve multi-byte characters in original string', () => {
+    ['🐶', 'Καλό κορίτσι, Μάιζεϊ!', 'Of margir hundar! Ég geri ráð fyrir að ég þurfi stærra rúm.'].forEach(orig => {
+      expect(() => {
+        unicodeToBase64(orig);
+      }).not.toThrowError();
+      expect(base64ToUnicode(unicodeToBase64(orig))).toEqual(orig);
+    });
+  });
+
+  test('throws an error when given invalid input', () => {
+    expect(() => {
+      unicodeToBase64(null as any);
+    }).toThrowError('Unable to convert to base64');
+    expect(() => {
+      unicodeToBase64(undefined as any);
+    }).toThrowError('Unable to convert to base64');
+    expect(() => {
+      unicodeToBase64({} as any);
+    }).toThrowError('Unable to convert to base64');
+
+    expect(() => {
+      base64ToUnicode(null as any);
+    }).toThrowError('Unable to convert from base64');
+    expect(() => {
+      base64ToUnicode(undefined as any);
+    }).toThrowError('Unable to convert from base64');
+    expect(() => {
+      base64ToUnicode({} as any);
+    }).toThrowError('Unable to convert from base64');
+
+    // Note that by design, in node base64 encoding and decoding will accept any string, whether or not it's valid
+    // base64, by ignoring all invalid characters, including whitespace. Therefore, no wacky strings have been included
+    // here because they don't actually error.
   });
 });


### PR DESCRIPTION
This is the result of rebasing the feature branch for the initial implementation of `tracestate` header handling (which had grown very stale) on top of current `master`. That branch is going to get deleted, so for posterity, it included the following PRs (oldest -> newest):

feat(tracing): Add dynamic sampling correlation context data to envelope header (#3062)
chore(utils): Split browser/node compatibility utils into separate module (#3123)
ref(tracing): Prework for initial `tracestate` implementation (#3242)
feat(tracing): Add `tracestate` header to outgoing requests (#3092)
ref(tracing): Rework tracestate internals to allow for third-party data (#3266)
feat(tracing): Handle incoming tracestate data, allow for third-party data (#3275)
chore(tracing): Various small fixes to first `tracestate` implementation (#3291)
fix(tracing): Use `Request.headers.append` correctly (#3311)
feat(tracing): Add user data to tracestate header (#3343)
chore(various): Small fixes (#3368)
fix(build): Prevent Node's `Buffer` module from being included in browser bundles (#3372)
fix(tracing): Remove undefined tracestate data rather than setting it to `null` (#3373)

(This isn't a literal rebasing - the commits in this PR are different from those above - because in each original commit there were _so_ many merge conflicts, in so many parts of so many different files, that it seemed easier to apply the final state of that branch to current `master` and back-engineer a commit history from there, so that I only had to detangle each section of code once.) 

Of all the `TODO`s included in those PR descriptions, the ones that remain relevant are:

- We don't currently handle weird edge cases in terms of third-party data in the headers (blank values, for instance), as detailed in the [official spec](https://www.w3.org/TR/trace-context/#tracestate-header-field-values).
- User data is included as an object, with the keys `id` and `segment`. For now, the id is sent un-hashed (until we can figure out exactly how we want to handle hashing in a way which is repeatable across platforms).

In the meantime, one new one has cropped up:

- We need to add transaction name to the `tracestate` data. In doing this, we'll need to note all of the places where a transaction's name changes partway through (or at the end of) its lifecycle, as this could mean that the value in the propagated `tracestate` (depending on when it's computed) might not match the final value on the transaction event itself. (Most often, these midstream name changes are the result of replacing a literal URL (`/dogs/maisey`) with a parameterized one (`/dogs/:name`), which can't be done until the framework has finished routing the request.) It's an open question what to do with such a mismatch, but at minimum we should know when it might happen.

The only other notable thing about the branch is that there's a fairly comprehensive description of `tracestate` lazy computation (which might be useful for the `develop` docs) included in the description for https://github.com/getsentry/sentry-javascript/pull/3343.
