### PR TITLE
build: Extract npm-run-all into main package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "lerna": "3.13.4",
     "madge": "4.0.2",
     "mocha": "^6.1.4",
-    "npm-run-all": "^4.1.2",
+    "npm-run-all": "^4.1.5",
     "prettier": "1.19.0",
     "replace-in-file": "^4.0.0",
     "rimraf": "^2.6.3",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -31,7 +31,6 @@
     "@angular/common": "^10.0.3",
     "@angular/core": "^10.0.3",
     "@angular/router": "^10.0.3",
-    "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "typescript": "3.7.5"

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -42,7 +42,6 @@
     "karma-typescript-es6-transform": "^4.0.0",
     "karma-webkit-launcher": "^1.0.2",
     "node-fetch": "^2.6.0",
-    "npm-run-all": "^4.1.2",
     "playwright": "^1.17.1",
     "prettier": "1.19.0",
     "rimraf": "^2.6.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "jest": "^24.7.1",
-    "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "typescript": "3.7.5"

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -76,7 +76,6 @@
     "eslint-plugin-ember": "~8.6.0",
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "~4.7.0",
-    "npm-run-all": "^4.1.5",
     "qunit-dom": "~1.2.0",
     "typescript": "3.7.5"
   },

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -37,7 +37,6 @@
     "@sentry/types": "6.15.0",
     "@testing-library/react": "^10.4.9",
     "jest": "^24.7.1",
-    "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",
     "react": "^17.0.0",
     "rimraf": "^2.6.3",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -22,7 +22,6 @@
   },
   "devDependencies": {
     "jest": "^24.7.1",
-    "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "typescript": "3.7.5"

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -24,7 +24,6 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "jest": "^24.7.1",
-    "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "rollup": "^1.10.1",

--- a/packages/minimal/package.json
+++ b/packages/minimal/package.json
@@ -22,7 +22,6 @@
   },
   "devDependencies": {
     "jest": "^24.7.1",
-    "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "typescript": "3.7.5"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -35,7 +35,6 @@
     "express": "^4.17.1",
     "jest": "^24.7.1",
     "nock": "^13.0.5",
-    "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "typescript": "3.7.5"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -43,7 +43,6 @@
     "history-5": "npm:history@4.9.0",
     "jest": "^24.7.1",
     "jsdom": "^16.2.2",
-    "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -38,7 +38,6 @@
     "jest": "^24.7.1",
     "nock": "^13.0.4",
     "npm-packlist": "^2.1.4",
-    "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",
     "read-pkg": "^5.2.0",
     "rimraf": "^2.6.3",

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -28,7 +28,6 @@
     "@types/jsdom": "^16.2.3",
     "jest": "^24.7.1",
     "jsdom": "^16.2.2",
-    "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "rollup": "^1.10.1",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,7 +16,6 @@
     "access": "public"
   },
   "devDependencies": {
-    "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",
     "typescript": "3.7.5"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -24,7 +24,6 @@
     "chai": "^4.1.2",
     "jest": "^24.7.1",
     "jsdom": "^16.2.2",
-    "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "typescript": "3.7.5"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -30,7 +30,6 @@
   "devDependencies": {
     "jest": "^24.7.1",
     "jsdom": "^16.2.2",
-    "npm-run-all": "^4.1.2",
     "prettier": "1.19.0",
     "rimraf": "^2.6.3",
     "rollup": "^1.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3996,31 +3996,10 @@ after@0.8.2:
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
   integrity sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
 
-agent-base@4, agent-base@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
-  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
-  dependencies:
-    es6-promisify "^5.0.0"
-
-agent-base@5:
+agent-base@4, agent-base@5, agent-base@6, agent-base@^4.3.0, agent-base@^6.0.2, agent-base@~4.2.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
   integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
-
-agent-base@6, agent-base@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
-  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
-  dependencies:
-    debug "4"
-
-agent-base@~4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
-  integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
-  dependencies:
-    es6-promisify "^5.0.0"
 
 agentkeepalive@^3.4.1:
   version "3.5.2"
@@ -9246,18 +9225,6 @@ es6-object-assign@^1.1.0:
   resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
   integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
 
-es6-promise@^4.0.3:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
-  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
-
-es6-promisify@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
-  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
-  dependencies:
-    es6-promise "^4.0.3"
-
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -12612,7 +12579,7 @@ jest-environment-jsdom@^24.9.0:
     jest-util "^24.9.0"
     jsdom "^11.5.1"
 
-"jest-environment-node@>=24 <=26", jest-environment-node@^24.9.0:
+jest-environment-node@24, "jest-environment-node@>=24 <=26", jest-environment-node@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-24.9.0.tgz#333d2d2796f9687f2aeebf0742b519f33c1cbfd3"
   integrity sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==


### PR DESCRIPTION
As prep for unifying our package.json, let's move dependencies that every package uses into the root `package.json`.

This patch does that for the `npm-run-all` package.

There is an argument that we should remove `npm-run-all`, but that can be discussed at a later time.
