### PR TITLE
ref(integrations): Make ReportTypes a const enum

### DIFF
--- a/packages/integrations/src/reportingobserver.ts
+++ b/packages/integrations/src/reportingobserver.ts
@@ -11,7 +11,7 @@ interface Report {
 }
 
 /** JSDoc */
-enum ReportTypes {
+const enum ReportTypes {
   /** JSDoc */
   Crash = 'crash',
   /** JSDoc */


### PR DESCRIPTION
`ReportTypes` is an interally used enum, so we do not need the runtime support. The `ReportTypes` enum lives in `packages/integrations/src/reportingobserver.ts` and is used by the `ReportingObserver` integration to manage report types.

According to the TS docs: https://www.typescriptlang.org/docs/handbook/enums.html 

> Const enums can only use constant enum expressions and unlike regular enums they are completely removed during compilation. Const enum members are inlined at use sites. This is possible since const enums cannot have computed members. 

This helps save on bundle size.