### PR TITLE
fix(build): Cache gatsby plugin types files in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ env:
     ${{ github.workspace }}/packages/**/esm
     ${{ github.workspace }}/packages/ember/*.d.ts
     ${{ github.workspace }}/packages/ember/instance-initializers
+    ${{ github.workspace }}/packages/gatsby/*.d.ts
     ${{ github.workspace }}/packages/serverless/dist-awslambda-layer/*.zip
 
   BUILD_CACHE_KEY: ${{ github.event.inputs.commit || github.sha }}


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/sentry-javascript/pull/4928, which added the creation of types files for the code in the gatsby SDK which lives outside of `src/`. One change which was missed was to have GHA include these new files in the build cache, so that they are available when tests are run. This fixes that oversight.
