### PR TITLE
build: Build AWS Lambda Layer after building dist

### DIFF
--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -41,7 +41,7 @@
     "typescript": "3.7.5"
   },
   "scripts": {
-    "build": "run-p build:cjs build:esm build:awslambda-layer",
+    "build": "run-p build:cjs build:esm && yarn build:awslambda-layer",
     "build:awslambda-layer": "node scripts/build-awslambda-layer.js",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:dev": "run-s build:cjs build:esm",


### PR DESCRIPTION
`yarn build:awslambda-layer` requires a `dist` to exist to work. Previously we were running all the commands in parallel, so there was a chance that the `dist` did not exist.
