### PR TITLE
[v7] feat(core): Delete API class

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -17,73 +17,6 @@ export interface APIDetails {
   readonly tunnel?: string;
 }
 
-/**
- * Helper class to provide urls, headers and metadata that can be used to form
- * different types of requests to Sentry endpoints.
- * Supports both envelopes and regular event requests.
- *
- * @deprecated Please use APIDetails
- **/
-export class API {
-  /** The DSN as passed to Sentry.init() */
-  public dsn: DsnLike;
-
-  /** Metadata about the SDK (name, version, etc) for inclusion in envelope headers */
-  public metadata: SdkMetadata;
-
-  /** The internally used Dsn object. */
-  private readonly _dsnObject: DsnComponents;
-
-  /** The envelope tunnel to use. */
-  private readonly _tunnel?: string;
-
-  /** Create a new instance of API */
-  public constructor(dsn: DsnLike, metadata: SdkMetadata = {}, tunnel?: string) {
-    this.dsn = dsn;
-    this._dsnObject = makeDsn(dsn);
-    this.metadata = metadata;
-    this._tunnel = tunnel;
-  }
-
-  /** Returns the Dsn object. */
-  public getDsn(): DsnComponents {
-    return this._dsnObject;
-  }
-
-  /** Does this transport force envelopes? */
-  public forceEnvelope(): boolean {
-    return !!this._tunnel;
-  }
-
-  /** Returns the prefix to construct Sentry ingestion API endpoints. */
-  public getBaseApiEndpoint(): string {
-    return getBaseApiEndpoint(this._dsnObject);
-  }
-
-  /** Returns the store endpoint URL. */
-  public getStoreEndpoint(): string {
-    return getStoreEndpoint(this._dsnObject);
-  }
-
-  /**
-   * Returns the store endpoint URL with auth in the query string.
-   *
-   * Sending auth as part of the query string and not as custom HTTP headers avoids CORS preflight requests.
-   */
-  public getStoreEndpointWithUrlEncodedAuth(): string {
-    return getStoreEndpointWithUrlEncodedAuth(this._dsnObject);
-  }
-
-  /**
-   * Returns the envelope endpoint URL with auth in the query string.
-   *
-   * Sending auth as part of the query string and not as custom HTTP headers avoids CORS preflight requests.
-   */
-  public getEnvelopeEndpointWithUrlEncodedAuth(): string {
-    return getEnvelopeEndpointWithUrlEncodedAuth(this._dsnObject, this._tunnel);
-  }
-}
-
 /** Initializes API Details */
 export function initAPIDetails(dsn: DsnLike, metadata?: SdkMetadata, tunnel?: string): APIDetails {
   return {
@@ -117,7 +50,7 @@ function _encodedAuth(dsn: DsnComponents): string {
 }
 
 /** Returns the store endpoint URL. */
-function getStoreEndpoint(dsn: DsnComponents): string {
+export function getStoreEndpoint(dsn: DsnComponents): string {
   return _getIngestEndpoint(dsn, 'store');
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,8 +15,6 @@ export {
 } from '@sentry/minimal';
 export { addGlobalEventProcessor, getCurrentHub, getHubFromCarrier, Hub, makeMain, Scope, Session } from '@sentry/hub';
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  API,
   APIDetails,
   getEnvelopeEndpointWithUrlEncodedAuth,
   getStoreEndpointWithUrlEncodedAuth,

--- a/packages/core/test/lib/api.test.ts
+++ b/packages/core/test/lib/api.test.ts
@@ -1,27 +1,38 @@
 /* eslint-disable deprecation/deprecation */
 import { makeDsn } from '@sentry/utils';
 
-import { API, getReportDialogEndpoint, getRequestHeaders } from '../../src/api';
+import {
+  getEnvelopeEndpointWithUrlEncodedAuth,
+  getReportDialogEndpoint,
+  getRequestHeaders,
+  getStoreEndpoint,
+  getStoreEndpointWithUrlEncodedAuth,
+  initAPIDetails,
+} from '../../src/api';
 
 const ingestDsn = 'https://abc@xxxx.ingest.sentry.io:1234/subpath/123';
 const dsnPublic = 'https://abc@sentry.io:1234/subpath/123';
 const legacyDsn = 'https://abc:123@sentry.io:1234/subpath/123';
 const tunnel = 'https://hello.com/world';
 
+const ingestDsnAPI = initAPIDetails(ingestDsn);
+const dsnPublicAPI = initAPIDetails(dsnPublic);
+
 describe('API', () => {
   test('getStoreEndpoint', () => {
-    expect(new API(dsnPublic).getStoreEndpointWithUrlEncodedAuth()).toEqual(
+    expect(getStoreEndpointWithUrlEncodedAuth(dsnPublicAPI.dsn)).toEqual(
       'https://sentry.io:1234/subpath/api/123/store/?sentry_key=abc&sentry_version=7',
     );
-    expect(new API(dsnPublic).getStoreEndpoint()).toEqual('https://sentry.io:1234/subpath/api/123/store/');
-    expect(new API(ingestDsn).getStoreEndpoint()).toEqual('https://xxxx.ingest.sentry.io:1234/subpath/api/123/store/');
+    expect(getStoreEndpoint(dsnPublicAPI.dsn)).toEqual('https://sentry.io:1234/subpath/api/123/store/');
+    expect(getStoreEndpoint(ingestDsnAPI.dsn)).toEqual('https://xxxx.ingest.sentry.io:1234/subpath/api/123/store/');
   });
 
   test('getEnvelopeEndpoint', () => {
-    expect(new API(dsnPublic).getEnvelopeEndpointWithUrlEncodedAuth()).toEqual(
+    expect(getEnvelopeEndpointWithUrlEncodedAuth(dsnPublicAPI.dsn)).toEqual(
       'https://sentry.io:1234/subpath/api/123/envelope/?sentry_key=abc&sentry_version=7',
     );
-    expect(new API(dsnPublic, {}, tunnel).getEnvelopeEndpointWithUrlEncodedAuth()).toEqual(tunnel);
+    const dsnPublicAPIWithTunnel = initAPIDetails(dsnPublic, {}, tunnel);
+    expect(getEnvelopeEndpointWithUrlEncodedAuth(dsnPublicAPIWithTunnel.dsn, tunnel)).toEqual(tunnel);
   });
 
   test('getRequestHeaders', () => {
@@ -119,12 +130,12 @@ describe('API', () => {
   });
 
   test('getDsn', () => {
-    expect(new API(dsnPublic).getDsn().host).toEqual(makeDsn(dsnPublic).host);
-    expect(new API(dsnPublic).getDsn().path).toEqual(makeDsn(dsnPublic).path);
-    expect(new API(dsnPublic).getDsn().pass).toEqual(makeDsn(dsnPublic).pass);
-    expect(new API(dsnPublic).getDsn().port).toEqual(makeDsn(dsnPublic).port);
-    expect(new API(dsnPublic).getDsn().protocol).toEqual(makeDsn(dsnPublic).protocol);
-    expect(new API(dsnPublic).getDsn().projectId).toEqual(makeDsn(dsnPublic).projectId);
-    expect(new API(dsnPublic).getDsn().publicKey).toEqual(makeDsn(dsnPublic).publicKey);
+    expect(dsnPublicAPI.dsn.host).toEqual(makeDsn(dsnPublic).host);
+    expect(dsnPublicAPI.dsn.path).toEqual(makeDsn(dsnPublic).path);
+    expect(dsnPublicAPI.dsn.pass).toEqual(makeDsn(dsnPublic).pass);
+    expect(dsnPublicAPI.dsn.port).toEqual(makeDsn(dsnPublic).port);
+    expect(dsnPublicAPI.dsn.protocol).toEqual(makeDsn(dsnPublic).protocol);
+    expect(dsnPublicAPI.dsn.projectId).toEqual(makeDsn(dsnPublic).projectId);
+    expect(dsnPublicAPI.dsn.publicKey).toEqual(makeDsn(dsnPublic).publicKey);
   });
 });

--- a/packages/core/test/lib/api.test.ts
+++ b/packages/core/test/lib/api.test.ts
@@ -129,7 +129,7 @@ describe('API', () => {
     );
   });
 
-  test('getDsn', () => {
+  test('initAPIDetails dsn', () => {
     expect(dsnPublicAPI.dsn.host).toEqual(makeDsn(dsnPublic).host);
     expect(dsnPublicAPI.dsn.path).toEqual(makeDsn(dsnPublic).path);
     expect(dsnPublicAPI.dsn.pass).toEqual(makeDsn(dsnPublic).pass);


### PR DESCRIPTION
Removes the deprecated `API` class.

See: https://github.com/getsentry/sentry-javascript/pull/4281

Resolves https://getsentry.atlassian.net/browse/WEB-549