### PR TITLE
setContext can now accept a callback for advanced update logic.

### DIFF
--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -3,6 +3,8 @@ import {
   Breadcrumb,
   BreadcrumbHint,
   Client,
+  Context,
+  ContextSetterCallback,
   CustomSamplingContext,
   Event,
   EventHint,
@@ -335,7 +337,7 @@ export class Hub implements HubInterface {
    * @inheritDoc
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public setContext(name: string, context: { [key: string]: any } | null): void {
+  public setContext(name: string, context: Context | null | ContextSetterCallback): void {
     const scope = this.getScope();
     if (scope) scope.setContext(name, context);
   }

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -4,6 +4,7 @@ import {
   CaptureContext,
   Context,
   Contexts,
+  ContextSetterCallback,
   Event,
   EventHint,
   EventProcessor,
@@ -234,12 +235,20 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public setContext(key: string, context: Context | null): this {
-    if (context === null) {
+  public setContext(key: string, context: Context | null | ContextSetterCallback): this {
+    let newContext;
+
+    if (typeof context === 'function') {
+      newContext = context(this._contexts[key] ?? null);
+    } else {
+      newContext = context;
+    }
+
+    if (newContext === null) {
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete this._contexts[key];
     } else {
-      this._contexts = { ...this._contexts, [key]: context };
+      this._contexts = { ...this._contexts, [key]: newContext };
     }
 
     this._notifyScopeListeners();

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -108,11 +108,66 @@ describe('Scope', () => {
       expect((scope as any)._contexts.os).toEqual({ id: '1' });
     });
 
+    test('setContext can set arrays as context', () => {
+      const scope = new Scope();
+      scope.setContext('os', [{ prop: 'abcd' }, 2]);
+      expect((scope as any)._contexts.os).toEqual([{ prop: 'abcd' }, 2]);
+    });
+
     test('setContext with null unsets it', () => {
       const scope = new Scope();
-      scope.setContext('os', { id: '1' });
+      scope.setContext('os', { prop: '1' });
       scope.setContext('os', null);
-      expect((scope as any)._user).toEqual({});
+      expect((scope as any)._contexts).toEqual({});
+    });
+
+    test('setContext with a callback should be able to create a context from scratch', () => {
+      const scope = new Scope();
+      scope.setContext('os', () => ({ prop: 1, anotherContextProp: 2 }));
+      expect((scope as any)._contexts.os).toEqual({
+        prop: 1,
+        anotherContextProp: 2,
+      });
+    });
+
+    test('setContext with a callback should be able to perform partial update without overwriting anything', () => {
+      const scope = new Scope();
+      scope.setContext('os', { prop: '1' });
+      scope.setContext('os', existingContext => ({ ...existingContext, anotherContextProp: 'value' }));
+      expect((scope as any)._contexts.os).toEqual({
+        prop: '1',
+        anotherContextProp: 'value',
+      });
+    });
+
+    test('setContext with a callback should be able to delete anything', () => {
+      const scope = new Scope();
+      scope.setContext('os', { prop: '1' });
+      scope.setContext('os', () => null);
+      expect((scope as any)._contexts).toEqual({});
+    });
+
+    test('setContext with a callback should be able to set a primitive', () => {
+      const scope = new Scope();
+      scope.setContext('os', () => Math.PI);
+      expect((scope as any)._contexts.os).toEqual(Math.PI);
+    });
+
+    test('setContext with a callback should be able delete and overwrite with mutation', () => {
+      const scope = new Scope();
+      scope.setContext('os', { prop: 2, anotherContextProp: ['a', 'b', 'c'] });
+      scope.setContext('os', existingContext => {
+        if (existingContext) {
+          existingContext.prop = 1;
+          delete existingContext.anotherContextProp;
+        }
+
+        return existingContext;
+      });
+
+      expect((scope as any)._contexts.os).toEqual({
+        prop: 1,
+      });
     });
 
     test('setSpan', () => {

--- a/packages/integration-tests/suites/public-api/configureScope/clear_scope/subject.js
+++ b/packages/integration-tests/suites/public-api/configureScope/clear_scope/subject.js
@@ -1,7 +1,9 @@
 Sentry.configureScope(scope => {
   scope.setTag('foo', 'bar');
-  scope.setUser({ id: 'baz' });
+  scope.setUser({id: 'baz'});
   scope.setExtra('qux', 'quux');
+  scope.setContext('context1', {prop: '123'})
+  scope.setContext('context2', () => ({anotherProp: [1, 2, 3]}))
   scope.clear();
 });
 

--- a/packages/integration-tests/suites/public-api/configureScope/clear_scope/test.ts
+++ b/packages/integration-tests/suites/public-api/configureScope/clear_scope/test.ts
@@ -12,4 +12,5 @@ sentryTest('should clear previously set properties of a scope', async ({ getLoca
   expect(eventData.user).toBeUndefined();
   expect(eventData.tags).toBeUndefined();
   expect(eventData.extra).toBeUndefined();
+  expect(eventData.contexts).toBeUndefined();
 });

--- a/packages/integration-tests/suites/public-api/configureScope/set_properties/subject.js
+++ b/packages/integration-tests/suites/public-api/configureScope/set_properties/subject.js
@@ -2,6 +2,9 @@ Sentry.configureScope(scope => {
   scope.setTag('foo', 'bar');
   scope.setUser({ id: 'baz' });
   scope.setExtra('qux', 'quux');
+  scope.setContext('context1', { prop: '1234'});
+  scope.setContext('context1', (existingContext) => ({ ...existingContext, anotherProp: { isNested: true }}));
+  scope.setContext('context2', { aNewPropForContext2: [1, 2, 3]});
 });
 
 Sentry.captureMessage('configured_scope');

--- a/packages/integration-tests/suites/public-api/configureScope/set_properties/test.ts
+++ b/packages/integration-tests/suites/public-api/configureScope/set_properties/test.ts
@@ -1,15 +1,26 @@
-import { expect } from '@playwright/test';
+import {expect} from '@playwright/test';
 
-import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryRequest } from '../../../../utils/helpers';
+import {sentryTest} from '../../../../utils/fixtures';
+import {getSentryRequest} from '../../../../utils/helpers';
 
-sentryTest('should set different properties of a scope', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('should set different properties of a scope', async ({getLocalTestPath, page}) => {
+  const url = await getLocalTestPath({testDir: __dirname});
 
   const eventData = await getSentryRequest(page, url);
 
   expect(eventData.message).toBe('configured_scope');
-  expect(eventData.user).toMatchObject({ id: 'baz' });
-  expect(eventData.tags).toMatchObject({ foo: 'bar' });
-  expect(eventData.extra).toMatchObject({ qux: 'quux' });
+  expect(eventData.user).toMatchObject({id: 'baz'});
+  expect(eventData.tags).toMatchObject({foo: 'bar'});
+  expect(eventData.extra).toMatchObject({qux: 'quux'});
+  expect(eventData.contexts).toMatchObject({
+    context1: {
+      prop: '1234',
+      anotherProp: {
+        isNested: true
+      }
+    },
+    context2: {
+      aNewPropForContext2: [1, 2, 3]
+    }
+  });
 });

--- a/packages/integration-tests/suites/public-api/setContext/multiple_contexts/subject.js
+++ b/packages/integration-tests/suites/public-api/setContext/multiple_contexts/subject.js
@@ -14,5 +14,7 @@ Sentry.setContext('context_3', null);
 Sentry.setContext('context_4');
 Sentry.setContext('context_5', NaN);
 Sentry.setContext('context_6', Math.PI);
+Sentry.setContext('context_7', { prop: 'abcd' });
+Sentry.setContext('context_7', existingContext => ({ ...existingContext, anotherProp: 42 }));
 
 Sentry.captureMessage('multiple_contexts');

--- a/packages/integration-tests/suites/public-api/setContext/multiple_contexts/test.ts
+++ b/packages/integration-tests/suites/public-api/setContext/multiple_contexts/test.ts
@@ -18,5 +18,9 @@ sentryTest('should record multiple contexts', async ({ getLocalTestPath, page })
     context_4: '[undefined]',
     context_5: '[NaN]',
     context_6: 3.141592653589793,
+    context_7: {
+      prop: 'abcd',
+      anotherProp: 42,
+    },
   });
 });

--- a/packages/integration-tests/suites/public-api/setContext/simple_context/subject.js
+++ b/packages/integration-tests/suites/public-api/setContext/simple_context/subject.js
@@ -1,2 +1,6 @@
 Sentry.setContext('foo', { bar: 'baz' });
+Sentry.setContext('foo', existingContext => ({
+  ...existingContext,
+  qux: '6789',
+}));
 Sentry.captureMessage('simple_context_object');

--- a/packages/integration-tests/suites/public-api/setContext/simple_context/test.ts
+++ b/packages/integration-tests/suites/public-api/setContext/simple_context/test.ts
@@ -12,6 +12,7 @@ sentryTest('should set a simple context', async ({ getLocalTestPath, page }) => 
   expect(eventData.contexts).toMatchObject({
     foo: {
       bar: 'baz',
+      qux: '6789',
     },
   });
 });

--- a/packages/types/src/context.ts
+++ b/packages/types/src/context.ts
@@ -1,2 +1,3 @@
-export type Context = Record<string, unknown>;
+export type Context = Record<string, unknown> | boolean | string | number | unknown[];
 export type Contexts = Record<string, Context>;
+export type ContextSetterCallback = (existingContext: Context | null) => Context | null;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,6 @@
 export { Breadcrumb, BreadcrumbHint } from './breadcrumb';
 export { Client } from './client';
-export { Context, Contexts } from './context';
+export { Context, Contexts, ContextSetterCallback } from './context';
 export { DsnComponents, DsnLike, DsnProtocol } from './dsn';
 export { DebugImage, DebugImageType, DebugMeta } from './debugMeta';
 export { ExtendedError } from './error';


### PR DESCRIPTION
- Fixes: #2782

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
