### PR TITLE
ref(build): Use rollup config function for `@sentry/browser`

### DIFF
--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -1,130 +1,37 @@
-import { terser } from 'rollup-plugin-terser';
-import typescript from 'rollup-plugin-typescript2';
+import { makeBaseBundleConfig, makeLicensePlugin, terserPlugin } from '../../rollup.config';
 
-import {
-  baseBundleConfig,
-  makeLicensePlugin,
-  markAsBrowserBuild,
-  nodeResolvePlugin,
-  paths,
-  typescriptPluginES5,
-} from '../../rollup.config';
+const builds = [];
 
 const licensePlugin = makeLicensePlugin();
 
-const terserInstance = terser({
-  compress: {
-    // Tell env.ts that we're building a browser bundle and that we do not
-    // want to have unnecessary debug functionality.
-    global_defs: {
-      __SENTRY_NO_DEBUG__: false,
-    },
-  },
-  mangle: {
-    // captureExceptions and captureMessage are public API methods and they don't need to be listed here
-    // as mangler doesn't touch user-facing thing, however sentryWrapped is not, and it would be mangled into a minified version.
-    // We need those full names to correctly detect our internal frames for stripping.
-    // I listed all of them here just for the clarity's sake, as they are all used in the frame-manipulation process.
-    reserved: ['captureException', 'captureMessage', 'sentryWrapped'],
-    properties: {
-      regex: /^_[^_]/,
-      // This exclusion prevents most of the occurrences of the bug linked below:
-      // https://github.com/getsentry/sentry-javascript/issues/2622
-      // The bug is caused by multiple SDK instances, where one is minified and one is using non-mangled code.
-      // Unfortunatelly we cannot fix it reliably (thus `typeof` check in the `InboundFilters` code),
-      // as we cannot force people using multiple instances in their apps to sync SDK versions.
-      reserved: ['_mergeOptions'],
-    },
-  },
-  output: {
-    comments: false,
-  },
+['es5', 'es6'].forEach(jsVersion => {
+  const baseBundleConfig = makeBaseBundleConfig({
+    input: 'src/index.ts',
+    isAddOn: false,
+    jsVersion,
+    outputFileBase: `build/bundle${jsVersion === 'es6' ? '.es6' : ''}`,
+  });
+
+  builds.push(
+    ...[
+      {
+        ...baseBundleConfig,
+        output: {
+          ...baseBundleConfig.output,
+          file: `${baseBundleConfig.output.file}.js`,
+        },
+        plugins: [...baseBundleConfig.plugins, licensePlugin],
+      },
+      {
+        ...baseBundleConfig,
+        output: {
+          ...baseBundleConfig.output,
+          file: `${baseBundleConfig.output.file}.min.js`,
+        },
+        plugins: [...baseBundleConfig.plugins, terserPlugin, licensePlugin],
+      },
+    ],
+  );
 });
 
-const plugins = [
-  typescriptPluginES5,
-  // replace `__SENTRY_BROWSER_BUNDLE__` with `true` to enable treeshaking of non-browser code
-  markAsBrowserBuild,
-  nodeResolvePlugin,
-];
-
-const bundleConfig = {
-  ...baseBundleConfig,
-  input: 'src/index.ts',
-  output: {
-    ...baseBundleConfig.output,
-    format: 'iife',
-    name: 'Sentry',
-  },
-  context: 'window',
-  plugins: [...plugins, licensePlugin],
-};
-
-export default [
-  // ES5 Browser Bundle
-  {
-    ...bundleConfig,
-    output: {
-      ...bundleConfig.output,
-      file: 'build/bundle.js',
-    },
-  },
-  {
-    ...bundleConfig,
-    output: {
-      ...bundleConfig.output,
-      file: 'build/bundle.min.js',
-    },
-    // Uglify has to be at the end of compilation, BUT before the license banner
-    plugins: bundleConfig.plugins.slice(0, -1).concat(terserInstance).concat(bundleConfig.plugins.slice(-1)),
-  },
-  // ------------------
-  // ES6 Browser Bundle
-  {
-    ...bundleConfig,
-    output: {
-      ...bundleConfig.output,
-      file: 'build/bundle.es6.js',
-    },
-    plugins: [
-      typescript({
-        tsconfig: 'tsconfig.esm.json',
-        tsconfigOverride: {
-          compilerOptions: {
-            declaration: false,
-            declarationMap: false,
-            paths,
-            baseUrl: '.',
-            target: 'es6',
-          },
-        },
-        include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
-      }),
-      ...plugins.slice(1).concat(bundleConfig.plugins.slice(-1)),
-    ],
-  },
-  {
-    ...bundleConfig,
-    output: {
-      ...bundleConfig.output,
-      file: 'build/bundle.es6.min.js',
-    },
-    plugins: [
-      typescript({
-        tsconfig: 'tsconfig.esm.json',
-        tsconfigOverride: {
-          compilerOptions: {
-            declaration: false,
-            declarationMap: false,
-            paths,
-            baseUrl: '.',
-            target: 'es6',
-          },
-        },
-        include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
-      }),
-      ...plugins.slice(1).slice(0, -1).concat(terserInstance).concat(bundleConfig.plugins.slice(-1)),
-    ],
-  },
-  // ------------------
-];
+export default builds;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,6 +42,13 @@ export function makeLicensePlugin(title) {
 }
 
 export const terserPlugin = terser({
+  compress: {
+    // Tell env.ts that we're building a browser bundle and that we do not
+    // want to have unnecessary debug functionality.
+    global_defs: {
+      __SENTRY_NO_DEBUG__: false,
+    },
+  },
   mangle: {
     // captureExceptions and captureMessage are public API methods and they don't need to be listed here
     // as mangler doesn't touch user-facing thing, however sentryWrapped is not, and it would be mangled into a minified version.


### PR DESCRIPTION
As part of centralizing and unifying our CDN rollup config, this uses the config generation function introduced in https://github.com/getsentry/sentry-javascript/pull/4650 to generate the config for all browser bundles.

Unlike many of the other PRs in this series, this one does actually have an effect on certain bundles, to wit:

- `_mergeOptions` is no longer a protected-from-minifcation property, as it's [about to be extracted into a stand-alone function](https://github.com/getsentry/sentry-javascript/pull/4625).

- Up until this point, one difference between the `@sentry/browser` rollup config and all of the other rollup configs was the former's use of the `__SENTRY_NO_DEBUG__` flag to suppress logs in the minified bundles. Rather than add a parameter to the function controlling whether or not each package should use the flag, I decided it was better to just apply the flag to all minified bundles. 

Ref: https://getsentry.atlassian.net/browse/WEB-639