### PR TITLE
fix(nextjs): Export `SentryWebpackPluginOptions` type

### DIFF
--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -127,6 +127,7 @@ function filterTransactions(event: Event): Event | null {
 }
 
 export { withSentryConfig } from './config';
+export { SentryWebpackPluginOptions } from './config/types';
 export { withSentry } from './utils/withSentry';
 
 // Wrap various server methods to enable error monitoring and tracing. (Note: This only happens for non-Vercel


### PR DESCRIPTION
This will allow people who want typing in their `next.config.js` file to have it without digging into `dist`.

See https://github.com/vercel/next.js/pull/28726.
