### PR TITLE
fix(node): attach local req scope to req.sentryScope

### DIFF
--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -281,6 +281,22 @@ describe('requestHandler', () => {
       done();
     });
   });
+
+  it('checks if local scope was correctly attached to req', done => {
+    client = new NodeClient({ autoSessionTracking: false, release: '1.2' });
+    const hub = new Hub(client);
+    jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
+
+    sentryRequestMiddleware(req, res, next);
+    const scope = sentryCore.getCurrentHub().getScope();
+    res.emit('finish');
+
+    setImmediate(() => {
+      expect((req as ExpressRequest).sentryScope).toBeDefined();
+      expect((req as ExpressRequest).sentryScope).toEqual(scope);
+      done();
+    });
+  });
 });
 
 describe('tracingHandler', () => {


### PR DESCRIPTION
This PR:

- Attaches the scope of the domain context inside of a request to req.sentryScope
- Adds a test to check if req.sentryScope is defined

Fixes #4607

