### PR TITLE
fix(core): Export new transport methods

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,13 @@ export { BackendClass, BaseBackend } from './basebackend';
 export { eventToSentryRequest, sessionToSentryRequest } from './request';
 export { initAndBind, ClientClass } from './sdk';
 export { NoopTransport } from './transports/noop';
+export {
+  BaseTransportOptions,
+  createTransport,
+  NewTransport,
+  TransportMakeRequestResponse,
+  TransportRequest,
+} from './transports/base';
 export { SDK_VERSION } from './version';
 
 import * as Integrations from './integrations';


### PR DESCRIPTION
- Export types and methods for new transports in core package
- Add logic for cleaning up event and adding SDK details to
  `createEventEnvelope`. This is duplicating code, but considering we
  are going to refactor this in v7, we can take the temporary bundle
  size hit.

This is extracted from https://github.com/getsentry/sentry-javascript/pull/4765