### PR TITLE
feat: Undeprecate Severity Enum

### DIFF
--- a/packages/browser/src/backend.ts
+++ b/packages/browser/src/backend.ts
@@ -1,5 +1,5 @@
 import { BaseBackend } from '@sentry/core';
-import { Event, EventHint, Options, SeverityLevel, Transport } from '@sentry/types';
+import { Event, EventHint, Options, Severity, Transport } from '@sentry/types';
 import { supportsFetch } from '@sentry/utils';
 
 import { eventFromException, eventFromMessage } from './eventbuilder';
@@ -45,7 +45,7 @@ export class BrowserBackend extends BaseBackend<BrowserOptions> {
   /**
    * @inheritDoc
    */
-  public eventFromMessage(message: string, level: SeverityLevel = 'info', hint?: EventHint): PromiseLike<Event> {
+  public eventFromMessage(message: string, level: Severity = Severity.Info, hint?: EventHint): PromiseLike<Event> {
     return eventFromMessage(this._options, message, level, hint);
   }
 

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -1,4 +1,4 @@
-import { Event, EventHint, Options, SeverityLevel } from '@sentry/types';
+import { Event, EventHint, Options, Severity } from '@sentry/types';
 import {
   addExceptionMechanism,
   addExceptionTypeValue,
@@ -24,7 +24,7 @@ export function eventFromException(options: Options, exception: unknown, hint?: 
     attachStacktrace: options.attachStacktrace,
   });
   addExceptionMechanism(event); // defaults to { type: 'generic', handled: true }
-  event.level = 'error';
+  event.level = Severity.Error;
   if (hint && hint.event_id) {
     event.event_id = hint.event_id;
   }
@@ -38,7 +38,7 @@ export function eventFromException(options: Options, exception: unknown, hint?: 
 export function eventFromMessage(
   options: Options,
   message: string,
-  level: SeverityLevel = 'info',
+  level: Severity = Severity.Info,
   hint?: EventHint,
 ): PromiseLike<Event> {
   const syntheticException = (hint && hint.syntheticException) || undefined;

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -8,6 +8,7 @@ export {
   EventStatus,
   Exception,
   Response,
+  Severity,
   SeverityLevel,
   StackFrame,
   Stacktrace,

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable max-lines */
 import { getCurrentHub } from '@sentry/core';
-import { Event, Integration } from '@sentry/types';
+import { Event, Integration, Severity } from '@sentry/types';
 import {
   addInstrumentationHandler,
   getEventDescription,
@@ -230,7 +230,7 @@ function _fetchBreadcrumb(handlerData: { [key: string]: any }): void {
       {
         category: 'fetch',
         data: handlerData.fetchData,
-        level: 'error',
+        level: Severity.Error,
         type: 'http',
       },
       {

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { getCurrentHub } from '@sentry/core';
-import { Event, EventHint, Hub, Integration, Primitive } from '@sentry/types';
+import { Event, EventHint, Hub, Integration, Primitive, Severity } from '@sentry/types';
 import {
   addExceptionMechanism,
   addInstrumentationHandler,
@@ -148,7 +148,7 @@ function _installGlobalOnUnhandledRejectionHandler(): void {
             isRejection: true,
           });
 
-      event.level = 'error';
+      event.level = Severity.Error;
 
       addMechanismAndCapture(hub, error, event, 'onunhandledrejection');
       return;

--- a/packages/core/src/basebackend.ts
+++ b/packages/core/src/basebackend.ts
@@ -1,4 +1,4 @@
-import { Event, EventHint, Options, Session, SeverityLevel, Transport } from '@sentry/types';
+import { Event, EventHint, Options, Session, Severity, Transport } from '@sentry/types';
 import { isDebugBuild, logger, SentryError } from '@sentry/utils';
 
 import { NoopTransport } from './transports/noop';
@@ -29,7 +29,7 @@ export interface Backend {
   eventFromException(exception: any, hint?: EventHint): PromiseLike<Event>;
 
   /** Creates an {@link Event} from primitive inputs to `captureMessage`. */
-  eventFromMessage(message: string, level?: SeverityLevel, hint?: EventHint): PromiseLike<Event>;
+  eventFromMessage(message: string, level?: Severity, hint?: EventHint): PromiseLike<Event>;
 
   /** Submits the event to Sentry */
   sendEvent(event: Event): void;
@@ -83,7 +83,7 @@ export abstract class BaseBackend<O extends Options> implements Backend {
   /**
    * @inheritDoc
    */
-  public eventFromMessage(_message: string, _level?: SeverityLevel, _hint?: EventHint): PromiseLike<Event> {
+  public eventFromMessage(_message: string, _level?: Severity, _hint?: EventHint): PromiseLike<Event> {
     throw new SentryError('Backend has to implement `eventFromMessage` method');
   }
 

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -8,7 +8,7 @@ import {
   Integration,
   IntegrationClass,
   Options,
-  SeverityLevel,
+  Severity,
   Transport,
 } from '@sentry/types';
 import {
@@ -129,7 +129,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
   /**
    * @inheritDoc
    */
-  public captureMessage(message: string, level?: SeverityLevel, hint?: EventHint, scope?: Scope): string | undefined {
+  public captureMessage(message: string, level?: Severity, hint?: EventHint, scope?: Scope): string | undefined {
     let eventId: string | undefined = hint && hint.event_id;
 
     const promisedEvent = isPrimitive(message)

--- a/packages/core/test/mocks/backend.ts
+++ b/packages/core/test/mocks/backend.ts
@@ -1,5 +1,5 @@
 import { Session } from '@sentry/hub';
-import { Event, Options, SeverityLevel, Transport } from '@sentry/types';
+import { Event, Options, Severity, Transport } from '@sentry/types';
 import { resolvedSyncPromise } from '@sentry/utils';
 
 import { BaseBackend } from '../../src/basebackend';
@@ -38,7 +38,7 @@ export class TestBackend extends BaseBackend<TestOptions> {
     });
   }
 
-  public eventFromMessage(message: string, level: SeverityLevel = 'info'): PromiseLike<Event> {
+  public eventFromMessage(message: string, level: Severity = Severity.Info): PromiseLike<Event> {
     return resolvedSyncPromise({ message, level });
   }
 

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -13,7 +13,7 @@ import {
   IntegrationClass,
   Primitive,
   SessionContext,
-  SeverityLevel,
+  Severity,
   Span,
   SpanContext,
   Transaction,
@@ -215,7 +215,7 @@ export class Hub implements HubInterface {
   /**
    * @inheritDoc
    */
-  public captureMessage(message: string, level?: SeverityLevel, hint?: EventHint): string {
+  public captureMessage(message: string, level?: Severity, hint?: EventHint): string {
     const eventId = (this._lastEventId = uuid4());
     let finalHint = hint;
 

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -13,7 +13,7 @@ import {
   RequestSession,
   Scope as ScopeInterface,
   ScopeContext,
-  SeverityLevel,
+  Severity,
   Span,
   Transaction,
   User,
@@ -61,7 +61,7 @@ export class Scope implements ScopeInterface {
   protected _fingerprint?: string[];
 
   /** Severity */
-  protected _level?: SeverityLevel;
+  protected _level?: Severity;
 
   /** Transaction Name */
   protected _transactionName?: string;
@@ -208,7 +208,7 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public setLevel(level: SeverityLevel): this {
+  public setLevel(level: Severity): this {
     this._level = level;
     this._notifyScopeListeners();
     return this;

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -1,4 +1,4 @@
-import { Event, EventHint } from '@sentry/types';
+import { Event, EventHint, Severity } from '@sentry/types';
 import { getGlobalObject } from '@sentry/utils';
 
 import { addGlobalEventProcessor, Scope } from '../src';
@@ -85,8 +85,8 @@ describe('Scope', () => {
 
     test('setLevel', () => {
       const scope = new Scope();
-      scope.setLevel('critical');
-      expect((scope as any)._level).toEqual('critical');
+      scope.setLevel(Severity.Critical);
+      expect((scope as any)._level).toEqual(Severity.Critical);
     });
 
     test('setTransactionName', () => {
@@ -137,8 +137,8 @@ describe('Scope', () => {
 
     test('chaining', () => {
       const scope = new Scope();
-      scope.setLevel('critical').setUser({ id: '1' });
-      expect((scope as any)._level).toEqual('critical');
+      scope.setLevel(Severity.Critical).setUser({ id: '1' });
+      expect((scope as any)._level).toEqual(Severity.Critical);
       expect((scope as any)._user).toEqual({ id: '1' });
     });
   });
@@ -202,7 +202,7 @@ describe('Scope', () => {
       scope.setTag('a', 'b');
       scope.setUser({ id: '1' });
       scope.setFingerprint(['abcd']);
-      scope.setLevel('warning');
+      scope.setLevel(Severity.Warning);
       scope.setTransactionName('/abc');
       scope.addBreadcrumb({ message: 'test' });
       scope.setContext('os', { id: '1' });
@@ -294,11 +294,11 @@ describe('Scope', () => {
     test('scope level should have priority over event level', () => {
       expect.assertions(1);
       const scope = new Scope();
-      scope.setLevel('warning');
+      scope.setLevel(Severity.Warning);
       const event: Event = {};
-      event.level = 'critical';
+      event.level = Severity.Critical;
       return scope.applyToEvent(event).then(processedEvent => {
-        expect(processedEvent!.level).toEqual('warning');
+        expect(processedEvent!.level).toEqual(Severity.Warning);
       });
     });
 
@@ -410,7 +410,7 @@ describe('Scope', () => {
       scope.setContext('foo', { id: '1' });
       scope.setContext('bar', { id: '2' });
       scope.setUser({ id: '1337' });
-      scope.setLevel('info');
+      scope.setLevel(Severity.Info);
       scope.setFingerprint(['foo']);
       scope.setRequestSession({ status: 'ok' });
     });
@@ -458,7 +458,7 @@ describe('Scope', () => {
       localScope.setContext('bar', { id: '3' });
       localScope.setContext('baz', { id: '4' });
       localScope.setUser({ id: '42' });
-      localScope.setLevel('warning');
+      localScope.setLevel(Severity.Warning);
       localScope.setFingerprint(['bar']);
       (localScope as any)._requestSession = { status: 'ok' };
 

--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -7,7 +7,7 @@ import {
   Extra,
   Extras,
   Primitive,
-  SeverityLevel,
+  Severity,
   Transaction,
   TransactionContext,
   User,
@@ -53,10 +53,10 @@ export function captureException(exception: any, captureContext?: CaptureContext
  * Captures a message event and sends it to Sentry.
  *
  * @param message The message to send to Sentry.
- * @param SeverityLevel Define the level of the message.
+ * @param Severity Define the level of the message.
  * @returns The generated eventId.
  */
-export function captureMessage(message: string, captureContext?: CaptureContext | SeverityLevel): string {
+export function captureMessage(message: string, captureContext?: CaptureContext | Severity): string {
   let syntheticException: Error;
   try {
     throw new Error(message);

--- a/packages/minimal/test/lib/minimal.test.ts
+++ b/packages/minimal/test/lib/minimal.test.ts
@@ -1,4 +1,5 @@
 import { getCurrentHub, getHubFromCarrier, Scope } from '@sentry/hub';
+import { Severity } from '@sentry/types';
 
 import {
   _callOnClient,
@@ -164,8 +165,8 @@ describe('Minimal', () => {
       const client: any = new TestClient({});
       const scope = getCurrentHub().pushScope();
       getCurrentHub().bindClient(client);
-      scope.setLevel('warning');
-      expect(global.__SENTRY__.hub._stack[1].scope._level).toEqual('warning');
+      scope.setLevel(Severity.Warning);
+      expect(global.__SENTRY__.hub._stack[1].scope._level).toEqual(Severity.Warning);
     });
   });
 
@@ -244,16 +245,16 @@ describe('Minimal', () => {
 
   test('withScope', () => {
     withScope(scope => {
-      scope.setLevel('warning');
+      scope.setLevel(Severity.Warning);
       scope.setFingerprint(['1']);
       withScope(scope2 => {
-        scope2.setLevel('info');
+        scope2.setLevel(Severity.Info);
         scope2.setFingerprint(['2']);
         withScope(scope3 => {
           scope3.clear();
-          expect(global.__SENTRY__.hub._stack[1].scope._level).toEqual('warning');
+          expect(global.__SENTRY__.hub._stack[1].scope._level).toEqual(Severity.Warning);
           expect(global.__SENTRY__.hub._stack[1].scope._fingerprint).toEqual(['1']);
-          expect(global.__SENTRY__.hub._stack[2].scope._level).toEqual('info');
+          expect(global.__SENTRY__.hub._stack[2].scope._level).toEqual(Severity.Info);
           expect(global.__SENTRY__.hub._stack[2].scope._fingerprint).toEqual(['2']);
           expect(global.__SENTRY__.hub._stack[3].scope._level).toBeUndefined();
         });

--- a/packages/node/src/backend.ts
+++ b/packages/node/src/backend.ts
@@ -1,5 +1,5 @@
 import { BaseBackend } from '@sentry/core';
-import { Event, EventHint, SeverityLevel, Transport, TransportOptions } from '@sentry/types';
+import { Event, EventHint, Severity, Transport, TransportOptions } from '@sentry/types';
 import { makeDsn } from '@sentry/utils';
 
 import { eventFromException, eventFromMessage } from './eventbuilder';
@@ -22,7 +22,7 @@ export class NodeBackend extends BaseBackend<NodeOptions> {
   /**
    * @inheritDoc
    */
-  public eventFromMessage(message: string, level: SeverityLevel = 'info', hint?: EventHint): PromiseLike<Event> {
+  public eventFromMessage(message: string, level: Severity = Severity.Info, hint?: EventHint): PromiseLike<Event> {
     return eventFromMessage(this._options, message, level, hint);
   }
 

--- a/packages/node/src/eventbuilder.ts
+++ b/packages/node/src/eventbuilder.ts
@@ -1,5 +1,5 @@
 import { getCurrentHub } from '@sentry/hub';
-import { Event, EventHint, Mechanism, Options, SeverityLevel } from '@sentry/types';
+import { Event, EventHint, Mechanism, Options, Severity } from '@sentry/types';
 import {
   addExceptionMechanism,
   addExceptionTypeValue,
@@ -69,7 +69,7 @@ export function eventFromException(options: Options, exception: unknown, hint?: 
 export function eventFromMessage(
   options: Options,
   message: string,
-  level: SeverityLevel = 'info',
+  level: Severity = Severity.Info,
   hint?: EventHint,
 ): PromiseLike<Event> {
   const event: Event = {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -8,6 +8,7 @@ export {
   EventStatus,
   Exception,
   Response,
+  Severity,
   SeverityLevel,
   StackFrame,
   Stacktrace,

--- a/packages/node/src/integrations/onuncaughtexception.ts
+++ b/packages/node/src/integrations/onuncaughtexception.ts
@@ -1,5 +1,5 @@
 import { getCurrentHub, Scope } from '@sentry/core';
-import { Integration } from '@sentry/types';
+import { Integration, Severity } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import { NodeClient } from '../client';
@@ -77,7 +77,7 @@ export class OnUncaughtException implements Integration {
 
         if (hub.getIntegration(OnUncaughtException)) {
           hub.withScope((scope: Scope) => {
-            scope.setLevel('fatal');
+            scope.setLevel(Severity.Fatal);
             hub.captureException(error, {
               originalException: error,
               data: { mechanism: { handled: false, type: 'onuncaughtexception' } },

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -274,7 +274,7 @@ export function wrapHandler<TEvent, TResult>(
       timeoutWarningTimer = setTimeout(() => {
         withScope(scope => {
           scope.setTag('timeout', humanReadableTimeout);
-          captureMessage(`Possible function timeout: ${context.functionName}`, 'warning');
+          captureMessage(`Possible function timeout: ${context.functionName}`, Sentry.Severity.Warning);
         });
       }, timeoutWarningDelay);
     }

--- a/packages/tracing/src/index.bundle.ts
+++ b/packages/tracing/src/index.bundle.ts
@@ -6,6 +6,7 @@ export {
   EventStatus,
   Exception,
   Response,
+  Severity,
   SeverityLevel,
   StackFrame,
   Stacktrace,

--- a/packages/types/src/breadcrumb.ts
+++ b/packages/types/src/breadcrumb.ts
@@ -1,9 +1,9 @@
-import { SeverityLevel } from './severity';
+import { Severity } from './severity';
 
 /** JSDoc */
 export interface Breadcrumb {
   type?: string;
-  level?: SeverityLevel;
+  level?: Severity;
   event_id?: string;
   category?: string;
   message?: string;

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -4,7 +4,7 @@ import { Integration, IntegrationClass } from './integration';
 import { Options } from './options';
 import { Scope } from './scope';
 import { Session } from './session';
-import { SeverityLevel } from './severity';
+import { Severity } from './severity';
 import { Transport } from './transport';
 
 /**
@@ -36,7 +36,7 @@ export interface Client<O extends Options = Options> {
    * @param scope An optional scope containing event metadata.
    * @returns The event id
    */
-  captureMessage(message: string, level?: SeverityLevel, hint?: EventHint, scope?: Scope): string | undefined;
+  captureMessage(message: string, level?: Severity, hint?: EventHint, scope?: Scope): string | undefined;
 
   /**
    * Captures a manually created event and sends it to Sentry.

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -7,7 +7,7 @@ import { Primitive } from './misc';
 import { Request } from './request';
 import { CaptureContext } from './scope';
 import { SdkInfo } from './sdkinfo';
-import { SeverityLevel } from './severity';
+import { Severity } from './severity';
 import { Span } from './span';
 import { Stacktrace } from './stacktrace';
 import { Measurements } from './transaction';
@@ -19,7 +19,7 @@ export interface Event {
   message?: string;
   timestamp?: number;
   start_timestamp?: number;
-  level?: SeverityLevel;
+  level?: Severity;
   platform?: string;
   logger?: string;
   server_name?: string;

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -6,7 +6,7 @@ import { Integration, IntegrationClass } from './integration';
 import { Primitive } from './misc';
 import { Scope } from './scope';
 import { Session, SessionContext } from './session';
-import { SeverityLevel } from './severity';
+import { Severity } from './severity';
 import { Span, SpanContext } from './span';
 import { CustomSamplingContext, Transaction, TransactionContext } from './transaction';
 import { User } from './user';
@@ -88,7 +88,7 @@ export interface Hub {
    * @param hint May contain additional information about the original exception.
    * @returns The generated eventId.
    */
-  captureMessage(message: string, level?: SeverityLevel, hint?: EventHint): string;
+  captureMessage(message: string, level?: Severity, hint?: EventHint): string;
 
   /**
    * Captures a manually created event and sends it to Sentry.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -32,7 +32,6 @@ export {
   SessionFlusherLike,
 } from './session';
 
-/* eslint-disable-next-line deprecation/deprecation */
 export { Severity } from './severity';
 export { SeverityLevel, SeverityLevels } from './severity';
 export { Span, SpanContext } from './span';

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -4,7 +4,7 @@ import { EventProcessor } from './eventprocessor';
 import { Extra, Extras } from './extra';
 import { Primitive } from './misc';
 import { RequestSession, Session } from './session';
-import { SeverityLevel } from './severity';
+import { Severity } from './severity';
 import { Span } from './span';
 import { Transaction } from './transaction';
 import { User } from './user';
@@ -15,7 +15,7 @@ export type CaptureContext = Scope | Partial<ScopeContext> | ((scope: Scope) => 
 /** JSDocs */
 export interface ScopeContext {
   user: User;
-  level: SeverityLevel;
+  level: Severity;
   extra: Extras;
   contexts: Contexts;
   tags: { [key: string]: Primitive };
@@ -81,7 +81,7 @@ export interface Scope {
    * Sets the level on the scope for future events.
    * @param level string {@link Severity}
    */
-  setLevel(level: SeverityLevel): this;
+  setLevel(level: Severity): this;
 
   /**
    * Sets the transaction name on the scope for future events.

--- a/packages/types/src/severity.ts
+++ b/packages/types/src/severity.ts
@@ -1,5 +1,5 @@
-/** JSDoc
- * @deprecated Use string literals - if you require type casting, cast to SeverityLevel type
+/**
+ * TODO(v7): Remove this enum and replace with SeverityLevel
  */
 export enum Severity {
   /** JSDoc */

--- a/packages/utils/src/severity.ts
+++ b/packages/utils/src/severity.ts
@@ -1,6 +1,6 @@
-import { SeverityLevel, SeverityLevels } from '@sentry/types';
+import { Severity, SeverityLevel, SeverityLevels } from '@sentry/types';
 
-function isSupportedSeverity(level: string): level is SeverityLevel {
+function isSupportedSeverity(level: string): level is Severity {
   return SeverityLevels.indexOf(level as SeverityLevel) !== -1;
 }
 /**
@@ -9,10 +9,10 @@ function isSupportedSeverity(level: string): level is SeverityLevel {
  * @param level string representation of Severity
  * @returns Severity
  */
-export function severityFromString(level: SeverityLevel | string): SeverityLevel {
-  if (level === 'warn') return 'warning';
+export function severityFromString(level: SeverityLevel | string): Severity {
+  if (level === 'warn') return Severity.Warning;
   if (isSupportedSeverity(level)) {
     return level;
   }
-  return 'log';
+  return Severity.Log;
 }


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/4280,
specifically in commit dd3aa70e5edb8efc317cb1ced7cf87e614e3957e, we
deprecated the `Severity` enum in favour of using a string union type,
`SeverityLevel`. It's important to note that this change affected the
type signature of one of our public API methods, `captureMessage`.

The change to deprecate the `Severity` enum was done for bundle size
reasons.

After releasing the beta with these changes, it was found that
deprecating the `Severity` enum and replacing it with `SeverityLevel`
was quite the disruptive change, which would make upgrading to the minor
version a hassle for users. As a result, this patch undeprecates the
`Severity` enum. The `Severity` enum will be removed in the upcoming
major release instead, as a breaking change.