### PR TITLE
ref(browser): Only set `event.stacktrace` if we have 1 or more frames

### DIFF
--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -143,9 +143,10 @@ export function eventFromString(
   };
 
   if (options.attachStacktrace && syntheticException) {
-    event.stacktrace = {
-      frames: parseStackFrames(syntheticException),
-    };
+    const frames = parseStackFrames(syntheticException);
+    if (frames.length) {
+      event.stacktrace = { frames };
+    }
   }
 
   return event;

--- a/packages/browser/src/parsers.ts
+++ b/packages/browser/src/parsers.ts
@@ -54,9 +54,10 @@ export function eventFromPlainObject(
   };
 
   if (syntheticException) {
-    event.stacktrace = {
-      frames: parseStackFrames(syntheticException),
-    };
+    const frames = parseStackFrames(syntheticException);
+    if (frames.length) {
+      event.stacktrace = { frames };
+    }
   }
 
   return event;


### PR DESCRIPTION
Fixes #4418

`event.stacktrace` is deprecated and will likely be moved to `exception` on the next major release. 

However, `no frames = no stacktrace` will still stand then!