### PR TITLE
build(ci): Add es6 bundle to size-limit

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,6 +1,6 @@
 module.exports = [
   {
-    name: '@sentry/browser - CDN Bundle (gzipped)',
+    name: '@sentry/browser - CDN Bundle (gzipped + minified)',
     path: 'packages/browser/build/bundle.min.js',
     gzip: true,
     limit: '100 KB',
@@ -12,7 +12,7 @@ module.exports = [
     limit: '120 KB',
   },
   {
-    name: '@sentry/browser - Webpack (gzipped)',
+    name: '@sentry/browser - Webpack (gzipped + minified)',
     path: 'packages/browser/esm/index.js',
     import: '{ init }',
     gzip: true,
@@ -26,27 +26,27 @@ module.exports = [
     limit: '100 KB',
   },
   {
-    name: '@sentry/react - Webpack (gzipped)',
+    name: '@sentry/react - Webpack (gzipped + minified)',
     path: 'packages/react/esm/index.js',
     import: '{ init }',
     gzip: true,
     limit: '100 KB',
   },
   {
-    name: '@sentry/nextjs Client - Webpack (gzipped)',
+    name: '@sentry/nextjs Client - Webpack (gzipped + minified)',
     path: 'packages/nextjs/esm/index.client.js',
     import: '{ init }',
     gzip: true,
     limit: '100 KB',
   },
   {
-    name: '@sentry/browser + @sentry/tracing - CDN Bundle (gzipped)',
+    name: '@sentry/browser + @sentry/tracing - CDN Bundle (gzipped + minified)',
     path: 'packages/tracing/build/bundle.tracing.min.js',
     gzip: true,
     limit: '100 KB',
   },
   {
-    name: '@sentry/browser - ES6 CDN Bundle (gzipped)',
+    name: '@sentry/browser - ES6 CDN Bundle (gzipped + minified)',
     path: 'packages/browser/build/bundle.es6.min.js',
     gzip: true,
     limit: '100 KB',

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -12,28 +12,31 @@ module.exports = [
     limit: '120 KB',
   },
   {
-    name: '@sentry/browser - Webpack',
+    name: '@sentry/browser - Webpack (gzipped)',
     path: 'packages/browser/esm/index.js',
     import: '{ init }',
+    gzip: true,
     limit: '100 KB',
   },
   {
-    name: '@sentry/browser - Webpack - gzip = false',
+    name: '@sentry/browser - Webpack (minified)',
     path: 'packages/browser/esm/index.js',
     import: '{ init }',
     gzip: false,
     limit: '100 KB',
   },
   {
-    name: '@sentry/react - Webpack',
+    name: '@sentry/react - Webpack (gzipped)',
     path: 'packages/react/esm/index.js',
     import: '{ init }',
+    gzip: true,
     limit: '100 KB',
   },
   {
-    name: '@sentry/nextjs Client - Webpack',
+    name: '@sentry/nextjs Client - Webpack (gzipped)',
     path: 'packages/nextjs/esm/index.client.js',
     import: '{ init }',
+    gzip: true,
     limit: '100 KB',
   },
   {
@@ -41,5 +44,17 @@ module.exports = [
     path: 'packages/tracing/build/bundle.tracing.min.js',
     gzip: true,
     limit: '100 KB',
+  },
+  {
+    name: '@sentry/browser - ES6 CDN Bundle (gzipped)',
+    path: 'packages/browser/build/bundle.es6.min.js',
+    gzip: true,
+    limit: '100 KB',
+  },
+  {
+    name: '@sentry/browser - ES6 CDN Bundle (minified)',
+    path: 'packages/browser/build/bundle.es6.min.js',
+    gzip: false,
+    limit: '120 KB',
   },
 ];

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,13 +1,25 @@
 module.exports = [
   {
-    name: '@sentry/browser - CDN Bundle (gzipped + minified)',
+    name: '@sentry/browser - ES5 CDN Bundle (gzipped + minified)',
     path: 'packages/browser/build/bundle.min.js',
     gzip: true,
     limit: '100 KB',
   },
   {
-    name: '@sentry/browser - CDN Bundle (minified)',
+    name: '@sentry/browser - ES5 CDN Bundle (minified)',
     path: 'packages/browser/build/bundle.min.js',
+    gzip: false,
+    limit: '120 KB',
+  },
+  {
+    name: '@sentry/browser - ES6 CDN Bundle (gzipped + minified)',
+    path: 'packages/browser/build/bundle.es6.min.js',
+    gzip: true,
+    limit: '100 KB',
+  },
+  {
+    name: '@sentry/browser - ES6 CDN Bundle (minified)',
+    path: 'packages/browser/build/bundle.es6.min.js',
     gzip: false,
     limit: '120 KB',
   },
@@ -33,6 +45,13 @@ module.exports = [
     limit: '100 KB',
   },
   {
+    name: '@sentry/react - Webpack (gzipped + minified)',
+    path: 'packages/react/esm/index.js',
+    import: '{ init }',
+    gzip: true,
+    limit: '100 KB',
+  },
+  {
     name: '@sentry/nextjs Client - Webpack (gzipped + minified)',
     path: 'packages/nextjs/esm/index.client.js',
     import: '{ init }',
@@ -40,21 +59,9 @@ module.exports = [
     limit: '100 KB',
   },
   {
-    name: '@sentry/browser + @sentry/tracing - CDN Bundle (gzipped + minified)',
+    name: '@sentry/browser + @sentry/tracing - ES5 CDN Bundle (gzipped + minified)',
     path: 'packages/tracing/build/bundle.tracing.min.js',
     gzip: true,
     limit: '100 KB',
-  },
-  {
-    name: '@sentry/browser - ES6 CDN Bundle (gzipped + minified)',
-    path: 'packages/browser/build/bundle.es6.min.js',
-    gzip: true,
-    limit: '100 KB',
-  },
-  {
-    name: '@sentry/browser - ES6 CDN Bundle (minified)',
-    path: 'packages/browser/build/bundle.es6.min.js',
-    gzip: false,
-    limit: '120 KB',
   },
 ];


### PR DESCRIPTION
This will help better justify decisions between es5 and es6 going forward

Atm there is a 10% decrease when going from es5 -> es6.