### PR TITLE
fix(nextjs): Show full stacktraces in integration tests

### DIFF
--- a/packages/nextjs/test/integration/test/utils/server.js
+++ b/packages/nextjs/test/integration/test/utils/server.js
@@ -2,6 +2,8 @@ const { get } = require('http');
 const nock = require('nock');
 const { logIf, parseEnvelope } = require('./common');
 
+Error.stackTraceLimit = Infinity;
+
 const getAsync = url => {
   return new Promise((resolve, reject) => {
     get(url, res => {


### PR DESCRIPTION
By default, Node only displays the top 10 frames in an error's stacktrace. Especially with async code (which, when down-compiled, introduces lots of frames just with its async-i-ness), this means you can be missing a lot of frames. This PR removes that cap for our integration tests, so we can see the full stacktrace when debugging.
