### PR TITLE
ref(build): Update to TypeScript 3.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "size-limit": "^4.5.5",
     "ts-jest": "^24.3.0",
     "typedoc": "^0.18.0",
-    "typescript": "3.7.5"
+    "typescript": "3.8.3"
   },
   "resolutions": {
     "**/agent-base": "5",

--- a/packages/integration-tests/suites/tracing/browsertracing/backgroundtab-pageload/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/backgroundtab-pageload/test.ts
@@ -8,7 +8,7 @@ sentryTest('should finish pageload transaction when the page goes background', a
 
   await page.goto(url);
 
-  page.click('#go-background');
+  void page.click('#go-background');
 
   const pageloadTransaction = await getSentryTransactionRequest(page);
 

--- a/packages/integration-tests/suites/tracing/metrics/web-vitals-fid/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/web-vitals-fid/test.ts
@@ -11,9 +11,9 @@ sentryTest('should capture a FID vital.', async ({ browserName, getLocalTestPath
 
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  page.goto(url);
+  await page.goto(url);
   // To trigger FID
-  page.click('#fid-btn');
+  await page.click('#fid-btn');
 
   const eventData = await getSentryTransactionRequest(page);
 

--- a/packages/integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -13,10 +13,10 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
   );
 
   const url = await getLocalTestPath({ testDir: __dirname });
-  page.goto(url);
+  await page.goto(url);
 
   // Force closure of LCP listener.
-  page.click('body');
+  await page.click('body');
   const eventData = await getSentryTransactionRequest(page);
 
   expect(eventData.measurements).toBeDefined();

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "tslint": "5.16.0",
-    "typescript": "3.7.5"
+    "typescript": "3.8.3"
   },
   "scripts": {
     "link:yarn": "yarn link",

--- a/scripts/verify-packages-versions.js
+++ b/scripts/verify-packages-versions.js
@@ -1,6 +1,6 @@
 const pkg = require('../package.json');
 
-const TYPESCRIPT_VERSION = '3.7.5';
+const TYPESCRIPT_VERSION = '3.8.3';
 
 if (pkg.devDependencies.typescript !== TYPESCRIPT_VERSION) {
   console.error(`

--- a/yarn.lock
+++ b/yarn.lock
@@ -21065,10 +21065,10 @@ typescript-memoize@^1.0.1:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.0.1.tgz#0a8199aa28f6fe18517f6e9308ef7bfbe9a98d59"
   integrity sha512-oJNge1qUrOK37d5Y6Ly2txKeuelYVsFtNF6U9kXIN7juudcQaHJQg2MxLOy0CqtkW65rVDYuTCOjnSIVPd8z3w==
 
-typescript@3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 typescript@^3.9.5, typescript@^3.9.7:
   version "3.9.9"


### PR DESCRIPTION
This updates the SDK to use Typescript 3.8.3, in order to be able to use [type-only imports and exports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export). (These are needed for us to turn on `isolatedModules`, which is in turn [is needed for us to switch our build tool away from `tsc`](https://www.typescriptlang.org/tsconfig#isolatedModules), since no other tool understands the relationship between files.)

As a result of this change, a few of the browser integration tests needed to be fixed so that all promises were explicitly awaited, a point about which the linter in 3.8 complains.

This is a breaking change for anyone using TS 3.7.x (there's no one using TS < 3.7.x, since that's our current minimum). That said, though there are plenty of [public projects on GH using TS 3.7 and `@sentry/xyz`](https://cs.github.com/?scopeName=All+repos&scope=&q=path%3Apackage.json+%2F%22%40sentry%5C%2F%2F+AND+%2F%22typescript%22%3A+%22%7E%3F3%5C.7%2F), if you restrict it to [projects using TS 3.7 and `@sentry/xyz` 6.x](https://cs.github.com/?scopeName=All+repos&scope=&q=path%3Apackage.json+%2F%22%40sentry%5C%2F.*%22%3A+%226%2F+AND+%2F%22typescript%22%3A+%22%7E%3F3%5C.7%2F), all you get are forks of this very repo. Granted, this isn't every project ever, but it's likely decently representative of the fact that if you've upgrade our SDK, you've almost certainly upgraded TS as well. We're going to wait until v7 to release this change in any case, but that's an indication that it won't affect many people when we do.

Ultimately we may end up upgrading all the way to 4.x, but that can be left for a future PR if so.