### PR TITLE
test(tracing): Add `connection.rtt` tests.

### DIFF
--- a/packages/integration-tests/suites/tracing/metrics/connection-rtt/template.hbs
+++ b/packages/integration-tests/suites/tracing/metrics/connection-rtt/template.hbs
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title></title>
+    <script src="{{htmlWebpackPlugin.options.initialization}}"></script>
+  </head>
+  <body>
+    <div>Rendered</div>
+  </body>
+</html>

--- a/packages/integration-tests/suites/tracing/metrics/connection-rtt/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/connection-rtt/test.ts
@@ -3,12 +3,10 @@ import { expect, Page } from '@playwright/test';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getSentryTransactionRequest } from '../../../../utils/helpers';
 
-sentryTest('should capture a `connection.rtt` metric.', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
-  const eventData = await getSentryTransactionRequest(page, url);
-
-  expect(eventData.measurements).toBeDefined();
-  expect(eventData.measurements?.['connection.rtt']?.value).toBe(0);
+sentryTest.beforeEach(({ browserName }) => {
+  if (browserName !== 'chromium') {
+    sentryTest.skip();
+  }
 });
 
 async function createSessionWithLatency(page: Page, latency: number) {
@@ -23,13 +21,17 @@ async function createSessionWithLatency(page: Page, latency: number) {
   return session;
 }
 
+sentryTest('should capture a `connection.rtt` metric.', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+  const eventData = await getSentryTransactionRequest(page, url);
+
+  expect(eventData.measurements).toBeDefined();
+  expect(eventData.measurements?.['connection.rtt']?.value).toBe(0);
+});
+
 sentryTest(
   'should capture a `connection.rtt` metric with emulated value 200ms on Chromium.',
-  async ({ browserName, getLocalTestPath, page }) => {
-    if (browserName !== 'chromium') {
-      sentryTest.skip();
-    }
-
+  async ({ getLocalTestPath, page }) => {
     const session = await createSessionWithLatency(page, 200);
 
     const url = await getLocalTestPath({ testDir: __dirname });
@@ -44,11 +46,7 @@ sentryTest(
 
 sentryTest(
   'should capture a `connection.rtt` metric with emulated value 100ms on Chromium.',
-  async ({ browserName, getLocalTestPath, page }) => {
-    if (browserName !== 'chromium') {
-      sentryTest.skip();
-    }
-
+  async ({ getLocalTestPath, page }) => {
     const session = await createSessionWithLatency(page, 100);
 
     const url = await getLocalTestPath({ testDir: __dirname });
@@ -63,11 +61,7 @@ sentryTest(
 
 sentryTest(
   'should capture a `connection.rtt` metric with emulated value 50ms on Chromium.',
-  async ({ browserName, getLocalTestPath, page }) => {
-    if (browserName !== 'chromium') {
-      sentryTest.skip();
-    }
-
+  async ({ getLocalTestPath, page }) => {
     const session = await createSessionWithLatency(page, 50);
 
     const url = await getLocalTestPath({ testDir: __dirname });

--- a/packages/integration-tests/suites/tracing/metrics/connection-rtt/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/connection-rtt/test.ts
@@ -1,0 +1,81 @@
+import { expect, Page } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { getSentryTransactionRequest } from '../../../../utils/helpers';
+
+sentryTest('should capture a `connection.rtt` metric.', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+  const eventData = await getSentryTransactionRequest(page, url);
+
+  expect(eventData.measurements).toBeDefined();
+  expect(eventData.measurements?.['connection.rtt']?.value).toBe(0);
+});
+
+async function createSessionWithLatency(page: Page, latency: number) {
+  const session = await page.context().newCDPSession(page);
+  await session.send('Network.emulateNetworkConditions', {
+    offline: false,
+    latency: latency,
+    downloadThroughput: (25 * 1024) / 8,
+    uploadThroughput: (5 * 1024) / 8,
+  });
+
+  return session;
+}
+
+sentryTest(
+  'should capture a `connection.rtt` metric with emulated value 200ms on Chromium.',
+  async ({ browserName, getLocalTestPath, page }) => {
+    if (browserName !== 'chromium') {
+      sentryTest.skip();
+    }
+
+    const session = await createSessionWithLatency(page, 200);
+
+    const url = await getLocalTestPath({ testDir: __dirname });
+    const eventData = await getSentryTransactionRequest(page, url);
+
+    await session.detach();
+
+    expect(eventData.measurements).toBeDefined();
+    expect(eventData.measurements?.['connection.rtt']?.value).toBe(200);
+  },
+);
+
+sentryTest(
+  'should capture a `connection.rtt` metric with emulated value 100ms on Chromium.',
+  async ({ browserName, getLocalTestPath, page }) => {
+    if (browserName !== 'chromium') {
+      sentryTest.skip();
+    }
+
+    const session = await createSessionWithLatency(page, 100);
+
+    const url = await getLocalTestPath({ testDir: __dirname });
+    const eventData = await getSentryTransactionRequest(page, url);
+
+    await session.detach();
+
+    expect(eventData.measurements).toBeDefined();
+    expect(eventData.measurements?.['connection.rtt']?.value).toBe(100);
+  },
+);
+
+sentryTest(
+  'should capture a `connection.rtt` metric with emulated value 50ms on Chromium.',
+  async ({ browserName, getLocalTestPath, page }) => {
+    if (browserName !== 'chromium') {
+      sentryTest.skip();
+    }
+
+    const session = await createSessionWithLatency(page, 50);
+
+    const url = await getLocalTestPath({ testDir: __dirname });
+    const eventData = await getSentryTransactionRequest(page, url);
+
+    await session.detach();
+
+    expect(eventData.measurements).toBeDefined();
+    expect(eventData.measurements?.['connection.rtt']?.value).toBe(50);
+  },
+);


### PR DESCRIPTION
Part of: #4262 