### PR TITLE
fix(test): Increase `MongoMemoryServer` creation timeout to fix  Node integration test flakiness

### DIFF
--- a/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
@@ -8,7 +8,7 @@ conditionalTest({ min: 12 })('MongoDB Test', () => {
   beforeAll(async () => {
     mongoServer = await MongoMemoryServer.create();
     process.env.MONGO_URL = mongoServer.getUri();
-  }, 30000);
+  }, 40000);
 
   afterAll(async () => {
     await mongoServer.stop();


### PR DESCRIPTION
This PR increases the creation timeout of `MongoMemoryServer` to temporarily fix Node integration test flakiness. The proper fix is being worked on in #4872. After a sync with @onurtemizkan, we decided to use this PR in the meantime.