### PR TITLE
fix(wasm): Check for browser bundle existence before running tests

### DIFF
--- a/packages/wasm/test/integration.test.js
+++ b/packages/wasm/test/integration.test.js
@@ -1,5 +1,14 @@
 /* global page, window */
+const fs = require('fs');
+const path = require('path');
+
 const HOST = `http://localhost:${process.env.PORT}`;
+
+if (!fs.existsSync(path.resolve(__dirname, '../../browser/build/bundle.js'))) {
+  throw new Error(
+    'ERROR: No browser bundle found in `packages/browser/build/`. Please run `yarn build` in the browser package before running wasm tests.',
+  );
+}
 
 describe('Wasm', () => {
   it('captured exception should include modified frames and debug_meta attribute', async () => {


### PR DESCRIPTION
As of https://github.com/getsentry/sentry-javascript/pull/4048, it's more likely that one might try to run the full test suite without having built the browser bundle. Since the wasm tests rely on it, this adds a check before they run, along with an error message letting the user know why things aren't working.
