### PR TITLE
feat(nextjs): Upgrade Sentry Webpack Plugin to 1.18.7

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -24,7 +24,7 @@
     "@sentry/react": "6.18.0",
     "@sentry/tracing": "6.18.0",
     "@sentry/utils": "6.18.0",
-    "@sentry/webpack-plugin": "1.18.5",
+    "@sentry/webpack-plugin": "1.18.7",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
@@ -34,8 +34,7 @@
   },
   "peerDependencies": {
     "next": "^10.0.8 || ^11.0 || ^12.0",
-    "react": "15.x || 16.x || 17.x",
-    "webpack": ">= 4.0.0"
+    "react": "15.x || 16.x || 17.x"
   },
   "scripts": {
     "build": "run-p build:cjs build:esm",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3157,6 +3157,13 @@
   dependencies:
     "@sentry/cli" "^1.72.0"
 
+"@sentry/webpack-plugin@1.18.7":
+  version "1.18.7"
+  resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-1.18.7.tgz#f48dbebb4989f3a357280f2c92a8d4b5b963f6ec"
+  integrity sha512-pOJLzC2unQdtrQarcicZ3aPs6hnQUjMvVmRN7s+/m7PEITvvf24hgIPdbLnn6PVQARvFA8mbbst0+eHMi44veA==
+  dependencies:
+    "@sentry/cli" "^1.72.0"
+
 "@simple-dom/interface@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@simple-dom/interface/-/interface-1.4.0.tgz#e8feea579232017f89b0138e2726facda6fbb71f"


### PR DESCRIPTION
This upgrades `@sentry/webpack-plugin` to https://github.com/getsentry/sentry-webpack-plugin/releases/tag/v1.18.7

This includes the changes from https://github.com/getsentry/sentry-webpack-plugin/pull/354, which means we can get rid of the webpack peer dep from the NextJS package.

fixes https://github.com/getsentry/sentry-javascript/issues/4632
supercedes https://github.com/getsentry/sentry-javascript/pull/4634
ref https://github.com/getsentry/sentry-javascript/pull/4576
