### PR TITLE
ref: Remove unused `_sendEvent` method in base client

### DIFF
--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -103,15 +103,7 @@ export class BrowserClient extends BaseClient<BrowserClientOptions> {
   /**
    * @inheritDoc
    */
-  protected _prepareEvent(event: Event, scope?: Scope, hint?: EventHint): PromiseLike<Event | null> {
-    event.platform = event.platform || 'javascript';
-    return super._prepareEvent(event, scope, hint);
-  }
-
-  /**
-   * @inheritDoc
-   */
-  protected _sendEvent(event: Event): void {
+  public sendEvent(event: Event): void {
     // We only want to add the sentry event breadcrumb when the user has the breadcrumb integration installed and
     // activated its `sentry` option.
     // We also do not want to use the `Breadcrumbs` class here directly, because we do not want it to be included in
@@ -140,7 +132,15 @@ export class BrowserClient extends BaseClient<BrowserClientOptions> {
       );
     }
 
-    super._sendEvent(event);
+    super.sendEvent(event);
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected _prepareEvent(event: Event, scope?: Scope, hint?: EventHint): PromiseLike<Event | null> {
+    event.platform = event.platform || 'javascript';
+    return super._prepareEvent(event, scope, hint);
   }
 
   /**

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -546,15 +546,6 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   }
 
   /**
-   * Sends the passed event
-   * @param event The Sentry event to send
-   */
-  // TODO(v7): refactor: get rid of method?
-  protected _sendEvent(event: Event): void {
-    this.sendEvent(event);
-  }
-
-  /**
    * Processes the event and logs an error in case of rejection
    * @param event
    * @param hint
@@ -631,7 +622,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
           this._updateSessionFromEvent(session, processedEvent);
         }
 
-        this._sendEvent(processedEvent);
+        this.sendEvent(processedEvent);
         return processedEvent;
       })
       .then(null, reason => {


### PR DESCRIPTION
Removes `_sendEvent` method on base client that has become unnecessary.