### PR TITLE
ref(syncpromise): trim down syncpromise

### DIFF
--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -8,7 +8,7 @@ import {
   isErrorEvent,
   isEvent,
   isPlainObject,
-  resolvedSyncPromise,
+  makeSyncPromise,
 } from '@sentry/utils';
 
 import { eventFromPlainObject, eventFromStacktrace, prepareFramesForEvent } from './parsers';
@@ -28,7 +28,7 @@ export function eventFromException(options: Options, exception: unknown, hint?: 
   if (hint && hint.event_id) {
     event.event_id = hint.event_id;
   }
-  return resolvedSyncPromise(event);
+  return makeSyncPromise().resolve(event);
 }
 
 /**
@@ -49,7 +49,7 @@ export function eventFromMessage(
   if (hint && hint.event_id) {
     event.event_id = hint.event_id;
   }
-  return resolvedSyncPromise(event);
+  return makeSyncPromise().resolve(event);
 }
 
 /**

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -8,7 +8,7 @@ import {
   isErrorEvent,
   isEvent,
   isPlainObject,
-  makeSyncPromise,
+  makePlatformResolvedPromise,
 } from '@sentry/utils';
 
 import { eventFromPlainObject, eventFromStacktrace, prepareFramesForEvent } from './parsers';
@@ -28,7 +28,7 @@ export function eventFromException(options: Options, exception: unknown, hint?: 
   if (hint && hint.event_id) {
     event.event_id = hint.event_id;
   }
-  return makeSyncPromise().resolve(event);
+  return makePlatformResolvedPromise(event);
 }
 
 /**
@@ -49,7 +49,7 @@ export function eventFromMessage(
   if (hint && hint.event_id) {
     event.event_id = hint.event_id;
   }
-  return makeSyncPromise().resolve(event);
+  return makePlatformResolvedPromise(event);
 }
 
 /**

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -1,6 +1,5 @@
 import { getCurrentHub, initAndBind, Integrations as CoreIntegrations } from '@sentry/core';
-import { Hub } from '@sentry/types';
-import { addInstrumentationHandler, getGlobalObject, isDebugBuild, logger, resolvedSyncPromise } from '@sentry/utils';
+import { addInstrumentationHandler, getGlobalObject, logger, makeSyncPromise } from '@sentry/utils';
 
 import { BrowserOptions } from './backend';
 import { BrowserClient } from './client';

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -1,5 +1,12 @@
-import { getCurrentHub, initAndBind, Integrations as CoreIntegrations } from '@sentry/core';
-import { addInstrumentationHandler, getGlobalObject, logger, makePlatformResolvedPromise } from '@sentry/utils';
+import { getCurrentHub, initAndBind, Integrations as CoreIntegration } from '@sentry/core';
+import { Hub } from '@sentry/types';
+import {
+  addInstrumentationHandler,
+  getGlobalObject,
+  isDebugBuild,
+  logger,
+  makePlatformResolvedPromise,
+} from '@sentry/utils';
 
 import { BrowserOptions } from './backend';
 import { BrowserClient } from './client';
@@ -162,7 +169,9 @@ export function flush(timeout?: number): PromiseLike<boolean> {
   if (client) {
     return client.flush(timeout);
   }
-  logger.warn('Cannot flush events. No client defined.');
+  if (isDebugBuild()) {
+    logger.warn('Cannot flush events. No client defined.');
+  }
   return makePlatformResolvedPromise(false);
 }
 
@@ -179,7 +188,9 @@ export function close(timeout?: number): PromiseLike<boolean> {
   if (client) {
     return client.close(timeout);
   }
-  logger.warn('Cannot flush events and disable SDK. No client defined.');
+  if (isDebugBuild()) {
+    logger.warn('Cannot flush events and disable SDK. No client defined.');
+  }
   return makePlatformResolvedPromise(false);
 }
 

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -1,5 +1,5 @@
 import { getCurrentHub, initAndBind, Integrations as CoreIntegrations } from '@sentry/core';
-import { addInstrumentationHandler, getGlobalObject, logger, makeSyncPromise } from '@sentry/utils';
+import { addInstrumentationHandler, getGlobalObject, logger, makePlatformResolvedPromise } from '@sentry/utils';
 
 import { BrowserOptions } from './backend';
 import { BrowserClient } from './client';
@@ -163,7 +163,7 @@ export function flush(timeout?: number): PromiseLike<boolean> {
     return client.flush(timeout);
   }
   logger.warn('Cannot flush events. No client defined.');
-  return makeSyncPromise().resolve(false);
+  return makePlatformResolvedPromise(false);
 }
 
 /**
@@ -180,7 +180,7 @@ export function close(timeout?: number): PromiseLike<boolean> {
     return client.close(timeout);
   }
   logger.warn('Cannot flush events and disable SDK. No client defined.');
-  return makeSyncPromise().resolve(false);
+  return makePlatformResolvedPromise(false);
 }
 
 /**

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -63,6 +63,7 @@ export const defaultIntegrations = [
  * ```
  *
  * import * as Sentry from '@sentry/browser';
+import { makeSyncPromise } from '../../utils/src/syncpromise';
  * Sentry.captureMessage('Hello, world!');
  * Sentry.captureException(new Error('Good bye'));
  * Sentry.captureEvent({
@@ -162,10 +163,8 @@ export function flush(timeout?: number): PromiseLike<boolean> {
   if (client) {
     return client.flush(timeout);
   }
-  if (isDebugBuild()) {
-    logger.warn('Cannot flush events. No client defined.');
-  }
-  return resolvedSyncPromise(false);
+  logger.warn('Cannot flush events. No client defined.');
+  return makeSyncPromise().resolve(false);
 }
 
 /**
@@ -181,10 +180,8 @@ export function close(timeout?: number): PromiseLike<boolean> {
   if (client) {
     return client.close(timeout);
   }
-  if (isDebugBuild()) {
-    logger.warn('Cannot flush events and disable SDK. No client defined.');
-  }
-  return resolvedSyncPromise(false);
+  logger.warn('Cannot flush events and disable SDK. No client defined.');
+  return makeSyncPromise().resolve(false);
 }
 
 /**

--- a/packages/browser/src/transports/base.ts
+++ b/packages/browser/src/transports/base.ts
@@ -165,7 +165,7 @@ export abstract class BaseTransport implements Transport {
     requestType: SentryRequestType;
     response: Response | XMLHttpRequest;
     headers: Record<string, string | null>;
-    resolve: (value?: SentryResponse | PromiseLike<SentryResponse> | null | undefined) => void;
+    resolve: (value?: SentryResponse | PromiseLike<SentryResponse> | undefined) => void;
     reject: (reason?: unknown) => void;
   }): void {
     const status = eventStatusFromHttpCode(response.status);

--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -1,5 +1,5 @@
 import { Event, Response, SentryRequest, Session, TransportOptions } from '@sentry/types';
-import { makeSyncPromise, SentryError, supportsReferrerPolicy } from '@sentry/utils';
+import { makePlatformPromise, SentryError, supportsReferrerPolicy } from '@sentry/utils';
 
 import { BaseTransport } from './base';
 import { FetchImpl, getNativeFetchImplementation } from './utils';
@@ -52,7 +52,7 @@ export class FetchTransport extends BaseTransport {
 
     return this._buffer
       .add(() =>
-        makeSyncPromise<Response>((resolve, reject) => {
+        makePlatformPromise<Response>((resolve, reject) => {
           void this._fetch(sentryRequest.url, options)
             .then(response => {
               const headers = {

--- a/packages/browser/src/transports/xhr.ts
+++ b/packages/browser/src/transports/xhr.ts
@@ -1,5 +1,5 @@
 import { Event, Response, SentryRequest, Session } from '@sentry/types';
-import { makeSyncPromise, SentryError } from '@sentry/utils';
+import { makePlatformPromise, SentryError } from '@sentry/utils';
 
 import { BaseTransport } from './base';
 
@@ -25,7 +25,7 @@ export class XHRTransport extends BaseTransport {
 
     return this._buffer
       .add(() =>
-        makeSyncPromise<Response>((resolve, reject) => {
+        makePlatformPromise<Response>((resolve, reject) => {
           const request = new XMLHttpRequest();
 
           request.onreadystatechange = (): void => {

--- a/packages/browser/test/unit/mocks/simpletransport.ts
+++ b/packages/browser/test/unit/mocks/simpletransport.ts
@@ -1,4 +1,4 @@
-import { eventStatusFromHttpCode, makeSyncPromise } from '@sentry/utils';
+import { eventStatusFromHttpCode, makePlatformResolvedPromise } from '@sentry/utils';
 
 import { Event, Response } from '../../../src';
 import { BaseTransport } from '../../../src/transports';
@@ -6,7 +6,7 @@ import { BaseTransport } from '../../../src/transports';
 export class SimpleTransport extends BaseTransport {
   public sendEvent(_: Event): PromiseLike<Response> {
     return this._buffer.add(() =>
-      makeSyncPromise().resolve({
+      makePlatformResolvedPromise({
         status: eventStatusFromHttpCode(200),
       }),
     );

--- a/packages/browser/test/unit/mocks/simpletransport.ts
+++ b/packages/browser/test/unit/mocks/simpletransport.ts
@@ -1,4 +1,4 @@
-import { eventStatusFromHttpCode, resolvedSyncPromise } from '@sentry/utils';
+import { eventStatusFromHttpCode, makeSyncPromise } from '@sentry/utils';
 
 import { Event, Response } from '../../../src';
 import { BaseTransport } from '../../../src/transports';
@@ -6,7 +6,7 @@ import { BaseTransport } from '../../../src/transports';
 export class SimpleTransport extends BaseTransport {
   public sendEvent(_: Event): PromiseLike<Response> {
     return this._buffer.add(() =>
-      resolvedSyncPromise({
+      makeSyncPromise().resolve({
         status: eventStatusFromHttpCode(200),
       }),
     );

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -14,17 +14,15 @@ import {
 import {
   checkOrSetAlreadyCaught,
   dateTimestampInSeconds,
-  isDebugBuild,
   isPlainObject,
   isPrimitive,
   isThenable,
   logger,
+  makeDsn,
   makePlatformPromise,
   makePlatformRejectedPromise,
   makePlatformResolvedPromise,
   normalize,
-  rejectedSyncPromise,
-  resolvedSyncPromise,
   SentryError,
   truncate,
   uuid4,
@@ -79,7 +77,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
   protected readonly _options: O;
 
   /** The client Dsn, if specified in options. Without this Dsn, the SDK will be disabled. */
-  protected readonly _dsn?: DsnComponents;
+  protected readonly _dsn?: Dsn;
 
   /** Array of used integrations. */
   protected _integrations: IntegrationIndex = {};
@@ -174,16 +172,12 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    */
   public captureSession(session: Session): void {
     if (!this._isEnabled()) {
-      if (isDebugBuild()) {
-        logger.warn('SDK not enabled, will not capture session.');
-      }
+      logger.warn('SDK not enabled, will not capture session.');
       return;
     }
 
     if (!(typeof session.release === 'string')) {
-      if (isDebugBuild()) {
-        logger.warn('Discarded session because of missing or non-string release');
-      }
+      logger.warn('Discarded session because of missing or non-string release');
     } else {
       this._sendSession(session);
       // After sending, we set init false to indicate it's not the first occurrence

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -363,7 +363,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
     }
 
     // We prepare the result here with a resolved Event.
-    let result = resolvedSyncPromise<Event | null>(prepared);
+    let result = makeSyncPromise().resolve<Event | null>(prepared);
 
     // This should be the last thing called, since we want that
     // {@link Hub.addEventProcessor} gets the finished prepared event.
@@ -538,7 +538,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
     }
 
     if (!this._isEnabled()) {
-      return rejectedSyncPromise(new SentryError('SDK not enabled, will not capture event.'));
+      return makeSyncPromise().reject(new SentryError('SDK not enabled, will not capture event.'));
     }
 
     const isTransaction = event.type === 'transaction';
@@ -547,7 +547,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
     // Sampling for transaction happens somewhere else
     if (!isTransaction && typeof sampleRate === 'number' && Math.random() > sampleRate) {
       recordLostEvent('sample_rate', 'event');
-      return rejectedSyncPromise(
+      return makeSyncPromise().reject(
         new SentryError(
           `Discarding event because it's not included in the random sample (sampling rate = ${sampleRate})`,
         ),

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -19,12 +19,11 @@ import {
   isPrimitive,
   isThenable,
   logger,
-  makeDsn,
+  makeSyncPromise,
   normalize,
   rejectedSyncPromise,
   resolvedSyncPromise,
   SentryError,
-  SyncPromise,
   truncate,
   uuid4,
 } from '@sentry/utils';
@@ -302,7 +301,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    * `false` otherwise
    */
   protected _isClientDoneProcessing(timeout?: number): PromiseLike<boolean> {
-    return new SyncPromise(resolve => {
+    return makeSyncPromise(resolve => {
       let ticked: number = 0;
       const tick: number = 1;
 

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -19,7 +19,9 @@ import {
   isPrimitive,
   isThenable,
   logger,
-  makeSyncPromise,
+  makePlatformPromise,
+  makePlatformRejectedPromise,
+  makePlatformResolvedPromise,
   normalize,
   rejectedSyncPromise,
   resolvedSyncPromise,
@@ -301,7 +303,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    * `false` otherwise
    */
   protected _isClientDoneProcessing(timeout?: number): PromiseLike<boolean> {
-    return makeSyncPromise(resolve => {
+    return makePlatformPromise<boolean>(resolve => {
       let ticked: number = 0;
       const tick: number = 1;
 
@@ -363,7 +365,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
     }
 
     // We prepare the result here with a resolved Event.
-    let result = makeSyncPromise().resolve<Event | null>(prepared);
+    let result = makePlatformResolvedPromise<Event | null>(prepared);
 
     // This should be the last thing called, since we want that
     // {@link Hub.addEventProcessor} gets the finished prepared event.
@@ -538,7 +540,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
     }
 
     if (!this._isEnabled()) {
-      return makeSyncPromise().reject(new SentryError('SDK not enabled, will not capture event.'));
+      return makePlatformRejectedPromise(new SentryError('SDK not enabled, will not capture event.'));
     }
 
     const isTransaction = event.type === 'transaction';
@@ -547,7 +549,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
     // Sampling for transaction happens somewhere else
     if (!isTransaction && typeof sampleRate === 'number' && Math.random() > sampleRate) {
       recordLostEvent('sample_rate', 'event');
-      return makeSyncPromise().reject(
+      return makePlatformRejectedPromise(
         new SentryError(
           `Discarding event because it's not included in the random sample (sampling rate = ${sampleRate})`,
         ),

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -77,7 +77,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
   protected readonly _options: O;
 
   /** The client Dsn, if specified in options. Without this Dsn, the SDK will be disabled. */
-  protected readonly _dsn?: Dsn;
+  protected readonly _dsn?: DsnComponents;
 
   /** Array of used integrations. */
   protected _integrations: IntegrationIndex = {};

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -36,8 +36,7 @@ export function sessionToSentryRequest(session: Session | SessionAggregates, api
     ...(sdkInfo && { sdk: sdkInfo }),
     ...(!!api.tunnel && { dsn: dsnToString(api.dsn) }),
   });
-  // I know this is hacky but we don't want to add `session` to request type since it's never rate limited
-  const type: SentryRequestType = 'aggregates' in session ? ('sessions' as SentryRequestType) : 'session';
+  const type: SentryRequestType = 'session';
   const itemHeaders = JSON.stringify({
     type,
   });

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -36,7 +36,7 @@ export function sessionToSentryRequest(session: Session | SessionAggregates, api
     ...(sdkInfo && { sdk: sdkInfo }),
     ...(!!api.tunnel && { dsn: dsnToString(api.dsn) }),
   });
-  const type: SentryRequestType = 'session';
+  const type: SentryRequestType = 'aggregates' in session ? ('sessions' as SentryRequestType) : 'session';
   const itemHeaders = JSON.stringify({
     type,
   });

--- a/packages/core/src/transports/noop.ts
+++ b/packages/core/src/transports/noop.ts
@@ -1,5 +1,5 @@
 import { Event, Response, Transport } from '@sentry/types';
-import { makeSyncPromise } from '@sentry/utils';
+import { makePlatformResolvedPromise } from '@sentry/utils';
 
 /** Noop transport */
 export class NoopTransport implements Transport {
@@ -7,7 +7,7 @@ export class NoopTransport implements Transport {
    * @inheritDoc
    */
   public sendEvent(_: Event): PromiseLike<Response> {
-    return makeSyncPromise().resolve({
+    return makePlatformResolvedPromise({
       reason: `NoopTransport: Event has been skipped because no Dsn is configured.`,
       status: 'skipped',
     });
@@ -17,6 +17,6 @@ export class NoopTransport implements Transport {
    * @inheritDoc
    */
   public close(_?: number): PromiseLike<boolean> {
-    return makeSyncPromise().resolve(true);
+    return makePlatformResolvedPromise(true);
   }
 }

--- a/packages/core/src/transports/noop.ts
+++ b/packages/core/src/transports/noop.ts
@@ -1,5 +1,5 @@
 import { Event, Response, Transport } from '@sentry/types';
-import { resolvedSyncPromise } from '@sentry/utils';
+import { makeSyncPromise } from '@sentry/utils';
 
 /** Noop transport */
 export class NoopTransport implements Transport {
@@ -7,7 +7,7 @@ export class NoopTransport implements Transport {
    * @inheritDoc
    */
   public sendEvent(_: Event): PromiseLike<Response> {
-    return resolvedSyncPromise({
+    return makeSyncPromise().resolve({
       reason: `NoopTransport: Event has been skipped because no Dsn is configured.`,
       status: 'skipped',
     });
@@ -17,6 +17,6 @@ export class NoopTransport implements Transport {
    * @inheritDoc
    */
   public close(_?: number): PromiseLike<boolean> {
-    return resolvedSyncPromise(true);
+    return makeSyncPromise().resolve(true);
   }
 }

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -1,6 +1,6 @@
 import { Hub, Scope, Session } from '@sentry/hub';
 import { Event, Span, Transport } from '@sentry/types';
-import { dsnToString, logger, SentryError, SyncPromise } from '@sentry/utils';
+import { logger, SentryError, makeSyncPromise } from '@sentry/utils';
 
 import * as integrationModule from '../../src/integration';
 import { TestBackend } from '../mocks/backend';
@@ -1229,11 +1229,10 @@ describe('BaseClient', () => {
 
       const delay = 300;
       const spy = jest.spyOn(TestBackend.instance!, 'eventFromMessage');
-      spy.mockImplementationOnce(
-        (message, level) =>
-          new SyncPromise(resolve => {
-            setTimeout(() => resolve({ message, level }), 150);
-          }),
+      spy.mockImplementationOnce((message, level) =>
+        makeSyncPromise(resolve => {
+          setTimeout(() => resolve({ message, level }), 150);
+        }),
       );
       const transportInstance = client.getTransport() as FakeTransport;
       transportInstance.delay = delay;

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -1,6 +1,6 @@
 import { Hub, Scope, Session } from '@sentry/hub';
 import { Event, Span, Transport } from '@sentry/types';
-import { logger, SentryError, makeSyncPromise } from '@sentry/utils';
+import { logger, makePlatformPromise,SentryError } from '@sentry/utils';
 
 import * as integrationModule from '../../src/integration';
 import { TestBackend } from '../mocks/backend';
@@ -1230,7 +1230,7 @@ describe('BaseClient', () => {
       const delay = 300;
       const spy = jest.spyOn(TestBackend.instance!, 'eventFromMessage');
       spy.mockImplementationOnce((message, level) =>
-        makeSyncPromise(resolve => {
+        makePlatformPromise(resolve => {
           setTimeout(() => resolve({ message, level }), 150);
         }),
       );

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -1,6 +1,6 @@
 import { Hub, Scope, Session } from '@sentry/hub';
 import { Event, Span, Transport } from '@sentry/types';
-import { logger, makePlatformPromise,SentryError } from '@sentry/utils';
+import { logger, makePlatformPromise, SentryError } from '@sentry/utils';
 
 import * as integrationModule from '../../src/integration';
 import { TestBackend } from '../mocks/backend';

--- a/packages/core/test/mocks/backend.ts
+++ b/packages/core/test/mocks/backend.ts
@@ -1,6 +1,6 @@
 import { Session } from '@sentry/hub';
 import { Event, Options, SeverityLevel, Transport } from '@sentry/types';
-import { makeSyncPromise } from '@sentry/utils';
+import { makePlatformResolvedPromise } from '@sentry/utils';
 
 import { BaseBackend } from '../../src/basebackend';
 
@@ -24,7 +24,7 @@ export class TestBackend extends BaseBackend<TestOptions> {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   public eventFromException(exception: any): PromiseLike<Event> {
-    return makeSyncPromise().resolve({
+    return makePlatformResolvedPromise({
       exception: {
         values: [
           {
@@ -39,7 +39,7 @@ export class TestBackend extends BaseBackend<TestOptions> {
   }
 
   public eventFromMessage(message: string, level: SeverityLevel = 'info'): PromiseLike<Event> {
-    return makeSyncPromise().resolve({ message, level });
+    return makePlatformResolvedPromise({ message, level });
   }
 
   public sendEvent(event: Event): void {

--- a/packages/core/test/mocks/backend.ts
+++ b/packages/core/test/mocks/backend.ts
@@ -1,6 +1,6 @@
 import { Session } from '@sentry/hub';
 import { Event, Options, SeverityLevel, Transport } from '@sentry/types';
-import { resolvedSyncPromise } from '@sentry/utils';
+import { makeSyncPromise } from '@sentry/utils';
 
 import { BaseBackend } from '../../src/basebackend';
 
@@ -24,7 +24,7 @@ export class TestBackend extends BaseBackend<TestOptions> {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   public eventFromException(exception: any): PromiseLike<Event> {
-    return resolvedSyncPromise({
+    return makeSyncPromise().resolve({
       exception: {
         values: [
           {
@@ -39,7 +39,7 @@ export class TestBackend extends BaseBackend<TestOptions> {
   }
 
   public eventFromMessage(message: string, level: SeverityLevel = 'info'): PromiseLike<Event> {
-    return resolvedSyncPromise({ message, level });
+    return makeSyncPromise().resolve({ message, level });
   }
 
   public sendEvent(event: Event): void {

--- a/packages/core/test/mocks/transport.ts
+++ b/packages/core/test/mocks/transport.ts
@@ -1,8 +1,8 @@
 import { Event, Response, Transport } from '@sentry/types';
-import { makePromiseBuffer, PromiseBuffer, SyncPromise } from '@sentry/utils';
+import { makePromiseBuffer, PromiseBuffer, makeSyncPromise } from '@sentry/utils';
 
 async function sleep(delay: number): Promise<void> {
-  return new SyncPromise(resolve => setTimeout(resolve, delay));
+  return makeSyncPromise(resolve => setTimeout(resolve, delay));
 }
 
 export class FakeTransport implements Transport {
@@ -15,13 +15,12 @@ export class FakeTransport implements Transport {
 
   public sendEvent(_event: Event): PromiseLike<Response> {
     this.sendCalled += 1;
-    return this._buffer.add(
-      () =>
-        new SyncPromise(async res => {
-          await sleep(this.delay);
-          this.sentCount += 1;
-          res({ status: 'success' });
-        }),
+    return this._buffer.add(() =>
+      makeSyncPromise(async res => {
+        await sleep(this.delay);
+        this.sentCount += 1;
+        res({ status: 'success' });
+      }),
     );
   }
 

--- a/packages/core/test/mocks/transport.ts
+++ b/packages/core/test/mocks/transport.ts
@@ -1,8 +1,8 @@
 import { Event, Response, Transport } from '@sentry/types';
-import { makePromiseBuffer, PromiseBuffer, makeSyncPromise } from '@sentry/utils';
+import { makePlatformPromise,makePromiseBuffer, PromiseBuffer } from '@sentry/utils';
 
 async function sleep(delay: number): Promise<void> {
-  return makeSyncPromise(resolve => setTimeout(resolve, delay));
+  return makePlatformPromise(resolve => setTimeout(resolve, delay));
 }
 
 export class FakeTransport implements Transport {
@@ -16,7 +16,7 @@ export class FakeTransport implements Transport {
   public sendEvent(_event: Event): PromiseLike<Response> {
     this.sendCalled += 1;
     return this._buffer.add(() =>
-      makeSyncPromise(async res => {
+      makePlatformPromise(async res => {
         await sleep(this.delay);
         this.sentCount += 1;
         res({ status: 'success' });

--- a/packages/core/test/mocks/transport.ts
+++ b/packages/core/test/mocks/transport.ts
@@ -1,5 +1,5 @@
 import { Event, Response, Transport } from '@sentry/types';
-import { makePlatformPromise,makePromiseBuffer, PromiseBuffer } from '@sentry/utils';
+import { makePlatformPromise, makePromiseBuffer, PromiseBuffer } from '@sentry/utils';
 
 async function sleep(delay: number): Promise<void> {
   return makePlatformPromise(resolve => setTimeout(resolve, delay));

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -66,7 +66,7 @@
     "ember-qunit": "~4.6.0",
     "ember-resolver": "~8.0.0",
     "ember-sinon-qunit": "~5.0.0",
-    "ember-source": "~3.20.0",
+    "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/release/shas/cf1f34e2c5d94ea0797e8f27b472372a07443b95.tgz",
     "ember-source-channel-url": "~2.0.1",
     "ember-template-lint": "~2.9.1",
     "ember-test-selectors": "~5.5.0",

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -66,7 +66,7 @@
     "ember-qunit": "~4.6.0",
     "ember-resolver": "~8.0.0",
     "ember-sinon-qunit": "~5.0.0",
-    "ember-source": "https://s3.amazonaws.com/builds.emberjs.com/release/shas/cf1f34e2c5d94ea0797e8f27b472372a07443b95.tgz",
+    "ember-source": "~3.20.0",
     "ember-source-channel-url": "~2.0.1",
     "ember-template-lint": "~2.9.1",
     "ember-test-selectors": "~5.5.0",

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -18,7 +18,7 @@ import {
   Transaction,
   User,
 } from '@sentry/types';
-import { dateTimestampInSeconds, getGlobalObject, isPlainObject, isThenable, makeSyncPromise } from '@sentry/utils';
+import { dateTimestampInSeconds, getGlobalObject, isPlainObject, isThenable, makePlatformPromise } from '@sentry/utils';
 
 import { Session } from './session';
 
@@ -459,7 +459,7 @@ export class Scope implements ScopeInterface {
     hint?: EventHint,
     index: number = 0,
   ): PromiseLike<Event | null> {
-    return makeSyncPromise<Event | null>((resolve, reject) => {
+    return makePlatformPromise<Event | null>((resolve, reject) => {
       const processor = processors[index];
       if (event === null || typeof processor !== 'function') {
         resolve(event);

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -18,7 +18,7 @@ import {
   Transaction,
   User,
 } from '@sentry/types';
-import { dateTimestampInSeconds, getGlobalObject, isPlainObject, isThenable, SyncPromise } from '@sentry/utils';
+import { dateTimestampInSeconds, getGlobalObject, isPlainObject, isThenable, makeSyncPromise } from '@sentry/utils';
 
 import { Session } from './session';
 
@@ -459,7 +459,7 @@ export class Scope implements ScopeInterface {
     hint?: EventHint,
     index: number = 0,
   ): PromiseLike<Event | null> {
-    return new SyncPromise<Event | null>((resolve, reject) => {
+    return makeSyncPromise<Event | null>((resolve, reject) => {
       const processor = processors[index];
       if (event === null || typeof processor !== 'function') {
         resolve(event);

--- a/packages/node/src/backend.ts
+++ b/packages/node/src/backend.ts
@@ -7,7 +7,7 @@ import {
   extractExceptionKeysForMessage,
   isError,
   isPlainObject,
-  makeSyncPromise,
+  makePlatformPromise,
   normalizeToSize,
 } from '@sentry/utils';
 
@@ -55,7 +55,7 @@ export class NodeBackend extends BaseBackend<NodeOptions> {
       mechanism.synthetic = true;
     }
 
-    return makeSyncPromise<Event>((resolve, reject) =>
+    return makePlatformPromise<Event>((resolve, reject) =>
       parseError(ex as Error, this._options)
         .then(event => {
           addExceptionTypeValue(event, undefined, undefined);
@@ -80,7 +80,7 @@ export class NodeBackend extends BaseBackend<NodeOptions> {
       message,
     };
 
-    return makeSyncPromise<Event>(resolve => {
+    return makePlatformPromise<Event>(resolve => {
       if (this._options.attachStacktrace && hint && hint.syntheticException) {
         const stack = hint.syntheticException ? extractStackFromError(hint.syntheticException) : [];
         void parseStack(stack, this._options)

--- a/packages/node/src/eventbuilder.ts
+++ b/packages/node/src/eventbuilder.ts
@@ -6,8 +6,8 @@ import {
   extractExceptionKeysForMessage,
   isError,
   isPlainObject,
+  makePlatformPromise,
   normalizeToSize,
-  SyncPromise,
 } from '@sentry/utils';
 
 import { extractStackFromError, parseError, parseStack, prepareFramesForEvent } from './parsers';
@@ -47,7 +47,7 @@ export function eventFromException(options: Options, exception: unknown, hint?: 
     mechanism.synthetic = true;
   }
 
-  return new SyncPromise<Event>((resolve, reject) =>
+  return makePlatformPromise<Event>((resolve, reject) =>
     parseError(ex as Error, options)
       .then(event => {
         addExceptionTypeValue(event, undefined, undefined);
@@ -78,7 +78,7 @@ export function eventFromMessage(
     message,
   };
 
-  return new SyncPromise<Event>(resolve => {
+  return makePlatformPromise<Event>(resolve => {
     if (options.attachStacktrace && hint && hint.syntheticException) {
       const stack = hint.syntheticException ? extractStackFromError(hint.syntheticException) : [];
       void parseStack(stack, options)

--- a/packages/node/src/integrations/linkederrors.ts
+++ b/packages/node/src/integrations/linkederrors.ts
@@ -1,6 +1,6 @@
 import { addGlobalEventProcessor, getCurrentHub } from '@sentry/core';
 import { Event, EventHint, Exception, ExtendedError, Integration } from '@sentry/types';
-import { isInstanceOf, makeSyncPromise } from '@sentry/utils';
+import { isInstanceOf, makePlatformPromise, makePlatformResolvedPromise } from '@sentry/utils';
 
 import { getExceptionFromError } from '../parsers';
 
@@ -56,10 +56,10 @@ export class LinkedErrors implements Integration {
    */
   private _handler(event: Event, hint?: EventHint): PromiseLike<Event> {
     if (!event.exception || !event.exception.values || !hint || !isInstanceOf(hint.originalException, Error)) {
-      return makeSyncPromise().resolve(event);
+      return makePlatformResolvedPromise(event);
     }
 
-    return makeSyncPromise<Event>(resolve => {
+    return makePlatformPromise<Event>(resolve => {
       void this._walkErrorTree(hint.originalException as Error, this._key)
         .then((linkedErrors: Exception[]) => {
           if (event && event.exception && event.exception.values) {
@@ -78,9 +78,9 @@ export class LinkedErrors implements Integration {
    */
   private _walkErrorTree(error: ExtendedError, key: string, stack: Exception[] = []): PromiseLike<Exception[]> {
     if (!isInstanceOf(error[key], Error) || stack.length + 1 >= this._limit) {
-      return makeSyncPromise().resolve(stack);
+      return makePlatformResolvedPromise(stack);
     }
-    return makeSyncPromise<Exception[]>((resolve, reject) => {
+    return makePlatformPromise<Exception[]>((resolve, reject) => {
       void getExceptionFromError(error[key])
         .then((exception: Exception) => {
           void this._walkErrorTree(error[key], key, [exception, ...stack])

--- a/packages/node/src/parsers.ts
+++ b/packages/node/src/parsers.ts
@@ -1,5 +1,5 @@
 import { Event, Exception, ExtendedError, StackFrame } from '@sentry/types';
-import { addContextToFrame, basename, dirname, makeSyncPromise } from '@sentry/utils';
+import { addContextToFrame, basename, dirname, makePlatformPromise, makePlatformResolvedPromise } from '@sentry/utils';
 import { readFile } from 'fs';
 import { LRUMap } from 'lru_map';
 
@@ -71,10 +71,10 @@ function getModule(filename: string, base?: string): string {
 function readSourceFiles(filenames: string[]): PromiseLike<{ [key: string]: string | null }> {
   // we're relying on filenames being de-duped already
   if (filenames.length === 0) {
-    return makeSyncPromise().resolve({});
+    return makePlatformResolvedPromise({});
   }
 
-  return makeSyncPromise<{
+  return makePlatformPromise<{
     [key: string]: string | null;
   }>(resolve => {
     const sourceFiles: {
@@ -176,7 +176,7 @@ export function parseStack(stack: stacktrace.StackFrame[], options?: NodeOptions
 
   // We do an early return if we do not want to fetch context liens
   if (linesOfContext <= 0) {
-    return makeSyncPromise().resolve(frames);
+    return makePlatformResolvedPromise(frames);
   }
 
   try {
@@ -184,7 +184,7 @@ export function parseStack(stack: stacktrace.StackFrame[], options?: NodeOptions
   } catch (_) {
     // This happens in electron for example where we are not able to read files from asar.
     // So it's fine, we recover be just returning all frames without pre/post context.
-    return makeSyncPromise().resolve(frames);
+    return makePlatformResolvedPromise(frames);
   }
 }
 
@@ -199,7 +199,7 @@ function addPrePostContext(
   frames: StackFrame[],
   linesOfContext: number,
 ): PromiseLike<StackFrame[]> {
-  return makeSyncPromise<StackFrame[]>(resolve =>
+  return makePlatformPromise<StackFrame[]>(resolve =>
     readSourceFiles(filesToRead).then(sourceFiles => {
       const result = frames.map(frame => {
         if (frame.filename && sourceFiles[frame.filename]) {
@@ -226,7 +226,7 @@ function addPrePostContext(
 export function getExceptionFromError(error: Error, options?: NodeOptions): PromiseLike<Exception> {
   const name = error.name || error.constructor.name;
   const stack = extractStackFromError(error);
-  return makeSyncPromise<Exception>(resolve =>
+  return makePlatformPromise<Exception>(resolve =>
     parseStack(stack, options).then(frames => {
       const result = {
         stacktrace: {
@@ -244,7 +244,7 @@ export function getExceptionFromError(error: Error, options?: NodeOptions): Prom
  * @hidden
  */
 export function parseError(error: ExtendedError, options?: NodeOptions): PromiseLike<Event> {
-  return makeSyncPromise<Event>(resolve =>
+  return makePlatformPromise<Event>(resolve =>
     getExceptionFromError(error, options).then((exception: Exception) => {
       resolve({
         exception: {

--- a/packages/node/src/transports/base/index.ts
+++ b/packages/node/src/transports/base/index.ts
@@ -212,6 +212,7 @@ export abstract class BaseTransport implements Transport {
           if (!this.module) {
             throw new SentryError('No module available');
           }
+
           const options = this._getRequestOptions(this.urlParser(sentryRequest.url));
           const req = this.module.request(options, res => {
             const statusCode = res.statusCode || 500;

--- a/packages/utils/src/promisebuffer.ts
+++ b/packages/utils/src/promisebuffer.ts
@@ -1,8 +1,8 @@
 import { SentryError } from './error';
 import { makePlatformPromise, makePlatformRejectedPromise, makePlatformResolvedPromise } from './syncpromise';
 
-function allPromises<U = unknown>(collection: Array<U | PromiseLike<U>>): PromiseLike<U[] | null> {
-  return makePlatformPromise<U[] | null>((resolve, reject) => {
+function allPromises<U = unknown>(collection: Array<U | PromiseLike<U>>): PromiseLike<U[]> {
+  return makePlatformPromise<U[]>((resolve, reject) => {
     if (collection.length === 0) {
       resolve(null);
       return;
@@ -24,7 +24,7 @@ function allPromises<U = unknown>(collection: Array<U | PromiseLike<U>>): Promis
 
 export interface PromiseBuffer<T> {
   length(): number;
-  add(taskProducer: () => PromiseLike<T | SentryError>): PromiseLike<T | SentryError>;
+  add(taskProducer: () => PromiseLike<T>): PromiseLike<T>;
   remove(task: PromiseLike<T>): PromiseLike<T>;
   drain(timeout?: number): PromiseLike<boolean>;
 }
@@ -60,8 +60,9 @@ export function makePromiseBuffer<T>(limit?: number): PromiseBuffer<T> {
    *        limit check.
    * @returns The original promise.
    */
-  function add(taskProducer: () => PromiseLike<T>): PromiseLike<T | SentryError> {
+  function add(taskProducer: () => PromiseLike<T>): PromiseLike<T> {
     if (!isReady()) {
+      // @ts-ignore this needs to be handled
       return makePlatformRejectedPromise(new SentryError('Not adding Promise due to buffer limit reached.'));
     }
 

--- a/packages/utils/src/syncpromise.ts
+++ b/packages/utils/src/syncpromise.ts
@@ -22,7 +22,6 @@ type PromiseExecutor<T> = (
 type Handler<T> = [boolean, (value: T) => void, (reason: any) => any];
 
 export interface SyncPromise<T> extends PromiseLike<T> {
-  getValue: () => T | undefined;
   finally: (onfinally?: (() => void) | null) => PromiseLike<T>;
   catch: <TResult = never>(
     onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null,
@@ -74,10 +73,6 @@ export function makeSyncPromise<T>(executor?: PromiseExecutor<T>): SyncPromise<T
   let _handlers: Array<Handler<T>> = [];
   let _state: States = States.PENDING;
   let _value: T | undefined = undefined;
-
-  function getValue(): T | undefined {
-    return _value;
-  }
 
   function maybeExecuteHandlers() {
     if (_state === States.PENDING) {
@@ -220,7 +215,6 @@ export function makeSyncPromise<T>(executor?: PromiseExecutor<T>): SyncPromise<T
   }
 
   const promise: SyncPromise<T> = {
-    getValue,
     then,
     finally: _finally,
     catch: _catch,

--- a/packages/utils/src/syncpromise.ts
+++ b/packages/utils/src/syncpromise.ts
@@ -27,7 +27,7 @@ export interface SyncPromise<T> extends PromiseLike<T> {
   catch: <TResult = never>(
     onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null,
   ) => PromiseLike<T | TResult>;
-  resolve: (value: T | PromiseLike<T>) => PromiseLike<T>;
+  resolve: <T>(value: T | PromiseLike<T>) => PromiseLike<T>;
   reject: <T = never>(reason?: any) => PromiseLike<T>;
 }
 /**

--- a/packages/utils/src/syncpromise.ts
+++ b/packages/utils/src/syncpromise.ts
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/typedef */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { isBrowserBundle } from './env';
 import { isThenable } from './is';
 
 /** SyncPromise internal states */
@@ -33,35 +32,38 @@ export interface SyncPromise<T> extends PromiseLike<T> {
 }
 
 /**
- *
+ * Create a resolved promise
  * @param value
  */
 export function makePlatformResolvedPromise<T>(value: T): PromiseLike<T> {
-  if (isBrowserBundle()) {
-    return Promise.resolve(value);
-  }
+  // Flip this when dropping support for IE11
+  // if (isBrowserBundle()) {
+  //   return Promise.resolve(value);
+  // }
   return makeSyncPromise().resolve(value);
 }
 
 /**
- *
+ * Create a rejected promise
  * @param reason
  */
 export function makePlatformRejectedPromise<T>(reason: T): PromiseLike<T> {
-  if (isBrowserBundle()) {
-    return Promise.reject(reason);
-  }
+  // Flip this when dropping support for IE11
+  // if (isBrowserBundle()) {
+  //   return Promise.reject(reason);
+  // }
   return makeSyncPromise().reject(reason);
 }
 
-const noopExecutor = (_reject: any, _resolve: any) => void 0;
 /**
- *
+ * Create a platform agnostic promise
+ * @param executor promise executor fn
  */
 export function makePlatformPromise<T>(executor?: PromiseExecutor<T>): Promise<T> | SyncPromise<T> {
-  if (isBrowserBundle()) {
-    return new Promise(executor || noopExecutor) as Promise<T>;
-  }
+  // Flip this when dropping support for IE11
+  // if (isBrowserBundle()) {
+  //   return new Promise(executor || noopExecutor) as Promise<T>;
+  // }
   return makeSyncPromise(executor);
 }
 /**

--- a/packages/utils/test/is.test.ts
+++ b/packages/utils/test/is.test.ts
@@ -1,7 +1,7 @@
 import { resolvedSyncPromise } from '../dist';
 import { isDOMError, isDOMException, isError, isErrorEvent, isInstanceOf, isPrimitive, isThenable } from '../src/is';
 import { supportsDOMError, supportsDOMException, supportsErrorEvent } from '../src/supports';
-import { makePlatformResolvedPromise,makeSyncPromise } from '../src/syncpromise';
+import { makePlatformResolvedPromise, makeSyncPromise } from '../src/syncpromise';
 
 class SentryError extends Error {
   public name: string;

--- a/packages/utils/test/is.test.ts
+++ b/packages/utils/test/is.test.ts
@@ -2,16 +2,7 @@ import { resolvedSyncPromise } from '../dist';
 import { isDOMError, isDOMException, isError, isErrorEvent, isInstanceOf, isPrimitive, isThenable } from '../src/is';
 import { supportsDOMError, supportsDOMException, supportsErrorEvent } from '../src/supports';
 import { makeSyncPromise, makePlatformResolvedPromise } from '../src/syncpromise';
-
-class SentryError extends Error {
-  public name: string;
-
-  public constructor(public message: string) {
-    super(message);
-    this.name = new.target.prototype.constructor.name;
-    Object.setPrototypeOf(this, new.target.prototype);
-  }
-}
+import { SentryError } from '../src/error';
 
 if (supportsDOMError()) {
   describe('isDOMError()', () => {

--- a/packages/utils/test/is.test.ts
+++ b/packages/utils/test/is.test.ts
@@ -1,8 +1,17 @@
 import { resolvedSyncPromise } from '../dist';
 import { isDOMError, isDOMException, isError, isErrorEvent, isInstanceOf, isPrimitive, isThenable } from '../src/is';
 import { supportsDOMError, supportsDOMException, supportsErrorEvent } from '../src/supports';
-import { makeSyncPromise, makePlatformResolvedPromise } from '../src/syncpromise';
-import { SentryError } from '../src/error';
+import { makePlatformResolvedPromise,makeSyncPromise } from '../src/syncpromise';
+
+class SentryError extends Error {
+  public name: string;
+
+  public constructor(public message: string) {
+    super(message);
+    this.name = new.target.prototype.constructor.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
 
 if (supportsDOMError()) {
   describe('isDOMError()', () => {

--- a/packages/utils/test/is.test.ts
+++ b/packages/utils/test/is.test.ts
@@ -1,7 +1,7 @@
 import { resolvedSyncPromise } from '../dist';
 import { isDOMError, isDOMException, isError, isErrorEvent, isInstanceOf, isPrimitive, isThenable } from '../src/is';
 import { supportsDOMError, supportsDOMException, supportsErrorEvent } from '../src/supports';
-import { makeSyncPromise } from '../src/syncpromise';
+import { makeSyncPromise, makePlatformResolvedPromise } from '../src/syncpromise';
 
 class SentryError extends Error {
   public name: string;
@@ -77,6 +77,7 @@ describe('isThenable()', () => {
   test('should work as advertised', () => {
     expect(isThenable(Promise.resolve(true))).toEqual(true);
     expect(isThenable(makeSyncPromise().resolve(true))).toEqual(true);
+    expect(isThenable(makePlatformResolvedPromise(true))).toEqual(true);
 
     expect(isThenable(undefined)).toEqual(false);
     expect(isThenable(null)).toEqual(false);

--- a/packages/utils/test/is.test.ts
+++ b/packages/utils/test/is.test.ts
@@ -1,6 +1,7 @@
 import { resolvedSyncPromise } from '../dist';
 import { isDOMError, isDOMException, isError, isErrorEvent, isInstanceOf, isPrimitive, isThenable } from '../src/is';
 import { supportsDOMError, supportsDOMException, supportsErrorEvent } from '../src/supports';
+import { makeSyncPromise } from '../src/syncpromise';
 
 class SentryError extends Error {
   public name: string;
@@ -75,7 +76,7 @@ describe('isPrimitive()', () => {
 describe('isThenable()', () => {
   test('should work as advertised', () => {
     expect(isThenable(Promise.resolve(true))).toEqual(true);
-    expect(isThenable(resolvedSyncPromise(true))).toEqual(true);
+    expect(isThenable(makeSyncPromise().resolve(true))).toEqual(true);
 
     expect(isThenable(undefined)).toEqual(false);
     expect(isThenable(null)).toEqual(false);

--- a/packages/utils/test/promisebuffer.test.ts
+++ b/packages/utils/test/promisebuffer.test.ts
@@ -1,11 +1,11 @@
 import { makePromiseBuffer } from '../src/promisebuffer';
-import { makeSyncPromise } from '../src/syncpromise';
+import { makePlatformPromise } from '../src/syncpromise';
 
 describe('PromiseBuffer', () => {
   describe('add()', () => {
     test('no limit', () => {
       const buffer = makePromiseBuffer();
-      const p = jest.fn(() => makeSyncPromise(resolve => setTimeout(resolve)));
+      const p = jest.fn(() => makePlatformPromise(resolve => setTimeout(resolve)));
       void buffer.add(p);
       expect(buffer.$.length).toEqual(1);
     });
@@ -14,10 +14,10 @@ describe('PromiseBuffer', () => {
       const buffer = makePromiseBuffer(1);
       let task1;
       const producer1 = jest.fn(() => {
-        task1 = makeSyncPromise(resolve => setTimeout(resolve));
+        task1 = makePlatformPromise(resolve => setTimeout(resolve));
         return task1;
       });
-      const producer2 = jest.fn(() => makeSyncPromise(resolve => setTimeout(resolve)));
+      const producer2 = jest.fn(() => makePlatformPromise(resolve => setTimeout(resolve)));
       expect(buffer.add(producer1)).toEqual(task1);
       void expect(buffer.add(producer2)).rejects.toThrowError();
       expect(buffer.$.length).toEqual(1);
@@ -30,7 +30,7 @@ describe('PromiseBuffer', () => {
     test('without timeout', async () => {
       const buffer = makePromiseBuffer();
       for (let i = 0; i < 5; i++) {
-        void buffer.add(() => makeSyncPromise(resolve => setTimeout(resolve)));
+        void buffer.add(() => makePlatformPromise(resolve => setTimeout(resolve)));
       }
       expect(buffer.$.length).toEqual(5);
       const result = await buffer.drain();
@@ -41,7 +41,7 @@ describe('PromiseBuffer', () => {
     test('with timeout', async () => {
       const buffer = makePromiseBuffer();
       for (let i = 0; i < 5; i++) {
-        void buffer.add(() => makeSyncPromise(resolve => setTimeout(resolve, 100)));
+        void buffer.add(() => makePlatformPromise(resolve => setTimeout(resolve, 100)));
       }
       expect(buffer.$.length).toEqual(5);
       const result = await buffer.drain(50);
@@ -59,7 +59,7 @@ describe('PromiseBuffer', () => {
 
   test('resolved promises should not show up in buffer length', async () => {
     const buffer = makePromiseBuffer();
-    const producer = () => makeSyncPromise(resolve => setTimeout(resolve));
+    const producer = () => makePlatformPromise(resolve => setTimeout(resolve));
     const task = buffer.add(producer);
     expect(buffer.$.length).toEqual(1);
     await task;
@@ -68,7 +68,7 @@ describe('PromiseBuffer', () => {
 
   test('rejected promises should not show up in buffer length', async () => {
     const buffer = makePromiseBuffer();
-    const producer = () => makeSyncPromise((_, reject) => setTimeout(reject));
+    const producer = () => makePlatformPromise((_, reject) => setTimeout(reject));
     const task = buffer.add(producer);
     expect(buffer.$.length).toEqual(1);
     try {
@@ -81,7 +81,7 @@ describe('PromiseBuffer', () => {
 
   test('resolved task should give an access to the return value', async () => {
     const buffer = makePromiseBuffer<string>();
-    const producer = () => makeSyncPromise<string>(resolve => setTimeout(() => resolve('test')));
+    const producer = () => makePlatformPromise<string>(resolve => setTimeout(() => resolve('test')));
     const task = buffer.add(producer);
     const result = await task;
     expect(result).toEqual('test');
@@ -90,7 +90,7 @@ describe('PromiseBuffer', () => {
   test('rejected task should give an access to the return value', async () => {
     expect.assertions(1);
     const buffer = makePromiseBuffer<string>();
-    const producer = () => makeSyncPromise<string>((_, reject) => setTimeout(() => reject(new Error('whoops'))));
+    const producer = () => makePlatformPromise<string>((_, reject) => setTimeout(() => reject(new Error('whoops'))));
     const task = buffer.add(producer);
     try {
       await task;

--- a/packages/utils/test/syncpromise.test.ts
+++ b/packages/utils/test/syncpromise.test.ts
@@ -1,4 +1,9 @@
-import { makeSyncPromise, SyncPromise } from '../src/syncpromise';
+import {
+  makePlatformRejectedPromise,
+  makePlatformResolvedPromise,
+  makeSyncPromise,
+  SyncPromise,
+} from '../src/syncpromise';
 
 describe('SyncPromise', () => {
   test('simple', () => {

--- a/packages/utils/test/syncpromise.test.ts
+++ b/packages/utils/test/syncpromise.test.ts
@@ -153,34 +153,15 @@ describe('SyncPromise', () => {
   });
 
   test('calling the callback not immediatly', () => {
-    jest.useFakeTimers();
-    expect.assertions(4);
+    jest.useRealTimers();
 
-    const qp = makeSyncPromise<number>(resolve =>
+    return makeSyncPromise<number>(resolve =>
       setTimeout(() => {
         resolve(2);
-      }),
-    );
-
-    void qp
-      .then(value => {
-        expect(value).toEqual(2);
-      })
-      .then(null, () => {
-        // no-empty
-      });
-
-    expect(qp.getValue()).toBe(undefined);
-
-    void qp
-      .then(value => {
-        expect(value).toEqual(2);
-      })
-      .then(null, () => {
-        // no-empty
-      });
-    jest.runAllTimers();
-    expect(qp.getValue()).toBe(2);
+      }, 10),
+    ).then(v => {
+      expect(v).toEqual(2);
+    });
   });
 
   test('multiple then returning undefined', () => {

--- a/packages/utils/test/syncpromise.test.ts
+++ b/packages/utils/test/syncpromise.test.ts
@@ -162,19 +162,23 @@ describe('SyncPromise', () => {
       }),
     );
 
-    qp.then(value => {
-      expect(value).toEqual(2);
-    }).then(null, () => {
-      // no-empty
-    });
+    void qp
+      .then(value => {
+        expect(value).toEqual(2);
+      })
+      .then(null, () => {
+        // no-empty
+      });
 
     expect(qp.getValue()).toBe(undefined);
 
-    qp.then(value => {
-      expect(value).toEqual(2);
-    }).then(null, () => {
-      // no-empty
-    });
+    void qp
+      .then(value => {
+        expect(value).toEqual(2);
+      })
+      .then(null, () => {
+        // no-empty
+      });
     jest.runAllTimers();
     expect(qp.getValue()).toBe(2);
   });


### PR DESCRIPTION
Deprecate syncpromise class and create a mechanism that will allow us to switch to a native promise implementation at some point. Since syncPromise seems to pretty much defeat the purpose of promises, maybe we can remove it entirely?