### PR TITLE
ci: Separate browser integration and build tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,4 +293,29 @@ jobs:
         run: |
           cd packages/browser
           yarn test:integration
+
+  job_browser_build_tests:
+    name: Browser Build Tests
+    needs: job_build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    continue-on-error: true
+    steps:
+      - name: Check out current commit (${{ github.sha }})
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v1
+      - name: Check dependency cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
+          key: ${{ needs.job_build.outputs.dependency_cache_key }}
+      - name: Check build cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.CACHED_BUILD_PATHS }}
+          key: ${{ env.BUILD_CACHE_KEY }}
+      - name: Run build tests
+        run: |
+          cd packages/browser
           yarn test:package


### PR DESCRIPTION
The jobs can run independently, and when we run the integration tests with a test matrix with multiple target browsers, we don't need to re-run the build tests for N browsers (the build test is browser-independent).