### PR TITLE
feat(nextjs): Support using `src/` directory

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -261,9 +261,9 @@ function checkWebpackPluginOverrides(
  */
 function shouldAddSentryToEntryPoint(entryPointName: string, isServer: boolean): boolean {
   return (
-    entryPointName === 'pages/_app' ||
+    entryPointName.includes('pages/_app') ||
     entryPointName.includes('pages/api') ||
-    (isServer && entryPointName === 'pages/_error')
+    (isServer && entryPointName.includes('pages/_error'))
   );
 }
 

--- a/packages/nextjs/test/config.test.ts
+++ b/packages/nextjs/test/config.test.ts
@@ -71,7 +71,7 @@ const userNextConfig: Partial<NextConfigObject> = {
     mode: 'universal-sniffing',
     entry: async () =>
       Promise.resolve({
-        ...(await (config.entry as EntryPropertyFunction)()),
+        ...(typeof config.entry === 'function' ? await config.entry() : config.entry),
         simulatorBundle: './src/simulator/index.ts',
       }),
   }),
@@ -203,8 +203,9 @@ async function materializeFinalWebpackConfig(options: {
 
   // call it to get concrete values for comparison
   const finalWebpackConfigValue = webpackConfigFunction(incomingWebpackConfig, incomingWebpackBuildContext);
-  const webpackEntryProperty = finalWebpackConfigValue.entry as EntryPropertyFunction;
-  finalWebpackConfigValue.entry = await webpackEntryProperty();
+  const webpackEntryProperty = finalWebpackConfigValue.entry;
+  finalWebpackConfigValue.entry =
+    typeof webpackEntryProperty === 'function' ? await webpackEntryProperty() : webpackEntryProperty;
 
   return finalWebpackConfigValue;
 }

--- a/packages/nextjs/test/config.test.ts
+++ b/packages/nextjs/test/config.test.ts
@@ -19,6 +19,7 @@ import {
   getWebpackPluginOptions,
   SentryWebpackPlugin,
 } from '../src/config/webpack';
+import { addSrcToEntryPoints } from './testUtils';
 
 const SERVER_SDK_CONFIG_FILE = 'sentry.server.config.js';
 const CLIENT_SDK_CONFIG_FILE = 'sentry.client.config.js';
@@ -401,6 +402,33 @@ describe('webpack config', () => {
       );
     });
 
+    it('injects user config file into `_app` in both server and client bundles when using `src` directory', async () => {
+      const serverWebpackConfigWithSrc = await addSrcToEntryPoints(serverWebpackConfig);
+      const clientWebpackConfigWithSrc = await addSrcToEntryPoints(clientWebpackConfig);
+
+      const finalServerWebpackConfig = await materializeFinalWebpackConfig({
+        userNextConfig,
+        incomingWebpackConfig: serverWebpackConfigWithSrc,
+        incomingWebpackBuildContext: serverBuildContext,
+      });
+      const finalClientWebpackConfig = await materializeFinalWebpackConfig({
+        userNextConfig,
+        incomingWebpackConfig: clientWebpackConfigWithSrc,
+        incomingWebpackBuildContext: clientBuildContext,
+      });
+
+      expect(finalServerWebpackConfig.entry).toEqual(
+        expect.objectContaining({
+          'src/pages/_app': expect.arrayContaining([serverConfigFilePath]),
+        }),
+      );
+      expect(finalClientWebpackConfig.entry).toEqual(
+        expect.objectContaining({
+          'src/pages/_app': expect.arrayContaining([clientConfigFilePath]),
+        }),
+      );
+    });
+
     it('injects user config file into `_error` in server bundle but not client bundle', async () => {
       const finalServerWebpackConfig = await materializeFinalWebpackConfig({
         userNextConfig,
@@ -425,6 +453,33 @@ describe('webpack config', () => {
       );
     });
 
+    it('injects user config file into `_error` in server bundle but not client bundle when using `src` directory', async () => {
+      const serverWebpackConfigWithSrc = await addSrcToEntryPoints(serverWebpackConfig);
+      const clientWebpackConfigWithSrc = await addSrcToEntryPoints(clientWebpackConfig);
+
+      const finalServerWebpackConfig = await materializeFinalWebpackConfig({
+        userNextConfig,
+        incomingWebpackConfig: serverWebpackConfigWithSrc,
+        incomingWebpackBuildContext: serverBuildContext,
+      });
+      const finalClientWebpackConfig = await materializeFinalWebpackConfig({
+        userNextConfig,
+        incomingWebpackConfig: clientWebpackConfigWithSrc,
+        incomingWebpackBuildContext: clientBuildContext,
+      });
+
+      expect(finalServerWebpackConfig.entry).toEqual(
+        expect.objectContaining({
+          'src/pages/_error': expect.arrayContaining([serverConfigFilePath]),
+        }),
+      );
+      expect(finalClientWebpackConfig.entry).toEqual(
+        expect.objectContaining({
+          'src/pages/_error': expect.not.arrayContaining([clientConfigFilePath]),
+        }),
+      );
+    });
+
     it('injects user config file into API routes', async () => {
       const finalWebpackConfig = await materializeFinalWebpackConfig({
         userNextConfig,
@@ -443,6 +498,31 @@ describe('webpack config', () => {
           },
 
           'pages/api/tricks/[trickName]': expect.objectContaining({
+            import: expect.arrayContaining([serverConfigFilePath]),
+          }),
+        }),
+      );
+    });
+
+    it('injects user config file into API routes when using `src` directory', async () => {
+      const webpackConfigWithSrc = await addSrcToEntryPoints(serverWebpackConfig);
+      const finalWebpackConfig = await materializeFinalWebpackConfig({
+        userNextConfig,
+        incomingWebpackConfig: webpackConfigWithSrc,
+        incomingWebpackBuildContext: serverBuildContext,
+      });
+
+      expect(finalWebpackConfig.entry).toEqual(
+        expect.objectContaining({
+          'src/pages/api/simulator/dogStats/[name]': {
+            import: expect.arrayContaining([serverConfigFilePath]),
+          },
+
+          'src/pages/api/simulator/leaderboard': {
+            import: expect.arrayContaining([serverConfigFilePath]),
+          },
+
+          'src/pages/api/tricks/[trickName]': expect.objectContaining({
             import: expect.arrayContaining([serverConfigFilePath]),
           }),
         }),

--- a/packages/nextjs/test/testUtils.ts
+++ b/packages/nextjs/test/testUtils.ts
@@ -1,0 +1,19 @@
+import { WebpackConfigObject } from '../src/config/types';
+
+export async function addSrcToEntryPoints(webpackConfig: WebpackConfigObject): Promise<WebpackConfigObject> {
+  // make a copy so we don't mutate the original mock
+  const entryPropertyObject = {
+    ...(typeof webpackConfig.entry === 'function' ? await webpackConfig.entry() : webpackConfig.entry),
+  };
+
+  // add `src/` to the beginning of every key (done by replacing each entry with one with the new key)
+  for (const [key, value] of Object.entries(entryPropertyObject)) {
+    const newKey = `src/${key}`;
+    entryPropertyObject[newKey] = value;
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete entryPropertyObject[key];
+  }
+
+  // make a copy so we don't mutate the original mock
+  return { ...webpackConfig, entry: entryPropertyObject };
+}


### PR DESCRIPTION
While the standard nextjs setup puts the `pages/` directory at the project root, [it is also permissible](https://nextjs.org/docs/advanced-features/src-directory) to locate the `pages/` directory inside of a `src/` directory. Currently, we don't support this, in that Sentry code doesn't get injected into the relevant pages unless the standard setup is used.

This PR adds support for using a `src/` directory to hold the `pages/` directory, by changing the filter deciding which pages should be Sentrified to use an inclusion match rather than strict equality. (In other words, for example, the page path just needs to _include_ `pages/_app` rather than _equal_ `pages/_app`.)

Note: While it's true that in rare cases this could give false positives (if, say, the user has an entrypoint with the path `somethingElse/pages/_app`), the chances seem very slim, and in any case, the only harm there would be injecting `Sentry.init()` code into a page which doesn't need it, which shouldn't break anything. So being a little too broad in the interests of simplicity should be safe.

Note to reviewer: The tests I added probably should be parameterized at some point, but in the interests of time, I did them the straightforward way. The `config.test.ts` file needs an overhaul in any case - it's gotten unwieldy - so that can happen then.