### PR TITLE
fix(ember): Allow ember-beta tests to fail

### DIFF
--- a/packages/ember/config/ember-try.js
+++ b/packages/ember/config/ember-try.js
@@ -30,6 +30,7 @@ module.exports = async function() {
             'ember-source': await getChannelURL('beta'),
           },
         },
+        allowedToFail: true,
       },
       embroiderSafe(),
       {


### PR DESCRIPTION
Though it's good to have a record of whether or not any given version of the SDK code plays nicely with ember-beta, it shouldn't be a blocker.

See also https://github.com/getsentry/sentry-javascript/pull/3104/. 
