### PR TITLE
feat(utils): Limit `normalize` maximum properties/elements

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -342,7 +342,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    * @returns A new event with more information.
    */
   protected _prepareEvent(event: Event, scope?: Scope, hint?: EventHint): PromiseLike<Event | null> {
-    const { normalizeDepth = 3, normalizeMaxProperties = 1_000 } = this.getOptions();
+    const { normalizeDepth = 3, normalizeMaxBreadth = 1_000 } = this.getOptions();
     const prepared: Event = {
       ...event,
       event_id: event.event_id || (hint && hint.event_id ? hint.event_id : uuid4()),
@@ -376,7 +376,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
         evt.sdkProcessingMetadata = { ...evt.sdkProcessingMetadata, normalizeDepth: normalize(normalizeDepth) };
       }
       if (typeof normalizeDepth === 'number' && normalizeDepth > 0) {
-        return this._normalizeEvent(evt, normalizeDepth, normalizeMaxProperties);
+        return this._normalizeEvent(evt, normalizeDepth, normalizeMaxBreadth);
       }
       return evt;
     });
@@ -392,7 +392,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    * @param event Event
    * @returns Normalized event
    */
-  protected _normalizeEvent(event: Event | null, depth: number, maxProperties: number): Event | null {
+  protected _normalizeEvent(event: Event | null, depth: number, maxBreadth: number): Event | null {
     if (!event) {
       return null;
     }
@@ -403,18 +403,18 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
         breadcrumbs: event.breadcrumbs.map(b => ({
           ...b,
           ...(b.data && {
-            data: normalize(b.data, depth, maxProperties),
+            data: normalize(b.data, depth, maxBreadth),
           }),
         })),
       }),
       ...(event.user && {
-        user: normalize(event.user, depth, maxProperties),
+        user: normalize(event.user, depth, maxBreadth),
       }),
       ...(event.contexts && {
-        contexts: normalize(event.contexts, depth, maxProperties),
+        contexts: normalize(event.contexts, depth, maxBreadth),
       }),
       ...(event.extra && {
-        extra: normalize(event.extra, depth, maxProperties),
+        extra: normalize(event.extra, depth, maxBreadth),
       }),
     };
     // event.contexts.trace stores information about a Transaction. Similarly,

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -110,7 +110,7 @@ export interface Options {
    * - `extra`
    * Defaults to `1000`
    */
-  normalizeMaxProperties?: number;
+  normalizeMaxBreadth?: number;
 
   /**
    * Controls how many milliseconds to wait before shutting down. The default is

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -102,6 +102,17 @@ export interface Options {
   normalizeDepth?: number;
 
   /**
+   * Maximum number of properties or elements that the normalization algorithm will output.
+   * Used when normalizing an event before sending, on all of the listed attributes:
+   * - `breadcrumbs.data`
+   * - `user`
+   * - `contexts`
+   * - `extra`
+   * Defaults to `1000`
+   */
+  normalizeMaxProperties?: number;
+
+  /**
    * Controls how many milliseconds to wait before shutting down. The default is
    * SDK-specific but typically around 2 seconds. Setting this too low can cause
    * problems for sending events from command line applications. Setting it too

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -102,7 +102,7 @@ export interface Options {
   normalizeDepth?: number;
 
   /**
-   * Maximum number of properties or elements that the normalization algorithm will output.
+   * Maximum number of properties or elements that the normalization algorithm will output in any single array or object included in the normalized event.
    * Used when normalizing an event before sending, on all of the listed attributes:
    * - `breadcrumbs.data`
    * - `user`

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -300,20 +300,26 @@ function makeSerializable<T>(value: T, key?: any): T | string {
   return value;
 }
 
-type UnknownMaybeToJson = unknown & { toJSON?: () => string };
+type UnknownMaybeWithToJson = unknown & { toJSON?: () => string };
 
 /**
- * normalize()
+ * Recursively normalizes the given object.
  *
  * - Creates a copy to prevent original input mutation
- * - Skip non-enumerable
- * - Calls `toJSON` if implemented
+ * - Skips non-enumerable properties
+ * - When stringifying, calls `toJSON` if implemented
  * - Removes circular references
- * - Translates non-serializable values (undefined/NaN/Functions) to serializable format
- * - Translates known global objects/Classes to a string representations
- * - Takes care of Error objects serialization
- * - Optionally limit depth of final output
- * - Optionally limit max number of properties/elements for each object/array
+ * - Translates non-serializable values (`undefined`/`NaN`/functions) to serializable format
+ * - Translates known global objects/classes to a string representations
+ * - Takes care of `Error` object serialization
+ * - Optionally limits depth of final output
+ * - Optionally limits number of properties/elements included in any single object/array
+ *
+ * @param input The object to be normalized.
+ * @param depth The max depth to which to normalize the object. (Anything deeper stringified whole.)
+ * @param maxProperties The max number of elements or properties to be included in any single array or 
+ * object in the normallized output..
+ * @returns A normalized version of the object, or `"**non-serializable**"` if any errors are thrown during normaliztion.
  */
 export function normalize(input: unknown, depth: number = +Infinity, maxProperties: number = +Infinity): any {
   const [memoize, unmemoize] = memoBuilder();

--- a/packages/utils/test/object.test.ts
+++ b/packages/utils/test/object.test.ts
@@ -533,6 +533,51 @@ describe('normalize()', () => {
     });
   });
 
+  describe('can limit max properties', () => {
+    test('object', () => {
+      const obj = {
+        nope: 'here',
+        foo: {
+          one: 1,
+          two: 2,
+          three: 3,
+          four: 4,
+          five: 5,
+          six: 6,
+          seven: 7,
+        },
+        after: 'more',
+      };
+
+      expect(normalize(obj, 10, 5)).toEqual({
+        nope: 'here',
+        foo: {
+          one: 1,
+          two: 2,
+          three: 3,
+          four: 4,
+          five: 5,
+          six: '[MaxProperties ~]',
+        },
+        after: 'more',
+      });
+    });
+
+    test('array', () => {
+      const obj = {
+        nope: 'here',
+        foo: new Array(100).fill('s'),
+        after: 'more',
+      };
+
+      expect(normalize(obj, 10, 5)).toEqual({
+        nope: 'here',
+        foo: ['s', 's', 's', 's', 's', '[MaxProperties ~]'],
+        after: 'more',
+      });
+    });
+  });
+
   test('normalizes value on every iteration of decycle and takes care of things like Reacts SyntheticEvents', () => {
     const obj = {
       foo: {


### PR DESCRIPTION
Limits number of properties/elements serialised for an object/array. An improvement over #4687 because it doesn't bail out of normalisation when the limit is reached. 

This protects against huge objects being serialised if users inadvertently log huge objects.

I chose a limit of 1000 properties/elements. If this is deemed too low for a minor release, we could increase this and reduce it again for v7?

**NOTE** 
This adds `normalizeMaxBreadth` to `init` options (documented in https://github.com/getsentry/sentry-docs/pull/4844)