### PR TITLE
feat(tracing): Add GB unit to device memory tag value

### DIFF
--- a/packages/tracing/src/browser/metrics.ts
+++ b/packages/tracing/src/browser/metrics.ts
@@ -211,7 +211,7 @@ export class MetricsInstrumentation {
     }
 
     if (isMeasurementValue(navigator.deviceMemory)) {
-      transaction.setTag('deviceMemory', String(navigator.deviceMemory));
+      transaction.setTag('deviceMemory', `${navigator.deviceMemory} GB`);
     }
 
     if (isMeasurementValue(navigator.hardwareConcurrency)) {


### PR DESCRIPTION
Since tag values are always strings, it'll be useful to attach units to the `deviceMemory` tag. Since `navigator.deviceMemory` are approximate in gigabytes, we can suffix the tag value with " GB".

When seeing these values in Sentry product, it's non-obvious that they're in gigabytes:

<img width="208" alt="Screen Shot 2022-04-13 at 3 35 41 PM" src="https://user-images.githubusercontent.com/139499/163256721-6854c073-b4b8-4db6-b037-6fb6d0dd36f7.png">


Reference: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/deviceMemory