### PR TITLE
fix(build): Raise time limit for build to 20 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
     name: Build
     needs: job_install_deps
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2


### PR DESCRIPTION
All of the changes happening to the build process (and all of the new bundles we're producing) mean that sometimes the build step is failing because it times out. While in the long run we should fix the build to be faster, in the short run, this ups the time limit, so at least CI won't error out unnecessarily.
