### PR TITLE
fix(build): Prevent unused utils code in integration bundles

### DIFF
--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -81,6 +81,7 @@ const bundleConfig = {
       banner: `/*! @sentry/browser <%= pkg.version %> (${commitHash}) | https://github.com/getsentry/sentry-javascript */`,
     }),
   ],
+  treeshake: 'smallest',
 };
 
 export default [

--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -86,6 +86,7 @@ function loadAllIntegrations() {
           strict: false,
         },
         plugins: build.plugins,
+        treeshake: 'smallest',
       })),
     );
   });

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -68,6 +68,7 @@ const bundleConfig = {
       banner: `/*! @sentry/tracing & @sentry/browser <%= pkg.version %> (${commitHash}) | https://github.com/getsentry/sentry-javascript */`,
     }),
   ],
+  treeshake: 'smallest',
 };
 
 export default [

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -68,6 +68,7 @@ const bundleConfig = {
       banner: `/*! @sentry/vue <%= pkg.version %> (${commitHash}) | https://github.com/getsentry/sentry-javascript */`,
     }),
   ],
+  treeshake: 'smallest',
 };
 
 export default [

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -79,6 +79,7 @@ function loadAllIntegrations() {
         strict: false,
       },
       plugins: build.plugins,
+      treeshake: 'smallest',
     });
   });
   return builds;


### PR DESCRIPTION
Even without a plugin like `terser`, Rollup by default will [treeshake code](https://rollupjs.org/guide/en/#tree-shaking) it sees isn't being used. That said, by default it will [err on the side of caution](https://rollupjs.org/guide/en/#tree-shaking-doesnt-seem-to-be-working), to make sure it doesn't break anyone's code.

One of the conservative choices it makes out of the box is to assume that any module with side effects ought to be retained, even if none of the code it contains is used. Some of the things it considers side effects make sense (`console.log()`, for example), but others are much less obvious (and, frankly, a little hard to understand), among them accessing `process` and using `SomeClass.prototype.someMethod.call(someInstance, ...args)` rather than `someInstance.someMethod(...args)`. (Disclaimer: These were discovered through repeated... and repeated... and repeated trial and error. The truth lies somewhere in rollup's [ast code](https://github.com/rollup/rollup/tree/master/src/ast), but in my testing they consistently were the two things which prevented treeshaking.) As it happens, we have the proverbial perfect storm in our `utils` package, in the form of `isNodeEnv()`, which has not one but both of those things. 

In any case, that's a lot of preamble to say that in `@sentry/utils`, the index file imports from `time.ts`,`time.ts` includes an IIFE which calls `getGlobalObject()`, and `getGlobalObject()` in turn calls `isNodeEnv()`. Thus, importing anything at all from `@sentry/utils` has meant that the entirety of `time.ts`, `global.js`, and `node.js` had to come along for the ride in any bundle we create, regardless of their use (or lack thereof). In particular, even though none of our integrations use any of the code in `time.ts`, it was being included all but two integration bundles, because they all use something else from `@sentry/utils`. 

Fortunately, rollup provides an option, `treeshake.moduleSideEffects : false`, to only consider actual code use when deciding which modules to include in a bundle, regardless of whatever side effects that bundle may or may not generate. This PR uses the more general `tresshake: "smallest"` (which includes setting `moduleSideEffects` to `false`) in order to eliminate the incorrect inclusion of `time.ts` in the integration bundles.

Before:

![image](https://user-images.githubusercontent.com/14812505/153550984-b91497d3-9111-40f4-ba3e-95d2de25816a.png)

After:

![image](https://user-images.githubusercontent.com/14812505/153551028-4f0bafc3-6720-4d7e-8d3f-3505dd0443aa.png)
