### PR TITLE
fix(nextjs): Move `@sentry/webpack-plugin` back to non-dev dependencies

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -23,11 +23,11 @@
     "@sentry/react": "6.12.0",
     "@sentry/tracing": "6.12.0",
     "@sentry/utils": "6.12.0",
+    "@sentry/webpack-plugin": "1.17.1",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
     "@sentry/types": "6.12.0",
-    "@sentry/webpack-plugin": "1.17.1",
     "@types/webpack": "^5.28.0",
     "eslint": "7.20.0",
     "next": "10.1.3",


### PR DESCRIPTION
This reverts the change made in https://github.com/getsentry/sentry-javascript/pull/3866. The SDK user needs the webpack plugin in order to upload their sourcemaps, so it needs to be installed when they install the SDK.
