### PR TITLE
feat(vue): Drop vue-router peerDep

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -24,8 +24,7 @@
     "tslib": "^1.9.3"
   },
   "peerDependencies": {
-    "vue": "2.x || 3.x",
-    "vue-router": "3.x || 4.x"
+    "vue": "2.x || 3.x"
   },
   "devDependencies": {
     "jsdom": "^16.2.2"


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/4748

We previously added vue-router as a peer dependency because we rely on
it's existence for Vue Performance Monitoring's router instrumentation.
We never import directly from this though, we always rely on the user
passing it in afterwards. As such, we don't really need to define
a peerDep for the vue-router package.

We use a similar pattern for the react-router stuff, and it has worked
out super well.

Resolves https://getsentry.atlassian.net/browse/WEB-739
