### PR TITLE
feat(integrations): Make ES6 integration bundles

### DIFF
--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -5,20 +5,20 @@ import { insertAt, makeBaseBundleConfig, makeConfigVariants } from '../../rollup
 const builds = [];
 
 const file = process.env.INTEGRATION_FILE;
+const jsVersion = process.env.JS_VERSION;
 
 const baseBundleConfig = makeBaseBundleConfig({
   input: `src/${file}`,
   isAddOn: true,
-  jsVersion: 'es5',
+  jsVersion,
   licenseTitle: '@sentry/integrations',
-  // TODO this doesn't currently need to be a template string, but soon will need to be, so leaving it in that form
-  // for now
-  outputFileBase: `${file.replace('.ts', '')}`,
+  outputFileBase: `${file.replace('.ts', '')}${jsVersion === 'ES6' ? '.es6' : ''}`,
 });
 
 // TODO We only need `commonjs` for localforage (used in the offline plugin). Once that's fixed, this can come out.
 baseBundleConfig.plugins = insertAt(baseBundleConfig.plugins, -2, commonjs());
 
+// this makes non-minified, minified, and minified-with-debug-logging versions of each bundle
 builds.push(...makeConfigVariants(baseBundleConfig));
 
 export default builds;

--- a/packages/integrations/scripts/buildBundles.sh
+++ b/packages/integrations/scripts/buildBundles.sh
@@ -1,20 +1,25 @@
 for filepath in ./src/*; do
-  file=$(basename $filepath)
+  for js_version in "ES5" "ES6"; do
 
-  # the index file is only there for the purposes of npm builds - for the CDN we create a separate bundle for each
-  # integration - so we can skip it here
-  if [[ $file == "index.ts" ]]; then
-    continue
-  fi
+    file=$(basename $filepath)
 
-  # run the build for each integration, pushing each build process into the background once it starts (that's what the
-  # trailing `&` does) so that we can start another one
-  echo -e "\nBuilding bundles for \`$file\`..."
-  INTEGRATION_FILE=$file yarn --silent rollup -c rollup.config.js 2>/dev/null && echo -e "\nFinished building bundles for \`$file\`." &
+    # the index file is only there for the purposes of npm builds - for the CDN we create a separate bundle for each
+    # integration - so we can skip it here
+    if [[ $file == "index.ts" ]]; then
+      continue
+    fi
 
+    # run the build for each integration, pushing each build process into the background once it starts (that's what the
+    # trailing `&` does) so that we can start another one
+    echo -e "Building $js_version bundles for \`$file\`..."
+    INTEGRATION_FILE=$file JS_VERSION=$js_version \
+      yarn --silent rollup -c rollup.config.js &&
+      echo -e "Finished building $js_version bundles for \`$file\`." &
+
+  done
 done
 
 # keep the process running until all backgrounded tasks have finished
 wait
 
-echo "Integration bundles built successfully"
+echo -e "\nIntegration bundles built successfully"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -94,6 +94,13 @@ export function makeBaseBundleConfig(options) {
       },
     },
     include: ['*.ts+(|x)', '**/*.ts+(|x)', '../**/*.ts+(|x)'],
+    // the typescript plugin doesn't handle concurrency very well, so clean the cache between builds
+    // (see https://github.com/ezolenko/rollup-plugin-typescript2/issues/15)
+    clean: true,
+    // TODO: For the moment, the above issue seems to have stopped spamming the build with (non-blocking) errors, as it
+    // was originally. If it starts again, this will suppress that output. If we get to the end of the bundle revamp and
+    // it still seems okay, we can take this out entirely.
+    // verbosity: 0,
   };
 
   const typescriptPluginES5 = typescript(


### PR DESCRIPTION
This changes the build config in the `integrations` package to generate ES6 bundles as well as ES5 bundles, in preparation for going ES6-first in v7. Which JS version to build is controlled by an environment variable, in order that the builds be parallelizable.

Ref: https://getsentry.atlassian.net/browse/WEB-693