### PR TITLE
fix(handlers): prevent errors thrown on `flush` from breaking response

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -410,8 +410,9 @@ export function requestHandler(
           .then(() => {
             _end.call(this, chunk, encoding, cb);
           })
-          .then(null, e => {
+          .catch(e => {
             logger.error(e);
+            _end.call(this, chunk, encoding, cb);
           });
       };
     }

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -410,7 +410,7 @@ export function requestHandler(
           .then(() => {
             _end.call(this, chunk, encoding, cb);
           })
-          .catch(e => {
+          .then(null, e => {
             logger.error(e);
             _end.call(this, chunk, encoding, cb);
           });

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -283,18 +283,6 @@ describe('requestHandler', () => {
       done();
     });
   });
-
-  it('patches `res.end`', () => {
-    const flush = jest.spyOn(SDK, 'flush').mockResolvedValue(true);
-
-    sentryRequestMiddleware(req, res, next);
-    res.end('ok');
-
-    setImmediate(() => {
-      expect(flush).toHaveBeenCalled();
-      expect(res.finished).toBe(true);
-    });
-  });
   
   it('patches `res.end` when `flushTimeout` is specified', () => {
     const flush = jest.spyOn(SDK, 'flush').mockResolvedValue(true);
@@ -312,6 +300,7 @@ describe('requestHandler', () => {
   it('prevents errors thrown during `flush` from breaking the response', async () => {
     jest.spyOn(SDK, 'flush').mockRejectedValue(new SentryError('HTTP Error (429)'));
 
+    const sentryRequestMiddleware = requestHandler({ flushTimeout: 1337 });
     sentryRequestMiddleware(req, res, next);
     res.end('ok');
 

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -283,7 +283,6 @@ describe('requestHandler', () => {
       done();
     });
   });
- 
   it('patches `res.end` when `flushTimeout` is specified', () => {
     const flush = jest.spyOn(SDK, 'flush').mockResolvedValue(true);
 

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -283,6 +283,7 @@ describe('requestHandler', () => {
       done();
     });
   });
+
   it('patches `res.end` when `flushTimeout` is specified', () => {
     const flush = jest.spyOn(SDK, 'flush').mockResolvedValue(true);
 

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -283,7 +283,7 @@ describe('requestHandler', () => {
       done();
     });
   });
-  
+ 
   it('patches `res.end` when `flushTimeout` is specified', () => {
     const flush = jest.spyOn(SDK, 'flush').mockResolvedValue(true);
 


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

---

We are using `Sentry.Handlers.requestHandler` with the `flushTimeout` parameter set. After a recent upgrade of the `@sentry/node` package we noticed a steady amount of failed requests on our application and determined that `res.end` was never called on these failed requests. Further complicating the diagnosis: no corresponding Issues reported in our Sentry account 🙃 

After some digging, it appears that the `Sentry.flush` command was actually throwing in these cases. In our case this appears to be due to throttling on Sentry's side based on rate limits associated with our account. However, when this happens it breaks the entire server response -- even if no errors have been captured on that particular session.

The more concerning part of this, however, is if Sentry ever goes down for any reason this would essentially result in every single request to our application never being served. I believe we hit this issue with one of our applications where our Sentry was only reporting 1,062 dropped events due to spike protection versus our server logs reporting nearly 1,500 such failed requests.

This appears to be a similar situation to https://github.com/getsentry/sentry-javascript/pull/4620 which was resolved for the `@sentry/serverless` package.

For now I've just amended the default behaviour to always call the original `res.end`, whether the call to `flush` succeeds or fails. I am certainly willing to make this opt-in with the same option flag as the recent change to `@sentry/serverless` -- however, this seems like it should be default behaviour since it can otherwise lead to a very broken app that is very hard to diagnose.