### PR TITLE
fix(core): Stop mangling `_experiments`

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -57,6 +57,8 @@ function makeIsDebugBuildPlugin(includeDebugging) {
   });
 }
 
+// `terser` options reference: https://github.com/terser/terser#api-reference
+// `rollup-plugin-terser` options reference: https://github.com/TrySound/rollup-plugin-terser#options
 export const terserPlugin = terser({
   mangle: {
     // captureExceptions and captureMessage are public API methods and they don't need to be listed here
@@ -66,6 +68,7 @@ export const terserPlugin = terser({
     reserved: ['captureException', 'captureMessage', 'sentryWrapped'],
     properties: {
       regex: /^_[^_]/,
+      reserved: ['_experiments'],
     },
   },
   output: {


### PR DESCRIPTION
We hide experimental options behind an `_experiments` flag. This is fine for folks using our npm packages, but for folks using CDN bundles it's a problem, because until now, we've been mangling the property name `_experiments`. (Normally, properties starting with a single underscore are private class methods or fields, the names of both of which it's fine to mangle. We therefore use that as our criterion when telling terser what it may and may not touch, and `_experiments` has been getting swept up by that regex.)

This carves out an exception for `_experiments`, so that it is no longer mangled.
