### PR TITLE
ref(utils): Make States a const enum

### DIFF
--- a/packages/utils/src/syncpromise.ts
+++ b/packages/utils/src/syncpromise.ts
@@ -5,7 +5,7 @@
 import { isThenable } from './is';
 
 /** SyncPromise internal states */
-enum States {
+const enum States {
   /** Pending */
   PENDING = 'PENDING',
   /** Resolved / OK */


### PR DESCRIPTION
`States` is an interally used enum, so we do not need the runtime support. The `States` enum lives in `packages/utils/src/syncpromise.ts` and is used by `SyncPromise` to manage state internally.

According to the TS docs: https://www.typescriptlang.org/docs/handbook/enums.html 

> Const enums can only use constant enum expressions and unlike regular enums they are completely removed during compilation. Const enum members are inlined at use sites. This is possible since const enums cannot have computed members. 

This helps save on bundle size.