### PR TITLE
fix(integrations): Fix type/async errors in `Offline` tests

### DIFF
--- a/packages/integrations/src/offline.ts
+++ b/packages/integrations/src/offline.ts
@@ -14,6 +14,8 @@ type LocalForage = {
   length(): Promise<number>;
 };
 
+export type Item = { key: string; value: Event };
+
 /**
  * cache offline errors and send when connected
  */

--- a/packages/integrations/src/offline.ts
+++ b/packages/integrations/src/offline.ts
@@ -11,6 +11,7 @@ type LocalForage = {
     callback?: (err: any, result: U) => void,
   ): Promise<U>;
   removeItem(key: string, callback?: (err: any) => void): Promise<void>;
+  length(): Promise<number>;
 };
 
 /**

--- a/packages/integrations/test/offline.test.ts
+++ b/packages/integrations/test/offline.test.ts
@@ -162,7 +162,7 @@ function getCurrentHub(): Hub {
     },
     getIntegration<T extends Integration>(_integration: IntegrationClass<T>): T | null {
       // pretend integration is enabled
-      return true;
+      return {} as T;
     },
   } as Hub;
 }

--- a/packages/integrations/test/offline.test.ts
+++ b/packages/integrations/test/offline.test.ts
@@ -52,15 +52,10 @@ describe('Offline', () => {
     });
 
     describe('when there are already events in the cache from a previous offline session', () => {
-      beforeEach(done => {
+      beforeEach(async () => {
         const event = { message: 'previous event' };
 
-        integration.offlineEventStore
-          .setItem('previous', event)
-          .then(() => {
-            done();
-          })
-          .catch(error => error);
+        await integration.offlineEventStore.setItem('previous', event);
       });
 
       it('sends stored events', async () => {
@@ -130,7 +125,7 @@ describe('Offline', () => {
     });
 
     describe('when connectivity is restored', () => {
-      it('sends stored events', async done => {
+      it('sends stored events', async () => {
         initIntegration();
         setupOnce();
         prepopulateEvents(1);
@@ -138,8 +133,6 @@ describe('Offline', () => {
         processEventListeners();
 
         expect(await integration.offlineEventStore.length()).toEqual(0);
-
-        setImmediate(done);
       });
     });
   });

--- a/packages/integrations/test/offline.test.ts
+++ b/packages/integrations/test/offline.test.ts
@@ -1,15 +1,15 @@
 import { Event, EventProcessor, Hub, Integration } from '@sentry/types';
 import * as utils from '@sentry/utils';
 
-import { Offline } from '../src/offline';
+import { Item, Offline } from '../src/offline';
 
 // mock localforage methods
 jest.mock('localforage', () => ({
   createInstance(_options: { name: string }): any {
-    let items: { key: string; value: Event }[] = [];
+    let items: Item[] = [];
 
     return {
-      async getItem(key: string): Event {
+      async getItem(key: string): Promise<Item | void> {
         return items.find(item => item.key === key);
       },
       async iterate(callback: () => void): void {

--- a/packages/integrations/test/offline.test.ts
+++ b/packages/integrations/test/offline.test.ts
@@ -166,14 +166,17 @@ function initIntegration(options: { maxStoredEvents?: number } = {}): void {
   eventProcessors = [];
   events = [];
 
-  utils.getGlobalObject = jest.fn(() => ({
-    addEventListener: (_windowEvent, callback) => {
-      eventListeners.push(callback);
-    },
-    navigator: {
-      onLine: online,
-    },
-  }));
+  jest.spyOn(utils, 'getGlobalObject').mockImplementation(
+    () =>
+      ({
+        addEventListener: (_windowEvent, callback) => {
+          eventListeners.push(callback);
+        },
+        navigator: {
+          onLine: online,
+        },
+      } as any),
+  );
 
   integration = new Offline(options);
 }


### PR DESCRIPTION
This fixes a number of longstanding types errors in the tests for the `Offline` integration. It also simplifies some of the async code (to avoid mixing async functions and `done()`) and changes a mock so it is no longer assigning to a read-only property.

Getting these fixed will help unmuddy the waters with respect to the `Offline` test errors which are cropping up in our TS upgrade. 
