### PR TITLE
ref(nextjs): Use real functions in client init tests

### DIFF
--- a/packages/nextjs/test/index.client.test.ts
+++ b/packages/nextjs/test/index.client.test.ts
@@ -1,44 +1,41 @@
 import { getCurrentHub } from '@sentry/hub';
+import * as SentryReact from '@sentry/react';
 import { Integrations as TracingIntegrations } from '@sentry/tracing';
 import { Integration } from '@sentry/types';
+import { getGlobalObject } from '@sentry/utils';
 
 import { init, Integrations, nextRouterInstrumentation } from '../src/index.client';
 import { NextjsOptions } from '../src/utils/nextjsOptions';
 
 const { BrowserTracing } = TracingIntegrations;
 
-const mockInit = jest.fn();
+const global = getGlobalObject();
 
-jest.mock('@sentry/react', () => {
-  const actual = jest.requireActual('@sentry/react');
-  return {
-    ...actual,
-    init: (options: NextjsOptions) => {
-      mockInit(options);
-    },
-  };
-});
+const reactInit = jest.spyOn(SentryReact, 'init');
 
 describe('Client init()', () => {
   afterEach(() => {
-    mockInit.mockClear();
+    reactInit.mockClear();
+    global.__SENTRY__.hub = undefined;
   });
 
   it('inits the React SDK', () => {
-    expect(mockInit).toHaveBeenCalledTimes(0);
+    expect(reactInit).toHaveBeenCalledTimes(0);
     init({});
-    expect(mockInit).toHaveBeenCalledTimes(1);
-    expect(mockInit).toHaveBeenLastCalledWith({
-      _metadata: {
-        sdk: {
-          name: 'sentry.javascript.nextjs',
-          version: expect.any(String),
-          packages: expect.any(Array),
+    expect(reactInit).toHaveBeenCalledTimes(1);
+    expect(reactInit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _metadata: {
+          sdk: {
+            name: 'sentry.javascript.nextjs',
+            version: expect.any(String),
+            packages: expect.any(Array),
+          },
         },
-      },
-      environment: 'test',
-      integrations: undefined,
-    });
+        environment: 'test',
+        integrations: undefined,
+      }),
+    );
   });
 
   it('sets runtime on scope', () => {
@@ -57,14 +54,14 @@ describe('Client init()', () => {
     it('does not add BrowserTracing integration by default if tracesSampleRate is not set', () => {
       init({});
 
-      const reactInitOptions: NextjsOptions = mockInit.mock.calls[0][0];
+      const reactInitOptions: NextjsOptions = reactInit.mock.calls[0][0];
       expect(reactInitOptions.integrations).toBeUndefined();
     });
 
     it('adds BrowserTracing integration by default if tracesSampleRate is set', () => {
       init({ tracesSampleRate: 1.0 });
 
-      const reactInitOptions: NextjsOptions = mockInit.mock.calls[0][0];
+      const reactInitOptions: NextjsOptions = reactInit.mock.calls[0][0];
       expect(reactInitOptions.integrations).toHaveLength(1);
 
       const integrations = reactInitOptions.integrations as Integration[];
@@ -78,7 +75,7 @@ describe('Client init()', () => {
     it('adds BrowserTracing integration by default if tracesSampler is set', () => {
       init({ tracesSampler: () => true });
 
-      const reactInitOptions: NextjsOptions = mockInit.mock.calls[0][0];
+      const reactInitOptions: NextjsOptions = reactInit.mock.calls[0][0];
       expect(reactInitOptions.integrations).toHaveLength(1);
 
       const integrations = reactInitOptions.integrations as Integration[];
@@ -91,7 +88,7 @@ describe('Client init()', () => {
 
     it('supports passing integration through options', () => {
       init({ tracesSampleRate: 1.0, integrations: [new Integrations.Breadcrumbs({ console: false })] });
-      const reactInitOptions: NextjsOptions = mockInit.mock.calls[0][0];
+      const reactInitOptions: NextjsOptions = reactInit.mock.calls[0][0];
       expect(reactInitOptions.integrations).toHaveLength(2);
 
       const integrations = reactInitOptions.integrations as Integration[];
@@ -104,7 +101,7 @@ describe('Client init()', () => {
         integrations: [new BrowserTracing({ idleTimeout: 5000, startTransactionOnLocationChange: false })],
       });
 
-      const reactInitOptions: NextjsOptions = mockInit.mock.calls[0][0];
+      const reactInitOptions: NextjsOptions = reactInit.mock.calls[0][0];
       expect(reactInitOptions.integrations).toHaveLength(1);
       const integrations = reactInitOptions.integrations as Integration[];
       expect((integrations[0] as InstanceType<typeof BrowserTracing>).options).toEqual(
@@ -122,7 +119,7 @@ describe('Client init()', () => {
         integrations: () => [new BrowserTracing({ idleTimeout: 5000, startTransactionOnLocationChange: false })],
       });
 
-      const reactInitOptions: NextjsOptions = mockInit.mock.calls[0][0];
+      const reactInitOptions: NextjsOptions = reactInit.mock.calls[0][0];
       const integrationFunc = reactInitOptions.integrations as () => Integration[];
       const integrations = integrationFunc();
       expect((integrations[0] as InstanceType<typeof BrowserTracing>).options).toEqual(


### PR DESCRIPTION
This changes the structure of the `index.client.ts` tests to stop mocking `configureScope` and `@sentry/react`'s `init` functions and instead spy on the real versions. This makes the structure of the client tests better match the structure of the server tests, and is also necessary for an upcoming PR in which the behavior of those functions is tested directly (meaning they have to actually do the thing they normally would).
