### PR TITLE
fix(build): Skip flags file when building integration bundles

### DIFF
--- a/packages/integrations/scripts/buildBundles.sh
+++ b/packages/integrations/scripts/buildBundles.sh
@@ -3,9 +3,10 @@ for filepath in ./src/*; do
 
     file=$(basename $filepath)
 
-    # the index file is only there for the purposes of npm builds - for the CDN we create a separate bundle for each
-    # integration - so we can skip it here
-    if [[ $file == "index.ts" ]]; then
+    # The index file is only there for the purposes of npm builds (for the CDN we create a separate bundle for each
+    # integration) and the flags file is just a helper for including or not including debug logging, whose contents gets
+    # incorporated into each of the individual integration bundles, so we can skip them both here.
+    if [[ $file == "index.ts" || $file == "flags.ts" ]]; then
       continue
     fi
 


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/4842, a `flags.ts` file was added to each package to fix logger treeshaking when using webpack. Because of the way that webpack works, this file has to exist separately in each individual package, including in `@sentry/integrations`. It is not itself an integration, though, so we shouldn't be building a separate CDN bundle for it (let alone six versions of one). This fixes the build script so that we're no longer doing that.
