### PR TITLE
fix(build): Remove node code from CDN bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   ],
   "devDependencies": {
     "@google-cloud/storage": "^5.7.0",
+    "@rollup/plugin-replace": "^3.0.1",
     "@size-limit/preset-small-lib": "^4.5.5",
     "@strictsoftware/typedoc-plugin-monorepo": "^0.3.1",
     "@types/chai": "^4.1.3",

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -3,6 +3,7 @@ import typescript from 'rollup-plugin-typescript2';
 import license from 'rollup-plugin-license';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
+import replace from '@rollup/plugin-replace';
 
 const commitHash = require('child_process')
   .execSync('git rev-parse --short HEAD', { encoding: 'utf-8' })
@@ -13,7 +14,6 @@ const terserInstance = terser({
     // Tell env.ts that we're building a browser bundle and that we do not
     // want to have unnecessary debug functionality.
     global_defs: {
-      __SENTRY_BROWSER_BUNDLE__: true,
       __SENTRY_NO_DEBUG__: false,
     },
   },
@@ -58,6 +58,16 @@ const plugins = [
       },
     },
     include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
+  }),
+  replace({
+    // don't replace `__placeholder__` where it's followed immediately by a single `=` (to prevent ending up
+    // with something of the form `let "replacementValue" = "some assigned value"`, which would cause a
+    // syntax error)
+    preventAssignment: true,
+    // the replacements to make
+    values: {
+      __SENTRY_BROWSER_BUNDLE__: true,
+    },
   }),
   resolve({
     mainFields: ['module'],

--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -4,6 +4,7 @@ import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
+import replace from '@rollup/plugin-replace';
 
 const terserInstance = terser({
   mangle: {
@@ -37,6 +38,16 @@ const plugins = [
       },
     },
     include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
+  }),
+  replace({
+    // don't replace `__placeholder__` where it's followed immediately by a single `=` (to prevent ending up
+    // with something of the form `let "replacementValue" = "some assigned value"`, which would cause a
+    // syntax error)
+    preventAssignment: true,
+    // the replacements to make
+    values: {
+      __SENTRY_BROWSER_BUNDLE__: true,
+    },
   }),
   resolve({
     mainFields: ['module'],

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -3,6 +3,7 @@ import typescript from 'rollup-plugin-typescript2';
 import license from 'rollup-plugin-license';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
+import replace from '@rollup/plugin-replace';
 
 const commitHash = require('child_process')
   .execSync('git rev-parse --short HEAD', { encoding: 'utf-8' })
@@ -45,6 +46,16 @@ const plugins = [
       },
     },
     include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
+  }),
+  replace({
+    // don't replace `__placeholder__` where it's followed immediately by a single `=` (to prevent ending up
+    // with something of the form `let "replacementValue" = "some assigned value"`, which would cause a
+    // syntax error)
+    preventAssignment: true,
+    // the replacements to make
+    values: {
+      __SENTRY_BROWSER_BUNDLE__: true,
+    },
   }),
   resolve({
     mainFields: ['module'],

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -3,6 +3,7 @@ import typescript from 'rollup-plugin-typescript2';
 import license from 'rollup-plugin-license';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
+import replace from '@rollup/plugin-replace';
 
 const commitHash = require('child_process')
   .execSync('git rev-parse --short HEAD', { encoding: 'utf-8' })
@@ -45,6 +46,16 @@ const plugins = [
       },
     },
     include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
+  }),
+  replace({
+    // don't replace `__placeholder__` where it's followed immediately by a single `=` (to prevent ending up
+    // with something of the form `let "replacementValue" = "some assigned value"`, which would cause a
+    // syntax error)
+    preventAssignment: true,
+    // the replacements to make
+    values: {
+      __SENTRY_BROWSER_BUNDLE__: true,
+    },
   }),
   resolve({
     mainFields: ['module'],

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -2,6 +2,7 @@ import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
+import replace from '@rollup/plugin-replace';
 
 const terserInstance = terser({
   mangle: {
@@ -35,6 +36,16 @@ const plugins = [
       },
     },
     include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
+  }),
+  replace({
+    // don't replace `__placeholder__` where it's followed immediately by a single `=` (to prevent ending up
+    // with something of the form `let "replacementValue" = "some assigned value"`, which would cause a
+    // syntax error)
+    preventAssignment: true,
+    // the replacements to make
+    values: {
+      __SENTRY_BROWSER_BUNDLE__: true,
+    },
   }),
   resolve({
     mainFields: ['module'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3088,6 +3088,23 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@rollup/plugin-replace@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-3.0.1.tgz#f774550f482091719e52e9f14f67ffc0046a883d"
+  integrity sha512-989J5oRzf3mm0pO/0djTijdfEh9U3n63BIXN5X7T4U9BP+fN4oxQ6DvDuBvFaHA6scaHQRclqmKQEkBhB7k7Hg==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    magic-string "^0.25.7"
+
+"@rollup/pluginutils@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
+  integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+  dependencies:
+    "@types/estree" "0.0.39"
+    estree-walker "^1.0.1"
+    picomatch "^2.2.2"
+
 "@rollup/pluginutils@^4.1.2":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.1.2.tgz#ed5821c15e5e05e32816f5fb9ec607cdf5a75751"
@@ -3558,6 +3575,11 @@
   version "0.0.47"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.47.tgz#d7a51db20f0650efec24cd04994f523d93172ed4"
   integrity sha512-c5ciR06jK8u9BstrmJyO97m+klJrrhCf9u3rLu3DEAJBirxRqSCvDQoYKmxuYwQI5SZChAWu+tq9oVlGRuzPAg==
+
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
 "@types/estree@^0.0.50":
   version "0.0.50"
@@ -4466,10 +4488,31 @@ after@0.8.2:
   resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
   integrity sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
 
-agent-base@4, agent-base@5, agent-base@6, agent-base@^4.3.0, agent-base@^6.0.2, agent-base@~4.2.1:
+agent-base@4, agent-base@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
+  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
+  dependencies:
+    es6-promisify "^5.0.0"
+
+agent-base@5:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
   integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
+
+agent-base@6, agent-base@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+  dependencies:
+    debug "4"
+
+agent-base@~4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.1.tgz#d89e5999f797875674c07d87f260fc41e83e8ca9"
+  integrity sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==
+  dependencies:
+    es6-promisify "^5.0.0"
 
 agentkeepalive@^3.4.1:
   version "3.5.2"
@@ -9922,6 +9965,18 @@ es6-object-assign@^1.1.0:
   resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
   integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
 
+es6-promise@^4.0.3:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
+  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
+  dependencies:
+    es6-promise "^4.0.3"
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -10246,6 +10301,11 @@ estree-walker@^0.6.0, estree-walker@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
   integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
+
+estree-walker@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
+  integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
 
 estree-walker@^2.0.1:
   version "2.0.2"
@@ -13394,7 +13454,7 @@ jest-environment-jsdom@^24.9.0:
     jest-util "^24.9.0"
     jsdom "^11.5.1"
 
-jest-environment-node@24, "jest-environment-node@>=24 <=26", jest-environment-node@^24.9.0:
+"jest-environment-node@>=24 <=26", jest-environment-node@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-24.9.0.tgz#333d2d2796f9687f2aeebf0742b519f33c1cbfd3"
   integrity sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==


### PR DESCRIPTION
This PR changes the way we substitute `true` for `__SENTRY_BROWSER_BUNDLE__`, our flag to let us treeshake away anything Node-related out of CDN bundles.

There are two main changes:

- In the browser rollup config, the substitution is moved from the terser stage to an earlier stage, immediately after TS compilation, in order that the treeshaking we need now applies to all versions of the bundle, minified or not.

- The substitution is added to all other rollup configs, (Even though packages like `@sentry/tracing` and `@sentry/integrations` are cross-platform, in this case we know we're building CDN bundles, which are only relevant in a browser setting.)

As an example, here's the effect of these changes on the main browser bundle:

![image](https://user-images.githubusercontent.com/14812505/153564596-abc0c8de-01fd-431a-ad3b-7700dc1072cd.png)
![image](https://user-images.githubusercontent.com/14812505/153564674-5d8c5fae-3470-4b63-935c-9e22c65cc851.png)
![image](https://user-images.githubusercontent.com/14812505/153564732-9dd75fbe-51dd-4b0d-a712-27f39e332986.png)
