### PR TITLE
ref(serverless): Remove `rethrowAfterCapture` use in AWS lambda wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-This patch contains a breaking change for anyone setting the undocumented `rethrowAfterCapture` option for `@sentry/serverless`'s AWS wrapper to `false`, as its functionality has been removed. (That said, we couldn't find any projects in GitHub which do.) For backwards compatibility with anyone setting it to `true` (which is also the default), the option remains in the `WrapperOptions` type for now. It will be removed in the next major release, though, so we recommend removing it from your code.
+This patch contains a breaking change for anyone setting the undocumented `rethrowAfterCapture` option for `@sentry/serverless`'s AWS wrapper to `false`, as its functionality has been removed. For backwards compatibility with anyone setting it to `true` (which is also the default), the option remains in the `WrapperOptions` type for now. It will be removed in the next major release, though, so we recommend removing it from your code.
 
 - ref(serverless): Remove `rethrowAfterCapture` use in AWS lambda wrapper (#4448)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+This patch contains a breaking change for anyone setting the undocumented `rethrowAfterCapture` option for `@sentry/serverless`'s AWS wrapper to `false`, as its functionality has been removed. (That said, we couldn't find any projects in GitHub which do.) For backwards compatibility with anyone setting it to `true` (which is also the default), the option remains in the `WrapperOptions` type for now. It will be removed in the next major release, though, so we recommend removing it from your code.
+
+- ref(serverless): Remove `rethrowAfterCapture` use in AWS lambda wrapper (#4448)
+
 ## 6.17.1
 
 - ref(core): Renormalize event only after stringification errors (#4425)
@@ -945,7 +949,7 @@ removed in the future. If you are only using the `Tracing` integration there is 
 
 ## 5.6.3
 
-- [browser] fix: Don't capture our own XHR events that somehow bubbled-up to global handler
+- [browser] fix: Don't capture our own XHR events that somehow bubbled-up to global handler (#2221)
 
 ## 5.6.2
 

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -42,7 +42,8 @@ export type AsyncHandler<T extends Handler> = (
 
 export interface WrapperOptions {
   flushTimeout: number;
-  rethrowAfterCapture: boolean;
+  // TODO: DEPRECATED - remove `rethrowAfterCapture` in v7
+  rethrowAfterCapture?: boolean;
   callbackWaitsForEmptyEventLoop: boolean;
   captureTimeoutWarning: boolean;
   timeoutWarningLimit: number;
@@ -215,11 +216,10 @@ function enhanceScopeWithEnvironmentData(scope: Scope, context: Context, startTi
 export function wrapHandler<TEvent, TResult>(
   handler: Handler<TEvent, TResult>,
   wrapOptions: Partial<WrapperOptions> = {},
-): Handler<TEvent, TResult | undefined> {
+): Handler<TEvent, TResult> {
   const START_TIME = performance.now();
   const options: WrapperOptions = {
     flushTimeout: 2000,
-    rethrowAfterCapture: true,
     callbackWaitsForEmptyEventLoop: false,
     captureTimeoutWarning: true,
     timeoutWarningLimit: 500,
@@ -293,7 +293,7 @@ export function wrapHandler<TEvent, TResult>(
 
     const hub = getCurrentHub();
     const scope = hub.pushScope();
-    let rv: TResult | undefined;
+    let rv: TResult;
     try {
       enhanceScopeWithEnvironmentData(scope, context, START_TIME);
       // We put the transaction on the scope so users can attach children to it
@@ -309,9 +309,7 @@ export function wrapHandler<TEvent, TResult>(
       }
     } catch (e) {
       captureException(e);
-      if (options.rethrowAfterCapture) {
-        throw e;
-      }
+      throw e;
     } finally {
       clearTimeout(timeoutWarningTimer);
       transaction.finish();

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -91,21 +91,6 @@ describe('AWSLambda', () => {
       expect(Sentry.flush).toBeCalledWith(1337);
     });
 
-    test('rethrowAfterCapture', async () => {
-      expect.assertions(3);
-
-      const error = new Error('wat');
-      const handler = () => {
-        throw error;
-      };
-      const wrappedHandlerWithRethrow = wrapHandler(handler, { rethrowAfterCapture: true });
-      const wrappedHandlerWithoutRethrow = wrapHandler(handler, { rethrowAfterCapture: false });
-
-      await expect(wrappedHandlerWithRethrow(fakeEvent, fakeContext, fakeCallback)).rejects.toThrow(error);
-      await expect(wrappedHandlerWithoutRethrow(fakeEvent, fakeContext, fakeCallback)).resolves.not.toThrow();
-      expect(Sentry.flush).toBeCalledTimes(2);
-    });
-
     test('captureTimeoutWarning enabled (default)', async () => {
       expect.assertions(2);
 


### PR DESCRIPTION
This PR removes the use of the `rethrowAfterCapture` option from the AWS handler-wrapping function `@sentry/serverless` provides. Without its use, the code follows the same path as it has been when the option has been set to its default value, which is `true`. Though this is _technically_ a breaking change for anyone who currently has it set to `false`, 

a) the option has never been documented,
b) it never should have existed in the first place (we do error _monitoring_, not error _handling_, meaning there should be no question as to whether we rethrow the error after recording it),
c) of all of the public projects on GH, only three are using it set explicitly to `true`, and zero are using it set to `false`.

For the three projects using it set to `true`, there is no behavior change. Further, since all three are written in TS, the option hasn't been removed from the `WrapperOptions` type, so that their continuing to pass it doesn’t cause type errors. It has been made optional, though, so that our non-use of it also doesn't cause type errors. There's also a TODO so that we remember to remove it in v7.

Fixes https://github.com/getsentry/sentry-javascript/issues/3364.