### PR TITLE
test(node): Add `configureScope` integration tests.

### DIFF
--- a/packages/node-integration-tests/suites/public-api/configureScope/clear_scope/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/configureScope/clear_scope/scenario.ts
@@ -1,0 +1,15 @@
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+});
+
+Sentry.configureScope(scope => {
+  scope.setTag('foo', 'bar');
+  scope.setUser({ id: 'baz' });
+  scope.setExtra('qux', 'quux');
+  scope.clear();
+});
+
+Sentry.captureMessage('cleared_scope');

--- a/packages/node-integration-tests/suites/public-api/configureScope/clear_scope/test.ts
+++ b/packages/node-integration-tests/suites/public-api/configureScope/clear_scope/test.ts
@@ -1,0 +1,16 @@
+import { Event } from '@sentry/node';
+
+import { assertSentryEvent, getEventRequest, runServer } from '../../../../utils';
+
+test('should clear previously set properties of a scope', async () => {
+  const url = await runServer(__dirname);
+  const requestBody = await getEventRequest(url);
+
+  assertSentryEvent(requestBody, {
+    message: 'cleared_scope',
+    tags: {},
+    extra: {},
+  });
+
+  expect((requestBody as Event).user).not.toBeDefined();
+});

--- a/packages/node-integration-tests/suites/public-api/configureScope/set_properties/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/configureScope/set_properties/scenario.ts
@@ -1,0 +1,14 @@
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+});
+
+Sentry.configureScope(scope => {
+  scope.setTag('foo', 'bar');
+  scope.setUser({ id: 'baz' });
+  scope.setExtra('qux', 'quux');
+});
+
+Sentry.captureMessage('configured_scope');

--- a/packages/node-integration-tests/suites/public-api/configureScope/set_properties/test.ts
+++ b/packages/node-integration-tests/suites/public-api/configureScope/set_properties/test.ts
@@ -1,0 +1,19 @@
+import { assertSentryEvent, getEventRequest, runServer } from '../../../../utils';
+
+test('should set different properties of a scope', async () => {
+  const url = await runServer(__dirname);
+  const requestBody = await getEventRequest(url);
+
+  assertSentryEvent(requestBody, {
+    message: 'configured_scope',
+    tags: {
+      foo: 'bar',
+    },
+    extra: {
+      qux: 'quux',
+    },
+    user: {
+      id: 'baz',
+    },
+  });
+});


### PR DESCRIPTION
Part of: #4762 