### PR TITLE
fix(build): Run integration bundle builds sequentially

### DIFF
--- a/packages/integrations/scripts/buildBundles.sh
+++ b/packages/integrations/scripts/buildBundles.sh
@@ -9,17 +9,10 @@ for filepath in ./src/*; do
       continue
     fi
 
-    # run the build for each integration, pushing each build process into the background once it starts (that's what the
-    # trailing `&` does) so that we can start another one
-    echo -e "Building $js_version bundles for \`$file\`..."
-    INTEGRATION_FILE=$file JS_VERSION=$js_version \
-      yarn --silent rollup -c rollup.config.js &&
-      echo -e "Finished building $js_version bundles for \`$file\`." &
+    # run the build for each integration
+    INTEGRATION_FILE=$file JS_VERSION=$js_version yarn --silent rollup -c rollup.config.js
 
   done
 done
-
-# keep the process running until all backgrounded tasks have finished
-wait
 
 echo -e "\nIntegration bundles built successfully"


### PR DESCRIPTION
When run in CI, the parallelized integration bundle builds are being flaky, and sometimes seeming to timeout before they complete. (They don't output a timeout message, but the ones that succeed take an extraordinarily long time, and others just log as `killed`. Because of the parallelization, of course, it's impossible to tell _which_ builds are killed, but the end result is that not all bundles get build and included in the artifact upload.) I can only speculate that this is because the GHA machine is trying to do too many things at once and runs out of memory.

This therefore removes the parallelization, by not backgrounding each build job as it starts, but instead running each one in turn, which should result in all bundles getting built.

Note: This significantly increases build time in CI. In a future PR, the integration bundle builds can get split over a number of different GHA jobs, which will restore the parallelization, without asking any one job to handle more than it's capable of.