### PR TITLE
chore(build): Remove unnecessary `esModuleInterop` settings

### DIFF
--- a/packages/gatsby/tsconfig.json
+++ b/packages/gatsby/tsconfig.json
@@ -5,7 +5,6 @@
 
   "compilerOptions": {
     // package-specific options
-    "esModuleInterop": true,
     "jsx": "react"
   }
 }

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -5,6 +5,5 @@
 
   "compilerOptions": {
     // package-specific options
-    "esModuleInterop": true,
   }
 }

--- a/packages/wasm/tsconfig.json
+++ b/packages/wasm/tsconfig.json
@@ -5,6 +5,5 @@
 
   "compilerOptions": {
     // package-specific options
-    "esModuleInterop": true,
   }
 }


### PR DESCRIPTION
This removes the `esModuleInterop` setting in the following places:

- `@sentry/gatsby`, where it's only being used for `@sentry/tracing`, which is an ES module, [making the injected helper a pass-through](https://github.com/microsoft/tslib/blob/a7129c7bd500ce378ec19234247f3d0b1635e89d/tslib.js#L263).

- `@sentry/vue` and `@sentry/wasm`, where it isn't being used at all (i.e., none of the helpers show up in the built code, meaning there's nothing in the source code that requires (no pun intended!) them).

Doing this saves us having to port more config than needed to the new build process.