### PR TITLE
ref(build): Centralize identical CDN rollup config

### DIFF
--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -56,6 +56,7 @@ const plugins = [
 ];
 
 const bundleConfig = {
+  ...baseBundleConfig,
   input: 'src/index.ts',
   output: {
     ...baseBundleConfig.output,
@@ -64,7 +65,6 @@ const bundleConfig = {
   },
   context: 'window',
   plugins: [...plugins, licensePlugin],
-  treeshake: 'smallest',
 };
 
 export default [

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -4,9 +4,7 @@ import license from 'rollup-plugin-license';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
-const commitHash = require('child_process')
-  .execSync('git rev-parse --short HEAD', { encoding: 'utf-8' })
-  .trim();
+const commitHash = require('child_process').execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
 
 const terserInstance = terser({
   compress: {
@@ -109,10 +107,7 @@ export default [
       file: 'build/bundle.min.js',
     },
     // Uglify has to be at the end of compilation, BUT before the license banner
-    plugins: bundleConfig.plugins
-      .slice(0, -1)
-      .concat(terserInstance)
-      .concat(bundleConfig.plugins.slice(-1)),
+    plugins: bundleConfig.plugins.slice(0, -1).concat(terserInstance).concat(bundleConfig.plugins.slice(-1)),
   },
   // ------------------
   // ES6 Browser Bundle
@@ -159,11 +154,7 @@ export default [
         },
         include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
       }),
-      ...plugins
-        .slice(1)
-        .slice(0, -1)
-        .concat(terserInstance)
-        .concat(bundleConfig.plugins.slice(-1)),
+      ...plugins.slice(1).slice(0, -1).concat(terserInstance).concat(bundleConfig.plugins.slice(-1)),
     ],
   },
   // ------------------

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -3,7 +3,7 @@ import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
-import { makeLicensePlugin } from '../../rollup.config';
+import { makeLicensePlugin, paths } from '../../rollup.config';
 
 const licensePlugin = makeLicensePlugin();
 
@@ -35,14 +35,6 @@ const terserInstance = terser({
     comments: false,
   },
 });
-
-const paths = {
-  '@sentry/utils': ['../utils/src'],
-  '@sentry/core': ['../core/src'],
-  '@sentry/hub': ['../hub/src'],
-  '@sentry/types': ['../types/src'],
-  '@sentry/minimal': ['../minimal/src'],
-};
 
 const plugins = [
   typescript({

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -1,11 +1,11 @@
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
-import resolve from '@rollup/plugin-node-resolve';
 
 import {
   baseBundleConfig,
   makeLicensePlugin,
   markAsBrowserBuild,
+  nodeResolvePlugin,
   paths,
   typescriptPluginES5,
 } from '../../rollup.config';
@@ -45,9 +45,7 @@ const plugins = [
   typescriptPluginES5,
   // replace `__SENTRY_BROWSER_BUNDLE__` with `true` to enable treeshaking of non-browser code
   markAsBrowserBuild,
-  resolve({
-    mainFields: ['module'],
-  }),
+  nodeResolvePlugin,
 ];
 
 const bundleConfig = {

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -1,9 +1,8 @@
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
-import replace from '@rollup/plugin-replace';
 
-import { makeLicensePlugin, paths } from '../../rollup.config';
+import { makeLicensePlugin, markAsBrowserBuild, paths } from '../../rollup.config';
 
 const licensePlugin = makeLicensePlugin();
 
@@ -49,16 +48,8 @@ const plugins = [
     },
     include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
   }),
-  replace({
-    // don't replace `__placeholder__` where it's followed immediately by a single `=` (to prevent ending up
-    // with something of the form `let "replacementValue" = "some assigned value"`, which would cause a
-    // syntax error)
-    preventAssignment: true,
-    // the replacements to make
-    values: {
-      __SENTRY_BROWSER_BUNDLE__: true,
-    },
-  }),
+  // replace `__SENTRY_BROWSER_BUNDLE__` with `true` to enable treeshaking of non-browser code
+  markAsBrowserBuild,
   resolve({
     mainFields: ['module'],
   }),

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -2,7 +2,13 @@ import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 
-import { baseBundleConfig, makeLicensePlugin, markAsBrowserBuild, paths } from '../../rollup.config';
+import {
+  baseBundleConfig,
+  makeLicensePlugin,
+  markAsBrowserBuild,
+  paths,
+  typescriptPluginES5,
+} from '../../rollup.config';
 
 const licensePlugin = makeLicensePlugin();
 
@@ -36,18 +42,7 @@ const terserInstance = terser({
 });
 
 const plugins = [
-  typescript({
-    tsconfig: 'tsconfig.esm.json',
-    tsconfigOverride: {
-      compilerOptions: {
-        declaration: false,
-        declarationMap: false,
-        paths,
-        baseUrl: '.',
-      },
-    },
-    include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
-  }),
+  typescriptPluginES5,
   // replace `__SENTRY_BROWSER_BUNDLE__` with `true` to enable treeshaking of non-browser code
   markAsBrowserBuild,
   resolve({

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -2,7 +2,7 @@ import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 
-import { makeLicensePlugin, markAsBrowserBuild, paths } from '../../rollup.config';
+import { baseBundleConfig, makeLicensePlugin, markAsBrowserBuild, paths } from '../../rollup.config';
 
 const licensePlugin = makeLicensePlugin();
 
@@ -58,11 +58,9 @@ const plugins = [
 const bundleConfig = {
   input: 'src/index.ts',
   output: {
+    ...baseBundleConfig.output,
     format: 'iife',
     name: 'Sentry',
-    sourcemap: true,
-    strict: false,
-    esModule: false,
   },
   context: 'window',
   plugins: [...plugins, licensePlugin],

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -1,10 +1,11 @@
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
-import license from 'rollup-plugin-license';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
-const commitHash = require('child_process').execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+import { makeLicensePlugin } from '../../rollup.config';
+
+const licensePlugin = makeLicensePlugin();
 
 const terserInstance = terser({
   compress: {
@@ -81,13 +82,7 @@ const bundleConfig = {
     esModule: false,
   },
   context: 'window',
-  plugins: [
-    ...plugins,
-    license({
-      sourcemap: true,
-      banner: `/*! @sentry/browser <%= pkg.version %> (${commitHash}) | https://github.com/getsentry/sentry-javascript */`,
-    }),
-  ],
+  plugins: [...plugins, licensePlugin],
   treeshake: 'smallest',
 };
 

--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -5,7 +5,7 @@ import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
-import { markAsBrowserBuild, paths } from '../../rollup.config';
+import { baseBundleConfig, markAsBrowserBuild, paths } from '../../rollup.config';
 
 const terserInstance = terser({
   mangle: {
@@ -78,11 +78,9 @@ function loadAllIntegrations() {
           intro: 'var exports = {};',
           outro: mergeIntoSentry(),
           footer: '}(window));',
+          ...baseBundleConfig.output,
           file: `build/${file.replace('.ts', build.extension)}`,
           format: 'cjs',
-          sourcemap: true,
-          strict: false,
-          esModule: false,
         },
         plugins: build.plugins,
         treeshake: 'smallest',

--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -72,6 +72,7 @@ function loadAllIntegrations() {
   ].forEach(build => {
     builds.push(
       ...allIntegrations().map(file => ({
+        ...baseBundleConfig,
         input: `src/${file}`,
         output: {
           banner: '(function (__window) {',
@@ -83,7 +84,6 @@ function loadAllIntegrations() {
           format: 'cjs',
         },
         plugins: build.plugins,
-        treeshake: 'smallest',
       })),
     );
   });

--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -6,6 +6,8 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
 
+import { paths } from '../../rollup.config';
+
 const terserInstance = terser({
   mangle: {
     // captureExceptions and captureMessage are public API methods and they don't need to be listed here
@@ -27,13 +29,7 @@ const plugins = [
       compilerOptions: {
         declaration: false,
         declarationMap: false,
-        paths: {
-          '@sentry/utils': ['../utils/src'],
-          '@sentry/core': ['../core/src'],
-          '@sentry/hub': ['../hub/src'],
-          '@sentry/types': ['../types/src'],
-          '@sentry/minimal': ['../minimal/src'],
-        },
+        paths,
         baseUrl: '.',
       },
     },

--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -1,11 +1,10 @@
 import * as fs from 'fs';
 
 import { terser } from 'rollup-plugin-terser';
-import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
-import { addOnBundleConfig, baseBundleConfig, markAsBrowserBuild, paths } from '../../rollup.config';
+import { addOnBundleConfig, baseBundleConfig, markAsBrowserBuild, typescriptPluginES5 } from '../../rollup.config';
 
 const terserInstance = terser({
   mangle: {
@@ -22,18 +21,7 @@ const terserInstance = terser({
 });
 
 const plugins = [
-  typescript({
-    tsconfig: 'tsconfig.esm.json',
-    tsconfigOverride: {
-      compilerOptions: {
-        declaration: false,
-        declarationMap: false,
-        paths,
-        baseUrl: '.',
-      },
-    },
-    include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
-  }),
+  typescriptPluginES5,
   // replace `__SENTRY_BROWSER_BUNDLE__` with `true` to enable treeshaking of non-browser code
   markAsBrowserBuild,
   resolve({

--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -1,10 +1,15 @@
 import * as fs from 'fs';
 
 import { terser } from 'rollup-plugin-terser';
-import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
-import { addOnBundleConfig, baseBundleConfig, markAsBrowserBuild, typescriptPluginES5 } from '../../rollup.config';
+import {
+  addOnBundleConfig,
+  baseBundleConfig,
+  markAsBrowserBuild,
+  nodeResolvePlugin,
+  typescriptPluginES5,
+} from '../../rollup.config';
 
 const terserInstance = terser({
   mangle: {
@@ -24,9 +29,7 @@ const plugins = [
   typescriptPluginES5,
   // replace `__SENTRY_BROWSER_BUNDLE__` with `true` to enable treeshaking of non-browser code
   markAsBrowserBuild,
-  resolve({
-    mainFields: ['module'],
-  }),
+  nodeResolvePlugin,
   commonjs(),
 ];
 

--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -4,9 +4,8 @@ import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import replace from '@rollup/plugin-replace';
 
-import { paths } from '../../rollup.config';
+import { markAsBrowserBuild, paths } from '../../rollup.config';
 
 const terserInstance = terser({
   mangle: {
@@ -35,16 +34,8 @@ const plugins = [
     },
     include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
   }),
-  replace({
-    // don't replace `__placeholder__` where it's followed immediately by a single `=` (to prevent ending up
-    // with something of the form `let "replacementValue" = "some assigned value"`, which would cause a
-    // syntax error)
-    preventAssignment: true,
-    // the replacements to make
-    values: {
-      __SENTRY_BROWSER_BUNDLE__: true,
-    },
-  }),
+  // replace `__SENTRY_BROWSER_BUNDLE__` with `true` to enable treeshaking of non-browser code
+  markAsBrowserBuild,
   resolve({
     mainFields: ['module'],
   }),

--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -5,7 +5,7 @@ import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
-import { baseBundleConfig, markAsBrowserBuild, paths } from '../../rollup.config';
+import { addOnBundleConfig, baseBundleConfig, markAsBrowserBuild, paths } from '../../rollup.config';
 
 const terserInstance = terser({
   mangle: {
@@ -42,18 +42,6 @@ const plugins = [
   commonjs(),
 ];
 
-function mergeIntoSentry() {
-  return `
-  __window.Sentry = __window.Sentry || {};
-  __window.Sentry.Integrations = __window.Sentry.Integrations || {};
-  for (var key in exports) {
-    if (Object.prototype.hasOwnProperty.call(exports, key)) {
-      __window.Sentry.Integrations[key] = exports[key];
-    }
-  }
-  `;
-}
-
 function allIntegrations() {
   return fs.readdirSync('./src').filter(file => file != 'index.ts');
 }
@@ -75,13 +63,9 @@ function loadAllIntegrations() {
         ...baseBundleConfig,
         input: `src/${file}`,
         output: {
-          banner: '(function (__window) {',
-          intro: 'var exports = {};',
-          outro: mergeIntoSentry(),
-          footer: '}(window));',
           ...baseBundleConfig.output,
+          ...addOnBundleConfig.output,
           file: `build/${file.replace('.ts', build.extension)}`,
-          format: 'cjs',
         },
         plugins: build.plugins,
       })),

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -1,23 +1,17 @@
-import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 
-import { baseBundleConfig, makeLicensePlugin, markAsBrowserBuild, paths, terserPlugin } from '../../rollup.config';
+import {
+  baseBundleConfig,
+  makeLicensePlugin,
+  markAsBrowserBuild,
+  terserPlugin,
+  typescriptPluginES5,
+} from '../../rollup.config';
 
 const licensePlugin = makeLicensePlugin('@sentry/tracing & @sentry/browser');
 
 const plugins = [
-  typescript({
-    tsconfig: 'tsconfig.esm.json',
-    tsconfigOverride: {
-      compilerOptions: {
-        declaration: false,
-        declarationMap: false,
-        paths,
-        baseUrl: '.',
-      },
-    },
-    include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
-  }),
+  typescriptPluginES5,
   // replace `__SENTRY_BROWSER_BUNDLE__` with `true` to enable treeshaking of non-browser code
   markAsBrowserBuild,
   resolve({

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -1,11 +1,10 @@
 import typescript from 'rollup-plugin-typescript2';
-import license from 'rollup-plugin-license';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
-import { terserPlugin } from '../../rollup.config';
+import { makeLicensePlugin, terserPlugin } from '../../rollup.config';
 
-const commitHash = require('child_process').execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+const licensePlugin = makeLicensePlugin('@sentry/tracing & @sentry/browser');
 
 const paths = {
   '@sentry/utils': ['../utils/src'],
@@ -54,13 +53,7 @@ const bundleConfig = {
     esModule: false,
   },
   context: 'window',
-  plugins: [
-    ...plugins,
-    license({
-      sourcemap: true,
-      banner: `/*! @sentry/tracing & @sentry/browser <%= pkg.version %> (${commitHash}) | https://github.com/getsentry/sentry-javascript */`,
-    }),
-  ],
+  plugins: [...plugins, licensePlugin],
   treeshake: 'smallest',
 };
 

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -1,9 +1,8 @@
-import resolve from '@rollup/plugin-node-resolve';
-
 import {
   baseBundleConfig,
   makeLicensePlugin,
   markAsBrowserBuild,
+  nodeResolvePlugin,
   terserPlugin,
   typescriptPluginES5,
 } from '../../rollup.config';
@@ -14,9 +13,7 @@ const plugins = [
   typescriptPluginES5,
   // replace `__SENTRY_BROWSER_BUNDLE__` with `true` to enable treeshaking of non-browser code
   markAsBrowserBuild,
-  resolve({
-    mainFields: ['module'],
-  }),
+  nodeResolvePlugin,
   licensePlugin,
 ];
 

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -1,7 +1,7 @@
 import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 
-import { makeLicensePlugin, markAsBrowserBuild, paths, terserPlugin } from '../../rollup.config';
+import { baseBundleConfig, makeLicensePlugin, markAsBrowserBuild, paths, terserPlugin } from '../../rollup.config';
 
 const licensePlugin = makeLicensePlugin('@sentry/tracing & @sentry/browser');
 
@@ -28,11 +28,9 @@ const plugins = [
 const bundleConfig = {
   input: 'src/index.ts',
   output: {
+    ...baseBundleConfig.output,
     format: 'iife',
     name: 'Sentry',
-    sourcemap: true,
-    strict: false,
-    esModule: false,
   },
   context: 'window',
   plugins: [...plugins, licensePlugin],

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -1,26 +1,11 @@
-import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import license from 'rollup-plugin-license';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
-const commitHash = require('child_process').execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+import { terserPlugin } from '../../rollup.config';
 
-const terserInstance = terser({
-  mangle: {
-    // captureExceptions and captureMessage are public API methods and they don't need to be listed here
-    // as mangler doesn't touch user-facing thing, however sentryWrapped is not, and it would be mangled into a minified version.
-    // We need those full names to correctly detect our internal frames for stripping.
-    // I listed all of them here just for the clarity sake, as they are all used in the frames manipulation process.
-    reserved: ['captureException', 'captureMessage', 'sentryWrapped'],
-    properties: {
-      regex: /^_[^_]/,
-    },
-  },
-  output: {
-    comments: false,
-  },
-});
+const commitHash = require('child_process').execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
 
 const paths = {
   '@sentry/utils': ['../utils/src'],
@@ -98,6 +83,6 @@ export default [
       file: 'build/bundle.tracing.min.js',
     },
     // Uglify has to be at the end of compilation, BUT before the license banner
-    plugins: bundleConfig.plugins.slice(0, -1).concat(terserInstance).concat(bundleConfig.plugins.slice(-1)),
+    plugins: bundleConfig.plugins.slice(0, -1).concat(terserPlugin).concat(bundleConfig.plugins.slice(-1)),
   },
 ];

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -1,8 +1,7 @@
 import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
-import replace from '@rollup/plugin-replace';
 
-import { makeLicensePlugin, paths, terserPlugin } from '../../rollup.config';
+import { makeLicensePlugin, markAsBrowserBuild, paths, terserPlugin } from '../../rollup.config';
 
 const licensePlugin = makeLicensePlugin('@sentry/tracing & @sentry/browser');
 
@@ -19,16 +18,8 @@ const plugins = [
     },
     include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
   }),
-  replace({
-    // don't replace `__placeholder__` where it's followed immediately by a single `=` (to prevent ending up
-    // with something of the form `let "replacementValue" = "some assigned value"`, which would cause a
-    // syntax error)
-    preventAssignment: true,
-    // the replacements to make
-    values: {
-      __SENTRY_BROWSER_BUNDLE__: true,
-    },
-  }),
+  // replace `__SENTRY_BROWSER_BUNDLE__` with `true` to enable treeshaking of non-browser code
+  markAsBrowserBuild,
   resolve({
     mainFields: ['module'],
   }),

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -17,6 +17,7 @@ const plugins = [
   resolve({
     mainFields: ['module'],
   }),
+  licensePlugin,
 ];
 
 const bundleConfig = {
@@ -28,7 +29,7 @@ const bundleConfig = {
     name: 'Sentry',
   },
   context: 'window',
-  plugins: [...plugins, licensePlugin],
+  plugins,
 };
 
 export default [

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -26,6 +26,7 @@ const plugins = [
 ];
 
 const bundleConfig = {
+  ...baseBundleConfig,
   input: 'src/index.ts',
   output: {
     ...baseBundleConfig.output,
@@ -34,7 +35,6 @@ const bundleConfig = {
   },
   context: 'window',
   plugins: [...plugins, licensePlugin],
-  treeshake: 'smallest',
 };
 
 export default [

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -2,18 +2,9 @@ import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
-import { makeLicensePlugin, terserPlugin } from '../../rollup.config';
+import { makeLicensePlugin, paths, terserPlugin } from '../../rollup.config';
 
 const licensePlugin = makeLicensePlugin('@sentry/tracing & @sentry/browser');
-
-const paths = {
-  '@sentry/utils': ['../utils/src'],
-  '@sentry/core': ['../core/src'],
-  '@sentry/hub': ['../hub/src'],
-  '@sentry/types': ['../types/src'],
-  '@sentry/minimal': ['../minimal/src'],
-  '@sentry/browser': ['../browser/src'],
-};
 
 const plugins = [
   typescript({

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -4,9 +4,7 @@ import license from 'rollup-plugin-license';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
-const commitHash = require('child_process')
-  .execSync('git rev-parse --short HEAD', { encoding: 'utf-8' })
-  .trim();
+const commitHash = require('child_process').execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
 
 const terserInstance = terser({
   mangle: {
@@ -100,9 +98,6 @@ export default [
       file: 'build/bundle.tracing.min.js',
     },
     // Uglify has to be at the end of compilation, BUT before the license banner
-    plugins: bundleConfig.plugins
-      .slice(0, -1)
-      .concat(terserInstance)
-      .concat(bundleConfig.plugins.slice(-1)),
+    plugins: bundleConfig.plugins.slice(0, -1).concat(terserInstance).concat(bundleConfig.plugins.slice(-1)),
   },
 ];

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -4,9 +4,7 @@ import license from 'rollup-plugin-license';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
-const commitHash = require('child_process')
-  .execSync('git rev-parse --short HEAD', { encoding: 'utf-8' })
-  .trim();
+const commitHash = require('child_process').execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
 
 const terserInstance = terser({
   mangle: {
@@ -100,9 +98,6 @@ export default [
       file: 'build/bundle.vue.min.js',
     },
     // Uglify has to be at the end of compilation, BUT before the license banner
-    plugins: bundleConfig.plugins
-      .slice(0, -1)
-      .concat(terserInstance)
-      .concat(bundleConfig.plugins.slice(-1)),
+    plugins: bundleConfig.plugins.slice(0, -1).concat(terserInstance).concat(bundleConfig.plugins.slice(-1)),
   },
 ];

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -1,9 +1,8 @@
-import resolve from '@rollup/plugin-node-resolve';
-
 import {
   baseBundleConfig,
   makeLicensePlugin,
   markAsBrowserBuild,
+  nodeResolvePlugin,
   terserPlugin,
   typescriptPluginES5,
 } from '../../rollup.config';
@@ -14,9 +13,7 @@ const plugins = [
   typescriptPluginES5,
   // replace `__SENTRY_BROWSER_BUNDLE__` with `true` to enable treeshaking of non-browser code
   markAsBrowserBuild,
-  resolve({
-    mainFields: ['module'],
-  }),
+  nodeResolvePlugin,
   licensePlugin,
 ];
 

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -1,26 +1,11 @@
-import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import license from 'rollup-plugin-license';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
-const commitHash = require('child_process').execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+import { terserPlugin } from '../../rollup.config';
 
-const terserInstance = terser({
-  mangle: {
-    // captureExceptions and captureMessage are public API methods and they don't need to be listed here
-    // as mangler doesn't touch user-facing thing, however sentryWrapped is not, and it would be mangled into a minified version.
-    // We need those full names to correctly detect our internal frames for stripping.
-    // I listed all of them here just for the clarity sake, as they are all used in the frames manipulation process.
-    reserved: ['captureException', 'captureMessage', 'sentryWrapped'],
-    properties: {
-      regex: /^_[^_]/,
-    },
-  },
-  output: {
-    comments: false,
-  },
-});
+const commitHash = require('child_process').execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
 
 const paths = {
   '@sentry/utils': ['../utils/src'],
@@ -98,6 +83,6 @@ export default [
       file: 'build/bundle.vue.min.js',
     },
     // Uglify has to be at the end of compilation, BUT before the license banner
-    plugins: bundleConfig.plugins.slice(0, -1).concat(terserInstance).concat(bundleConfig.plugins.slice(-1)),
+    plugins: bundleConfig.plugins.slice(0, -1).concat(terserPlugin).concat(bundleConfig.plugins.slice(-1)),
   },
 ];

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -1,7 +1,7 @@
 import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 
-import { makeLicensePlugin, markAsBrowserBuild, paths, terserPlugin } from '../../rollup.config';
+import { baseBundleConfig, makeLicensePlugin, markAsBrowserBuild, paths, terserPlugin } from '../../rollup.config';
 
 const licensePlugin = makeLicensePlugin();
 
@@ -28,11 +28,9 @@ const plugins = [
 const bundleConfig = {
   input: 'src/index.ts',
   output: {
+    ...baseBundleConfig.output,
     format: 'iife',
     name: 'Sentry',
-    sourcemap: true,
-    strict: false,
-    esModule: false,
   },
   context: 'window',
   plugins: [...plugins, licensePlugin],

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -17,6 +17,7 @@ const plugins = [
   resolve({
     mainFields: ['module'],
   }),
+  licensePlugin,
 ];
 
 const bundleConfig = {
@@ -28,7 +29,7 @@ const bundleConfig = {
     name: 'Sentry',
   },
   context: 'window',
-  plugins: [...plugins, licensePlugin],
+  plugins,
 };
 
 export default [

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -2,18 +2,9 @@ import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
-import { makeLicensePlugin, terserPlugin } from '../../rollup.config';
+import { makeLicensePlugin, paths, terserPlugin } from '../../rollup.config';
 
 const licensePlugin = makeLicensePlugin();
-
-const paths = {
-  '@sentry/utils': ['../utils/src'],
-  '@sentry/core': ['../core/src'],
-  '@sentry/hub': ['../hub/src'],
-  '@sentry/types': ['../types/src'],
-  '@sentry/minimal': ['../minimal/src'],
-  '@sentry/browser': ['../browser/src'],
-};
 
 const plugins = [
   typescript({

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -26,6 +26,7 @@ const plugins = [
 ];
 
 const bundleConfig = {
+  ...baseBundleConfig,
   input: 'src/index.ts',
   output: {
     ...baseBundleConfig.output,
@@ -34,7 +35,6 @@ const bundleConfig = {
   },
   context: 'window',
   plugins: [...plugins, licensePlugin],
-  treeshake: 'smallest',
 };
 
 export default [

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -1,8 +1,7 @@
 import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
-import replace from '@rollup/plugin-replace';
 
-import { makeLicensePlugin, paths, terserPlugin } from '../../rollup.config';
+import { makeLicensePlugin, markAsBrowserBuild, paths, terserPlugin } from '../../rollup.config';
 
 const licensePlugin = makeLicensePlugin();
 
@@ -19,16 +18,8 @@ const plugins = [
     },
     include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
   }),
-  replace({
-    // don't replace `__placeholder__` where it's followed immediately by a single `=` (to prevent ending up
-    // with something of the form `let "replacementValue" = "some assigned value"`, which would cause a
-    // syntax error)
-    preventAssignment: true,
-    // the replacements to make
-    values: {
-      __SENTRY_BROWSER_BUNDLE__: true,
-    },
-  }),
+  // replace `__SENTRY_BROWSER_BUNDLE__` with `true` to enable treeshaking of non-browser code
+  markAsBrowserBuild,
   resolve({
     mainFields: ['module'],
   }),

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -1,23 +1,17 @@
-import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 
-import { baseBundleConfig, makeLicensePlugin, markAsBrowserBuild, paths, terserPlugin } from '../../rollup.config';
+import {
+  baseBundleConfig,
+  makeLicensePlugin,
+  markAsBrowserBuild,
+  terserPlugin,
+  typescriptPluginES5,
+} from '../../rollup.config';
 
 const licensePlugin = makeLicensePlugin();
 
 const plugins = [
-  typescript({
-    tsconfig: 'tsconfig.esm.json',
-    tsconfigOverride: {
-      compilerOptions: {
-        declaration: false,
-        declarationMap: false,
-        paths,
-        baseUrl: '.',
-      },
-    },
-    include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
-  }),
+  typescriptPluginES5,
   // replace `__SENTRY_BROWSER_BUNDLE__` with `true` to enable treeshaking of non-browser code
   markAsBrowserBuild,
   resolve({

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -1,11 +1,10 @@
 import typescript from 'rollup-plugin-typescript2';
-import license from 'rollup-plugin-license';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
-import { terserPlugin } from '../../rollup.config';
+import { makeLicensePlugin, terserPlugin } from '../../rollup.config';
 
-const commitHash = require('child_process').execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+const licensePlugin = makeLicensePlugin();
 
 const paths = {
   '@sentry/utils': ['../utils/src'],
@@ -54,13 +53,7 @@ const bundleConfig = {
     esModule: false,
   },
   context: 'window',
-  plugins: [
-    ...plugins,
-    license({
-      sourcemap: true,
-      banner: `/*! @sentry/vue <%= pkg.version %> (${commitHash}) | https://github.com/getsentry/sentry-javascript */`,
-    }),
-  ],
+  plugins: [...plugins, licensePlugin],
   treeshake: 'smallest',
 };
 

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -1,8 +1,7 @@
 import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
-import replace from '@rollup/plugin-replace';
 
-import { paths, terserPlugin } from '../../rollup.config';
+import { paths, markAsBrowserBuild, terserPlugin } from '../../rollup.config';
 
 const plugins = [
   typescript({
@@ -17,16 +16,8 @@ const plugins = [
     },
     include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
   }),
-  replace({
-    // don't replace `__placeholder__` where it's followed immediately by a single `=` (to prevent ending up
-    // with something of the form `let "replacementValue" = "some assigned value"`, which would cause a
-    // syntax error)
-    preventAssignment: true,
-    // the replacements to make
-    values: {
-      __SENTRY_BROWSER_BUNDLE__: true,
-    },
-  }),
+  // replace `__SENTRY_BROWSER_BUNDLE__` with `true` to enable treeshaking of non-browser code
+  markAsBrowserBuild,
   resolve({
     mainFields: ['module'],
   }),

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -1,21 +1,15 @@
-import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 
-import { addOnBundleConfig, baseBundleConfig, paths, markAsBrowserBuild, terserPlugin } from '../../rollup.config';
+import {
+  addOnBundleConfig,
+  baseBundleConfig,
+  markAsBrowserBuild,
+  terserPlugin,
+  typescriptPluginES5,
+} from '../../rollup.config';
 
 const plugins = [
-  typescript({
-    tsconfig: 'tsconfig.esm.json',
-    tsconfigOverride: {
-      compilerOptions: {
-        declaration: false,
-        declarationMap: false,
-        paths,
-        baseUrl: '.',
-      },
-    },
-    include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
-  }),
+  typescriptPluginES5,
   // replace `__SENTRY_BROWSER_BUNDLE__` with `true` to enable treeshaking of non-browser code
   markAsBrowserBuild,
   resolve({

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -1,9 +1,8 @@
-import resolve from '@rollup/plugin-node-resolve';
-
 import {
   addOnBundleConfig,
   baseBundleConfig,
   markAsBrowserBuild,
+  nodeResolvePlugin,
   terserPlugin,
   typescriptPluginES5,
 } from '../../rollup.config';
@@ -12,9 +11,7 @@ const plugins = [
   typescriptPluginES5,
   // replace `__SENTRY_BROWSER_BUNDLE__` with `true` to enable treeshaking of non-browser code
   markAsBrowserBuild,
-  resolve({
-    mainFields: ['module'],
-  }),
+  nodeResolvePlugin,
 ];
 
 function loadAllIntegrations() {

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -2,7 +2,7 @@ import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
-import { terserPlugin } from '../../rollup.config';
+import { paths, terserPlugin } from '../../rollup.config';
 
 const plugins = [
   typescript({
@@ -11,13 +11,7 @@ const plugins = [
       compilerOptions: {
         declaration: false,
         declarationMap: false,
-        paths: {
-          '@sentry/utils': ['../utils/src'],
-          '@sentry/core': ['../core/src'],
-          '@sentry/hub': ['../hub/src'],
-          '@sentry/types': ['../types/src'],
-          '@sentry/minimal': ['../minimal/src'],
-        },
+        paths,
         baseUrl: '.',
       },
     },

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -1,7 +1,7 @@
 import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 
-import { baseBundleConfig, paths, markAsBrowserBuild, terserPlugin } from '../../rollup.config';
+import { addOnBundleConfig, baseBundleConfig, paths, markAsBrowserBuild, terserPlugin } from '../../rollup.config';
 
 const plugins = [
   typescript({
@@ -23,18 +23,6 @@ const plugins = [
   }),
 ];
 
-function mergeIntoSentry() {
-  return `
-  __window.Sentry = __window.Sentry || {};
-  __window.Sentry.Integrations = __window.Sentry.Integrations || {};
-  for (var key in exports) {
-    if (Object.prototype.hasOwnProperty.call(exports, key)) {
-      __window.Sentry.Integrations[key] = exports[key];
-    }
-  }
-  `;
-}
-
 function loadAllIntegrations() {
   const builds = [];
   [
@@ -51,13 +39,9 @@ function loadAllIntegrations() {
       ...baseBundleConfig,
       input: `src/index.ts`,
       output: {
-        banner: '(function (__window) {',
-        intro: 'var exports = {};',
-        outro: mergeIntoSentry(),
-        footer: '}(window));',
         ...baseBundleConfig.output,
+        ...addOnBundleConfig.output,
         file: `build/wasm${build.extension}`,
-        format: 'cjs',
       },
       plugins: build.plugins,
     });

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -1,7 +1,7 @@
 import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 
-import { paths, markAsBrowserBuild, terserPlugin } from '../../rollup.config';
+import { baseBundleConfig, paths, markAsBrowserBuild, terserPlugin } from '../../rollup.config';
 
 const plugins = [
   typescript({
@@ -54,11 +54,9 @@ function loadAllIntegrations() {
         intro: 'var exports = {};',
         outro: mergeIntoSentry(),
         footer: '}(window));',
+        ...baseBundleConfig.output,
         file: `build/wasm${build.extension}`,
         format: 'cjs',
-        sourcemap: true,
-        strict: false,
-        esModule: false,
       },
       plugins: build.plugins,
       treeshake: 'smallest',

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -1,23 +1,8 @@
-import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 
-const terserInstance = terser({
-  mangle: {
-    // captureExceptions and captureMessage are public API methods and they don't need to be listed here
-    // as mangler doesn't touch user-facing thing, however sentryWrapped is not, and it would be mangled into a minified version.
-    // We need those full names to correctly detect our internal frames for stripping.
-    // I listed all of them here just for the clarity sake, as they are all used in the frames manipulation process.
-    reserved: ['captureException', 'captureMessage', 'sentryWrapped'],
-    properties: {
-      regex: /^_[^_]/,
-    },
-  },
-  output: {
-    comments: false,
-  },
-});
+import { terserPlugin } from '../../rollup.config';
 
 const plugins = [
   typescript({
@@ -74,7 +59,7 @@ function loadAllIntegrations() {
     },
     {
       extension: '.min.js',
-      plugins: [...plugins, terserInstance],
+      plugins: [...plugins, terserPlugin],
     },
   ].forEach(build => {
     builds.push({

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -48,6 +48,7 @@ function loadAllIntegrations() {
     },
   ].forEach(build => {
     builds.push({
+      ...baseBundleConfig,
       input: `src/index.ts`,
       output: {
         banner: '(function (__window) {',
@@ -59,7 +60,6 @@ function loadAllIntegrations() {
         format: 'cjs',
       },
       plugins: build.plugins,
-      treeshake: 'smallest',
     });
   });
   return builds;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@
  */
 
 import license from 'rollup-plugin-license';
+import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 
 export const paths = {
@@ -44,5 +45,16 @@ export const terserPlugin = terser({
   },
   output: {
     comments: false,
+  },
+});
+
+export const markAsBrowserBuild = replace({
+  // don't replace `__placeholder__` where it's followed immediately by a single `=` (to prevent ending up
+  // with something of the form `let "replacementValue" = "some assigned value"`, which would cause a
+  // syntax error)
+  preventAssignment: true,
+  // the replacement to make
+  values: {
+    __SENTRY_BROWSER_BUNDLE__: true,
   },
 });

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,14 @@
 import license from 'rollup-plugin-license';
 import { terser } from 'rollup-plugin-terser';
 
+export const paths = {
+  '@sentry/browser': ['../browser/src'],
+  '@sentry/core': ['../core/src'],
+  '@sentry/hub': ['../hub/src'],
+  '@sentry/minimal': ['../minimal/src'],
+  '@sentry/types': ['../types/src'],
+  '@sentry/utils': ['../utils/src'],
+};
 
 /**
  * Create a plugin to add an identification banner to the top of stand-alone bundles.

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,21 @@
+/**
+ * Shared config used by individual packages' Rollup configs
+ */
+
+import { terser } from 'rollup-plugin-terser';
+
+export const terserPlugin = terser({
+  mangle: {
+    // captureExceptions and captureMessage are public API methods and they don't need to be listed here
+    // as mangler doesn't touch user-facing thing, however sentryWrapped is not, and it would be mangled into a minified version.
+    // We need those full names to correctly detect our internal frames for stripping.
+    // I listed all of them here just for the clarity sake, as they are all used in the frames manipulation process.
+    reserved: ['captureException', 'captureMessage', 'sentryWrapped'],
+    properties: {
+      regex: /^_[^_]/,
+    },
+  },
+  output: {
+    comments: false,
+  },
+});

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -58,3 +58,11 @@ export const markAsBrowserBuild = replace({
     __SENTRY_BROWSER_BUNDLE__: true,
   },
 });
+
+export const baseBundleConfig = {
+  output: {
+    sourcemap: true,
+    strict: false,
+    esModule: false,
+  },
+};

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,26 @@
  * Shared config used by individual packages' Rollup configs
  */
 
+import license from 'rollup-plugin-license';
 import { terser } from 'rollup-plugin-terser';
+
+
+/**
+ * Create a plugin to add an identification banner to the top of stand-alone bundles.
+ *
+ * @param title The title to use for the SDK, if not the package name
+ * @returns An instance of the `rollup-plugin-license` plugin
+ */
+export function makeLicensePlugin(title) {
+  const commitHash = require('child_process').execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
+
+  return license({
+    banner: {
+      content: `/*! <%= data.title || pkg.name %> <%= pkg.version %> (${commitHash}) | https://github.com/getsentry/sentry-javascript */`,
+      data: { title },
+    },
+  });
+}
 
 export const terserPlugin = terser({
   mangle: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@
 import license from 'rollup-plugin-license';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
+import typescript from 'rollup-plugin-typescript2';
 
 export const paths = {
   '@sentry/browser': ['../browser/src'],
@@ -57,6 +58,19 @@ export const markAsBrowserBuild = replace({
   values: {
     __SENTRY_BROWSER_BUNDLE__: true,
   },
+});
+
+export const typescriptPluginES5 = typescript({
+  tsconfig: 'tsconfig.esm.json',
+  tsconfigOverride: {
+    compilerOptions: {
+      declaration: false,
+      declarationMap: false,
+      paths,
+      baseUrl: '.',
+    },
+  },
+  include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
 });
 
 export const baseBundleConfig = {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -67,3 +67,34 @@ export const baseBundleConfig = {
   },
   treeshake: 'smallest',
 };
+
+export const addOnBundleConfig = {
+  // These output settings are designed to mimic an IIFE. We don't use Rollup's `iife` format because we don't want to
+  // attach this code to a new global variable, but rather inject it into the existing SDK's `Integrations` object.
+  output: {
+    format: 'cjs',
+
+    // code to add before the CJS wrapper
+    banner: '(function (__window) {',
+
+    // code to add just inside the CJS wrapper, before any of the wrapped code
+    intro: 'var exports = {};',
+
+    // code to add after all of the wrapped code, but still inside the CJS wrapper
+    outro: () =>
+      [
+        '',
+        "  // Add this module's exports to the global `Sentry.Integrations`",
+        '  __window.Sentry = __window.Sentry || {};',
+        '  __window.Sentry.Integrations = __window.Sentry.Integrations || {};',
+        '  for (var key in exports) {',
+        '    if (Object.prototype.hasOwnProperty.call(exports, key)) {',
+        '      __window.Sentry.Integrations[key] = exports[key];',
+        '    }',
+        '  }',
+      ].join('\n'),
+
+    // code to add after the CJS wrapper
+    footer: '}(window));',
+  },
+};

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -65,4 +65,5 @@ export const baseBundleConfig = {
     strict: false,
     esModule: false,
   },
+  treeshake: 'smallest',
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@
  */
 
 import license from 'rollup-plugin-license';
+import resolve from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
@@ -71,6 +72,10 @@ export const typescriptPluginES5 = typescript({
     },
   },
   include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
+});
+
+export const nodeResolvePlugin = resolve({
+  mainFields: ['module'],
 });
 
 export const baseBundleConfig = {


### PR DESCRIPTION
There is a great deal of overlap between the rollup config files we use to generate our CDN bundles. As part of moving to the new bundling process, this pulls the most obvious pieces of shared config into a central file. (In this case, “most obvious” means that they are strictly identical across files, with no tweaks needed. A follow-up PR will handle the places where there are slight differences between one rollup config and another.)

As one would hope when moving things without changing them, there is no effect on the content of the bundles produced.

Ref: https://getsentry.atlassian.net/browse/WEB-627