### PR TITLE
build(bundles): Stop publishing CDN bundles on npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,9 +3,6 @@
 
 *
 
-# TODO remove bundles (which in the tarball are inside `build`) in v7
-!/build/**/*
-
 !/dist/**/*
 !/esm/**/*
 !/types/**/*

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -43,7 +43,7 @@
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
-    "build:npm": "ts-node ../../scripts/prepack.ts --bundles --skipBundleCopy && npm pack ./build/npm",
+    "build:npm": "ts-node ../../scripts/prepack.ts --bundles && npm pack ./build/npm",
     "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf dist esm build coverage *.js.map *.d.ts",
     "fix": "run-s fix:eslint fix:prettier",

--- a/scripts/prepack.ts
+++ b/scripts/prepack.ts
@@ -7,7 +7,6 @@
 */
 
 import * as fs from 'fs';
-import * as fse from 'fs-extra';
 import * as path from 'path';
 
 const NPM_BUILD_DIR = 'build/npm';

--- a/scripts/prepack.ts
+++ b/scripts/prepack.ts
@@ -49,26 +49,6 @@ ASSETS.forEach(asset => {
   }
 });
 
-// TODO remove in v7! Until then:
-// copy CDN bundles into npm dir to temporarily keep bundles in npm tarball
-// inside the tarball, they are located in `build/`
-// for now, copy it by default, unless explicitly forbidden via an command line arg
-const tmpCopyBundles = packageWithBundles && !process.argv.includes('--skipBundleCopy');
-if (tmpCopyBundles) {
-  const npmTmpBundlesPath = path.resolve(buildDir, 'build');
-  const cdnBundlesPath = path.resolve('build', 'bundles');
-  try {
-    if (!fs.existsSync(npmTmpBundlesPath)) {
-      fs.mkdirSync(npmTmpBundlesPath);
-    }
-    void fse.copy(cdnBundlesPath, npmTmpBundlesPath);
-  } catch (error) {
-    console.error(`Error while tmp copying CDN bundles to ${buildDir}`);
-    process.exit(1);
-  }
-}
-// end remove
-
 // package.json modifications
 const packageJsonPath = path.resolve(buildDir, 'package.json');
 // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
Exclude CDN bundles from being published on npm by including them in `.npmignore`.

Ref: https://getsentry.atlassian.net/browse/WEB-674