### PR TITLE
feat(nextjs): Upgrade Sentry Webpack Plugin to 1.18.8

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -24,7 +24,7 @@
     "@sentry/react": "6.18.0",
     "@sentry/tracing": "6.18.0",
     "@sentry/utils": "6.18.0",
-    "@sentry/webpack-plugin": "1.18.5",
+    "@sentry/webpack-plugin": "1.18.8",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3138,18 +3138,6 @@
     estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
-"@sentry/cli@^1.72.0":
-  version "1.72.1"
-  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.72.1.tgz#3e83e6ffad0a95bf5a6568dc9a4432c8b71c4ca5"
-  integrity sha512-SCh32bMYnkCZd4Old/GjArnjtyt3PuQXC6fOmBqKWPpvi56H3rYYjrT0FVxRRu8ovU2Qws1AhPdUbLPOEEj8lQ==
-  dependencies:
-    https-proxy-agent "^5.0.0"
-    mkdirp "^0.5.5"
-    node-fetch "^2.6.7"
-    npmlog "^4.1.2"
-    progress "^2.0.3"
-    proxy-from-env "^1.1.0"
-
 "@sentry/cli@^1.73.0":
   version "1.73.0"
   resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.73.0.tgz#0d0bce913e0060ae192741c6693c57e50078c886"
@@ -3161,13 +3149,6 @@
     npmlog "^4.1.2"
     progress "^2.0.3"
     proxy-from-env "^1.1.0"
-
-"@sentry/webpack-plugin@1.18.5":
-  version "1.18.5"
-  resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-1.18.5.tgz#aaff79d8e05b8d803654490324252406c976b1cd"
-  integrity sha512-HycNZEcVRj/LxaG6hLsxjHo47mpxop3j7u2aUkriE2pT7XNpeypsa0WiokYzStxzCfSu8rbAbX4PchTGLMlTjw==
-  dependencies:
-    "@sentry/cli" "^1.72.0"
 
 "@sentry/webpack-plugin@1.18.8":
   version "1.18.8"


### PR DESCRIPTION
https://github.com/getsentry/sentry-webpack-plugin/releases/tag/v1.18.8