### PR TITLE
build(browser): Build legacy packages

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -44,7 +44,7 @@
     "webpack": "^4.30.0"
   },
   "scripts": {
-    "build": "run-p build:cjs build:esm build:bundle build:types",
+    "build": "run-p build:cjs build:esm build:bundle build:types build:legacy",
     "build:bundle": "rollup --config",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:dev": "run-p build:cjs build:esm build:types",
@@ -58,7 +58,11 @@
     "build:dev:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
-    "build:npm": "ts-node ../../scripts/prepack.ts && npm pack ./build/npm",
+    "build:legacy": "run-p build:types:legacy build:cjs:legacy build:esm:legacy",
+    "build:types:legacy": "tsc -p tsconfig.types.json --outDir build/npm-legacy/types",
+    "build:cjs:legacy": "tsc -p tsconfig.cjs.json --outDir build/npm-legacy/dist",
+    "build:esm:legacy": "tsc -p tsconfig.esm.json --outDir build/npm-legacy/esm",
+    "build:npm": "ts-node ../../scripts/prepack.ts -legacyPackage && npm pack ./build/npm && npm pack ./build/npm-legacy",
     "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf build coverage .rpt2_cache",
     "fix": "run-s fix:eslint fix:prettier",

--- a/scripts/prepack.ts
+++ b/scripts/prepack.ts
@@ -11,8 +11,12 @@ import * as fse from 'fs-extra';
 import * as path from 'path';
 
 const NPM_BUILD_DIR = 'build/npm';
-const ASSETS = ['README.md', 'LICENSE', 'package.json', '.npmignore'];
+const NPM_LEGACY_BUILD_DIR = 'build/npm-legacy';
+
+const ASSETS = ['README.md', 'LICENSE', '.npmignore'];
 const ENTRY_POINTS = ['main', 'module', 'types'];
+
+const shouldPrepareLegacyPackage = process.argv.includes('-legacyPackage');
 
 // check if build dir exists
 try {
@@ -26,20 +30,43 @@ try {
   process.exit(1);
 }
 
-// copy non-code assets to build dir
-ASSETS.forEach(asset => {
-  const assetPath = path.resolve(asset);
+if (shouldPrepareLegacyPackage) {
+  // check if legacy build dir exists
   try {
-    if (!fs.existsSync(assetPath)) {
-      console.error(`Asset ${asset} does not exist.`);
+    if (!fs.existsSync(path.resolve(NPM_LEGACY_BUILD_DIR))) {
+      console.error(`Directory ${NPM_LEGACY_BUILD_DIR} DOES NOT exist`);
+      console.error('Legacy files have not been built yet. Have you run "yarn:build"?');
       process.exit(1);
     }
-    fs.copyFileSync(assetPath, path.resolve(NPM_BUILD_DIR, asset));
   } catch (error) {
-    console.error(`Error while copying ${asset} to ${NPM_BUILD_DIR}`);
+    console.error(`Error while looking up directory ${NPM_LEGACY_BUILD_DIR}`);
     process.exit(1);
   }
-});
+}
+
+// copy non-code assets to build dir
+function copyAssets(target: string): void {
+  ASSETS.forEach(asset => {
+    const assetPath = path.resolve(asset);
+    try {
+      if (!fs.existsSync(assetPath)) {
+        console.error(`Asset ${asset} does not exist.`);
+        process.exit(1);
+      }
+
+      fs.copyFileSync(assetPath, path.resolve(target, asset));
+    } catch (error) {
+      console.error(`Error while copying ${asset} to ${target}`, error);
+      process.exit(1);
+    }
+  });
+}
+
+copyAssets(NPM_BUILD_DIR);
+
+if (shouldPrepareLegacyPackage) {
+  copyAssets(NPM_LEGACY_BUILD_DIR);
+}
 
 // TODO remove in v7! Until then:
 // copy CDN bundles into npm dir to temporarily keep bundles in npm tarball
@@ -59,26 +86,49 @@ if (tmpCopyBundles) {
     process.exit(1);
   }
 }
-// package.json modifications
-const packageJsonPath = path.resolve(NPM_BUILD_DIR, 'package.json');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const pkgJson: { [key: string]: unknown } = require(packageJsonPath);
 
-// modify entry points to point to correct paths (i.e. strip out the build directory)
-ENTRY_POINTS.filter(entryPoint => pkgJson[entryPoint]).forEach(entryPoint => {
-  pkgJson[entryPoint] = (pkgJson[entryPoint] as string).replace(`${NPM_BUILD_DIR}/`, '');
-});
+const packageJsonPath = path.resolve('package.json');
+const pkgJson: { [key: string]: unknown } = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
 
-delete pkgJson.scripts;
-delete pkgJson.volta;
-delete pkgJson.jest;
+function getModifiedPkgJson(newName: string): Record<string, unknown> {
+  const newPkgJson = { ...pkgJson };
+  newPkgJson.name = newName;
 
-// write modified package.json to file (pretty-printed with 2 spaces)
+  delete newPkgJson.scripts;
+  delete newPkgJson.volta;
+  delete newPkgJson.jest;
+
+  // modify entry points to point to correct paths (i.e. strip out the build directory)
+  ENTRY_POINTS.forEach(entryPoint => {
+    const oldEntryPoint = pkgJson[entryPoint] as string | undefined;
+    if (oldEntryPoint) {
+      newPkgJson[entryPoint] = path.relative(NPM_BUILD_DIR, oldEntryPoint);
+    }
+  });
+
+  return newPkgJson;
+}
+
+// write modified package.json to new location
 try {
-  fs.writeFileSync(packageJsonPath, JSON.stringify(pkgJson, null, 2));
+  const modifiedPkgJson = getModifiedPkgJson(pkgJson.name as string);
+  const modifiedPkgJsonPath = path.resolve(NPM_BUILD_DIR, 'package.json');
+  fs.writeFileSync(modifiedPkgJsonPath, JSON.stringify(modifiedPkgJson, null, 2));
 } catch (error) {
   console.error('Error while writing package.json to disk');
   process.exit(1);
+}
+
+// write modified package.json for legacy package to new location
+if (shouldPrepareLegacyPackage) {
+  try {
+    const modifiedPkgJson = getModifiedPkgJson(`${pkgJson.name}-legacy`);
+    const modifiedPkgJsonPath = path.resolve(NPM_LEGACY_BUILD_DIR, 'package.json');
+    fs.writeFileSync(modifiedPkgJsonPath, JSON.stringify(modifiedPkgJson, null, 2));
+  } catch (error) {
+    console.error('Error while writing legacy package.json to disk');
+    process.exit(1);
+  }
 }
 
 console.log(`\nSuccessfully finished prepack commands for ${pkgJson.name}\n`);


### PR DESCRIPTION
With out move to es6 we want to provide legacy packages that support es5. We are starting with the browser package.

This PR adds commands to build the legacy package files and updates the prepackage script to bundle everything up correctly with an additional flag.

Currently the legacy package is identical to the one we currently publish.

Ref: https://getsentry.atlassian.net/browse/WEB-682