### PR TITLE
ref(types): Stop using `Severity` enum

### DIFF
--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -91,7 +91,7 @@ export class BrowserClient extends BaseClient<BrowserOptions> {
    */
   public eventFromMessage(
     message: string,
-    level: Severity | SeverityLevel = Severity.Info,
+    level: Severity | SeverityLevel = 'info',
     hint?: EventHint,
   ): PromiseLike<Event> {
     return eventFromMessage(

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -1,5 +1,5 @@
 import { BaseClient, getEnvelopeEndpointWithUrlEncodedAuth, initAPIDetails, Scope, SDK_VERSION } from '@sentry/core';
-import { Event, EventHint, Options, Severity, Transport, TransportOptions } from '@sentry/types';
+import { Event, EventHint, Options, Severity, SeverityLevel, Transport, TransportOptions } from '@sentry/types';
 import { getGlobalObject, logger, stackParserFromOptions, supportsFetch } from '@sentry/utils';
 
 import { eventFromException, eventFromMessage } from './eventbuilder';
@@ -89,7 +89,11 @@ export class BrowserClient extends BaseClient<BrowserOptions> {
   /**
    * @inheritDoc
    */
-  public eventFromMessage(message: string, level: Severity = Severity.Info, hint?: EventHint): PromiseLike<Event> {
+  public eventFromMessage(
+    message: string,
+    level: Severity | SeverityLevel = Severity.Info,
+    hint?: EventHint,
+  ): PromiseLike<Event> {
     return eventFromMessage(
       stackParserFromOptions(this._options),
       message,

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -91,6 +91,7 @@ export class BrowserClient extends BaseClient<BrowserOptions> {
    */
   public eventFromMessage(
     message: string,
+    // eslint-disable-next-line deprecation/deprecation
     level: Severity | SeverityLevel = 'info',
     hint?: EventHint,
   ): PromiseLike<Event> {

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -164,6 +164,7 @@ export function eventFromException(
 export function eventFromMessage(
   stackParser: StackParser,
   message: string,
+  // eslint-disable-next-line deprecation/deprecation
   level: Severity | SeverityLevel = 'info',
   hint?: EventHint,
   attachStacktrace?: boolean,

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -1,4 +1,4 @@
-import { Event, EventHint, Exception, Severity, StackFrame, StackParser } from '@sentry/types';
+import { Event, EventHint, Exception, Severity, SeverityLevel, StackFrame, StackParser } from '@sentry/types';
 import {
   addExceptionMechanism,
   addExceptionTypeValue,
@@ -164,7 +164,7 @@ export function eventFromException(
 export function eventFromMessage(
   stackParser: StackParser,
   message: string,
-  level: Severity = Severity.Info,
+  level: Severity | SeverityLevel = Severity.Info,
   hint?: EventHint,
   attachStacktrace?: boolean,
 ): PromiseLike<Event> {

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -150,7 +150,7 @@ export function eventFromException(
   const syntheticException = (hint && hint.syntheticException) || undefined;
   const event = eventFromUnknownInput(stackParser, exception, syntheticException, attachStacktrace);
   addExceptionMechanism(event); // defaults to { type: 'generic', handled: true }
-  event.level = Severity.Error;
+  event.level = 'error';
   if (hint && hint.event_id) {
     event.event_id = hint.event_id;
   }
@@ -164,7 +164,7 @@ export function eventFromException(
 export function eventFromMessage(
   stackParser: StackParser,
   message: string,
-  level: Severity | SeverityLevel = Severity.Info,
+  level: Severity | SeverityLevel = 'info',
   hint?: EventHint,
   attachStacktrace?: boolean,
 ): PromiseLike<Event> {

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -8,6 +8,7 @@ export {
   EventStatus,
   Exception,
   Response,
+  // eslint-disable-next-line deprecation/deprecation
   Severity,
   SeverityLevel,
   StackFrame,

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -9,13 +9,12 @@ export {
   Exception,
   Response,
   Severity,
+  SeverityLevel,
   StackFrame,
   Stacktrace,
   Thread,
   User,
 } from '@sentry/types';
-
-export { SeverityLevel } from '@sentry/utils';
 
 export {
   addGlobalEventProcessor,

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -9,7 +9,7 @@ import {
   htmlTreeAsString,
   parseUrl,
   safeJoin,
-  severityFromString,
+  severityLevelFromString,
 } from '@sentry/utils';
 
 /** JSDoc */
@@ -157,7 +157,7 @@ function _consoleBreadcrumb(handlerData: { [key: string]: any }): void {
       arguments: handlerData.args,
       logger: 'console',
     },
-    level: severityFromString(handlerData.level),
+    level: severityLevelFromString(handlerData.level),
     message: safeJoin(handlerData.args, ' '),
   };
 

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable max-lines */
 import { getCurrentHub } from '@sentry/core';
-import { Event, Integration, Severity } from '@sentry/types';
+import { Event, Integration } from '@sentry/types';
 import {
   addInstrumentationHandler,
   getEventDescription,
@@ -230,7 +230,7 @@ function _fetchBreadcrumb(handlerData: { [key: string]: any }): void {
       {
         category: 'fetch',
         data: handlerData.fetchData,
-        level: Severity.Error,
+        level: 'error',
         type: 'http',
       },
       {

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { getCurrentHub } from '@sentry/core';
-import { Event, EventHint, Hub, Integration, Primitive, Severity, StackParser } from '@sentry/types';
+import { Event, EventHint, Hub, Integration, Primitive, StackParser } from '@sentry/types';
 import {
   addExceptionMechanism,
   addInstrumentationHandler,
@@ -100,7 +100,7 @@ function _installGlobalOnErrorHandler(): void {
               column,
             );
 
-      event.level = Severity.Error;
+      event.level = 'error';
 
       addMechanismAndCapture(hub, error, event, 'onerror');
     },
@@ -146,7 +146,7 @@ function _installGlobalOnUnhandledRejectionHandler(): void {
         ? _eventFromRejectionWithPrimitive(error)
         : eventFromUnknownInput(stackParser, error, undefined, attachStacktrace, true);
 
-      event.level = Severity.Error;
+      event.level = 'error';
 
       addMechanismAndCapture(hub, error, event, 'onunhandledrejection');
       return;

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -9,6 +9,7 @@ import {
   IntegrationClass,
   Options,
   Severity,
+  SeverityLevel,
   Transport,
 } from '@sentry/types';
 import {
@@ -131,7 +132,12 @@ export abstract class BaseClient<O extends Options> implements Client<O> {
   /**
    * @inheritDoc
    */
-  public captureMessage(message: string, level?: Severity, hint?: EventHint, scope?: Scope): string | undefined {
+  public captureMessage(
+    message: string,
+    level?: Severity | SeverityLevel,
+    hint?: EventHint,
+    scope?: Scope,
+  ): string | undefined {
     let eventId: string | undefined = hint && hint.event_id;
 
     const promisedEvent = isPrimitive(message)
@@ -685,7 +691,11 @@ export abstract class BaseClient<O extends Options> implements Client<O> {
   /**
    * @inheritDoc
    */
-  public abstract eventFromMessage(_message: string, _level?: Severity, _hint?: EventHint): PromiseLike<Event>;
+  public abstract eventFromMessage(
+    _message: string,
+    _level?: Severity | SeverityLevel,
+    _hint?: EventHint,
+  ): PromiseLike<Event>;
 }
 
 /**

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -134,6 +134,7 @@ export abstract class BaseClient<O extends Options> implements Client<O> {
    */
   public captureMessage(
     message: string,
+    // eslint-disable-next-line deprecation/deprecation
     level?: Severity | SeverityLevel,
     hint?: EventHint,
     scope?: Scope,
@@ -693,6 +694,7 @@ export abstract class BaseClient<O extends Options> implements Client<O> {
    */
   public abstract eventFromMessage(
     _message: string,
+    // eslint-disable-next-line deprecation/deprecation
     _level?: Severity | SeverityLevel,
     _hint?: EventHint,
   ): PromiseLike<Event>;

--- a/packages/core/test/mocks/client.ts
+++ b/packages/core/test/mocks/client.ts
@@ -38,7 +38,7 @@ export class TestClient extends BaseClient<TestOptions> {
     });
   }
 
-  public eventFromMessage(message: string, level: Severity | SeverityLevel = Severity.Info): PromiseLike<Event> {
+  public eventFromMessage(message: string, level: Severity | SeverityLevel = 'info'): PromiseLike<Event> {
     return resolvedSyncPromise({ message, level });
   }
 

--- a/packages/core/test/mocks/client.ts
+++ b/packages/core/test/mocks/client.ts
@@ -1,5 +1,5 @@
 import { Session } from '@sentry/hub';
-import { Event, Options, Severity, Transport } from '@sentry/types';
+import { Event, Options, Severity, SeverityLevel, Transport } from '@sentry/types';
 import { resolvedSyncPromise } from '@sentry/utils';
 
 import { BaseClient } from '../../src/baseclient';
@@ -38,7 +38,7 @@ export class TestClient extends BaseClient<TestOptions> {
     });
   }
 
-  public eventFromMessage(message: string, level: Severity = Severity.Info): PromiseLike<Event> {
+  public eventFromMessage(message: string, level: Severity | SeverityLevel = Severity.Info): PromiseLike<Event> {
     return resolvedSyncPromise({ message, level });
   }
 

--- a/packages/core/test/mocks/client.ts
+++ b/packages/core/test/mocks/client.ts
@@ -38,7 +38,11 @@ export class TestClient extends BaseClient<TestOptions> {
     });
   }
 
-  public eventFromMessage(message: string, level: Severity | SeverityLevel = 'info'): PromiseLike<Event> {
+  public eventFromMessage(
+    message: string,
+    // eslint-disable-next-line deprecation/deprecation
+    level: Severity | SeverityLevel = 'info',
+  ): PromiseLike<Event> {
     return resolvedSyncPromise({ message, level });
   }
 

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -14,6 +14,7 @@ import {
   Primitive,
   SessionContext,
   Severity,
+  SeverityLevel,
   Transaction,
   TransactionContext,
   User,
@@ -213,7 +214,7 @@ export class Hub implements HubInterface {
   /**
    * @inheritDoc
    */
-  public captureMessage(message: string, level?: Severity, hint?: EventHint): string {
+  public captureMessage(message: string, level?: Severity | SeverityLevel, hint?: EventHint): string {
     const eventId = (this._lastEventId = hint && hint.event_id ? hint.event_id : uuid4());
     let finalHint = hint;
 

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -214,7 +214,12 @@ export class Hub implements HubInterface {
   /**
    * @inheritDoc
    */
-  public captureMessage(message: string, level?: Severity | SeverityLevel, hint?: EventHint): string {
+  public captureMessage(
+    message: string,
+    // eslint-disable-next-line deprecation/deprecation
+    level?: Severity | SeverityLevel,
+    hint?: EventHint,
+  ): string {
     const eventId = (this._lastEventId = hint && hint.event_id ? hint.event_id : uuid4());
     let finalHint = hint;
 

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -14,6 +14,7 @@ import {
   Scope as ScopeInterface,
   ScopeContext,
   Severity,
+  SeverityLevel,
   Span,
   Transaction,
   User,
@@ -61,7 +62,7 @@ export class Scope implements ScopeInterface {
   protected _fingerprint?: string[];
 
   /** Severity */
-  protected _level?: Severity;
+  protected _level?: Severity | SeverityLevel;
 
   /** Transaction Name */
   protected _transactionName?: string;
@@ -208,7 +209,7 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public setLevel(level: Severity): this {
+  public setLevel(level: Severity | SeverityLevel): this {
     this._level = level;
     this._notifyScopeListeners();
     return this;

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -62,6 +62,7 @@ export class Scope implements ScopeInterface {
   protected _fingerprint?: string[];
 
   /** Severity */
+  // eslint-disable-next-line deprecation/deprecation
   protected _level?: Severity | SeverityLevel;
 
   /** Transaction Name */
@@ -209,7 +210,10 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public setLevel(level: Severity | SeverityLevel): this {
+  public setLevel(
+    // eslint-disable-next-line deprecation/deprecation
+    level: Severity | SeverityLevel,
+  ): this {
     this._level = level;
     this._notifyScopeListeners();
     return this;

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -1,4 +1,4 @@
-import { Event, EventHint, Severity } from '@sentry/types';
+import { Event, EventHint } from '@sentry/types';
 import { getGlobalObject } from '@sentry/utils';
 
 import { addGlobalEventProcessor, Scope } from '../src';
@@ -85,8 +85,8 @@ describe('Scope', () => {
 
     test('setLevel', () => {
       const scope = new Scope();
-      scope.setLevel(Severity.Critical);
-      expect((scope as any)._level).toEqual(Severity.Critical);
+      scope.setLevel('critical');
+      expect((scope as any)._level).toEqual('critical');
     });
 
     test('setTransactionName', () => {
@@ -137,8 +137,8 @@ describe('Scope', () => {
 
     test('chaining', () => {
       const scope = new Scope();
-      scope.setLevel(Severity.Critical).setUser({ id: '1' });
-      expect((scope as any)._level).toEqual(Severity.Critical);
+      scope.setLevel('critical').setUser({ id: '1' });
+      expect((scope as any)._level).toEqual('critical');
       expect((scope as any)._user).toEqual({ id: '1' });
     });
   });
@@ -202,7 +202,7 @@ describe('Scope', () => {
       scope.setTag('a', 'b');
       scope.setUser({ id: '1' });
       scope.setFingerprint(['abcd']);
-      scope.setLevel(Severity.Warning);
+      scope.setLevel('warning');
       scope.setTransactionName('/abc');
       scope.addBreadcrumb({ message: 'test' });
       scope.setContext('os', { id: '1' });
@@ -294,11 +294,11 @@ describe('Scope', () => {
     test('scope level should have priority over event level', () => {
       expect.assertions(1);
       const scope = new Scope();
-      scope.setLevel(Severity.Warning);
+      scope.setLevel('warning');
       const event: Event = {};
-      event.level = Severity.Critical;
+      event.level = 'critical';
       return scope.applyToEvent(event).then(processedEvent => {
-        expect(processedEvent!.level).toEqual(Severity.Warning);
+        expect(processedEvent!.level).toEqual('warning');
       });
     });
 
@@ -410,7 +410,7 @@ describe('Scope', () => {
       scope.setContext('foo', { id: '1' });
       scope.setContext('bar', { id: '2' });
       scope.setUser({ id: '1337' });
-      scope.setLevel(Severity.Info);
+      scope.setLevel('info');
       scope.setFingerprint(['foo']);
       scope.setRequestSession({ status: 'ok' });
     });
@@ -458,7 +458,7 @@ describe('Scope', () => {
       localScope.setContext('bar', { id: '3' });
       localScope.setContext('baz', { id: '4' });
       localScope.setUser({ id: '42' });
-      localScope.setLevel(Severity.Warning);
+      localScope.setLevel('warning');
       localScope.setFingerprint(['bar']);
       (localScope as any)._requestSession = { status: 'ok' };
 

--- a/packages/integrations/src/captureconsole.ts
+++ b/packages/integrations/src/captureconsole.ts
@@ -1,5 +1,5 @@
 import { EventProcessor, Hub, Integration } from '@sentry/types';
-import { CONSOLE_LEVELS, fill, getGlobalObject, safeJoin, severityFromString } from '@sentry/utils';
+import { CONSOLE_LEVELS, fill, getGlobalObject, safeJoin, severityLevelFromString } from '@sentry/utils';
 
 const global = getGlobalObject<Window | NodeJS.Global>();
 
@@ -48,7 +48,7 @@ export class CaptureConsole implements Integration {
 
         if (hub.getIntegration(CaptureConsole)) {
           hub.withScope(scope => {
-            scope.setLevel(severityFromString(level));
+            scope.setLevel(severityLevelFromString(level));
             scope.setExtra('arguments', args);
             scope.addEventProcessor(event => {
               event.logger = 'console';

--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -53,7 +53,11 @@ export function captureException(exception: any, captureContext?: CaptureContext
  * @param Severity Define the level of the message.
  * @returns The generated eventId.
  */
-export function captureMessage(message: string, captureContext?: CaptureContext | Severity | SeverityLevel): string {
+export function captureMessage(
+  message: string,
+  // eslint-disable-next-line deprecation/deprecation
+  captureContext?: CaptureContext | Severity | SeverityLevel,
+): string {
   const syntheticException = new Error(message);
 
   // This is necessary to provide explicit scopes upgrade, without changing the original

--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -8,6 +8,7 @@ import {
   Extras,
   Primitive,
   Severity,
+  SeverityLevel,
   Transaction,
   TransactionContext,
   User,
@@ -52,7 +53,7 @@ export function captureException(exception: any, captureContext?: CaptureContext
  * @param Severity Define the level of the message.
  * @returns The generated eventId.
  */
-export function captureMessage(message: string, captureContext?: CaptureContext | Severity): string {
+export function captureMessage(message: string, captureContext?: CaptureContext | Severity | SeverityLevel): string {
   const syntheticException = new Error(message);
 
   // This is necessary to provide explicit scopes upgrade, without changing the original

--- a/packages/minimal/test/lib/minimal.test.ts
+++ b/packages/minimal/test/lib/minimal.test.ts
@@ -1,5 +1,4 @@
 import { getCurrentHub, getHubFromCarrier, Scope } from '@sentry/hub';
-import { Severity } from '@sentry/types';
 
 import {
   _callOnClient,
@@ -165,8 +164,8 @@ describe('Minimal', () => {
       const client: any = new TestClient({});
       const scope = getCurrentHub().pushScope();
       getCurrentHub().bindClient(client);
-      scope.setLevel(Severity.Warning);
-      expect(global.__SENTRY__.hub._stack[1].scope._level).toEqual(Severity.Warning);
+      scope.setLevel('warning');
+      expect(global.__SENTRY__.hub._stack[1].scope._level).toEqual('warning');
     });
   });
 
@@ -245,16 +244,16 @@ describe('Minimal', () => {
 
   test('withScope', () => {
     withScope(scope => {
-      scope.setLevel(Severity.Warning);
+      scope.setLevel('warning');
       scope.setFingerprint(['1']);
       withScope(scope2 => {
-        scope2.setLevel(Severity.Info);
+        scope2.setLevel('info');
         scope2.setFingerprint(['2']);
         withScope(scope3 => {
           scope3.clear();
-          expect(global.__SENTRY__.hub._stack[1].scope._level).toEqual(Severity.Warning);
+          expect(global.__SENTRY__.hub._stack[1].scope._level).toEqual('warning');
           expect(global.__SENTRY__.hub._stack[1].scope._fingerprint).toEqual(['1']);
-          expect(global.__SENTRY__.hub._stack[2].scope._level).toEqual(Severity.Info);
+          expect(global.__SENTRY__.hub._stack[2].scope._level).toEqual('info');
           expect(global.__SENTRY__.hub._stack[2].scope._fingerprint).toEqual(['2']);
           expect(global.__SENTRY__.hub._stack[3].scope._level).toBeUndefined();
         });

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/scenario.ts
@@ -8,7 +8,7 @@ Sentry.init({
 Sentry.addBreadcrumb({
   category: 'foo',
   message: 'bar',
-  level: Sentry.Severity.Critical,
+  level: 'critical',
 });
 
 Sentry.addBreadcrumb({

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/scenario.ts
@@ -8,7 +8,7 @@ Sentry.init({
 Sentry.addBreadcrumb({
   category: 'foo',
   message: 'bar',
-  level: Sentry.Severity.Critical,
+  level: 'critical',
 });
 
 Sentry.captureMessage('test_simple');

--- a/packages/node-integration-tests/suites/public-api/captureMessage/with_level/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/captureMessage/with_level/scenario.ts
@@ -5,10 +5,10 @@ Sentry.init({
   release: '1.0',
 });
 
-Sentry.captureMessage('debug_message', Sentry.Severity.Debug);
-Sentry.captureMessage('info_message', Sentry.Severity.Info);
-Sentry.captureMessage('warning_message', Sentry.Severity.Warning);
-Sentry.captureMessage('error_message', Sentry.Severity.Error);
-Sentry.captureMessage('fatal_message', Sentry.Severity.Fatal);
-Sentry.captureMessage('critical_message', Sentry.Severity.Critical);
-Sentry.captureMessage('log_message', Sentry.Severity.Log);
+Sentry.captureMessage('debug_message', 'debug');
+Sentry.captureMessage('info_message', 'info');
+Sentry.captureMessage('warning_message', 'warning');
+Sentry.captureMessage('error_message', 'error');
+Sentry.captureMessage('fatal_message', 'fatal');
+Sentry.captureMessage('critical_message', 'critical');
+Sentry.captureMessage('log_message', 'log');

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -1,6 +1,6 @@
 import { BaseClient, getEnvelopeEndpointWithUrlEncodedAuth, initAPIDetails, Scope, SDK_VERSION } from '@sentry/core';
 import { SessionFlusher } from '@sentry/hub';
-import { Event, EventHint, Severity, Transport, TransportOptions } from '@sentry/types';
+import { Event, EventHint, Severity, SeverityLevel, Transport, TransportOptions } from '@sentry/types';
 import { logger, makeDsn, resolvedSyncPromise, stackParserFromOptions } from '@sentry/utils';
 
 import { eventFromMessage, eventFromUnknownInput } from './eventbuilder';
@@ -118,7 +118,11 @@ export class NodeClient extends BaseClient<NodeOptions> {
   /**
    * @inheritDoc
    */
-  public eventFromMessage(message: string, level: Severity = Severity.Info, hint?: EventHint): PromiseLike<Event> {
+  public eventFromMessage(
+    message: string,
+    level: Severity | SeverityLevel = Severity.Info,
+    hint?: EventHint,
+  ): PromiseLike<Event> {
     return resolvedSyncPromise(
       eventFromMessage(stackParserFromOptions(this._options), message, level, hint, this._options.attachStacktrace),
     );

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -120,7 +120,7 @@ export class NodeClient extends BaseClient<NodeOptions> {
    */
   public eventFromMessage(
     message: string,
-    level: Severity | SeverityLevel = Severity.Info,
+    level: Severity | SeverityLevel = 'info',
     hint?: EventHint,
   ): PromiseLike<Event> {
     return resolvedSyncPromise(

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -120,6 +120,7 @@ export class NodeClient extends BaseClient<NodeOptions> {
    */
   public eventFromMessage(
     message: string,
+    // eslint-disable-next-line deprecation/deprecation
     level: Severity | SeverityLevel = 'info',
     hint?: EventHint,
   ): PromiseLike<Event> {

--- a/packages/node/src/eventbuilder.ts
+++ b/packages/node/src/eventbuilder.ts
@@ -99,7 +99,7 @@ export function eventFromUnknownInput(stackParser: StackParser, exception: unkno
 export function eventFromMessage(
   stackParser: StackParser,
   message: string,
-  level: Severity | SeverityLevel = Severity.Info,
+  level: Severity | SeverityLevel = 'info',
   hint?: EventHint,
   attachStacktrace?: boolean,
 ): Event {

--- a/packages/node/src/eventbuilder.ts
+++ b/packages/node/src/eventbuilder.ts
@@ -99,6 +99,7 @@ export function eventFromUnknownInput(stackParser: StackParser, exception: unkno
 export function eventFromMessage(
   stackParser: StackParser,
   message: string,
+  // eslint-disable-next-line deprecation/deprecation
   level: Severity | SeverityLevel = 'info',
   hint?: EventHint,
   attachStacktrace?: boolean,

--- a/packages/node/src/eventbuilder.ts
+++ b/packages/node/src/eventbuilder.ts
@@ -1,5 +1,14 @@
 import { getCurrentHub } from '@sentry/hub';
-import { Event, EventHint, Exception, Mechanism, Severity, StackFrame, StackParser } from '@sentry/types';
+import {
+  Event,
+  EventHint,
+  Exception,
+  Mechanism,
+  Severity,
+  SeverityLevel,
+  StackFrame,
+  StackParser,
+} from '@sentry/types';
 import {
   addExceptionMechanism,
   addExceptionTypeValue,
@@ -90,7 +99,7 @@ export function eventFromUnknownInput(stackParser: StackParser, exception: unkno
 export function eventFromMessage(
   stackParser: StackParser,
   message: string,
-  level: Severity = Severity.Info,
+  level: Severity | SeverityLevel = Severity.Info,
   hint?: EventHint,
   attachStacktrace?: boolean,
 ): Event {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -8,6 +8,7 @@ export {
   EventStatus,
   Exception,
   Response,
+  // eslint-disable-next-line deprecation/deprecation
   Severity,
   SeverityLevel,
   StackFrame,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -9,13 +9,12 @@ export {
   Exception,
   Response,
   Severity,
+  SeverityLevel,
   StackFrame,
   Stacktrace,
   Thread,
   User,
 } from '@sentry/types';
-
-export { SeverityLevel } from '@sentry/utils';
 
 export {
   addGlobalEventProcessor,

--- a/packages/node/src/integrations/console.ts
+++ b/packages/node/src/integrations/console.ts
@@ -1,6 +1,6 @@
 import { getCurrentHub } from '@sentry/core';
 import { Integration } from '@sentry/types';
-import { fill, severityFromString } from '@sentry/utils';
+import { fill, severityLevelFromString } from '@sentry/utils';
 import * as util from 'util';
 
 /** Console module integration */
@@ -30,7 +30,7 @@ export class Console implements Integration {
  */
 function createConsoleWrapper(level: string): (originalConsoleMethod: () => void) => void {
   return function consoleWrapper(originalConsoleMethod: () => void): () => void {
-    const sentryLevel = severityFromString(level);
+    const sentryLevel = severityLevelFromString(level);
 
     /* eslint-disable prefer-rest-params */
     return function (this: typeof console): void {

--- a/packages/node/src/integrations/onuncaughtexception.ts
+++ b/packages/node/src/integrations/onuncaughtexception.ts
@@ -1,5 +1,5 @@
 import { getCurrentHub, Scope } from '@sentry/core';
-import { Integration, Severity } from '@sentry/types';
+import { Integration } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import { NodeClient } from '../client';
@@ -78,7 +78,7 @@ export class OnUncaughtException implements Integration {
 
         if (hub.getIntegration(OnUncaughtException)) {
           hub.withScope((scope: Scope) => {
-            scope.setLevel(Severity.Fatal);
+            scope.setLevel('fatal');
             hub.captureException(error, {
               originalException: error,
               data: { mechanism: { handled: false, type: 'onuncaughtexception' } },

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -277,7 +277,7 @@ export function wrapHandler<TEvent, TResult>(
       timeoutWarningTimer = setTimeout(() => {
         withScope(scope => {
           scope.setTag('timeout', humanReadableTimeout);
-          captureMessage(`Possible function timeout: ${context.functionName}`, Sentry.Severity.Warning);
+          captureMessage(`Possible function timeout: ${context.functionName}`, 'warning');
         });
       }, timeoutWarningDelay);
     }

--- a/packages/tracing/src/index.bundle.ts
+++ b/packages/tracing/src/index.bundle.ts
@@ -7,13 +7,12 @@ export {
   Exception,
   Response,
   Severity,
+  SeverityLevel,
   StackFrame,
   Stacktrace,
   Thread,
   User,
 } from '@sentry/types';
-
-export { SeverityLevel } from '@sentry/utils';
 
 export {
   addGlobalEventProcessor,

--- a/packages/tracing/src/index.bundle.ts
+++ b/packages/tracing/src/index.bundle.ts
@@ -6,6 +6,7 @@ export {
   EventStatus,
   Exception,
   Response,
+  // eslint-disable-next-line deprecation/deprecation
   Severity,
   SeverityLevel,
   StackFrame,

--- a/packages/types/src/breadcrumb.ts
+++ b/packages/types/src/breadcrumb.ts
@@ -1,9 +1,9 @@
-import { Severity } from './severity';
+import { Severity, SeverityLevel } from './severity';
 
 /** JSDoc */
 export interface Breadcrumb {
   type?: string;
-  level?: Severity;
+  level?: Severity | SeverityLevel;
   event_id?: string;
   category?: string;
   message?: string;

--- a/packages/types/src/breadcrumb.ts
+++ b/packages/types/src/breadcrumb.ts
@@ -3,6 +3,7 @@ import { Severity, SeverityLevel } from './severity';
 /** JSDoc */
 export interface Breadcrumb {
   type?: string;
+  // eslint-disable-next-line deprecation/deprecation
   level?: Severity | SeverityLevel;
   event_id?: string;
   category?: string;

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -38,6 +38,7 @@ export interface Client<O extends Options = Options> {
    */
   captureMessage(
     message: string,
+    // eslint-disable-next-line deprecation/deprecation
     level?: Severity | SeverityLevel,
     hint?: EventHint,
     scope?: Scope,
@@ -104,7 +105,12 @@ export interface Client<O extends Options = Options> {
   eventFromException(exception: any, hint?: EventHint): PromiseLike<Event>;
 
   /** Creates an {@link Event} from primitive inputs to `captureMessage`. */
-  eventFromMessage(message: string, level?: Severity | SeverityLevel, hint?: EventHint): PromiseLike<Event>;
+  eventFromMessage(
+    message: string,
+    // eslint-disable-next-line deprecation/deprecation
+    level?: Severity | SeverityLevel,
+    hint?: EventHint,
+  ): PromiseLike<Event>;
 
   /** Submits the event to Sentry */
   sendEvent(event: Event): void;

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -4,7 +4,7 @@ import { Integration, IntegrationClass } from './integration';
 import { Options } from './options';
 import { Scope } from './scope';
 import { Session } from './session';
-import { Severity } from './severity';
+import { Severity, SeverityLevel } from './severity';
 import { Transport } from './transport';
 
 /**
@@ -36,7 +36,12 @@ export interface Client<O extends Options = Options> {
    * @param scope An optional scope containing event metadata.
    * @returns The event id
    */
-  captureMessage(message: string, level?: Severity, hint?: EventHint, scope?: Scope): string | undefined;
+  captureMessage(
+    message: string,
+    level?: Severity | SeverityLevel,
+    hint?: EventHint,
+    scope?: Scope,
+  ): string | undefined;
 
   /**
    * Captures a manually created event and sends it to Sentry.
@@ -99,7 +104,7 @@ export interface Client<O extends Options = Options> {
   eventFromException(exception: any, hint?: EventHint): PromiseLike<Event>;
 
   /** Creates an {@link Event} from primitive inputs to `captureMessage`. */
-  eventFromMessage(message: string, level?: Severity, hint?: EventHint): PromiseLike<Event>;
+  eventFromMessage(message: string, level?: Severity | SeverityLevel, hint?: EventHint): PromiseLike<Event>;
 
   /** Submits the event to Sentry */
   sendEvent(event: Event): void;

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -7,7 +7,7 @@ import { Primitive } from './misc';
 import { Request } from './request';
 import { CaptureContext } from './scope';
 import { SdkInfo } from './sdkinfo';
-import { Severity } from './severity';
+import { Severity, SeverityLevel } from './severity';
 import { Span } from './span';
 import { Measurements } from './transaction';
 import { User } from './user';
@@ -18,7 +18,7 @@ export interface Event {
   message?: string;
   timestamp?: number;
   start_timestamp?: number;
-  level?: Severity;
+  level?: Severity | SeverityLevel;
   platform?: string;
   logger?: string;
   server_name?: string;

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -18,6 +18,7 @@ export interface Event {
   message?: string;
   timestamp?: number;
   start_timestamp?: number;
+  // eslint-disable-next-line deprecation/deprecation
   level?: Severity | SeverityLevel;
   platform?: string;
   logger?: string;

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -6,7 +6,7 @@ import { Integration, IntegrationClass } from './integration';
 import { Primitive } from './misc';
 import { Scope } from './scope';
 import { Session, SessionContext } from './session';
-import { Severity } from './severity';
+import { Severity, SeverityLevel } from './severity';
 import { CustomSamplingContext, Transaction, TransactionContext } from './transaction';
 import { User } from './user';
 
@@ -87,7 +87,7 @@ export interface Hub {
    * @param hint May contain additional information about the original exception.
    * @returns The generated eventId.
    */
-  captureMessage(message: string, level?: Severity, hint?: EventHint): string;
+  captureMessage(message: string, level?: Severity | SeverityLevel, hint?: EventHint): string;
 
   /**
    * Captures a manually created event and sends it to Sentry.

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -87,7 +87,12 @@ export interface Hub {
    * @param hint May contain additional information about the original exception.
    * @returns The generated eventId.
    */
-  captureMessage(message: string, level?: Severity | SeverityLevel, hint?: EventHint): string;
+  captureMessage(
+    message: string,
+    // eslint-disable-next-line deprecation/deprecation
+    level?: Severity | SeverityLevel,
+    hint?: EventHint,
+  ): string;
 
   /**
    * Captures a manually created event and sends it to Sentry.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -46,6 +46,7 @@ export {
   SessionFlusherLike,
 } from './session';
 
+// eslint-disable-next-line deprecation/deprecation
 export { Severity, SeverityLevel } from './severity';
 export { Span, SpanContext } from './span';
 export { StackFrame } from './stackframe';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -46,8 +46,7 @@ export {
   SessionFlusherLike,
 } from './session';
 
-export { Severity } from './severity';
-export { SeverityLevel, SeverityLevels } from './severity';
+export { Severity, SeverityLevel } from './severity';
 export { Span, SpanContext } from './span';
 export { StackFrame } from './stackframe';
 export { Stacktrace, StackParser, StackLineParser, StackLineParserFn } from './stacktrace';

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -4,7 +4,7 @@ import { EventProcessor } from './eventprocessor';
 import { Extra, Extras } from './extra';
 import { Primitive } from './misc';
 import { RequestSession, Session } from './session';
-import { Severity } from './severity';
+import { Severity, SeverityLevel } from './severity';
 import { Span } from './span';
 import { Transaction } from './transaction';
 import { User } from './user';
@@ -15,7 +15,7 @@ export type CaptureContext = Scope | Partial<ScopeContext> | ((scope: Scope) => 
 /** JSDocs */
 export interface ScopeContext {
   user: User;
-  level: Severity;
+  level: Severity | SeverityLevel;
   extra: Extras;
   contexts: Contexts;
   tags: { [key: string]: Primitive };
@@ -79,9 +79,9 @@ export interface Scope {
 
   /**
    * Sets the level on the scope for future events.
-   * @param level string {@link Severity}
+   * @param level string {@link SeverityLevel}
    */
-  setLevel(level: Severity): this;
+  setLevel(level: Severity | SeverityLevel): this;
 
   /**
    * Sets the transaction name on the scope for future events.

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -15,6 +15,7 @@ export type CaptureContext = Scope | Partial<ScopeContext> | ((scope: Scope) => 
 /** JSDocs */
 export interface ScopeContext {
   user: User;
+  // eslint-disable-next-line deprecation/deprecation
   level: Severity | SeverityLevel;
   extra: Extras;
   contexts: Contexts;
@@ -81,7 +82,10 @@ export interface Scope {
    * Sets the level on the scope for future events.
    * @param level string {@link SeverityLevel}
    */
-  setLevel(level: Severity | SeverityLevel): this;
+  setLevel(
+    // eslint-disable-next-line deprecation/deprecation
+    level: Severity | SeverityLevel,
+  ): this;
 
   /**
    * Sets the transaction name on the scope for future events.

--- a/packages/types/src/severity.ts
+++ b/packages/types/src/severity.ts
@@ -20,5 +20,4 @@ export enum Severity {
 
 // TODO: in v7, these can disappear, because they now also exist in `@sentry/utils`. (Having them there rather than here
 // is nice because then it enforces the idea that only types are exported from `@sentry/types`.)
-export const SeverityLevels = ['fatal', 'error', 'warning', 'log', 'info', 'debug', 'critical'] as const;
-export type SeverityLevel = typeof SeverityLevels[number];
+export type SeverityLevel = 'fatal' | 'error' | 'warning' | 'log' | 'info' | 'debug' | 'critical';

--- a/packages/types/src/severity.ts
+++ b/packages/types/src/severity.ts
@@ -1,5 +1,6 @@
 /**
- * TODO(v7): Remove this enum and replace with SeverityLevel
+ * @deprecated Please use a `SeverityLevel` string instead of the `Severity` enum. Acceptable values are 'fatal',
+ * 'critical', 'error', 'warning', 'log', 'info', and 'debug'.
  */
 export enum Severity {
   /** JSDoc */

--- a/packages/types/src/severity.ts
+++ b/packages/types/src/severity.ts
@@ -18,6 +18,6 @@ export enum Severity {
   Critical = 'critical',
 }
 
-// TODO: in v7, these can disappear, because they now also exist in `@sentry/utils`. (Having them there rather than here
-// is nice because then it enforces the idea that only types are exported from `@sentry/types`.)
+// Note: If this is ever changed, the `validSeverityLevels` array in `@sentry/utils` needs to be changed, also. (See
+// note there for why we can't derive one from the other.)
 export type SeverityLevel = 'fatal' | 'error' | 'warning' | 'log' | 'info' | 'debug' | 'critical';

--- a/packages/utils/src/enums.ts
+++ b/packages/utils/src/enums.ts
@@ -1,2 +1,1 @@
-export const SeverityLevels = ['fatal', 'error', 'warning', 'log', 'info', 'debug', 'critical'] as const;
-export type SeverityLevel = typeof SeverityLevels[number];
+export type SeverityLevel = 'fatal' | 'error' | 'warning' | 'log' | 'info' | 'debug' | 'critical';

--- a/packages/utils/src/enums.ts
+++ b/packages/utils/src/enums.ts
@@ -1,1 +1,0 @@
-export type SeverityLevel = 'fatal' | 'error' | 'warning' | 'log' | 'info' | 'debug' | 'critical';

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,7 +1,6 @@
 export * from './async';
 export * from './browser';
 export * from './dsn';
-export * from './enums';
 export * from './error';
 export * from './global';
 export * from './instrument';

--- a/packages/utils/src/severity.ts
+++ b/packages/utils/src/severity.ts
@@ -1,9 +1,11 @@
 import { Severity } from '@sentry/types';
 
-import { SeverityLevel, SeverityLevels } from './enums';
+import { SeverityLevel } from './enums';
+
+export const validSeverityLevels = ['fatal', 'error', 'warning', 'log', 'info', 'debug', 'critical'];
 
 function isSupportedSeverity(level: string): level is Severity {
-  return SeverityLevels.indexOf(level as SeverityLevel) !== -1;
+  return validSeverityLevels.indexOf(level as SeverityLevel) !== -1;
 }
 /**
  * Converts a string-based level into a {@link Severity}.

--- a/packages/utils/src/severity.ts
+++ b/packages/utils/src/severity.ts
@@ -19,7 +19,7 @@ export const validSeverityLevels = ['fatal', 'error', 'warning', 'log', 'info', 
  * @returns Severity
  */
 export function severityFromString(level: Severity | SeverityLevel | string): Severity {
-  return (level === 'warn' ? 'warning' : validSeverityLevels.includes(level) ? level : 'log') as Severity;
+  return severityLevelFromString(level) as Severity;
 }
 
 /**

--- a/packages/utils/src/severity.ts
+++ b/packages/utils/src/severity.ts
@@ -2,9 +2,6 @@ import { Severity, SeverityLevel } from '@sentry/types';
 
 export const validSeverityLevels = ['fatal', 'error', 'warning', 'log', 'info', 'debug', 'critical'];
 
-function isSupportedSeverity(level: string): level is Severity {
-  return validSeverityLevels.indexOf(level as SeverityLevel) !== -1;
-}
 /**
  * Converts a string-based level into a {@link Severity}.
  *
@@ -12,9 +9,5 @@ function isSupportedSeverity(level: string): level is Severity {
  * @returns Severity
  */
 export function severityFromString(level: SeverityLevel | string): Severity {
-  if (level === 'warn') return Severity.Warning;
-  if (isSupportedSeverity(level)) {
-    return level;
-  }
-  return Severity.Log;
+  return (level === 'warn' ? Severity.Warning : validSeverityLevels.includes(level) ? level : Severity.Log) as Severity;
 }

--- a/packages/utils/src/severity.ts
+++ b/packages/utils/src/severity.ts
@@ -21,3 +21,13 @@ export const validSeverityLevels = ['fatal', 'error', 'warning', 'log', 'info', 
 export function severityFromString(level: SeverityLevel | string): Severity {
   return (level === 'warn' ? Severity.Warning : validSeverityLevels.includes(level) ? level : Severity.Log) as Severity;
 }
+
+/**
+ * Converts a string-based level into a `SeverityLevel`, normalizing it along the way.
+ *
+ * @param level String representation of desired `SeverityLevel`.
+ * @returns The `SeverityLevel` corresponding to the given string, or 'log' if the string isn't a valid level.
+ */
+export function severityLevelFromString(level: SeverityLevel | string): SeverityLevel {
+  return (level === 'warn' ? 'warning' : validSeverityLevels.includes(level) ? level : 'log') as SeverityLevel;
+}

--- a/packages/utils/src/severity.ts
+++ b/packages/utils/src/severity.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import { Severity, SeverityLevel } from '@sentry/types';
 
 // Note: Ideally the `SeverityLevel` type would be derived from `validSeverityLevels`, but that would mean either

--- a/packages/utils/src/severity.ts
+++ b/packages/utils/src/severity.ts
@@ -1,11 +1,21 @@
 import { Severity, SeverityLevel } from '@sentry/types';
 
+// Note: Ideally the `SeverityLevel` type would be derived from `validSeverityLevels`, but that would mean either
+//
+// a) moving `validSeverityLevels` to `@sentry/types`,
+// b) moving the`SeverityLevel` type here, or
+// c) importing `validSeverityLevels` from here into `@sentry/types`.
+//
+// Option A would make `@sentry/types` a runtime dependency of `@sentry/utils` (not good), and options B and C would
+// create a circular dependency between `@sentry/types` and `@sentry/utils` (also not good). So a TODO accompanying the
+// type, reminding anyone who changes it to change this list also, will have to do.
+
 export const validSeverityLevels = ['fatal', 'error', 'warning', 'log', 'info', 'debug', 'critical'];
 
 /**
- * Converts a string-based level into a {@link Severity}.
+ * Converts a string-based level into a member of the {@link Severity} enum.
  *
- * @param level string representation of Severity
+ * @param level String representation of Severity
  * @returns Severity
  */
 export function severityFromString(level: SeverityLevel | string): Severity {

--- a/packages/utils/src/severity.ts
+++ b/packages/utils/src/severity.ts
@@ -18,7 +18,7 @@ export const validSeverityLevels = ['fatal', 'error', 'warning', 'log', 'info', 
  * @param level String representation of Severity
  * @returns Severity
  */
-export function severityFromString(level: SeverityLevel | string): Severity {
+export function severityFromString(level: Severity | SeverityLevel | string): Severity {
   return (level === 'warn' ? Severity.Warning : validSeverityLevels.includes(level) ? level : Severity.Log) as Severity;
 }
 

--- a/packages/utils/src/severity.ts
+++ b/packages/utils/src/severity.ts
@@ -1,6 +1,4 @@
-import { Severity } from '@sentry/types';
-
-import { SeverityLevel } from './enums';
+import { Severity, SeverityLevel } from '@sentry/types';
 
 export const validSeverityLevels = ['fatal', 'error', 'warning', 'log', 'info', 'debug', 'critical'];
 

--- a/packages/utils/src/severity.ts
+++ b/packages/utils/src/severity.ts
@@ -13,7 +13,9 @@ import { Severity, SeverityLevel } from '@sentry/types';
 export const validSeverityLevels = ['fatal', 'error', 'warning', 'log', 'info', 'debug', 'critical'];
 
 /**
- * Converts a string-based level into a member of the {@link Severity} enum.
+ * Converts a string-based level into a member of the deprecated {@link Severity} enum.
+ *
+ * @deprecated `severityFromString` is deprecated. Please use `severityLevelFromString` instead.
  *
  * @param level String representation of Severity
  * @returns Severity

--- a/packages/utils/src/severity.ts
+++ b/packages/utils/src/severity.ts
@@ -19,7 +19,7 @@ export const validSeverityLevels = ['fatal', 'error', 'warning', 'log', 'info', 
  * @returns Severity
  */
 export function severityFromString(level: Severity | SeverityLevel | string): Severity {
-  return (level === 'warn' ? Severity.Warning : validSeverityLevels.includes(level) ? level : Severity.Log) as Severity;
+  return (level === 'warn' ? 'warning' : validSeverityLevels.includes(level) ? level : 'log') as Severity;
 }
 
 /**

--- a/packages/utils/test/severity.test.ts
+++ b/packages/utils/test/severity.test.ts
@@ -1,17 +1,17 @@
-import { severityFromString, validSeverityLevels } from '../src/severity';
+import { severityLevelFromString, validSeverityLevels } from '../src/severity';
 
-describe('severityFromString()', () => {
+describe('severityLevelFromString()', () => {
   test("converts 'warn' to 'warning'", () => {
-    expect(severityFromString('warn')).toBe('warning');
+    expect(severityLevelFromString('warn')).toBe('warning');
   });
 
   test('defaults to log', () => {
-    expect(severityFromString('foo')).toBe('log');
+    expect(severityLevelFromString('foo')).toBe('log');
   });
 
   test('acts as a pass-through for valid level strings', () => {
     for (const level of validSeverityLevels) {
-      expect(severityFromString(level)).toBe(level);
+      expect(severityLevelFromString(level)).toBe(level);
     }
   });
 });

--- a/packages/utils/test/severity.test.ts
+++ b/packages/utils/test/severity.test.ts
@@ -2,13 +2,8 @@ import { severityFromString, validSeverityLevels } from '../src/severity';
 
 describe('severityFromString()', () => {
   describe('normalize warn and warning', () => {
-    test('handles warn and warning', () => {
+    test("converts 'warn' to 'warning'", () => {
       expect(severityFromString('warn')).toBe('warning');
-      expect(severityFromString('warning')).toBe('warning');
-    });
-    test('handles warn and warning', () => {
-      expect(severityFromString('warn')).toBe('warning');
-      expect(severityFromString('warning')).toBe('warning');
     });
   });
   describe('default to log', () => {

--- a/packages/utils/test/severity.test.ts
+++ b/packages/utils/test/severity.test.ts
@@ -1,5 +1,4 @@
-import { SeverityLevels } from '../src/enums';
-import { severityFromString } from '../src/severity';
+import { severityFromString, validSeverityLevels } from '../src/severity';
 
 describe('severityFromString()', () => {
   describe('normalize warn and warning', () => {
@@ -16,7 +15,7 @@ describe('severityFromString()', () => {
     expect(severityFromString('foo')).toBe('log');
   });
   describe('allows ', () => {
-    for (const level of SeverityLevels) {
+    for (const level of validSeverityLevels) {
       expect(severityFromString(level)).toBe(level);
     }
   });

--- a/packages/utils/test/severity.test.ts
+++ b/packages/utils/test/severity.test.ts
@@ -1,15 +1,15 @@
 import { severityFromString, validSeverityLevels } from '../src/severity';
 
 describe('severityFromString()', () => {
-  describe('normalize warn and warning', () => {
-    test("converts 'warn' to 'warning'", () => {
-      expect(severityFromString('warn')).toBe('warning');
-    });
+  test("converts 'warn' to 'warning'", () => {
+    expect(severityFromString('warn')).toBe('warning');
   });
-  describe('default to log', () => {
+
+  test('defaults to log', () => {
     expect(severityFromString('foo')).toBe('log');
   });
-  describe('allows ', () => {
+
+  test('acts as a pass-through for valid level strings', () => {
     for (const level of validSeverityLevels) {
       expect(severityFromString(level)).toBe(level);
     }

--- a/packages/vue/src/index.bundle.ts
+++ b/packages/vue/src/index.bundle.ts
@@ -6,13 +6,12 @@ export {
   EventStatus,
   Exception,
   Response,
+  SeverityLevel,
   StackFrame,
   Stacktrace,
   Thread,
   User,
 } from '@sentry/types';
-
-export { SeverityLevel } from '@sentry/utils';
 
 export {
   BrowserClient,


### PR DESCRIPTION
_Note: This and https://github.com/getsentry/sentry-javascript/pull/4896 are together a (slightly updated) repeat of https://github.com/getsentry/sentry-javascript/pull/4497, to get it onto the main v7 branch._

Our original v7 plan called for deprecating and then removing the `Severity` enum which lives in `@sentry/types`, because enums transpile to a two-way lookup function with a fairly hefty footprint (see [this](https://stackoverflow.com/a/28818850) SO answer from one of the maintainers of TS). We therefore added a new `SeverityLevel` type, which is the union of all of `Severity`'s underlying values, and directed people to use that instead. Though we subsequently decided not to remove `Severity` (at least in v7), we agreed that we should stop using it internally. This implements that change.

Key Changes:

- `Severity` and `severityFromString` have been redeprecated.
- The original plan to have `SeverityLevel` live in `@sentry/utils` has been reverted, and it now lives only in `@sentry/types`. 
- The internal `SeverityLevels` array on which we were basing `SeverityLevel` has been removed. While we lose the elegance of the derived type, we gain the ability to truly only export types from `@sentry/types`.
- Wherever we accept a `Severity` value, we now also accept a `SeverityLevel`.
- All internal uses of `Severity` values have been replaced with the equivalent string constants.
- A new `severityLevelFromString` function has been introduced, and is now used in place of `SeverityFromString`.
- The tests for `severityFromString` have been cleaned up and replaced with equivalent tests for `SeverityLevelFromString`.
