### PR TITLE
fix(ember): Fix merging env config

### DIFF
--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -14,6 +14,11 @@ function getSentryConfig() {
   const _global = getGlobalObject<GlobalConfig>();
   _global.__sentryEmberConfig = _global.__sentryEmberConfig ?? {};
   const environmentConfig = getOwnConfig<OwnConfig>().sentryConfig;
+  if (!environmentConfig.sentry) {
+    environmentConfig.sentry = {
+      browserTracingOptions: {},
+    };
+  }
   Object.assign(environmentConfig.sentry, _global.__sentryEmberConfig);
   return environmentConfig;
 }


### PR DESCRIPTION
### Summary
Previously getting config from macros looks to be potentially pulling a fresh object instance in prod mode, which means the previous assign into the object no longer applies, and if the config didn't have a Sentry entry the initialize would crash. This should hopefully fix this issue for those no longer using env config.

Refs #4015