### PR TITLE
fix(nextjs): webpack as optional peer-dependency

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -37,6 +37,11 @@
     "react": "15.x || 16.x || 17.x",
     "webpack": ">= 4.0.0"
   },
+  "peerDependenciesMeta": {
+    "webpack": {
+      "optional": true
+    }
+  },
   "scripts": {
     "build": "run-p build:cjs build:esm",
     "build:cjs": "tsc -p tsconfig.cjs.json",


### PR DESCRIPTION
Should close https://github.com/getsentry/sentry-javascript/issues/4632

- fix a warning about a missing peer-dep on webpack.
- should fix install with yarn pnp / pnpm modules linkers

## Notes

- Nextjs actually provides webpack (through a ncc'ed dep since https://github.com/vercel/next.js/pull/32742/).
