### PR TITLE
Add missing peer dependencies to Gatsby package

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -31,7 +31,9 @@
     "@sentry/webpack-plugin": "1.18.5"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0",
+    "react": "15.x || 16.x || 17.x",
+    "webpack": ">= 4.0.0"
   },
   "devDependencies": {
     "@sentry/types": "6.17.6",


### PR DESCRIPTION
Fixes #4549 by copying missing peer dependencies from `packages/nextjs/package.json`.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
