### PR TITLE
[v7] feat(hub): Remove setTransaction scope method

### DIFF
--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -224,14 +224,6 @@ export class Scope implements ScopeInterface {
   }
 
   /**
-   * Can be removed in major version.
-   * @deprecated in favor of {@link this.setTransactionName}
-   */
-  public setTransaction(name?: string): this {
-    return this.setTransactionName(name);
-  }
-
-  /**
    * @inheritDoc
    */
   public setContext(key: string, context: Context | null): this {


### PR DESCRIPTION
Remove the deprecated `setTransaction` method.

Deprecated in this PR https://github.com/getsentry/sentry-javascript/pull/2668

Resolves https://getsentry.atlassian.net/browse/WEB-797