### PR TITLE
test(node): Add integration tests for new node transports

### DIFF
--- a/packages/node-integration-tests/suites/public-api/captureException/new-transport/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/captureException/new-transport/scenario.ts
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  _experiments: {
+    newTransport: true, // use new transport
+  },
+});
+
+Sentry.captureException(new Error('test_simple_error'));

--- a/packages/node-integration-tests/suites/public-api/captureException/new-transport/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureException/new-transport/test.ts
@@ -1,0 +1,23 @@
+import { getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+
+test('should correctly send envelope', async () => {
+  const url = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+
+  const errorEnvelope = envelopes[1];
+
+  expect(errorEnvelope).toHaveLength(3);
+  expect(errorEnvelope[2]).toMatchObject({
+    exception: {
+      values: [
+        {
+          type: 'Error',
+          value: 'test_simple_error',
+        },
+      ],
+    },
+    release: '1.0',
+    event_id: expect.any(String),
+    timestamp: expect.any(Number),
+  });
+});

--- a/packages/node-integration-tests/suites/public-api/startTransaction/new-transport/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/startTransaction/new-transport/scenario.ts
@@ -1,0 +1,17 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import '@sentry/tracing';
+
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  _experiments: {
+    newTransport: true, // use new transport
+  },
+});
+
+const transaction = Sentry.startTransaction({ name: 'test_transaction_1' });
+
+transaction.finish();

--- a/packages/node-integration-tests/suites/public-api/startTransaction/new-transport/test.ts
+++ b/packages/node-integration-tests/suites/public-api/startTransaction/new-transport/test.ts
@@ -1,0 +1,12 @@
+import { assertSentryTransaction, getEnvelopeRequest, runServer } from '../../../../utils';
+
+test('should send a manually started transaction when @sentry/tracing is imported using unnamed import', async () => {
+  const url = await runServer(__dirname);
+  const envelope = await getEnvelopeRequest(url);
+
+  expect(envelope).toHaveLength(3);
+
+  assertSentryTransaction(envelope[2], {
+    transaction: 'test_transaction_1',
+  });
+});


### PR DESCRIPTION
Add integration tests for the new node transports which got introduced in #4781.