### PR TITLE
fix(tracing): Make `method` required in `transactionSampling` type

### DIFF
--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -120,7 +120,7 @@ export type Measurements = Record<string, { value: number }>;
 export type TransactionSamplingMethod = 'explicitly_set' | 'client_sampler' | 'client_rate' | 'inheritance';
 
 export interface TransactionMetadata {
-  transactionSampling?: { rate?: number; method?: TransactionSamplingMethod };
+  transactionSampling?: { rate?: number; method: TransactionSamplingMethod };
 
   /** The two halves (sentry and third-party) of a transaction's tracestate header, used for dynamic sampling */
   tracestate?: {


### PR DESCRIPTION
Though every transaction should have `transactionSampling` metadata, we mark the property as optional because we add it after the transaction is created, in the process of computing a sampling decision for it. Once `transactionSampling` exists, however, it should always have a `method` property.