### PR TITLE
feat(gatsby): Support Gatsby v4

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -30,7 +30,7 @@
     "@sentry/tracing": "6.14.0"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "@sentry/types": "6.14.0",


### PR DESCRIPTION
Add support for [Gatsby v4](https://www.gatsbyjs.com/docs/reference/release-notes/v4.0/).

The only relevant changes for our SDK to support v4 are [these notes for plugin maintainers](https://v4.gatsbyjs.com/docs/reference/release-notes/migrating-from-v3-to-v4/#for-plugin-maintainers), and only the `gatsby` peer dependency version upgrade applies, addressed in this PR. [Future breaking changes](https://v4.gatsbyjs.com/docs/reference/release-notes/migrating-from-v3-to-v4/#future-breaking-changes) don't apply either.

Resolves #4107.