### PR TITLE
ref(core): Extract _ensureBeforeSendRv into func

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -619,7 +619,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
 function _ensureBeforeSendRv(rv: PromiseLike<Event | null> | Event | null): PromiseLike<Event | null> | Event | null {
   const nullErr = '`beforeSend` method has to return `null` or a valid event.';
   if (isThenable(rv)) {
-    return (rv as PromiseLike<Event | null>).then(
+    return rv.then(
       event => {
         if (!(isPlainObject(event) || event === null)) {
           throw new SentryError(nullErr);

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -562,7 +562,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
         }
 
         const beforeSendResult = beforeSend(prepared, hint);
-        return this._ensureBeforeSendRv(beforeSendResult);
+        return _ensureBeforeSendRv(beforeSendResult);
       })
       .then(processedEvent => {
         if (processedEvent === null) {
@@ -611,29 +611,27 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
       },
     );
   }
+}
 
-  /**
-   * Verifies that return value of configured `beforeSend` is of expected type.
-   */
-  protected _ensureBeforeSendRv(
-    rv: PromiseLike<Event | null> | Event | null,
-  ): PromiseLike<Event | null> | Event | null {
-    const nullErr = '`beforeSend` method has to return `null` or a valid event.';
-    if (isThenable(rv)) {
-      return (rv as PromiseLike<Event | null>).then(
-        event => {
-          if (!(isPlainObject(event) || event === null)) {
-            throw new SentryError(nullErr);
-          }
-          return event;
-        },
-        e => {
-          throw new SentryError(`beforeSend rejected with ${e}`);
-        },
-      );
-    } else if (!(isPlainObject(rv) || rv === null)) {
-      throw new SentryError(nullErr);
-    }
-    return rv;
+/**
+ * Verifies that return value of configured `beforeSend` is of expected type.
+ */
+function _ensureBeforeSendRv(rv: PromiseLike<Event | null> | Event | null): PromiseLike<Event | null> | Event | null {
+  const nullErr = '`beforeSend` method has to return `null` or a valid event.';
+  if (isThenable(rv)) {
+    return (rv as PromiseLike<Event | null>).then(
+      event => {
+        if (!(isPlainObject(event) || event === null)) {
+          throw new SentryError(nullErr);
+        }
+        return event;
+      },
+      e => {
+        throw new SentryError(`beforeSend rejected with ${e}`);
+      },
+    );
+  } else if (!(isPlainObject(rv) || rv === null)) {
+    throw new SentryError(nullErr);
   }
+  return rv;
 }


### PR DESCRIPTION
Extract out protected method `_ensureBeforeSendRv` from `baseclient` as it doesn't use any class props - this helps save a small amount of bundle size.