### PR TITLE
build(bundles): Rename CDN bundles to be es6 per default

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,25 +1,25 @@
 module.exports = [
   {
     name: '@sentry/browser - ES5 CDN Bundle (gzipped + minified)',
-    path: 'packages/browser/build/bundles/bundle.min.js',
+    path: 'packages/browser/build/bundles/bundle.es5.min.js',
     gzip: true,
     limit: '100 KB',
   },
   {
     name: '@sentry/browser - ES5 CDN Bundle (minified)',
-    path: 'packages/browser/build/bundles/bundle.min.js',
+    path: 'packages/browser/build/bundles/bundle.es5.min.js',
     gzip: false,
     limit: '120 KB',
   },
   {
     name: '@sentry/browser - ES6 CDN Bundle (gzipped + minified)',
-    path: 'packages/browser/build/bundles/bundle.es6.min.js',
+    path: 'packages/browser/build/bundles/bundle.min.js',
     gzip: true,
     limit: '100 KB',
   },
   {
     name: '@sentry/browser - ES6 CDN Bundle (minified)',
-    path: 'packages/browser/build/bundles/bundle.es6.min.js',
+    path: 'packages/browser/build/bundles/bundle.min.js',
     gzip: false,
     limit: '120 KB',
   },
@@ -53,13 +53,13 @@ module.exports = [
   },
   {
     name: '@sentry/browser + @sentry/tracing - ES5 CDN Bundle (gzipped + minified)',
-    path: 'packages/tracing/build/bundles/bundle.tracing.min.js',
+    path: 'packages/tracing/build/bundles/bundle.tracing.es5.min.js',
     gzip: true,
     limit: '100 KB',
   },
   {
     name: '@sentry/browser + @sentry/tracing - ES6 CDN Bundle (gzipped + minified)',
-    path: 'packages/tracing/build/bundles/bundle.tracing.es6.min.js',
+    path: 'packages/tracing/build/bundles/bundle.tracing.min.js',
     gzip: true,
     limit: '100 KB',
   },

--- a/packages/browser/rollup.bundle.config.js
+++ b/packages/browser/rollup.bundle.config.js
@@ -8,7 +8,7 @@ const builds = [];
     isAddOn: false,
     jsVersion,
     licenseTitle: '@sentry/browser',
-    outputFileBase: `bundles/bundle${jsVersion === 'es6' ? '.es6' : ''}`,
+    outputFileBase: `bundles/bundle${jsVersion === 'es5' ? '.es5' : ''}`,
   });
 
   builds.push(...makeBundleConfigVariants(baseBundleConfig));

--- a/packages/integration-tests/utils/generatePlugin.ts
+++ b/packages/integration-tests/utils/generatePlugin.ts
@@ -19,18 +19,18 @@ const BUNDLE_PATHS: Record<string, Record<string, string>> = {
   browser: {
     cjs: 'build/npm/cjs/index.js',
     esm: 'build/npm/esm/index.js',
-    bundle_es5: 'build/bundles/bundle.js',
-    bundle_es5_min: 'build/bundles/bundle.min.js',
-    bundle_es6: 'build/bundles/bundle.es6.js',
-    bundle_es6_min: 'build/bundles/bundle.es6.min.js',
+    bundle_es5: 'build/bundles/bundle.es5.js',
+    bundle_es5_min: 'build/bundles/bundle.es5.min.js',
+    bundle_es6: 'build/bundles/bundle.js',
+    bundle_es6_min: 'build/bundles/bundle.min.js',
   },
   tracing: {
     cjs: 'build/npm/cjs/index.js',
     esm: 'build/npm/esm/index.js',
-    bundle_es5: 'build/bundles/bundle.tracing.js',
-    bundle_es5_min: 'build/bundles/bundle.tracing.min.js',
-    bundle_es6: 'build/bundles/bundle.tracing.es6.js',
-    bundle_es6_min: 'build/bundles/bundle.tracing.es6.min.js',
+    bundle_es5: 'build/bundles/bundle.tracing.es5.js',
+    bundle_es5_min: 'build/bundles/bundle.tracing.es5.min.js',
+    bundle_es6: 'build/bundles/bundle.tracing.js',
+    bundle_es6_min: 'build/bundles/bundle.tracing.min.js',
   },
 };
 

--- a/packages/integrations/rollup.bundle.config.js
+++ b/packages/integrations/rollup.bundle.config.js
@@ -12,7 +12,7 @@ const baseBundleConfig = makeBaseBundleConfig({
   isAddOn: true,
   jsVersion,
   licenseTitle: '@sentry/integrations',
-  outputFileBase: `bundles/${file.replace('.ts', '')}${jsVersion === 'ES6' ? '.es6' : ''}`,
+  outputFileBase: `bundles/${file.replace('.ts', '')}${jsVersion === 'ES5' ? '.es5' : ''}`,
 });
 
 // TODO We only need `commonjs` for localforage (used in the offline plugin). Once that's fixed, this can come out.

--- a/packages/tracing/rollup.bundle.config.js
+++ b/packages/tracing/rollup.bundle.config.js
@@ -8,7 +8,7 @@ const builds = [];
     isAddOn: false,
     jsVersion,
     licenseTitle: '@sentry/tracing & @sentry/browser',
-    outputFileBase: `bundles/bundle.tracing${jsVersion === 'es6' ? '.es6' : ''}`,
+    outputFileBase: `bundles/bundle.tracing${jsVersion === 'es5' ? '.es5' : ''}`,
   });
 
   builds.push(...makeBundleConfigVariants(baseBundleConfig));

--- a/packages/vue/rollup.bundle.config.js
+++ b/packages/vue/rollup.bundle.config.js
@@ -3,7 +3,7 @@ import { makeBaseBundleConfig, makeBundleConfigVariants } from '../../rollup/ind
 const baseBundleConfig = makeBaseBundleConfig({
   input: 'src/index.bundle.ts',
   isAddOn: false,
-  jsVersion: 'es5',
+  jsVersion: 'es6',
   licenseTitle: '@sentry/vue',
   outputFileBase: 'bundle.vue',
 });

--- a/packages/wasm/rollup.bundle.config.js
+++ b/packages/wasm/rollup.bundle.config.js
@@ -3,7 +3,7 @@ import { makeBaseBundleConfig, makeBundleConfigVariants } from '../../rollup/ind
 const baseBundleConfig = makeBaseBundleConfig({
   input: 'src/index.ts',
   isAddOn: true,
-  jsVersion: 'es5',
+  jsVersion: 'es6',
   licenseTitle: '@sentry/wasm',
   outputFileBase: 'bundles/wasm',
 });


### PR DESCRIPTION
This PR will adjust the naming of our CDN bundle. All bundles named `*.es6*.js` will now be named `*.js` and all bundles previously named `*.js` will now be named `*.es5*.js`.

This effectively makes the ES6 browser bundles the new default.

Migration docs have already been updated in #4918

Ref: https://getsentry.atlassian.net/browse/WEB-838