### PR TITLE
fix(vue): Property _isVue not defined in Vue3

### DIFF
--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -47,7 +47,7 @@ export const formatComponentName = (vm?: ViewModel, includeFile?: boolean): stri
 };
 
 export const generateComponentTrace = (vm?: ViewModel): string => {
-  if (vm?._isVue && vm?.$parent) {
+  if ((vm?._isVue || vm?.__isVue) && vm?.$parent) {
     const tree = [];
     let currentRecursiveSequence = 0;
     while (vm) {

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -12,7 +12,8 @@ export interface Vue {
 }
 
 export type ViewModel = {
-  _isVue: boolean;
+  _isVue?: boolean;
+  __isVue?: boolean;
   $root: ViewModel;
   $parent?: ViewModel;
   $props: { [key: string]: any };


### PR DESCRIPTION
fix #4170 
add a optional Property `__isVue` which is in Vue3.
