### PR TITLE
fix(nextjs): Unwrap `req` and `res` if necessary when instrumenting server

### DIFF
--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -34,14 +34,27 @@ interface Server {
   publicDir: string;
 }
 
-export interface NextRequest extends http.IncomingMessage {
+export type NextRequest = (
+  | http.IncomingMessage // in nextjs versions < 12.0.9, `NextRequest` extends `http.IncomingMessage`
+  | {
+      _req: http.IncomingMessage; // in nextjs versions >= 12.0.9, `NextRequest` wraps `http.IncomingMessage`
+    }
+) & {
   cookies: Record<string, string>;
   url: string;
   query: { [key: string]: string };
   headers: { [key: string]: string };
   body: string | { [key: string]: unknown };
-}
-type NextResponse = http.ServerResponse;
+  method: string;
+};
+
+type NextResponse =
+  // in nextjs versions < 12.0.9, `NextResponse` extends `http.ServerResponse`
+  | http.ServerResponse
+  // in nextjs versions >= 12.0.9, `NextResponse` wraps `http.ServerResponse`
+  | {
+      _res: http.ServerResponse;
+    };
 
 // the methods we'll wrap
 type HandlerGetter = () => Promise<ReqHandler>;

--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -222,6 +222,12 @@ function makeWrappedReqHandler(origReqHandler: ReqHandler): WrappedReqHandler {
     nextRes: NextResponse,
     parsedUrl?: url.UrlWithParsedQuery,
   ): Promise<void> {
+    // Starting with version 12.0.9, nextjs wraps the incoming request in a `NodeNextRequest` object and the outgoing
+    // response in a `NodeNextResponse` object before passing them to the handler. (This is necessary here but not in
+    // `withSentry` because by the time nextjs passes them to an API handler, it's unwrapped them again.)
+    const req = '_req' in nextReq ? nextReq._req : nextReq;
+    const res = '_res' in nextRes ? nextRes._res : nextRes;
+
     // wrap everything in a domain in order to prevent scope bleed between requests
     const local = domain.create();
     local.add(req);


### PR DESCRIPTION
_h/t to @YukiKitagata for finding the relevant change to Next.js and providing an [initial implementation](https://github.com/getsentry/sentry-javascript/pull/4462) of this fix_

In https://github.com/vercel/next.js/pull/32999 (released as part of 12.0.9), Next.js made an internal change, so that it now wraps the raw `http.IncomingMessage` and `http.ServerResponse` objects which get passed to the main server request handler in `NodeNextRequest` and `NodeNextResponse` objects, respectively. We therefore need to unwrap them before we can use them.

This does that unwrapping (if necessary; older versions of nextjs still don't need it) and fixes the relevant types.

Fixes https://github.com/getsentry/sentry-javascript/issues/4463
Fixes https://github.com/vercel/next.js/issues/33726