### PR TITLE
ref(core): Use helpers with session envelopes

### DIFF
--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -1,5 +1,7 @@
 import {
   Event,
+  EventEnvelope,
+  EventItem,
   SdkInfo,
   SentryRequest,
   SentryRequestType,

--- a/packages/core/src/request.ts
+++ b/packages/core/src/request.ts
@@ -49,7 +49,7 @@ export function sessionToSentryRequest(session: Session | SessionAggregates, api
   // I know this is hacky but we don't want to add `sessions` to request type since it's never rate limited
   const type = 'aggregates' in session ? ('sessions' as SentryRequestType) : 'session';
 
-  // Have to cast type because envelope items do not accept a `SentryRequestType`
+  // TODO (v7) Have to cast type because envelope items do not accept a `SentryRequestType`
   const envelopeItem = [{ type } as { type: 'session' | 'sessions' }, session] as SessionItem;
   const envelope = createEnvelope<SessionEnvelope>(envelopeHeaders, [envelopeItem]);
   return {


### PR DESCRIPTION
This patch converts the sessions logic in `packages/core/src/request.ts`
to use the recently introduced envelope helpers.

ref: https://github.com/getsentry/sentry-javascript/pull/4587

Resolves https://getsentry.atlassian.net/browse/WEB-626
