### PR TITLE
fix(nextjs): Export `BrowserTracing` integration directly

### DIFF
--- a/packages/nextjs/src/index.client.ts
+++ b/packages/nextjs/src/index.client.ts
@@ -11,6 +11,22 @@ export { nextRouterInstrumentation } from './performance/client';
 
 export const Integrations = { ...BrowserIntegrations, BrowserTracing };
 
+// This is already exported as part of `Integrations` above (and for the moment will remain so for
+// backwards compatibility), but that interferes with treeshaking, so we also export it separately
+// here.
+//
+// Previously we expected users to import `BrowserTracing` like this:
+//
+// import { Integrations } from '@sentry/nextjs';
+// const instance = new Integrations.BrowserTracing();
+//
+// This makes the integrations unable to be treeshaken though. To address this, we now have
+// this individual export. We now expect users to consume BrowserTracing like so:
+//
+// import { BrowserTracing } from '@sentry/nextjs';
+// const instance = new BrowserTracing();
+export { BrowserTracing };
+
 /** Inits the Sentry NextJS SDK on the browser with the React SDK. */
 export function init(options: NextjsOptions): void {
   buildMetadata(options, ['nextjs', 'react']);


### PR DESCRIPTION
This applies the changes made in https://github.com/getsentry/sentry-javascript/pull/4204 (exporting `BrowserTracing` outside of `Integrations`, in order that it be treeshakable if necessary) to the nextjs SDK, which got left out of that PR.

Fixes https://github.com/getsentry/sentry-javascript/issues/4411.
