### PR TITLE
ref(build): Turn on `isolatedModules` TS option

### DIFF
--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,7 +1,9 @@
+export type { ErrorHandlerOptions } from './errorhandler';
+
 export * from '@sentry/browser';
 
 export { init } from './sdk';
-export { createErrorHandler, ErrorHandlerOptions, SentryErrorHandler } from './errorhandler';
+export { createErrorHandler, SentryErrorHandler } from './errorhandler';
 export {
   getActiveTransaction,
   // TODO `instrumentAngularRouting` is just an alias for `routingInstrumentation`; deprecate the latter at some point

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   Breadcrumb,
   BreadcrumbHint,
   Request,
@@ -16,6 +16,9 @@ export {
   Thread,
   User,
 } from '@sentry/types';
+
+export type { BrowserOptions } from './client';
+export type { ReportDialogOptions } from './helpers';
 
 export {
   addGlobalEventProcessor,
@@ -41,8 +44,7 @@ export {
   withScope,
 } from '@sentry/core';
 
-export { BrowserClient, BrowserOptions } from './client';
-
+export { BrowserClient } from './client';
 export {
   defaultStackParsers,
   chromeStackParser,
@@ -51,6 +53,6 @@ export {
   opera11StackParser,
   winjsStackParser,
 } from './stack-parsers';
-export { injectReportDialog, ReportDialogOptions } from './helpers';
+export { injectReportDialog } from './helpers';
 export { defaultIntegrations, forceLoad, init, lastEventId, onLoad, showReportDialog, flush, close, wrap } from './sdk';
 export { SDK_NAME } from './version';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,13 @@
+export type { APIDetails } from './api';
+export type { ClientClass } from './sdk';
+export type {
+  BaseTransportOptions,
+  NewTransport,
+  TransportMakeRequestResponse,
+  TransportRequest,
+  TransportRequestExecutor,
+} from './transports/base';
+
 export {
   addBreadcrumb,
   captureException,
@@ -15,7 +25,6 @@ export {
 } from '@sentry/minimal';
 export { addGlobalEventProcessor, getCurrentHub, getHubFromCarrier, Hub, makeMain, Scope, Session } from '@sentry/hub';
 export {
-  APIDetails,
   getEnvelopeEndpointWithUrlEncodedAuth,
   getStoreEndpointWithUrlEncodedAuth,
   getRequestHeaders,
@@ -24,16 +33,9 @@ export {
 } from './api';
 export { BaseClient } from './baseclient';
 export { eventToSentryRequest, sessionToSentryRequest } from './request';
-export { initAndBind, ClientClass } from './sdk';
+export { initAndBind } from './sdk';
 export { NoopTransport } from './transports/noop';
-export {
-  BaseTransportOptions,
-  createTransport,
-  NewTransport,
-  TransportMakeRequestResponse,
-  TransportRequest,
-  TransportRequestExecutor,
-} from './transports/base';
+export { createTransport } from './transports/base';
 export { SDK_VERSION } from './version';
 
 import * as Integrations from './integrations';

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -1,13 +1,6 @@
+export type { Carrier, Layer } from './hub';
+
 export { addGlobalEventProcessor, Scope } from './scope';
 export { Session } from './session';
 export { SessionFlusher } from './sessionflusher';
-export {
-  getCurrentHub,
-  getHubFromCarrier,
-  getMainCarrier,
-  Hub,
-  makeMain,
-  setHubOnCarrier,
-  Carrier,
-  Layer,
-} from './hub';
+export { getCurrentHub, getHubFromCarrier, getMainCarrier, Hub, makeMain, setHubOnCarrier } from './hub';

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -135,8 +135,8 @@ function filterTransactions(event: Event): Event | null {
   return event.type === 'transaction' && event.transaction === '/404' ? null : event;
 }
 
+export type { SentryWebpackPluginOptions } from './config/types';
 export { withSentryConfig } from './config';
-export { SentryWebpackPluginOptions } from './config/types';
 export { withSentry } from './utils/withSentry';
 
 // Wrap various server methods to enable error monitoring and tracing. (Note: This only happens for non-Vercel

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   Breadcrumb,
   BreadcrumbHint,
   Request,
@@ -16,6 +16,8 @@ export {
   Thread,
   User,
 } from '@sentry/types';
+
+export type { NodeOptions } from './types';
 
 export {
   addGlobalEventProcessor,
@@ -41,7 +43,6 @@ export {
   withScope,
 } from '@sentry/core';
 
-export { NodeOptions } from './types';
 export { NodeClient } from './client';
 export { defaultIntegrations, init, lastEventId, flush, close, getSentryRelease } from './sdk';
 export { deepReadDirSync } from './utils';

--- a/packages/node/src/transports/index.ts
+++ b/packages/node/src/transports/index.ts
@@ -1,4 +1,6 @@
+export type { NodeTransportOptions } from './new';
+
 export { BaseTransport } from './base';
 export { HTTPTransport } from './http';
 export { HTTPSTransport } from './https';
-export { makeNodeTransport, NodeTransportOptions } from './new';
+export { makeNodeTransport } from './new';

--- a/packages/serverless/src/gcpfunction/general.ts
+++ b/packages/serverless/src/gcpfunction/general.ts
@@ -62,4 +62,4 @@ export function configureScopeWithContext(scope: Scope, context: Context): void 
   scope.setContext('gcp.function.context', { ...context } as SentryContext);
 }
 
-export { Request, Response };
+export type { Request, Response };

--- a/packages/tracing/src/browser/index.ts
+++ b/packages/tracing/src/browser/index.ts
@@ -1,6 +1,4 @@
+export type { RequestInstrumentationOptions } from './request';
+
 export { BrowserTracing } from './browsertracing';
-export {
-  instrumentOutgoingRequests,
-  RequestInstrumentationOptions,
-  defaultRequestInstrumentationOptions,
-} from './request';
+export { instrumentOutgoingRequests, defaultRequestInstrumentationOptions } from './request';

--- a/packages/tracing/src/index.bundle.ts
+++ b/packages/tracing/src/index.bundle.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   Breadcrumb,
   Request,
   SdkInfo,
@@ -14,6 +14,8 @@ export {
   Thread,
   User,
 } from '@sentry/types';
+
+export type { BrowserOptions, ReportDialogOptions } from '@sentry/browser';
 
 export {
   addGlobalEventProcessor,
@@ -37,8 +39,7 @@ export {
   withScope,
 } from '@sentry/browser';
 
-export { BrowserOptions } from '@sentry/browser';
-export { BrowserClient, ReportDialogOptions } from '@sentry/browser';
+export { BrowserClient } from '@sentry/browser';
 export {
   defaultIntegrations,
   forceLoad,

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -1,6 +1,9 @@
 import { addExtensionMethods } from './hubextensions';
 import * as Integrations from './integrations';
 
+export type { RequestInstrumentationOptions } from './browser';
+export type { SpanStatusType } from './span';
+
 export { Integrations };
 
 // This is already exported as part of `Integrations` above (and for the moment will remain so for
@@ -21,15 +24,11 @@ export { Integrations };
 // For an example of of the new usage of BrowserTracing, see @sentry/nextjs index.client.ts
 export { BrowserTracing } from './browser';
 
-export { Span, SpanStatusType, spanStatusfromHttpCode } from './span';
+export { Span, spanStatusfromHttpCode } from './span';
 // eslint-disable-next-line deprecation/deprecation
 export { SpanStatus } from './spanstatus';
 export { Transaction } from './transaction';
-export {
-  instrumentOutgoingRequests,
-  RequestInstrumentationOptions,
-  defaultRequestInstrumentationOptions,
-} from './browser';
+export { instrumentOutgoingRequests, defaultRequestInstrumentationOptions } from './browser';
 export { IdleTransaction } from './idletransaction';
 export { startIdleTransaction } from './hubextensions';
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,10 +1,10 @@
-export { Breadcrumb, BreadcrumbHint } from './breadcrumb';
-export { Client } from './client';
-export { ClientReport } from './clientreport';
-export { Context, Contexts } from './context';
-export { DsnComponents, DsnLike, DsnProtocol } from './dsn';
-export { DebugImage, DebugImageType, DebugMeta } from './debugMeta';
-export {
+export type { Breadcrumb, BreadcrumbHint } from './breadcrumb';
+export type { Client } from './client';
+export type { ClientReport } from './clientreport';
+export type { Context, Contexts } from './context';
+export type { DsnComponents, DsnLike, DsnProtocol } from './dsn';
+export type { DebugImage, DebugImageType, DebugMeta } from './debugMeta';
+export type {
   AttachmentItem,
   BaseEnvelopeHeaders,
   BaseEnvelopeItemHeaders,
@@ -17,25 +17,25 @@ export {
   SessionItem,
   UserFeedbackItem,
 } from './envelope';
-export { ExtendedError } from './error';
-export { Event, EventHint } from './event';
-export { EventStatus } from './eventstatus';
-export { EventProcessor } from './eventprocessor';
-export { Exception } from './exception';
-export { Extra, Extras } from './extra';
-export { Hub } from './hub';
-export { Integration, IntegrationClass } from './integration';
-export { Mechanism } from './mechanism';
-export { ExtractedNodeRequestData, Primitive, WorkerLocation } from './misc';
-export { Options } from './options';
-export { Package } from './package';
-export { QueryParams, Request, SentryRequest, SentryRequestType } from './request';
-export { Response } from './response';
-export { Runtime } from './runtime';
-export { CaptureContext, Scope, ScopeContext } from './scope';
-export { SdkInfo } from './sdkinfo';
-export { SdkMetadata } from './sdkmetadata';
-export {
+export type { ExtendedError } from './error';
+export type { Event, EventHint } from './event';
+export type { EventStatus } from './eventstatus';
+export type { EventProcessor } from './eventprocessor';
+export type { Exception } from './exception';
+export type { Extra, Extras } from './extra';
+export type { Hub } from './hub';
+export type { Integration, IntegrationClass } from './integration';
+export type { Mechanism } from './mechanism';
+export type { ExtractedNodeRequestData, Primitive, WorkerLocation } from './misc';
+export type { Options } from './options';
+export type { Package } from './package';
+export type { QueryParams, Request, SentryRequest, SentryRequestType } from './request';
+export type { Response } from './response';
+export type { Runtime } from './runtime';
+export type { CaptureContext, Scope, ScopeContext } from './scope';
+export type { SdkInfo } from './sdkinfo';
+export type { SdkMetadata } from './sdkmetadata';
+export type {
   SessionAggregates,
   AggregationCounts,
   Session,
@@ -47,11 +47,11 @@ export {
 } from './session';
 
 // eslint-disable-next-line deprecation/deprecation
-export { Severity, SeverityLevel } from './severity';
-export { Span, SpanContext } from './span';
-export { StackFrame } from './stackframe';
-export { Stacktrace, StackParser, StackLineParser, StackLineParserFn } from './stacktrace';
-export {
+export type { Severity, SeverityLevel } from './severity';
+export type { Span, SpanContext } from './span';
+export type { StackFrame } from './stackframe';
+export type { Stacktrace, StackParser, StackLineParser, StackLineParserFn } from './stacktrace';
+export type {
   CustomSamplingContext,
   Measurements,
   SamplingContext,
@@ -61,7 +61,7 @@ export {
   TransactionMetadata,
   TransactionSamplingMethod,
 } from './transaction';
-export { Thread } from './thread';
-export { Outcome, Transport, TransportOptions, TransportClass } from './transport';
-export { User, UserFeedback } from './user';
-export { WrappedFunction } from './wrappedfunction';
+export type { Thread } from './thread';
+export type { Outcome, Transport, TransportOptions, TransportClass } from './transport';
+export type { User, UserFeedback } from './user';
+export type { WrappedFunction } from './wrappedfunction';

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -6,6 +6,7 @@
     "downlevelIteration": true,
     "importHelpers": true,
     "inlineSources": true,
+    "isolatedModules": true,
     "lib": ["es6", "dom"],
     // "module": "commonjs", // implied by "target" : "es5"
     "moduleResolution": "node",

--- a/packages/vue/src/index.bundle.ts
+++ b/packages/vue/src/index.bundle.ts
@@ -1,4 +1,4 @@
-export {
+export type {
   Breadcrumb,
   Request,
   SdkInfo,
@@ -13,9 +13,10 @@ export {
   User,
 } from '@sentry/types';
 
+export type { BrowserOptions, ReportDialogOptions } from '@sentry/browser';
+
 export {
   BrowserClient,
-  BrowserOptions,
   defaultIntegrations,
   forceLoad,
   lastEventId,
@@ -24,7 +25,6 @@ export {
   flush,
   close,
   wrap,
-  ReportDialogOptions,
   addGlobalEventProcessor,
   addBreadcrumb,
   captureException,


### PR DESCRIPTION
_Note: This and https://github.com/getsentry/sentry-javascript/pull/4926 are together a (slightly updated) repeat of https://github.com/getsentry/sentry-javascript/pull/4497, to get it onto the main v7 branch._

This applies [the TypeScript `isolatedModules` setting](https://www.typescriptlang.org/tsconfig#isolatedModules) to all packages in the repo, which is necessary in order for us to use any compiler other than `tsc`. (All other compilers handle each file separately, without understanding the relationships between them the way `tsc` does, so we need TS to warn us if we're doing anything which would make that a problem).

It also makes two code changes necessary in order to be compatible with the `isolatedModules` flag, specifically:

- All re-exported types and interfaces (anything that will get stripped away when compiling from TS to JS) are now exported using `export type`. This lets non-`tsc` compilers know that the exported types are eligible for stripping, in spite of the fact that said compilers can't follow the export path backwards to see the types' implementation.

- ~Usages of the `Severity` enum from `@sentry/types` were replaced with string literals, which was necessary here because non-`tsc` compilers can't trace usages of a const enum back to their underlying values to do the substitution. They therefore leave those usages alone, while at the same time stripping the enum definitions the way `tsc` would. This leads to usages of something which no longer exists, which is obviously a problem. Using the string literals prevents that.~ Update: This has been split off into its own PR, linked above.