### PR TITLE
ref(utils): Simplify console instrumentation

### DIFF
--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -116,13 +116,13 @@ function instrumentConsole(): void {
       return;
     }
 
-    fill(global.console, level, function (originalConsoleLevel: () => any): Function {
+    fill(global.console, level, function (originalConsoleMethod: () => any): Function {
       return function (...args: any[]): void {
         triggerHandlers('console', { args, level });
 
         // this fails for some browsers. :(
-        if (originalConsoleLevel) {
-          Function.prototype.apply.call(originalConsoleLevel, global.console, args);
+        if (originalConsoleMethod) {
+          originalConsoleMethod.call(global.console, args);
         }
       };
     });


### PR DESCRIPTION
Apply changes from https://github.com/getsentry/sentry-javascript/pull/4505 that applied to `CaptureConsole` integration to the `instrumentConsole` func in `@sentry/utils`.

It's important to note that the logic in utils, in `CaptureConsole` and the node `Console` integration is very similar, perhaps we can refactor to combine them.

Opened https://github.com/getsentry/sentry-javascript/issues/4532 to track this.