### PR TITLE
fix(browser): Make sure that document.head or document.body exists for injectReportDialog

### DIFF
--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -211,5 +211,9 @@ export function injectReportDialog(options: ReportDialogOptions = {}): void {
     script.onload = options.onLoad;
   }
 
-  (document.head || document.body).appendChild(script);
+  const injectionPoint = document.head || document.body;
+
+  if (injectionPoint) {
+    injectionPoint.appendChild(script);
+  }
 }


### PR DESCRIPTION
We had a report of this exact code failing, so better safe than sorry.