### PR TITLE
ci: Run size limit on master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,6 @@ jobs:
     needs: job_build
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    if: ${{ github.head_ref }}
     steps:
       - name: Check out current commit (${{ github.sha }})
         uses: actions/checkout@v2


### PR DESCRIPTION
We want to run size limit on master so that we can grab artifacts to
compare against.

https://github.com/getsentry/size-limit-action/blob/0a503754cf43579108061e44bbfa4d432b39d5a7/src/main.ts#L67
