### PR TITLE
ref: Stop disabling no-prototype-builtins rule

### DIFF
--- a/packages/browser/src/transports/xhr.ts
+++ b/packages/browser/src/transports/xhr.ts
@@ -56,7 +56,7 @@ export class XHRTransport extends BaseTransport {
 
             request.open('POST', sentryRequest.url);
             for (const header in this.options.headers) {
-              if (Object.prototype.hasOwnProperty.call(this, header)) {
+              if (Object.prototype.hasOwnProperty.call(this.options.headers, header)) {
                 request.setRequestHeader(header, this.options.headers[header]);
               }
             }

--- a/packages/browser/src/transports/xhr.ts
+++ b/packages/browser/src/transports/xhr.ts
@@ -56,8 +56,7 @@ export class XHRTransport extends BaseTransport {
 
             request.open('POST', sentryRequest.url);
             for (const header in this.options.headers) {
-              // eslint-disable-next-line no-prototype-builtins
-              if (this.options.headers.hasOwnProperty(header)) {
+              if (Object.prototype.hasOwnProperty.call(this, header)) {
                 request.setRequestHeader(header, this.options.headers[header]);
               }
             }

--- a/packages/serverless/src/utils.ts
+++ b/packages/serverless/src/utils.ts
@@ -60,8 +60,7 @@ export function proxyFunction<A extends any[], R, F extends (...args: A) => R>(
 
   if (overrides) {
     handler.get = (target, prop) => {
-      // eslint-disable-next-line no-prototype-builtins
-      if (overrides.hasOwnProperty(prop)) {
+      if (Object.prototype.hasOwnProperty.call(overrides, prop)) {
         return overrides[prop as string];
       }
       return (target as Record<PropertyKey, unknown>)[prop as string];

--- a/packages/utils/src/polyfill.ts
+++ b/packages/utils/src/polyfill.ts
@@ -17,8 +17,7 @@ function setProtoOf<TTarget extends object, TProto>(obj: TTarget, proto: TProto)
 // eslint-disable-next-line @typescript-eslint/ban-types
 function mixinProperties<TTarget extends object, TProto>(obj: TTarget, proto: TProto): TTarget & TProto {
   for (const prop in proto) {
-    // eslint-disable-next-line no-prototype-builtins
-    if (!obj.hasOwnProperty(prop)) {
+    if (!Object.prototype.hasOwnProperty.call(obj, prop)) {
       // @ts-ignore typescript complains about indexing so we remove
       obj[prop] = proto[prop];
     }


### PR DESCRIPTION
Updates browser, serverless and utils packages to no longer disable the `no-prototype-builtins` eslint rule.

https://eslint.org/docs/rules/no-prototype-builtins

Based on work from https://github.com/getsentry/sentry-javascript/pull/4111