### PR TITLE
test(browser): Add integration tests for new XHR Transport

### DIFF
--- a/packages/integration-tests/suites/new-transports/xhr-captureException/subject.js
+++ b/packages/integration-tests/suites/new-transports/xhr-captureException/subject.js
@@ -1,0 +1,4 @@
+// deactivate fetch s.t. the SDK falls back to XHR transport
+window.fetch = undefined;
+
+Sentry.captureException(new Error('this is an error'));

--- a/packages/integration-tests/suites/new-transports/xhr-captureException/test.ts
+++ b/packages/integration-tests/suites/new-transports/xhr-captureException/test.ts
@@ -1,0 +1,21 @@
+import { expect } from '@playwright/test';
+import { Event } from '@sentry/types';
+
+import { sentryTest } from '../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
+
+sentryTest('should capture an error with the new fetch transport', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
+
+  expect(eventData.exception?.values).toHaveLength(1);
+  expect(eventData.exception?.values?.[0]).toMatchObject({
+    type: 'Error',
+    value: 'this is an error',
+    mechanism: {
+      type: 'generic',
+      handled: true,
+    },
+  });
+});

--- a/packages/integration-tests/suites/new-transports/xhr-startTransaction/subject.js
+++ b/packages/integration-tests/suites/new-transports/xhr-startTransaction/subject.js
@@ -1,0 +1,5 @@
+// deactivate fetch s.t. the SDK falls back to XHR transport
+window.fetch = undefined;
+
+const transaction = Sentry.startTransaction({ name: 'test_transaction_1' });
+transaction.finish();

--- a/packages/integration-tests/suites/new-transports/xhr-startTransaction/test.ts
+++ b/packages/integration-tests/suites/new-transports/xhr-startTransaction/test.ts
@@ -1,0 +1,13 @@
+import { expect } from '@playwright/test';
+import { Event } from '@sentry/types';
+
+import { sentryTest } from '../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
+
+sentryTest('should report a transaction with the new XHR transport', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+  const transaction = await getFirstSentryEnvelopeRequest<Event>(page, url);
+
+  expect(transaction.transaction).toBe('test_transaction_1');
+  expect(transaction.spans).toBeDefined();
+});


### PR DESCRIPTION
This PR adds integration tests to test the new XHR transport introduced in #4803 

The tests are very similar to the new Fetch transport integration tests introduced in #4765. The only difference is that they disable the browsers' Fetch API by setting `window.fetch = undefined`. This way, the SDK falls back to the XHR transport.

ref: https://getsentry.atlassian.net/browse/WEB-752
