### PR TITLE
feat(nextjs): Tag backend events when running on vercel

### DIFF
--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -53,6 +53,9 @@ export function init(options: NextjsOptions): void {
 
   configureScope(scope => {
     scope.setTag('runtime', 'node');
+    if (process.env.VERCEL) {
+      scope.setTag('vercel', true);
+    }
   });
 
   if (activeDomain) {

--- a/packages/nextjs/test/index.server.test.ts
+++ b/packages/nextjs/test/index.server.test.ts
@@ -63,6 +63,30 @@ describe('Server init()', () => {
     expect(currentScope._tags).toEqual({ runtime: 'node' });
   });
 
+  it('applies `vercel` tag when running on vercel', () => {
+    const currentScope = getCurrentHub().getScope();
+
+    process.env.VERCEL = '1';
+
+    init({});
+
+    // @ts-ignore need access to protected _tags attribute
+    expect(currentScope._tags.vercel).toEqual(true);
+
+    delete process.env.VERCEL;
+  });
+
+  it('does not apply `vercel` tag when not running on vercel', () => {
+    const currentScope = getCurrentHub().getScope();
+
+    expect(process.env.VERCEL).toBeUndefined();
+
+    init({});
+
+    // @ts-ignore need access to protected _tags attribute
+    expect(currentScope._tags.vercel).toBeUndefined();
+  });
+
   it("initializes both global hub and domain hub when there's an active domain", () => {
     const globalHub = getCurrentHub();
     const local = domain.create();


### PR DESCRIPTION
Because nextjs apps behave somewhat differently on vercel than off, it's helpful to know when an event came from a vercel-deployed app vs. a non-vercel-deployed app. This adds a tag to events from vercel, based on an environment variable which vercel sets in the serverless environment in which backend lambdas run.

Note: If the user has overridden the default and turned off `Automatically expose System Environment Variables` in their project settings, we won't know they're on vercel. That said, it's hard to know why one ever would, and likely most people don't, so presumably this data will be close enough to accurate to remain useful. See https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables.