### PR TITLE
fix(build): Ensure full stacktraces when running `rollup`

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,6 +11,8 @@ import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import typescript from 'rollup-plugin-typescript2';
 
+Error.stackTraceLimit = Infinity;
+
 /**
  * Helper functions to compensate for the fact that JS can't handle negative array indices very well
  *


### PR DESCRIPTION
By default, node [cuts stacktraces down to the final 10 frames](https://nodejs.org/api/errors.html#errorstacktracelimit). Sometimes, though, the stuff you're interested in is below that. This removes the cap for errors generated when running `rollup` (which turned out to be necessary to diagnose a problem encountered during work on the new build process).
