### PR TITLE
[v7] Drop support for Node 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,7 +217,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [6, 8, 10, 12, 14, 16]
+        node: [8, 10, 12, 14, 16]
     steps:
       - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "build/dist/index.js",
   "module": "build/esm/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/eslint-config-sdk/package.json
+++ b/packages/eslint-config-sdk/package.json
@@ -12,7 +12,7 @@
     "sentry"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "src/index.js",
   "publishConfig": {

--- a/packages/eslint-plugin-sdk/package.json
+++ b/packages/eslint-plugin-sdk/package.json
@@ -12,7 +12,7 @@
     "sentry"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "src/index.js",
   "publishConfig": {

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -11,7 +11,7 @@
     "gatsby-plugin"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/minimal/package.json
+++ b/packages/minimal/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "./dist/index.server.js",
   "module": "./esm/index.server.js",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -44,9 +44,7 @@ describe('tracing', () => {
 
     http.get('http://dogs.are.great/');
 
-    // TODO: For some reason in node 6 two request spans are appearing. Once we stop testing against it, this can go
-    // back to being `toEqual()`.
-    expect(spans.length).toBeGreaterThanOrEqual(2);
+    expect(spans.length).toEqual(2);
 
     // our span is at index 1 because the transaction itself is at index 0
     expect(spans[1].description).toEqual('GET http://dogs.are.great/');

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -11,21 +11,7 @@ function run(cmd: string, cwd: string = '') {
 
 const nodeMajorVersion = parseInt(process.version.split('.')[0].replace('v', ''), 10);
 
-// control which packages we test on each version of node
-if (nodeMajorVersion <= 6) {
-  // install legacy versions of packages whose current versions don't support node 6
-  // ignoring engines and scripts lets us get away with having incompatible things installed for packages we're not testing
-  run('yarn add --dev --ignore-engines --ignore-scripts nock@10.x', 'packages/node');
-  run('yarn add --dev --ignore-engines --ignore-scripts jsdom@11.x', 'packages/tracing');
-  run('yarn add --dev --ignore-engines --ignore-scripts jsdom@11.x', 'packages/utils');
-
-  // only test against @sentry/node and its dependencies - node 6 is too old for anything else to work
-  const scope = ['@sentry/core', '@sentry/hub', '@sentry/minimal', '@sentry/node', '@sentry/utils', '@sentry/tracing']
-    .map(dep => `--scope="${dep}"`)
-    .join(' ');
-
-  run(`yarn test ${scope}`);
-} else if (nodeMajorVersion <= 8) {
+if (nodeMajorVersion <= 8) {
   // install legacy versions of packages whose current versions don't support node 8
   // ignoring engines and scripts lets us get away with having incompatible things installed for packages we're not testing
   run('yarn add --dev --ignore-engines --ignore-scripts jsdom@15.x', 'packages/tracing');


### PR DESCRIPTION
Drops support for Node 6. Remove from our CI pipeline and fix a test.

Resolves https://getsentry.atlassian.net/browse/WEB-779