### PR TITLE
ref(browser): Don't use Breadcrumbs integration in send event flow

### DIFF
--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -113,7 +113,7 @@ export class BrowserClient extends BaseClient<BrowserClientOptions> {
    */
   protected _sendEvent(event: Event): void {
     // We only want to add the sentry event breadcrumb when the user has the breadcrumb integration installed and
-    // activated its`sentry` option.
+    // activated its `sentry` option.
     // We also do not want to use the `Breadcrumbs` class here directly, because we do not want it to be included in
     // bundles, if it is not used by the SDK.
     // This all sadly is a bit ugly, but we currently don't have a "pre-send" hook on the integrations so we do it this

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -259,6 +259,15 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   }
 
   /**
+   * Gets an installed integration by its `id`.
+   *
+   * @returns The installed integration or `undefined` if no integration with that `id` was installed.
+   */
+  public getIntegrationById(integrationId: string): Integration | undefined {
+    return this._integrations[integrationId];
+  }
+
+  /**
    * @inheritDoc
    */
   public getIntegration<T extends Integration>(integration: IntegrationClass<T>): T | null {


### PR DESCRIPTION
Avoids directly using the `Breadcrumbs` integration class in non-integration code to reduce bundle size if manually creating a client instead of using `Sentry.init()`.

Ref: https://getsentry.atlassian.net/browse/WEB-820
