### PR TITLE
build: configure static globals to control bundle/debug code

### DIFF
--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -14,7 +14,7 @@ const terserInstance = terser({
     // want to have unnecessary debug functionality.
     global_defs: {
       __SENTRY_BROWSER_BUNDLE__: true,
-      __SENTRY_NDEBUG__: true,
+      __SENTRY_NO_DEBUG__: true,
     },
   },
   mangle: {

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -9,6 +9,14 @@ const commitHash = require('child_process')
   .trim();
 
 const terserInstance = terser({
+  compress: {
+    // Tell env.ts that we're building a browser bundle and that we do not
+    // want to have unnecessary debug functionality.
+    global_defs: {
+      __SENTRY_BROWSER_BUNDLE__: true,
+      __SENTRY_NDEBUG__: true,
+    },
+  },
   mangle: {
     // captureExceptions and captureMessage are public API methods and they don't need to be listed here
     // as mangler doesn't touch user-facing thing, however sentryWrapped is not, and it would be mangled into a minified version.

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -18,7 +18,7 @@ declare const __SENTRY_NDEBUG__: boolean | undefined;
  * @returns true if this is a debug build
  */
 export function isDebugBuild(): boolean {
-  return !__SENTRY_NDEBUG__;
+  return typeof __SENTRY_NDEBUG__ !== 'undefined' && !__SENTRY_BROWSER_BUNDLE__;
 }
 
 /**
@@ -27,5 +27,5 @@ export function isDebugBuild(): boolean {
  * @returns true if this is a browser bundle build.
  */
 export function isBrowserBundle(): boolean {
-  return !!__SENTRY_BROWSER_BUNDLE__;
+  return typeof __SENTRY_BROWSER_BUNDLE__ !== 'undefined' && !!__SENTRY_BROWSER_BUNDLE__;
 }

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -10,7 +10,7 @@
  */
 
 declare const __SENTRY_BROWSER_BUNDLE__: boolean | undefined;
-declare const __SENTRY_NDEBUG__: boolean | undefined;
+declare const __SENTRY_NO_DEBUG__: boolean | undefined;
 
 /**
  * Figures out if we're building with debug functionality.
@@ -18,7 +18,7 @@ declare const __SENTRY_NDEBUG__: boolean | undefined;
  * @returns true if this is a debug build
  */
 export function isDebugBuild(): boolean {
-  return typeof __SENTRY_NDEBUG__ !== 'undefined' && !__SENTRY_BROWSER_BUNDLE__;
+  return typeof __SENTRY_NO_DEBUG__ !== 'undefined' && !__SENTRY_BROWSER_BUNDLE__;
 }
 
 /**

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -1,0 +1,31 @@
+/**
+ * This module mostly exists for optimizations in the build process
+ * through rollup and terser.  We define some global constants which
+ * are normally undefined.  However terser overrides these with global
+ * definitions which can be evaluated by the static analyzer when
+ * creating a bundle.
+ *
+ * In turn the `isDebugBuild` and `isBrowserBundle` functions are pure
+ * and can help us remove unused code from the bundles.
+ */
+
+declare const __SENTRY_BROWSER_BUNDLE__: boolean | undefined;
+declare const __SENTRY_NDEBUG__: boolean | undefined;
+
+/**
+ * Figures out if we're building with debug functionality.
+ *
+ * @returns true if this is a debug build
+ */
+export function isDebugBuild(): boolean {
+  return !__SENTRY_NDEBUG__;
+}
+
+/**
+ * Figures out if we're building a browser bundle.
+ *
+ * @returns true if this is a browser bundle build.
+ */
+export function isBrowserBundle(): boolean {
+  return !!__SENTRY_BROWSER_BUNDLE__;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -17,3 +17,4 @@ export * from './string';
 export * from './supports';
 export * from './syncpromise';
 export * from './time';
+export * from './env';

--- a/packages/utils/src/node.ts
+++ b/packages/utils/src/node.ts
@@ -3,13 +3,20 @@
  * you must either a) use `console.log` rather than the logger, or b) put your function elsewhere.
  */
 
+import { isBrowserBundle } from './env';
+
 /**
  * Checks whether we're in the Node.js or Browser environment
  *
  * @returns Answer to given question
  */
 export function isNodeEnv(): boolean {
-  return Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]';
+  // explicitly check for browser bundles as those can be optimized statically
+  // by terser/rollup.
+  return (
+    !isBrowserBundle() &&
+    Object.prototype.toString.call(typeof process !== 'undefined' ? process : 0) === '[object process]'
+  );
 }
 
 /**


### PR DESCRIPTION
This adds experimental configuration to rollup and terser to make enable dead code elimination for browser bundles. In particular right now we want to make sure some code that is absolutely pointless in browser never makes it there without having to modify reusable code from the node version.

In addition this provides a flag we can then use to turn on/off functionality that's only relevant for debugging.

I was unable to make this work with a constant instead of a function call due to limitations in terser. However this overhead this adds to non terser builds should be small enough that I believe we should be merging this as such and then optimize later to get rid of this newfound overhead.