### PR TITLE
fix(nextjs): Use env variable for build detection

### DIFF
--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -23,12 +23,20 @@ const domain = domainModule as typeof domainModule & { active: (domainModule.Dom
 // During build, the main process is invoked by
 //   `node next build`
 // and child processes are invoked as
-//   `node <path>/node_modules/jest-worker/build/workers/processChild.js`,
-// whereas at runtime the process is invoked as
+//   `node <path>/node_modules/.../jest-worker/processChild.js`.
+// The former is (obviously) easy to recognize, but the latter could happen at runtime as well. Fortunately, the main
+// process hits this file before any of the child processes do, so we're able to set an env variable which the child
+// processes can then check. During runtime, the main process is invoked as
 //   `node next start`
 // or
-//   `node /var/runtime/index.js`.
-const isBuild = new RegExp('build').test(process.argv.toString());
+//   `node /var/runtime/index.js`,
+// so we never drop into the `if` in the first place.
+let isBuild;
+if (process.argv.includes('build') || process.env.BUILD_PHASE) {
+  process.env.BUILD_PHASE = 'true';
+  isBuild = true;
+}
+
 const isVercel = !!process.env.VERCEL;
 
 /** Inits the Sentry NextJS SDK on node. */


### PR DESCRIPTION
In non-Vercel-deployed nextjs apps using our SDK, we instrument the server in order to be able to capture transactions for a wider variety of incoming requests than is possible using or `withSentry` API route handler wrapper. We don't do this during build, however, because there's no server to wrap.

Until now, we've been relying on the fact that child processes of the main build process were invoked by `node <path>/node_modules/jest-worker/build/workers/processChild.js` in order to recognize them as happening during build time. Recently, however, next [started vendoring](https://github.com/vercel/next.js/pull/32742/) pre-compiled versions of more of its dependencies, including `jest-worker`, such that now those child process are invoked by `node <path>/node_modules/next/dist/compiled/jest-worker/processChild.js`. This broke our build detection.

Rather than just switch to using the new path, this PR refactors the check to use an env variable set by the main build process, in order that the check not get fooled by any child processes spawned at runtime. (I don't actually know if that ever happens, but there's no reason it couldn't, so better to have a foolproof indicator.)
