### PR TITLE
ref(utils): Use type predicates for `isError` and `isString`

### DIFF
--- a/packages/utils/src/is.ts
+++ b/packages/utils/src/is.ts
@@ -13,7 +13,7 @@ const objectToString = Object.prototype.toString;
  * @param wat A value to be checked.
  * @returns A boolean representing the result.
  */
-export function isError(wat: unknown): boolean {
+export function isError(wat: unknown): wat is Error {
   switch (objectToString.call(wat)) {
     case '[object Error]':
     case '[object Exception]':
@@ -68,7 +68,7 @@ export function isDOMException(wat: unknown): boolean {
  * @param wat A value to be checked.
  * @returns A boolean representing the result.
  */
-export function isString(wat: unknown): boolean {
+export function isString(wat: unknown): wat is string {
   return isBuiltin(wat, 'String');
 }
 


### PR DESCRIPTION
This restores part of the work done in https://github.com/getsentry/sentry-javascript/pull/4124, which then got reverted in https://github.com/getsentry/sentry-javascript/pull/4149. The problem there was the predicates for `DOMError` and `DOMException`, both of which only exist in a browser context. This restores the predicates for `isError` and `isString`, which should be safe, because both `Error` and `string` exist in both browser and node contexts.