### PR TITLE
[WIP] chore(dev): Upgrade to node 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "lerna run --ignore @sentry-internal/browser-integration-tests --stream --concurrency 1 --sort test"
   },
   "volta": {
-    "node": "14.17.0",
+    "node": "16.14.0",
     "yarn": "1.22.5"
   },
   "workspaces": [
@@ -59,7 +59,7 @@
     "@types/chai": "^4.1.3",
     "@types/jest": "^24.0.11",
     "@types/mocha": "^5.2.0",
-    "@types/node": "~10.17.0",
+    "@types/node": "^16.11.26",
     "@types/sinon": "^7.0.11",
     "chai": "^4.1.2",
     "codecov": "^3.6.5",

--- a/packages/integrations/src/captureconsole.ts
+++ b/packages/integrations/src/captureconsole.ts
@@ -1,7 +1,7 @@
 import { EventProcessor, Hub, Integration } from '@sentry/types';
 import { fill, getGlobalObject, safeJoin, severityFromString } from '@sentry/utils';
 
-const global = getGlobalObject<Window | NodeJS.Global>();
+const global = getGlobalObject<Window | typeof globalThis>();
 
 /** Send Console API calls as Sentry Events */
 export class CaptureConsole implements Integration {

--- a/packages/tracing/src/integrations/node/express.ts
+++ b/packages/tracing/src/integrations/node/express.ts
@@ -106,7 +106,7 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
 
   switch (arity) {
     case 2: {
-      return function (this: NodeJS.Global, req: unknown, res: ExpressResponse & SentryTracingResponse): void {
+      return function (this: typeof globalThis, req: unknown, res: ExpressResponse & SentryTracingResponse): void {
         const transaction = res.__sentry_transaction;
         if (transaction) {
           const span = transaction.startChild({
@@ -122,7 +122,7 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
     }
     case 3: {
       return function (
-        this: NodeJS.Global,
+        this: typeof globalThis,
         req: unknown,
         res: ExpressResponse & SentryTracingResponse,
         next: () => void,
@@ -132,7 +132,7 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
           description: fn.name,
           op: `express.middleware.${method}`,
         });
-        fn.call(this, req, res, function (this: NodeJS.Global, ...args: unknown[]): void {
+        fn.call(this, req, res, function (this: typeof globalThis, ...args: unknown[]): void {
           span?.finish();
           next.call(this, ...args);
         });
@@ -140,7 +140,7 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
     }
     case 4: {
       return function (
-        this: NodeJS.Global,
+        this: typeof globalThis,
         err: Error,
         req: Request,
         res: Response & SentryTracingResponse,
@@ -151,7 +151,7 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
           description: fn.name,
           op: `express.middleware.${method}`,
         });
-        fn.call(this, err, req, res, function (this: NodeJS.Global, ...args: unknown[]): void {
+        fn.call(this, err, req, res, function (this: typeof globalThis, ...args: unknown[]): void {
           span?.finish();
           next.call(this, ...args);
         });

--- a/packages/tracing/test/testutils.ts
+++ b/packages/tracing/test/testutils.ts
@@ -14,7 +14,7 @@ export function addDOMPropertiesToGlobal(properties: string[]): void {
   // we have to add things into the real global object (rather than mocking the return value of getGlobalObject)
   // because there are modules which call getGlobalObject as they load, which is too early for jest to intervene
   const { window } = new JSDOM('', { url: 'http://dogs.are.great/' });
-  const global = getGlobalObject<NodeJS.Global & Window>();
+  const global = getGlobalObject<typeof globalThis & Window>();
 
   properties.forEach(prop => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -4,7 +4,7 @@ import { WrappedFunction } from '@sentry/types';
 import { getGlobalObject } from './global';
 
 // TODO: Implement different loggers for different environments
-const global = getGlobalObject<Window | NodeJS.Global>();
+const global = getGlobalObject<Window | typeof globalThis>();
 
 /** Prefix for logging strings */
 const PREFIX = 'Sentry Logger ';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3802,6 +3802,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.48.tgz#46a3df718aed5217277f2395a682e055a487e341"
   integrity sha512-z8wvSsgWQzkr4sVuMEEOvwMdOQjiRY2Y/ZW4fDfjfe3+TfQrZqFKOthBgk2RnVEmtOKrkwdZ7uTvsxTBLjKGDQ==
 
+"@types/node@^16.11.26":
+  version "16.11.26"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.26.tgz#63d204d136c9916fb4dcd1b50f9740fe86884e47"
+  integrity sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==
+
 "@types/node@~10.17.0":
   version "10.17.56"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.56.tgz#010c9e047c3ff09ddcd11cbb6cf5912725cdc2b3"


### PR DESCRIPTION
This is a WIP because there is still a mismatch in types in the nextjs SDK's `withSentry` function. (The fact that we're changing `res.end` from a sync function to an async function is finally coming back to bite us.)

Ref: https://getsentry.atlassian.net/browse/WEB-631