### PR TITLE
feat(wasm): Add test against minified browser bundle

### DIFF
--- a/packages/wasm/test/integration.test.js
+++ b/packages/wasm/test/integration.test.js
@@ -3,40 +3,46 @@
 const HOST = `http://localhost:${process.env.PORT}`;
 
 describe('Wasm', () => {
-  it('captured exception should include modified frames and debug_meta attribute', async () => {
-    await page.goto(HOST);
-    const event = await page.evaluate(async () => {
-      return window.getEvent();
-    });
+  // TODO: This is a quick and dirty way to test the minified browser bundle - `min-bundle.html` is an exact replica of
+  // `index.html` save the browser bundle `src` value. In the long run, we should rig it so just the bundle can be
+  // passed in. (Or, once the new bundling process is nailed down, stop testing against the minified bundle, since
+  // that's not really what this test is for.)
+  ['index.html', 'min-bundle.html'].forEach(pagePath =>
+    it(`captured exception should include modified frames and debug_meta attribute - ${pagePath}`, async () => {
+      await page.goto(`${HOST}/${pagePath}`);
+      const event = await page.evaluate(async () => {
+        return window.getEvent();
+      });
 
-    expect(event.exception.values[0].stacktrace.frames).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          filename: `${HOST}/simple.wasm`,
-          function: 'internal_func',
-          in_app: true,
-          instruction_addr: '0x8c',
-          addr_mode: 'rel:0',
-          platform: 'native',
-        }),
-        expect.objectContaining({
-          filename: `${HOST}/`,
-          function: 'crash',
-          in_app: true,
-        }),
-      ]),
-    );
+      expect(event.exception.values[0].stacktrace.frames).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            filename: `${HOST}/simple.wasm`,
+            function: 'internal_func',
+            in_app: true,
+            instruction_addr: '0x8c',
+            addr_mode: 'rel:0',
+            platform: 'native',
+          }),
+          expect.objectContaining({
+            filename: `${HOST}/${pagePath}`,
+            function: 'crash',
+            in_app: true,
+          }),
+        ]),
+      );
 
-    expect(event.debug_meta).toMatchObject({
-      images: [
-        {
-          code_file: `${HOST}/simple.wasm`,
-          code_id: '0ba020cdd2444f7eafdd25999a8e9010',
-          debug_file: null,
-          debug_id: '0ba020cdd2444f7eafdd25999a8e90100',
-          type: 'wasm',
-        },
-      ],
-    });
-  });
+      expect(event.debug_meta).toMatchObject({
+        images: [
+          {
+            code_file: `${HOST}/simple.wasm`,
+            code_id: '0ba020cdd2444f7eafdd25999a8e9010',
+            debug_file: null,
+            debug_id: '0ba020cdd2444f7eafdd25999a8e90100',
+            type: 'wasm',
+          },
+        ],
+      });
+    }),
+  );
 });

--- a/packages/wasm/test/public/min-bundle.html
+++ b/packages/wasm/test/public/min-bundle.html
@@ -1,0 +1,40 @@
+<!-- TODO: This is a quick and dirty way to test the minified browser bundle - an exact replica of `index.html` save the
+browser bundle `src` value. In the long run, we should rig it so the bundle can be passed in. (Or, once the new bundling
+process is nailed down, stop testing against the minified bundle, since that's not really what this test is for.)-->
+
+<!DOCTYPE html>
+<!-- Browser SDK Bundle -->
+<script src="bundle.min.js"></script>
+<!-- Wasm Integration Bundle -->
+<script src="wasm.js"></script>
+<script>
+  Sentry.init({
+    dsn: 'https://1337@sentry.io/42',
+    integrations: [new Sentry.Integrations.Wasm()],
+    beforeSend: event => {
+      window.events.push(event);
+      return null;
+    },
+  });
+
+  window.events = [];
+
+  window.getEvent = async () => {
+    function crash() {
+      throw new Error('whoops');
+    }
+
+    const { instance } = await WebAssembly.instantiateStreaming(fetch('simple.wasm'), {
+      env: {
+        external_func: crash,
+      },
+    });
+
+    try {
+      instance.exports.internal_func();
+    } catch (err) {
+      Sentry.captureException(err);
+      return window.events.pop();
+    }
+  };
+</script>


### PR DESCRIPTION
The current wasm integration test uses the browser bundle, and is therefore a quick smoke test of whether the bundle is legit. At least temporarily, this makes it test against the minified bundle, too, so it can act as a similar smoke test there. This is helpful as we're changing the bundling process, as it's an extra check to make sure we haven't broken the world.

Because this is a likely-temporary (ab)use of this integration test, it's done in the quickest and dirtiest way possible: the page which gets loaded is replicated, with the SDK bundle pointing to the minified version rather than the regular version. If we decide to keep testing against both bundles, we should do it in a more elegant way.