### PR TITLE
fix(nextjs): Fix tmp path of rewriteFramesHelper

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -137,10 +137,10 @@ async function addSentryToEntryProperty(
   // because it somehow tricks the file watcher into thinking that compilation itself is a file change, triggering an
   // infinite recompiling loop. (This should be fine because we don't upload sourcemaps in dev in any case.)
   if (isServer && !isDev) {
-    const rewriteFramesHelper = path.resolve(
-      fs.mkdtempSync(path.resolve(os.tmpdir(), 'sentry-')),
-      'rewriteFramesHelper.js',
-    );
+    const rewriteFramesHelper = path.resolve(os.tmpdir(), 'sentry-javascript', 'rewriteFramesHelper.js');
+    if (!fs.existsSync(path.dirname(rewriteFramesHelper))) {
+      fs.mkdirSync(path.dirname(rewriteFramesHelper));
+    }
     fs.writeFileSync(rewriteFramesHelper, `global.__rewriteFramesDistDir__ = '${userNextConfig.distDir}';\n`);
     // stick our helper file ahead of the user's config file so the value is in the global namespace *before*
     // `Sentry.init()` is called

--- a/packages/nextjs/test/config.test.ts
+++ b/packages/nextjs/test/config.test.ts
@@ -332,8 +332,7 @@ describe('webpack config', () => {
         incomingWebpackBuildContext: serverBuildContext,
       });
 
-      const tempDir = mkdtempSyncSpy.mock.results[0].value;
-      const rewriteFramesHelper = path.join(tempDir, 'rewriteFramesHelper.js');
+      const rewriteFramesHelper = path.join(os.tmpdir(), 'sentry-javascript', 'rewriteFramesHelper.js');
 
       expect(finalWebpackConfig.entry).toEqual(
         expect.objectContaining({
@@ -515,8 +514,7 @@ describe('webpack config', () => {
           incomingWebpackBuildContext: getBuildContext('server', userNextConfigDistDir),
         });
 
-        const tempDir = mkdtempSyncSpy.mock.results[0].value;
-        const rewriteFramesHelper = path.join(tempDir, 'rewriteFramesHelper.js');
+        const rewriteFramesHelper = path.join(os.tmpdir(), 'sentry-javascript', 'rewriteFramesHelper.js');
 
         expect(fs.existsSync(rewriteFramesHelper)).toBe(true);
 


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

# Overview

This PR fixes the temp path of `rewriteFramesHelper.js` to be static.

# Problem

webpack determines an id of each module from its file path and embeds it to dist. Currently, sentry-nextjs generates the path of `rewriteFramesHelper.js` dynamically and causes the diff of dist on every build.

There is no problem with the runtime behavior but inconvenient for caching on build process. So fix the path of `rewriteFramesHelper.js` to be static.

