### PR TITLE
ref: Enforce stackParser through options.

### DIFF
--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -1,6 +1,6 @@
 import { BaseClient, NewTransport, Scope, SDK_VERSION } from '@sentry/core';
 import { ClientOptions, Event, EventHint, Options, Severity, SeverityLevel, Transport } from '@sentry/types';
-import { getGlobalObject, logger, stackParserFromOptions } from '@sentry/utils';
+import { getGlobalObject, logger } from '@sentry/utils';
 
 import { eventFromException, eventFromMessage } from './eventbuilder';
 import { IS_DEBUG_BUILD } from './flags';
@@ -89,7 +89,7 @@ export class BrowserClient extends BaseClient<BrowserClientOptions> {
    * @inheritDoc
    */
   public eventFromException(exception: unknown, hint?: EventHint): PromiseLike<Event> {
-    return eventFromException(stackParserFromOptions(this._options), exception, hint, this._options.attachStacktrace);
+    return eventFromException(this._options.stackParser, exception, hint, this._options.attachStacktrace);
   }
 
   /**
@@ -101,13 +101,7 @@ export class BrowserClient extends BaseClient<BrowserClientOptions> {
     level: Severity | SeverityLevel = 'info',
     hint?: EventHint,
   ): PromiseLike<Event> {
-    return eventFromMessage(
-      stackParserFromOptions(this._options),
-      message,
-      level,
-      hint,
-      this._options.attachStacktrace,
-    );
+    return eventFromMessage(this._options.stackParser, message, level, hint, this._options.attachStacktrace);
   }
 
   /**

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -9,7 +9,6 @@ import {
   isPrimitive,
   isString,
   logger,
-  stackParserFromOptions,
 } from '@sentry/utils';
 
 import { BrowserClient } from '../client';
@@ -255,8 +254,9 @@ function addMechanismAndCapture(hub: Hub, error: EventHint['originalException'],
 function getHubAndOptions(): [Hub, StackParser, boolean | undefined] {
   const hub = getCurrentHub();
   const client = hub.getClient<BrowserClient>();
-  const options = client?.getOptions();
-  const parser = stackParserFromOptions(options);
-  const attachStacktrace = options?.attachStacktrace;
-  return [hub, parser, attachStacktrace];
+  const options = (client && client.getOptions()) || {
+    stackParser: () => [],
+    attachStacktrace: false,
+  };
+  return [hub, options.stackParser, options.attachStacktrace];
 }

--- a/packages/browser/src/integrations/linkederrors.ts
+++ b/packages/browser/src/integrations/linkederrors.ts
@@ -1,6 +1,6 @@
 import { addGlobalEventProcessor, getCurrentHub } from '@sentry/core';
 import { Event, EventHint, Exception, ExtendedError, Integration, StackParser } from '@sentry/types';
-import { isInstanceOf, stackParserFromOptions } from '@sentry/utils';
+import { isInstanceOf } from '@sentry/utils';
 
 import { BrowserClient } from '../client';
 import { exceptionFromError } from '../eventbuilder';
@@ -47,12 +47,14 @@ export class LinkedErrors implements Integration {
    * @inheritDoc
    */
   public setupOnce(): void {
-    const options = getCurrentHub().getClient<BrowserClient>()?.getOptions();
-    const parser = stackParserFromOptions(options);
-
+    const client = getCurrentHub().getClient<BrowserClient>();
+    const options = client && client.getOptions();
+    if (!options) {
+      return;
+    }
     addGlobalEventProcessor((event: Event, hint?: EventHint) => {
       const self = getCurrentHub().getIntegration(LinkedErrors);
-      return self ? _handler(parser, self._key, self._limit, event, hint) : event;
+      return self ? _handler(options.stackParser, self._key, self._limit, event, hint) : event;
     });
   }
 }

--- a/packages/browser/src/integrations/linkederrors.ts
+++ b/packages/browser/src/integrations/linkederrors.ts
@@ -48,13 +48,12 @@ export class LinkedErrors implements Integration {
    */
   public setupOnce(): void {
     const client = getCurrentHub().getClient<BrowserClient>();
-    const options = client && client.getOptions();
-    if (!options) {
+    if (!client) {
       return;
     }
     addGlobalEventProcessor((event: Event, hint?: EventHint) => {
       const self = getCurrentHub().getIntegration(LinkedErrors);
-      return self ? _handler(options.stackParser, self._key, self._limit, event, hint) : event;
+      return self ? _handler(client.getOptions().stackParser, self._key, self._limit, event, hint) : event;
     });
   }
 }

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -102,14 +102,11 @@ export function init(options: BrowserOptions = {}): void {
   if (options.sendClientReports === undefined) {
     options.sendClientReports = true;
   }
-  if (options.stackParser === undefined) {
-    options.stackParser = defaultStackParsers;
-  }
   const { transport, newTransport } = setupBrowserTransport(options);
 
   const clientOptions: BrowserClientOptions = {
     ...options,
-    stackParser: stackParserFromOptions(options),
+    stackParser: stackParserFromOptions(options.stackParser || defaultStackParsers),
     integrations: getIntegrationsToSetup(options),
     // TODO(v7): get rid of transport being passed down below
     transport: options.transport || (supportsFetch() ? FetchTransport : XHRTransport),

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -1,7 +1,7 @@
 import { BaseClient, NewTransport, Scope, SDK_VERSION } from '@sentry/core';
 import { SessionFlusher } from '@sentry/hub';
 import { Event, EventHint, Severity, SeverityLevel, Transport } from '@sentry/types';
-import { logger, resolvedSyncPromise, stackParserFromOptions } from '@sentry/utils';
+import { logger, resolvedSyncPromise } from '@sentry/utils';
 
 import { eventFromMessage, eventFromUnknownInput } from './eventbuilder';
 import { IS_DEBUG_BUILD } from './flags';
@@ -111,7 +111,7 @@ export class NodeClient extends BaseClient<NodeClientOptions> {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   public eventFromException(exception: any, hint?: EventHint): PromiseLike<Event> {
-    return resolvedSyncPromise(eventFromUnknownInput(stackParserFromOptions(this._options), exception, hint));
+    return resolvedSyncPromise(eventFromUnknownInput(this._options.stackParser, exception, hint));
   }
 
   /**
@@ -124,7 +124,7 @@ export class NodeClient extends BaseClient<NodeClientOptions> {
     hint?: EventHint,
   ): PromiseLike<Event> {
     return resolvedSyncPromise(
-      eventFromMessage(stackParserFromOptions(this._options), message, level, hint, this._options.attachStacktrace),
+      eventFromMessage(this._options.stackParser, message, level, hint, this._options.attachStacktrace),
     );
   }
 

--- a/packages/node/src/integrations/linkederrors.ts
+++ b/packages/node/src/integrations/linkederrors.ts
@@ -1,6 +1,6 @@
 import { addGlobalEventProcessor, getCurrentHub } from '@sentry/core';
 import { Event, EventHint, Exception, ExtendedError, Integration, StackParser } from '@sentry/types';
-import { isInstanceOf, resolvedSyncPromise, stackParserFromOptions, SyncPromise } from '@sentry/utils';
+import { isInstanceOf, resolvedSyncPromise, SyncPromise } from '@sentry/utils';
 
 import { NodeClient } from '../client';
 import { exceptionFromError } from '../eventbuilder';
@@ -46,12 +46,10 @@ export class LinkedErrors implements Integration {
     addGlobalEventProcessor(async (event: Event, hint?: EventHint) => {
       const hub = getCurrentHub();
       const self = hub.getIntegration(LinkedErrors);
-      const stackParser = stackParserFromOptions(hub.getClient<NodeClient>()?.getOptions());
-
-      if (self) {
-        await self._handler(stackParser, event, hint);
+      const client = hub.getClient<NodeClient>();
+      if (client && self) {
+        await self._handler(client.getOptions().stackParser, event, hint);
       }
-
       return event;
     });
   }

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -122,10 +122,6 @@ export function init(options: NodeOptions = {}): void {
     options.autoSessionTracking = true;
   }
 
-  if (options.stackParser === undefined) {
-    options.stackParser = [nodeStackParser];
-  }
-
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
   if ((domain as any).active) {
     setHubOnCarrier(carrier, getCurrentHub());
@@ -136,7 +132,7 @@ export function init(options: NodeOptions = {}): void {
   // TODO(v7): Refactor this to reduce the logic above
   const clientOptions: NodeClientOptions = {
     ...options,
-    stackParser: stackParserFromOptions(options),
+    stackParser: stackParserFromOptions(options.stackParser || [nodeStackParser]),
     integrations: getIntegrationsToSetup(options),
     // TODO(v7): Fix me when we switch to new transports entirely.
     transport: options.transport || (transport instanceof HTTPTransport ? HTTPTransport : HTTPSTransport),

--- a/packages/utils/src/stacktrace.ts
+++ b/packages/utils/src/stacktrace.ts
@@ -30,27 +30,17 @@ export function createStackParser(...parsers: StackLineParser[]): StackParser {
   };
 }
 
-interface StackParserOptions {
-  stackParser?: StackParser | StackLineParser[];
-}
-
 /**
- * Gets a stack parser implementation from options
+ * Gets a stack parser implementation from Options.stackParser
+ * @see Options
  *
  * If options contains an array of line parsers, it is converted into a parser
  */
-export function stackParserFromOptions(options: StackParserOptions | undefined): StackParser {
-  if (options) {
-    if (Array.isArray(options.stackParser)) {
-      options.stackParser = createStackParser(...options.stackParser);
-    }
-
-    if (typeof options.stackParser === 'function') {
-      return options.stackParser;
-    }
+export function stackParserFromOptions(stackParser: StackParser | StackLineParser[]): StackParser {
+  if (Array.isArray(stackParser)) {
+    return createStackParser(...stackParser);
   }
-
-  return _ => [];
+  return stackParser;
 }
 
 /**


### PR DESCRIPTION
As stackParser will always be defined in client options, we can remove
the usage of `stackParserFromOptions` outside of SDK init.

cc @timfish