### PR TITLE
test(node): Add `setTag` integration tests.

### DIFF
--- a/packages/node-integration-tests/suites/public-api/setTag/with-primitives/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/setTag/with-primitives/scenario.ts
@@ -1,0 +1,15 @@
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+});
+
+Sentry.setTag('tag_1', 'foo');
+Sentry.setTag('tag_2', Math.PI);
+Sentry.setTag('tag_3', false);
+Sentry.setTag('tag_4', null);
+Sentry.setTag('tag_5', undefined);
+Sentry.setTag('tag_6', -1);
+
+Sentry.captureMessage('primitive_tags');

--- a/packages/node-integration-tests/suites/public-api/setTag/with-primitives/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setTag/with-primitives/test.ts
@@ -1,0 +1,17 @@
+import { assertSentryEvent, getEventRequest, runServer } from '../../../../utils';
+
+test('should set primitive tags', async () => {
+  const url = await runServer(__dirname);
+  const requestBody = await getEventRequest(url);
+
+  assertSentryEvent(requestBody, {
+    message: 'primitive_tags',
+    tags: {
+      tag_1: 'foo',
+      tag_2: 3.141592653589793,
+      tag_3: false,
+      tag_4: null,
+      tag_6: -1,
+    },
+  });
+});


### PR DESCRIPTION
Part of: #4762 

TS covers non-primitive cases here.