### PR TITLE
fix(tracing): Only log defined `op` in transaction-related logs

### DIFF
--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -195,8 +195,10 @@ export class BrowserTracing implements Integration {
 
   /** Create routing idle transaction. */
   private _createRouteTransaction(context: TransactionContext): Transaction | undefined {
+    const op = context.op ? `${context.op} ` : '';
+
     if (!this._getCurrentHub) {
-      logger.warn(`[Tracing] Did not create ${context.op} transaction because _getCurrentHub is invalid.`);
+      logger.warn(`[Tracing] Did not create ${op}transaction because _getCurrentHub is invalid.`);
       return undefined;
     }
 
@@ -217,10 +219,10 @@ export class BrowserTracing implements Integration {
     const finalContext = modifiedContext === undefined ? { ...expandedContext, sampled: false } : modifiedContext;
 
     if (finalContext.sampled === false) {
-      logger.log(`[Tracing] Will not send ${finalContext.op} transaction because of beforeNavigate.`);
+      logger.log(`[Tracing] Will not send ${op}transaction because of beforeNavigate.`);
     }
 
-    logger.log(`[Tracing] Starting ${finalContext.op} transaction on scope`);
+    logger.log(`[Tracing] Starting ${op}transaction on scope`);
 
     const hub = this._getCurrentHub();
     const { location } = getGlobalObject() as WindowOrWorkerGlobalScope & { location: Location };

--- a/packages/tracing/src/hubextensions.ts
+++ b/packages/tracing/src/hubextensions.ts
@@ -118,7 +118,8 @@ function sample<T extends Transaction>(transaction: T, options: Options, samplin
     return transaction;
   }
 
-  logger.log(`[Tracing] starting ${transaction.op} transaction - ${transaction.name}`);
+  const op = transaction.op ? `${transaction.op} ` : '';
+  logger.log(`[Tracing] Starting ${op}transaction: ${transaction.name}`);
   return transaction;
 }
 

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -142,7 +142,8 @@ export class Transaction extends SpanClass implements TransactionInterface {
       transaction.measurements = this._measurements;
     }
 
-    logger.log(`[Tracing] Finishing ${this.op} transaction: ${this.name}.`);
+    const op = this.op ? `${this.op} ` : '';
+    logger.log(`[Tracing] Finishing ${op}transaction: ${this.name}.`);
 
     return this._hub.captureEvent(transaction);
   }


### PR DESCRIPTION
Currently, in cases where a transaction doesn't have its `op` value set, we log things like, `Sentry Logger [Log]: [Tracing] Starting undefined transaction: <transaction name>` and `Sentry Logger [Log]: [Tracing] Finishing undefined transaction: <transaction name>`, which can be confusing to users. This PR prevents the `op` value from being included in the message if it's undefined.

Note: To answer the "why now?" question, this came up today in the process of trying to help another engineer debug a customer's missing events, and seemed like a quick win.
