### PR TITLE
fix(dev): Correctly lint `scripts` typescript files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,6 +34,14 @@ module.exports = {
       },
     },
     {
+      files: ['**/scripts/**/*.ts'],
+      parserOptions: {
+        // since filepaths are relative to the working directory, we need to go back up to reach the repo root level
+        // tsconfig
+        project: ['../../tsconfig.json'],
+      },
+    },
+    {
       files: ['*.tsx'],
       rules: {
         // Turn off jsdoc on tsx files until jsdoc is fixed for tsx files

--- a/packages/gatsby/.eslintrc.js
+++ b/packages/gatsby/.eslintrc.js
@@ -7,6 +7,6 @@ module.exports = {
     jsx: true,
   },
   // ignore these because they're not covered by a `tsconfig`, which makes eslint throw an error
-  ignorePatterns: ['scripts/prepack.ts', 'gatsby-browser.d.ts', 'gatsby-node.d.ts'],
+  ignorePatterns: ['gatsby-browser.d.ts', 'gatsby-node.d.ts'],
   extends: ['../../.eslintrc.js'],
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "extends": "./packages/typescript/tsconfig.json",
 
+  // include scripts here because their TS config isn't package-specific, and they need to be included in a tsconfig
+  // file to be linted
+  "include": ["**/scripts/**/*.ts"],
+
   "compilerOptions": {
     // TODO: turn these on once we switch to only generating types once, using `tsconfig.types.json`
     // "declaration": false,


### PR DESCRIPTION
Previously, we've had to tell eslint to ignore TS files in package-level `scripts` directories, because they weren't included by any existing TS eslint config. This fixes that, by adding them to both our main `.eslintrc.js` and (since that new entry needs a tsconfig to which to point) our main `tsconfig.json`.
