### PR TITLE
ref(serverless): Added option ignoreSentryErrors for lambda WrapperOptions

### DIFF
--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -11,7 +11,7 @@ import {
 } from '@sentry/node';
 import { extractTraceparentData } from '@sentry/tracing';
 import { Integration } from '@sentry/types';
-import { isString, logger } from '@sentry/utils';
+import { isString, logger, SentryError } from '@sentry/utils';
 // NOTE: I have no idea how to fix this right now, and don't want to waste more time, as it builds just fine — Kamil
 // eslint-disable-next-line import/no-unresolved
 import { Context, Handler } from 'aws-lambda';
@@ -53,6 +53,7 @@ export interface WrapperOptions {
    * @default false
    */
   captureAllSettledReasons: boolean;
+  ignoreSentryErrors: boolean;
 }
 
 export const defaultIntegrations: Integration[] = [...Sentry.defaultIntegrations, new AWSServices({ optional: true })];
@@ -224,6 +225,7 @@ export function wrapHandler<TEvent, TResult>(
     captureTimeoutWarning: true,
     timeoutWarningLimit: 500,
     captureAllSettledReasons: false,
+    ignoreSentryErrors: false,
     ...wrapOptions,
   };
   let timeoutWarningTimer: NodeJS.Timeout;
@@ -314,7 +316,12 @@ export function wrapHandler<TEvent, TResult>(
       clearTimeout(timeoutWarningTimer);
       transaction.finish();
       hub.popScope();
-      await flush(options.flushTimeout);
+      await flush(options.flushTimeout).catch(e => {
+        if (options.ignoreSentryErrors && e instanceof SentryError) {
+          return;
+        }
+        throw e;
+      });
     }
     return rv;
   };

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -318,6 +318,7 @@ export function wrapHandler<TEvent, TResult>(
       hub.popScope();
       await flush(options.flushTimeout).catch(e => {
         if (options.ignoreSentryErrors && e instanceof SentryError) {
+          logger.error(e);
           return;
         }
         throw e;

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -1,6 +1,6 @@
+import { SentryError } from '@sentry/utils';
 // NOTE: I have no idea how to fix this right now, and don't want to waste more time, as it builds just fine — Kamil
 // eslint-disable-next-line import/no-unresolved
-import { SentryError } from '@sentry/utils';
 import { Callback, Handler } from 'aws-lambda';
 
 import * as Sentry from '../src';

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -212,7 +212,7 @@ describe('AWSLambda', () => {
       await expect(wrappedHandlerWithoutIgnoringSentryErrors(fakeEvent, fakeContext, fakeCallback)).rejects.toThrow(
         sentryError,
       );
-      await expect(wrappedHandlerWithIgnoringSentryErrors(fakeEvent, fakeContext, fakeCallback)).resolves.not.toThrow(
+      await expect(wrappedHandlerWithIgnoringSentryErrors(fakeEvent, fakeContext, fakeCallback)).rejects.toThrow(
         criticalUnhandledError,
       );
     });

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -1,5 +1,6 @@
 // NOTE: I have no idea how to fix this right now, and don't want to waste more time, as it builds just fine — Kamil
 // eslint-disable-next-line import/no-unresolved
+import { SentryError } from '@sentry/utils';
 import { Callback, Handler } from 'aws-lambda';
 
 import * as Sentry from '../src';
@@ -176,6 +177,44 @@ describe('AWSLambda', () => {
       expect(Sentry.captureException).toHaveBeenNthCalledWith(1, error);
       expect(Sentry.captureException).toHaveBeenNthCalledWith(2, error2);
       expect(Sentry.captureException).toBeCalledTimes(2);
+    });
+
+    test('ignoreSentryErrors - with successful handler', async () => {
+      const sentryError = new SentryError('HTTP Error (429)');
+      jest.spyOn(Sentry, 'flush').mockRejectedValueOnce(sentryError);
+
+      const handledError = new Error('handled error, and we want to monitor it');
+      const expectedSuccessStatus = { status: 'success', reason: 'we handled error, so success' };
+      const handler = () => {
+        Sentry.captureException(handledError);
+        return Promise.resolve(expectedSuccessStatus);
+      };
+      const wrappedHandlerWithoutIgnoringSentryErrors = wrapHandler(handler, { ignoreSentryErrors: false });
+      const wrappedHandlerWithIgnoringSentryErrors = wrapHandler(handler, { ignoreSentryErrors: true });
+
+      await expect(wrappedHandlerWithoutIgnoringSentryErrors(fakeEvent, fakeContext, fakeCallback)).rejects.toThrow(
+        sentryError,
+      );
+      await expect(wrappedHandlerWithIgnoringSentryErrors(fakeEvent, fakeContext, fakeCallback)).resolves.toBe(
+        expectedSuccessStatus,
+      );
+    });
+
+    test('ignoreSentryErrors - with failed handler', async () => {
+      const sentryError = new SentryError('HTTP Error (429)');
+      jest.spyOn(Sentry, 'flush').mockRejectedValueOnce(sentryError);
+
+      const criticalUnhandledError = new Error('critical unhandled error ');
+      const handler = () => Promise.reject(criticalUnhandledError);
+      const wrappedHandlerWithoutIgnoringSentryErrors = wrapHandler(handler, { ignoreSentryErrors: false });
+      const wrappedHandlerWithIgnoringSentryErrors = wrapHandler(handler, { ignoreSentryErrors: true });
+
+      await expect(wrappedHandlerWithoutIgnoringSentryErrors(fakeEvent, fakeContext, fakeCallback)).rejects.toThrow(
+        sentryError,
+      );
+      await expect(wrappedHandlerWithIgnoringSentryErrors(fakeEvent, fakeContext, fakeCallback)).resolves.not.toThrow(
+        criticalUnhandledError,
+      );
     });
   });
 


### PR DESCRIPTION
This PR was built on top of https://github.com/getsentry/sentry-javascript/issues/4582 so the changes here will allow sdk consumers to ignore sentry internal errors like 429 - too many requests, or 413 payload too large, etc...

in our case 429 error happens quite often per day since we added rate limit for each lambda project (that is recommended as a [sentry quota management strategy](https://docs.sentry.io/product/accounts/quotas/manage-event-stream-guide/#6-rate-limiting) ). 
so, as u can find in tests, even for successful lambda executions, 429 error can fail the whole lambda invocation, which heavily affects our clients user experience