### PR TITLE
ref(integrations): Simplify calling original method in `CaptureConsole`

### DIFF
--- a/packages/integrations/src/captureconsole.ts
+++ b/packages/integrations/src/captureconsole.ts
@@ -43,7 +43,7 @@ export class CaptureConsole implements Integration {
       }
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      fill(global.console, level, (originalConsoleLevel: () => any) => (...args: any[]): void => {
+      fill(global.console, level, (originalConsoleMethod: () => any) => (...args: any[]): void => {
         const hub = getCurrentHub();
 
         if (hub.getIntegration(CaptureConsole)) {
@@ -71,8 +71,8 @@ export class CaptureConsole implements Integration {
         }
 
         // this fails for some browsers. :(
-        if (originalConsoleLevel) {
-          Function.prototype.apply.call(originalConsoleLevel, global.console, args);
+        if (originalConsoleMethod) {
+          originalConsoleMethod.call(global.console, args);
         }
       });
     });


### PR DESCRIPTION
In responding to https://github.com/getsentry/sentry-javascript/pull/4504, I noticed two things which could be improved about the code in question:

1) The author of that PR was misled by the admittedly confusing name of the original method we're wrapping.

2) We've been calling that method in a more complex way than necessary.

This PR fixes both of those problems.

Note: There are no tests for this integration. We should definitely add some, but that is fodder for a separate PR.