### PR TITLE
ref(build): Switch tsconfig `target` to es6

### DIFF
--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -23,6 +23,6 @@
     "sourceMap": true,
     "strict": true,
     "strictBindCallApply": false,
-    "target": "es5"
+    "target": "es6"
   }
 }

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'child_process';
+import * as fs from 'fs';
 import { join } from 'path';
 
 function run(cmd: string, cwd: string = '') {
@@ -37,6 +38,7 @@ if (nodeMajorVersion <= 10) {
       '@sentry/gatsby',
       '@sentry/serverless',
       '@sentry/nextjs',
+      '@sentry/angular',
     ];
 
     // This is a hack, to deal the fact that the browser-based tests fail under Node 8, because of a conflict buried
@@ -46,6 +48,12 @@ if (nodeMajorVersion <= 10) {
     // against a single version of node, but in the short run, this at least allows us to not be blocked by the
     // failures.)
     run('rm -rf packages/tracing/test/browser');
+
+    // TODO Pull this out once we switch to sucrase builds
+    // Recompile as es5, so as not to have to fix a compatibility problem that will soon be moot
+    const baseTSConfig = 'packages/typescript/tsconfig.json';
+    fs.writeFileSync(baseTSConfig, String(fs.readFileSync(baseTSConfig)).replace('"target": "es6"', '"target": "es5"'));
+    run(`yarn build:dev ${ignorePackages.map(dep => `--ignore="${dep}"`).join(' ')}`);
   }
   // Node 10
   else {


### PR DESCRIPTION
This switches our default tsonfig `target` value from `es5` to `es6`. (Though we'll soon not be using `tsc` for transpilation, our tsconfig still matters for things like tests, because ts-jest uses it.)

Note: Doing this required adding a temporary workaround to get node 8 tests to pass. Once we switch to sucrase builds (which don't have the same problem), it will come out.