### PR TITLE
fix(nextjs): Prevent infinite recompilation in dev

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -138,8 +138,10 @@ async function addSentryToEntryProperty(
   const filesToInject = [`./${userConfigFile}`];
 
   // Support non-default output directories by making the output path (easy to get here at build-time) available to the
-  // server SDK's default `RewriteFrames` instance (which needs it at runtime).
-  if (buildContext.isServer) {
+  // server SDK's default `RewriteFrames` instance (which needs it at runtime). Doesn't work when using the dev server
+  // because it somehow tricks the file watcher into thinking that compilation itself is a file change, triggering an
+  // infinite recompiling loop. (This should be fine because we don't upload sourcemaps in dev in any case.)
+  if (buildContext.isServer && !buildContext.dev) {
     const rewriteFramesHelper = path.resolve(
       fs.mkdtempSync(path.resolve(os.tmpdir(), 'sentry-')),
       'rewriteFramesHelper.js',


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/pull/4017 introduced a bug wherein running the dev server would lead to an infinite recompilation loop. (Something about the implementation tricks the file watcher into thinking there's been a change when there hasn't.) Fortunately, since we don't upload sourcemaps in dev, the change made by that PR (accounting for the nextjs `distDir` option in our server-side `RewriteFrames` integration, which in turn enables sourcemaps to work) is actually a moot point there. This PR solves the issue by simply not applying that change to the dev server.

Fixes https://github.com/getsentry/sentry-javascript/issues/4115