### PR TITLE
chore(build): Update and hoist `rollup-plugin-node-resolve`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@google-cloud/storage": "^5.7.0",
     "@rollup/plugin-commonjs": "^21.0.1",
+    "@rollup/plugin-node-resolve": "^13.1.3",
     "@rollup/plugin-replace": "^3.0.1",
     "@size-limit/preset-small-lib": "^4.5.5",
     "@strictsoftware/typedoc-plugin-monorepo": "^0.3.1",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -40,7 +40,6 @@
     "karma-webkit-launcher": "^1.0.2",
     "node-fetch": "^2.6.0",
     "playwright": "^1.17.1",
-    "rollup-plugin-node-resolve": "^4.2.3",
     "sinon": "^7.3.2",
     "webpack": "^4.30.0"
   },

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -1,7 +1,7 @@
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import license from 'rollup-plugin-license';
-import resolve from 'rollup-plugin-node-resolve';
+import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
 

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -22,8 +22,7 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
-    "rollup-plugin-node-resolve": "^4.2.3"
+    "chai": "^4.1.2"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",

--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
-import resolve from 'rollup-plugin-node-resolve';
+import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
 

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -26,8 +26,7 @@
     "@sentry/browser": "6.17.8",
     "@types/express": "^4.17.1",
     "@types/jsdom": "^16.2.3",
-    "jsdom": "^16.2.2",
-    "rollup-plugin-node-resolve": "^4.2.3"
+    "jsdom": "^16.2.2"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -1,7 +1,7 @@
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import license from 'rollup-plugin-license';
-import resolve from 'rollup-plugin-node-resolve';
+import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
 

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -28,8 +28,7 @@
     "vue-router": "3.x || 4.x"
   },
   "devDependencies": {
-    "jsdom": "^16.2.2",
-    "rollup-plugin-node-resolve": "^4.2.3"
+    "jsdom": "^16.2.2"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -1,7 +1,7 @@
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import license from 'rollup-plugin-license';
-import resolve from 'rollup-plugin-node-resolve';
+import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
 

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -26,8 +26,7 @@
     "cross-env": "^7.0.3",
     "express": "^4.17.1",
     "jest-puppeteer": "^4.4.0",
-    "puppeteer": "^5.5.0",
-    "rollup-plugin-node-resolve": "^4.2.3"
+    "puppeteer": "^5.5.0"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -1,6 +1,6 @@
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
-import resolve from 'rollup-plugin-node-resolve';
+import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3101,6 +3101,18 @@
     magic-string "^0.25.7"
     resolve "^1.17.0"
 
+"@rollup/plugin-node-resolve@^13.1.3":
+  version "13.1.3"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz#2ed277fb3ad98745424c1d2ba152484508a92d79"
+  integrity sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    "@types/resolve" "1.17.1"
+    builtin-modules "^3.1.0"
+    deepmerge "^4.2.2"
+    is-module "^1.0.0"
+    resolve "^1.19.0"
+
 "@rollup/plugin-replace@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-3.0.1.tgz#f774550f482091719e52e9f14f67ffc0046a883d"
@@ -3881,10 +3893,10 @@
     "@types/scheduler" "*"
     csstype "^3.0.2"
 
-"@types/resolve@0.0.8":
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
-  integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
+"@types/resolve@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
+  integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
   dependencies:
     "@types/node" "*"
 
@@ -8471,6 +8483,11 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
 defaults@^1.0.3:
   version "1.0.3"
@@ -18937,16 +18954,6 @@ rollup-plugin-license@^2.6.1:
     package-name-regex "2.0.5"
     spdx-expression-validate "2.0.0"
     spdx-satisfies "5.0.1"
-
-rollup-plugin-node-resolve@^4.2.3:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.2.4.tgz#7d370f8d6fd3031006a0032c38262dd9be3c6250"
-  integrity sha512-t/64I6l7fZ9BxqD3XlX4ZeO6+5RLKyfpwE2CiPNUKa+GocPlQhf/C208ou8y3AwtNsc6bjSk/8/6y/YAyxCIvw==
-  dependencies:
-    "@types/resolve" "0.0.8"
-    builtin-modules "^3.1.0"
-    is-module "^1.0.0"
-    resolve "^1.10.0"
 
 rollup-plugin-terser@^7.0.2:
   version "7.0.2"


### PR DESCRIPTION
As part of the new bundling process, this updates `rollup-plugin-node-resolve` to latest (which includes referring to it by its new name, `@rollup/plugin-node-resolve`) and hoists it to the main `package.js`.

This change has no effect on the generated bundles.