### PR TITLE
fix(build): Find release branches correctly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Check bundle sizes
         uses: getsentry/size-limit-action@v4
         # Don't run size check on release branches - at that point, we're already committed
-        if: ${{ !startsWith(github.ref, 'release') }}
+        if: ${{ !startsWith(github.ref, 'refs/heads/release/') != true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           skip_step: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Check bundle sizes
         uses: getsentry/size-limit-action@v4
         # Don't run size check on release branches - at that point, we're already committed
-        if: ${{ !startsWith(github.ref, 'refs/heads/release/') != true
+        if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           skip_step: build


### PR DESCRIPTION
Use `refs/heads/release/` instead of `release` when comparing against `github.ref` to see if size-check should be run.

Needed to unblock next release.
