### PR TITLE
chore(build): Update and hoist `rollup`

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "prettier": "2.5.1",
     "replace-in-file": "^4.0.0",
     "rimraf": "^3.0.2",
+    "rollup": "^2.67.1",
     "rollup-plugin-license": "^2.6.1",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.31.2",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -40,7 +40,6 @@
     "karma-webkit-launcher": "^1.0.2",
     "node-fetch": "^2.6.0",
     "playwright": "^1.17.1",
-    "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-node-resolve": "^4.2.3",
     "sinon": "^7.3.2",

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -82,6 +82,7 @@ const bundleConfig = {
     name: 'Sentry',
     sourcemap: true,
     strict: false,
+    esModule: false,
   },
   context: 'window',
   plugins: [

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -23,7 +23,6 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-node-resolve": "^4.2.3"
   },

--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -95,6 +95,7 @@ function loadAllIntegrations() {
           format: 'cjs',
           sourcemap: true,
           strict: false,
+          esModule: false,
         },
         plugins: build.plugins,
         treeshake: 'smallest',

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -27,7 +27,6 @@
     "@types/express": "^4.17.1",
     "@types/jsdom": "^16.2.3",
     "jsdom": "^16.2.2",
-    "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-node-resolve": "^4.2.3"
   },

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -70,6 +70,7 @@ const bundleConfig = {
     name: 'Sentry',
     sourcemap: true,
     strict: false,
+    esModule: false,
   },
   context: 'window',
   plugins: [

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -29,7 +29,6 @@
   },
   "devDependencies": {
     "jsdom": "^16.2.2",
-    "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-node-resolve": "^4.2.3"
   },

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -70,6 +70,7 @@ const bundleConfig = {
     name: 'Sentry',
     sourcemap: true,
     strict: false,
+    esModule: false,
   },
   context: 'window',
   plugins: [

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -27,7 +27,6 @@
     "express": "^4.17.1",
     "jest-puppeteer": "^4.4.0",
     "puppeteer": "^5.5.0",
-    "rollup": "^1.10.1",
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-node-resolve": "^4.2.3"
   },

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -88,6 +88,7 @@ function loadAllIntegrations() {
         format: 'cjs',
         sourcemap: true,
         strict: false,
+        esModule: false,
       },
       plugins: build.plugins,
       treeshake: 'smallest',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11231,7 +11231,7 @@ fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
-fsevents@~2.3.1:
+fsevents@~2.3.1, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -18972,14 +18972,12 @@ rollup-pluginutils@^2.6.0:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^1.10.1:
-  version "1.32.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-1.32.1.tgz#4480e52d9d9e2ae4b46ba0d9ddeaf3163940f9c4"
-  integrity sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==
-  dependencies:
-    "@types/estree" "*"
-    "@types/node" "*"
-    acorn "^7.1.0"
+rollup@^2.67.1:
+  version "2.67.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.67.1.tgz#4402665706fa00f321d446ce45f880e02cf54f01"
+  integrity sha512-1Sbcs4OuW+aD+hhqpIRl+RqooIpF6uQcfzU/QSI7vGkwADY6cM4iLsBGRM2CGLXDTDN5y/yShohFmnKegSPWzg==
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 rsvp@^3.0.14, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0:
   version "3.6.2"


### PR DESCRIPTION
As prep for the new bundling process, this updates `rollup` to latest and hoists it to the main `package.json`.

Other than single-character changes to generated variable names, the only effect this has on the generated bundles is to add `Object.defineProperty(exports, '__esModule', { value: true });` (or its minified counterpart) at the end of each bundle. According to the [Rollup docs](https://rollupjs.org/guide/en/#outputesmodule):

> This property signifies that the exported value is the namespace of an ES module and that the default export of this module corresponds to the .default property of the exported object.

Since we don't have default exports from our SDKs or integrations, this isn't necessary and just adds dead weight to the bundles. Setting `output.esModule` to `false` in the Rollup config prevents this addition.
