### PR TITLE
ref(browser): Make attachStacktrace usage more explicit

### DIFF
--- a/packages/browser/src/backend.ts
+++ b/packages/browser/src/backend.ts
@@ -40,13 +40,13 @@ export class BrowserBackend extends BaseBackend<BrowserOptions> {
    * @inheritDoc
    */
   public eventFromException(exception: unknown, hint?: EventHint): PromiseLike<Event> {
-    return eventFromException(this._options, exception, hint);
+    return eventFromException(exception, hint, this._options.attachStacktrace);
   }
   /**
    * @inheritDoc
    */
   public eventFromMessage(message: string, level: Severity = Severity.Info, hint?: EventHint): PromiseLike<Event> {
-    return eventFromMessage(this._options, message, level, hint);
+    return eventFromMessage(message, level, hint, this._options.attachStacktrace);
   }
 
   /**

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -1,4 +1,4 @@
-import { Event, EventHint, Options, Severity } from '@sentry/types';
+import { Event, EventHint, Severity } from '@sentry/types';
 import {
   addExceptionMechanism,
   addExceptionTypeValue,
@@ -20,7 +20,7 @@ import { eventFromError, eventFromPlainObject, parseStackFrames } from './parser
 export function eventFromException(
   exception: unknown,
   hint?: EventHint,
-  attachStacktrace?: Options['attachStacktrace'],
+  attachStacktrace?: boolean,
 ): PromiseLike<Event> {
   const syntheticException = (hint && hint.syntheticException) || undefined;
   const event = eventFromUnknownInput(exception, syntheticException, attachStacktrace);
@@ -40,7 +40,7 @@ export function eventFromMessage(
   message: string,
   level: Severity = Severity.Info,
   hint?: EventHint,
-  attachStacktrace?: Options['attachStacktrace'],
+  attachStacktrace?: boolean,
 ): PromiseLike<Event> {
   const syntheticException = (hint && hint.syntheticException) || undefined;
   const event = eventFromString(message, syntheticException, attachStacktrace);
@@ -57,7 +57,7 @@ export function eventFromMessage(
 export function eventFromUnknownInput(
   exception: unknown,
   syntheticException?: Error,
-  attachStacktrace?: Options['attachStacktrace'],
+  attachStacktrace?: boolean,
   isUnhandledRejection?: boolean,
 ): Event {
   let event: Event;
@@ -129,11 +129,7 @@ export function eventFromUnknownInput(
 /**
  * @hidden
  */
-export function eventFromString(
-  input: string,
-  syntheticException?: Error,
-  attachStacktrace?: Options['attachStacktrace'],
-): Event {
+export function eventFromString(input: string, syntheticException?: Error, attachStacktrace?: boolean): Event {
   const event: Event = {
     message: input,
   };

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -92,10 +92,7 @@ function _installGlobalOnErrorHandler(): void {
         error === undefined && isString(msg)
           ? _eventFromIncompleteOnError(msg, url, line, column)
           : _enhanceEventWithInitialFrame(
-              eventFromUnknownInput(error || msg, undefined, {
-                attachStacktrace,
-                isRejection: false,
-              }),
+              eventFromUnknownInput(error || msg, undefined, attachStacktrace, false),
               url,
               line,
               column,
@@ -145,10 +142,7 @@ function _installGlobalOnUnhandledRejectionHandler(): void {
 
       const event = isPrimitive(error)
         ? _eventFromRejectionWithPrimitive(error)
-        : eventFromUnknownInput(error, undefined, {
-            attachStacktrace,
-            isRejection: true,
-          });
+        : eventFromUnknownInput(error, undefined, attachStacktrace, true);
 
       event.level = Severity.Error;
 

--- a/packages/browser/src/parsers.ts
+++ b/packages/browser/src/parsers.ts
@@ -35,15 +35,15 @@ export function exceptionFromError(ex: Error): Exception {
 export function eventFromPlainObject(
   exception: Record<string, unknown>,
   syntheticException?: Error,
-  rejection?: boolean,
+  isUnhandledRejection?: boolean,
 ): Event {
   const event: Event = {
     exception: {
       values: [
         {
-          type: isEvent(exception) ? exception.constructor.name : rejection ? 'UnhandledRejection' : 'Error',
+          type: isEvent(exception) ? exception.constructor.name : isUnhandledRejection ? 'UnhandledRejection' : 'Error',
           value: `Non-Error ${
-            rejection ? 'promise rejection' : 'exception'
+            isUnhandledRejection ? 'promise rejection' : 'exception'
           } captured with keys: ${extractExceptionKeysForMessage(exception)}`,
         },
       ],


### PR DESCRIPTION
Instead of passing down options objects, we instead directly pass down
options as appropriate. This makes it very clear how they are being
used. Also helps saves on bundle size slightly.
