### PR TITLE
fix(browser): Don't special case DOMExceptions that are also Errors

### DIFF
--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -7,6 +7,7 @@ import {
   isError,
   isErrorEvent,
   isEvent,
+  isInstanceOf,
   isPlainObject,
   SyncPromise,
 } from '@sentry/utils';
@@ -73,7 +74,10 @@ export function eventFromUnknownInput(
     event = eventFromStacktrace(computeStackTrace(exception as Error));
     return event;
   }
-  if (isDOMError(exception as DOMError) || isDOMException(exception as DOMException)) {
+  if (
+    isDOMError(exception as DOMError) ||
+    (isDOMException(exception as DOMException) && !isInstanceOf(exception, Error))
+  ) {
     // If it is a DOMError or DOMException (which are legacy APIs, but still supported in some browsers)
     // then we just extract the name, code, and message, as they don't provide anything else
     // https://developer.mozilla.org/en-US/docs/Web/API/DOMError


### PR DESCRIPTION
As mentioned in #4085, `DOMException`s are not a legacy API and on current browsers are instances of `Error`. This change tests whether the exception is an instance of `Error` before throwing away all the good bits.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Fixes #4085
Fixes #3119