### PR TITLE
test(browser): Add integration tests to LinkedErrors

### DIFF
--- a/packages/browser/test/unit/integrations/linkederrors.test.ts
+++ b/packages/browser/test/unit/integrations/linkederrors.test.ts
@@ -1,7 +1,5 @@
-import { ExtendedError } from '@sentry/types';
 import { stub } from 'sinon';
 
-import { BrowserBackend } from '../../../src/backend';
 import { LinkedErrors } from '../../../src/integrations/linkederrors';
 
 let linkedErrors: any;
@@ -48,96 +46,6 @@ describe('LinkedErrors', () => {
       };
       linkedErrors._handler(event, hint);
       expect(spy.calledOnce).toBe(true);
-    });
-
-    it('should recursively walk error to find linked exceptions and assign them to the event', async () => {
-      const three: ExtendedError = new SyntaxError('three');
-
-      const two: ExtendedError = new TypeError('two');
-      two.cause = three;
-
-      const one: ExtendedError = new Error('one');
-      one.cause = two;
-
-      const originalException = one;
-      const backend = new BrowserBackend({});
-      return backend.eventFromException(originalException).then(event => {
-        const result = linkedErrors._handler(event, {
-          originalException,
-        });
-
-        // It shouldn't include root exception, as it's already processed in the event by the main error handler
-        expect(result.exception.values.length).toBe(3);
-        expect(result.exception.values[0].type).toBe('SyntaxError');
-        expect(result.exception.values[0].value).toBe('three');
-        expect(result.exception.values[0].stacktrace).toHaveProperty('frames');
-        expect(result.exception.values[1].type).toBe('TypeError');
-        expect(result.exception.values[1].value).toBe('two');
-        expect(result.exception.values[1].stacktrace).toHaveProperty('frames');
-        expect(result.exception.values[2].type).toBe('Error');
-        expect(result.exception.values[2].value).toBe('one');
-        expect(result.exception.values[2].stacktrace).toHaveProperty('frames');
-      });
-    });
-
-    it('should allow to change walk key', async () => {
-      linkedErrors = new LinkedErrors({
-        key: 'reason',
-      });
-
-      const three: ExtendedError = new SyntaxError('three');
-
-      const two: ExtendedError = new TypeError('two');
-      two.reason = three;
-
-      const one: ExtendedError = new Error('one');
-      one.reason = two;
-
-      const originalException = one;
-      const backend = new BrowserBackend({});
-      return backend.eventFromException(originalException).then(event => {
-        const result = linkedErrors._handler(event, {
-          originalException,
-        });
-
-        expect(result.exception.values.length).toBe(3);
-        expect(result.exception.values[0].type).toBe('SyntaxError');
-        expect(result.exception.values[0].value).toBe('three');
-        expect(result.exception.values[0].stacktrace).toHaveProperty('frames');
-        expect(result.exception.values[1].type).toBe('TypeError');
-        expect(result.exception.values[1].value).toBe('two');
-        expect(result.exception.values[1].stacktrace).toHaveProperty('frames');
-        expect(result.exception.values[2].type).toBe('Error');
-        expect(result.exception.values[2].value).toBe('one');
-        expect(result.exception.values[2].stacktrace).toHaveProperty('frames');
-      });
-    });
-
-    it('should allow to change stack size limit', async () => {
-      linkedErrors = new LinkedErrors({
-        limit: 2,
-      });
-
-      const one: ExtendedError = new Error('one');
-      const two: ExtendedError = new TypeError('two');
-      const three: ExtendedError = new SyntaxError('three');
-      one.cause = two;
-      two.cause = three;
-
-      const backend = new BrowserBackend({});
-      return backend.eventFromException(one).then(event => {
-        const result = linkedErrors._handler(event, {
-          originalException: one,
-        });
-
-        expect(result.exception.values.length).toBe(2);
-        expect(result.exception.values[0].type).toBe('TypeError');
-        expect(result.exception.values[0].value).toBe('two');
-        expect(result.exception.values[0].stacktrace).toHaveProperty('frames');
-        expect(result.exception.values[1].type).toBe('Error');
-        expect(result.exception.values[1].value).toBe('one');
-        expect(result.exception.values[1].stacktrace).toHaveProperty('frames');
-      });
     });
   });
 });

--- a/packages/integration-tests/suites/linkederrors/init.js
+++ b/packages/integration-tests/suites/linkederrors/init.js
@@ -1,0 +1,7 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+});

--- a/packages/integration-tests/suites/linkederrors/linkedexception/subject.js
+++ b/packages/integration-tests/suites/linkederrors/linkedexception/subject.js
@@ -1,0 +1,9 @@
+const three = new SyntaxError('three');
+
+const two = new TypeError('two');
+two.cause = three;
+
+const one = new Error('one');
+one.cause = two;
+
+Sentry.captureException(one);

--- a/packages/integration-tests/suites/linkederrors/linkedexception/test.ts
+++ b/packages/integration-tests/suites/linkederrors/linkedexception/test.ts
@@ -1,0 +1,52 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../utils/fixtures';
+import { getSentryRequest } from '../../../utils/helpers';
+
+sentryTest('should associate linked exceptions to an event event', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  const eventData = await getSentryRequest(page, url);
+
+  const exception = eventData.exception;
+  expect(eventData.exception).toBeDefined();
+
+  const exceptionValues = exception!.values!;
+  expect(exceptionValues).toBeDefined();
+
+  // It shouldn't include root exception, as it's already processed in the event by the main error handler
+  expect(exceptionValues.length).toBe(3);
+  expect(exceptionValues[0].type).toBe('SyntaxError');
+  expect(exceptionValues[0].value).toBe('three');
+  expect(exceptionValues[0].stacktrace).toHaveProperty('frames');
+  expect(exceptionValues[1].type).toBe('TypeError');
+  expect(exceptionValues[1].value).toBe('two');
+  expect(exceptionValues[1].stacktrace).toHaveProperty('frames');
+  expect(exceptionValues[2].type).toBe('Error');
+  expect(exceptionValues[2].value).toBe('one');
+  expect(exceptionValues[2].stacktrace).toHaveProperty('frames');
+});
+
+sentryTest('should associate linked exceptions to an event event', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  const eventData = await getSentryRequest(page, url);
+
+  const exception = eventData.exception;
+  expect(eventData.exception).toBeDefined();
+
+  const exceptionValues = exception!.values!;
+  expect(exceptionValues).toBeDefined();
+
+  // It shouldn't include root exception, as it's already processed in the event by the main error handler
+  expect(exceptionValues.length).toBe(3);
+  expect(exceptionValues[0].type).toBe('SyntaxError');
+  expect(exceptionValues[0].value).toBe('three');
+  expect(exceptionValues[0].stacktrace).toHaveProperty('frames');
+  expect(exceptionValues[1].type).toBe('TypeError');
+  expect(exceptionValues[1].value).toBe('two');
+  expect(exceptionValues[1].stacktrace).toHaveProperty('frames');
+  expect(exceptionValues[2].type).toBe('Error');
+  expect(exceptionValues[2].value).toBe('one');
+  expect(exceptionValues[2].stacktrace).toHaveProperty('frames');
+});

--- a/packages/integration-tests/suites/linkederrors/template.hbs
+++ b/packages/integration-tests/suites/linkederrors/template.hbs
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title></title>
+  <script src="{{htmlWebpackPlugin.options.initialization}}"></script>
+  </head>
+  <body>
+    <script src="{{htmlWebpackPlugin.options.subject}}"></script>
+  </body>
+</html>

--- a/packages/integration-tests/suites/linkederrors/variablekey/init.js
+++ b/packages/integration-tests/suites/linkederrors/variablekey/init.js
@@ -1,0 +1,12 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [
+    new Sentry.Integrations.LinkedErrors({
+      key: 'reason',
+    }),
+  ]
+});

--- a/packages/integration-tests/suites/linkederrors/variablekey/subject.js
+++ b/packages/integration-tests/suites/linkederrors/variablekey/subject.js
@@ -1,0 +1,9 @@
+const three = new SyntaxError('three');
+
+const two = new TypeError('two');
+two.reason = three;
+
+const one = new Error('one');
+one.reason = two;
+
+Sentry.captureException(one);

--- a/packages/integration-tests/suites/linkederrors/variablekey/test.ts
+++ b/packages/integration-tests/suites/linkederrors/variablekey/test.ts
@@ -1,0 +1,28 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../utils/fixtures';
+import { getSentryRequest } from '../../../utils/helpers';
+
+sentryTest('should allow to change walk key', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  const eventData = await getSentryRequest(page, url);
+
+  const exception = eventData.exception;
+  expect(eventData.exception).toBeDefined();
+
+  const exceptionValues = exception!.values!;
+  expect(exceptionValues).toBeDefined();
+
+  // It shouldn't include root exception, as it's already processed in the event by the main error handler
+  expect(exceptionValues.length).toBe(3);
+  expect(exceptionValues[0].type).toBe('SyntaxError');
+  expect(exceptionValues[0].value).toBe('three');
+  expect(exceptionValues[0].stacktrace).toHaveProperty('frames');
+  expect(exceptionValues[1].type).toBe('TypeError');
+  expect(exceptionValues[1].value).toBe('two');
+  expect(exceptionValues[1].stacktrace).toHaveProperty('frames');
+  expect(exceptionValues[2].type).toBe('Error');
+  expect(exceptionValues[2].value).toBe('one');
+  expect(exceptionValues[2].stacktrace).toHaveProperty('frames');
+});

--- a/packages/integration-tests/suites/linkederrors/variablelimit/init.js
+++ b/packages/integration-tests/suites/linkederrors/variablelimit/init.js
@@ -1,0 +1,12 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [
+    new Sentry.Integrations.LinkedErrors({
+      limit: 2,
+    }),
+  ]
+});

--- a/packages/integration-tests/suites/linkederrors/variablelimit/subject.js
+++ b/packages/integration-tests/suites/linkederrors/variablelimit/subject.js
@@ -1,0 +1,9 @@
+const three = new SyntaxError('three');
+
+const two = new TypeError('two');
+two.cause = three;
+
+const one = new Error('one');
+one.cause = two;
+
+Sentry.captureException(one);

--- a/packages/integration-tests/suites/linkederrors/variablelimit/test.ts
+++ b/packages/integration-tests/suites/linkederrors/variablelimit/test.ts
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
 import { getSentryRequest } from '../../../utils/helpers';
 
-sentryTest('should allow to change walk key', async ({ getLocalTestPath, page }) => {
+sentryTest('should allow to change stack size limit', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
 
   const eventData = await getSentryRequest(page, url);

--- a/packages/integration-tests/suites/linkederrors/variablelimit/test.ts
+++ b/packages/integration-tests/suites/linkederrors/variablelimit/test.ts
@@ -1,0 +1,25 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../utils/fixtures';
+import { getSentryRequest } from '../../../utils/helpers';
+
+sentryTest('should allow to change walk key', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  const eventData = await getSentryRequest(page, url);
+
+  const exception = eventData.exception;
+  expect(eventData.exception).toBeDefined();
+
+  const exceptionValues = exception!.values!;
+  expect(exceptionValues).toBeDefined();
+
+  // It shouldn't include root exception, as it's already processed in the event by the main error handler
+  expect(exceptionValues.length).toBe(2);
+  expect(exceptionValues[0].type).toBe('TypeError');
+  expect(exceptionValues[0].value).toBe('two');
+  expect(exceptionValues[0].stacktrace).toHaveProperty('frames');
+  expect(exceptionValues[1].type).toBe('Error');
+  expect(exceptionValues[1].value).toBe('one');
+  expect(exceptionValues[1].stacktrace).toHaveProperty('frames');
+});


### PR DESCRIPTION
To gain more confidence in https://github.com/getsentry/sentry-javascript/pull/4295, I've pulled the primary `LinkedErrors` logic into integration tests.