### PR TITLE
ref(tracing): Remove legacy method of getting transaction from scope

### DIFF
--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -266,21 +266,10 @@ export class Scope implements ScopeInterface {
    * @inheritDoc
    */
   public getTransaction(): Transaction | undefined {
-    // often, this span will be a transaction, but it's not guaranteed to be
-    const span = this.getSpan() as undefined | (Span & { spanRecorder: { spans: Span[] } });
-
-    // try it the new way first
-    if (span && span.transaction) {
-      return span.transaction;
-    }
-
-    // fallback to the old way (known bug: this only finds transactions with sampled = true)
-    if (span && span.spanRecorder && span.spanRecorder.spans[0]) {
-      return span.spanRecorder.spans[0] as Transaction;
-    }
-
-    // neither way found a transaction
-    return undefined;
+    // Often, this span (if it exists at all) will be a transaction, but it's not guaranteed to be. Regardless, it will
+    // have a pointer to the currently-active transaction.
+    const span = this.getSpan();
+    return span && span.transaction;
   }
 
   /**


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/2952, a new way of pulling the currently-active transaction off of the scope was introduced. That new way is no longer so new, and the legacy way was left in place at that time only out of an (over-)abundance of caution. It's time we removed it, both for ease of reading and for the few bytes we'll gain in bundle size reduction.