### PR TITLE
ref(nextjs): Move BrowserTracing var into function

### DIFF
--- a/packages/nextjs/src/index.client.ts
+++ b/packages/nextjs/src/index.client.ts
@@ -48,12 +48,12 @@ export function init(options: NextjsOptions): void {
   });
 }
 
-const defaultBrowserTracingIntegration = new BrowserTracing({
-  tracingOrigins: [...defaultRequestInstrumentationOptions.tracingOrigins, /^(api\/)/],
-  routingInstrumentation: nextRouterInstrumentation,
-});
-
 function createClientIntegrations(integrations?: UserIntegrations): UserIntegrations {
+  const defaultBrowserTracingIntegration = new BrowserTracing({
+    tracingOrigins: [...defaultRequestInstrumentationOptions.tracingOrigins, /^(api\/)/],
+    routingInstrumentation: nextRouterInstrumentation,
+  });
+
   if (integrations) {
     return addIntegration(defaultBrowserTracingIntegration, integrations, {
       BrowserTracing: { keyPath: 'options.routingInstrumentation', value: nextRouterInstrumentation },


### PR DESCRIPTION
Move `BrowserTracing` into the function.

This was showing some pretty crazy size-limit results, so opening a PR to see what's going on.
