### PR TITLE
fix(build): Build bundles in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "node ./scripts/verify-packages-versions.js && lerna run --stream --concurrency 1 --sort build",
-    "build:bundle": "lerna run --stream --concurrency 1 --sort build:bundle",
+    "build:bundle": "lerna run --parallel build:bundle",
     "build:cjs": "lerna run --stream --concurrency 1 --sort build:cjs",
     "build:dev": "lerna run --stream --concurrency 1 --sort build:dev",
     "build:dev:filter": "lerna run --stream --concurrency 1 --sort build:dev --include-filtered-dependencies --include-filtered-dependents --scope",


### PR DESCRIPTION
This PR parallelizes our top-level `build:bundle` yarn script, in order to make it run faster. Because so much of the total time is spent on one package (`@sentry/integrations`, which currently produces 24 bundles to every other package's max 4 bundles), the time savings isn't earth-shattering, but it does run 20-30% faster in my informal tests.