### PR TITLE
fix(vue): Vue 3 external recognition error (#4431)

### DIFF
--- a/packages/vue/src/sdk.ts
+++ b/packages/vue/src/sdk.ts
@@ -49,11 +49,11 @@ export function init(
     return;
   }
 
-  if (options.Vue) {
-    vueInit(options.Vue, options);
-  } else if (options.app) {
+  if (options.app) {
     const apps = Array.isArray(options.app) ? options.app : [options.app];
     apps.forEach(app => vueInit(app, options));
+  } else if (options.Vue) {
+    vueInit(options.Vue, options);
   }
 }
 


### PR DESCRIPTION
Improve the judgment priority of variable `app` to avoid duplicate name pollution caused by global variable Vue.

Fixes https://github.com/getsentry/sentry-javascript/issues/4431