### PR TITLE
fix(vue): Check if route name is defined before casting

### DIFF
--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -54,7 +54,7 @@ export function vueRouterInstrumentation(router: VueRouter): VueRouterInstrument
       if (startTransactionOnPageLoad && isPageLoadNavigation) {
         startTransaction({
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          name: to.name.toString() || to.path,
+          name: (to.name && to.name.toString()) || to.path,
           op: 'pageload',
           tags,
           data,
@@ -64,7 +64,7 @@ export function vueRouterInstrumentation(router: VueRouter): VueRouterInstrument
       if (startTransactionOnLocationChange && !isPageLoadNavigation) {
         startTransaction({
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          name: to.name.toString() || (to.matched[0] && to.matched[0].path) || to.path,
+          name: (to.name && to.name.toString()) || (to.matched[0] && to.matched[0].path) || to.path,
           op: 'navigation',
           tags,
           data,


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/pull/4483

`to.name` can be undefined, so we should guard against it.
