### PR TITLE
test(gatsby): Remove version test on SDK test

### DIFF
--- a/packages/gatsby/test/sdk.test.ts
+++ b/packages/gatsby/test/sdk.test.ts
@@ -18,14 +18,10 @@ describe('Initialize React SDK', () => {
     const sdkMetadata = calledWith._metadata.sdk;
     expect(sdkMetadata.name).toStrictEqual('sentry.javascript.gatsby');
     expect(sdkMetadata.version).toBe(SDK_VERSION);
-    expect(sdkMetadata.packages).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "name": "npm:@sentry/gatsby",
-          "version": "6.13.3",
-        },
-      ]
-    `);
+    expect(sdkMetadata.packages).toHaveLength(1); // Only Gatsby SDK
+    expect(sdkMetadata.packages[0].name).toStrictEqual('npm:@sentry/gatsby');
+    // Explicit tests on the version fail when making new releases
+    expect(sdkMetadata.packages[0].version).toBeDefined();
   });
 
   describe('Environment', () => {


### PR DESCRIPTION
Explicitly checking the SDK version on tests is a bad idea, since making new releases update the SDK version and thus tests fail.