### PR TITLE
fix(ember): use `_backburner` if it exists

### DIFF
--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -33,9 +33,7 @@ function getBackburner() {
     return _backburner;
   }
 
-  if (run.backburner) {
-    return run.backburner;
-  }
+  return run.backburner;
 }
 
 function getTransitionInformation(transition: any, router: any) {

--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -2,6 +2,7 @@ import ApplicationInstance from '@ember/application/instance';
 import Ember from 'ember';
 import { run, _backburner, scheduleOnce } from '@ember/runloop';
 import * as Sentry from '@sentry/browser';
+import { ExtendedBackburner } from "@sentry/ember/runloop";
 import { Span, Transaction, Integration } from '@sentry/types';
 import { EmberRunQueues } from '@ember/runloop/-private/types';
 import { getActiveTransaction } from '..';
@@ -28,12 +29,19 @@ export function initialize(appInstance: ApplicationInstance): void {
   }
 }
 
-function getBackburner() {
+function getBackburner(): Pick<ExtendedBackburner, "on" | "off"> {
   if (_backburner) {
     return _backburner;
   }
 
-  return run.backburner;
+  if (run.backburner) {
+    return run.backburner;
+  }
+
+  return {
+    on() {},
+    off() {}
+  }
 }
 
 function getTransitionInformation(transition: any, router: any) {

--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -29,10 +29,13 @@ export function initialize(appInstance: ApplicationInstance): void {
 }
 
 function getBackburner() {
+  if (_backburner) {
+    return _backburner;
+  }
+
   if (run.backburner) {
     return run.backburner;
   }
-  return _backburner;
 }
 
 function getTransitionInformation(transition: any, router: any) {


### PR DESCRIPTION
`run.backburner` is deprecated and creates errors now when used and when [ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow) is in your dependencies.

This commit fixes the issue by using the `_backburner` if it exists (which is the case in recent versions of Ember), or `run.backbackburner` if not (which is the case in older versions of Ember). Thus, `run.backburner` is not called if `_backburner` is present and thus does not create a deprecation warning.

This fixes the issue reported [here](https://github.com/getsentry/sentry-javascript/issues/3911) event after the PR was merged.
