### PR TITLE
ref(build): Handle JS version in rollup config generation function

### DIFF
--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -15,6 +15,7 @@ function loadAllIntegrations() {
     const baseBundleConfig = makeBaseBundleConfig({
       input: `src/${file}`,
       isAddOn: true,
+      jsVersion: 'es5',
       outputFileBase: `build/${file.replace('.ts', '')}`,
     });
 

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -5,6 +5,7 @@ const licensePlugin = makeLicensePlugin('@sentry/tracing & @sentry/browser');
 const baseBundleConfig = makeBaseBundleConfig({
   input: 'src/index.bundle.ts',
   isAddOn: false,
+  jsVersion: 'es5',
   outputFileBase: 'build/bundle.tracing',
 });
 

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -5,6 +5,7 @@ const licensePlugin = makeLicensePlugin();
 const baseBundleConfig = makeBaseBundleConfig({
   input: 'src/index.bundle.ts',
   isAddOn: false,
+  jsVersion: 'es5',
   outputFileBase: 'build/bundle.vue',
 });
 

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -3,6 +3,7 @@ import { makeBaseBundleConfig, terserPlugin } from '../../rollup.config';
 const baseBundleConfig = makeBaseBundleConfig({
   input: 'src/index.ts',
   isAddOn: true,
+  jsVersion: 'es5',
   outputFileBase: 'build/wasm',
 });
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -68,7 +68,7 @@ export const markAsBrowserBuild = replace({
   },
 });
 
-export const typescriptPluginES5 = typescript({
+const baseTSPluginOptions = {
   tsconfig: 'tsconfig.esm.json',
   tsconfigOverride: {
     compilerOptions: {
@@ -79,7 +79,27 @@ export const typescriptPluginES5 = typescript({
     },
   },
   include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
-});
+};
+
+export const typescriptPluginES5 = typescript(
+  deepMerge(baseTSPluginOptions, {
+    tsconfigOverride: {
+      compilerOptions: {
+        target: 'es5',
+      },
+    },
+  }),
+);
+
+export const typescriptPluginES6 = typescript(
+  deepMerge(baseTSPluginOptions, {
+    tsconfigOverride: {
+      compilerOptions: {
+        target: 'es6',
+      },
+    },
+  }),
+);
 
 export const nodeResolvePlugin = resolve();
 
@@ -124,7 +144,7 @@ export const addOnBundleConfig = {
 };
 
 export function makeBaseBundleConfig(options) {
-  const { input, isAddOn, outputFileBase } = options;
+  const { input, isAddOn, jsVersion, outputFileBase } = options;
 
   const standAloneBundleConfig = {
     output: {
@@ -174,7 +194,7 @@ export function makeBaseBundleConfig(options) {
       strict: false,
       esModule: false,
     },
-    plugins: [typescriptPluginES5, markAsBrowserBuild, nodeResolvePlugin],
+    plugins: [jsVersion === 'es5' ? typescriptPluginES5 : typescriptPluginES6, markAsBrowserBuild, nodeResolvePlugin],
     treeshake: 'smallest',
   };
 


### PR DESCRIPTION
This builds on https://github.com/getsentry/sentry-javascript/pull/4650, which introduced a function to generate rollup configs for our CDN bundles, allowing that function to handle both ES5 and ES6 compilation. No change to bundle contents.

Note: This doesn't make any difference for the four packages the change is applied to in this PR, but will enable `@sentry/browser` to use the new config generation function, a change which will come in a future PR.

Ref: https://getsentry.atlassian.net/browse/WEB-644