### PR TITLE
fix(browser): Reassign `lastEventId` while eliminating duplicate events.

### DIFF
--- a/packages/browser/src/integrations/dedupe.ts
+++ b/packages/browser/src/integrations/dedupe.ts
@@ -23,11 +23,16 @@ export class Dedupe implements Integration {
    */
   public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
     addGlobalEventProcessor((currentEvent: Event) => {
-      const self = getCurrentHub().getIntegration(Dedupe);
+      const hub = getCurrentHub();
+      const self = hub.getIntegration(Dedupe);
+
       if (self) {
         // Juuust in case something goes wrong
         try {
           if (self._shouldDropEvent(currentEvent, self._previousEvent)) {
+            if (self._previousEvent?.event_id) {
+              hub.setLastEventId(self._previousEvent?.event_id);
+            }
             logger.warn(`Event dropped due to being a duplicate of previously captured event.`);
             return null;
           }

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -186,7 +186,7 @@ export class Hub implements HubInterface {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   public captureException(exception: any, hint?: EventHint): string {
-    const eventId = (this._lastEventId = uuid4());
+    const eventId = this.setLastEventId(uuid4());
     let finalHint = hint;
 
     // If there's no explicit hint provided, mimic the same thing that would happen
@@ -217,7 +217,7 @@ export class Hub implements HubInterface {
    * @inheritDoc
    */
   public captureMessage(message: string, level?: Severity, hint?: EventHint): string {
-    const eventId = (this._lastEventId = uuid4());
+    const eventId = this.setLastEventId(uuid4());
     let finalHint = hint;
 
     // If there's no explicit hint provided, mimic the same thing that would happen
@@ -250,7 +250,7 @@ export class Hub implements HubInterface {
   public captureEvent(event: Event, hint?: EventHint): string {
     const eventId = uuid4();
     if (event.type !== 'transaction') {
-      this._lastEventId = eventId;
+      this.setLastEventId(eventId);
     }
 
     this._invokeClient('captureEvent', event, {
@@ -265,6 +265,13 @@ export class Hub implements HubInterface {
    */
   public lastEventId(): string | undefined {
     return this._lastEventId;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public setLastEventId(id: string): string {
+    return (this._lastEventId = id);
   }
 
   /**

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -117,6 +117,13 @@ export interface Hub {
   addBreadcrumb(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): void;
 
   /**
+   * This is the setter for lastEventId.
+   *
+   * @returns The event id which has set.
+   */
+  setLastEventId(id: string): string;
+
+  /**
    * Updates user context information for future events.
    *
    * @param user User context object to be set in the current context. Pass `null` to unset the user.


### PR DESCRIPTION
Fixes: #4018 