### PR TITLE
[v7] Remove deprecated `frameContextLines`

### DIFF
--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -1,10 +1,7 @@
-import { getCurrentHub } from '@sentry/core';
 import { Event, EventProcessor, Integration, StackFrame } from '@sentry/types';
 import { addContextToFrame } from '@sentry/utils';
 import { readFile } from 'fs';
 import { LRUMap } from 'lru_map';
-
-import { NodeClient } from '../client';
 
 const FILE_CONTENT_CACHE = new LRUMap<string, string | null>(100);
 const DEFAULT_LINES_OF_CONTEXT = 7;

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -53,16 +53,6 @@ export class ContextLines implements Integration {
 
   /** Get's the number of context lines to add */
   private get _contextLines(): number {
-    // This is only here to copy frameContextLines from init options if it hasn't
-    // been set via this integrations constructor.
-    //
-    // TODO: Remove on next major!
-    if (this._options.frameContextLines === undefined) {
-      const initOptions = getCurrentHub().getClient<NodeClient>()?.getOptions();
-      // eslint-disable-next-line deprecation/deprecation
-      this._options.frameContextLines = initOptions?.frameContextLines;
-    }
-
     return this._options.frameContextLines !== undefined ? this._options.frameContextLines : DEFAULT_LINES_OF_CONTEXT;
   }
 

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -20,21 +20,6 @@ export interface NodeOptions extends Options {
   /** HTTPS proxy certificates path */
   caCerts?: string;
 
-  /**
-   * Sets the number of context lines for each frame when loading a file.
-   *
-   * @deprecated Context lines configuration has moved to the `ContextLines` integration, and can be used like this:
-   *
-   * ```
-   * init({
-   *   dsn: '__DSN__',
-   *   integrations: [new ContextLines({ frameContextLines: 10 })]
-   * })
-   * ```
-   *
-   * */
-  frameContextLines?: number;
-
   /** Callback that is executed when a fatal global error occurs. */
   onFatalError?(error: Error): void;
 }


### PR DESCRIPTION
This PR removes the previously deprecated `frameContextLines` from `NodeOptions`.

See https://github.com/getsentry/sentry-javascript/pull/3729