### PR TITLE
ref(hub): Mimic `sentry-python`'s behaviour of creating and passing `event_id`s

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,6 +30,30 @@
       "internalConsoleOptions": "neverOpen", // since we're not using it, don't automatically switch to it
     },
 
+    // @sentry/hub - run a specific test file in watch mode
+    // must have file in currently active tab when hitting the play button
+    {
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/packages/hub",
+      "name": "Debug @sentry/hub tests - just open file",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": [
+        "--watch",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/packages/hub/package.json",
+        "--coverage",
+        "false", // coverage messes up the source maps
+        "${relativeFile}" // remove this to run all package tests
+      ],
+      "disableOptimisticBPs": true,
+      "sourceMaps": true,
+      "smartStep": true,
+      "console": "integratedTerminal", // otherwise it goes to the VSCode debug terminal, which prints the test output or console logs (depending on "outputCapture" option here), but not both
+      "internalConsoleOptions": "neverOpen", // since we're not using it, don't automatically switch to it
+    },
+
     // @sentry/nextjs - run a specific test file in watch mode
     // must have file in currently active tab when hitting the play button
     {

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -78,7 +78,7 @@ export interface Hub {
    * @param hint May contain additional information about the original exception.
    * @returns The generated eventId.
    */
-  captureException(exception: any, hint?: EventHint): string;
+  captureException(exception: any, hint?: EventHint): string | undefined;
 
   /**
    * Captures a message event and sends it to Sentry.
@@ -88,7 +88,7 @@ export interface Hub {
    * @param hint May contain additional information about the original exception.
    * @returns The generated eventId.
    */
-  captureMessage(message: string, level?: Severity, hint?: EventHint): string;
+  captureMessage(message: string, level?: Severity, hint?: EventHint): string | undefined;
 
   /**
    * Captures a manually created event and sends it to Sentry.
@@ -96,7 +96,7 @@ export interface Hub {
    * @param event The event to send to Sentry.
    * @param hint May contain additional information about the original exception.
    */
-  captureEvent(event: Event, hint?: EventHint): string;
+  captureEvent(event: Event, hint?: EventHint): string | undefined;
 
   /**
    * This is the getter for lastEventId.


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/4018#issuecomment-937818003

 