### PR TITLE
fix(react): correct typo in ErrorBoundaryProps

### DIFF
--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -40,7 +40,7 @@ export type ErrorBoundaryProps = {
    *
    */
   fallback?: React.ReactElement | FallbackRender;
-  /** Called with the error boundary encounters an error */
+  /** Called when the error boundary encounters an error */
   onError?(error: Error, componentStack: string, eventId: string): void;
   /** Called on componentDidMount() */
   onMount?(): void;


### PR DESCRIPTION
corrects typo from "with" to "when"
