### PR TITLE
feat(eslint): Allow short circuit expressions

### DIFF
--- a/packages/eslint-config-sdk/src/index.js
+++ b/packages/eslint-config-sdk/src/index.js
@@ -84,7 +84,7 @@ module.exports = {
         // Make sure all expressions are used. Turned off in tests
         // Must disable base rule to prevent false positives
         'no-unused-expressions': 'off',
-        '@typescript-eslint/no-unused-expressions': 'error',
+        '@typescript-eslint/no-unused-expressions': ['error', { allowShortCircuit: true }],
 
         // Make sure Promises are handled appropriately
         '@typescript-eslint/no-floating-promises': 'error',


### PR DESCRIPTION
This changes the default `eslint` config in order to allow expressions of the form `someBoolean  && doStuff()` or `someBoolean && (someVariable = someValue)` (which are just alternate, slightly shorter forms of single-line `if` blocks), in order to be able to use them when checking whether or not to emit logs.