### PR TITLE
chore(build): Use standard regex for wasm terser `mangle.properties` option

### DIFF
--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -10,7 +10,9 @@ const terserInstance = terser({
     // We need those full names to correctly detect our internal frames for stripping.
     // I listed all of them here just for the clarity sake, as they are all used in the frames manipulation process.
     reserved: ['captureException', 'captureMessage', 'sentryWrapped'],
-    properties: false,
+    properties: {
+      regex: /^_[^_]/,
+    },
   },
   output: {
     comments: false,


### PR DESCRIPTION
Currently, `@sentry/wasm`'s minification settings (the `mangle.properties` option in rollup's terser plugin) prevent the mangling of any property names. (Note: This is different from variable names, which do get mangled.)

In other packages, internal property names (those starting with a single `_`) _are_ mangled. This PR ports that setting to the wasm package, which turns out not to meaningfully change the bundle, because nowhere in the package do such properties appear. As a result, the only effects of this change are different single-letter variables being used in the final minified bundle:

![image](https://user-images.githubusercontent.com/14812505/154202340-ac0696c3-7ae8-44a2-944b-4a407e540557.png)

(That isn't the whole file, but the rest looks much the same.)
