### PR TITLE
[v7] feat(gatsby): Remove Sentry from window

### DIFF
--- a/packages/gatsby/gatsby-browser.js
+++ b/packages/gatsby/gatsby-browser.js
@@ -6,12 +6,11 @@ exports.onClientEntry = function (_, pluginParams) {
   const areOptionsDefined = areSentryOptionsDefined(pluginParams);
 
   if (isIntialized) {
-    window.Sentry = Sentry; // For backwards compatibility
     if (areOptionsDefined) {
       console.warn(
         'Sentry Logger [Warn]: The SDK was initialized in the Sentry config file, but options were found in the Gatsby config. ' +
-          'These have been ignored, merge them to the Sentry config if you want to use them.\n' +
-          'Learn more about the Gatsby SDK on https://docs.sentry.io/platforms/javascript/guides/gatsby/',
+        'These have been ignored, merge them to the Sentry config if you want to use them.\n' +
+        'Learn more about the Gatsby SDK on https://docs.sentry.io/platforms/javascript/guides/gatsby/',
       );
     }
     return;
@@ -20,7 +19,7 @@ exports.onClientEntry = function (_, pluginParams) {
   if (!areOptionsDefined) {
     console.error(
       'Sentry Logger [Error]: No config for the Gatsby SDK was found.\n' +
-        'Learn how to configure it on https://docs.sentry.io/platforms/javascript/guides/gatsby/',
+      'Learn how to configure it on https://docs.sentry.io/platforms/javascript/guides/gatsby/',
     );
     return;
   }
@@ -32,7 +31,6 @@ exports.onClientEntry = function (_, pluginParams) {
     dsn: __SENTRY_DSN__,
     ...pluginParams,
   });
-  window.Sentry = Sentry; // For backwards compatibility
 };
 
 function isSentryInitialized() {

--- a/packages/gatsby/test/gatsby-browser.test.ts
+++ b/packages/gatsby/test/gatsby-browser.test.ts
@@ -36,10 +36,6 @@ describe('onClientEntry', () => {
     tracingAddExtensionMethods = jest.fn();
   });
 
-  afterEach(() => {
-    (window as any).Sentry = undefined;
-  });
-
   it.each([
     [{}, ['dsn', 'release']],
     [{ key: 'value' }, ['dsn', 'release', 'key']],
@@ -54,7 +50,6 @@ describe('onClientEntry', () => {
 
   describe('inits Sentry once', () => {
     afterEach(() => {
-      delete (window as any).Sentry;
       delete (window as any).__SENTRY__;
       (global.console.warn as jest.Mock).mockClear();
       (global.console.error as jest.Mock).mockClear();
@@ -78,7 +73,6 @@ describe('onClientEntry', () => {
       // eslint-disable-next-line no-console
       expect(console.error).not.toHaveBeenCalled();
       expect(sentryInit).not.toHaveBeenCalled();
-      expect((window as any).Sentry).toBeDefined();
     });
 
     it('initialized in injected config, with pluginParams', () => {
@@ -94,7 +88,6 @@ describe('onClientEntry', () => {
       // eslint-disable-next-line no-console
       expect(console.error).not.toHaveBeenCalled();
       expect(sentryInit).not.toHaveBeenCalled();
-      expect((window as any).Sentry).toBeDefined();
     });
 
     it('not initialized in injected config, without pluginParams', () => {
@@ -108,7 +101,6 @@ describe('onClientEntry', () => {
         Learn how to configure it on https://docs.sentry.io/platforms/javascript/guides/gatsby/",
         ]
       `);
-      expect((window as any).Sentry).not.toBeDefined();
     });
 
     it('not initialized in injected config, with pluginParams', () => {
@@ -125,7 +117,6 @@ describe('onClientEntry', () => {
                 "release": "release",
               }
             `);
-      expect((window as any).Sentry).toBeDefined();
     });
   });
 
@@ -164,7 +155,6 @@ describe('onClientEntry', () => {
   it('does not run if plugin params are undefined', () => {
     onClientEntry();
     expect(sentryInit).toHaveBeenCalledTimes(0);
-    expect((window as any).Sentry).toBeUndefined();
     expect(tracingAddExtensionMethods).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/gatsby/test/integration.test.tsx
+++ b/packages/gatsby/test/integration.test.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import * as React from 'react';
 
 import { onClientEntry } from '../gatsby-browser';
+import * as Sentry from '../src';
 
 beforeAll(() => {
   (global as any).__SENTRY_RELEASE__ = '683f3a6ab819d47d23abfca9a914c81f0524d35b';
@@ -28,7 +29,7 @@ describe('useEffect', () => {
     function TestComponent() {
       useEffect(() => {
         const error = new Error('testing 123');
-        (window as any).Sentry.captureException(error);
+        Sentry.captureException(error);
       });
 
       return <div>Hello</div>;


### PR DESCRIPTION
Removes Sentry from `window`. See https://github.com/getsentry/sentry-javascript/pull/4064 for the PR that makes this change.

Resolves https://getsentry.atlassian.net/browse/WEB-554