### PR TITLE
changed(tracing): always clear timeout when new activity starts within idle timeout

### DIFF
--- a/packages/tracing/src/idletransaction.ts
+++ b/packages/tracing/src/idletransaction.ts
@@ -221,7 +221,10 @@ export class IdleTransaction extends Transaction {
       // Remember timestampWithMs is in seconds, timeout is in ms
       const end = timestampWithMs() + timeout / 1000;
 
-      setTimeout(() => {
+      if (this._initTimeout) {
+        clearTimeout(this._initTimeout);
+      }
+      this._initTimeout = setTimeout(() => {
         if (!this._finished) {
           this.setTag(FINISH_REASON_TAG, IDLE_TRANSACTION_FINISH_REASONS[1]);
           this.finish(end);

--- a/packages/tracing/test/idletransaction.test.ts
+++ b/packages/tracing/test/idletransaction.test.ts
@@ -188,6 +188,8 @@ describe('IdleTransaction', () => {
     it('does not finish if a activity is started', () => {
       const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub, DEFAULT_IDLE_TIMEOUT);
       transaction.initSpanRecorder(10);
+      const span = transaction.startChild({});
+      span.finish();
       transaction.startChild({});
 
       jest.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT);

--- a/packages/tracing/test/idletransaction.test.ts
+++ b/packages/tracing/test/idletransaction.test.ts
@@ -190,10 +190,14 @@ describe('IdleTransaction', () => {
       transaction.initSpanRecorder(10);
       const span = transaction.startChild({});
       span.finish();
-      transaction.startChild({});
+      const span2 = transaction.startChild({});
 
       jest.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT);
       expect(transaction.endTimestamp).toBeUndefined();
+
+      span2.finish();
+      jest.advanceTimersByTime(DEFAULT_IDLE_TIMEOUT + DEFAULT_IDLE_TIMEOUT);
+      expect(transaction.endTimestamp).toBeDefined();
     });
   });
 


### PR DESCRIPTION
- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

## Summary
Always clear idle timeout when new activity starts within the idle timeout, by assigning the `popAcitivity` timeout to the instance's timeout.

### Example
#### Before
1. (t = 0) Starts an `IdleTransaction` with `idleTimeout` = `1000`
    i. Idle timeout is created 
2. (t = 100) Push activity A
    i. Idle timeout is cleared
3. (t = 200) Pop activity A
    i. An unstoppable idle timeout is created
4. (t = 800) Push activity B
5. (t = 1200) Idle timeout created in [3.i.] finishes the IdleTransaction although activity B is still active

#### After
1. (t = 0) Starts an `IdleTransaction` with `idleTimeout` = `1000`
    i. Idle timeout is created
2. (t = 100) Push activity A
    i. Idle timeout is cleared
3. (t = 200) Pop activity A
    i. Idle timeout is created
4. (t = 800) Push activity B
    i. Idle timeout is cleared
5. (t = 1500) Pop activity B
    i. Idle timeout is created
6. (t = 2500) Idle timeout created in [5.i.] finishes the IdleTransaction

### Notes
* Rename `_initTimeout` to `_idleTimeout` to match its new(?) purpose more accurately.
* Not sure if the behavior should be toggleable via an option?