### PR TITLE
build: add minified bundle to size-limit

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -6,6 +6,12 @@ module.exports = [
     limit: '100 KB',
   },
   {
+    name: '@sentry/browser - CDN Bundle (minified)',
+    path: 'packages/browser/build/bundle.min.js',
+    gzip: false,
+    limit: '120 KB',
+  },
+  {
     name: '@sentry/browser - Webpack',
     path: 'packages/browser/esm/index.js',
     import: '{ init }',


### PR DESCRIPTION
This adds the minified but non-gzipped bundle to the size limit report to make it easier to track changes to the minified independent of the compression.