### PR TITLE
ref(nextjs): Update webpack-plugin and change how cli binary is detected

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@sentry/react": "7.0.0-alpha.1",
     "@sentry/tracing": "7.0.0-alpha.1",
-    "@sentry/webpack-plugin": "1.18.8"
+    "@sentry/webpack-plugin": "1.18.9"
   },
   "peerDependencies": {
     "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -24,7 +24,7 @@
     "@sentry/react": "7.0.0-alpha.1",
     "@sentry/tracing": "7.0.0-alpha.1",
     "@sentry/utils": "7.0.0-alpha.1",
-    "@sentry/webpack-plugin": "1.18.8",
+    "@sentry/webpack-plugin": "1.18.9",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -325,6 +325,12 @@ export function getWebpackPluginOptions(
   return { ...defaultPluginOptions, ...userPluginOptions };
 }
 
+/**
+ * NOTE: `eval` usage is a workaround for @vercel/nft detecting the binary itself as the hard dependency
+ *       and effectively always including it in the bundle, which is not what we want.
+ * ref: https://github.com/getsentry/sentry-javascript/issues/3865
+ * ref: https://github.com/vercel/nft/issues/203
+ */
 function ensureCLIBinaryExists(): boolean {
-  return fs.existsSync(path.join(require.resolve('@sentry/cli'), '../../sentry-cli'));
+  return eval("fs.existsSync(path.join(require.resolve('@sentry/cli'), '../../sentry-cli'))");
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4237,10 +4237,10 @@
     semver "7.3.2"
     semver-intersect "1.4.0"
 
-"@sentry/cli@^1.73.0":
-  version "1.73.0"
-  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.73.0.tgz#0d0bce913e0060ae192741c6693c57e50078c886"
-  integrity sha512-n4YINqmoncGUkLEpd4WuW+oD+aoUyQPhRbSBSYkbCFxPPmopn1VExCB2Vvzwj7vjXYRRGkix6keBMS0LLs3A3Q==
+"@sentry/cli@^1.74.4":
+  version "1.74.4"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.74.4.tgz#7df82f68045a155e1885bfcbb5d303e5259eb18e"
+  integrity sha512-BMfzYiedbModsNBJlKeBOLVYUtwSi99LJ8gxxE4Bp5N8hyjNIN0WVrozAVZ27mqzAuy6151Za3dpmOLO86YlGw==
   dependencies:
     https-proxy-agent "^5.0.0"
     mkdirp "^0.5.5"
@@ -4248,13 +4248,14 @@
     npmlog "^4.1.2"
     progress "^2.0.3"
     proxy-from-env "^1.1.0"
+    which "^2.0.2"
 
-"@sentry/webpack-plugin@1.18.8":
-  version "1.18.8"
-  resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-1.18.8.tgz#247a73a0aa9e28099a736bbe89ca0d35cbac7636"
-  integrity sha512-PtKr0NL62b5L3kPFGjwSNbIUwwcW5E5G6bQxAYZGpkgL1MFPnS4ND0SAsySuX0byQJRFFium5A19LpzyvQZSlQ==
+"@sentry/webpack-plugin@1.18.9":
+  version "1.18.9"
+  resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-1.18.9.tgz#acb48c0f96fdb9e73f1e1db374ea31ded6d883a8"
+  integrity sha512-+TrenJrgFM0QTOwBnw0ZXWMvc0PiOebp6GN5EbGEx3JPCQqXOfXFzCaEjBtASKRgcNCL7zGly41S25YR6Hm+jw==
   dependencies:
-    "@sentry/cli" "^1.73.0"
+    "@sentry/cli" "^1.74.4"
 
 "@simple-dom/interface@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
Based on https://github.com/getsentry/sentry-javascript/pull/4984, rebased for the v7 branch.

Switch to using `eval` to workaround @vercel/nft detecting the binary itself as the hard dependency.

Fixes https://github.com/getsentry/sentry-javascript/issues/3865
Ref: https://github.com/vercel/nft/issues/203
