### PR TITLE
ref(utils): Improve logging of objects in `logger` methods

### DIFF
--- a/packages/core/src/basebackend.ts
+++ b/packages/core/src/basebackend.ts
@@ -93,7 +93,7 @@ export abstract class BaseBackend<O extends Options> implements Backend {
   public sendEvent(event: Event): void {
     void this._transport.sendEvent(event).then(null, reason => {
       if (isDebugBuild()) {
-        logger.error(`Error while sending event: ${reason}`);
+        logger.error(`Error while sending event:`, reason);
       }
     });
   }
@@ -111,7 +111,7 @@ export abstract class BaseBackend<O extends Options> implements Backend {
 
     void this._transport.sendSession(session).then(null, reason => {
       if (isDebugBuild()) {
-        logger.error(`Error while sending session: ${reason}`);
+        logger.error(`Error while sending session:`, reason);
       }
     });
   }

--- a/packages/hub/src/sessionflusher.ts
+++ b/packages/hub/src/sessionflusher.ts
@@ -39,7 +39,7 @@ export class SessionFlusher implements SessionFlusherLike {
       return;
     }
     void this._transport.sendSession(sessionAggregates).then(null, reason => {
-      logger.error(`Error while sending session: ${reason}`);
+      logger.error(`Error while sending session:`, reason);
     });
   }
 

--- a/packages/nextjs/src/utils/withSentry.ts
+++ b/packages/nextjs/src/utils/withSentry.ts
@@ -188,6 +188,6 @@ async function finishSentryProcessing(res: AugmentedNextApiResponse): Promise<vo
     await flush(2000);
     logger.log('Done flushing events');
   } catch (e) {
-    logger.log(`Error while flushing events:\n${e}`);
+    logger.log(`Error while flushing events:\n`, e);
   }
 }

--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -96,9 +96,8 @@ function triggerHandlers(type: InstrumentHandlerType, data: any): void {
     } catch (e) {
       if (isDebugBuild()) {
         logger.error(
-          `Error while triggering instrumentation handler.\nType: ${type}\nName: ${getFunctionName(
-            handler,
-          )}\nError: ${e}`,
+          `Error while triggering instrumentation handler.\nType: ${type}\nName: ${getFunctionName(handler)}\nError:`,
+          e,
         );
       }
     }

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -79,7 +79,7 @@ class Logger {
       return;
     }
     consoleSandbox(() => {
-      global.console.log(`${PREFIX}[Log]: ${args.join(' ')}`);
+      global.console.log(`${PREFIX}[Log]:`, ...args);
     });
   }
 
@@ -89,7 +89,7 @@ class Logger {
       return;
     }
     consoleSandbox(() => {
-      global.console.warn(`${PREFIX}[Warn]: ${args.join(' ')}`);
+      global.console.warn(`${PREFIX}[Warn]:`, ...args);
     });
   }
 
@@ -99,7 +99,7 @@ class Logger {
       return;
     }
     consoleSandbox(() => {
-      global.console.error(`${PREFIX}[Error]: ${args.join(' ')}`);
+      global.console.error(`${PREFIX}[Error]:`, ...args);
     });
   }
 }


### PR DESCRIPTION
When a variable is used in a template string, its `.toString()` method is called, and most non-native objects, when stringified with `.toString()`, come out as `"[object Object]"`. In our `logger`, we use a template string to concatenate all of the arguments we're given. As a result, users can get error messages like:

```
Sentry Logger [Error]: Error while sending event: [object Object]
```

in cases where the error is not an actual `Error`, which is obviously not very helpful.

The underlying `console` methods upon which our `logger` methods rely can generally do better, though, and will attempt to print the actual contents of any object they're given. You can see the difference here:

![image](https://user-images.githubusercontent.com/14812505/156275473-f0bc7fc6-c2fa-4083-8cfb-2ecf888a0eab.png)

This PR changes the `logger` methods so that they pass their arguments on to the `console` methods intact, rather than as a pre-concatenated string, in order to be able to take advantage of the improved logging of objects. It also changes all instances of "error while" logs like the one above to pass their error objects separately rather than as part of a template string, in order to take advantage of this change.

Note: There are almost certainly other places in the repo where we log objects which could benefit from this change. In the interests of time, however, this PR is restricted to the ones which brought this issue to light, and others can be solved in future PRs as necessary.