### PR TITLE
chore: Update 6.17.9 to reflect contributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - fix(gatsby): Add missing React peer dependency ([#4576](https://github.com/getsentry/sentry-javascript/pull/4576))
 - fix(types): Use Sentry event type instead of dom one ([#4584](https://github.com/getsentry/sentry-javascript/pull/4584))
 
+Work in this release contributed by @aaronadamsCA. Thank you for your contribution!
+
 ## 6.17.8
 
 - feat(types): Add Envelope types ([#4527](https://github.com/getsentry/sentry-javascript/pull/4527))


### PR DESCRIPTION
Sorry for missing you @aaronadamsCA - you are now in the changelog!

Also updated the release at https://github.com/getsentry/sentry-javascript/releases/tag/6.17.9 to reflect this.