### PR TITLE
TS4.4 exactOptionalPropertyTypes: backend

### DIFF
--- a/packages/browser/src/backend.ts
+++ b/packages/browser/src/backend.ts
@@ -15,20 +15,20 @@ export interface BrowserOptions extends Options {
    * This is the opposite of {@link Options.denyUrls}.
    * By default, all errors will be sent.
    */
-  allowUrls?: Array<string | RegExp>;
+  allowUrls?: Array<string | RegExp> | undefined;
 
   /**
    * A pattern for error URLs which should not be sent to Sentry.
    * To allow certain errors instead, use {@link Options.allowUrls}.
    * By default, all errors will be sent.
    */
-  denyUrls?: Array<string | RegExp>;
+  denyUrls?: Array<string | RegExp> | undefined;
 
   /** @deprecated use {@link Options.allowUrls} instead. */
-  whitelistUrls?: Array<string | RegExp>;
+  whitelistUrls?: Array<string | RegExp> | undefined;
 
   /** @deprecated use {@link Options.denyUrls} instead. */
-  blacklistUrls?: Array<string | RegExp>;
+  blacklistUrls?: Array<string | RegExp> | undefined;
 }
 
 /**
@@ -39,13 +39,13 @@ export class BrowserBackend extends BaseBackend<BrowserOptions> {
   /**
    * @inheritDoc
    */
-  public eventFromException(exception: unknown, hint?: EventHint): PromiseLike<Event> {
+  public eventFromException(exception: unknown, hint?: EventHint | undefined): PromiseLike<Event> {
     return eventFromException(this._options, exception, hint);
   }
   /**
    * @inheritDoc
    */
-  public eventFromMessage(message: string, level: Severity = Severity.Info, hint?: EventHint): PromiseLike<Event> {
+  public eventFromMessage(message: string, level: Severity = Severity.Info, hint?: EventHint | undefined): PromiseLike<Event> {
     return eventFromMessage(this._options, message, level, hint);
   }
 


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

I cannot lint in this instance, because I am PR'ing from the GitHub web UI. 🙃
Hopefully the PRs have GitHub workflows that will lint on my behalf.

---

TypeScript 4.4 added a new compiler option, `exactOptionalPropertyTypes`, which distinguishes between `{}` and `{ key: undefined }`. With this flag, `f(key?: string)`  may either be `f()` or `f('str')`, but may _not_ be `f(undefined)`. In most cases, `f(undefined)` should be acceptable, including in Sentry.

Example:

```
function myInit({ allowUrls }) {
  init({ allowUrls });
}

myInit({}); // should be valid,
```

In the above example, TypeScript 4.4 throws an error with the flag because `allowUrls` must either be an array or _not set at all_. It does not allow this code such that it is set to `undefined`.

For future consumer-facing code, please replace `[key]?: T` with `[key]?: T | undefined`. 🙃

---

Sorry in advance that each file is a separate PR. This also, however, allows blast radius to be reduced, and is particularly relevant for any properties where `undefined` should not be supported.