### PR TITLE
ref(utils): Simplify `isDebugBuild` logging guard

### DIFF
--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -1,16 +1,14 @@
 /**
- * This module mostly exists for optimizations in the build process
- * through rollup and terser.  We define some global constants which
- * are normally undefined.  However terser overrides these with global
- * definitions which can be evaluated by the static analyzer when
- * creating a bundle.
- *
- * In turn the `isDebugBuild` and `isBrowserBundle` functions are pure
- * and can help us remove unused code from the bundles.
+ * This module exists for optimizations in the build process through rollup and terser.  We define some global
+ * constants, which can be overridden during build. By guarding certain pieces of code with functions that return these
+ * constants, we can control whether or not they appear in the final bundle. (Any code guarded by a false condition will
+ * never run, and will hence be dropped during treeshaking.) The two primary uses for this are stripping out calls to
+ * `logger` and preventing node-related code from appearing in browser bundles.
  */
 
 declare const __SENTRY_BROWSER_BUNDLE__: boolean | undefined;
-declare const __SENTRY_NO_DEBUG__: boolean | undefined;
+
+const __SENTRY_DEBUG__ = true;
 
 /**
  * Figures out if we're building with debug functionality.
@@ -18,7 +16,7 @@ declare const __SENTRY_NO_DEBUG__: boolean | undefined;
  * @returns true if this is a debug build
  */
 export function isDebugBuild(): boolean {
-  return typeof __SENTRY_NO_DEBUG__ !== 'undefined' && !__SENTRY_BROWSER_BUNDLE__;
+  return __SENTRY_DEBUG__;
 }
 
 /**


### PR DESCRIPTION
This simplifies the `isDebugBuild` check used to strip logging from minified bundles in two ways:

- It makes the return value independent of the value of `__SENTRY_BROWSER_BUNDLE__`, since we want to be able to have debug and non-debug browser bundles.

- It switches the variable on which it's based from one preventing debug logging which defaults to being unset to one enabling debug logging which defaults to being true. The effect is the same, but eliminating the double negative makes the intention clearer.

Note: This increases the bundle size because it turns off the fact that we've been unintentionally already stripping some logging from our bundles. (The old flag, `__SENTRY_NO_DEBUG__`, is set to `false` in our rollup config, but until this change `isDebugBuild()` has only been checking for _a_ value (any value), not a truthy value, so setting it to `false` has had the same effect as setting it to `true`.) The increase is only temporary, though, as this change is really just prework for an improved debug/no-debug bundle generation system.