### PR TITLE
ref: Record dropped events in `BaseClient`

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -270,7 +270,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   public sendEvent(event: Event): void {
     if (this._dsn) {
       const env = createEventEnvelope(event, this._dsn, this._options._metadata, this._options.tunnel);
-      this.sendEnvelope(env);
+      this._sendEnvelope(env);
     }
   }
 
@@ -280,20 +280,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   public sendSession(session: Session | SessionAggregates): void {
     if (this._dsn) {
       const env = createSessionEnvelope(session, this._dsn, this._options._metadata, this._options.tunnel);
-      this.sendEnvelope(env);
-    }
-  }
-
-  /**
-   * @inheritdoc
-   */
-  public sendEnvelope(env: Envelope): void {
-    if (this._transport && this._dsn) {
-      this._transport.send(env).then(null, reason => {
-        IS_DEBUG_BUILD && logger.error('Error while sending event:', reason);
-      });
-    } else {
-      IS_DEBUG_BUILD && logger.error('Transport disabled');
+      this._sendEnvelope(env);
     }
   }
 
@@ -657,6 +644,19 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
         return reason;
       },
     );
+  }
+
+  /**
+   * @inheritdoc
+   */
+  private _sendEnvelope(envelope: Envelope): void {
+    if (this._transport && this._dsn) {
+      this._transport.send(envelope).then(null, reason => {
+        IS_DEBUG_BUILD && logger.error('Error while sending event:', reason);
+      });
+    } else {
+      IS_DEBUG_BUILD && logger.error('Transport disabled');
+    }
   }
 
   /**

--- a/packages/core/test/mocks/client.ts
+++ b/packages/core/test/mocks/client.ts
@@ -1,14 +1,10 @@
 import { Session } from '@sentry/hub';
-import { ClientOptions, Event, Integration, Severity, SeverityLevel } from '@sentry/types';
+import { ClientOptions, Event, Integration, Outcome, Severity, SeverityLevel } from '@sentry/types';
 import { resolvedSyncPromise } from '@sentry/utils';
 
 import { BaseClient } from '../../src/baseclient';
 import { initAndBind } from '../../src/sdk';
 import { createTransport } from '../../src/transports/base';
-
-// TODO(v7): Add client reports tests to this file
-// See old tests in packages/browser/test/unit/transports/base.test.ts
-// from https://github.com/getsentry/sentry-javascript/pull/4967
 
 export function getDefaultTestClientOptions(options: Partial<TestClientOptions> = {}): TestClientOptions {
   return {
@@ -78,6 +74,11 @@ export class TestClient extends BaseClient<TestClientOptions> {
 
   public sendSession(session: Session): void {
     this.session = session;
+  }
+
+  // Public proxy for protected method
+  public _clearOutcomes(): Outcome[] {
+    return super._clearOutcomes();
   }
 }
 

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -103,12 +103,11 @@ export class Transaction extends SpanClass implements TransactionInterface {
       // At this point if `sampled !== true` we want to discard the transaction.
       IS_DEBUG_BUILD && logger.log('[Tracing] Discarding transaction because its trace was not chosen to be sampled.');
 
-      // TODO(v7): Add back client reports functionality
-      // const client = this._hub.getClient();
-      // const transport = client && client.getTransport && client.getTransport();
-      // if (transport && transport.recordLostEvent) {
-      //   transport.recordLostEvent('sample_rate', 'transaction');
-      // }
+      const client = this._hub.getClient();
+      if (client) {
+        client.recordDroppedEvent('sample_rate', 'transaction');
+      }
+
       return undefined;
     }
 

--- a/packages/tracing/test/idletransaction.test.ts
+++ b/packages/tracing/test/idletransaction.test.ts
@@ -163,19 +163,18 @@ describe('IdleTransaction', () => {
     }
   });
 
-  // TODO(v7): Add with client reports
-  // it('should record dropped transactions', async () => {
-  //   const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234, sampled: false }, hub, 1000);
+  it('should record dropped transactions', async () => {
+    const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234, sampled: false }, hub, 1000);
 
-  //   const transport = hub.getClient()!.getTransport!();
+    const client = hub.getClient()!;
 
-  //   const spy = jest.spyOn(transport, 'recordLostEvent');
+    const recordDroppedEventSpy = jest.spyOn(client, 'recordDroppedEvent');
 
-  //   transaction.initSpanRecorder(10);
-  //   transaction.finish(transaction.startTimestamp + 10);
+    transaction.initSpanRecorder(10);
+    transaction.finish(transaction.startTimestamp + 10);
 
-  //   expect(spy).toHaveBeenCalledWith('sample_rate', 'transaction');
-  // });
+    expect(recordDroppedEventSpy).toHaveBeenCalledWith('sample_rate', 'transaction');
+  });
 
   describe('_initTimeout', () => {
     it('finishes if no activities are added to the transaction', () => {

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -1,3 +1,5 @@
+import { EventDropReason } from './clientreport';
+import { DataCategory } from './datacategory';
 import { DsnComponents } from './dsn';
 import { Event, EventHint } from './event';
 import { Integration, IntegrationClass } from './integration';
@@ -54,7 +56,8 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    */
   captureEvent(event: Event, hint?: EventHint, scope?: Scope): string | undefined;
 
-  /** Captures a session
+  /**
+   * Captures a session
    *
    * @param session Session to be delivered
    */
@@ -117,4 +120,12 @@ export interface Client<O extends ClientOptions = ClientOptions> {
 
   /** Submits the session to Sentry */
   sendSession(session: Session | SessionAggregates): void;
+
+  /**
+   * Record on the client that an event got dropped (ie, an event that will not be sent to sentry).
+   *
+   * @param reason The reason why the event got dropped.
+   * @param category The data category of the dropped event.
+   */
+  recordDroppedEvent(reason: EventDropReason, category: DataCategory): void;
 }

--- a/packages/types/src/clientreport.ts
+++ b/packages/types/src/clientreport.ts
@@ -8,7 +8,13 @@ export type EventDropReason =
   | 'ratelimit_backoff'
   | 'sample_rate';
 
+export type Outcome = {
+  reason: EventDropReason;
+  category: DataCategory;
+  quantity: number;
+};
+
 export type ClientReport = {
   timestamp: number;
-  discarded_events: Array<{ reason: EventDropReason; category: DataCategory; quantity: number }>;
+  discarded_events: Outcome[];
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,6 +1,6 @@
 export type { Breadcrumb, BreadcrumbHint } from './breadcrumb';
 export type { Client } from './client';
-export type { ClientReport, EventDropReason } from './clientreport';
+export type { ClientReport, Outcome, EventDropReason } from './clientreport';
 export type { Context, Contexts } from './context';
 export type { DataCategory } from './datacategory';
 export type { DsnComponents, DsnLike, DsnProtocol } from './dsn';


### PR DESCRIPTION
Builds on #5008 to now track any dropped events on the `BaseClient`. Next we can implement the sending of the client reports on the SDK specific clients.

Ref: https://getsentry.atlassian.net/browse/WEB-775
