### PR TITLE
[v7] feat(tracing): Rename registerRequestInstrumentation -> instrumentOutgoingRequests

### DIFF
--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -26,8 +26,7 @@ export { Span, SpanStatusType, spanStatusfromHttpCode } from './span';
 export { SpanStatus } from './spanstatus';
 export { Transaction } from './transaction';
 export {
-  // TODO deprecate old name in v7
-  instrumentOutgoingRequests as registerRequestInstrumentation,
+  instrumentOutgoingRequests,
   RequestInstrumentationOptions,
   defaultRequestInstrumentationOptions,
 } from './browser';


### PR DESCRIPTION
Renames `registerRequestInstrumentation` to `instrumentOutgoingRequests`.

See https://github.com/getsentry/sentry-javascript/pull/3338 for context.

Resolves https://getsentry.atlassian.net/browse/WEB-608
