### PR TITLE
fix(tracing): Adjust sideEffects package.json entry for v7

### DIFF
--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -58,9 +58,9 @@
     "extends": "../../package.json"
   },
   "sideEffects": [
-    "./dist/index.js",
+    "./cjs/index.js",
     "./esm/index.js",
-    "./build/npm/dist/index.js",
+    "./build/npm/cjs/index.js",
     "./build/npm/esm/index.js",
     "./src/index.ts"
   ]


### PR DESCRIPTION
This PR adjusts the fix from #4955 which was merged into 6.19.7 for v7. It changes the `sideEffects` paths in `package.json` of `@sentry/tracing` by renaming the `dist` dir to `cjs`. 
