### PR TITLE
fix(nextjs): Add `sentry-cli` existence check for enabling webpack plugin

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -62,9 +62,17 @@ export function constructWebpackConfigFunction(
     newConfig.entry = async () => addSentryToEntryProperty(origEntryProperty, buildContext);
 
     // Enable the Sentry plugin (which uploads source maps to Sentry when not in dev) by default
-    const enableWebpackPlugin = buildContext.isServer
-      ? !userNextConfig.sentry?.disableServerWebpackPlugin
-      : !userNextConfig.sentry?.disableClientWebpackPlugin;
+    const enableWebpackPlugin =
+      // TODO: this is a hack to fix https://github.com/getsentry/sentry-cli/issues/1085, which is caused by
+      // https://github.com/getsentry/sentry-cli/issues/915. Once the latter is addressed, this existence check can come
+      // out. (The check is necessary because currently, `@sentry/cli` uses a post-install script to download an
+      // architecture-specific version of the `sentry-cli` binary. If `yarn install`, `npm install`, or `npm ci` are run
+      // with the `--ignore-scripts` option, this will be blocked and the missing binary will cause an error when users
+      // try to build their apps.)
+      ensureCLIBinaryExists() &&
+      (buildContext.isServer
+        ? !userNextConfig.sentry?.disableServerWebpackPlugin
+        : !userNextConfig.sentry?.disableClientWebpackPlugin);
 
     if (enableWebpackPlugin) {
       // TODO Handle possibility that user is using `SourceMapDevToolPlugin` (see
@@ -295,4 +303,8 @@ export function getWebpackPluginOptions(
   checkWebpackPluginOverrides(defaultPluginOptions, userPluginOptions);
 
   return { ...defaultPluginOptions, ...userPluginOptions };
+}
+
+function ensureCLIBinaryExists(): boolean {
+  return fs.existsSync(path.join(require.resolve('@sentry/cli'), '../../sentry-cli'));
 }


### PR DESCRIPTION
Our nextjs SDK uses `sentry-cli` (by way of `SentryWebpackPlugin` and `@sentry/cli`) to upload sourcemaps. Because binaries (like the `sentry-cli` executable) need to be compiled differently for different OSs and architectures, `@sentry/cli` uses a post-install script to download the correct one as part of its install process, rather than ship with all possible binaries at once.

Of course, this goes awry if the post-install script isn't run, which is exactly what happens when `@sentry/cli` is installed with the `--ignore-scripts` option. The resulting missing binary then causes errors which bubble up to and through our SDK to the nextjs build process, which promptly crashes.

This fixes that by checking to make sure they binary has been downloaded before enabling `SentryWebpackPlugin`.

Fixes https://github.com/getsentry/sentry-cli/issues/1085.