### PR TITLE
ref(core): Log `normalizeDepth` type when normalization is skipped

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -373,7 +373,10 @@ export abstract class BaseClient<B extends Backend, O extends Options> implement
       if (evt) {
         // TODO this is more of the hack trying to solve https://github.com/getsentry/sentry-javascript/issues/2809
         // it is only attached as extra data to the event if the event somehow skips being normalized
-        evt.sdkProcessingMetadata = { ...evt.sdkProcessingMetadata, normalizeDepth: normalize(normalizeDepth) };
+        evt.sdkProcessingMetadata = {
+          ...evt.sdkProcessingMetadata,
+          normalizeDepth: `${normalize(normalizeDepth)} (${typeof normalizeDepth})`,
+        };
       }
       if (typeof normalizeDepth === 'number' && normalizeDepth > 0) {
         return this._normalizeEvent(evt, normalizeDepth, normalizeMaxBreadth);


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/sentry-javascript/pull/4425 and https://github.com/getsentry/sentry-javascript/pull/4574, all in aid of debugging https://github.com/getsentry/sentry-javascript/issues/2809, wherein serializing events leads to a circular reference error. One of the possible culprits is that the event is somehow skipping our usual normalization process, and one of the reasons that might happen is if `normalizeDepth` is set to something other than a number. We're already logging its value in problematic cases, and this change makes it so that we'll now log its type as well.