### PR TITLE
fix(types): Use Sentry event type instead of dom one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+## 6.17.9
+
+- fix(gatsby): Add missing React peer dependency ([#4576](https://github.com/getsentry/sentry-javascript/pull/4576))
+- fix(types): Use Sentry event type instead of dom one ([#4584](https://github.com/getsentry/sentry-javascript/pull/4584))
+
 ## 6.17.8
 
 - feat(types): Add Envelope types ([#4527](https://github.com/getsentry/sentry-javascript/pull/4527))

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -1,3 +1,4 @@
+import { Event } from './event';
 import { SentryRequestType } from './request';
 import { SdkInfo } from './sdkinfo';
 import { Session, SessionAggregates } from './session';


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/pull/4527 introduced
Envelope types. In that patch, we included the `Event` DOM type, which
is not declared in all TS environments. This was done accidentally, we meant to
include Sentry's `Event` type.

This patch explicitly introduces Sentry's Event type by importing it in,
fixing the build errors that folks were having.

I would like to release after this, so I am going to update the changelog in this PR as well.

Fixes https://github.com/getsentry/sentry-javascript/issues/4583
