### PR TITLE
feat(nextjs): Add ability for integration tests to use linked `@sentry/xxxx` packages

### DIFF
--- a/packages/nextjs/test/integration_test_utils.sh
+++ b/packages/nextjs/test/integration_test_utils.sh
@@ -1,13 +1,12 @@
 function link_package() {
   local package_abs_path=$1
   local package_name=$2
-  local current_dir=$(pwd)
 
   echo "Setting up @sentry/${package_name} for linking"
-  cd $package_abs_path
+  pushd $package_abs_path
   yarn link
+  popd
 
-  cd $current_dir
   echo "Linking @sentry/$package_name"
   yarn link "@sentry/$package_name"
 
@@ -33,10 +32,9 @@ function linkplugin() {
       # the webpack plugin depends on `@sentry/cli`, so if we're using a linked version of the cli package, the plugin
       # needs to link to it, too
       if [[ $LINK_CLI ]]; then
-        local current_dir=$(pwd)
-        cd $WEBPACK_PLUGIN_REPO
-        link_package $CLI_REPO "cli"
-        cd $current_dir
+        pushd $WEBPACK_PLUGIN_REPO
+        link_cli
+        popd
       fi
     else
       echo "Can't link @sentry/wepack-plugin because WEBPACK_PLUGIN_REPO is not set."

--- a/packages/nextjs/test/integration_test_utils.sh
+++ b/packages/nextjs/test/integration_test_utils.sh
@@ -12,32 +12,40 @@ function link_package() {
 
 }
 
-# Note: CLI_REPO and WEBPACK_PLUGIN_REPO in the functions below should be set to the absolute path of each local repo
+# Note: LINKED_CLI_REPO and LINKED_PLUGIN_REPO in the functions below should be set to the absolute path of each local repo
 
 function linkcli() {
-  if [[ $LINK_CLI ]]; then
-    if [[ $CLI_REPO ]]; then
-      link_package $CLI_REPO "cli"
-    else
-      echo "Can't link @sentry/cli because CLI_REPO is not set."
-    fi
+  if [[ ! $LINKED_CLI_REPO ]]; then
+    return
+  fi
+
+  # check to make sure the repo directory exists
+  if [[ -d $LINKED_CLI_REPO ]]; then
+    link_package $LINKED_CLI_REPO "cli"
+  else
+    # the $1 lets us insert a string in that spot if one is passed to `linkcli` (useful for when we're calling this from
+    # within another linking function)
+    echo "ERROR: Can't link @sentry/cli $1because directory $LINKED_CLI_REPO does not exist."
   fi
 }
 
 function linkplugin() {
-  if [[ $LINK_PLUGIN ]]; then
-    if [[ $WEBPACK_PLUGIN_REPO ]]; then
-      link_package $WEBPACK_PLUGIN_REPO "webpack-plugin"
+  if [[ ! $LINKED_PLUGIN_REPO ]]; then
+    return
+  fi
 
-      # the webpack plugin depends on `@sentry/cli`, so if we're using a linked version of the cli package, the plugin
-      # needs to link to it, too
-      if [[ $LINK_CLI ]]; then
-        pushd $WEBPACK_PLUGIN_REPO
-        link_cli
-        popd
-      fi
-    else
-      echo "Can't link @sentry/wepack-plugin because WEBPACK_PLUGIN_REPO is not set."
+  # check to make sure the repo directory exists
+  if [[ -d $LINKED_PLUGIN_REPO ]]; then
+    link_package $LINKED_PLUGIN_REPO "webpack-plugin"
+
+    # the webpack plugin depends on `@sentry/cli`, so if we're also using a linked version of the cli package, the
+    # plugin needs to link to it, too
+    if [[ $LINKED_CLI_REPO ]]; then
+      pushd $LINKED_PLUGIN_REPO
+      link_cli "in webpack plugin repo "
+      popd
     fi
+  else
+    echo "ERROR: Can't link @sentry/wepack-plugin because $LINKED_PLUGIN_REPO does not exist."
   fi
 }

--- a/packages/nextjs/test/integration_test_utils.sh
+++ b/packages/nextjs/test/integration_test_utils.sh
@@ -1,0 +1,45 @@
+function link_package() {
+  local package_abs_path=$1
+  local package_name=$2
+  local current_dir=$(pwd)
+
+  echo "Setting up @sentry/${package_name} for linking"
+  cd $package_abs_path
+  yarn link
+
+  cd $current_dir
+  echo "Linking @sentry/$package_name"
+  yarn link "@sentry/$package_name"
+
+}
+
+# Note: CLI_REPO and WEBPACK_PLUGIN_REPO in the functions below should be set to the absolute path of each local repo
+
+function linkcli() {
+  if [[ $LINK_CLI ]]; then
+    if [[ $CLI_REPO ]]; then
+      link_package $CLI_REPO "cli"
+    else
+      echo "Can't link @sentry/cli because CLI_REPO is not set."
+    fi
+  fi
+}
+
+function linkplugin() {
+  if [[ $LINK_PLUGIN ]]; then
+    if [[ $WEBPACK_PLUGIN_REPO ]]; then
+      link_package $WEBPACK_PLUGIN_REPO "webpack-plugin"
+
+      # the webpack plugin depends on `@sentry/cli`, so if we're using a linked version of the cli package, the plugin
+      # needs to link to it, too
+      if [[ $LINK_CLI ]]; then
+        local current_dir=$(pwd)
+        cd $WEBPACK_PLUGIN_REPO
+        link_package $CLI_REPO "cli"
+        cd $current_dir
+      fi
+    else
+      echo "Can't link @sentry/wepack-plugin because WEBPACK_PLUGIN_REPO is not set."
+    fi
+  fi
+}

--- a/packages/nextjs/test/run-integration-tests.sh
+++ b/packages/nextjs/test/run-integration-tests.sh
@@ -58,8 +58,7 @@ for NEXTJS_VERSION in 10 11; do
   fi
   yarn --no-lockfile --silent >/dev/null 2>&1
   # if applicable, use local versions of `@sentry/cli` and/or `@sentry/webpack-plugin` (these commands no-op unless
-  # LINK_CLI, CLI_REPO, LINK_PLUGIN, and WEBPACK_PLUGIN_REPO (or just the first two if only `@sentry/cli` is being
-  # linked) are set)
+  # LINKED_CLI_REPO and/or LINKED_PLUGIN_REPO is set)
   linkcli && linkplugin
   mv -f package.json.bak package.json 2>/dev/null || true
 

--- a/packages/nextjs/test/run-integration-tests.sh
+++ b/packages/nextjs/test/run-integration-tests.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source test/integration_test_utils.sh
+
 set -e
 
 START_TIME=$(date -R)
@@ -55,6 +57,10 @@ for NEXTJS_VERSION in 10 11; do
     sed -i /"next.*latest"/s/latest/"${NEXTJS_VERSION}.x"/ package.json
   fi
   yarn --no-lockfile --silent >/dev/null 2>&1
+  # if applicable, use local versions of `@sentry/cli` and/or `@sentry/webpack-plugin` (these commands no-op unless
+  # LINK_CLI, CLI_REPO, LINK_PLUGIN, and WEBPACK_PLUGIN_REPO (or just the first two if only `@sentry/cli` is being
+  # linked) are set)
+  linkcli && linkplugin
   mv -f package.json.bak package.json 2>/dev/null || true
 
   for RUN_WEBPACK_5 in false true; do
@@ -72,9 +78,10 @@ for NEXTJS_VERSION in 10 11; do
     echo "[nextjs@$NEXTJS_VERSION | webpack@$WEBPACK_VERSION] Building..."
     yarn build | grep "Using webpack"
 
+    # if the user hasn't passed any args, use the default one, which restricts each test to only outputting success and
+    # failure messages
     args=$*
     if [[ ! $args ]]; then
-      # restrict each test to only output success and failure messages
       args="--silent"
     fi
 


### PR DESCRIPTION
In the nextjs integration tests, we use file dependencies for all of the packages in the `sentry-javascript` repo, so that the tests test the local (rather than published) version of the SDK. We don't do the same for `@sentry/cli` or `@sentry/webpack-plugin`, though, because they're in a separate repo and we can't predict where the local copy of that repo lives. As a result, we currently can't (in the nextjs integration tests, at least) test any local changes in either package.

This solves that problem by optionally linking to the local copies of those repos as part of the integration test runner script. In order to use this optional linking:

- To link `@sentry/cli`, set `LINKED_CLI_REPO=<abs path of local sentry-cli repo>`.
- To link `@sentry/webpack-plugin`, set the CLI variable above (since `@sentry/cli` is a dependency of `@sentry/webpack-plugin`, we need to link it in the plugin repo also) as well as `LINKED_PLUGIN_REPO=<abs path of local sentry-webpack-plugin repo>`