### PR TITLE
fix(wasm): Ensure browser bundle exists before running tests

### DIFF
--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -55,7 +55,7 @@
     "lint:eslint": "eslint . --cache --cache-location '../../eslintcache/' --format stylish",
     "lint:prettier": "prettier --check \"{src,test}/**/*.ts\"",
     "pack": "npm pack",
-    "test": "cross-env PORT=1337 jest",
+    "test": "node test/scripts/ensure-browser-bundle.js && cross-env PORT=1337 jest",
     "test:watch": "jest --watch"
   },
   "volta": {

--- a/packages/wasm/test/integration.test.js
+++ b/packages/wasm/test/integration.test.js
@@ -1,14 +1,6 @@
 /* global page, window */
-const fs = require('fs');
-const path = require('path');
 
 const HOST = `http://localhost:${process.env.PORT}`;
-
-if (!fs.existsSync(path.resolve(__dirname, '../../browser/build/bundle.js'))) {
-  throw new Error(
-    'ERROR: No browser bundle found in `packages/browser/build/`. Please run `yarn build` in the browser package before running wasm tests.',
-  );
-}
 
 describe('Wasm', () => {
   it('captured exception should include modified frames and debug_meta attribute', async () => {

--- a/packages/wasm/test/scripts/ensure-browser-bundle.js
+++ b/packages/wasm/test/scripts/ensure-browser-bundle.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+function ensureBrowserBundle() {
+  const browserPackageDir = path.resolve(__dirname, '../../../browser');
+  if (!fs.existsSync(path.resolve(browserPackageDir, 'build/bundle.js'))) {
+    // eslint-disable-next-line no-console
+    console.warn('\nWARNING: Missing browser bundle. Bundle will be created before running wasm integration tests.');
+    execSync(`pushd ${browserPackageDir} && yarn build:bundle && popd`);
+  }
+}
+
+ensureBrowserBundle();


### PR DESCRIPTION
The tests in our `wasm` package use the browser bundle, and therefore won't run if the bundle hasn't been built. https://github.com/getsentry/sentry-javascript/pull/4074 added a warning for this situation. This PR improves that by actually building the missing bundles, ensuring the tests will always run.
