### PR TITLE
fix(dev): Use correct schema for GHA workflow files in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,8 @@
     "editor.formatOnType": false,
     "editor.formatOnPaste": false,
     "editor.formatOnSave": false
-  }
+  },
+  "yaml.schemas": {
+    "https://json.schemastore.org/github-workflow.json": ".github/workflows/**.yml"
+  },
 }


### PR DESCRIPTION
VSCode has a [feature](https://code.visualstudio.com/docs/languages/json#_json-schemas-and-settings) wherein it auto-detects what schema to use to validate certain JSON and yml files. The problem is, [sometimes it's wrong](https://github.com/microsoft/vscode/issues/74943#issuecomment-876013151), and when it is, it will throw errors* because it's misconstrued what kind of file you're editing. The incorrect association can be overridden, though, with a correct association in settings.

This PR adds such an association, to prevent VSCode from complaining about our GHA `build` workflow.

\*It correctly detects that it's a GHA config, but also checks it against the schema for [a different build tool](https://no0dles.gitbook.io/hammerkit/) called `hammerkit`, and throws errors because the two schemas (schemae?) are incompatible, as can be seen here:

![image](https://user-images.githubusercontent.com/14812505/158717141-d94af123-446f-43ff-9f80-5ac8ef0fdc37.png)

