### PR TITLE
feat(dev): Build/test CI improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -332,10 +332,12 @@ jobs:
           - true
           - false
         exclude:
+          # `tracing_only` only makes a difference for bundles - tests of the esm and cjs builds always include the
+          # tracing tests
           - bundle: esm
-            tracing_only: true
+            tracing_only: false
           - bundle: cjs
-            tracing_only: true
+            tracing_only: false
     steps:
       - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,14 @@ on:
       - release/**
   pull_request:
   workflow_dispatch:
+    inputs:
+      commit:
+        description: If the commit you want to test isn't the head of a branch, provide its SHA here
+        required: false
 
 env:
+  HEAD_COMMIT: ${{ github.event.inputs.commit || github.sha }}
+
   CACHED_DEPENDENCY_PATHS: |
     ${{ github.workspace }}/node_modules
     ${{ github.workspace }}/packages/**/node_modules
@@ -23,7 +29,7 @@ env:
     ${{ github.workspace }}/packages/ember/instance-initializers
     ${{ github.workspace }}/packages/serverless/dist-awslambda-layer/*.zip
 
-  BUILD_CACHE_KEY: ${{ github.sha }}
+  BUILD_CACHE_KEY: ${{ github.event.inputs.commit || github.sha }}
 
 jobs:
   job_install_deps:
@@ -31,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Check out current commit (${{ github.sha }})
+      - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -58,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Check out current commit (${{ github.sha }})
+      - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -99,7 +105,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - name: Check out current commit (${{ github.sha }})
+      - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -129,7 +135,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: Check out current commit (${{ github.sha }})
+      - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -152,7 +158,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: Check out current commit (${{ github.sha }})
+      - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -213,7 +219,7 @@ jobs:
       matrix:
         node: [6, 8, 10, 12, 14, 16]
     steps:
-      - name: Check out current commit (${{ github.sha }})
+      - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -246,7 +252,7 @@ jobs:
       matrix:
         node: [10, 12, 14, 16]
     steps:
-      - name: Check out current commit (${{ github.sha }})
+      - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -278,7 +284,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - name: Check out current commit (${{ github.sha }})
+      - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2
         # TODO: removing `fetch-depth` below seems to have no effect, and the commit which added it had no description,
         # so it's not clear why it's necessary. That said, right now ember tests are xfail, so it's a little hard to
@@ -331,7 +337,7 @@ jobs:
           - bundle: cjs
             tracing_only: true
     steps:
-      - name: Check out current commit (${{ github.sha }})
+      - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -369,7 +375,7 @@ jobs:
           - FirefoxHeadless
           - WebkitHeadless
     steps:
-      - name: Check out current commit (${{ github.sha }})
+      - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -398,7 +404,7 @@ jobs:
     timeout-minutes: 5
     continue-on-error: true
     steps:
-      - name: Check out current commit (${{ github.sha }})
+      - name: Check out current commit (${ env.HEAD_COMMIT }})
         uses: actions/checkout@v2
       - name: Set up Node
         uses: actions/setup-node@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
       - master
       - release/**
   pull_request:
+  workflow_dispatch:
 
 env:
   CACHED_DEPENDENCY_PATHS: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,8 +123,8 @@ jobs:
           key: ${{ env.BUILD_CACHE_KEY }}
       - name: Check bundle sizes
         uses: getsentry/size-limit-action@v4
-        # Only run size check on master or pull requests
-        if: github.ref == 'refs/heads/master' || github.event_name == 'pull_request'
+        # Don't run size check on release branches - at that point, we're already committed
+        if: ${{ !startsWith(github.ref, 'release') }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           skip_step: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -365,7 +365,7 @@ jobs:
           yarn test:ci
 
   job_browser_integration_tests:
-    name: Browser Integration Tests (${{ matrix.browser }})
+    name: Old Browser Integration Tests (${{ matrix.browser }})
     needs: job_build
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -316,7 +316,7 @@ jobs:
         uses: codecov/codecov-action@v1
 
   job_browser_playwright_tests:
-    name: Browser Playwright Tests (${{ matrix.bundle }} - tracing_only = ${{ matrix.tracing_only }})
+    name: Playwright - ${{ (matrix.tracing_only && 'Browser + Tracing') || 'Browser' }} (${{ matrix.bundle }})
     needs: job_build
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,40 @@ jobs:
       - name: Run madge
         run: yarn circularDepCheck
 
+  job_artifacts:
+    name: Upload Artifacts
+    needs: job_build
+    runs-on: ubuntu-latest
+    # Build artifacts are only needed for releasing workflow.
+    if: startsWith(github.ref, 'refs/heads/release/')
+    steps:
+      - name: Check out current commit (${{ github.sha }})
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v1
+      - name: Check dependency cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
+          key: ${{ needs.job_build.outputs.dependency_cache_key }}
+      - name: Check build cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.CACHED_BUILD_PATHS }}
+          key: ${{ env.BUILD_CACHE_KEY }}
+      - name: Pack
+        run: yarn build:npm
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.sha }}
+          path: |
+            ${{ github.workspace }}/packages/browser/build/bundles/**
+            ${{ github.workspace }}/packages/integrations/build/**
+            ${{ github.workspace }}/packages/tracing/build/**
+            ${{ github.workspace }}/packages/**/*.tgz
+            ${{ github.workspace }}/packages/serverless/dist-awslambda-layer/*.zip
+
   job_unit_test:
     name: Test (Node ${{ matrix.node }})
     needs: job_build
@@ -273,40 +307,6 @@ jobs:
         run: yarn test --scope=@sentry/ember
       - name: Compute test coverage
         uses: codecov/codecov-action@v1
-
-  job_artifacts:
-    name: Upload Artifacts
-    needs: job_build
-    runs-on: ubuntu-latest
-    # Build artifacts are only needed for releasing workflow. 
-    if: startsWith(github.ref, 'refs/heads/release/')
-    steps:
-      - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@v2
-      - name: Set up Node
-        uses: actions/setup-node@v1
-      - name: Check dependency cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
-          key: ${{ needs.job_build.outputs.dependency_cache_key }}
-      - name: Check build cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.CACHED_BUILD_PATHS }}
-          key: ${{ env.BUILD_CACHE_KEY }}
-      - name: Pack
-        run: yarn build:npm
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ github.sha }}
-          path: |
-            ${{ github.workspace }}/packages/browser/build/bundles/**
-            ${{ github.workspace }}/packages/integrations/build/**
-            ${{ github.workspace }}/packages/tracing/build/**
-            ${{ github.workspace }}/packages/**/*.tgz
-            ${{ github.workspace }}/packages/serverless/dist-awslambda-layer/*.zip
 
   job_browser_playwright_tests:
     name: Browser Playwright Tests (${{ matrix.bundle }} - tracing_only = ${{ matrix.tracing_only }})


### PR DESCRIPTION
This makes a few changes to our "Build and Test" GHA workflow:

- For mysterious reasons, occasionally pushing to a PR fails to trigger CI. On the PR it says "queued," but on the Actions page, nothing ever appears. There are also times when you might want to run CI before creating a PR. This introduces the ability to run the "Build and Test" GHA on demand. As long as a branch is pushed, it can be chosen from the dropdown and its `HEAD` will be run against CI. If for whatever reason the commit you want to test has been pushed but _isn't_ the head of a branch, its SHA can be filled in instead, and it will be used instead of the branch showing in the dropdown.

- The titles of the browser and tracing playwright tests are currently long enough that they are truncated in the GH UI, which obscures some of the information they contain, namely the ways in which each one differs from the others. This changes the naming scheme to be more space efficient. Also, since it helps the naming and doesn't change the test behavior, the excluded tests have been switched from `tracing_only: true` to `tracing_only: false`. (Because the `tracing_only` value doesn't influence the `cjs` and `esm` tests, we exclude one `tracing_only` value just so as not to run the same tests twice, which means changing which one is excluded doesn't change the actual tests.)

- The artifacts job has been moved above all of the test-related jobs, so that all non-test-related jobs come before all test-related ones.

- The original browser integration tests, the ones which existed before we adopted the playwright framework, have been renamed the "Old" tests, so it's easier to distinguish them from the new ones.