### PR TITLE
feat(tracing): add `autoSentryTrace` to enbale/disable sentry-trace

### DIFF
--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -177,6 +177,7 @@ export class BrowserTracing implements Integration {
       traceFetch,
       traceXHR,
       tracingOrigins,
+      autoSentryTrace,
       shouldCreateSpanForRequest,
     } = this.options;
 
@@ -190,7 +191,7 @@ export class BrowserTracing implements Integration {
       registerBackgroundTabDetection();
     }
 
-    instrumentOutgoingRequests({ traceFetch, traceXHR, tracingOrigins, shouldCreateSpanForRequest });
+    instrumentOutgoingRequests({ traceFetch, traceXHR, tracingOrigins, autoSentryTrace, shouldCreateSpanForRequest });
   }
 
   /** Create routing idle transaction. */

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -145,7 +145,7 @@ export function fetchCallback(
   handlerData: FetchData,
   shouldCreateSpan: (url: string) => boolean,
   spans: Record<string, Span>,
-  autoSentryTrace: boolean
+  autoSentryTrace: boolean,
 ): void {
   if (!hasTracingEnabled() || !(handlerData.fetchData && shouldCreateSpan(handlerData.fetchData.url))) {
     return;
@@ -214,7 +214,7 @@ export function xhrCallback(
   handlerData: XHRData,
   shouldCreateSpan: (url: string) => boolean,
   spans: Record<string, Span>,
-  autoSentryTrace: boolean
+  autoSentryTrace: boolean,
 ): void {
   if (
     !hasTracingEnabled() ||


### PR DESCRIPTION
This pr adds the tracing.config - `autoSentryTrace`, which is used to enbale/disable `sentry-trace` in the request header.

Because when i only use the `Sentry-javascript` SDK in the browser, if there are some async request before send the transaction to the server, would occur the cors issues.

Also see this issue [#4184](https://github.com/getsentry/sentry-javascript/issues/4184)