### PR TITLE
test(node): Add `withScope` integration tests.

### DIFF
--- a/packages/node-integration-tests/suites/public-api/withScope/nested-scopes/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/withScope/nested-scopes/scenario.ts
@@ -1,0 +1,25 @@
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+});
+
+Sentry.setUser({ id: 'qux' });
+Sentry.captureMessage('root_before');
+
+Sentry.withScope(scope => {
+  scope.setTag('foo', false);
+  Sentry.captureMessage('outer_before');
+
+  Sentry.withScope(scope => {
+    scope.setTag('bar', 10);
+    scope.setUser(null);
+    Sentry.captureMessage('inner');
+  });
+
+  scope.setUser({ id: 'baz' });
+  Sentry.captureMessage('outer_after');
+});
+
+Sentry.captureMessage('root_after');

--- a/packages/node-integration-tests/suites/public-api/withScope/nested-scopes/test.ts
+++ b/packages/node-integration-tests/suites/public-api/withScope/nested-scopes/test.ts
@@ -1,0 +1,54 @@
+import { Event } from '@sentry/node';
+
+import { assertSentryEvent, getMultipleEventRequests, runServer } from '../../../../utils';
+
+test('should allow nested scoping', async () => {
+  const url = await runServer(__dirname);
+  const events = await getMultipleEventRequests(url, 5);
+
+  assertSentryEvent(events[0], {
+    message: 'root_before',
+    user: {
+      id: 'qux',
+    },
+    tags: {},
+  });
+
+  assertSentryEvent(events[1], {
+    message: 'outer_before',
+    user: {
+      id: 'qux',
+    },
+    tags: {
+      foo: false,
+    },
+  });
+
+  assertSentryEvent(events[2], {
+    message: 'inner',
+    tags: {
+      foo: false,
+      bar: 10,
+    },
+  });
+
+  expect((events[2] as Event).user).toBeUndefined();
+
+  assertSentryEvent(events[3], {
+    message: 'outer_after',
+    user: {
+      id: 'baz',
+    },
+    tags: {
+      foo: false,
+    },
+  });
+
+  assertSentryEvent(events[4], {
+    message: 'root_after',
+    user: {
+      id: 'qux',
+    },
+    tags: {},
+  });
+});


### PR DESCRIPTION
Part of: #4762