### PR TITLE
fix(dev): Fix unit test debugging configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,9 +47,6 @@
         // this runs one test at a time, rather than running them in parallel (necessary for debugging so that you know
         // you're hitting a single test's breakpoints, in order)
         "--runInBand",
-        // TODO: when we unify jest config, we may need to change this
-        "--config",
-        "${workspaceFolder}/packages/${input:getPackageName}/package.json",
         // coverage messes up the source maps
         "--coverage",
         "false",


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/4907, all of our jest config was pulled out of `package.json` and put into `jest.config.js` files. This fixes our VSCode debug profile for unit tests to point to the new config.

(To be fair, the TODO in `launch.json` predicated this, but I missed it when doing that PR.)