### PR TITLE
ref(browser): Extract private methods from LinkedErrors

### DIFF
--- a/packages/browser/src/integrations/linkederrors.ts
+++ b/packages/browser/src/integrations/linkederrors.ts
@@ -8,6 +8,11 @@ import { computeStackTrace } from '../tracekit';
 const DEFAULT_KEY = 'cause';
 const DEFAULT_LIMIT = 5;
 
+interface LinkedErrorsOptions {
+  key: string;
+  limit: number;
+}
+
 /** Adds SDK info to an event. */
 export class LinkedErrors implements Integration {
   /**
@@ -23,17 +28,17 @@ export class LinkedErrors implements Integration {
   /**
    * @inheritDoc
    */
-  private readonly _key: string;
+  private readonly _key: LinkedErrorsOptions['key'];
 
   /**
    * @inheritDoc
    */
-  private readonly _limit: number;
+  private readonly _limit: LinkedErrorsOptions['limit'];
 
   /**
    * @inheritDoc
    */
-  public constructor(options: { key?: string; limit?: number } = {}) {
+  public constructor(options: Partial<LinkedErrorsOptions> = {}) {
     this._key = options.key || DEFAULT_KEY;
     this._limit = options.limit || DEFAULT_LIMIT;
   }
@@ -43,36 +48,34 @@ export class LinkedErrors implements Integration {
    */
   public setupOnce(): void {
     addGlobalEventProcessor((event: Event, hint?: EventHint) => {
-      const self = getCurrentHub().getIntegration(LinkedErrors);
-      if (self) {
-        const handler = self._handler && self._handler.bind(self);
-        return typeof handler === 'function' ? handler(event, hint) : event;
+      if (getCurrentHub().getIntegration(LinkedErrors)) {
+        return typeof handler === 'function' ? handler(this._key, this._limit, event, hint) : event;
       }
       return event;
     });
   }
+}
 
-  /**
-   * @inheritDoc
-   */
-  private _handler(event: Event, hint?: EventHint): Event | null {
-    if (!event.exception || !event.exception.values || !hint || !isInstanceOf(hint.originalException, Error)) {
-      return event;
-    }
-    const linkedErrors = this._walkErrorTree(hint.originalException as ExtendedError, this._key);
-    event.exception.values = [...linkedErrors, ...event.exception.values];
+/**
+ * @inheritDoc
+ */
+function handler(key: string, limit: number, event: Event, hint?: EventHint): Event | null {
+  if (!event.exception || !event.exception.values || !hint || !isInstanceOf(hint.originalException, Error)) {
     return event;
   }
+  const linkedErrors = _walkErrorTree(limit, hint.originalException as ExtendedError, key);
+  event.exception.values = [...linkedErrors, ...event.exception.values];
+  return event;
+}
 
-  /**
-   * @inheritDoc
-   */
-  private _walkErrorTree(error: ExtendedError, key: string, stack: Exception[] = []): Exception[] {
-    if (!isInstanceOf(error[key], Error) || stack.length + 1 >= this._limit) {
-      return stack;
-    }
-    const stacktrace = computeStackTrace(error[key]);
-    const exception = exceptionFromStacktrace(stacktrace);
-    return this._walkErrorTree(error[key], key, [exception, ...stack]);
+/**
+ * JSDOC
+ */
+function _walkErrorTree(limit: number, error: ExtendedError, key: string, stack: Exception[] = []): Exception[] {
+  if (!isInstanceOf(error[key], Error) || stack.length + 1 >= limit) {
+    return stack;
   }
+  const stacktrace = computeStackTrace(error[key]);
+  const exception = exceptionFromStacktrace(stacktrace);
+  return _walkErrorTree(limit, error[key], key, [exception, ...stack]);
 }

--- a/packages/browser/src/integrations/linkederrors.ts
+++ b/packages/browser/src/integrations/linkederrors.ts
@@ -48,10 +48,7 @@ export class LinkedErrors implements Integration {
    */
   public setupOnce(): void {
     addGlobalEventProcessor((event: Event, hint?: EventHint) => {
-      if (getCurrentHub().getIntegration(LinkedErrors)) {
-        return typeof handler === 'function' ? handler(this._key, this._limit, event, hint) : event;
-      }
-      return event;
+      return getCurrentHub().getIntegration(LinkedErrors) ? _handler(this._key, this._limit, event, hint) : event;
     });
   }
 }
@@ -59,7 +56,7 @@ export class LinkedErrors implements Integration {
 /**
  * @inheritDoc
  */
-function handler(key: string, limit: number, event: Event, hint?: EventHint): Event | null {
+export function _handler(key: string, limit: number, event: Event, hint?: EventHint): Event | null {
   if (!event.exception || !event.exception.values || !hint || !isInstanceOf(hint.originalException, Error)) {
     return event;
   }
@@ -71,7 +68,7 @@ function handler(key: string, limit: number, event: Event, hint?: EventHint): Ev
 /**
  * JSDOC
  */
-function _walkErrorTree(limit: number, error: ExtendedError, key: string, stack: Exception[] = []): Exception[] {
+export function _walkErrorTree(limit: number, error: ExtendedError, key: string, stack: Exception[] = []): Exception[] {
   if (!isInstanceOf(error[key], Error) || stack.length + 1 >= limit) {
     return stack;
   }

--- a/packages/browser/test/unit/integrations/linkederrors.test.ts
+++ b/packages/browser/test/unit/integrations/linkederrors.test.ts
@@ -5,18 +5,15 @@ import * as LinkedErrorsModule from '../../../src/integrations/linkederrors';
 
 describe('LinkedErrors', () => {
   describe('handler', () => {
-    it('should bail out if event doesnt contain exception', () => {
-      const spy = jest.spyOn(LinkedErrorsModule, '_walkErrorTree');
+    it('should bail out if event does not contain exception', () => {
       const event = {
         message: 'foo',
       };
       const result = LinkedErrorsModule._handler('cause', 5, event);
-      expect(spy).toHaveBeenCalledTimes(0);
       expect(result).toEqual(event);
     });
 
     it('should bail out if event contains exception, but no hint', () => {
-      const spy = jest.spyOn(LinkedErrorsModule, '_walkErrorTree');
       const event = {
         exception: {
           values: [],
@@ -24,23 +21,7 @@ describe('LinkedErrors', () => {
         message: 'foo',
       };
       const result = LinkedErrorsModule._handler('cause', 5, event);
-      expect(spy).toHaveBeenCalledTimes(0);
       expect(result).toEqual(event);
-    });
-
-    it('should call walkErrorTree if event contains exception and hint with originalException', () => {
-      const spy = jest.spyOn(LinkedErrorsModule, '_walkErrorTree').mockImplementation(() => []);
-      const event = {
-        exception: {
-          values: [],
-        },
-        message: 'foo',
-      };
-      const hint = {
-        originalException: new Error('originalException'),
-      };
-      LinkedErrorsModule._handler('cause', 5, event, hint);
-      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('should recursively walk error to find linked exceptions and assign them to the event', async () => {


### PR DESCRIPTION
Move out private methods into their own functions as they do not need
access to class properties. This helps save on bundle size.