### PR TITLE
fix(tracing): Target tracing bundles for side effects

### DIFF
--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -80,8 +80,8 @@
     }
   },
   "sideEffects": [
-    "./npm/dist/index.js",
-    "./npm/esm/index.js",
+    "./dist/index.js",
+    "./esm/index.js",
     "./src/index.ts"
   ]
 }

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -82,6 +82,8 @@
   "sideEffects": [
     "./dist/index.js",
     "./esm/index.js",
+    "./npm/dist/index.js",
+    "./npm/esm/index.js",
     "./src/index.ts"
   ]
 }


### PR DESCRIPTION
The prepack script runs in bundles mode for this module, which puts the build targets in the root of the package rather than the npm folder. https://github.com/getsentry/sentry-javascript/blob/master/scripts/prepack.ts#L20-L21 

This was tested manually against webpack 5.56.0.

This reverts commit eb09c284180d5024158b569adb343468457a50ed.

Partial #4731