### PR TITLE
fix(react): Add children prop type to ErrorBoundary component

### DIFF
--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -20,7 +20,7 @@ export type FallbackRender = (errorData: {
 }) => React.ReactElement;
 
 export type ErrorBoundaryProps = {
-  children?: React.ReactNode | undefined;
+  children?: React.ReactNode | (() => React.ReactNode) | undefined;
   /** If a Sentry report dialog should be rendered on error */
   showDialog?: boolean;
   /**

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -20,6 +20,7 @@ export type FallbackRender = (errorData: {
 }) => React.ReactElement;
 
 export type ErrorBoundaryProps = {
+  children?: React.ReactNode | (() => React.ReactNode);
   /** If a Sentry report dialog should be rendered on error */
   showDialog?: boolean;
   /**
@@ -66,7 +67,7 @@ const INITIAL_STATE = {
  * Sentry React SDK ErrorBoundary caught an error invoking your application code. This
  * is expected behavior and NOT indicative of a bug with the Sentry React SDK.
  */
-class ErrorBoundary extends React.Component<React.PropsWithChildren<ErrorBoundaryProps>, ErrorBoundaryState> {
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
   public state: ErrorBoundaryState = INITIAL_STATE;
 
   public componentDidCatch(error: Error & { cause?: Error }, { componentStack }: React.ErrorInfo): void {
@@ -151,7 +152,7 @@ class ErrorBoundary extends React.Component<React.PropsWithChildren<ErrorBoundar
     }
 
     if (typeof children === 'function') {
-      return children();
+      return (children as () => React.ReactNode)();
     }
     return children;
   }

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -20,7 +20,6 @@ export type FallbackRender = (errorData: {
 }) => React.ReactElement;
 
 export type ErrorBoundaryProps = {
-  children?: React.ReactNode | (() => React.ReactNode) | undefined;
   /** If a Sentry report dialog should be rendered on error */
   showDialog?: boolean;
   /**
@@ -67,7 +66,7 @@ const INITIAL_STATE = {
  * Sentry React SDK ErrorBoundary caught an error invoking your application code. This
  * is expected behavior and NOT indicative of a bug with the Sentry React SDK.
  */
-class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+class ErrorBoundary extends React.Component<React.PropsWithChildren<ErrorBoundaryProps>, ErrorBoundaryState> {
   public state: ErrorBoundaryState = INITIAL_STATE;
 
   public componentDidCatch(error: Error & { cause?: Error }, { componentStack }: React.ErrorInfo): void {

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -20,6 +20,7 @@ export type FallbackRender = (errorData: {
 }) => React.ReactElement;
 
 export type ErrorBoundaryProps = {
+  children?: React.ReactNode | undefined;
   /** If a Sentry report dialog should be rendered on error */
   showDialog?: boolean;
   /**


### PR DESCRIPTION
To support React 18, which removed `children` as an optional prop for functional components, this adds `children` as an option prop for the `ErrorBoundary` component.

Fixes #4904 