### PR TITLE
test(tracing): Add TTFB tests.

### DIFF
--- a/packages/integration-tests/suites/tracing/metrics/web-vitals-ttfb/template.hbs
+++ b/packages/integration-tests/suites/tracing/metrics/web-vitals-ttfb/template.hbs
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title></title>
+    <script src="{{htmlWebpackPlugin.options.initialization}}"></script>
+  </head>
+  <body>
+    <div>Rendered</div>
+  </body>
+</html>

--- a/packages/integration-tests/suites/tracing/metrics/web-vitals-ttfb/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/web-vitals-ttfb/test.ts
@@ -1,0 +1,13 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { getSentryTransactionRequest } from '../../../../utils/helpers';
+
+sentryTest('should capture TTFB vital.', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+  const eventData = await getSentryTransactionRequest(page, url);
+
+  expect(eventData.measurements).toBeDefined();
+  expect(eventData.measurements?.ttfb?.value).toBeDefined();
+  expect(eventData.measurements?.['ttfb.requestTime']?.value).toBeDefined();
+});


### PR DESCRIPTION
Part of: #4262

Only checks the existence of measurement entries, as I could not find a way to emulate TTFB values like I've done with `connection.rtt` (#4423). Suggestions are welcome.