### PR TITLE
build: Extract typescript pkg into main package.json

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -30,8 +30,7 @@
   "devDependencies": {
     "@angular/common": "^10.0.3",
     "@angular/core": "^10.0.3",
-    "@angular/router": "^10.0.3",
-    "typescript": "3.7.5"
+    "@angular/router": "^10.0.3"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -47,7 +47,6 @@
     "rollup-plugin-terser": "^4.0.4",
     "rollup-plugin-typescript2": "^0.21.0",
     "sinon": "^7.3.2",
-    "typescript": "3.7.5",
     "webpack": "^4.30.0"
   },
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,9 +22,7 @@
     "@sentry/utils": "6.16.1",
     "tslib": "^1.9.3"
   },
-  "devDependencies": {
-    "typescript": "3.7.5"
-  },
+  "devDependencies": {},
   "scripts": {
     "build": "run-p build:cjs build:esm",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -75,8 +75,7 @@
     "eslint-plugin-ember": "~8.6.0",
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "~4.7.0",
-    "qunit-dom": "~1.2.0",
-    "typescript": "3.7.5"
+    "qunit-dom": "~1.2.0"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/packages/eslint-config-sdk/package.json
+++ b/packages/eslint-config-sdk/package.json
@@ -33,8 +33,7 @@
     "eslint": ">=5"
   },
   "devDependencies": {
-    "eslint": "7.32.0",
-    "typescript": "3.7.5"
+    "eslint": "7.32.0"
   },
   "scripts": {
     "link:yarn": "yarn link",

--- a/packages/eslint-plugin-sdk/package.json
+++ b/packages/eslint-plugin-sdk/package.json
@@ -22,8 +22,7 @@
     "requireindex": "~1.1.0"
   },
   "devDependencies": {
-    "mocha": "^6.2.0",
-    "typescript": "3.7.5"
+    "mocha": "^6.2.0"
   },
   "scripts": {
     "link:yarn": "yarn link",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -36,8 +36,7 @@
   "devDependencies": {
     "@sentry/types": "6.16.1",
     "@testing-library/react": "^10.4.9",
-    "react": "^17.0.0",
-    "typescript": "3.7.5"
+    "react": "^17.0.0"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -20,9 +20,7 @@
     "@sentry/utils": "6.16.1",
     "tslib": "^1.9.3"
   },
-  "devDependencies": {
-    "typescript": "3.7.5"
-  },
+  "devDependencies": {},
   "scripts": {
     "build": "run-p build:cjs build:esm",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -27,8 +27,7 @@
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-node-resolve": "^4.2.3",
     "rollup-plugin-terser": "^4.0.4",
-    "rollup-plugin-typescript2": "^0.21.0",
-    "typescript": "3.7.5"
+    "rollup-plugin-typescript2": "^0.21.0"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",

--- a/packages/minimal/package.json
+++ b/packages/minimal/package.json
@@ -20,9 +20,7 @@
     "@sentry/types": "6.16.1",
     "tslib": "^1.9.3"
   },
-  "devDependencies": {
-    "typescript": "3.7.5"
-  },
+  "devDependencies": {},
   "scripts": {
     "build": "run-p build:cjs build:esm",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -32,8 +32,7 @@
     "@types/lru-cache": "^5.1.0",
     "@types/node": "~10.17.0",
     "express": "^4.17.1",
-    "nock": "^13.0.5",
-    "typescript": "3.7.5"
+    "nock": "^13.0.5"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -47,8 +47,7 @@
     "react-router-4": "npm:react-router@4.1.0",
     "react-router-5": "npm:react-router@5.0.0",
     "react-test-renderer": "^16.13.1",
-    "redux": "^4.0.5",
-    "typescript": "3.7.5"
+    "redux": "^4.0.5"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm",

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -36,8 +36,7 @@
     "google-gax": "^2.9.0",
     "nock": "^13.0.4",
     "npm-packlist": "^2.1.4",
-    "read-pkg": "^5.2.0",
-    "typescript": "3.7.5"
+    "read-pkg": "^5.2.0"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm && yarn build:awslambda-layer",

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -32,8 +32,7 @@
     "rollup-plugin-license": "^0.8.1",
     "rollup-plugin-node-resolve": "^4.2.3",
     "rollup-plugin-terser": "^4.0.4",
-    "rollup-plugin-typescript2": "^0.21.0",
-    "typescript": "3.7.5"
+    "rollup-plugin-typescript2": "^0.21.0"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,9 +15,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "devDependencies": {
-    "typescript": "3.7.5"
-  },
+  "devDependencies": {},
   "scripts": {
     "build": "run-p build:cjs build:esm",
     "build:cjs": "tsc -p tsconfig.cjs.json",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,8 +21,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "jsdom": "^16.2.2",
-    "typescript": "3.7.5"
+    "jsdom": "^16.2.2"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -34,8 +34,7 @@
     "rollup-plugin-license": "^0.8.1",
     "rollup-plugin-node-resolve": "^4.2.3",
     "rollup-plugin-terser": "^4.0.4",
-    "rollup-plugin-typescript2": "^0.21.0",
-    "typescript": "3.7.5"
+    "rollup-plugin-typescript2": "^0.21.0"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -31,8 +31,7 @@
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-node-resolve": "^4.2.3",
     "rollup-plugin-terser": "^4.0.4",
-    "rollup-plugin-typescript2": "^0.21.0",
-    "typescript": "3.7.5"
+    "rollup-plugin-typescript2": "^0.21.0"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",


### PR DESCRIPTION
As prep for unifying our package.json, let's move dependencies that every package uses into the root `package.json`.

This patch does that for the `typescript` package.