### PR TITLE
fix(dev): Add missing `--ignore` in main `yarn test` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:eslint": "lerna run --parallel lint:eslint",
     "prepublishOnly": "lerna run --stream --concurrency 1 prepublishOnly",
     "postpublish": "make publish-docs && lerna run --stream --concurrency 1 postpublish",
-    "test": "lerna run --ignore @sentry-internal/browser-integration-tests @sentry-internal/node-integration-tests --stream --concurrency 1 --sort test",
+    "test": "lerna run --ignore @sentry-internal/browser-integration-tests --ignore @sentry-internal/node-integration-tests --stream --concurrency 1 --sort test",
     "test-ci": "ts-node ./scripts/test.ts"
   },
   "volta": {


### PR DESCRIPTION
As part of https://github.com/getsentry/sentry-javascript/pull/4694, which adds integration tests for node, a change was made to the repo-level `yarn test` command, in order to skip running the new tests. The new version of the command was missing a `--ignore` flag, though, causing the command to error out. This adds the missing flag.
