### PR TITLE
fix(nextjs): Stop injecting sentry into API middleware

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -262,7 +262,7 @@ function checkWebpackPluginOverrides(
 function shouldAddSentryToEntryPoint(entryPointName: string, isServer: boolean): boolean {
   return (
     entryPointName === 'pages/_app' ||
-    entryPointName.includes('pages/api') ||
+    (entryPointName.includes('pages/api') && !entryPointName.includes('_middleware')) ||
     (isServer && entryPointName === 'pages/_error')
   );
 }

--- a/packages/nextjs/test/config.test.ts
+++ b/packages/nextjs/test/config.test.ts
@@ -92,6 +92,7 @@ const serverWebpackConfig = {
     Promise.resolve({
       'pages/_error': 'private-next-pages/_error.js',
       'pages/_app': ['./node_modules/smellOVision/index.js', 'private-next-pages/_app.js'],
+      'pages/api/_middleware': 'private-next-pages/api/_middleware.js',
       'pages/api/simulator/dogStats/[name]': { import: 'private-next-pages/api/simulator/dogStats/[name].js' },
       'pages/api/simulator/leaderboard': {
         import: ['./node_modules/dogPoints/converter.js', 'private-next-pages/api/simulator/leaderboard.js'],
@@ -444,6 +445,21 @@ describe('webpack config', () => {
           'pages/api/tricks/[trickName]': expect.objectContaining({
             import: expect.arrayContaining([serverConfigFilePath]),
           }),
+        }),
+      );
+    });
+
+    it('does not inject user config file into API middleware', async () => {
+      const finalWebpackConfig = await materializeFinalWebpackConfig({
+        userNextConfig,
+        incomingWebpackConfig: serverWebpackConfig,
+        incomingWebpackBuildContext: serverBuildContext,
+      });
+
+      expect(finalWebpackConfig.entry).toEqual(
+        expect.objectContaining({
+          // no injected file
+          'pages/api/_middleware': 'private-next-pages/api/_middleware.js',
         }),
       );
     });


### PR DESCRIPTION
During the build of a nextjs app, our SDK injects the user's `sentry.server.config.js` (which contains the call to `Sentry.init()`) into all API routes, so that `withSentry` will work. That said, we don't yet support nextjs [middleware](https://nextjs.org/docs/middleware), so we shouldn't be injecting the file into middleware pages, even if they're in the `api/` folder. 

This prevents that by adding another condition to `shouldAddSentryToEntryPoint`.

Note: This came up as part of the issue referenced below, and it does fix it, but only in a temporary way. The underlying issue is (I believe) something outside of sentry. I've encouraged the user to debug it, so that when we start supporting middleware (and therefore remove this filter), he doesn't run into problems again. See [this comment](https://github.com/getsentry/sentry-javascript/issues/4507#issuecomment-1032128100). 

Fixes https://github.com/getsentry/sentry-javascript/issues/4507.