### PR TITLE
ref(core): remove ternary

### DIFF
--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -35,8 +35,7 @@ export function sessionToSentryRequest(session: Session | SessionAggregates, api
     ...(sdkInfo && { sdk: sdkInfo }),
     ...(!!api.tunnel && { dsn: api.dsn.toString() }),
   });
-  // I know this is hacky but we don't want to add `session` to request type since it's never rate limited
-  const type: SentryRequestType = 'aggregates' in session ? ('sessions' as SentryRequestType) : 'session';
+  const type: SentryRequestType = 'session';
   const itemHeaders = JSON.stringify({
     type,
   });


### PR DESCRIPTION
Found this while looking through minified code as it compiled to `i = 'aggregates' in t ? 'sessions' : 'session'`