### PR TITLE
fix(utils): Remove circular dependency in instrument

### DIFF
--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { WrappedFunction } from '@sentry/types';
 
-import { isDebugBuild } from '.';
+import { isDebugBuild } from './env';
 import { getGlobalObject } from './global';
 import { isInstanceOf, isString } from './is';
 import { logger } from './logger';


### PR DESCRIPTION
Instead of importing from the index, import directly from the file itself. This was causing warnings when bundling with rollup.