### PR TITLE
[v7] Remove eventbuilder exports which were historically used in `@sentry/electron`

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -44,6 +44,5 @@ export {
 export { BrowserOptions } from './backend';
 export { BrowserClient } from './client';
 export { injectReportDialog, ReportDialogOptions } from './helpers';
-export { eventFromException, eventFromMessage } from './eventbuilder';
 export { defaultIntegrations, forceLoad, init, lastEventId, onLoad, showReportDialog, flush, close, wrap } from './sdk';
 export { SDK_NAME } from './version';


### PR DESCRIPTION
These exports aren't even used in the React Native SDK:
https://github.com/getsentry/sentry-react-native/blob/a8d5ac86e3c53c90ef8e190cc082bdac440bd2a7/src/js/backend.ts#L45-L61