### PR TITLE
chore(browser): Rename `UserAgent` integration to `HttpContext`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -277,6 +277,7 @@ For our efforts to reduce bundle size of the SDK we had to remove and refactor p
   not present in other Sentry SDKs. For the sake of reducing complexity, increasing consistency with other Sentry SDKs and
   decreasing bundle-size, `Backend` was removed.
 - Remove support for Opera browser pre v15
+- Rename `UserAgent` integration to `HttpContext` [TODO]()
 
 ## Sentry Angular SDK Changes
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -277,7 +277,7 @@ For our efforts to reduce bundle size of the SDK we had to remove and refactor p
   not present in other Sentry SDKs. For the sake of reducing complexity, increasing consistency with other Sentry SDKs and
   decreasing bundle-size, `Backend` was removed.
 - Remove support for Opera browser pre v15
-- Rename `UserAgent` integration to `HttpContext` [TODO]()
+- Rename `UserAgent` integration to `HttpContext` (see [#5027](https://github.com/getsentry/sentry-javascript/pull/5027))
 
 ## Sentry Angular SDK Changes
 

--- a/packages/browser/src/integrations/httpcontext.ts
+++ b/packages/browser/src/integrations/httpcontext.ts
@@ -4,24 +4,24 @@ import { getGlobalObject } from '@sentry/utils';
 
 const global = getGlobalObject<Window>();
 
-/** UserAgent */
-export class UserAgent implements Integration {
+/** HttpContext integration collects information about HTTP request headers */
+export class HttpContext implements Integration {
   /**
    * @inheritDoc
    */
-  public static id: string = 'UserAgent';
+  public static id: string = 'HttpContext';
 
   /**
    * @inheritDoc
    */
-  public name: string = UserAgent.id;
+  public name: string = HttpContext.id;
 
   /**
    * @inheritDoc
    */
   public setupOnce(): void {
     addGlobalEventProcessor((event: Event) => {
-      if (getCurrentHub().getIntegration(UserAgent)) {
+      if (getCurrentHub().getIntegration(HttpContext)) {
         // if none of the information we want exists, don't bother
         if (!global.navigator && !global.location && !global.document) {
           return event;

--- a/packages/browser/src/integrations/index.ts
+++ b/packages/browser/src/integrations/index.ts
@@ -2,5 +2,5 @@ export { GlobalHandlers } from './globalhandlers';
 export { TryCatch } from './trycatch';
 export { Breadcrumbs } from './breadcrumbs';
 export { LinkedErrors } from './linkederrors';
-export { UserAgent } from './useragent';
+export { HttpContext } from './httpcontext';
 export { Dedupe } from './dedupe';

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -18,7 +18,7 @@ import {
 import { BrowserClient, BrowserClientOptions, BrowserOptions } from './client';
 import { IS_DEBUG_BUILD } from './flags';
 import { ReportDialogOptions, wrap as internalWrap } from './helpers';
-import { Breadcrumbs, Dedupe, GlobalHandlers, LinkedErrors, TryCatch, UserAgent } from './integrations';
+import { Breadcrumbs, Dedupe, GlobalHandlers, HttpContext, LinkedErrors, TryCatch } from './integrations';
 import { defaultStackParser } from './stack-parsers';
 import { makeFetchTransport, makeXHRTransport } from './transports';
 
@@ -30,7 +30,7 @@ export const defaultIntegrations = [
   new GlobalHandlers(),
   new LinkedErrors(),
   new Dedupe(),
-  new UserAgent(),
+  new HttpContext(),
 ];
 
 /**


### PR DESCRIPTION
As suggested in this [comment](https://github.com/getsentry/sentry-javascript/pull/2906#issuecomment-692910191) of #2906, this PR renames the Browser `UserAgent` integration to `HttpContext`. The reason for doing this is that the integration does more than collecting the user agent information and thus the name wasn't reflecting its entire purpose. 

Also added a note in the Migration doc about the change. 

Sentry-docs PR: https://github.com/getsentry/sentry-docs/pull/4997

ref: https://getsentry.atlassian.net/browse/WEB-270