### PR TITLE
feat(build): Add various rollup plugins to sucrase build

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.67.1",
     "rollup-plugin-license": "^2.6.1",
+    "rollup-plugin-re": "^1.0.7",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.31.2",
     "sinon": "^7.3.2",

--- a/rollup/npmHelpers.js
+++ b/rollup/npmHelpers.js
@@ -7,7 +7,12 @@ import * as path from 'path';
 
 import deepMerge from 'deepmerge';
 
-import { makeConstToVarPlugin, makeNodeResolvePlugin, makeSucrasePlugin } from './plugins/index.js';
+import {
+  makeConstToVarPlugin,
+  makeNodeResolvePlugin,
+  makeRemoveESLintCommentsPlugin,
+  makeSucrasePlugin,
+} from './plugins/index.js';
 
 const packageDotJSON = require(path.resolve(process.cwd(), './package.json'));
 
@@ -22,6 +27,7 @@ export function makeBaseNPMConfig(options = {}) {
   const nodeResolvePlugin = makeNodeResolvePlugin();
   const sucrasePlugin = makeSucrasePlugin();
   const constToVarPlugin = makeConstToVarPlugin();
+  const removeESLintCommentsPlugin = makeRemoveESLintCommentsPlugin();
 
   // return {
   const config = {
@@ -63,7 +69,7 @@ export function makeBaseNPMConfig(options = {}) {
       interop: esModuleInterop ? 'auto' : 'esModule',
     },
 
-    plugins: [nodeResolvePlugin, sucrasePlugin, constToVarPlugin],
+    plugins: [nodeResolvePlugin, sucrasePlugin, constToVarPlugin, removeESLintCommentsPlugin],
 
     // don't include imported modules from outside the package in the final output
     external: [

--- a/rollup/npmHelpers.js
+++ b/rollup/npmHelpers.js
@@ -10,6 +10,7 @@ import deepMerge from 'deepmerge';
 import {
   makeConstToVarPlugin,
   makeNodeResolvePlugin,
+  makeRemoveBlankLinesPlugin,
   makeRemoveESLintCommentsPlugin,
   makeSucrasePlugin,
 } from './plugins/index.js';
@@ -28,6 +29,7 @@ export function makeBaseNPMConfig(options = {}) {
   const sucrasePlugin = makeSucrasePlugin();
   const constToVarPlugin = makeConstToVarPlugin();
   const removeESLintCommentsPlugin = makeRemoveESLintCommentsPlugin();
+  const removeBlankLinesPlugin = makeRemoveBlankLinesPlugin();
 
   // return {
   const config = {
@@ -69,7 +71,7 @@ export function makeBaseNPMConfig(options = {}) {
       interop: esModuleInterop ? 'auto' : 'esModule',
     },
 
-    plugins: [nodeResolvePlugin, sucrasePlugin, constToVarPlugin, removeESLintCommentsPlugin],
+    plugins: [nodeResolvePlugin, sucrasePlugin, constToVarPlugin, removeESLintCommentsPlugin, removeBlankLinesPlugin],
 
     // don't include imported modules from outside the package in the final output
     external: [

--- a/rollup/npmHelpers.js
+++ b/rollup/npmHelpers.js
@@ -7,7 +7,7 @@ import * as path from 'path';
 
 import deepMerge from 'deepmerge';
 
-import { makeNodeResolvePlugin, makeSucrasePlugin } from './plugins/index.js';
+import { makeConstToVarPlugin, makeNodeResolvePlugin, makeSucrasePlugin } from './plugins/index.js';
 
 const packageDotJSON = require(path.resolve(process.cwd(), './package.json'));
 
@@ -21,6 +21,7 @@ export function makeBaseNPMConfig(options = {}) {
 
   const nodeResolvePlugin = makeNodeResolvePlugin();
   const sucrasePlugin = makeSucrasePlugin();
+  const constToVarPlugin = makeConstToVarPlugin();
 
   // return {
   const config = {
@@ -62,7 +63,7 @@ export function makeBaseNPMConfig(options = {}) {
       interop: esModuleInterop ? 'auto' : 'esModule',
     },
 
-    plugins: [nodeResolvePlugin, sucrasePlugin],
+    plugins: [nodeResolvePlugin, sucrasePlugin, constToVarPlugin],
 
     // don't include imported modules from outside the package in the final output
     external: [

--- a/rollup/plugins/npmPlugins.js
+++ b/rollup/plugins/npmPlugins.js
@@ -42,3 +42,22 @@ export function makeConstToVarPlugin() {
     },
   });
 }
+
+/**
+ * Create a plugin which can be used to pause the build process at the given hook.
+ *
+ * Hooks can be found here: https://rollupjs.org/guide/en/#build-hooks
+ *
+ * @param hookName The name of the hook at which to pause.
+ * @returns A plugin which inserts a debugger statement in the phase represented by the given hook
+ */
+export function makeDebuggerPlugin(hookName) {
+  return {
+    name: 'debugger-plugin',
+    [hookName]: () => {
+      // eslint-disable-next-line no-debugger
+      debugger;
+      return null;
+    },
+  };
+}

--- a/rollup/plugins/npmPlugins.js
+++ b/rollup/plugins/npmPlugins.js
@@ -1,8 +1,12 @@
 /**
+ * Regex Replace plugin docs: https://github.com/jetiny/rollup-plugin-re
  * Replace plugin docs: https://github.com/rollup/plugins/tree/master/packages/replace
  * Sucrase plugin docs: https://github.com/rollup/plugins/tree/master/packages/sucrase
  */
 
+// We need both replacement plugins because one handles regex and the other runs both before and after rollup does its
+// bundling work.
+import regexReplace from 'rollup-plugin-re';
 import replace from '@rollup/plugin-replace';
 import sucrase from '@rollup/plugin-sucrase';
 
@@ -60,4 +64,20 @@ export function makeDebuggerPlugin(hookName) {
       return null;
     },
   };
+}
+
+/**
+ * Create a plugin to strip eslint-style comments from the output.
+ *
+ * @returns A `rollup-plugin-re` instance.
+ */
+export function makeRemoveESLintCommentsPlugin() {
+  return regexReplace({
+    patterns: [
+      {
+        test: /\/[/*] eslint-disable.*\n/g,
+        replace: '',
+      },
+    ],
+  });
 }

--- a/rollup/plugins/npmPlugins.js
+++ b/rollup/plugins/npmPlugins.js
@@ -1,7 +1,9 @@
 /**
+ * Replace plugin docs: https://github.com/rollup/plugins/tree/master/packages/replace
  * Sucrase plugin docs: https://github.com/rollup/plugins/tree/master/packages/sucrase
  */
 
+import replace from '@rollup/plugin-replace';
 import sucrase from '@rollup/plugin-sucrase';
 
 /**
@@ -12,5 +14,31 @@ import sucrase from '@rollup/plugin-sucrase';
 export function makeSucrasePlugin() {
   return sucrase({
     transforms: ['typescript', 'jsx'],
+  });
+}
+
+/**
+ * Create a plugin to switch all instances of `const` to `var`, both to prevent problems when we shadow `global` and
+ * because it's fewer characters.
+ *
+ * Note that the generated plugin runs the replacement both before and after rollup does its code manipulation, to
+ * increase the chances that nothing is missed.
+ *
+ * TODO This is pretty brute-force-y. Perhaps we could switch to using a parser, the way we (will) do for both our jest
+ * transformer and the polyfill build script.
+ *
+ * @returns An instance of the `@rollup/plugin-replace` plugin
+ */
+export function makeConstToVarPlugin() {
+  return replace({
+    // TODO `preventAssignment` will default to true in version 5.x of the replace plugin, at which point we can get rid
+    // of this. (It actually makes no difference in this case whether it's true or false, since we never assign to
+    // `const`, but if we don't give it a value, it will spam with warnings.)
+    preventAssignment: true,
+    values: {
+      // Include a space at the end to guarantee we're not accidentally catching the beginning of the words "constant,"
+      // "constantly," etc.
+      'const ': 'var ',
+    },
   });
 }

--- a/rollup/plugins/npmPlugins.js
+++ b/rollup/plugins/npmPlugins.js
@@ -81,3 +81,19 @@ export function makeRemoveESLintCommentsPlugin() {
     ],
   });
 }
+
+/**
+ * Create a plugin to strip multiple consecutive blank lines, with or without whitespace in them. from the output.
+ *
+ * @returns A `rollup-plugin-re` instance.
+ */
+export function makeRemoveBlankLinesPlugin() {
+  return regexReplace({
+    patterns: [
+      {
+        test: /\n(\n\s*)+\n/g,
+        replace: '\n\n',
+      },
+    ],
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12051,6 +12051,11 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
+estree-walker@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
+  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
+
 estree-walker@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
@@ -17307,6 +17312,13 @@ magic-string@0.25.7, magic-string@^0.25.1, magic-string@^0.25.7:
   dependencies:
     sourcemap-codec "^1.4.4"
 
+magic-string@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.16.0.tgz#970ebb0da7193301285fb1aa650f39bdd81eb45a"
+  integrity sha1-lw67DacZMwEoX7GqZQ85vdgetFo=
+  dependencies:
+    vlq "^0.2.1"
+
 magic-string@^0.25.0:
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
@@ -21872,6 +21884,14 @@ rollup-plugin-license@^2.6.1:
     spdx-expression-validate "2.0.0"
     spdx-satisfies "5.0.1"
 
+rollup-plugin-re@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-re/-/rollup-plugin-re-1.0.7.tgz#fe174704ed59cda84caf02bd013b582e6fdaa4f6"
+  integrity sha1-/hdHBO1ZzahMrwK9ATtYLm/apPY=
+  dependencies:
+    magic-string "^0.16.0"
+    rollup-pluginutils "^2.0.1"
+
 rollup-plugin-sourcemaps@^0.6.0:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.6.3.tgz#bf93913ffe056e414419607f1d02780d7ece84ed"
@@ -21901,6 +21921,13 @@ rollup-plugin-typescript2@^0.31.2:
     fs-extra "^10.0.0"
     resolve "^1.20.0"
     tslib "^2.3.1"
+
+rollup-pluginutils@^2.0.1:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
+  integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
+  dependencies:
+    estree-walker "^0.6.1"
 
 rollup@2.26.5:
   version "2.26.5"
@@ -24952,6 +24979,11 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vlq@^0.2.1:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
+  integrity sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==
 
 vm-browserify@1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This adds four rollup plugins for use in the new build process:

- A plugin which converts all `const`s in the output to `var`s, both after sucrase's code modifications and after those done by rollup itself, to make sure that all instances of `const` are caught. This transformation has two advantages: 
    - It prevents errors arising from the way we redefine `global` (as the return value of `getGlobalObject`), since `var`s can be redeclared where `const`s can't.
    - It replaces a very common token which is four letters with one which is three letters. Not a huge bundle size savings, but it at least prevents us from going the wrong direction. (Our current builds use `var` because they are ES5, so this puts the new build in line with the current build, number-of-characters-in-variable-specifiers-wise.)

- A plugin which strips eslint-style comments and another which reduces multiple consecutive blank lines down to one. Neither of these affects either code behavior or bundle size, but they do make the eventual output a little less messy. One of the odd quirks of sucrase is that it has the goal of [never changing the line number of an expression](https://github.com/alangpierce/sucrase/issues/452#issuecomment-522278591), in order that even stacktrces from un-sourcemapped code are meaningful, and this can result in some odd-looking files. These two plugins don't totally undo the oddness, but they're simple and fast and certainly don't hurt readability.

- A plugin to be used during our development, which allows you to place a debugger in the [rollup hook](https://rollupjs.org/guide/en/#build-hooks) of your choice.