### PR TITLE
ci: Add workflow name to size-limit-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           skip_step: build
+          workflow_name: 'build'
 
   job_lint:
     name: Lint


### PR DESCRIPTION
This will allow it to download assets properly when checking the size
limit action delta. GH does not require this on upload artifacts, only
for download.