### PR TITLE
feat(utils): Add `isNaN` function

### DIFF
--- a/packages/utils/src/is.ts
+++ b/packages/utils/src/is.ts
@@ -146,6 +146,18 @@ export function isThenable(wat: any): wat is PromiseLike<any> {
 export function isSyntheticEvent(wat: unknown): boolean {
   return isPlainObject(wat) && 'nativeEvent' in wat && 'preventDefault' in wat && 'stopPropagation' in wat;
 }
+
+/**
+ * Checks whether given value is NaN
+ * {@link isNaN}.
+ *
+ * @param wat A value to be checked.
+ * @returns A boolean representing the result.
+ */
+export function isNaN(wat: unknown): boolean {
+  return typeof wat === 'number' && wat !== wat;
+}
+
 /**
  * Checks whether given value's type is an instance of provided constructor.
  * {@link isInstanceOf}.

--- a/packages/utils/test/is.test.ts
+++ b/packages/utils/test/is.test.ts
@@ -1,4 +1,13 @@
-import { isDOMError, isDOMException, isError, isErrorEvent, isInstanceOf, isPrimitive, isThenable } from '../src/is';
+import {
+  isDOMError,
+  isDOMException,
+  isError,
+  isErrorEvent,
+  isInstanceOf,
+  isNaN,
+  isPrimitive,
+  isThenable,
+} from '../src/is';
 import { supportsDOMError, supportsDOMException, supportsErrorEvent } from '../src/supports';
 import { resolvedSyncPromise } from '../src/syncpromise';
 
@@ -108,5 +117,20 @@ describe('isInstanceOf()', () => {
     expect(isInstanceOf(new Error('wat'), 'wat')).toEqual(false);
     expect(isInstanceOf(new Error('wat'), null)).toEqual(false);
     expect(isInstanceOf(new Error('wat'), undefined)).toEqual(false);
+  });
+});
+
+describe('isNaN()', () => {
+  test('should work as advertised', () => {
+    expect(isNaN(NaN)).toEqual(true);
+
+    expect(isNaN(null)).toEqual(false);
+    expect(isNaN(true)).toEqual(false);
+    expect(isNaN('foo')).toEqual(false);
+    expect(isNaN(42)).toEqual(false);
+    expect(isNaN({})).toEqual(false);
+    expect(isNaN([])).toEqual(false);
+    expect(isNaN(new Error('foo'))).toEqual(false);
+    expect(isNaN(new Date())).toEqual(false);
   });
 });


### PR DESCRIPTION
This adds a function, `isNaN`, to our `is` module. While it's true that there is a built-in function of the same name, it assumes it's being passed a number (which messes up types), whereas the function introduced here makes no such assumptions.

(This change was extracted from an upcoming PR, to reduce noise there.)