### PR TITLE
fix: use current config in linkederrors

### DIFF
--- a/packages/browser/src/integrations/linkederrors.ts
+++ b/packages/browser/src/integrations/linkederrors.ts
@@ -48,7 +48,8 @@ export class LinkedErrors implements Integration {
    */
   public setupOnce(): void {
     addGlobalEventProcessor((event: Event, hint?: EventHint) => {
-      return getCurrentHub().getIntegration(LinkedErrors) ? _handler(this._key, this._limit, event, hint) : event;
+      const self = getCurrentHub().getIntegration(LinkedErrors);
+      return self ? _handler(self._key, self._limit, event, hint) : event;
     });
   }
 }


### PR DESCRIPTION
A regression slipped in for an integration in a recent refactor that caused the wrong config to be picked up.