### PR TITLE
fix(utils): Make new non-enumerable properties mutable

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -277,7 +277,7 @@ export function checkOrSetAlreadyCaught(exception: unknown): boolean {
   try {
     // set it this way rather than by assignment so that it's not ennumerable and therefore isn't recorded by the
     // `ExtraErrorData` integration
-    addNonEnumerableProperty(exception, '__sentry_captured__', true);
+    addNonEnumerableProperty(exception as { [key: string]: unknown }, '__sentry_captured__', true);
   } catch (err) {
     // `exception` is a primitive, so we can't mark it seen
   }

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -42,16 +42,18 @@ export function fill(source: { [key: string]: any }, name: string, replacementFa
 }
 
 /**
- * Defines a non enumerable property.  This creates a non enumerable property on an object.
+ * Defines a non-enumerable property on the given object.
  *
- * @param func The function to set a property to
- * @param name the name of the special sentry property
- * @param value the property to define
+ * @param obj The object on which to set the property
+ * @param name The name of the property to be set
+ * @param value The value to which to set the property
  */
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function addNonEnumerableProperty(func: any, name: string, value: any): void {
-  Object.defineProperty(func, name, {
+export function addNonEnumerableProperty(obj: { [key: string]: unknown }, name: string, value: unknown): void {
+  Object.defineProperty(obj, name, {
+    // enumerable: false, // the default, so we can save on bundle size by not explicitly setting it
     value: value,
+    writable: true,
+    configurable: true,
   });
 }
 


### PR DESCRIPTION
There are a few places in the SDK where we add properties to an object in order to store data for internal use. In cases where there's a chance that object might be serialized, we need to make sure the new properties are non-enumerable, which we do with the (appropriately-named) function `addNonEnumerableProperty`.

Currently, the non-enumerable properties we add are also immutable, even though nothing requires them to be, simply because that's the default when using `Object.defineProperty()`. This blocks use-cases in which a user might choose to modify an internal property's value in order to change how the SDK behaves. (See the attached issue for an example of such a use-case.)

This PR explicitly makes these properties mutable. It also changes the docstring to reflect the fact that the function can be used for more than just setting properties on function objects.

Fixes https://github.com/getsentry/sentry-javascript/issues/4525.