### PR TITLE
ref(build): Move build directory to main rollup config

### DIFF
--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -8,7 +8,7 @@ const builds = [];
     isAddOn: false,
     jsVersion,
     licenseTitle: '@sentry/browser',
-    outputFileBase: `build/bundle${jsVersion === 'es6' ? '.es6' : ''}`,
+    outputFileBase: `bundle${jsVersion === 'es6' ? '.es6' : ''}`,
   });
 
   builds.push(...makeConfigVariants(baseBundleConfig));

--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -14,7 +14,9 @@ integrationSourceFiles.forEach(file => {
     isAddOn: true,
     jsVersion: 'es5',
     licenseTitle: '@sentry/integrations',
-    outputFileBase: `build/${file.replace('.ts', '')}`,
+    // TODO this doesn't currently need to be a template string, but soon will need to be, so leaving it in that form
+    // for now
+    outputFileBase: `${file.replace('.ts', '')}`,
   });
 
   // TODO We only need `commonjs` for localforage (used in the offline plugin). Once that's fixed, this can come out.

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -8,7 +8,7 @@ const builds = [];
     isAddOn: false,
     jsVersion,
     licenseTitle: '@sentry/tracing & @sentry/browser',
-    outputFileBase: `build/bundle.tracing${jsVersion === 'es6' ? '.es6' : ''}`,
+    outputFileBase: `bundle.tracing${jsVersion === 'es6' ? '.es6' : ''}`,
   });
 
   builds.push(...makeConfigVariants(baseBundleConfig));

--- a/packages/vue/rollup.config.js
+++ b/packages/vue/rollup.config.js
@@ -5,7 +5,7 @@ const baseBundleConfig = makeBaseBundleConfig({
   isAddOn: false,
   jsVersion: 'es5',
   licenseTitle: '@sentry/vue',
-  outputFileBase: 'build/bundle.vue',
+  outputFileBase: 'bundle.vue',
 });
 
 export default makeConfigVariants(baseBundleConfig);

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -5,7 +5,7 @@ const baseBundleConfig = makeBaseBundleConfig({
   isAddOn: true,
   jsVersion: 'es5',
   licenseTitle: '@sentry/wasm',
-  outputFileBase: 'build/wasm',
+  outputFileBase: 'wasm',
 });
 
 export default makeConfigVariants(baseBundleConfig);

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -177,7 +177,7 @@ export function makeBaseBundleConfig(options) {
     input,
     output: {
       // a file extension will be added to this base value when we specify either a minified or non-minified build
-      file: outputFileBase,
+      file: `build/${outputFileBase}`,
       sourcemap: true,
       strict: false,
       esModule: false,


### PR DESCRIPTION
While reviewing https://github.com/getsentry/sentry-javascript/pull/4688, it occurred to me that our bundles directory, `build`, is the same in every package, and therefore should live in the centralized rollup config rather than all of the package-specific ones.
