### PR TITLE
fix(integrations): Add default for `ExtraErrorData`'s `depth` option

### DIFF
--- a/packages/integrations/src/extraerrordata.ts
+++ b/packages/integrations/src/extraerrordata.ts
@@ -18,10 +18,18 @@ export class ExtraErrorData implements Integration {
    */
   public name: string = ExtraErrorData.id;
 
+  /** JSDoc */
+  private readonly _options: ExtraErrorDataOptions;
+
   /**
    * @inheritDoc
    */
-  public constructor(private readonly _options: ExtraErrorDataOptions = { depth: 3 }) {}
+  public constructor(options?: ExtraErrorDataOptions) {
+    this._options = {
+      depth: 3,
+      ...options,
+    };
+  }
 
   /**
    * @inheritDoc

--- a/packages/integrations/test/extraerrordata.test.ts
+++ b/packages/integrations/test/extraerrordata.test.ts
@@ -42,6 +42,31 @@ describe('ExtraErrorData()', () => {
     });
   });
 
+  it('should stringify up to 3 nested levels by default', () => {
+    const error = new TypeError('foo') as ExtendedError;
+    error['1'] = {
+      2: {
+        3: {
+          4: 'foo',
+        },
+      },
+    };
+
+    const enhancedEvent = extraErrorData.enhanceEventWithErrorData(event, {
+      originalException: error,
+    });
+
+    expect(enhancedEvent.contexts).toEqual({
+      TypeError: {
+        1: {
+          2: {
+            3: '[Object]',
+          },
+        },
+      },
+    });
+  });
+
   it('should not remove previous data existing in extra field', () => {
     event = {
       // @ts-ignore Allow contexts on event


### PR DESCRIPTION
Ensure that `ExtraErrorData`'s `depth` option is by default set to 3. Currently, if the user provides an empty options object, `depth` gets set to `undefined`.

Fixes #4186
