### PR TITLE
fix(nextjs): Include nextjs config's basePath on urlPrefix

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -247,14 +247,15 @@ function getWebpackPluginOptions(
   const isWebpack5 = webpack.version.startsWith('5');
   const isServerless = nextConfig.target === 'experimental-serverless-trace';
   const hasSentryProperties = fs.existsSync(path.resolve(projectDir, 'sentry.properties'));
+  const urlPrefix = nextConfig.basePath ? `~${nextConfig.basePath}/_next` : '~/_next';
 
   const serverInclude = isServerless
-    ? [{ paths: ['.next/serverless/'], urlPrefix: '~/_next/serverless' }]
-    : [{ paths: ['.next/server/pages/'], urlPrefix: '~/_next/server/pages' }].concat(
-        isWebpack5 ? [{ paths: ['.next/server/chunks/'], urlPrefix: '~/_next/server/chunks' }] : [],
+    ? [{ paths: ['.next/serverless/'], urlPrefix: `${urlPrefix}/serverless` }]
+    : [{ paths: ['.next/server/pages/'], urlPrefix: `${urlPrefix}/server/pages` }].concat(
+        isWebpack5 ? [{ paths: ['.next/server/chunks/'], urlPrefix: `${urlPrefix}/server/chunks` }] : [],
       );
 
-  const clientInclude = [{ paths: ['.next/static/chunks/pages'], urlPrefix: '~/_next/static/chunks/pages' }];
+  const clientInclude = [{ paths: ['.next/static/chunks/pages'], urlPrefix: `${urlPrefix}/static/chunks/pages` }];
 
   const defaultPluginOptions = dropUndefinedKeys({
     include: isServer ? serverInclude : clientInclude,
@@ -265,7 +266,7 @@ function getWebpackPluginOptions(
     authToken: process.env.SENTRY_AUTH_TOKEN,
     configFile: hasSentryProperties ? 'sentry.properties' : undefined,
     stripPrefix: ['webpack://_N_E/'],
-    urlPrefix: `~/_next`,
+    urlPrefix,
     entries: shouldAddSentryToEntryPoint,
     release: getSentryRelease(buildId),
     dryRun: isDev,


### PR DESCRIPTION
When using `SentryWebpackPlugin` as part of the nextjs SDK, uploaded sourcemap names point to the wrong path if the nextjs `basePath` setting is used. This makes it so that the `urlPrefix` value includes `basePath`, if set.