### PR TITLE
feat(tracing): Export BrowserTracing by itself

### DIFF
--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -4,6 +4,9 @@ import * as TracingIntegrations from './integrations';
 
 const Integrations = { ...TracingIntegrations, BrowserTracing };
 
+export { BrowserTracing };
+
+// TODO(v7): Individually export each integration from integrations
 export { Integrations };
 export { Span } from './span';
 export { Transaction } from './transaction';


### PR DESCRIPTION
This allows users to explicitly import BrowserTracing, allowing them to
treeshake out the other integrations.

The next step here is to change our docs after we cut a release.