### PR TITLE
Limit `normalize` edge nodes

### DIFF
--- a/packages/utils/test/object.test.ts
+++ b/packages/utils/test/object.test.ts
@@ -533,6 +533,72 @@ describe('normalize()', () => {
     });
   });
 
+  describe('can limit number of edge nodes', () => {
+    test('array', () => {
+      const obj = {
+        foo: new Array(100).fill(1, 0, 100),
+      };
+
+      expect(normalize(obj, 10, 10)).toEqual({
+        foo: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, '[Max Edges Reached...]'],
+      });
+    });
+
+    test('object', () => {
+      const obj = {
+        foo1: 1,
+        foo2: 1,
+        foo3: 1,
+        foo4: 1,
+        foo5: 1,
+        foo6: 1,
+        foo7: 1,
+        foo8: 1,
+        foo9: 1,
+        foo10: 1,
+        foo11: 1,
+        foo12: 1,
+      };
+
+      expect(normalize(obj, 10, 10)).toEqual({
+        foo1: 1,
+        foo2: 1,
+        foo3: 1,
+        foo4: 1,
+        foo5: 1,
+        foo6: 1,
+        foo7: 1,
+        foo8: 1,
+        foo9: 1,
+        foo10: 1,
+        foo11: '[Max Edges Reached...]',
+      });
+    });
+
+    test('objects and arrays', () => {
+      const obj = {
+        foo1: 1,
+        foo2: 1,
+        foo3: 1,
+        foo4: 1,
+        foo5: 1,
+        foo6: [1, 1, 1, 1, 1, 1],
+        foo7: [1, 1, 1, 1, 1, 1],
+        foo8: [1, 1, 1, 1, 1, 1],
+      };
+
+      expect(normalize(obj, 10, 10)).toEqual({
+        foo1: 1,
+        foo2: 1,
+        foo3: 1,
+        foo4: 1,
+        foo5: 1,
+        foo6: [1, 1, 1, 1, 1, '[Max Edges Reached...]'],
+        foo7: '[Max Edges Reached...]',
+      });
+    });
+  });
+
   test('normalizes value on every iteration of decycle and takes care of things like Reacts SyntheticEvents', () => {
     const obj = {
       foo: {


### PR DESCRIPTION
I have been reviewing `normalize` and `walk` as part of #4579. 

Looking through the recent PRs from @lobsterkatie it looks like most of the issues have already been sorted! 

The last remaining thing I wanted to improve was limiting the overall work normalisation/serialisation has to do if users inadvertently log large objects. The existing implementation only considers depth but this can still result in huge output. 

For example, the following will result in a huge serialised event, even with a normalisation depth set to 3:
```ts
const smallArray = new Array(1_000).fill('a');
const bigArray = new Array(10_000).fill(smallArrar);
console.log('my data', bigArray)
```

This PR moves `walk` inside `normalize` which allows counting enge nodes and bailing out when the limit is reached.

This means this:
```ts
JSON.stringify(someObj, walk)
```
now becomes:
```ts
JSON.stringify(normalize(someObj))
```

## Alternatives

This PR halts object/array properties output when the limit is reached which favours properties that are encountered earlier and this may not be desirable. 

An alternative would be to limit individual objects/arrays to a maximum number of properties/elements. 