### PR TITLE
chore(nextjs): Remove `require` call on TypeScript file

### DIFF
--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -140,13 +140,7 @@ if (!isVercel && !isBuild) {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { instrumentServer } = require('./utils/instrumentServer.js');
     instrumentServer();
-  } catch {
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { instrumentServer } = require('./utils/instrumentServer.ts');
-      instrumentServer();
-    } catch {
-      // Server not instrumented. Not adding logs to avoid noise.
-    }
+  } catch (err) {
+    logger.warn(`Error: Unable to instrument server for tracing. Got ${err}.`);
   }
 }


### PR DESCRIPTION
As part of server start-up on nextjs, we instrument various server methods for tracing, in a module called (appropriately enough) `instrumentServer`. Because even importing the `instrumentServer` module can throw errors in certain situations (during build, or in Next 12 on Vercel), the JS version of the module (which is what will exist at runtime) is conditionally required rather than imported at the top of the index file.

Just for safety, that dynamic `require` is wrapped in a `try-catch`. Currently, in the catch block exists a fallback attempt to require the TS version of the module:

https://github.com/getsentry/sentry-javascript/blob/ad37109568479bb8459b76f6bdfe0c0bd54e66dd/packages/nextjs/src/index.server.ts#L137-L151

 This causes warnings in Next 12. Since there's no logical or replicable way to have the JS `require` fail but the TS `require` work (in spite of the comment, tests do not actually trigger this), and since no one can recall* why it's in there in the first place, this PR removes it, thus preventing the warnings.

_\*Careful readers will notice that the PR which introduced this code was, as it turns out, authored by me. The reason I don't know why it's there in spite of that fact is because it was added by someone else, who then merged the PR._

Note: I thought it was worthwhile to log a warning when instrumenting the server fails, so I added that back in. It doesn't have the debug-build guard the way all other log statements currently do, but that's because the debug-build build process will have changed by the time it's relevant (in v7).