### PR TITLE
ref: Add argument-less overload to `resolvedSyncPromise`

### DIFF
--- a/packages/utils/src/syncpromise.ts
+++ b/packages/utils/src/syncpromise.ts
@@ -14,13 +14,17 @@ const enum States {
   REJECTED = 2,
 }
 
+// Overloads so we can call resolvedSyncPromise without arguments and generic argument
+export function resolvedSyncPromise(): PromiseLike<void>;
+export function resolvedSyncPromise<T>(value: T | PromiseLike<T>): PromiseLike<T>;
+
 /**
  * Creates a resolved sync promise.
  *
  * @param value the value to resolve the promise with
  * @returns the resolved sync promise
  */
-export function resolvedSyncPromise<T>(value: T | PromiseLike<T>): PromiseLike<T> {
+export function resolvedSyncPromise<T>(value?: T | PromiseLike<T>): PromiseLike<T> {
   return new SyncPromise(resolve => {
     resolve(value);
   });


### PR DESCRIPTION
Add an overload to `resolvedSyncPromise` so we can call it without arguments and without having to do `resolvedSyncPromise<void>(undefined)`.

This is inspired by typescripts way of defining `Promise.resolve()`: 
https://github.com/microsoft/TypeScript/blob/2a78b225d00170044becdbfe499909e7d6cad68b/lib/lib.es2015.promise.d.ts#L136-L147