### PR TITLE
chore(tests): Add `@utils` alias for integration tests.

### DIFF
--- a/packages/integration-tests/.eslintrc.js
+++ b/packages/integration-tests/.eslintrc.js
@@ -8,4 +8,12 @@ module.exports = {
   parserOptions: {
     sourceType: 'module',
   },
+  settings: {
+    'import/resolver': {
+      alias: {
+        map: [['@utils', './utils']],
+        extensions: ['.ts', '.js'],
+      },
+    },
+  },
 };

--- a/packages/integration-tests/README.md
+++ b/packages/integration-tests/README.md
@@ -27,13 +27,17 @@ suites/
 
 ## Writing Tests
 
+### Utils
+
+Test utilities can be imported using `@utils` alias from tests and test subjects.
+
 ### Helpers
 
-`utils/helpers.ts` contains helpers that could be used in assertions (`test.ts`). These helpers define a convenient and reliable API to interact with Playwright's native API. It's highly recommended to define all common patterns of Playwright usage in helpers.
+`@utils/helpers.ts` contains helpers that could be used in assertions (`test.ts`). These helpers define a convenient and reliable API to interact with Playwright's native API. It's highly recommended to define all common patterns of Playwright usage in helpers.
 
 ### Fixtures
 
-[Fixtures](https://playwright.dev/docs/api/class-fixtures) allows us to define the globals and test-specific information in assertion groups (`test.ts` files). In it's current state, `fixtures.ts` contains an extension over the pure version of `test()` function of Playwright. All the tests should import `sentryTest` function from `utils/fixtures.ts` instead of `@playwright/test` to be able to access the extra fixtures.
+[Fixtures](https://playwright.dev/docs/api/class-fixtures) allows us to define the globals and test-specific information in assertion groups (`test.ts` files). In it's current state, `fixtures.ts` contains an extension over the pure version of `test()` function of Playwright. All the tests should import `sentryTest` function from `@utils/fixtures` instead of `@playwright/test` to be able to access the extra fixtures.
 
 ## Running Tests Locally
 

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -19,11 +19,13 @@
     "test": "playwright test ./suites"
   },
   "dependencies": {
-    "@playwright/test": "^1.17.0",
+    "@babel/preset-typescript": "^7.16.7",
+    "@playwright/test": "^1.18.0-rc1",
     "babel-loader": "^8.2.2",
+    "eslint-import-resolver-alias": "^1.1.2",
     "handlebars-loader": "^1.7.1",
     "html-webpack-plugin": "^5.5.0",
-    "playwright": "^1.17.1",
+    "playwright": "^1.18.0-rc1",
     "typescript": "^4.5.2",
     "webpack": "^5.52.0"
   }

--- a/packages/integration-tests/suites/public-api/addBreadcrumb/empty_obj/test.ts
+++ b/packages/integration-tests/suites/public-api/addBreadcrumb/empty_obj/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest(
   'should add an empty breadcrumb initialized with a timestamp, when an empty object is given',

--- a/packages/integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/test.ts
+++ b/packages/integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should add multiple breadcrumbs', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/test.ts
+++ b/packages/integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should add a simple breadcrumb', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/addBreadcrumb/undefined_arg/test.ts
+++ b/packages/integration-tests/suites/public-api/addBreadcrumb/undefined_arg/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest(
   'should add an empty breadcrumb initialized with a timestamp, when no argument is given',

--- a/packages/integration-tests/suites/public-api/captureException/empty_obj/test.ts
+++ b/packages/integration-tests/suites/public-api/captureException/empty_obj/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should capture an empty object', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/captureException/simple_error/test.ts
+++ b/packages/integration-tests/suites/public-api/captureException/simple_error/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should capture a simple error with message', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/captureException/undefined_arg/test.ts
+++ b/packages/integration-tests/suites/public-api/captureException/undefined_arg/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should capture an undefined error when no arguments are provided', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/captureMessage/simple_message/test.ts
+++ b/packages/integration-tests/suites/public-api/captureMessage/simple_message/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should capture a simple message string', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/captureMessage/with_level/test.ts
+++ b/packages/integration-tests/suites/public-api/captureMessage/with_level/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getMultipleSentryRequests } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getMultipleSentryRequests } from '@utils/helpers';
 
 sentryTest('should capture with different severity levels', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/configureScope/clear_scope/test.ts
+++ b/packages/integration-tests/suites/public-api/configureScope/clear_scope/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should clear previously set properties of a scope', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/configureScope/set_properties/test.ts
+++ b/packages/integration-tests/suites/public-api/configureScope/set_properties/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should set different properties of a scope', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/setContext/multiple_contexts/test.ts
+++ b/packages/integration-tests/suites/public-api/setContext/multiple_contexts/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should record multiple contexts', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/setContext/non_serializable_context/test.ts
+++ b/packages/integration-tests/suites/public-api/setContext/non_serializable_context/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should normalize non-serializable context', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/setContext/simple_context/test.ts
+++ b/packages/integration-tests/suites/public-api/setContext/simple_context/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should set a simple context', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/setExtra/multiple_extras/test.ts
+++ b/packages/integration-tests/suites/public-api/setExtra/multiple_extras/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should record multiple extras of different types', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/setExtra/non_serializable_extra/test.ts
+++ b/packages/integration-tests/suites/public-api/setExtra/non_serializable_extra/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should normalize non-serializable extra', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/setExtra/simple_extra/test.ts
+++ b/packages/integration-tests/suites/public-api/setExtra/simple_extra/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should record a simple extra object', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/setExtras/consecutive_calls/test.ts
+++ b/packages/integration-tests/suites/public-api/setExtras/consecutive_calls/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should set extras from multiple consecutive calls', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/setExtras/multiple_extras/test.ts
+++ b/packages/integration-tests/suites/public-api/setExtras/multiple_extras/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should record an extras object', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/setTag/with_non_primitives/test.ts
+++ b/packages/integration-tests/suites/public-api/setTag/with_non_primitives/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should not accept non-primitive tags', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/setTag/with_primitives/test.ts
+++ b/packages/integration-tests/suites/public-api/setTag/with_primitives/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should set primitive tags', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/setTags/with_non_primitives/test.ts
+++ b/packages/integration-tests/suites/public-api/setTags/with_non_primitives/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should not accept non-primitive tags', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/setTags/with_primitives/test.ts
+++ b/packages/integration-tests/suites/public-api/setTags/with_primitives/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryRequest } from '@utils/helpers';
 
 sentryTest('should set primitive tags', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/setUser/unset_user/test.ts
+++ b/packages/integration-tests/suites/public-api/setUser/unset_user/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getMultipleSentryRequests } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getMultipleSentryRequests } from '@utils/helpers';
 
 sentryTest('should unset user', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/setUser/update_user/test.ts
+++ b/packages/integration-tests/suites/public-api/setUser/update_user/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getMultipleSentryRequests } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getMultipleSentryRequests } from '@utils/helpers';
 
 sentryTest('should update user', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/showReportDialog/inject-script/test.ts
+++ b/packages/integration-tests/suites/public-api/showReportDialog/inject-script/test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
+import { sentryTest } from '@utils/fixtures';
 
 sentryTest('should inject dialog script into <head> with correct attributes', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/startTransaction/basic_usage/test.ts
+++ b/packages/integration-tests/suites/public-api/startTransaction/basic_usage/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryTransactionRequest } from '@utils/helpers';
 
 sentryTest('should report a transaction in an envelope', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/public-api/withScope/nested_scopes/test.ts
+++ b/packages/integration-tests/suites/public-api/withScope/nested_scopes/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getMultipleSentryRequests } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getMultipleSentryRequests } from '@utils/helpers';
 
 sentryTest('should allow nested scoping', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/tracing/browsertracing/meta/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/meta/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryTransactionRequest } from '@utils/helpers';
 
 sentryTest(
   'should create a pageload transaction based on `sentry-trace` <meta>',

--- a/packages/integration-tests/suites/tracing/browsertracing/navigation/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/navigation/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryTransactionRequest } from '@utils/helpers';
 
 sentryTest('should create a navigation transaction on page navigation', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/tracing/browsertracing/pageload/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/pageload/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryTransactionRequest } from '@utils/helpers';
 
 sentryTest('should create a pageload transaction', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/tracing/metrics/pageload-browser-spans/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/pageload-browser-spans/test.ts
@@ -1,7 +1,6 @@
 import { expect } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryTransactionRequest } from '@utils/helpers';
 
 sentryTest('should add browser-related spans to pageload transaction', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/tracing/metrics/pageload-resource-spans/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/pageload-resource-spans/test.ts
@@ -1,7 +1,6 @@
 import { expect, Route } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryTransactionRequest } from '@utils/helpers';
 
 sentryTest('should add resource spans to pageload transaction', async ({ getLocalTestPath, page }) => {
   // Intercepting asset requests to avoid network-related flakiness and random retries (on Firefox).

--- a/packages/integration-tests/suites/tracing/request/fetch/test.ts
+++ b/packages/integration-tests/suites/tracing/request/fetch/test.ts
@@ -1,7 +1,6 @@
 import { expect, Request } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryTransactionRequest } from '@utils/helpers';
 
 sentryTest('should create spans for multiple fetch requests', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/tracing/request/xhr/test.ts
+++ b/packages/integration-tests/suites/tracing/request/xhr/test.ts
@@ -1,7 +1,6 @@
 import { expect, Request } from '@playwright/test';
-
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { sentryTest } from '@utils/fixtures';
+import { getSentryTransactionRequest } from '@utils/helpers';
 
 sentryTest('should create spans for multiple XHR requests', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/tsconfig.json
+++ b/packages/integration-tests/tsconfig.json
@@ -5,7 +5,11 @@
     "lib": ["dom", "es2019"],
     "moduleResolution": "node",
     "noEmit": true,
-    "strict": true
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@utils/*": ["./utils/*"]
+    }
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules"]

--- a/packages/integration-tests/utils/generatePage.ts
+++ b/packages/integration-tests/utils/generatePage.ts
@@ -2,7 +2,7 @@ import { Package } from '@sentry/types';
 import { existsSync, mkdirSync, promises } from 'fs';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import path from 'path';
-import webpack from 'webpack';
+import { webpack } from 'webpack';
 
 import webpackConfig from '../webpack.config';
 
@@ -39,6 +39,8 @@ export async function generatePage(
   const bundlePath = `${localPath}/index.html`;
 
   const alias = await generateSentryAlias();
+
+  alias['@utils'] = `${__dirname}`;
 
   if (!existsSync(localPath)) {
     mkdirSync(localPath, { recursive: true });

--- a/packages/integration-tests/webpack.config.ts
+++ b/packages/integration-tests/webpack.config.ts
@@ -7,9 +7,10 @@ const config = function(userConfig: Record<string, unknown>): Configuration {
     module: {
       rules: [
         {
-          test: /\.js$/,
+          test: /\.(js|ts)$/,
           exclude: /node_modules/,
           loader: 'babel-loader',
+          options: { presets: [['@babel/preset-typescript', { allowNamespaces: true }]] },
         },
         {
           test: /\.hbs$/,

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,6 +44,13 @@
   dependencies:
     "@babel/highlight" "^7.16.0"
 
+"@babel/code-frame@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
+  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
+  dependencies:
+    "@babel/highlight" "^7.16.7"
+
 "@babel/compat-data@^7.13.0", "@babel/compat-data@^7.13.12", "@babel/compat-data@^7.13.8", "@babel/compat-data@^7.15.0":
   version "7.15.0"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.15.0.tgz#2dbaf8b85334796cafbb0f5793a90a2fc010b176"
@@ -135,6 +142,15 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/generator@^7.16.8":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.16.8.tgz#359d44d966b8cd059d543250ce79596f792f2ebe"
+  integrity sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==
+  dependencies:
+    "@babel/types" "^7.16.8"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
 "@babel/helper-annotate-as-pure@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.13.tgz#0f58e86dfc4bb3b1fcd7db806570e177d439b6ab"
@@ -148,6 +164,13 @@
   integrity sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==
   dependencies:
     "@babel/types" "^7.16.0"
+
+"@babel/helper-annotate-as-pure@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz#bb2339a7534a9c128e3102024c60760a3a7f3862"
+  integrity sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==
+  dependencies:
+    "@babel/types" "^7.16.7"
 
 "@babel/helper-builder-binary-assignment-operator-visitor@^7.12.13":
   version "7.12.13"
@@ -200,6 +223,19 @@
     "@babel/helper-replace-supers" "^7.16.0"
     "@babel/helper-split-export-declaration" "^7.16.0"
 
+"@babel/helper-create-class-features-plugin@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.7.tgz#9c5b34b53a01f2097daf10678d65135c1b9f84ba"
+  integrity sha512-kIFozAvVfK05DM4EVQYKK+zteWvY85BFdGBRQBytRyY3y+6PX0DkDOn/CZ3lEuczCfrCxEzwt0YtP/87YPTWSw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.7"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.16.7"
+    "@babel/helper-member-expression-to-functions" "^7.16.7"
+    "@babel/helper-optimise-call-expression" "^7.16.7"
+    "@babel/helper-replace-supers" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+
 "@babel/helper-create-regexp-features-plugin@^7.12.13":
   version "7.12.17"
   resolved "https://registry.yarnpkg.com/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.17.tgz#a2ac87e9e319269ac655b8d4415e94d38d663cb7"
@@ -221,6 +257,13 @@
     lodash.debounce "^4.0.8"
     resolve "^1.14.2"
     semver "^6.1.2"
+
+"@babel/helper-environment-visitor@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz#ff484094a839bde9d89cd63cba017d7aae80ecd7"
+  integrity sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==
+  dependencies:
+    "@babel/types" "^7.16.7"
 
 "@babel/helper-explode-assignable-expression@^7.12.13":
   version "7.13.0"
@@ -247,6 +290,15 @@
     "@babel/template" "^7.16.0"
     "@babel/types" "^7.16.0"
 
+"@babel/helper-function-name@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz#f1ec51551fb1c8956bc8dd95f38523b6cf375f8f"
+  integrity sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.16.7"
+    "@babel/template" "^7.16.7"
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-get-function-arity@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz#098818934a137fce78b536a3e015864be1e2879b"
@@ -260,6 +312,13 @@
   integrity sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==
   dependencies:
     "@babel/types" "^7.16.0"
+
+"@babel/helper-get-function-arity@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz#ea08ac753117a669f1508ba06ebcc49156387419"
+  integrity sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==
+  dependencies:
+    "@babel/types" "^7.16.7"
 
 "@babel/helper-hoist-variables@^7.13.0", "@babel/helper-hoist-variables@^7.15.4":
   version "7.15.4"
@@ -275,6 +334,13 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
+"@babel/helper-hoist-variables@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz#86bcb19a77a509c7b77d0e22323ef588fa58c246"
+  integrity sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-member-expression-to-functions@^7.13.0", "@babel/helper-member-expression-to-functions@^7.15.4":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz#bfd34dc9bba9824a4658b0317ec2fd571a51e6ef"
@@ -289,6 +355,13 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
+"@babel/helper-member-expression-to-functions@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.7.tgz#42b9ca4b2b200123c3b7e726b0ae5153924905b0"
+  integrity sha512-VtJ/65tYiU/6AbMTDwyoXGPKHgTsfRarivm+YbB5uAzKUyuPjgZSgAFeG87FCigc7KNHu2Pegh1XIT3lXjvz3Q==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.15.4", "@babel/helper-module-imports@^7.8.3":
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz#e18007d230632dea19b47853b984476e7b4e103f"
@@ -302,6 +375,13 @@
   integrity sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==
   dependencies:
     "@babel/types" "^7.16.0"
+
+"@babel/helper-module-imports@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz#25612a8091a999704461c8a222d0efec5d091437"
+  integrity sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==
+  dependencies:
+    "@babel/types" "^7.16.7"
 
 "@babel/helper-module-transforms@^7.13.0", "@babel/helper-module-transforms@^7.15.4":
   version "7.15.4"
@@ -345,10 +425,22 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
+"@babel/helper-optimise-call-expression@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz#a34e3560605abbd31a18546bd2aad3e6d9a174f2"
+  integrity sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
   integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
+
+"@babel/helper-plugin-utils@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5"
+  integrity sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==
 
 "@babel/helper-remap-async-to-generator@^7.13.0":
   version "7.13.0"
@@ -378,6 +470,17 @@
     "@babel/helper-optimise-call-expression" "^7.16.0"
     "@babel/traverse" "^7.16.0"
     "@babel/types" "^7.16.0"
+
+"@babel/helper-replace-supers@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz#e9f5f5f32ac90429c1a4bdec0f231ef0c2838ab1"
+  integrity sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-member-expression-to-functions" "^7.16.7"
+    "@babel/helper-optimise-call-expression" "^7.16.7"
+    "@babel/traverse" "^7.16.7"
+    "@babel/types" "^7.16.7"
 
 "@babel/helper-simple-access@^7.12.13", "@babel/helper-simple-access@^7.15.4":
   version "7.15.4"
@@ -421,6 +524,13 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
+"@babel/helper-split-export-declaration@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz#0b648c0c42da9d3920d85ad585f2778620b8726b"
+  integrity sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-validator-identifier@^7.12.11", "@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.9":
   version "7.14.9"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz#6654d171b2024f6d8ee151bf2509699919131d48"
@@ -431,10 +541,20 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
   integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
 
+"@babel/helper-validator-identifier@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
+  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+
 "@babel/helper-validator-option@^7.12.17", "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
   integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
+
+"@babel/helper-validator-option@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz#b203ce62ce5fe153899b617c08957de860de4d23"
+  integrity sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==
 
 "@babel/helper-wrap-function@^7.13.0":
   version "7.13.0"
@@ -482,6 +602,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.7.tgz#81a01d7d675046f0d96f82450d9d9578bdfd6b0b"
+  integrity sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.13.13", "@babel/parser@^7.4.3", "@babel/parser@^7.4.5", "@babel/parser@^7.7.0":
   version "7.14.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.2.tgz#0c1680aa44ad4605b16cbdcc5c341a61bde9c746"
@@ -496,6 +625,11 @@
   version "7.16.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.3.tgz#271bafcb811080905a119222edbc17909c82261d"
   integrity sha512-dcNwU1O4sx57ClvLBVFbEgx0UZWfd0JQX5X6fxFRCLHelFBGXFfSz6Y0FAq2PEwUqlqLkdVjVr4VASEOuUnLJw==
+
+"@babel/parser@^7.16.7", "@babel/parser@^7.16.8":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.8.tgz#61c243a3875f7d0b0962b0543a33ece6ff2f1f17"
+  integrity sha512-i7jDUfrVBWc+7OKcBzEe5n7fbv3i2fWtxKzzCvOjnzSxMfWMigAhtfJ7qzZNGFNMsCCd67+uz553dYKWXPvCKw==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.13.12":
   version "7.13.12"
@@ -741,6 +875,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
+"@babel/plugin-syntax-jsx@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz#50b6571d13f764266a113d77c82b4a6508bbe665"
+  integrity sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz#ca91ef46303530448b906652bac2e9fe9941f699"
@@ -810,6 +951,13 @@
   integrity sha512-Xv6mEXqVdaqCBfJFyeab0fH2DnUoMsDmhamxsSi4j8nLd4Vtw213WMJr55xxqipC/YVWyPY3K0blJncPYji+dQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-syntax-typescript@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.7.tgz#39c9b55ee153151990fb038651d58d3fd03f98f8"
+  integrity sha512-YhUIJHHGkqPgEcMYkPCKTyGUdoGKWtopIycQyjJH8OjvRgOYsXsaKehLVPScKJWAULPxMa4N1vCe6szREFlZ7A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-arrow-functions@^7.13.0":
   version "7.13.0"
@@ -1011,6 +1159,17 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
 
+"@babel/plugin-transform-react-jsx@^7.14.5":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.16.7.tgz#86a6a220552afd0e4e1f0388a68a372be7add0d4"
+  integrity sha512-8D16ye66fxiE8m890w0BpPpngG9o9OVBBy0gH2E+2AR7qMR2ZpTYJEqLxAsoroenMId0p/wMW+Blc0meDgu0Ag==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.16.7"
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/plugin-syntax-jsx" "^7.16.7"
+    "@babel/types" "^7.16.7"
+
 "@babel/plugin-transform-regenerator@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.13.tgz#b628bcc9c85260ac1aeb05b45bde25210194a2f5"
@@ -1090,6 +1249,15 @@
     "@babel/helper-create-class-features-plugin" "^7.16.0"
     "@babel/helper-plugin-utils" "^7.14.5"
     "@babel/plugin-syntax-typescript" "^7.16.0"
+
+"@babel/plugin-transform-typescript@^7.16.7":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.8.tgz#591ce9b6b83504903fa9dd3652c357c2ba7a1ee0"
+  integrity sha512-bHdQ9k7YpBDO2d0NVfkj51DpQcvwIzIusJ7mEUaMlbZq3Kt/U47j24inXZHQ5MDiYpCs+oZiwnXyKedE8+q7AQ==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/plugin-syntax-typescript" "^7.16.7"
 
 "@babel/plugin-transform-typescript@~7.4.0":
   version "7.4.5"
@@ -1226,6 +1394,15 @@
     "@babel/helper-validator-option" "^7.14.5"
     "@babel/plugin-transform-typescript" "^7.16.0"
 
+"@babel/preset-typescript@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.16.7.tgz#ab114d68bb2020afc069cd51b37ff98a046a70b9"
+  integrity sha512-WbVEmgXdIyvzB77AQjGBEyYPZx+8tTsO50XtfozQrkW8QB2rLJpH2lgx0TRw5EJrBxOZQ+wCcyPVQvS8tjEHpQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-validator-option" "^7.16.7"
+    "@babel/plugin-transform-typescript" "^7.16.7"
+
 "@babel/runtime-corejs3@^7.10.2":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.13.10.tgz#14c3f4c85de22ba88e8e86685d13e8861a82fe86"
@@ -1273,6 +1450,15 @@
     "@babel/parser" "^7.16.0"
     "@babel/types" "^7.16.0"
 
+"@babel/template@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
+  integrity sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/parser" "^7.16.7"
+    "@babel/types" "^7.16.7"
+
 "@babel/traverse@^7.1.0", "@babel/traverse@^7.1.6", "@babel/traverse@^7.13.0", "@babel/traverse@^7.13.13", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.5", "@babel/traverse@^7.7.0":
   version "7.13.13"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.13.13.tgz#39aa9c21aab69f74d948a486dd28a2dbdbf5114d"
@@ -1317,6 +1503,22 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.16.7":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.16.8.tgz#bab2f2b09a5fe8a8d9cad22cbfe3ba1d126fef9c"
+  integrity sha512-xe+H7JlvKsDQwXRsBhSnq1/+9c+LlQcCK3Tn/l5sbx02HYns/cn7ibp9+RV1sIUqu7hKg91NWsgHurO9dowITQ==
+  dependencies:
+    "@babel/code-frame" "^7.16.7"
+    "@babel/generator" "^7.16.8"
+    "@babel/helper-environment-visitor" "^7.16.7"
+    "@babel/helper-function-name" "^7.16.7"
+    "@babel/helper-hoist-variables" "^7.16.7"
+    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/parser" "^7.16.8"
+    "@babel/types" "^7.16.8"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.3.tgz#5a383dffa5416db1b73dedffd311ffd0788fb31c"
@@ -1349,6 +1551,14 @@
   integrity sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.15.7"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.16.7", "@babel/types@^7.16.8":
+  version "7.16.8"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.16.8.tgz#0ba5da91dd71e0a4e7781a30f22770831062e3c1"
+  integrity sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
 "@cnakazawa/watch@^1.0.3":
@@ -2804,10 +3014,10 @@
     "@opentelemetry/resources" "^0.12.0"
     "@opentelemetry/semantic-conventions" "^0.12.0"
 
-"@playwright/test@^1.17.0":
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.17.1.tgz#9e5aca496d2c90ce95ca19ac2c3a8867a4f606d3"
-  integrity sha512-mMZS5OMTN/vUlqd1JZkFoAk2FsIZ4/E/00tw5it2c/VF4+3z/aWO+PPd8ShEGzYME7B16QGWNPjyFpDQI1t4RQ==
+"@playwright/test@^1.18.0-rc1":
+  version "1.18.0-rc1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.18.0-rc1.tgz#1c4f414c22063f1355dba7be9b6460b749ef6478"
+  integrity sha512-D6savDw2zknI9DTCRRFfL4mswDXxYt2w1PbcqmQnwS72is054nb5SR5Sxl43eot1pOfx6u+SH7mHU8ptUzNR+Q==
   dependencies:
     "@babel/code-frame" "^7.14.5"
     "@babel/core" "^7.14.8"
@@ -2825,20 +3035,23 @@
     "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
     "@babel/plugin-transform-modules-commonjs" "^7.14.5"
+    "@babel/plugin-transform-react-jsx" "^7.14.5"
     "@babel/preset-typescript" "^7.14.5"
-    colors "^1.4.0"
+    babel-plugin-module-resolver "^4.1.0"
+    colors "1.4.0"
     commander "^8.2.0"
     debug "^4.1.1"
     expect "=27.2.5"
     jest-matcher-utils "=27.2.5"
     jpeg-js "^0.4.2"
+    json5 "^2.2.0"
     mime "^2.4.6"
     minimatch "^3.0.3"
     ms "^2.1.2"
     open "^8.3.0"
     pirates "^4.0.1"
     pixelmatch "^5.2.1"
-    playwright-core "=1.17.1"
+    playwright-core "=1.18.0-rc1"
     pngjs "^5.0.0"
     rimraf "^3.0.2"
     source-map-support "^0.4.18"
@@ -5172,7 +5385,7 @@ babel-plugin-module-resolver@^3.2.0:
     reselect "^3.0.1"
     resolve "^1.4.0"
 
-babel-plugin-module-resolver@^4.0.0:
+babel-plugin-module-resolver@^4.0.0, babel-plugin-module-resolver@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-module-resolver/-/babel-plugin-module-resolver-4.1.0.tgz#22a4f32f7441727ec1fbf4967b863e1e3e9f33e2"
   integrity sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==
@@ -7256,7 +7469,7 @@ colors@1.0.3:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-colors@^1.1.0, colors@^1.1.2, colors@^1.4.0:
+colors@1.4.0, colors@^1.1.0, colors@^1.1.2, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -9773,6 +9986,11 @@ eslint-config-prettier@^6.11.0:
   integrity sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==
   dependencies:
     get-stdin "^6.0.0"
+
+eslint-import-resolver-alias@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-alias/-/eslint-import-resolver-alias-1.1.2.tgz#297062890e31e4d6651eb5eba9534e1f6e68fc97"
+  integrity sha512-WdviM1Eu834zsfjHtcGHtGfcu+F30Od3V7I9Fi57uhBEwPkjDcii7/yW8jAT+gOhn4P/vOxxNAXbFAKsrrc15w==
 
 eslint-import-resolver-node@^0.3.4:
   version "0.3.4"
@@ -13731,7 +13949,7 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@2.x, json5@^2.1.2:
+json5@2.x, json5@^2.1.2, json5@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
@@ -16848,12 +17066,41 @@ playwright-core@=1.17.1:
     yauzl "^2.10.0"
     yazl "^2.5.1"
 
+playwright-core@=1.18.0-rc1:
+  version "1.18.0-rc1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.18.0-rc1.tgz#585b542055729b6a6c55bd847a6805d3490984e1"
+  integrity sha512-l1kd9Z4msyQH6ozfyD5SM6b6g2t8l78E+plI0HSKe3b+FhFMd2LY3dDKXjR2DNOs4roowspX4znlFMxKTiFhUg==
+  dependencies:
+    commander "^8.2.0"
+    debug "^4.1.1"
+    extract-zip "^2.0.1"
+    https-proxy-agent "^5.0.0"
+    jpeg-js "^0.4.2"
+    mime "^2.4.6"
+    pngjs "^5.0.0"
+    progress "^2.0.3"
+    proper-lockfile "^4.1.1"
+    proxy-from-env "^1.1.0"
+    rimraf "^3.0.2"
+    socks-proxy-agent "^6.1.0"
+    stack-utils "^2.0.3"
+    ws "^7.4.6"
+    yauzl "^2.10.0"
+    yazl "^2.5.1"
+
 playwright@^1.17.1:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.17.1.tgz#a6d63302ee40f41283c4bf869de261c4743a787c"
   integrity sha512-DisCkW9MblDJNS3rG61p8LiLA2WA7IY/4A4W7DX4BphWe/HuWjKmGQptuk4NVIh5UuSwXpW/jaH2+ZgjHs3GMA==
   dependencies:
     playwright-core "=1.17.1"
+
+playwright@^1.18.0-rc1:
+  version "1.18.0-rc1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.18.0-rc1.tgz#a9d4052f33dd61654215dd21dd18b4aa30d2e655"
+  integrity sha512-+68fRfn0ybC/wszfKTet7LzkbWNQj/NQI4pYooU+Ud0lBj0EaodnPLVvwOHZqUrgA4ZNRRKQu49+BGQU2nxydw==
+  dependencies:
+    playwright-core "=1.18.0-rc1"
 
 plugin-error@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
To have a common alias for both assertions and subjects, I added the alias to:

1 - Webpack config (for browser-related utils in `subject.js` files)
2 - TypeScript config (for assertion utils in `test.ts` files)
3 - ESLint config (To prevent false positives from `import/no-undefined` rule)

Also updated `playwright` and `@playwright/test` to `1.18.0-rc1` to be able to use aliases defined in `tsconfig.json`: https://github.com/microsoft/playwright/releases/tag/v1.18.0-rc1