### PR TITLE
ref: Add back client reporting to `BrowserClient`

### DIFF
--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -127,7 +127,7 @@ export class BrowserClient extends BaseClient<BrowserClientOptions> {
       return;
     }
 
-    IS_DEBUG_BUILD && logger.log(`Sending outcomes:\n${JSON.stringify(outcomes, null, 2)}`);
+    IS_DEBUG_BUILD && logger.log('Sending outcomes:', outcomes);
 
     const url = getEnvelopeEndpointWithUrlEncodedAuth(this._dsn, this._options.tunnel);
     const envelope = createClientReportEnvelope(outcomes, this._options.tunnel && dsnToString(this._dsn));

--- a/packages/browser/src/transports/utils.ts
+++ b/packages/browser/src/transports/utils.ts
@@ -93,10 +93,8 @@ export function sendReport(url: string, body: string): void {
   if (hasSendBeacon) {
     // Prevent illegal invocations - https://xgwang.me/posts/you-may-not-know-beacon/#it-may-throw-error%2C-be-sure-to-catch
     const sendBeacon = global.navigator.sendBeacon.bind(global.navigator);
-    return sendBeacon(url, body);
-  }
-
-  if (supportsFetch()) {
+    sendBeacon(url, body);
+  } else if (supportsFetch()) {
     const fetch = getNativeFetchImplementation();
     fetch(url, {
       body,


### PR DESCRIPTION
This adds back the sending of client reports in the browser client.

Ref: https://getsentry.atlassian.net/browse/WEB-775