### PR TITLE
ref(tracing): Remove `BrowserTracing` logging flag default value

### DIFF
--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -139,7 +139,7 @@ export class BrowserTracing implements Integration {
       if (_options.tracingOrigins && Array.isArray(_options.tracingOrigins) && _options.tracingOrigins.length !== 0) {
         tracingOrigins = _options.tracingOrigins;
       } else {
-        this._emitOptionsWarning = true;
+        isDebugBuild() && (this._emitOptionsWarning = true);
       }
     }
 

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -126,7 +126,7 @@ export class BrowserTracing implements Integration {
 
   private readonly _metrics: MetricsInstrumentation;
 
-  private readonly _emitOptionsWarning: boolean = false;
+  private readonly _emitOptionsWarning?: boolean;
 
   /** Store configured idle timeout so that it can be added as a tag to transactions */
   private _configuredIdleTimeout: BrowserTracingOptions['idleTimeout'] | undefined = undefined;


### PR DESCRIPTION
In the `BrowserTracing` integration, we use a flag as a way to [delay logging an warning message](https://github.com/getsentry/sentry-javascript/blob/af7081c9e9be240578cf608048734572ce709ac0/packages/tracing/src/browser/browsertracing.ts#L136-L144) from the constructor until we can guarantee the logger has been enabled. Until now, that flag defaulted to `false`, which has prevented it from being treeshaken, even in non-debug bundles in which it's not otherwise touched.

This PR makes the flag optional, and removes the default value. Since `undefined` is falsy there are no runtime behavior changes, but the fact that it's never used, not even to be set to a default value, allows it to be fully removed by treeshaking. Here's the difference in the non-minified, non-debug ES5 tracing bundle, before and after:

![image](https://user-images.githubusercontent.com/14812505/157929306-9a46e981-7df1-4149-98ff-880e765931bf.png)

Ref: https://getsentry.atlassian.net/browse/WEB-696