### PR TITLE
feat(core): Introduce New Transports API

### DIFF
--- a/packages/core/src/transports/base.ts
+++ b/packages/core/src/transports/base.ts
@@ -33,7 +33,11 @@ export type TransportRequest = {
 
 export type TransportMakeRequestResponse = {
   body?: string;
-  headers?: Record<string, string | null>;
+  headers?: {
+    [key: string]: string | null;
+    'x-sentry-rate-limits': string | null;
+    'retry-after': string | null;
+  };
   reason?: string;
   statusCode: number;
 };

--- a/packages/core/test/lib/transports/base.test.ts
+++ b/packages/core/test/lib/transports/base.test.ts
@@ -128,6 +128,7 @@ describe('createTransport', () => {
 
         const [transport, setTransportResponse] = createTestTransport({
           headers: {
+            'x-sentry-rate-limits': null,
             'retry-after': `${retryAfterSeconds}`,
           },
           statusCode: 429,
@@ -174,6 +175,7 @@ describe('createTransport', () => {
         const [transport, setTransportResponse] = createTestTransport({
           headers: {
             'x-sentry-rate-limits': `${retryAfterSeconds}:error:scope`,
+            'retry-after': null,
           },
           statusCode: 429,
         });
@@ -226,6 +228,7 @@ describe('createTransport', () => {
         const [transport, setTransportResponse] = createTestTransport({
           headers: {
             'x-sentry-rate-limits': `${retryAfterSeconds}:error;transaction:scope`,
+            'retry-after': null,
           },
           statusCode: 429,
         });
@@ -287,6 +290,7 @@ describe('createTransport', () => {
         const [transport, setTransportResponse] = createTestTransport({
           headers: {
             'x-sentry-rate-limits': `${retryAfterSeconds}::scope`,
+            'retry-after': null,
           },
           statusCode: 429,
         });
@@ -342,6 +346,7 @@ describe('createTransport', () => {
         const [transport] = createTestTransport({
           headers: {
             'x-sentry-rate-limits': `${retryAfterSeconds}:error;transaction:scope`,
+            'retry-after': null,
           },
           statusCode: 200,
         });


### PR DESCRIPTION
Part 1 of https://github.com/getsentry/sentry-javascript/issues/4660
Supercedes https://github.com/getsentry/sentry-javascript/pull/4662

This PR introduces a functional transport based on what was discussed in https://github.com/getsentry/sentry-javascript/issues/4660.

The transport is defined by an interface, which sets two basic functions, `send` and `flush`, which both interact directly with an internal `PromiseBuffer` data structure, a queue of requests that represents the data that needs to be sent to Sentry.

```ts
interface NewTransport {
  // If `$` is set, we know that this is a new transport.
  // TODO(v7): Remove this as we will no longer have split between
  // old and new transports.
  $: boolean;
  send(request: Envelope, category: TransportCategory): PromiseLike<TransportResponse>;
  flush(timeout: number): PromiseLike<boolean>;
}
```

`send` relies on an externally defined `makeRequest` function (that is passed into a `makeTransport` constructor) to make a request, and then return a status based on it. It also updates internal rate-limits according to the response from `makeRequest`. The status will be also used by the client in the future for client outcomes (we will extract client outcomes from the transport -> client because it living in the transport is not the best pattern).

`send` takes in an envelope, which means that for now, no errors will go through this transport when we update the client to use this new transport.

`flush`, flushes the promise buffer, pretty much how it worked before.

To make a custom transport (and how we'll be making fetch, xhr transports), you essentially define a `makeRequest` function.

```ts
function createFetchTransport(options: FetchTransportOptions): NewTransport {
  function makeRequest(request: TransportRequest): PromiseLike<TransportMakeRequestResponse> {
    return fetch(options.url, options.fetchOptions).then(response => {
      return response.text().then(body => ({
        body,
        headers: {
          'x-sentry-rate-limits': response.headers.get('X-Sentry-Rate-Limits'),
          'retry-after': response.headers.get('Retry-After'),
        },
        reason: response.statusText,
        statusCode: response.status,
      }));
    });
  }

  return createTransport({ bufferSize: options.bufferSize }, makeRequest);
}
```

^^ Look how clean that is!!

Resolves https://getsentry.atlassian.net/browse/WEB-662