### PR TITLE
fix(nextjs): Delay error propagation until `withSentry` is done

### DIFF
--- a/packages/nextjs/src/utils/withSentry.ts
+++ b/packages/nextjs/src/utils/withSentry.ts
@@ -157,7 +157,9 @@ export const withSentry = (origHandler: NextApiHandler): WrappedNextApiHandler =
       }
     });
 
-    return await boundHandler();
+    // Since API route handlers are all async, nextjs always awaits the return value (meaning it's fine for us to return
+    // a promise here rather than a real result, and it saves us the overhead of an `await` call.)
+    return boundHandler();
   };
 };
 

--- a/packages/nextjs/src/utils/withSentry.ts
+++ b/packages/nextjs/src/utils/withSentry.ts
@@ -150,6 +150,12 @@ export const withSentry = (origHandler: NextApiHandler): WrappedNextApiHandler =
           captureException(objectifiedErr);
         }
 
+        // Because we're going to finish and send the transaction before passing the error onto nextjs, it won't yet
+        // have had a chance to set the status to 500, so unless we do it ourselves now, we'll incorrectly report that
+        // the transaction was error-free
+        res.statusCode = 500;
+        res.statusMessage = 'Internal Server Error';
+
         // Make sure we have a chance to finish the transaction and flush events to Sentry before the handler errors
         // out. (Apps which are deployed on Vercel run their API routes in lambdas, and those lambdas will shut down the
         // moment they detect an error, so it's important to get this done before rethrowing the error. Apps not

--- a/packages/nextjs/src/utils/withSentry.ts
+++ b/packages/nextjs/src/utils/withSentry.ts
@@ -3,12 +3,13 @@ import { extractTraceparentData, hasTracingEnabled } from '@sentry/tracing';
 import { Transaction } from '@sentry/types';
 import { addExceptionMechanism, isString, logger, objectify, stripUrlQueryAndFragment } from '@sentry/utils';
 import * as domain from 'domain';
-import { NextApiHandler, NextApiResponse } from 'next';
+import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 
 const { parseRequest } = Handlers;
 
-// purely for clarity
-type WrappedNextApiHandler = NextApiHandler;
+// This is the same as the `NextApiHandler` type, except instead of having a return type of `void | Promise<void>`, it's
+// only `Promise<void>`, because wrapped handlers are always async
+export type WrappedNextApiHandler = (req: NextApiRequest, res: NextApiResponse) => Promise<void>;
 
 export type AugmentedNextApiResponse = NextApiResponse & {
   __sentryTransaction?: Transaction;

--- a/packages/nextjs/test/utils/withSentry.test.ts
+++ b/packages/nextjs/test/utils/withSentry.test.ts
@@ -47,13 +47,13 @@ const flushSpy = jest.spyOn(Sentry, 'flush').mockImplementation(async () => {
 describe('withSentry', () => {
   let req: NextApiRequest, res: NextApiResponse;
 
-  const error = new Error('Oh, no! Charlie ate the flip-flops! :-(');
+  const noShoesError = new Error('Oh, no! Charlie ate the flip-flops! :-(');
 
   const origHandlerNoError: NextApiHandler = async (_req, res) => {
     res.send('Good dog, Maisey!');
   };
   const origHandlerWithError: NextApiHandler = async (_req, _res) => {
-    throw error;
+    throw noShoesError;
   };
 
   const wrappedHandlerNoError = withSentry(origHandlerNoError);
@@ -80,10 +80,10 @@ describe('withSentry', () => {
       try {
         await callWrappedHandler(wrappedHandlerWithError, req, res);
       } catch (err) {
-        expect(err).toBe(error);
+        expect(err).toBe(noShoesError);
       }
 
-      expect(captureExceptionSpy).toHaveBeenCalledWith(error);
+      expect(captureExceptionSpy).toHaveBeenCalledWith(noShoesError);
       expect(flushSpy).toHaveBeenCalled();
       expect(loggerSpy).toHaveBeenCalledWith('Done flushing events');
 

--- a/packages/nextjs/test/utils/withSentry.test.ts
+++ b/packages/nextjs/test/utils/withSentry.test.ts
@@ -1,0 +1,92 @@
+import * as Sentry from '@sentry/node';
+import * as utils from '@sentry/utils';
+import { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
+
+import { AugmentedNextApiResponse, withSentry, WrappedNextApiHandler } from '../../src/utils/withSentry';
+
+const FLUSH_DURATION = 200;
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function callWrappedHandler(wrappedHandler: WrappedNextApiHandler, req: NextApiRequest, res: NextApiResponse) {
+  await wrappedHandler(req, res);
+
+  // Within the wrapped handler, we await `flush()` inside `res.end()`, but nothing awaits `res.end()`, because in its
+  // original version, it's sync (unlike the function we wrap around it). The original does actually *act* like an async
+  // function being awaited - subsequent steps in the request/response lifecycle don't happen until it emits a
+  // `prefinished` event (which is why it's safe for us to make the switch). But here in tests, there's nothing past
+  // `res.end()`, so we have to manually wait for it to be done.
+  await sleep(FLUSH_DURATION);
+  while (!res.finished) {
+    await sleep(100);
+  }
+}
+
+// We mock `captureException` as a no-op because under normal circumstances it is an un-awaited effectively-async
+// function which might or might not finish before any given test ends, potentially leading jest to error out.
+const captureExceptionSpy = jest.spyOn(Sentry, 'captureException').mockImplementation(jest.fn());
+const loggerSpy = jest.spyOn(utils.logger, 'log');
+const flushSpy = jest.spyOn(Sentry, 'flush').mockImplementation(async () => {
+  // simulate the time it takes time to flush all events
+  await sleep(FLUSH_DURATION);
+  return true;
+});
+
+describe('withSentry', () => {
+  let req: NextApiRequest, res: NextApiResponse;
+
+  const error = new Error('Oh, no! Charlie ate the flip-flops! :-(');
+
+  const origHandlerNoError: NextApiHandler = async (_req, res) => {
+    res.send('Good dog, Maisey!');
+  };
+  const origHandlerWithError: NextApiHandler = async (_req, _res) => {
+    throw error;
+  };
+
+  const wrappedHandlerNoError = withSentry(origHandlerNoError);
+  const wrappedHandlerWithError = withSentry(origHandlerWithError);
+
+  beforeEach(() => {
+    req = { url: 'http://dogs.are.great' } as NextApiRequest;
+    res = ({
+      send: function(this: AugmentedNextApiResponse) {
+        this.end();
+      },
+      end: function(this: AugmentedNextApiResponse) {
+        this.finished = true;
+      },
+    } as unknown) as AugmentedNextApiResponse;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('flushing', () => {
+    it('flushes events before rethrowing error', async () => {
+      try {
+        await callWrappedHandler(wrappedHandlerWithError, req, res);
+      } catch (err) {
+        expect(err).toBe(error);
+      }
+
+      expect(captureExceptionSpy).toHaveBeenCalledWith(error);
+      expect(flushSpy).toHaveBeenCalled();
+      expect(loggerSpy).toHaveBeenCalledWith('Done flushing events');
+
+      // This ensures the expect inside the `catch` block actually ran, i.e., that in the end the wrapped handler
+      // errored out the same way it would without sentry, meaning the error was indeed rethrown
+      expect.assertions(4);
+    });
+
+    it('flushes events before finishing non-erroring response', async () => {
+      await callWrappedHandler(wrappedHandlerNoError, req, res);
+
+      expect(flushSpy).toHaveBeenCalled();
+      expect(loggerSpy).toHaveBeenCalledWith('Done flushing events');
+    });
+  });
+});


### PR DESCRIPTION
In our nextjs API route wrapper `withSentry`, we capture any errors thrown by the original handler, and then once we've captured them, we rethrow them, so that our capturing of them doesn't interfere with whatever other error handling might go on. Until recently, that was fine, as nextjs didn't actually propagate the error any farther, and so it didn't interfere with our processing pipeline and didn't prevent `res.end()` (on which we rely for finishing the transaction and flushing events to Sentry) from running.

However, Vercel [released a change](https://github.com/vercel/next.js/pull/26875) which caused said errors to begin propagating if the API route is running on Vercel. (Technically, it's if the server is running in minimal mode, but all API handlers on vercel do.) A side effect of this change is that when there's an error, `res.end()` is no longer called. As a result, the SDK's work is cut short, and neither errors in API route handlers nor transactions tracing such routes make it to Sentry.

This fixes that, by moving the work of finishing the transaction and flushing events into its own function and calling it not only in `res.end()` but also before we rethrow the error.

(Note: In the cases where there is an error and the server is not running in minimal mode, this means that function will be hit twice, but that's okay, since the second time around it will just no-op, since `transaction.finish()` bails immediately if the transaction is already finished, and `flush()` returns immediately if there's nothing to flush.)

H/t to @jmurty for his work in https://github.com/getsentry/sentry-javascript/pull/4044, which helped me fix some problems in my first approach to solving this problem.

Fixes https://github.com/getsentry/sentry-javascript/issues/3917.