### PR TITLE
ref(utils): Use array constant for console levels

### DIFF
--- a/packages/integrations/src/captureconsole.ts
+++ b/packages/integrations/src/captureconsole.ts
@@ -1,5 +1,5 @@
 import { EventProcessor, Hub, Integration } from '@sentry/types';
-import { fill, getGlobalObject, safeJoin, severityFromString } from '@sentry/utils';
+import { CONSOLE_LEVELS, fill, getGlobalObject, safeJoin, severityFromString } from '@sentry/utils';
 
 const global = getGlobalObject<Window | NodeJS.Global>();
 
@@ -18,7 +18,7 @@ export class CaptureConsole implements Integration {
   /**
    * @inheritDoc
    */
-  private readonly _levels: string[] = ['log', 'info', 'warn', 'error', 'debug', 'assert'];
+  private readonly _levels: string[] = CONSOLE_LEVELS;
 
   /**
    * @inheritDoc

--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -6,7 +6,7 @@ import { WrappedFunction } from '@sentry/types';
 import { isDebugBuild } from './env';
 import { getGlobalObject } from './global';
 import { isInstanceOf, isString } from './is';
-import { logger } from './logger';
+import { CONSOLE_LEVELS, logger } from './logger';
 import { fill } from './object';
 import { getFunctionName } from './stacktrace';
 import { supportsHistory, supportsNativeFetch } from './supports';
@@ -110,7 +110,7 @@ function instrumentConsole(): void {
     return;
   }
 
-  ['debug', 'info', 'warn', 'error', 'log', 'assert'].forEach(function (level: string): void {
+  CONSOLE_LEVELS.forEach(function (level: string): void {
     if (!(level in global.console)) {
       return;
     }

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -10,6 +10,8 @@ const global = getGlobalObject<Window | NodeJS.Global>();
 /** Prefix for logging strings */
 const PREFIX = 'Sentry Logger ';
 
+export const CONSOLE_LEVELS = ['debug', 'info', 'warn', 'error', 'log', 'assert'];
+
 /** JSDoc */
 interface ExtensibleConsole extends Console {
   [key: string]: any;
@@ -24,7 +26,6 @@ interface ExtensibleConsole extends Console {
  */
 export function consoleSandbox(callback: () => any): any {
   const global = getGlobalObject<Window>();
-  const levels = ['debug', 'info', 'warn', 'error', 'log', 'assert'];
 
   if (!('console' in global)) {
     return callback();
@@ -35,7 +36,7 @@ export function consoleSandbox(callback: () => any): any {
   const wrappedLevels: { [key: string]: any } = {};
 
   // Restore all wrapped console methods
-  levels.forEach(level => {
+  CONSOLE_LEVELS.forEach(level => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (level in (global as any).console && (originalConsole[level] as WrappedFunction).__sentry_original__) {
       wrappedLevels[level] = originalConsole[level] as WrappedFunction;


### PR DESCRIPTION
Currently, the array `['log', 'info', 'warn', 'error', 'debug', 'assert']` appears three times in our code, and because it's an array of strings, it's can't be minified. This PR uses a constant in its place, for a small bundle size win.
