### PR TITLE
feat(eventprocessors): Add name field to EventProcessor

### DIFF
--- a/packages/browser/src/integrations/dedupe.ts
+++ b/packages/browser/src/integrations/dedupe.ts
@@ -42,7 +42,7 @@ export class Dedupe implements Integration {
       return currentEvent;
     };
 
-    eventProcessor.id = 'DedupeIntegration';
+    eventProcessor.id = this.name;
     addGlobalEventProcessor(eventProcessor);
   }
 }

--- a/packages/browser/src/integrations/dedupe.ts
+++ b/packages/browser/src/integrations/dedupe.ts
@@ -24,7 +24,7 @@ export class Dedupe implements Integration {
    * @inheritDoc
    */
   public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    addGlobalEventProcessor((currentEvent: Event) => {
+    const eventProcessor: EventProcessor = currentEvent => {
       const self = getCurrentHub().getIntegration(Dedupe);
       if (self) {
         // Juuust in case something goes wrong
@@ -40,7 +40,10 @@ export class Dedupe implements Integration {
         return (self._previousEvent = currentEvent);
       }
       return currentEvent;
-    });
+    };
+
+    eventProcessor.id = 'DedupeIntegration';
+    addGlobalEventProcessor(eventProcessor);
   }
 }
 

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -33,7 +33,7 @@ export class InboundFilters implements Integration {
    * @inheritDoc
    */
   public setupOnce(addGlobalEventProcessor: (processor: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    addGlobalEventProcessor((event: Event) => {
+    const eventProcess: EventProcessor = (event: Event) => {
       const hub = getCurrentHub();
       if (hub) {
         const self = hub.getIntegration(InboundFilters);
@@ -45,7 +45,10 @@ export class InboundFilters implements Integration {
         }
       }
       return event;
-    });
+    };
+
+    eventProcess.id = 'InboundFiltersIntegration';
+    addGlobalEventProcessor(eventProcess);
   }
 }
 

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -47,7 +47,7 @@ export class InboundFilters implements Integration {
       return event;
     };
 
-    eventProcess.id = 'InboundFiltersIntegration';
+    eventProcess.id = this.name;
     addGlobalEventProcessor(eventProcess);
   }
 }

--- a/packages/core/test/mocks/integration.ts
+++ b/packages/core/test/mocks/integration.ts
@@ -1,6 +1,6 @@
 import { getCurrentHub } from '@sentry/hub';
 import { configureScope } from '@sentry/minimal';
-import { Event, Integration } from '@sentry/types';
+import { Event, EventProcessor, Integration } from '@sentry/types';
 
 export class TestIntegration implements Integration {
   public static id: string = 'TestIntegration';
@@ -8,14 +8,18 @@ export class TestIntegration implements Integration {
   public name: string = 'TestIntegration';
 
   public setupOnce(): void {
-    configureScope(scope => {
-      scope.addEventProcessor((event: Event) => {
-        if (!getCurrentHub().getIntegration(TestIntegration)) {
-          return event;
-        }
+    const eventProcessor: EventProcessor = (event: Event) => {
+      if (!getCurrentHub().getIntegration(TestIntegration)) {
+        return event;
+      }
 
-        return null;
-      });
+      return null;
+    };
+
+    eventProcessor.id = 'TestIntegration';
+
+    configureScope(scope => {
+      scope.addEventProcessor(eventProcessor);
     });
   }
 }

--- a/packages/core/test/mocks/integration.ts
+++ b/packages/core/test/mocks/integration.ts
@@ -16,7 +16,7 @@ export class TestIntegration implements Integration {
       return null;
     };
 
-    eventProcessor.id = 'TestIntegration';
+    eventProcessor.id = this.name;
 
     configureScope(scope => {
       scope.addEventProcessor(eventProcessor);

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -467,9 +467,9 @@ export class Scope implements ScopeInterface {
         const result = processor({ ...event }, hint) as Event | null;
 
         IS_DEBUG_BUILD &&
-          processor.name &&
+          processor.identifier &&
           result === null &&
-          logger.log(`Event processor ${processor.name} dropped event.`);
+          logger.log(`Event processor ${processor.identifier} dropped event.`);
 
         if (isThenable(result)) {
           void result

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -23,12 +23,12 @@ import {
   getGlobalSingleton,
   isPlainObject,
   isThenable,
-  SyncPromise,
   logger,
+  SyncPromise,
 } from '@sentry/utils';
 
-import { Session } from './session';
 import { IS_DEBUG_BUILD } from './flags';
+import { Session } from './session';
 
 /**
  * Absolute maximum number of breadcrumbs added to an event.
@@ -467,9 +467,9 @@ export class Scope implements ScopeInterface {
         const result = processor({ ...event }, hint) as Event | null;
 
         IS_DEBUG_BUILD &&
-          processor.identifier &&
+          processor.id &&
           result === null &&
-          logger.log(`Event processor ${processor.identifier} dropped event.`);
+          logger.log(`Event processor "${processor.id}" dropped event`);
 
         if (isThenable(result)) {
           void result

--- a/packages/integrations/src/dedupe.ts
+++ b/packages/integrations/src/dedupe.ts
@@ -24,7 +24,7 @@ export class Dedupe implements Integration {
    * @inheritDoc
    */
   public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    addGlobalEventProcessor((currentEvent: Event) => {
+    const eventProcessor = (currentEvent: Event): Event | null => {
       const self = getCurrentHub().getIntegration(Dedupe);
       if (self) {
         // Juuust in case something goes wrong
@@ -40,7 +40,11 @@ export class Dedupe implements Integration {
         return (self._previousEvent = currentEvent);
       }
       return currentEvent;
-    });
+    };
+
+    eventProcessor.identifier = 'dedupe-processor';
+
+    addGlobalEventProcessor(eventProcessor);
   }
 }
 

--- a/packages/integrations/src/dedupe.ts
+++ b/packages/integrations/src/dedupe.ts
@@ -42,7 +42,7 @@ export class Dedupe implements Integration {
       return currentEvent;
     };
 
-    eventProcessor.id = 'DedupeIntegration';
+    eventProcessor.id = this.name;
     addGlobalEventProcessor(eventProcessor);
   }
 }

--- a/packages/integrations/src/dedupe.ts
+++ b/packages/integrations/src/dedupe.ts
@@ -24,7 +24,7 @@ export class Dedupe implements Integration {
    * @inheritDoc
    */
   public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    const eventProcessor = (currentEvent: Event): Event | null => {
+    const eventProcessor: EventProcessor = currentEvent => {
       const self = getCurrentHub().getIntegration(Dedupe);
       if (self) {
         // Juuust in case something goes wrong
@@ -42,8 +42,7 @@ export class Dedupe implements Integration {
       return currentEvent;
     };
 
-    eventProcessor.identifier = 'dedupe-processor';
-
+    eventProcessor.id = 'DedupeIntegration';
     addGlobalEventProcessor(eventProcessor);
   }
 }

--- a/packages/integrations/src/offline.ts
+++ b/packages/integrations/src/offline.ts
@@ -100,7 +100,7 @@ export class Offline implements Integration {
       return event;
     };
 
-    eventProcessor.id = 'OfflineIntegration';
+    eventProcessor.id = this.name;
     addGlobalEventProcessor(eventProcessor);
 
     // if online now, send any events stored in a previous offline session

--- a/packages/integrations/src/offline.ts
+++ b/packages/integrations/src/offline.ts
@@ -80,10 +80,12 @@ export class Offline implements Integration {
       });
     }
 
-    addGlobalEventProcessor((event: Event) => {
+    const eventProcessor: EventProcessor = event => {
       if (this.hub && this.hub.getIntegration(Offline)) {
         // cache if we are positively offline
         if ('navigator' in this.global && 'onLine' in this.global.navigator && !this.global.navigator.onLine) {
+          IS_DEBUG_BUILD && logger.log('Event dropped due to being a offline - caching instead');
+
           void this._cacheEvent(event)
             .then((_event: Event): Promise<void> => this._enforceMaxEvents())
             .catch((_error): void => {
@@ -96,7 +98,10 @@ export class Offline implements Integration {
       }
 
       return event;
-    });
+    };
+
+    eventProcessor.id = 'OfflineIntegration';
+    addGlobalEventProcessor(eventProcessor);
 
     // if online now, send any events stored in a previous offline session
     if ('navigator' in this.global && 'onLine' in this.global.navigator && this.global.navigator.onLine) {

--- a/packages/nextjs/src/index.client.ts
+++ b/packages/nextjs/src/index.client.ts
@@ -1,5 +1,6 @@
 import { configureScope, init as reactInit, Integrations as BrowserIntegrations } from '@sentry/react';
 import { BrowserTracing, defaultRequestInstrumentationOptions } from '@sentry/tracing';
+import { EventProcessor } from '@sentry/types';
 
 import { nextRouterInstrumentation } from './performance/client';
 import { buildMetadata } from './utils/metadata';
@@ -42,9 +43,13 @@ export function init(options: NextjsOptions): void {
     ...options,
     integrations,
   });
+
   configureScope(scope => {
     scope.setTag('runtime', 'browser');
-    scope.addEventProcessor(event => (event.type === 'transaction' && event.transaction === '/404' ? null : event));
+    const filterTransactions: EventProcessor = event =>
+      event.type === 'transaction' && event.transaction === '/404' ? null : event;
+    filterTransactions.id = 'NextClient404Filter';
+    scope.addEventProcessor(filterTransactions);
   });
 }
 

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -2,7 +2,7 @@ import { Carrier, getHubFromCarrier, getMainCarrier } from '@sentry/hub';
 import { RewriteFrames } from '@sentry/integrations';
 import { configureScope, getCurrentHub, init as nodeInit, Integrations } from '@sentry/node';
 import { hasTracingEnabled } from '@sentry/tracing';
-import { Event } from '@sentry/types';
+import { Event, EventProcessor } from '@sentry/types';
 import { escapeStringForRegex, logger } from '@sentry/utils';
 import * as domainModule from 'domain';
 import * as path from 'path';
@@ -71,6 +71,12 @@ export function init(options: NextjsOptions): void {
 
   nodeInit(options);
 
+  const filterTransactions: EventProcessor = event => {
+    return event.type === 'transaction' && event.transaction === '/404' ? null : event;
+  };
+
+  filterTransactions.id = 'NextServer404Filter';
+
   configureScope(scope => {
     scope.setTag('runtime', 'node');
     if (isVercel) {
@@ -129,10 +135,6 @@ function addServerIntegrations(options: NextjsOptions): void {
       Http: { keyPath: '_tracing', value: true },
     });
   }
-}
-
-function filterTransactions(event: Event): Event | null {
-  return event.type === 'transaction' && event.transaction === '/404' ? null : event;
 }
 
 export { withSentryConfig } from './config';

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -2,7 +2,7 @@ import { Carrier, getHubFromCarrier, getMainCarrier } from '@sentry/hub';
 import { RewriteFrames } from '@sentry/integrations';
 import { configureScope, getCurrentHub, init as nodeInit, Integrations } from '@sentry/node';
 import { hasTracingEnabled } from '@sentry/tracing';
-import { Event, EventProcessor } from '@sentry/types';
+import { EventProcessor } from '@sentry/types';
 import { escapeStringForRegex, logger } from '@sentry/utils';
 import * as domainModule from 'domain';
 import * as path from 'path';

--- a/packages/types/src/eventprocessor.ts
+++ b/packages/types/src/eventprocessor.ts
@@ -6,4 +6,7 @@ import { Event, EventHint } from './event';
  * Returning a PromiseLike<Event | null> will work just fine, but better be sure that you know what you are doing.
  * Event processing will be deferred until your Promise is resolved.
  */
-export type EventProcessor = (event: Event, hint?: EventHint) => PromiseLike<Event | null> | Event | null;
+export interface EventProcessor {
+  name?: string;
+  (event: Event, hint?: EventHint): PromiseLike<Event | null> | Event | null;
+}

--- a/packages/types/src/eventprocessor.ts
+++ b/packages/types/src/eventprocessor.ts
@@ -7,6 +7,6 @@ import { Event, EventHint } from './event';
  * Event processing will be deferred until your Promise is resolved.
  */
 export interface EventProcessor {
-  identifier?: string; // This field can't be named "name" because functions already have this field natively
+  id?: string; // This field can't be named "name" because functions already have this field natively
   (event: Event, hint?: EventHint): PromiseLike<Event | null> | Event | null;
 }

--- a/packages/types/src/eventprocessor.ts
+++ b/packages/types/src/eventprocessor.ts
@@ -7,6 +7,6 @@ import { Event, EventHint } from './event';
  * Event processing will be deferred until your Promise is resolved.
  */
 export interface EventProcessor {
-  name?: string;
+  identifier?: string; // This field can't be named "name" because functions already have this field natively
   (event: Event, hint?: EventHint): PromiseLike<Event | null> | Event | null;
 }


### PR DESCRIPTION
Adds an `identifier` field to `EventProcessor` so we can log if an event processor drops an event.

Ref: https://getsentry.atlassian.net/browse/WEB-817