### PR TITLE
doc(angular): Add Angular migration instructions to migration doc

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -123,6 +123,19 @@ For our efforts to reduce bundle size of the SDK we had to remove and refactor p
   `setupBrowserTransport` or `setupNodeTransport` for default transports, depending on your requirements.
 - Remove support for Opera browser pre v15
 
+## Sentry Angular SDK Changes
+
+The Sentry Angular SDK (`@sentry/angular`) is now compiled with the Angular compiler (see [#4641](https://github.com/getsentry/sentry-javascript/pull/4641)). This change was necessary to fix a long-lasting bug in the SDK (see [#3282](https://github.com/getsentry/sentry-javascript/issues/3282)): `TraceDirective` and `TraceModule` can now be used again without risking an application compiler error or having to disable AOT compilation.
+
+### Angular Version Compatibility
+
+Given the forward compatibility of the Angular compiler, v7 of our SDK will only work with Angular 10 and above. Previously, it was possible to use the SDK with versions <10, although we officially only supported Angular 10-13 as `peerDependencies`. If you are using Angular <10 in your project, we recommend staying on the latest 6.x version until you can upgrade your Angular version.
+
+### Import Changes
+
+Due to the compiler change, our NPM package structure changed as well as it now conforms to the [Angular Package Format v10](https://docs.google.com/document/d/1uh2D6XqaGh2yjjXwfF4SrJqWl1MBhMPntlNBBsk6rbw/edit).
+In case you're importing from specific paths other than `@sentry/angular` you will have to adjust these paths. As an example, `import ... from '@sentry/angular/esm/injex.js'` should be changed to `import ... from '@sentry/angular/esm2015/index.js'`. Generally, we strongly recommend only importing from `@sentry/angular`.
+
 # Upgrading from 6.17.x to 6.18.0
 
 Version 6.18.0 deprecates the `frameContextLines` top-level option for the Node SDK. This option will be removed in an upcoming major version. To migrate off of the top-level option, pass it instead to the new `ContextLines` integration.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -129,7 +129,7 @@ The Sentry Angular SDK (`@sentry/angular`) is now compiled with the Angular comp
 
 ### Angular Version Compatibility
 
-Given the forward compatibility of the Angular compiler, v7 of our SDK will only work with Angular 10 and above. Previously, it was possible to use the SDK with versions <10, although we officially only supported Angular 10-13 as `peerDependencies`. If you are using Angular <10 in your project, we recommend staying on the latest 6.x version until you can upgrade your Angular version.
+Given the forward compatibility of the Angular compiler, v7 of our SDK will only work with Angular 10 and above. Previously, it was possible to use the SDK with versions <10, although we officially only supported Angular 10-13 as peer dependencies. If you are using Angular <10 in your project, we recommend staying on the latest 6.x version until you can upgrade your Angular version.
 
 ### Import Changes
 

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -12,6 +12,11 @@
 - [Official SDK Docs](https://docs.sentry.io/platforms/javascript/angular/)
 - [TypeDoc](http://getsentry.github.io/sentry-javascript/)
 
+## Angular Version Compatibility
+
+For Angular 10-13 use the latest version of the Sentry Angular SDK. In case
+you are using an Angular 9 or earlier, use version 6.x of the SDK as newer versions do not support Angular <10.
+
 ## General
 
 This package is a wrapper around `@sentry/browser`, with added functionality related to Angular. All methods available


### PR DESCRIPTION
This PR adds Angular migration and compatibility information to `MIGRATION.md` and `README.MD`. A separate PR for Sentry Docs will follow soon.

Will merge once #4641 is merged

ref: https://getsentry.atlassian.net/browse/WEB-840