### PR TITLE
ref(core): Make getTransport method on client optional

### DIFF
--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -106,7 +106,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
 
       this._hub
         .getClient()
-        ?.getTransport()
+        ?.getTransport?.()
         .recordLostEvent?.(Outcome.SampleRate, 'transaction');
 
       return undefined;

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -61,7 +61,7 @@ export interface Client<O extends Options = Options> {
   getOptions(): O;
 
   /** Returns clients transport. */
-  getTransport(): Transport;
+  getTransport?(): Transport;
 
   /**
    * Flush the event queue and set the client to `enabled = false`. See {@link Client.flush}.


### PR DESCRIPTION
I changed it to optional instead of just adding `?.` check to make sure that we won't forget to do that in case we use it in other places. We do the same with `sendSession` already.

Closes https://github.com/getsentry/sentry-javascript/issues/3995