### PR TITLE
ci: Dont upload artifacts for non-release related runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,6 +280,8 @@ jobs:
     name: Upload Artifacts
     needs: job_build
     runs-on: ubuntu-latest
+    # Build artifacts are only needed for releasing workflow. 
+    if: startsWith(github.ref, 'refs/heads/release/')
     steps:
       - name: Check out current commit (${{ github.sha }})
         uses: actions/checkout@v2


### PR DESCRIPTION
Saves us time and resources.