### PR TITLE
meta: CHANGELOG for 6.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## 6.17.0
 
-This release contains several internal refactors that help reduce the bundle size of the SDK and help prep for our [upcoming major release](https://github.com/getsentry/sentry-javascript/issues/4240). There are no breaking changes in this patch unless you are using our internal `Dsn` class. We also deprecated our typescript enums and our internal `API` class. We've detailed how to update your sdk usage if you are using the `Dsn` class or any of the deprecated methods in our [migration documentation](./MIGRATION.md#upgrading-from-6.x-to-6.17.0).
+This release contains several internal refactors that help reduce the bundle size of the SDK and help prep for our [upcoming major release](https://github.com/getsentry/sentry-javascript/issues/4240). There are no breaking changes in this patch unless you are using our internal `Dsn` class, which has been removed. We also deprecated a few of our typescript enums and our internal `API` class. We've detailed in our [migration documentation](./MIGRATION.md#upgrading-from-6.x-to-6.17.0) how to update your sdk usage if you are using any of these in your code.
 
 - feat: Undeprecate Severity Enum (#4412)
 - feat(core): Add processing metadata to scope and event (#4252)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-## 6.17.0-beta.0
+## 6.17.0
 
-This beta releases contains several internal refactors that help reduce the bundle size of the SDK and help prep for our [upcoming major release](https://github.com/getsentry/sentry-javascript/issues/4240). There are no breaking changes in this patch unless you are using our internal `Dsn` class. We also deprecated our typescript enums and our internal `API` class. We've detailed how to update your sdk usage if you are using the `Dsn` class or any of the deprecated methods in our [migration documentation](./MIGRATION.md#upgrading-from-6.x-to-6.17.0).
+This release contains several internal refactors that help reduce the bundle size of the SDK and help prep for our [upcoming major release](https://github.com/getsentry/sentry-javascript/issues/4240). There are no breaking changes in this patch unless you are using our internal `Dsn` class. We also deprecated our typescript enums and our internal `API` class. We've detailed how to update your sdk usage if you are using the `Dsn` class or any of the deprecated methods in our [migration documentation](./MIGRATION.md#upgrading-from-6.x-to-6.17.0).
+
+- feat: Undeprecate Severity Enum (#4412)
+- feat(core): Add processing metadata to scope and event (#4252)
+- fix(nextjs): Inject sentry.x.config.js into pages/_error (#4397)
+
+## 6.17.0-beta.0
 
 - feat(core): Deprecate API class (#4281)
 - feat(dsn): Remove Dsn class (#4325)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This release contains several internal refactors that help reduce the bundle siz
 - ref(types): deprecate status enum (#4298)
 - ref(types): deprecate severity enum (#4280)
 
+Work in this release contributed by @yordis. Thank you for your contribution!
+
 ## 6.16.1
 
 - feat(nextjs): Support Next.js v12 (#4093)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,11 @@
 This release contains several internal refactors that help reduce the bundle size of the SDK and help prep for our [upcoming major release](https://github.com/getsentry/sentry-javascript/issues/4240). There are no breaking changes in this patch unless you are using our internal `Dsn` class, which has been removed. We also deprecated a few of our typescript enums and our internal `API` class. We've detailed in our [migration documentation](./MIGRATION.md#upgrading-from-6.x-to-6.17.0) how to update your sdk usage if you are using any of these in your code.
 
 - feat: Undeprecate Severity Enum (#4412)
+- feat: Remove Dsn class (#4325)
 - feat(core): Add processing metadata to scope and event (#4252)
-- fix(nextjs): Inject sentry.x.config.js into pages/_error (#4397)
-
-## 6.17.0-beta.0
-
 - feat(core): Deprecate API class (#4281)
-- feat(dsn): Remove Dsn class (#4325)
 - feat(ember): Update ember dependencies (#4253)
+- fix(nextjs): Inject sentry.x.config.js into pages/_error (#4397)
 - fix(nextjs): Add sentry-cli existence check for enabling webpack plugin #4311
 - ref(tracing): deprecate span status enum (#4299)
 - ref(types): drop unused logLevel (#4317)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -44,23 +44,7 @@ const envelopeEndpoint = api.getEnvelopeEndpointWithUrlEncodedAuth();
 
 ## Enum changes
 
-We've detailed how to migrate off our enums `Severity`, `Status` and `SpanStatus`. We also made changes to deprecate `TransactionMethod`, `Outcome` and `RequestSessionStatus` enums, but those are internal only APIs.
-
-#### Severity
-
-We deprecated the `Severity` enum in `@sentry/types` and it will be removed in the next major release. We recommend using string literals to save on bundle size. [PR](https://github.com/getsentry/sentry-javascript/pull/4280). We also removed the `Severity.fromString` method. This was done to save on bundle size.
-
-```js
-// New in 6.17.0:
-import { severityFromString } from '@sentry/utils';
-
-const severity = severityFromString(level);
-
-// Before:
-import { Severity } from '@sentry/types';
-
-const severity = Severity.fromString(level);
-```
+We've detailed how to migrate off the enums `Status` and `SpanStatus`. We also made changes to deprecate `TransactionMethod`, `Outcome` and `RequestSessionStatus` enums, but those are internal only APIs.
 
 #### Status
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -44,7 +44,11 @@ const envelopeEndpoint = api.getEnvelopeEndpointWithUrlEncodedAuth();
 
 ## Enum changes
 
-We've detailed how to migrate off the enums `Status` and `SpanStatus`. We also made changes to deprecate `TransactionMethod`, `Outcome` and `RequestSessionStatus` enums, but those are internal only APIs.
+The enums `Status` and `SpanStatus` were deprecated, and we've detailed how to migrate away from them below. We also deprecated the `TransactionMethod`, `Outcome` and `RequestSessionStatus` enums, but those are internal-only APIs. If you are using them, we encourage you to take a look at the corresponding PRs to see how we've changed our code as a result.
+
+- `TransactionMethod`: https://github.com/getsentry/sentry-javascript/pull/4314
+- `Outcome`: https://github.com/getsentry/sentry-javascript/pull/4315
+- `RequestSessionStatus`: https://github.com/getsentry/sentry-javascript/pull/4316
 
 #### Status
 
@@ -87,7 +91,7 @@ In this version upgrade, there are a few breaking changes. This guide should hel
 We moved optional integrations into their own package, called `@sentry/integrations`. Also, we made a few default
 integrations now optional. This is probably the biggest breaking change regarding the upgrade.
 
-Integrations that are now opt-in and were default before:
+Integrations that are now opt-in and were Wedefault before:
 
 - Dedupe (responsible for sending the same error only once)
 - ExtraErrorData (responsible for doing fancy magic, trying to extract data out of the error object using any

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -91,7 +91,7 @@ In this version upgrade, there are a few breaking changes. This guide should hel
 We moved optional integrations into their own package, called `@sentry/integrations`. Also, we made a few default
 integrations now optional. This is probably the biggest breaking change regarding the upgrade.
 
-Integrations that are now opt-in and were Wedefault before:
+Integrations that are now opt-in and were default before:
 
 - Dedupe (responsible for sending the same error only once)
 - ExtraErrorData (responsible for doing fancy magic, trying to extract data out of the error object using any


### PR DESCRIPTION
- Add changelog for 6.17.0
- Update MIGRATION doc to reflect undeprecation of Severity enum
