### PR TITLE
ref(types): Move `SeverityLevel` and `SeverityLevels` to `@sentry/utils`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+This release deprecates the `Severity` enum, the `SeverityLevel` type, and the internal `SeverityLevels` array, all from `@sentry/types`. In v7, `Severity` will disappear (in favor of `SeverityLevel`) and `SeverityLevel` and `SeverityLevels` will live in `@sentry/utils`. If you are using any of the three, we encourage you to migrate your usage now, using our [migration guide](./MIGRATION.md#upgrading-from-6.x-to-6.17.x).
+
 ## 6.17.4
 
 - chore(deps): Bump `@sentry/webpack-plugin` from 1.18.3 to 1.18.4 (#4464)
@@ -37,7 +39,7 @@ Work in this release contributed by @datbth. Thank you for your contribution!
 
 ## 6.17.0
 
-This release contains several internal refactors that help reduce the bundle size of the SDK and help prep for our [upcoming major release](https://github.com/getsentry/sentry-javascript/issues/4240). There are no breaking changes in this patch unless you are using our internal `Dsn` class, which has been removed. We also deprecated a few of our typescript enums and our internal `API` class. We've detailed in our [migration documentation](./MIGRATION.md#upgrading-from-6.x-to-6.17.0) how to update your sdk usage if you are using any of these in your code.
+This release contains several internal refactors that help reduce the bundle size of the SDK and help prep for our [upcoming major release](https://github.com/getsentry/sentry-javascript/issues/4240). There are no breaking changes in this patch unless you are using our internal `Dsn` class, which has been removed. We also deprecated a few of our typescript enums and our internal `API` class. We've detailed in our [migration documentation](./MIGRATION.md#upgrading-from-6.x-to-6.17.x) how to update your sdk usage if you are using any of these in your code.
 
 - feat: Remove Dsn class (#4325)
 - feat(core): Add processing metadata to scope and event (#4252)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
-# Upgrading from 6.x to 6.17.0
+# Upgrading from 6.x to 6.17.x
 
-You only need to make changes when migrating to `6.17.0` if you are using our internal `Dsn` class. Our internal API class and typescript enums were deprecated, so we recommend you migrate them as well.
+You only need to make changes when migrating to `6.17.x` if you are using our internal `Dsn` class. Our internal API class and typescript enums were deprecated, so we recommend you migrate them as well.
 
 The internal `Dsn` class was removed in `6.17.0`. For additional details, you can look at the [PR where this change happened](https://github.com/getsentry/sentry-javascript/pull/4325). To migrate, see the following example.
 
@@ -44,7 +44,7 @@ const envelopeEndpoint = api.getEnvelopeEndpointWithUrlEncodedAuth();
 
 ## Enum changes
 
-The enums `Status` and `SpanStatus` were deprecated, and we've detailed how to migrate away from them below. We also deprecated the `TransactionMethod`, `Outcome` and `RequestSessionStatus` enums, but those are internal-only APIs. If you are using them, we encourage you to take a look at the corresponding PRs to see how we've changed our code as a result.
+The enums `Status`, `SpanStatus`, and `Severity` were deprecated, and we've detailed how to migrate away from them below. We also deprecated the `TransactionMethod`, `Outcome` and `RequestSessionStatus` enums, but those are internal-only APIs. If you are using them, we encourage you to take a look at the corresponding PRs to see how we've changed our code as a result.
 
 - `TransactionMethod`: https://github.com/getsentry/sentry-javascript/pull/4314
 - `Outcome`: https://github.com/getsentry/sentry-javascript/pull/4315
@@ -81,6 +81,27 @@ import { SpanStatus } from '@sentry/tracing';
 
 const status = SpanStatus.fromHttpCode(403);
 ```
+
+#### Severity, SeverityLevel, and SeverityLevels
+
+We deprecated the `Severity` enum in `@sentry/types` and it will be removed in the next major release. We recommend using string literals (typed as `SeverityLevel`) to save on bundle size.
+
+`SeverityLevel` and `SeverityLevels` will continue to exist in v7, but they will live in `@sentry/utils` rather than `@sentry/types`. Currently, they live in both, for ease of migration. (`SeverityLevels` isn't included in the examples below because it is only useful internally.)
+
+```js
+// New in 6.17.5:
+import { SeverityLevel } from '@sentry/utils';
+
+const levelA = "error" as SeverityLevel;
+
+const levelB: SeverityLevel = "error"
+
+// Before:
+import { Severity, SeverityLevel } from '@sentry/types';
+
+const levelA = Severity.error;
+
+const levelB: SeverityLevel = "error"
 
 # Upgrading from 4.x to 5.x/6.x
 

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -9,12 +9,13 @@ export {
   Exception,
   Response,
   Severity,
-  SeverityLevel,
   StackFrame,
   Stacktrace,
   Thread,
   User,
 } from '@sentry/types';
+
+export { SeverityLevel } from '@sentry/utils';
 
 export {
   addGlobalEventProcessor,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -9,12 +9,13 @@ export {
   Exception,
   Response,
   Severity,
-  SeverityLevel,
   StackFrame,
   Stacktrace,
   Thread,
   User,
 } from '@sentry/types';
+
+export { SeverityLevel } from '@sentry/utils';
 
 export {
   addGlobalEventProcessor,

--- a/packages/tracing/src/index.bundle.ts
+++ b/packages/tracing/src/index.bundle.ts
@@ -7,12 +7,13 @@ export {
   Exception,
   Response,
   Severity,
-  SeverityLevel,
   StackFrame,
   Stacktrace,
   Thread,
   User,
 } from '@sentry/types';
+
+export { SeverityLevel } from '@sentry/utils';
 
 export {
   addGlobalEventProcessor,

--- a/packages/types/src/severity.ts
+++ b/packages/types/src/severity.ts
@@ -18,5 +18,7 @@ export enum Severity {
   Critical = 'critical',
 }
 
+// TODO: in v7, these can disappear, because they now also exist in `@sentry/utils`. (Having them there rather than here
+// is nice because then it enforces the idea that only types are exported from `@sentry/types`.)
 export const SeverityLevels = ['fatal', 'error', 'warning', 'log', 'info', 'debug', 'critical'] as const;
 export type SeverityLevel = typeof SeverityLevels[number];

--- a/packages/utils/src/enums.ts
+++ b/packages/utils/src/enums.ts
@@ -1,0 +1,2 @@
+export const SeverityLevels = ['fatal', 'error', 'warning', 'log', 'info', 'debug', 'critical'] as const;
+export type SeverityLevel = typeof SeverityLevels[number];

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,6 +1,7 @@
 export * from './async';
 export * from './browser';
 export * from './dsn';
+export * from './enums';
 export * from './error';
 export * from './global';
 export * from './instrument';

--- a/packages/utils/src/severity.ts
+++ b/packages/utils/src/severity.ts
@@ -1,4 +1,6 @@
-import { Severity, SeverityLevel, SeverityLevels } from '@sentry/types';
+import { Severity } from '@sentry/types';
+
+import { SeverityLevel, SeverityLevels } from './enums';
 
 function isSupportedSeverity(level: string): level is Severity {
   return SeverityLevels.indexOf(level as SeverityLevel) !== -1;

--- a/packages/utils/test/severity.test.ts
+++ b/packages/utils/test/severity.test.ts
@@ -1,5 +1,4 @@
-import { SeverityLevels } from '@sentry/types';
-
+import { SeverityLevels } from '../src/enums';
 import { severityFromString } from '../src/severity';
 
 describe('severityFromString()', () => {

--- a/packages/vue/src/index.bundle.ts
+++ b/packages/vue/src/index.bundle.ts
@@ -6,12 +6,13 @@ export {
   EventStatus,
   Exception,
   Response,
-  SeverityLevel,
   StackFrame,
   Stacktrace,
   Thread,
   User,
 } from '@sentry/types';
+
+export { SeverityLevel } from '@sentry/utils';
 
 export {
   BrowserClient,


### PR DESCRIPTION
This PR includes three changes:

- It moves the type `SeverityLevel` and the const string array `SeverityLevels` from `@sentry/types` to `@sentry/utils`, in order that only types get exported from `@sentry/types`. Since every package other than `@sentry/types` depends on `@sentry/utils`, they're still accessible to any package which needs them.

- It changes all of our uses of `SeverityLevel` and `SeverityLevels` so that they point to the copies in `@sentry/utils` rather than those in `@sentry/types`.

- It adds a corresponding entry to the migration guide.

The copies of `SeverityLevel` and `SeverityLevels` in `@sentry/types` remain, for backwards compatibility, but can be removed in v7. 
