### PR TITLE
chore(lint): Fix backticks around non-template strings

### DIFF
--- a/packages/core/src/basebackend.ts
+++ b/packages/core/src/basebackend.ts
@@ -93,7 +93,7 @@ export abstract class BaseBackend<O extends Options> implements Backend {
   public sendEvent(event: Event): void {
     void this._transport.sendEvent(event).then(null, reason => {
       if (isDebugBuild()) {
-        logger.error(`Error while sending event:`, reason);
+        logger.error('Error while sending event:', reason);
       }
     });
   }
@@ -111,7 +111,7 @@ export abstract class BaseBackend<O extends Options> implements Backend {
 
     void this._transport.sendSession(session).then(null, reason => {
       if (isDebugBuild()) {
-        logger.error(`Error while sending session:`, reason);
+        logger.error('Error while sending session:', reason);
       }
     });
   }

--- a/packages/hub/src/sessionflusher.ts
+++ b/packages/hub/src/sessionflusher.ts
@@ -39,7 +39,7 @@ export class SessionFlusher implements SessionFlusherLike {
       return;
     }
     void this._transport.sendSession(sessionAggregates).then(null, reason => {
-      logger.error(`Error while sending session:`, reason);
+      logger.error('Error while sending session:', reason);
     });
   }
 

--- a/packages/nextjs/src/utils/withSentry.ts
+++ b/packages/nextjs/src/utils/withSentry.ts
@@ -188,6 +188,6 @@ async function finishSentryProcessing(res: AugmentedNextApiResponse): Promise<vo
     await flush(2000);
     logger.log('Done flushing events');
   } catch (e) {
-    logger.log(`Error while flushing events:\n`, e);
+    logger.log('Error while flushing events:\n', e);
   }
 }


### PR DESCRIPTION
Making the linter happy...
