### PR TITLE
chore(dev): Unlinkify changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,48 +6,48 @@
 
 ## 6.19.3
 
-- feat(browser): Add new v7 Fetch Transport ([#4765](https://github.com/getsentry/sentry-javascript/pull/4765))
-- feat(browser): Add new v7 XHR Transport ([#4803](https://github.com/getsentry/sentry-javascript/pull/4803))
-- fix(core): Use correct version of event when tagging normalization ([#4780](https://github.com/getsentry/sentry-javascript/pull/4780))
-- fix(core): Stop mangling _experiments ([#4807](https://github.com/getsentry/sentry-javascript/pull/4807))
-- feat(node): Add new v7 http/s Transports ([#4781](https://github.com/getsentry/sentry-javascript/pull/4781))
+- feat(browser): Add new v7 Fetch Transport (#4765)
+- feat(browser): Add new v7 XHR Transport (#4803)
+- fix(core): Use correct version of event when tagging normalization (#4780)
+- fix(core): Stop mangling _experiments (#4807)
+- feat(node): Add new v7 http/s Transports (#4781)
 
 ## 6.19.2
 
-- feat(core): Add new transports to base backend ([#4752](https://github.com/getsentry/sentry-javascript/pull/4752))
-- feat(utils): Add `isNaN` function ([#4759](https://github.com/getsentry/sentry-javascript/pull/4759))
-- fix(integrations): Emit ES5 code in ES5 bundles ([#4769](https://github.com/getsentry/sentry-javascript/pull/4769))
-- fix(vue): Drop vue-router peerDep ([#4764](https://github.com/getsentry/sentry-javascript/pull/4764))
-- ref(core): Reduce inboundfilters bundle size ([#4625](https://github.com/getsentry/sentry-javascript/pull/4625))
+- feat(core): Add new transports to base backend (#4752)
+- feat(utils): Add `isNaN` function (#4759)
+- fix(integrations): Emit ES5 code in ES5 bundles (#4769)
+- fix(vue): Drop vue-router peerDep (#4764)
+- ref(core): Reduce inboundfilters bundle size (#4625)
 - ref(integrations): Make ReportTypes a union type
-- ref(node): Add source code context when using LinkedErrors ([#4753](https://github.com/getsentry/sentry-javascript/pull/4753))
-- ref(utils): Introduce getEnvelopeType helper ([#4751](https://github.com/getsentry/sentry-javascript/pull/4751))
-- ref(utils): Split normalization code into separate module ([#4760](https://github.com/getsentry/sentry-javascript/pull/4760))
+- ref(node): Add source code context when using LinkedErrors (#4753)
+- ref(utils): Introduce getEnvelopeType helper (#4751)
+- ref(utils): Split normalization code into separate module (#4760)
 
 ## 6.19.1
 
 This release fixes a bug from 6.19.0 causing type import errors in most JS SDKs.
 
-- fix(types): Point to type definitions in dist folder [#4745](https://github.com/getsentry/sentry-javascript/pull/4745)
+- fix(types): Point to type definitions in dist folder (#4745)
 
 ## 6.19.0
 
 This release makes a change to the data normalization process, limiting the number of entries or properties which will be included in any given array or object to 1000. Previously there was no limit, so in rare cases you may notice a change in your context data. If this is a problem, you can increase the limit with the new `maxNormalizationBreadth` setting. See [#4689](https://github.com/getsentry/sentry-javascript/pull/4689) for details.
 
-- feat(build): Create debug versions of minified bundles ([#4699](https://github.com/getsentry/sentry-javascript/pull/4699))
-- feat(integrations): Make ES6 integration bundles ([#4718](https://github.com/getsentry/sentry-javascript/pull/4718))
-- feat(utils): Limit `normalize` maximum properties/elements ([#4689](https://github.com/getsentry/sentry-javascript/pull/4689))
-- feat(various): Apply debug guard to logger everywhere ([#4698](https://github.com/getsentry/sentry-javascript/pull/4698))
-- fix(browser): Use `apply` rather than `call` in `try-catch` integration ([#4695](https://github.com/getsentry/sentry-javascript/pull/4695))
-- fix(ember): Fix merging env config ([#4714](https://github.com/getsentry/sentry-javascript/pull/4714))
-- fix(nextjs): Add env var to suppress API non-response meta-warning ([#4706](https://github.com/getsentry/sentry-javascript/pull/4706))
-- fix(nextjs): Widen scope for client file upload ([#4705](https://github.com/getsentry/sentry-javascript/pull/4705))
-- fix(node): Fix async stack parsing ([#4721](https://github.com/getsentry/sentry-javascript/pull/4721))
-- ref(browser): Use ratelimit utils in base transport ([#4686](https://github.com/getsentry/sentry-javascript/pull/4686))
-- ref(build): Introduce root build directory in `@sentry/browser` ([#4688](https://github.com/getsentry/sentry-javascript/pull/4688))
-- ref(minimal): Simplify `syntheticException` creation ([#4691](https://github.com/getsentry/sentry-javascript/pull/4691))
-- ref(tracing): Remove `BrowserTracing` logging flag default value ([#4708](https://github.com/getsentry/sentry-javascript/pull/4708))
-- ref(utils): Simplify `isDebugBuild` logging guard ([#4696](https://github.com/getsentry/sentry-javascript/pull/4696))
+- feat(build): Create debug versions of minified bundles (#4699)
+- feat(integrations): Make ES6 integration bundles (#4718)
+- feat(utils): Limit `normalize` maximum properties/elements (#4689)
+- feat(various): Apply debug guard to logger everywhere (#4698)
+- fix(browser): Use `apply` rather than `call` in `try-catch` integration (#4695)
+- fix(ember): Fix merging env config (#4714)
+- fix(nextjs): Add env var to suppress API non-response meta-warning (#4706)
+- fix(nextjs): Widen scope for client file upload (#4705)
+- fix(node): Fix async stack parsing (#4721)
+- ref(browser): Use ratelimit utils in base transport (#4686)
+- ref(build): Introduce root build directory in `@sentry/browser` (#4688)
+- ref(minimal): Simplify `syntheticException` creation (#4691)
+- ref(tracing): Remove `BrowserTracing` logging flag default value (#4708)
+- ref(utils): Simplify `isDebugBuild` logging guard (#4696)
 
 Work in this release contributed by @Turbo87. Thank you for your contribution!
 
@@ -59,20 +59,20 @@ This release also removes `@sentry/tracing` as a dependency of `@sentry/node`. P
 
 We also now produce an ES6 version of our [CDN tracing bundle](https://docs.sentry.io/platforms/javascript/install/cdn/#performance-bundle), which can be accessed with `bundle.tracing.es6.min.js`.
 
-- chore(eslint): Turn on quotes rules ([#4671](https://github.com/getsentry/sentry-javascript/pull/4671))
-- fix(node): prevent errors thrown on flush from breaking response ([#4667](https://github.com/getsentry/sentry-javascript/pull/4667))
-- ref(node): Remove dependency on @sentry/tracing ([#4647](https://github.com/getsentry/sentry-javascript/pull/4647))
-- fix(tracing): Make method required in transactionSampling type ([#4657](https://github.com/getsentry/sentry-javascript/pull/4657))
-- feat(tracing): Add ES6 tracing bundle ([#4674](https://github.com/getsentry/sentry-javascript/pull/4674))
+- chore(eslint): Turn on quotes rules (#4671)
+- fix(node): prevent errors thrown on flush from breaking response (#4667)
+- ref(node): Remove dependency on @sentry/tracing (#4647)
+- fix(tracing): Make method required in transactionSampling type (#4657)
+- feat(tracing): Add ES6 tracing bundle (#4674)
 
 Work in this release contributed by @Ignigena. Thank you for your contribution!
 
 ## 6.18.1
 
-- fix(ember): use _backburner if it exists ([#4603](https://github.com/getsentry/sentry-javascript/pull/4603))
-- feat(gatsby): Upgrade Sentry Webpack Plugin to 1.18.8 ([#4636](https://github.com/getsentry/sentry-javascript/pull/4636))
-- feat(nextjs): Upgrade Sentry Webpack Plugin to 1.18.8 ([#4643](https://github.com/getsentry/sentry-javascript/pull/4643))
-- fix(nextjs): webpack as optional peer-dependency ([#4634](https://github.com/getsentry/sentry-javascript/pull/4634))
+- fix(ember): use _backburner if it exists (#4603)
+- feat(gatsby): Upgrade Sentry Webpack Plugin to 1.18.8 (#4636)
+- feat(nextjs): Upgrade Sentry Webpack Plugin to 1.18.8 (#4643)
+- fix(nextjs): webpack as optional peer-dependency (#4634)
 
 Work in this release contributed by @belgattitude, @pbernery, and @kylemh. Thank you for your contributions!
 
@@ -80,44 +80,44 @@ Work in this release contributed by @belgattitude, @pbernery, and @kylemh. Thank
 
 This patch deprecates the `frameContextLines` option for the Node SDK. The [migration documentation](./MIGRATION.md#upgrading-from-6.17.x-to-6.18.0) details how to migrate off the deprecated `frameContextLines` option.
 
-- fix(browser): Only set event.stacktrace if we have 1 or more frames ([#4614](https://github.com/getsentry/sentry-javascript/pull/4614))
-- fix(hub): keep hint event id if it's provided ([#4577](https://github.com/getsentry/sentry-javascript/pull/4577))
-- fix(nextjs): Use env variable for build detection ([#4608](https://github.com/getsentry/sentry-javascript/pull/4608))
-- ref(node): Refactor node source fetching into integration ([#3729](https://github.com/getsentry/sentry-javascript/pull/3729))
-- feat(serverless): Added `ignoreSentryErrors` option for AWS lambda ([#4620](https://github.com/getsentry/sentry-javascript/pull/4620))
+- fix(browser): Only set event.stacktrace if we have 1 or more frames (#4614)
+- fix(hub): keep hint event id if it's provided (#4577)
+- fix(nextjs): Use env variable for build detection (#4608)
+- ref(node): Refactor node source fetching into integration (#3729)
+- feat(serverless): Added `ignoreSentryErrors` option for AWS lambda (#4620)
 
 Work in this release contributed by @GoshaEgorian and @ichina. Thank you for your contributions!
 
 ## 6.17.9
 
-- fix(gatsby): Add missing React peer dependency ([#4576](https://github.com/getsentry/sentry-javascript/pull/4576))
-- fix(types): Use Sentry event type instead of dom one ([#4584](https://github.com/getsentry/sentry-javascript/pull/4584))
+- fix(gatsby): Add missing React peer dependency (#4576)
+- fix(types): Use Sentry event type instead of dom one (#4584)
 
 Work in this release contributed by @aaronadamsCA. Thank you for your contribution!
 
 ## 6.17.8
 
-- feat(types): Add Envelope types ([#4527](https://github.com/getsentry/sentry-javascript/pull/4527))
-- fix(build): Remove node code from CDN bundles ([#4548](https://github.com/getsentry/sentry-javascript/pull/4548))
-- fix(build): Prevent unused utils code in integration bundles ([#4547](https://github.com/getsentry/sentry-javascript/pull/4547))
-- fix(tracing): Export BrowserTracing directly in CDN bundle ([#4570](https://github.com/getsentry/sentry-javascript/pull/4570))
-- fix(utils): Use apply in console instrumentation ([#4568](https://github.com/getsentry/sentry-javascript/pull/4568))
-- ref(core): Log `normalizeDepth` when normalization is skipped([#4574](https://github.com/getsentry/sentry-javascript/pull/4574))
+- feat(types): Add Envelope types (#4527)
+- fix(build): Remove node code from CDN bundles (#4548)
+- fix(build): Prevent unused utils code in integration bundles (#4547)
+- fix(tracing): Export BrowserTracing directly in CDN bundle (#4570)
+- fix(utils): Use apply in console instrumentation (#4568)
+- ref(core): Log `normalizeDepth` when normalization is skipped(#4574)
 
 Work in this release contributed by @mydea. Thank you for your contribution!
 
 ## 6.17.7
 
-- fix(utils): Make new non-enumerable properties mutable ([#4528](https://github.com/getsentry/sentry-javascript/pull/4528))
-- fix(vue): Check if route name is defined before casting ([#4530](https://github.com/getsentry/sentry-javascript/pull/4530))
+- fix(utils): Make new non-enumerable properties mutable (#4528)
+- fix(vue): Check if route name is defined before casting (#4530)
 
 Work in this release contributed by @connorjclark. Thank you for your contribution!
 
 ## 6.17.6
 
-- fix(angular): Add check for global.location in angular universal ([#4513](https://github.com/getsentry/sentry-javascript/issues/4513))
-- fix(nextjs): Stop injecting sentry into API middleware ([#4517](https://github.com/getsentry/sentry-javascript/issues/4517))
-- fix(nextjs): Revert #4139 - remove manipulation of res.finished value ([#4516](https://github.com/getsentry/sentry-javascript/issues/4516))
+- fix(angular): Add check for global.location in angular universal (#4513)
+- fix(nextjs): Stop injecting sentry into API middleware (#4517)
+- fix(nextjs): Revert #4139 - remove manipulation of res.finished value (#4516)
 
 Work in this release contributed by @mobilestar1. Thank you for your contribution!
 
@@ -125,41 +125,41 @@ Work in this release contributed by @mobilestar1. Thank you for your contributio
 
 This release deprecates the `Severity` enum, the `SeverityLevel` type, and the internal `SeverityLevels` array, all from `@sentry/types`. In v7, `Severity` will disappear (in favor of `SeverityLevel`) and `SeverityLevel` and `SeverityLevels` will live in `@sentry/utils`. If you are using any of the three, we encourage you to migrate your usage now, using our [migration guide](./MIGRATION.md#upgrading-from-6.x-to-6.17.x).
 
-- ref: Export Session class from core/browser/node ([#4508](https://github.com/getsentry/sentry-javascript/issues/4508))
-- chore(nextjs): Bump`@sentry/webpack-plugin` to 1.18.5 ([#4501](https://github.com/getsentry/sentry-javascript/issues/4501))
-- ref(types): Move SeverityLevel and SeverityLevels to `@sentry/utils` ([#4492](https://github.com/getsentry/sentry-javascript/issues/4492))
-- fix(vue): Cast name parameter to string ([#4483](https://github.com/getsentry/sentry-javascript/issues/4483))
+- ref: Export Session class from core/browser/node (#4508)
+- chore(nextjs): Bump`@sentry/webpack-plugin` to 1.18.5 (#4501)
+- ref(types): Move SeverityLevel and SeverityLevels to `@sentry/utils` (#4492)
+- fix(vue): Cast name parameter to string (#4483)
 
 Work in this release contributed by @Bobakanoosh and @ssnielsen. Thank you for your contributions!
 
 ## 6.17.4
 
-- chore(deps): Bump `@sentry/webpack-plugin` from 1.18.3 to 1.18.4 ([#4464](https://github.com/getsentry/sentry-javascript/issues/4464))
-- fix(browser): Set severity level for events captured by the global error handler ([#4460](https://github.com/getsentry/sentry-javascript/issues/4460))
-- fix(integrations): Add default for `ExtraErrorData`'s `depth` option ([#4487](https://github.com/getsentry/sentry-javascript/issues/4487))
-- fix(nextjs): Export `BrowserTracing` integration directly ([#4480](https://github.com/getsentry/sentry-javascript/issues/4480))
-- fix(tracing): Export `SpanStatus` enum ([#4478](https://github.com/getsentry/sentry-javascript/issues/4478))
-- fix(vue): Property `_isVue` not defined in Vue3 ([#4461](https://github.com/getsentry/sentry-javascript/issues/4461))
+- chore(deps): Bump `@sentry/webpack-plugin` from 1.18.3 to 1.18.4 (#4464)
+- fix(browser): Set severity level for events captured by the global error handler (#4460)
+- fix(integrations): Add default for `ExtraErrorData`'s `depth` option (#4487)
+- fix(nextjs): Export `BrowserTracing` integration directly (#4480)
+- fix(tracing): Export `SpanStatus` enum (#4478)
+- fix(vue): Property `_isVue` not defined in Vue3 (#4461)
 
 Work in this release contributed by @7inspire, @jaeseokk, and @rchl. Thank you for your contributions!
 
 ## 6.17.3
 
-- fix(nextjs): Unwrap `req` and `res` if necessary when instrumenting server ([#4467](https://github.com/getsentry/sentry-javascript/issues/4467))
+- fix(nextjs): Unwrap `req` and `res` if necessary when instrumenting server (#4467)
 
 ## 6.17.2
 
 This patch contains a breaking change for anyone setting the undocumented `rethrowAfterCapture` option for `@sentry/serverless`'s AWS wrapper to `false`, as its functionality has been removed. For backwards compatibility with anyone setting it to `true` (which is also the default), the option remains in the `WrapperOptions` type for now. It will be removed in the next major release, though, so we recommend removing it from your code.
 
-- ref(serverless): Remove `rethrowAfterCapture` use in AWS lambda wrapper ([#4448](https://github.com/getsentry/sentry-javascript/issues/4448))
-- fix(utils): Remove dom is casting ([#4451](https://github.com/getsentry/sentry-javascript/issues/4451))
+- ref(serverless): Remove `rethrowAfterCapture` use in AWS lambda wrapper (#4448)
+- fix(utils): Remove dom is casting (#4451)
 
 ## 6.17.1
 
-- ref(core): Renormalize event only after stringification errors ([#4425](https://github.com/getsentry/sentry-javascript/issues/4425))
-- feat(nextjs): Add option to use `hidden-source-map` as webpack devtool value ([#4436](https://github.com/getsentry/sentry-javascript/issues/4436))
-- fix(tracing): ignore the xhr/fetch response if its request is not being tracked ([#4428](https://github.com/getsentry/sentry-javascript/issues/4428))
-- fix(vue): prevent after hook from starting new span ([#4438](https://github.com/getsentry/sentry-javascript/issues/4438))
+- ref(core): Renormalize event only after stringification errors (#4425)
+- feat(nextjs): Add option to use `hidden-source-map` as webpack devtool value (#4436)
+- fix(tracing): ignore the xhr/fetch response if its request is not being tracked (#4428)
+- fix(vue): prevent after hook from starting new span (#4438)
 
 Work in this release contributed by @datbth. Thank you for your contribution!
 
@@ -167,411 +167,411 @@ Work in this release contributed by @datbth. Thank you for your contribution!
 
 This release contains several internal refactors that help reduce the bundle size of the SDK and help prep for our [upcoming major release](https://github.com/getsentry/sentry-javascript/issues/4240). There are no breaking changes in this patch unless you are using our internal `Dsn` class, which has been removed. We also deprecated a few of our typescript enums and our internal `API` class. We've detailed in our [migration documentation](./MIGRATION.md#upgrading-from-6.x-to-6.17.x) how to update your sdk usage if you are using any of these in your code.
 
-- feat: Remove Dsn class ([#4325](https://github.com/getsentry/sentry-javascript/issues/4325))
-- feat(core): Add processing metadata to scope and event ([#4252](https://github.com/getsentry/sentry-javascript/issues/4252))
-- feat(core): Deprecate API class ([#4281](https://github.com/getsentry/sentry-javascript/issues/4281))
-- feat(ember): Update ember dependencies ([#4253](https://github.com/getsentry/sentry-javascript/issues/4253))
-- fix(nextjs): Inject sentry.x.config.js into pages/_error ([#4397](https://github.com/getsentry/sentry-javascript/issues/4397))
+- feat: Remove Dsn class (#4325)
+- feat(core): Add processing metadata to scope and event (#4252)
+- feat(core): Deprecate API class (#4281)
+- feat(ember): Update ember dependencies (#4253)
+- fix(nextjs): Inject sentry.x.config.js into pages/_error (#4397)
 - fix(nextjs): Add sentry-cli existence check for enabling webpack plugin #4311
-- ref(tracing): deprecate span status enum ([#4299](https://github.com/getsentry/sentry-javascript/issues/4299))
-- ref(tracing): Remove script evaluation span ([#4433](https://github.com/getsentry/sentry-javascript/issues/4433))
-- ref(types): drop unused logLevel ([#4317](https://github.com/getsentry/sentry-javascript/issues/4317))
-- ref(types): deprecate request status enum ([#4316](https://github.com/getsentry/sentry-javascript/issues/4316))
-- ref(types): deprecate outcome enum ([#4315](https://github.com/getsentry/sentry-javascript/issues/4315))
-- ref(types): deprecate transactionmethod enum ([#4314](https://github.com/getsentry/sentry-javascript/issues/4314))
-- ref(types): deprecate status enum ([#4298](https://github.com/getsentry/sentry-javascript/issues/4298))
-- ref(utils): improve invalid dsn error message ([#4430](https://github.com/getsentry/sentry-javascript/issues/4430))
-- fix(vue): Prioritize app variable to avoid duplicate name pollution ([#4437](https://github.com/getsentry/sentry-javascript/issues/4437))
+- ref(tracing): deprecate span status enum (#4299)
+- ref(tracing): Remove script evaluation span (#4433)
+- ref(types): drop unused logLevel (#4317)
+- ref(types): deprecate request status enum (#4316)
+- ref(types): deprecate outcome enum (#4315)
+- ref(types): deprecate transactionmethod enum (#4314)
+- ref(types): deprecate status enum (#4298)
+- ref(utils): improve invalid dsn error message (#4430)
+- fix(vue): Prioritize app variable to avoid duplicate name pollution (#4437)
 
 Work in this release contributed by @yordis, @Badisi, and @lh1me. Thank you for your contribution!
 
 ## 6.16.1
 
-- feat(nextjs): Support Next.js v12 ([#4093](https://github.com/getsentry/sentry-javascript/issues/4093))
-- fix(nextjs): Disable server instrumentation on Vercel ([#4255](https://github.com/getsentry/sentry-javascript/issues/4255))
-- feat(tracing): Add metadata around idleTimeout ([#4251](https://github.com/getsentry/sentry-javascript/issues/4251))
+- feat(nextjs): Support Next.js v12 (#4093)
+- fix(nextjs): Disable server instrumentation on Vercel (#4255)
+- feat(tracing): Add metadata around idleTimeout (#4251)
 
 Work in this release contributed by @KATT. Thank you for your contribution!
 
 ## 6.16.0
 
-- feat(angular): Add Angular 13 to peer dep ([#4183](https://github.com/getsentry/sentry-javascript/issues/4183))
-- fix(angular): Finish routing span before starting another one ([#4191](https://github.com/getsentry/sentry-javascript/issues/4191))
-- fix(angular): Use ui category for span operations ([#4222](https://github.com/getsentry/sentry-javascript/issues/4222))
-- feat(ember): Use @types/ember__debug ([#4173](https://github.com/getsentry/sentry-javascript/issues/4173))
-- fix(ember): Use ui category for span operations ([#4221](https://github.com/getsentry/sentry-javascript/issues/4221))
-- feat(eslint-config): Enable array-callback-return rule ([#4229](https://github.com/getsentry/sentry-javascript/issues/4229))
-- ref(eslint-config): Update spaced-comment rule ([#4235](https://github.com/getsentry/sentry-javascript/issues/4235))
-- fix(integrations): Use ui category for vue span operations ([#4219](https://github.com/getsentry/sentry-javascript/issues/4219))
-- fix(nextjs): Add sideEffects flag to NextJS SDK ([#4216](https://github.com/getsentry/sentry-javascript/issues/4216))
-- fix(node): Make http integration spans have http span operation ([#4224](https://github.com/getsentry/sentry-javascript/issues/4224))
-- fix(react): Mark react package as having no side effects ([#4213](https://github.com/getsentry/sentry-javascript/issues/4213))
-- fix(react): Use ui category for operations ([#4218](https://github.com/getsentry/sentry-javascript/issues/4218))
-- fix(tracing): Add express category to express middleware spans ([#4223](https://github.com/getsentry/sentry-javascript/issues/4223))
-- fix(tracing): Treat HTTP status code below 100 as UnknownError ([#4131](https://github.com/getsentry/sentry-javascript/issues/4131))
-- fix(types): Make Options type method params contravariant ([#4234](https://github.com/getsentry/sentry-javascript/issues/4234))
-- fix(vue): Mark Vue as having no side effects. ([#4217](https://github.com/getsentry/sentry-javascript/issues/4217))
-- fix(vue): Use ui category for span operations ([#4220](https://github.com/getsentry/sentry-javascript/issues/4220))
+- feat(angular): Add Angular 13 to peer dep (#4183)
+- fix(angular): Finish routing span before starting another one (#4191)
+- fix(angular): Use ui category for span operations (#4222)
+- feat(ember): Use @types/ember__debug (#4173)
+- fix(ember): Use ui category for span operations (#4221)
+- feat(eslint-config): Enable array-callback-return rule (#4229)
+- ref(eslint-config): Update spaced-comment rule (#4235)
+- fix(integrations): Use ui category for vue span operations (#4219)
+- fix(nextjs): Add sideEffects flag to NextJS SDK (#4216)
+- fix(node): Make http integration spans have http span operation (#4224)
+- fix(react): Mark react package as having no side effects (#4213)
+- fix(react): Use ui category for operations (#4218)
+- fix(tracing): Add express category to express middleware spans (#4223)
+- fix(tracing): Treat HTTP status code below 100 as UnknownError (#4131)
+- fix(types): Make Options type method params contravariant (#4234)
+- fix(vue): Mark Vue as having no side effects. (#4217)
+- fix(vue): Use ui category for span operations (#4220)
 
 Work in this release contributed by @jherdman and @travigd. Thank you for your contribution!
 
 ## 6.15.0
 
-- fix(browser): Capture stacktrace on `DOMExceptions`, if possible ([#4160](https://github.com/getsentry/sentry-javascript/issues/4160))
-- fix(nextjs): Delay error propagation until `withSentry` is done ([#4027](https://github.com/getsentry/sentry-javascript/issues/4027))
+- fix(browser): Capture stacktrace on `DOMExceptions`, if possible (#4160)
+- fix(nextjs): Delay error propagation until `withSentry` is done (#4027)
 
 Work in this release contributed by @nowylie. Thank you for your contribution!
 
 ## 6.14.3
 
-- Revert: ref(utils): Use type predicates in `is` utility functions ([#4124](https://github.com/getsentry/sentry-javascript/issues/4124))
+- Revert: ref(utils): Use type predicates in `is` utility functions (#4124)
 
 ## 6.14.2
 
-- feat(awslambda) : Capture errors individually on sqs partial batch failure ([#4130](https://github.com/getsentry/sentry-javascript/issues/4130))
-- feat(gatsby): Upload source maps automatically when sentry-cli is configured ([#4109](https://github.com/getsentry/sentry-javascript/issues/4109))
-- fix(nextjs): Prevent `false API resolved without sending a response` warning ([#4139](https://github.com/getsentry/sentry-javascript/issues/4139))
-- fix(vue): Merge default and manual hooks while creating mixins. ([#4132](https://github.com/getsentry/sentry-javascript/issues/4132))
-- ref(utils): Use type predicates in `is` utility functions ([#4124](https://github.com/getsentry/sentry-javascript/issues/4124))
+- feat(awslambda) : Capture errors individually on sqs partial batch failure (#4130)
+- feat(gatsby): Upload source maps automatically when sentry-cli is configured (#4109)
+- fix(nextjs): Prevent `false API resolved without sending a response` warning (#4139)
+- fix(vue): Merge default and manual hooks while creating mixins. (#4132)
+- ref(utils): Use type predicates in `is` utility functions (#4124)
 
 Work in this release contributed by @J4YF7O. Thank you for your contribution!
 
 ## 6.14.1
 
-- feat(gatsby): Support Gatsby v4 ([#4120](https://github.com/getsentry/sentry-javascript/issues/4120))
-- fix(nextjs): Stop sending transactions for requests that 404 ([#4095](https://github.com/getsentry/sentry-javascript/issues/4095))
-- fix(nextjs): Prevent infinite recompilation in dev ([#4123](https://github.com/getsentry/sentry-javascript/issues/4123))
-- fix(node): Prioritize globalAgent while figuring out protocol ([#4087](https://github.com/getsentry/sentry-javascript/issues/4087))
+- feat(gatsby): Support Gatsby v4 (#4120)
+- fix(nextjs): Stop sending transactions for requests that 404 (#4095)
+- fix(nextjs): Prevent infinite recompilation in dev (#4123)
+- fix(node): Prioritize globalAgent while figuring out protocol (#4087)
 
 ## 6.14.0
 
-- chore(deps): Bump @sentry/webpack-plugin to 1.18.1 ([#4063](https://github.com/getsentry/sentry-javascript/issues/4063))
-- feat(awslambda): Add requestId filter to aws.cloudwatch.logs URL ([#4032](https://github.com/getsentry/sentry-javascript/issues/4032))
-- feat(gatsby): Support non-serializable SDK options ([#4064](https://github.com/getsentry/sentry-javascript/issues/4064))
-- feat(gatsby): Support user integrations as a function ([#4050](https://github.com/getsentry/sentry-javascript/issues/4050))
-- feat(integrations): Call toJSON of originalException to extract more data ([#4038](https://github.com/getsentry/sentry-javascript/issues/4038))
-- feat(integrations): Capture console.error as an exception ([#4034](https://github.com/getsentry/sentry-javascript/issues/4034))
-- feat(nextjs): Add mechanism to error-logger-caught errors ([#4061](https://github.com/getsentry/sentry-javascript/issues/4061))
-- feat(nextjs): Add mechanism to withSentry-caught errors ([#4046](https://github.com/getsentry/sentry-javascript/issues/4046))
-- feat(nextjs): Tag backend events when running on vercel ([#4091](https://github.com/getsentry/sentry-javascript/issues/4091))
-- fix(browser): Send client outcomes through tunnel if configured ([#4031](https://github.com/getsentry/sentry-javascript/issues/4031))
-- fix(core): Be stricter about mechanism values ([#4068](https://github.com/getsentry/sentry-javascript/issues/4068))
-- fix(core): Prevent exception recapturing ([#4067](https://github.com/getsentry/sentry-javascript/issues/4067))
-- fix(nextjs): Always initialize SDK with global hub ([#4086](https://github.com/getsentry/sentry-javascript/issues/4086))
-- fix(nextjs): Fix types in config code ([#4057](https://github.com/getsentry/sentry-javascript/issues/4057))
-- fix(nextjs): Remove logic merging include values in withSentryConfig ([#4056](https://github.com/getsentry/sentry-javascript/issues/4056))
-- fix(node): Check for potentially undefined httpModule ([#4037](https://github.com/getsentry/sentry-javascript/issues/4037))
-- fix(tracing): Update paths for DB drivers auto-instrumentation ([#4083](https://github.com/getsentry/sentry-javascript/issues/4083))
-- fix(vue): Move ROOT_SPAN_TIMER into Vue context. ([#4081](https://github.com/getsentry/sentry-javascript/issues/4081))
+- chore(deps): Bump @sentry/webpack-plugin to 1.18.1 (#4063)
+- feat(awslambda): Add requestId filter to aws.cloudwatch.logs URL (#4032)
+- feat(gatsby): Support non-serializable SDK options (#4064)
+- feat(gatsby): Support user integrations as a function (#4050)
+- feat(integrations): Call toJSON of originalException to extract more data (#4038)
+- feat(integrations): Capture console.error as an exception (#4034)
+- feat(nextjs): Add mechanism to error-logger-caught errors (#4061)
+- feat(nextjs): Add mechanism to withSentry-caught errors (#4046)
+- feat(nextjs): Tag backend events when running on vercel (#4091)
+- fix(browser): Send client outcomes through tunnel if configured (#4031)
+- fix(core): Be stricter about mechanism values (#4068)
+- fix(core): Prevent exception recapturing (#4067)
+- fix(nextjs): Always initialize SDK with global hub (#4086)
+- fix(nextjs): Fix types in config code (#4057)
+- fix(nextjs): Remove logic merging include values in withSentryConfig (#4056)
+- fix(node): Check for potentially undefined httpModule (#4037)
+- fix(tracing): Update paths for DB drivers auto-instrumentation (#4083)
+- fix(vue): Move ROOT_SPAN_TIMER into Vue context. (#4081)
 
 Work in this release contributed by @tmilar, @deammer, and @freekii. Thank you for your contributions!
 
 ## 6.13.3
 
-- feat(nextjs): Add ability for integration tests to use linked `@sentry/xxxx` packages ([#4019](https://github.com/getsentry/sentry-javascript/issues/4019))
-- feat(nextjs): Support `distDir` Next.js option ([#3990](https://github.com/getsentry/sentry-javascript/issues/3990))
-- fix(tracing): Call hasTracingEnabled with correct options when invoking startTransaction ([#4020](https://github.com/getsentry/sentry-javascript/issues/4020))
-- ref(browser): Refactor sending client reports w. fetch fallback ([#4008](https://github.com/getsentry/sentry-javascript/issues/4008))
-- ref(core): Make getTransport method on client optional ([#4013](https://github.com/getsentry/sentry-javascript/issues/4013))
-- ref(ember): Update htmlbars dependency ([#4026](https://github.com/getsentry/sentry-javascript/issues/4026))
-- ref(integrations): Minor simplification of ExtraErrorData code ([#4024](https://github.com/getsentry/sentry-javascript/issues/4024))
-- ref(react): Rely on error.cause to link ErrorBoundary errors ([#4005](https://github.com/getsentry/sentry-javascript/issues/4005))
+- feat(nextjs): Add ability for integration tests to use linked `@sentry/xxxx` packages (#4019)
+- feat(nextjs): Support `distDir` Next.js option (#3990)
+- fix(tracing): Call hasTracingEnabled with correct options when invoking startTransaction (#4020)
+- ref(browser): Refactor sending client reports w. fetch fallback (#4008)
+- ref(core): Make getTransport method on client optional (#4013)
+- ref(ember): Update htmlbars dependency (#4026)
+- ref(integrations): Minor simplification of ExtraErrorData code (#4024)
+- ref(react): Rely on error.cause to link ErrorBoundary errors (#4005)
 
 ## 6.13.2
 
-- fix(browser): Use getGlobalObject for document check ([#3996](https://github.com/getsentry/sentry-javascript/issues/3996))
-- misc(all): Disallow direct usage of globals ([#3999](https://github.com/getsentry/sentry-javascript/issues/3999))
+- fix(browser): Use getGlobalObject for document check (#3996)
+- misc(all): Disallow direct usage of globals (#3999)
 
 ## 6.13.1
 
-- fix(browser): Check for document when sending outcomes ([#3993](https://github.com/getsentry/sentry-javascript/issues/3993))
+- fix(browser): Check for document when sending outcomes (#3993)
 
 ## 6.13.0
 
-- feat(browser): Client Report Support ([#3955](https://github.com/getsentry/sentry-javascript/issues/3955))
-- feat(perf): Add experimental option to improve LCP collection ([#3879](https://github.com/getsentry/sentry-javascript/issues/3879))
-- fix(browser): Make sure that `document.head` or `document.body` exists for `injectReportDialog` ([#3972](https://github.com/getsentry/sentry-javascript/issues/3972))
-- fix(browser): Parse frames-only `safari(-web)-extension` stack ([#3929](https://github.com/getsentry/sentry-javascript/issues/3929))
-- fix(ember): Move `ember-source` to `devDependencies` ([#3962](https://github.com/getsentry/sentry-javascript/issues/3962))
-- fix(hub): Don't set `lastEventID` for transactions ([#3966](https://github.com/getsentry/sentry-javascript/issues/3966))
-- fix(nextjs): Include nextjs config's `basePath` on `urlPrefix` ([#3922](https://github.com/getsentry/sentry-javascript/issues/3922))
-- fix(node): Add protocol detection for get/request calls without explict protocol ([#3950](https://github.com/getsentry/sentry-javascript/issues/3950))
-- fix(node): Disable `autoSessionTracking` if dsn undefined ([#3954](https://github.com/getsentry/sentry-javascript/issues/3954))
-- fix(vue): Check for matched route existence before starting transaction ([#3973](https://github.com/getsentry/sentry-javascript/issues/3973))
-- ref(browser): Migrate unit tests from Chai and Karma to Jest ([#3965](https://github.com/getsentry/sentry-javascript/issues/3965))
-- ref(nextjs): Exclude cross-platform tracing code from bundles ([#3978](https://github.com/getsentry/sentry-javascript/issues/3978))
-- ref(tracing): Idle transaction refactoring ([#3988](https://github.com/getsentry/sentry-javascript/issues/3988))
+- feat(browser): Client Report Support (#3955)
+- feat(perf): Add experimental option to improve LCP collection (#3879)
+- fix(browser): Make sure that `document.head` or `document.body` exists for `injectReportDialog` (#3972)
+- fix(browser): Parse frames-only `safari(-web)-extension` stack (#3929)
+- fix(ember): Move `ember-source` to `devDependencies` (#3962)
+- fix(hub): Don't set `lastEventID` for transactions (#3966)
+- fix(nextjs): Include nextjs config's `basePath` on `urlPrefix` (#3922)
+- fix(node): Add protocol detection for get/request calls without explict protocol (#3950)
+- fix(node): Disable `autoSessionTracking` if dsn undefined (#3954)
+- fix(vue): Check for matched route existence before starting transaction (#3973)
+- ref(browser): Migrate unit tests from Chai and Karma to Jest (#3965)
+- ref(nextjs): Exclude cross-platform tracing code from bundles (#3978)
+- ref(tracing): Idle transaction refactoring (#3988)
 
 ## 6.12.0
 
-- fix(nextjs): Differentiate between webpack 4 and 5 in server builds ([#3878](https://github.com/getsentry/sentry-javascript/issues/3878))
-- fix(core): Skip native frames while searching frame URLs. ([#3897](https://github.com/getsentry/sentry-javascript/issues/3897))
-- fix(vue): Attach props only if VM is available ([#3902](https://github.com/getsentry/sentry-javascript/issues/3902))
-- feat(tracing): Add pg-native support to Postgres integration. ([#3894](https://github.com/getsentry/sentry-javascript/issues/3894))
-- ref(ember): Update addon to support Ember 4.0.0 (beta) ([#3915](https://github.com/getsentry/sentry-javascript/issues/3915))
-- feat(react): Make Profiler _mountSpan attribute protected ([#3904](https://github.com/getsentry/sentry-javascript/issues/3904))
-- fix(ember): allow ember-beta to fail ([#3910](https://github.com/getsentry/sentry-javascript/issues/3910))
-- fix(tracing): Prevent metrics erroring module load in web workers ([#3941](https://github.com/getsentry/sentry-javascript/issues/3941))
-- misc(browser): Log when event is dropped by Dedupe integration ([#3943](https://github.com/getsentry/sentry-javascript/issues/3943))
+- fix(nextjs): Differentiate between webpack 4 and 5 in server builds (#3878)
+- fix(core): Skip native frames while searching frame URLs. (#3897)
+- fix(vue): Attach props only if VM is available (#3902)
+- feat(tracing): Add pg-native support to Postgres integration. (#3894)
+- ref(ember): Update addon to support Ember 4.0.0 (beta) (#3915)
+- feat(react): Make Profiler _mountSpan attribute protected (#3904)
+- fix(ember): allow ember-beta to fail (#3910)
+- fix(tracing): Prevent metrics erroring module load in web workers (#3941)
+- misc(browser): Log when event is dropped by Dedupe integration (#3943)
 
 ## 6.11.0
 
-- feat(nextjs): Allow for TypeScript user config files ([#3847](https://github.com/getsentry/sentry-javascript/issues/3847))
-- fix(browser): Make sure handler exists for LinkedErrors Integration ([#3861](https://github.com/getsentry/sentry-javascript/issues/3861))
-- fix(core): Skip anonymous callbacks while searching frame URLs. ([#3842](https://github.com/getsentry/sentry-javascript/issues/3842))
-- fix(core): Stop rejecting in `flush` and `close` when client undefined ([#3846](https://github.com/getsentry/sentry-javascript/issues/3846))
-- fix(nextjs): Stop `SentryWebpackPlugin` from uploading unnecessary files ([#3845](https://github.com/getsentry/sentry-javascript/issues/3845))
-- fix(react): Require ReactElement in ErrorBoundary props and render ([#3857](https://github.com/getsentry/sentry-javascript/issues/3857))
-- fix(tests): Allow tests to run on Windows without WSL ([#3813](https://github.com/getsentry/sentry-javascript/issues/3813))
-- fix(utils): Fix false-positive circular references when normalizing `Event` objects ([#3864](https://github.com/getsentry/sentry-javascript/issues/3864))
-- fix(vue): Make Router.name type optional to match VueRouter ([#3843](https://github.com/getsentry/sentry-javascript/issues/3843))
-- ref(core): Prevent redundant setup work ([#3862](https://github.com/getsentry/sentry-javascript/issues/3862))
-- ref(nextjs): Stop reinitializing the server SDK unnecessarily ([#3860](https://github.com/getsentry/sentry-javascript/issues/3860))
+- feat(nextjs): Allow for TypeScript user config files (#3847)
+- fix(browser): Make sure handler exists for LinkedErrors Integration (#3861)
+- fix(core): Skip anonymous callbacks while searching frame URLs. (#3842)
+- fix(core): Stop rejecting in `flush` and `close` when client undefined (#3846)
+- fix(nextjs): Stop `SentryWebpackPlugin` from uploading unnecessary files (#3845)
+- fix(react): Require ReactElement in ErrorBoundary props and render (#3857)
+- fix(tests): Allow tests to run on Windows without WSL (#3813)
+- fix(utils): Fix false-positive circular references when normalizing `Event` objects (#3864)
+- fix(vue): Make Router.name type optional to match VueRouter (#3843)
+- ref(core): Prevent redundant setup work (#3862)
+- ref(nextjs): Stop reinitializing the server SDK unnecessarily (#3860)
 
 ## 6.10.0
 
-- feat(vue): Rework tracing and add support for `Vue 3` ([#3804](https://github.com/getsentry/sentry-javascript/issues/3804))
-- feat(tracing): Upgrade to `web-vitals 2.1.0` ([#3781](https://github.com/getsentry/sentry-javascript/issues/3781))
-- fix(ember): Make argument to `InitSentryForEmber` optional ([#3802](https://github.com/getsentry/sentry-javascript/issues/3802))
-- fix(nextjs): Do not start a navigation if the from URL is the same ([#3814](https://github.com/getsentry/sentry-javascript/issues/3814))
-- fix(nextjs): Let `flush` finish in API routes ([#3811](https://github.com/getsentry/sentry-javascript/issues/3811))
-- fix(nextjs): Use `domains` to prevent scope bleed ([#3788](https://github.com/getsentry/sentry-javascript/issues/3788))
-- fix(react): Make `Route` typing more generic ([#3809](https://github.com/getsentry/sentry-javascript/issues/3809))
-- ref(tracing): Update span op for outgoing HTTP requests ([#3821](https://github.com/getsentry/sentry-javascript/issues/3821))
-- ref(tracing): Remove updated CLS from web-vitals ([#3822](https://github.com/getsentry/sentry-javascript/issues/3822))
+- feat(vue): Rework tracing and add support for `Vue 3` (#3804)
+- feat(tracing): Upgrade to `web-vitals 2.1.0` (#3781)
+- fix(ember): Make argument to `InitSentryForEmber` optional (#3802)
+- fix(nextjs): Do not start a navigation if the from URL is the same (#3814)
+- fix(nextjs): Let `flush` finish in API routes (#3811)
+- fix(nextjs): Use `domains` to prevent scope bleed (#3788)
+- fix(react): Make `Route` typing more generic (#3809)
+- ref(tracing): Update span op for outgoing HTTP requests (#3821)
+- ref(tracing): Remove updated CLS from web-vitals (#3822)
 
 ## 6.9.0
 
-- feat(browser): Use scope data in report dialog ([#3792](https://github.com/getsentry/sentry-javascript/issues/3792))
-- feat(core): Add `ensureNoCircularStructures` experiment to help debug serialization bugs ([#3776](https://github.com/getsentry/sentry-javascript/issues/3776))
-- feat(nextjs): Add options to disable webpack plugin ([#3771](https://github.com/getsentry/sentry-javascript/issues/3771))
-- feat(react): Support render props in `ErrorBoundary` ([#3793](https://github.com/getsentry/sentry-javascript/issues/3793))
-- fix(ember): Correctly cache ember types from prepublish hook ([#3749](https://github.com/getsentry/sentry-javascript/issues/3749))
-- fix(ember): Fix runtime config options not being merged ([#3791](https://github.com/getsentry/sentry-javascript/issues/3791))
-- fix(metrics): Check for cls entry sources ([#3775](https://github.com/getsentry/sentry-javascript/issues/3775))
-- fix(nextjs): Make `withSentryConfig` return type match given config type ([#3760](https://github.com/getsentry/sentry-javascript/issues/3760))
-- fix(node): Check if `captureRequestSession` is available before its called ([#3773](https://github.com/getsentry/sentry-javascript/issues/3773))
-- fix(node): Enable `autoSessionTracking` correctly ([#3758](https://github.com/getsentry/sentry-javascript/issues/3758))
-- fix(react): `allRoutes` cannot triple equal a new array instance ([#3779](https://github.com/getsentry/sentry-javascript/issues/3779))
-- fix(tracing): Add check for `document.scripts` in metrics ([#3766](https://github.com/getsentry/sentry-javascript/issues/3766))
-- fix(types): Update `ExtractedNodeRequestData` to include valid `query_params` for `tracesSampler` ([#3715](https://github.com/getsentry/sentry-javascript/issues/3715))
-- ref(gatsby): Default release to empty string ([#3759](https://github.com/getsentry/sentry-javascript/issues/3759))
-- ref(nextjs): Inject init code in `_app` and API routes ([#3786](https://github.com/getsentry/sentry-javascript/issues/3786))
-- ref(nextjs): Pre-disable-plugin-option config cleanup ([#3770](https://github.com/getsentry/sentry-javascript/issues/3770))
-- ref(nextjs): Stop setting redundant `productionBrowserSourceMaps` in config ([#3765](https://github.com/getsentry/sentry-javascript/issues/3765))
+- feat(browser): Use scope data in report dialog (#3792)
+- feat(core): Add `ensureNoCircularStructures` experiment to help debug serialization bugs (#3776)
+- feat(nextjs): Add options to disable webpack plugin (#3771)
+- feat(react): Support render props in `ErrorBoundary` (#3793)
+- fix(ember): Correctly cache ember types from prepublish hook (#3749)
+- fix(ember): Fix runtime config options not being merged (#3791)
+- fix(metrics): Check for cls entry sources (#3775)
+- fix(nextjs): Make `withSentryConfig` return type match given config type (#3760)
+- fix(node): Check if `captureRequestSession` is available before its called (#3773)
+- fix(node): Enable `autoSessionTracking` correctly (#3758)
+- fix(react): `allRoutes` cannot triple equal a new array instance (#3779)
+- fix(tracing): Add check for `document.scripts` in metrics (#3766)
+- fix(types): Update `ExtractedNodeRequestData` to include valid `query_params` for `tracesSampler` (#3715)
+- ref(gatsby): Default release to empty string (#3759)
+- ref(nextjs): Inject init code in `_app` and API routes (#3786)
+- ref(nextjs): Pre-disable-plugin-option config cleanup (#3770)
+- ref(nextjs): Stop setting redundant `productionBrowserSourceMaps` in config (#3765)
 
 ## 6.8.0
 
-- [browser] feat: Enable serialization of multiple DOM attributes for breadcrumbs. ([#3755](https://github.com/getsentry/sentry-javascript/issues/3755))
-- [browser] feat: Make dedupe integration default for browser ([#3730](https://github.com/getsentry/sentry-javascript/issues/3730))
-- [core] fix: Correctly limit Buffer requests ([#3736](https://github.com/getsentry/sentry-javascript/issues/3736))
-- [ember] ref: Allow initing Ember without config entry ([#3745](https://github.com/getsentry/sentry-javascript/issues/3745))
-- [serverless] fix: wrapEventFunction does not await for async code ([#3740](https://github.com/getsentry/sentry-javascript/issues/3740))
+- [browser] feat: Enable serialization of multiple DOM attributes for breadcrumbs. (#3755)
+- [browser] feat: Make dedupe integration default for browser (#3730)
+- [core] fix: Correctly limit Buffer requests (#3736)
+- [ember] ref: Allow initing Ember without config entry (#3745)
+- [serverless] fix: wrapEventFunction does not await for async code (#3740)
 
 ## 6.7.2
 
-- [core] fix: Do not track sessions if not enabled ([#3686](https://github.com/getsentry/sentry-javascript/issues/3686))
-- [core] fix: Prevent sending terminal status session updates ([#3701](https://github.com/getsentry/sentry-javascript/issues/3701))
-- [core] ref: Make `beforeSend` more strict ([#3713](https://github.com/getsentry/sentry-javascript/issues/3713))
-- [browser] ref: Log which request type has been limited ([#3687](https://github.com/getsentry/sentry-javascript/issues/3687))
-- [nextjs] feat: Auto enable node http integration on server ([#3675](https://github.com/getsentry/sentry-javascript/issues/3675))
-- [nextjs] fix: Correctly handle functional next config in `withSentryConfig` ([#3698](https://github.com/getsentry/sentry-javascript/issues/3698))
-- [nextjs] fix: Fix conflict with other libraries modifying webpack `entry` property ([#3703](https://github.com/getsentry/sentry-javascript/issues/3703))
-- [nextjs] fix: Update @sentry/webpack-plugin to 1.15.1 in @sentry/nextjs to resolve build timeouts issue ([#3708](https://github.com/getsentry/sentry-javascript/issues/3708))
-- [nextjs] ref: Split up config code and add tests ([#3693](https://github.com/getsentry/sentry-javascript/issues/3693))
+- [core] fix: Do not track sessions if not enabled (#3686)
+- [core] fix: Prevent sending terminal status session updates (#3701)
+- [core] ref: Make `beforeSend` more strict (#3713)
+- [browser] ref: Log which request type has been limited (#3687)
+- [nextjs] feat: Auto enable node http integration on server (#3675)
+- [nextjs] fix: Correctly handle functional next config in `withSentryConfig` (#3698)
+- [nextjs] fix: Fix conflict with other libraries modifying webpack `entry` property (#3703)
+- [nextjs] fix: Update @sentry/webpack-plugin to 1.15.1 in @sentry/nextjs to resolve build timeouts issue (#3708)
+- [nextjs] ref: Split up config code and add tests (#3693)
 
 ## 6.7.1
 
-- [core] fix: Add event type to item header when envelopes are forced ([#3676](https://github.com/getsentry/sentry-javascript/issues/3676))
-- [core] fix: Include DSN in envelope header for sessions ([#3680](https://github.com/getsentry/sentry-javascript/issues/3680))
-- [core] fix: Prevent scope from storing more than 100 breadcrumbs at the time ([#3677](https://github.com/getsentry/sentry-javascript/issues/3677))
-- [node] ref: Remove default http(s) import from http-module ([#3681](https://github.com/getsentry/sentry-javascript/issues/3681))
-- [nextjs] feat: Add body data to transaction `request` context ([#3672](https://github.com/getsentry/sentry-javascript/issues/3672))
+- [core] fix: Add event type to item header when envelopes are forced (#3676)
+- [core] fix: Include DSN in envelope header for sessions (#3680)
+- [core] fix: Prevent scope from storing more than 100 breadcrumbs at the time (#3677)
+- [node] ref: Remove default http(s) import from http-module (#3681)
+- [nextjs] feat: Add body data to transaction `request` context (#3672)
 
 ## 6.7.0
 
-- [core] feat: Add `tunnel` option to support request tunneling for dealing with ad-blockers ([#3521](https://github.com/getsentry/sentry-javascript/issues/3521))
+- [core] feat: Add `tunnel` option to support request tunneling for dealing with ad-blockers (#3521)
 
 ## 6.6.0
 
-- [node] feat: Allow for overriding custom `UrlParser` in Node.js transports ([#3612](https://github.com/getsentry/sentry-javascript/issues/3612))
-- [browser] feat: Add `serializeAttribute` option to DOM breadcrumbs. ([#3620](https://github.com/getsentry/sentry-javascript/issues/3620))
-- [nextjs] fix: `Improve NextConfigExports` compatibility ([#3592](https://github.com/getsentry/sentry-javascript/issues/3592))
-- [nextjs] fix: Use correct abs path for server init ([#3649](https://github.com/getsentry/sentry-javascript/issues/3649))
-- [angular] fix: Do not run change detection when capturing the exception ([#3618](https://github.com/getsentry/sentry-javascript/issues/3618))
-- [angular] fix: Do not run change detection when finishing transaction ([#3622](https://github.com/getsentry/sentry-javascript/issues/3622))
-- [angular] fix: Provide a single compilation unit for the `trace` directive ([#3617](https://github.com/getsentry/sentry-javascript/issues/3617))
-- [utils] fix: Check for `performance.now` when calculating browser timing ([#3657](https://github.com/getsentry/sentry-javascript/issues/3657))
-- [integrations] fix: Run rewriting for both `exception` and `stacktrace` events ([#3653](https://github.com/getsentry/sentry-javascript/issues/3653))
-- [node] ref: Replace old-style `require(console)` with a global object ([#3623](https://github.com/getsentry/sentry-javascript/issues/3623))
-- [node] ref: Make `HTTPModule` more abstract to be able to use it in non-Node.JS environments ([#3655](https://github.com/getsentry/sentry-javascript/issues/3655))
-- [nextjs] ref: Export `BrowserTracing` integration directly from `@sentry/nextjs` ([#3647](https://github.com/getsentry/sentry-javascript/issues/3647))
+- [node] feat: Allow for overriding custom `UrlParser` in Node.js transports (#3612)
+- [browser] feat: Add `serializeAttribute` option to DOM breadcrumbs. (#3620)
+- [nextjs] fix: `Improve NextConfigExports` compatibility (#3592)
+- [nextjs] fix: Use correct abs path for server init (#3649)
+- [angular] fix: Do not run change detection when capturing the exception (#3618)
+- [angular] fix: Do not run change detection when finishing transaction (#3622)
+- [angular] fix: Provide a single compilation unit for the `trace` directive (#3617)
+- [utils] fix: Check for `performance.now` when calculating browser timing (#3657)
+- [integrations] fix: Run rewriting for both `exception` and `stacktrace` events (#3653)
+- [node] ref: Replace old-style `require(console)` with a global object (#3623)
+- [node] ref: Make `HTTPModule` more abstract to be able to use it in non-Node.JS environments (#3655)
+- [nextjs] ref: Export `BrowserTracing` integration directly from `@sentry/nextjs` (#3647)
 
 ## 6.5.1
 
-- [nextjs] fix: Prevent webpack 5 from crashing server ([#3642](https://github.com/getsentry/sentry-javascript/issues/3642))
-- [eslint] build: Upgrade to eslint 7.27.0 ([#3639](https://github.com/getsentry/sentry-javascript/issues/3639))
-- [nextjs] test: Add nextjs integration tests for Server and Browser ([#3632](https://github.com/getsentry/sentry-javascript/issues/3632))
-- [browser] ref: Don't send session duration in browser environments ([#3616](https://github.com/getsentry/sentry-javascript/issues/3616))
-- [hub] fix: Correctly compute session durations ([#3616](https://github.com/getsentry/sentry-javascript/issues/3616))
+- [nextjs] fix: Prevent webpack 5 from crashing server (#3642)
+- [eslint] build: Upgrade to eslint 7.27.0 (#3639)
+- [nextjs] test: Add nextjs integration tests for Server and Browser (#3632)
+- [browser] ref: Don't send session duration in browser environments (#3616)
+- [hub] fix: Correctly compute session durations (#3616)
 
 ## 6.5.0
 
-- [angular] fix: prevent memory leak when the root view is removed ([#3594](https://github.com/getsentry/sentry-javascript/issues/3594))
-- [browser] fix: Do not trigger session on meaningless navigation ([#3608](https://github.com/getsentry/sentry-javascript/issues/3608))
-- [nextjs] feat: Frontend + withSentry Performance Monitoring ([#3580](https://github.com/getsentry/sentry-javascript/issues/3580))
-- [react] fix: Use history object for init transaction name ([#3609](https://github.com/getsentry/sentry-javascript/issues/3609))
+- [angular] fix: prevent memory leak when the root view is removed (#3594)
+- [browser] fix: Do not trigger session on meaningless navigation (#3608)
+- [nextjs] feat: Frontend + withSentry Performance Monitoring (#3580)
+- [react] fix: Use history object for init transaction name (#3609)
 
 ## 6.4.1
 
-- [ember] ref: Fix merging of runtime config with environment config. ([#3563](https://github.com/getsentry/sentry-javascript/issues/3563))
-- [angular] ref: Allow angular v12 as a peer dependency. ([#3569](https://github.com/getsentry/sentry-javascript/issues/3569))
-- [tracing] fix: Avoid browser tracing initialization on node environment ([#3548](https://github.com/getsentry/sentry-javascript/issues/3548))
-- [react] ref: Make RouteProps typing more generic ([#3570](https://github.com/getsentry/sentry-javascript/issues/3570))
-- [tracing] fix: Correctly handle pg.Cursor in pg query method ([#3567](https://github.com/getsentry/sentry-javascript/issues/3567))
-- [types] fix: Add attachment to SentryRequestType ([#3561](https://github.com/getsentry/sentry-javascript/issues/3561))
-- [nextjs] ref: Disable node session for next.js ([#3558](https://github.com/getsentry/sentry-javascript/issues/3558))
-- [eslint] feat: Add new eslint rules ([#3545](https://github.com/getsentry/sentry-javascript/issues/3545))
+- [ember] ref: Fix merging of runtime config with environment config. (#3563)
+- [angular] ref: Allow angular v12 as a peer dependency. (#3569)
+- [tracing] fix: Avoid browser tracing initialization on node environment (#3548)
+- [react] ref: Make RouteProps typing more generic (#3570)
+- [tracing] fix: Correctly handle pg.Cursor in pg query method (#3567)
+- [types] fix: Add attachment to SentryRequestType (#3561)
+- [nextjs] ref: Disable node session for next.js (#3558)
+- [eslint] feat: Add new eslint rules (#3545)
 
 ## 6.4.0
 
-- [core] feat: initialScope in SDK Options ([#3544](https://github.com/getsentry/sentry-javascript/issues/3544))
-- [node] feat: Release Health for Node (Session Aggregates) ([#3319](https://github.com/getsentry/sentry-javascript/issues/3319))
-- [node] feat: Autoload Database Integrations in Node environment ([#3483](https://github.com/getsentry/sentry-javascript/issues/3483))
-- [react] feat: Add support for React 17 Error Boundaries ([#3532](https://github.com/getsentry/sentry-javascript/issues/3532))
-- [tracing] fix: Generate TTFB (Time to first byte) from span data ([#3515](https://github.com/getsentry/sentry-javascript/issues/3515))
+- [core] feat: initialScope in SDK Options (#3544)
+- [node] feat: Release Health for Node (Session Aggregates) (#3319)
+- [node] feat: Autoload Database Integrations in Node environment (#3483)
+- [react] feat: Add support for React 17 Error Boundaries (#3532)
+- [tracing] fix: Generate TTFB (Time to first byte) from span data (#3515)
 
 ## 6.3.6
 
-- [nextjs] fix: Fix error logging ([#3512](https://github.com/getsentry/sentry-javascript/issues/3512))
-- [nextjs] fix: Add environment automatically ([#3495](https://github.com/getsentry/sentry-javascript/issues/3495))
-- [node] feat: Implement category based rate limiting ([#3435](https://github.com/getsentry/sentry-javascript/issues/3435))
-- [node] fix: Set handled to false when it is a crash ([#3493](https://github.com/getsentry/sentry-javascript/issues/3493))
-- [tracing] fix: Mark tracing distributables as side effects ([#3519](https://github.com/getsentry/sentry-javascript/issues/3519))
+- [nextjs] fix: Fix error logging (#3512)
+- [nextjs] fix: Add environment automatically (#3495)
+- [node] feat: Implement category based rate limiting (#3435)
+- [node] fix: Set handled to false when it is a crash (#3493)
+- [tracing] fix: Mark tracing distributables as side effects (#3519)
 
 ## 6.3.5
 
-- [nextjs] fix: Add tslib dependecy; change inject order ([#3487](https://github.com/getsentry/sentry-javascript/issues/3487))
+- [nextjs] fix: Add tslib dependecy; change inject order (#3487)
 
 ## 6.3.4
 
-- [nextjs] fix: API routes logging ([#3479](https://github.com/getsentry/sentry-javascript/issues/3479))
+- [nextjs] fix: API routes logging (#3479)
 
 ## 6.3.3
 
-- [nextjs] fix: User server types ([#3471](https://github.com/getsentry/sentry-javascript/issues/3471))
+- [nextjs] fix: User server types (#3471)
 
 ## 6.3.2
 
-- [nextjs] ref: Remove next.js plugin ([#3462](https://github.com/getsentry/sentry-javascript/issues/3462))
-- [core] fix: Prevent InboundFilters mergeOptions method from breaking users code ([#3458](https://github.com/getsentry/sentry-javascript/issues/3458))
+- [nextjs] ref: Remove next.js plugin (#3462)
+- [core] fix: Prevent InboundFilters mergeOptions method from breaking users code (#3458)
 
 ## 6.3.1
 
-- [angular] fix: Make SentryErrorHandler extensible and export it publicly ([#3438](https://github.com/getsentry/sentry-javascript/issues/3438))
-- [browser] feat: Capture information about the LCP element culprit ([#3427](https://github.com/getsentry/sentry-javascript/issues/3427))
-- [core] fix: Correctly attach installed integrations to sdkinfo ([#3447](https://github.com/getsentry/sentry-javascript/issues/3447))
-- [ember] fix: Add guards to ensure marks exist ([#3436](https://github.com/getsentry/sentry-javascript/issues/3436))
-- [nextjs] fix: Fix incomplete merging of user config with Sentry config ([#3434](https://github.com/getsentry/sentry-javascript/issues/3434))
-- [nextjs] ref: Use resolved paths for `require` calls in config code ([#3426](https://github.com/getsentry/sentry-javascript/issues/3426))
-- [node] fix: Fix for manual tests in node ([#3428](https://github.com/getsentry/sentry-javascript/issues/3428))
-- [transports] feat: Honor no_proxy env variable ([#3412](https://github.com/getsentry/sentry-javascript/issues/3412))
+- [angular] fix: Make SentryErrorHandler extensible and export it publicly (#3438)
+- [browser] feat: Capture information about the LCP element culprit (#3427)
+- [core] fix: Correctly attach installed integrations to sdkinfo (#3447)
+- [ember] fix: Add guards to ensure marks exist (#3436)
+- [nextjs] fix: Fix incomplete merging of user config with Sentry config (#3434)
+- [nextjs] ref: Use resolved paths for `require` calls in config code (#3426)
+- [node] fix: Fix for manual tests in node (#3428)
+- [transports] feat: Honor no_proxy env variable (#3412)
 
 ## 6.3.0
 
-- [browser] feat: Parse safari-extension and safari-web-extension errors ([#3374](https://github.com/getsentry/sentry-javascript/issues/3374))
-- [browser] fix: Provide better descriptions for the performance navigation timing spans ([#3245](https://github.com/getsentry/sentry-javascript/issues/3245))
-- [browser] test: Replace Authorization with Accept header ([#3400](https://github.com/getsentry/sentry-javascript/issues/3400))
+- [browser] feat: Parse safari-extension and safari-web-extension errors (#3374)
+- [browser] fix: Provide better descriptions for the performance navigation timing spans (#3245)
+- [browser] test: Replace Authorization with Accept header (#3400)
 - [ci] ci: Add CodeQL scanning
-- [core] Drop session if release is not a string or is missing and log ([#3396](https://github.com/getsentry/sentry-javascript/issues/3396))
-- [docs] Document how to publish a new release ([#3361](https://github.com/getsentry/sentry-javascript/issues/3361))
-- [gatsby] fix: Specify gatsby peer dep ([#3385](https://github.com/getsentry/sentry-javascript/issues/3385))
-- [gatsby] chore(docs): Update @sentry/gatsby README ([#3384](https://github.com/getsentry/sentry-javascript/issues/3384))
-- [integrations] feat(integrations): add prefix support for RewriteFrames ([#3416](https://github.com/getsentry/sentry-javascript/issues/3416))
-- [integrations] ref: Use esm imports with localforage and add esModuleInterop ([#3403](https://github.com/getsentry/sentry-javascript/issues/3403))
-- [nextjs] feat: Next.js SDK + Plugin ([#3301](https://github.com/getsentry/sentry-javascript/issues/3301))
-- [node] fix: Generate a Sentry Release string from env if its not provided ([#3393](https://github.com/getsentry/sentry-javascript/issues/3393))
-- [tracing] fix: Replace performance.timeOrigin in favour of browserPerformanceTimeOrigin ([#3397](https://github.com/getsentry/sentry-javascript/issues/3397))
-- [tracing] fix: Mark span as failed when fetch API call fails ([#3351](https://github.com/getsentry/sentry-javascript/issues/3351))
-- [utils] fix: Use the more reliable timeOrigin ([#3398](https://github.com/getsentry/sentry-javascript/issues/3398))
-- [utils] fix: Wrap oldOnPopState.apply call in try/catch to prevent Firefox from crashing ([#3377](https://github.com/getsentry/sentry-javascript/issues/3377))
+- [core] Drop session if release is not a string or is missing and log (#3396)
+- [docs] Document how to publish a new release (#3361)
+- [gatsby] fix: Specify gatsby peer dep (#3385)
+- [gatsby] chore(docs): Update @sentry/gatsby README (#3384)
+- [integrations] feat(integrations): add prefix support for RewriteFrames (#3416)
+- [integrations] ref: Use esm imports with localforage and add esModuleInterop (#3403)
+- [nextjs] feat: Next.js SDK + Plugin (#3301)
+- [node] fix: Generate a Sentry Release string from env if its not provided (#3393)
+- [tracing] fix: Replace performance.timeOrigin in favour of browserPerformanceTimeOrigin (#3397)
+- [tracing] fix: Mark span as failed when fetch API call fails (#3351)
+- [utils] fix: Use the more reliable timeOrigin (#3398)
+- [utils] fix: Wrap oldOnPopState.apply call in try/catch to prevent Firefox from crashing (#3377)
 
 ## 6.2.5
 
-- [utils] fix: Avoid performance.timeOrigin if too skewed ([#3356](https://github.com/getsentry/sentry-javascript/issues/3356))
+- [utils] fix: Avoid performance.timeOrigin if too skewed (#3356)
 
 ## 6.2.4
 
-- [browser] fix: Add `SentryRequestType` to `RateLimitingCategory` mapping ([#3328](https://github.com/getsentry/sentry-javascript/issues/3328))
-- [browser] ref: Add fast-path to `fetchImpl` and cleanup redundant iframe ([#3341](https://github.com/getsentry/sentry-javascript/issues/3341))
-- [node] fix: Fallback to empty string if `req.baseUrl` is empty ([#3329](https://github.com/getsentry/sentry-javascript/issues/3329))
-- [node] ref: Remove circular dependency in `@sentry/node` ([#3335](https://github.com/getsentry/sentry-javascript/issues/3335))
-- [tracing] fix: Attach mysql tracing to `Connection.createQuery` instead of `Connection.prototype.query` ([#3353](https://github.com/getsentry/sentry-javascript/issues/3353))
-- [tracing] ref: Clarify naming in `BrowserTracing` integration ([#3338](https://github.com/getsentry/sentry-javascript/issues/3338))
-- [ember] ref: Fix tests to be forward compatible with component changes ([#3347](https://github.com/getsentry/sentry-javascript/issues/3347))
-- [ember] ref: Silence deprecation warnings in beta ([#3346](https://github.com/getsentry/sentry-javascript/issues/3346))
+- [browser] fix: Add `SentryRequestType` to `RateLimitingCategory` mapping (#3328)
+- [browser] ref: Add fast-path to `fetchImpl` and cleanup redundant iframe (#3341)
+- [node] fix: Fallback to empty string if `req.baseUrl` is empty (#3329)
+- [node] ref: Remove circular dependency in `@sentry/node` (#3335)
+- [tracing] fix: Attach mysql tracing to `Connection.createQuery` instead of `Connection.prototype.query` (#3353)
+- [tracing] ref: Clarify naming in `BrowserTracing` integration (#3338)
+- [ember] ref: Fix tests to be forward compatible with component changes (#3347)
+- [ember] ref: Silence deprecation warnings in beta (#3346)
 
 ## 6.2.3
 
-- [gatsby] fix: Update Vercel environment variables to match their current system variables ([#3337](https://github.com/getsentry/sentry-javascript/issues/3337))
+- [gatsby] fix: Update Vercel environment variables to match their current system variables (#3337)
 
 ## 6.2.2
 
-- [hub] fix: Only create sessions if the correct methods are defined ([#3281](https://github.com/getsentry/sentry-javascript/issues/3281))
-- [core] fix: Don't override SDK metadata ([#3304](https://github.com/getsentry/sentry-javascript/issues/3304))
-- [browser] fix: Prevent fetch errors loops with invalid fetch implementations ([#3318](https://github.com/getsentry/sentry-javascript/issues/3318))
-- [serverless] ref: Add compatible runtime nodejs14.x to building awslambda layer ([#3303](https://github.com/getsentry/sentry-javascript/issues/3303))
-- [ember] fix: Keep route hook context when performance-wrapping ([#3274](https://github.com/getsentry/sentry-javascript/issues/3274))
-- [integrations] fix: Normalized Event before caching. ([#3305](https://github.com/getsentry/sentry-javascript/issues/3305))
+- [hub] fix: Only create sessions if the correct methods are defined (#3281)
+- [core] fix: Don't override SDK metadata (#3304)
+- [browser] fix: Prevent fetch errors loops with invalid fetch implementations (#3318)
+- [serverless] ref: Add compatible runtime nodejs14.x to building awslambda layer (#3303)
+- [ember] fix: Keep route hook context when performance-wrapping (#3274)
+- [integrations] fix: Normalized Event before caching. (#3305)
 
 ## 6.2.1
 
-- [core] fix: Moves SDK metadata-setting into the `NodeClient/BrowserClient` to protect it from being overwritten by other classes extending `BaseClient` like @sentry/serverless ([#3279](https://github.com/getsentry/sentry-javascript/issues/3279))
+- [core] fix: Moves SDK metadata-setting into the `NodeClient/BrowserClient` to protect it from being overwritten by other classes extending `BaseClient` like @sentry/serverless (#3279)
 
 ## 6.2.0
 
-- [tracing] feat: Mongoose tracing support added to MongoDB ([#3252](https://github.com/getsentry/sentry-javascript/issues/3252))
-- [tracing] fix: Add missing `find` method from mongo tracing list ([#3253](https://github.com/getsentry/sentry-javascript/issues/3253))
-- [tracing] fix: Create `spanRecorder` whenever transactions are sampled ([#3255](https://github.com/getsentry/sentry-javascript/issues/3255))
-- [node] fix: Parse ESM based frames with `file://` protocol ([#3264](https://github.com/getsentry/sentry-javascript/issues/3264))
-- [react] fix: Remove react-dom peer dependency for RN ([#3250](https://github.com/getsentry/sentry-javascript/issues/3250))
-- [ember] fix: Fixing fetching config during build step ([#3246](https://github.com/getsentry/sentry-javascript/issues/3246))
-- [serverless]: fix: Handle incoming `sentry-trace` header ([#3261](https://github.com/getsentry/sentry-javascript/issues/3261))
+- [tracing] feat: Mongoose tracing support added to MongoDB (#3252)
+- [tracing] fix: Add missing `find` method from mongo tracing list (#3253)
+- [tracing] fix: Create `spanRecorder` whenever transactions are sampled (#3255)
+- [node] fix: Parse ESM based frames with `file://` protocol (#3264)
+- [react] fix: Remove react-dom peer dependency for RN (#3250)
+- [ember] fix: Fixing fetching config during build step (#3246)
+- [serverless]: fix: Handle incoming `sentry-trace` header (#3261)
 
 ## 6.1.0
 
 We updated the way how we calculate errored and crashed sessions with this update. Please be aware that some numbers might change for you and they now should reflect the actual reality. Visit [our docs](https://docs.sentry.io/platforms/javascript/configuration/releases/#release-health) for more information.
 
-- [browser] feat: Rework how we track sessions ([#3224](https://github.com/getsentry/sentry-javascript/issues/3224))
-- [hub] ref: Simplify getting hub from active domain ([#3227](https://github.com/getsentry/sentry-javascript/issues/3227))
-- [core] ref: Rename `user` to `publicKey` in `Dsn` type and class ([#3225](https://github.com/getsentry/sentry-javascript/issues/3225))
-- [ember] fix: Fix backwards compatibility with Embroider changes ([#3230](https://github.com/getsentry/sentry-javascript/issues/3230))
+- [browser] feat: Rework how we track sessions (#3224)
+- [hub] ref: Simplify getting hub from active domain (#3227)
+- [core] ref: Rename `user` to `publicKey` in `Dsn` type and class (#3225)
+- [ember] fix: Fix backwards compatibility with Embroider changes (#3230)
 
 ## 6.0.4
 
-- [browser] fix: Don't break when function call context is undefined ([#3222](https://github.com/getsentry/sentry-javascript/issues/3222))
-- [tracing] fix: Set default sampling context data where `startTransaction` is called ([#3210](https://github.com/getsentry/sentry-javascript/issues/3210))
-- [tracing] fix: Remove stray sampling data tags ([#3197](https://github.com/getsentry/sentry-javascript/issues/3197))
-- [tracing] fix: Clear activeTransaction from the scope and always start idle timers ([#3215](https://github.com/getsentry/sentry-javascript/issues/3215))
-- [angular] ref: Add Angular 11 to possible peerDependencies list ([#3201](https://github.com/getsentry/sentry-javascript/issues/3201))
-- [vue] ref: Add `vue-router` to peerDependencies list ([#3214](https://github.com/getsentry/sentry-javascript/issues/3214))
+- [browser] fix: Don't break when function call context is undefined (#3222)
+- [tracing] fix: Set default sampling context data where `startTransaction` is called (#3210)
+- [tracing] fix: Remove stray sampling data tags (#3197)
+- [tracing] fix: Clear activeTransaction from the scope and always start idle timers (#3215)
+- [angular] ref: Add Angular 11 to possible peerDependencies list (#3201)
+- [vue] ref: Add `vue-router` to peerDependencies list (#3214)
 
 ## 6.0.3
 
-- [tracing] ref: feat(tracing): Add context update methods to Span and Transaction ([#3192](https://github.com/getsentry/sentry-javascript/issues/3192))
-- [node] ref: Make ExpressRequest not extend http.IncomingMessage anymore ([#3211](https://github.com/getsentry/sentry-javascript/issues/3211))
-- [browser] deps: Allow for LocalForage >=1.8.1 ([#3205](https://github.com/getsentry/sentry-javascript/issues/3205))
-- [ember] fix(ember): Fix location url for 'hash' location type ([#3195](https://github.com/getsentry/sentry-javascript/issues/3195))
-- [ember] fix(ember): Fix Ember to work with Embroider and Fastboot ([#3181](https://github.com/getsentry/sentry-javascript/issues/3181))
+- [tracing] ref: feat(tracing): Add context update methods to Span and Transaction (#3192)
+- [node] ref: Make ExpressRequest not extend http.IncomingMessage anymore (#3211)
+- [browser] deps: Allow for LocalForage >=1.8.1 (#3205)
+- [ember] fix(ember): Fix location url for 'hash' location type (#3195)
+- [ember] fix(ember): Fix Ember to work with Embroider and Fastboot (#3181)
 
 ## 6.0.2
 
-- [browser] fix: Disable session tracking in non-browser environments ([#3194](https://github.com/getsentry/sentry-javascript/issues/3194))
+- [browser] fix: Disable session tracking in non-browser environments (#3194)
 
 ## 6.0.1
 
-- [vue] fix: Make sure that error is present before logging it in Vue ([#3183](https://github.com/getsentry/sentry-javascript/issues/3183))
-- [serverless] fix: Fix issue when `/dist` didn't exist before building ([#3190](https://github.com/getsentry/sentry-javascript/issues/3190))
+- [vue] fix: Make sure that error is present before logging it in Vue (#3183)
+- [serverless] fix: Fix issue when `/dist` didn't exist before building (#3190)
 
 ## 6.0.0
 
@@ -584,21 +584,21 @@ during SDK initialization.
 
 ---
 
-- [wasm] feat: Introduce a `@sentry/wasm` package ([#3080](https://github.com/getsentry/sentry-javascript/issues/3080))
-- [tracing] feat: Turn Sessions Tracking on by default ([#3099](https://github.com/getsentry/sentry-javascript/issues/3099))
-- [tracing] feat: Create session on history change ([#3179](https://github.com/getsentry/sentry-javascript/issues/3179))
-- [core] feat: Attach SDK metadata to options and pass it to the API and transports ([#3177](https://github.com/getsentry/sentry-javascript/issues/3177))
-- [build] feat: AWS Lambda layer target config for Craft ([#3175](https://github.com/getsentry/sentry-javascript/issues/3175))
-- [tracing] fix: Make sure that mongo method is thenable before calling it ([#3173](https://github.com/getsentry/sentry-javascript/issues/3173))
+- [wasm] feat: Introduce a `@sentry/wasm` package (#3080)
+- [tracing] feat: Turn Sessions Tracking on by default (#3099)
+- [tracing] feat: Create session on history change (#3179)
+- [core] feat: Attach SDK metadata to options and pass it to the API and transports (#3177)
+- [build] feat: AWS Lambda layer target config for Craft (#3175)
+- [tracing] fix: Make sure that mongo method is thenable before calling it (#3173)
 
 ## 5.30.0
 
-- [node] fix: esbuild warning dynamic require ([#3164](https://github.com/getsentry/sentry-javascript/issues/3164))
-- [tracing] ref: Expose required things for React Native auto tracing ([#3144](https://github.com/getsentry/sentry-javascript/issues/3144))
-- [ember] fix: rootURL breaking route recognition ([#3166](https://github.com/getsentry/sentry-javascript/issues/3166))
-- [serverless] feat: Zip serverless dependencies for AWS Lambda ([#3110](https://github.com/getsentry/sentry-javascript/issues/3110))
-- [build] feat: Target to deploy on AWS Lambda ([#3165](https://github.com/getsentry/sentry-javascript/issues/3165))
-- [build] ref: Remove TravisCI ([#3149](https://github.com/getsentry/sentry-javascript/issues/3149))
+- [node] fix: esbuild warning dynamic require (#3164)
+- [tracing] ref: Expose required things for React Native auto tracing (#3144)
+- [ember] fix: rootURL breaking route recognition (#3166)
+- [serverless] feat: Zip serverless dependencies for AWS Lambda (#3110)
+- [build] feat: Target to deploy on AWS Lambda (#3165)
+- [build] ref: Remove TravisCI (#3149)
 - [build] ref: Upgrade action-prepare-release to latest version
 
 ## 5.29.2
@@ -607,26 +607,26 @@ during SDK initialization.
 
 ## 5.29.1
 
-- [types] ref: Loosen tag types, create new `Primitive` type ([#3108](https://github.com/getsentry/sentry-javascript/issues/3108))
-- [tracing] feat: Send sample rate and type in transaction item header in envelope ([#3068](https://github.com/getsentry/sentry-javascript/issues/3068))
-- [tracing] fix(web-vitals): Fix TTFB capture in Safari ([#3106](https://github.com/getsentry/sentry-javascript/issues/3106))
+- [types] ref: Loosen tag types, create new `Primitive` type (#3108)
+- [tracing] feat: Send sample rate and type in transaction item header in envelope (#3068)
+- [tracing] fix(web-vitals): Fix TTFB capture in Safari (#3106)
 
 ## 5.29.0
 
-- [tracing] feat: MongoDB Tracing Support ([#3072](https://github.com/getsentry/sentry-javascript/issues/3072))
-- [tracing] feat: MySQL Tracing Support ([#3088](https://github.com/getsentry/sentry-javascript/issues/3088))
-- [tracing] feat: PostgreSQL Tracing Support ([#3064](https://github.com/getsentry/sentry-javascript/issues/3064))
-- [tracing] fix: Add `sentry-trace` header to outgoing http(s) requests in node ([#3053](https://github.com/getsentry/sentry-javascript/issues/3053))
-- [node] fix: Revert express tracing integration type to use any ([#3093](https://github.com/getsentry/sentry-javascript/issues/3093))
+- [tracing] feat: MongoDB Tracing Support (#3072)
+- [tracing] feat: MySQL Tracing Support (#3088)
+- [tracing] feat: PostgreSQL Tracing Support (#3064)
+- [tracing] fix: Add `sentry-trace` header to outgoing http(s) requests in node (#3053)
+- [node] fix: Revert express tracing integration type to use any (#3093)
 
 ## 5.28.0
 
-- [browser] fix: Handle expo file dir stack frames ([#3070](https://github.com/getsentry/sentry-javascript/issues/3070))
-- [vue] feat: @sentry/vue ([#2953](https://github.com/getsentry/sentry-javascript/issues/2953))
-- [node] ref: Revamp express route info extraction ([#3084](https://github.com/getsentry/sentry-javascript/issues/3084))
-- [browser] fix: Dont append dsn twice to report dialog calls ([#3079](https://github.com/getsentry/sentry-javascript/issues/3079))
-- [ember] fix: Use correct import from `@sentry/browser` ([#3077](https://github.com/getsentry/sentry-javascript/issues/3077))
-- [node] ref: Express integration span name change and path unification ([#3078](https://github.com/getsentry/sentry-javascript/issues/3078))
+- [browser] fix: Handle expo file dir stack frames (#3070)
+- [vue] feat: @sentry/vue (#2953)
+- [node] ref: Revamp express route info extraction (#3084)
+- [browser] fix: Dont append dsn twice to report dialog calls (#3079)
+- [ember] fix: Use correct import from `@sentry/browser` (#3077)
+- [node] ref: Express integration span name change and path unification (#3078)
 
 ## 5.27.6
 
@@ -634,132 +634,132 @@ during SDK initialization.
 
 ## 5.27.5
 
-- [hub] fix: Sync ScopeListeners ([#3065](https://github.com/getsentry/sentry-javascript/issues/3065))
-- [tracing] fix: Typo in constant name in @sentry/tracing ([#3058](https://github.com/getsentry/sentry-javascript/issues/3058))
+- [hub] fix: Sync ScopeListeners (#3065)
+- [tracing] fix: Typo in constant name in @sentry/tracing (#3058)
 
 ## 5.27.4
 
-- [core] fix: Remove globalThis usage ([#3033](https://github.com/getsentry/sentry-javascript/issues/3033))
-- [react] ref: Add React 17.x to peerDependencies ([#3034](https://github.com/getsentry/sentry-javascript/issues/3034))
-- [tracing] fix: Express transaction name ([#3048](https://github.com/getsentry/sentry-javascript/issues/3048))
-- [serverless] fix: AWS Execution duration ([#3032](https://github.com/getsentry/sentry-javascript/issues/3032))
-- [serverless] fix: Add `optional` parameter to AWSServices integration ([#3030](https://github.com/getsentry/sentry-javascript/issues/3030))
-- [serverless] fix: Wrap google cloud functions with a Proxy(). ([#3035](https://github.com/getsentry/sentry-javascript/issues/3035))
-- [hub] fix: stop using @types/node in @sentry/hub ([#3050](https://github.com/getsentry/sentry-javascript/issues/3050))
+- [core] fix: Remove globalThis usage (#3033)
+- [react] ref: Add React 17.x to peerDependencies (#3034)
+- [tracing] fix: Express transaction name (#3048)
+- [serverless] fix: AWS Execution duration (#3032)
+- [serverless] fix: Add `optional` parameter to AWSServices integration (#3030)
+- [serverless] fix: Wrap google cloud functions with a Proxy(). (#3035)
+- [hub] fix: stop using @types/node in @sentry/hub (#3050)
 
 ## 5.27.3
 
-- [hub] fix: Make sure that `getSession` exists before calling it ([#3017](https://github.com/getsentry/sentry-javascript/issues/3017))
-- [browser] feat: Add `DOMException.code` as tag if it exists ([#3018](https://github.com/getsentry/sentry-javascript/issues/3018))
-- [browser] fix: Call `removeEventListener` twice only when necessary ([#3016](https://github.com/getsentry/sentry-javascript/issues/3016))
-- [tracing] fix: Schedule the execution of the finish to let all the spans being closed first ([#3022](https://github.com/getsentry/sentry-javascript/issues/3022))
-- [tracing] fix: Adjust some web vitals to be relative to fetchStart and some other improvements ([#3019](https://github.com/getsentry/sentry-javascript/issues/3019))
-- [tracing] fix: Add transaction name as tag on error events ([#3024](https://github.com/getsentry/sentry-javascript/issues/3024))
+- [hub] fix: Make sure that `getSession` exists before calling it (#3017)
+- [browser] feat: Add `DOMException.code` as tag if it exists (#3018)
+- [browser] fix: Call `removeEventListener` twice only when necessary (#3016)
+- [tracing] fix: Schedule the execution of the finish to let all the spans being closed first (#3022)
+- [tracing] fix: Adjust some web vitals to be relative to fetchStart and some other improvements (#3019)
+- [tracing] fix: Add transaction name as tag on error events (#3024)
 
 ## 5.27.2
 
-- [apm] ref: Delete sentry/apm package ([#2990](https://github.com/getsentry/sentry-javascript/issues/2990))
-- [types] fix: make requestHandler options an own type ([#2995](https://github.com/getsentry/sentry-javascript/issues/2995))
-- [core] fix: Use 'production' as default value for environment key ([#3013](https://github.com/getsentry/sentry-javascript/issues/3013))
+- [apm] ref: Delete sentry/apm package (#2990)
+- [types] fix: make requestHandler options an own type (#2995)
+- [core] fix: Use 'production' as default value for environment key (#3013)
 
 ## 5.27.1
 
-- [hub] fix: Preserve original user data for explicitly updated scopes ([#2991](https://github.com/getsentry/sentry-javascript/issues/2991))
-- [ember] fix: prevent unexpected errors on transition ([#2988](https://github.com/getsentry/sentry-javascript/issues/2988))
+- [hub] fix: Preserve original user data for explicitly updated scopes (#2991)
+- [ember] fix: prevent unexpected errors on transition (#2988)
 
 ## 5.27.0
 
-- [browser] feat: Sessions Health Tracking ([#2973](https://github.com/getsentry/sentry-javascript/issues/2973))
-- [core] fix: Correct `processing` flag in `BaseClient` ([#2983](https://github.com/getsentry/sentry-javascript/issues/2983))
-- [node] feat: use `req.cookies` if available instead of parsing ([#2985](https://github.com/getsentry/sentry-javascript/issues/2985))
-- [core] ref: Use SentryError for `prepareEvent` rejections ([#2973](https://github.com/getsentry/sentry-javascript/issues/2973))
-- [core] ref: Errors handling in `prepareEvent` pipeline ([#2987](https://github.com/getsentry/sentry-javascript/issues/2987))
-- [serverless] feat: Implement tracing of Google Cloud Requests ([#2981](https://github.com/getsentry/sentry-javascript/issues/2981))
-- [serverless] ref: Set global event processor and pass scope data for transactions ([#2975](https://github.com/getsentry/sentry-javascript/issues/2975))
-- [tracing] feat: Add secure connect navigation timing ([#2980](https://github.com/getsentry/sentry-javascript/issues/2980))
-- [tracing] feat: Capture time spent redirecting before loading the current page ([#2986](https://github.com/getsentry/sentry-javascript/issues/2986))
-- [tracing] feat: Capture browser navigator information ([#2966](https://github.com/getsentry/sentry-javascript/issues/2966))
-- [tracing] feat: Express router methods tracing ([#2972](https://github.com/getsentry/sentry-javascript/issues/2972))
-- [tracing] ref: Only report FCP or FP if the page wasn't hidden prior to their instrumentation ([#2979](https://github.com/getsentry/sentry-javascript/issues/2979))
+- [browser] feat: Sessions Health Tracking (#2973)
+- [core] fix: Correct `processing` flag in `BaseClient` (#2983)
+- [node] feat: use `req.cookies` if available instead of parsing (#2985)
+- [core] ref: Use SentryError for `prepareEvent` rejections (#2973)
+- [core] ref: Errors handling in `prepareEvent` pipeline (#2987)
+- [serverless] feat: Implement tracing of Google Cloud Requests (#2981)
+- [serverless] ref: Set global event processor and pass scope data for transactions (#2975)
+- [tracing] feat: Add secure connect navigation timing (#2980)
+- [tracing] feat: Capture time spent redirecting before loading the current page (#2986)
+- [tracing] feat: Capture browser navigator information (#2966)
+- [tracing] feat: Express router methods tracing (#2972)
+- [tracing] ref: Only report FCP or FP if the page wasn't hidden prior to their instrumentation (#2979)
 
 ## 5.26.0
 
-- [serverless] feat: Implement error handling and tracing for `Google Cloud Functions` ([#2945](https://github.com/getsentry/sentry-javascript/issues/2945))
-- [serverless] feat: Enable tracing for `AWSLambda` ([#2945](https://github.com/getsentry/sentry-javascript/issues/2945))
-- [serverless] feat: Add `AWSResources` integration ([#2945](https://github.com/getsentry/sentry-javascript/issues/2945))
-- [browser] feat: Implement `X-Sentry-Rate-Limits` handling for transports ([#2962](https://github.com/getsentry/sentry-javascript/issues/2962))
-- [tracing] feat: Add measurements support and web vitals ([#2909](https://github.com/getsentry/sentry-javascript/issues/2909))
-- [tracing] feat: Add web vitals: CLS and TTFB ([#2964](https://github.com/getsentry/sentry-javascript/issues/2964))
-- [angular] ref: Make `@angular/common` a peerDependency instead of dependency ([#2961](https://github.com/getsentry/sentry-javascript/issues/2961))
-- [ember] feat: Add more render instrumentation ([#2902](https://github.com/getsentry/sentry-javascript/issues/2902))
-- [ember] ref: Use `@embroider/macros` instead of `runInDebug` ([#2873](https://github.com/getsentry/sentry-javascript/issues/2873))
-- [hub] ref: Do not allow for popping last layer and unify getter methods ([#2955](https://github.com/getsentry/sentry-javascript/issues/2955))
+- [serverless] feat: Implement error handling and tracing for `Google Cloud Functions` (#2945)
+- [serverless] feat: Enable tracing for `AWSLambda` (#2945)
+- [serverless] feat: Add `AWSResources` integration (#2945)
+- [browser] feat: Implement `X-Sentry-Rate-Limits` handling for transports (#2962)
+- [tracing] feat: Add measurements support and web vitals (#2909)
+- [tracing] feat: Add web vitals: CLS and TTFB (#2964)
+- [angular] ref: Make `@angular/common` a peerDependency instead of dependency (#2961)
+- [ember] feat: Add more render instrumentation (#2902)
+- [ember] ref: Use `@embroider/macros` instead of `runInDebug` (#2873)
+- [hub] ref: Do not allow for popping last layer and unify getter methods (#2955)
 
 ## 5.25.0
 
-- [tracing] fix: Expose `startTransaction` in CDN bundle ([#2938](https://github.com/getsentry/sentry-javascript/issues/2938))
-- [tracing] fix: Allow unsampled transactions to be findable by `getTransaction()` ([#2952](https://github.com/getsentry/sentry-javascript/issues/2952))
-- [tracing] fix: Reimplement timestamp computation ([#2947](https://github.com/getsentry/sentry-javascript/issues/2947))
-- [tracing] ref: Clean up sampling decision inheritance ([#2921](https://github.com/getsentry/sentry-javascript/issues/2921)) ([#2944](https://github.com/getsentry/sentry-javascript/issues/2944))
-- [react] fix: Makes `normalizeTransactionName` take a callback function in router-v3 ([#2946](https://github.com/getsentry/sentry-javascript/issues/2946))
-- [ember] feat: Add more render instrumentation to @sentry/ember ([#2902](https://github.com/getsentry/sentry-javascript/issues/2902))
-- [types] ref: Use correct types for `event.context` and allow for context removal ([#2910](https://github.com/getsentry/sentry-javascript/issues/2910))
-- [types] ref: Make name required on transaction class ([#2949](https://github.com/getsentry/sentry-javascript/issues/2949))
-- [build] feat: Update to use extends w. Volta ([#2930](https://github.com/getsentry/sentry-javascript/issues/2930))
+- [tracing] fix: Expose `startTransaction` in CDN bundle (#2938)
+- [tracing] fix: Allow unsampled transactions to be findable by `getTransaction()` (#2952)
+- [tracing] fix: Reimplement timestamp computation (#2947)
+- [tracing] ref: Clean up sampling decision inheritance (#2921) (#2944)
+- [react] fix: Makes `normalizeTransactionName` take a callback function in router-v3 (#2946)
+- [ember] feat: Add more render instrumentation to @sentry/ember (#2902)
+- [types] ref: Use correct types for `event.context` and allow for context removal (#2910)
+- [types] ref: Make name required on transaction class (#2949)
+- [build] feat: Update to use extends w. Volta (#2930)
 
 ## 5.24.2
 
-- [utils] fix: Check that performance is available before calling it in RN ([#2924](https://github.com/getsentry/sentry-javascript/issues/2924))
+- [utils] fix: Check that performance is available before calling it in RN (#2924)
 
 ## 5.24.1
 
-- [types] fix: Remove Location type to avoid dom lib dependency ([#2922](https://github.com/getsentry/sentry-javascript/issues/2922))
+- [types] fix: Remove Location type to avoid dom lib dependency (#2922)
 
 ## 5.24.0
 
-- [angular] fix: Make sure that message exist before returning it in angular error handler ([#2903](https://github.com/getsentry/sentry-javascript/issues/2903))
-- [integrations] feat: Add referrer to data collected by UserAgent integration ([#2912](https://github.com/getsentry/sentry-javascript/issues/2912))
-- [core] fix: Make sure that body is not exposed in the breadcrumb by default ([#2911](https://github.com/getsentry/sentry-javascript/issues/2911))
-- [core] feat: Give access to XHR requests body in breadcrumb hint ([#2904](https://github.com/getsentry/sentry-javascript/issues/2904))
-- [core] fix: Add a wrapper around performance for React Native ([#2915](https://github.com/getsentry/sentry-javascript/issues/2915))
-- [integrations] fix: Make Vue tracing options optional ([#2897](https://github.com/getsentry/sentry-javascript/issues/2897))
-- [integrations] ref: Remove unnecessary eventID check in offline integration ([#2890](https://github.com/getsentry/sentry-javascript/issues/2890))
-- [tracing] feat: Add hook for trace sampling function to SDK options ([#2820](https://github.com/getsentry/sentry-javascript/issues/2820))
+- [angular] fix: Make sure that message exist before returning it in angular error handler (#2903)
+- [integrations] feat: Add referrer to data collected by UserAgent integration (#2912)
+- [core] fix: Make sure that body is not exposed in the breadcrumb by default (#2911)
+- [core] feat: Give access to XHR requests body in breadcrumb hint (#2904)
+- [core] fix: Add a wrapper around performance for React Native (#2915)
+- [integrations] fix: Make Vue tracing options optional (#2897)
+- [integrations] ref: Remove unnecessary eventID check in offline integration (#2890)
+- [tracing] feat: Add hook for trace sampling function to SDK options (#2820)
 
 ## 5.23.0
 
-- [serverless] feat: Introduce `@sentry/serverless` with `AWSLambda` support ([#2886](https://github.com/getsentry/sentry-javascript/issues/2886))
-- [ember] feat: Add performance instrumentation for routes ([#2784](https://github.com/getsentry/sentry-javascript/issues/2784))
-- [node] ref: Remove query strings from transaction and span names ([#2857](https://github.com/getsentry/sentry-javascript/issues/2857))
-- [angular] ref: Strip query and fragment from Angular tracing URLs ([#2874](https://github.com/getsentry/sentry-javascript/issues/2874))
-- [tracing] ref: Simplify `shouldCreateSpanForRequest` ([#2867](https://github.com/getsentry/sentry-javascript/issues/2867))
+- [serverless] feat: Introduce `@sentry/serverless` with `AWSLambda` support (#2886)
+- [ember] feat: Add performance instrumentation for routes (#2784)
+- [node] ref: Remove query strings from transaction and span names (#2857)
+- [angular] ref: Strip query and fragment from Angular tracing URLs (#2874)
+- [tracing] ref: Simplify `shouldCreateSpanForRequest` (#2867)
 
 ## 5.22.3
 
-- [integrations] fix: Window type ([#2864](https://github.com/getsentry/sentry-javascript/issues/2864))
+- [integrations] fix: Window type (#2864)
 
 ## 5.22.2
 
-- [integrations] fix: localforage typing ([#2861](https://github.com/getsentry/sentry-javascript/issues/2861))
+- [integrations] fix: localforage typing (#2861)
 
 ## 5.22.1
 
-- [integrations] fix: Add localforage typing ([#2856](https://github.com/getsentry/sentry-javascript/issues/2856))
-- [tracing] fix: Make sure BrowserTracing is exported in CDN correctly ([#2855](https://github.com/getsentry/sentry-javascript/issues/2855))
+- [integrations] fix: Add localforage typing (#2856)
+- [tracing] fix: Make sure BrowserTracing is exported in CDN correctly (#2855)
 
 ## 5.22.0
 
-- [browser] ref: Recognize `Capacitor` scheme as `Gecko` ([#2836](https://github.com/getsentry/sentry-javascript/issues/2836))
-- [node]: fix: Save `string` exception as a message for `syntheticException` ([#2837](https://github.com/getsentry/sentry-javascript/issues/2837))
-- [tracing] feat: Add `build` dir in npm package ([#2846](https://github.com/getsentry/sentry-javascript/issues/2846))
-- [tracing] fix: Fix typo in `addPerformanceEntries` method name ([#2847](https://github.com/getsentry/sentry-javascript/issues/2847))
-- [apm] ref: Deprecate `@sentry/apm` package ([#2844](https://github.com/getsentry/sentry-javascript/issues/2844))
-- [angular] fix: Allow for empty DSN/disabling with `AngularJS` integration ([#2842](https://github.com/getsentry/sentry-javascript/issues/2842))
-- [gatsby] ref: Make `@sentry/tracing` mandatory + add tests ([#2841](https://github.com/getsentry/sentry-javascript/issues/2841))
-- [integrations] feat: Add integration for offline support ([#2778](https://github.com/getsentry/sentry-javascript/issues/2778))
-- [utils] ref: Revert the usage of `globalThis` for `getGlobalObject` util ([#2851](https://github.com/getsentry/sentry-javascript/issues/2851))
-- [build] fix: Lock in `TypeScript` to `3.7.5` ([#2848](https://github.com/getsentry/sentry-javascript/issues/2848))
-- [build] misc: Upgrade `Prettier` to `1.19.0` ([#2850](https://github.com/getsentry/sentry-javascript/issues/2850))
+- [browser] ref: Recognize `Capacitor` scheme as `Gecko` (#2836)
+- [node]: fix: Save `string` exception as a message for `syntheticException` (#2837)
+- [tracing] feat: Add `build` dir in npm package (#2846)
+- [tracing] fix: Fix typo in `addPerformanceEntries` method name (#2847)
+- [apm] ref: Deprecate `@sentry/apm` package (#2844)
+- [angular] fix: Allow for empty DSN/disabling with `AngularJS` integration (#2842)
+- [gatsby] ref: Make `@sentry/tracing` mandatory + add tests (#2841)
+- [integrations] feat: Add integration for offline support (#2778)
+- [utils] ref: Revert the usage of `globalThis` for `getGlobalObject` util (#2851)
+- [build] fix: Lock in `TypeScript` to `3.7.5` (#2848)
+- [build] misc: Upgrade `Prettier` to `1.19.0` (#2850)
 
 ## 5.21.4
 
@@ -767,119 +767,119 @@ during SDK initialization.
 
 ## 5.21.3
 
-- [tracing] feat: Track span status for fetch requests ([#2835](https://github.com/getsentry/sentry-javascript/issues/2835))
-- [react] fix: Return an any from createReduxEnhancer to avoid type conflicts ([#2834](https://github.com/getsentry/sentry-javascript/issues/2834))
-- [react] fix: Make sure profiler is typed with any ([#2838](https://github.com/getsentry/sentry-javascript/issues/2838))
+- [tracing] feat: Track span status for fetch requests (#2835)
+- [react] fix: Return an any from createReduxEnhancer to avoid type conflicts (#2834)
+- [react] fix: Make sure profiler is typed with any (#2838)
 
 ## 5.21.2
 
-- [tracing] fix: Normalize transaction names for express methods to match those of other SDKs ([#2832](https://github.com/getsentry/sentry-javascript/issues/2832))
-- [tracing] feat: Change resource span op name and add data ([#2816](https://github.com/getsentry/sentry-javascript/issues/2816))
-- [tracing] ref: Make sure error status is set on transactions ([#2818](https://github.com/getsentry/sentry-javascript/issues/2818))
-- [apm/tracing] fix: Make sure Performance Observer takeRecords() is defined ([#2825](https://github.com/getsentry/sentry-javascript/issues/2825))
+- [tracing] fix: Normalize transaction names for express methods to match those of other SDKs (#2832)
+- [tracing] feat: Change resource span op name and add data (#2816)
+- [tracing] ref: Make sure error status is set on transactions (#2818)
+- [apm/tracing] fix: Make sure Performance Observer takeRecords() is defined (#2825)
 
 ## 5.21.1
 
-- [ember] fix: Make the package public and fix the build by bumping TypeScript to v3.9 ([#2811](https://github.com/getsentry/sentry-javascript/issues/2811))
+- [ember] fix: Make the package public and fix the build by bumping TypeScript to v3.9 (#2811)
 - [eslint] test: Don't test eslint config/plugin on Node <= v8
 
 ## 5.21.0
 
-- [all] feat: Convert `sentry-javascript` to `ESLint` ([#2786](https://github.com/getsentry/sentry-javascript/issues/2786))
-- [internal/eslint] feat: Add `@sentry-internal/eslint-config-sdk` ([#2807](https://github.com/getsentry/sentry-javascript/issues/2807))
-- [ember] feat: Add `@sentry/ember` ([#2739](https://github.com/getsentry/sentry-javascript/issues/2739))
-- [angular] feat: Add `@sentry/angular` ([#2787](https://github.com/getsentry/sentry-javascript/issues/2787))
-- [react] feat: Add routing instrumentation for `React Router v4/v5` ([#2780](https://github.com/getsentry/sentry-javascript/issues/2780))
-- [gatsby] feat: support `process.env.SENTRY_RELEASE` ([#2776](https://github.com/getsentry/sentry-javascript/issues/2776))
-- [apm/tracing] feat: Export `addExtensionMethods` for SDKs to use ([#2805](https://github.com/getsentry/sentry-javascript/issues/2805))
-- [apm/tracing] ref: Remove `express` typing ([#2803](https://github.com/getsentry/sentry-javascript/issues/2803))
-- [node] fix: `Retry-After` header in node should be lower-case ([#2779](https://github.com/getsentry/sentry-javascript/issues/2779))
+- [all] feat: Convert `sentry-javascript` to `ESLint` (#2786)
+- [internal/eslint] feat: Add `@sentry-internal/eslint-config-sdk` (#2807)
+- [ember] feat: Add `@sentry/ember` (#2739)
+- [angular] feat: Add `@sentry/angular` (#2787)
+- [react] feat: Add routing instrumentation for `React Router v4/v5` (#2780)
+- [gatsby] feat: support `process.env.SENTRY_RELEASE` (#2776)
+- [apm/tracing] feat: Export `addExtensionMethods` for SDKs to use (#2805)
+- [apm/tracing] ref: Remove `express` typing (#2803)
+- [node] fix: `Retry-After` header in node should be lower-case (#2779)
 
 ## 5.20.1
 
-- [core] ref: Expose sentry request for electron ([#2774](https://github.com/getsentry/sentry-javascript/issues/2774))
-- [browser] fix: Make sure that DSN is always passed to report dialog ([#2770](https://github.com/getsentry/sentry-javascript/issues/2770))
-- [apm/tracing] fix: Make sure fetch requests are being timed correctly ([#2772](https://github.com/getsentry/sentry-javascript/issues/2772))
-- [apm/tracing] fix: Make sure pageload transactions start timestamps are correctly generated ([#2773](https://github.com/getsentry/sentry-javascript/issues/2773))
-- [react] feat: Add instrumentation for React Router v3 ([#2759](https://github.com/getsentry/sentry-javascript/issues/2759))
-- [react] ref: Use inline types to avoid redux dependency. ([#2768](https://github.com/getsentry/sentry-javascript/issues/2768))
-- [node] fix: Set transaction on scope in node for request ([#2769](https://github.com/getsentry/sentry-javascript/issues/2769))
+- [core] ref: Expose sentry request for electron (#2774)
+- [browser] fix: Make sure that DSN is always passed to report dialog (#2770)
+- [apm/tracing] fix: Make sure fetch requests are being timed correctly (#2772)
+- [apm/tracing] fix: Make sure pageload transactions start timestamps are correctly generated (#2773)
+- [react] feat: Add instrumentation for React Router v3 (#2759)
+- [react] ref: Use inline types to avoid redux dependency. (#2768)
+- [node] fix: Set transaction on scope in node for request (#2769)
 
 ## 5.20.0
 
-- [browser] feat: Make `@sentry/browser` more treeshakeable ([#2747](https://github.com/getsentry/sentry-javascript/issues/2747))
-- [browser] fix: Make sure that handler exists in `LinkedErrors` integration ([#2742](https://github.com/getsentry/sentry-javascript/issues/2742))
-- [tracing] feat: Introduce `@sentry/tracing` ([#2719](https://github.com/getsentry/sentry-javascript/issues/2719))
-- [tracing] ref: Use `idleTimout` if no activities occur in idle transaction ([#2752](https://github.com/getsentry/sentry-javascript/issues/2752))
-- [react] feat: Export `createReduxEnhancer` to log redux actions as breadcrumbs, and attach state as an extra. ([#2717](https://github.com/getsentry/sentry-javascript/issues/2717))
-- [react] feat: Add `beforeCapture` option to ErrorBoundary ([#2753](https://github.com/getsentry/sentry-javascript/issues/2753))
-- [react] fix: Change import of `hoist-non-react-statics` ([#2755](https://github.com/getsentry/sentry-javascript/issues/2755))
-- [gatsby] fix: Make `@sentry/apm` optional in `@sentry/gatsby` package ([#2752](https://github.com/getsentry/sentry-javascript/issues/2752))
+- [browser] feat: Make `@sentry/browser` more treeshakeable (#2747)
+- [browser] fix: Make sure that handler exists in `LinkedErrors` integration (#2742)
+- [tracing] feat: Introduce `@sentry/tracing` (#2719)
+- [tracing] ref: Use `idleTimout` if no activities occur in idle transaction (#2752)
+- [react] feat: Export `createReduxEnhancer` to log redux actions as breadcrumbs, and attach state as an extra. (#2717)
+- [react] feat: Add `beforeCapture` option to ErrorBoundary (#2753)
+- [react] fix: Change import of `hoist-non-react-statics` (#2755)
+- [gatsby] fix: Make `@sentry/apm` optional in `@sentry/gatsby` package (#2752)
 
 ## 5.19.2
 
-- [gatsby] fix: Include correct gatsby files in npm tarball ([#2731](https://github.com/getsentry/sentry-javascript/issues/2731))
-- [browser] fix: Correctly detach event listeners ([#2737](https://github.com/getsentry/sentry-javascript/issues/2737))
-- [browser] fix: Drop initial frame for production react errors ([#2728](https://github.com/getsentry/sentry-javascript/issues/2728))
-- [node] chore: Upgrade https-proxy-agent to v5 ([#2702](https://github.com/getsentry/sentry-javascript/issues/2702))
-- [types] ref: Define type for Extra(s) ([#2727](https://github.com/getsentry/sentry-javascript/issues/2727))
+- [gatsby] fix: Include correct gatsby files in npm tarball (#2731)
+- [browser] fix: Correctly detach event listeners (#2737)
+- [browser] fix: Drop initial frame for production react errors (#2728)
+- [node] chore: Upgrade https-proxy-agent to v5 (#2702)
+- [types] ref: Define type for Extra(s) (#2727)
 
 ## 5.19.1
 
-- [browser] fix: Correctly remove all event listeners ([#2725](https://github.com/getsentry/sentry-javascript/issues/2725))
-- [tracing] fix: APM CDN bundle expose startTransaction ([#2726](https://github.com/getsentry/sentry-javascript/issues/2726))
-- [tracing] fix: Add manual `DOMStringList` typing ([#2718](https://github.com/getsentry/sentry-javascript/issues/2718))
+- [browser] fix: Correctly remove all event listeners (#2725)
+- [tracing] fix: APM CDN bundle expose startTransaction (#2726)
+- [tracing] fix: Add manual `DOMStringList` typing (#2718)
 
 ## 5.19.0
 
-- [react] feat: Expose eventId on ErrorBoundary component ([#2704](https://github.com/getsentry/sentry-javascript/issues/2704))
-- [node] fix: Extract transaction from nested express paths correctly ([#2714](https://github.com/getsentry/sentry-javascript/issues/2714))
-- [tracing] feat: Pick up sentry-trace in JS `<meta/>` tag ([#2703](https://github.com/getsentry/sentry-javascript/issues/2703))
-- [tracing] fix: Respect fetch headers ([#2712](https://github.com/getsentry/sentry-javascript/issues/2712)) ([#2713](https://github.com/getsentry/sentry-javascript/issues/2713))
-- [tracing] fix: Check if performance.getEntries() exists ([#2710](https://github.com/getsentry/sentry-javascript/issues/2710))
-- [tracing] fix: Add manual Location typing ([#2700](https://github.com/getsentry/sentry-javascript/issues/2700))
-- [tracing] fix: Respect sample decision when continuing trace from header in node ([#2703](https://github.com/getsentry/sentry-javascript/issues/2703))
-- [tracing] fix: All options of adding fetch headers ([#2712](https://github.com/getsentry/sentry-javascript/issues/2712))
-- [gatsby] fix: Add gatsby SDK identifier ([#2709](https://github.com/getsentry/sentry-javascript/issues/2709))
-- [gatsby] fix: Package gatsby files properly ([#2711](https://github.com/getsentry/sentry-javascript/issues/2711))
+- [react] feat: Expose eventId on ErrorBoundary component (#2704)
+- [node] fix: Extract transaction from nested express paths correctly (#2714)
+- [tracing] feat: Pick up sentry-trace in JS `<meta/>` tag (#2703)
+- [tracing] fix: Respect fetch headers (#2712) (#2713)
+- [tracing] fix: Check if performance.getEntries() exists (#2710)
+- [tracing] fix: Add manual Location typing (#2700)
+- [tracing] fix: Respect sample decision when continuing trace from header in node (#2703)
+- [tracing] fix: All options of adding fetch headers (#2712)
+- [gatsby] fix: Add gatsby SDK identifier (#2709)
+- [gatsby] fix: Package gatsby files properly (#2711)
 
 ## 5.18.1
 
-- [react] feat: Update peer dependencies for `react` and `react-dom` ([#2694](https://github.com/getsentry/sentry-javascript/issues/2694))
-- [react] ref: Change Profiler prop names ([#2699](https://github.com/getsentry/sentry-javascript/issues/2699))
+- [react] feat: Update peer dependencies for `react` and `react-dom` (#2694)
+- [react] ref: Change Profiler prop names (#2699)
 
 ## 5.18.0
 
-- [core] ref: Rename `whitelistUrls/blacklistUrls` to `allowUrls/denyUrls` ([#2671](https://github.com/getsentry/sentry-javascript/issues/2671))
-- [core] feat: Export `makeMain` ([#2665](https://github.com/getsentry/sentry-javascript/issues/2665))
-- [core] fix: Call `bindClient` when creating new `Hub` to make integrations work automatically ([#2665](https://github.com/getsentry/sentry-javascript/issues/2665))
-- [react] feat: Add @sentry/react package ([#2631](https://github.com/getsentry/sentry-javascript/issues/2631))
-- [react] feat: Add Error Boundary component ([#2647](https://github.com/getsentry/sentry-javascript/issues/2647))
-- [react] feat: Add useProfiler hook ([#2659](https://github.com/getsentry/sentry-javascript/issues/2659))
-- [react] ref: Refactor Profiler to account for update and render ([#2677](https://github.com/getsentry/sentry-javascript/issues/2677))
-- [gatsby] feat: Add @sentry/gatsby package ([#2652](https://github.com/getsentry/sentry-javascript/issues/2652))
-- [apm] feat: Add ability to get span from activity using `getActivitySpan` ([#2677](https://github.com/getsentry/sentry-javascript/issues/2677))
-- [apm] fix: Check if `performance.mark` exists before calling it ([#2680](https://github.com/getsentry/sentry-javascript/issues/2680))
-- [tracing] feat: Add `scope.getTransaction` to return a Transaction if it exists ([#2668](https://github.com/getsentry/sentry-javascript/issues/2668))
-- [tracing] ref: Deprecate `scope.setTransaction` in favor of `scope.setTransactionName` ([#2668](https://github.com/getsentry/sentry-javascript/issues/2668))
-- [tracing] feat: Add `beforeNavigate` option ([#2691](https://github.com/getsentry/sentry-javascript/issues/2691))
+- [core] ref: Rename `whitelistUrls/blacklistUrls` to `allowUrls/denyUrls` (#2671)
+- [core] feat: Export `makeMain` (#2665)
+- [core] fix: Call `bindClient` when creating new `Hub` to make integrations work automatically (#2665)
+- [react] feat: Add @sentry/react package (#2631)
+- [react] feat: Add Error Boundary component (#2647)
+- [react] feat: Add useProfiler hook (#2659)
+- [react] ref: Refactor Profiler to account for update and render (#2677)
+- [gatsby] feat: Add @sentry/gatsby package (#2652)
+- [apm] feat: Add ability to get span from activity using `getActivitySpan` (#2677)
+- [apm] fix: Check if `performance.mark` exists before calling it (#2680)
+- [tracing] feat: Add `scope.getTransaction` to return a Transaction if it exists (#2668)
+- [tracing] ref: Deprecate `scope.setTransaction` in favor of `scope.setTransactionName` (#2668)
+- [tracing] feat: Add `beforeNavigate` option (#2691)
 - [tracing] ref: Create navigation transactions using `window.location.pathname` instead of `window.location.href`
-  ([#2691](https://github.com/getsentry/sentry-javascript/issues/2691))
+  (#2691)
 
 ## 5.17.0
 
-- [browser] feat: Support `fetchParameters` ([#2567](https://github.com/getsentry/sentry-javascript/issues/2567))
-- [apm] feat: Report LCP metric on pageload transactions ([#2624](https://github.com/getsentry/sentry-javascript/issues/2624))
-- [core] fix: Normalize Transaction and Span consistently ([#2655](https://github.com/getsentry/sentry-javascript/issues/2655))
-- [core] fix: Handle DSN qs and show better error messages ([#2639](https://github.com/getsentry/sentry-javascript/issues/2639))
-- [browser] fix: Change XHR instrumentation order to handle `onreadystatechange` breadcrumbs correctly ([#2643](https://github.com/getsentry/sentry-javascript/issues/2643))
-- [apm] fix: Re-add TraceContext for all events ([#2656](https://github.com/getsentry/sentry-javascript/issues/2656))
-- [integrations] fix: Change Vue interface to be inline with the original types ([#2634](https://github.com/getsentry/sentry-javascript/issues/2634))
-- [apm] ref: Use startTransaction where appropriate ([#2644](https://github.com/getsentry/sentry-javascript/issues/2644))
+- [browser] feat: Support `fetchParameters` (#2567)
+- [apm] feat: Report LCP metric on pageload transactions (#2624)
+- [core] fix: Normalize Transaction and Span consistently (#2655)
+- [core] fix: Handle DSN qs and show better error messages (#2639)
+- [browser] fix: Change XHR instrumentation order to handle `onreadystatechange` breadcrumbs correctly (#2643)
+- [apm] fix: Re-add TraceContext for all events (#2656)
+- [integrations] fix: Change Vue interface to be inline with the original types (#2634)
+- [apm] ref: Use startTransaction where appropriate (#2644)
 
 ## 5.16.1
 
-- [node] fix: Requests to old `/store` endpoint need the `x-sentry-auth` header in node ([#2637](https://github.com/getsentry/sentry-javascript/issues/2637))
+- [node] fix: Requests to old `/store` endpoint need the `x-sentry-auth` header in node (#2637)
 
 ## 5.16.0
 
@@ -888,75 +888,75 @@ to the API. The recommended entry point for manual instrumentation now is `Sentr
 Span by calling `startChild` on it. We have internal workarounds in place so the old code should still work but will be
 removed in the future. If you are only using the `Tracing` integration there is no need for action._
 
-- [core] feat: Send transactions in envelopes ([#2553](https://github.com/getsentry/sentry-javascript/issues/2553))
-- [core] fix: Send event timestamp ([#2575](https://github.com/getsentry/sentry-javascript/issues/2575))
-- [browser] feat: Allow for configuring TryCatch integration ([#2601](https://github.com/getsentry/sentry-javascript/issues/2601))
-- [browser] fix: Call wrapped `RequestAnimationFrame` with correct context ([#2570](https://github.com/getsentry/sentry-javascript/issues/2570))
-- [node] fix: Prevent reading the same source file multiple times ([#2569](https://github.com/getsentry/sentry-javascript/issues/2569))
-- [integrations] feat: Vue performance monitoring ([#2571](https://github.com/getsentry/sentry-javascript/issues/2571))
-- [apm] fix: Use proper type name for op ([#2584](https://github.com/getsentry/sentry-javascript/issues/2584))
-- [core] fix: sent_at for envelope headers to use same clock ([#2597](https://github.com/getsentry/sentry-javascript/issues/2597))
-- [apm] fix: Improve bundle size by moving span status to @sentry/apm ([#2589](https://github.com/getsentry/sentry-javascript/issues/2589))
-- [apm] feat: No longer discard transactions instead mark them deadline exceeded ([#2588](https://github.com/getsentry/sentry-javascript/issues/2588))
-- [apm] feat: Introduce `Sentry.startTransaction` and `Transaction.startChild` ([#2600](https://github.com/getsentry/sentry-javascript/issues/2600))
-- [apm] feat: Transactions no longer go through `beforeSend` ([#2600](https://github.com/getsentry/sentry-javascript/issues/2600))
-- [browser] fix: Emit Sentry Request breadcrumbs from inside the client ([#2615](https://github.com/getsentry/sentry-javascript/issues/2615))
-- [apm] fix: No longer debounce IdleTransaction ([#2618](https://github.com/getsentry/sentry-javascript/issues/2618))
-- [apm] feat: Add pageload transaction option + fixes ([#2623](https://github.com/getsentry/sentry-javascript/issues/2623))
-- [minimal/core] feat: Allow for explicit scope through 2nd argument to `captureException/captureMessage` ([#2627](https://github.com/getsentry/sentry-javascript/issues/2627))
+- [core] feat: Send transactions in envelopes (#2553)
+- [core] fix: Send event timestamp (#2575)
+- [browser] feat: Allow for configuring TryCatch integration (#2601)
+- [browser] fix: Call wrapped `RequestAnimationFrame` with correct context (#2570)
+- [node] fix: Prevent reading the same source file multiple times (#2569)
+- [integrations] feat: Vue performance monitoring (#2571)
+- [apm] fix: Use proper type name for op (#2584)
+- [core] fix: sent_at for envelope headers to use same clock (#2597)
+- [apm] fix: Improve bundle size by moving span status to @sentry/apm (#2589)
+- [apm] feat: No longer discard transactions instead mark them deadline exceeded (#2588)
+- [apm] feat: Introduce `Sentry.startTransaction` and `Transaction.startChild` (#2600)
+- [apm] feat: Transactions no longer go through `beforeSend` (#2600)
+- [browser] fix: Emit Sentry Request breadcrumbs from inside the client (#2615)
+- [apm] fix: No longer debounce IdleTransaction (#2618)
+- [apm] feat: Add pageload transaction option + fixes (#2623)
+- [minimal/core] feat: Allow for explicit scope through 2nd argument to `captureException/captureMessage` (#2627)
 
 ## 5.15.5
 
-- [browser/node] Add missing `BreadcrumbHint` and `EventHint` types exports ([#2545](https://github.com/getsentry/sentry-javascript/issues/2545))
-- [utils] fix: Prevent `isMatchingPattern` from failing on invalid input ([#2543](https://github.com/getsentry/sentry-javascript/issues/2543))
+- [browser/node] Add missing `BreadcrumbHint` and `EventHint` types exports (#2545)
+- [utils] fix: Prevent `isMatchingPattern` from failing on invalid input (#2543)
 
 ## 5.15.4
 
-- [node] fix: Path domain onto global extension method to not use require ([#2527](https://github.com/getsentry/sentry-javascript/issues/2527))
+- [node] fix: Path domain onto global extension method to not use require (#2527)
 
 ## 5.15.3
 
-- [hub] fix: Restore dynamicRequire, but for `perf_hooks` only ([#2524](https://github.com/getsentry/sentry-javascript/issues/2524))
+- [hub] fix: Restore dynamicRequire, but for `perf_hooks` only (#2524)
 
 ## 5.15.2
 
-- [hub] fix: Remove dynamicRequire, Fix require call ([#2521](https://github.com/getsentry/sentry-javascript/issues/2521))
+- [hub] fix: Remove dynamicRequire, Fix require call (#2521)
 
 ## 5.15.1
 
-- [browser] fix: Prevent crash for react native instrumenting fetch ([#2510](https://github.com/getsentry/sentry-javascript/issues/2510))
-- [node] fix: Remove the no longer required dynamicRequire hack to fix scope memory leak ([#2515](https://github.com/getsentry/sentry-javascript/issues/2515))
-- [node] fix: Guard against invalid req.user input ([#2512](https://github.com/getsentry/sentry-javascript/issues/2512))
-- [node] ref: Move node version to runtime context ([#2507](https://github.com/getsentry/sentry-javascript/issues/2507))
-- [utils] fix: Make sure that SyncPromise handler is called only once ([#2511](https://github.com/getsentry/sentry-javascript/issues/2511))
+- [browser] fix: Prevent crash for react native instrumenting fetch (#2510)
+- [node] fix: Remove the no longer required dynamicRequire hack to fix scope memory leak (#2515)
+- [node] fix: Guard against invalid req.user input (#2512)
+- [node] ref: Move node version to runtime context (#2507)
+- [utils] fix: Make sure that SyncPromise handler is called only once (#2511)
 
 ## 5.15.0
 
-- [apm] fix: Sampling of traces work now only depending on the client option `tracesSampleRate` ([#2500](https://github.com/getsentry/sentry-javascript/issues/2500))
-- [apm] fix: Remove internal `forceNoChild` parameter from `hub.startSpan` ([#2500](https://github.com/getsentry/sentry-javascript/issues/2500))
-- [apm] fix: Made constructor of `Span` internal, only use `hub.startSpan` ([#2500](https://github.com/getsentry/sentry-javascript/issues/2500))
-- [apm] ref: Remove status from tags in transaction ([#2497](https://github.com/getsentry/sentry-javascript/issues/2497))
-- [browser] fix: Respect breadcrumbs sentry:false option ([#2499](https://github.com/getsentry/sentry-javascript/issues/2499))
-- [node] ref: Skip body parsing for GET/HEAD requests ([#2504](https://github.com/getsentry/sentry-javascript/issues/2504))
+- [apm] fix: Sampling of traces work now only depending on the client option `tracesSampleRate` (#2500)
+- [apm] fix: Remove internal `forceNoChild` parameter from `hub.startSpan` (#2500)
+- [apm] fix: Made constructor of `Span` internal, only use `hub.startSpan` (#2500)
+- [apm] ref: Remove status from tags in transaction (#2497)
+- [browser] fix: Respect breadcrumbs sentry:false option (#2499)
+- [node] ref: Skip body parsing for GET/HEAD requests (#2504)
 
 ## 5.14.2
 
-- [apm] fix: Use Performance API for timings when available, including Web Workers ([#2492](https://github.com/getsentry/sentry-javascript/issues/2492))
-- [apm] fix: Remove Performance references ([#2495](https://github.com/getsentry/sentry-javascript/issues/2495))
-- [apm] fix: Set `op` in node http.server transaction ([#2496](https://github.com/getsentry/sentry-javascript/issues/2496))
+- [apm] fix: Use Performance API for timings when available, including Web Workers (#2492)
+- [apm] fix: Remove Performance references (#2495)
+- [apm] fix: Set `op` in node http.server transaction (#2496)
 
 ## 5.14.1
 
-- [apm] fix: Check for performance.timing in webworkers ([#2491](https://github.com/getsentry/sentry-javascript/issues/2491))
-- [apm] ref: Remove performance clear entry calls ([#2490](https://github.com/getsentry/sentry-javascript/issues/2490))
+- [apm] fix: Check for performance.timing in webworkers (#2491)
+- [apm] ref: Remove performance clear entry calls (#2490)
 
 ## 5.14.0
 
-- [apm] feat: Add a simple heartbeat check, if activities don't change in 3 beats, finish the transaction ([#2478](https://github.com/getsentry/sentry-javascript/issues/2478))
-- [apm] feat: Make use of the `performance` browser API to provide better instrumentation ([#2474](https://github.com/getsentry/sentry-javascript/issues/2474))
-- [browser] ref: Move global error handler + unhandled promise rejection to instrument ([#2475](https://github.com/getsentry/sentry-javascript/issues/2475))
-- [apm] ref: Always use monotonic clock for time calculations ([#2485](https://github.com/getsentry/sentry-javascript/issues/2485))
-- [apm] fix: Add trace context to all events ([#2486](https://github.com/getsentry/sentry-javascript/issues/2486))
+- [apm] feat: Add a simple heartbeat check, if activities don't change in 3 beats, finish the transaction (#2478)
+- [apm] feat: Make use of the `performance` browser API to provide better instrumentation (#2474)
+- [browser] ref: Move global error handler + unhandled promise rejection to instrument (#2475)
+- [apm] ref: Always use monotonic clock for time calculations (#2485)
+- [apm] fix: Add trace context to all events (#2486)
 
 ## 5.13.2
 
@@ -968,31 +968,31 @@ removed in the future. If you are only using the `Tracing` integration there is 
 
 ## 5.13.0
 
-- [apm] feat: Add `options.autoPopAfter` parameter to `pushActivity` to prevent never-ending spans ([#2459](https://github.com/getsentry/sentry-javascript/issues/2459))
-- [apm] fix: Use monotonic clock to compute durations ([#2441](https://github.com/getsentry/sentry-javascript/issues/2441))
-- [core] ref: Remove unused `sentry_timestamp` header ([#2458](https://github.com/getsentry/sentry-javascript/issues/2458))
-- [node] ref: Drop Node v6, add Node v12 to test matrix, move all scripts to Node v12 ([#2455](https://github.com/getsentry/sentry-javascript/issues/2455))
-- [utils] ref: Prevent instantiating unnecessary Date objects in `timestampWithMs` ([#2442](https://github.com/getsentry/sentry-javascript/issues/2442))
+- [apm] feat: Add `options.autoPopAfter` parameter to `pushActivity` to prevent never-ending spans (#2459)
+- [apm] fix: Use monotonic clock to compute durations (#2441)
+- [core] ref: Remove unused `sentry_timestamp` header (#2458)
+- [node] ref: Drop Node v6, add Node v12 to test matrix, move all scripts to Node v12 (#2455)
+- [utils] ref: Prevent instantiating unnecessary Date objects in `timestampWithMs` (#2442)
 - [browser] fix: Mark transactions as event.transaction in breadcrumbs correctly
 
 ## 5.12.5
 
-- [browser] ref: Mark transactions as event.transaction in breadcrumbs ([#2450](https://github.com/getsentry/sentry-javascript/issues/2450))
-- [node] fix: Dont overwrite servername in requestHandler ([#2449](https://github.com/getsentry/sentry-javascript/issues/2449))
-- [utils] ref: Move creation of iframe into try/catch in fetch support check ([#2447](https://github.com/getsentry/sentry-javascript/issues/2447))
+- [browser] ref: Mark transactions as event.transaction in breadcrumbs (#2450)
+- [node] fix: Dont overwrite servername in requestHandler (#2449)
+- [utils] ref: Move creation of iframe into try/catch in fetch support check (#2447)
 
 ## 5.12.4
 
-- [browser] ref: Rework XHR wrapping logic to make sure it always triggers ([#2438](https://github.com/getsentry/sentry-javascript/issues/2438))
-- [browser] fix: Handle PromiseRejectionEvent-like CustomEvents ([#2429](https://github.com/getsentry/sentry-javascript/issues/2429))
-- [core] ref: Notify user when event failed to deliver because of digestion pipeline issue ([#2416](https://github.com/getsentry/sentry-javascript/issues/2416))
-- [node] fix: Improve incorrect `ParseRequest` typing ([#2433](https://github.com/getsentry/sentry-javascript/issues/2433))
-- [apm] fix: Remove auto unknown_error transaction status ([#2440](https://github.com/getsentry/sentry-javascript/issues/2440))
-- [apm] fix: Properly remove undefined keys from apm payload ([#2414](https://github.com/getsentry/sentry-javascript/issues/2414))
+- [browser] ref: Rework XHR wrapping logic to make sure it always triggers (#2438)
+- [browser] fix: Handle PromiseRejectionEvent-like CustomEvents (#2429)
+- [core] ref: Notify user when event failed to deliver because of digestion pipeline issue (#2416)
+- [node] fix: Improve incorrect `ParseRequest` typing (#2433)
+- [apm] fix: Remove auto unknown_error transaction status (#2440)
+- [apm] fix: Properly remove undefined keys from apm payload (#2414)
 
 ## 5.12.3
 
-- [apm] fix: Remove undefined keys from trace.context ([#2413](https://github.com/getsentry/sentry-javascript/issues/2413))
+- [apm] fix: Remove undefined keys from trace.context (#2413)
 
 ## 5.12.2
 
@@ -1000,18 +1000,18 @@ removed in the future. If you are only using the `Tracing` integration there is 
 
 ## 5.12.1
 
-- [apm] ref: If `maxTransactionTimeout` = `0` there is no timeout ([#2410](https://github.com/getsentry/sentry-javascript/issues/2410))
-- [apm] fix: Make sure that the `maxTransactionTimeout` is always enforced on transaction events ([#2410](https://github.com/getsentry/sentry-javascript/issues/2410))
-- [browser] fix: Support for Hermes stacktraces ([#2406](https://github.com/getsentry/sentry-javascript/issues/2406))
+- [apm] ref: If `maxTransactionTimeout` = `0` there is no timeout (#2410)
+- [apm] fix: Make sure that the `maxTransactionTimeout` is always enforced on transaction events (#2410)
+- [browser] fix: Support for Hermes stacktraces (#2406)
 
 ## 5.12.0
 
-- [core] feat: Provide `normalizeDepth` option and sensible default for scope methods ([#2404](https://github.com/getsentry/sentry-javascript/issues/2404))
-- [browser] fix: Export `EventHint` type ([#2407](https://github.com/getsentry/sentry-javascript/issues/2407))
+- [core] feat: Provide `normalizeDepth` option and sensible default for scope methods (#2404)
+- [browser] fix: Export `EventHint` type (#2407)
 
 ## 5.11.2
 
-- [apm] fix: Add new option to `Tracing` `maxTransactionTimeout` determines the max length of a transaction ([#2399](https://github.com/getsentry/sentry-javascript/issues/2399))
+- [apm] fix: Add new option to `Tracing` `maxTransactionTimeout` determines the max length of a transaction (#2399)
 - [hub] ref: Always also set transaction name on the top span in the scope
 - [core] fix: Use `event_id` from hint given by top-level hub calls
 
@@ -1022,31 +1022,31 @@ removed in the future. If you are only using the `Tracing` integration there is 
 
 ## 5.11.0
 
-- [apm] fix: Always attach `contexts.trace` to finished transaction ([#2353](https://github.com/getsentry/sentry-javascript/issues/2353))
-- [integrations] fix: Make RewriteFrame integration process all exceptions ([#2362](https://github.com/getsentry/sentry-javascript/issues/2362))
-- [node] ref: Update agent-base to 5.0 to remove http/s patching ([#2355](https://github.com/getsentry/sentry-javascript/issues/2355))
-- [browser] feat: Set headers from options in XHR/fetch transport ([#2363](https://github.com/getsentry/sentry-javascript/issues/2363))
+- [apm] fix: Always attach `contexts.trace` to finished transaction (#2353)
+- [integrations] fix: Make RewriteFrame integration process all exceptions (#2362)
+- [node] ref: Update agent-base to 5.0 to remove http/s patching (#2355)
+- [browser] feat: Set headers from options in XHR/fetch transport (#2363)
 
 ## 5.10.2
 
-- [browser] fix: Always trigger default browser onerror handler ([#2348](https://github.com/getsentry/sentry-javascript/issues/2348))
-- [browser] fix: Restore correct `functionToString` behavior for updated `fill` method ([#2346](https://github.com/getsentry/sentry-javascript/issues/2346))
-- [integrations] ref: Allow for backslashes in unix paths ([#2319](https://github.com/getsentry/sentry-javascript/issues/2319))
-- [integrations] feat: Support Windows-style path in RewriteFrame iteratee ([#2319](https://github.com/getsentry/sentry-javascript/issues/2319))
+- [browser] fix: Always trigger default browser onerror handler (#2348)
+- [browser] fix: Restore correct `functionToString` behavior for updated `fill` method (#2346)
+- [integrations] ref: Allow for backslashes in unix paths (#2319)
+- [integrations] feat: Support Windows-style path in RewriteFrame iteratee (#2319)
 
 ## 5.10.1
 
-- [apm] fix: Sent correct span id with outgoing requests ([#2341](https://github.com/getsentry/sentry-javascript/issues/2341))
-- [utils] fix: Make `fill` and `wrap` work nicely together to prevent double-triggering instrumentations ([#2343](https://github.com/getsentry/sentry-javascript/issues/2343))
-- [node] ref: Require `https-proxy-agent` only when actually needed ([#2334](https://github.com/getsentry/sentry-javascript/issues/2334))
+- [apm] fix: Sent correct span id with outgoing requests (#2341)
+- [utils] fix: Make `fill` and `wrap` work nicely together to prevent double-triggering instrumentations (#2343)
+- [node] ref: Require `https-proxy-agent` only when actually needed (#2334)
 
 ## 5.10.0
 
-- [hub] feat: Update `span` implementation ([#2161](https://github.com/getsentry/sentry-javascript/issues/2161))
+- [hub] feat: Update `span` implementation (#2161)
 - [apm] feat: Add `@sentry/apm` package
-- [integrations] feat: Change `Tracing` integration ([#2161](https://github.com/getsentry/sentry-javascript/issues/2161))
+- [integrations] feat: Change `Tracing` integration (#2161)
 - [utils] feat: Introduce `instrument` util to allow for custom handlers
-- [utils] Optimize `supportsNativeFetch` with a fast path that avoids DOM I/O ([#2326](https://github.com/getsentry/sentry-javascript/issues/2326))
+- [utils] Optimize `supportsNativeFetch` with a fast path that avoids DOM I/O (#2326)
 - [utils] feat: Add `isInstanceOf` util for safety reasons
 
 ## 5.9.1
@@ -1061,16 +1061,16 @@ removed in the future. If you are only using the `Tracing` integration there is 
 
 ## 5.8.0
 
-- [browser/node] feat: 429 http code handling in node/browser transports ([#2300](https://github.com/getsentry/sentry-javascript/issues/2300))
-- [core] feat: Make sure that Debug integration is always setup as the last one ([#2285](https://github.com/getsentry/sentry-javascript/issues/2285))
-- [browser] fix: Gracefuly handle incorrect input from onerror ([#2302](https://github.com/getsentry/sentry-javascript/issues/2302))
-- [utils] fix: Safer normalizing for input with `domain` key ([#2305](https://github.com/getsentry/sentry-javascript/issues/2305))
-- [utils] ref: Remove dom references from utils for old TS and env interop ([#2303](https://github.com/getsentry/sentry-javascript/issues/2303))
+- [browser/node] feat: 429 http code handling in node/browser transports (#2300)
+- [core] feat: Make sure that Debug integration is always setup as the last one (#2285)
+- [browser] fix: Gracefuly handle incorrect input from onerror (#2302)
+- [utils] fix: Safer normalizing for input with `domain` key (#2305)
+- [utils] ref: Remove dom references from utils for old TS and env interop (#2303)
 
 ## 5.7.1
 
-- [core] ref: Use the smallest possible interface for our needs - `PromiseLike` ([#2273](https://github.com/getsentry/sentry-javascript/issues/2273))
-- [utils] fix: Add TS dom reference to make sure its in place for compilation ([#2274](https://github.com/getsentry/sentry-javascript/issues/2274))
+- [core] ref: Use the smallest possible interface for our needs - `PromiseLike` (#2273)
+- [utils] fix: Add TS dom reference to make sure its in place for compilation (#2274)
 
 ## 5.7.0
 
@@ -1085,53 +1085,53 @@ removed in the future. If you are only using the `Tracing` integration there is 
 - [browser] ref: Improve usage of types in `addEventListener` breadcrumbs wrapper
 - [browser] ci: Use Galaxy S9 Plus for Android 9
 - [browser] ci: Increase timeouts and retries between Travis and BrowserStack
-- [node] fix: Update https-proxy-agent to 3.0.0 for security reasons ([#2262](https://github.com/getsentry/sentry-javascript/issues/2262))
-- [node] feat: Extract prototyped data in `extractUserData` ([#2247](https://github.com/getsentry/sentry-javascript/issues/2247))
+- [node] fix: Update https-proxy-agent to 3.0.0 for security reasons (#2262)
+- [node] feat: Extract prototyped data in `extractUserData` (#2247)
 - [node] ref: Use domain Hub detection only in Node environment
-- [integrations] feat: Use `contexts` to handle ExtraErrorData ([#2208](https://github.com/getsentry/sentry-javascript/issues/2208))
-- [integrations] ref: Remove `process.env.NODE_ENV` from Vue integration ([#2263](https://github.com/getsentry/sentry-javascript/issues/2263))
+- [integrations] feat: Use `contexts` to handle ExtraErrorData (#2208)
+- [integrations] ref: Remove `process.env.NODE_ENV` from Vue integration (#2263)
 - [types] fix: Breadcrumb `data` needs to be an object
 - [utils] ref: Make `Event` instances somewhat serializeable
 
 ## 5.6.3
 
-- [browser] fix: Don't capture our own XHR events that somehow bubbled-up to global handler ([#2221](https://github.com/getsentry/sentry-javascript/issues/2221))
+- [browser] fix: Don't capture our own XHR events that somehow bubbled-up to global handler (#2221)
 
 ## 5.6.2
 
-- [browser] feat: Use framesToPop for InvaliantViolations in React errors ([#2204](https://github.com/getsentry/sentry-javascript/issues/2204))
-- [browser] fix: Apply crossorigin attribute with setAttribute tag for userReport dialog ([#2196](https://github.com/getsentry/sentry-javascript/issues/2196))
-- [browser] fix: Make sure that falsy values are captured in unhandledrejections ([#2207](https://github.com/getsentry/sentry-javascript/issues/2207))
-- [loader] fix: Loader should also retrigger falsy values as errors ([#2207](https://github.com/getsentry/sentry-javascript/issues/2207))
+- [browser] feat: Use framesToPop for InvaliantViolations in React errors (#2204)
+- [browser] fix: Apply crossorigin attribute with setAttribute tag for userReport dialog (#2196)
+- [browser] fix: Make sure that falsy values are captured in unhandledrejections (#2207)
+- [loader] fix: Loader should also retrigger falsy values as errors (#2207)
 
 ## 5.6.1
 
-- [core] fix: Correctly detect when client is enabled before installing integrations ([#2193](https://github.com/getsentry/sentry-javascript/issues/2193))
+- [core] fix: Correctly detect when client is enabled before installing integrations (#2193)
 - [browser] ref: Loosen typings in `wrap` method
 
 ## 5.6.0
 
-- [core] fix: When using enabled:false integrations shouldnt be installed ([#2181](https://github.com/getsentry/sentry-javascript/issues/2181))
+- [core] fix: When using enabled:false integrations shouldnt be installed (#2181)
 - [browser] feat: Add support for custom schemes to Tracekit
 - [browser] ref: Return function call result from `wrap` method
-- [browser] ref: Better UnhandledRejection messages ([#2185](https://github.com/getsentry/sentry-javascript/issues/2185))
-- [browser] test: Complete rewrite of Browser Integration Tests ([#2176](https://github.com/getsentry/sentry-javascript/issues/2176))
-- [node] feat: Add cookies as an optional property in the request handler ([#2167](https://github.com/getsentry/sentry-javascript/issues/2167))
-- [node] ref: Unify method name casing in breadcrumbs ([#2183](https://github.com/getsentry/sentry-javascript/issues/2183))
-- [integrations] feat: Add logErrors option to Vue integration ([#2182](https://github.com/getsentry/sentry-javascript/issues/2182))
+- [browser] ref: Better UnhandledRejection messages (#2185)
+- [browser] test: Complete rewrite of Browser Integration Tests (#2176)
+- [node] feat: Add cookies as an optional property in the request handler (#2167)
+- [node] ref: Unify method name casing in breadcrumbs (#2183)
+- [integrations] feat: Add logErrors option to Vue integration (#2182)
 
 ## 5.5.0
 
-- [core] fix: Store processing state for each `flush` call separately ([#2143](https://github.com/getsentry/sentry-javascript/issues/2143))
-- [scope] feat: Generate hint if not provided in the Hub calls ([#2142](https://github.com/getsentry/sentry-javascript/issues/2142))
-- [browser] feat: Read `window.SENTRY_RELEASE` to set release by default ([#2132](https://github.com/getsentry/sentry-javascript/issues/2132))
-- [browser] fix: Don't call `fn.handleEvent.bind` if `fn.handleEvent` does not exist ([#2138](https://github.com/getsentry/sentry-javascript/issues/2138))
-- [browser] fix: Correctly handle events that utilize `handleEvent` object ([#2149](https://github.com/getsentry/sentry-javascript/issues/2149))
-- [node] feat: Provide optional `shouldHandleError` option for node `errorHandler` ([#2146](https://github.com/getsentry/sentry-javascript/issues/2146))
-- [node] fix: Remove unsafe `any` from `NodeOptions` type ([#2111](https://github.com/getsentry/sentry-javascript/issues/2111))
-- [node] fix: Merge `transportOptions` correctly ([#2151](https://github.com/getsentry/sentry-javascript/issues/2151))
-- [utils] fix: Add polyfill for `Object.setPrototypeOf` ([#2127](https://github.com/getsentry/sentry-javascript/issues/2127))
-- [integrations] feat: `SessionDuration` integration ([#2150](https://github.com/getsentry/sentry-javascript/issues/2150))
+- [core] fix: Store processing state for each `flush` call separately (#2143)
+- [scope] feat: Generate hint if not provided in the Hub calls (#2142)
+- [browser] feat: Read `window.SENTRY_RELEASE` to set release by default (#2132)
+- [browser] fix: Don't call `fn.handleEvent.bind` if `fn.handleEvent` does not exist (#2138)
+- [browser] fix: Correctly handle events that utilize `handleEvent` object (#2149)
+- [node] feat: Provide optional `shouldHandleError` option for node `errorHandler` (#2146)
+- [node] fix: Remove unsafe `any` from `NodeOptions` type (#2111)
+- [node] fix: Merge `transportOptions` correctly (#2151)
+- [utils] fix: Add polyfill for `Object.setPrototypeOf` (#2127)
+- [integrations] feat: `SessionDuration` integration (#2150)
 
 ## 5.4.3
 
@@ -1498,7 +1498,7 @@ the public API and removed some classes from the default export.
 ## 4.2.4
 
 - [browser]: Use `withScope` in `Ember` integration instead of manual `pushPop/popScope` calls
-- [browser] fix: rethrow errors in testing mode with `Ember` integration ([#1696](https://github.com/getsentry/sentry-javascript/issues/1696))
+- [browser] fix: rethrow errors in testing mode with `Ember` integration (#1696)
 - [browser/node]: Fix `LinkedErrors` integration to send exceptions in correct order and take main exception into the
   `limit` count
 - [browser/node] ref: Re-export `addGlobalEventProcessor`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,5 @@ _These steps are only relevant to Sentry employees when preparing and publishing
 4. Paste in the logs you copied earlier.
 5. Delete any which aren't user-facing changes.
 6. Alphabetize the rest.
-7. Run a regex find and replace, searching for `\(#(\d+)\)` and replacing it with `([#$1](https://github.com/getsentry/sentry-javascript/pull/$1))`. (This will linkify all of the PR references.)
-8. If any of the PRs are from external contributors, include underneath the commits `Work in this release contributed by <list of external contributors' GitHub usernames>. Thank you for your contributions!`. If there's only one external PR, don't forget to remove the final `s`. If there are three or more, use an Oxford comma. (It's in the Sentry styleguide!)
-9. Commit, push, and open a PR with the title `meta: Update changelog for <fill in relevant version here>`.
+7. If any of the PRs are from external contributors, include underneath the commits `Work in this release contributed by <list of external contributors' GitHub usernames>. Thank you for your contributions!`. If there's only one external PR, don't forget to remove the final `s`. If there are three or more, use an Oxford comma. (It's in the Sentry styleguide!)
+8. Commit, push, and open a PR with the title `meta: Update changelog for <fill in relevant version here>`.


### PR DESCRIPTION
GH now automatically linkifies PR numbers in changelogs, so we don't have to do it ourselves. This removes the manual links from the changelog and the linkifying step from the changelog instructions.