### PR TITLE
poc(perf): Add browser session id to transactions

### DIFF
--- a/packages/tracing/src/browser/browsersession.ts
+++ b/packages/tracing/src/browser/browsersession.ts
@@ -1,0 +1,35 @@
+import { getGlobalObject, uuid4 } from '@sentry/utils';
+
+import { Transaction } from '../transaction';
+const sentryBrowserSessionKey = 'SENTRY_SESSION_UUID';
+
+/**
+ * Retrieves / creates a session dependent key for the current browser session.
+ */
+function getBrowserSessionID() {
+  try {
+    const global = getGlobalObject<Window>();
+    if (global && global.sessionStorage) {
+      let id = global.sessionStorage.getItem(sentryBrowserSessionKey);
+      if (!id || id.length !== 16) {
+        id = uuid4().substring(16);
+        global.sessionStorage.setItem(sentryBrowserSessionKey, id);
+      }
+
+      return id;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Adds browser session data to the transaction.
+ */
+export function addBrowserSessionData(transaction: Transaction) {
+  const id = getBrowserSessionID();
+  if (id) {
+    transaction.setTag('browser.session', id);
+  }
+}


### PR DESCRIPTION
### Summary
An example of how we might add browser sessions (via session-storage) to experiment with performance across user journeys. We can release this as a private option, or try out this branch via beta on the Sentry app. Use of sessionStorage vs. localStorage is debatable and likely something we'd need to experiment with.
