### PR TITLE
[v7] feat: Delete deprecated `startSpan` and `child` methods

### DIFF
--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -14,8 +14,6 @@ import {
   Primitive,
   SessionContext,
   Severity,
-  Span,
-  SpanContext,
   Transaction,
   TransactionContext,
   User,

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -387,13 +387,6 @@ export class Hub implements HubInterface {
   /**
    * @inheritDoc
    */
-  public startSpan(context: SpanContext): Span {
-    return this._callExtensionMethod('startSpan', context);
-  }
-
-  /**
-   * @inheritDoc
-   */
   public startTransaction(context: TransactionContext, customSamplingContext?: CustomSamplingContext): Transaction {
     return this._callExtensionMethod('startTransaction', context, customSamplingContext);
   }

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -151,16 +151,6 @@ export class Span implements SpanInterface {
 
   /**
    * @inheritDoc
-   * @deprecated
-   */
-  public child(
-    spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId' | 'sampled' | 'traceId' | 'parentSpanId'>>,
-  ): Span {
-    return this.startChild(spanContext);
-  }
-
-  /**
-   * @inheritDoc
    */
   public startChild(
     spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId' | 'sampled' | 'traceId' | 'parentSpanId'>>,

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -7,7 +7,6 @@ import { Primitive } from './misc';
 import { Scope } from './scope';
 import { Session, SessionContext } from './session';
 import { Severity } from './severity';
-import { Span, SpanContext } from './span';
 import { CustomSamplingContext, Transaction, TransactionContext } from './transaction';
 import { User } from './user';
 

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -181,11 +181,6 @@ export interface Hub {
   traceHeaders(): { [key: string]: string };
 
   /**
-   * @deprecated No longer does anything. Use use {@link Transaction.startChild} instead.
-   */
-  startSpan(context: SpanContext): Span;
-
-  /**
    * Starts a new `Transaction` and returns it. This is the entry point to manual tracing instrumentation.
    *
    * A tree structure can be built by adding child spans to the transaction, and child spans to other spans. To start a

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -129,14 +129,6 @@ export interface Span extends SpanContext {
   setHttpStatus(httpStatus: number): this;
 
   /**
-   * Use {@link startChild}
-   * @deprecated
-   */
-  child(
-    spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId' | 'sampled' | 'traceId' | 'parentSpanId'>>,
-  ): Span;
-
-  /**
    * Creates a new `Span` while setting the current `Span.id` as `parentSpanId`.
    * Also the `sampled` decision will be inherited.
    */


### PR DESCRIPTION
Remove deprecated methods `startSpan` and `child`.

These deprecated methods were removed in favour of `span.startChild` in https://github.com/getsentry/sentry-javascript/pull/2600

Resolves https://getsentry.atlassian.net/browse/WEB-553