### PR TITLE
Use @types/ember__debug

### DIFF
--- a/packages/ember/addon/index.ts
+++ b/packages/ember/addon/index.ts
@@ -8,10 +8,6 @@ import { timestampWithMs } from '@sentry/utils';
 import { GlobalConfig, OwnConfig } from './types';
 import { getGlobalObject } from '@sentry/utils';
 
-declare module '@ember/debug' {
-  export function assert(desc: string, test: unknown): void;
-}
-
 function _getSentryInitConfig() {
   const _global = getGlobalObject<GlobalConfig>();
   _global.__sentryEmberConfig = _global.__sentryEmberConfig ?? {};

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -49,6 +49,7 @@
     "@sentry-internal/eslint-config-sdk": "6.15.0",
     "@types/ember": "~3.16.5",
     "@types/ember-qunit": "~3.4.9",
+    "@types/ember__debug": "^3.16.5",
     "@types/ember__test-helpers": "~1.7.0",
     "@types/qunit": "~2.9.1",
     "@types/rsvp": "~4.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3145,6 +3145,15 @@
     "@types/ember__engine" "*"
     "@types/ember__object" "*"
 
+"@types/ember__debug@^3.16.5":
+  version "3.16.5"
+  resolved "https://registry.yarnpkg.com/@types/ember__debug/-/ember__debug-3.16.5.tgz#ce04532c100fdc1c97c9f308d69a88d6e956db97"
+  integrity sha512-Sj0idBMOd33PubBbxtXty+tzyVIAbxK4cf8q0AKZ0z5wOL0wsFOLCvMgRMxSME3DB2uvJd4u9tGr15XFM+Z03A==
+  dependencies:
+    "@types/ember__debug" "*"
+    "@types/ember__engine" "*"
+    "@types/ember__object" "*"
+
 "@types/ember__destroyable@*":
   version "3.22.0"
   resolved "https://registry.yarnpkg.com/@types/ember__destroyable/-/ember__destroyable-3.22.0.tgz#2af2c27f5d8996694c3f0fe906e2536b2e4c5aca"


### PR DESCRIPTION
No need to roll a version of this module when a better one is available. This has the added benefit of allowing `assert` to assert the `test` param.