### PR TITLE
ref(tracing): Extract strings into constants

### DIFF
--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -2,6 +2,7 @@ import { Hub } from '@sentry/hub';
 import { EventProcessor, Integration, Transaction, TransactionContext } from '@sentry/types';
 import { getGlobalObject, logger } from '@sentry/utils';
 
+import { PAGELOAD_OP } from '../constants';
 import { startIdleTransaction } from '../hubextensions';
 import { DEFAULT_IDLE_TIMEOUT, IdleTransaction } from '../idletransaction';
 import { SpanStatus } from '../spanstatus';
@@ -202,7 +203,7 @@ export class BrowserTracing implements Integration {
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const { beforeNavigate, idleTimeout, maxTransactionDuration } = this.options;
 
-    const parentContextFromHeader = context.op === 'pageload' ? getHeaderContext() : undefined;
+    const parentContextFromHeader = context.op === PAGELOAD_OP ? getHeaderContext() : undefined;
 
     const expandedContext = {
       ...context,

--- a/packages/tracing/src/browser/router.ts
+++ b/packages/tracing/src/browser/router.ts
@@ -1,6 +1,8 @@
 import { Transaction, TransactionContext } from '@sentry/types';
 import { addInstrumentationHandler, getGlobalObject, logger } from '@sentry/utils';
 
+import { NAVIGATION, PAGELOAD_OP } from '../constants';
+
 const global = getGlobalObject<Window>();
 
 /**
@@ -20,7 +22,7 @@ export function instrumentRoutingWithDefaults<T extends Transaction>(
 
   let activeTransaction: T | undefined;
   if (startTransactionOnPageLoad) {
-    activeTransaction = customStartTransaction({ name: global.location.pathname, op: 'pageload' });
+    activeTransaction = customStartTransaction({ name: global.location.pathname, op: PAGELOAD_OP });
   }
 
   if (startTransactionOnLocationChange) {
@@ -47,7 +49,7 @@ export function instrumentRoutingWithDefaults<T extends Transaction>(
             // If there's an open transaction on the scope, we need to finish it before creating an new one.
             activeTransaction.finish();
           }
-          activeTransaction = customStartTransaction({ name: global.location.pathname, op: 'navigation' });
+          activeTransaction = customStartTransaction({ name: global.location.pathname, op: NAVIGATION });
         }
       },
       type: 'history',

--- a/packages/tracing/src/constants.ts
+++ b/packages/tracing/src/constants.ts
@@ -1,0 +1,9 @@
+export const SENTRY_TRACING_INIT = 'sentry-tracing-init';
+
+export const NAVIGATION = 'navigation';
+
+export const RESOURCE = 'resource';
+
+export const BROWSER_OP = 'browser';
+
+export const PAGELOAD_OP = 'pageload';


### PR DESCRIPTION
Extract commonly used strings in the tracing package into their own
package. This saves around 1kb gzipped.
