### PR TITLE
ref(node): Add source code context from LinkedErrors so integration order doesn't matter

### DIFF
--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -12,6 +12,7 @@ export const defaultIntegrations = [
   // Common
   new CoreIntegrations.InboundFilters(),
   new CoreIntegrations.FunctionToString(),
+  new ContextLines(),
   // Native Wrappers
   new Console(),
   new Http(),
@@ -20,8 +21,6 @@ export const defaultIntegrations = [
   new OnUnhandledRejection(),
   // Misc
   new LinkedErrors(),
-  // ContextLines must come after LinkedErrors so that context is added to linked errors
-  new ContextLines(),
 ];
 
 /**

--- a/packages/node/test/context-lines.test.ts
+++ b/packages/node/test/context-lines.test.ts
@@ -9,8 +9,8 @@ describe('ContextLines', () => {
   let readFileSpy: jest.SpyInstance;
   let contextLines: ContextLines;
 
-  async function addContext(frames: StackFrame[], lines: number = 7): Promise<void> {
-    await contextLines.addSourceContext({ exception: { values: [{ stacktrace: { frames } }] } }, lines);
+  async function addContext(frames: StackFrame[]): Promise<void> {
+    await contextLines.addSourceContext({ exception: { values: [{ stacktrace: { frames } }] } });
   }
 
   beforeEach(() => {
@@ -97,10 +97,12 @@ describe('ContextLines', () => {
     });
 
     test('parseStack with no context', async () => {
+      contextLines = new ContextLines({ frameContextLines: 0 });
+
       expect.assertions(1);
       const frames = parseStackFrames(new Error('test'));
 
-      await addContext(frames, 0);
+      await addContext(frames);
       expect(readFileSpy).toHaveBeenCalledTimes(0);
     });
   });

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -16,7 +16,7 @@ import {
   Scope,
 } from '../src';
 import { NodeBackend } from '../src/backend';
-import { LinkedErrors } from '../src/integrations';
+import { ContextLines, LinkedErrors } from '../src/integrations';
 
 jest.mock('@sentry/core', () => {
   const original = jest.requireActual('@sentry/core');
@@ -199,11 +199,11 @@ describe('SentryNode', () => {
       }
     });
 
-    test.only('capture a linked exception with pre/post context', done => {
+    test('capture a linked exception with pre/post context', done => {
       expect.assertions(15);
       getCurrentHub().bindClient(
         new NodeClient({
-          integrations: i => [new LinkedErrors(), ...i],
+          integrations: [new ContextLines(), new LinkedErrors()],
           beforeSend: (event: Event) => {
             expect(event.exception).not.toBeUndefined();
             expect(event.exception!.values![1]).not.toBeUndefined();


### PR DESCRIPTION
Fixes #4729

@AbhiPrasad This is an alternative that gets this working for now without ordered integrations.

This PR:
- Modifies the `ContextLines` integration so it can be used from elsewhere with it's options
- In the `LinkedErrors` integration, if the  `ContextLines` integration is enabled, adds context to linked errors 

Also noticed that I left one of the tests with `only` enabled!