### PR TITLE
fix(tracing): Export `BrowserTracing` directly in CDN bundle

### DIFF
--- a/packages/tracing/src/index.bundle.ts
+++ b/packages/tracing/src/index.bundle.ts
@@ -75,6 +75,11 @@ const INTEGRATIONS = {
 };
 
 export { INTEGRATIONS as Integrations };
+// Though in this case exporting this separately in addition to exporting it as part of `Sentry.Integrations` doesn't
+// gain us any bundle size advantage (we're making the bundle here, not the user, and we can't leave anything out of
+// ours), it does bring the API for using the integration in line with that recommended for users bundling Sentry
+// themselves.
+export { BrowserTracing };
 
 // We are patching the global object with our hub extension methods
 addExtensionMethods();


### PR DESCRIPTION
When we made the changes in https://github.com/getsentry/sentry-javascript/pull/4204 (to export `BrowserTracing` directly rather than as part of `Sentry.Integrations`), we didn't make the change in the tracing CDN bundle. While It's true that there's no bundle size issue there (mongo and friends never were getting included in the CDN bundle, so there was nothing to fix), it did mean that when we changed the docs to match the above PR's changes, we ended up breaking CDN folks' usage of `BrowserTracing`.

This fixes that by making the same change in the tracing CDN bundle as was made for the npm package.

Fixes https://github.com/getsentry/sentry-docs/issues/4722.