### PR TITLE
fix(tracing): Treat HTTP status code below 100 as `UnknownError`.

### DIFF
--- a/packages/tracing/src/spanstatus.ts
+++ b/packages/tracing/src/spanstatus.ts
@@ -46,7 +46,7 @@ export namespace SpanStatus {
    * @returns The span status or {@link SpanStatus.UnknownError}.
    */
   export function fromHttpCode(httpStatus: number): SpanStatus {
-    if (httpStatus < 400) {
+    if (httpStatus < 400 && httpStatus >= 100) {
       return SpanStatus.Ok;
     }
 

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -90,6 +90,14 @@ describe('Span', () => {
       expect(span.isSuccess()).toBe(true);
       span.setStatus(SpanStatus.PermissionDenied);
       expect(span.isSuccess()).toBe(false);
+      span.setHttpStatus(0);
+      expect(span.isSuccess()).toBe(false);
+      span.setHttpStatus(-1);
+      expect(span.isSuccess()).toBe(false);
+      span.setHttpStatus(99);
+      expect(span.isSuccess()).toBe(false);
+      span.setHttpStatus(100);
+      expect(span.isSuccess()).toBe(true);
     });
   });
 


### PR DESCRIPTION
Fixes: #4058 