### PR TITLE
ref(node): Don't return after process.exit

### DIFF
--- a/packages/node/src/integrations/utils/errorhandling.ts
+++ b/packages/node/src/integrations/utils/errorhandling.ts
@@ -17,7 +17,6 @@ export function logAndExitProcess(error: Error): void {
   if (client === undefined) {
     logger.warn('No NodeClient was defined, we are exiting the process now.');
     global.process.exit(1);
-    return;
   }
 
   const options = client.getOptions();


### PR DESCRIPTION
Any code after `process.exit(1)` is unreachable, so this return statement does nothing. We can remove it safely.
