### PR TITLE
feat(tracing): Add transaction name to `tracestate` value

### DIFF
--- a/packages/core/test/lib/request.test.ts
+++ b/packages/core/test/lib/request.test.ts
@@ -87,12 +87,13 @@ describe('eventToSentryRequest', () => {
           //   public_key: 'dogsarebadatkeepingsecrets',
           //   release: 'off.leash.park',
           //   user: { id: '1121', segment: 'bigs' },
+          //   transaction: '/dogs/are/great/',
           // }),
           tracestate: {
             sentry:
               'sentry=eyJ0cmFjZV9pZCI6IjEyMzEyMDEyMTEyMTIwMTIiLCJlbnZpcm9ubWVudCI6ImRvZ3BhcmsiLCJwdWJsaWNfa2V5Ijo' +
               'iZG9nc2FyZWJhZGF0a2VlcGluZ3NlY3JldHMiLCJyZWxlYXNlIjoib2ZmLmxlYXNoLnBhcmsiLCJ1c2VyIjp7ImlkIjoiMTEyM' +
-              'SIsInNlZ21lbnQiOiJiaWdzIn19',
+              'SIsInNlZ21lbnQiOiJiaWdzIn0sInRyYW5zYWN0aW9uIjoiL2RvZ3MvYXJlL2dyZWF0LyJ9',
           },
         },
         spans: [],
@@ -135,6 +136,7 @@ describe('eventToSentryRequest', () => {
           public_key: 'dogsarebadatkeepingsecrets',
           release: 'off.leash.park',
           user: { id: '1121', segment: 'bigs' },
+          transaction: '/dogs/are/great/',
         });
       });
     });

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -393,6 +393,7 @@ export class Span implements SpanInterface {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       public_key: dsn.publicKey!,
       user,
+      transaction: this.transaction?.name,
     })}`;
   }
 

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -157,6 +157,7 @@ type SentryTracestateData = {
   release?: string;
   public_key: string;
   user?: { id?: string; segment?: string };
+  transaction?: string;
 };
 
 /**

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -110,14 +110,20 @@ describe('Span', () => {
     const environment = 'dogpark';
     const traceId = '12312012123120121231201212312012';
     const user = { id: '1121', segment: 'bigs' };
+    const transactionName = 'FETCH /ball';
 
-    const computedTracestate = `sentry=${computeTracestateValue({
+    const baseTracestateData = {
       trace_id: traceId,
       environment,
       release,
       public_key: publicKey,
       user,
+    };
+    const computedTracestate = `sentry=${computeTracestateValue({
+      ...baseTracestateData,
+      transaction: transactionName,
     })}`;
+    const computedOrphanTracestate = `sentry=${computeTracestateValue(baseTracestateData)}`;
     const thirdpartyData = 'maisey=silly,charlie=goofy';
 
     const hub = new Hub(
@@ -134,14 +140,14 @@ describe('Span', () => {
     });
 
     test('no third-party data', () => {
-      const transaction = new Transaction({ name: 'FETCH /ball', traceId }, hub);
+      const transaction = new Transaction({ name: transactionName, traceId }, hub);
       const span = transaction.startChild({ op: 'dig.hole' });
 
       expect(span.getTraceHeaders().tracestate).toEqual(computedTracestate);
     });
 
     test('third-party data', () => {
-      const transaction = new Transaction({ name: 'FETCH /ball' }, hub);
+      const transaction = new Transaction({ name: transactionName }, hub);
       transaction.setMetadata({ tracestate: { sentry: computedTracestate, thirdparty: thirdpartyData } });
       const span = transaction.startChild({ op: 'dig.hole' });
 
@@ -153,7 +159,7 @@ describe('Span', () => {
       const span = new Span({ op: 'dig.hole' });
       span.traceId = traceId;
 
-      expect(span.getTraceHeaders().tracestate).toEqual(computedTracestate);
+      expect(span.getTraceHeaders().tracestate).toEqual(computedOrphanTracestate);
     });
   });
 


### PR DESCRIPTION
This adds transaction name to the `tracetate` value. 

Doing this has two known limitations, which, though we've discussed them, I'm adding here for posterity:

1) Adding this data puts us over the character limit for tracestate values [listed in the W3C spec](https://www.w3.org/TR/trace-context/#value) (256 characters). To be fair, depending on the data, we might already be over this limit with the previous addition of `user` . For reference:

    Given the tracestate data:

    ```
    {
      trace_id: "12312012123120121231201212312012",
      environment: dogpark,
      release: off.leash.park,
      public_key: dogsarebadatkeepingsecrets,
      user: {id: 12312013, segment: "bigs"},
      transaction: /interactions/other-dogs/new-dog/
    }
    ```

    `tracestate`  with without either: 196 characters
    `tracestate` with `user` data: 256 characters
    `tracestate` with `transaction`: 264 characters
    `tracestate` with both: 324 characters

2) This data may change and/or get added to the scope after the tracestate value has been calculated, making it impossible to sample based on those attributes. This is especially a problem for transaction name, which in some frameworks isn't set to its final value until the transaction ends. This poses the added problem that the transaction name in its raw, un-finalized form may contain PII, because it is often the raw URL as opposed to the parameterized one (so, `/users/maisey/tricks/` rather than `/users/:username/tricks/`). More work needs to be done to investigate whether the final transaction name can be set earlier in any/all of the frameworks where this poses a problem. (For instance, it is a known problem in our Express integration, but not yet clear if it is a problem in any Python frameworks.)
