### PR TITLE
fix(ci): Exclude `config/types.ts`  in `@sentry/nextjs` from circular dependency check

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -48,7 +48,7 @@
     "build:dev:watch": "run-s build:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
-    "circularDepCheck": "madge --circular src/index.client.ts && madge --circular src/index.server.ts",
+    "circularDepCheck": "madge --circular src/index.client.ts && madge --circular --exclude 'config/types\\.ts' src/index.server.ts # see https://github.com/pahen/madge/issues/306",
     "clean": "rimraf dist esm coverage *.js *.js.map *.d.ts",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",


### PR DESCRIPTION
The library we use to detect circular dependencies, `madge`, has a bug wherein local files whose names match node modules cause false positives. (For more details, see https://github.com/pahen/madge/issues/306.) In our case, it was triggered by https://github.com/getsentry/sentry-javascript/pull/4597, which added an export from  file (`config/types.ts`) which depends on the node module `webpack` and which is depended upon by the local file `config/webpack.ts`.

To solve this for the moment, this PR excludes the problematic file from the check.