### PR TITLE
chore(build): Upgrade to Prettier 2.x

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
+  "arrowParens": "avoid",
   "printWidth": 120,
   "proseWrap": "always",
   "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "madge": "4.0.2",
     "mocha": "^6.1.4",
     "npm-run-all": "^4.1.5",
-    "prettier": "1.19.1",
+    "prettier": "2.5.1",
     "replace-in-file": "^4.0.0",
     "rimraf": "^3.0.2",
     "sinon": "^7.3.2",

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -183,7 +183,7 @@ export function TraceClassDecorator(): ClassDecorator {
   return target => {
     const originalOnInit = target.prototype.ngOnInit;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    target.prototype.ngOnInit = function(...args: any[]): ReturnType<typeof originalOnInit> {
+    target.prototype.ngOnInit = function (...args: any[]): ReturnType<typeof originalOnInit> {
       const activeTransaction = getActiveTransaction();
       if (activeTransaction) {
         tracingSpan = activeTransaction.startChild({
@@ -198,7 +198,7 @@ export function TraceClassDecorator(): ClassDecorator {
 
     const originalAfterViewInit = target.prototype.ngAfterViewInit;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    target.prototype.ngAfterViewInit = function(...args: any[]): ReturnType<typeof originalAfterViewInit> {
+    target.prototype.ngAfterViewInit = function (...args: any[]): ReturnType<typeof originalAfterViewInit> {
       if (tracingSpan) {
         tracingSpan.finish();
       }
@@ -218,7 +218,7 @@ export function TraceMethodDecorator(): MethodDecorator {
   return (target: Object, propertyKey: string | symbol, descriptor: PropertyDescriptor) => {
     const originalMethod = descriptor.value;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    descriptor.value = function(...args: any[]): ReturnType<typeof originalMethod> {
+    descriptor.value = function (...args: any[]): ReturnType<typeof originalMethod> {
       const now = timestampWithMs();
       const activeTransaction = getActiveTransaction();
       if (activeTransaction) {

--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -80,7 +80,7 @@ export function wrap(
 
   /* eslint-disable prefer-rest-params */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const sentryWrapped: WrappedFunction = function(this: any): void {
+  const sentryWrapped: WrappedFunction = function (this: any): void {
     const args = Array.prototype.slice.call(arguments);
 
     try {

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -121,7 +121,7 @@ function _domBreadcrumb(dom: BreadcrumbsOptions['dom']): (handlerData: { [key: s
     try {
       target = handlerData.event.target
         ? htmlTreeAsString(handlerData.event.target as Node, keyAttrs)
-        : htmlTreeAsString((handlerData.event as unknown) as Node, keyAttrs);
+        : htmlTreeAsString(handlerData.event as unknown as Node, keyAttrs);
     } catch (e) {
       target = '<unknown>';
     }

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -181,7 +181,8 @@ function _eventFromRejectionWithPrimitive(reason: Primitive): Event {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function _eventFromIncompleteOnError(msg: any, url: any, line: any, column: any): Event {
-  const ERROR_TYPES_RE = /^(?:[Uu]ncaught (?:exception: )?)?(?:((?:Eval|Internal|Range|Reference|Syntax|Type|URI|)Error): )?(.*)$/i;
+  const ERROR_TYPES_RE =
+    /^(?:[Uu]ncaught (?:exception: )?)?(?:((?:Eval|Internal|Range|Reference|Syntax|Type|URI|)Error): )?(.*)$/i;
 
   // If 'message' is ErrorEvent, get real message from inside
   let message = isErrorEvent(msg) ? msg.message : msg;

--- a/packages/browser/src/integrations/trycatch.ts
+++ b/packages/browser/src/integrations/trycatch.ts
@@ -109,7 +109,7 @@ export class TryCatch implements Integration {
 /** JSDoc */
 function _wrapTimeFunction(original: () => void): () => number {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function(this: any, ...args: any[]): number {
+  return function (this: any, ...args: any[]): number {
     const originalCallback = args[0];
     args[0] = wrap(originalCallback, {
       mechanism: {
@@ -126,7 +126,7 @@ function _wrapTimeFunction(original: () => void): () => number {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function _wrapRAF(original: any): (callback: () => void) => any {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function(this: any, callback: () => void): () => void {
+  return function (this: any, callback: () => void): () => void {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     return original.call(
       this,
@@ -147,7 +147,7 @@ function _wrapRAF(original: any): (callback: () => void) => any {
 /** JSDoc */
 function _wrapXHR(originalSend: () => void): () => void {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return function(this: XMLHttpRequest, ...args: any[]): void {
+  return function (this: XMLHttpRequest, ...args: any[]): void {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const xhr = this;
     const xmlHttpRequestProps: XMLHttpRequestProp[] = ['onload', 'onerror', 'onprogress', 'onreadystatechange'];
@@ -155,7 +155,7 @@ function _wrapXHR(originalSend: () => void): () => void {
     xmlHttpRequestProps.forEach(prop => {
       if (prop in xhr && typeof xhr[prop] === 'function') {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        fill(xhr, prop, function(original: WrappedFunction): () => any {
+        fill(xhr, prop, function (original: WrappedFunction): () => any {
           const wrapOptions = {
             mechanism: {
               data: {
@@ -195,10 +195,12 @@ function _wrapEventTarget(target: string): void {
     return;
   }
 
-  fill(proto, 'addEventListener', function(
-    original: () => void,
-  ): (eventName: string, fn: EventListenerObject, options?: boolean | AddEventListenerOptions) => void {
-    return function(
+  fill(proto, 'addEventListener', function (original: () => void): (
+    eventName: string,
+    fn: EventListenerObject,
+    options?: boolean | AddEventListenerOptions,
+  ) => void {
+    return function (
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       this: any,
       eventName: string,
@@ -227,7 +229,7 @@ function _wrapEventTarget(target: string): void {
         this,
         eventName,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        wrap((fn as any) as WrappedFunction, {
+        wrap(fn as any as WrappedFunction, {
           mechanism: {
             data: {
               function: 'addEventListener',
@@ -243,44 +245,48 @@ function _wrapEventTarget(target: string): void {
     };
   });
 
-  fill(proto, 'removeEventListener', function(
-    originalRemoveEventListener: () => void,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ): (this: any, eventName: string, fn: EventListenerObject, options?: boolean | EventListenerOptions) => () => void {
-    return function(
+  fill(
+    proto,
+    'removeEventListener',
+    function (
+      originalRemoveEventListener: () => void,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      this: any,
-      eventName: string,
-      fn: EventListenerObject,
-      options?: boolean | EventListenerOptions,
-    ): () => void {
-      /**
-       * There are 2 possible scenarios here:
-       *
-       * 1. Someone passes a callback, which was attached prior to Sentry initialization, or by using unmodified
-       * method, eg. `document.addEventListener.call(el, name, handler). In this case, we treat this function
-       * as a pass-through, and call original `removeEventListener` with it.
-       *
-       * 2. Someone passes a callback, which was attached after Sentry was initialized, which means that it was using
-       * our wrapped version of `addEventListener`, which internally calls `wrap` helper.
-       * This helper "wraps" whole callback inside a try/catch statement, and attached appropriate metadata to it,
-       * in order for us to make a distinction between wrapped/non-wrapped functions possible.
-       * If a function was wrapped, it has additional property of `__sentry_wrapped__`, holding the handler.
-       *
-       * When someone adds a handler prior to initialization, and then do it again, but after,
-       * then we have to detach both of them. Otherwise, if we'd detach only wrapped one, it'd be impossible
-       * to get rid of the initial handler and it'd stick there forever.
-       */
-      const wrappedEventHandler = (fn as unknown) as WrappedFunction;
-      try {
-        const originalEventHandler = wrappedEventHandler && wrappedEventHandler.__sentry_wrapped__;
-        if (originalEventHandler) {
-          originalRemoveEventListener.call(this, eventName, originalEventHandler, options);
+    ): (this: any, eventName: string, fn: EventListenerObject, options?: boolean | EventListenerOptions) => () => void {
+      return function (
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        this: any,
+        eventName: string,
+        fn: EventListenerObject,
+        options?: boolean | EventListenerOptions,
+      ): () => void {
+        /**
+         * There are 2 possible scenarios here:
+         *
+         * 1. Someone passes a callback, which was attached prior to Sentry initialization, or by using unmodified
+         * method, eg. `document.addEventListener.call(el, name, handler). In this case, we treat this function
+         * as a pass-through, and call original `removeEventListener` with it.
+         *
+         * 2. Someone passes a callback, which was attached after Sentry was initialized, which means that it was using
+         * our wrapped version of `addEventListener`, which internally calls `wrap` helper.
+         * This helper "wraps" whole callback inside a try/catch statement, and attached appropriate metadata to it,
+         * in order for us to make a distinction between wrapped/non-wrapped functions possible.
+         * If a function was wrapped, it has additional property of `__sentry_wrapped__`, holding the handler.
+         *
+         * When someone adds a handler prior to initialization, and then do it again, but after,
+         * then we have to detach both of them. Otherwise, if we'd detach only wrapped one, it'd be impossible
+         * to get rid of the initial handler and it'd stick there forever.
+         */
+        const wrappedEventHandler = fn as unknown as WrappedFunction;
+        try {
+          const originalEventHandler = wrappedEventHandler && wrappedEventHandler.__sentry_wrapped__;
+          if (originalEventHandler) {
+            originalRemoveEventListener.call(this, eventName, originalEventHandler, options);
+          }
+        } catch (e) {
+          // ignore, accessing __sentry_wrapped__ will throw in some Selenium environments
         }
-      } catch (e) {
-        // ignore, accessing __sentry_wrapped__ will throw in some Selenium environments
-      }
-      return originalRemoveEventListener.call(this, eventName, wrappedEventHandler, options);
-    };
-  });
+        return originalRemoveEventListener.call(this, eventName, wrappedEventHandler, options);
+      };
+    },
+  );
 }

--- a/packages/browser/src/tracekit.ts
+++ b/packages/browser/src/tracekit.ts
@@ -42,12 +42,15 @@ export interface StackTrace {
 const UNKNOWN_FUNCTION = '?';
 
 // Chromium based browsers: Chrome, Brave, new Opera, new Edge
-const chrome = /^\s*at (?:(.*?) ?\()?((?:file|https?|blob|chrome-extension|address|native|eval|webpack|<anonymous>|[-a-z]+:|.*bundle|\/).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i;
+const chrome =
+  /^\s*at (?:(.*?) ?\()?((?:file|https?|blob|chrome-extension|address|native|eval|webpack|<anonymous>|[-a-z]+:|.*bundle|\/).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i;
 // gecko regex: `(?:bundle|\d+\.js)`: `bundle` is for react native, `\d+\.js` also but specifically for ram bundles because it
 // generates filenames without a prefix like `file://` the filenames in the stacktrace are just 42.js
 // We need this specific case for now because we want no other regex to match.
-const gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)?((?:file|https?|blob|chrome|webpack|resource|moz-extension|capacitor).*?:\/.*?|\[native code\]|[^@]*(?:bundle|\d+\.js)|\/[\w\-. /=]+)(?::(\d+))?(?::(\d+))?\s*$/i;
-const winjs = /^\s*at (?:((?:\[object object\])?.+) )?\(?((?:file|ms-appx|https?|webpack|blob):.*?):(\d+)(?::(\d+))?\)?\s*$/i;
+const gecko =
+  /^\s*(.*?)(?:\((.*?)\))?(?:^|@)?((?:file|https?|blob|chrome|webpack|resource|moz-extension|capacitor).*?:\/.*?|\[native code\]|[^@]*(?:bundle|\d+\.js)|\/[\w\-. /=]+)(?::(\d+))?(?::(\d+))?\s*$/i;
+const winjs =
+  /^\s*at (?:((?:\[object object\])?.+) )?\(?((?:file|ms-appx|https?|webpack|blob):.*?):(\d+)(?::(\d+))?\)?\s*$/i;
 const geckoEval = /(\S+) line (\d+)(?: > eval line \d+)* > eval/i;
 const chromeEval = /\((\S*)(?::(\d+))(?::(\d+))\)/;
 // Based on our own mapping pattern - https://github.com/getsentry/sentry/blob/9f08305e09866c8bd6d0c24f5b0aabdd7dd6c59c/src/sentry/lang/javascript/errormapping.py#L83-L108
@@ -204,7 +207,8 @@ function computeStackTraceFromStacktraceProp(ex: any): StackTrace | null {
   // reliably in other circumstances.
   const stacktrace = ex.stacktrace;
   const opera10Regex = / line (\d+).*script (?:in )?(\S+)(?:: in function (\S+))?$/i;
-  const opera11Regex = / line (\d+), column (\d+)\s*(?:in (?:<anonymous function: ([^>]+)>|([^)]+))\((.*)\))? in (.*):\s*$/i;
+  const opera11Regex =
+    / line (\d+), column (\d+)\s*(?:in (?:<anonymous function: ([^>]+)>|([^)]+))\((.*)\))? in (.*):\s*$/i;
   const lines = stacktrace.split('\n');
   const stack = [];
   let parts;

--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -325,7 +325,7 @@ describe('wrap()', () => {
 
   it('should allow for passing this and arguments through binding', () => {
     const result = wrap(
-      function(this: unknown, a: string, b: number): unknown[] {
+      function (this: unknown, a: string, b: number): unknown[] {
         return [this, a, b];
       }.bind({ context: 'this' }, 'b', 42),
     );
@@ -335,7 +335,7 @@ describe('wrap()', () => {
     expect((result as unknown[])[2]).toBe(42);
 
     const result2 = wrap(
-      function(this: { x: number }): number {
+      function (this: { x: number }): number {
         return this.x;
       }.bind({ x: 42 }),
     );

--- a/packages/browser/test/unit/integrations/helpers.test.ts
+++ b/packages/browser/test/unit/integrations/helpers.test.ts
@@ -135,7 +135,7 @@ describe('internal wrap()', () => {
       },
     };
     // @ts-ignore eventFn does not have property handleEvent
-    context.eventFn.handleEvent = function(): void {
+    context.eventFn.handleEvent = function (): void {
       expect(this).toBe(context);
     };
 

--- a/packages/browser/test/unit/tracekit/custom.test.ts
+++ b/packages/browser/test/unit/tracekit/custom.test.ts
@@ -186,32 +186,28 @@ describe('Tracekit - Custom Tests', () => {
     const stacktrace = computeStackTrace(REACT_NATIVE_EXPO_EXCEPTION);
     expect(stacktrace.stack).toEqual([
       {
-        url:
-          '/data/user/0/com.sentrytest/files/.expo-internal/bundle-613EDD44F3305B9D75D4679663900F2BCDDDC326F247CA3202A3A4219FD412D3',
+        url: '/data/user/0/com.sentrytest/files/.expo-internal/bundle-613EDD44F3305B9D75D4679663900F2BCDDDC326F247CA3202A3A4219FD412D3',
         func: 'onPress',
         args: [],
         line: 595,
         column: 658,
       },
       {
-        url:
-          '/data/user/0/com.sentrytest/files/.expo-internal/bundle-613EDD44F3305B9D75D4679663900F2BCDDDC326F247CA3202A3A4219FD412D3',
+        url: '/data/user/0/com.sentrytest/files/.expo-internal/bundle-613EDD44F3305B9D75D4679663900F2BCDDDC326F247CA3202A3A4219FD412D3',
         func: 'value',
         args: [],
         line: 221,
         column: 7656,
       },
       {
-        url:
-          '/data/user/0/com.sentrytest/files/.expo-internal/bundle-613EDD44F3305B9D75D4679663900F2BCDDDC326F247CA3202A3A4219FD412D3',
+        url: '/data/user/0/com.sentrytest/files/.expo-internal/bundle-613EDD44F3305B9D75D4679663900F2BCDDDC326F247CA3202A3A4219FD412D3',
         func: 'onResponderRelease',
         args: [],
         line: 221,
         column: 5666,
       },
       {
-        url:
-          '/data/user/0/com.sentrytest/files/.expo-internal/bundle-613EDD44F3305B9D75D4679663900F2BCDDDC326F247CA3202A3A4219FD412D3',
+        url: '/data/user/0/com.sentrytest/files/.expo-internal/bundle-613EDD44F3305B9D75D4679663900F2BCDDDC326F247CA3202A3A4219FD412D3',
         func: 'p',
         args: [],
         line: 96,

--- a/packages/browser/test/unit/tracekit/original.test.ts
+++ b/packages/browser/test/unit/tracekit/original.test.ts
@@ -881,8 +881,7 @@ describe('Tracekit - Original Tests', () => {
       column: 24,
     });
     expect(stackFrames.stack[7]).toEqual({
-      url:
-        '/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/native/ReactNativeBaseComponent.js',
+      url: '/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/native/ReactNativeBaseComponent.js',
       func: 'this',
       args: [],
       line: 74,

--- a/packages/browser/test/unit/transports/base.test.ts
+++ b/packages/browser/test/unit/transports/base.test.ts
@@ -14,7 +14,7 @@ describe('BaseTransport', () => {
       navigator.sendBeacon = sendBeaconSpy;
       Object.defineProperty(document, 'visibilityState', {
         configurable: true,
-        get: function() {
+        get: function () {
           return visibilityState;
         },
       });

--- a/packages/core/src/integrations/functiontostring.ts
+++ b/packages/core/src/integrations/functiontostring.ts
@@ -23,7 +23,7 @@ export class FunctionToString implements Integration {
     originalFunctionToString = Function.prototype.toString;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Function.prototype.toString = function(this: WrappedFunction, ...args: any[]): string {
+    Function.prototype.toString = function (this: WrappedFunction, ...args: any[]): string {
       const context = getOriginalFunction(this) || this;
       return originalFunctionToString.apply(context, args);
     };

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -834,7 +834,7 @@ describe('BaseClient', () => {
         environment: 'production',
         event_id: '972f45b826a248bba98e990878a177e1',
         spans: [
-          ({
+          {
             data: { _sentry_extra_metrics: { M1: { value: 1 }, M2: { value: 2 } } },
             description: 'first-paint',
             endTimestamp: 1591603196.637835,
@@ -843,8 +843,8 @@ describe('BaseClient', () => {
             spanId: '9e15bf99fbe4bc80',
             startTimestamp: 1591603196.637835,
             traceId: '86f39e84263a4de99c326acab3bfe3bd',
-          } as unknown) as Span,
-          ({
+          } as unknown as Span,
+          {
             description: 'first-contentful-paint',
             endTimestamp: 1591603196.637835,
             op: 'paint',
@@ -852,7 +852,7 @@ describe('BaseClient', () => {
             spanId: 'aa554c1f506b0783',
             startTimestamp: 1591603196.637835,
             traceId: '86f39e84263a4de99c326acab3bfe3bd',
-          } as any) as Span,
+          } as any as Span,
         ],
         start_timestamp: 1591603196.614865,
         timestamp: 1591603196.728485,
@@ -1026,9 +1026,9 @@ describe('BaseClient', () => {
       const recordLostEventSpy = jest.fn();
       jest.spyOn(client, 'getTransport').mockImplementationOnce(
         () =>
-          (({
+          ({
             recordLostEvent: recordLostEventSpy,
-          } as any) as Transport),
+          } as any as Transport),
       );
 
       client.captureEvent({ message: 'hello' }, {});
@@ -1060,9 +1060,9 @@ describe('BaseClient', () => {
       const recordLostEventSpy = jest.fn();
       jest.spyOn(client, 'getTransport').mockImplementationOnce(
         () =>
-          (({
+          ({
             recordLostEvent: recordLostEventSpy,
-          } as any) as Transport),
+          } as any as Transport),
       );
 
       const scope = new Scope();
@@ -1112,9 +1112,9 @@ describe('BaseClient', () => {
       const recordLostEventSpy = jest.fn();
       jest.spyOn(client, 'getTransport').mockImplementationOnce(
         () =>
-          (({
+          ({
             recordLostEvent: recordLostEventSpy,
-          } as any) as Transport),
+          } as any as Transport),
       );
 
       client.captureEvent({ message: 'hello' }, {});

--- a/packages/eslint-plugin-sdk/src/rules/no-async-await.js
+++ b/packages/eslint-plugin-sdk/src/rules/no-async-await.js
@@ -19,7 +19,7 @@ module.exports = {
     fixable: null,
     schema: [],
   },
-  create: function(context) {
+  create: function (context) {
     // variables should be defined here
 
     //----------------------------------------------------------------------

--- a/packages/eslint-plugin-sdk/src/rules/no-eq-empty.js
+++ b/packages/eslint-plugin-sdk/src/rules/no-eq-empty.js
@@ -22,7 +22,7 @@ module.exports = {
       equality: 'Do not apply the equality operator on an empty {{ name }}.{{ fix }}',
     },
   },
-  create: function(context) {
+  create: function (context) {
     // variables should be defined here
 
     //----------------------------------------------------------------------

--- a/packages/hub/test/global.test.ts
+++ b/packages/hub/test/global.test.ts
@@ -23,7 +23,7 @@ describe('global', () => {
   test('hub extension methods receive correct hub instance', () => {
     const newestHub = new Hub(undefined, undefined, 999999);
     (global as any).__SENTRY__.hub = newestHub;
-    const fn = jest.fn().mockImplementation(function(...args: []) {
+    const fn = jest.fn().mockImplementation(function (...args: []) {
       // @ts-ignore typescript complains that this can be `any`
       expect(this).toBe(newestHub);
       expect(args).toEqual([1, 2, 3]);

--- a/packages/hub/test/hub.test.ts
+++ b/packages/hub/test/hub.test.ts
@@ -60,7 +60,7 @@ describe('Hub', () => {
       hub.pushScope();
       expect(hub.getStack()).toHaveLength(2);
       expect(hub.getStack()[1].scope).not.toBe(localScope);
-      expect(((hub.getStack()[1].scope as Scope) as any)._extra).toEqual({ a: 'b' });
+      expect((hub.getStack()[1].scope as Scope as any)._extra).toEqual({ a: 'b' });
     });
 
     test('inherit client', () => {

--- a/packages/integrations/src/vue.ts
+++ b/packages/integrations/src/vue.ts
@@ -8,16 +8,16 @@ import { basename, getGlobalObject, logger, timestampWithMs } from '@sentry/util
  * without the need to import `Tracing` itself from the @sentry/apm package.
  * @deprecated as @sentry/tracing should be used over @sentry/apm.
  */
-const TRACING_GETTER = ({
+const TRACING_GETTER = {
   id: 'Tracing',
-} as any) as IntegrationClass<Integration>;
+} as any as IntegrationClass<Integration>;
 
 /**
  * Used to extract BrowserTracing integration from @sentry/tracing
  */
-const BROWSER_TRACING_GETTER = ({
+const BROWSER_TRACING_GETTER = {
   id: 'BrowserTracing',
-} as any) as IntegrationClass<Integration>;
+} as any as IntegrationClass<Integration>;
 
 const VUE_OP = 'ui.vue';
 

--- a/packages/integrations/test/extraerrordata.test.ts
+++ b/packages/integrations/test/extraerrordata.test.ts
@@ -93,7 +93,7 @@ describe('ExtraErrorData()', () => {
     const error = new TypeError('foo') as ExtendedError;
     error.baz = 42;
     error.foo = 'bar';
-    error.toJSON = function() {
+    error.toJSON = function () {
       return {
         bar: 1337,
         qux: `${this.message} but nicer`,
@@ -117,7 +117,7 @@ describe('ExtraErrorData()', () => {
   it('toJSON props should have priority over directly assigned ones', () => {
     const error = new TypeError('foo') as ExtendedError;
     error.baz = 42;
-    error.toJSON = function() {
+    error.toJSON = function () {
       return {
         baz: 1337,
       };
@@ -137,7 +137,7 @@ describe('ExtraErrorData()', () => {
   it('toJSON props should allow for usage of native names', () => {
     const error = new TypeError('foo') as ExtendedError;
     error.baz = 42;
-    error.toJSON = function() {
+    error.toJSON = function () {
       return {
         message: 'bar',
       };

--- a/packages/nextjs/src/config/index.ts
+++ b/packages/nextjs/src/config/index.ts
@@ -15,7 +15,7 @@ export function withSentryConfig(
   // If the user has passed us a function, we need to return a function, so that we have access to `phase` and
   // `defaults` in order to pass them along to the user's function
   if (typeof userNextConfig === 'function') {
-    return function(phase: string, defaults: { defaultConfig: NextConfigObject }): Partial<NextConfigObject> {
+    return function (phase: string, defaults: { defaultConfig: NextConfigObject }): Partial<NextConfigObject> {
       const materializedUserNextConfig = userNextConfig(phase, defaults);
       return {
         ...materializedUserNextConfig,

--- a/packages/nextjs/src/performance/client.ts
+++ b/packages/nextjs/src/performance/client.ts
@@ -73,7 +73,7 @@ type WrappedRouterChangeState = RouterChangeState;
  * Start a navigation transaction every time the router changes state.
  */
 function changeStateWrapper(originalChangeStateWrapper: RouterChangeState): WrappedRouterChangeState {
-  const wrapper = function(
+  const wrapper = function (
     this: any,
     method: string,
     // The parameterized url, ex. posts/[id]/[comment]

--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -117,7 +117,7 @@ export function instrumentServer(): void {
 function makeWrappedHandlerGetter(origHandlerGetter: HandlerGetter): WrappedHandlerGetter {
   // We wrap this purely in order to be able to grab data and do further monkeypatching the first time it runs.
   // Otherwise, it's just a pass-through to the original method.
-  const wrappedHandlerGetter = async function(this: NextServer): Promise<ReqHandler> {
+  const wrappedHandlerGetter = async function (this: NextServer): Promise<ReqHandler> {
     if (!sdkSetupComplete) {
       // stash this in the closure so that `makeWrappedReqHandler` can use it
       liveServer = this.server;
@@ -152,7 +152,7 @@ function makeWrappedHandlerGetter(origHandlerGetter: HandlerGetter): WrappedHand
  * @returns A wrapped version of that logger
  */
 function makeWrappedErrorLogger(origErrorLogger: ErrorLogger): WrappedErrorLogger {
-  return function(this: Server, err: Error): void {
+  return function (this: Server, err: Error): void {
     // TODO add more context data here
 
     // We can use `configureScope` rather than `withScope` here because we're using domains to ensure that each request
@@ -203,7 +203,7 @@ function getPublicDirFiles(): Set<string> {
 function makeWrappedReqHandler(origReqHandler: ReqHandler): WrappedReqHandler {
   const publicDirFiles = getPublicDirFiles();
   // add transaction start and stop to the normal request handling
-  const wrappedReqHandler = async function(
+  const wrappedReqHandler = async function (
     this: Server,
     req: NextRequest,
     res: NextResponse,
@@ -288,7 +288,7 @@ function makeWrappedMethodForGettingParameterizedPath(
   origMethod: ApiPageEnsurer | PageComponentFinder,
 ): WrappedApiPageEnsurer | WrappedPageComponentFinder {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const wrappedMethod = async function(this: Server, parameterizedPath: string, ...args: any[]): Promise<any> {
+  const wrappedMethod = async function (this: Server, parameterizedPath: string, ...args: any[]): Promise<any> {
     const transaction = getActiveTransaction();
 
     // replace specific URL with parameterized version

--- a/packages/nextjs/test/utils/withSentry.test.ts
+++ b/packages/nextjs/test/utils/withSentry.test.ts
@@ -61,14 +61,14 @@ describe('withSentry', () => {
 
   beforeEach(() => {
     req = { url: 'http://dogs.are.great' } as NextApiRequest;
-    res = ({
-      send: function(this: AugmentedNextApiResponse) {
+    res = {
+      send: function (this: AugmentedNextApiResponse) {
         this.end();
       },
-      end: function(this: AugmentedNextApiResponse) {
+      end: function (this: AugmentedNextApiResponse) {
         this.finished = true;
       },
-    } as unknown) as AugmentedNextApiResponse;
+    } as unknown as AugmentedNextApiResponse;
   });
 
   afterEach(() => {

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -399,7 +399,7 @@ export function requestHandler(
     if (options && options.flushTimeout && options.flushTimeout > 0) {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       const _end = res.end;
-      res.end = function(chunk?: any | (() => void), encoding?: string | (() => void), cb?: () => void): void {
+      res.end = function (chunk?: any | (() => void), encoding?: string | (() => void), cb?: () => void): void {
         void flush(options.flushTimeout)
           .then(() => {
             _end.call(this, chunk, encoding, cb);

--- a/packages/node/src/integrations/console.ts
+++ b/packages/node/src/integrations/console.ts
@@ -33,7 +33,7 @@ function createConsoleWrapper(level: string): (originalConsoleMethod: () => void
     const sentryLevel = severityFromString(level);
 
     /* eslint-disable prefer-rest-params */
-    return function(this: typeof console): void {
+    return function (this: typeof console): void {
       if (getCurrentHub().getIntegration(Console)) {
         getCurrentHub().addBreadcrumb(
           {

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -128,7 +128,7 @@ function _createWrappedRequestMethodFactory(
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       return originalRequestMethod
         .apply(httpModule, requestArgs)
-        .once('response', function(this: http.ClientRequest, res: http.IncomingMessage): void {
+        .once('response', function (this: http.ClientRequest, res: http.IncomingMessage): void {
           // eslint-disable-next-line @typescript-eslint/no-this-alias
           const req = this;
           if (breadcrumbsEnabled) {
@@ -142,7 +142,7 @@ function _createWrappedRequestMethodFactory(
             span.finish();
           }
         })
-        .once('error', function(this: http.ClientRequest): void {
+        .once('error', function (this: http.ClientRequest): void {
           // eslint-disable-next-line @typescript-eslint/no-this-alias
           const req = this;
 

--- a/packages/node/src/integrations/utils/http.ts
+++ b/packages/node/src/integrations/utils/http.ts
@@ -11,9 +11,7 @@ const NODE_VERSION = parseSemver(process.versions.node);
  * @param url url to verify
  */
 export function isSentryRequest(url: string): boolean {
-  const dsn = getCurrentHub()
-    .getClient()
-    ?.getDsn();
+  const dsn = getCurrentHub().getClient()?.getDsn();
   return dsn ? url.includes(dsn.host) : false;
 }
 

--- a/packages/node/src/parsers.ts
+++ b/packages/node/src/parsers.ts
@@ -29,8 +29,9 @@ function getFunction(frame: stacktrace.StackFrame): string {
   }
 }
 
-const mainModule: string = `${(require.main && require.main.filename && dirname(require.main.filename)) ||
-  global.process.cwd()}/`;
+const mainModule: string = `${
+  (require.main && require.main.filename && dirname(require.main.filename)) || global.process.cwd()
+}/`;
 
 /** JSDoc */
 function getModule(filename: string, base?: string): string {

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -205,13 +205,13 @@ describe('requestHandler', () => {
   }
 
   beforeEach(() => {
-    req = ({
+    req = {
       headers,
       method,
       protocol,
       hostname,
       originalUrl: `${path}?${queryString}`,
-    } as unknown) as http.IncomingMessage;
+    } as unknown as http.IncomingMessage;
     res = new http.ServerResponse(req);
     next = createNoOpSpy();
   });
@@ -302,13 +302,13 @@ describe('tracingHandler', () => {
   }
 
   beforeEach(() => {
-    req = ({
+    req = {
       headers,
       method,
       protocol,
       hostname,
       originalUrl: `${path}?${queryString}`,
-    } as unknown) as http.IncomingMessage;
+    } as unknown as http.IncomingMessage;
     res = new http.ServerResponse(req);
     next = createNoOpSpy();
   });
@@ -370,10 +370,7 @@ describe('tracingHandler', () => {
 
     sentryTracingMiddleware(req, res, next);
 
-    const transaction = sentryCore
-      .getCurrentHub()
-      .getScope()
-      ?.getTransaction();
+    const transaction = sentryCore.getCurrentHub().getScope()?.getTransaction();
 
     expect(transaction).toBeDefined();
     expect(transaction).toEqual(
@@ -680,13 +677,13 @@ describe('errorHandler()', () => {
   }
 
   beforeEach(() => {
-    req = ({
+    req = {
       headers,
       method,
       protocol,
       hostname,
       originalUrl: `${path}?${queryString}`,
-    } as unknown) as http.IncomingMessage;
+    } as unknown as http.IncomingMessage;
     res = new http.ServerResponse(req);
     next = createNoOpSpy();
   });

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -37,9 +37,7 @@ describe('tracing', () => {
   }
 
   it("creates a span for each outgoing non-sentry request when there's a transaction on the scope", () => {
-    nock('http://dogs.are.great')
-      .get('/')
-      .reply(200);
+    nock('http://dogs.are.great').get('/').reply(200);
 
     const transaction = createTransactionOnScope();
     const spans = (transaction as Span).spanRecorder?.spans as Span[];
@@ -56,9 +54,7 @@ describe('tracing', () => {
   });
 
   it("doesn't create a span for outgoing sentry requests", () => {
-    nock('http://squirrelchasers.ingest.sentry.io')
-      .get('/api/12312012/store/')
-      .reply(200);
+    nock('http://squirrelchasers.ingest.sentry.io').get('/api/12312012/store/').reply(200);
 
     const transaction = createTransactionOnScope();
     const spans = (transaction as Span).spanRecorder?.spans as Span[];
@@ -71,9 +67,7 @@ describe('tracing', () => {
   });
 
   it('attaches the sentry-trace header to outgoing non-sentry requests', async () => {
-    nock('http://dogs.are.great')
-      .get('/')
-      .reply(200);
+    nock('http://dogs.are.great').get('/').reply(200);
 
     createTransactionOnScope();
 
@@ -85,9 +79,7 @@ describe('tracing', () => {
   });
 
   it("doesn't attach the sentry-trace header to outgoing sentry requests", () => {
-    nock('http://squirrelchasers.ingest.sentry.io')
-      .get('/api/12312012/store/')
-      .reply(200);
+    nock('http://squirrelchasers.ingest.sentry.io').get('/api/12312012/store/').reply(200);
 
     createTransactionOnScope();
 
@@ -127,9 +119,7 @@ describe('default protocols', () => {
     const key = 'catrunners';
     const p = captureBreadcrumb(key);
 
-    nock(`http://${key}.ingest.sentry.io`)
-      .get('/api/123122332/store/')
-      .reply(200);
+    nock(`http://${key}.ingest.sentry.io`).get('/api/123122332/store/').reply(200);
 
     http.get({
       host: `${key}.ingest.sentry.io`,
@@ -163,9 +153,7 @@ describe('default protocols', () => {
     if (NODE_VERSION.major && NODE_VERSION.major < 9) {
       nockProtocol = 'http';
     }
-    nock(`${nockProtocol}://${key}.ingest.sentry.io`)
-      .get('/api/123122332/store/')
-      .reply(200);
+    nock(`${nockProtocol}://${key}.ingest.sentry.io`).get('/api/123122332/store/').reply(200);
 
     https.get({
       host: `${key}.ingest.sentry.io`,
@@ -189,9 +177,7 @@ describe('default protocols', () => {
       nockProtocol = 'http';
     }
 
-    nock(`${nockProtocol}://${key}.ingest.sentry.io`)
-      .get('/api/123122332/store/')
-      .reply(200);
+    nock(`${nockProtocol}://${key}.ingest.sentry.io`).get('/api/123122332/store/').reply(200);
 
     https.get({
       host: `${key}.ingest.sentry.io`,

--- a/packages/node/test/transports/http.test.ts
+++ b/packages/node/test/transports/http.test.ts
@@ -646,7 +646,7 @@ describe('HTTPTransport', () => {
         dsn,
         httpProxy: 'http://example.com:8080',
       });
-      const client = (transport.client as unknown) as { proxy: Record<string, string | number>; secureProxy: boolean };
+      const client = transport.client as unknown as { proxy: Record<string, string | number>; secureProxy: boolean };
       expect(client).toBeInstanceOf(HttpsProxyAgent);
       expect(client.secureProxy).toEqual(false);
       expect(client.proxy).toEqual(expect.objectContaining({ protocol: 'http:', port: 8080, host: 'example.com' }));
@@ -658,7 +658,7 @@ describe('HTTPTransport', () => {
         dsn,
         httpProxy: 'http://example.com:8080',
       });
-      const client = (transport.client as unknown) as { proxy: Record<string, string | number>; secureProxy: boolean };
+      const client = transport.client as unknown as { proxy: Record<string, string | number>; secureProxy: boolean };
       expect(client).toBeInstanceOf(HttpsProxyAgent);
       expect(client.secureProxy).toEqual(false);
       expect(client.proxy).toEqual(expect.objectContaining({ protocol: 'http:', port: 8080, host: 'example.com' }));
@@ -671,7 +671,7 @@ describe('HTTPTransport', () => {
         dsn,
         httpProxy: 'http://example.com:8080',
       });
-      const client = (transport.client as unknown) as { proxy: Record<string, string | number>; secureProxy: boolean };
+      const client = transport.client as unknown as { proxy: Record<string, string | number>; secureProxy: boolean };
       expect(client).toBeInstanceOf(HttpsProxyAgent);
       expect(client.secureProxy).toEqual(false);
       expect(client.proxy).toEqual(expect.objectContaining({ protocol: 'http:', port: 8080, host: 'example.com' }));

--- a/packages/node/test/transports/https.test.ts
+++ b/packages/node/test/transports/https.test.ts
@@ -229,7 +229,7 @@ describe('HTTPSTransport', () => {
         dsn,
         httpsProxy: 'https://example.com:8080',
       });
-      const client = (transport.client as unknown) as { proxy: Record<string, string | number>; secureProxy: boolean };
+      const client = transport.client as unknown as { proxy: Record<string, string | number>; secureProxy: boolean };
       expect(client).toBeInstanceOf(HttpsProxyAgent);
       expect(client.secureProxy).toEqual(true);
       expect(client.proxy).toEqual(expect.objectContaining({ protocol: 'https:', port: 8080, host: 'example.com' }));
@@ -241,7 +241,7 @@ describe('HTTPSTransport', () => {
         dsn,
         httpsProxy: 'https://example.com:8080',
       });
-      const client = (transport.client as unknown) as { proxy: Record<string, string | number>; secureProxy: boolean };
+      const client = transport.client as unknown as { proxy: Record<string, string | number>; secureProxy: boolean };
       expect(client).toBeInstanceOf(HttpsProxyAgent);
       expect(client.secureProxy).toEqual(true);
       expect(client.proxy).toEqual(expect.objectContaining({ protocol: 'https:', port: 8080, host: 'example.com' }));
@@ -254,7 +254,7 @@ describe('HTTPSTransport', () => {
         httpProxy: 'http://unsecure-example.com:8080',
         httpsProxy: 'https://example.com:8080',
       });
-      const client = (transport.client as unknown) as { proxy: Record<string, string | number>; secureProxy: boolean };
+      const client = transport.client as unknown as { proxy: Record<string, string | number>; secureProxy: boolean };
       expect(client).toBeInstanceOf(HttpsProxyAgent);
       expect(client.secureProxy).toEqual(true);
       expect(client.proxy).toEqual(expect.objectContaining({ protocol: 'https:', port: 8080, host: 'example.com' }));
@@ -266,7 +266,7 @@ describe('HTTPSTransport', () => {
       const transport = createTransport({
         dsn,
       });
-      const client = (transport.client as unknown) as { proxy: Record<string, string | number>; secureProxy: boolean };
+      const client = transport.client as unknown as { proxy: Record<string, string | number>; secureProxy: boolean };
       expect(client).toBeInstanceOf(HttpsProxyAgent);
       expect(client.secureProxy).toEqual(true);
       expect(client.proxy).toEqual(expect.objectContaining({ protocol: 'https:', port: 8080, host: 'example.com' }));
@@ -280,7 +280,7 @@ describe('HTTPSTransport', () => {
         dsn,
         httpsProxy: 'https://example.com:8080',
       });
-      const client = (transport.client as unknown) as { proxy: Record<string, string | number>; secureProxy: boolean };
+      const client = transport.client as unknown as { proxy: Record<string, string | number>; secureProxy: boolean };
       expect(client).toBeInstanceOf(HttpsProxyAgent);
       expect(client.secureProxy).toEqual(true);
       expect(client.proxy).toEqual(expect.objectContaining({ protocol: 'https:', port: 8080, host: 'example.com' }));

--- a/packages/react/src/reactrouterv3.ts
+++ b/packages/react/src/reactrouterv3.ts
@@ -44,7 +44,7 @@ export function reactRouterV3Instrumentation(
 
     // Have to use global.location because history.location might not be defined.
     if (startTransactionOnPageLoad && global && global.location) {
-      normalizeTransactionName(routes, (global.location as unknown) as Location, match, (localName: string) => {
+      normalizeTransactionName(routes, global.location as unknown as Location, match, (localName: string) => {
         prevName = localName;
         activeTransaction = startTransaction({
           name: prevName,

--- a/packages/serverless/src/awsservices.ts
+++ b/packages/serverless/src/awsservices.ts
@@ -53,7 +53,7 @@ export class AWSServices implements Integration {
 function wrapMakeRequest<TService extends AWSService, TResult>(
   orig: MakeRequestFunction<GenericParams, TResult>,
 ): MakeRequestFunction<GenericParams, TResult> {
-  return function(this: TService, operation: string, params?: GenericParams, callback?: MakeRequestCallback<TResult>) {
+  return function (this: TService, operation: string, params?: GenericParams, callback?: MakeRequestCallback<TResult>) {
     let transaction: Transaction | undefined;
     let span: Span | undefined;
     const scope = getCurrentHub().getScope();

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -85,7 +85,7 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const _end = res.end;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    res.end = function(chunk?: any | (() => void), encoding?: string | (() => void), cb?: () => void): void {
+    res.end = function (chunk?: any | (() => void), encoding?: string | (() => void), cb?: () => void): void {
       transaction.setHttpStatus(res.statusCode);
       transaction.finish();
 

--- a/packages/serverless/src/google-cloud-http.ts
+++ b/packages/serverless/src/google-cloud-http.ts
@@ -48,7 +48,7 @@ export class GoogleCloudHttp implements Integration {
 
 /** Returns a wrapped function that makes a request with tracing enabled */
 function wrapRequestFunction(orig: RequestFunction): RequestFunction {
-  return function(this: common.Service, reqOpts: RequestOptions, callback: ResponseCallback): void {
+  return function (this: common.Service, reqOpts: RequestOptions, callback: ResponseCallback): void {
     let transaction: Transaction | undefined;
     let span: Span | undefined;
     const scope = getCurrentHub().getScope();

--- a/packages/serverless/test/awsservices.test.ts
+++ b/packages/serverless/test/awsservices.test.ts
@@ -27,9 +27,7 @@ describe('AWSServices', () => {
     const s3 = new AWS.S3({ accessKeyId: '-', secretAccessKey: '-' });
 
     test('getObject', async () => {
-      nock('https://foo.s3.amazonaws.com')
-        .get('/bar')
-        .reply(200, 'contents');
+      nock('https://foo.s3.amazonaws.com').get('/bar').reply(200, 'contents');
       const data = await s3.getObject({ Bucket: 'foo', Key: 'bar' }).promise();
       expect(data.Body?.toString('utf-8')).toEqual('contents');
       // @ts-ignore see "Why @ts-ignore" note
@@ -43,9 +41,7 @@ describe('AWSServices', () => {
 
     test('getObject with callback', done => {
       expect.assertions(3);
-      nock('https://foo.s3.amazonaws.com')
-        .get('/bar')
-        .reply(200, 'contents');
+      nock('https://foo.s3.amazonaws.com').get('/bar').reply(200, 'contents');
       s3.getObject({ Bucket: 'foo', Key: 'bar' }, (err, data) => {
         expect(err).toBeNull();
         expect(data.Body?.toString('utf-8')).toEqual('contents');
@@ -63,9 +59,7 @@ describe('AWSServices', () => {
     const lambda = new AWS.Lambda({ accessKeyId: '-', secretAccessKey: '-', region: 'eu-north-1' });
 
     test('invoke', async () => {
-      nock('https://lambda.eu-north-1.amazonaws.com')
-        .post('/2015-03-31/functions/foo/invocations')
-        .reply(201, 'reply');
+      nock('https://lambda.eu-north-1.amazonaws.com').post('/2015-03-31/functions/foo/invocations').reply(201, 'reply');
       const data = await lambda.invoke({ FunctionName: 'foo' }).promise();
       expect(data.Payload?.toString('utf-8')).toEqual('reply');
       // @ts-ignore see "Why @ts-ignore" note

--- a/packages/serverless/test/google-cloud-grpc.test.ts
+++ b/packages/serverless/test/google-cloud-grpc.test.ts
@@ -71,7 +71,7 @@ function mockHttp2Session(): FakeSession {
   const session = new FakeSession();
   spyConnect.mockImplementationOnce(() => {
     process.nextTick(() => session.emit('connect'));
-    return (session as unknown) as http2.ClientHttp2Session;
+    return session as unknown as http2.ClientHttp2Session;
   });
   return session;
 }
@@ -82,9 +82,7 @@ describe('GoogleCloudGrpc tracing', () => {
   });
 
   beforeEach(() => {
-    nock('https://www.googleapis.com')
-      .post('/oauth2/v4/token')
-      .reply(200, []);
+    nock('https://www.googleapis.com').post('/oauth2/v4/token').reply(200, []);
   });
   afterEach(() => {
     // @ts-ignore see "Why @ts-ignore" note

--- a/packages/tracing/src/integrations/node/express.ts
+++ b/packages/tracing/src/integrations/node/express.ts
@@ -106,7 +106,7 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
 
   switch (arity) {
     case 2: {
-      return function(this: NodeJS.Global, req: unknown, res: ExpressResponse & SentryTracingResponse): void {
+      return function (this: NodeJS.Global, req: unknown, res: ExpressResponse & SentryTracingResponse): void {
         const transaction = res.__sentry_transaction;
         if (transaction) {
           const span = transaction.startChild({
@@ -121,7 +121,7 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
       };
     }
     case 3: {
-      return function(
+      return function (
         this: NodeJS.Global,
         req: unknown,
         res: ExpressResponse & SentryTracingResponse,
@@ -132,14 +132,14 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
           description: fn.name,
           op: `express.middleware.${method}`,
         });
-        fn.call(this, req, res, function(this: NodeJS.Global, ...args: unknown[]): void {
+        fn.call(this, req, res, function (this: NodeJS.Global, ...args: unknown[]): void {
           span?.finish();
           next.call(this, ...args);
         });
       };
     }
     case 4: {
-      return function(
+      return function (
         this: NodeJS.Global,
         err: Error,
         req: Request,
@@ -151,7 +151,7 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
           description: fn.name,
           op: `express.middleware.${method}`,
         });
-        fn.call(this, err, req, res, function(this: NodeJS.Global, ...args: unknown[]): void {
+        fn.call(this, err, req, res, function (this: NodeJS.Global, ...args: unknown[]): void {
           span?.finish();
           next.call(this, ...args);
         });
@@ -198,7 +198,7 @@ function wrapMiddlewareArgs(args: unknown[], method: Method): unknown[] {
 function patchMiddleware(router: Router, method: Method): Router {
   const originalCallback = router[method];
 
-  router[method] = function(...args: unknown[]): void {
+  router[method] = function (...args: unknown[]): void {
     return originalCallback.call(this, ...wrapMiddlewareArgs(args, method));
   };
 

--- a/packages/tracing/src/integrations/node/mongo.ts
+++ b/packages/tracing/src/integrations/node/mongo.ts
@@ -108,9 +108,7 @@ export class Mongo implements Integration {
    * @inheritDoc
    */
   public constructor(options: MongoOptions = {}) {
-    this._operations = Array.isArray(options.operations)
-      ? options.operations
-      : ((OPERATIONS as unknown) as Operation[]);
+    this._operations = Array.isArray(options.operations) ? options.operations : (OPERATIONS as unknown as Operation[]);
     this._describeOperations = 'describeOperations' in options ? options.describeOperations : true;
     this._useMongoose = !!options.useMongoose;
   }
@@ -145,8 +143,8 @@ export class Mongo implements Integration {
 
     const getSpanContext = this._getSpanContextFromOperationArguments.bind(this);
 
-    fill(collection.prototype, operation, function(orig: () => void | Promise<unknown>) {
-      return function(this: unknown, ...args: unknown[]) {
+    fill(collection.prototype, operation, function (orig: () => void | Promise<unknown>) {
+      return function (this: unknown, ...args: unknown[]) {
         const lastArg = args[args.length - 1];
         const scope = getCurrentHub().getScope();
         const parentSpan = scope?.getSpan();
@@ -169,7 +167,7 @@ export class Mongo implements Integration {
         }
 
         const span = parentSpan?.startChild(getSpanContext(this, operation, args.slice(0, -1)));
-        return orig.call(this, ...args.slice(0, -1), function(err: Error, result: unknown) {
+        return orig.call(this, ...args.slice(0, -1), function (err: Error, result: unknown) {
           span?.finish();
           lastArg(err, result);
         });

--- a/packages/tracing/src/integrations/node/mysql.ts
+++ b/packages/tracing/src/integrations/node/mysql.ts
@@ -33,8 +33,8 @@ export class Mysql implements Integration {
     //    function (callback) => void
     //    function (options, callback) => void
     //    function (options, values, callback) => void
-    fill(pkg, 'createQuery', function(orig: () => void) {
-      return function(this: unknown, options: unknown, values: unknown, callback: unknown) {
+    fill(pkg, 'createQuery', function (orig: () => void) {
+      return function (this: unknown, options: unknown, values: unknown, callback: unknown) {
         const scope = getCurrentHub().getScope();
         const parentSpan = scope?.getSpan();
         const span = parentSpan?.startChild({
@@ -43,14 +43,14 @@ export class Mysql implements Integration {
         });
 
         if (typeof callback === 'function') {
-          return orig.call(this, options, values, function(err: Error, result: unknown, fields: unknown) {
+          return orig.call(this, options, values, function (err: Error, result: unknown, fields: unknown) {
             span?.finish();
             callback(err, result, fields);
           });
         }
 
         if (typeof values === 'function') {
-          return orig.call(this, options, function(err: Error, result: unknown, fields: unknown) {
+          return orig.call(this, options, function (err: Error, result: unknown, fields: unknown) {
             span?.finish();
             values(err, result, fields);
           });

--- a/packages/tracing/src/integrations/node/postgres.ts
+++ b/packages/tracing/src/integrations/node/postgres.ts
@@ -55,8 +55,8 @@ export class Postgres implements Integration {
      * function (query, params) => Promise
      * function (pg.Cursor) => pg.Cursor
      */
-    fill(Client.prototype, 'query', function(orig: () => void | Promise<unknown>) {
-      return function(this: unknown, config: unknown, values: unknown, callback: unknown) {
+    fill(Client.prototype, 'query', function (orig: () => void | Promise<unknown>) {
+      return function (this: unknown, config: unknown, values: unknown, callback: unknown) {
         const scope = getCurrentHub().getScope();
         const parentSpan = scope?.getSpan();
         const span = parentSpan?.startChild({
@@ -65,14 +65,14 @@ export class Postgres implements Integration {
         });
 
         if (typeof callback === 'function') {
-          return orig.call(this, config, values, function(err: Error, result: unknown) {
+          return orig.call(this, config, values, function (err: Error, result: unknown) {
             span?.finish();
             callback(err, result);
           });
         }
 
         if (typeof values === 'function') {
-          return orig.call(this, config, function(err: Error, result: unknown) {
+          return orig.call(this, config, function (err: Error, result: unknown) {
             span?.finish();
             values(err, result);
           });

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -21,7 +21,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
   /**
    * The reference to the current hub.
    */
-  private readonly _hub: Hub = (getCurrentHub() as unknown) as Hub;
+  private readonly _hub: Hub = getCurrentHub() as unknown as Hub;
 
   private _trimEnd?: boolean;
 

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -3,9 +3,9 @@ import { Options, TraceparentData, Transaction } from '@sentry/types';
 
 export const TRACEPARENT_REGEXP = new RegExp(
   '^[ \\t]*' + // whitespace
-  '([0-9a-f]{32})?' + // trace_id
-  '-?([0-9a-f]{16})?' + // span_id
-  '-?([01])?' + // sampled
+    '([0-9a-f]{32})?' + // trace_id
+    '-?([0-9a-f]{16})?' + // span_id
+    '-?([01])?' + // sampled
     '[ \\t]*$', // whitespace
 );
 

--- a/packages/tracing/test/integrations/node/mongo.test.ts
+++ b/packages/tracing/test/integrations/node/mongo.test.ts
@@ -64,7 +64,7 @@ describe('patchOperation()', () => {
   });
 
   it('should wrap method accepting callback as the last argument', done => {
-    collection.insertOne(doc, {}, function() {
+    collection.insertOne(doc, {}, function () {
       expect(scope.getSpan).toBeCalled();
       expect(parentSpan.startChild).toBeCalledWith({
         data: {

--- a/packages/tracing/test/integrations/node/postgres.test.ts
+++ b/packages/tracing/test/integrations/node/postgres.test.ts
@@ -61,7 +61,7 @@ describe('setupOnce', () => {
     });
 
     it(`should wrap ${pgApi}'s query method accepting callback as the last argument`, done => {
-      Client.query('SELECT NOW()', {}, function() {
+      Client.query('SELECT NOW()', {}, function () {
         expect(scope.getSpan).toBeCalled();
         expect(parentSpan.startChild).toBeCalledWith({
           description: 'SELECT NOW()',
@@ -73,7 +73,7 @@ describe('setupOnce', () => {
     });
 
     it(`should wrap ${pgApi}'s query method accepting callback as the second argument`, done => {
-      Client.query('SELECT NOW()', function() {
+      Client.query('SELECT NOW()', function () {
         expect(scope.getSpan).toBeCalled();
         expect(parentSpan.startChild).toBeCalledWith({
           description: 'SELECT NOW()',

--- a/packages/utils/src/global.ts
+++ b/packages/utils/src/global.ts
@@ -34,11 +34,13 @@ const fallbackGlobalObject = {};
  * @returns Global scope object
  */
 export function getGlobalObject<T>(): T & SentryGlobal {
-  return (isNodeEnv()
-    ? global
-    : typeof window !== 'undefined' // eslint-disable-line no-restricted-globals
-    ? window // eslint-disable-line no-restricted-globals
-    : typeof self !== 'undefined'
-    ? self
-    : fallbackGlobalObject) as T & SentryGlobal;
+  return (
+    isNodeEnv()
+      ? global
+      : typeof window !== 'undefined' // eslint-disable-line no-restricted-globals
+      ? window // eslint-disable-line no-restricted-globals
+      : typeof self !== 'undefined'
+      ? self
+      : fallbackGlobalObject
+  ) as T & SentryGlobal;
 }

--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -111,13 +111,13 @@ function instrumentConsole(): void {
     return;
   }
 
-  ['debug', 'info', 'warn', 'error', 'log', 'assert'].forEach(function(level: string): void {
+  ['debug', 'info', 'warn', 'error', 'log', 'assert'].forEach(function (level: string): void {
     if (!(level in global.console)) {
       return;
     }
 
-    fill(global.console, level, function(originalConsoleLevel: () => any): Function {
-      return function(...args: any[]): void {
+    fill(global.console, level, function (originalConsoleLevel: () => any): Function {
+      return function (...args: any[]): void {
         triggerHandlers('console', { args, level });
 
         // this fails for some browsers. :(
@@ -135,8 +135,8 @@ function instrumentFetch(): void {
     return;
   }
 
-  fill(global, 'fetch', function(originalFetch: () => void): () => void {
-    return function(...args: any[]): void {
+  fill(global, 'fetch', function (originalFetch: () => void): () => void {
+    return function (...args: any[]): void {
       const handlerData = {
         args,
         fetchData: {
@@ -221,8 +221,8 @@ function instrumentXHR(): void {
 
   const xhrproto = XMLHttpRequest.prototype;
 
-  fill(xhrproto, 'open', function(originalOpen: () => void): () => void {
-    return function(this: SentryWrappedXMLHttpRequest, ...args: any[]): void {
+  fill(xhrproto, 'open', function (originalOpen: () => void): () => void {
+    return function (this: SentryWrappedXMLHttpRequest, ...args: any[]): void {
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const xhr = this;
       const url = args[1];
@@ -238,7 +238,7 @@ function instrumentXHR(): void {
         xhr.__sentry_own_request__ = true;
       }
 
-      const onreadystatechangeHandler = function(): void {
+      const onreadystatechangeHandler = function (): void {
         if (xhr.readyState === 4) {
           try {
             // touching statusCode in some platforms throws
@@ -258,8 +258,8 @@ function instrumentXHR(): void {
       };
 
       if ('onreadystatechange' in xhr && typeof xhr.onreadystatechange === 'function') {
-        fill(xhr, 'onreadystatechange', function(original: WrappedFunction): Function {
-          return function(...readyStateArgs: any[]): void {
+        fill(xhr, 'onreadystatechange', function (original: WrappedFunction): Function {
+          return function (...readyStateArgs: any[]): void {
             onreadystatechangeHandler();
             return original.apply(xhr, readyStateArgs);
           };
@@ -272,8 +272,8 @@ function instrumentXHR(): void {
     };
   });
 
-  fill(xhrproto, 'send', function(originalSend: () => void): () => void {
-    return function(this: SentryWrappedXMLHttpRequest, ...args: any[]): void {
+  fill(xhrproto, 'send', function (originalSend: () => void): () => void {
+    return function (this: SentryWrappedXMLHttpRequest, ...args: any[]): void {
       if (this.__sentry_xhr__ && args[0] !== undefined) {
         this.__sentry_xhr__.body = args[0];
       }
@@ -298,7 +298,7 @@ function instrumentHistory(): void {
   }
 
   const oldOnPopState = global.onpopstate;
-  global.onpopstate = function(this: WindowEventHandlers, ...args: any[]): any {
+  global.onpopstate = function (this: WindowEventHandlers, ...args: any[]): any {
     const to = global.location.href;
     // keep track of the current URL state, as we always receive only the updated state
     const from = lastHref;
@@ -321,7 +321,7 @@ function instrumentHistory(): void {
 
   /** @hidden */
   function historyReplacementFunction(originalHistoryFunction: () => void): () => void {
-    return function(this: History, ...args: any[]): void {
+    return function (this: History, ...args: any[]): void {
       const url = args.length > 2 ? args[2] : undefined;
       if (url) {
         // coerce to string (this is what pushState does)
@@ -508,8 +508,8 @@ function instrumentDOM(): void {
       return;
     }
 
-    fill(proto, 'addEventListener', function(originalAddEventListener: AddEventListener): AddEventListener {
-      return function(
+    fill(proto, 'addEventListener', function (originalAddEventListener: AddEventListener): AddEventListener {
+      return function (
         this: Element,
         type: string,
         listener: EventListenerOrEventListenerObject,
@@ -538,42 +538,46 @@ function instrumentDOM(): void {
       };
     });
 
-    fill(proto, 'removeEventListener', function(originalRemoveEventListener: RemoveEventListener): RemoveEventListener {
-      return function(
-        this: Element,
-        type: string,
-        listener: EventListenerOrEventListenerObject,
-        options?: boolean | EventListenerOptions,
-      ): () => void {
-        if (type === 'click' || type == 'keypress') {
-          try {
-            const el = this as InstrumentedElement;
-            const handlers = el.__sentry_instrumentation_handlers__ || {};
-            const handlerForType = handlers[type];
+    fill(
+      proto,
+      'removeEventListener',
+      function (originalRemoveEventListener: RemoveEventListener): RemoveEventListener {
+        return function (
+          this: Element,
+          type: string,
+          listener: EventListenerOrEventListenerObject,
+          options?: boolean | EventListenerOptions,
+        ): () => void {
+          if (type === 'click' || type == 'keypress') {
+            try {
+              const el = this as InstrumentedElement;
+              const handlers = el.__sentry_instrumentation_handlers__ || {};
+              const handlerForType = handlers[type];
 
-            if (handlerForType) {
-              handlerForType.refCount -= 1;
-              // If there are no longer any custom handlers of the current type on this element, we can remove ours, too.
-              if (handlerForType.refCount <= 0) {
-                originalRemoveEventListener.call(this, type, handlerForType.handler, options);
-                handlerForType.handler = undefined;
-                delete handlers[type]; // eslint-disable-line @typescript-eslint/no-dynamic-delete
-              }
+              if (handlerForType) {
+                handlerForType.refCount -= 1;
+                // If there are no longer any custom handlers of the current type on this element, we can remove ours, too.
+                if (handlerForType.refCount <= 0) {
+                  originalRemoveEventListener.call(this, type, handlerForType.handler, options);
+                  handlerForType.handler = undefined;
+                  delete handlers[type]; // eslint-disable-line @typescript-eslint/no-dynamic-delete
+                }
 
-              // If there are no longer any custom handlers of any type on this element, cleanup everything.
-              if (Object.keys(handlers).length === 0) {
-                delete el.__sentry_instrumentation_handlers__;
+                // If there are no longer any custom handlers of any type on this element, cleanup everything.
+                if (Object.keys(handlers).length === 0) {
+                  delete el.__sentry_instrumentation_handlers__;
+                }
               }
+            } catch (e) {
+              // Accessing dom properties is always fragile.
+              // Also allows us to skip `addEventListenrs` calls with no proper `this` context.
             }
-          } catch (e) {
-            // Accessing dom properties is always fragile.
-            // Also allows us to skip `addEventListenrs` calls with no proper `this` context.
           }
-        }
 
-        return originalRemoveEventListener.call(this, type, listener, options);
-      };
-    });
+          return originalRemoveEventListener.call(this, type, listener, options);
+        };
+      },
+    );
   });
 }
 
@@ -582,7 +586,7 @@ let _oldOnErrorHandler: OnErrorEventHandler = null;
 function instrumentError(): void {
   _oldOnErrorHandler = global.onerror;
 
-  global.onerror = function(msg: any, url: any, line: any, column: any, error: any): boolean {
+  global.onerror = function (msg: any, url: any, line: any, column: any, error: any): boolean {
     triggerHandlers('error', {
       column,
       error,
@@ -605,7 +609,7 @@ let _oldOnUnhandledRejectionHandler: ((e: any) => void) | null = null;
 function instrumentUnhandledRejection(): void {
   _oldOnUnhandledRejectionHandler = global.onunhandledrejection;
 
-  global.onunhandledrejection = function(e: any): boolean {
+  global.onunhandledrejection = function (e: any): boolean {
     triggerHandlers('unhandledrejection', e);
 
     if (_oldOnUnhandledRejectionHandler) {

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -62,9 +62,7 @@ export function uuid4(): string {
  * // environments where DOM might not be available
  * @returns parsed URL object
  */
-export function parseUrl(
-  url: string,
-): {
+export function parseUrl(url: string): {
   host?: string;
   path?: string;
   protocol?: string;
@@ -158,7 +156,8 @@ export function addExceptionMechanism(event: Event, newMechanism?: Partial<Mecha
 }
 
 // https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-const SEMVER_REGEXP = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+const SEMVER_REGEXP =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
 
 /**
  * Represents Semantic Versioning object

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -97,9 +97,7 @@ export function urlEncode(object: { [key: string]: any }): string {
  *
  * @param value Initial source that we have to transform in order for it to be usable by the serializer
  */
-function getWalkSource(
-  value: any,
-): {
+function getWalkSource(value: any): {
   [key: string]: any;
 } {
   if (isError(value)) {
@@ -135,7 +133,7 @@ function getWalkSource(
       currentTarget?: unknown;
     }
 
-    const event = (value as unknown) as SimpleEvent;
+    const event = value as unknown as SimpleEvent;
 
     const source: {
       [key: string]: any;
@@ -245,7 +243,7 @@ function serializeValue(value: any): any {
  * - filter global objects
  */
 function normalizeValue<T>(value: T, key?: any): T | string {
-  if (key === 'domain' && value && typeof value === 'object' && ((value as unknown) as { _events: any })._events) {
+  if (key === 'domain' && value && typeof value === 'object' && (value as unknown as { _events: any })._events) {
     return '[Domain]';
   }
 

--- a/packages/utils/src/syncpromise.ts
+++ b/packages/utils/src/syncpromise.ts
@@ -128,7 +128,7 @@ class SyncPromise<T> implements PromiseLike<T> {
           return;
         }
 
-        resolve((val as unknown) as any);
+        resolve(val as unknown as any);
       });
     });
   }
@@ -176,7 +176,7 @@ class SyncPromise<T> implements PromiseLike<T> {
 
       if (this._state === States.RESOLVED) {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        handler[1]((this._value as unknown) as any);
+        handler[1](this._value as unknown as any);
       }
 
       if (this._state === States.REJECTED) {

--- a/packages/utils/test/async.test.ts
+++ b/packages/utils/test/async.test.ts
@@ -7,7 +7,7 @@ describe('forget', () => {
   };
 
   beforeEach(() => {
-    global.console = (console as any) as Console;
+    global.console = console as any as Console;
   });
 
   test('logs rejections to console.error', done => {

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -71,10 +71,12 @@ export const generateComponentTrace = (vm?: ViewModel): string => {
     const formattedTree = tree
       .map(
         (vm, i) =>
-          `${(i === 0 ? '---> ' : repeat(' ', 5 + i * 2)) +
+          `${
+            (i === 0 ? '---> ' : repeat(' ', 5 + i * 2)) +
             (Array.isArray(vm)
               ? `${formatComponentName(vm[0])}... (${vm[1]} recursive calls)`
-              : formatComponentName(vm))}`,
+              : formatComponentName(vm))
+          }`,
       )
       .join('\n');
 

--- a/packages/vue/src/tracing.ts
+++ b/packages/vue/src/tracing.ts
@@ -30,9 +30,7 @@ const HOOKS: { [key in Operation]: Hook[] } = {
 
 /** Grabs active transaction off scope, if any */
 function getActiveTransaction(): Transaction | undefined {
-  return getCurrentHub()
-    .getScope()
-    ?.getTransaction();
+  return getCurrentHub().getScope()?.getTransaction();
 }
 
 /** Finish top-level span and activity with a debounce configured using `timeout` option */
@@ -67,7 +65,7 @@ export const createTracingMixins = (options: TracingOptions): Mixins => {
     }
 
     for (const internalHook of internalHooks) {
-      mixins[internalHook] = function(this: VueSentry) {
+      mixins[internalHook] = function (this: VueSentry) {
         const isRoot = this.$root === this;
 
         if (isRoot) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17489,10 +17489,10 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
-prettier@1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
 
 pretty-error@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This upgrades all of our packages to use the latest version of Prettier, which is currently 2.5.1, in order to have support for linting of code written in typescript 3.8 and above.

When Prettier went to 2.0, it introduced some [changes to its defaults](https://prettier.io/blog/2020/03/21/2.0.0.html), most notably:

- casting between two unlike types, with a cast to `unknown` in between, no longer requires parentheses around the first cast,
- inline functions defined with the `function` keyword now have a space after the word `function`, and
- indentation of multi-line expressions and statements is adjusted, sometimes to make more lines, sometimes fewer.

All three of these have been applied to all of the code in the repo.

The final change to defaults - to make it so that parameter lists in arrow functions always have parentheses around them, even if they only consist of one parameter - led to a lot of visual noise, so it's been overridden to preserve the current formatting.