### PR TITLE
ref(measurements): Make `setMeasurement` public API

### DIFF
--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -68,12 +68,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
   }
 
   /**
-   * Set observed measurement for this transaction.
-   *
-   * @param name Name of the measurement
-   * @param value Value of the measurement
-   * @param unit Unit of the measurement. (Defaults to an empty string)
-   * @hidden
+   * @inheritDoc
    */
   public setMeasurement(name: string, value: number, unit: string = ''): void {
     this._measurements[name] = { value, unit };

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -73,6 +73,15 @@ export interface Transaction extends TransactionContext, Span {
    */
   setName(name: string): void;
 
+  /**
+   * Set observed measurement for this transaction.
+   *
+   * @param name Name of the measurement
+   * @param value Value of the measurement
+   * @param unit Unit of the measurement. (Defaults to an empty string)
+   */
+  setMeasurement(name: string, value: number, unit: string): void;
+
   /** Returns the current transaction properties as a `TransactionContext` */
   toContext(): TransactionContext;
 


### PR DESCRIPTION
Makes `setMeasurement` part of `Transaction`s public API.

Ref: https://getsentry.atlassian.net/browse/WEB-836