### PR TITLE
fix(wasm): Ensure wasm bundle exists before running wasm tests

### DIFF
--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -53,7 +53,7 @@
     "lint": "run-s lint:prettier lint:eslint",
     "lint:eslint": "eslint . --cache --cache-location '../../eslintcache/' --format stylish",
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/*.ts\"",
-    "test": "node test/scripts/ensure-browser-bundle.js && cross-env PORT=1337 jest",
+    "test": "node test/scripts/ensure-bundles.js && cross-env PORT=1337 jest",
     "test:watch": "jest --watch"
   },
   "volta": {

--- a/packages/wasm/test/scripts/ensure-bundles.js
+++ b/packages/wasm/test/scripts/ensure-bundles.js
@@ -11,4 +11,13 @@ function ensureBrowserBundle() {
   }
 }
 
+function ensureWasmBundle() {
+  if (!fs.existsSync('build/bundles/wasm.js')) {
+    // eslint-disable-next-line no-console
+    console.warn('\nWARNING: Missing wasm bundle. Bundle will be created before running wasm integration tests.');
+    execSync('yarn build:bundle');
+  }
+}
+
 ensureBrowserBundle();
+ensureWasmBundle();


### PR DESCRIPTION
The `@sentry/wasm` test suite requires both the browser bundle and the wasm bundle. Currently, before running the tests, we check to make sure the browser bundle exists, and build it if it's missing. We don't do the same for the wasm bundle, however. This fixes that, so that both bundles are guaranteed to exist before we try to run tests.