### PR TITLE
ref: Refactor transport, request, and client report types

### DIFF
--- a/packages/core/src/envelope.ts
+++ b/packages/core/src/envelope.ts
@@ -5,7 +5,6 @@ import {
   EventItem,
   SdkInfo,
   SdkMetadata,
-  SentryRequestType,
   Session,
   SessionAggregates,
   SessionEnvelope,
@@ -52,14 +51,10 @@ export function createSessionEnvelope(
     ...(!!tunnel && { dsn: dsnToString(dsn) }),
   };
 
-  // I know this is hacky but we don't want to add `sessions` to request type since it's never rate limited
-  const type = 'aggregates' in session ? ('sessions' as SentryRequestType) : 'session';
+  const envelopeItem: SessionItem =
+    'aggregates' in session ? [{ type: 'sessions' }, session] : [{ type: 'session' }, session];
 
-  // TODO (v7) Have to cast type because envelope items do not accept a `SentryRequestType`
-  const envelopeItem = [{ type } as { type: 'session' | 'sessions' }, session] as SessionItem;
-  const envelope = createEnvelope<SessionEnvelope>(envelopeHeaders, [envelopeItem]);
-
-  return envelope;
+  return createEnvelope<SessionEnvelope>(envelopeHeaders, [envelopeItem]);
 }
 
 /**

--- a/packages/core/src/transports/base.ts
+++ b/packages/core/src/transports/base.ts
@@ -1,8 +1,8 @@
 import {
+  DataCategory,
   Envelope,
   InternalBaseTransportOptions,
   Transport,
-  TransportCategory,
   TransportRequestExecutor,
 } from '@sentry/types';
 import {
@@ -35,7 +35,7 @@ export function createTransport(
 
   function send(envelope: Envelope): PromiseLike<void> {
     const envCategory = getEnvelopeType(envelope);
-    const category = envCategory === 'event' ? 'error' : (envCategory as TransportCategory);
+    const category = envCategory === 'event' ? 'error' : (envCategory as DataCategory);
 
     // Don't add to buffer if transport is already rate-limited
     if (isRateLimited(rateLimits, category)) {

--- a/packages/types/src/clientreport.ts
+++ b/packages/types/src/clientreport.ts
@@ -1,7 +1,14 @@
-import { SentryRequestType } from './request';
-import { Outcome } from './transport';
+import { DataCategory } from './datacategory';
+
+export type EventDropReason =
+  | 'before_send'
+  | 'event_processor'
+  | 'network_error'
+  | 'queue_overflow'
+  | 'ratelimit_backoff'
+  | 'sample_rate';
 
 export type ClientReport = {
   timestamp: number;
-  discarded_events: Array<{ reason: Outcome; category: SentryRequestType; quantity: number }>;
+  discarded_events: Array<{ reason: EventDropReason; category: DataCategory; quantity: number }>;
 };

--- a/packages/types/src/datacategory.ts
+++ b/packages/types/src/datacategory.ts
@@ -1,0 +1,20 @@
+// This type is used in various places like Client Reports and Rate Limit Categories
+// See:
+// - https://develop.sentry.dev/sdk/rate-limiting/#definitions
+// - https://github.com/getsentry/relay/blob/10874b587bb676bd6d50ad42d507216513660082/relay-common/src/constants.rs#L97-L113
+// - https://develop.sentry.dev/sdk/client-reports/#envelope-item-payload under `discarded_events`
+export type DataCategory =
+  // Reserved and only used in edgecases, unlikely to be ever actually used
+  | 'default'
+  // Error events
+  | 'error'
+  // Transaction type event
+  | 'transaction'
+  // Events with `event_type` csp, hpkp, expectct, expectstaple
+  | 'security'
+  // Attachment bytes stored (unused for rate limiting
+  | 'attachment'
+  // Session update events
+  | 'session'
+  // SDK internal event, like client_reports
+  | 'internal';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,7 +1,8 @@
 export type { Breadcrumb, BreadcrumbHint } from './breadcrumb';
 export type { Client } from './client';
-export type { ClientReport } from './clientreport';
+export type { ClientReport, EventDropReason } from './clientreport';
 export type { Context, Contexts } from './context';
+export type { DataCategory } from './datacategory';
 export type { DsnComponents, DsnLike, DsnProtocol } from './dsn';
 export type { DebugImage, DebugImageType, DebugMeta } from './debugMeta';
 export type {
@@ -28,7 +29,7 @@ export type { Mechanism } from './mechanism';
 export type { ExtractedNodeRequestData, Primitive, WorkerLocation } from './misc';
 export type { ClientOptions, Options } from './options';
 export type { Package } from './package';
-export type { QueryParams, Request, SentryRequest, SentryRequestType } from './request';
+export type { QueryParams, Request } from './request';
 export type { Runtime } from './runtime';
 export type { CaptureContext, Scope, ScopeContext } from './scope';
 export type { SdkInfo } from './sdkinfo';
@@ -61,9 +62,7 @@ export type {
 } from './transaction';
 export type { Thread } from './thread';
 export type {
-  Outcome,
   Transport,
-  TransportCategory,
   TransportRequest,
   TransportMakeRequestResponse,
   InternalBaseTransportOptions,

--- a/packages/types/src/request.ts
+++ b/packages/types/src/request.ts
@@ -1,14 +1,3 @@
-/** Possible SentryRequest types that can be used to make a distinction between Sentry features */
-// NOTE(kamil): It would be nice if we make it a valid enum instead
-export type SentryRequestType = 'event' | 'transaction' | 'session' | 'attachment';
-
-/** A generic client request. */
-export interface SentryRequest {
-  body: string;
-  type: SentryRequestType;
-  url: string;
-}
-
 /** Request data included in an event as sent to Sentry */
 export interface Request {
   url?: string;

--- a/packages/types/src/transport.ts
+++ b/packages/types/src/transport.ts
@@ -1,15 +1,5 @@
 import { Envelope } from './envelope';
 
-export type Outcome =
-  | 'before_send'
-  | 'event_processor'
-  | 'network_error'
-  | 'queue_overflow'
-  | 'ratelimit_backoff'
-  | 'sample_rate';
-
-export type TransportCategory = 'error' | 'transaction' | 'attachment' | 'session';
-
 export type TransportRequest = {
   body: string;
 };

--- a/packages/utils/test/clientreport.test.ts
+++ b/packages/utils/test/clientreport.test.ts
@@ -6,7 +6,7 @@ import { serializeEnvelope } from '../src/envelope';
 const DEFAULT_DISCARDED_EVENTS: ClientReport['discarded_events'] = [
   {
     reason: 'before_send',
-    category: 'event',
+    category: 'error',
     quantity: 30,
   },
   {
@@ -45,7 +45,7 @@ describe('createClientReportEnvelope', () => {
     expect(serializedEnv).toMatchInlineSnapshot(`
       "{\\"dsn\\":\\"https://public@example.com/1\\"}
       {\\"type\\":\\"client_report\\"}
-      {\\"timestamp\\":123456,\\"discarded_events\\":[{\\"reason\\":\\"before_send\\",\\"category\\":\\"event\\",\\"quantity\\":30},{\\"reason\\":\\"network_error\\",\\"category\\":\\"transaction\\",\\"quantity\\":23}]}"
+      {\\"timestamp\\":123456,\\"discarded_events\\":[{\\"reason\\":\\"before_send\\",\\"category\\":\\"error\\",\\"quantity\\":30},{\\"reason\\":\\"network_error\\",\\"category\\":\\"transaction\\",\\"quantity\\":23}]}"
     `);
   });
 });


### PR DESCRIPTION
This PR cleans up a few types we intend to use for client reports:
- Create `EventDropReason` in favor of `Outcome`. The term `Outcome` is a bit overloaded and the [docs use it to describe the structure of the objects](https://develop.sentry.dev/sdk/client-reports/#:~:text=discarded_events-,List%20of%20outcome%20objects,-%7Breason%2C%20category%2C%20quantity) we should send as client report. We change this to better match the docs.
- Introduce `DataCategory` type in favor of `TransportCategory` and `SentryRequestType`. Data categories are used in more places than the transports and we should reflect that. This is also to better match the docs.
- Remove unused `SentryRequest` type.

Bonus:
- Tiny cleanup in `createSessionEnvelope` so we don't need a type-cast :)

Ref: https://getsentry.atlassian.net/browse/WEB-775