### PR TITLE
build: Make merge target optional

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
       force:
         description: Force a release even when there are release-blockers (optional)
         required: false
+      merge_target:
+        description: Target branch to merge into. Uses the default branch as a fallback (optional)
+        required: false
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -24,3 +27,4 @@ jobs:
         with:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
+          merge_target: ${{ github.event.inputs.merge_target }}


### PR DESCRIPTION
Make `merge_target` not merge to master by default so we can work off the v7 branch and cut betas off it.

Resolves https://getsentry.atlassian.net/browse/WEB-654