### PR TITLE
chore(gatsby): Create type declarations for gatsby plugin files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ tmp.js
 # eslint
 .eslintcache
 eslintcache/*
+
+*.d.ts

--- a/packages/gatsby/.eslintrc.js
+++ b/packages/gatsby/.eslintrc.js
@@ -6,8 +6,7 @@ module.exports = {
   parserOptions: {
     jsx: true,
   },
-  // ignoring the package-specific prepack script here b/c it is not
-  // covered by a `tsconfig` which makes eslint throw an error
-  ignorePatterns: ['scripts/prepack.ts'],
+  // ignore these because they're not covered by a `tsconfig`, which makes eslint throw an error
+  ignorePatterns: ['scripts/prepack.ts', 'gatsby-browser.d.ts', 'gatsby-node.d.ts'],
   extends: ['../../.eslintrc.js'],
 };

--- a/packages/gatsby/.npmignore
+++ b/packages/gatsby/.npmignore
@@ -10,3 +10,5 @@
 # Gatsby specific
 !gatsby-browser.js
 !gatsby-node.js
+!gatsby-browser.d.ts
+!gatsby-node.d.ts

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -34,11 +34,12 @@
     "react": "^18.0.0"
   },
   "scripts": {
-    "build": "run-p build:cjs build:esm build:types",
+    "build": "run-p build:cjs build:esm build:types build:plugin",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:dev": "run-s build",
     "build:es5": "yarn build:cjs # *** backwards compatibility - remove in v7 ***",
     "build:esm": "tsc -p tsconfig.esm.json",
+    "build:plugin": "tsc -p tsconfig.plugin.json",
     "build:types": "tsc -p tsconfig.types.json",
     "build:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -49,7 +49,7 @@
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "ts-node ../../scripts/prepack.ts && npm pack ./build",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf build coverage",
+    "clean": "rimraf build coverage *.d.ts",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",

--- a/packages/gatsby/scripts/prepack.ts
+++ b/packages/gatsby/scripts/prepack.ts
@@ -6,7 +6,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-const PACKAGE_ASSETS = ['gatsby-browser.js', 'gatsby-node.js'];
+const PACKAGE_ASSETS = ['gatsby-browser.js', 'gatsby-browser.d.ts', 'gatsby-node.js', 'gatsby-node.d.ts'];
 
 export function prepack(buildDir: string): boolean {
   // copy package-specific assets to build dir

--- a/packages/gatsby/tsconfig.plugin.json
+++ b/packages/gatsby/tsconfig.plugin.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+
+  "include": ["gatsby-browser.js", "gatsby-node.js"],
+
+  "compilerOptions": {
+    // should include all types from `./tsconfig.json` plus types for all test frameworks used
+    // "types": ["node", "jest"]
+    "declaration": true,
+    "declarationMap": false,
+    "emitDeclarationOnly": true,
+    "allowJs": true,
+    "skipLibCheck": true
+
+    // other package-specific, plugin-specific options
+  }
+}


### PR DESCRIPTION
When creating a Gatsby plugin (which is what `@sentry/gatsby` actually is), there are [certain files](https://www.gatsbyjs.com/docs/files-gatsby-looks-for-in-a-plugin/) which need to live at the package root level. Because they are written in JS (not TS) and don't live in `src/`, we have thus far more or less ignored them as far as type-ful processing goes. With the recent updates to TS, jest, and ts-jest, typechecking has now gotten stricter (especially in tests) and so now declaration files are needed for those gatsby-required, root-level files if we want to test them (which we do).

This adds machinery to create, manage, and publish these declaration files.