### PR TITLE
chore(build): Update and hoist `rollup-plugin-terser`

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "replace-in-file": "^4.0.0",
     "rimraf": "^3.0.2",
     "rollup-plugin-license": "^2.6.1",
+    "rollup-plugin-terser": "^5.0.2",
     "rollup-plugin-typescript2": "^0.31.2",
     "sinon": "^7.3.2",
     "size-limit": "^4.5.5",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "replace-in-file": "^4.0.0",
     "rimraf": "^3.0.2",
     "rollup-plugin-license": "^2.6.1",
-    "rollup-plugin-terser": "^5.0.2",
+    "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.31.2",
     "sinon": "^7.3.2",
     "size-limit": "^4.5.5",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -43,7 +43,6 @@
     "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-node-resolve": "^4.2.3",
-    "rollup-plugin-terser": "^4.0.4",
     "sinon": "^7.3.2",
     "webpack": "^4.30.0"
   },

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -33,6 +33,9 @@ const terserInstance = terser({
       reserved: ['_mergeOptions'],
     },
   },
+  output: {
+    comments: false,
+  },
 });
 
 const paths = {

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -25,8 +25,7 @@
     "chai": "^4.1.2",
     "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",
-    "rollup-plugin-node-resolve": "^4.2.3",
-    "rollup-plugin-terser": "^4.0.4"
+    "rollup-plugin-node-resolve": "^4.2.3"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",

--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -14,6 +14,9 @@ const terserInstance = terser({
     reserved: ['captureException', 'captureMessage', 'sentryWrapped'],
     properties: false,
   },
+  output: {
+    comments: false,
+  },
 });
 
 const plugins = [

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -29,8 +29,7 @@
     "jsdom": "^16.2.2",
     "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",
-    "rollup-plugin-node-resolve": "^4.2.3",
-    "rollup-plugin-terser": "^4.0.4"
+    "rollup-plugin-node-resolve": "^4.2.3"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -19,6 +19,9 @@ const terserInstance = terser({
       regex: /^_[^_]/,
     },
   },
+  output: {
+    comments: false,
+  },
 });
 
 const paths = {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -31,8 +31,7 @@
     "jsdom": "^16.2.2",
     "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",
-    "rollup-plugin-node-resolve": "^4.2.3",
-    "rollup-plugin-terser": "^4.0.4"
+    "rollup-plugin-node-resolve": "^4.2.3"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -19,6 +19,9 @@ const terserInstance = terser({
       regex: /^_[^_]/,
     },
   },
+  output: {
+    comments: false,
+  },
 });
 
 const paths = {

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -29,8 +29,7 @@
     "puppeteer": "^5.5.0",
     "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",
-    "rollup-plugin-node-resolve": "^4.2.3",
-    "rollup-plugin-terser": "^4.0.4"
+    "rollup-plugin-node-resolve": "^4.2.3"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -12,6 +12,9 @@ const terserInstance = terser({
     reserved: ['captureException', 'captureMessage', 'sentryWrapped'],
     properties: false,
   },
+  output: {
+    comments: false,
+  },
 });
 
 const plugins = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,7 +44,7 @@
   dependencies:
     "@babel/highlight" "^7.16.0"
 
-"@babel/code-frame@^7.16.7", "@babel/code-frame@^7.5.5":
+"@babel/code-frame@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
   integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
@@ -13721,6 +13721,15 @@ jest-worker@^24.6.0, jest-worker@^24.9.0:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
 
+jest-worker@^26.2.1:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
+  integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^7.0.0"
+
 jest-worker@^27.0.6:
   version "27.4.2"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.4.2.tgz#0fb123d50955af1a450267787f340a1bf7e12bc4"
@@ -18907,16 +18916,15 @@ rollup-plugin-node-resolve@^4.2.3:
     is-module "^1.0.0"
     resolve "^1.10.0"
 
-rollup-plugin-terser@^5.0.2:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-5.3.1.tgz#8c650062c22a8426c64268548957463bf981b413"
-  integrity sha512-1pkwkervMJQGFYvM9nscrUoncPwiKR/K+bHdjv6PFgRo3cgPHoRT83y2Aa3GvINj4539S15t/tpFPb775TDs6w==
+rollup-plugin-terser@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
+  integrity sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==
   dependencies:
-    "@babel/code-frame" "^7.5.5"
-    jest-worker "^24.9.0"
-    rollup-pluginutils "^2.8.2"
+    "@babel/code-frame" "^7.10.4"
+    jest-worker "^26.2.1"
     serialize-javascript "^4.0.0"
-    terser "^4.6.2"
+    terser "^5.0.0"
 
 rollup-plugin-typescript2@^0.31.2:
   version "0.31.2"
@@ -18930,7 +18938,7 @@ rollup-plugin-typescript2@^0.31.2:
     resolve "^1.20.0"
     tslib "^2.3.1"
 
-rollup-pluginutils@^2.6.0, rollup-pluginutils@^2.8.2:
+rollup-pluginutils@^2.6.0:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
   integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
@@ -20333,7 +20341,7 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.1.0:
+supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -20563,7 +20571,7 @@ terser-webpack-plugin@^5.1.3:
     source-map "^0.6.1"
     terser "^5.7.2"
 
-terser@^4.1.2, terser@^4.3.9, terser@^4.6.2:
+terser@^4.1.2, terser@^4.3.9:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
   integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
@@ -20572,7 +20580,7 @@ terser@^4.1.2, terser@^4.3.9, terser@^4.6.2:
     source-map "~0.6.1"
     source-map-support "~0.5.12"
 
-terser@^5.10.0, terser@^5.7.2:
+terser@^5.0.0, terser@^5.10.0, terser@^5.7.2:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-5.10.0.tgz#b86390809c0389105eb0a0b62397563096ddafcc"
   integrity sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,7 +44,7 @@
   dependencies:
     "@babel/highlight" "^7.16.0"
 
-"@babel/code-frame@^7.16.7":
+"@babel/code-frame@^7.16.7", "@babel/code-frame@^7.5.5":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
   integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
@@ -7514,7 +7514,7 @@ commander@7.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.1.0.tgz#f2eaecf131f10e36e07d894698226e36ae0eb5ff"
   integrity sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==
 
-commander@^2.16.0, commander@^2.19.0, commander@^2.20.0, commander@^2.20.3, commander@^2.6.0, commander@^2.8.1:
+commander@^2.16.0, commander@^2.20.0, commander@^2.20.3, commander@^2.6.0, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -13713,7 +13713,7 @@ jest-worker@27.0.0-next.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest-worker@^24.0.0, jest-worker@^24.6.0, jest-worker@^24.9.0:
+jest-worker@^24.6.0, jest-worker@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-24.9.0.tgz#5dbfdb5b2d322e98567898238a9697bcce67b3e5"
   integrity sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==
@@ -18907,15 +18907,16 @@ rollup-plugin-node-resolve@^4.2.3:
     is-module "^1.0.0"
     resolve "^1.10.0"
 
-rollup-plugin-terser@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-4.0.4.tgz#6f661ef284fa7c27963d242601691dc3d23f994e"
-  integrity sha512-wPANT5XKVJJ8RDUN0+wIr7UPd0lIXBo4UdJ59VmlPCtlFsE20AM+14pe+tk7YunCsWEiuzkDBY3QIkSCjtrPXg==
+rollup-plugin-terser@^5.0.2:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-5.3.1.tgz#8c650062c22a8426c64268548957463bf981b413"
+  integrity sha512-1pkwkervMJQGFYvM9nscrUoncPwiKR/K+bHdjv6PFgRo3cgPHoRT83y2Aa3GvINj4539S15t/tpFPb775TDs6w==
   dependencies:
-    "@babel/code-frame" "^7.0.0"
-    jest-worker "^24.0.0"
-    serialize-javascript "^1.6.1"
-    terser "^3.14.1"
+    "@babel/code-frame" "^7.5.5"
+    jest-worker "^24.9.0"
+    rollup-pluginutils "^2.8.2"
+    serialize-javascript "^4.0.0"
+    terser "^4.6.2"
 
 rollup-plugin-typescript2@^0.31.2:
   version "0.31.2"
@@ -18929,7 +18930,7 @@ rollup-plugin-typescript2@^0.31.2:
     resolve "^1.20.0"
     tslib "^2.3.1"
 
-rollup-pluginutils@^2.6.0:
+rollup-pluginutils@^2.6.0, rollup-pluginutils@^2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
   integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
@@ -19168,11 +19169,6 @@ send@0.17.1:
     on-finished "~2.3.0"
     range-parser "~1.2.1"
     statuses "~1.5.0"
-
-serialize-javascript@^1.6.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
-  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
 
 serialize-javascript@^4.0.0:
   version "4.0.0"
@@ -19630,7 +19626,7 @@ source-map-support@^0.4.15, source-map-support@^0.4.18:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.6, source-map-support@~0.5.10, source-map-support@~0.5.12:
+source-map-support@^0.5.6, source-map-support@~0.5.12:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -20567,16 +20563,7 @@ terser-webpack-plugin@^5.1.3:
     source-map "^0.6.1"
     terser "^5.7.2"
 
-terser@^3.14.1:
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-3.17.0.tgz#f88ffbeda0deb5637f9d24b0da66f4e15ab10cb2"
-  integrity sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==
-  dependencies:
-    commander "^2.19.0"
-    source-map "~0.6.1"
-    source-map-support "~0.5.10"
-
-terser@^4.1.2, terser@^4.3.9:
+terser@^4.1.2, terser@^4.3.9, terser@^4.6.2:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
   integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==


### PR DESCRIPTION
In preparation for the new bundling process, this updates `rollup-plugin-terser` to latest and hoists it into the main `package.json`.

To see what effects this has on the resulting minified bundles (because this is terser we're talking about, there's no effect on non-minified bundles), it's easiest to think of the upgrade in stages.

First bump: 4.x -> 5.x.

Effect 1: License text in minified bundles: 

![image](https://user-images.githubusercontent.com/14812505/153337139-49438bbf-f195-48de-bfdd-00e18aa18861.png)

This can be mitigated by enforcing the removal of comments (in the terser settings):

![image](https://user-images.githubusercontent.com/14812505/153337946-db2b52fa-8afa-46e3-990d-7c093e828d26.png)
 
![image](https://user-images.githubusercontent.com/14812505/153338049-dec39aa0-c7ba-48cc-8550-d4f99857875c.png)

Effect 2: Extra parentheses. This is easiest to see in a file where each character has been put on its own line. 

![image](https://user-images.githubusercontent.com/14812505/153338602-11ad30f0-45ce-4a20-8efb-cd4d6efcb726.png)

Second bump: 5.x -> 6.x

This results in no bundle changes

Third bump: 6.x -> 7.x

(Note: screenshots are all from `bundle.min.js` from `@sentry/browser` after it's been run through auto-formatting to make it easier for git to figure out what the actual differences are.)

Effect 1: `return (x = someFunc)(args)` -> `return( (x = someFunc), x(args) )`

![image](https://user-images.githubusercontent.com/14812505/153348595-aba40345-21ec-4334-90f4-69bdffe044f1.png)

Effect 2: Assigning repeated values to a variable 

![image](https://user-images.githubusercontent.com/14812505/153349030-1a3641c8-b157-4dc7-9bf1-524fb162adf2.png)

Effect 3: Lots of renaming of single-letter variables

![image](https://user-images.githubusercontent.com/14812505/153349099-83109644-926e-405b-8399-1db9f9facc26.png)

Because these are all essentially cosmetic changes, this should be a safe upgrade.