### PR TITLE
ref(eslint): Consolidate initial set of packages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,28 @@
+module.exports = {
+  root: true,
+  env: {
+    es6: true,
+  },
+  parserOptions: {
+    ecmaVersion: 2018,
+  },
+  extends: ['@sentry-internal/sdk'],
+  ignorePatterns: [
+    'coverage/**',
+    'build/**',
+    'dist/**',
+    'esm/**',
+    'cjs/**',
+    'examples/**',
+    'scripts/**',
+    'test/manual/**',
+  ],
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx', '*.d.ts'],
+      parserOptions: {
+        project: './tsconfig.json',
+      },
+    }
+  ],
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,6 @@ module.exports = {
     'build/**',
     'dist/**',
     'esm/**',
-    'cjs/**',
     'examples/**',
     'scripts/**',
     'test/manual/**',

--- a/packages/angular/.eslintrc.js
+++ b/packages/angular/.eslintrc.js
@@ -1,6 +1,5 @@
 module.exports = {
   env: {
-    es6: true,
     browser: true,
   },
   extends: ['../../.eslintrc.js'],

--- a/packages/angular/.eslintrc.js
+++ b/packages/angular/.eslintrc.js
@@ -1,20 +1,7 @@
 module.exports = {
-  root: true,
   env: {
     es6: true,
     browser: true,
   },
-  parserOptions: {
-    ecmaVersion: 2018,
-  },
-  extends: ['@sentry-internal/sdk'],
-  ignorePatterns: ['build/**', 'dist/**', 'esm/**', 'examples/**', 'scripts/**'],
-  overrides: [
-    {
-      files: ['*.ts', '*.tsx', '*.d.ts'],
-      parserOptions: {
-        project: './tsconfig.json',
-      },
-    },
-  ],
+  extends: ['../../.eslintrc.js'],
 };

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -31,7 +31,6 @@
     "@angular/common": "^10.0.3",
     "@angular/core": "^10.0.3",
     "@angular/router": "^10.0.3",
-    "@sentry-internal/eslint-config-sdk": "6.13.3",
     "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",
     "rimraf": "^2.6.3",

--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -1,6 +1,3 @@
 module.exports = {
-  env: {
-    es6: true,
-  },
   extends: ['../../.eslintrc.js'],
 };

--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -1,26 +1,6 @@
 module.exports = {
-  root: true,
   env: {
     es6: true,
   },
-  parserOptions: {
-    ecmaVersion: 2018,
-  },
-  extends: ['@sentry-internal/sdk'],
-  ignorePatterns: ['build/**', 'dist/**', 'esm/**', 'examples/**', 'scripts/**'],
-  overrides: [
-    {
-      files: ['*.ts', '*.tsx', '*.d.ts'],
-      parserOptions: {
-        project: './tsconfig.json',
-      },
-    },
-    {
-      files: ['test/**'],
-      rules: {
-        '@typescript-eslint/no-explicit-any': 'off',
-        '@typescript-eslint/no-non-null-assertion': 'off',
-      },
-    },
-  ],
+  extends: ['../../.eslintrc.js'],
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,6 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "6.13.3",
     "jest": "^24.7.1",
     "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",

--- a/packages/eslint-config-sdk/src/index.js
+++ b/packages/eslint-config-sdk/src/index.js
@@ -166,7 +166,6 @@ module.exports = {
       files: ['*.test.ts', '*.test.tsx', '*.test.js', '*.test.jsx', 'test/**/*.ts', 'test/**/*.js'],
       rules: {
         'max-lines': 'off',
-
         '@typescript-eslint/explicit-function-return-type': 'off',
         'no-unused-expressions': 'off',
         '@typescript-eslint/no-unused-expressions': 'off',

--- a/packages/eslint-config-sdk/src/index.js
+++ b/packages/eslint-config-sdk/src/index.js
@@ -163,7 +163,7 @@ module.exports = {
       env: {
         jest: true,
       },
-      files: ['*.test.ts', '*.test.tsx', '*.test.js', '*.test.jsx'],
+      files: ['*.test.ts', '*.test.tsx', '*.test.js', '*.test.jsx', 'test/**/*.ts', 'test/**/*.js'],
       rules: {
         'max-lines': 'off',
 

--- a/packages/eslint-config-sdk/src/index.js
+++ b/packages/eslint-config-sdk/src/index.js
@@ -172,6 +172,8 @@ module.exports = {
         '@typescript-eslint/no-unused-expressions': 'off',
         '@typescript-eslint/no-unsafe-member-access': 'off',
         '@typescript-eslint/explicit-member-accessibility': 'off',
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-non-null-assertion': 'off',
       },
     },
     {

--- a/packages/gatsby/.eslintrc.js
+++ b/packages/gatsby/.eslintrc.js
@@ -1,6 +1,5 @@
 module.exports = {
   env: {
-    es6: true,
     browser: true,
     node: true,
   },

--- a/packages/gatsby/.eslintrc.js
+++ b/packages/gatsby/.eslintrc.js
@@ -1,22 +1,12 @@
 module.exports = {
-  root: true,
   env: {
     es6: true,
     browser: true,
     node: true,
   },
   parserOptions: {
-    ecmaVersion: 2018,
     jsx: true,
   },
-  extends: ['@sentry-internal/sdk'],
-  ignorePatterns: ['build/**', 'dist/**', 'esm/**', 'examples/**', 'scripts/**'],
-  overrides: [
-    {
-      files: ['*.ts', '*.tsx', '*.d.ts'],
-      parserOptions: {
-        project: './tsconfig.json',
-      },
-    },
-  ],
+  extends: ['../../.eslintrc.js'],
 };
+

--- a/packages/gatsby/.eslintrc.js
+++ b/packages/gatsby/.eslintrc.js
@@ -9,4 +9,3 @@ module.exports = {
   },
   extends: ['../../.eslintrc.js'],
 };
-

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -33,7 +33,6 @@
     "gatsby": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "6.13.3",
     "@sentry/types": "6.13.3",
     "@testing-library/react": "^10.4.9",
     "jest": "^24.7.1",

--- a/packages/hub/.eslintrc.js
+++ b/packages/hub/.eslintrc.js
@@ -1,4 +1,3 @@
 module.exports = {
   extends: ['../../.eslintrc.js'],
 };
-

--- a/packages/hub/.eslintrc.js
+++ b/packages/hub/.eslintrc.js
@@ -1,26 +1,7 @@
 module.exports = {
-  root: true,
   env: {
     es6: true,
   },
-  parserOptions: {
-    ecmaVersion: 2018,
-  },
-  extends: ['@sentry-internal/sdk'],
-  ignorePatterns: ['build/**', 'dist/**', 'esm/**', 'examples/**', 'scripts/**'],
-  overrides: [
-    {
-      files: ['*.ts', '*.tsx', '*.d.ts'],
-      parserOptions: {
-        project: './tsconfig.json',
-      },
-    },
-    {
-      files: ['test/**'],
-      rules: {
-        '@typescript-eslint/no-explicit-any': 'off',
-        '@typescript-eslint/no-non-null-assertion': 'off',
-      },
-    },
-  ],
+  extends: ['../../.eslintrc.js'],
 };
+

--- a/packages/hub/.eslintrc.js
+++ b/packages/hub/.eslintrc.js
@@ -1,7 +1,4 @@
 module.exports = {
-  env: {
-    es6: true,
-  },
   extends: ['../../.eslintrc.js'],
 };
 

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -21,7 +21,6 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "6.13.3",
     "jest": "^24.7.1",
     "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",

--- a/packages/integrations/.eslintrc.js
+++ b/packages/integrations/.eslintrc.js
@@ -1,4 +1,3 @@
 module.exports = {
   extends: ['../../.eslintrc.js'],
 };
-

--- a/packages/integrations/.eslintrc.js
+++ b/packages/integrations/.eslintrc.js
@@ -1,29 +1,7 @@
 module.exports = {
-  root: true,
   env: {
     es6: true,
   },
-  parserOptions: {
-    ecmaVersion: 2018,
-  },
-  extends: ['@sentry-internal/sdk'],
-  ignorePatterns: ['build/**', 'dist/**', 'esm/**', 'examples/**', 'scripts/**'],
-  overrides: [
-    {
-      files: ['*.ts', '*.tsx', '*.d.ts'],
-      parserOptions: {
-        project: './tsconfig.json',
-      },
-    },
-    {
-      files: ['test/**'],
-      env: {
-        mocha: true,
-      },
-      rules: {
-        '@typescript-eslint/no-explicit-any': 'off',
-        '@typescript-eslint/no-non-null-assertion': 'off',
-      },
-    },
-  ],
+  extends: ['../../.eslintrc.js'],
 };
+

--- a/packages/integrations/.eslintrc.js
+++ b/packages/integrations/.eslintrc.js
@@ -1,7 +1,4 @@
 module.exports = {
-  env: {
-    es6: true,
-  },
   extends: ['../../.eslintrc.js'],
 };
 

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -22,7 +22,6 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "6.13.3",
     "chai": "^4.1.2",
     "jest": "^24.7.1",
     "npm-run-all": "^4.1.2",

--- a/packages/minimal/.eslintrc.js
+++ b/packages/minimal/.eslintrc.js
@@ -1,4 +1,3 @@
 module.exports = {
   extends: ['../../.eslintrc.js'],
 };
-

--- a/packages/minimal/.eslintrc.js
+++ b/packages/minimal/.eslintrc.js
@@ -1,26 +1,7 @@
 module.exports = {
-  root: true,
   env: {
     es6: true,
   },
-  parserOptions: {
-    ecmaVersion: 2018,
-  },
-  extends: ['@sentry-internal/sdk'],
-  ignorePatterns: ['build/**', 'dist/**', 'esm/**', 'examples/**', 'scripts/**'],
-  overrides: [
-    {
-      files: ['*.ts', '*.tsx', '*.d.ts'],
-      parserOptions: {
-        project: './tsconfig.json',
-      },
-    },
-    {
-      files: ['test/**'],
-      rules: {
-        '@typescript-eslint/no-explicit-any': 'off',
-        '@typescript-eslint/no-non-null-assertion': 'off',
-      },
-    },
-  ],
+  extends: ['../../.eslintrc.js'],
 };
+

--- a/packages/minimal/.eslintrc.js
+++ b/packages/minimal/.eslintrc.js
@@ -1,7 +1,4 @@
 module.exports = {
-  env: {
-    es6: true,
-  },
   extends: ['../../.eslintrc.js'],
 };
 

--- a/packages/minimal/package.json
+++ b/packages/minimal/package.json
@@ -21,7 +21,6 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "6.13.3",
     "jest": "^24.7.1",
     "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",

--- a/packages/node/.eslintrc.js
+++ b/packages/node/.eslintrc.js
@@ -1,7 +1,6 @@
 module.exports = {
   root: true,
   env: {
-    es6: true,
     node: true,
   },
   parserOptions: {

--- a/packages/react/test/errorboundary.test.tsx
+++ b/packages/react/test/errorboundary.test.tsx
@@ -1,5 +1,4 @@
 import { Scope } from '@sentry/browser';
-import { Event, Severity } from '@sentry/types';
 import { fireEvent, render, screen } from '@testing-library/react';
 import * as React from 'react';
 import { useState } from 'react';

--- a/packages/tracing/.eslintrc.js
+++ b/packages/tracing/.eslintrc.js
@@ -1,6 +1,3 @@
 module.exports = {
-  env: {
-    es6: true,
-  },
   extends: ['../../.eslintrc.js'],
 };

--- a/packages/tracing/.eslintrc.js
+++ b/packages/tracing/.eslintrc.js
@@ -1,26 +1,6 @@
 module.exports = {
-  root: true,
   env: {
     es6: true,
   },
-  parserOptions: {
-    ecmaVersion: 2018,
-  },
-  extends: ['@sentry-internal/sdk'],
-  ignorePatterns: ['build/**', 'dist/**', 'esm/**', 'examples/**', 'scripts/**'],
-  overrides: [
-    {
-      files: ['*.ts', '*.tsx', '*.d.ts'],
-      parserOptions: {
-        project: './tsconfig.json',
-      },
-    },
-    {
-      files: ['test/**'],
-      rules: {
-        '@typescript-eslint/no-explicit-any': 'off',
-        '@typescript-eslint/no-non-null-assertion': 'off',
-      },
-    },
-  ],
+  extends: ['../../.eslintrc.js'],
 };

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -23,7 +23,6 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "6.13.3",
     "@sentry/browser": "6.13.3",
     "@types/express": "^4.17.1",
     "@types/jsdom": "^16.2.3",

--- a/packages/types/.eslintrc.js
+++ b/packages/types/.eslintrc.js
@@ -4,4 +4,3 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 'off',
   }
 };
-

--- a/packages/types/.eslintrc.js
+++ b/packages/types/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
   extends: ['../../.eslintrc.js'],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+  }
 };
 

--- a/packages/types/.eslintrc.js
+++ b/packages/types/.eslintrc.js
@@ -1,22 +1,4 @@
 module.exports = {
-  root: true,
-  env: {
-    es6: true,
-  },
-  parserOptions: {
-    ecmaVersion: 2018,
-  },
-  extends: ['@sentry-internal/sdk'],
-  ignorePatterns: ['build/**', 'dist/**', 'esm/**', 'examples/**', 'scripts/**'],
-  overrides: [
-    {
-      files: ['*.ts', '*.tsx', '*.d.ts'],
-      parserOptions: {
-        project: './tsconfig.json',
-      },
-    },
-  ],
-  rules: {
-    '@typescript-eslint/no-explicit-any': 'off',
-  },
+  extends: ['../../.eslintrc.js'],
 };
+

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,7 +16,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "6.13.3",
     "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",
     "typescript": "3.7.5"

--- a/packages/utils/.eslintrc.js
+++ b/packages/utils/.eslintrc.js
@@ -1,4 +1,3 @@
 module.exports = {
   extends: ['../../.eslintrc.js'],
 };
-

--- a/packages/utils/.eslintrc.js
+++ b/packages/utils/.eslintrc.js
@@ -1,29 +1,4 @@
 module.exports = {
-  root: true,
-  env: {
-    es6: true,
-  },
-  parserOptions: {
-    ecmaVersion: 2018,
-  },
-  extends: ['@sentry-internal/sdk'],
-  ignorePatterns: ['build/**', 'dist/**', 'esm/**', 'examples/**', 'scripts/**'],
-  overrides: [
-    {
-      files: ['*.ts', '*.tsx', '*.d.ts'],
-      parserOptions: {
-        project: './tsconfig.json',
-      },
-    },
-    {
-      files: ['test/**'],
-      rules: {
-        '@typescript-eslint/no-explicit-any': 'off',
-        '@typescript-eslint/no-non-null-assertion': 'off',
-      },
-    },
-  ],
-  rules: {
-    'max-lines': 'off',
-  },
+  extends: ['../../.eslintrc.js'],
 };
+

--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/ban-types */
 import { WrappedFunction } from '@sentry/types';

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { ExtendedError, WrappedFunction } from '@sentry/types';
 

--- a/packages/vue/.eslintrc.js
+++ b/packages/vue/.eslintrc.js
@@ -1,6 +1,5 @@
 module.exports = {
   env: {
-    es6: true,
     browser: true,
   },
   extends: ['../../.eslintrc.js'],

--- a/packages/vue/.eslintrc.js
+++ b/packages/vue/.eslintrc.js
@@ -1,26 +1,7 @@
 module.exports = {
-  root: true,
   env: {
     es6: true,
     browser: true,
   },
-  parserOptions: {
-    ecmaVersion: 2018,
-    jsx: true,
-  },
-  extends: ['@sentry-internal/sdk'],
-  ignorePatterns: ['build/**', 'dist/**', 'esm/**', 'examples/**', 'scripts/**'],
-  overrides: [
-    {
-      files: ['*.ts', '*.d.ts'],
-      parserOptions: {
-        project: './tsconfig.json',
-      },
-    },
-  ],
-  rules: {
-    'react/prop-types': 'off',
-    '@typescript-eslint/no-unsafe-member-access': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
-  },
+  extends: ['../../.eslintrc.js'],
 };

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -28,7 +28,6 @@
     "vue-router": "3.x || 4.x"
   },
   "devDependencies": {
-    "@sentry-internal/eslint-config-sdk": "6.13.3",
     "jest": "^24.7.1",
     "jsdom": "^16.2.2",
     "npm-run-all": "^4.1.2",

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -52,7 +52,9 @@ export const generateComponentTrace = (vm?: ViewModel): string => {
     let currentRecursiveSequence = 0;
     while (vm) {
       if (tree.length > 0) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const last = tree[tree.length - 1] as any;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (last.constructor === vm.constructor) {
           currentRecursiveSequence += 1;
           vm = vm.$parent; // eslint-disable-line no-param-reassign

--- a/packages/vue/src/errorhandler.ts
+++ b/packages/vue/src/errorhandler.ts
@@ -3,6 +3,8 @@ import { getCurrentHub } from '@sentry/browser';
 import { formatComponentName, generateComponentTrace } from './components';
 import { Options, ViewModel, Vue } from './types';
 
+type UnknownFunc = (...args: unknown[]) => void;
+
 export const attachErrorHandler = (app: Vue, options: Options): void => {
   const { errorHandler, warnHandler, silent } = app.config;
 
@@ -30,7 +32,7 @@ export const attachErrorHandler = (app: Vue, options: Options): void => {
     });
 
     if (typeof errorHandler === 'function') {
-      errorHandler.call(app, error, vm, lifecycleHook);
+      (errorHandler as UnknownFunc).call(app, error, vm, lifecycleHook);
     }
 
     if (options.logErrors) {
@@ -38,7 +40,7 @@ export const attachErrorHandler = (app: Vue, options: Options): void => {
       const message = `Error in ${lifecycleHook}: "${error && error.toString()}"`;
 
       if (warnHandler) {
-        warnHandler.call(null, message, vm, trace);
+        (warnHandler as UnknownFunc).call(null, message, vm, trace);
       } else if (hasConsole && !silent) {
         // eslint-disable-next-line no-console
         console.error(`[Vue warn]: ${message}${trace}`);

--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { captureException } from '@sentry/browser';
 import { Transaction, TransactionContext } from '@sentry/types';
 
@@ -61,6 +62,7 @@ export function vueRouterInstrumentation(router: VueRouter): VueRouterInstrument
 
       if (startTransactionOnLocationChange && !isPageLoadNavigation) {
         startTransaction({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           name: to.name || (to.matched[0] && to.matched[0].path) || to.path,
           op: 'navigation',
           tags,

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -1,13 +1,14 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { BrowserOptions } from '@sentry/browser';
 
-// This is not great, but kinda nacessary to make it woth with Vue@2 and Vue@3 at the same time.
+// This is not great, but kinda necessary to make it woth with Vue@2 and Vue@3 at the same time.
 export interface Vue {
   config: {
     errorHandler?: any;
     warnHandler?: any;
     silent?: boolean;
   };
-  mixin: (mixins: any) => void;
+  mixin: (mixins: Partial<Record<Hook, any>>) => void;
 }
 
 export type ViewModel = {

--- a/packages/wasm/.eslintrc.js
+++ b/packages/wasm/.eslintrc.js
@@ -1,6 +1,3 @@
 module.exports = {
-  env: {
-    es6: true,
-  },
   extends: ['../../.eslintrc.js'],
 };

--- a/packages/wasm/.eslintrc.js
+++ b/packages/wasm/.eslintrc.js
@@ -1,29 +1,6 @@
 module.exports = {
-  root: true,
   env: {
     es6: true,
   },
-  parserOptions: {
-    ecmaVersion: 2018,
-  },
-  extends: ['@sentry-internal/sdk'],
-  ignorePatterns: ['build/**', 'dist/**', 'esm/**', 'examples/**', 'scripts/**'],
-  overrides: [
-    {
-      files: ['*.ts', '*.tsx', '*.d.ts'],
-      parserOptions: {
-        project: './tsconfig.json',
-      },
-    },
-    {
-      files: ['test/**'],
-      rules: {
-        '@typescript-eslint/no-explicit-any': 'off',
-        '@typescript-eslint/no-non-null-assertion': 'off',
-      },
-    },
-  ],
-  rules: {
-    'max-lines': 'off',
-  },
+  extends: ['../../.eslintrc.js'],
 };


### PR DESCRIPTION
Create a central `.eslintrc.js` that every individual package should extend from. Certain packages (react, nextjs, node, browser) were skipped as they are more involved.

- Refactoring each eslint file: https://github.com/getsentry/sentry-javascript/commit/026e6e0209db9d75c4f04ec69d434c2b04bcb3cb
- Fixing or ignoring things that broke when rules were changed: https://github.com/getsentry/sentry-javascript/commit/11ff81d674d34751d8f409514cef86f467d75160