### PR TITLE
fix(react): Mark packages as having no side effects

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -103,7 +103,5 @@
       }
     }
   },
-  "sideEffects": [
-    "./src/index.ts"
-  ]
+  "sideEffects": false
 }


### PR DESCRIPTION
Mark `@sentry/react` as having no side effects.

Previously we had this because we would add an event processor to change all Sentry events (hence why we introduced this change), but we later changed to passing this info down through `_metadata`. Please see: https://github.com/getsentry/sentry-javascript/commit/06d6bd87971b22dcaba99b03e1f885158c7dd66f#diff-1cee8646d2cfba37d6ce6a6e9a8d16f8caba0b99fc3a1ad0cb997ed8c7384d2eL8 for the change in question.