### PR TITLE
ref(node): Remove dependency on `@sentry/tracing`

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@sentry/core": "6.18.1",
     "@sentry/hub": "6.18.1",
-    "@sentry/tracing": "6.18.1",
     "@sentry/types": "6.18.1",
     "@sentry/utils": "6.18.1",
     "cookie": "^0.4.1",

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -1,9 +1,15 @@
 /* eslint-disable max-lines */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { captureException, getCurrentHub, startTransaction, withScope } from '@sentry/core';
-import { extractTraceparentData, Span } from '@sentry/tracing';
-import { Event, ExtractedNodeRequestData, Transaction } from '@sentry/types';
-import { isPlainObject, isString, logger, normalize, stripUrlQueryAndFragment } from '@sentry/utils';
+import { Event, ExtractedNodeRequestData, Span, Transaction } from '@sentry/types';
+import {
+  extractTraceparentData,
+  isPlainObject,
+  isString,
+  logger,
+  normalize,
+  stripUrlQueryAndFragment,
+} from '@sentry/utils';
 import * as cookie from 'cookie';
 import * as domain from 'domain';
 import * as http from 'http';

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -7,7 +7,7 @@ import { Options, Transaction } from '@sentry/types';
  * move to remove `@sentry/tracing` dependencies from `@sentry/node` (`extractTraceparentData`
  * is the only tracing function used by `@sentry/node`).
  *
- * These exports are kept here for backwards compatability's sack.
+ * These exports are kept here for backwards compatability's sake.
  *
  * TODO(v7): Reorganize these exports
  *

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -1,13 +1,19 @@
 import { getCurrentHub, Hub } from '@sentry/hub';
-import { Options, TraceparentData, Transaction } from '@sentry/types';
+import { Options, Transaction } from '@sentry/types';
 
-export const TRACEPARENT_REGEXP = new RegExp(
-  '^[ \\t]*' + // whitespace
-    '([0-9a-f]{32})?' + // trace_id
-    '-?([0-9a-f]{16})?' + // span_id
-    '-?([01])?' + // sampled
-    '[ \\t]*$', // whitespace
-);
+/**
+ * The `extractTraceparentData` function and `TRACEPARENT_REGEXP` constant used
+ * to be declared in this file. It was later moved into `@sentry/utils` as part of a
+ * move to remove `@sentry/tracing` dependencies from `@sentry/node` (`extractTraceparentData`
+ * is the only tracing function used by `@sentry/node`).
+ *
+ * These exports are kept here for backwards compatability's sack.
+ *
+ * TODO(v7): Reorganize these exports
+ *
+ * See https://github.com/getsentry/sentry-javascript/issues/4642 for more details.
+ */
+export { TRACEPARENT_REGEXP, extractTraceparentData } from '@sentry/utils';
 
 /**
  * Determines if tracing is currently enabled.
@@ -18,31 +24,6 @@ export function hasTracingEnabled(maybeOptions?: Options | undefined): boolean {
   const client = getCurrentHub().getClient();
   const options = maybeOptions || (client && client.getOptions());
   return !!options && ('tracesSampleRate' in options || 'tracesSampler' in options);
-}
-
-/**
- * Extract transaction context data from a `sentry-trace` header.
- *
- * @param traceparent Traceparent string
- *
- * @returns Object containing data from the header, or undefined if traceparent string is malformed
- */
-export function extractTraceparentData(traceparent: string): TraceparentData | undefined {
-  const matches = traceparent.match(TRACEPARENT_REGEXP);
-  if (matches) {
-    let parentSampled: boolean | undefined;
-    if (matches[3] === '1') {
-      parentSampled = true;
-    } else if (matches[3] === '0') {
-      parentSampled = false;
-    }
-    return {
-      traceId: matches[1],
-      parentSampled,
-      parentSpanId: matches[2],
-    };
-  }
-  return undefined;
 }
 
 /** Grabs active transaction off scope, if any */

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -20,6 +20,7 @@ export * from './string';
 export * from './supports';
 export * from './syncpromise';
 export * from './time';
+export * from './tracing';
 export * from './env';
 export * from './envelope';
 export * from './clientreport';

--- a/packages/utils/src/tracing.ts
+++ b/packages/utils/src/tracing.ts
@@ -1,0 +1,34 @@
+import { TraceparentData } from '@sentry/types';
+
+export const TRACEPARENT_REGEXP = new RegExp(
+  '^[ \\t]*' + // whitespace
+    '([0-9a-f]{32})?' + // trace_id
+    '-?([0-9a-f]{16})?' + // span_id
+    '-?([01])?' + // sampled
+    '[ \\t]*$', // whitespace
+);
+
+/**
+ * Extract transaction context data from a `sentry-trace` header.
+ *
+ * @param traceparent Traceparent string
+ *
+ * @returns Object containing data from the header, or undefined if traceparent string is malformed
+ */
+export function extractTraceparentData(traceparent: string): TraceparentData | undefined {
+  const matches = traceparent.match(TRACEPARENT_REGEXP);
+  if (matches) {
+    let parentSampled: boolean | undefined;
+    if (matches[3] === '1') {
+      parentSampled = true;
+    } else if (matches[3] === '0') {
+      parentSampled = false;
+    }
+    return {
+      traceId: matches[1],
+      parentSampled,
+      parentSpanId: matches[2],
+    };
+  }
+  return undefined;
+}


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/4642

We would like to remove `@sentry/tracing` as a dependency to `@sentry/node` since it has a massive impact on startup time.

We do this by eliminating the `import { extractTraceparentData, Span } from '@sentry/tracing';` in `packages/node/src/handlers.ts`

We move `extractTraceparentData` into `@sentry/utils` and use `Span` from `@sentry/types` instead of `@sentry/tracing`.

Resolves https://getsentry.atlassian.net/browse/WEB-637