### PR TITLE
fix(nextjs): Fix `nock` wrapping conflict in integration tests

### DIFF
--- a/packages/nextjs/test/integration/test/server/tracingHttp.js
+++ b/packages/nextjs/test/integration/test/server/tracingHttp.js
@@ -40,7 +40,10 @@ module.exports = async ({ url: urlBase, argv }) => {
     'tracingHttp',
   );
 
-  await getAsync(url);
+  // The `true` causes `getAsync` to rewrap `http.get` in next 12, since it will have been overwritten by the import of
+  // `nock` above. See https://github.com/getsentry/sentry-javascript/pull/4619.
+  // TODO: see note in `getAsync` about removing the boolean
+  await getAsync(url, true);
   await sleep(250);
 
   assert.ok(capturedRequest.isDone(), 'Did not intercept expected request');

--- a/packages/nextjs/test/integration/test/utils/server.js
+++ b/packages/nextjs/test/integration/test/utils/server.js
@@ -1,12 +1,22 @@
 const { get } = require('http');
 const nock = require('nock');
+const nodeSDK = require('@sentry/node');
 const { logIf, parseEnvelope } = require('./common');
 
 Error.stackTraceLimit = Infinity;
 
-const getAsync = url => {
+const getAsync = (url, rewrap = false) => {
+  // Depending on what version of Nextjs we're testing, the wrapping which happens in the `Http` integration may have
+  // happened too early and gotten overwritten by `nock`. This redoes the wrapping if so.
+  //
+  // TODO: This works but is pretty hacky in that it has the potential to wrap things multiple times, more even than the
+  // double-wrapping which is discussed at length in the comment in `ensureWrappedGet` below, which is why we need
+  // `rewrap`. Once we fix `fill` to not wrap things twice, we should be able to take this out and just always call
+  // `ensureWrappedGet`.
+  const wrappedGet = rewrap ? ensureWrappedGet(get, url) : get;
+
   return new Promise((resolve, reject) => {
-    get(url, res => {
+    wrappedGet(url, res => {
       res.setEncoding('utf8');
       let rawData = '';
       res.on('data', chunk => {
@@ -98,6 +108,60 @@ const objectMatches = (actual, expected) => {
 
   return true;
 };
+
+/**
+ * Rewrap `http.get` if the wrapped version has been overridden by `nock`.
+ *
+ * This is only relevant for Nextjs >= 12.1, which changed when `_app` is initialized, which in turn changed the order
+ * in which our SDK and `nock` wrap `http.get`. See https://github.com/getsentry/sentry-javascript/pull/4619.
+ *
+ * TODO: We'll have to do this for `ClientRequest` also if we decide to start wrapping that.
+ * TODO: Can we fix the wrapping-things-twice problem discussed in the comment below?
+ */
+function ensureWrappedGet(importedGet, url) {
+  // we always test against the latest minor for any given Nextjs major version, so if we're testing Next 12, it's
+  // definitely at least 12.1, making this check against the major version sufficient
+  if (Number(process.env.NEXTJS_VERSION) < 12) {
+    return importedGet;
+  }
+
+  // As of Next 12.1, creating a `NextServer` instance (which we do immediately upon starting this test runner) loads
+  // `_app`, which has the effect of initializing the SDK. So, unless something's gone wrong, we should always be able
+  // to find the integration
+  let httpIntegration;
+  try {
+    httpIntegration = nodeSDK.getCurrentHub().getClient().getIntegration(nodeSDK.Integrations.Http);
+  } catch (err) {
+    console.warn(`Warning: Sentry SDK not set up at \`NextServer\` initialization. Request URL: ${url}`);
+    return importedGet;
+  }
+
+  // This rewraps `http.get` and `http.request`, which, at this point, look like `nockWrapper(sentryWrapper(get))` and
+  // `nockWrapper(sentryWrapper(request))`. By the time we're done with this function, they'll look like
+  // `sentryWrapper(nockWrapper(sentryWrapper(get)))` and `sentryWrapper(nockWrapper(sentryWrapper(request)))`,
+  // respectively. Though this seems less than ideal, we don't have to worry about our instrumentation being
+  // (meaningfully) called twice because:
+  //
+  // 1) As long as we set up a `nock` interceptor for any outgoing http request, `nock`'s wrapper will call a replacement
+  //    function for that request rather than call the function it's wrapping (in other words, it will look more like
+  //    `sentryWrapper(nockWrapper(getSubstitute))` than `sentryWrapper(nockWrapper(sentryWrapper(get)))`), which means
+  //    our code is only called once.
+  // 2) In cases where we don't set up an interceptor (such as for the `wrappedGet` call in `getAsync` above), it's true
+  //    that we can end up with `sentryWrapper(nockWrapper(sentryWrapper(get)))`, meaning our wrapper code will run
+  //    twice. For now that's okay because in those cases we're not in the middle of a transactoin and therefore
+  //    the two wrappers' respective attempts to start spans will both no-op.
+  //
+  // TL; DR - if the double-wrapping means you're seeing two spans where you really only want one, set up a nock
+  // interceptor for the request.
+  //
+  // TODO: add in a "don't do this twice" check (in `fill`, maybe moved from `wrap`), so that we don't wrap the outer
+  // wrapper with a third wrapper
+  httpIntegration.setupOnce();
+
+  // now that we've rewrapped it, grab the correct version of `get` for use in our tests
+  const httpModule = require('http');
+  return httpModule.get;
+}
 
 module.exports = {
   getAsync,

--- a/packages/nextjs/test/run-integration-tests.sh
+++ b/packages/nextjs/test/run-integration-tests.sh
@@ -32,6 +32,11 @@ mv next.config.js next.config.js.bak
 
 for NEXTJS_VERSION in 10 11 12; do
 
+  # export this to the env so that we can behave differently depending on which version of next we're testing, without
+  # having to pass this value from function to function to function to the one spot, deep in some callstack, where we
+  # actually need it
+  export NEXTJS_VERSION=$NEXTJS_VERSION
+
   # Next 10 requires at least Node v10
   if [ "$NODE_MAJOR" -lt "10" ]; then
     echo "[nextjs] Next.js is not compatible with versions of Node older than v10. Current version $NODE_VERSION"


### PR DESCRIPTION
**Background**

In our integration tests for nextjs, we use `nock` to intercept outgoing http requests, which lets us both examine a request’s payload (useful for seeing what would get sent to Sentry) and mock its response. As part of its initialization, `nock` monkeypatches  the `get` and `request` methods in both the `http` and `https` Node built-in modules. Our `Http` integration also monkeypatches those methods.

There’s one key difference between our monkeypatching and their monkeypatching, however: while we _always_ eventually call the method we’re wrapping, `nock`’s substitute methods only _sometimes_ call the method being wrapped. In practical terms, what that means is that the order in which the two monkeypatching operations happen matters.

If `nock` monkeypatches before we do, we effectively end up with `sentryWrapper(nockWrapper(originalGet))`, which means that no matter what `nock` does or doesn’t do with `originalGet`, our wrapper code will always run. But if `nock` monkeypatches after we do, we end up with `nockWrapper(sentryWrapper(originalGet))`, meaning that if `nock` chooses not to call the function it’s wrapping, our code never runs.

Up until now, the test we have for the `Http` integration has been working because it’s fallen into that first scenario. More specifically, the sequence of events when running the test has gone like this (monkeypatching steps have been starred):

```
(1)       `yarn test:integration` -> 
(2)       test runner starts test nextjs server -> 
(3)       test runner requires `Http` test file -> 
(4)       `Http` test file requires `nock` (which it will use to intercept the request it'll make to trigger span creation) -> 
(5) *     `nock` initializes, does monkeypatching -> 
(6)       `Http` test makes request to API route whose handler will trigger the outgoing request -> 
(7)       nextjs loads API route file, which has had `Sentry.init()` code injected during build -> 
(8)       `Sentry.init()` runs ->
(9) *     `Http` integration is initialized, does monkeypatching
```

Starting with Nextjs 12.1, however, things go in a different order:

```
(1)       `yarn test:integration` -> 
(2)       test runner starts test nextjs server -> 
(2a)      nextjs server loads `_app`, which has had `Sentry.init()` code injected during build
(8/2b)    `Sentry.init()` runs ->
(9/2c) *  `Http` integration is initialized, does monkeypatching ->
(3)       test runner requires `Http` test file -> 
(4)       `Http` test file requires `nock` (which it will use to intercept the request it'll make to trigger span creation) -> 
(5) *     `nock` initializes, does monkeypatching -> 
(6)       `Http` test makes request to API route whose handler will trigger the outgoing request -> 
(7)       nextjs loads API route file, which has had `Sentry.init()` code injected during build -> 
(8)       `Sentry.init()` runs ->
(9')      the SDK is already running, so `Sentry.init()` bails
```

Note the new steps after (2), including the former (8) and (9), and the new version of (9). As we can see, the order of the monkeypatching has been reversed.

**Cause**

The reason for this change is [this PR](https://github.com/vercel/next.js/pull/23261), which causes Next to load the `_app` and `_document` pages as soon as the server starts, in the interest of serving the first requested page more quickly.

**Impact**

The consequence of this change is that in our integration test of the `Http` integration, our wrapper code isn't called. As a result, the span the test expects will be created when it makes an http request isn't actually created, and the test fails.

**Solution**

Though it's somewhat hacky, the solution in this PR is to force `get` (and `request`, though that's irrelevant here) to be wrapped again by Sentry after they are wrapped by `nock`. The result is a little messy, but fortunately turns out to be messy in ways which don't matter, as described in a comment in the new function which does the rewrapping:

```
  // This rewraps `http.get` and `http.request`, which, at this point, look like `nockWrapper(sentryWrapper(get))` and
  // `nockWrapper(sentryWrapper(request))`. By the time we're done with this function, they'll look like
  // `sentryWrapper(nockWrapper(sentryWrapper(get)))` and `sentryWrapper(nockWrapper(sentryWrapper(request)))`,
  // respectively. Though this seems less than ideal, we don't have to worry about our instrumentation being
  // (meaningfully) called twice because:
  //
  // 1) As long as we set up a `nock` interceptor for any outgoing http request, `nock`'s wrapper will call a replacement
  //    function for that request rather than call the function it's wrapping (in other words, it will look more like
  //    `sentryWrapper(nockWrapper(getSubstitute))` than `sentryWrapper(nockWrapper(sentryWrapper(get)))`), which means
  //    our code is only called once.
  // 2) In cases where we don't set up an interceptor (such as for the `wrappedGet` call in `getAsync` above), it's true
  //    that we can end up with `sentryWrapper(nockWrapper(sentryWrapper(get)))`, meaning our wrapper code will run
  //    twice. For now that's okay because in those cases we're not in the middle of a transactoin and therefore
  //    the two wrappers' respective attempts to start spans will both no-op.
  //
  // TL; DR - if the double-wrapping means you're seeing two spans where you really only want one, set up a nock
  // interceptor for the request.
  ```

There are other comments (TODOs) in the code discussing a somewhat simpler strategy, but other work will need to be done first, and this should at least get CI unblocked.