### PR TITLE
chore(build): Remove misplaced `fetch-depth` option in ember CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,6 +213,10 @@ jobs:
     steps:
       - name: Check out current commit (${{ github.sha }})
         uses: actions/checkout@v2
+        # TODO: removing `fetch-depth` below seems to have no effect, and the commit which added it had no description,
+        # so it's not clear why it's necessary. That said, right now ember tests are xfail, so it's a little hard to
+        # tell if it's safe to remove. Once ember tests are fixed, let's try again with it turned off, and if all goes
+        # well, we can pull it out.
         with:
           fetch-depth: 0
       - name: Set up Node
@@ -223,7 +227,6 @@ jobs:
           # that. If it passes, newer versions of Node should also be fine. This saves us from having to run the Ember
           # tests in our Node matrix above.
           node-version: '10'
-          fetch-depth: 0
       - name: Check dependency cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/3610, a change was made to the ember tests in CI, to fix an unspecified problem with checking out the relevant commit for testing. Unfortunately, the change was added in the wrong spot. As a result, 

1) the problem wasn't fixed, and
2) we started getting warnings in CI like this:

![image](https://user-images.githubusercontent.com/14812505/144286902-0726f06f-05cc-42ef-9940-0a2db605fcc9.png)

Problem 1 was fixed in https://github.com/getsentry/sentry-javascript/commit/9b5ab617238f35267b59e348483c92bc0630c379#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721, by adding the option to the right spot (again, for an unspecified reason).

This PR fixes problem 2, by removing the option from the wrong spot.

Given the mystery surrounding the addition of `fetch-depth` in the first place, it also adds a TODO to reconsider if we need it once ember tests are again all passing.