### PR TITLE
[v7] feat: Remove references to @sentry/apm

### DIFF
--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getCurrentHub, Hub } from '@sentry/browser';
-import { Integration, IntegrationClass, Span, Transaction } from '@sentry/types';
+import { Span, Transaction } from '@sentry/types';
 import { timestampWithMs } from '@sentry/utils';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
@@ -9,66 +9,6 @@ import * as React from 'react';
 import { REACT_MOUNT_OP, REACT_RENDER_OP, REACT_UPDATE_OP } from './constants';
 
 export const UNKNOWN_COMPONENT = 'unknown';
-
-const TRACING_GETTER = ({
-  id: 'Tracing',
-} as any) as IntegrationClass<Integration>;
-
-let globalTracingIntegration: Integration | null = null;
-/** @deprecated remove when @sentry/apm no longer used */
-const getTracingIntegration = (): Integration | null => {
-  if (globalTracingIntegration) {
-    return globalTracingIntegration;
-  }
-
-  globalTracingIntegration = getCurrentHub().getIntegration(TRACING_GETTER);
-  return globalTracingIntegration;
-};
-
-/**
- * pushActivity creates an new react activity.
- * Is a no-op if Tracing integration is not valid
- * @param name displayName of component that started activity
- * @deprecated remove when @sentry/apm no longer used
- */
-function pushActivity(name: string, op: string): number | null {
-  if (globalTracingIntegration === null) {
-    return null;
-  }
-
-  return (globalTracingIntegration as any).constructor.pushActivity(name, {
-    description: `<${name}>`,
-    op,
-  });
-}
-
-/**
- * popActivity removes a React activity.
- * Is a no-op if Tracing integration is not valid.
- * @param activity id of activity that is being popped
- * @deprecated remove when @sentry/apm no longer used
- */
-function popActivity(activity: number | null): void {
-  if (activity === null || globalTracingIntegration === null) {
-    return;
-  }
-
-  (globalTracingIntegration as any).constructor.popActivity(activity);
-}
-
-/**
- * Obtain a span given an activity id.
- * Is a no-op if Tracing integration is not valid.
- * @param activity activity id associated with obtained span
- * @deprecated remove when @sentry/apm no longer used
- */
-function getActivitySpan(activity: number | null): Span | undefined {
-  if (activity === null || globalTracingIntegration === null) {
-    return undefined;
-  }
-
-  return (globalTracingIntegration as any).constructor.getActivitySpan(activity) as Span | undefined;
-}
 
 export type ProfilerProps = {
   // The name of the component being profiled.
@@ -95,9 +35,6 @@ class Profiler extends React.Component<ProfilerProps> {
    */
   protected _mountSpan: Span | undefined = undefined;
 
-  // The activity representing how long it takes to mount a component.
-  private _mountActivity: number | null = null;
-
   // eslint-disable-next-line @typescript-eslint/member-ordering
   public static defaultProps: Partial<ProfilerProps> = {
     disabled: false,
@@ -113,19 +50,12 @@ class Profiler extends React.Component<ProfilerProps> {
       return;
     }
 
-    // If they are using @sentry/apm, we need to push/pop activities
-    // eslint-disable-next-line deprecation/deprecation
-    if (getTracingIntegration()) {
-      // eslint-disable-next-line deprecation/deprecation
-      this._mountActivity = pushActivity(name, REACT_MOUNT_OP);
-    } else {
-      const activeTransaction = getActiveTransaction();
-      if (activeTransaction) {
-        this._mountSpan = activeTransaction.startChild({
-          description: `<${name}>`,
-          op: REACT_MOUNT_OP,
-        });
-      }
+    const activeTransaction = getActiveTransaction();
+    if (activeTransaction) {
+      this._mountSpan = activeTransaction.startChild({
+        description: `<${name}>`,
+        op: REACT_MOUNT_OP,
+      });
     }
   }
 
@@ -133,12 +63,6 @@ class Profiler extends React.Component<ProfilerProps> {
   public componentDidMount(): void {
     if (this._mountSpan) {
       this._mountSpan.finish();
-    } else {
-      // eslint-disable-next-line deprecation/deprecation
-      this._mountSpan = getActivitySpan(this._mountActivity);
-      // eslint-disable-next-line deprecation/deprecation
-      popActivity(this._mountActivity);
-      this._mountActivity = null;
     }
   }
 


### PR DESCRIPTION
Removes all references to `@sentry/apm`, a deprecated package we do not use anymore.

Resolves https://getsentry.atlassian.net/browse/WEB-550