### PR TITLE
build(legacy): Build legacy packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,7 +217,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [6, 8, 10, 12, 14, 16]
+        node: [8, 10, 12, 14, 16]
     steps:
       - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "ts-node": "^8.10.2",
     "tslib": "^2.3.1",
     "typedoc": "^0.18.0",
-    "typescript": "3.7.5"
+    "typescript": "3.8.3"
   },
   "resolutions": {
     "**/agent-base": "5",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "dist/index.js",
   "module": "esm/index.js",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -44,7 +44,7 @@
     "webpack": "^4.30.0"
   },
   "scripts": {
-    "build": "run-p build:cjs build:esm build:bundle build:types",
+    "build": "run-p build:cjs build:esm build:bundle build:types build:legacy",
     "build:bundle": "rollup --config",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:dev": "run-p build:cjs build:esm build:types",
@@ -58,7 +58,11 @@
     "build:dev:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
-    "build:npm": "ts-node ../../scripts/prepack.ts --bundles && npm pack ./build/npm",
+    "build:legacy": "run-p build:types:legacy build:cjs:legacy build:esm:legacy",
+    "build:types:legacy": "tsc -p tsconfig.types.json --outDir build/npm-legacy/types",
+    "build:cjs:legacy": "tsc -p tsconfig.cjs.json --outDir build/npm-legacy/dist",
+    "build:esm:legacy": "tsc -p tsconfig.esm.json --outDir build/npm-legacy/esm",
+    "build:npm": "ts-node ../../scripts/prepack.ts --bundles --legacyPackage && npm pack ./build/npm && npm pack ./build/npm-legacy",
     "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf build coverage .rpt2_cache",
     "fix": "run-s fix:eslint fix:prettier",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "build/npm/dist/index.js",
   "module": "build/npm/esm/index.js",

--- a/packages/browser/src/backend.ts
+++ b/packages/browser/src/backend.ts
@@ -23,12 +23,6 @@ export interface BrowserOptions extends Options {
    * By default, all errors will be sent.
    */
   denyUrls?: Array<string | RegExp>;
-
-  /** @deprecated use {@link Options.allowUrls} instead. */
-  whitelistUrls?: Array<string | RegExp>;
-
-  /** @deprecated use {@link Options.denyUrls} instead. */
-  blacklistUrls?: Array<string | RegExp>;
 }
 
 /**

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -44,6 +44,5 @@ export {
 export { BrowserOptions } from './backend';
 export { BrowserClient } from './client';
 export { injectReportDialog, ReportDialogOptions } from './helpers';
-export { eventFromException, eventFromMessage } from './eventbuilder';
 export { defaultIntegrations, forceLoad, init, lastEventId, onLoad, showReportDialog, flush, close, wrap } from './sdk';
 export { SDK_NAME } from './version';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "build/dist/index.js",
   "module": "build/esm/index.js",

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -17,73 +17,6 @@ export interface APIDetails {
   readonly tunnel?: string;
 }
 
-/**
- * Helper class to provide urls, headers and metadata that can be used to form
- * different types of requests to Sentry endpoints.
- * Supports both envelopes and regular event requests.
- *
- * @deprecated Please use APIDetails
- **/
-export class API {
-  /** The DSN as passed to Sentry.init() */
-  public dsn: DsnLike;
-
-  /** Metadata about the SDK (name, version, etc) for inclusion in envelope headers */
-  public metadata: SdkMetadata;
-
-  /** The internally used Dsn object. */
-  private readonly _dsnObject: DsnComponents;
-
-  /** The envelope tunnel to use. */
-  private readonly _tunnel?: string;
-
-  /** Create a new instance of API */
-  public constructor(dsn: DsnLike, metadata: SdkMetadata = {}, tunnel?: string) {
-    this.dsn = dsn;
-    this._dsnObject = makeDsn(dsn);
-    this.metadata = metadata;
-    this._tunnel = tunnel;
-  }
-
-  /** Returns the Dsn object. */
-  public getDsn(): DsnComponents {
-    return this._dsnObject;
-  }
-
-  /** Does this transport force envelopes? */
-  public forceEnvelope(): boolean {
-    return !!this._tunnel;
-  }
-
-  /** Returns the prefix to construct Sentry ingestion API endpoints. */
-  public getBaseApiEndpoint(): string {
-    return getBaseApiEndpoint(this._dsnObject);
-  }
-
-  /** Returns the store endpoint URL. */
-  public getStoreEndpoint(): string {
-    return getStoreEndpoint(this._dsnObject);
-  }
-
-  /**
-   * Returns the store endpoint URL with auth in the query string.
-   *
-   * Sending auth as part of the query string and not as custom HTTP headers avoids CORS preflight requests.
-   */
-  public getStoreEndpointWithUrlEncodedAuth(): string {
-    return getStoreEndpointWithUrlEncodedAuth(this._dsnObject);
-  }
-
-  /**
-   * Returns the envelope endpoint URL with auth in the query string.
-   *
-   * Sending auth as part of the query string and not as custom HTTP headers avoids CORS preflight requests.
-   */
-  public getEnvelopeEndpointWithUrlEncodedAuth(): string {
-    return getEnvelopeEndpointWithUrlEncodedAuth(this._dsnObject, this._tunnel);
-  }
-}
-
 /** Initializes API Details */
 export function initAPIDetails(dsn: DsnLike, metadata?: SdkMetadata, tunnel?: string): APIDetails {
   return {
@@ -117,7 +50,7 @@ function _encodedAuth(dsn: DsnComponents): string {
 }
 
 /** Returns the store endpoint URL. */
-function getStoreEndpoint(dsn: DsnComponents): string {
+export function getStoreEndpoint(dsn: DsnComponents): string {
   return _getIngestEndpoint(dsn, 'store');
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,8 +15,6 @@ export {
 } from '@sentry/minimal';
 export { addGlobalEventProcessor, getCurrentHub, getHubFromCarrier, Hub, makeMain, Scope, Session } from '@sentry/hub';
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  API,
   APIDetails,
   getEnvelopeEndpointWithUrlEncodedAuth,
   getStoreEndpointWithUrlEncodedAuth,

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -13,11 +13,6 @@ export interface InboundFiltersOptions {
   denyUrls: Array<string | RegExp>;
   ignoreErrors: Array<string | RegExp>;
   ignoreInternal: boolean;
-
-  /** @deprecated use {@link InboundFiltersOptions.allowUrls} instead. */
-  whitelistUrls: Array<string | RegExp>;
-  /** @deprecated use {@link InboundFiltersOptions.denyUrls} instead. */
-  blacklistUrls: Array<string | RegExp>;
 }
 
 /** Inbound filters configurable by the user */
@@ -60,22 +55,8 @@ export function _mergeOptions(
   clientOptions: Partial<InboundFiltersOptions> = {},
 ): Partial<InboundFiltersOptions> {
   return {
-    allowUrls: [
-      // eslint-disable-next-line deprecation/deprecation
-      ...(internalOptions.whitelistUrls || []),
-      ...(internalOptions.allowUrls || []),
-      // eslint-disable-next-line deprecation/deprecation
-      ...(clientOptions.whitelistUrls || []),
-      ...(clientOptions.allowUrls || []),
-    ],
-    denyUrls: [
-      // eslint-disable-next-line deprecation/deprecation
-      ...(internalOptions.blacklistUrls || []),
-      ...(internalOptions.denyUrls || []),
-      // eslint-disable-next-line deprecation/deprecation
-      ...(clientOptions.blacklistUrls || []),
-      ...(clientOptions.denyUrls || []),
-    ],
+    allowUrls: [...(internalOptions.allowUrls || []), ...(clientOptions.allowUrls || [])],
+    denyUrls: [...(internalOptions.denyUrls || []), ...(clientOptions.denyUrls || [])],
     ignoreErrors: [
       ...(internalOptions.ignoreErrors || []),
       ...(clientOptions.ignoreErrors || []),

--- a/packages/core/test/lib/api.test.ts
+++ b/packages/core/test/lib/api.test.ts
@@ -1,27 +1,38 @@
 /* eslint-disable deprecation/deprecation */
 import { makeDsn } from '@sentry/utils';
 
-import { API, getReportDialogEndpoint, getRequestHeaders } from '../../src/api';
+import {
+  getEnvelopeEndpointWithUrlEncodedAuth,
+  getReportDialogEndpoint,
+  getRequestHeaders,
+  getStoreEndpoint,
+  getStoreEndpointWithUrlEncodedAuth,
+  initAPIDetails,
+} from '../../src/api';
 
 const ingestDsn = 'https://abc@xxxx.ingest.sentry.io:1234/subpath/123';
 const dsnPublic = 'https://abc@sentry.io:1234/subpath/123';
 const legacyDsn = 'https://abc:123@sentry.io:1234/subpath/123';
 const tunnel = 'https://hello.com/world';
 
+const ingestDsnAPI = initAPIDetails(ingestDsn);
+const dsnPublicAPI = initAPIDetails(dsnPublic);
+
 describe('API', () => {
   test('getStoreEndpoint', () => {
-    expect(new API(dsnPublic).getStoreEndpointWithUrlEncodedAuth()).toEqual(
+    expect(getStoreEndpointWithUrlEncodedAuth(dsnPublicAPI.dsn)).toEqual(
       'https://sentry.io:1234/subpath/api/123/store/?sentry_key=abc&sentry_version=7',
     );
-    expect(new API(dsnPublic).getStoreEndpoint()).toEqual('https://sentry.io:1234/subpath/api/123/store/');
-    expect(new API(ingestDsn).getStoreEndpoint()).toEqual('https://xxxx.ingest.sentry.io:1234/subpath/api/123/store/');
+    expect(getStoreEndpoint(dsnPublicAPI.dsn)).toEqual('https://sentry.io:1234/subpath/api/123/store/');
+    expect(getStoreEndpoint(ingestDsnAPI.dsn)).toEqual('https://xxxx.ingest.sentry.io:1234/subpath/api/123/store/');
   });
 
   test('getEnvelopeEndpoint', () => {
-    expect(new API(dsnPublic).getEnvelopeEndpointWithUrlEncodedAuth()).toEqual(
+    expect(getEnvelopeEndpointWithUrlEncodedAuth(dsnPublicAPI.dsn)).toEqual(
       'https://sentry.io:1234/subpath/api/123/envelope/?sentry_key=abc&sentry_version=7',
     );
-    expect(new API(dsnPublic, {}, tunnel).getEnvelopeEndpointWithUrlEncodedAuth()).toEqual(tunnel);
+    const dsnPublicAPIWithTunnel = initAPIDetails(dsnPublic, {}, tunnel);
+    expect(getEnvelopeEndpointWithUrlEncodedAuth(dsnPublicAPIWithTunnel.dsn, tunnel)).toEqual(tunnel);
   });
 
   test('getRequestHeaders', () => {
@@ -118,13 +129,13 @@ describe('API', () => {
     );
   });
 
-  test('getDsn', () => {
-    expect(new API(dsnPublic).getDsn().host).toEqual(makeDsn(dsnPublic).host);
-    expect(new API(dsnPublic).getDsn().path).toEqual(makeDsn(dsnPublic).path);
-    expect(new API(dsnPublic).getDsn().pass).toEqual(makeDsn(dsnPublic).pass);
-    expect(new API(dsnPublic).getDsn().port).toEqual(makeDsn(dsnPublic).port);
-    expect(new API(dsnPublic).getDsn().protocol).toEqual(makeDsn(dsnPublic).protocol);
-    expect(new API(dsnPublic).getDsn().projectId).toEqual(makeDsn(dsnPublic).projectId);
-    expect(new API(dsnPublic).getDsn().publicKey).toEqual(makeDsn(dsnPublic).publicKey);
+  test('initAPIDetails dsn', () => {
+    expect(dsnPublicAPI.dsn.host).toEqual(makeDsn(dsnPublic).host);
+    expect(dsnPublicAPI.dsn.path).toEqual(makeDsn(dsnPublic).path);
+    expect(dsnPublicAPI.dsn.pass).toEqual(makeDsn(dsnPublic).pass);
+    expect(dsnPublicAPI.dsn.port).toEqual(makeDsn(dsnPublic).port);
+    expect(dsnPublicAPI.dsn.protocol).toEqual(makeDsn(dsnPublic).protocol);
+    expect(dsnPublicAPI.dsn.projectId).toEqual(makeDsn(dsnPublic).projectId);
+    expect(dsnPublicAPI.dsn.publicKey).toEqual(makeDsn(dsnPublic).publicKey);
   });
 });

--- a/packages/eslint-config-sdk/package.json
+++ b/packages/eslint-config-sdk/package.json
@@ -12,7 +12,7 @@
     "sentry"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "src/index.js",
   "publishConfig": {

--- a/packages/eslint-plugin-sdk/package.json
+++ b/packages/eslint-plugin-sdk/package.json
@@ -12,7 +12,7 @@
     "sentry"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "src/index.js",
   "publishConfig": {

--- a/packages/gatsby/gatsby-browser.js
+++ b/packages/gatsby/gatsby-browser.js
@@ -6,12 +6,11 @@ exports.onClientEntry = function (_, pluginParams) {
   const areOptionsDefined = areSentryOptionsDefined(pluginParams);
 
   if (isIntialized) {
-    window.Sentry = Sentry; // For backwards compatibility
     if (areOptionsDefined) {
       console.warn(
         'Sentry Logger [Warn]: The SDK was initialized in the Sentry config file, but options were found in the Gatsby config. ' +
-          'These have been ignored, merge them to the Sentry config if you want to use them.\n' +
-          'Learn more about the Gatsby SDK on https://docs.sentry.io/platforms/javascript/guides/gatsby/',
+        'These have been ignored, merge them to the Sentry config if you want to use them.\n' +
+        'Learn more about the Gatsby SDK on https://docs.sentry.io/platforms/javascript/guides/gatsby/',
       );
     }
     return;
@@ -20,7 +19,7 @@ exports.onClientEntry = function (_, pluginParams) {
   if (!areOptionsDefined) {
     console.error(
       'Sentry Logger [Error]: No config for the Gatsby SDK was found.\n' +
-        'Learn how to configure it on https://docs.sentry.io/platforms/javascript/guides/gatsby/',
+      'Learn how to configure it on https://docs.sentry.io/platforms/javascript/guides/gatsby/',
     );
     return;
   }
@@ -32,7 +31,6 @@ exports.onClientEntry = function (_, pluginParams) {
     dsn: __SENTRY_DSN__,
     ...pluginParams,
   });
-  window.Sentry = Sentry; // For backwards compatibility
 };
 
 function isSentryInitialized() {

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -11,7 +11,7 @@
     "gatsby-plugin"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "build/dist/index.js",
   "module": "build/esm/index.js",

--- a/packages/gatsby/test/gatsby-browser.test.ts
+++ b/packages/gatsby/test/gatsby-browser.test.ts
@@ -36,10 +36,6 @@ describe('onClientEntry', () => {
     tracingAddExtensionMethods = jest.fn();
   });
 
-  afterEach(() => {
-    (window as any).Sentry = undefined;
-  });
-
   it.each([
     [{}, ['dsn', 'release']],
     [{ key: 'value' }, ['dsn', 'release', 'key']],
@@ -54,7 +50,6 @@ describe('onClientEntry', () => {
 
   describe('inits Sentry once', () => {
     afterEach(() => {
-      delete (window as any).Sentry;
       delete (window as any).__SENTRY__;
       (global.console.warn as jest.Mock).mockClear();
       (global.console.error as jest.Mock).mockClear();
@@ -78,7 +73,6 @@ describe('onClientEntry', () => {
       // eslint-disable-next-line no-console
       expect(console.error).not.toHaveBeenCalled();
       expect(sentryInit).not.toHaveBeenCalled();
-      expect((window as any).Sentry).toBeDefined();
     });
 
     it('initialized in injected config, with pluginParams', () => {
@@ -94,7 +88,6 @@ describe('onClientEntry', () => {
       // eslint-disable-next-line no-console
       expect(console.error).not.toHaveBeenCalled();
       expect(sentryInit).not.toHaveBeenCalled();
-      expect((window as any).Sentry).toBeDefined();
     });
 
     it('not initialized in injected config, without pluginParams', () => {
@@ -108,7 +101,6 @@ describe('onClientEntry', () => {
         Learn how to configure it on https://docs.sentry.io/platforms/javascript/guides/gatsby/",
         ]
       `);
-      expect((window as any).Sentry).not.toBeDefined();
     });
 
     it('not initialized in injected config, with pluginParams', () => {
@@ -125,7 +117,6 @@ describe('onClientEntry', () => {
                 "release": "release",
               }
             `);
-      expect((window as any).Sentry).toBeDefined();
     });
   });
 
@@ -164,7 +155,6 @@ describe('onClientEntry', () => {
   it('does not run if plugin params are undefined', () => {
     onClientEntry();
     expect(sentryInit).toHaveBeenCalledTimes(0);
-    expect((window as any).Sentry).toBeUndefined();
     expect(tracingAddExtensionMethods).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/gatsby/test/integration.test.tsx
+++ b/packages/gatsby/test/integration.test.tsx
@@ -5,6 +5,7 @@ import { useEffect } from 'react';
 import * as React from 'react';
 
 import { onClientEntry } from '../gatsby-browser';
+import * as Sentry from '../src';
 
 beforeAll(() => {
   (global as any).__SENTRY_RELEASE__ = '683f3a6ab819d47d23abfca9a914c81f0524d35b';
@@ -28,7 +29,7 @@ describe('useEffect', () => {
     function TestComponent() {
       useEffect(() => {
         const error = new Error('testing 123');
-        (window as any).Sentry.captureException(error);
+        Sentry.captureException(error);
       });
 
       return <div>Hello</div>;

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "build/dist/index.js",
   "module": "build/esm/index.js",

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -81,15 +81,6 @@ export interface Carrier {
 }
 
 /**
- * @hidden
- * @deprecated Can be removed once `Hub.getActiveDomain` is removed.
- */
-export interface DomainAsCarrier extends Carrier {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  members: { [key: string]: any }[];
-}
-
-/**
  * @inheritDoc
  */
 export class Hub implements HubInterface {
@@ -557,20 +548,6 @@ export function getCurrentHub(): Hub {
   }
   // Return hub that lives on a global object
   return getHubFromCarrier(registry);
-}
-
-/**
- * Returns the active domain, if one exists
- * @deprecated No longer used; remove in v7
- * @returns The domain, or undefined if there is no active domain
- */
-// eslint-disable-next-line deprecation/deprecation
-export function getActiveDomain(): DomainAsCarrier | undefined {
-  IS_DEBUG_BUILD && logger.warn('Function `getActiveDomain` is deprecated and will be removed in a future version.');
-
-  const sentry = getMainCarrier().__SENTRY__;
-
-  return sentry && sentry.extensions && sentry.extensions.domain && sentry.extensions.domain.active;
 }
 
 /**

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -14,8 +14,6 @@ import {
   Primitive,
   SessionContext,
   Severity,
-  Span,
-  SpanContext,
   Transaction,
   TransactionContext,
   User,
@@ -383,13 +381,6 @@ export class Hub implements HubInterface {
       IS_DEBUG_BUILD && logger.warn(`Cannot retrieve integration ${integration.id} from the current Hub`);
       return null;
     }
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public startSpan(context: SpanContext): Span {
-    return this._callExtensionMethod('startSpan', context);
   }
 
   /**

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -2,8 +2,6 @@ export { addGlobalEventProcessor, Scope } from './scope';
 export { Session } from './session';
 export { SessionFlusher } from './sessionflusher';
 export {
-  // eslint-disable-next-line deprecation/deprecation
-  getActiveDomain,
   getCurrentHub,
   getHubFromCarrier,
   getMainCarrier,
@@ -11,7 +9,5 @@ export {
   makeMain,
   setHubOnCarrier,
   Carrier,
-  // eslint-disable-next-line deprecation/deprecation
-  DomainAsCarrier,
   Layer,
 } from './hub';

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -224,14 +224,6 @@ export class Scope implements ScopeInterface {
   }
 
   /**
-   * Can be removed in major version.
-   * @deprecated in favor of {@link this.setTransactionName}
-   */
-  public setTransaction(name?: string): this {
-    return this.setTransactionName(name);
-  }
-
-  /**
    * @inheritDoc
    */
   public setContext(key: string, context: Context | null): this {

--- a/packages/integration-tests/suites/tracing/browsertracing/backgroundtab-pageload/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/backgroundtab-pageload/test.ts
@@ -9,7 +9,7 @@ sentryTest('should finish pageload transaction when the page goes background', a
 
   await page.goto(url);
 
-  page.click('#go-background');
+  void page.click('#go-background');
 
   const pageloadTransaction = await getFirstSentryEnvelopeRequest<Event>(page);
 

--- a/packages/integration-tests/suites/tracing/metrics/web-vitals-fid/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/web-vitals-fid/test.ts
@@ -12,9 +12,9 @@ sentryTest('should capture a FID vital.', async ({ browserName, getLocalTestPath
 
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  page.goto(url);
+  await page.goto(url);
   // To trigger FID
-  page.click('#fid-btn');
+  await page.click('#fid-btn');
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page);
 

--- a/packages/integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -14,10 +14,10 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
   );
 
   const url = await getLocalTestPath({ testDir: __dirname });
-  page.goto(url);
+  await page.goto(url);
 
   // Force closure of LCP listener.
-  page.click('body');
+  await page.click('body');
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page);
 
   expect(eventData.measurements).toBeDefined();

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -25,7 +25,7 @@
     "chai": "^4.1.2"
   },
   "scripts": {
-    "build": "run-p build:cjs build:esm build:types build:bundle",
+    "build": "run-p build:cjs build:esm build:types build:legacy build:bundle",
     "build:bundle": "bash scripts/buildBundles.sh",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:dev": "run-p build:cjs build:esm build:types",
@@ -38,7 +38,11 @@
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
-    "build:npm": "ts-node ../../scripts/prepack.ts --bundles && npm pack ./build/npm",
+    "build:legacy": "run-p build:types:legacy build:cjs:legacy build:esm:legacy",
+    "build:types:legacy": "tsc -p tsconfig.types.json --outDir build/npm-legacy/types",
+    "build:cjs:legacy": "tsc -p tsconfig.cjs.json --outDir build/npm-legacy/dist",
+    "build:esm:legacy": "tsc -p tsconfig.esm.json --outDir build/npm-legacy/esm",
+    "build:npm": "ts-node ../../scripts/prepack.ts --bundles --legacyPackage && npm pack ./build/npm && npm pack ./build/npm-legacy",
     "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf dist esm build coverage .rpt2_cache",
     "fix": "run-s fix:eslint fix:prettier",

--- a/packages/integrations/src/vue.ts
+++ b/packages/integrations/src/vue.ts
@@ -6,15 +6,6 @@ import { basename, getGlobalObject, logger, timestampWithMs } from '@sentry/util
 import { IS_DEBUG_BUILD } from './flags';
 
 /**
- * Used to extract Tracing integration from the current client,
- * without the need to import `Tracing` itself from the @sentry/apm package.
- * @deprecated as @sentry/tracing should be used over @sentry/apm.
- */
-const TRACING_GETTER = {
-  id: 'Tracing',
-} as any as IntegrationClass<Integration>;
-
-/**
  * Used to extract BrowserTracing integration from @sentry/tracing
  */
 const BROWSER_TRACING_GETTER = {
@@ -150,7 +141,6 @@ export class Vue implements Integration {
   private readonly _componentsCache: { [key: string]: string } = {};
   private _rootSpan?: Span;
   private _rootSpanTimer?: ReturnType<typeof setTimeout>;
-  private _tracingActivity?: number;
 
   /**
    * @inheritDoc
@@ -260,30 +250,12 @@ export class Vue implements Integration {
         vm.$once(`hook:${hook}`, () => {
           // Create an activity on the first event call. There'll be no second call, as rootSpan will be in place,
           // thus new event handler won't be attached.
-
-          // We do this whole dance with `TRACING_GETTER` to prevent `@sentry/apm` from becoming a peerDependency.
-          // We also need to ask for the `.constructor`, as `pushActivity` and `popActivity` are static, not instance methods.
-          /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-          // eslint-disable-next-line deprecation/deprecation
-          const tracingIntegration = getCurrentHub().getIntegration(TRACING_GETTER);
-          if (tracingIntegration) {
-            this._tracingActivity = (tracingIntegration as any).constructor.pushActivity('Vue Application Render');
-            const transaction = (tracingIntegration as any).constructor.getTransaction();
-            if (transaction) {
-              this._rootSpan = transaction.startChild({
-                description: 'Application Render',
-                op: VUE_OP,
-              });
-            }
-            // Use functionality from @sentry/tracing
-          } else {
-            const activeTransaction = getActiveTransaction(getCurrentHub());
-            if (activeTransaction) {
-              this._rootSpan = activeTransaction.startChild({
-                description: 'Application Render',
-                op: VUE_OP,
-              });
-            }
+          const activeTransaction = getActiveTransaction(getCurrentHub());
+          if (activeTransaction) {
+            this._rootSpan = activeTransaction.startChild({
+              description: 'Application Render',
+              op: VUE_OP,
+            });
           }
           /* eslint-enable @typescript-eslint/no-unsafe-member-access */
         });
@@ -349,24 +321,13 @@ export class Vue implements Integration {
   };
 
   /** Finish top-level span and activity with a debounce configured using `timeout` option */
-  private _finishRootSpan(timestamp: number, getCurrentHub: () => Hub): void {
+  private _finishRootSpan(timestamp: number, _getCurrentHub: () => Hub): void {
     if (this._rootSpanTimer) {
       clearTimeout(this._rootSpanTimer);
     }
 
     this._rootSpanTimer = setTimeout(() => {
-      if (this._tracingActivity) {
-        // We do this whole dance with `TRACING_GETTER` to prevent `@sentry/apm` from becoming a peerDependency.
-        // We also need to ask for the `.constructor`, as `pushActivity` and `popActivity` are static, not instance methods.
-        // eslint-disable-next-line deprecation/deprecation
-        const tracingIntegration = getCurrentHub().getIntegration(TRACING_GETTER);
-        if (tracingIntegration) {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          (tracingIntegration as any).constructor.popActivity(this._tracingActivity);
-        }
-      }
-
-      // We should always finish the span, only should pop activity if using @sentry/apm
+      // We should always finish the span
       if (this._rootSpan) {
         this._rootSpan.finish(timestamp);
       }
@@ -379,8 +340,7 @@ export class Vue implements Integration {
 
     this._options.Vue.mixin({
       beforeCreate(this: ViewModel): void {
-        // eslint-disable-next-line deprecation/deprecation
-        if (getCurrentHub().getIntegration(TRACING_GETTER) || getCurrentHub().getIntegration(BROWSER_TRACING_GETTER)) {
+        if (getCurrentHub().getIntegration(BROWSER_TRACING_GETTER)) {
           // `this` points to currently rendered component
           applyTracingHooks(this, getCurrentHub);
         } else {

--- a/packages/minimal/package.json
+++ b/packages/minimal/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "build/dist/index.js",
   "module": "build/esm/index.js",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "build/dist/index.server.js",
   "module": "build/esm/index.server.js",

--- a/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
@@ -8,7 +8,7 @@ conditionalTest({ min: 12 })('MongoDB Test', () => {
   beforeAll(async () => {
     mongoServer = await MongoMemoryServer.create();
     process.env.MONGO_URL = mongoServer.getUri();
-  }, 30000);
+  }, 40000);
 
   afterAll(async () => {
     await mongoServer.stop();

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "build/dist/index.js",
   "module": "build/esm/index.js",

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -1,10 +1,7 @@
-import { getCurrentHub } from '@sentry/core';
 import { Event, EventProcessor, Integration, StackFrame } from '@sentry/types';
 import { addContextToFrame } from '@sentry/utils';
 import { readFile } from 'fs';
 import { LRUMap } from 'lru_map';
-
-import { NodeClient } from '../client';
 
 const FILE_CONTENT_CACHE = new LRUMap<string, string | null>(100);
 const DEFAULT_LINES_OF_CONTEXT = 7;
@@ -53,16 +50,6 @@ export class ContextLines implements Integration {
 
   /** Get's the number of context lines to add */
   private get _contextLines(): number {
-    // This is only here to copy frameContextLines from init options if it hasn't
-    // been set via this integrations constructor.
-    //
-    // TODO: Remove on next major!
-    if (this._options.frameContextLines === undefined) {
-      const initOptions = getCurrentHub().getClient<NodeClient>()?.getOptions();
-      // eslint-disable-next-line deprecation/deprecation
-      this._options.frameContextLines = initOptions?.frameContextLines;
-    }
-
     return this._options.frameContextLines !== undefined ? this._options.frameContextLines : DEFAULT_LINES_OF_CONTEXT;
   }
 

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -20,21 +20,6 @@ export interface NodeOptions extends Options {
   /** HTTPS proxy certificates path */
   caCerts?: string;
 
-  /**
-   * Sets the number of context lines for each frame when loading a file.
-   *
-   * @deprecated Context lines configuration has moved to the `ContextLines` integration, and can be used like this:
-   *
-   * ```
-   * init({
-   *   dsn: '__DSN__',
-   *   integrations: [new ContextLines({ frameContextLines: 10 })]
-   * })
-   * ```
-   *
-   * */
-  frameContextLines?: number;
-
   /** Callback that is executed when a fatal global error occurs. */
   onFatalError?(error: Error): void;
 }

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -44,9 +44,7 @@ describe('tracing', () => {
 
     http.get('http://dogs.are.great/');
 
-    // TODO: For some reason in node 6 two request spans are appearing. Once we stop testing against it, this can go
-    // back to being `toEqual()`.
-    expect(spans.length).toBeGreaterThanOrEqual(2);
+    expect(spans.length).toEqual(2);
 
     // our span is at index 1 because the transaction itself is at index 0
     expect(spans[1].description).toEqual('GET http://dogs.are.great/');

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "build/dist/index.js",
   "module": "build/esm/index.js",

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getCurrentHub, Hub } from '@sentry/browser';
-import { Integration, IntegrationClass, Span, Transaction } from '@sentry/types';
+import { Span, Transaction } from '@sentry/types';
 import { timestampWithMs } from '@sentry/utils';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
@@ -9,66 +9,6 @@ import * as React from 'react';
 import { REACT_MOUNT_OP, REACT_RENDER_OP, REACT_UPDATE_OP } from './constants';
 
 export const UNKNOWN_COMPONENT = 'unknown';
-
-const TRACING_GETTER = ({
-  id: 'Tracing',
-} as any) as IntegrationClass<Integration>;
-
-let globalTracingIntegration: Integration | null = null;
-/** @deprecated remove when @sentry/apm no longer used */
-const getTracingIntegration = (): Integration | null => {
-  if (globalTracingIntegration) {
-    return globalTracingIntegration;
-  }
-
-  globalTracingIntegration = getCurrentHub().getIntegration(TRACING_GETTER);
-  return globalTracingIntegration;
-};
-
-/**
- * pushActivity creates an new react activity.
- * Is a no-op if Tracing integration is not valid
- * @param name displayName of component that started activity
- * @deprecated remove when @sentry/apm no longer used
- */
-function pushActivity(name: string, op: string): number | null {
-  if (globalTracingIntegration === null) {
-    return null;
-  }
-
-  return (globalTracingIntegration as any).constructor.pushActivity(name, {
-    description: `<${name}>`,
-    op,
-  });
-}
-
-/**
- * popActivity removes a React activity.
- * Is a no-op if Tracing integration is not valid.
- * @param activity id of activity that is being popped
- * @deprecated remove when @sentry/apm no longer used
- */
-function popActivity(activity: number | null): void {
-  if (activity === null || globalTracingIntegration === null) {
-    return;
-  }
-
-  (globalTracingIntegration as any).constructor.popActivity(activity);
-}
-
-/**
- * Obtain a span given an activity id.
- * Is a no-op if Tracing integration is not valid.
- * @param activity activity id associated with obtained span
- * @deprecated remove when @sentry/apm no longer used
- */
-function getActivitySpan(activity: number | null): Span | undefined {
-  if (activity === null || globalTracingIntegration === null) {
-    return undefined;
-  }
-
-  return (globalTracingIntegration as any).constructor.getActivitySpan(activity) as Span | undefined;
-}
 
 export type ProfilerProps = {
   // The name of the component being profiled.
@@ -95,9 +35,6 @@ class Profiler extends React.Component<ProfilerProps> {
    */
   protected _mountSpan: Span | undefined = undefined;
 
-  // The activity representing how long it takes to mount a component.
-  private _mountActivity: number | null = null;
-
   // eslint-disable-next-line @typescript-eslint/member-ordering
   public static defaultProps: Partial<ProfilerProps> = {
     disabled: false,
@@ -113,19 +50,12 @@ class Profiler extends React.Component<ProfilerProps> {
       return;
     }
 
-    // If they are using @sentry/apm, we need to push/pop activities
-    // eslint-disable-next-line deprecation/deprecation
-    if (getTracingIntegration()) {
-      // eslint-disable-next-line deprecation/deprecation
-      this._mountActivity = pushActivity(name, REACT_MOUNT_OP);
-    } else {
-      const activeTransaction = getActiveTransaction();
-      if (activeTransaction) {
-        this._mountSpan = activeTransaction.startChild({
-          description: `<${name}>`,
-          op: REACT_MOUNT_OP,
-        });
-      }
+    const activeTransaction = getActiveTransaction();
+    if (activeTransaction) {
+      this._mountSpan = activeTransaction.startChild({
+        description: `<${name}>`,
+        op: REACT_MOUNT_OP,
+      });
     }
   }
 
@@ -133,12 +63,6 @@ class Profiler extends React.Component<ProfilerProps> {
   public componentDidMount(): void {
     if (this._mountSpan) {
       this._mountSpan.finish();
-    } else {
-      // eslint-disable-next-line deprecation/deprecation
-      this._mountSpan = getActivitySpan(this._mountActivity);
-      // eslint-disable-next-line deprecation/deprecation
-      popActivity(this._mountActivity);
-      this._mountActivity = null;
     }
   }
 

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "build/npm/dist/index.js",
   "module": "build/npm/esm/index.js",

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -29,7 +29,7 @@
     "jsdom": "^16.2.2"
   },
   "scripts": {
-    "build": "run-p build:cjs build:esm build:types build:bundle && ts-node ../../scripts/prepack.ts #necessary for integration tests",
+    "build": "run-p build:cjs build:esm build:types build:bundle build:legacy && ts-node ../../scripts/prepack.ts #necessary for integration tests",
     "build:bundle": "rollup --config",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:dev": "run-p build:cjs build:esm build:types",
@@ -43,7 +43,11 @@
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
-    "build:npm": "ts-node ../../scripts/prepack.ts --bundles && npm pack ./build/npm",
+    "build:legacy": "run-p build:types:legacy build:cjs:legacy build:esm:legacy",
+    "build:types:legacy": "tsc -p tsconfig.types.json --outDir build/npm-legacy/types",
+    "build:cjs:legacy": "tsc -p tsconfig.cjs.json --outDir build/npm-legacy/dist",
+    "build:esm:legacy": "tsc -p tsconfig.esm.json --outDir build/npm-legacy/esm",
+    "build:npm": "ts-node ../../scripts/prepack.ts --bundles --legacyPackage && npm pack ./build/npm && npm pack ./build/npm-legacy",
     "clean": "rimraf dist esm build coverage",
     "circularDepCheck": "madge --circular src/index.ts",
     "fix": "run-s fix:eslint fix:prettier",

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -26,8 +26,7 @@ export { Span, SpanStatusType, spanStatusfromHttpCode } from './span';
 export { SpanStatus } from './spanstatus';
 export { Transaction } from './transaction';
 export {
-  // TODO deprecate old name in v7
-  instrumentOutgoingRequests as registerRequestInstrumentation,
+  instrumentOutgoingRequests,
   RequestInstrumentationOptions,
   defaultRequestInstrumentationOptions,
 } from './browser';

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -151,16 +151,6 @@ export class Span implements SpanInterface {
 
   /**
    * @inheritDoc
-   * @deprecated
-   */
-  public child(
-    spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId' | 'sampled' | 'traceId' | 'parentSpanId'>>,
-  ): Span {
-    return this.startChild(spanContext);
-  }
-
-  /**
-   * @inheritDoc
    */
   public startChild(
     spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId' | 'sampled' | 'traceId' | 'parentSpanId'>>,

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "build/dist/index.js",
   "module": "build/esm/index.js",

--- a/packages/types/src/dsn.ts
+++ b/packages/types/src/dsn.ts
@@ -5,8 +5,6 @@ export type DsnProtocol = 'http' | 'https';
 export interface DsnComponents {
   /** Protocol used to connect to Sentry. */
   protocol: DsnProtocol;
-  /** Public authorization key (deprecated, renamed to publicKey). */
-  user?: string;
   /** Public authorization key. */
   publicKey?: string;
   /** Private authorization key (deprecated, optional). */

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -7,7 +7,6 @@ import { Primitive } from './misc';
 import { Scope } from './scope';
 import { Session, SessionContext } from './session';
 import { Severity } from './severity';
-import { Span, SpanContext } from './span';
 import { CustomSamplingContext, Transaction, TransactionContext } from './transaction';
 import { User } from './user';
 
@@ -179,11 +178,6 @@ export interface Hub {
 
   /** Returns all trace headers that are currently on the top scope. */
   traceHeaders(): { [key: string]: string };
-
-  /**
-   * @deprecated No longer does anything. Use use {@link Transaction.startChild} instead.
-   */
-  startSpan(context: SpanContext): Span;
 
   /**
    * Starts a new `Transaction` and returns it. This is the entry point to manual tracing instrumentation.

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -129,14 +129,6 @@ export interface Span extends SpanContext {
   setHttpStatus(httpStatus: number): this;
 
   /**
-   * Use {@link startChild}
-   * @deprecated
-   */
-  child(
-    spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId' | 'sampled' | 'traceId' | 'parentSpanId'>>,
-  ): Span;
-
-  /**
    * Creates a new `Span` while setting the current `Span.id` as `parentSpanId`.
    * Also the `sampled` decision will be inherited.
    */

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -16,7 +16,7 @@
   },
   "peerDependencies": {
     "tslint": "5.16.0",
-    "typescript": "3.7.5"
+    "typescript": "3.8.3"
   },
   "scripts": {
     "link:yarn": "yarn link",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "build/dist/index.js",
   "module": "build/esm/index.js",

--- a/packages/utils/src/dsn.ts
+++ b/packages/utils/src/dsn.ts
@@ -55,13 +55,7 @@ function dsnFromString(str: string): DsnComponents {
 }
 
 function dsnFromComponents(components: DsnComponents): DsnComponents {
-  // TODO this is for backwards compatibility, and can be removed in a future version
-  if ('user' in components && !('publicKey' in components)) {
-    components.publicKey = components.user;
-  }
-
   return {
-    user: components.publicKey || '',
     protocol: components.protocol,
     publicKey: components.publicKey || '',
     pass: components.pass || '',

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "build/dist/index.js",
   "module": "build/esm/index.js",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -7,7 +7,7 @@
   "author": "Sentry",
   "license": "MIT",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "main": "build/npm/dist/index.js",
   "module": "build/npm/esm/index.js",

--- a/scripts/prepack.ts
+++ b/scripts/prepack.ts
@@ -110,8 +110,16 @@ function getModifiedPkgJson(newName: string, removeDependencies?: boolean): Reco
   delete newPkgJson.volta;
   delete newPkgJson.jest;
 
-  if (removeDependencies) {
-    newPkgJson.dependencies = {};
+  if (removeDependencies && typeof pkgJson.dependencies === 'object' && pkgJson.dependencies !== null) {
+    const newDependencies: Record<string, string> = {};
+
+    for (const dependency in pkgJson.dependencies) {
+      if (!dependency.startsWith('@sentry')) {
+        newDependencies[dependency] = (pkgJson.dependencies as Record<string, string>)[dependency];
+      }
+    }
+
+    newPkgJson.dependencies = newDependencies;
   }
 
   // modify entry points to point to correct paths (i.e. strip out the build directory)

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -11,21 +11,7 @@ function run(cmd: string, cwd: string = '') {
 
 const nodeMajorVersion = parseInt(process.version.split('.')[0].replace('v', ''), 10);
 
-// control which packages we test on each version of node
-if (nodeMajorVersion <= 6) {
-  // install legacy versions of packages whose current versions don't support node 6
-  // ignoring engines and scripts lets us get away with having incompatible things installed for packages we're not testing
-  run('yarn add --dev --ignore-engines --ignore-scripts nock@10.x', 'packages/node');
-  run('yarn add --dev --ignore-engines --ignore-scripts jsdom@11.x', 'packages/tracing');
-  run('yarn add --dev --ignore-engines --ignore-scripts jsdom@11.x', 'packages/utils');
-
-  // only test against @sentry/node and its dependencies - node 6 is too old for anything else to work
-  const scope = ['@sentry/core', '@sentry/hub', '@sentry/minimal', '@sentry/node', '@sentry/utils', '@sentry/tracing']
-    .map(dep => `--scope="${dep}"`)
-    .join(' ');
-
-  run(`yarn test ${scope}`);
-} else if (nodeMajorVersion <= 8) {
+if (nodeMajorVersion <= 8) {
   // install legacy versions of packages whose current versions don't support node 8
   // ignoring engines and scripts lets us get away with having incompatible things installed for packages we're not testing
   run('yarn add --dev --ignore-engines --ignore-scripts jsdom@15.x', 'packages/tracing');

--- a/scripts/verify-packages-versions.js
+++ b/scripts/verify-packages-versions.js
@@ -1,6 +1,6 @@
 const pkg = require('../package.json');
 
-const TYPESCRIPT_VERSION = '3.7.5';
+const TYPESCRIPT_VERSION = '3.8.3';
 
 if (pkg.devDependencies.typescript !== TYPESCRIPT_VERSION) {
   console.error(`

--- a/yarn.lock
+++ b/yarn.lock
@@ -21523,10 +21523,10 @@ typescript-memoize@^1.0.1:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.0.1.tgz#0a8199aa28f6fe18517f6e9308ef7bfbe9a98d59"
   integrity sha512-oJNge1qUrOK37d5Y6Ly2txKeuelYVsFtNF6U9kXIN7juudcQaHJQg2MxLOy0CqtkW65rVDYuTCOjnSIVPd8z3w==
 
-typescript@3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 typescript@^3.9.5, typescript@^3.9.7:
   version "3.9.9"


### PR DESCRIPTION
With out move to es6 we want to provide legacy packages that support es5.
This PR adds commands to build legacy package files and updates the prepackage script to bundle everything up correctly with an additional flag.

Currently the legacy package is identical to the one we currently publish.

Ref: https://getsentry.atlassian.net/browse/WEB-682