### PR TITLE
fix(nextjs): Update install-sentry-from-branch

### DIFF
--- a/packages/nextjs/vercel/install-sentry-from-branch.sh
+++ b/packages/nextjs/vercel/install-sentry-from-branch.sh
@@ -27,6 +27,8 @@ yarn --prod false
 
 echo " "
 echo "BUILDING SDK"
+# Types are required for any type of build to succeed
+yarn build:types
 # We need to build es5 versions because `next.config.js` calls `require` on the SDK (to get `withSentryConfig`) and
 # therefore it looks for `dist/index.js`
 yarn build:cjs


### PR DESCRIPTION
Add missing `yarn build:types` command.