### PR TITLE
fix(nextjs): Increase timeout for client integration tests

### DIFF
--- a/packages/nextjs/test/integration/test/client.js
+++ b/packages/nextjs/test/integration/test/client.js
@@ -27,7 +27,7 @@ const execute = async (scenario, env) => {
 
   const page = (env.page = await env.browser.newPage());
   await page.setRequestInterception(true);
-  page.setDefaultTimeout(2000);
+  page.setDefaultTimeout(4000);
   page.on('request', createRequestInterceptor(env));
 
   return scenario(env);


### PR DESCRIPTION
Occasionally the nextjs client integration tests fail because they timeout, even if there's nothing wrong with them. This increases the timeout from 2 seconds to 4 seconds, in hopes of preventing that behavior.
