### PR TITLE
build(browser): Add back debug func to CDN bundle

### DIFF
--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -14,7 +14,7 @@ const terserInstance = terser({
     // want to have unnecessary debug functionality.
     global_defs: {
       __SENTRY_BROWSER_BUNDLE__: true,
-      __SENTRY_NO_DEBUG__: true,
+      __SENTRY_NO_DEBUG__: false,
     },
   },
   mangle: {


### PR DESCRIPTION
Temporarily stop removing debug functionality from the CDN bundle while
we work on a more fleshed out bundling solution.

We previously added static globals in
https://github.com/getsentry/sentry-javascript/pull/4273 to leverage
dead code elimination to remove debug functionality from the browser
CDN. Currently though, we only publish a single CDN bundle, the one that
has the debug functionality stripped. Until we publish seperate CDN
bundles for debug and production, we will disable stripped debug
functionality from the production bundle.