### PR TITLE
chore(build): Fix missed `es5` to `cjs` conversions in build commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "private": true,
   "scripts": {
     "build": "node ./scripts/verify-packages-versions.js && lerna run --stream --concurrency 1 --sort build",
+    "build:cjs": "lerna run --stream --concurrency 1 --sort build:cjs",
     "build:dev": "lerna run --stream --concurrency 1 --sort build:dev",
     "build:dev:filter": "lerna run --stream --concurrency 1 --sort build:dev --include-filtered-dependencies --include-filtered-dependents --scope",
-    "build:es5": "lerna run --stream --concurrency 1 --sort build:es5",
+    "build:es5": "yarn lerna run --stream --concurrency 1 --sort build:cjs # *** backwards compatibility - remove in v7 ***",
     "build:esm": "lerna run --stream --concurrency 1 --sort build:esm",
     "build:watch": "lerna run --parallel build:watch",
     "build:dev:watch": "lerna run --parallel build:dev:watch",

--- a/packages/nextjs/vercel/install-sentry-from-branch.sh
+++ b/packages/nextjs/vercel/install-sentry-from-branch.sh
@@ -29,7 +29,7 @@ echo " "
 echo "BUILDING SDK"
 # We need to build es5 versions because `next.config.js` calls `require` on the SDK (to get `withSentryConfig`) and
 # therefore it looks for `dist/index.js`
-yarn build:es5
+yarn build:cjs
 # We need to build esm versions because that's what `next` actually uses when it builds the app
 yarn build:esm
 


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry-javascript/pull/4178.

This fixes two spots which were missed when converting the build command from `build:es5` to `build:cjs`.