### PR TITLE
fix(core): Use correct version of event when tagging normalization

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -429,7 +429,7 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
       normalized.contexts.trace = event.contexts.trace;
     }
 
-    event.sdkProcessingMetadata = { ...event.sdkProcessingMetadata, baseClientNormalized: true };
+    normalized.sdkProcessingMetadata = { ...normalized.sdkProcessingMetadata, baseClientNormalized: true };
 
     return normalized;
   }

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -879,6 +879,13 @@ describe('BaseClient', () => {
           delete capturedEvent.sdkProcessingMetadata.normalizeDepth;
         }
       }
+      if (capturedEvent.sdkProcessingMetadata?.baseClientNormalized) {
+        if (Object.keys(capturedEvent.sdkProcessingMetadata).length === 1) {
+          delete capturedEvent.sdkProcessingMetadata;
+        } else {
+          delete capturedEvent.sdkProcessingMetadata.baseClientNormalized;
+        }
+      }
 
       expect(capturedEvent).toEqual(normalizedTransaction);
       // expect(TestBackend.instance!.event!).toEqual(normalizedTransaction);

--- a/packages/integration-tests/utils/helpers.ts
+++ b/packages/integration-tests/utils/helpers.ts
@@ -82,7 +82,10 @@ async function getMultipleRequests(
           // removed. See https://github.com/getsentry/sentry-javascript/pull/4425.
           const parsedRequest = requestParser(request);
           if (parsedRequest.tags) {
-            if (parsedRequest.tags.skippedNormalization && Object.keys(parsedRequest.tags).length === 1) {
+            if (
+              Object.keys(parsedRequest.tags).length === 0 ||
+              (Object.keys(parsedRequest.tags).length === 1 && 'skippedNormalization' in parsedRequest.tags)
+            ) {
               delete parsedRequest.tags;
             } else {
               delete parsedRequest.tags.skippedNormalization;


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/4425, various hacks were added to the SDK to try to diagnose the root cause of https://github.com/getsentry/sentry-javascript/issues/2809. Unfortunately, one of those hacks (tagging when events are normalized) was applied to the pre-normalized version of the event rather than the normalized version that continues on through the event processing pipeline. This led to false positives, where events got tagged as if they'd skipped the normalization process even when they hadn't.

This fixes that by adding the flag to the normalized version of the event instead. Thanks to @klaussner for pointing this out.
