### PR TITLE
fix(serverless): Re-add missing modules in Node AWS Lambda Layer

### DIFF
--- a/packages/minimal/.npmignore
+++ b/packages/minimal/.npmignore
@@ -1,0 +1,11 @@
+# The paths in this file are specified so that they align with the file structure in `./build` after this file is copied
+# into it by the prepack script `scripts/prepack.ts`.
+
+*
+
+# TODO remove bundles (which in the tarball are inside `build`) in v7
+!/build/**/*
+
+!/dist/**/*
+!/esm/**/*
+!/types/**/*

--- a/packages/node/.npmignore
+++ b/packages/node/.npmignore
@@ -1,0 +1,11 @@
+# The paths in this file are specified so that they align with the file structure in `./build` after this file is copied
+# into it by the prepack script `scripts/prepack.ts`.
+
+*
+
+# TODO remove bundles (which in the tarball are inside `build`) in v7
+!/build/**/*
+
+!/dist/**/*
+!/esm/**/*
+!/types/**/*

--- a/packages/serverless/scripts/build-awslambda-layer.js
+++ b/packages/serverless/scripts/build-awslambda-layer.js
@@ -145,6 +145,13 @@ async function main() {
   const zipFilename = `sentry-node-serverless-${version}.zip`;
 
   try {
+    fs.symlinkSync(path.resolve(destRoot, 'build', 'dist'), path.resolve(destRoot, 'dist'));
+    fs.symlinkSync(path.resolve(destRoot, 'build', 'esm'), path.resolve(destRoot, 'esm'));
+  } catch (error) {
+    console.error(error);
+  }
+
+  try {
     fs.unlinkSync(path.resolve(dist, zipFilename));
   } catch (error) {
     // If the ZIP file hasn't been previously created (e.g. running this script for the first time),

--- a/packages/tracing/.npmignore
+++ b/packages/tracing/.npmignore
@@ -1,0 +1,11 @@
+# The paths in this file are specified so that they align with the file structure in `./build` after this file is copied
+# into it by the prepack script `scripts/prepack.ts`.
+
+*
+
+# TODO remove bundles (which in the tarball are inside `build`) in v7
+!/build/**/*
+
+!/dist/**/*
+!/esm/**/*
+!/types/**/*

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -29,7 +29,7 @@
     "jsdom": "^16.2.2"
   },
   "scripts": {
-    "build": "run-p build:cjs build:esm build:types build:bundle && ts-node ../../scripts/prepack.ts #necessary for integration tests",
+    "build": "run-p build:cjs build:esm build:types build:bundle && ts-node ../../scripts/prepack.ts --bundles #necessary for integration tests",
     "build:bundle": "rollup --config",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:dev": "run-p build:cjs build:esm build:types",
@@ -82,8 +82,8 @@
   "sideEffects": [
     "./dist/index.js",
     "./esm/index.js",
-    "./npm/dist/index.js",
-    "./npm/esm/index.js",
+    "./build/npm/dist/index.js",
+    "./build/npm/esm/index.js",
     "./src/index.ts"
   ]
 }

--- a/packages/types/.npmignore
+++ b/packages/types/.npmignore
@@ -1,0 +1,11 @@
+# The paths in this file are specified so that they align with the file structure in `./build` after this file is copied
+# into it by the prepack script `scripts/prepack.ts`.
+
+*
+
+# TODO remove bundles (which in the tarball are inside `build`) in v7
+!/build/**/*
+
+!/dist/**/*
+!/esm/**/*
+!/types/**/*

--- a/packages/utils/.npmignore
+++ b/packages/utils/.npmignore
@@ -1,0 +1,11 @@
+# The paths in this file are specified so that they align with the file structure in `./build` after this file is copied
+# into it by the prepack script `scripts/prepack.ts`.
+
+*
+
+# TODO remove bundles (which in the tarball are inside `build`) in v7
+!/build/**/*
+
+!/dist/**/*
+!/esm/**/*
+!/types/**/*


### PR DESCRIPTION
This PR fixes the AWS Lambda layer in `@sentry/serverless`. 

The problem was caused by changes introduced in #4882. 

Some unintended consequences of these changes were:
* By centralising most `.npmignore` files, `npm-packlist` did not find all the necessary (but also unnecessary) files when creating the list of files that should end up in the lambda layer Zip file. Due to the missing `.npmignore` files, it resorted to `.gitignore` which ignores generated JS files. This PR re-adds local `.npmignore` files in the dependencies of `@sentry/serverless` to fix this.
* `@sentry/tracing` is a special case where we need to execute `prepack.ts` also after building. The call to prepack was missing the `--bundles` flag, resulting in a weird directory structure. This PR adds the flag and adjusts the `sideEffects` entry we need for our integration tests.

As a hotfix, this PR ensures further that the directory structure in the Lambda layer conforms to the `NODE_OPTIONS` environment variable set by Sentry

Fixes #4949
ref: https://getsentry.atlassian.net/browse/INC-135
ref: https://getsentry.atlassian.net/browse/WEB-860