### PR TITLE
ref(build): Turn on `isolatedModules` TS option

### DIFF
--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,7 +1,9 @@
+export type { ErrorHandlerOptions } from './errorhandler';
+
 export * from '@sentry/browser';
 
 export { init } from './sdk';
-export { createErrorHandler, ErrorHandlerOptions, SentryErrorHandler } from './errorhandler';
+export { createErrorHandler, SentryErrorHandler } from './errorhandler';
 export {
   getActiveTransaction,
   // TODO `instrumentAngularRouting` is just an alias for `routingInstrumentation`; deprecate the latter at some point

--- a/packages/browser/src/backend.ts
+++ b/packages/browser/src/backend.ts
@@ -45,7 +45,7 @@ export class BrowserBackend extends BaseBackend<BrowserOptions> {
   /**
    * @inheritDoc
    */
-  public eventFromMessage(message: string, level: Severity = Severity.Info, hint?: EventHint): PromiseLike<Event> {
+  public eventFromMessage(message: string, level: Severity = 'info' as Severity, hint?: EventHint): PromiseLike<Event> {
     return eventFromMessage(this._options, message, level, hint);
   }
 

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -24,7 +24,7 @@ export function eventFromException(options: Options, exception: unknown, hint?: 
     attachStacktrace: options.attachStacktrace,
   });
   addExceptionMechanism(event); // defaults to { type: 'generic', handled: true }
-  event.level = Severity.Error;
+  event.level = 'error' as Severity;
   if (hint && hint.event_id) {
     event.event_id = hint.event_id;
   }
@@ -38,7 +38,7 @@ export function eventFromException(options: Options, exception: unknown, hint?: 
 export function eventFromMessage(
   options: Options,
   message: string,
-  level: Severity = Severity.Info,
+  level: Severity = 'info' as Severity,
   hint?: EventHint,
 ): PromiseLike<Event> {
   const syntheticException = (hint && hint.syntheticException) || undefined;

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   Breadcrumb,
   BreadcrumbHint,
   Request,
@@ -15,7 +15,10 @@ export {
   User,
 } from '@sentry/types';
 
-export { SeverityLevel } from '@sentry/utils';
+export type { SeverityLevel } from '@sentry/utils';
+
+export type { BrowserOptions } from './backend';
+export type { ReportDialogOptions } from './helpers';
 
 export {
   addGlobalEventProcessor,
@@ -40,9 +43,8 @@ export {
   withScope,
 } from '@sentry/core';
 
-export { BrowserOptions } from './backend';
 export { BrowserClient } from './client';
-export { injectReportDialog, ReportDialogOptions } from './helpers';
+export { injectReportDialog } from './helpers';
 export { eventFromException, eventFromMessage } from './eventbuilder';
 export { defaultIntegrations, forceLoad, init, lastEventId, onLoad, showReportDialog, flush, close, wrap } from './sdk';
 export { SDK_NAME } from './version';

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -230,7 +230,7 @@ function _fetchBreadcrumb(handlerData: { [key: string]: any }): void {
       {
         category: 'fetch',
         data: handlerData.fetchData,
-        level: Severity.Error,
+        level: 'error' as Severity,
         type: 'http',
       },
       {

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -101,7 +101,7 @@ function _installGlobalOnErrorHandler(): void {
               column,
             );
 
-      event.level = Severity.Error;
+      event.level = 'error' as Severity;
 
       addMechanismAndCapture(hub, error, event, 'onerror');
     },
@@ -150,7 +150,7 @@ function _installGlobalOnUnhandledRejectionHandler(): void {
             isRejection: true,
           });
 
-      event.level = Severity.Error;
+      event.level = 'error' as Severity;
 
       addMechanismAndCapture(hub, error, event, 'onunhandledrejection');
       return;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,7 @@
+export type { APIDetails } from './api';
+export type { BackendClass } from './basebackend';
+export type { ClientClass } from './sdk';
+
 export {
   addBreadcrumb,
   captureException,
@@ -17,7 +21,6 @@ export { addGlobalEventProcessor, getCurrentHub, getHubFromCarrier, Hub, makeMai
 export {
   // eslint-disable-next-line deprecation/deprecation
   API,
-  APIDetails,
   getEnvelopeEndpointWithUrlEncodedAuth,
   getStoreEndpointWithUrlEncodedAuth,
   getRequestHeaders,
@@ -25,9 +28,9 @@ export {
   getReportDialogEndpoint,
 } from './api';
 export { BaseClient } from './baseclient';
-export { BackendClass, BaseBackend } from './basebackend';
+export { BaseBackend } from './basebackend';
 export { eventToSentryRequest, sessionToSentryRequest } from './request';
-export { initAndBind, ClientClass } from './sdk';
+export { initAndBind } from './sdk';
 export { NoopTransport } from './transports/noop';
 export { SDK_VERSION } from './version';
 

--- a/packages/core/test/mocks/backend.ts
+++ b/packages/core/test/mocks/backend.ts
@@ -38,7 +38,7 @@ export class TestBackend extends BaseBackend<TestOptions> {
     });
   }
 
-  public eventFromMessage(message: string, level: Severity = Severity.Info): PromiseLike<Event> {
+  public eventFromMessage(message: string, level: Severity = 'info' as Severity): PromiseLike<Event> {
     return resolvedSyncPromise({ message, level });
   }
 

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -1,3 +1,10 @@
+export type {
+  Carrier,
+  // eslint-disable-next-line deprecation/deprecation
+  DomainAsCarrier,
+  Layer,
+} from './hub';
+
 export { addGlobalEventProcessor, Scope } from './scope';
 export { Session } from './session';
 export { SessionFlusher } from './sessionflusher';
@@ -10,8 +17,4 @@ export {
   Hub,
   makeMain,
   setHubOnCarrier,
-  Carrier,
-  // eslint-disable-next-line deprecation/deprecation
-  DomainAsCarrier,
-  Layer,
 } from './hub';

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -85,8 +85,8 @@ describe('Scope', () => {
 
     test('setLevel', () => {
       const scope = new Scope();
-      scope.setLevel(Severity.Critical);
-      expect((scope as any)._level).toEqual(Severity.Critical);
+      scope.setLevel('critical' as Severity);
+      expect((scope as any)._level).toEqual('critical' as Severity);
     });
 
     test('setTransactionName', () => {
@@ -137,8 +137,8 @@ describe('Scope', () => {
 
     test('chaining', () => {
       const scope = new Scope();
-      scope.setLevel(Severity.Critical).setUser({ id: '1' });
-      expect((scope as any)._level).toEqual(Severity.Critical);
+      scope.setLevel('critical' as Severity).setUser({ id: '1' });
+      expect((scope as any)._level).toEqual('critical' as Severity);
       expect((scope as any)._user).toEqual({ id: '1' });
     });
   });
@@ -202,7 +202,7 @@ describe('Scope', () => {
       scope.setTag('a', 'b');
       scope.setUser({ id: '1' });
       scope.setFingerprint(['abcd']);
-      scope.setLevel(Severity.Warning);
+      scope.setLevel('warning' as Severity);
       scope.setTransactionName('/abc');
       scope.addBreadcrumb({ message: 'test' });
       scope.setContext('os', { id: '1' });
@@ -294,11 +294,11 @@ describe('Scope', () => {
     test('scope level should have priority over event level', () => {
       expect.assertions(1);
       const scope = new Scope();
-      scope.setLevel(Severity.Warning);
+      scope.setLevel('warning' as Severity);
       const event: Event = {};
-      event.level = Severity.Critical;
+      event.level = 'critical' as Severity;
       return scope.applyToEvent(event).then(processedEvent => {
-        expect(processedEvent!.level).toEqual(Severity.Warning);
+        expect(processedEvent!.level).toEqual('warning' as Severity);
       });
     });
 
@@ -410,7 +410,7 @@ describe('Scope', () => {
       scope.setContext('foo', { id: '1' });
       scope.setContext('bar', { id: '2' });
       scope.setUser({ id: '1337' });
-      scope.setLevel(Severity.Info);
+      scope.setLevel('info' as Severity);
       scope.setFingerprint(['foo']);
       scope.setRequestSession({ status: 'ok' });
     });
@@ -458,7 +458,7 @@ describe('Scope', () => {
       localScope.setContext('bar', { id: '3' });
       localScope.setContext('baz', { id: '4' });
       localScope.setUser({ id: '42' });
-      localScope.setLevel(Severity.Warning);
+      localScope.setLevel('warning' as Severity);
       localScope.setFingerprint(['bar']);
       (localScope as any)._requestSession = { status: 'ok' };
 

--- a/packages/minimal/test/lib/minimal.test.ts
+++ b/packages/minimal/test/lib/minimal.test.ts
@@ -165,8 +165,8 @@ describe('Minimal', () => {
       const client: any = new TestClient({});
       const scope = getCurrentHub().pushScope();
       getCurrentHub().bindClient(client);
-      scope.setLevel(Severity.Warning);
-      expect(global.__SENTRY__.hub._stack[1].scope._level).toEqual(Severity.Warning);
+      scope.setLevel('warning' as Severity);
+      expect(global.__SENTRY__.hub._stack[1].scope._level).toEqual('warning' as Severity);
     });
   });
 
@@ -245,16 +245,16 @@ describe('Minimal', () => {
 
   test('withScope', () => {
     withScope(scope => {
-      scope.setLevel(Severity.Warning);
+      scope.setLevel('warning' as Severity);
       scope.setFingerprint(['1']);
       withScope(scope2 => {
-        scope2.setLevel(Severity.Info);
+        scope2.setLevel('info' as Severity);
         scope2.setFingerprint(['2']);
         withScope(scope3 => {
           scope3.clear();
-          expect(global.__SENTRY__.hub._stack[1].scope._level).toEqual(Severity.Warning);
+          expect(global.__SENTRY__.hub._stack[1].scope._level).toEqual('warning' as Severity);
           expect(global.__SENTRY__.hub._stack[1].scope._fingerprint).toEqual(['1']);
-          expect(global.__SENTRY__.hub._stack[2].scope._level).toEqual(Severity.Info);
+          expect(global.__SENTRY__.hub._stack[2].scope._level).toEqual('info' as Severity);
           expect(global.__SENTRY__.hub._stack[2].scope._fingerprint).toEqual(['2']);
           expect(global.__SENTRY__.hub._stack[3].scope._level).toBeUndefined();
         });

--- a/packages/node/src/backend.ts
+++ b/packages/node/src/backend.ts
@@ -22,7 +22,7 @@ export class NodeBackend extends BaseBackend<NodeOptions> {
   /**
    * @inheritDoc
    */
-  public eventFromMessage(message: string, level: Severity = Severity.Info, hint?: EventHint): PromiseLike<Event> {
+  public eventFromMessage(message: string, level: Severity = 'info' as Severity, hint?: EventHint): PromiseLike<Event> {
     return eventFromMessage(this._options, message, level, hint);
   }
 

--- a/packages/node/src/eventbuilder.ts
+++ b/packages/node/src/eventbuilder.ts
@@ -69,7 +69,7 @@ export function eventFromException(options: Options, exception: unknown, hint?: 
 export function eventFromMessage(
   options: Options,
   message: string,
-  level: Severity = Severity.Info,
+  level: Severity = 'info' as Severity,
   hint?: EventHint,
 ): PromiseLike<Event> {
   const event: Event = {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   Breadcrumb,
   BreadcrumbHint,
   Request,
@@ -15,7 +15,9 @@ export {
   User,
 } from '@sentry/types';
 
-export { SeverityLevel } from '@sentry/utils';
+export type { SeverityLevel } from '@sentry/utils';
+
+export type { NodeOptions } from './types';
 
 export {
   addGlobalEventProcessor,
@@ -40,7 +42,6 @@ export {
   withScope,
 } from '@sentry/core';
 
-export { NodeOptions } from './types';
 export { NodeBackend } from './backend';
 export { NodeClient } from './client';
 export { defaultIntegrations, init, lastEventId, flush, close, getSentryRelease } from './sdk';

--- a/packages/node/src/integrations/onuncaughtexception.ts
+++ b/packages/node/src/integrations/onuncaughtexception.ts
@@ -77,7 +77,7 @@ export class OnUncaughtException implements Integration {
 
         if (hub.getIntegration(OnUncaughtException)) {
           hub.withScope((scope: Scope) => {
-            scope.setLevel(Severity.Fatal);
+            scope.setLevel('fatal' as Severity);
             hub.captureException(error, {
               originalException: error,
               data: { mechanism: { handled: false, type: 'onuncaughtexception' } },

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -274,7 +274,7 @@ export function wrapHandler<TEvent, TResult>(
       timeoutWarningTimer = setTimeout(() => {
         withScope(scope => {
           scope.setTag('timeout', humanReadableTimeout);
-          captureMessage(`Possible function timeout: ${context.functionName}`, Sentry.Severity.Warning);
+          captureMessage(`Possible function timeout: ${context.functionName}`, 'warning' as Sentry.Severity);
         });
       }, timeoutWarningDelay);
     }

--- a/packages/serverless/src/gcpfunction/general.ts
+++ b/packages/serverless/src/gcpfunction/general.ts
@@ -62,4 +62,4 @@ export function configureScopeWithContext(scope: Scope, context: Context): void 
   scope.setContext('gcp.function.context', { ...context } as SentryContext);
 }
 
-export { Request, Response };
+export type { Request, Response };

--- a/packages/tracing/src/browser/index.ts
+++ b/packages/tracing/src/browser/index.ts
@@ -1,6 +1,4 @@
+export type { RequestInstrumentationOptions } from './request';
+
 export { BrowserTracing } from './browsertracing';
-export {
-  instrumentOutgoingRequests,
-  RequestInstrumentationOptions,
-  defaultRequestInstrumentationOptions,
-} from './request';
+export { instrumentOutgoingRequests, defaultRequestInstrumentationOptions } from './request';

--- a/packages/tracing/src/index.bundle.ts
+++ b/packages/tracing/src/index.bundle.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   Breadcrumb,
   Request,
   SdkInfo,
@@ -13,7 +13,9 @@ export {
   User,
 } from '@sentry/types';
 
-export { SeverityLevel } from '@sentry/utils';
+export type { BrowserOptions, ReportDialogOptions } from '@sentry/browser';
+
+export type { SeverityLevel } from '@sentry/utils';
 
 export {
   addGlobalEventProcessor,
@@ -37,8 +39,7 @@ export {
   withScope,
 } from '@sentry/browser';
 
-export { BrowserOptions } from '@sentry/browser';
-export { BrowserClient, ReportDialogOptions } from '@sentry/browser';
+export { BrowserClient } from '@sentry/browser';
 export {
   defaultIntegrations,
   forceLoad,

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -1,6 +1,9 @@
 import { addExtensionMethods } from './hubextensions';
 import * as Integrations from './integrations';
 
+export type { RequestInstrumentationOptions } from './browser';
+export type { SpanStatusType } from './span';
+
 export { Integrations };
 
 // This is already exported as part of `Integrations` above (and for the moment will remain so for
@@ -21,14 +24,13 @@ export { Integrations };
 // For an example of of the new usage of BrowserTracing, see @sentry/nextjs index.client.ts
 export { BrowserTracing } from './browser';
 
-export { Span, SpanStatusType, spanStatusfromHttpCode } from './span';
+export { Span, spanStatusfromHttpCode } from './span';
 // eslint-disable-next-line deprecation/deprecation
 export { SpanStatus } from './spanstatus';
 export { Transaction } from './transaction';
 export {
   // TODO deprecate old name in v7
   instrumentOutgoingRequests as registerRequestInstrumentation,
-  RequestInstrumentationOptions,
   defaultRequestInstrumentationOptions,
 } from './browser';
 export { IdleTransaction } from './idletransaction';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,27 +1,27 @@
-export { Breadcrumb, BreadcrumbHint } from './breadcrumb';
-export { Client } from './client';
-export { Context, Contexts } from './context';
-export { DsnComponents, DsnLike, DsnProtocol } from './dsn';
-export { DebugImage, DebugImageType, DebugMeta } from './debugMeta';
-export { ExtendedError } from './error';
-export { Event, EventHint } from './event';
-export { EventStatus } from './eventstatus';
-export { EventProcessor } from './eventprocessor';
-export { Exception } from './exception';
-export { Extra, Extras } from './extra';
-export { Hub } from './hub';
-export { Integration, IntegrationClass } from './integration';
-export { Mechanism } from './mechanism';
-export { ExtractedNodeRequestData, Primitive, WorkerLocation } from './misc';
-export { Options } from './options';
-export { Package } from './package';
-export { QueryParams, Request, SentryRequest, SentryRequestType } from './request';
-export { Response } from './response';
-export { Runtime } from './runtime';
-export { CaptureContext, Scope, ScopeContext } from './scope';
-export { SdkInfo } from './sdkinfo';
-export { SdkMetadata } from './sdkmetadata';
-export {
+export type { Breadcrumb, BreadcrumbHint } from './breadcrumb';
+export type { Client } from './client';
+export type { Context, Contexts } from './context';
+export type { DsnComponents, DsnLike, DsnProtocol } from './dsn';
+export type { DebugImage, DebugImageType, DebugMeta } from './debugMeta';
+export type { ExtendedError } from './error';
+export type { Event, EventHint } from './event';
+export type { EventStatus } from './eventstatus';
+export type { EventProcessor } from './eventprocessor';
+export type { Exception } from './exception';
+export type { Extra, Extras } from './extra';
+export type { Hub } from './hub';
+export type { Integration, IntegrationClass } from './integration';
+export type { Mechanism } from './mechanism';
+export type { ExtractedNodeRequestData, Primitive, WorkerLocation } from './misc';
+export type { Options } from './options';
+export type { Package } from './package';
+export type { QueryParams, Request, SentryRequest, SentryRequestType } from './request';
+export type { Response } from './response';
+export type { Runtime } from './runtime';
+export type { CaptureContext, Scope, ScopeContext } from './scope';
+export type { SdkInfo } from './sdkinfo';
+export type { SdkMetadata } from './sdkmetadata';
+export type {
   SessionAggregates,
   AggregationCounts,
   Session,
@@ -32,12 +32,12 @@ export {
   SessionFlusherLike,
 } from './session';
 
-export { Severity } from './severity';
-export { SeverityLevel, SeverityLevels } from './severity';
-export { Span, SpanContext } from './span';
-export { StackFrame } from './stackframe';
-export { Stacktrace } from './stacktrace';
-export {
+export type { Severity } from './severity';
+export type { SeverityLevel, SeverityLevels } from './severity';
+export type { Span, SpanContext } from './span';
+export type { StackFrame } from './stackframe';
+export type { Stacktrace } from './stacktrace';
+export type {
   CustomSamplingContext,
   Measurements,
   SamplingContext,
@@ -47,7 +47,7 @@ export {
   TransactionMetadata,
   TransactionSamplingMethod,
 } from './transaction';
-export { Thread } from './thread';
-export { Outcome, Transport, TransportOptions, TransportClass } from './transport';
-export { User } from './user';
-export { WrappedFunction } from './wrappedfunction';
+export type { Thread } from './thread';
+export type { Outcome, Transport, TransportOptions, TransportClass } from './transport';
+export type { User } from './user';
+export type { WrappedFunction } from './wrappedfunction';

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -6,6 +6,7 @@
     "downlevelIteration": true,
     "importHelpers": true,
     "inlineSources": true,
+    "isolatedModules": true,
     "lib": ["es6", "dom"],
     // "module": "commonjs", // implied by "target" : "es5"
     "moduleResolution": "node",

--- a/packages/utils/src/severity.ts
+++ b/packages/utils/src/severity.ts
@@ -12,9 +12,9 @@ function isSupportedSeverity(level: string): level is Severity {
  * @returns Severity
  */
 export function severityFromString(level: SeverityLevel | string): Severity {
-  if (level === 'warn') return Severity.Warning;
+  if (level === 'warn') return 'warning' as Severity;
   if (isSupportedSeverity(level)) {
     return level;
   }
-  return Severity.Log;
+  return 'log' as Severity;
 }

--- a/packages/vue/src/index.bundle.ts
+++ b/packages/vue/src/index.bundle.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   Breadcrumb,
   Request,
   SdkInfo,
@@ -12,11 +12,12 @@ export {
   User,
 } from '@sentry/types';
 
-export { SeverityLevel } from '@sentry/utils';
+export type { BrowserOptions, ReportDialogOptions } from '@sentry/browser';
+
+export type { SeverityLevel } from '@sentry/utils';
 
 export {
   BrowserClient,
-  BrowserOptions,
   defaultIntegrations,
   forceLoad,
   lastEventId,
@@ -25,7 +26,6 @@ export {
   flush,
   close,
   wrap,
-  ReportDialogOptions,
   addGlobalEventProcessor,
   addBreadcrumb,
   captureException,


### PR DESCRIPTION
This applies [the TypeScript `isolatedModules` setting](https://www.typescriptlang.org/tsconfig#isolatedModules) to all packages in the repo, which is necessary in order for us to use any compiler other than `tsc`. (All other compilers handle each file separately, without understanding the relationships between them the way `tsc` does, so we need TS to warn us if we're doing anything which would make that a problem).

It also makes two code changes necessary in order to be compatible with the `isolatedModules` flag, specifically:

- All re-exported types and interfaces (anything that will get stripped away when compiling from TS to JS) are now exported using `export type`. This lets non-`tsc` compilers know that the exported types are eligible for stripping, in spite of the fact that said compilers can't follow the export path backwards to see the types' implementation.

- Usages of the `Severity` enum from `@sentry/types` were replaced with string literals, which was necessary here because non-`tsc` compilers can't trace usages of a const enum back to their underlying values to do the substitution. They therefore leave those usages alone, while at the same time stripping the enum definitions the way `tsc` would. This leads to usages of something which no longer exists, which is obviously a problem. Using the string literals prevents that.


