### PR TITLE
fix(dev): Remove eslint cache when cleaning repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:types:watch": "ts-node scripts/build-types-watch.ts",
     "build:npm": "lerna run --parallel build:npm",
     "circularDepCheck": "lerna run --parallel circularDepCheck",
-    "clean": "lerna run --parallel clean && lerna clean --yes",
+    "clean": "lerna run --parallel clean && lerna clean --yes && yarn rimraf eslintcache",
     "codecov": "codecov",
     "fix": "lerna run --parallel fix",
     "link:yarn": "lerna run --stream --concurrency 1 link:yarn",


### PR DESCRIPTION
This adds the eslint cache to the list of things which are removed when running the repo-level `yarn clean` command, to prevent false positives or negatives because of cached results.