### PR TITLE
feat(various): Apply debug guard to logger everywhere

### DIFF
--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -2,7 +2,7 @@ import { AfterViewInit, Directive, Injectable, Input, NgModule, OnDestroy, OnIni
 import { Event, NavigationEnd, NavigationStart, Router } from '@angular/router';
 import { getCurrentHub } from '@sentry/browser';
 import { Span, Transaction, TransactionContext } from '@sentry/types';
-import { getGlobalObject, logger, stripUrlQueryAndFragment, timestampWithMs } from '@sentry/utils';
+import { getGlobalObject, isDebugBuild, logger, stripUrlQueryAndFragment, timestampWithMs } from '@sentry/utils';
 import { Observable, Subscription } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
 
@@ -63,7 +63,8 @@ export class TraceService implements OnDestroy {
     filter(event => event instanceof NavigationStart),
     tap(event => {
       if (!instrumentationInitialized) {
-        logger.error('Angular integration has tracing enabled, but Tracing integration is not configured');
+        isDebugBuild() &&
+          logger.error('Angular integration has tracing enabled, but Tracing integration is not configured');
         return;
       }
 

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -1,6 +1,6 @@
 import { BaseClient, Scope, SDK_VERSION } from '@sentry/core';
 import { Event, EventHint } from '@sentry/types';
-import { getGlobalObject, logger } from '@sentry/utils';
+import { getGlobalObject, isDebugBuild, logger } from '@sentry/utils';
 
 import { BrowserBackend, BrowserOptions } from './backend';
 import { injectReportDialog, ReportDialogOptions } from './helpers';
@@ -47,7 +47,7 @@ export class BrowserClient extends BaseClient<BrowserBackend, BrowserOptions> {
     }
 
     if (!this._isEnabled()) {
-      logger.error('Trying to call showReportDialog with Sentry Client disabled');
+      isDebugBuild() && logger.error('Trying to call showReportDialog with Sentry Client disabled');
       return;
     }
 

--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -192,16 +192,12 @@ export function injectReportDialog(options: ReportDialogOptions = {}): void {
   }
 
   if (!options.eventId) {
-    if (isDebugBuild()) {
-      logger.error('Missing eventId option in showReportDialog call');
-    }
+    isDebugBuild() && logger.error('Missing eventId option in showReportDialog call');
     return;
   }
 
   if (!options.dsn) {
-    if (isDebugBuild()) {
-      logger.error('Missing dsn option in showReportDialog call');
-    }
+    isDebugBuild() && logger.error('Missing dsn option in showReportDialog call');
     return;
   }
 

--- a/packages/browser/src/integrations/dedupe.ts
+++ b/packages/browser/src/integrations/dedupe.ts
@@ -1,5 +1,5 @@
 import { Event, EventProcessor, Exception, Hub, Integration, StackFrame } from '@sentry/types';
-import { logger } from '@sentry/utils';
+import { isDebugBuild, logger } from '@sentry/utils';
 
 /** Deduplication filter */
 export class Dedupe implements Integration {
@@ -28,7 +28,7 @@ export class Dedupe implements Integration {
         // Juuust in case something goes wrong
         try {
           if (_shouldDropEvent(currentEvent, self._previousEvent)) {
-            logger.warn('Event dropped due to being a duplicate of previously captured event.');
+            isDebugBuild() && logger.warn('Event dropped due to being a duplicate of previously captured event.');
             return null;
           }
         } catch (_oO) {

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -237,9 +237,7 @@ function _enhanceEventWithInitialFrame(event: Event, url: any, line: any, column
 }
 
 function globalHandlerLog(type: string): void {
-  if (isDebugBuild()) {
-    logger.log(`Global Handler attached: ${type}`);
-  }
+  isDebugBuild() && logger.log(`Global Handler attached: ${type}`);
 }
 
 function addMechanismAndCapture(hub: Hub, error: EventHint['originalException'], event: Event, type: string): void {

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -162,9 +162,7 @@ export function flush(timeout?: number): PromiseLike<boolean> {
   if (client) {
     return client.flush(timeout);
   }
-  if (isDebugBuild()) {
-    logger.warn('Cannot flush events. No client defined.');
-  }
+  isDebugBuild() && logger.warn('Cannot flush events. No client defined.');
   return resolvedSyncPromise(false);
 }
 
@@ -181,9 +179,7 @@ export function close(timeout?: number): PromiseLike<boolean> {
   if (client) {
     return client.close(timeout);
   }
-  if (isDebugBuild()) {
-    logger.warn('Cannot flush events and disable SDK. No client defined.');
-  }
+  isDebugBuild() && logger.warn('Cannot flush events and disable SDK. No client defined.');
   return resolvedSyncPromise(false);
 }
 
@@ -212,9 +208,7 @@ function startSessionTracking(): void {
   const document = window.document;
 
   if (typeof document === 'undefined') {
-    if (isDebugBuild()) {
-      logger.warn('Session tracking in non-browser environment with @sentry/browser is not supported.');
-    }
+    isDebugBuild() && logger.warn('Session tracking in non-browser environment with @sentry/browser is not supported.');
     return;
   }
 

--- a/packages/browser/src/transports/base.ts
+++ b/packages/browser/src/transports/base.ts
@@ -105,7 +105,7 @@ export abstract class BaseTransport implements Transport {
     // A correct type for map-based implementation if we want to go that route
     // would be `Partial<Record<SentryRequestType, Partial<Record<Outcome, number>>>>`
     const key = `${requestTypeToCategory(category)}:${reason}`;
-    logger.log(`Adding outcome: ${key}`);
+    isDebugBuild() && logger.log(`Adding outcome: ${key}`);
     this._outcomes[key] = (this._outcomes[key] ?? 0) + 1;
   }
 
@@ -122,11 +122,11 @@ export abstract class BaseTransport implements Transport {
 
     // Nothing to send
     if (!Object.keys(outcomes).length) {
-      logger.log('No outcomes to flush');
+      isDebugBuild() && logger.log('No outcomes to flush');
       return;
     }
 
-    logger.log(`Flushing outcomes:\n${JSON.stringify(outcomes, null, 2)}`);
+    isDebugBuild() && logger.log(`Flushing outcomes:\n${JSON.stringify(outcomes, null, 2)}`);
 
     const url = getEnvelopeEndpointWithUrlEncodedAuth(this._api.dsn, this._api.tunnel);
 
@@ -144,7 +144,7 @@ export abstract class BaseTransport implements Transport {
     try {
       sendReport(url, serializeEnvelope(envelope));
     } catch (e) {
-      logger.error(e);
+      isDebugBuild() && logger.error(e);
     }
   }
 
@@ -170,8 +170,9 @@ export abstract class BaseTransport implements Transport {
      * https://developer.mozilla.org/en-US/docs/Web/API/Headers/get
      */
     const limited = this._handleRateLimit(headers);
-    if (limited && isDebugBuild()) {
-      logger.warn(`Too many ${requestType} requests, backing off until: ${this._disabledUntil(requestType)}`);
+    if (limited) {
+      isDebugBuild() &&
+        logger.warn(`Too many ${requestType} requests, backing off until: ${this._disabledUntil(requestType)}`);
     }
 
     if (status === 'success') {

--- a/packages/browser/src/transports/utils.ts
+++ b/packages/browser/src/transports/utils.ts
@@ -69,9 +69,8 @@ export function getNativeFetchImplementation(): FetchImpl {
       }
       document.head.removeChild(sandbox);
     } catch (e) {
-      if (isDebugBuild()) {
+      isDebugBuild() &&
         logger.warn('Could not create sandbox iframe for pure fetch check, bailing to window.fetch: ', e);
-      }
     }
   }
 

--- a/packages/core/src/basebackend.ts
+++ b/packages/core/src/basebackend.ts
@@ -67,7 +67,7 @@ export abstract class BaseBackend<O extends Options> implements Backend {
   public constructor(options: O) {
     this._options = options;
     if (!this._options.dsn) {
-      logger.warn('No DSN provided, backend will not do anything.');
+      isDebugBuild() && logger.warn('No DSN provided, backend will not do anything.');
     }
     this._transport = this._setupTransport();
   }

--- a/packages/core/src/basebackend.ts
+++ b/packages/core/src/basebackend.ts
@@ -92,9 +92,7 @@ export abstract class BaseBackend<O extends Options> implements Backend {
    */
   public sendEvent(event: Event): void {
     void this._transport.sendEvent(event).then(null, reason => {
-      if (isDebugBuild()) {
-        logger.error('Error while sending event:', reason);
-      }
+      isDebugBuild() && logger.error('Error while sending event:', reason);
     });
   }
 
@@ -103,16 +101,12 @@ export abstract class BaseBackend<O extends Options> implements Backend {
    */
   public sendSession(session: Session): void {
     if (!this._transport.sendSession) {
-      if (isDebugBuild()) {
-        logger.warn("Dropping session because custom transport doesn't implement sendSession");
-      }
+      isDebugBuild() && logger.warn("Dropping session because custom transport doesn't implement sendSession");
       return;
     }
 
     void this._transport.sendSession(session).then(null, reason => {
-      if (isDebugBuild()) {
-        logger.error('Error while sending session:', reason);
-      }
+      isDebugBuild() && logger.error('Error while sending session:', reason);
     });
   }
 

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -108,7 +108,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
   public captureException(exception: any, hint?: EventHint, scope?: Scope): string | undefined {
     // ensure we haven't captured this very object before
     if (checkOrSetAlreadyCaught(exception)) {
-      logger.log(ALREADY_SEEN_ERROR);
+      isDebugBuild() && logger.log(ALREADY_SEEN_ERROR);
       return;
     }
 
@@ -153,7 +153,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
   public captureEvent(event: Event, hint?: EventHint, scope?: Scope): string | undefined {
     // ensure we haven't captured this very object before
     if (hint && hint.originalException && checkOrSetAlreadyCaught(hint.originalException)) {
-      logger.log(ALREADY_SEEN_ERROR);
+      isDebugBuild() && logger.log(ALREADY_SEEN_ERROR);
       return;
     }
 
@@ -244,7 +244,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
     try {
       return (this._integrations[integration.id] as T) || null;
     } catch (_oO) {
-      logger.warn(`Cannot retrieve integration ${integration.id} from the current Client`);
+      isDebugBuild() && logger.warn(`Cannot retrieve integration ${integration.id} from the current Client`);
       return null;
     }
   }
@@ -503,7 +503,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
         return finalEvent.event_id;
       },
       reason => {
-        logger.error(reason);
+        isDebugBuild() && logger.error(reason);
         return undefined;
       },
     );

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -173,16 +173,12 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
    */
   public captureSession(session: Session): void {
     if (!this._isEnabled()) {
-      if (isDebugBuild()) {
-        logger.warn('SDK not enabled, will not capture session.');
-      }
+      isDebugBuild() && logger.warn('SDK not enabled, will not capture session.');
       return;
     }
 
     if (!(typeof session.release === 'string')) {
-      if (isDebugBuild()) {
-        logger.warn('Discarded session because of missing or non-string release');
-      }
+      isDebugBuild() && logger.warn('Discarded session because of missing or non-string release');
     } else {
       this._sendSession(session);
       // After sending, we set init false to indicate it's not the first occurrence

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -1,6 +1,6 @@
 import { addGlobalEventProcessor, getCurrentHub } from '@sentry/hub';
 import { Integration, Options } from '@sentry/types';
-import { addNonEnumerableProperty, logger } from '@sentry/utils';
+import { addNonEnumerableProperty, isDebugBuild, logger } from '@sentry/utils';
 
 export const installedIntegrations: string[] = [];
 
@@ -59,7 +59,7 @@ export function setupIntegration(integration: Integration): void {
   }
   integration.setupOnce(addGlobalEventProcessor, getCurrentHub);
   installedIntegrations.push(integration.name);
-  logger.log(`Integration installed: ${integration.name}`);
+  isDebugBuild() && logger.log(`Integration installed: ${integration.name}`);
 }
 
 /**

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -64,37 +64,33 @@ export class InboundFilters implements Integration {
   /** JSDoc */
   private _shouldDropEvent(event: Event, options: Partial<InboundFiltersOptions>): boolean {
     if (this._isSentryError(event, options)) {
-      if (isDebugBuild()) {
+      isDebugBuild() &&
         logger.warn(`Event dropped due to being internal Sentry Error.\nEvent: ${getEventDescription(event)}`);
-      }
       return true;
     }
     if (this._isIgnoredError(event, options)) {
-      if (isDebugBuild()) {
+      isDebugBuild() &&
         logger.warn(
           `Event dropped due to being matched by \`ignoreErrors\` option.\nEvent: ${getEventDescription(event)}`,
         );
-      }
       return true;
     }
     if (this._isDeniedUrl(event, options)) {
-      if (isDebugBuild()) {
+      isDebugBuild() &&
         logger.warn(
           `Event dropped due to being matched by \`denyUrls\` option.\nEvent: ${getEventDescription(
             event,
           )}.\nUrl: ${this._getEventFilterUrl(event)}`,
         );
-      }
       return true;
     }
     if (!this._isAllowedUrl(event, options)) {
-      if (isDebugBuild()) {
+      isDebugBuild() &&
         logger.warn(
           `Event dropped due to not being matched by \`allowUrls\` option.\nEvent: ${getEventDescription(
             event,
           )}.\nUrl: ${this._getEventFilterUrl(event)}`,
         );
-      }
       return true;
     }
     return false;
@@ -187,9 +183,7 @@ export class InboundFilters implements Integration {
         const { type = '', value = '' } = (event.exception.values && event.exception.values[0]) || {};
         return [`${value}`, `${type}: ${value}`];
       } catch (oO) {
-        if (isDebugBuild()) {
-          logger.error(`Cannot extract message for event ${getEventDescription(event)}`);
-        }
+        isDebugBuild() && logger.error(`Cannot extract message for event ${getEventDescription(event)}`);
         return [];
       }
     }
@@ -224,9 +218,7 @@ export class InboundFilters implements Integration {
       }
       return frames ? this._getLastValidUrl(frames) : null;
     } catch (oO) {
-      if (isDebugBuild()) {
-        logger.error(`Cannot extract url for event ${getEventDescription(event)}`);
-      }
+      isDebugBuild() && logger.error(`Cannot extract url for event ${getEventDescription(event)}`);
       return null;
     }
   }

--- a/packages/core/src/sdk.ts
+++ b/packages/core/src/sdk.ts
@@ -1,6 +1,6 @@
 import { getCurrentHub } from '@sentry/hub';
 import { Client, Options } from '@sentry/types';
-import { logger } from '@sentry/utils';
+import { isDebugBuild, logger } from '@sentry/utils';
 
 /** A class object that can instantiate Client objects. */
 export type ClientClass<F extends Client, O extends Options> = new (options: O) => F;
@@ -14,7 +14,13 @@ export type ClientClass<F extends Client, O extends Options> = new (options: O) 
  */
 export function initAndBind<F extends Client, O extends Options>(clientClass: ClientClass<F, O>, options: O): void {
   if (options.debug === true) {
-    logger.enable();
+    if (isDebugBuild()) {
+      logger.enable();
+    } else {
+      // use `console.warn` rather than `logger.warn` since by non-debug bundles have all `logger.x` statements stripped
+      // eslint-disable-next-line no-console
+      console.warn('[Sentry] Cannot initialize SDK with `debug` option using a non-debug bundle.');
+    }
   }
   const hub = getCurrentHub();
   const scope = hub.getScope();

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -20,7 +20,15 @@ import {
   TransactionContext,
   User,
 } from '@sentry/types';
-import { consoleSandbox, dateTimestampInSeconds, getGlobalObject, isNodeEnv, logger, uuid4 } from '@sentry/utils';
+import {
+  consoleSandbox,
+  dateTimestampInSeconds,
+  getGlobalObject,
+  isDebugBuild,
+  isNodeEnv,
+  logger,
+  uuid4,
+} from '@sentry/utils';
 
 import { Scope } from './scope';
 import { Session } from './session';
@@ -371,7 +379,7 @@ export class Hub implements HubInterface {
     try {
       return client.getIntegration(integration);
     } catch (_oO) {
-      logger.warn(`Cannot retrieve integration ${integration.id} from the current Hub`);
+      isDebugBuild() && logger.warn(`Cannot retrieve integration ${integration.id} from the current Hub`);
       return null;
     }
   }
@@ -503,7 +511,7 @@ export class Hub implements HubInterface {
     if (sentry && sentry.extensions && typeof sentry.extensions[method] === 'function') {
       return sentry.extensions[method].apply(this, args);
     }
-    logger.warn(`Extension method ${method} couldn't be found, doing nothing.`);
+    isDebugBuild() && logger.warn(`Extension method ${method} couldn't be found, doing nothing.`);
   }
 }
 
@@ -566,7 +574,7 @@ export function getCurrentHub(): Hub {
  */
 // eslint-disable-next-line deprecation/deprecation
 export function getActiveDomain(): DomainAsCarrier | undefined {
-  logger.warn('Function `getActiveDomain` is deprecated and will be removed in a future version.');
+  isDebugBuild() && logger.warn('Function `getActiveDomain` is deprecated and will be removed in a future version.');
 
   const sentry = getMainCarrier().__SENTRY__;
 

--- a/packages/hub/src/sessionflusher.ts
+++ b/packages/hub/src/sessionflusher.ts
@@ -5,7 +5,7 @@ import {
   SessionFlusherLike,
   Transport,
 } from '@sentry/types';
-import { dropUndefinedKeys, logger } from '@sentry/utils';
+import { dropUndefinedKeys, isDebugBuild, logger } from '@sentry/utils';
 
 import { getCurrentHub } from './hub';
 
@@ -35,11 +35,11 @@ export class SessionFlusher implements SessionFlusherLike {
   /** Sends session aggregates to Transport */
   public sendSessionAggregates(sessionAggregates: SessionAggregates): void {
     if (!this._transport.sendSession) {
-      logger.warn("Dropping session because custom transport doesn't implement sendSession");
+      isDebugBuild() && logger.warn("Dropping session because custom transport doesn't implement sendSession");
       return;
     }
     void this._transport.sendSession(sessionAggregates).then(null, reason => {
-      logger.error('Error while sending session:', reason);
+      isDebugBuild() && logger.error('Error while sending session:', reason);
     });
   }
 

--- a/packages/integrations/src/angular.ts
+++ b/packages/integrations/src/angular.ts
@@ -1,5 +1,5 @@
 import { Event, EventProcessor, Hub, Integration } from '@sentry/types';
-import { getGlobalObject, logger } from '@sentry/utils';
+import { getGlobalObject, isDebugBuild, logger } from '@sentry/utils';
 
 // See https://github.com/angular/angular.js/blob/v1.4.7/src/minErr.js
 const angularPattern = /^\[((?:[$a-zA-Z0-9]+:)?(?:[$a-zA-Z0-9]+))\] (.*?)\n?(\S+)$/;
@@ -47,13 +47,13 @@ export class Angular implements Integration {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public constructor(options: { angular?: any } = {}) {
-    logger.log('You are still using the Angular integration, consider moving to @sentry/angular');
+    isDebugBuild() && logger.log('You are still using the Angular integration, consider moving to @sentry/angular');
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     this._angular = options.angular || getGlobalObject<any>().angular;
 
     if (!this._angular) {
-      logger.error('AngularIntegration is missing an Angular instance');
+      isDebugBuild() && logger.error('AngularIntegration is missing an Angular instance');
       return;
     }
 

--- a/packages/integrations/src/dedupe.ts
+++ b/packages/integrations/src/dedupe.ts
@@ -1,5 +1,5 @@
 import { Event, EventProcessor, Exception, Hub, Integration, StackFrame } from '@sentry/types';
-import { logger } from '@sentry/utils';
+import { isDebugBuild, logger } from '@sentry/utils';
 
 /** Deduplication filter */
 export class Dedupe implements Integration {
@@ -28,7 +28,7 @@ export class Dedupe implements Integration {
         // Juuust in case something goes wrong
         try {
           if (_shouldDropEvent(currentEvent, self._previousEvent)) {
-            logger.warn('Event dropped due to being a duplicate of previously captured event.');
+            isDebugBuild() && logger.warn('Event dropped due to being a duplicate of previously captured event.');
             return null;
           }
         } catch (_oO) {

--- a/packages/integrations/src/ember.ts
+++ b/packages/integrations/src/ember.ts
@@ -1,5 +1,5 @@
 import { EventProcessor, Hub, Integration } from '@sentry/types';
-import { getGlobalObject, isInstanceOf, logger } from '@sentry/utils';
+import { getGlobalObject, isDebugBuild, isInstanceOf, logger } from '@sentry/utils';
 
 /** JSDoc */
 export class Ember implements Integration {
@@ -33,7 +33,7 @@ export class Ember implements Integration {
    */
   public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
     if (!this._Ember) {
-      logger.error('EmberIntegration is missing an Ember instance');
+      isDebugBuild() && logger.error('EmberIntegration is missing an Ember instance');
       return;
     }
 

--- a/packages/integrations/src/extraerrordata.ts
+++ b/packages/integrations/src/extraerrordata.ts
@@ -1,5 +1,5 @@
 import { Event, EventHint, EventProcessor, ExtendedError, Hub, Integration } from '@sentry/types';
-import { isError, isPlainObject, logger, normalize } from '@sentry/utils';
+import { isDebugBuild, isError, isPlainObject, logger, normalize } from '@sentry/utils';
 
 /** JSDoc */
 interface ExtraErrorDataOptions {
@@ -120,7 +120,7 @@ export class ExtraErrorData implements Integration {
 
       return extraErrorInfo;
     } catch (oO) {
-      logger.error('Unable to extract extra data from the Error object:', oO);
+      isDebugBuild() && logger.error('Unable to extract extra data from the Error object:', oO);
     }
 
     return null;

--- a/packages/integrations/src/offline.ts
+++ b/packages/integrations/src/offline.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { Event, EventProcessor, Hub, Integration } from '@sentry/types';
-import { getGlobalObject, logger, normalize, uuid4 } from '@sentry/utils';
+import { getGlobalObject, isDebugBuild, logger, normalize, uuid4 } from '@sentry/utils';
 import localForage from 'localforage';
 
 type LocalForage = {
@@ -70,7 +70,7 @@ export class Offline implements Integration {
     if ('addEventListener' in this.global) {
       this.global.addEventListener('online', () => {
         void this._sendEvents().catch(() => {
-          logger.warn('could not send cached events');
+          isDebugBuild() && logger.warn('could not send cached events');
         });
       });
     }
@@ -82,7 +82,7 @@ export class Offline implements Integration {
           void this._cacheEvent(event)
             .then((_event: Event): Promise<void> => this._enforceMaxEvents())
             .catch((_error): void => {
-              logger.warn('could not cache event while offline');
+              isDebugBuild() && logger.warn('could not cache event while offline');
             });
 
           // return null on success or failure, because being offline will still result in an error
@@ -96,7 +96,7 @@ export class Offline implements Integration {
     // if online now, send any events stored in a previous offline session
     if ('navigator' in this.global && 'onLine' in this.global.navigator && this.global.navigator.onLine) {
       void this._sendEvents().catch(() => {
-        logger.warn('could not send cached events');
+        isDebugBuild() && logger.warn('could not send cached events');
       });
     }
   }
@@ -132,7 +132,7 @@ export class Offline implements Integration {
           ),
       )
       .catch((_error): void => {
-        logger.warn('could not enforce max events');
+        isDebugBuild() && logger.warn('could not enforce max events');
       });
   }
 
@@ -160,10 +160,10 @@ export class Offline implements Integration {
         this.hub.captureEvent(event);
 
         void this._purgeEvent(cacheKey).catch((_error): void => {
-          logger.warn('could not purge event from cache');
+          isDebugBuild() && logger.warn('could not purge event from cache');
         });
       } else {
-        logger.warn('no hub found - could not send cached event');
+        isDebugBuild() && logger.warn('no hub found - could not send cached event');
       }
     });
   }

--- a/packages/integrations/src/vue.ts
+++ b/packages/integrations/src/vue.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { EventProcessor, Hub, Integration, IntegrationClass, Scope, Span, Transaction } from '@sentry/types';
-import { basename, getGlobalObject, logger, timestampWithMs } from '@sentry/utils';
+import { basename, getGlobalObject, isDebugBuild, logger, timestampWithMs } from '@sentry/utils';
 
 /**
  * Used to extract Tracing integration from the current client,
@@ -156,7 +156,7 @@ export class Vue implements Integration {
   public constructor(
     options: Partial<Omit<IntegrationOptions, 'tracingOptions'> & { tracingOptions: Partial<TracingOptions> }>,
   ) {
-    logger.log('You are still using the Vue.js integration, consider moving to @sentry/vue');
+    isDebugBuild() && logger.log('You are still using the Vue.js integration, consider moving to @sentry/vue');
     this._options = {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       Vue: getGlobalObject<any>().Vue,
@@ -178,7 +178,7 @@ export class Vue implements Integration {
    */
   public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
     if (!this._options.Vue) {
-      logger.error('Vue integration is missing a Vue instance');
+      isDebugBuild() && logger.error('Vue integration is missing a Vue instance');
       return;
     }
 
@@ -325,7 +325,7 @@ export class Vue implements Integration {
       const internalHooks = HOOKS[operation];
 
       if (!internalHooks) {
-        logger.warn(`Unknown hook: ${operation}`);
+        isDebugBuild() && logger.warn(`Unknown hook: ${operation}`);
         return;
       }
 
@@ -382,7 +382,8 @@ export class Vue implements Integration {
           // `this` points to currently rendered component
           applyTracingHooks(this, getCurrentHub);
         } else {
-          logger.error('Vue integration has tracing enabled, but Tracing integration is not configured');
+          isDebugBuild() &&
+            logger.error('Vue integration has tracing enabled, but Tracing integration is not configured');
         }
       },
     });
@@ -404,7 +405,7 @@ export class Vue implements Integration {
             metadata.propsData = vm.$options.propsData;
           }
         } catch (_oO) {
-          logger.warn('Unable to extract metadata from Vue component.');
+          isDebugBuild() && logger.warn('Unable to extract metadata from Vue component.');
         }
       }
 

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import { getSentryRelease } from '@sentry/node';
-import { dropUndefinedKeys, logger } from '@sentry/utils';
+import { dropUndefinedKeys, isDebugBuild, logger } from '@sentry/utils';
 import { default as SentryWebpackPlugin } from '@sentry/webpack-plugin';
 import * as fs from 'fs';
 import * as os from 'os';
@@ -244,11 +244,12 @@ function checkWebpackPluginOverrides(
   // warn if any of the default options for the webpack plugin are getting overridden
   const sentryWebpackPluginOptionOverrides = Object.keys(defaultOptions).filter(key => key in userOptions);
   if (sentryWebpackPluginOptionOverrides.length > 0) {
-    logger.warn(
-      '[Sentry] You are overriding the following automatically-set SentryWebpackPlugin config options:\n' +
-        `\t${sentryWebpackPluginOptionOverrides.toString()},\n` +
-        "which has the possibility of breaking source map upload and application. This is only a good idea if you know what you're doing.",
-    );
+    isDebugBuild() &&
+      logger.warn(
+        '[Sentry] You are overriding the following automatically-set SentryWebpackPlugin config options:\n' +
+          `\t${sentryWebpackPluginOptionOverrides.toString()},\n` +
+          "which has the possibility of breaking source map upload and application. This is only a good idea if you know what you're doing.",
+      );
   }
 }
 

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -3,7 +3,7 @@ import { RewriteFrames } from '@sentry/integrations';
 import { configureScope, getCurrentHub, init as nodeInit, Integrations } from '@sentry/node';
 import { hasTracingEnabled } from '@sentry/tracing';
 import { Event } from '@sentry/types';
-import { escapeStringForRegex, logger } from '@sentry/utils';
+import { escapeStringForRegex, isDebugBuild, logger } from '@sentry/utils';
 import * as domainModule from 'domain';
 import * as path from 'path';
 
@@ -45,10 +45,10 @@ export function init(options: NextjsOptions): void {
     logger.enable();
   }
 
-  logger.log('Initializing SDK...');
+  isDebugBuild() && logger.log('Initializing SDK...');
 
   if (sdkAlreadyInitialized()) {
-    logger.log('SDK already initialized');
+    isDebugBuild() && logger.log('SDK already initialized');
     return;
   }
 
@@ -93,7 +93,7 @@ export function init(options: NextjsOptions): void {
     domain.active = activeDomain;
   }
 
-  logger.log('SDK successfully initialized');
+  isDebugBuild() && logger.log('SDK successfully initialized');
 }
 
 function sdkAlreadyInitialized(): boolean {
@@ -150,6 +150,6 @@ if (!isVercel && !isBuild) {
     const { instrumentServer } = require('./utils/instrumentServer.js');
     instrumentServer();
   } catch (err) {
-    logger.warn(`Error: Unable to instrument server for tracing. Got ${err}.`);
+    isDebugBuild() && logger.warn(`Error: Unable to instrument server for tracing. Got ${err}.`);
   }
 }

--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -8,7 +8,7 @@ import {
   startTransaction,
 } from '@sentry/node';
 import { extractTraceparentData, getActiveTransaction, hasTracingEnabled } from '@sentry/tracing';
-import { addExceptionMechanism, fill, isString, logger, stripUrlQueryAndFragment } from '@sentry/utils';
+import { addExceptionMechanism, fill, isDebugBuild, isString, logger, stripUrlQueryAndFragment } from '@sentry/utils';
 import * as domain from 'domain';
 import * as http from 'http';
 import { default as createNextServer } from 'next';
@@ -247,7 +247,7 @@ function makeWrappedReqHandler(origReqHandler: ReqHandler): WrappedReqHandler {
           let traceparentData;
           if (nextReq.headers && isString(nextReq.headers['sentry-trace'])) {
             traceparentData = extractTraceparentData(nextReq.headers['sentry-trace'] as string);
-            logger.log(`[Tracing] Continuing trace ${traceparentData?.traceId}.`);
+            isDebugBuild() && logger.log(`[Tracing] Continuing trace ${traceparentData?.traceId}.`);
           }
 
           // pull off query string, if any

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -1,7 +1,7 @@
 import { BaseClient, Scope, SDK_VERSION } from '@sentry/core';
 import { SessionFlusher } from '@sentry/hub';
 import { Event, EventHint } from '@sentry/types';
-import { logger } from '@sentry/utils';
+import { isDebugBuild, logger } from '@sentry/utils';
 
 import { NodeBackend } from './backend';
 import { NodeOptions } from './types';
@@ -96,7 +96,7 @@ export class NodeClient extends BaseClient<NodeBackend, NodeOptions> {
   public initSessionFlusher(): void {
     const { release, environment } = this._options;
     if (!release) {
-      logger.warn('Cannot initialise an instance of SessionFlusher if no release is provided!');
+      isDebugBuild() && logger.warn('Cannot initialise an instance of SessionFlusher if no release is provided!');
     } else {
       this._sessionFlusher = new SessionFlusher(this.getTransport(), {
         release,
@@ -122,7 +122,7 @@ export class NodeClient extends BaseClient<NodeBackend, NodeOptions> {
    */
   protected _captureRequestSession(): void {
     if (!this._sessionFlusher) {
-      logger.warn('Discarded request mode session because autoSessionTracking option was disabled');
+      isDebugBuild() && logger.warn('Discarded request mode session because autoSessionTracking option was disabled');
     } else {
       this._sessionFlusher.incrementSessionStatusCount();
     }

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -4,6 +4,7 @@ import { captureException, getCurrentHub, startTransaction, withScope } from '@s
 import { Event, ExtractedNodeRequestData, Span, Transaction } from '@sentry/types';
 import {
   extractTraceparentData,
+  isDebugBuild,
   isPlainObject,
   isString,
   logger,
@@ -411,7 +412,7 @@ export function requestHandler(
             _end.call(this, chunk, encoding, cb);
           })
           .then(null, e => {
-            logger.error(e);
+            isDebugBuild() && logger.error(e);
             _end.call(this, chunk, encoding, cb);
           });
       };

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -1,6 +1,6 @@
 import { getCurrentHub } from '@sentry/core';
 import { Integration, Span } from '@sentry/types';
-import { fill, logger, parseSemver } from '@sentry/utils';
+import { fill, isDebugBuild, logger, parseSemver } from '@sentry/utils';
 import * as http from 'http';
 import * as https from 'https';
 
@@ -118,9 +118,10 @@ function _createWrappedRequestMethodFactory(
           });
 
           const sentryTraceHeader = span.toTraceparent();
-          logger.log(
-            `[Tracing] Adding sentry-trace header ${sentryTraceHeader} to outgoing request to ${requestUrl}: `,
-          );
+          isDebugBuild() &&
+            logger.log(
+              `[Tracing] Adding sentry-trace header ${sentryTraceHeader} to outgoing request to ${requestUrl}: `,
+            );
           requestOptions.headers = { ...requestOptions.headers, 'sentry-trace': sentryTraceHeader };
         }
       }

--- a/packages/node/src/integrations/onuncaughtexception.ts
+++ b/packages/node/src/integrations/onuncaughtexception.ts
@@ -1,6 +1,6 @@
 import { getCurrentHub, Scope } from '@sentry/core';
 import { Integration, Severity } from '@sentry/types';
-import { logger } from '@sentry/utils';
+import { isDebugBuild, logger } from '@sentry/utils';
 
 import { NodeClient } from '../client';
 import { logAndExitProcess } from './utils/errorhandling';
@@ -95,7 +95,8 @@ export class OnUncaughtException implements Integration {
         }
       } else if (calledFatalError) {
         // we hit an error *after* calling onFatalError - pretty boned at this point, just shut it down
-        logger.warn('uncaught exception after calling fatal error shutdown callback - this is bad! forcing shutdown');
+        isDebugBuild() &&
+          logger.warn('uncaught exception after calling fatal error shutdown callback - this is bad! forcing shutdown');
         logAndExitProcess(error);
       } else if (!caughtSecondError) {
         // two cases for how we can hit this branch:

--- a/packages/node/src/integrations/utils/errorhandling.ts
+++ b/packages/node/src/integrations/utils/errorhandling.ts
@@ -1,5 +1,5 @@
 import { getCurrentHub } from '@sentry/core';
-import { forget, logger } from '@sentry/utils';
+import { forget, isDebugBuild, logger } from '@sentry/utils';
 
 import { NodeClient } from '../../client';
 
@@ -15,7 +15,7 @@ export function logAndExitProcess(error: Error): void {
   const client = getCurrentHub().getClient<NodeClient>();
 
   if (client === undefined) {
-    logger.warn('No NodeClient was defined, we are exiting the process now.');
+    isDebugBuild() && logger.warn('No NodeClient was defined, we are exiting the process now.');
     global.process.exit(1);
   }
 
@@ -26,7 +26,7 @@ export function logAndExitProcess(error: Error): void {
   forget(
     client.close(timeout).then((result: boolean) => {
       if (!result) {
-        logger.warn('We reached the timeout for emptying the request buffer, still exiting now!');
+        isDebugBuild() && logger.warn('We reached the timeout for emptying the request buffer, still exiting now!');
       }
       global.process.exit(1);
     }),

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -1,7 +1,7 @@
 import { getCurrentHub, initAndBind, Integrations as CoreIntegrations } from '@sentry/core';
 import { getMainCarrier, setHubOnCarrier } from '@sentry/hub';
 import { SessionStatus } from '@sentry/types';
-import { getGlobalObject, logger } from '@sentry/utils';
+import { getGlobalObject, isDebugBuild, logger } from '@sentry/utils';
 import * as domain from 'domain';
 
 import { NodeClient } from './client';
@@ -153,7 +153,7 @@ export async function flush(timeout?: number): Promise<boolean> {
   if (client) {
     return client.flush(timeout);
   }
-  logger.warn('Cannot flush events. No client defined.');
+  isDebugBuild() && logger.warn('Cannot flush events. No client defined.');
   return Promise.resolve(false);
 }
 
@@ -170,7 +170,7 @@ export async function close(timeout?: number): Promise<boolean> {
   if (client) {
     return client.close(timeout);
   }
-  logger.warn('Cannot flush events and disable SDK. No client defined.');
+  isDebugBuild() && logger.warn('Cannot flush events and disable SDK. No client defined.');
   return Promise.resolve(false);
 }
 

--- a/packages/node/src/transports/base/index.ts
+++ b/packages/node/src/transports/base/index.ts
@@ -12,6 +12,7 @@ import {
 } from '@sentry/types';
 import {
   eventStatusFromHttpCode,
+  isDebugBuild,
   logger,
   makePromiseBuffer,
   parseRetryAfterHeader,
@@ -236,11 +237,12 @@ export abstract class BaseTransport implements Transport {
 
             const limited = this._handleRateLimit(headers);
             if (limited)
-              logger.warn(
-                `Too many ${sentryRequest.type} requests, backing off until: ${this._disabledUntil(
-                  sentryRequest.type,
-                )}`,
-              );
+              isDebugBuild() &&
+                logger.warn(
+                  `Too many ${sentryRequest.type} requests, backing off until: ${this._disabledUntil(
+                    sentryRequest.type,
+                  )}`,
+                );
 
             if (status === 'success') {
               resolve({ status });

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -1,5 +1,5 @@
 import { captureException, ReportDialogOptions, Scope, showReportDialog, withScope } from '@sentry/browser';
-import { logger } from '@sentry/utils';
+import { isDebugBuild, logger } from '@sentry/utils';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
 
@@ -141,7 +141,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
       }
 
       if (fallback) {
-        logger.warn('fallback did not produce a valid ReactElement');
+        isDebugBuild() && logger.warn('fallback did not produce a valid ReactElement');
       }
 
       // Fail gracefully if no fallback provided or is not valid

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -11,7 +11,7 @@ import {
 } from '@sentry/node';
 import { extractTraceparentData } from '@sentry/tracing';
 import { Integration } from '@sentry/types';
-import { isString, logger, SentryError } from '@sentry/utils';
+import { isDebugBuild, isString, logger, SentryError } from '@sentry/utils';
 // NOTE: I have no idea how to fix this right now, and don't want to waste more time, as it builds just fine — Kamil
 // eslint-disable-next-line import/no-unresolved
 import { Context, Handler } from 'aws-lambda';
@@ -124,7 +124,7 @@ export function tryPatchHandler(taskRoot: string, handlerPath: string): void {
   const handlerDesc = basename(handlerPath);
   const match = handlerDesc.match(/^([^.]*)\.(.*)$/);
   if (!match) {
-    logger.error(`Bad handler ${handlerDesc}`);
+    isDebugBuild() && logger.error(`Bad handler ${handlerDesc}`);
     return;
   }
 
@@ -135,7 +135,7 @@ export function tryPatchHandler(taskRoot: string, handlerPath: string): void {
     const handlerDir = handlerPath.substring(0, handlerPath.indexOf(handlerDesc));
     obj = tryRequire(taskRoot, handlerDir, handlerMod);
   } catch (e) {
-    logger.error(`Cannot require ${handlerPath} in ${taskRoot}`, e);
+    isDebugBuild() && logger.error(`Cannot require ${handlerPath} in ${taskRoot}`, e);
     return;
   }
 
@@ -147,11 +147,11 @@ export function tryPatchHandler(taskRoot: string, handlerPath: string): void {
     functionName = name;
   });
   if (!obj) {
-    logger.error(`${handlerPath} is undefined or not exported`);
+    isDebugBuild() && logger.error(`${handlerPath} is undefined or not exported`);
     return;
   }
   if (typeof obj !== 'function') {
-    logger.error(`${handlerPath} is not a function`);
+    isDebugBuild() && logger.error(`${handlerPath} is not a function`);
     return;
   }
 
@@ -318,7 +318,7 @@ export function wrapHandler<TEvent, TResult>(
       hub.popScope();
       await flush(options.flushTimeout).catch(e => {
         if (options.ignoreSentryErrors && e instanceof SentryError) {
-          logger.error(e);
+          isDebugBuild() && logger.error(e);
           return;
         }
         throw e;

--- a/packages/serverless/src/gcpfunction/cloud_events.ts
+++ b/packages/serverless/src/gcpfunction/cloud_events.ts
@@ -1,5 +1,5 @@
 import { captureException, flush, getCurrentHub, startTransaction } from '@sentry/node';
-import { logger } from '@sentry/utils';
+import { isDebugBuild, logger } from '@sentry/utils';
 
 import { domainify, getActiveDomain, proxyFunction } from '../utils';
 import {
@@ -64,7 +64,7 @@ function _wrapCloudEventFunction(
           callback(...args);
         })
         .then(null, e => {
-          logger.error(e);
+          isDebugBuild() && logger.error(e);
         });
     });
 

--- a/packages/serverless/src/gcpfunction/events.ts
+++ b/packages/serverless/src/gcpfunction/events.ts
@@ -1,5 +1,5 @@
 import { captureException, flush, getCurrentHub, startTransaction } from '@sentry/node';
-import { logger } from '@sentry/utils';
+import { isDebugBuild, logger } from '@sentry/utils';
 
 import { domainify, getActiveDomain, proxyFunction } from '../utils';
 import { configureScopeWithContext, EventFunction, EventFunctionWithCallback, WrapperOptions } from './general';
@@ -59,7 +59,7 @@ function _wrapEventFunction(
           callback(...args);
         })
         .then(null, e => {
-          logger.error(e);
+          isDebugBuild() && logger.error(e);
         });
     });
 

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -1,6 +1,6 @@
 import { captureException, flush, getCurrentHub, Handlers, startTransaction } from '@sentry/node';
 import { extractTraceparentData } from '@sentry/tracing';
-import { isString, logger, stripUrlQueryAndFragment } from '@sentry/utils';
+import { isDebugBuild, isString, logger, stripUrlQueryAndFragment } from '@sentry/utils';
 
 import { domainify, getActiveDomain, proxyFunction } from './../utils';
 import { HttpFunction, WrapperOptions } from './general';
@@ -94,7 +94,7 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
           _end.call(this, chunk, encoding, cb);
         })
         .then(null, e => {
-          logger.error(e);
+          isDebugBuild() && logger.error(e);
         });
     };
 

--- a/packages/tracing/src/browser/backgroundtab.ts
+++ b/packages/tracing/src/browser/backgroundtab.ts
@@ -1,4 +1,4 @@
-import { getGlobalObject, logger } from '@sentry/utils';
+import { getGlobalObject, isDebugBuild, logger } from '@sentry/utils';
 
 import { FINISH_REASON_TAG, IDLE_TRANSACTION_FINISH_REASONS } from '../constants';
 import { IdleTransaction } from '../idletransaction';
@@ -18,9 +18,10 @@ export function registerBackgroundTabDetection(): void {
       if (global.document.hidden && activeTransaction) {
         const statusType: SpanStatusType = 'cancelled';
 
-        logger.log(
-          `[Tracing] Transaction: ${statusType} -> since tab moved to the background, op: ${activeTransaction.op}`,
-        );
+        isDebugBuild() &&
+          logger.log(
+            `[Tracing] Transaction: ${statusType} -> since tab moved to the background, op: ${activeTransaction.op}`,
+          );
         // We should not set status if it is already set, this prevent important statuses like
         // error or data loss from being overwritten on transaction.
         if (!activeTransaction.status) {
@@ -32,6 +33,6 @@ export function registerBackgroundTabDetection(): void {
       }
     });
   } else {
-    logger.warn('[Tracing] Could not set up background tab detection due to lack of global document');
+    isDebugBuild() && logger.warn('[Tracing] Could not set up background tab detection due to lack of global document');
   }
 }

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -1,6 +1,6 @@
 import { Hub } from '@sentry/hub';
 import { EventProcessor, Integration, Transaction, TransactionContext } from '@sentry/types';
-import { getGlobalObject, logger } from '@sentry/utils';
+import { getGlobalObject, isDebugBuild, logger } from '@sentry/utils';
 
 import { startIdleTransaction } from '../hubextensions';
 import { DEFAULT_IDLE_TIMEOUT, IdleTransaction } from '../idletransaction';
@@ -160,12 +160,14 @@ export class BrowserTracing implements Integration {
     this._getCurrentHub = getCurrentHub;
 
     if (this._emitOptionsWarning) {
-      logger.warn(
-        '[Tracing] You need to define `tracingOrigins` in the options. Set an array of urls or patterns to trace.',
-      );
-      logger.warn(
-        `[Tracing] We added a reasonable default for you: ${defaultRequestInstrumentationOptions.tracingOrigins}`,
-      );
+      isDebugBuild() &&
+        logger.warn(
+          '[Tracing] You need to define `tracingOrigins` in the options. Set an array of urls or patterns to trace.',
+        );
+      isDebugBuild() &&
+        logger.warn(
+          `[Tracing] We added a reasonable default for you: ${defaultRequestInstrumentationOptions.tracingOrigins}`,
+        );
     }
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -196,7 +198,8 @@ export class BrowserTracing implements Integration {
   /** Create routing idle transaction. */
   private _createRouteTransaction(context: TransactionContext): Transaction | undefined {
     if (!this._getCurrentHub) {
-      logger.warn(`[Tracing] Did not create ${context.op} transaction because _getCurrentHub is invalid.`);
+      isDebugBuild() &&
+        logger.warn(`[Tracing] Did not create ${context.op} transaction because _getCurrentHub is invalid.`);
       return undefined;
     }
 
@@ -217,10 +220,10 @@ export class BrowserTracing implements Integration {
     const finalContext = modifiedContext === undefined ? { ...expandedContext, sampled: false } : modifiedContext;
 
     if (finalContext.sampled === false) {
-      logger.log(`[Tracing] Will not send ${finalContext.op} transaction because of beforeNavigate.`);
+      isDebugBuild() && logger.log(`[Tracing] Will not send ${finalContext.op} transaction because of beforeNavigate.`);
     }
 
-    logger.log(`[Tracing] Starting ${finalContext.op} transaction on scope`);
+    isDebugBuild() && logger.log(`[Tracing] Starting ${finalContext.op} transaction on scope`);
 
     const hub = this._getCurrentHub();
     const { location } = getGlobalObject() as WindowOrWorkerGlobalScope & { location: Location };

--- a/packages/tracing/src/browser/router.ts
+++ b/packages/tracing/src/browser/router.ts
@@ -1,5 +1,5 @@
 import { Transaction, TransactionContext } from '@sentry/types';
-import { addInstrumentationHandler, getGlobalObject, logger } from '@sentry/utils';
+import { addInstrumentationHandler, getGlobalObject, isDebugBuild, logger } from '@sentry/utils';
 
 const global = getGlobalObject<Window>();
 
@@ -12,7 +12,7 @@ export function instrumentRoutingWithDefaults<T extends Transaction>(
   startTransactionOnLocationChange: boolean = true,
 ): void {
   if (!global || !global.location) {
-    logger.warn('Could not initialize routing instrumentation due to invalid location');
+    isDebugBuild() && logger.warn('Could not initialize routing instrumentation due to invalid location');
     return;
   }
 
@@ -42,7 +42,7 @@ export function instrumentRoutingWithDefaults<T extends Transaction>(
       if (from !== to) {
         startingUrl = undefined;
         if (activeTransaction) {
-          logger.log(`[Tracing] Finishing current transaction with op: ${activeTransaction.op}`);
+          isDebugBuild() && logger.log(`[Tracing] Finishing current transaction with op: ${activeTransaction.op}`);
           // If there's an open transaction on the scope, we need to finish it before creating an new one.
           activeTransaction.finish();
         }

--- a/packages/tracing/src/errors.ts
+++ b/packages/tracing/src/errors.ts
@@ -1,4 +1,4 @@
-import { addInstrumentationHandler, logger } from '@sentry/utils';
+import { addInstrumentationHandler, isDebugBuild, logger } from '@sentry/utils';
 
 import { SpanStatusType } from './span';
 import { getActiveTransaction } from './utils';
@@ -18,7 +18,7 @@ function errorCallback(): void {
   const activeTransaction = getActiveTransaction();
   if (activeTransaction) {
     const status: SpanStatusType = 'internal_error';
-    logger.log(`[Tracing] Transaction: ${status} -> Global error occured`);
+    isDebugBuild() && logger.log(`[Tracing] Transaction: ${status} -> Global error occured`);
     activeTransaction.setStatus(status);
   }
 }

--- a/packages/tracing/src/hubextensions.ts
+++ b/packages/tracing/src/hubextensions.ts
@@ -7,7 +7,7 @@ import {
   SamplingContext,
   TransactionContext,
 } from '@sentry/types';
-import { dynamicRequire, isNodeEnv, loadModule, logger } from '@sentry/utils';
+import { dynamicRequire, isDebugBuild, isNodeEnv, loadModule, logger } from '@sentry/utils';
 
 import { registerErrorInstrumentation } from './errors';
 import { IdleTransaction } from './idletransaction';
@@ -86,20 +86,21 @@ function sample<T extends Transaction>(transaction: T, options: Options, samplin
   // Since this is coming from the user (or from a function provided by the user), who knows what we might get. (The
   // only valid values are booleans or numbers between 0 and 1.)
   if (!isValidSampleRate(sampleRate)) {
-    logger.warn('[Tracing] Discarding transaction because of invalid sample rate.');
+    isDebugBuild() && logger.warn('[Tracing] Discarding transaction because of invalid sample rate.');
     transaction.sampled = false;
     return transaction;
   }
 
   // if the function returned 0 (or false), or if `tracesSampleRate` is 0, it's a sign the transaction should be dropped
   if (!sampleRate) {
-    logger.log(
-      `[Tracing] Discarding transaction because ${
-        typeof options.tracesSampler === 'function'
-          ? 'tracesSampler returned 0 or false'
-          : 'a negative sampling decision was inherited or tracesSampleRate is set to 0'
-      }`,
-    );
+    isDebugBuild() &&
+      logger.log(
+        `[Tracing] Discarding transaction because ${
+          typeof options.tracesSampler === 'function'
+            ? 'tracesSampler returned 0 or false'
+            : 'a negative sampling decision was inherited or tracesSampleRate is set to 0'
+        }`,
+      );
     transaction.sampled = false;
     return transaction;
   }
@@ -110,15 +111,16 @@ function sample<T extends Transaction>(transaction: T, options: Options, samplin
 
   // if we're not going to keep it, we're done
   if (!transaction.sampled) {
-    logger.log(
-      `[Tracing] Discarding transaction because it's not included in the random sample (sampling rate = ${Number(
-        sampleRate,
-      )})`,
-    );
+    isDebugBuild() &&
+      logger.log(
+        `[Tracing] Discarding transaction because it's not included in the random sample (sampling rate = ${Number(
+          sampleRate,
+        )})`,
+      );
     return transaction;
   }
 
-  logger.log(`[Tracing] starting ${transaction.op} transaction - ${transaction.name}`);
+  isDebugBuild() && logger.log(`[Tracing] starting ${transaction.op} transaction - ${transaction.name}`);
   return transaction;
 }
 
@@ -129,17 +131,19 @@ function isValidSampleRate(rate: unknown): boolean {
   // we need to check NaN explicitly because it's of type 'number' and therefore wouldn't get caught by this typecheck
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if (isNaN(rate as any) || !(typeof rate === 'number' || typeof rate === 'boolean')) {
-    logger.warn(
-      `[Tracing] Given sample rate is invalid. Sample rate must be a boolean or a number between 0 and 1. Got ${JSON.stringify(
-        rate,
-      )} of type ${JSON.stringify(typeof rate)}.`,
-    );
+    isDebugBuild() &&
+      logger.warn(
+        `[Tracing] Given sample rate is invalid. Sample rate must be a boolean or a number between 0 and 1. Got ${JSON.stringify(
+          rate,
+        )} of type ${JSON.stringify(typeof rate)}.`,
+      );
     return false;
   }
 
   // in case sampleRate is a boolean, it will get automatically cast to 1 if it's true and 0 if it's false
   if (rate < 0 || rate > 1) {
-    logger.warn(`[Tracing] Given sample rate is invalid. Sample rate must be between 0 and 1. Got ${rate}.`);
+    isDebugBuild() &&
+      logger.warn(`[Tracing] Given sample rate is invalid. Sample rate must be between 0 and 1. Got ${rate}.`);
     return false;
   }
   return true;

--- a/packages/tracing/src/integrations/node/express.ts
+++ b/packages/tracing/src/integrations/node/express.ts
@@ -1,5 +1,5 @@
 import { Integration, Transaction } from '@sentry/types';
-import { logger } from '@sentry/utils';
+import { isDebugBuild, logger } from '@sentry/utils';
 
 type Method =
   | 'all'
@@ -79,7 +79,7 @@ export class Express implements Integration {
    */
   public setupOnce(): void {
     if (!this._router) {
-      logger.error('ExpressIntegration is missing an Express instance');
+      isDebugBuild() && logger.error('ExpressIntegration is missing an Express instance');
       return;
     }
     instrumentMiddlewares(this._router, this._methods);

--- a/packages/tracing/src/integrations/node/mongo.ts
+++ b/packages/tracing/src/integrations/node/mongo.ts
@@ -1,6 +1,6 @@
 import { Hub } from '@sentry/hub';
 import { EventProcessor, Integration, SpanContext } from '@sentry/types';
-import { fill, isThenable, loadModule, logger } from '@sentry/utils';
+import { fill, isDebugBuild, isThenable, loadModule, logger } from '@sentry/utils';
 
 // This allows us to use the same array for both defaults options and the type itself.
 // (note `as const` at the end to make it a union of string literal types (i.e. "a" | "b" | ... )
@@ -121,7 +121,7 @@ export class Mongo implements Integration {
     const pkg = loadModule<{ Collection: MongoCollection }>(moduleName);
 
     if (!pkg) {
-      logger.error(`Mongo Integration was unable to require \`${moduleName}\` package.`);
+      isDebugBuild() && logger.error(`Mongo Integration was unable to require \`${moduleName}\` package.`);
       return;
     }
 

--- a/packages/tracing/src/integrations/node/mysql.ts
+++ b/packages/tracing/src/integrations/node/mysql.ts
@@ -1,6 +1,6 @@
 import { Hub } from '@sentry/hub';
 import { EventProcessor, Integration } from '@sentry/types';
-import { fill, loadModule, logger } from '@sentry/utils';
+import { fill, isDebugBuild, loadModule, logger } from '@sentry/utils';
 
 interface MysqlConnection {
   createQuery: () => void;
@@ -25,7 +25,7 @@ export class Mysql implements Integration {
     const pkg = loadModule<MysqlConnection>('mysql/lib/Connection.js');
 
     if (!pkg) {
-      logger.error('Mysql Integration was unable to require `mysql` package.');
+      isDebugBuild() && logger.error('Mysql Integration was unable to require `mysql` package.');
       return;
     }
 

--- a/packages/tracing/src/integrations/node/postgres.ts
+++ b/packages/tracing/src/integrations/node/postgres.ts
@@ -1,6 +1,6 @@
 import { Hub } from '@sentry/hub';
 import { EventProcessor, Integration } from '@sentry/types';
-import { fill, isThenable, loadModule, logger } from '@sentry/utils';
+import { fill, isDebugBuild, isThenable, loadModule, logger } from '@sentry/utils';
 
 interface PgClient {
   prototype: {
@@ -37,12 +37,12 @@ export class Postgres implements Integration {
     const pkg = loadModule<{ Client: PgClient; native: { Client: PgClient } }>('pg');
 
     if (!pkg) {
-      logger.error('Postgres Integration was unable to require `pg` package.');
+      isDebugBuild() && logger.error('Postgres Integration was unable to require `pg` package.');
       return;
     }
 
     if (this._usePgNative && !pkg.native?.Client) {
-      logger.error("Postgres Integration was unable to access 'pg-native' bindings.");
+      isDebugBuild() && logger.error("Postgres Integration was unable to access 'pg-native' bindings.");
       return;
     }
 

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -6,7 +6,7 @@ import {
   TransactionContext,
   TransactionMetadata,
 } from '@sentry/types';
-import { dropUndefinedKeys, isInstanceOf, logger } from '@sentry/utils';
+import { dropUndefinedKeys, isDebugBuild, isInstanceOf, logger } from '@sentry/utils';
 
 import { Span as SpanClass, SpanRecorder } from './span';
 
@@ -92,7 +92,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
     }
 
     if (!this.name) {
-      logger.warn('Transaction has no name, falling back to `<unlabeled transaction>`.');
+      isDebugBuild() && logger.warn('Transaction has no name, falling back to `<unlabeled transaction>`.');
       this.name = '<unlabeled transaction>';
     }
 
@@ -101,7 +101,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
 
     if (this.sampled !== true) {
       // At this point if `sampled !== true` we want to discard the transaction.
-      logger.log('[Tracing] Discarding transaction because its trace was not chosen to be sampled.');
+      isDebugBuild() && logger.log('[Tracing] Discarding transaction because its trace was not chosen to be sampled.');
 
       const client = this._hub.getClient();
       const transport = client && client.getTransport && client.getTransport();
@@ -138,11 +138,15 @@ export class Transaction extends SpanClass implements TransactionInterface {
     const hasMeasurements = Object.keys(this._measurements).length > 0;
 
     if (hasMeasurements) {
-      logger.log('[Measurements] Adding measurements to transaction', JSON.stringify(this._measurements, undefined, 2));
+      isDebugBuild() &&
+        logger.log(
+          '[Measurements] Adding measurements to transaction',
+          JSON.stringify(this._measurements, undefined, 2),
+        );
       transaction.measurements = this._measurements;
     }
 
-    logger.log(`[Tracing] Finishing ${this.op} transaction: ${this.name}.`);
+    isDebugBuild() && logger.log(`[Tracing] Finishing ${this.op} transaction: ${this.name}.`);
 
     return this._hub.captureEvent(transaction);
   }

--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -94,12 +94,11 @@ function triggerHandlers(type: InstrumentHandlerType, data: any): void {
     try {
       handler(data);
     } catch (e) {
-      if (isDebugBuild()) {
+      isDebugBuild() &&
         logger.error(
           `Error while triggering instrumentation handler.\nType: ${type}\nName: ${getFunctionName(handler)}\nError:`,
           e,
         );
-      }
     }
   }
 }

--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -69,7 +69,8 @@ function instrument(type: InstrumentHandlerType): void {
       instrumentUnhandledRejection();
       break;
     default:
-      logger.warn('unknown instrumentation type:', type);
+      isDebugBuild() && logger.warn('unknown instrumentation type:', type);
+      return;
   }
 }
 

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { WrappedFunction } from '@sentry/types';
 
+import { isDebugBuild } from './env';
 import { getGlobalObject } from './global';
 
 // TODO: Implement different loggers for different environments
@@ -104,8 +105,13 @@ class Logger {
   }
 }
 
-// Ensure we only have a single logger instance, even if multiple versions of @sentry/utils are being used
-global.__SENTRY__ = global.__SENTRY__ || {};
-const logger = (global.__SENTRY__.logger as Logger) || (global.__SENTRY__.logger = new Logger());
+const sentryGlobal = global.__SENTRY__ || {};
+const logger = (sentryGlobal.logger as Logger) || new Logger();
+
+if (isDebugBuild()) {
+  // Ensure we only have a single logger instance, even if multiple versions of @sentry/utils are being used
+  sentryGlobal.logger = logger;
+  global.__SENTRY__ = sentryGlobal;
+}
 
 export { logger };

--- a/packages/utils/src/supports.ts
+++ b/packages/utils/src/supports.ts
@@ -113,9 +113,8 @@ export function supportsNativeFetch(): boolean {
       }
       doc.head.removeChild(sandbox);
     } catch (err) {
-      if (isDebugBuild()) {
+      isDebugBuild() &&
         logger.warn('Could not create sandbox iframe for pure fetch check, bailing to window.fetch: ', err);
-      }
     }
   }
 

--- a/packages/vue/src/sdk.ts
+++ b/packages/vue/src/sdk.ts
@@ -1,5 +1,5 @@
 import { init as browserInit, SDK_VERSION } from '@sentry/browser';
-import { getGlobalObject, logger } from '@sentry/utils';
+import { getGlobalObject, isDebugBuild, logger } from '@sentry/utils';
 
 import { DEFAULT_HOOKS } from './constants';
 import { attachErrorHandler } from './errorhandler';
@@ -41,11 +41,12 @@ export function init(
   browserInit(options);
 
   if (!options.Vue && !options.app) {
-    logger.warn(
-      'Misconfigured SDK. Vue specific errors will not be captured.\n' +
-        'Update your `Sentry.init` call with an appropriate config option:\n' +
-        '`app` (Application Instance - Vue 3) or `Vue` (Vue Constructor - Vue 2).',
-    );
+    isDebugBuild() &&
+      logger.warn(
+        'Misconfigured SDK. Vue specific errors will not be captured.\n' +
+          'Update your `Sentry.init` call with an appropriate config option:\n' +
+          '`app` (Application Instance - Vue 3) or `Vue` (Vue Constructor - Vue 2).',
+      );
     return;
   }
 

--- a/packages/vue/src/tracing.ts
+++ b/packages/vue/src/tracing.ts
@@ -1,6 +1,6 @@
 import { getCurrentHub } from '@sentry/browser';
 import { Span, Transaction } from '@sentry/types';
-import { logger, timestampInSeconds } from '@sentry/utils';
+import { isDebugBuild, logger, timestampInSeconds } from '@sentry/utils';
 
 import { formatComponentName } from './components';
 import { DEFAULT_HOOKS } from './constants';
@@ -60,7 +60,7 @@ export const createTracingMixins = (options: TracingOptions): Mixins => {
     // eg. mount => ['beforeMount', 'mounted']
     const internalHooks = HOOKS[operation];
     if (!internalHooks) {
-      logger.warn(`Unknown hook: ${operation}`);
+      isDebugBuild() && logger.warn(`Unknown hook: ${operation}`);
       continue;
     }
 


### PR DESCRIPTION
This applies the `isDebugBuild()` guard (which allows logging code to be stripped when creating minified bundles) to a number of aspects of the logger:

- All calls to the logger now have the guard. While it's true that not all log statements appear in spots which currently have any chance of making it into a bundle, applying the guard universally reduces cognitive load for both folks reading and writing our code, and future-proofs (or, perhaps more accurately, new-bundling-situation-proofs) all of our logging.

- The `Sentry.init()` option `debug` now only enables the logger if we're in a debug build. This allows us to remove any reference to the logger in non-debug builds, making it able to be dropped from the code. A warning message has also been added to non-debug builds, because someone using `debug` is presumably doing so because they actually do want logging.

- The `logger` singleton is only attached to `global.__SENTRY__` if we're in a debug build. This makes `logger.ts` side-effect-free in non-debug builds, allowing it to be treeshaken freely.

Note that because the return value of `isDebugBuild()` is always `true` (absent intervention by a bundler), it's safe to use everywhere without changing any current behavior.

Finally, all preexisting `if`-block versions of the check are converted to short-circuit versions, for consistency and concision.

NOTE: The bundle size increases here come because this PR is part of a series refactoring the way we strip logging when creating minified bundles, after the old way has been taken out but before the new way has been phased in. Once all PRs have been merged, there should be a net savings.