### PR TITLE
ref(browser): Extract private methods from Dedupe integration

### DIFF
--- a/packages/browser/src/integrations/dedupe.ts
+++ b/packages/browser/src/integrations/dedupe.ts
@@ -27,7 +27,7 @@ export class Dedupe implements Integration {
       if (self) {
         // Juuust in case something goes wrong
         try {
-          if (self._shouldDropEvent(currentEvent, self._previousEvent)) {
+          if (_shouldDropEvent(currentEvent, self._previousEvent)) {
             logger.warn(`Event dropped due to being a duplicate of previously captured event.`);
             return null;
           }
@@ -40,164 +40,164 @@ export class Dedupe implements Integration {
       return currentEvent;
     });
   }
+}
 
-  /** JSDoc */
-  private _shouldDropEvent(currentEvent: Event, previousEvent?: Event): boolean {
-    if (!previousEvent) {
-      return false;
-    }
-
-    if (this._isSameMessageEvent(currentEvent, previousEvent)) {
-      return true;
-    }
-
-    if (this._isSameExceptionEvent(currentEvent, previousEvent)) {
-      return true;
-    }
-
+/** JSDoc */
+function _shouldDropEvent(currentEvent: Event, previousEvent?: Event): boolean {
+  if (!previousEvent) {
     return false;
   }
 
-  /** JSDoc */
-  private _isSameMessageEvent(currentEvent: Event, previousEvent: Event): boolean {
-    const currentMessage = currentEvent.message;
-    const previousMessage = previousEvent.message;
-
-    // If neither event has a message property, they were both exceptions, so bail out
-    if (!currentMessage && !previousMessage) {
-      return false;
-    }
-
-    // If only one event has a stacktrace, but not the other one, they are not the same
-    if ((currentMessage && !previousMessage) || (!currentMessage && previousMessage)) {
-      return false;
-    }
-
-    if (currentMessage !== previousMessage) {
-      return false;
-    }
-
-    if (!this._isSameFingerprint(currentEvent, previousEvent)) {
-      return false;
-    }
-
-    if (!this._isSameStacktrace(currentEvent, previousEvent)) {
-      return false;
-    }
-
+  if (_isSameMessageEvent(currentEvent, previousEvent)) {
     return true;
   }
 
-  /** JSDoc */
-  private _getFramesFromEvent(event: Event): StackFrame[] | undefined {
-    const exception = event.exception;
-
-    if (exception) {
-      try {
-        // @ts-ignore Object could be undefined
-        return exception.values[0].stacktrace.frames;
-      } catch (_oO) {
-        return undefined;
-      }
-    } else if (event.stacktrace) {
-      return event.stacktrace.frames;
-    }
-    return undefined;
-  }
-
-  /** JSDoc */
-  private _isSameStacktrace(currentEvent: Event, previousEvent: Event): boolean {
-    let currentFrames = this._getFramesFromEvent(currentEvent);
-    let previousFrames = this._getFramesFromEvent(previousEvent);
-
-    // If neither event has a stacktrace, they are assumed to be the same
-    if (!currentFrames && !previousFrames) {
-      return true;
-    }
-
-    // If only one event has a stacktrace, but not the other one, they are not the same
-    if ((currentFrames && !previousFrames) || (!currentFrames && previousFrames)) {
-      return false;
-    }
-
-    currentFrames = currentFrames as StackFrame[];
-    previousFrames = previousFrames as StackFrame[];
-
-    // If number of frames differ, they are not the same
-    if (previousFrames.length !== currentFrames.length) {
-      return false;
-    }
-
-    // Otherwise, compare the two
-    for (let i = 0; i < previousFrames.length; i++) {
-      const frameA = previousFrames[i];
-      const frameB = currentFrames[i];
-
-      if (
-        frameA.filename !== frameB.filename ||
-        frameA.lineno !== frameB.lineno ||
-        frameA.colno !== frameB.colno ||
-        frameA.function !== frameB.function
-      ) {
-        return false;
-      }
-    }
-
+  if (_isSameExceptionEvent(currentEvent, previousEvent)) {
     return true;
   }
 
-  /** JSDoc */
-  private _getExceptionFromEvent(event: Event): Exception | undefined {
-    return event.exception && event.exception.values && event.exception.values[0];
+  return false;
+}
+
+/** JSDoc */
+function _isSameMessageEvent(currentEvent: Event, previousEvent: Event): boolean {
+  const currentMessage = currentEvent.message;
+  const previousMessage = previousEvent.message;
+
+  // If neither event has a message property, they were both exceptions, so bail out
+  if (!currentMessage && !previousMessage) {
+    return false;
   }
 
-  /** JSDoc */
-  private _isSameExceptionEvent(currentEvent: Event, previousEvent: Event): boolean {
-    const previousException = this._getExceptionFromEvent(previousEvent);
-    const currentException = this._getExceptionFromEvent(currentEvent);
+  // If only one event has a stacktrace, but not the other one, they are not the same
+  if ((currentMessage && !previousMessage) || (!currentMessage && previousMessage)) {
+    return false;
+  }
 
-    if (!previousException || !currentException) {
-      return false;
-    }
+  if (currentMessage !== previousMessage) {
+    return false;
+  }
 
-    if (previousException.type !== currentException.type || previousException.value !== currentException.value) {
-      return false;
-    }
+  if (!_isSameFingerprint(currentEvent, previousEvent)) {
+    return false;
+  }
 
-    if (!this._isSameFingerprint(currentEvent, previousEvent)) {
-      return false;
-    }
+  if (!_isSameStacktrace(currentEvent, previousEvent)) {
+    return false;
+  }
 
-    if (!this._isSameStacktrace(currentEvent, previousEvent)) {
-      return false;
-    }
+  return true;
+}
 
+/** JSDoc */
+function _isSameExceptionEvent(currentEvent: Event, previousEvent: Event): boolean {
+  const previousException = _getExceptionFromEvent(previousEvent);
+  const currentException = _getExceptionFromEvent(currentEvent);
+
+  if (!previousException || !currentException) {
+    return false;
+  }
+
+  if (previousException.type !== currentException.type || previousException.value !== currentException.value) {
+    return false;
+  }
+
+  if (!_isSameFingerprint(currentEvent, previousEvent)) {
+    return false;
+  }
+
+  if (!_isSameStacktrace(currentEvent, previousEvent)) {
+    return false;
+  }
+
+  return true;
+}
+
+/** JSDoc */
+function _isSameStacktrace(currentEvent: Event, previousEvent: Event): boolean {
+  let currentFrames = _getFramesFromEvent(currentEvent);
+  let previousFrames = _getFramesFromEvent(previousEvent);
+
+  // If neither event has a stacktrace, they are assumed to be the same
+  if (!currentFrames && !previousFrames) {
     return true;
   }
 
-  /** JSDoc */
-  private _isSameFingerprint(currentEvent: Event, previousEvent: Event): boolean {
-    let currentFingerprint = currentEvent.fingerprint;
-    let previousFingerprint = previousEvent.fingerprint;
+  // If only one event has a stacktrace, but not the other one, they are not the same
+  if ((currentFrames && !previousFrames) || (!currentFrames && previousFrames)) {
+    return false;
+  }
 
-    // If neither event has a fingerprint, they are assumed to be the same
-    if (!currentFingerprint && !previousFingerprint) {
-      return true;
-    }
+  currentFrames = currentFrames as StackFrame[];
+  previousFrames = previousFrames as StackFrame[];
 
-    // If only one event has a fingerprint, but not the other one, they are not the same
-    if ((currentFingerprint && !previousFingerprint) || (!currentFingerprint && previousFingerprint)) {
+  // If number of frames differ, they are not the same
+  if (previousFrames.length !== currentFrames.length) {
+    return false;
+  }
+
+  // Otherwise, compare the two
+  for (let i = 0; i < previousFrames.length; i++) {
+    const frameA = previousFrames[i];
+    const frameB = currentFrames[i];
+
+    if (
+      frameA.filename !== frameB.filename ||
+      frameA.lineno !== frameB.lineno ||
+      frameA.colno !== frameB.colno ||
+      frameA.function !== frameB.function
+    ) {
       return false;
     }
+  }
 
-    currentFingerprint = currentFingerprint as string[];
-    previousFingerprint = previousFingerprint as string[];
+  return true;
+}
 
-    // Otherwise, compare the two
+/** JSDoc */
+function _isSameFingerprint(currentEvent: Event, previousEvent: Event): boolean {
+  let currentFingerprint = currentEvent.fingerprint;
+  let previousFingerprint = previousEvent.fingerprint;
+
+  // If neither event has a fingerprint, they are assumed to be the same
+  if (!currentFingerprint && !previousFingerprint) {
+    return true;
+  }
+
+  // If only one event has a fingerprint, but not the other one, they are not the same
+  if ((currentFingerprint && !previousFingerprint) || (!currentFingerprint && previousFingerprint)) {
+    return false;
+  }
+
+  currentFingerprint = currentFingerprint as string[];
+  previousFingerprint = previousFingerprint as string[];
+
+  // Otherwise, compare the two
+  try {
+    return !!(currentFingerprint.join('') === previousFingerprint.join(''));
+  } catch (_oO) {
+    return false;
+  }
+}
+
+/** JSDoc */
+function _getExceptionFromEvent(event: Event): Exception | undefined {
+  return event.exception && event.exception.values && event.exception.values[0];
+}
+
+/** JSDoc */
+function _getFramesFromEvent(event: Event): StackFrame[] | undefined {
+  const exception = event.exception;
+
+  if (exception) {
     try {
-      return !!(currentFingerprint.join('') === previousFingerprint.join(''));
+      // @ts-ignore Object could be undefined
+      return exception.values[0].stacktrace.frames;
     } catch (_oO) {
-      return false;
+      return undefined;
     }
+  } else if (event.stacktrace) {
+    return event.stacktrace.frames;
   }
+  return undefined;
 }

--- a/packages/integrations/src/dedupe.ts
+++ b/packages/integrations/src/dedupe.ts
@@ -43,7 +43,7 @@ export class Dedupe implements Integration {
 }
 
 /** JSDoc */
-function _shouldDropEvent(currentEvent: Event, previousEvent?: Event): boolean {
+export function _shouldDropEvent(currentEvent: Event, previousEvent?: Event): boolean {
   if (!previousEvent) {
     return false;
   }

--- a/packages/integrations/src/dedupe.ts
+++ b/packages/integrations/src/dedupe.ts
@@ -27,7 +27,7 @@ export class Dedupe implements Integration {
       if (self) {
         // Juuust in case something goes wrong
         try {
-          if (self._shouldDropEvent(currentEvent, self._previousEvent)) {
+          if (_shouldDropEvent(currentEvent, self._previousEvent)) {
             logger.warn(`Event dropped due to being a duplicate of previously captured event.`);
             return null;
           }
@@ -40,164 +40,164 @@ export class Dedupe implements Integration {
       return currentEvent;
     });
   }
+}
 
-  /** JSDoc */
-  private _shouldDropEvent(currentEvent: Event, previousEvent?: Event): boolean {
-    if (!previousEvent) {
-      return false;
-    }
-
-    if (this._isSameMessageEvent(currentEvent, previousEvent)) {
-      return true;
-    }
-
-    if (this._isSameExceptionEvent(currentEvent, previousEvent)) {
-      return true;
-    }
-
+/** JSDoc */
+function _shouldDropEvent(currentEvent: Event, previousEvent?: Event): boolean {
+  if (!previousEvent) {
     return false;
   }
 
-  /** JSDoc */
-  private _isSameMessageEvent(currentEvent: Event, previousEvent: Event): boolean {
-    const currentMessage = currentEvent.message;
-    const previousMessage = previousEvent.message;
-
-    // If neither event has a message property, they were both exceptions, so bail out
-    if (!currentMessage && !previousMessage) {
-      return false;
-    }
-
-    // If only one event has a stacktrace, but not the other one, they are not the same
-    if ((currentMessage && !previousMessage) || (!currentMessage && previousMessage)) {
-      return false;
-    }
-
-    if (currentMessage !== previousMessage) {
-      return false;
-    }
-
-    if (!this._isSameFingerprint(currentEvent, previousEvent)) {
-      return false;
-    }
-
-    if (!this._isSameStacktrace(currentEvent, previousEvent)) {
-      return false;
-    }
-
+  if (_isSameMessageEvent(currentEvent, previousEvent)) {
     return true;
   }
 
-  /** JSDoc */
-  private _getFramesFromEvent(event: Event): StackFrame[] | undefined {
-    const exception = event.exception;
-
-    if (exception) {
-      try {
-        // @ts-ignore Object could be undefined
-        return exception.values[0].stacktrace.frames;
-      } catch (_oO) {
-        return undefined;
-      }
-    } else if (event.stacktrace) {
-      return event.stacktrace.frames;
-    }
-    return undefined;
-  }
-
-  /** JSDoc */
-  private _isSameStacktrace(currentEvent: Event, previousEvent: Event): boolean {
-    let currentFrames = this._getFramesFromEvent(currentEvent);
-    let previousFrames = this._getFramesFromEvent(previousEvent);
-
-    // If neither event has a stacktrace, they are assumed to be the same
-    if (!currentFrames && !previousFrames) {
-      return true;
-    }
-
-    // If only one event has a stacktrace, but not the other one, they are not the same
-    if ((currentFrames && !previousFrames) || (!currentFrames && previousFrames)) {
-      return false;
-    }
-
-    currentFrames = currentFrames as StackFrame[];
-    previousFrames = previousFrames as StackFrame[];
-
-    // If number of frames differ, they are not the same
-    if (previousFrames.length !== currentFrames.length) {
-      return false;
-    }
-
-    // Otherwise, compare the two
-    for (let i = 0; i < previousFrames.length; i++) {
-      const frameA = previousFrames[i];
-      const frameB = currentFrames[i];
-
-      if (
-        frameA.filename !== frameB.filename ||
-        frameA.lineno !== frameB.lineno ||
-        frameA.colno !== frameB.colno ||
-        frameA.function !== frameB.function
-      ) {
-        return false;
-      }
-    }
-
+  if (_isSameExceptionEvent(currentEvent, previousEvent)) {
     return true;
   }
 
-  /** JSDoc */
-  private _getExceptionFromEvent(event: Event): Exception | undefined {
-    return event.exception && event.exception.values && event.exception.values[0];
+  return false;
+}
+
+/** JSDoc */
+function _isSameMessageEvent(currentEvent: Event, previousEvent: Event): boolean {
+  const currentMessage = currentEvent.message;
+  const previousMessage = previousEvent.message;
+
+  // If neither event has a message property, they were both exceptions, so bail out
+  if (!currentMessage && !previousMessage) {
+    return false;
   }
 
-  /** JSDoc */
-  private _isSameExceptionEvent(currentEvent: Event, previousEvent: Event): boolean {
-    const previousException = this._getExceptionFromEvent(previousEvent);
-    const currentException = this._getExceptionFromEvent(currentEvent);
+  // If only one event has a stacktrace, but not the other one, they are not the same
+  if ((currentMessage && !previousMessage) || (!currentMessage && previousMessage)) {
+    return false;
+  }
 
-    if (!previousException || !currentException) {
-      return false;
-    }
+  if (currentMessage !== previousMessage) {
+    return false;
+  }
 
-    if (previousException.type !== currentException.type || previousException.value !== currentException.value) {
-      return false;
-    }
+  if (!_isSameFingerprint(currentEvent, previousEvent)) {
+    return false;
+  }
 
-    if (!this._isSameFingerprint(currentEvent, previousEvent)) {
-      return false;
-    }
+  if (!_isSameStacktrace(currentEvent, previousEvent)) {
+    return false;
+  }
 
-    if (!this._isSameStacktrace(currentEvent, previousEvent)) {
-      return false;
-    }
+  return true;
+}
 
+/** JSDoc */
+function _isSameExceptionEvent(currentEvent: Event, previousEvent: Event): boolean {
+  const previousException = _getExceptionFromEvent(previousEvent);
+  const currentException = _getExceptionFromEvent(currentEvent);
+
+  if (!previousException || !currentException) {
+    return false;
+  }
+
+  if (previousException.type !== currentException.type || previousException.value !== currentException.value) {
+    return false;
+  }
+
+  if (!_isSameFingerprint(currentEvent, previousEvent)) {
+    return false;
+  }
+
+  if (!_isSameStacktrace(currentEvent, previousEvent)) {
+    return false;
+  }
+
+  return true;
+}
+
+/** JSDoc */
+function _isSameStacktrace(currentEvent: Event, previousEvent: Event): boolean {
+  let currentFrames = _getFramesFromEvent(currentEvent);
+  let previousFrames = _getFramesFromEvent(previousEvent);
+
+  // If neither event has a stacktrace, they are assumed to be the same
+  if (!currentFrames && !previousFrames) {
     return true;
   }
 
-  /** JSDoc */
-  private _isSameFingerprint(currentEvent: Event, previousEvent: Event): boolean {
-    let currentFingerprint = currentEvent.fingerprint;
-    let previousFingerprint = previousEvent.fingerprint;
+  // If only one event has a stacktrace, but not the other one, they are not the same
+  if ((currentFrames && !previousFrames) || (!currentFrames && previousFrames)) {
+    return false;
+  }
 
-    // If neither event has a fingerprint, they are assumed to be the same
-    if (!currentFingerprint && !previousFingerprint) {
-      return true;
-    }
+  currentFrames = currentFrames as StackFrame[];
+  previousFrames = previousFrames as StackFrame[];
 
-    // If only one event has a fingerprint, but not the other one, they are not the same
-    if ((currentFingerprint && !previousFingerprint) || (!currentFingerprint && previousFingerprint)) {
+  // If number of frames differ, they are not the same
+  if (previousFrames.length !== currentFrames.length) {
+    return false;
+  }
+
+  // Otherwise, compare the two
+  for (let i = 0; i < previousFrames.length; i++) {
+    const frameA = previousFrames[i];
+    const frameB = currentFrames[i];
+
+    if (
+      frameA.filename !== frameB.filename ||
+      frameA.lineno !== frameB.lineno ||
+      frameA.colno !== frameB.colno ||
+      frameA.function !== frameB.function
+    ) {
       return false;
     }
+  }
 
-    currentFingerprint = currentFingerprint as string[];
-    previousFingerprint = previousFingerprint as string[];
+  return true;
+}
 
-    // Otherwise, compare the two
+/** JSDoc */
+function _isSameFingerprint(currentEvent: Event, previousEvent: Event): boolean {
+  let currentFingerprint = currentEvent.fingerprint;
+  let previousFingerprint = previousEvent.fingerprint;
+
+  // If neither event has a fingerprint, they are assumed to be the same
+  if (!currentFingerprint && !previousFingerprint) {
+    return true;
+  }
+
+  // If only one event has a fingerprint, but not the other one, they are not the same
+  if ((currentFingerprint && !previousFingerprint) || (!currentFingerprint && previousFingerprint)) {
+    return false;
+  }
+
+  currentFingerprint = currentFingerprint as string[];
+  previousFingerprint = previousFingerprint as string[];
+
+  // Otherwise, compare the two
+  try {
+    return !!(currentFingerprint.join('') === previousFingerprint.join(''));
+  } catch (_oO) {
+    return false;
+  }
+}
+
+/** JSDoc */
+function _getExceptionFromEvent(event: Event): Exception | undefined {
+  return event.exception && event.exception.values && event.exception.values[0];
+}
+
+/** JSDoc */
+function _getFramesFromEvent(event: Event): StackFrame[] | undefined {
+  const exception = event.exception;
+
+  if (exception) {
     try {
-      return !!(currentFingerprint.join('') === previousFingerprint.join(''));
+      // @ts-ignore Object could be undefined
+      return exception.values[0].stacktrace.frames;
     } catch (_oO) {
-      return false;
+      return undefined;
     }
+  } else if (event.stacktrace) {
+    return event.stacktrace.frames;
   }
+  return undefined;
 }

--- a/packages/integrations/test/dedupe.test.ts
+++ b/packages/integrations/test/dedupe.test.ts
@@ -1,11 +1,10 @@
-import { Dedupe } from '../src/dedupe';
+import { _shouldDropEvent } from '../src/dedupe';
 
 /** JSDoc */
 function clone<T>(data: T): T {
   return JSON.parse(JSON.stringify(data));
 }
 
-const dedupe = new Dedupe();
 const messageEvent = {
   fingerprint: ['MrSnuffles'],
   message: 'PickleRick',
@@ -58,21 +57,21 @@ describe('Dedupe', () => {
   describe('shouldDropEvent(messageEvent)', () => {
     it('should not drop if there was no previous event', () => {
       const event = clone(messageEvent);
-      expect((dedupe as any)._shouldDropEvent(event)).toBe(false);
+      expect(_shouldDropEvent(event)).toBe(false);
     });
 
     it('should not drop if events have different messages', () => {
       const eventA = clone(messageEvent);
       const eventB = clone(messageEvent);
       eventB.message = 'EvilMorty';
-      expect((dedupe as any)._shouldDropEvent(eventA, eventB)).toBe(false);
+      expect(_shouldDropEvent(eventA, eventB)).toBe(false);
     });
 
     it('should not drop if events have same messages, but different stacktraces', () => {
       const eventA = clone(messageEvent);
       const eventB = clone(messageEvent);
       eventB.stacktrace.frames[0].colno = 1337;
-      expect((dedupe as any)._shouldDropEvent(eventA, eventB)).toBe(false);
+      expect(_shouldDropEvent(eventA, eventB)).toBe(false);
     });
 
     it('should drop if there are two events with same messages and no fingerprints', () => {
@@ -80,13 +79,13 @@ describe('Dedupe', () => {
       delete eventA.fingerprint;
       const eventB = clone(messageEvent);
       delete eventB.fingerprint;
-      expect((dedupe as any)._shouldDropEvent(eventA, eventB)).toBe(true);
+      expect(_shouldDropEvent(eventA, eventB)).toBe(true);
     });
 
     it('should drop if there are two events with same messages and same fingerprints', () => {
       const eventA = clone(messageEvent);
       const eventB = clone(messageEvent);
-      expect((dedupe as any)._shouldDropEvent(eventA, eventB)).toBe(true);
+      expect(_shouldDropEvent(eventA, eventB)).toBe(true);
     });
 
     it('should not drop if there are two events with same message but different fingerprints', () => {
@@ -95,42 +94,42 @@ describe('Dedupe', () => {
       eventA.fingerprint = ['Birdperson'];
       const eventC = clone(messageEvent);
       delete eventC.fingerprint;
-      expect((dedupe as any)._shouldDropEvent(eventA, eventB)).toBe(false);
-      expect((dedupe as any)._shouldDropEvent(eventA, eventC)).toBe(false);
-      expect((dedupe as any)._shouldDropEvent(eventB, eventC)).toBe(false);
+      expect(_shouldDropEvent(eventA, eventB)).toBe(false);
+      expect(_shouldDropEvent(eventA, eventC)).toBe(false);
+      expect(_shouldDropEvent(eventB, eventC)).toBe(false);
     });
   });
 
   describe('shouldDropEvent(exceptionEvent)', () => {
     it('should not drop if there was no previous event', () => {
       const event = clone(exceptionEvent);
-      expect((dedupe as any)._shouldDropEvent(event)).toBe(false);
+      expect(_shouldDropEvent(event)).toBe(false);
     });
 
     it('should drop when events type, value and stacktrace are the same', () => {
       const event = clone(exceptionEvent);
-      expect((dedupe as any)._shouldDropEvent(event, event)).toBe(true);
+      expect(_shouldDropEvent(event, event)).toBe(true);
     });
 
     it('should not drop if types are different', () => {
       const eventA = clone(exceptionEvent);
       const eventB = clone(exceptionEvent);
       eventB.exception.values[0].type = 'TypeError';
-      expect((dedupe as any)._shouldDropEvent(eventA, eventB)).toBe(false);
+      expect(_shouldDropEvent(eventA, eventB)).toBe(false);
     });
 
     it('should not drop if values are different', () => {
       const eventA = clone(exceptionEvent);
       const eventB = clone(exceptionEvent);
       eventB.exception.values[0].value = 'Expected number, got string';
-      expect((dedupe as any)._shouldDropEvent(eventA, eventB)).toBe(false);
+      expect(_shouldDropEvent(eventA, eventB)).toBe(false);
     });
 
     it('should not drop if stacktraces are different', () => {
       const eventA = clone(exceptionEvent);
       const eventB = clone(exceptionEvent);
       eventB.exception.values[0].stacktrace.frames[0].colno = 1337;
-      expect((dedupe as any)._shouldDropEvent(eventA, eventB)).toBe(false);
+      expect(_shouldDropEvent(eventA, eventB)).toBe(false);
     });
 
     it('should drop if there are two events with same exception and no fingerprints', () => {
@@ -138,13 +137,13 @@ describe('Dedupe', () => {
       delete eventA.fingerprint;
       const eventB = clone(exceptionEvent);
       delete eventB.fingerprint;
-      expect((dedupe as any)._shouldDropEvent(eventA, eventB)).toBe(true);
+      expect(_shouldDropEvent(eventA, eventB)).toBe(true);
     });
 
     it('should drop if there are two events with same exception and same fingerprints', () => {
       const eventA = clone(exceptionEvent);
       const eventB = clone(exceptionEvent);
-      expect((dedupe as any)._shouldDropEvent(eventA, eventB)).toBe(true);
+      expect(_shouldDropEvent(eventA, eventB)).toBe(true);
     });
 
     it('should not drop if there are two events with same exception but different fingerprints', () => {
@@ -153,9 +152,9 @@ describe('Dedupe', () => {
       eventA.fingerprint = ['Birdperson'];
       const eventC = clone(exceptionEvent);
       delete eventC.fingerprint;
-      expect((dedupe as any)._shouldDropEvent(eventA, eventB)).toBe(false);
-      expect((dedupe as any)._shouldDropEvent(eventA, eventC)).toBe(false);
-      expect((dedupe as any)._shouldDropEvent(eventB, eventC)).toBe(false);
+      expect(_shouldDropEvent(eventA, eventB)).toBe(false);
+      expect(_shouldDropEvent(eventA, eventC)).toBe(false);
+      expect(_shouldDropEvent(eventB, eventC)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Move out private methods into their own functions as they do not need
access to class properties. This helps save on bundle size.
