### PR TITLE
fix(hub): Add missing parameter to `captureException` docstring

### DIFF
--- a/packages/hub/src/exports.ts
+++ b/packages/hub/src/exports.ts
@@ -26,6 +26,7 @@ import { Scope } from './scope';
  * Captures an exception event and sends it to Sentry.
  *
  * @param exception An exception-like object.
+ * @param captureContext Additional scope data to apply to exception event.
  * @returns The generated eventId.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types


### PR DESCRIPTION
Our current docstring is missing the `captureContext` parameter. This adds it.
