### PR TITLE
fix(vue): prevent after hook from starting new span

### DIFF
--- a/packages/vue/src/tracing.ts
+++ b/packages/vue/src/tracing.ts
@@ -108,7 +108,9 @@ export const createTracingMixins = (options: TracingOptions): Mixins => {
         } else {
           // The span should already be added via the first handler call (in the 'before' hook)
           const span = this.$_sentrySpans[operation];
-          if (!span) return; // If not, then the before hook did not start the tracking span, probably because it happened even before there is an active transaction
+          // The before hook did not start the tracking span, so the span was not added.
+          // This is probably because it happened before there is an active transaction
+          if (!span) return;
 
           span.finish();
           finishRootSpan(this, timestampInSeconds(), options.timeout);


### PR DESCRIPTION
- [ ] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Fix issue similar to https://github.com/getsentry/sentry-javascript/issues/4427, where:
1. The 'before' hook is triggered before Vue routing happens, hence 'pageload' transaction has not started and the tracking span is not created
2. The 'after' hook is called afterwards. But because there is no corresponding tracking span, the handler starts a new tracking span
3. The new tracking span never finishes and eventually gets marked as 'cancelled'

Notes:
* Currently, I have only actually experienced this issue with `ui.vue.activate`

I'm not able to find any existing tracing tests, so please tell me what I should do with the testing if necessary.