### PR TITLE
feat(tracing): Add integration for IORedis

### DIFF
--- a/packages/tracing/src/hubextensions.ts
+++ b/packages/tracing/src/hubextensions.ts
@@ -249,6 +249,10 @@ function _autoloadDatabaseIntegrations(): void {
       };
       return new integration.Postgres();
     },
+    ioredis() {
+      const integration = dynamicRequire(module, './integration/ioredis') as { IORedis: IntegrationClass<Integration> };
+      return new integration.IORedis();
+    },
   };
 
   const mappedPackages = Object.keys(packageToIntegrationMapping)

--- a/packages/tracing/src/integrations/index.ts
+++ b/packages/tracing/src/integrations/index.ts
@@ -2,3 +2,4 @@ export { Express } from './node/express';
 export { Postgres } from './node/postgres';
 export { Mysql } from './node/mysql';
 export { Mongo } from './node/mongo';
+export { IORedis } from './node/ioredis';

--- a/packages/tracing/src/integrations/node/ioredis.ts
+++ b/packages/tracing/src/integrations/node/ioredis.ts
@@ -1,0 +1,101 @@
+import { Hub } from '@sentry/hub';
+import { EventProcessor, Integration, SpanContext } from '@sentry/types';
+import { fill, loadModule, logger } from '@sentry/utils';
+
+type CommandArgs = string | Buffer | number | unknown[];
+
+interface Command {
+  name: string;
+  args: CommandArgs[];
+}
+
+interface IORedisInstance {
+  prototype: {
+    sendCommand: (command: Command, ...args: unknown[]) => unknown;
+  };
+}
+
+interface IORedisOptions {
+  // location of the ioredis package
+  // allows users to specify the direct in case they are using
+  // libraries that are wrappers around ioredis
+  moduleLocation?: string;
+}
+
+/** Tracing integration for the IORedis library */
+export class IORedis implements Integration {
+  /**
+   * @inheritDoc
+   */
+  public static id: string = 'IORedis';
+
+  /**
+   * @inheritDoc
+   */
+  public name: string = IORedis.id;
+
+  /**
+   * Location of the IORedis package
+   */
+  private _moduleLocation: string;
+
+  /**
+   * @inheritDoc
+   */
+  public constructor(options: IORedisOptions = {}) {
+    this._moduleLocation = options.moduleLocation ?? 'ioredis';
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
+    const pkg = loadModule<IORedisInstance>(this._moduleLocation);
+
+    if (!pkg) {
+      logger.error(`IORedis integration was unable to require \`${this._moduleLocation}\` package.`);
+      return;
+    }
+
+    this._patchOperation(pkg, getCurrentHub);
+  }
+
+  /**
+   *  Patches the sendCommand function to utilize tracing
+   */
+  private _patchOperation(ioredis: IORedisInstance, getCurrentHub: () => Hub): void {
+    const getSpanContext = this._getSpanContextFromCommandArguments.bind(this);
+
+    fill(ioredis.prototype, 'sendCommand', function(orig: () => Promise<unknown>) {
+      return function(this: unknown, command: Command, ...args: unknown[]) {
+        const scope = getCurrentHub().getScope();
+        const parentSpan = scope?.getSpan();
+
+        const span = parentSpan?.startChild(getSpanContext(command));
+        const responsePromise = orig.call(this, command, ...args) as Promise<unknown>;
+
+        return responsePromise.then((res: unknown) => {
+          span?.finish();
+          return res;
+        });
+      };
+    });
+  }
+
+  /**
+   *
+   */
+  private _getSpanContextFromCommandArguments(command: Command): SpanContext {
+    const data: { [key: string]: string } = {
+      arguments: command.args.toString(),
+    };
+
+    const spanContext: SpanContext = {
+      op: 'redis',
+      description: command.name,
+      data,
+    };
+
+    return spanContext;
+  }
+}

--- a/packages/tracing/test/integrations/node/ioredis.test.ts
+++ b/packages/tracing/test/integrations/node/ioredis.test.ts
@@ -1,0 +1,64 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { Hub, Scope } from '@sentry/hub';
+
+import { IORedis } from '../../../src/integrations/node/ioredis';
+import { Span } from '../../../src/span';
+
+class Redis {
+  public sendCommand(_command: unknown, ..._args: unknown[]) {
+    return Promise.resolve();
+  }
+}
+
+jest.mock('@sentry/utils', () => {
+  const actual = jest.requireActual('@sentry/utils');
+  return {
+    ...actual,
+    loadModule() {
+      return Redis;
+    },
+  };
+});
+
+describe('patchOperation', () => {
+  const redis: Redis = new Redis();
+  let scope = new Scope();
+  let parentSpan: Span;
+  let childSpan: Span;
+
+  beforeAll(() => {
+    new IORedis().setupOnce(
+      () => undefined,
+      () => new Hub(undefined, scope),
+    );
+  });
+
+  beforeEach(() => {
+    scope = new Scope();
+    parentSpan = new Span();
+    childSpan = parentSpan.startChild();
+    jest.spyOn(scope, 'getSpan').mockReturnValueOnce(parentSpan);
+    jest.spyOn(parentSpan, 'startChild').mockReturnValueOnce(childSpan);
+    jest.spyOn(childSpan, 'finish');
+  });
+
+  it('should wrap the sendCommand method and process a new span', done => {
+    void redis
+      .sendCommand({
+        name: 'set',
+        args: ['key', 'value'],
+      })
+      .then(() => {
+        expect(scope.getSpan).toBeCalled();
+        expect(parentSpan.startChild).toBeCalledWith({
+          op: 'redis',
+          description: 'set',
+          data: {
+            arguments: 'key,value',
+          },
+        });
+        expect(childSpan.finish).toBeCalled();
+        done();
+      });
+  });
+});


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [✔️] If you've added code that should be tested, please add tests.
- [✔️] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

This PR adds a basic tracing integration for IORedis. It currently accepts all commands that IORedis supports (there is no filtering on the basis of command names).

I took the Mongo tracing integration as the basis for the structure of the code & tests. Please let me know if I need to change anything there.

How it looks in the UI - 
![image](https://user-images.githubusercontent.com/6716458/133802517-ec3685a3-9236-406e-a6f1-078b08fef8a4.png)


Addresses #3856 
