### PR TITLE
TS4.4 exactOptionalPropertyTypes: options

### DIFF
--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -12,88 +12,88 @@ export interface Options {
   /**
    * Enable debug functionality in the SDK itself
    */
-  debug?: boolean;
+  debug?: boolean | undefined;
 
   /**
    * Specifies whether this SDK should activate and send events to Sentry.
    * Disabling the SDK reduces all overhead from instrumentation, collecting
    * breadcrumbs and capturing events. Defaults to true.
    */
-  enabled?: boolean;
+  enabled?: boolean | undefined;
 
   /**
    * The Dsn used to connect to Sentry and identify the project. If omitted, the
    * SDK will not send any data to Sentry.
    */
-  dsn?: string;
+  dsn?: string | undefined;
 
   /**
    * If this is set to false, default integrations will not be added, otherwise this will internally be set to the
    * recommended default integrations.
    * TODO: We should consider changing this to `boolean | Integration[]`
    */
-  defaultIntegrations?: false | Integration[];
+  defaultIntegrations?: false | Integration[] | undefined;
 
   /**
    * List of integrations that should be installed after SDK was initialized.
    * Accepts either a list of integrations or a function that receives
    * default integrations and returns a new, updated list.
    */
-  integrations?: Integration[] | ((integrations: Integration[]) => Integration[]);
+  integrations?: Integration[] | ((integrations: Integration[]) => Integration[]) | undefined;
 
   /**
    * A pattern for error messages which should not be sent to Sentry.
    * By default, all errors will be sent.
    */
-  ignoreErrors?: Array<string | RegExp>;
+  ignoreErrors?: Array<string | RegExp> | undefined;
 
   /**
    * Transport object that should be used to send events to Sentry
    */
-  transport?: TransportClass<Transport>;
+  transport?: TransportClass<Transport> | undefined;
 
   /**
    * Options for the default transport that the SDK uses.
    */
-  transportOptions?: TransportOptions;
+  transportOptions?: TransportOptions | undefined;
 
   /**
    * A URL to an envelope tunnel endpoint. An envelope tunnel is an HTTP endpoint
    * that accepts Sentry envelopes for forwarding. This can be used to force data
    * through a custom server independent of the type of data.
    */
-  tunnel?: string;
+  tunnel?: string | undefined;
 
   /**
    * The release identifier used when uploading respective source maps. Specify
    * this value to allow Sentry to resolve the correct source maps when
    * processing events.
    */
-  release?: string;
+  release?: string | undefined;
 
   /** The current environment of your application (e.g. "production"). */
-  environment?: string;
+  environment?: string | undefined;
 
   /** Sets the distribution for all events */
-  dist?: string;
+  dist?: string | undefined;
 
   /**
    * The maximum number of breadcrumbs sent with events. Defaults to 100.
    * Values over 100 will be ignored and 100 used instead.
    */
-  maxBreadcrumbs?: number;
+  maxBreadcrumbs?: number | undefined;
 
   /** Console logging verbosity for the SDK Client. */
-  logLevel?: LogLevel;
+  logLevel?: LogLevel | undefined;
 
   /** A global sample rate to apply to all events (0 - 1). */
-  sampleRate?: number;
+  sampleRate?: number | undefined;
 
   /** Attaches stacktraces to pure capture message / log integrations */
-  attachStacktrace?: boolean;
+  attachStacktrace?: boolean | undefined;
 
   /** Maxium number of chars a single value can have before it will be truncated. */
-  maxValueLength?: number;
+  maxValueLength?: number | undefined;
 
   /**
    * Maximum number of levels that normalization algorithm will traverse in objects and arrays.
@@ -104,7 +104,7 @@ export interface Options {
    * - `extra`
    * Defaults to `3`. Set to `0` to disable.
    */
-  normalizeDepth?: number;
+  normalizeDepth?: number | undefined;
 
   /**
    * Controls how many milliseconds to wait before shutting down. The default is
@@ -113,7 +113,7 @@ export interface Options {
    * high can cause the application to block for users with network connectivity
    * problems.
    */
-  shutdownTimeout?: number;
+  shutdownTimeout?: number | undefined;
 
   /**
    * Sample rate to determine trace sampling.
@@ -124,31 +124,31 @@ export interface Options {
    * Tracing is enabled if either this or `tracesSampler` is defined. If both are defined, `tracesSampleRate` is
    * ignored.
    */
-  tracesSampleRate?: number;
+  tracesSampleRate?: number | undefined;
 
   /**
    * A flag enabling Sessions Tracking feature.
    * By default, Sessions Tracking is enabled.
    */
-  autoSessionTracking?: boolean;
+  autoSessionTracking?: boolean | undefined;
 
   /**
    * Initial data to populate scope.
    */
-  initialScope?: CaptureContext;
+  initialScope?: CaptureContext | undefined;
 
   /**
    * Set of metadata about the SDK that can be internally used to enhance envelopes and events,
    * and provide additional data about every request.
    * */
-  _metadata?: SdkMetadata;
+  _metadata?: SdkMetadata | undefined;
 
   /**
    * Options which are in beta, or otherwise not guaranteed to be stable.
    */
   _experiments?: {
     [key: string]: any;
-  };
+  } | undefined;
 
   /**
    * Function to compute tracing sample rate dynamically and filter unwanted traces.
@@ -162,7 +162,7 @@ export interface Options {
    * @returns A sample rate between 0 and 1 (0 drops the trace, 1 guarantees it will be sent). Returning `true` is
    * equivalent to returning 1 and returning `false` is equivalent to returning 0.
    */
-  tracesSampler?(samplingContext: SamplingContext): number | boolean;
+  tracesSampler?: undefined | ((samplingContext: SamplingContext) => number | boolean);
 
   /**
    * A callback invoked during event submission, allowing to optionally modify
@@ -176,7 +176,7 @@ export interface Options {
    * @param hint May contain additional information about the original exception.
    * @returns A new event that will be sent | null.
    */
-  beforeSend?(event: Event, hint?: EventHint): PromiseLike<Event | null> | Event | null;
+  beforeSend?: undefined | ((event: Event, hint?: EventHint) => PromiseLike<Event | null> | Event | null);
 
   /**
    * A callback invoked when adding a breadcrumb, allowing to optionally modify
@@ -189,5 +189,5 @@ export interface Options {
    * @param breadcrumb The breadcrumb as created by the SDK.
    * @returns The breadcrumb that will be added | null.
    */
-  beforeBreadcrumb?(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): Breadcrumb | null;
+  beforeBreadcrumb?: undefined | ((breadcrumb: Breadcrumb, hint?: BreadcrumbHint) => Breadcrumb | null);
 }


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

I cannot lint in this instance, because I am PR'ing from the GitHub web UI. 🙃

---

TypeScript 4.4 added a new compiler option, `exactOptionalPropertyTypes`, which distinguishes between `{}` and `{ key: undefined }`. With this flag, `f(key?: string)`  may either be `f()` or `f('str')`, but may _not_ be `f(undefined)`. In most cases, `f(undefined)` should be acceptable, including in Sentry.

Example:

```
function myInit({ allowUrls }) {
  init({ allowUrls });
}

myInit({}); // should be valid,
```

In the above example, TypeScript 4.4 throws an error with the flag because `allowUrls` must either be an array or _not set at all_. It does not allow this code such that it is set to `undefined`.

For future consumer-facing code, please replace `[key]?: T` with `[key]?: T | undefined`. 🙃

---

Sorry in advance that each file is a separate PR. This also, however, allows blast radius to be reduced, and is particularly relevant for any properties where `undefined` should not be supported.