### PR TITLE
ref(test): Switch to `mongodb-memory-server-global`.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ env:
     ${{ github.workspace }}/node_modules
     ${{ github.workspace }}/packages/**/node_modules
     ~/.cache/ms-playwright/
+    ~/.cache/mongodb-binaries/
 
   # DEPENDENCY_CACHE_KEY: can't be set here because we don't have access to yarn.lock
 

--- a/packages/node-integration-tests/package.json
+++ b/packages/node-integration-tests/package.json
@@ -26,5 +26,10 @@
     "nock": "^13.1.0",
     "pg": "^8.7.3",
     "portfinder": "^1.0.28"
+  },
+  "config": {
+    "mongodbMemoryServer": {
+      "downloadDir": "./node_modules/mongodb-memory-server"
+    }
   }
 }

--- a/packages/node-integration-tests/package.json
+++ b/packages/node-integration-tests/package.json
@@ -29,7 +29,8 @@
   },
   "config": {
     "mongodbMemoryServer": {
-      "downloadDir": "./node_modules/mongodb-memory-server"
+      "preferGlobalPath": true,
+      "runtimeDownload": false
     }
   }
 }

--- a/packages/node-integration-tests/package.json
+++ b/packages/node-integration-tests/package.json
@@ -21,7 +21,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.3",
     "mongodb": "^3.7.3",
-    "mongodb-memory-server": "^7.6.3",
+    "mongodb-memory-server-global": "^7.6.3",
     "mysql": "^2.18.1",
     "nock": "^13.1.0",
     "pg": "^8.7.3",

--- a/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
@@ -1,4 +1,4 @@
-import { MongoMemoryServer } from 'mongodb-memory-server';
+import { MongoMemoryServer } from 'mongodb-memory-server-global';
 
 import { assertSentryTransaction, conditionalTest, getEnvelopeRequest, runServer } from '../../../../utils';
 

--- a/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
@@ -2,13 +2,16 @@ import { MongoMemoryServer } from 'mongodb-memory-server-global';
 
 import { assertSentryTransaction, conditionalTest, getEnvelopeRequest, runServer } from '../../../../utils';
 
+// This test can take longer.
+jest.setTimeout(15000);
+
 conditionalTest({ min: 12 })('MongoDB Test', () => {
   let mongoServer: MongoMemoryServer;
 
   beforeAll(async () => {
     mongoServer = await MongoMemoryServer.create();
     process.env.MONGO_URL = mongoServer.getUri();
-  }, 40000);
+  }, 10000);
 
   afterAll(async () => {
     await mongoServer.stop();

--- a/yarn.lock
+++ b/yarn.lock
@@ -16329,10 +16329,10 @@ mongodb-memory-server-core@7.6.3:
     uuid "^8.3.1"
     yauzl "^2.10.0"
 
-mongodb-memory-server@^7.6.3:
+mongodb-memory-server-global@^7.6.3:
   version "7.6.3"
-  resolved "https://registry.yarnpkg.com/mongodb-memory-server/-/mongodb-memory-server-7.6.3.tgz#8b2827363ca16aaf250cba07f7a2b49e502735d4"
-  integrity sha512-yHDE9FGxOpSRUzitF9Qx3JjEgayCSJI3JOW2wgeBH/5PAsUdisy2nRxRiNwwLDooQ7tohllWCRTXlWqyarUEMQ==
+  resolved "https://registry.yarnpkg.com/mongodb-memory-server-global/-/mongodb-memory-server-global-7.6.3.tgz#ad662a640db254eea7927668834c26b665c13547"
+  integrity sha512-WLlMqkEasuanHjoxyMxlyvQ/HtJgq0eGyrfCXX6lTnY/26Zfs96W2daeWLOQ48VLInSOh2umBvE74Ykqj7gVyA==
   dependencies:
     mongodb-memory-server-core "7.6.3"
     tslib "^2.3.0"


### PR DESCRIPTION
Switching to `mongodb-memory-server-global` which downloads MongoDB binaries on `postinstall` instead of first test run.

This will fix test flakiness caused by timeouts [here](https://github.com/getsentry/sentry-javascript/blob/0a985ceada1ff866641d0ab33903bc0a344351b7/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts#L8).