### PR TITLE
feat(utils): Introduce getGlobalSingleton helper

### DIFF
--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -20,7 +20,15 @@ import {
   TransactionContext,
   User,
 } from '@sentry/types';
-import { consoleSandbox, dateTimestampInSeconds, getGlobalObject, isNodeEnv, logger, uuid4 } from '@sentry/utils';
+import {
+  consoleSandbox,
+  dateTimestampInSeconds,
+  getGlobalObject,
+  getGlobalSingleton,
+  isNodeEnv,
+  logger,
+  uuid4,
+} from '@sentry/utils';
 
 import { IS_DEBUG_BUILD } from './flags';
 import { Scope } from './scope';
@@ -617,10 +625,7 @@ function hasHubOnCarrier(carrier: Carrier): boolean {
  * @hidden
  */
 export function getHubFromCarrier(carrier: Carrier): Hub {
-  if (carrier && carrier.__SENTRY__ && carrier.__SENTRY__.hub) return carrier.__SENTRY__.hub;
-  carrier.__SENTRY__ = carrier.__SENTRY__ || {};
-  carrier.__SENTRY__.hub = new Hub();
-  return carrier.__SENTRY__.hub;
+  return getGlobalSingleton<Hub>('hub', () => new Hub(), carrier);
 }
 
 /**
@@ -631,7 +636,7 @@ export function getHubFromCarrier(carrier: Carrier): Hub {
  */
 export function setHubOnCarrier(carrier: Carrier, hub: Hub): boolean {
   if (!carrier) return false;
-  carrier.__SENTRY__ = carrier.__SENTRY__ || {};
-  carrier.__SENTRY__.hub = hub;
+  const sentry = (carrier.__SENTRY__ = carrier.__SENTRY__ || {});
+  sentry.hub = hub;
   return true;
 }

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -636,7 +636,7 @@ export function getHubFromCarrier(carrier: Carrier): Hub {
  */
 export function setHubOnCarrier(carrier: Carrier, hub: Hub): boolean {
   if (!carrier) return false;
-  const sentry = (carrier.__SENTRY__ = carrier.__SENTRY__ || {});
-  sentry.hub = hub;
+  const __SENTRY__ = (carrier.__SENTRY__ = carrier.__SENTRY__ || {});
+  __SENTRY__.hub = hub;
   return true;
 }

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -18,7 +18,7 @@ import {
   Transaction,
   User,
 } from '@sentry/types';
-import { dateTimestampInSeconds, getGlobalObject, isPlainObject, isThenable, SyncPromise } from '@sentry/utils';
+import { dateTimestampInSeconds, getGlobalSingleton, isPlainObject, isThenable, SyncPromise } from '@sentry/utils';
 
 import { Session } from './session';
 
@@ -522,12 +522,7 @@ export class Scope implements ScopeInterface {
  * Returns the global event processors.
  */
 function getGlobalEventProcessors(): EventProcessor[] {
-  /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access  */
-  const global = getGlobalObject<any>();
-  global.__SENTRY__ = global.__SENTRY__ || {};
-  global.__SENTRY__.globalEventProcessors = global.__SENTRY__.globalEventProcessors || [];
-  return global.__SENTRY__.globalEventProcessors;
-  /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access */
+  return getGlobalSingleton<EventProcessor[]>('globalEventProcessors', () => []);
 }
 
 /**

--- a/packages/utils/src/global.ts
+++ b/packages/utils/src/global.ts
@@ -44,3 +44,16 @@ export function getGlobalObject<T>(): T & SentryGlobal {
       : fallbackGlobalObject
   ) as T & SentryGlobal;
 }
+
+/**
+ * Returns a global singleton contained on the global `__SENTRY__` object.
+ *
+ * @param name name of the global singleton on __SENTRY__
+ * @param creator creation function
+ * @returns the singleton
+ */
+export function getGlobalSingleton<T>(name: keyof SentryGlobal['__SENTRY__'], creator: () => T, obj?: unknown): T {
+  const global = (obj || getGlobalObject()) as SentryGlobal;
+  const sentry = (global.__SENTRY__ = global.__SENTRY__ || {});
+  return sentry[name] || (sentry[name] = creator());
+}

--- a/packages/utils/src/global.ts
+++ b/packages/utils/src/global.ts
@@ -46,14 +46,19 @@ export function getGlobalObject<T>(): T & SentryGlobal {
 }
 
 /**
- * Returns a global singleton contained on the global `__SENTRY__` object.
+ * Returns a global singleton contained in the global `__SENTRY__` object.
+ *
+ * If the singleton doesn't already exist in `__SENTRY__`, it will be created using the given factory
+ * function and added to the `__SENTRY__` object.
  *
  * @param name name of the global singleton on __SENTRY__
- * @param creator creation function
+ * @param creator creator Factory function to create the singleton if it doesn't already exist on `__SENTRY__`
+ * @param obj (Optional) The global object on which to look for `__SENTRY__`, if not `getGlobalObject`'s return value
  * @returns the singleton
  */
 export function getGlobalSingleton<T>(name: keyof SentryGlobal['__SENTRY__'], creator: () => T, obj?: unknown): T {
   const global = (obj || getGlobalObject()) as SentryGlobal;
-  const sentry = (global.__SENTRY__ = global.__SENTRY__ || {});
-  return sentry[name] || (sentry[name] = creator());
+  const __SENTRY__ = (global.__SENTRY__ = global.__SENTRY__ || {});
+  const singleton = __SENTRY__[name] || (__SENTRY__[name] = creator());
+  return singleton;
 }


### PR DESCRIPTION
This helper abstracts away the logic of getting an variable from the global `__SENTRY__` object. It does this by introducing a new `getGlobalSingleton` utility function.

For now, this is used by the event processors and hub logic. In an upcoming PR, we'll update the logger logic to also use this utility.

Based on the excellent work in https://github.com/getsentry/sentry-javascript/pull/4285 - ~should be a small bundle size win as well.~ Well ok size-bot, say no more.

Resolves https://getsentry.atlassian.net/browse/WEB-796
