### PR TITLE
Fix metrics borking module load in worker

### DIFF
--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -23,7 +23,7 @@ export class MetricsInstrumentation {
   private _clsEntry: LayoutShift | undefined;
 
   public constructor() {
-    if (!isNodeEnv() && global?.performance) {
+    if (!isNodeEnv() && global?.performance && global?.document) {
       if (global.performance.mark) {
         global.performance.mark('sentry-tracing-init');
       }

--- a/packages/tracing/test/browser/metrics.test.ts
+++ b/packages/tracing/test/browser/metrics.test.ts
@@ -183,7 +183,25 @@ describe('MetricsInstrumentation', () => {
     trackers.forEach(tracker => expect(tracker).not.toBeCalled());
   });
 
-  it('initializes trackers when not on node and `global.performance` is available.', () => {
+  it('does not initialize trackers when not on node but `global.document` is not available (in worker)', () => {
+    // window not necessary for this test, but it is here to exercise that it is absence of document that is checked
+    addDOMPropertiesToGlobal(['performance', 'addEventListener', 'window']);
+    const processBackup = global.process;
+    global.process = undefined;
+    const documentBackup = global.document;
+    global.document = undefined;
+
+    const trackers = ['_trackCLS', '_trackLCP', '_trackFID'].map(tracker =>
+      jest.spyOn(MetricsInstrumentation.prototype as any, tracker),
+    );
+    new MetricsInstrumentation();
+    global.process = processBackup;
+    global.document = documentBackup;
+
+    trackers.forEach(tracker => expect(tracker).not.toBeCalled());
+  });
+
+  it('initializes trackers when not on node and `global.performance` and `global.document` are available.', () => {
     addDOMPropertiesToGlobal(['performance', 'document', 'addEventListener', 'window']);
     const backup = global.process;
     global.process = undefined;


### PR DESCRIPTION
Minimal fix for getsentry/sentry-javascript#3934

Added a test case exercising this fix.

Test case sidenote 1: I noticed state bleeding between test cases. If this new test case is placed _after_ the existing `initializes trackers when not on node and...` case, then it fails because that existing test case adds properties onto the global object and leaves them there. It should clean up, but I've not tried to address this.

Test case sidenote 2: when I _remove_ my fix to verify that the new test case fails, then actually the whole test suite fails to run because the `expect` library borks on `process` being falsy --- despite the process backup having been put back onto the global object before `expect` is called. This must be some jest execution reordering black magic and I have not tried to trobuleshoot it.


Tested manually that this fixes the problem in my setup.



Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
