### PR TITLE
fix(dev): Fix linting for top-level `scripts` folder

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,11 +34,9 @@ module.exports = {
       },
     },
     {
-      files: ['**/scripts/**/*.ts'],
+      files: ['scripts/**/*.ts'],
       parserOptions: {
-        // since filepaths are relative to the working directory, we need to go back up to reach the repo root level
-        // tsconfig
-        project: ['../../tsconfig.json'],
+        project: ['tsconfig.dev.json'],
       },
     },
     {

--- a/packages/gatsby/.eslintrc.js
+++ b/packages/gatsby/.eslintrc.js
@@ -8,5 +8,13 @@ module.exports = {
   },
   // ignore these because they're not covered by a `tsconfig`, which makes eslint throw an error
   ignorePatterns: ['gatsby-browser.d.ts', 'gatsby-node.d.ts'],
+  overrides: [
+    {
+      files: ['scripts/**/*.ts'],
+      parserOptions: {
+        project: ['../../tsconfig.dev.json'],
+      },
+    },
+  ],
   extends: ['../../.eslintrc.js'],
 };

--- a/scripts/build-types-watch.ts
+++ b/scripts/build-types-watch.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /**
  * If `yarn build:types:watch` is run without types files previously having been created, the build will get stuck in an
  * errored state. This happens because lerna runs all of the packages' `yarn build:types:watch` statements in parallel,
@@ -28,7 +29,9 @@ for (const pkg of packages) {
     continue;
   }
 
-  const packageJSON = JSON.parse(fs.readFileSync(path.resolve(packagePath, 'package.json'), 'utf-8'));
+  const packageJSON = JSON.parse(fs.readFileSync(path.resolve(packagePath, 'package.json'), 'utf-8')) as {
+    scripts: Record<string, string>;
+  };
 
   if ('build:types' in packageJSON.scripts && !fs.existsSync(path.resolve(packagePath, 'build/types'))) {
     console.warn(

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -1,0 +1,6 @@
+// TODO This should eventually end up as the tsconfig for a dev-utils package
+{
+  "extends": "./tsconfig.json",
+
+  "include": ["**/scripts/**/*.ts"],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "extends": "./packages/typescript/tsconfig.json",
 
-  // include scripts here because their TS config isn't package-specific, and they need to be included in a tsconfig
-  // file to be linted
-  "include": ["**/scripts/**/*.ts"],
-
   "compilerOptions": {
     // TODO: turn these on once we switch to only generating types once, using `tsconfig.types.json`
     // "declaration": false,


### PR DESCRIPTION
This is a follow up to https://github.com/getsentry/sentry-javascript/pull/4963, which aimed to fix linting for `ts-node` scripts. That PR worked for `packages/*/scripts/*.ts`, but turned out not to work for the top-level `scripts/*.ts`, because the glob for file matching in the eslint config override matched both sets of scripts, but the tsconfig being pointed at only worked for package-level scripts.  This fixes that by pulling the package-level linting override into the package-level `.eslintrc.js`, thus allowing the top-level override to apply only to the top-level scripts folder. Also, in order not to have to muck with the main repo `tsconfig` in any future changes/fixes, both sets of scripts now point to a new, dev-specific tsconfig for their linting. Finally, it fixes linting errors in the top-level `build:types:watch` script which were brought to light by the newly-fixed linting.
