### PR TITLE
ref(tests): Replace transaction listeners with envelope listeners.

### DIFF
--- a/packages/integration-tests/suites/public-api/startTransaction/basic_usage/test.ts
+++ b/packages/integration-tests/suites/public-api/startTransaction/basic_usage/test.ts
@@ -1,11 +1,12 @@
 import { expect } from '@playwright/test';
+import { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest('should report a transaction in an envelope', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
-  const transaction = await getSentryTransactionRequest(page, url);
+  const transaction = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
   expect(transaction.transaction).toBe('test_transaction_1');
   expect(transaction.spans).toBeDefined();
@@ -13,7 +14,7 @@ sentryTest('should report a transaction in an envelope', async ({ getLocalTestPa
 
 sentryTest('should report finished spans as children of the root transaction', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
-  const transaction = await getSentryTransactionRequest(page, url);
+  const transaction = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
   const rootSpanId = transaction?.contexts?.trace.spanId;
 

--- a/packages/integration-tests/suites/tracing/browsertracing/backgroundtab-custom/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/backgroundtab-custom/test.ts
@@ -1,7 +1,8 @@
 import { expect, JSHandle } from '@playwright/test';
+import { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 async function getPropertyValue(handle: JSHandle, prop: string) {
   return (await handle.getProperty(prop))?.jsonValue();
@@ -10,7 +11,7 @@ async function getPropertyValue(handle: JSHandle, prop: string) {
 sentryTest('should finish a custom transaction when the page goes background', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  const pageloadTransaction = await getSentryTransactionRequest(page, url);
+  const pageloadTransaction = await getFirstSentryEnvelopeRequest<Event>(page, url);
   expect(pageloadTransaction).toBeDefined();
 
   await page.click('#start-transaction');

--- a/packages/integration-tests/suites/tracing/browsertracing/backgroundtab-pageload/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/backgroundtab-pageload/test.ts
@@ -1,7 +1,8 @@
 import { expect } from '@playwright/test';
+import { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest('should finish pageload transaction when the page goes background', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
@@ -10,7 +11,7 @@ sentryTest('should finish pageload transaction when the page goes background', a
 
   page.click('#go-background');
 
-  const pageloadTransaction = await getSentryTransactionRequest(page);
+  const pageloadTransaction = await getFirstSentryEnvelopeRequest<Event>(page);
 
   expect(pageloadTransaction.contexts?.trace.op).toBe('pageload');
   expect(pageloadTransaction.contexts?.trace.status).toBe('cancelled');

--- a/packages/integration-tests/suites/tracing/browsertracing/meta/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/meta/test.ts
@@ -1,14 +1,15 @@
 import { expect } from '@playwright/test';
+import { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest(
   'should create a pageload transaction based on `sentry-trace` <meta>',
   async ({ getLocalTestPath, page }) => {
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    const eventData = await getSentryTransactionRequest(page, url);
+    const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
     expect(eventData.contexts?.trace).toMatchObject({
       op: 'pageload',
@@ -25,8 +26,8 @@ sentryTest(
   async ({ getLocalTestPath, page }) => {
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    const pageloadRequest = await getSentryTransactionRequest(page, url);
-    const navigationRequest = await getSentryTransactionRequest(page, `${url}#foo`);
+    const pageloadRequest = await getFirstSentryEnvelopeRequest<Event>(page, url);
+    const navigationRequest = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#foo`);
 
     expect(pageloadRequest.contexts?.trace).toMatchObject({
       op: 'pageload',

--- a/packages/integration-tests/suites/tracing/browsertracing/navigation/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/navigation/test.ts
@@ -1,13 +1,14 @@
 import { expect } from '@playwright/test';
+import { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest('should create a navigation transaction on page navigation', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  const pageloadRequest = await getSentryTransactionRequest(page, url);
-  const navigationRequest = await getSentryTransactionRequest(page, `${url}#foo`);
+  const pageloadRequest = await getFirstSentryEnvelopeRequest<Event>(page, url);
+  const navigationRequest = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#foo`);
 
   expect(pageloadRequest.contexts?.trace.op).toBe('pageload');
   expect(navigationRequest.contexts?.trace.op).toBe('navigation');

--- a/packages/integration-tests/suites/tracing/browsertracing/pageload/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/pageload/test.ts
@@ -1,12 +1,13 @@
 import { expect } from '@playwright/test';
+import { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest('should create a pageload transaction', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  const eventData = await getSentryTransactionRequest(page, url);
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
   expect(eventData.contexts?.trace?.op).toBe('pageload');
   expect(eventData.spans?.length).toBeGreaterThan(0);

--- a/packages/integration-tests/suites/tracing/metrics/connection-rtt/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/connection-rtt/test.ts
@@ -1,7 +1,8 @@
 import { expect, Page } from '@playwright/test';
+import { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest.beforeEach(({ browserName }) => {
   if (browserName !== 'chromium') {
@@ -23,7 +24,7 @@ async function createSessionWithLatency(page: Page, latency: number) {
 
 sentryTest('should capture a `connection.rtt` metric.', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
-  const eventData = await getSentryTransactionRequest(page, url);
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.['connection.rtt']?.value).toBe(0);
@@ -35,7 +36,7 @@ sentryTest(
     const session = await createSessionWithLatency(page, 200);
 
     const url = await getLocalTestPath({ testDir: __dirname });
-    const eventData = await getSentryTransactionRequest(page, url);
+    const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
     await session.detach();
 
@@ -50,7 +51,7 @@ sentryTest(
     const session = await createSessionWithLatency(page, 100);
 
     const url = await getLocalTestPath({ testDir: __dirname });
-    const eventData = await getSentryTransactionRequest(page, url);
+    const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
     await session.detach();
 
@@ -65,7 +66,7 @@ sentryTest(
     const session = await createSessionWithLatency(page, 50);
 
     const url = await getLocalTestPath({ testDir: __dirname });
-    const eventData = await getSentryTransactionRequest(page, url);
+    const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
     await session.detach();
 

--- a/packages/integration-tests/suites/tracing/metrics/pageload-browser-spans/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/pageload-browser-spans/test.ts
@@ -1,12 +1,13 @@
 import { expect } from '@playwright/test';
+import { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest('should add browser-related spans to pageload transaction', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  const eventData = await getSentryTransactionRequest(page, url);
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const browserSpans = eventData.spans?.filter(({ op }) => op === 'browser');
 
   // Spans `connect`, `cache` and `DNS` are not always inside `pageload` transaction.

--- a/packages/integration-tests/suites/tracing/metrics/pageload-resource-spans/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/pageload-resource-spans/test.ts
@@ -1,7 +1,8 @@
 import { expect, Route } from '@playwright/test';
+import { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest('should add resource spans to pageload transaction', async ({ getLocalTestPath, page }) => {
   // Intercepting asset requests to avoid network-related flakiness and random retries (on Firefox).
@@ -11,7 +12,7 @@ sentryTest('should add resource spans to pageload transaction', async ({ getLoca
 
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  const eventData = await getSentryTransactionRequest(page, url);
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const resourceSpans = eventData.spans?.filter(({ op }) => op?.startsWith('resource'));
 
   expect(resourceSpans?.length).toBe(3);

--- a/packages/integration-tests/suites/tracing/metrics/web-vitals-cls/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/web-vitals-cls/test.ts
@@ -1,7 +1,8 @@
 import { expect } from '@playwright/test';
+import { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest.beforeEach(async ({ browserName, page }) => {
   if (browserName !== 'chromium') {
@@ -13,7 +14,7 @@ sentryTest.beforeEach(async ({ browserName, page }) => {
 
 sentryTest('should capture a "GOOD" CLS vital with its source(s).', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
-  const eventData = await getSentryTransactionRequest(page, `${url}#0.05`);
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#0.05`);
 
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.cls?.value).toBeDefined();
@@ -23,7 +24,7 @@ sentryTest('should capture a "GOOD" CLS vital with its source(s).', async ({ get
 
 sentryTest('should capture a "MEH" CLS vital with its source(s).', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
-  const eventData = await getSentryTransactionRequest(page, `${url}#0.21`);
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#0.21`);
 
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.cls?.value).toBeDefined();
@@ -33,7 +34,7 @@ sentryTest('should capture a "MEH" CLS vital with its source(s).', async ({ getL
 
 sentryTest('should capture a "POOR" CLS vital with its source(s).', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
-  const eventData = await getSentryTransactionRequest(page, `${url}#0.35`);
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, `${url}#0.35`);
 
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.cls?.value).toBeDefined();

--- a/packages/integration-tests/suites/tracing/metrics/web-vitals-fid/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/web-vitals-fid/test.ts
@@ -1,7 +1,8 @@
 import { expect } from '@playwright/test';
+import { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest('should capture a FID vital.', async ({ browserName, getLocalTestPath, page }) => {
   // FID measurement is not generated on webkit
@@ -15,7 +16,7 @@ sentryTest('should capture a FID vital.', async ({ browserName, getLocalTestPath
   // To trigger FID
   page.click('#fid-btn');
 
-  const eventData = await getSentryTransactionRequest(page);
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page);
 
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.fid?.value).toBeDefined();

--- a/packages/integration-tests/suites/tracing/metrics/web-vitals-fp-fcp/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/web-vitals-fp-fcp/test.ts
@@ -1,7 +1,8 @@
 import { expect } from '@playwright/test';
+import { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest('should capture FP vital.', async ({ browserName, getLocalTestPath, page }) => {
   // FP is not generated on webkit or firefox
@@ -10,7 +11,7 @@ sentryTest('should capture FP vital.', async ({ browserName, getLocalTestPath, p
   }
 
   const url = await getLocalTestPath({ testDir: __dirname });
-  const eventData = await getSentryTransactionRequest(page, url);
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.fp?.value).toBeDefined();
@@ -26,7 +27,7 @@ sentryTest('should capture FP vital.', async ({ browserName, getLocalTestPath, p
 
 sentryTest('should capture FCP vital.', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
-  const eventData = await getSentryTransactionRequest(page, url);
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.fcp?.value).toBeDefined();

--- a/packages/integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -1,7 +1,8 @@
 import { expect, Route } from '@playwright/test';
+import { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest('should capture a LCP vital with element details.', async ({ browserName, getLocalTestPath, page }) => {
   if (browserName !== 'chromium') {
@@ -17,7 +18,7 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
 
   // Force closure of LCP listener.
   page.click('body');
-  const eventData = await getSentryTransactionRequest(page);
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page);
 
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.lcp?.value).toBeDefined();

--- a/packages/integration-tests/suites/tracing/metrics/web-vitals-ttfb/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/web-vitals-ttfb/test.ts
@@ -1,11 +1,12 @@
 import { expect } from '@playwright/test';
+import { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest('should capture TTFB vital.', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
-  const eventData = await getSentryTransactionRequest(page, url);
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
 
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.ttfb?.value).toBeDefined();

--- a/packages/integration-tests/suites/tracing/request/fetch/test.ts
+++ b/packages/integration-tests/suites/tracing/request/fetch/test.ts
@@ -1,12 +1,13 @@
 import { expect, Request } from '@playwright/test';
+import { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest('should create spans for multiple fetch requests', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  const eventData = await getSentryTransactionRequest(page, url);
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const requestSpans = eventData.spans?.filter(({ op }) => op === 'http.client');
 
   expect(requestSpans).toHaveLength(3);

--- a/packages/integration-tests/suites/tracing/request/xhr/test.ts
+++ b/packages/integration-tests/suites/tracing/request/xhr/test.ts
@@ -1,12 +1,13 @@
 import { expect, Request } from '@playwright/test';
+import { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getSentryTransactionRequest } from '../../../../utils/helpers';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest('should create spans for multiple XHR requests', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  const eventData = await getSentryTransactionRequest(page, url);
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const requestSpans = eventData.spans?.filter(({ op }) => op === 'http.client');
 
   expect(requestSpans).toHaveLength(3);

--- a/packages/integration-tests/utils/helpers.ts
+++ b/packages/integration-tests/utils/helpers.ts
@@ -36,18 +36,6 @@ async function getSentryRequest(page: Page, url?: string): Promise<Event> {
 }
 
 /**
- * Wait and get Sentry's request sending transaction at the given URL, or the current page
- *
- * @param {Page} page
- * @param {string} [url]
- * @return {*}  {Promise<Event>}
- */
-async function getSentryTransactionRequest(page: Page, url?: string): Promise<Event> {
-  // TODO: Remove this and update all usages in favour of `getFirstSentryEnvelopeRequest` and `getMultipleSentryEnvelopeRequests`
-  return (await getMultipleSentryEnvelopeRequests<Event>(page, 1, url))[0];
-}
-
-/**
  * Get Sentry events at the given URL, or the current page.
  *
  * @param {Page} page
@@ -185,7 +173,6 @@ export {
   getMultipleSentryEnvelopeRequests,
   getFirstSentryEnvelopeRequest,
   getSentryRequest,
-  getSentryTransactionRequest,
   getSentryEvents,
   injectScriptAndGetEvents,
 };


### PR DESCRIPTION
Related: https://github.com/getsentry/sentry-javascript/pull/4500#discussion_r802849535