### PR TITLE
fix(tests): Make CLS web vital test less flaky

### DIFF
--- a/packages/integration-tests/suites/tracing/metrics/web-vitals-cls/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/web-vitals-cls/test.ts
@@ -37,6 +37,12 @@ sentryTest('should capture a "POOR" CLS vital with its source(s).', async ({ get
 
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.cls?.value).toBeDefined();
-  expect(eventData.measurements?.cls?.value).toBeCloseTo(0.35);
+  // This test in particular seems to be flaky, such that the received value is frequently within 0.006 rather than the
+  // 0.005 that `toBeCloseTo()` requires. While it's true that each test is retried twice if it fails, in the flaky
+  // cases all three attempts always seem to come up with the exact same slightly-too-far-away number. Rather than ramp
+  // down `toBeCloseTo()`'s precision (which would make it accept anything between 0.30 and 0.40), we can just do the
+  // check manually.
+  expect(eventData.measurements?.cls?.value).toBeGreaterThan(0.34);
+  expect(eventData.measurements?.cls?.value).toBeLessThan(0.36);
   expect(eventData.tags?.['cls.source.1']).toBe('body > div#content > p');
 });


### PR DESCRIPTION
Despite the fact that we're using a `toBeCloseTo()` check rather than a `toEqual()` check on the integration test for recording a "poor" CLS web vital, that test seems to have a habit of failing in CI, by ending up being not quite close enough to the desired value.

This fixes that by widening the window of tolerance just slightly, hopefully enough to prevent the flakiness.
