### PR TITLE
fix(integrations): Emit ES5 code in ES5 bundles

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -190,7 +190,7 @@ export function makeBaseBundleConfig(options) {
       esModule: false,
     },
     plugins: [
-      jsVersion === 'es5' ? typescriptPluginES5 : typescriptPluginES6,
+      jsVersion.toLowerCase() === 'es5' ? typescriptPluginES5 : typescriptPluginES6,
       markAsBrowserBuildPlugin,
       nodeResolvePlugin,
       licensePlugin,


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/4718, a change was made to use an environment variable to control the version of JS emitted when building integration bundles. Unfortunately, the values then given to that variable were uppercase, whereas our code assumes a lowercase version. Further, the default output is ES6 (in preparation for going ES6-first in v7), so when the version flag `ES5` doesn't match the checked-for `es5`, we emit ES6 in the supposedly-ES5 bundle.

This controls for casing by casting the value to lowercase before comparison.

Fixes https://github.com/getsentry/sentry-javascript/issues/4768.
