### PR TITLE
feat: Add attachments API

### DIFF
--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -1,6 +1,6 @@
 import { BaseClient, Scope, SDK_VERSION } from '@sentry/core';
-import { ClientOptions, Event, EventHint, Options, Severity, SeverityLevel } from '@sentry/types';
-import { getGlobalObject, logger } from '@sentry/utils';
+import { AttachmentItem, ClientOptions, Event, EventHint, Options, Severity, SeverityLevel } from '@sentry/types';
+import { attachmentItemFromAttachment, getGlobalObject, logger } from '@sentry/utils';
 
 import { eventFromException, eventFromMessage } from './eventbuilder';
 import { IS_DEBUG_BUILD } from './flags';
@@ -115,11 +115,18 @@ export class BrowserClient extends BaseClient<BrowserClientOptions> {
   /**
    * @inheritDoc
    */
-  protected _sendEvent(event: Event): void {
+  protected _sendEvent(event: Event, attachments: AttachmentItem[]): void {
     const integration = this.getIntegration(Breadcrumbs);
     if (integration) {
       integration.addSentryBreadcrumb(event);
     }
-    super._sendEvent(event);
+    super._sendEvent(event, attachments);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected _getAttachments(scope: Scope | undefined): AttachmentItem[] {
+    return (scope?.getAttachments() || []).map(a => attachmentItemFromAttachment(a));
   }
 }

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 import { Scope, Session } from '@sentry/hub';
 import {
+  AttachmentItem,
   Client,
   ClientOptions,
   DsnComponents,
@@ -263,9 +264,9 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   /**
    * @inheritDoc
    */
-  public sendEvent(event: Event): void {
+  public sendEvent(event: Event, attachments?: AttachmentItem[]): void {
     if (this._dsn) {
-      const env = createEventEnvelope(event, this._dsn, this._options._metadata, this._options.tunnel);
+      const env = createEventEnvelope(event, this._dsn, attachments, this._options._metadata, this._options.tunnel);
       this.sendEnvelope(env);
     }
   }
@@ -525,8 +526,8 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    * @param event The Sentry event to send
    */
   // TODO(v7): refactor: get rid of method?
-  protected _sendEvent(event: Event): void {
-    this.sendEvent(event);
+  protected _sendEvent(event: Event, attachments: AttachmentItem[]): void {
+    this.sendEvent(event, attachments);
   }
 
   /**
@@ -618,7 +619,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
           this._updateSessionFromEvent(session, processedEvent);
         }
 
-        this._sendEvent(processedEvent);
+        this._sendEvent(processedEvent, this._getAttachments(scope));
         return processedEvent;
       })
       .then(null, reason => {
@@ -670,6 +671,9 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
     _level?: Severity | SeverityLevel,
     _hint?: EventHint,
   ): PromiseLike<Event>;
+
+  /** */
+  protected abstract _getAttachments(scope: Scope | undefined): AttachmentItem[];
 }
 
 /**

--- a/packages/core/src/envelope.ts
+++ b/packages/core/src/envelope.ts
@@ -1,4 +1,5 @@
 import {
+  AttachmentItem,
   DsnComponents,
   Event,
   EventEnvelope,
@@ -68,6 +69,7 @@ export function createSessionEnvelope(
 export function createEventEnvelope(
   event: Event,
   dsn: DsnComponents,
+  attachments: AttachmentItem[] = [],
   metadata?: SdkMetadata,
   tunnel?: string,
 ): EventEnvelope {
@@ -119,5 +121,5 @@ export function createEventEnvelope(
     },
     event,
   ];
-  return createEnvelope<EventEnvelope>(envelopeHeaders, [eventItem]);
+  return createEnvelope<EventEnvelope>(envelopeHeaders, [eventItem, ...attachments]);
 }

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -1,5 +1,7 @@
 /* eslint-disable max-lines */
 import {
+  Attachment,
+  AttachmentOptions,
   Breadcrumb,
   CaptureContext,
   Context,
@@ -85,6 +87,9 @@ export class Scope implements ScopeInterface {
   /** Request Mode Session Status */
   protected _requestSession?: RequestSession;
 
+  /** Attachments */
+  protected _attachments: Attachment[] = [];
+
   /**
    * A place to stash data which is needed at some point in the SDK's event processing pipeline but which shouldn't get
    * sent to Sentry
@@ -110,6 +115,7 @@ export class Scope implements ScopeInterface {
       newScope._fingerprint = scope._fingerprint;
       newScope._eventProcessors = [...scope._eventProcessors];
       newScope._requestSession = scope._requestSession;
+      newScope._attachments = [...scope._attachments];
     }
     return newScope;
   }
@@ -365,6 +371,7 @@ export class Scope implements ScopeInterface {
     this._span = undefined;
     this._session = undefined;
     this._notifyScopeListeners();
+    this._attachments = [];
     return this;
   }
 
@@ -395,6 +402,29 @@ export class Scope implements ScopeInterface {
   public clearBreadcrumbs(): this {
     this._breadcrumbs = [];
     this._notifyScopeListeners();
+    return this;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public addAttachment(pathOrData: string | Uint8Array, options?: AttachmentOptions): this {
+    this._attachments.push([pathOrData, options]);
+    return this;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public getAttachments(): Attachment[] {
+    return this._attachments;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public clearAttachments(): this {
+    this._attachments = [];
     return this;
   }
 

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -1,7 +1,7 @@
 import { BaseClient, Scope, SDK_VERSION } from '@sentry/core';
 import { SessionFlusher } from '@sentry/hub';
-import { Event, EventHint, Severity, SeverityLevel } from '@sentry/types';
-import { logger, resolvedSyncPromise } from '@sentry/utils';
+import { AttachmentItem, Event, EventHint, Severity, SeverityLevel } from '@sentry/types';
+import { attachmentItemFromAttachment, logger, resolvedSyncPromise } from '@sentry/utils';
 
 import { eventFromMessage, eventFromUnknownInput } from './eventbuilder';
 import { IS_DEBUG_BUILD } from './flags';
@@ -149,5 +149,13 @@ export class NodeClient extends BaseClient<NodeClientOptions> {
     } else {
       this._sessionFlusher.incrementSessionStatusCount();
     }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected _getAttachments(scope: Scope | undefined): AttachmentItem[] {
+    // TODO: load attachment from path...
+    return (scope?.getAttachments() || []).map(a => attachmentItemFromAttachment(a));
   }
 }

--- a/packages/node/src/transports/http.ts
+++ b/packages/node/src/transports/http.ts
@@ -9,7 +9,9 @@ import {
 import { eventStatusFromHttpCode } from '@sentry/utils';
 import * as http from 'http';
 import * as https from 'https';
+import { Readable, Writable } from 'stream';
 import { URL } from 'url';
+import { createGzip } from 'zlib';
 
 import { HTTPModule } from './http-module';
 
@@ -22,6 +24,22 @@ export interface NodeTransportOptions extends BaseTransportOptions {
   caCerts?: string | Buffer | Array<string | Buffer>;
   /** Custom HTTP module. Defaults to the native 'http' and 'https' modules. */
   httpModule?: HTTPModule;
+}
+
+// Estimated maximum size for reasonable standalone event
+const GZIP_THRESHOLD = 1024 * 32;
+
+/**
+ * Gets a stream from a Uint8Array or string
+ * We don't have Readable.from in earlier versions of node
+ */
+function streamFromBody(body: Uint8Array | string): Readable {
+  return new Readable({
+    read() {
+      this.push(body);
+      this.push(null);
+    },
+  });
 }
 
 /**
@@ -86,6 +104,14 @@ function createRequestExecutor(
   const { hostname, pathname, port, protocol, search } = new URL(options.url);
   return function makeRequest(request: TransportRequest): Promise<TransportMakeRequestResponse> {
     return new Promise((resolve, reject) => {
+      let bodyStream = streamFromBody(request.body);
+
+      if (request.body.length > GZIP_THRESHOLD) {
+        options.headers = options.headers || {};
+        options.headers['Content-Encoding'] = 'gzip';
+        bodyStream = bodyStream.pipe(createGzip());
+      }
+
       const req = httpModule.request(
         {
           method: 'POST',
@@ -128,7 +154,9 @@ function createRequestExecutor(
       );
 
       req.on('error', reject);
-      req.end(request.body);
+
+      // The docs say that HTTPModuleClientRequest is Writable but the types don't match exactly
+      bodyStream.pipe(req as unknown as Writable);
     });
   };
 }

--- a/packages/types/src/attachment.ts
+++ b/packages/types/src/attachment.ts
@@ -1,0 +1,7 @@
+export interface AttachmentOptions {
+  filename?: string;
+  contentType?: string;
+  attachmentType?: string;
+}
+
+export type Attachment = [string | Uint8Array, AttachmentOptions | undefined];

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -30,7 +30,13 @@ type EventItemHeaders = {
   type: 'event' | 'transaction';
   sample_rates?: [{ id?: TransactionSamplingMethod; rate?: number }];
 };
-type AttachmentItemHeaders = { type: 'attachment'; filename: string };
+type AttachmentItemHeaders = {
+  type: 'attachment';
+  length: number;
+  filename: string;
+  content_type?: string;
+  attachment_type?: string;
+};
 type UserFeedbackItemHeaders = { type: 'user_report' };
 type SessionItemHeaders = { type: 'session' };
 type SessionAggregatesItemHeaders = { type: 'sessions' };
@@ -40,7 +46,7 @@ type ClientReportItemHeaders = { type: 'client_report' };
 // We have to allow this hack for now as we pre-serialize events because we support
 // both store and envelope endpoints.
 export type EventItem = BaseEnvelopeItem<EventItemHeaders, Event | string>;
-export type AttachmentItem = BaseEnvelopeItem<AttachmentItemHeaders, unknown>;
+export type AttachmentItem = BaseEnvelopeItem<AttachmentItemHeaders, Uint8Array>;
 export type UserFeedbackItem = BaseEnvelopeItem<UserFeedbackItemHeaders, UserFeedback>;
 export type SessionItem =
   | BaseEnvelopeItem<SessionItemHeaders, Session>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,3 +1,4 @@
+export type { Attachment, AttachmentOptions } from './attachment';
 export type { Breadcrumb, BreadcrumbHint } from './breadcrumb';
 export type { Client } from './client';
 export type { ClientReport } from './clientreport';

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -1,3 +1,4 @@
+import { Attachment, AttachmentOptions } from './attachment';
 import { Breadcrumb } from './breadcrumb';
 import { Context, Contexts } from './context';
 import { EventProcessor } from './eventprocessor';
@@ -158,4 +159,10 @@ export interface Scope {
    * Clears all currently set Breadcrumbs.
    */
   clearBreadcrumbs(): this;
+
+  addAttachment(pathOrData: string | Uint8Array, options?: AttachmentOptions): this;
+
+  getAttachments(): Attachment[];
+
+  clearAttachments(): this;
 }

--- a/packages/types/src/transport.ts
+++ b/packages/types/src/transport.ts
@@ -12,7 +12,7 @@ export type Outcome =
 export type TransportCategory = 'error' | 'transaction' | 'attachment' | 'session';
 
 export type TransportRequest = {
-  body: string;
+  body: string | Uint8Array;
   category: TransportCategory;
 };
 

--- a/packages/utils/src/attachment.ts
+++ b/packages/utils/src/attachment.ts
@@ -1,0 +1,6 @@
+import { Attachment, AttachmentItem } from '@sentry/types';
+
+/** */
+export function attachmentItemFromAttachment(_attachment: Attachment): AttachmentItem {
+  throw new Error('Not implemented');
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -24,3 +24,4 @@ export * from './env';
 export * from './envelope';
 export * from './clientreport';
 export * from './ratelimit';
+export * from './attachment';


### PR DESCRIPTION
Closes #4996

Still a WIP with some missing implementation and no tests...

This PR:
- Adds/extends some types for attachments
- Adds `addAttachment`, `getAttachments` and `clearAttachments` to `Scope`
- Passes the attachments through the client methods so they end up in the envelope
- Adds abstract `_getAttachments` to the client so `@sentry/node` can optionally read attachments from disk
- Adds binary serialisation support for envelopes
- Adds binary support + compression to node http transport
  - This is stolen from the Electron SDK

## Issues
- Simple binary serialisation relies on `TextEncoder` which is only available on the global in node.js >= v11
  - It's possible to do all this without `TextEncoder` but manual UTF8 to binary is a lot of code and this would end up in the browser bundle 
  - Perhaps only support attachments on node.js >= 11?

## Bonus
- This will all simplify sending minidumps from the Electron SDK
