### PR TITLE
fix(build): Add top-level `build:bundle` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "scripts": {
     "build": "node ./scripts/verify-packages-versions.js && lerna run --stream --concurrency 1 --sort build",
+    "build:bundle": "lerna run --stream --concurrency 1 --sort build:bundle",
     "build:cjs": "lerna run --stream --concurrency 1 --sort build:cjs",
     "build:dev": "lerna run --stream --concurrency 1 --sort build:dev",
     "build:dev:filter": "lerna run --stream --concurrency 1 --sort build:dev --include-filtered-dependencies --include-filtered-dependents --scope",


### PR DESCRIPTION
This allows us to build all bundles at once, the same way we can build all `cjs` or `esm` files at once.
