### PR TITLE
fix(types): Point to type definitions in dist folder

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -11,7 +11,7 @@
   },
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -11,7 +11,7 @@
   },
   "main": "build/dist/index.js",
   "module": "build/esm/index.js",
-  "types": "build/types/index.d.ts",
+  "types": "build/dist/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
   },
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -15,7 +15,7 @@
   },
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "/dist",
     "/esm",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -11,7 +11,7 @@
   },
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -14,7 +14,7 @@
   },
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "dependencies": {
     "@sentry/types": "6.19.0",
     "@sentry/utils": "6.19.0",

--- a/packages/minimal/package.json
+++ b/packages/minimal/package.json
@@ -11,7 +11,7 @@
   },
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -12,7 +12,7 @@
   "main": "./dist/index.server.js",
   "module": "./esm/index.server.js",
   "browser": "./esm/index.client.js",
-  "types": "./build/types/index.server.d.ts",
+  "types": "./esm/index.server.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -11,7 +11,7 @@
   },
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,7 +11,7 @@
   },
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -11,7 +11,7 @@
   },
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -11,7 +11,7 @@
   },
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -11,7 +11,7 @@
   },
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -11,7 +11,7 @@
   },
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -11,7 +11,7 @@
   },
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -11,7 +11,7 @@
   },
   "main": "dist/index.js",
   "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/4744

https://github.com/getsentry/sentry-javascript/pull/4724 introduced an issue where we point to type definitions in the `build` folder. For some reason, this build folder did not get published in the build artefact.

This PR changes the pointer to the type definitions back to where we know they exist. We will update this again in the future.