### PR TITLE
ref(core): Use `sdkProcessingMetadata` field for transaction sampling data

### DIFF
--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -55,13 +55,8 @@ export function eventToSentryRequest(event: Event, api: APIDetails): SentryReque
   const eventType = event.type || 'event';
   const useEnvelope = eventType === 'transaction' || !!api.tunnel;
 
-  const { transactionSampling, ...metadata } = event.debug_meta || {};
+  const { transactionSampling } = event.sdkProcessingMetadata || {};
   const { method: samplingMethod, rate: sampleRate } = transactionSampling || {};
-  if (Object.keys(metadata).length === 0) {
-    delete event.debug_meta;
-  } else {
-    event.debug_meta = metadata;
-  }
 
   // prevent this data from being sent to sentry
   delete event.sdkProcessingMetadata;

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -132,7 +132,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
       timestamp: this.endTimestamp,
       transaction: this.name,
       type: 'transaction',
-      debug_meta: this.metadata,
+      sdkProcessingMetadata: this.metadata,
     };
 
     const hasMeasurements = Object.keys(this._measurements).length > 0;

--- a/packages/types/src/debugMeta.ts
+++ b/packages/types/src/debugMeta.ts
@@ -3,7 +3,6 @@
  **/
 export interface DebugMeta {
   images?: Array<DebugImage>;
-  transactionSampling?: { rate?: number; method?: string };
 }
 
 /**


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/4252, a new `sdkProcessingMetadata` field was added to the `Scope` and `Event` interfaces, to provide a place to put data which is needed for in-SDK event processing but shouldn't be sent to Sentry. This refactors one step in that processing... process... to use the new field, eliminating the need to pull the data out of `debug_meta` before the event is sent.
