### PR TITLE
fix(build): Add missing `build:types:watch` instances

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "build:dev:watch": "run-s build:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
+    "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "npm pack",
     "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf dist esm coverage",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -54,6 +54,7 @@
     "build:dev:watch": "run-s build:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
+    "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "npm pack",
     "circularDepCheck": "madge --circular src/index.client.ts && madge --circular --exclude 'config/types\\.ts' src/index.server.ts # see https://github.com/pahen/madge/issues/306",
     "clean": "rimraf dist esm coverage *.js *.js.map *.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -61,6 +61,7 @@
     "build:dev:watch": "run-s build:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
+    "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "npm pack",
     "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf dist esm build coverage",

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -51,6 +51,7 @@
     "build:dev:watch": "run-s build:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
+    "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "npm pack",
     "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf dist esm build dist-awslambda-layer coverage",


### PR DESCRIPTION
A few of the `build:types:watch` instances added in https://github.com/getsentry/sentry-javascript/pull/4724 got clobbered in a subsequent rebase. This adds the missing ones back in.
