### PR TITLE
ref(eslint): Update `spaced-comment` rule

### DIFF
--- a/packages/eslint-config-sdk/src/index.js
+++ b/packages/eslint-config-sdk/src/index.js
@@ -215,7 +215,22 @@ module.exports = {
     'max-lines': 'error',
 
     // We should require a whitespace beginning a comment
-    'spaced-comment': 'error',
+    'spaced-comment': [
+      'error',
+      'always',
+      {
+        line: {
+          // this lets us use triple-slash directives
+          markers: ['/'],
+        },
+        block: {
+          // comments of the form /* ..... */ should always have whitespace before the closing `*/` marker...
+          balanced: true,
+          // ... unless they're jsdoc-style block comments, which end with `**/`
+          exceptions: ['*'],
+        },
+      },
+    ],
 
     // Disallow usage of bitwise operators - this makes it an opt in operation
     'no-bitwise': 'error',


### PR DESCRIPTION
This makes two changes to the `spaced-comment` [rule](https://eslint.org/docs/rules/spaced-comment) in our global eslint config:

- It allows comments to start with `///` in addition to `//`, in order to allow the use of [triple-slash directives](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html).

- In comments which start and end with `/*` and `*/`, respectively,  the basic form of the rule enforces there being a space after the opening token. With this change, it also enforces there being a space before the closing token. The one exception is jsdoc-style block comments, which are allowed to start and end with an extra asterisk.