### PR TITLE
ref(browser): Extract getReportDialogEndpoint from API class

### DIFF
--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -1,6 +1,6 @@
-import { API, captureException, withScope } from '@sentry/core';
+import { captureException, getReportDialogEndpoint, withScope } from '@sentry/core';
 import { DsnLike, Event as SentryEvent, Mechanism, Scope, WrappedFunction } from '@sentry/types';
-import { addExceptionMechanism, addExceptionTypeValue, getGlobalObject, logger } from '@sentry/utils';
+import { addExceptionMechanism, addExceptionTypeValue, Dsn, getGlobalObject, logger } from '@sentry/utils';
 
 const global = getGlobalObject<Window>();
 let ignoreOnError: number = 0;
@@ -210,7 +210,7 @@ export function injectReportDialog(options: ReportDialogOptions = {}): void {
 
   const script = global.document.createElement('script');
   script.async = true;
-  script.src = new API(options.dsn).getReportDialogEndpoint(options);
+  script.src = getReportDialogEndpoint(new Dsn(options.dsn), options);
 
   if (options.onLoad) {
     // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -1,6 +1,6 @@
 import { captureException, getReportDialogEndpoint, withScope } from '@sentry/core';
 import { DsnLike, Event as SentryEvent, Mechanism, Scope, WrappedFunction } from '@sentry/types';
-import { addExceptionMechanism, addExceptionTypeValue, Dsn, getGlobalObject, logger } from '@sentry/utils';
+import { addExceptionMechanism, addExceptionTypeValue, getGlobalObject, logger } from '@sentry/utils';
 
 const global = getGlobalObject<Window>();
 let ignoreOnError: number = 0;
@@ -210,7 +210,7 @@ export function injectReportDialog(options: ReportDialogOptions = {}): void {
 
   const script = global.document.createElement('script');
   script.async = true;
-  script.src = getReportDialogEndpoint(new Dsn(options.dsn), options);
+  script.src = getReportDialogEndpoint(options.dsn, options);
 
   if (options.onLoad) {
     // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -4,25 +4,9 @@ import { Dsn, urlEncode } from '@sentry/utils';
 const SENTRY_API_VERSION = '7';
 
 /**
- * Stores details about a Sentry SDK
- */
-export interface APIDetails {
-  /** The DSN as passed to Sentry.init() */
-  initDsn: DsnLike;
-  /** Metadata about the SDK (name, version, etc) for inclusion in envelope headers */
-  metadata: SdkMetadata;
-  /** The internally used Dsn object. */
-  readonly dsn: Dsn;
-  /** The envelope tunnel to use. */
-  readonly tunnel?: string;
-}
-
-/**
  * Helper class to provide urls, headers and metadata that can be used to form
  * different types of requests to Sentry endpoints.
  * Supports both envelopes and regular event requests.
- *
- * @deprecated Please use the function component
  **/
 export class API {
   /** The DSN as passed to Sentry.init() */
@@ -139,16 +123,6 @@ export class API {
     };
     return urlEncode(auth);
   }
-}
-
-/** Initializes API Details */
-export function initAPIDetails(dsn: DsnLike, metadata?: SdkMetadata, tunnel?: string): APIDetails {
-  return {
-    initDsn: dsn,
-    metadata: metadata || {},
-    dsn: new Dsn(dsn),
-    tunnel,
-  } as APIDetails;
 }
 
 /** Returns the prefix to construct Sentry ingestion API endpoints. */

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -134,17 +134,17 @@ function getBaseApiEndpoint(dsn: Dsn): string {
 
 /** Returns the url to the report dialog endpoint. */
 export function getReportDialogEndpoint(
-  dsn: Dsn,
+  dsnLike: DsnLike,
   dialogOptions: {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any;
     user?: { name?: string; email?: string };
   },
 ): string {
+  const dsn = new Dsn(dsnLike);
   const endpoint = `${getBaseApiEndpoint(dsn)}embed/error-page/`;
 
-  const encodedOptions = [];
-  encodedOptions.push(`dsn=${dsn.toString()}`);
+  const encodedOptions = [`dsn=${dsn.toString()}`];
   for (const key in dialogOptions) {
     if (key === 'dsn') {
       continue;
@@ -164,9 +164,6 @@ export function getReportDialogEndpoint(
       encodedOptions.push(`${encodeURIComponent(key)}=${encodeURIComponent(dialogOptions[key] as string)}`);
     }
   }
-  if (encodedOptions.length) {
-    return `${endpoint}?${encodedOptions.join('&')}`;
-  }
 
-  return endpoint;
+  return encodedOptions.length ? `${endpoint}?${encodedOptions.join('&')}` : endpoint;
 }

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -144,7 +144,7 @@ export function getReportDialogEndpoint(
   const dsn = new Dsn(dsnLike);
   const endpoint = `${getBaseApiEndpoint(dsn)}embed/error-page/`;
 
-  const encodedOptions = [`dsn=${dsn.toString()}`];
+  let encodedOptions = `dsn=${dsn.toString()}`;
   for (const key in dialogOptions) {
     if (key === 'dsn') {
       continue;
@@ -155,15 +155,15 @@ export function getReportDialogEndpoint(
         continue;
       }
       if (dialogOptions.user.name) {
-        encodedOptions.push(`name=${encodeURIComponent(dialogOptions.user.name)}`);
+        encodedOptions += `&name=${encodeURIComponent(dialogOptions.user.name)}`;
       }
       if (dialogOptions.user.email) {
-        encodedOptions.push(`email=${encodeURIComponent(dialogOptions.user.email)}`);
+        encodedOptions += `&email=${encodeURIComponent(dialogOptions.user.email)}`;
       }
     } else {
-      encodedOptions.push(`${encodeURIComponent(key)}=${encodeURIComponent(dialogOptions[key] as string)}`);
+      encodedOptions += `&${encodeURIComponent(key)}=${encodeURIComponent(dialogOptions[key] as string)}`;
     }
   }
 
-  return encodedOptions.length ? `${endpoint}?${encodedOptions.join('&')}` : endpoint;
+  return `${endpoint}?${encodedOptions}`;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,8 +14,7 @@ export {
   withScope,
 } from '@sentry/minimal';
 export { addGlobalEventProcessor, getCurrentHub, getHubFromCarrier, Hub, makeMain, Scope } from '@sentry/hub';
-// eslint-disable-next-line deprecation/deprecation
-export { API, APIDetails, initAPIDetails, getReportDialogEndpoint } from './api';
+export { API, getReportDialogEndpoint } from './api';
 export { BaseClient } from './baseclient';
 export { BackendClass, BaseBackend } from './basebackend';
 export { eventToSentryRequest, sessionToSentryRequest } from './request';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,8 @@ export {
   withScope,
 } from '@sentry/minimal';
 export { addGlobalEventProcessor, getCurrentHub, getHubFromCarrier, Hub, makeMain, Scope } from '@sentry/hub';
-export { API } from './api';
+// eslint-disable-next-line deprecation/deprecation
+export { API, APIDetails, initAPIDetails, getReportDialogEndpoint } from './api';
 export { BaseClient } from './baseclient';
 export { BackendClass, BaseBackend } from './basebackend';
 export { eventToSentryRequest, sessionToSentryRequest } from './request';

--- a/packages/core/test/lib/api.test.ts
+++ b/packages/core/test/lib/api.test.ts
@@ -1,7 +1,6 @@
 import { Dsn } from '@sentry/utils';
 
 import { API, getReportDialogEndpoint } from '../../src/api';
-import { DsnLike } from '@sentry/types';
 
 const ingestDsn = 'https://abc@xxxx.ingest.sentry.io:1234/subpath/123';
 const dsnPublic = 'https://abc@sentry.io:1234/subpath/123';

--- a/packages/core/test/lib/api.test.ts
+++ b/packages/core/test/lib/api.test.ts
@@ -1,6 +1,7 @@
 import { Dsn } from '@sentry/utils';
 
 import { API, getReportDialogEndpoint } from '../../src/api';
+import { DsnLike } from '@sentry/types';
 
 const ingestDsn = 'https://abc@xxxx.ingest.sentry.io:1234/subpath/123';
 const dsnPublic = 'https://abc@sentry.io:1234/subpath/123';
@@ -37,42 +38,83 @@ describe('API', () => {
     });
   });
 
-  test('getReportDialogEndpoint', () => {
-    expect(getReportDialogEndpoint(ingestDsn, {})).toEqual(
-      'https://xxxx.ingest.sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@xxxx.ingest.sentry.io:1234/subpath/123',
-    );
-
-    expect(getReportDialogEndpoint(dsnPublic, {})).toEqual(
-      'https://sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@sentry.io:1234/subpath/123',
-    );
-    expect(
-      getReportDialogEndpoint(dsnPublic, {
-        eventId: 'abc',
-        testy: '2',
-      }),
-    ).toEqual(
-      'https://sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@sentry.io:1234/subpath/123&eventId=abc&testy=2',
-    );
-
-    expect(
-      getReportDialogEndpoint(dsnPublic, {
-        eventId: 'abc',
-        user: {
-          email: 'email',
-          name: 'yo',
+  describe('getReportDialogEndpoint', () => {
+    test.each([
+      [
+        'with Ingest DSN',
+        ingestDsn,
+        {},
+        'https://xxxx.ingest.sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@xxxx.ingest.sentry.io:1234/subpath/123',
+      ],
+      [
+        'with Public DSN',
+        dsnPublic,
+        {},
+        'https://sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@sentry.io:1234/subpath/123',
+      ],
+      [
+        'with Public DSN and dynamic options',
+        dsnPublic,
+        { eventId: 'abc', testy: '2' },
+        'https://sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@sentry.io:1234/subpath/123&eventId=abc&testy=2',
+      ],
+      [
+        'with Public DSN, dynamic options and user name and email',
+        dsnPublic,
+        {
+          eventId: 'abc',
+          user: {
+            email: 'email',
+            name: 'yo',
+          },
         },
-      }),
-    ).toEqual(
-      'https://sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@sentry.io:1234/subpath/123&eventId=abc&name=yo&email=email',
-    );
-
-    expect(
-      getReportDialogEndpoint(dsnPublic, {
-        eventId: 'abc',
-        user: undefined,
-      }),
-    ).toEqual(
-      'https://sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@sentry.io:1234/subpath/123&eventId=abc',
+        'https://sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@sentry.io:1234/subpath/123&eventId=abc&name=yo&email=email',
+      ],
+      [
+        'with Public DSN and user name',
+        dsnPublic,
+        {
+          user: {
+            name: 'yo',
+          },
+        },
+        'https://sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@sentry.io:1234/subpath/123&name=yo',
+      ],
+      [
+        'with Public DSN and user email',
+        dsnPublic,
+        {
+          user: {
+            email: 'email',
+          },
+        },
+        'https://sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@sentry.io:1234/subpath/123&email=email',
+      ],
+      [
+        'with Public DSN, dynamic options and undefined user',
+        dsnPublic,
+        {
+          eventId: 'abc',
+          user: undefined,
+        },
+        'https://sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@sentry.io:1234/subpath/123&eventId=abc',
+      ],
+      [
+        'with Public DSN and undefined user',
+        dsnPublic,
+        { user: undefined },
+        'https://sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@sentry.io:1234/subpath/123',
+      ],
+    ])(
+      '%s',
+      (
+        _: string,
+        dsn: Parameters<typeof getReportDialogEndpoint>[0],
+        options: Parameters<typeof getReportDialogEndpoint>[1],
+        output: ReturnType<typeof getReportDialogEndpoint>,
+      ) => {
+        expect(getReportDialogEndpoint(dsn, options)).toBe(output);
+      },
     );
   });
 

--- a/packages/core/test/lib/api.test.ts
+++ b/packages/core/test/lib/api.test.ts
@@ -1,6 +1,6 @@
 import { Dsn } from '@sentry/utils';
 
-import { API } from '../../src/api';
+import { API, getReportDialogEndpoint } from '../../src/api';
 
 const ingestDsn = 'https://abc@xxxx.ingest.sentry.io:1234/subpath/123';
 const dsnPublic = 'https://abc@sentry.io:1234/subpath/123';
@@ -38,15 +38,15 @@ describe('API', () => {
   });
 
   test('getReportDialogEndpoint', () => {
-    expect(new API(ingestDsn).getReportDialogEndpoint({})).toEqual(
+    expect(getReportDialogEndpoint(ingestDsn, {})).toEqual(
       'https://xxxx.ingest.sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@xxxx.ingest.sentry.io:1234/subpath/123',
     );
 
-    expect(new API(dsnPublic).getReportDialogEndpoint({})).toEqual(
+    expect(getReportDialogEndpoint(dsnPublic, {})).toEqual(
       'https://sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@sentry.io:1234/subpath/123',
     );
     expect(
-      new API(dsnPublic).getReportDialogEndpoint({
+      getReportDialogEndpoint(dsnPublic, {
         eventId: 'abc',
         testy: '2',
       }),
@@ -55,7 +55,7 @@ describe('API', () => {
     );
 
     expect(
-      new API(dsnPublic).getReportDialogEndpoint({
+      getReportDialogEndpoint(dsnPublic, {
         eventId: 'abc',
         user: {
           email: 'email',
@@ -67,7 +67,7 @@ describe('API', () => {
     );
 
     expect(
-      new API(dsnPublic).getReportDialogEndpoint({
+      getReportDialogEndpoint(dsnPublic, {
         eventId: 'abc',
         user: undefined,
       }),
@@ -75,6 +75,7 @@ describe('API', () => {
       'https://sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@sentry.io:1234/subpath/123&eventId=abc',
     );
   });
+
   test('getDsn', () => {
     expect(new API(dsnPublic).getDsn()).toEqual(new Dsn(dsnPublic));
   });


### PR DESCRIPTION
Although this is a public API, we can extract it from the API class as it should only be used by browser. Electron and React Native are not using this field.

