### PR TITLE
fix(utils): Fix `loadModule` when using PnP

### DIFF
--- a/packages/utils/src/node.ts
+++ b/packages/utils/src/node.ts
@@ -40,6 +40,19 @@ export function loadModule<T>(moduleName: string): T | undefined {
   let mod: T | undefined;
 
   try {
+    if (require.main) {
+      const { createRequire } = dynamicRequire(module, 'module');
+      const req = createRequire(require.main.filename);
+      mod = req(moduleName);
+      if (mod) {
+        return mod;
+      }
+    }
+  } catch (e) {
+    // no-empty
+  }
+
+  try {
     mod = dynamicRequire(module, moduleName);
   } catch (e) {
     // no-empty


### PR DESCRIPTION
Fixes #4076

Uses `createRequire` to ensure that modules are correctly located and scoped to the main package that is running.

See: 
https://nodejs.org/docs/latest/api/modules.html#modules_accessing_the_main_module
https://nodejs.org/api/module.html#module_module_createrequire_filename

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
