### PR TITLE
ref(minimal): Simplify `syntheticException` creation

### DIFF
--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -36,12 +36,8 @@ function callOnHub<T>(method: string, ...args: any[]): T {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 export function captureException(exception: any, captureContext?: CaptureContext): string {
-  let syntheticException: Error;
-  try {
-    throw new Error('Sentry syntheticException');
-  } catch (exception) {
-    syntheticException = exception as Error;
-  }
+  const syntheticException = new Error('Sentry syntheticException');
+
   return callOnHub('captureException', exception, {
     captureContext,
     originalException: exception,
@@ -57,12 +53,7 @@ export function captureException(exception: any, captureContext?: CaptureContext
  * @returns The generated eventId.
  */
 export function captureMessage(message: string, captureContext?: CaptureContext | Severity): string {
-  let syntheticException: Error;
-  try {
-    throw new Error(message);
-  } catch (exception) {
-    syntheticException = exception as Error;
-  }
+  const syntheticException = new Error(message);
 
   // This is necessary to provide explicit scopes upgrade, without changing the original
   // arity of the `captureMessage(message, level)` method.


### PR DESCRIPTION
Whether the error is thrown or not does not matter because stacktraces are generated when `new Error()` is called. In other words: the try-catch in `captureException()` and `captureMessage()` is unnecessary, and we can assign the new `Error` instance directly.

You can verify this by running the following snippet somewhere in your code:

```js
let e = new Error('bla');
console.log(e);

try {
  throw new Error('bla');
} catch (error) {
  console.log(error);
}
```

Before submitting a pull request, please take a look at our [Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
