### PR TITLE
fix(gatsby): Add script to ensure types files exist when testing

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -59,8 +59,8 @@
     "lint": "run-s lint:prettier lint:eslint",
     "lint:eslint": "eslint . --cache --cache-location '../../eslintcache/' --format stylish",
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/*.ts\"",
-    "test": "jest",
-    "test:watch": "jest --watch"
+    "test": "yarn ts-node scripts/pretest.ts && yarn jest",
+    "test:watch": "yarn ts-node scripts/pretest.ts && yarn jest --watch"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/gatsby/scripts/pretest.ts
+++ b/packages/gatsby/scripts/pretest.ts
@@ -1,0 +1,14 @@
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+
+function ensurePluginTypes(): void {
+  if (!fs.existsSync('gatsby-browser.d.ts') || !fs.existsSync('gatsby-node.d.ts')) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '\nWARNING: Missing types for gatsby plugin files. Types will be created before running gatsby tests.',
+    );
+    execSync('yarn build:plugin');
+  }
+}
+
+ensurePluginTypes();


### PR DESCRIPTION
This adds a check to the beginning of the gatsby tests which makes sure that the necessary types files exist and creates them before starting the tests if they don't. 

Note: These files are not the normal files built by `yarn build:types` but additional ones made necessary by the structure gatsby plugins are required to have. See https://github.com/getsentry/sentry-javascript/pull/4928.
