### PR TITLE
ref(tracing): Remove script evaluation span

### DIFF
--- a/packages/tracing/test/browser/metrics.test.ts
+++ b/packages/tracing/test/browser/metrics.test.ts
@@ -94,7 +94,7 @@ describe('addResourceSpans', () => {
     const startTime = 23;
     const duration = 356;
 
-    const endTimestamp = addResourceSpans(transaction, entry, '/assets/to/css', startTime, duration, timeOrigin);
+    addResourceSpans(transaction, entry, '/assets/to/css', startTime, duration, timeOrigin);
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(transaction.startChild).toHaveBeenCalledTimes(1);
@@ -110,8 +110,6 @@ describe('addResourceSpans', () => {
       op: 'resource.css',
       startTimestamp: timeOrigin + startTime,
     });
-
-    expect(endTimestamp).toBe(timeOrigin + startTime + duration);
   });
 
   it('creates a variety of resource spans', () => {


### PR DESCRIPTION
Tracking the script evaluation span is inconsistent, and often doesn't
show up in most pageload transactions. In addition, the value of this
span is not clear.

To reduce bundle size and complexity, this patch removes the script
evaluation span.