### PR TITLE
test(browser): Add integration tests for `configureScope`

### DIFF
--- a/packages/integration-tests/suites/public-api/configureScope/clear_scope/subject.js
+++ b/packages/integration-tests/suites/public-api/configureScope/clear_scope/subject.js
@@ -1,0 +1,8 @@
+Sentry.configureScope(scope => {
+  scope.setTag('foo', 'bar');
+  scope.setUser({ id: 'baz' });
+  scope.setExtra('qux', 'quux');
+  scope.clear();
+});
+
+Sentry.captureMessage('cleared_scope');

--- a/packages/integration-tests/suites/public-api/configureScope/clear_scope/test.ts
+++ b/packages/integration-tests/suites/public-api/configureScope/clear_scope/test.ts
@@ -1,0 +1,15 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { getSentryRequest } from '../../../../utils/helpers';
+
+sentryTest('should clear previously set properties of a scope', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  const eventData = await getSentryRequest(page, url);
+
+  expect(eventData.message).toBe('cleared_scope');
+  expect(eventData.user).toBeUndefined();
+  expect(eventData.tags).toBeUndefined();
+  expect(eventData.extra).toBeUndefined();
+});

--- a/packages/integration-tests/suites/public-api/configureScope/init.js
+++ b/packages/integration-tests/suites/public-api/configureScope/init.js
@@ -1,0 +1,7 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+});

--- a/packages/integration-tests/suites/public-api/configureScope/set_properties/subject.js
+++ b/packages/integration-tests/suites/public-api/configureScope/set_properties/subject.js
@@ -1,0 +1,7 @@
+Sentry.configureScope(scope => {
+  scope.setTag('foo', 'bar');
+  scope.setUser({ id: 'baz' });
+  scope.setExtra('qux', 'quux');
+});
+
+Sentry.captureMessage('configured_scope');

--- a/packages/integration-tests/suites/public-api/configureScope/set_properties/test.ts
+++ b/packages/integration-tests/suites/public-api/configureScope/set_properties/test.ts
@@ -1,0 +1,15 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { getSentryRequest } from '../../../../utils/helpers';
+
+sentryTest('should set different properties of a scope', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  const eventData = await getSentryRequest(page, url);
+
+  expect(eventData.message).toBe('configured_scope');
+  expect(eventData.user).toMatchObject({ id: 'baz' });
+  expect(eventData.tags).toMatchObject({ foo: 'bar' });
+  expect(eventData.extra).toMatchObject({ qux: 'quux' });
+});

--- a/packages/integration-tests/suites/public-api/configureScope/template.hbs
+++ b/packages/integration-tests/suites/public-api/configureScope/template.hbs
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title></title>
+  <script src="{{htmlWebpackPlugin.options.initialization}}"></script>
+  </head>
+  <body>
+    <script src="{{htmlWebpackPlugin.options.subject}}"></script>
+  </body>
+</html>


### PR DESCRIPTION
Part of: #4333