### PR TITLE
build: extract rimraf into main package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "1.19.1",
     "replace-in-file": "^4.0.0",
-    "rimraf": "^2.6.3",
+    "rimraf": "^3.0.2",
     "sinon": "^7.3.2",
     "size-limit": "^4.5.5",
     "ts-jest": "^24.0.2",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -31,8 +31,6 @@
     "@angular/common": "^10.0.3",
     "@angular/core": "^10.0.3",
     "@angular/router": "^10.0.3",
-    "npm-run-all": "^4.1.2",
-    "rimraf": "^2.6.3",
     "typescript": "3.7.5"
   },
   "scripts": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -43,7 +43,6 @@
     "karma-webkit-launcher": "^1.0.2",
     "node-fetch": "^2.6.0",
     "playwright": "^1.17.1",
-    "rimraf": "^2.6.3",
     "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-license": "^0.8.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "jest": "^24.7.1",
-    "rimraf": "^2.6.3",
     "typescript": "3.7.5"
   },
   "scripts": {

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -38,7 +38,6 @@
     "@testing-library/react": "^10.4.9",
     "jest": "^24.7.1",
     "react": "^17.0.0",
-    "rimraf": "^2.6.3",
     "typescript": "3.7.5"
   },
   "scripts": {

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -22,7 +22,6 @@
   },
   "devDependencies": {
     "jest": "^24.7.1",
-    "rimraf": "^2.6.3",
     "typescript": "3.7.5"
   },
   "scripts": {

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -24,7 +24,6 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "jest": "^24.7.1",
-    "rimraf": "^2.6.3",
     "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-node-resolve": "^4.2.3",

--- a/packages/minimal/package.json
+++ b/packages/minimal/package.json
@@ -22,7 +22,6 @@
   },
   "devDependencies": {
     "jest": "^24.7.1",
-    "rimraf": "^2.6.3",
     "typescript": "3.7.5"
   },
   "scripts": {

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -30,8 +30,7 @@
   "devDependencies": {
     "@sentry/types": "6.15.0",
     "@types/webpack": "^4.41.31",
-    "next": "10.1.3",
-    "rimraf": "3.0.2"
+    "next": "10.1.3"
   },
   "peerDependencies": {
     "next": "^10.0.8 || ^11.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -35,7 +35,6 @@
     "express": "^4.17.1",
     "jest": "^24.7.1",
     "nock": "^13.0.5",
-    "rimraf": "^2.6.3",
     "typescript": "3.7.5"
   },
   "scripts": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -50,7 +50,6 @@
     "react-router-5": "npm:react-router@5.0.0",
     "react-test-renderer": "^16.13.1",
     "redux": "^4.0.5",
-    "rimraf": "^2.6.3",
     "typescript": "3.7.5"
   },
   "scripts": {

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -39,7 +39,6 @@
     "nock": "^13.0.4",
     "npm-packlist": "^2.1.4",
     "read-pkg": "^5.2.0",
-    "rimraf": "^2.6.3",
     "typescript": "3.7.5"
   },
   "scripts": {

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -28,7 +28,6 @@
     "@types/jsdom": "^16.2.3",
     "jest": "^24.7.1",
     "jsdom": "^16.2.2",
-    "rimraf": "^2.6.3",
     "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-license": "^0.8.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -24,7 +24,6 @@
     "chai": "^4.1.2",
     "jest": "^24.7.1",
     "jsdom": "^16.2.2",
-    "rimraf": "^2.6.3",
     "typescript": "3.7.5"
   },
   "scripts": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -30,7 +30,6 @@
   "devDependencies": {
     "jest": "^24.7.1",
     "jsdom": "^16.2.2",
-    "rimraf": "^2.6.3",
     "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-license": "^0.8.1",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -30,7 +30,6 @@
     "jest-puppeteer": "^4.4.0",
     "npm-run-all": "^4.1.2",
     "puppeteer": "^5.5.0",
-    "rimraf": "^2.6.3",
     "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-node-resolve": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17827,7 +17827,7 @@ rimraf@2, rimraf@^2.2.8, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.
   dependencies:
     glob "^7.1.3"
 
-rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.1, rimraf@^3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.1, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==


### PR DESCRIPTION
Similar in motivation to: https://github.com/getsentry/sentry-javascript/pull/4236

As prep for unifying our package.json, let's move dependencies that every package uses into the root `package.json`.

This patch does that for the `rimraf` package.