### PR TITLE
ref(build): Handle minification in rollup config generation function

### DIFF
--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -1,14 +1,13 @@
-import { makeBaseBundleConfig, makeLicensePlugin, terserPlugin } from '../../rollup.config';
+import { makeBaseBundleConfig, terserPlugin } from '../../rollup.config';
 
 const builds = [];
-
-const licensePlugin = makeLicensePlugin();
 
 ['es5', 'es6'].forEach(jsVersion => {
   const baseBundleConfig = makeBaseBundleConfig({
     input: 'src/index.ts',
     isAddOn: false,
     jsVersion,
+    licenseTitle: '@sentry/browser',
     outputFileBase: `build/bundle${jsVersion === 'es6' ? '.es6' : ''}`,
   });
 
@@ -20,7 +19,7 @@ const licensePlugin = makeLicensePlugin();
           ...baseBundleConfig.output,
           file: `${baseBundleConfig.output.file}.js`,
         },
-        plugins: [...baseBundleConfig.plugins, licensePlugin],
+        plugins: [...baseBundleConfig.plugins],
       },
       {
         ...baseBundleConfig,
@@ -28,7 +27,7 @@ const licensePlugin = makeLicensePlugin();
           ...baseBundleConfig.output,
           file: `${baseBundleConfig.output.file}.min.js`,
         },
-        plugins: [...baseBundleConfig.plugins, terserPlugin, licensePlugin],
+        plugins: [...baseBundleConfig.plugins, terserPlugin],
       },
     ],
   );

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -1,4 +1,4 @@
-import { makeBaseBundleConfig, terserPlugin } from '../../rollup.config';
+import { makeBaseBundleConfig, makeMinificationVariants } from '../../rollup.config';
 
 const builds = [];
 
@@ -11,26 +11,7 @@ const builds = [];
     outputFileBase: `build/bundle${jsVersion === 'es6' ? '.es6' : ''}`,
   });
 
-  builds.push(
-    ...[
-      {
-        ...baseBundleConfig,
-        output: {
-          ...baseBundleConfig.output,
-          file: `${baseBundleConfig.output.file}.js`,
-        },
-        plugins: [...baseBundleConfig.plugins],
-      },
-      {
-        ...baseBundleConfig,
-        output: {
-          ...baseBundleConfig.output,
-          file: `${baseBundleConfig.output.file}.min.js`,
-        },
-        plugins: [...baseBundleConfig.plugins, terserPlugin],
-      },
-    ],
-  );
+  builds.push(...makeMinificationVariants(baseBundleConfig));
 });
 
 export default builds;

--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -16,6 +16,7 @@ function loadAllIntegrations() {
       input: `src/${file}`,
       isAddOn: true,
       jsVersion: 'es5',
+      licenseTitle: '@sentry/integrations',
       outputFileBase: `build/${file.replace('.ts', '')}`,
     });
 

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -1,4 +1,4 @@
-import { makeBaseBundleConfig, terserPlugin } from '../../rollup.config';
+import { makeBaseBundleConfig, makeMinificationVariants } from '../../rollup.config';
 
 const builds = [];
 
@@ -11,26 +11,7 @@ const builds = [];
     outputFileBase: `build/bundle.tracing${jsVersion === 'es6' ? '.es6' : ''}`,
   });
 
-  builds.push(
-    ...[
-      {
-        ...baseBundleConfig,
-        output: {
-          ...baseBundleConfig.output,
-          file: `${baseBundleConfig.output.file}.js`,
-        },
-        plugins: baseBundleConfig.plugins,
-      },
-      {
-        ...baseBundleConfig,
-        output: {
-          ...baseBundleConfig.output,
-          file: `${baseBundleConfig.output.file}.min.js`,
-        },
-        plugins: [...baseBundleConfig.plugins, terserPlugin],
-      },
-    ],
-  );
+  builds.push(...makeMinificationVariants(baseBundleConfig));
 });
 
 export default builds;

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -1,14 +1,13 @@
-import { makeBaseBundleConfig, makeLicensePlugin, terserPlugin } from '../../rollup.config';
+import { makeBaseBundleConfig, terserPlugin } from '../../rollup.config';
 
 const builds = [];
-
-const licensePlugin = makeLicensePlugin('@sentry/tracing & @sentry/browser');
 
 ['es5', 'es6'].forEach(jsVersion => {
   const baseBundleConfig = makeBaseBundleConfig({
     input: 'src/index.bundle.ts',
     isAddOn: false,
     jsVersion,
+    licenseTitle: '@sentry/tracing & @sentry/browser',
     outputFileBase: `build/bundle.tracing${jsVersion === 'es6' ? '.es6' : ''}`,
   });
 
@@ -20,7 +19,7 @@ const licensePlugin = makeLicensePlugin('@sentry/tracing & @sentry/browser');
           ...baseBundleConfig.output,
           file: `${baseBundleConfig.output.file}.js`,
         },
-        plugins: [...baseBundleConfig.plugins, licensePlugin],
+        plugins: baseBundleConfig.plugins,
       },
       {
         ...baseBundleConfig,
@@ -28,7 +27,7 @@ const licensePlugin = makeLicensePlugin('@sentry/tracing & @sentry/browser');
           ...baseBundleConfig.output,
           file: `${baseBundleConfig.output.file}.min.js`,
         },
-        plugins: [...baseBundleConfig.plugins, terserPlugin, licensePlugin],
+        plugins: [...baseBundleConfig.plugins, terserPlugin],
       },
     ],
   );

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -1,11 +1,10 @@
-import { makeBaseBundleConfig, makeLicensePlugin, terserPlugin } from '../../rollup.config';
-
-const licensePlugin = makeLicensePlugin();
+import { makeBaseBundleConfig, terserPlugin } from '../../rollup.config';
 
 const baseBundleConfig = makeBaseBundleConfig({
   input: 'src/index.bundle.ts',
   isAddOn: false,
   jsVersion: 'es5',
+  licenseTitle: '@sentry/vue',
   outputFileBase: 'build/bundle.vue',
 });
 
@@ -16,7 +15,7 @@ export default [
       ...baseBundleConfig.output,
       file: `${baseBundleConfig.output.file}.js`,
     },
-    plugins: [...baseBundleConfig.plugins, licensePlugin],
+    plugins: baseBundleConfig.plugins,
   },
   {
     ...baseBundleConfig,
@@ -24,6 +23,6 @@ export default [
       ...baseBundleConfig.output,
       file: `${baseBundleConfig.output.file}.min.js`,
     },
-    plugins: [...baseBundleConfig.plugins, terserPlugin, licensePlugin],
+    plugins: [...baseBundleConfig.plugins, terserPlugin],
   },
 ];

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -1,4 +1,4 @@
-import { makeBaseBundleConfig, terserPlugin } from '../../rollup.config';
+import { makeBaseBundleConfig, makeMinificationVariants } from '../../rollup.config';
 
 const baseBundleConfig = makeBaseBundleConfig({
   input: 'src/index.bundle.ts',
@@ -8,21 +8,4 @@ const baseBundleConfig = makeBaseBundleConfig({
   outputFileBase: 'build/bundle.vue',
 });
 
-export default [
-  {
-    ...baseBundleConfig,
-    output: {
-      ...baseBundleConfig.output,
-      file: `${baseBundleConfig.output.file}.js`,
-    },
-    plugins: baseBundleConfig.plugins,
-  },
-  {
-    ...baseBundleConfig,
-    output: {
-      ...baseBundleConfig.output,
-      file: `${baseBundleConfig.output.file}.min.js`,
-    },
-    plugins: [...baseBundleConfig.plugins, terserPlugin],
-  },
-];
+export default makeMinificationVariants(baseBundleConfig);

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -4,6 +4,7 @@ const baseBundleConfig = makeBaseBundleConfig({
   input: 'src/index.ts',
   isAddOn: true,
   jsVersion: 'es5',
+  licenseTitle: '@sentry/wasm',
   outputFileBase: 'build/wasm',
 });
 

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -1,4 +1,4 @@
-import { makeBaseBundleConfig, terserPlugin } from '../../rollup.config';
+import { makeBaseBundleConfig, makeMinificationVariants } from '../../rollup.config';
 
 const baseBundleConfig = makeBaseBundleConfig({
   input: 'src/index.ts',
@@ -8,28 +8,4 @@ const baseBundleConfig = makeBaseBundleConfig({
   outputFileBase: 'build/wasm',
 });
 
-function loadAllIntegrations() {
-  const builds = [];
-  [
-    {
-      extension: '.js',
-      plugins: baseBundleConfig.plugins,
-    },
-    {
-      extension: '.min.js',
-      plugins: [...baseBundleConfig.plugins, terserPlugin],
-    },
-  ].forEach(build => {
-    builds.push({
-      ...baseBundleConfig,
-      output: {
-        ...baseBundleConfig.output,
-        file: `${baseBundleConfig.output.file}${build.extension}`,
-      },
-      plugins: build.plugins,
-    });
-  });
-  return builds;
-}
-
-export default loadAllIntegrations();
+export default makeMinificationVariants(baseBundleConfig);

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,12 +21,12 @@ import typescript from 'rollup-plugin-typescript2';
  * @param title The title to use for the SDK, if not the package name
  * @returns An instance of the `rollup-plugin-license` plugin
  */
-export function makeLicensePlugin(title) {
+function makeLicensePlugin(title) {
   const commitHash = require('child_process').execSync('git rev-parse --short HEAD', { encoding: 'utf-8' }).trim();
 
   return license({
     banner: {
-      content: `/*! <%= data.title || pkg.name %> <%= pkg.version %> (${commitHash}) | https://github.com/getsentry/sentry-javascript */`,
+      content: `/*! <%= data.title %> <%= pkg.version %> (${commitHash}) | https://github.com/getsentry/sentry-javascript */`,
       data: { title },
     },
   });
@@ -56,7 +56,7 @@ export const terserPlugin = terser({
 });
 
 export function makeBaseBundleConfig(options) {
-  const { input, isAddOn, jsVersion, outputFileBase } = options;
+  const { input, isAddOn, jsVersion, licenseTitle, outputFileBase } = options;
 
   const baseTSPluginOptions = {
     tsconfig: 'tsconfig.esm.json',
@@ -111,6 +111,8 @@ export function makeBaseBundleConfig(options) {
     },
   });
 
+  const licensePlugin = makeLicensePlugin(licenseTitle);
+
   const standAloneBundleConfig = {
     output: {
       format: 'iife',
@@ -159,7 +161,12 @@ export function makeBaseBundleConfig(options) {
       strict: false,
       esModule: false,
     },
-    plugins: [jsVersion === 'es5' ? typescriptPluginES5 : typescriptPluginES6, markAsBrowserBuild, nodeResolvePlugin],
+    plugins: [
+      jsVersion === 'es5' ? typescriptPluginES5 : typescriptPluginES6,
+      markAsBrowserBuild,
+      nodeResolvePlugin,
+      licensePlugin,
+    ],
     treeshake: 'smallest',
   };
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,11 +1,5 @@
 /**
- * Shared config used by individual packages' Rollup configs. Items here come in three flavors:
- *   - stand-alone: used by `@sentry/browser`, `@sentry/tracing`, and `@sentry/vue` (bundles which are a full SDK in
- *     and of themselves)
- *   - add-on: used by `@sentry/integrations` and `@sentry/wasm` (bundles which need to be combined with a stand-alone
- *     SDK bundle)
- *   - shared: used by both types of bundles
- *
+ * Code for generating config used by individual packages' Rollup configs
  */
 
 import assert from 'assert';
@@ -133,6 +127,7 @@ export function makeBaseBundleConfig(options) {
 
   const licensePlugin = makeLicensePlugin(licenseTitle);
 
+  // used by `@sentry/browser`, `@sentry/tracing`, and `@sentry/vue` (bundles which are a full SDK in and of themselves)
   const standAloneBundleConfig = {
     output: {
       format: 'iife',
@@ -141,6 +136,7 @@ export function makeBaseBundleConfig(options) {
     context: 'window',
   };
 
+  // used by `@sentry/integrations` and `@sentry/wasm` (bundles which need to be combined with a stand-alone SDK bundle)
   const addOnBundleConfig = {
     // These output settings are designed to mimic an IIFE. We don't use Rollup's `iife` format because we don't want to
     // attach this code to a new global variable, but rather inject it into the existing SDK's `Integrations` object.
@@ -172,6 +168,7 @@ export function makeBaseBundleConfig(options) {
     },
   };
 
+  // used by all bundles
   const sharedBundleConfig = {
     input,
     output: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,15 +15,6 @@ import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 
-export const paths = {
-  '@sentry/browser': ['../browser/src'],
-  '@sentry/core': ['../core/src'],
-  '@sentry/hub': ['../hub/src'],
-  '@sentry/minimal': ['../minimal/src'],
-  '@sentry/types': ['../types/src'],
-  '@sentry/utils': ['../utils/src'],
-};
-
 /**
  * Create a plugin to add an identification banner to the top of stand-alone bundles.
  *
@@ -64,94 +55,61 @@ export const terserPlugin = terser({
   },
 });
 
-export const markAsBrowserBuild = replace({
-  // don't replace `__placeholder__` where it's followed immediately by a single `=` (to prevent ending up
-  // with something of the form `let "replacementValue" = "some assigned value"`, which would cause a
-  // syntax error)
-  preventAssignment: true,
-  // the replacement to make
-  values: {
-    __SENTRY_BROWSER_BUNDLE__: true,
-  },
-});
-
-const baseTSPluginOptions = {
-  tsconfig: 'tsconfig.esm.json',
-  tsconfigOverride: {
-    compilerOptions: {
-      declaration: false,
-      declarationMap: false,
-      paths,
-      baseUrl: '.',
-    },
-  },
-  include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
-};
-
-export const typescriptPluginES5 = typescript(
-  deepMerge(baseTSPluginOptions, {
-    tsconfigOverride: {
-      compilerOptions: {
-        target: 'es5',
-      },
-    },
-  }),
-);
-
-export const typescriptPluginES6 = typescript(
-  deepMerge(baseTSPluginOptions, {
-    tsconfigOverride: {
-      compilerOptions: {
-        target: 'es6',
-      },
-    },
-  }),
-);
-
-export const nodeResolvePlugin = resolve();
-
-export const baseBundleConfig = {
-  output: {
-    sourcemap: true,
-    strict: false,
-    esModule: false,
-  },
-  treeshake: 'smallest',
-};
-
-export const addOnBundleConfig = {
-  // These output settings are designed to mimic an IIFE. We don't use Rollup's `iife` format because we don't want to
-  // attach this code to a new global variable, but rather inject it into the existing SDK's `Integrations` object.
-  output: {
-    format: 'cjs',
-
-    // code to add before the CJS wrapper
-    banner: '(function (__window) {',
-
-    // code to add just inside the CJS wrapper, before any of the wrapped code
-    intro: 'var exports = {};',
-
-    // code to add after all of the wrapped code, but still inside the CJS wrapper
-    outro: () =>
-      [
-        '',
-        "  // Add this module's exports to the global `Sentry.Integrations`",
-        '  __window.Sentry = __window.Sentry || {};',
-        '  __window.Sentry.Integrations = __window.Sentry.Integrations || {};',
-        '  for (var key in exports) {',
-        '    if (Object.prototype.hasOwnProperty.call(exports, key)) {',
-        '      __window.Sentry.Integrations[key] = exports[key];',
-        '    }',
-        '  }',
-      ].join('\n'),
-
-    // code to add after the CJS wrapper
-    footer: '}(window));',
-  },
-};
-
 export function makeBaseBundleConfig(options) {
   const { input, isAddOn, jsVersion, outputFileBase } = options;
+
+  const baseTSPluginOptions = {
+    tsconfig: 'tsconfig.esm.json',
+    tsconfigOverride: {
+      compilerOptions: {
+        declaration: false,
+        declarationMap: false,
+        paths: {
+          '@sentry/browser': ['../browser/src'],
+          '@sentry/core': ['../core/src'],
+          '@sentry/hub': ['../hub/src'],
+          '@sentry/minimal': ['../minimal/src'],
+          '@sentry/types': ['../types/src'],
+          '@sentry/utils': ['../utils/src'],
+        },
+        baseUrl: '.',
+      },
+    },
+    include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
+  };
+
+  const typescriptPluginES5 = typescript(
+    deepMerge(baseTSPluginOptions, {
+      tsconfigOverride: {
+        compilerOptions: {
+          target: 'es5',
+        },
+      },
+    }),
+  );
+
+  const typescriptPluginES6 = typescript(
+    deepMerge(baseTSPluginOptions, {
+      tsconfigOverride: {
+        compilerOptions: {
+          target: 'es6',
+        },
+      },
+    }),
+  );
+
+  const nodeResolvePlugin = resolve();
+
+  const markAsBrowserBuild = replace({
+    // don't replace `__placeholder__` where it's followed immediately by a single `=` (to prevent ending up
+    // with something of the form `let "replacementValue" = "some assigned value"`, which would cause a
+    // syntax error)
+    preventAssignment: true,
+    // the replacement to make
+    values: {
+      __SENTRY_BROWSER_BUNDLE__: true,
+    },
+  });
 
   const standAloneBundleConfig = {
     output: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -114,7 +114,7 @@ export function makeBaseBundleConfig(options) {
 
   const nodeResolvePlugin = resolve();
 
-  const markAsBrowserBuild = replace({
+  const markAsBrowserBuildPlugin = replace({
     // don't replace `__placeholder__` where it's followed immediately by a single `=` (to prevent ending up
     // with something of the form `let "replacementValue" = "some assigned value"`, which would cause a
     // syntax error)
@@ -180,7 +180,7 @@ export function makeBaseBundleConfig(options) {
     },
     plugins: [
       jsVersion === 'es5' ? typescriptPluginES5 : typescriptPluginES6,
-      markAsBrowserBuild,
+      markAsBrowserBuildPlugin,
       nodeResolvePlugin,
       licensePlugin,
     ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,6 +16,24 @@ import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 
 /**
+ * Helper functions to compensate for the fact that JS can't handle negative array indices very well
+ *
+ * TODO `insertAt` is only exported so the integrations config can inject the `commonjs` plugin, for localforage (used
+ * in the offline plugin). Once that's fixed to no longer be necessary, this can stop being exported.
+ */
+const getLastElement = array => {
+  return array[array.length - 1];
+};
+export const insertAt = (arr, index, insertee) => {
+  const newArr = [...arr];
+  // Add 1 to the array length so that the inserted element ends up in the right spot with respect to the length of the
+  // new array (which will be one element longer), rather than that of the current array
+  const destinationIndex = index >= 0 ? index : arr.length + 1 + index;
+  newArr.splice(destinationIndex, 0, insertee);
+  return newArr;
+};
+
+/**
  * Create a plugin to add an identification banner to the top of stand-alone bundles.
  *
  * @param title The title to use for the SDK, if not the package name

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,8 @@
  *
  */
 
+import assert from 'assert';
+
 import deepMerge from 'deepmerge';
 import license from 'rollup-plugin-license';
 import resolve from '@rollup/plugin-node-resolve';
@@ -189,4 +191,47 @@ export function makeBaseBundleConfig(options) {
   };
 
   return deepMerge(sharedBundleConfig, isAddOn ? addOnBundleConfig : standAloneBundleConfig);
+}
+
+export function makeMinificationVariants(existingConfigs) {
+  const newConfigs = [];
+
+  // ensure we've got an array of configs rather than a single config
+  existingConfigs = Array.isArray(existingConfigs) ? existingConfigs : [existingConfigs];
+
+  existingConfigs.forEach(existingConfig => {
+    const { plugins } = existingConfig;
+
+    // The license plugin has to be last, so it ends up after terser. Otherwise, terser will remove the license banner.
+    assert(
+      getLastElement(plugins).name === 'rollup-plugin-license',
+      `Last plugin in given options should be \`rollup-plugin-license\`. Found ${getLastElement(plugins).name}`,
+    );
+
+    const bundleVariants = [
+      {
+        output: {
+          file: `${existingConfig.output.file}.js`,
+        },
+        plugins,
+      },
+      {
+        output: {
+          file: `${existingConfig.output.file}.min.js`,
+        },
+        plugins: insertAt(plugins, -2, terserPlugin),
+      },
+    ];
+
+    bundleVariants.forEach(variant => {
+      const mergedConfig = deepMerge(existingConfig, variant, {
+        // this makes it so that instead of concatenating the `plugin` properties of the two objects, the first value is
+        // just overwritten by the second value
+        arrayMerge: (first, second) => second,
+      });
+      newConfigs.push(mergedConfig);
+    });
+  });
+
+  return newConfigs;
 }


### PR DESCRIPTION
As part of the new build process, this removes minification config from being hardcoded in individual `rollup.config.js` files and instead uses a new function in the main `rollup.config.js` to generate minified and unminified variants of each build config it's given. 

This PR also includes a few other small changes:

- Moved the license plugin to the main config function.
- Removed exports which were no longer necessary now that most config is centralized.
- Refactored individual `rollup.config.js` files to have more parallel structure.
- Moved a comment and renamed the `markAsBrowserBulid` plugin so it has the work "plugin" in its name.

Ref: https://getsentry.atlassian.net/browse/WEB-633
