### PR TITLE
ref(build): Parallelize integration bundling

### DIFF
--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "build": "run-p build:cjs build:esm build:bundle",
-    "build:bundle": "rollup --config",
+    "build:bundle": "bash scripts/buildBundles.sh",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:dev": "run-s build:cjs build:esm",
     "build:es5": "yarn build:cjs # *** backwards compatibility - remove in v7 ***",

--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -1,28 +1,24 @@
-import * as fs from 'fs';
-
 import commonjs from '@rollup/plugin-commonjs';
 
 import { insertAt, makeBaseBundleConfig, makeConfigVariants } from '../../rollup.config';
 
 const builds = [];
 
-const integrationSourceFiles = fs.readdirSync('./src').filter(file => file != 'index.ts');
+const file = process.env.INTEGRATION_FILE;
 
-integrationSourceFiles.forEach(file => {
-  const baseBundleConfig = makeBaseBundleConfig({
-    input: `src/${file}`,
-    isAddOn: true,
-    jsVersion: 'es5',
-    licenseTitle: '@sentry/integrations',
-    // TODO this doesn't currently need to be a template string, but soon will need to be, so leaving it in that form
-    // for now
-    outputFileBase: `${file.replace('.ts', '')}`,
-  });
-
-  // TODO We only need `commonjs` for localforage (used in the offline plugin). Once that's fixed, this can come out.
-  baseBundleConfig.plugins = insertAt(baseBundleConfig.plugins, -2, commonjs());
-
-  builds.push(...makeConfigVariants(baseBundleConfig));
+const baseBundleConfig = makeBaseBundleConfig({
+  input: `src/${file}`,
+  isAddOn: true,
+  jsVersion: 'es5',
+  licenseTitle: '@sentry/integrations',
+  // TODO this doesn't currently need to be a template string, but soon will need to be, so leaving it in that form
+  // for now
+  outputFileBase: `${file.replace('.ts', '')}`,
 });
+
+// TODO We only need `commonjs` for localforage (used in the offline plugin). Once that's fixed, this can come out.
+baseBundleConfig.plugins = insertAt(baseBundleConfig.plugins, -2, commonjs());
+
+builds.push(...makeConfigVariants(baseBundleConfig));
 
 export default builds;

--- a/packages/integrations/scripts/buildBundles.sh
+++ b/packages/integrations/scripts/buildBundles.sh
@@ -1,0 +1,20 @@
+for filepath in ./src/*; do
+  file=$(basename $filepath)
+
+  # the index file is only there for the purposes of npm builds - for the CDN we create a separate bundle for each
+  # integration - so we can skip it here
+  if [[ $file == "index.ts" ]]; then
+    continue
+  fi
+
+  # run the build for each integration, pushing each build process into the background once it starts (that's what the
+  # trailing `&` does) so that we can start another one
+  echo -e "\nBuilding bundles for \`$file\`..."
+  INTEGRATION_FILE=$file yarn --silent rollup -c rollup.config.js 2>/dev/null && echo -e "\nFinished building bundles for \`$file\`." &
+
+done
+
+# keep the process running until all backgrounded tasks have finished
+wait
+
+echo "Integration bundles built successfully"


### PR DESCRIPTION
Given that now most of our testing runs in parallel in CI, the biggest bottleneck has become the build step. Within that step, the single slowest thing we do is build integration bundles, simply because of the number of bundles which need to be created. (This is especially true now that we're [creating three versions of each bundle rather than two](https://github.com/getsentry/sentry-javascript/pull/4699).)

To speed things up a bit, this parallelizes the building of those bundles. Though it ends up not being as dramatic a time savings as one might hope (because the typescript plugin's caching mechanism [doesn't play nicely with concurrent builds](https://github.com/ezolenko/rollup-plugin-typescript2/issues/15)), it nonetheless drops the total build time from roughly two minutes down to 70-80 seconds in my local testing.

Ref: https://getsentry.atlassian.net/browse/WEB-664