### PR TITLE
Change .call() for modern spread call

### DIFF
--- a/packages/integrations/src/captureconsole.ts
+++ b/packages/integrations/src/captureconsole.ts
@@ -71,8 +71,8 @@ export class CaptureConsole implements Integration {
         }
 
         // this fails for some browsers. :(
-        if (originalConsoleLevel) {
-          Function.prototype.apply.call(originalConsoleLevel, global.console, args);
+        if (originalConsoleLevel && 'originalConsoleLevel' in global.console) {
+          global.console[originalConsoleLevel](...args);
         }
       });
     });

--- a/packages/integrations/src/captureconsole.ts
+++ b/packages/integrations/src/captureconsole.ts
@@ -70,7 +70,6 @@ export class CaptureConsole implements Integration {
           });
         }
 
-        // this fails for some browsers. :(
         if (originalConsoleLevel && 'originalConsoleLevel' in global.console) {
           global.console[originalConsoleLevel](...args);
         }


### PR DESCRIPTION
The current logic causes the following warning:

```
Cannot assign to read only property 'call' of object '#<Object>'
```

There's no need to do a `.call()` here we can just use argument spread.