### PR TITLE
feat(nextjs): Sourcemaps for custom build directories

### DIFF
--- a/packages/nextjs/src/config/nextConfigToWebpackPluginConfig.ts
+++ b/packages/nextjs/src/config/nextConfigToWebpackPluginConfig.ts
@@ -117,6 +117,7 @@ export function includeDistDir(
       );
       // Keep the same object even if it's incorrect, so that the user can get a more precise error from sentry-cli
       // Casting to `any` for TS not complaining about it being `unknown`
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       sourcesToInclude = usersInclude as any;
     }
   }

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -122,7 +122,7 @@ const BASEPATH_VARNAME = 'PROJECT_BASEPATH';
 function updateRewriteFramesBasepath(distDir: string): void {
   if (distDir === PROJECT_BASEPATH) return;
   // esm
-  setProjectBasepath('./node_modules/@sentry/minimal/esm/index.server.js', 'var ', distDir);
+  setProjectBasepath('./node_modules/@sentry/nextjs/esm/index.server.js', 'var ', distDir);
   // es5
   setProjectBasepath('./node_modules/@sentry/nextjs/dist/index.server.js', 'exports.', distDir);
 }

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -122,7 +122,7 @@ const BASEPATH_VARNAME = 'PROJECT_BASEPATH';
 function updateRewriteFramesBasepath(distDir: string): void {
   if (distDir === PROJECT_BASEPATH) return;
   // esm
-  setProjectBasepath('./node_modules/@sentry/minimal/esm/index.js', 'var ', distDir);
+  setProjectBasepath('./node_modules/@sentry/minimal/esm/index.server.js', 'var ', distDir);
   // es5
   setProjectBasepath('./node_modules/@sentry/nextjs/dist/index.server.js', 'exports.', distDir);
 }

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -136,6 +136,7 @@ function updateRewriteFramesBasepath(projectRootDir: string, distDir: string): v
       distDir,
     );
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.warn(
       'Sentry Logger [Warn]: ' +
         `Could not set custom build directory \`${distDir}\`, required for correct display of source maps. `,

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -55,7 +55,7 @@ export function constructWebpackConfigFunction(
     // `distDir` is always defined in real life: either the user defines a value, or Next.js sets the default `.next`.
     // The check is for different environments, such as in tests.
     if (buildContext.isServer && buildContext.config.distDir) {
-      updateRewriteFramesBasepath(buildContext.config.distDir as string);
+      updateRewriteFramesBasepath(buildContext.dir, buildContext.config.distDir as string);
     }
 
     // Tell webpack to inject user config files (containing the two `Sentry.init()` calls) into the appropriate output
@@ -120,13 +120,21 @@ export function constructWebpackConfigFunction(
 // TODO: make sure in tests that `PROJECT_BASEPATH` var exists in `index.server.ts`
 const BASEPATH_VARNAME = 'PROJECT_BASEPATH';
 
-function updateRewriteFramesBasepath(distDir: string): void {
+function updateRewriteFramesBasepath(projectRootDir: string, distDir: string): void {
   if (distDir === PROJECT_BASEPATH) return;
   try {
     // esm
-    setProjectBasepath('./node_modules/@sentry/nextjs/esm/index.server.js', 'var ', distDir);
+    setProjectBasepath(
+      path.join(projectRootDir, 'node_modules', '@sentry', 'nextjs', 'esm', 'index.server.js'),
+      'var ',
+      distDir,
+    );
     // es5
-    setProjectBasepath('./node_modules/@sentry/nextjs/dist/index.server.js', 'exports.', distDir);
+    setProjectBasepath(
+      path.join(projectRootDir, 'node_modules', '@sentry', 'nextjs', 'dist', 'index.server.js'),
+      'exports.',
+      distDir,
+    );
   } catch (error) {
     console.warn(
       'Sentry Logger [Warn]: ' +

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -133,6 +133,18 @@ export const BASEPATH_VARNAME = 'PROJECT_BASEPATH';
  * files that must be overwritten. This use case arises when you run the build step in
  * a different directory from the one the project is; for example, in tests.
  *
+ * Why this approach?
+ * There are two times to define the path: run time and build time. In any case,
+ * Next.js requires the user to set `distDir` in the options to compile the project.
+ * To get this path at run time and the SDK build it, users must also define the
+ * option in the SDK's server's configuration. However, to get the path at build time,
+ * users only need to set it once since the `withSentryConfig` wrapper can read the
+ * user's Next.js configuration. The SDK generates the `RewriteFrames` integration at
+ * initialization, meaning it's impossible to dynamically set the distribution directory
+ * path at build time if the option is only available at run time. To solve this issue,
+ * the SDK at build time rewrites the files where the default path of the integration is,
+ * so it's successfully generated at run time without additional configuration.
+ *
  * The project root is
  * @param projectRootDir Root directory of the Next.js project.
  * @param distDir The distribution directory.

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -47,9 +47,26 @@ function sdkAlreadyInitialized(): boolean {
   return !!hub.getClient();
 }
 
+/**
+ * WARNING: don't refactor this variable.
+ * This variable gets overridden at build time to set the correct path -- what users
+ * defined in the `distDir` option in their Next.js configuration.
+ *
+ * Why this approach?
+ * There are two times to define the path: run time and build time. In any case,
+ * Next.js requires the user to set `distDir` in the options to compile the project.
+ * To get this path at run time and the SDK build it, users must also define the
+ * option in the SDK's server's configuration. However, to get the path at build time,
+ * users only need to set it once since the `withSentryConfig` wrapper can read the
+ * user's Next.js configuration. The SDK generates the `RewriteFrames` integration at
+ * initialization, meaning it's impossible to dynamically set the distribution directory
+ * path at build time if the option is only available at run time. To solve this issue,
+ * the SDK at build time rewrites the file where the default path of the integration is,
+ * so it's successfully generated at run time without additional configuration.
+ */
 export const PROJECT_BASEPATH = '.next';
-const projectBasepathRegexp = PROJECT_BASEPATH[0] === '.' ? `\\${PROJECT_BASEPATH}` : PROJECT_BASEPATH;
-const sourcemapFilenameRegex = new RegExp(`^.*/${projectBasepathRegexp}/`);
+const projectBasepathRegex = PROJECT_BASEPATH[0] === '.' ? `\\${PROJECT_BASEPATH}` : PROJECT_BASEPATH;
+const sourcemapFilenameRegex = new RegExp(`^.*/${projectBasepathRegex}/`);
 
 const defaultRewriteFramesIntegration = new RewriteFrames({
   iteratee: frame => {

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -47,11 +47,13 @@ function sdkAlreadyInitialized(): boolean {
   return !!hub.getClient();
 }
 
-const SOURCEMAP_FILENAME_REGEX = /^.*\/\.next\//;
+export const PROJECT_BASEPATH = '.next';
+const projectBasepathRegexp = PROJECT_BASEPATH[0] === '.' ? `\\${PROJECT_BASEPATH}` : PROJECT_BASEPATH;
+const sourcemapFilenameRegex = new RegExp(`^.*/${projectBasepathRegexp}/`);
 
 const defaultRewriteFramesIntegration = new RewriteFrames({
   iteratee: frame => {
-    frame.filename = frame.filename?.replace(SOURCEMAP_FILENAME_REGEX, 'app:///_next/');
+    frame.filename = frame.filename?.replace(sourcemapFilenameRegex, 'app:///_next/');
     return frame;
   },
 });

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -51,18 +51,6 @@ function sdkAlreadyInitialized(): boolean {
  * WARNING: don't refactor this variable.
  * This variable gets overridden at build time to set the correct path -- what users
  * defined in the `distDir` option in their Next.js configuration.
- *
- * Why this approach?
- * There are two times to define the path: run time and build time. In any case,
- * Next.js requires the user to set `distDir` in the options to compile the project.
- * To get this path at run time and the SDK build it, users must also define the
- * option in the SDK's server's configuration. However, to get the path at build time,
- * users only need to set it once since the `withSentryConfig` wrapper can read the
- * user's Next.js configuration. The SDK generates the `RewriteFrames` integration at
- * initialization, meaning it's impossible to dynamically set the distribution directory
- * path at build time if the option is only available at run time. To solve this issue,
- * the SDK at build time rewrites the file where the default path of the integration is,
- * so it's successfully generated at run time without additional configuration.
  */
 export const PROJECT_BASEPATH = '.next';
 const projectBasepathRegex = PROJECT_BASEPATH[0] === '.' ? `\\${PROJECT_BASEPATH}` : PROJECT_BASEPATH;

--- a/packages/nextjs/test/config.test.ts
+++ b/packages/nextjs/test/config.test.ts
@@ -392,7 +392,7 @@ describe('webpack config', () => {
           es5: "exports.PROJECT_BASEPATH = '.test';",
         },
       ],
-      /** `expectedContents === null` => contents shouldn't change */
+      // `expectedContents === null` => contents shouldn't change
     ])('%s', async (_testName, buildContext, expectedContents: null | Record<string, string>) => {
       await materializeFinalWebpackConfig({
         userNextConfig,

--- a/packages/nextjs/test/config.test.ts
+++ b/packages/nextjs/test/config.test.ts
@@ -14,6 +14,7 @@ import {
   WebpackConfigObject,
 } from '../src/config/types';
 import {
+  BASEPATH_VARNAME,
   constructWebpackConfigFunction,
   getUserConfigFile,
   getWebpackPluginOptions,
@@ -402,6 +403,12 @@ describe('webpack config', () => {
         const contents = fs.readFileSync(format.file).toString();
         expect(contents).toStrictEqual(expectedContents ? expectedContents[format.name] : format.contents);
       });
+    });
+
+    test(`\`${BASEPATH_VARNAME}\` is defined in \`index.server.ts\``, () => {
+      const indexServerPath = path.join(__dirname, '..', 'src', 'index.server.ts');
+      const fileContents = fs.readFileSync(indexServerPath).toString();
+      expect(fileContents).toMatch(new RegExp(`\\Wconst ${BASEPATH_VARNAME} =\\W`));
     });
   });
 });


### PR DESCRIPTION
This PR makes the Next.js SDK rewrite at build time the `RewriteFrames` integration's base path RegExp to the `distDir` option the user has defined in the Next.js configuration.

**Why this approach?**
The file names of the source maps must be formatted to display correct stack traces on server errors, defining the file names in the `RewriteFrames` integration. One use case is defining a custom distribution directory (the `distDir` option), and that's the option explored below.

There are two times to define the path: run time and build time. In any case, Next.js requires the user to set `distDir` in the options to compile the project. To get this path at run time and the SDK build it, users must also define the option in the SDK's server's configuration. However, to get the path at build time, users only need to set it once since the `withSentryConfig` wrapper can read the user's Next.js configuration. The SDK generates the `RewriteFrames` integration at initialization, meaning it's impossible to dynamically set the distribution directory path at build time if the option is only available at run time. To solve this issue, the SDK at build time rewrites the file where the default path of the integration is, so it's successfully generated at run time without additional configuration.

Since the second option improves the user experience, it's the approach taken in this PR.