### PR TITLE
Ensure `withSentry` reports API (serverless) errors from Vercel

### DIFF
--- a/packages/nextjs/src/utils/withSentry.ts
+++ b/packages/nextjs/src/utils/withSentry.ts
@@ -10,7 +10,7 @@ const { parseRequest } = Handlers;
 // purely for clarity
 type WrappedNextApiHandler = NextApiHandler;
 
-type AugmentedResponse = NextApiResponse & { __sentryTransaction?: Transaction, __flushed?: boolean };
+type AugmentedResponse = NextApiResponse & { __sentryTransaction?: Transaction; __flushed?: boolean };
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const withSentry = (handler: NextApiHandler): WrappedNextApiHandler => {
@@ -105,7 +105,7 @@ async function finishTransactionAndFlush(res: AugmentedResponse) {
 
     // Push `transaction.finish` to the next event loop so open spans have a better chance of finishing before the
     // transaction closes, and make sure to wait until that's done before flushing events
-    const transactionFinished: Promise<void> = new Promise((resolve) => {
+    const transactionFinished: Promise<void> = new Promise(resolve => {
       setImmediate(() => {
         transaction.finish();
         resolve();
@@ -134,7 +134,6 @@ type WrappedResponseEndMethod = AugmentedResponse['end'];
 
 function wrapEndMethod(origEnd: ResponseEndMethod): WrappedResponseEndMethod {
   return async function newEnd(this: AugmentedResponse, ...args: unknown[]) {
-
     if (this.__flushed) {
       logger.log('Skip finish transaction and flush, already done');
     } else {

--- a/packages/nextjs/src/utils/withSentry.ts
+++ b/packages/nextjs/src/utils/withSentry.ts
@@ -97,7 +97,7 @@ export const withSentry = (handler: NextApiHandler): WrappedNextApiHandler => {
   };
 };
 
-async function finishTransactionAndFlush(res: AugmentedResponse) {
+async function finishTransactionAndFlush(res: AugmentedResponse): Promise<void> {
   const transaction = res.__sentryTransaction;
 
   if (transaction) {


### PR DESCRIPTION
Potential fix for #3917 to ensure Sentry error reporting clean-up is
done -- transaction finished and error flushed -- when run from a
Vercel deployment, by explicitly calling the clean-up code in two
places: directly from the `withSentry` handler wrapper function, as
well as the existing monkey-patched `res.end()`.

In Vercel the `res.end()` function is not (or is not always) called,
which means the prior approach that relied on monkey-patching of
that function for clean-up did not work in Vercel.

Note 1: this is a naive fix: I'm not sure why res.end() isn't
called as expected or if there might be a better target for monkey-
patching.

Note 2: a new `__flushed` variable is used to avoid running the
clean-up code twice, should both the explicit and the monkey-patched
path be run. See the TODO asking whether this flag should be set at
the beginning, instead of the end, of the clean-up function
`finishTransactionAndFlush()`

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
