### PR TITLE
ref(browser): Make `sendEvent` an abstract method on the BaseTransport

### DIFF
--- a/packages/browser/src/transports/base.ts
+++ b/packages/browser/src/transports/base.ts
@@ -20,7 +20,6 @@ import {
   makePromiseBuffer,
   parseRetryAfterHeader,
   PromiseBuffer,
-  SentryError,
 } from '@sentry/utils';
 
 import { sendReport } from './utils';
@@ -62,13 +61,6 @@ export abstract class BaseTransport implements Transport {
         }
       });
     }
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public sendEvent(_: Event): PromiseLike<SentryResponse> {
-    throw new SentryError('Transport Class has to implement `sendEvent` method');
   }
 
   /**
@@ -222,4 +214,9 @@ export abstract class BaseTransport implements Transport {
     }
     return false;
   }
+
+  /**
+   * @inheritDoc
+   */
+  public abstract sendEvent(_: Event): PromiseLike<SentryResponse>;
 }

--- a/packages/browser/test/unit/transports/base.test.ts
+++ b/packages/browser/test/unit/transports/base.test.ts
@@ -112,12 +112,13 @@ describe('BaseTransport', () => {
   });
 
   it('doesnt provide sendEvent() implementation', () => {
+    expect.assertions(1);
     const transport = new SimpleTransport({ dsn: testDsn });
 
     try {
       void transport.sendEvent({});
     } catch (e) {
-      expect(e.message).toBe('Transport Class has to implement `sendEvent` method');
+      expect(e).toBeDefined();
     }
   });
 


### PR DESCRIPTION
This patch makes the public `sendEvent` method abstract on the
`BaseTransport`. This means that consumers of the `BaseTransport` must
always make sure to define a `sendEvent` on their transport
implementation. This helps save on bundle size.
