### PR TITLE
ref(build): Use standard regex for minifying integration bundles

### DIFF
--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -18,7 +18,9 @@ const terserInstance = terser({
     // We need those full names to correctly detect our internal frames for stripping.
     // I listed all of them here just for the clarity sake, as they are all used in the frames manipulation process.
     reserved: ['captureException', 'captureMessage', 'sentryWrapped'],
-    properties: false,
+    properties: {
+      regex: /^_[^_]/,
+    },
   },
   output: {
     comments: false,


### PR DESCRIPTION
This is very similar to https://github.com/getsentry/sentry-javascript/pull/4592, which brought `@sentry/wasm` in line with other bundles in terms of which object properties it was willing to mangle (changing it from "nope, nuthin'" to "anything private, a.k.a., anything starting with exactly one underscore").

That PR was effectively a no-op,  in that we made a change to a class of property which it turns out doesn't exist anywhere in the wasm package. In the case of this PR, though, that's not true: private properties do exist, and where they've been heretofore left alone by terser, they will now be mangled. This is a small bundle size win, but it is also _technically_ a breaking change, at least for anyone using those properties directly.

That said, there's a _reason_ we use a leading underscore to mark them as internal and tag them as private in TS - people aren't supposed to be using them. Further, out of the (hopefully very small if not non-existent) group of people mucking with our internals, this will only affect the subset who are both using the CDN and using one of these optional integrations, which the majority of our users do not. I therefore think it's a very small risk with not one but _two_ small rewards, the bundle size reduction and further standardization of our rollup config.