### PR TITLE
build: Upload coverage for @sentry/browser

### DIFF
--- a/packages/browser/test/unit/jest.config.js
+++ b/packages/browser/test/unit/jest.config.js
@@ -2,6 +2,8 @@ module.exports = {
   transform: {
     '^.+\\.ts$': 'ts-jest',
   },
+  collectCoverage: true,
+  coverageDirectory: '../../coverage',
   moduleFileExtensions: ['js', 'ts'],
   testEnvironment: 'jsdom',
   testMatch: ['**/*.test.ts'],


### PR DESCRIPTION
`@sentry/browser` is the only package we don't upload coverage for yet. This patch enables that.

Resolves https://getsentry.atlassian.net/browse/WEB-403