### PR TITLE
test(utils): Remove usage of testOnlyIfNodeVersionAtLeast(8)

### DIFF
--- a/packages/utils/test/normalize.test.ts
+++ b/packages/utils/test/normalize.test.ts
@@ -5,7 +5,6 @@
 import * as isModule from '../src/is';
 import { normalize } from '../src/normalize';
 import * as stacktraceModule from '../src/stacktrace';
-import { testOnlyIfNodeVersionAtLeast } from './testutils';
 
 describe('normalize()', () => {
   describe('acts as a pass-through for simple-cases', () => {
@@ -48,7 +47,7 @@ describe('normalize()', () => {
       });
     });
 
-    testOnlyIfNodeVersionAtLeast(8)('extracts data from `Event` objects', () => {
+    describe('extracts data from `Event` objects', () => {
       const isElement = jest.spyOn(isModule, 'isElement').mockReturnValue(true);
       const getAttribute = () => undefined;
 


### PR DESCRIPTION
We do not support Node 6 anymore, so we don't need to guard against
running on Node 6 in the tests.

Resolves https://getsentry.atlassian.net/browse/WEB-736
