### PR TITLE
ref(tests): Suppress unconstructive listener and open handle warnings.

### DIFF
--- a/packages/node-integration-tests/jest.config.js
+++ b/packages/node-integration-tests/jest.config.js
@@ -1,6 +1,7 @@
 const baseConfig = require('../../jest.config.js');
 
 module.exports = {
+  globalSetup: '<rootDir>/setup-tests.ts',
   ...baseConfig,
   testMatch: ['**/test.ts'],
 };

--- a/packages/node-integration-tests/package.json
+++ b/packages/node-integration-tests/package.json
@@ -11,7 +11,7 @@
     "lint:eslint": "eslint . --cache --cache-location '../../eslintcache/' --format stylish",
     "lint:prettier": "prettier --check \"{suites,utils}/**/*.ts\"",
     "type-check": "tsc",
-    "test": "jest --detectOpenHandles --runInBand --forceExit",
+    "test": "jest --runInBand --forceExit",
     "test:watch": "yarn test --watch"
   },
   "dependencies": {

--- a/packages/node-integration-tests/setup-tests.ts
+++ b/packages/node-integration-tests/setup-tests.ts
@@ -1,0 +1,8 @@
+import EventEmitter from 'events';
+
+const setup = async (): Promise<void> => {
+  // Remove MaxEventListeners warning.
+  EventEmitter.defaultMaxListeners = 0;
+};
+
+export default setup;

--- a/packages/node-integration-tests/setup-tests.ts
+++ b/packages/node-integration-tests/setup-tests.ts
@@ -1,7 +1,11 @@
 import EventEmitter from 'events';
 
 const setup = async (): Promise<void> => {
-  // Remove MaxEventListeners warning.
+  // Node warns about a potential memory leak
+  // when more than 10 event listeners are assigned inside a single thread.
+  // Initializing Sentry for each test triggers these warnings after 10th test inside Jest thread.
+  // As we know that it's not a memory leak and number of listeners are limited to the number of tests,
+  // removing the limit on listener count here.
   EventEmitter.defaultMaxListeners = 0;
 };
 


### PR DESCRIPTION
Removes warnings that we can't address at the moment from Jest logs. 

1 - `MaxEventListener` warning is about a potential memory leak when more than 10 event listeners are assigned inside a single thread. As we're running all our integration tests on a single Jest thread, after 10th Sentry initialization, this warning starts polluting logs. Still, it's not great to have unregistered handles around. But we know it's limited to the number of test scenarios here. So IMO this workaround is safe to use for these tests.

2 - `detectOpenHandles` warns about uncleared intervals from `session` tests (where we're hackily replacing flush interval), which we are eventually clearing but can't set a reliable timeout, and we're also using `--forceExit` that does that on exit. (Also today I learned it should be [debugging only](https://jestjs.io/docs/cli#--detectopenhandles))