### PR TITLE
feat(tracing): Add ES6 tracing bundle

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -57,4 +57,10 @@ module.exports = [
     gzip: true,
     limit: '100 KB',
   },
+  {
+    name: '@sentry/browser + @sentry/tracing - ES6 CDN Bundle (gzipped + minified)',
+    path: 'packages/tracing/build/bundle.tracing.es6.min.js',
+    gzip: true,
+    limit: '100 KB',
+  },
 ];

--- a/packages/integration-tests/utils/generatePlugin.ts
+++ b/packages/integration-tests/utils/generatePlugin.ts
@@ -29,9 +29,8 @@ const BUNDLE_PATHS: Record<string, Record<string, string>> = {
     esm: 'esm/index.js',
     bundle_es5: 'build/bundle.tracing.js',
     bundle_es5_min: 'build/bundle.tracing.min.js',
-    // `tracing` doesn't have an es6 build yet
-    bundle_es6: 'build/bundle.tracing.js',
-    bundle_es6_min: 'build/bundle.tracing.min.js',
+    bundle_es6: 'build/bundle.tracing.es6.js',
+    bundle_es6_min: 'build/bundle.tracing.es6.min.js',
   },
 };
 

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -1,30 +1,37 @@
 import { makeBaseBundleConfig, makeLicensePlugin, terserPlugin } from '../../rollup.config';
 
+const builds = [];
+
 const licensePlugin = makeLicensePlugin('@sentry/tracing & @sentry/browser');
 
-const baseBundleConfig = makeBaseBundleConfig({
-  input: 'src/index.bundle.ts',
-  isAddOn: false,
-  jsVersion: 'es5',
-  outputFileBase: 'build/bundle.tracing',
+['es5', 'es6'].forEach(jsVersion => {
+  const baseBundleConfig = makeBaseBundleConfig({
+    input: 'src/index.bundle.ts',
+    isAddOn: false,
+    jsVersion,
+    outputFileBase: `build/bundle.tracing${jsVersion === 'es6' ? '.es6' : ''}`,
+  });
+
+  builds.push(
+    ...[
+      {
+        ...baseBundleConfig,
+        output: {
+          ...baseBundleConfig.output,
+          file: `${baseBundleConfig.output.file}.js`,
+        },
+        plugins: [...baseBundleConfig.plugins, licensePlugin],
+      },
+      {
+        ...baseBundleConfig,
+        output: {
+          ...baseBundleConfig.output,
+          file: `${baseBundleConfig.output.file}.min.js`,
+        },
+        plugins: [...baseBundleConfig.plugins, terserPlugin, licensePlugin],
+      },
+    ],
+  );
 });
 
-export default [
-  // ES5 Browser Tracing Bundle
-  {
-    ...baseBundleConfig,
-    output: {
-      ...baseBundleConfig.output,
-      file: `${baseBundleConfig.output.file}.js`,
-    },
-    plugins: [...baseBundleConfig.plugins, licensePlugin],
-  },
-  {
-    ...baseBundleConfig,
-    output: {
-      ...baseBundleConfig.output,
-      file: `${baseBundleConfig.output.file}.min.js`,
-    },
-    plugins: [...baseBundleConfig.plugins, terserPlugin, licensePlugin],
-  },
-];
+export default builds;


### PR DESCRIPTION
This adds an ES6 version of our tracing CDN bundle, both for the sake of users and as a step towards becoming ES6-first in v7. It also adds the new bundle to the size check and the playwright integration tests.

A note about the new bundle is added to the docs in https://github.com/getsentry/sentry-docs/pull/4789.