### PR TITLE
[v7] feat(types): Remove deprecated user dsn field

### DIFF
--- a/packages/types/src/dsn.ts
+++ b/packages/types/src/dsn.ts
@@ -5,8 +5,6 @@ export type DsnProtocol = 'http' | 'https';
 export interface DsnComponents {
   /** Protocol used to connect to Sentry. */
   protocol: DsnProtocol;
-  /** Public authorization key (deprecated, renamed to publicKey). */
-  user?: string;
   /** Public authorization key. */
   publicKey?: string;
   /** Private authorization key (deprecated, optional). */

--- a/packages/utils/src/dsn.ts
+++ b/packages/utils/src/dsn.ts
@@ -55,13 +55,7 @@ function dsnFromString(str: string): DsnComponents {
 }
 
 function dsnFromComponents(components: DsnComponents): DsnComponents {
-  // TODO this is for backwards compatibility, and can be removed in a future version
-  if ('user' in components && !('publicKey' in components)) {
-    components.publicKey = components.user;
-  }
-
   return {
-    user: components.publicKey || '',
     protocol: components.protocol,
     publicKey: components.publicKey || '',
     pass: components.pass || '',


### PR DESCRIPTION
The `user` dsn component was renamed to `publicKey`. This PR removes that from the dsn field.

See PR that deprecates this field: https://github.com/getsentry/sentry-javascript/pull/3225

Resolves https://getsentry.atlassian.net/browse/WEB-798

