### PR TITLE
fix(tracing): Export SpanStatus enum

### DIFF
--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -22,6 +22,7 @@ export { Integrations };
 export { BrowserTracing } from './browser';
 
 export { Span, SpanStatusType, spanStatusfromHttpCode } from './span';
+export { SpanStatus } from './spanstatus';
 export { Transaction } from './transaction';
 export {
   // TODO deprecate old name in v7


### PR DESCRIPTION
This enum is deprecated, but we should still export it. It should be
treeshaken out, so there should be no bundle impact.