### PR TITLE
chore(build): Remove default `@rollup/plugin-node-resolve` option

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -74,9 +74,7 @@ export const typescriptPluginES5 = typescript({
   include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
 });
 
-export const nodeResolvePlugin = resolve({
-  mainFields: ['module'],
-});
+export const nodeResolvePlugin = resolve();
 
 export const baseBundleConfig = {
   output: {


### PR DESCRIPTION
According to the `@rollup/plugin-node-resolve` [docs](https://github.com/rollup/plugins/tree/master/packages/node-resolve#mainfields), the `mainFields` option tells the plugin what field in `package.json` to use as an entry point. The default value is `['module', 'main']`, and the plugin will use the first element of the array for which it finds a match in `package.json`.

All of our `package.json` files have a `module` entry, which is reflected in the fact that we've had `mainFields` set to `['module']`. But that of course leads to the same outcome as the just using the default would - there's a match on `'module'`, and so that's what's used. This PR therefore removes the option in favor of using the default. As would be expected, there is no change in the bundle content.