### PR TITLE
fix(node): Disable autoSessionTracking if dsn undefined

### DIFF
--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -114,7 +114,7 @@ export function init(options: NodeOptions = {}): void {
     options.environment = process.env.SENTRY_ENVIRONMENT;
   }
 
-  if (options.autoSessionTracking === undefined) {
+  if (options.autoSessionTracking === undefined && options.dsn !== undefined) {
     options.autoSessionTracking = true;
   }
 

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -402,7 +402,7 @@ describe('SentryNode initialization', () => {
     });
   });
 
-  describe.only('autoSessionTracking', () => {
+  describe('autoSessionTracking', () => {
     it('enables autoSessionTracking if there is a release', () => {
       init({
         dsn: '',

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -377,7 +377,7 @@ describe('SentryNode initialization', () => {
           defaultIntegrations: [new MockIntegration('bar')],
         });
         const integrations = (initAndBind as jest.Mock).mock.calls[0][1].defaultIntegrations;
-        expect(integrations.map(i => i.name)).toEqual(['bar', 'foo']);
+        expect(integrations.map((i: { name: string }) => i.name)).toEqual(['bar', 'foo']);
       });
     });
 
@@ -387,7 +387,7 @@ describe('SentryNode initialization', () => {
           defaultIntegrations: [new MockIntegration('baz'), new MockIntegration('qux')],
         });
         const integrations = (initAndBind as jest.Mock).mock.calls[0][1].defaultIntegrations;
-        expect(integrations.map(i => i.name)).toEqual(['baz', 'qux', 'foo', 'bar']);
+        expect(integrations.map((i: { name: string }) => i.name)).toEqual(['baz', 'qux', 'foo', 'bar']);
       });
     });
 
@@ -399,6 +399,27 @@ describe('SentryNode initialization', () => {
         const integrations = (initAndBind as jest.Mock).mock.calls[0][1].defaultIntegrations;
         expect(integrations).toEqual([]);
       });
+    });
+  });
+
+  describe.only('autoSessionTracking', () => {
+    it('enables autoSessionTracking if there is a release', () => {
+      init({
+        dsn: '',
+        release: '3.5.7',
+      });
+
+      const options = (initAndBind as jest.Mock).mock.calls[0][1];
+      expect(options.autoSessionTracking).toBe(true);
+    });
+
+    it('disables autoSessionTracking if dsn is undefined', () => {
+      init({
+        release: '3.5.7',
+      });
+
+      const options = (initAndBind as jest.Mock).mock.calls[0][1];
+      expect(options.autoSessionTracking).toBe(undefined);
     });
   });
 });


### PR DESCRIPTION
Will help address situations like #3827, where user's have an open handle from the session flusher in tests.