### PR TITLE
chore(build): Remove unused instances of `@rollup/plugin-commonjs`

### DIFF
--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -2,7 +2,6 @@ import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import license from 'rollup-plugin-license';
 import resolve from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
 
 const commitHash = require('child_process')
@@ -72,7 +71,6 @@ const plugins = [
   resolve({
     mainFields: ['module'],
   }),
-  commonjs(),
 ];
 
 const bundleConfig = {

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -2,7 +2,6 @@ import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import license from 'rollup-plugin-license';
 import resolve from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
 
 const commitHash = require('child_process')
@@ -60,7 +59,6 @@ const plugins = [
   resolve({
     mainFields: ['module'],
   }),
-  commonjs(),
 ];
 
 const bundleConfig = {

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -2,7 +2,6 @@ import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import license from 'rollup-plugin-license';
 import resolve from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
 
 const commitHash = require('child_process')
@@ -60,7 +59,6 @@ const plugins = [
   resolve({
     mainFields: ['module'],
   }),
-  commonjs(),
 ];
 
 const bundleConfig = {

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -1,7 +1,6 @@
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
 
 const terserInstance = terser({
@@ -50,7 +49,6 @@ const plugins = [
   resolve({
     mainFields: ['module'],
   }),
-  commonjs(),
 ];
 
 function mergeIntoSentry() {


### PR DESCRIPTION
In four of the five packages in which we're using `@rollup/plugin-commonjs`, it has no effect (removing it doesn't change the bundles at all). This makes sense, because nowhere in those four packages are we importing any CJS modules. This PR removes those extraneous plugin instances.

(The exception is `@sentry/integrations`, because the `Offline` plugin imports `localforage`, which is CJS. As a result, its rollup config hasn't been changed.)