### PR TITLE
ref: Export Session class from core/browser/node

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -29,6 +29,7 @@ export {
   Hub,
   makeMain,
   Scope,
+  Session,
   startTransaction,
   SDK_VERSION,
   setContext,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,7 +13,7 @@ export {
   setUser,
   withScope,
 } from '@sentry/minimal';
-export { addGlobalEventProcessor, getCurrentHub, getHubFromCarrier, Hub, makeMain, Scope } from '@sentry/hub';
+export { addGlobalEventProcessor, getCurrentHub, getHubFromCarrier, Hub, makeMain, Scope, Session } from '@sentry/hub';
 export {
   // eslint-disable-next-line deprecation/deprecation
   API,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -29,6 +29,7 @@ export {
   Hub,
   makeMain,
   Scope,
+  Session,
   startTransaction,
   SDK_VERSION,
   setContext,


### PR DESCRIPTION
This makes it possible to write hub-less code like:

```js
const release = `${inputs.repo}@${inputs.version}`;
const client = new Sentry.NodeClient({
  dsn: process.env.SENTRY_DSN,
  release
});
const session = new Sentry.Session({
  status: 'crashed',
  release
});

client.captureMessage(`Release failed: ${inputs.repo}`);
client.captureSession(session);
```

instead of going through `const session = Sentry.getCurrentHub().startSession({ ... })`