### PR TITLE
fix(browser): Use `apply` rather than `call` in `try-catch` integration

### DIFF
--- a/packages/browser/src/integrations/trycatch.ts
+++ b/packages/browser/src/integrations/trycatch.ts
@@ -128,8 +128,7 @@ function _wrapRAF(original: any): (callback: () => void) => any {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return function (this: any, callback: () => void): () => void {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    return original.call(
-      this,
+    return original.apply(this, [
       wrap(callback, {
         mechanism: {
           data: {
@@ -140,7 +139,7 @@ function _wrapRAF(original: any): (callback: () => void) => any {
           type: 'instrument',
         },
       }),
-    );
+    ]);
   };
 }
 
@@ -225,8 +224,7 @@ function _wrapEventTarget(target: string): void {
         // can sometimes get 'Permission denied to access property "handle Event'
       }
 
-      return original.call(
-        this,
+      return original.apply(this, [
         eventName,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         wrap(fn as any as WrappedFunction, {
@@ -241,7 +239,7 @@ function _wrapEventTarget(target: string): void {
           },
         }),
         options,
-      );
+      ]);
     };
   });
 


### PR DESCRIPTION
Users have reported running into a bug in Chrome wherein calling `addEventListener` or `requestAnimationFrame` too many times on `window` eventually throws an error when our `try-catch` integration is running, specifically because of how we wrap those functions. In the discussion of that bug, [one user](https://github.com/getsentry/sentry-javascript/issues/2074#issuecomment-496561134) reported that replacing our `call` call with an `apply` call in our wrapping functions solved the problem for him.

This makes that change, in the hopes it will fix the problem for everyone.

Fixes https://github.com/getsentry/sentry-javascript/issues/3388
Fixes https://github.com/getsentry/sentry-javascript/issues/2074

Ref: https://getsentry.atlassian.net/browse/WEB-669