### PR TITLE
test(nextjs): Update type cast for integration test

### DIFF
--- a/packages/nextjs/test/integration/pages/users/[id].tsx
+++ b/packages/nextjs/test/integration/pages/users/[id].tsx
@@ -52,6 +52,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     // will receive `item` as a prop at build time
     return { props: { item } };
   } catch (err) {
-    return { props: { errors: (err as any).message } };
+    return { props: { errors: (err as Error).message } };
   }
 };


### PR DESCRIPTION
Currently on master tests are failing with:

```
./pages/users/[id].tsx:55:31
Type error: Object is of type 'unknown'.

  53 |     return { props: { item } };
  54 |   } catch (err) {
> 55 |     return { props: { errors: err.message } };
     |                               ^
  56 |   }
  57 | };
  58 |
```

To fix this, we cast err to `Error` type.