### PR TITLE
test(node): Add `setContext` integration tests.

### DIFF
--- a/packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/scenario.ts
@@ -1,0 +1,22 @@
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+});
+
+Sentry.setContext('context_1', {
+  foo: 'bar',
+  baz: {
+    qux: 'quux',
+  },
+});
+
+Sentry.setContext('context_2', {
+  1: 'foo',
+  bar: false,
+});
+
+Sentry.setContext('context_3', null);
+
+Sentry.captureMessage('multiple_contexts');

--- a/packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/test.ts
@@ -1,0 +1,21 @@
+import { Event } from '@sentry/node';
+
+import { assertSentryEvent, getEventRequest, runServer } from '../../../../utils';
+
+test('should record multiple contexts', async () => {
+  const url = await runServer(__dirname);
+  const requestBody = await getEventRequest(url);
+
+  assertSentryEvent(requestBody, {
+    message: 'multiple_contexts',
+    contexts: {
+      context_1: {
+        foo: 'bar',
+        baz: { qux: 'quux' },
+      },
+      context_2: { 1: 'foo', bar: false },
+    },
+  });
+
+  expect((requestBody as Event).contexts?.context_3).not.toBeDefined();
+});

--- a/packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/scenario.ts
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+});
+
+type Circular = {
+  self?: Circular;
+};
+
+const objCircular: Circular = {};
+objCircular.self = objCircular;
+
+Sentry.setContext('non_serializable', objCircular);
+
+Sentry.captureMessage('non_serializable');

--- a/packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/test.ts
@@ -1,0 +1,15 @@
+import { Event } from '@sentry/node';
+
+import { assertSentryEvent, getEventRequest, runServer } from '../../../../utils';
+
+test('should normalize non-serializable context', async () => {
+  const url = await runServer(__dirname);
+  const requestBody = await getEventRequest(url);
+
+  assertSentryEvent(requestBody, {
+    message: 'non_serializable',
+    contexts: {},
+  });
+
+  expect((requestBody as Event).contexts?.context_3).not.toBeDefined();
+});

--- a/packages/node-integration-tests/suites/public-api/setContext/simple-context/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/simple-context/scenario.ts
@@ -1,0 +1,9 @@
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+});
+
+Sentry.setContext('foo', { bar: 'baz' });
+Sentry.captureMessage('simple_context_object');

--- a/packages/node-integration-tests/suites/public-api/setContext/simple-context/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/simple-context/test.ts
@@ -1,0 +1,19 @@
+import { Event } from '@sentry/node';
+
+import { assertSentryEvent, getEventRequest, runServer } from '../../../../utils';
+
+test('should set a simple context', async () => {
+  const url = await runServer(__dirname);
+  const requestBody = await getEventRequest(url);
+
+  assertSentryEvent(requestBody, {
+    message: 'simple_context_object',
+    contexts: {
+      foo: {
+        bar: 'baz',
+      },
+    },
+  });
+
+  expect((requestBody as Event).contexts?.context_3).not.toBeDefined();
+});


### PR DESCRIPTION
Part of: #4762 