### PR TITLE
chore(dev): Remove redundant `.gitignore` in `utils` package

### DIFF
--- a/packages/utils/.gitignore
+++ b/packages/utils/.gitignore
@@ -1,5 +1,0 @@
-*.js.map
-*.d.ts
-*.js
-!test/types/*
-!.eslintrc.js


### PR DESCRIPTION
The `.gitignore` file in the `utils` package isn't ignoring any current files which the main `.gitignore` (the one at the root level of the repo) isn't already ignoring, as evidenced by the fact that deleting the former doesn't cause anything to new to come to git's attention. What it will ignore, however, is future `.js` files (such as `rollup.config.js` and `jest.config.js`) which we don't want ignored (and which aren't ignored in any other package). This therefore removes the `.gitignore` in `utils`, in order to prevent that future problem.
