### PR TITLE
[WIP] chore(build): Remove unused `@rollup/plugin-node-resolve` instances

### DIFF
--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -1,7 +1,6 @@
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import license from 'rollup-plugin-license';
-import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
 const commitHash = require('child_process')
@@ -67,9 +66,6 @@ const plugins = [
     values: {
       __SENTRY_BROWSER_BUNDLE__: true,
     },
-  }),
-  resolve({
-    mainFields: ['module'],
   }),
 ];
 

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -1,7 +1,6 @@
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import license from 'rollup-plugin-license';
-import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
 const commitHash = require('child_process')
@@ -55,9 +54,6 @@ const plugins = [
     values: {
       __SENTRY_BROWSER_BUNDLE__: true,
     },
-  }),
-  resolve({
-    mainFields: ['module'],
   }),
 ];
 

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -1,7 +1,6 @@
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import license from 'rollup-plugin-license';
-import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
 const commitHash = require('child_process')
@@ -55,9 +54,6 @@ const plugins = [
     values: {
       __SENTRY_BROWSER_BUNDLE__: true,
     },
-  }),
-  resolve({
-    mainFields: ['module'],
   }),
 ];
 

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -1,6 +1,5 @@
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
-import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
 const terserInstance = terser({
@@ -45,9 +44,6 @@ const plugins = [
     values: {
       __SENTRY_BROWSER_BUNDLE__: true,
     },
-  }),
-  resolve({
-    mainFields: ['module'],
   }),
 ];
 


### PR DESCRIPTION
In four of the five packages in which we're using `@rollup/plugin-node-resolve`, it has no effect (removing it doesn't change the bundles at all). This makes sense, because nowhere in those four packages are we importing any third-party modules from `node_modules`. This PR removes those extraneous plugin instances.

(The exception is `@sentry/integrations`, because the `Offline` plugin imports `localforage`, which is a third-party library. As a result, its rollup config hasn't been changed.)
