### PR TITLE
ref(nextjs): Small improvements to config tests

### DIFF
--- a/packages/nextjs/src/config/index.ts
+++ b/packages/nextjs/src/config/index.ts
@@ -15,7 +15,7 @@ export function withSentryConfig(
   // If the user has passed us a function, we need to return a function, so that we have access to `phase` and
   // `defaults` in order to pass them along to the user's function
   if (typeof userNextConfig === 'function') {
-    return function(phase: string, defaults: { defaultConfig: { [key: string]: unknown } }): NextConfigObject {
+    return function(phase: string, defaults: { defaultConfig: NextConfigObject }): NextConfigObject {
       const materializedUserNextConfig = userNextConfig(phase, defaults);
       return {
         ...materializedUserNextConfig,

--- a/packages/nextjs/test/config.test.ts
+++ b/packages/nextjs/test/config.test.ts
@@ -51,7 +51,9 @@ process.env.SENTRY_RELEASE = 'doGsaREgReaT';
 
 /** Mocks of the arguments passed to the result of `withSentryConfig` (when it's a function). */
 const runtimePhase = 'ball-fetching';
-const defaultNextConfig = { nappingHoursPerDay: 20, oversizeFeet: true, shouldChaseTail: true };
+// `defaultConfig` is the defaults for all nextjs options (we don't use these at all in the tests, so for our purposes
+// here the values don't matter)
+const defaultsObject = { defaultConfig: {} };
 
 /** mocks of the arguments passed to `nextConfig.webpack` */
 const serverWebpackConfig = {
@@ -114,9 +116,7 @@ function materializeFinalNextConfig(
   if (typeof sentrifiedConfig === 'function') {
     // for some reason TS won't recognize that `finalConfigValues` is now a NextConfigObject, which is why the cast
     // below is necessary
-    finalConfigValues = sentrifiedConfig(runtimePhase, {
-      defaultConfig: defaultNextConfig,
-    });
+    finalConfigValues = sentrifiedConfig(runtimePhase, defaultsObject);
   }
 
   return finalConfigValues as NextConfigObject;
@@ -145,11 +145,7 @@ async function materializeFinalWebpackConfig(options: {
 
   // if the user's next config is a function, run it so we have access to the values
   const materializedUserNextConfig =
-    typeof userNextConfig === 'function'
-      ? userNextConfig('phase-production-build', {
-          defaultConfig: {},
-        })
-      : userNextConfig;
+    typeof userNextConfig === 'function' ? userNextConfig('phase-production-build', defaultsObject) : userNextConfig;
 
   // get the webpack config function we'd normally pass back to next
   const webpackConfigFunction = constructWebpackConfigFunction(
@@ -211,9 +207,7 @@ describe('withSentryConfig', () => {
 
     materializeFinalNextConfig(userNextConfigFunction);
 
-    expect(userNextConfigFunction).toHaveBeenCalledWith(runtimePhase, {
-      defaultConfig: defaultNextConfig,
-    });
+    expect(userNextConfigFunction).toHaveBeenCalledWith(runtimePhase, defaultsObject);
   });
 });
 

--- a/packages/nextjs/test/config.test.ts
+++ b/packages/nextjs/test/config.test.ts
@@ -33,7 +33,7 @@ const mockExistsSync = (path: fs.PathLike) => {
 const exitsSync = jest.spyOn(fs, 'existsSync').mockImplementation(mockExistsSync);
 
 /** Mocks of the arguments passed to `withSentryConfig` */
-const userNextConfig = {
+const userNextConfig: Partial<NextConfigObject> = {
   publicRuntimeConfig: { location: 'dogpark', activities: ['fetch', 'chasing', 'digging'] },
   webpack: (config: WebpackConfigObject, _options: BuildContext) => ({
     ...config,
@@ -243,7 +243,7 @@ describe('webpack config', () => {
 
     // Run the user's webpack config function, so we can check the results against ours. Delete `entry` because we'll
     // test it separately, and besides, it's one that we *should* be overwriting.
-    const materializedUserWebpackConfig = userNextConfig.webpack(serverWebpackConfig, serverBuildContext);
+    const materializedUserWebpackConfig = userNextConfig.webpack!(serverWebpackConfig, serverBuildContext);
     // @ts-ignore `entry` may be required in real life, but we don't need it for our tests
     delete materializedUserWebpackConfig.entry;
 

--- a/packages/nextjs/test/config.test.ts
+++ b/packages/nextjs/test/config.test.ts
@@ -86,19 +86,18 @@ const clientWebpackConfig = {
   context: '/Users/Maisey/projects/squirrelChasingSimulator',
 };
 
-// In real life, next will copy the userNextConfig into the buildContext. Since we're providing mocks for both of
-// those, though, we need to do that manually.
+// In real life, next will copy the `userNextConfig` into the `buildContext`. Since we're providing mocks for both of
+// those, we need to mimic that behavior, and since `userNextConfig` can vary per test, we need to have the option do it
+// dynamically.
 function getBuildContext(buildTarget: 'server' | 'client', userNextConfig: Partial<NextConfigObject>): BuildContext {
-  const baseBuildContext = {
+  return {
     dev: false,
     buildId: 'sItStAyLiEdOwN',
     dir: '/Users/Maisey/projects/squirrelChasingSimulator',
     config: { target: 'server', ...userNextConfig },
     webpack: { version: '5.4.15' },
+    isServer: buildTarget === 'server',
   };
-  const isServer = buildTarget === 'server';
-
-  return { isServer, ...baseBuildContext } as BuildContext;
 }
 const serverBuildContext = getBuildContext('server', userNextConfig);
 const clientBuildContext = getBuildContext('client', userNextConfig);


### PR DESCRIPTION
In the process of reviewing https://github.com/getsentry/sentry-javascript/pull/3922, I realized that there was some cleanup work I could do to make that PR work better. Specifically:

- `withSentryConfig` had an incorrect type for one of the arguments  to the `userNextConfig` function.
- The mock for that same argument was missing its outer layer, and therefore wasn't really what it said it was.
- In real life, the `config` property of `buildContext` is equal to the combination of next's default config and the user-provided config. The mock wasn't reflecting this.
- That PR was having to compensate for the fact that the mocks for build context were static rather than dynamic, even though those test cases especially illustrate the ways in which the value of the mock needs to change depending on other values in the test. Where necessary, the build context is now calculated as part of the test.
