### PR TITLE
ref(nextjs): Remove `resolve.alias` treeshaking hack

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -61,24 +61,6 @@ export function constructWebpackConfigFunction(
     const origEntryProperty = newConfig.entry;
     newConfig.entry = async () => addSentryToEntryProperty(origEntryProperty, buildContext);
 
-    // In webpack 5, you can get webpack to replace any module you'd like with an empty object, just by setting its
-    // `resolve.alias` value to `false`. Not much of our code is neatly separated into "things node needs" and "things
-    // the browser needs," but where it is, we can save ~1.6 kb in eventual bundle size by excluding code we know we
-    // don't need. (Normally this would only matter for the client side, but because vercel turns backend code into
-    // serverless functions, it's worthwhile to do it for both.)
-    if (buildContext.webpack.version.startsWith('5')) {
-      const excludedTracingDir = buildContext.isServer ? 'browser' : 'integrations/node';
-      newConfig.resolve = {
-        ...newConfig.resolve,
-        alias: {
-          ...newConfig.resolve?.alias,
-          [path.resolve(buildContext.dir, `./node_modules/@sentry/tracing/esm/${excludedTracingDir}`)]: false,
-          // TODO It's not clear if it will ever pull from `dist` (in testing it never does), so we may not need this.
-          [path.resolve(buildContext.dir, `./node_modules/@sentry/tracing/dist/${excludedTracingDir}`)]: false,
-        },
-      };
-    }
-
     // Enable the Sentry plugin (which uploads source maps to Sentry when not in dev) by default
     const enableWebpackPlugin = buildContext.isServer
       ? !userNextConfig.sentry?.disableServerWebpackPlugin


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/3978, code was introduced to prevent node tracing integrations (mongo, postgres, etc) from appearing in the browser bundle where they don't belong. However, as part of our larger push to make our code more treeshakable, we recently [changed how we export those integrations](https://github.com/getsentry/sentry-javascript/pull/4204), making the previous workaround unnecessary.

As a bonus, this should fix a rendering issue some users were having when using the `fallback` flag.

Tested locally and on vercel.

Fixes https://github.com/getsentry/sentry-javascript/issues/4090.
