### PR TITLE
build(craft): Update target execution order

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -2,9 +2,16 @@ minVersion: '0.23.1'
 changelogPolicy: simple
 preReleaseCommand: bash scripts/craft-pre-release.sh
 targets:
-  - name: npm
-  - name: github
-    includeNames: /^sentry-.*$/
+  - name: aws-lambda-layer
+    includeNames: /^sentry-node-serverless-\d+(\.\d+)*\.zip$/
+    layerName: SentryNodeServerlessSDK
+    compatibleRuntimes:
+      - name: node
+        versions:
+          - nodejs10.x
+          - nodejs12.x
+          - nodejs14.x
+    license: MIT
   - name: gcs
     includeNames: /.*\.js.*$/
     bucket: sentry-js-sdk
@@ -12,6 +19,9 @@ targets:
       - path: /{{version}}/
         metadata:
           cacheControl: 'public, max-age=31536000'
+  - name: github
+    includeNames: /^sentry-.*$/
+  - name: npm
   - name: registry
     sdks:
       'npm:@sentry/browser':
@@ -34,13 +44,3 @@ targets:
         onlyIfPresent: /^sentry-wasm-.*\.tgz$/
       'npm:@sentry/nextjs':
         onlyIfPresent: /^sentry-nextjs-.*\.tgz$/
-  - name: aws-lambda-layer
-    includeNames: /^sentry-node-serverless-\d+(\.\d+)*\.zip$/
-    layerName: SentryNodeServerlessSDK
-    compatibleRuntimes:
-      - name: node
-        versions:
-          - nodejs10.x
-          - nodejs12.x
-          - nodejs14.x
-    license: MIT


### PR DESCRIPTION
The goal of this PR is to minimize harm when a release fails. For example, last
week [this release](https://github.com/getsentry/publish/issues/630) failed, and
with the changes this PR makes, the `npm` target wouldn't have run.

The order of targets Craft runs in a release matters. If a target fails, Craft
exits and stops the release, not running the targets that come after the failed
one. For this reason, targets that are easy to undo and don't have big
consequences should come first, and those that are harder to undo and have more
impact should run last; i.e. targets are sorted by ascending impact/cost of
reverting ratio.

Based on that guideline, this is the new order:

1. `aws-lambda-layer`
a. Users using new layers have to manually choose the version, so there's no
risk of someone upgrading the version without manually doing it. See
[integration docs](https://docs.sentry.io/platforms/node/guides/aws-lambda/layer/).
b. It's easy to undo: logging in with a write-permission account and deleting
the latest layer.
c. Users aren't notified.
d. The versions the AWS Lambda layer integration show are picked from the
registry.
e. Low impact, easy to revert.

2. `gcs`
a. Only affects CDN, and users have to manually upgrade the version. See
[CDN docs](https://docs.sentry.io/platforms/javascript/install/cdn/).
b. Users aren't notified.
c. Can revert it by removing the files from GCS.
d. Low impact, easy to revert.

3. `github`
a. It may notify users.
b. Creates a release, a tag, and links them on GitHub. To undo, can manually
remove everything created from the GitHub UI.
c. Medium impact, easy to revert.

4. `npm`
a. Affects users installing the SDKs for the first time, and to those upgrading
them.
b. High impact, can't revert after 72h.

5. `registry`
a. Sentry notifies customers based on updates to the registry. We don't want
to notify them if a release doesn't go well.
b. We own it and can revert the changes with ease, but the prior point is bad
enough.
c. Very high impact, can revert.