### PR TITLE
feat(browser): simplify wrap/fill

### DIFF
--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -3,11 +3,11 @@ import { DsnLike, Event as SentryEvent, Mechanism, Scope, WrappedFunction } from
 import {
   addExceptionMechanism,
   addExceptionTypeValue,
+  addNonEnumerableProperty,
   getGlobalObject,
   getOriginalFunction,
   logger,
   rememberOriginalFunction,
-  addNonEnumerableProperty,
 } from '@sentry/utils';
 
 const global = getGlobalObject<Window>();

--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -1,6 +1,13 @@
 import { captureException, getReportDialogEndpoint, withScope } from '@sentry/core';
 import { DsnLike, Event as SentryEvent, Mechanism, Scope, WrappedFunction } from '@sentry/types';
-import { addExceptionMechanism, addExceptionTypeValue, getGlobalObject, logger, rememberOriginal } from '@sentry/utils';
+import {
+  addExceptionMechanism,
+  addExceptionTypeValue,
+  getGlobalObject,
+  logger,
+  rememberOriginalFunction,
+  getOriginalFunction,
+} from '@sentry/utils';
 
 const global = getGlobalObject<Window>();
 let ignoreOnError: number = 0;
@@ -45,7 +52,7 @@ export function wrap(
 
   try {
     // We don't wanna wrap it twice
-    if (fn.__sentry_original__) {
+    if (getOriginalFunction(fn)) {
       return fn;
     }
   } catch (e) {
@@ -129,7 +136,7 @@ export function wrap(
 
   // Signal that this function has been wrapped/filled already
   // for both debugging and to prevent it to being wrapped/filled twice
-  rememberOriginal(sentryWrapped, fn);
+  rememberOriginalFunction(sentryWrapped, fn);
 
   // Restore original function name (not all browsers allow that)
   try {

--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -4,9 +4,9 @@ import {
   addExceptionMechanism,
   addExceptionTypeValue,
   getGlobalObject,
+  getOriginalFunction,
   logger,
   rememberOriginalFunction,
-  getOriginalFunction,
 } from '@sentry/utils';
 
 const global = getGlobalObject<Window>();

--- a/packages/browser/src/integrations/trycatch.ts
+++ b/packages/browser/src/integrations/trycatch.ts
@@ -1,5 +1,5 @@
 import { Integration, WrappedFunction } from '@sentry/types';
-import { fill, getFunctionName, getGlobalObject } from '@sentry/utils';
+import { fill, getFunctionName, getGlobalObject, getOriginalFunction } from '@sentry/utils';
 
 import { wrap } from '../helpers';
 
@@ -268,8 +268,9 @@ export class TryCatch implements Integration {
             };
 
             // If Instrument integration has been called before TryCatch, get the name of original function
-            if (original.__sentry_original__) {
-              wrapOptions.mechanism.data.handler = getFunctionName(original.__sentry_original__);
+            const originalFunction = getOriginalFunction(original);
+            if (originalFunction) {
+              wrapOptions.mechanism.data.handler = getFunctionName(originalFunction);
             }
 
             // Otherwise wrap directly

--- a/packages/browser/test/unit/integrations/helpers.test.ts
+++ b/packages/browser/test/unit/integrations/helpers.test.ts
@@ -31,20 +31,10 @@ describe('internal wrap()', () => {
 
   it('bail out with the original if accessing custom props go bad', () => {
     const fn = (() => 1337) as WrappedFunction;
-    fn.__sentry__ = false;
     Object.defineProperty(fn, '__sentry_wrapped__', {
       get(): void {
         throw new Error('boom');
       },
-    });
-
-    expect(wrap(fn)).toBe(fn);
-
-    Object.defineProperty(fn, '__sentry__', {
-      get(): void {
-        throw new Error('boom');
-      },
-      configurable: true,
     });
 
     expect(wrap(fn)).toBe(fn);

--- a/packages/browser/test/unit/integrations/helpers.test.ts
+++ b/packages/browser/test/unit/integrations/helpers.test.ts
@@ -73,9 +73,6 @@ describe('internal wrap()', () => {
     expect(fn).toHaveProperty('__sentry_wrapped__');
     expect(fn.__sentry_wrapped__).toBe(wrapped);
 
-    expect(wrapped).toHaveProperty('__sentry__');
-    expect(wrapped.__sentry__).toBe(true);
-
     expect(wrapped).toHaveProperty('__sentry_original__');
     expect(wrapped.__sentry_original__).toBe(fn);
   });
@@ -118,27 +115,14 @@ describe('internal wrap()', () => {
     expect(fnArgB).toHaveProperty('__sentry_wrapped__');
   });
 
-  it('calls either `handleEvent` property if it exists or the original function', () => {
-    interface SinonEventSpy extends SinonSpy {
-      handleEvent: SinonSpy;
-    }
-
+  it('calls the original function', () => {
     const fn = spy();
-    const eventFn = spy() as SinonEventSpy;
-    eventFn.handleEvent = spy();
 
     wrap(fn)(123, 'Rick');
-    wrap(eventFn)(123, 'Morty');
 
     expect(fn.called).toBe(true);
     expect(fn.getCalls()[0].args[0]).toBe(123);
     expect(fn.getCalls()[0].args[1]).toBe('Rick');
-
-    expect(eventFn.handleEvent.called).toBe(true);
-    expect(eventFn.handleEvent.getCalls()[0].args[0]).toBe(123);
-    expect(eventFn.handleEvent.getCalls()[0].args[1]).toBe('Morty');
-
-    expect(eventFn.called).toBe(false);
   });
 
   it('preserves `this` context for all the calls', () => {
@@ -182,14 +166,11 @@ describe('internal wrap()', () => {
     const wrapped = wrap(fn);
 
     // Shouldn't show up in iteration
-    expect(Object.keys(fn)).toEqual(expect.not.arrayContaining(['__sentry__']));
     expect(Object.keys(fn)).toEqual(expect.not.arrayContaining(['__sentry_original__']));
     expect(Object.keys(fn)).toEqual(expect.not.arrayContaining(['__sentry_wrapped__']));
-    expect(Object.keys(wrapped)).toEqual(expect.not.arrayContaining(['__sentry__']));
     expect(Object.keys(wrapped)).toEqual(expect.not.arrayContaining(['__sentry_original__']));
     expect(Object.keys(wrapped)).toEqual(expect.not.arrayContaining(['__sentry_wrapped__']));
     // But should be accessible directly
-    expect(wrapped.__sentry__).toBe(true);
     expect(wrapped.__sentry_original__).toBe(fn);
     expect(fn.__sentry_wrapped__).toBe(wrapped);
   });

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -1,6 +1,6 @@
 import { addGlobalEventProcessor, getCurrentHub } from '@sentry/hub';
 import { Integration, Options } from '@sentry/types';
-import { logger, addNonEnumerableProperty } from '@sentry/utils';
+import { addNonEnumerableProperty, logger } from '@sentry/utils';
 
 export const installedIntegrations: string[] = [];
 

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -1,6 +1,6 @@
 import { addGlobalEventProcessor, getCurrentHub } from '@sentry/hub';
 import { Integration, Options } from '@sentry/types';
-import { logger } from '@sentry/utils';
+import { logger, addNonEnumerableProperty } from '@sentry/utils';
 
 export const installedIntegrations: string[] = [];
 
@@ -77,6 +77,6 @@ export function setupIntegrations<O extends Options>(options: O): IntegrationInd
   // set the `initialized` flag so we don't run through the process again unecessarily; use `Object.defineProperty`
   // because by default it creates a property which is nonenumerable, which we want since `initialized` shouldn't be
   // considered a member of the index the way the actual integrations are
-  Object.defineProperty(integrations, 'initialized', { value: true });
+  addNonEnumerableProperty(integrations, 'initialized', true);
   return integrations;
 }

--- a/packages/core/src/integrations/functiontostring.ts
+++ b/packages/core/src/integrations/functiontostring.ts
@@ -1,4 +1,5 @@
 import { Integration, WrappedFunction } from '@sentry/types';
+import { getOriginalFunction } from '@sentry/utils';
 
 let originalFunctionToString: () => void;
 
@@ -23,7 +24,7 @@ export class FunctionToString implements Integration {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     Function.prototype.toString = function(this: WrappedFunction, ...args: any[]): string {
-      const context = this.__sentry_original__ || this;
+      const context = getOriginalFunction(this) || this;
       return originalFunctionToString.apply(context, args);
     };
   }

--- a/packages/nextjs/src/performance/client.ts
+++ b/packages/nextjs/src/performance/client.ts
@@ -8,9 +8,9 @@ const global = getGlobalObject<Window>();
 
 type StartTransactionCb = (context: TransactionContext) => Transaction | undefined;
 
-const DEFAULT_TAGS = Object.freeze({
+const DEFAULT_TAGS = {
   'routing.instrumentation': 'next-router',
-});
+} as const;
 
 let activeTransaction: Transaction | undefined = undefined;
 let prevTransactionName: string | undefined = undefined;

--- a/packages/types/src/wrappedfunction.ts
+++ b/packages/types/src/wrappedfunction.ts
@@ -1,7 +1,6 @@
 /** JSDoc */
 export interface WrappedFunction extends Function {
   [key: string]: any;
-  __sentry__?: boolean;
   __sentry_wrapped__?: WrappedFunction;
   __sentry_original__?: WrappedFunction;
 }

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -3,6 +3,7 @@ import { Event, Mechanism, StackFrame } from '@sentry/types';
 
 import { getGlobalObject } from './global';
 import { snipLine } from './string';
+import { addNonEnumerableProperty } from './object';
 
 /**
  * Extended Window interface that allows for Crypto API usage in IE browsers
@@ -268,9 +269,7 @@ export function checkOrSetAlreadyCaught(exception: unknown): boolean {
   try {
     // set it this way rather than by assignment so that it's not ennumerable and therefore isn't recorded by the
     // `ExtraErrorData` integration
-    Object.defineProperty(exception, '__sentry_captured__', {
-      value: true,
-    });
+    addNonEnumerableProperty(exception, '__sentry_captured__', true);
   } catch (err) {
     // `exception` is a primitive, so we can't mark it seen
   }

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -2,8 +2,8 @@
 import { Event, Mechanism, StackFrame } from '@sentry/types';
 
 import { getGlobalObject } from './global';
-import { snipLine } from './string';
 import { addNonEnumerableProperty } from './object';
+import { snipLine } from './string';
 
 /**
  * Extended Window interface that allows for Crypto API usage in IE browsers

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -32,7 +32,7 @@ export function fill(source: { [key: string]: any }, name: string, replacementFa
   if (typeof wrapped === 'function') {
     try {
       wrapped.prototype = wrapped.prototype || {};
-      rememberOriginal(wrapped, original);
+      rememberOriginalFunction(wrapped, original);
     } catch (_Oo) {
       // This can throw if multiple fill happens on a global object like XMLHttpRequest
       // Fixes https://github.com/getsentry/sentry-javascript/issues/2043
@@ -48,13 +48,24 @@ export function fill(source: { [key: string]: any }, name: string, replacementFa
  * @param wrapped the wrapper function
  * @param original the original function that gets wrapped
  */
-export function rememberOriginal(wrapped: any, original: any): void {
+export function rememberOriginalFunction(wrapped: WrappedFunction, original: WrappedFunction): void {
   Object.defineProperties(wrapped, {
     __sentry_original__: {
       enumerable: false,
       value: original,
     },
   });
+}
+
+/**
+ * This extracts the original function if available.  This is the inverse
+ * of `rememberOriginalFunction`.
+ *
+ * @param func the function to unwrap
+ * @returns the unwrapped version of the function if available.
+ */
+export function getOriginalFunction(func: WrappedFunction): WrappedFunction | undefined {
+  return func.__sentry_original__;
 }
 
 /**

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -32,12 +32,7 @@ export function fill(source: { [key: string]: any }, name: string, replacementFa
   if (typeof wrapped === 'function') {
     try {
       wrapped.prototype = wrapped.prototype || {};
-      Object.defineProperties(wrapped, {
-        __sentry_original__: {
-          enumerable: false,
-          value: original,
-        },
-      });
+      rememberOriginal(wrapped, original);
     } catch (_Oo) {
       // This can throw if multiple fill happens on a global object like XMLHttpRequest
       // Fixes https://github.com/getsentry/sentry-javascript/issues/2043
@@ -45,6 +40,21 @@ export function fill(source: { [key: string]: any }, name: string, replacementFa
   }
 
   source[name] = wrapped;
+}
+
+/**
+ * Remembers the original function on the wrapped function.
+ *
+ * @param wrapped the wrapper function
+ * @param original the original function that gets wrapped
+ */
+export function rememberOriginal(wrapped: any, original: any): void {
+  Object.defineProperties(wrapped, {
+    __sentry_original__: {
+      enumerable: false,
+      value: original,
+    },
+  });
 }
 
 /**

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -43,18 +43,27 @@ export function fill(source: { [key: string]: any }, name: string, replacementFa
 }
 
 /**
+ * Defines a non enumerable property.  This creates a non enumerable property on an object.
+ *
+ * @param func The function to set a property to
+ * @param name the name of the special sentry property
+ * @param value the property to define
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function addNonEnumerableProperty(func: any, name: string, value: any): void {
+  Object.defineProperty(func, name, {
+    value: value,
+  });
+}
+
+/**
  * Remembers the original function on the wrapped function.
  *
  * @param wrapped the wrapper function
  * @param original the original function that gets wrapped
  */
 export function rememberOriginalFunction(wrapped: WrappedFunction, original: WrappedFunction): void {
-  Object.defineProperties(wrapped, {
-    __sentry_original__: {
-      enumerable: false,
-      value: original,
-    },
-  });
+  addNonEnumerableProperty(wrapped, '__sentry_original__', original);
 }
 
 /**

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -31,8 +31,7 @@ export function fill(source: { [key: string]: any }, name: string, replacementFa
   // otherwise it'll throw "TypeError: Object.defineProperties called on non-object"
   if (typeof wrapped === 'function') {
     try {
-      wrapped.prototype = wrapped.prototype || {};
-      rememberOriginalFunction(wrapped, original);
+      markFunctionWrapped(wrapped, original);
     } catch (_Oo) {
       // This can throw if multiple fill happens on a global object like XMLHttpRequest
       // Fixes https://github.com/getsentry/sentry-javascript/issues/2043
@@ -57,18 +56,21 @@ export function addNonEnumerableProperty(func: any, name: string, value: any): v
 }
 
 /**
- * Remembers the original function on the wrapped function.
+ * Remembers the original function on the wrapped function and
+ * patches up the prototype.
  *
  * @param wrapped the wrapper function
  * @param original the original function that gets wrapped
  */
-export function rememberOriginalFunction(wrapped: WrappedFunction, original: WrappedFunction): void {
+export function markFunctionWrapped(wrapped: WrappedFunction, original: WrappedFunction): void {
+  const proto = original.prototype || {};
+  wrapped.prototype = original.prototype = proto;
   addNonEnumerableProperty(wrapped, '__sentry_original__', original);
 }
 
 /**
- * This extracts the original function if available.  This is the inverse
- * of `rememberOriginalFunction`.
+ * This extracts the original function if available.  See
+ * `markFunctionWrapped` for more information.
  *
  * @param func the function to unwrap
  * @returns the unwrapped version of the function if available.


### PR DESCRIPTION
This is a small experiment what happens if we do not define `__sentry__` on our wrappers. It tries to reuse some code and removes `handleEvent` which is a dead code path in practice.  I would prefer if i could also remove the `wrap()` calls on the args. As far as I can see this is all undocumented behavior and it does not look like we depend on this.