### PR TITLE
feat(nextjs): Add option to use `hidden-source-map` as webpack `devtool` value

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -20,6 +20,7 @@ export type NextConfigObject = {
   sentry?: {
     disableServerWebpackPlugin?: boolean;
     disableClientWebpackPlugin?: boolean;
+    hideSourceMaps?: boolean;
   };
 } & {
   // other `next.config.js` options

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -77,12 +77,11 @@ export function constructWebpackConfigFunction(
     if (enableWebpackPlugin) {
       // TODO Handle possibility that user is using `SourceMapDevToolPlugin` (see
       // https://webpack.js.org/plugins/source-map-dev-tool-plugin/)
-      // TODO Give user option to use `hidden-source-map` ?
 
       // Next doesn't let you change this is dev even if you want to - see
       // https://github.com/vercel/next.js/blob/master/errors/improper-devtool.md
       if (!buildContext.dev) {
-        newConfig.devtool = 'source-map';
+        newConfig.devtool = userNextConfig.sentry?.hideSourceMaps ? 'hidden-source-map' : 'source-map';
       }
 
       newConfig.plugins = newConfig.plugins || [];

--- a/packages/nextjs/test/config.test.ts
+++ b/packages/nextjs/test/config.test.ts
@@ -300,6 +300,19 @@ describe('webpack config', () => {
     expect(finalWebpackConfig).toEqual(expect.objectContaining(materializedUserWebpackConfig));
   });
 
+  it('allows for the use of `hidden-source-map` as `devtool` value', async () => {
+    const userNextConfigHiddenSourceMaps = { ...userNextConfig, sentry: { ...userNextConfig.sentry } };
+    userNextConfigHiddenSourceMaps.sentry.hideSourceMaps = true;
+
+    const finalWebpackConfig = await materializeFinalWebpackConfig({
+      userNextConfig: userNextConfigHiddenSourceMaps,
+      incomingWebpackConfig: serverWebpackConfig,
+      incomingWebpackBuildContext: serverBuildContext,
+    });
+
+    expect(finalWebpackConfig.devtool).toEqual('hidden-source-map');
+  });
+
   describe('webpack `entry` property config', () => {
     const serverConfigFilePath = `./${SERVER_SDK_CONFIG_FILE}`;
     const clientConfigFilePath = `./${CLIENT_SDK_CONFIG_FILE}`;

--- a/packages/nextjs/test/config.test.ts
+++ b/packages/nextjs/test/config.test.ts
@@ -300,17 +300,24 @@ describe('webpack config', () => {
     expect(finalWebpackConfig).toEqual(expect.objectContaining(materializedUserWebpackConfig));
   });
 
-  it('allows for the use of `hidden-source-map` as `devtool` value', async () => {
+  it('allows for the use of `hidden-source-map` as `devtool` value for client-side builds', async () => {
     const userNextConfigHiddenSourceMaps = { ...userNextConfig, sentry: { ...userNextConfig.sentry } };
     userNextConfigHiddenSourceMaps.sentry.hideSourceMaps = true;
 
-    const finalWebpackConfig = await materializeFinalWebpackConfig({
+    const finalClientWebpackConfig = await materializeFinalWebpackConfig({
+      userNextConfig: userNextConfigHiddenSourceMaps,
+      incomingWebpackConfig: clientWebpackConfig,
+      incomingWebpackBuildContext: clientBuildContext,
+    });
+
+    const finalServerWebpackConfig = await materializeFinalWebpackConfig({
       userNextConfig: userNextConfigHiddenSourceMaps,
       incomingWebpackConfig: serverWebpackConfig,
       incomingWebpackBuildContext: serverBuildContext,
     });
 
-    expect(finalWebpackConfig.devtool).toEqual('hidden-source-map');
+    expect(finalClientWebpackConfig.devtool).toEqual('hidden-source-map');
+    expect(finalServerWebpackConfig.devtool).toEqual('source-map');
   });
 
   describe('webpack `entry` property config', () => {


### PR DESCRIPTION
We currently force the value of the webpack option `devtool` to be `source-map`, in order to guarantee that the correct sourcemaps are generated during build. There is [another `devtool` value](https://webpack.js.org/configuration/devtool/), `hidden-source-map`, which produces the same maps (so just as good for our purposes), but without adding `sourceMappingURL` comments at the bottom of the resulting JS files. (Some users prefer this as a way not to have the browser complain when it tries to follow the `sourceMappingURL` link and comes up empty.)

This PR adds an option that users can pass in their nextjs config, under the key `sentry.hideSourceMaps`. When this is set to true, the SDK will use `hidden-source-map` as the `devtool` value instead of `source-map`. Note that since this is a front-end-only problem, the option only applies to client-side builds.

The new option is documented in https://github.com/getsentry/sentry-docs/pull/4627.

Fixes https://github.com/getsentry/sentry-javascript/issues/3549.