### PR TITLE
chore: Use white Sentry logo in all README when GH dark mode 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+      <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>
@@ -52,7 +55,7 @@ package. Please refer to the README and instructions of those SDKs for more deta
 - [`@sentry/node`](https://github.com/getsentry/sentry-javascript/tree/master/packages/node): SDK for Node, including
   integrations for Express, Koa, Loopback, Sails and Connect
 - [`@sentry/angular`](https://github.com/getsentry/sentry-javascript/tree/master/packages/angular): browser SDK with Angular integration enabled
-- [`@sentry/react`](https://github.com/getsentry/sentry-javascript/tree/master/packages/react): browser SDK with React integration enabled 
+- [`@sentry/react`](https://github.com/getsentry/sentry-javascript/tree/master/packages/react): browser SDK with React integration enabled
 - [`@sentry/ember`](https://github.com/getsentry/sentry-javascript/tree/master/packages/ember): browser SDK with Ember integration enabled
 - [`@sentry/vue`](https://github.com/getsentry/sentry-javascript/tree/master/packages/vue): browser SDK with Vue integration enabled
 - [`@sentry/gatsby`](https://github.com/getsentry/sentry-javascript/tree/master/packages/gatsby): SDK for Gatsby

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/ember/README.md
+++ b/packages/ember/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/eslint-config-sdk/README.md
+++ b/packages/eslint-config-sdk/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/gatsby/README.md
+++ b/packages/gatsby/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/minimal/README.md
+++ b/packages/minimal/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/serverless/README.md
+++ b/packages/serverless/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/tracing/README.md
+++ b/packages/tracing/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>

--- a/packages/wasm/README.md
+++ b/packages/wasm/README.md
@@ -1,6 +1,9 @@
 <p align="center">
-  <a href="https://sentry.io" target="_blank" align="center">
+  <a href="https://sentry.io#gh-light-mode-only" target="_blank" align="center">
     <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <a href="https://sentry.io#gh-dark-mode-only" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" width="280">
   </a>
   <br />
 </p>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1150298/154063165-296fde86-21c6-44ad-b216-20ed2b2f2c77.png)

Docs [here](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to) and community help [here](https://github.community/t/support-theme-context-for-images-in-light-vs-dark-mode/147981/84).

You can see the result [here](https://github.com/timfish/sentry-javascript/tree/test/readme-images).
