### PR TITLE
ref(browser): Consolidate transport methods 

### DIFF
--- a/packages/browser/src/transports/base.ts
+++ b/packages/browser/src/transports/base.ts
@@ -3,14 +3,19 @@ import {
   getEnvelopeEndpointWithUrlEncodedAuth,
   getStoreEndpointWithUrlEncodedAuth,
   initAPIDetails,
+  eventToSentryRequest,
+  sessionToSentryRequest,
 } from '@sentry/core';
+import { Session } from '@sentry/hub';
 import {
   Event,
   Outcome,
   Response as SentryResponse,
+  SentryRequest,
   SentryRequestType,
   Transport,
   TransportOptions,
+  Response,
 } from '@sentry/types';
 import {
   dateTimestampInSeconds,
@@ -67,8 +72,15 @@ export abstract class BaseTransport implements Transport {
   /**
    * @inheritDoc
    */
-  public sendEvent(_: Event): PromiseLike<SentryResponse> {
-    throw new SentryError('Transport Class has to implement `sendEvent` method');
+  public sendEvent(event: Event): PromiseLike<Response> {
+    return this._sendRequest(eventToSentryRequest(event, this._api), event);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public sendSession(session: Session): PromiseLike<Response> {
+    return this._sendRequest(sessionToSentryRequest(session, this._api), session);
   }
 
   /**
@@ -222,4 +234,9 @@ export abstract class BaseTransport implements Transport {
     }
     return false;
   }
+
+  protected abstract _sendRequest(
+    sentryRequest: SentryRequest,
+    originalPayload: Event | Session,
+  ): PromiseLike<Response>;
 }

--- a/packages/browser/src/transports/base.ts
+++ b/packages/browser/src/transports/base.ts
@@ -6,13 +6,13 @@ import {
   initAPIDetails,
   sessionToSentryRequest,
 } from '@sentry/core';
-import { Session } from '@sentry/hub';
 import {
   Event,
   Outcome,
   Response as SentryResponse,
   SentryRequest,
   SentryRequestType,
+  Session,
   Transport,
   TransportOptions,
 } from '@sentry/types';

--- a/packages/browser/src/transports/base.ts
+++ b/packages/browser/src/transports/base.ts
@@ -10,7 +10,6 @@ import { Session } from '@sentry/hub';
 import {
   Event,
   Outcome,
-  Response,
   Response as SentryResponse,
   SentryRequest,
   SentryRequestType,
@@ -71,14 +70,14 @@ export abstract class BaseTransport implements Transport {
   /**
    * @inheritDoc
    */
-  public sendEvent(event: Event): PromiseLike<Response> {
+  public sendEvent(event: Event): PromiseLike<SentryResponse> {
     return this._sendRequest(eventToSentryRequest(event, this._api), event);
   }
 
   /**
    * @inheritDoc
    */
-  public sendSession(session: Session): PromiseLike<Response> {
+  public sendSession(session: Session): PromiseLike<SentryResponse> {
     return this._sendRequest(sessionToSentryRequest(session, this._api), session);
   }
 
@@ -237,5 +236,5 @@ export abstract class BaseTransport implements Transport {
   protected abstract _sendRequest(
     sentryRequest: SentryRequest,
     originalPayload: Event | Session,
-  ): PromiseLike<Response>;
+  ): PromiseLike<SentryResponse>;
 }

--- a/packages/browser/src/transports/base.ts
+++ b/packages/browser/src/transports/base.ts
@@ -1,21 +1,21 @@
 import {
   APIDetails,
+  eventToSentryRequest,
   getEnvelopeEndpointWithUrlEncodedAuth,
   getStoreEndpointWithUrlEncodedAuth,
   initAPIDetails,
-  eventToSentryRequest,
   sessionToSentryRequest,
 } from '@sentry/core';
 import { Session } from '@sentry/hub';
 import {
   Event,
   Outcome,
+  Response,
   Response as SentryResponse,
   SentryRequest,
   SentryRequestType,
   Transport,
   TransportOptions,
-  Response,
 } from '@sentry/types';
 import {
   dateTimestampInSeconds,
@@ -25,7 +25,6 @@ import {
   makePromiseBuffer,
   parseRetryAfterHeader,
   PromiseBuffer,
-  SentryError,
 } from '@sentry/utils';
 
 import { sendReport } from './utils';

--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -1,4 +1,3 @@
-import { eventToSentryRequest, sessionToSentryRequest } from '@sentry/core';
 import { Event, Response, SentryRequest, Session, TransportOptions } from '@sentry/types';
 import { SentryError, supportsReferrerPolicy, SyncPromise } from '@sentry/utils';
 
@@ -18,24 +17,10 @@ export class FetchTransport extends BaseTransport {
   }
 
   /**
-   * @inheritDoc
-   */
-  public sendEvent(event: Event): PromiseLike<Response> {
-    return this._sendRequest(eventToSentryRequest(event, this._api), event);
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public sendSession(session: Session): PromiseLike<Response> {
-    return this._sendRequest(sessionToSentryRequest(session, this._api), session);
-  }
-
-  /**
    * @param sentryRequest Prepared SentryRequest to be delivered
    * @param originalPayload Original payload used to create SentryRequest
    */
-  private _sendRequest(sentryRequest: SentryRequest, originalPayload: Event | Session): PromiseLike<Response> {
+  protected _sendRequest(sentryRequest: SentryRequest, originalPayload: Event | Session): PromiseLike<Response> {
     if (this._isRateLimited(sentryRequest.type)) {
       this.recordLostEvent('ratelimit_backoff', sentryRequest.type);
 

--- a/packages/browser/src/transports/xhr.ts
+++ b/packages/browser/src/transports/xhr.ts
@@ -1,4 +1,3 @@
-import { eventToSentryRequest, sessionToSentryRequest } from '@sentry/core';
 import { Event, Response, SentryRequest, Session } from '@sentry/types';
 import { SentryError, SyncPromise } from '@sentry/utils';
 
@@ -7,24 +6,10 @@ import { BaseTransport } from './base';
 /** `XHR` based transport */
 export class XHRTransport extends BaseTransport {
   /**
-   * @inheritDoc
-   */
-  public sendEvent(event: Event): PromiseLike<Response> {
-    return this._sendRequest(eventToSentryRequest(event, this._api), event);
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public sendSession(session: Session): PromiseLike<Response> {
-    return this._sendRequest(sessionToSentryRequest(session, this._api), session);
-  }
-
-  /**
    * @param sentryRequest Prepared SentryRequest to be delivered
    * @param originalPayload Original payload used to create SentryRequest
    */
-  private _sendRequest(sentryRequest: SentryRequest, originalPayload: Event | Session): PromiseLike<Response> {
+  protected _sendRequest(sentryRequest: SentryRequest, originalPayload: Event | Session): PromiseLike<Response> {
     if (this._isRateLimited(sentryRequest.type)) {
       this.recordLostEvent('ratelimit_backoff', sentryRequest.type);
 

--- a/packages/browser/test/unit/integrations/helpers.test.ts
+++ b/packages/browser/test/unit/integrations/helpers.test.ts
@@ -1,5 +1,5 @@
 import { WrappedFunction } from '@sentry/types';
-import { SinonSpy, spy } from 'sinon';
+import { spy } from 'sinon';
 
 import { wrap } from '../../../src/helpers';
 

--- a/packages/browser/test/unit/transports/base.test.ts
+++ b/packages/browser/test/unit/transports/base.test.ts
@@ -112,12 +112,13 @@ describe('BaseTransport', () => {
   });
 
   it('doesnt provide sendEvent() implementation', () => {
+    expect.assertions(1);
     const transport = new SimpleTransport({ dsn: testDsn });
 
     try {
       void transport.sendEvent({});
     } catch (e) {
-      expect(e.message).toBe('Transport Class has to implement `sendEvent` method');
+      expect(e).toBeDefined();
     }
   });
 


### PR DESCRIPTION
Now transports only override a protected `_sendRequest`. Removes duplication of `sendEvent`.

Supercedes https://github.com/getsentry/sentry-javascript/pull/4339