### PR TITLE
chore(ci): add informational Codecov status checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,7 @@ coverage:
   status:
     project:
       default:
-        enabled: no
+        informational: true
     patch:
       default:
-        enabled: no
+        informational: true


### PR DESCRIPTION
Hi, Tom from Codecov here. I noticed that you were using Codecov but weren't actually getting any notifications on pull requests. I figured it would be useful to get some idea if code being changed is being tested, but also not blocking CI/merging. Let me know if this makes sense or if we can do something that would be helpful.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
