### PR TITLE
ref(ember): Remove Ember source from main deps

### DIFF
--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -39,8 +39,7 @@
     "ember-auto-import": "^1.6.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^5.1.2",
-    "ember-cli-typescript": "^3.1.4",
-    "ember-source": "3.24.3"
+    "ember-cli-typescript": "^3.1.4"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",


### PR DESCRIPTION
Ember source only needs to be included as a dev dep for addons.

Fixes #3962
