### PR TITLE
test(node): Add `addBreadcrumb` integration tests.

### DIFF
--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/scenario.ts
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+});
+
+Sentry.addBreadcrumb({});
+Sentry.captureMessage('test-empty-obj');

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/test.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/test.ts
@@ -1,0 +1,10 @@
+import { assertSentryEvent, getEventRequest, runServer } from '../../../../utils';
+
+test('should add an empty breadcrumb, when an empty object is given', async () => {
+  const url = await runServer(__dirname);
+  const requestBody = await getEventRequest(url);
+
+  assertSentryEvent(requestBody, {
+    message: 'test-empty-obj',
+  });
+});

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/scenario.ts
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+});
+
+Sentry.addBreadcrumb({
+  category: 'foo',
+  message: 'bar',
+  level: Sentry.Severity.Critical,
+});
+
+Sentry.addBreadcrumb({
+  category: 'qux',
+});
+
+Sentry.captureMessage('test_multi_breadcrumbs');

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/test.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/test.ts
@@ -1,0 +1,20 @@
+import { assertSentryEvent, getEventRequest, runServer } from '../../../../utils';
+
+test('should add multiple breadcrumbs', async () => {
+  const url = await runServer(__dirname);
+  const requestBody = await getEventRequest(url);
+
+  assertSentryEvent(requestBody, {
+    message: 'test_multi_breadcrumbs',
+    breadcrumbs: [
+      {
+        category: 'foo',
+        message: 'bar',
+        level: 'critical',
+      },
+      {
+        category: 'qux',
+      },
+    ],
+  });
+});

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/scenario.ts
@@ -1,0 +1,14 @@
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+});
+
+Sentry.addBreadcrumb({
+  category: 'foo',
+  message: 'bar',
+  level: Sentry.Severity.Critical,
+});
+
+Sentry.captureMessage('test_simple');

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/test.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/test.ts
@@ -1,0 +1,17 @@
+import { assertSentryEvent, getEventRequest, runServer } from '../../../../utils';
+
+test('should add a simple breadcrumb', async () => {
+  const url = await runServer(__dirname);
+  const requestBody = await getEventRequest(url);
+
+  assertSentryEvent(requestBody, {
+    message: 'test_simple',
+    breadcrumbs: [
+      {
+        category: 'foo',
+        message: 'bar',
+        level: 'critical',
+      },
+    ],
+  });
+});


### PR DESCRIPTION
Part of: #4762 