### PR TITLE
meta: Update CHANGELOG for 6.19.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@
 
 ## 6.19.4
 
-- feat(react): Add React 18 as peer dep (#4819)
-- ref(build): Add `build/types` to tarballs and adjust `types` entry points (#4824)
+- feat(react): Add React 18 as peer dep ([#4819](https://github.com/getsentry/sentry-javascript/pull/4819)))
+- ref(build): Add `build/types` to tarballs and adjust `types` entry points ([#4824](https://github.com/getsentry/sentry-javascript/pull/4824)))
 
-Work in this release contributed by @Turbo87. Thank you for your contribution!
+Work in this release contributed by @MikevPeeren. Thank you for your contribution!
 
 ## 6.19.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+## 6.19.4
+
+- feat(react): Add React 18 as peer dep (#4819)
+- ref(build): Add `build/types` to tarballs and adjust `types` entry points (#4824)
+
+Work in this release contributed by @Turbo87. Thank you for your contribution!
+
 ## 6.19.3
 
 - feat(browser): Add new v7 Fetch Transport ([#4765](https://github.com/getsentry/sentry-javascript/pull/4765))


### PR DESCRIPTION
- unblocks React 18 across our SDKs
- updates NextJS SDK to add React 18 peer dep
