### PR TITLE
[v7] feat(hub): Remove getActiveDomain

### DIFF
--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -75,15 +75,6 @@ export interface Carrier {
 }
 
 /**
- * @hidden
- * @deprecated Can be removed once `Hub.getActiveDomain` is removed.
- */
-export interface DomainAsCarrier extends Carrier {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  members: { [key: string]: any }[];
-}
-
-/**
  * @inheritDoc
  */
 export class Hub implements HubInterface {
@@ -558,20 +549,6 @@ export function getCurrentHub(): Hub {
   }
   // Return hub that lives on a global object
   return getHubFromCarrier(registry);
-}
-
-/**
- * Returns the active domain, if one exists
- * @deprecated No longer used; remove in v7
- * @returns The domain, or undefined if there is no active domain
- */
-// eslint-disable-next-line deprecation/deprecation
-export function getActiveDomain(): DomainAsCarrier | undefined {
-  IS_DEBUG_BUILD && logger.warn('Function `getActiveDomain` is deprecated and will be removed in a future version.');
-
-  const sentry = getMainCarrier().__SENTRY__;
-
-  return sentry && sentry.extensions && sentry.extensions.domain && sentry.extensions.domain.active;
 }
 
 /**

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -2,8 +2,6 @@ export { addGlobalEventProcessor, Scope } from './scope';
 export { Session } from './session';
 export { SessionFlusher } from './sessionflusher';
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  getActiveDomain,
   getCurrentHub,
   getHubFromCarrier,
   getMainCarrier,
@@ -11,7 +9,5 @@ export {
   makeMain,
   setHubOnCarrier,
   Carrier,
-  // eslint-disable-next-line deprecation/deprecation
-  DomainAsCarrier,
   Layer,
 } from './hub';


### PR DESCRIPTION
Removes `getActiveDomain` function and corresponding type. See the PR which deprecated this here: https://github.com/getsentry/sentry-javascript/pull/3227.

Resolves https://getsentry.atlassian.net/browse/WEB-606

