### PR TITLE
fix(vue): Mark Vue as having no side effects.

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -88,7 +88,5 @@
       }
     }
   },
-  "sideEffects": [
-    "./src/index.ts"
-  ]
+  "sideEffects": false
 }


### PR DESCRIPTION
The vue package has never had any side effects. We should align with the rest of our SDKS and set the `sideEffects` field in package.json to be false.