### PR TITLE
docs(transports): Update Migration document with custom Transport changes

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -149,9 +149,10 @@ export function makeMyCustomTransport(options: BaseTransportOptions): Transport 
   function makeRequest(request: TransportRequest): PromiseLike<TransportMakeRequestResponse> {
     // this is where your sending logic goes
     const myCustomRequest = {
-      request.body,
+      body: request.body,
       url: options.url
     };
+    // you define how `sendMyCustomRequest` works
     return sendMyCustomRequest(myCustomRequest).then(response => ({
       headers: {
         'x-sentry-rate-limits': response.headers.get('X-Sentry-Rate-Limits'),
@@ -199,7 +200,7 @@ Sentry.init({
 
 Overall, the new way of transport creation allows you to create your custom sending implementation
 without having to deal with the conversion of events or sessions to envelopes.
-We recommend calling `createTransport` as demonstrated in the example above which, besides creating the `Transport`
+We recommend calling using the `createTransport` function from `@sentry/core` as demonstrated in the example above which, besides creating the `Transport`
 object with your custom logic, will also take care of rate limiting and flushing.
 
 Passing in the factory function instead of an initialized transport provides the advantage that you do not have to take

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -135,7 +135,7 @@ export interface Transport {
 If you rely on a custom transport, you will need to make some adjustments to how it is created when migrating
 to v7. Note that we changed our transports from a class-based to a functional approach, meaning that
 the previously class-based transports are now created via functions. This also means that custom transports
-are now passed by specifying a factory method in the `Sentry.init` options object instead passing the custom
+are now passed by specifying a factory function in the `Sentry.init` options object instead passing the custom
 transport's class.
 
 The following example shows how to create a custom transport in v7 vs. how it was done in v6:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -203,10 +203,6 @@ without having to deal with the conversion of events or sessions to envelopes.
 We recommend calling using the `createTransport` function from `@sentry/core` as demonstrated in the example above which, besides creating the `Transport`
 object with your custom logic, will also take care of rate limiting and flushing.
 
-Passing in the factory function instead of an initialized transport provides the advantage that you do not have to take
-care of decoding the URL from your DSN. Essentially, it provides the same abstraction level as in v6
-where you passed in the class instead of an instance.
-
 For a complete v7 transport implementation, take a look at our [browser fetch transport](https://github.com/getsentry/sentry-javascript/blob/ebc938a03d6efe7d0c4bbcb47714e84c9a566a9c/packages/browser/src/transports/fetch.ts#L1-L34).
 
 ## Enum Changes


### PR DESCRIPTION
This PR adds the Transport changes to MIGRATION.md. It shows the difference between old and new transports and gives an example how to migrate a custom v6 transport to v7.

Feedback is greatly appreciated as I might not have covered all essential aspects.

ref: https://getsentry.atlassian.net/browse/WEB-867
