### PR TITLE
ref(build): Add central `build` directory to packages without CDN bundles (Part 1)

### DIFF
--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -1,4 +1,9 @@
+# Info: the paths in this file are specified so that they align with the file
+# structure in `./build` where this file is copied to. This is done by the
+# prepack script `sentry-javascript/scripts/prepack.ts`.
+
 *
+
 !/dist/**/*
 !/esm/**/*
-!/build/types/**/*
+!/types/**/*

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,8 +9,8 @@
   "engines": {
     "node": ">=6"
   },
-  "main": "dist/index.js",
-  "module": "esm/index.js",
+  "main": "build/dist/index.js",
+  "module": "build/esm/index.js",
   "types": "build/types/index.d.ts",
   "publishConfig": {
     "access": "public"
@@ -35,9 +35,9 @@
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
-    "build:npm": "npm pack",
+    "build:npm": "ts-node ../../scripts/prepack.ts -noBundles && npm pack ./build",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf dist esm coverage",
+    "clean": "rimraf dist esm build coverage",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",

--- a/packages/core/tsconfig.cjs.json
+++ b/packages/core/tsconfig.cjs.json
@@ -3,6 +3,6 @@
 
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "dist"
+    "outDir": "build/dist"
   }
 }

--- a/packages/core/tsconfig.esm.json
+++ b/packages/core/tsconfig.esm.json
@@ -3,6 +3,6 @@
 
   "compilerOptions": {
     "module": "es6",
-    "outDir": "esm"
+    "outDir": "build/esm"
   }
 }

--- a/packages/gatsby/.eslintrc.js
+++ b/packages/gatsby/.eslintrc.js
@@ -6,6 +6,8 @@ module.exports = {
   parserOptions: {
     jsx: true,
   },
+  // ignoring the package-specific prepack script here b/c it is not
+  // covered by a `tsconfig` which makes eslint throw an error
   ignorePatterns: ['scripts/prepack.ts'],
   extends: ['../../.eslintrc.js'],
 };

--- a/packages/gatsby/.eslintrc.js
+++ b/packages/gatsby/.eslintrc.js
@@ -6,5 +6,6 @@ module.exports = {
   parserOptions: {
     jsx: true,
   },
+  ignorePatterns: ['scripts/prepack.ts'],
   extends: ['../../.eslintrc.js'],
 };

--- a/packages/gatsby/.npmignore
+++ b/packages/gatsby/.npmignore
@@ -1,6 +1,13 @@
+# Info: the paths in this file are specified so that they align with the file
+# structure in `./build` where this file is copied to. This is done by the
+# prepack script `sentry-javascript/scripts/prepack.ts`.
+
 *
+
 !/dist/**/*
 !/esm/**/*
-!/build/types/**/*
+!/types/**/*
+
+# Gatsby specific
 !gatsby-browser.js
 !gatsby-node.js

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -13,8 +13,8 @@
   "engines": {
     "node": ">=6"
   },
-  "main": "dist/index.js",
-  "module": "esm/index.js",
+  "main": "build/dist/index.js",
+  "module": "build/esm/index.js",
   "types": "build/types/index.d.ts",
   "publishConfig": {
     "access": "public"
@@ -46,7 +46,7 @@
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
-    "build:npm": "npm pack",
+    "build:npm": "ts-node ../../scripts/prepack.ts -noBundles && npm pack ./build",
     "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf dist esm build coverage",
     "fix": "run-s fix:eslint fix:prettier",

--- a/packages/gatsby/scripts/prepack.ts
+++ b/packages/gatsby/scripts/prepack.ts
@@ -8,19 +8,20 @@ import * as path from 'path';
 
 const PACKAGE_ASSETS = ['gatsby-browser.js', 'gatsby-node.js'];
 
-export function prepack(buildDir: string): void {
+export function prepack(buildDir: string): boolean {
   // copy package-specific assets to build dir
-  PACKAGE_ASSETS.forEach(asset => {
+  return PACKAGE_ASSETS.every(asset => {
     const assetPath = path.resolve(asset);
     try {
       if (!fs.existsSync(assetPath)) {
         console.error(`Asset ${asset} does not exist.`);
-        process.exit(1);
+        return false;
       }
       fs.copyFileSync(assetPath, path.resolve(buildDir, asset));
     } catch (error) {
       console.error(`Error while copying ${asset} to ${buildDir}`);
-      process.exit(1);
+      return false;
     }
+    return true;
   });
 }

--- a/packages/gatsby/scripts/prepack.ts
+++ b/packages/gatsby/scripts/prepack.ts
@@ -1,0 +1,22 @@
+/* eslint-disable no-console */
+// DO NOT RUN this script yourself!
+// This is invoked from the main `prepack.ts` script in `sentry-javascript/scripts/prepack.ts`.
+import * as fs from 'fs';
+import * as path from 'path';
+
+const BUILD_DIR = 'build';
+const PACKAGE_ASSETS = ['gatsby-browser.js', 'gatsby-node.js'];
+
+// copy package-specific assets to build dir
+PACKAGE_ASSETS.forEach(asset => {
+  const assetPath = path.resolve(asset);
+  try {
+    if (!fs.existsSync(assetPath)) {
+      console.error(`Asset ${asset} does not exist.`);
+      process.exit(1);
+    }
+    fs.copyFileSync(assetPath, path.resolve(BUILD_DIR, asset));
+  } catch (error) {
+    console.error(`Error while copying ${asset} to ${BUILD_DIR}`);
+  }
+});

--- a/packages/gatsby/scripts/prepack.ts
+++ b/packages/gatsby/scripts/prepack.ts
@@ -1,22 +1,26 @@
 /* eslint-disable no-console */
+
 // DO NOT RUN this script yourself!
 // This is invoked from the main `prepack.ts` script in `sentry-javascript/scripts/prepack.ts`.
+
 import * as fs from 'fs';
 import * as path from 'path';
 
-const BUILD_DIR = 'build';
 const PACKAGE_ASSETS = ['gatsby-browser.js', 'gatsby-node.js'];
 
-// copy package-specific assets to build dir
-PACKAGE_ASSETS.forEach(asset => {
-  const assetPath = path.resolve(asset);
-  try {
-    if (!fs.existsSync(assetPath)) {
-      console.error(`Asset ${asset} does not exist.`);
+export function prepack(buildDir: string): void {
+  // copy package-specific assets to build dir
+  PACKAGE_ASSETS.forEach(asset => {
+    const assetPath = path.resolve(asset);
+    try {
+      if (!fs.existsSync(assetPath)) {
+        console.error(`Asset ${asset} does not exist.`);
+        process.exit(1);
+      }
+      fs.copyFileSync(assetPath, path.resolve(buildDir, asset));
+    } catch (error) {
+      console.error(`Error while copying ${asset} to ${buildDir}`);
       process.exit(1);
     }
-    fs.copyFileSync(assetPath, path.resolve(BUILD_DIR, asset));
-  } catch (error) {
-    console.error(`Error while copying ${asset} to ${BUILD_DIR}`);
-  }
-});
+  });
+}

--- a/packages/gatsby/tsconfig.cjs.json
+++ b/packages/gatsby/tsconfig.cjs.json
@@ -3,6 +3,6 @@
 
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "dist"
+    "outDir": "build/dist"
   }
 }

--- a/packages/gatsby/tsconfig.esm.json
+++ b/packages/gatsby/tsconfig.esm.json
@@ -3,6 +3,6 @@
 
   "compilerOptions": {
     "module": "es6",
-    "outDir": "esm"
+    "outDir": "build/esm"
   }
 }

--- a/packages/hub/.npmignore
+++ b/packages/hub/.npmignore
@@ -1,4 +1,9 @@
+# Info: the paths in this file are specified so that they align with the file
+# structure in `./build` where this file is copied to. This is done by the
+# prepack script `sentry-javascript/scripts/prepack.ts`.
+
 *
+
 !/dist/**/*
 !/esm/**/*
-!/build/types/**/*
+!/types/**/*

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -9,8 +9,8 @@
   "engines": {
     "node": ">=6"
   },
-  "main": "dist/index.js",
-  "module": "esm/index.js",
+  "main": "build/dist/index.js",
+  "module": "build/esm/index.js",
   "types": "build/types/index.d.ts",
   "publishConfig": {
     "access": "public"
@@ -33,6 +33,7 @@
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
+    "build:npm": "ts-node ../../scripts/prepack.ts -noBundles && npm pack ./build",
     "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf dist esm coverage",
     "fix": "run-s fix:eslint fix:prettier",
@@ -41,8 +42,7 @@
     "link:yarn": "yarn link",
     "lint": "run-s lint:prettier lint:eslint",
     "lint:eslint": "eslint . --cache --cache-location '../../eslintcache/' --format stylish",
-    "lint:prettier": "prettier --check \"{src,test,scripts}/**/*.ts\"",
-    "build:npm": "npm pack",
+    "lint:prettier": "prettier --check \"{src,test}/**/*.ts\"",
     "test": "jest",
     "test:watch": "jest --watch"
   },

--- a/packages/hub/tsconfig.cjs.json
+++ b/packages/hub/tsconfig.cjs.json
@@ -3,6 +3,6 @@
 
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "dist"
+    "outDir": "build/dist"
   }
 }

--- a/packages/hub/tsconfig.esm.json
+++ b/packages/hub/tsconfig.esm.json
@@ -3,6 +3,6 @@
 
   "compilerOptions": {
     "module": "es6",
-    "outDir": "esm"
+    "outDir": "build/esm"
   }
 }

--- a/packages/minimal/.npmignore
+++ b/packages/minimal/.npmignore
@@ -1,4 +1,9 @@
+# Info: the paths in this file are specified so that they align with the file
+# structure in `./build` where this file is copied to. This is done by the
+# prepack script `sentry-javascript/scripts/prepack.ts`.
+
 *
+
 !/dist/**/*
 !/esm/**/*
-!/build/types/**/*
+!/types/**/*

--- a/packages/minimal/package.json
+++ b/packages/minimal/package.json
@@ -9,8 +9,8 @@
   "engines": {
     "node": ">=6"
   },
-  "main": "dist/index.js",
-  "module": "esm/index.js",
+  "main": "build/dist/index.js",
+  "module": "build/esm/index.js",
   "types": "build/types/index.d.ts",
   "publishConfig": {
     "access": "public"
@@ -33,8 +33,9 @@
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
+    "build:npm": "ts-node ../../scripts/prepack.ts -noBundles && npm pack ./build",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf dist esm coverage",
+    "clean": "rimraf dist esm build coverage",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",
@@ -42,7 +43,6 @@
     "lint": "run-s lint:prettier lint:eslint",
     "lint:eslint": "eslint . --cache --cache-location '../../eslintcache/' --format stylish",
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/*.ts\"",
-    "build:npm": "npm pack",
     "test": "jest",
     "test:watch": "jest --watch"
   },

--- a/packages/minimal/tsconfig.cjs.json
+++ b/packages/minimal/tsconfig.cjs.json
@@ -3,6 +3,6 @@
 
   "compilerOptions": {
     "module": "commonjs",
-    "outDir": "dist"
+    "outDir": "build/dist"
   }
 }

--- a/packages/minimal/tsconfig.esm.json
+++ b/packages/minimal/tsconfig.esm.json
@@ -3,6 +3,6 @@
 
   "compilerOptions": {
     "module": "es6",
-    "outDir": "esm"
+    "outDir": "build/esm"
   }
 }

--- a/scripts/prepack.ts
+++ b/scripts/prepack.ts
@@ -91,10 +91,16 @@ try {
 async function runPackagePrepack(packagePrepackPath: string): Promise<void> {
   const { prepack } = await import(packagePrepackPath);
   if (prepack && typeof prepack === 'function') {
-    const success = prepack(buildDir);
-    if (!success) {
+    const isScuccess = prepack(buildDir);
+    if (!isScuccess) {
       process.exit(1);
     }
+  } else {
+    console.error(`Could not find a prepack function in ${packagePrepackPath}.`);
+    console.error(
+      'Make sure, your package-specific prepack script exports `function prepack(buildDir: string): boolean`.',
+    );
+    process.exit(1);
   }
 }
 

--- a/scripts/prepack.ts
+++ b/scripts/prepack.ts
@@ -6,7 +6,6 @@
   the directory structure inside `build`.
 */
 
-import * as childProcess from 'child_process';
 import * as fs from 'fs';
 import * as fse from 'fs-extra';
 import * as path from 'path';
@@ -89,19 +88,20 @@ try {
   process.exit(1);
 }
 
+async function runPackagePrepack(packagePrepackPath: string): Promise<void> {
+  const { prepack } = await import(packagePrepackPath);
+  if (prepack && typeof prepack === 'function') {
+    prepack(buildDir);
+  }
+}
+
 // execute package specific settings
 // 1. check if a package called `<package-root>/scripts/prepack.ts` exitsts
 // if yes, 2.) execute that script for things that are package-specific
 const packagePrepackPath = path.resolve('scripts', 'prepack.ts');
 try {
   if (fs.existsSync(packagePrepackPath)) {
-    const proc = childProcess.fork(packagePrepackPath);
-    proc.on('exit', code => {
-      if (code !== 0) {
-        console.error(`Error while executing ${packagePrepackPath.toString()}`);
-        process.exit(1);
-      }
-    });
+    void runPackagePrepack(packagePrepackPath);
   }
 } catch (error) {
   console.error(`Error while trying to access ${packagePrepackPath.toString()}`);

--- a/scripts/prepack.ts
+++ b/scripts/prepack.ts
@@ -91,8 +91,8 @@ try {
 async function runPackagePrepack(packagePrepackPath: string): Promise<void> {
   const { prepack } = await import(packagePrepackPath);
   if (prepack && typeof prepack === 'function') {
-    const isScuccess = prepack(buildDir);
-    if (!isScuccess) {
+    const isSuccess = prepack(buildDir);
+    if (!isSuccess) {
       process.exit(1);
     }
   } else {

--- a/scripts/prepack.ts
+++ b/scripts/prepack.ts
@@ -91,7 +91,10 @@ try {
 async function runPackagePrepack(packagePrepackPath: string): Promise<void> {
   const { prepack } = await import(packagePrepackPath);
   if (prepack && typeof prepack === 'function') {
-    prepack(buildDir);
+    const success = prepack(buildDir);
+    if (!success) {
+      process.exit(1);
+    }
   }
 }
 

--- a/scripts/prepack.ts
+++ b/scripts/prepack.ts
@@ -98,14 +98,15 @@ async function runPackagePrepack(packagePrepackPath: string): Promise<void> {
 // execute package specific settings
 // 1. check if a package called `<package-root>/scripts/prepack.ts` exitsts
 // if yes, 2.) execute that script for things that are package-specific
-const packagePrepackPath = path.resolve('scripts', 'prepack.ts');
-try {
-  if (fs.existsSync(packagePrepackPath)) {
-    void runPackagePrepack(packagePrepackPath);
+void (async () => {
+  const packagePrepackPath = path.resolve('scripts', 'prepack.ts');
+  try {
+    if (fs.existsSync(packagePrepackPath)) {
+      await runPackagePrepack(packagePrepackPath);
+    }
+  } catch (error) {
+    console.error(`Error while trying to access ${packagePrepackPath.toString()}`);
+    process.exit(1);
   }
-} catch (error) {
-  console.error(`Error while trying to access ${packagePrepackPath.toString()}`);
-  process.exit(1);
-}
-
-console.log(`\nSuccessfully finished prepack commands for ${pkgJson.name}\n`);
+  console.log(`\nSuccessfully finished prepack commands for ${pkgJson.name}\n`);
+})();


### PR DESCRIPTION
# Background
This PR is the continuation of our ongoing effort of introducing a central `build` directory in all* our packages. In the last PR (#4838), the `build` directory was added to packages _with_ CDN bundles. 

*some packages will not be adjusted, as their build process differs significantly from our other packages (e.g. Ember, Angular soon).

# Changes
This PR is part 1 of adding the `build` directory to packages _without_ CDN bundles. It is split into two parts to make reviewing easier. It covers the following packages:

* Core
* Gatsby
* Hub
* Minimal

Additionally, it adjusts `prepack.ts` to handle both kinds of packages (with/without CDN bundles) via a CL argument. For the Gatsby SDK, additional actions have to be performed which are only relevant for this package. Therefore, `prepack.ts` now supports calling a package-specific `prepack.ts` file located in `<package>/scripts/prepack.ts`. 

While the tarball structure is identical to the structure in #4838 (except for temporary CDN bundles), the `build` directory structure is simplified due to the fact that there are no CDN bundles or legacy NPM packages to be added to it. Therefore we can reduce one hierarchy level, resulting in the following structure:

```
<sdk>/
├─ build/
│  ├─ cjs/    // dist until v7
│  │  ├─ CJS modules (+maps)
│  ├─ esm/
│  │  ├─ ES6 modules (+maps)
│  ├─ types/
│  │  ├─ *.d.ts files (+maps)
│  ├─ package.json
│  ├─ LICENSE
│  ├─ README.md
├─ ...
```


