### PR TITLE
ref(build): Introduce central `build` directory to packages with bundles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,7 @@ jobs:
           name: ${{ github.sha }}
           path: |
             ${{ github.workspace }}/packages/browser/build/bundles/**
-            ${{ github.workspace }}/packages/integrations/build/**
+            ${{ github.workspace }}/packages/integrations/build/bundles/**
             ${{ github.workspace }}/packages/tracing/build/**
             ${{ github.workspace }}/packages/**/*.tgz
             ${{ github.workspace }}/packages/serverless/dist-awslambda-layer/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,7 @@ jobs:
           path: |
             ${{ github.workspace }}/packages/browser/build/bundles/**
             ${{ github.workspace }}/packages/integrations/build/bundles/**
-            ${{ github.workspace }}/packages/tracing/build/**
+            ${{ github.workspace }}/packages/tracing/build/bundles/**
             ${{ github.workspace }}/packages/**/*.tgz
             ${{ github.workspace }}/packages/serverless/dist-awslambda-layer/*.zip
 

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -25,14 +25,14 @@ module.exports = [
   },
   {
     name: '@sentry/browser - Webpack (gzipped + minified)',
-    path: 'packages/browser/build/esm/index.js',
+    path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init }',
     gzip: true,
     limit: '100 KB',
   },
   {
     name: '@sentry/browser - Webpack (minified)',
-    path: 'packages/browser/build/esm/index.js',
+    path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init }',
     gzip: false,
     limit: '100 KB',

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -53,13 +53,13 @@ module.exports = [
   },
   {
     name: '@sentry/browser + @sentry/tracing - ES5 CDN Bundle (gzipped + minified)',
-    path: 'packages/tracing/build/bundle.tracing.min.js',
+    path: 'packages/tracing/build/bundles/bundle.tracing.min.js',
     gzip: true,
     limit: '100 KB',
   },
   {
     name: '@sentry/browser + @sentry/tracing - ES6 CDN Bundle (gzipped + minified)',
-    path: 'packages/tracing/build/bundle.tracing.es6.min.js',
+    path: 'packages/tracing/build/bundles/bundle.tracing.es6.min.js',
     gzip: true,
     limit: '100 KB',
   },

--- a/packages/browser/.npmignore
+++ b/packages/browser/.npmignore
@@ -1,6 +1,6 @@
 # Info: the paths in this file are specified so that they align with the file
 # structure in `./build` where this file is copied to. This is done by the
-# postbuild script `sentry-javascript/scripts/postbuild.ts`.
+# prepack script `sentry-javascript/scripts/prepack.ts`.
 
 *
 

--- a/packages/browser/.npmignore
+++ b/packages/browser/.npmignore
@@ -4,8 +4,8 @@
 
 *
 
-# TODO remove bundles in v7
-!/bundles/**/*
+# TODO remove bundles (which in the tarball are inside `build`) in v7
+!/build/**/*
 
 !/dist/**/*
 !/types/**/*

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -44,7 +44,7 @@
     "webpack": "^4.30.0"
   },
   "scripts": {
-    "build": "run-p build:cjs build:esm build:bundle build:types && ts-node ../../scripts/postbuild.ts",
+    "build": "run-p build:cjs build:esm build:bundle build:types",
     "build:bundle": "rollup --config",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:dev": "run-p build:cjs build:esm build:types",
@@ -58,7 +58,7 @@
     "build:dev:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
-    "build:npm": "npm pack ./build/npm",
+    "build:npm": "ts-node ../../scripts/prepack.ts && npm pack ./build/npm",
     "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf build coverage .rpt2_cache",
     "fix": "run-s fix:eslint fix:prettier",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -9,9 +9,9 @@
   "engines": {
     "node": ">=6"
   },
-  "main": "build/dist/index.js",
-  "module": "build/esm/index.js",
-  "types": "build/types/index.d.ts",
+  "main": "build/npm/dist/index.js",
+  "module": "build/npm/esm/index.js",
+  "types": "build/npm/types/index.d.ts",
   "publishConfig": {
     "access": "public"
   },
@@ -58,7 +58,7 @@
     "build:dev:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
-    "build:npm": "npm pack ./build",
+    "build:npm": "npm pack ./build/npm",
     "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf build coverage .rpt2_cache",
     "fix": "run-s fix:eslint fix:prettier",

--- a/packages/browser/test/integration/run.js
+++ b/packages/browser/test/integration/run.js
@@ -73,7 +73,7 @@ function build() {
 
   writeFile(
     'artifacts/dedupe.js',
-    readFile('../../../integrations/build/dedupe.js').replace('//# sourceMappingURL=dedupe.js.map', '')
+    readFile('../../../integrations/build/bundles/dedupe.js').replace('//# sourceMappingURL=dedupe.js.map', '')
   );
   concatFiles('artifacts/setup.js', ['artifacts/dedupe.js', 'common/utils.js', 'common/triggers.js', 'common/init.js']);
   rmdir('artifacts/dedupe.js');

--- a/packages/browser/test/package/test-code.js
+++ b/packages/browser/test/package/test-code.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
-const Sentry = require('../../build/dist/index.js');
-const Integrations = require('../../../integrations/dist/dedupe.js');
+const Sentry = require('../../build/npm/dist/index.js');
+const Integrations = require('../../../integrations/build/npm/dist/dedupe.js');
 
 // Init
 Sentry.init({

--- a/packages/browser/tsconfig.cjs.json
+++ b/packages/browser/tsconfig.cjs.json
@@ -3,6 +3,6 @@
 
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "build/dist",
+    "outDir": "build/npm/dist"
   }
 }

--- a/packages/browser/tsconfig.esm.json
+++ b/packages/browser/tsconfig.esm.json
@@ -3,6 +3,6 @@
 
   "compilerOptions": {
     "module": "es6",
-    "outDir": "build/esm",
+    "outDir": "build/npm/esm"
   }
 }

--- a/packages/browser/tsconfig.types.json
+++ b/packages/browser/tsconfig.types.json
@@ -5,6 +5,6 @@
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,
-    "outDir": "build/types"
+    "outDir": "build/npm/types"
   }
 }

--- a/packages/integration-tests/utils/generatePlugin.ts
+++ b/packages/integration-tests/utils/generatePlugin.ts
@@ -25,12 +25,12 @@ const BUNDLE_PATHS: Record<string, Record<string, string>> = {
     bundle_es6_min: 'build/bundles/bundle.es6.min.js',
   },
   tracing: {
-    cjs: 'dist/index.js',
-    esm: 'esm/index.js',
-    bundle_es5: 'build/bundle.tracing.js',
-    bundle_es5_min: 'build/bundle.tracing.min.js',
-    bundle_es6: 'build/bundle.tracing.es6.js',
-    bundle_es6_min: 'build/bundle.tracing.es6.min.js',
+    cjs: 'build/npm/dist/index.js',
+    esm: 'build/npm/esm/index.js',
+    bundle_es5: 'build/bundles/bundle.tracing.js',
+    bundle_es5_min: 'build/bundles/bundle.tracing.min.js',
+    bundle_es6: 'build/bundles/bundle.tracing.es6.js',
+    bundle_es6_min: 'build/bundles/bundle.tracing.es6.min.js',
   },
 };
 

--- a/packages/integration-tests/utils/generatePlugin.ts
+++ b/packages/integration-tests/utils/generatePlugin.ts
@@ -17,8 +17,8 @@ const useBundle = bundleKey && !useCompiledModule;
 
 const BUNDLE_PATHS: Record<string, Record<string, string>> = {
   browser: {
-    cjs: 'build/dist/index.js',
-    esm: 'build/esm/index.js',
+    cjs: 'build/npm/dist/index.js',
+    esm: 'build/npm/esm/index.js',
     bundle_es5: 'build/bundles/bundle.js',
     bundle_es5_min: 'build/bundles/bundle.min.js',
     bundle_es6: 'build/bundles/bundle.es6.js',

--- a/packages/integrations/.npmignore
+++ b/packages/integrations/.npmignore
@@ -1,6 +1,6 @@
 # Info: the paths in this file are specified so that they align with the file
 # structure in `./build` where this file is copied to. This is done by the
-# postbuild script `sentry-javascript/scripts/postbuild.ts`.
+# prepack script `sentry-javascript/scripts/prepack.ts`.
 
 *
 

--- a/packages/integrations/.npmignore
+++ b/packages/integrations/.npmignore
@@ -1,4 +1,12 @@
+# Info: the paths in this file are specified so that they align with the file
+# structure in `./build` where this file is copied to. This is done by the
+# postbuild script `sentry-javascript/scripts/postbuild.ts`.
+
 *
-!/dist/**/*
+
+# TODO remove bundles (which in the tarball are inside `build`) in v7
 !/build/**/*
+
+!/dist/**/*
 !/esm/**/*
+!/types/**/*

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -12,9 +12,9 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/index.js",
-  "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "main": "build/npm/dist/index.js",
+  "module": "build/npm/esm/index.js",
+  "types": "build/npm/types/index.d.ts",
   "dependencies": {
     "@sentry/types": "6.19.4",
     "@sentry/utils": "6.19.4",
@@ -25,7 +25,7 @@
     "chai": "^4.1.2"
   },
   "scripts": {
-    "build": "run-p build:cjs build:esm build:types build:bundle",
+    "build": "run-p build:cjs build:esm build:types build:bundle && ts-node ../../scripts/postbuild.ts",
     "build:bundle": "bash scripts/buildBundles.sh",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:dev": "run-p build:cjs build:esm build:types",
@@ -38,7 +38,7 @@
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
-    "build:npm": "npm pack",
+    "build:npm": "npm pack ./build/npm",
     "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf dist esm build coverage .rpt2_cache",
     "fix": "run-s fix:eslint fix:prettier",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -25,7 +25,7 @@
     "chai": "^4.1.2"
   },
   "scripts": {
-    "build": "run-p build:cjs build:esm build:types build:bundle && ts-node ../../scripts/postbuild.ts",
+    "build": "run-p build:cjs build:esm build:types build:bundle",
     "build:bundle": "bash scripts/buildBundles.sh",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:dev": "run-p build:cjs build:esm build:types",
@@ -38,7 +38,7 @@
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
-    "build:npm": "npm pack ./build/npm",
+    "build:npm": "ts-node ../../scripts/prepack.ts && npm pack ./build/npm",
     "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf dist esm build coverage .rpt2_cache",
     "fix": "run-s fix:eslint fix:prettier",

--- a/packages/integrations/rollup.config.js
+++ b/packages/integrations/rollup.config.js
@@ -12,7 +12,7 @@ const baseBundleConfig = makeBaseBundleConfig({
   isAddOn: true,
   jsVersion,
   licenseTitle: '@sentry/integrations',
-  outputFileBase: `${file.replace('.ts', '')}${jsVersion === 'ES6' ? '.es6' : ''}`,
+  outputFileBase: `bundles/${file.replace('.ts', '')}${jsVersion === 'ES6' ? '.es6' : ''}`,
 });
 
 // TODO We only need `commonjs` for localforage (used in the offline plugin). Once that's fixed, this can come out.

--- a/packages/integrations/tsconfig.cjs.json
+++ b/packages/integrations/tsconfig.cjs.json
@@ -3,6 +3,6 @@
 
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "dist"
+    "outDir": "build/npm/dist"
   }
 }

--- a/packages/integrations/tsconfig.esm.json
+++ b/packages/integrations/tsconfig.esm.json
@@ -3,6 +3,6 @@
 
   "compilerOptions": {
     "module": "es6",
-    "outDir": "esm"
+    "outDir": "build/npm/esm"
   }
 }

--- a/packages/integrations/tsconfig.types.json
+++ b/packages/integrations/tsconfig.types.json
@@ -5,6 +5,6 @@
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,
-    "outDir": "build/types"
+    "outDir": "build/npm/types"
   }
 }

--- a/packages/tracing/.npmignore
+++ b/packages/tracing/.npmignore
@@ -1,6 +1,6 @@
 # Info: the paths in this file are specified so that they align with the file
 # structure in `./build` where this file is copied to. This is done by the
-# postbuild script `sentry-javascript/scripts/postbuild.ts`.
+# prepack script `sentry-javascript/scripts/prepack.ts`.
 
 *
 

--- a/packages/tracing/.npmignore
+++ b/packages/tracing/.npmignore
@@ -1,4 +1,12 @@
+# Info: the paths in this file are specified so that they align with the file
+# structure in `./build` where this file is copied to. This is done by the
+# postbuild script `sentry-javascript/scripts/postbuild.ts`.
+
 *
-!/dist/**/*
+
+# TODO remove bundles (which in the tarball are inside `build`) in v7
 !/build/**/*
+
+!/dist/**/*
 !/esm/**/*
+!/types/**/*

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -29,7 +29,7 @@
     "jsdom": "^16.2.2"
   },
   "scripts": {
-    "build": "run-p build:cjs build:esm build:types build:bundle",
+    "build": "run-p build:cjs build:esm build:types build:bundle && ts-node ../../scripts/prepack.ts #necessary for integration tests",
     "build:bundle": "rollup --config",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:dev": "run-p build:cjs build:esm build:types",

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -9,9 +9,9 @@
   "engines": {
     "node": ">=6"
   },
-  "main": "dist/index.js",
-  "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "main": "build/npm/dist/index.js",
+  "module": "build/npm/esm/index.js",
+  "types": "build/npm/types/index.d.ts",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "jsdom": "^16.2.2"
   },
   "scripts": {
-    "build": "run-p build:cjs build:esm build:types build:bundle",
+    "build": "run-p build:cjs build:esm build:types build:bundle && ts-node ../../scripts/postbuild.ts",
     "build:bundle": "rollup --config",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:dev": "run-p build:cjs build:esm build:types",
@@ -43,7 +43,7 @@
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
-    "build:npm": "npm pack",
+    "build:npm": "npm pack ./build/npm",
     "clean": "rimraf dist esm build coverage",
     "circularDepCheck": "madge --circular src/index.ts",
     "fix": "run-s fix:eslint fix:prettier",

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -29,7 +29,7 @@
     "jsdom": "^16.2.2"
   },
   "scripts": {
-    "build": "run-p build:cjs build:esm build:types build:bundle && ts-node ../../scripts/postbuild.ts",
+    "build": "run-p build:cjs build:esm build:types build:bundle",
     "build:bundle": "rollup --config",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:dev": "run-p build:cjs build:esm build:types",
@@ -43,7 +43,7 @@
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
-    "build:npm": "npm pack ./build/npm",
+    "build:npm": "ts-node ../../scripts/prepack.ts && npm pack ./build/npm",
     "clean": "rimraf dist esm build coverage",
     "circularDepCheck": "madge --circular src/index.ts",
     "fix": "run-s fix:eslint fix:prettier",

--- a/packages/tracing/rollup.config.js
+++ b/packages/tracing/rollup.config.js
@@ -8,7 +8,7 @@ const builds = [];
     isAddOn: false,
     jsVersion,
     licenseTitle: '@sentry/tracing & @sentry/browser',
-    outputFileBase: `bundle.tracing${jsVersion === 'es6' ? '.es6' : ''}`,
+    outputFileBase: `bundles/bundle.tracing${jsVersion === 'es6' ? '.es6' : ''}`,
   });
 
   builds.push(...makeConfigVariants(baseBundleConfig));

--- a/packages/tracing/tsconfig.cjs.json
+++ b/packages/tracing/tsconfig.cjs.json
@@ -3,6 +3,6 @@
 
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "dist"
+    "outDir": "build/npm/dist"
   }
 }

--- a/packages/tracing/tsconfig.esm.json
+++ b/packages/tracing/tsconfig.esm.json
@@ -3,6 +3,6 @@
 
   "compilerOptions": {
     "module": "es6",
-    "outDir": "esm"
+    "outDir": "build/npm/esm"
   }
 }

--- a/packages/tracing/tsconfig.types.json
+++ b/packages/tracing/tsconfig.types.json
@@ -5,6 +5,6 @@
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,
-    "outDir": "build/types"
+    "outDir": "build/npm/types"
   }
 }

--- a/packages/wasm/.npmignore
+++ b/packages/wasm/.npmignore
@@ -1,4 +1,9 @@
+# Info: the paths in this file are specified so that they align with the file
+# structure in `./build` where this file is copied to. This is done by the
+# postbuild script `sentry-javascript/scripts/postbuild.ts`.
+
 *
+
 !/dist/**/*
 !/esm/**/*
-!/build/types/**/*
+!/types/**/*

--- a/packages/wasm/.npmignore
+++ b/packages/wasm/.npmignore
@@ -1,6 +1,6 @@
 # Info: the paths in this file are specified so that they align with the file
 # structure in `./build` where this file is copied to. This is done by the
-# postbuild script `sentry-javascript/scripts/postbuild.ts`.
+# prepack script `sentry-javascript/scripts/prepack.ts`.
 
 *
 

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -29,7 +29,7 @@
     "puppeteer": "^5.5.0"
   },
   "scripts": {
-    "build": "run-p build:cjs build:esm build:bundle build:types && ts-node ../../scripts/postbuild.ts -skipBundleCopy",
+    "build": "run-p build:cjs build:esm build:bundle build:types",
     "build:bundle": "rollup --config",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:dev": "run-p build:cjs build:esm build:types",
@@ -43,7 +43,7 @@
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
-    "build:npm": "npm pack ./build/npm",
+    "build:npm": "ts-node ../../scripts/prepack.ts -skipBundleCopy && npm pack ./build/npm",
     "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf dist esm build coverage *.js.map *.d.ts",
     "fix": "run-s fix:eslint fix:prettier",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -9,9 +9,9 @@
   "engines": {
     "node": ">=6"
   },
-  "main": "dist/index.js",
-  "module": "esm/index.js",
-  "types": "build/types/index.d.ts",
+  "main": "build/npm/dist/index.js",
+  "module": "build/npm/esm/index.js",
+  "types": "build/npm/types/index.d.ts",
   "publishConfig": {
     "access": "public"
   },
@@ -29,7 +29,7 @@
     "puppeteer": "^5.5.0"
   },
   "scripts": {
-    "build": "run-p build:cjs build:esm build:bundle build:types",
+    "build": "run-p build:cjs build:esm build:bundle build:types && ts-node ../../scripts/postbuild.ts -skipBundleCopy",
     "build:bundle": "rollup --config",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:dev": "run-p build:cjs build:esm build:types",
@@ -43,9 +43,9 @@
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
-    "build:npm": "npm pack",
+    "build:npm": "npm pack ./build/npm",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf dist esm coverage *.js.map *.d.ts",
+    "clean": "rimraf dist esm build coverage *.js.map *.d.ts",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",

--- a/packages/wasm/rollup.config.js
+++ b/packages/wasm/rollup.config.js
@@ -5,7 +5,7 @@ const baseBundleConfig = makeBaseBundleConfig({
   isAddOn: true,
   jsVersion: 'es5',
   licenseTitle: '@sentry/wasm',
-  outputFileBase: 'wasm',
+  outputFileBase: 'bundles/wasm',
 });
 
 export default makeConfigVariants(baseBundleConfig);

--- a/packages/wasm/test/server.js
+++ b/packages/wasm/test/server.js
@@ -6,7 +6,7 @@ const app = express();
 // Wasm Integration Tests Artifacts
 app.use(express.static(path.resolve(__dirname, 'public')));
 // Wasm Integration Bundle
-app.use(express.static(path.resolve(__dirname, '../build')));
+app.use(express.static(path.resolve(__dirname, '../build/bundles')));
 // Browser SDK Bundle
 app.use(express.static(path.resolve(__dirname, '../../browser/build/bundles')));
 app.listen(process.env.PORT);

--- a/packages/wasm/tsconfig.cjs.json
+++ b/packages/wasm/tsconfig.cjs.json
@@ -3,6 +3,6 @@
 
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "dist"
+    "outDir": "build/npm/dist"
   }
 }

--- a/packages/wasm/tsconfig.esm.json
+++ b/packages/wasm/tsconfig.esm.json
@@ -3,6 +3,6 @@
 
   "compilerOptions": {
     "module": "es6",
-    "outDir": "esm"
+    "outDir": "build/npm/esm"
   }
 }

--- a/packages/wasm/tsconfig.types.json
+++ b/packages/wasm/tsconfig.types.json
@@ -5,6 +5,6 @@
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,
-    "outDir": "build/types"
+    "outDir": "build/npm/types"
   }
 }

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -43,18 +43,20 @@ ASSETS.forEach(asset => {
 // TODO remove in v7! Until then:
 // copy CDN bundles into npm dir to temporarily keep bundles in npm tarball
 // inside the tarball, they are located in `build/`
-const npmTmpBundlesPath = path.resolve(NPM_BUILD_DIR, 'build');
-const cdnBundlesPaht = path.resolve('build', 'bundles');
-try {
-  if (!fs.existsSync(npmTmpBundlesPath)) {
-    fs.mkdirSync(npmTmpBundlesPath);
+// for now, copy it by default, unless explicitly forbidden via an command line arg
+const tmpCopyBundles = !process.argv.includes('-skipBundleCopy');
+if (tmpCopyBundles) {
+  const npmTmpBundlesPath = path.resolve(NPM_BUILD_DIR, 'build');
+  const cdnBundlesPaht = path.resolve('build', 'bundles');
+  try {
+    if (!fs.existsSync(npmTmpBundlesPath)) {
+      fs.mkdirSync(npmTmpBundlesPath);
+    }
+    fse.copy(cdnBundlesPaht, npmTmpBundlesPath);
+  } catch (error) {
+    console.error(`Error while tmp copying CDN bundles to ${NPM_BUILD_DIR}`);
   }
-  fse.copy(cdnBundlesPaht, npmTmpBundlesPath);
-} catch (error) {
-  console.error(`Error while tmp copying CDN bundles to ${NPM_BUILD_DIR}`);
 }
-// end remove
-
 // package.json modifications
 const packageJsonPath = path.resolve(NPM_BUILD_DIR, 'package.json');
 const pkgJson: { [key: string]: unknown } = require(packageJsonPath);

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -55,6 +55,7 @@ if (tmpCopyBundles) {
     fse.copy(cdnBundlesPaht, npmTmpBundlesPath);
   } catch (error) {
     console.error(`Error while tmp copying CDN bundles to ${NPM_BUILD_DIR}`);
+    process.exit(1);
   }
 }
 // package.json modifications

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /*
   This script prepares the central `build` directory for NPM package creation.
   It first copies all non-code files into the `build` directory, including `package.json`, which
@@ -47,12 +48,12 @@ ASSETS.forEach(asset => {
 const tmpCopyBundles = !process.argv.includes('-skipBundleCopy');
 if (tmpCopyBundles) {
   const npmTmpBundlesPath = path.resolve(NPM_BUILD_DIR, 'build');
-  const cdnBundlesPaht = path.resolve('build', 'bundles');
+  const cdnBundlesPath = path.resolve('build', 'bundles');
   try {
     if (!fs.existsSync(npmTmpBundlesPath)) {
       fs.mkdirSync(npmTmpBundlesPath);
     }
-    fse.copy(cdnBundlesPaht, npmTmpBundlesPath);
+    void fse.copy(cdnBundlesPath, npmTmpBundlesPath);
   } catch (error) {
     console.error(`Error while tmp copying CDN bundles to ${NPM_BUILD_DIR}`);
     process.exit(1);
@@ -60,6 +61,7 @@ if (tmpCopyBundles) {
 }
 // package.json modifications
 const packageJsonPath = path.resolve(NPM_BUILD_DIR, 'package.json');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const pkgJson: { [key: string]: unknown } = require(packageJsonPath);
 
 // modify entry points to point to correct paths (i.e. strip out the build directory)
@@ -75,7 +77,7 @@ delete pkgJson.jest;
 try {
   fs.writeFileSync(packageJsonPath, JSON.stringify(pkgJson, null, 2));
 } catch (error) {
-  console.error(`Error while writing package.json to disk`);
+  console.error('Error while writing package.json to disk');
   process.exit(1);
 }
 

--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -6,22 +6,22 @@
 */
 
 import * as fs from 'fs';
-
+import * as fse from 'fs-extra';
 import * as path from 'path';
 
-const BUILD_DIR = 'build';
+const NPM_BUILD_DIR = 'build/npm';
 const ASSETS = ['README.md', 'LICENSE', 'package.json', '.npmignore'];
 const ENTRY_POINTS = ['main', 'module', 'types'];
 
 // check if build dir exists
 try {
-  if (!fs.existsSync(path.resolve(BUILD_DIR))) {
-    console.error(`Directory ${BUILD_DIR} DOES NOT exist`);
+  if (!fs.existsSync(path.resolve(NPM_BUILD_DIR))) {
+    console.error(`Directory ${NPM_BUILD_DIR} DOES NOT exist`);
     console.error("This script should only be executed after you've run `yarn build`.");
     process.exit(1);
   }
 } catch (error) {
-  console.error(`Error while looking up directory ${BUILD_DIR}`);
+  console.error(`Error while looking up directory ${NPM_BUILD_DIR}`);
   process.exit(1);
 }
 
@@ -33,24 +33,40 @@ ASSETS.forEach(asset => {
       console.error(`Asset ${asset} does not exist.`);
       process.exit(1);
     }
-    fs.copyFileSync(assetPath, path.resolve(BUILD_DIR, asset));
+    fs.copyFileSync(assetPath, path.resolve(NPM_BUILD_DIR, asset));
   } catch (error) {
-    console.error(`Error while copying ${asset} to ${BUILD_DIR}`);
+    console.error(`Error while copying ${asset} to ${NPM_BUILD_DIR}`);
     process.exit(1);
   }
 });
 
+// TODO remove in v7! Until then:
+// copy CDN bundles into npm dir to temporarily keep bundles in npm tarball
+// inside the tarball, they are located in `build/`
+const npmTmpBundlesPath = path.resolve(NPM_BUILD_DIR, 'build');
+const cdnBundlesPaht = path.resolve('build', 'bundles');
+try {
+  if (!fs.existsSync(npmTmpBundlesPath)) {
+    fs.mkdirSync(npmTmpBundlesPath);
+  }
+  fse.copy(cdnBundlesPaht, npmTmpBundlesPath);
+} catch (error) {
+  console.error(`Error while tmp copying CDN bundles to ${NPM_BUILD_DIR}`);
+}
+// end remove
+
 // package.json modifications
-const packageJsonPath = path.resolve(BUILD_DIR, 'package.json');
+const packageJsonPath = path.resolve(NPM_BUILD_DIR, 'package.json');
 const pkgJson: { [key: string]: unknown } = require(packageJsonPath);
 
 // modify entry points to point to correct paths (i.e. strip out the build directory)
 ENTRY_POINTS.filter(entryPoint => pkgJson[entryPoint]).forEach(entryPoint => {
-  pkgJson[entryPoint] = (pkgJson[entryPoint] as string).replace(`${BUILD_DIR}/`, '');
+  pkgJson[entryPoint] = (pkgJson[entryPoint] as string).replace(`${NPM_BUILD_DIR}/`, '');
 });
 
 delete pkgJson.scripts;
 delete pkgJson.volta;
+delete pkgJson.jest;
 
 // write modified package.json to file (pretty-printed with 2 spaces)
 try {

--- a/scripts/prepack.ts
+++ b/scripts/prepack.ts
@@ -81,4 +81,4 @@ try {
   process.exit(1);
 }
 
-console.log(`\nSuccessfully finished postbuild commands for ${pkgJson.name}`);
+console.log(`\nSuccessfully finished prepack commands for ${pkgJson.name}\n`);


### PR DESCRIPTION
# Background
This is the continuation of the build directory restructuring started in #4688. The goal is to put everything building related (i.e. compiled code and non-code assets for NPM tarballs) into one central directory.

# Changes
This PR introduces the central `build` directory to all our packages producing CDN bundles in addition to NPM tarballs:

* Browser
* Integrations
* Tracing
* WASM

The new `build` directory for packages with CDN bundles will have the following structure:

```
<sdk>/
├─ build/
│  ├─ bundles/
│  │  ├─ CDN bundles (rollup) (es5, es6) (+min, maps)
│  ├─ npm/
│  │  ├─ build/ <-- this is just temporary and will be gone with v7
│  │  │  ├─ CDN bundles (rollup) (es5, es6) (+min, maps)
│  │  ├─ cjs/    // dist until v7
│  │  │  ├─ CJS modules (+maps)
│  │  ├─ esm/
│  │  │  ├─ ES6 modules (+maps)
│  │  ├─ types/
│  │  │  ├─ *.d.ts files (+maps)
│  │  ├─ package.json
│  │  ├─ LICENSE
│  |  ├─ README.md
│  ├─ npm-legacy/ <-- this is not included in this PR but will come once we introduce our ES5 legacy NPM tarballs
├─ ...
```

Inside the tarball, the directory structure is as follows*: 

```
sentry-<sdk>-<version>.tgz/
├─ build/                        // bundles will be removed from the tarball in v7
│  ├─ CDN bundles
├─ dist/                        // will be changed to 'cjs' in v7
│  ├─ CJS modules (+maps)
├─ esm/
│  ├─ ES6 modules (+maps)
├─ types/
│  ├─ *.d.ts files (+maps)
├─ package.json
├─ LICENSE
├─ README.md
```

A small note here: CDN bundles will be removed from the tarball in v7. Until then, they remain in the `build` directory _in_ the tarball, which should not be mistaken for the central `build` directory described above. I know, this is confusing but otherwise, this would be a breaking change for people unofficially using our CDN bundles e.g. via UNPKG.  

*for WASM, CDN bundles are not added to the tarball as they were not previously included.

Procedure:
* running `yarn build` will start compilation (no changes on this end).
* running `yarn build:npm` starts the prepack script and subsequently creates the NPM tarball. The `prepack.ts` script:
  * copies all additional (non-code) files into `build/npm`
  * temporarily copies CDN bundles into the `build/npm/build` until v7
  * adjusts `package.json` entry points to align with the NPM tarball structure described above
  * deletes unnecessary properties from the copied `package.json` 
* running `yarn build:npm` will pack the NPM tarball from inside `build/npm` and save it in the package root directory.

# Additional Information
_"But what about Vue ~and WASM~ bundles!?"_ you might ask. Well, it turns out, those are created but not published. So we actually do not need to create them either for every build. To not clutter this PR too much, I'll deactivate the bundle creation by default in a separate one coming soon (TM).

How to best review: Every commit represents the changes for one package. For reviewing, it might be helpful to go through the changes commit-by-commit, starting with [fd0da2c](https://github.com/getsentry/sentry-javascript/pull/4838/commits/fd0da2c0ef9e3fce2ce3e9c0b4679b9be6ea5ad0). I double and triple checked the correct tarball creation but given that a bug in this PR could easily break users, a second pair of eyes can't hurt. 

ref: https://getsentry.atlassian.net/browse/WEB-780

