### PR TITLE
chore(serverless): set ignoreSentryErrors to true by default

### DIFF
--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -226,7 +226,7 @@ export function wrapHandler<TEvent, TResult>(
     captureTimeoutWarning: true,
     timeoutWarningLimit: 500,
     captureAllSettledReasons: false,
-    ignoreSentryErrors: false,
+    ignoreSentryErrors: true,
     ...wrapOptions,
   };
   let timeoutWarningTimer: NodeJS.Timeout;


### PR DESCRIPTION
This PR is adding on top of the #4620 making `ignoreSentryErrors: true` by default.

When rate limiting is enabled, users get 429s. Whenever they experience this, they fix/fallback into adding:

```javascript
const Sentry = require('@sentry/serverless');

async function main() {
  return { statusCode: 200, body: 'pong' };
}

exports.handler = Sentry.AWSLambda.wrapHandler(main, {
  ignoreSentryErrors: true,
});
```

so they can get `ignoreSentryErrors: true`.



Using our lambda layer and having `ignoreSentryErrors: true` by default will make their setup a working out-of-the-box solution:
```javascript
exports.handler = function(event, context, callback) {
  return { statusCode: 200, body: 'pong' };
}
```

Fixes: #4949 #4582 #4799

