### PR TITLE
docs(nextjs): Update README to indicate Next 12 support

### DIFF
--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -19,7 +19,7 @@
 
 ## Compatibility
 
-Currently, the Sentry Next.js SDK supports Next.js versions `10.0.8` - `11.1.3`. The SDK may work with some projects using Next.js 12, but it is not yet officially supported.
+Currently, the minimum Next.js supported version is `10.0.8`.
 
 ## General
 


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/4110 we added the note as we didn't support Next 12, but now with https://github.com/getsentry/sentry-javascript/pull/4093 merged, we can update this.
