### PR TITLE
fix(nextjs): Add env var to suppress API non-response meta-warning

### DIFF
--- a/packages/nextjs/src/utils/withSentry.ts
+++ b/packages/nextjs/src/utils/withSentry.ts
@@ -86,10 +86,12 @@ export const withSentry = (origHandler: NextApiHandler): WrappedNextApiHandler =
       try {
         const handlerResult = await origHandler(req, res);
 
-        if (process.env.NODE_ENV === 'development') {
+        if (process.env.NODE_ENV === 'development' && !process.env.SENTRY_IGNORE_API_RESOLUTION_ERROR) {
           // eslint-disable-next-line no-console
           console.warn(
-            '[sentry] If Next.js logs a warning "API resolved without sending a response", it\'s a false positive, which we\'re working to rectify.',
+            `[sentry] If Next.js logs a warning "API resolved without sending a response", it's a false positive, which we're working to rectify.
+            In the meantime, to suppress this warning, set \`SENTRY_IGNORE_API_RESOLUTION_ERROR\` to 1 in your env.
+            To suppress the nextjs warning, use the \`externalResolver\` API route option (see https://nextjs.org/docs/api-routes/api-middlewares#custom-config for details).`,
           );
         }
 


### PR DESCRIPTION
In the nextjs SDK, when we wrap users' API routes, we also wrap the response's `end` method, in order to keep the lambda running the route handler alive long enough to send events to Sentry. As a consequence, however, Next thinks a response hasn't been sent at all, because `end` hasn't been called within the timeframe that it expects, so it throws a warning in dev. 

A [previous attempt](https://github.com/getsentry/sentry-javascript/pull/4139) to fix this problem [backfired](https://github.com/getsentry/sentry-javascript/issues/4151), and had to be [reverted](https://github.com/getsentry/sentry-javascript/pull/4516), so as a compromise option for the moment, we log a warning about the Next warning, so at least people know it's nothing to worry about. Some people are finding this behavior [spammy](https://github.com/getsentry/sentry-javascript/issues/3852#issuecomment-1062933254), though, so this PR adds an env variable check which allows a user to suppress our meta-warning, and also improves the warning itself so that people know the option is there.