### PR TITLE
ref(utils): Simplify value normalization

### DIFF
--- a/packages/utils/src/memo.ts
+++ b/packages/utils/src/memo.ts
@@ -1,7 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export type MemoFunc = [(obj: any) => boolean, (obj: any) => void];
+export type MemoFunc = [
+  // memoize
+  (obj: any) => boolean,
+  // unmemoize
+  (obj: any) => void,
+];
 
 /**
  * Helper to decycle json objects

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -310,6 +310,8 @@ function makeSerializable<T>(value: T, key?: any): T | string {
  */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function walk(key: string, value: any, depth: number = +Infinity, memo: MemoFunc = memoBuilder()): any {
+  const [memoize, unmemoize] = memo;
+
   // If we reach the maximum depth, serialize whatever is left
   if (depth === 0) {
     return serializeValue(value);
@@ -338,7 +340,7 @@ export function walk(key: string, value: any, depth: number = +Infinity, memo: M
   const acc: { [key: string]: any } = Array.isArray(value) ? [] : {};
 
   // If we already walked that branch, bail out, as it's circular reference
-  if (memo[0](value)) {
+  if (memoize(value)) {
     return '[Circular ~]';
   }
 
@@ -354,7 +356,7 @@ export function walk(key: string, value: any, depth: number = +Infinity, memo: M
   }
 
   // Once walked through all the branches, remove the parent from memo storage
-  memo[1](value);
+  unmemoize(value);
 
   // Return accumulated values
   return acc;

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -335,7 +335,7 @@ export function walk(key: string, value: any, depth: number = +Infinity, memo: M
   const source = getWalkSource(value);
 
   // Create an accumulator that will act as a parent for all future itterations of that branch
-  const acc = Array.isArray(value) ? [] : {};
+  const acc: { [key: string]: any } = Array.isArray(value) ? [] : {};
 
   // If we already walked that branch, bail out, as it's circular reference
   if (memo[0](value)) {
@@ -349,7 +349,8 @@ export function walk(key: string, value: any, depth: number = +Infinity, memo: M
       continue;
     }
     // Recursively walk through all the child nodes
-    (acc as { [key: string]: any })[innerKey] = walk(innerKey, source[innerKey], depth - 1, memo);
+    const innerValue: any = source[innerKey];
+    acc[innerKey] = walk(innerKey, innerValue, depth - 1, memo);
   }
 
   // Once walked through all the branches, remove the parent from memo storage

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -372,7 +372,8 @@ export function walk(key: string, value: any, depth: number = +Infinity, memo: M
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function normalize(input: any, depth?: number): any {
   try {
-    return JSON.parse(JSON.stringify(input, (key: string, value: any) => walk(key, value, depth)));
+    // since we're at the outermost level, there is no key
+    return walk('', input, depth);
   } catch (_oO) {
     return '**non-serializable**';
   }


### PR DESCRIPTION
This PR makes a few changes to the internals of `utils.normalize`:

- Instead of using `JSON.stringify` to handle the recursive visiting of nodes in an object tree (and then giving it a visit function (`walk`) which is itself a recursive visitor of nodes), forcing us then to call `JSON.parse` on the results, it simply uses said recursive visitor to recursively visit the object tree nodes.

- It renames `normalizeValue` to `makeSerializable` (since that's more accurately and specifically what it's doing) and updates its out-of-date docstring to match its behavior.

- It refers to the methods in our memoizer by name rather than number, splits out an inlined value, and moves a typecast, all to increase readability.

Note: This was a branch I had lying around, about which I was reminded while reading https://github.com/getsentry/sentry-javascript/issues/4579. I don't think this will help with that a ton, but I think it can't hurt.