### PR TITLE
chore(react): Add ts-ignore for fallback tests

### DIFF
--- a/packages/react/test/errorboundary.test.tsx
+++ b/packages/react/test/errorboundary.test.tsx
@@ -80,6 +80,7 @@ describe('ErrorBoundary', () => {
 
   it('renders null if not given a valid `fallback` prop', () => {
     const { container } = render(
+      // @ts-ignore Passing wrong type on purpose
       <ErrorBoundary fallback="Not a ReactElement">
         <Bam />
       </ErrorBoundary>,
@@ -90,6 +91,7 @@ describe('ErrorBoundary', () => {
 
   it('renders null if not given a valid `fallback` prop function', () => {
     const { container } = render(
+      // @ts-ignore Passing wrong type on purpose
       <ErrorBoundary fallback={() => 'Not a ReactElement'}>
         <Bam />
       </ErrorBoundary>,


### PR DESCRIPTION
Some tests are testing behaviour when we pass the wrong type on purpose. We should make sure we ts-ignore in those cases.
