### PR TITLE
feat: Export browser integrations individually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **(breaking)**: ref(node): Remove raven-node backward-compat code (#4942)
 - chore: Remove tslint from `@sentry-internal/typescript` (#4940)
 - feat: Add client report hook to makeTransport (#5008)
+- feat: Export browser integrations individually (#5028)
 - ref(build): Switch tsconfig target to es6 (#5005)
 - ref(core): Make event processing log warnings instead of errors (#5010)
 - fix(hub): Add missing parameter to captureException docstring (#5001)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -43,7 +43,7 @@ import { BrowserClient, defaultStackParser, defaultIntegrations, makeFetchTransp
 const client = new BrowserClient({
   transport: makeFetchTransport,
   stackParser: defaultStackParser,
-  integrations: [...defaultIntegrations],
+  integrations: defaultIntegrations,
 });
 
 // Before:
@@ -53,18 +53,22 @@ const client = new BrowserClient();
 Since you now explicitly pass in the dependencies of the client, you can also tree-shake out dependencies that you do not use this way. For example, you can tree-shake out the SDK's default integrations and only use the ones that you want like so:
 
 ```ts
-import { BrowserClient, defaultStackParser, Integrations, makeFetchTransport } from '@sentry/browser';
+import {
+  BrowserClient,
+  Breadcrumbs,
+  Dedupe,
+  defaultStackParser,
+  GlobalHandlers,
+  Integrations,
+  makeFetchTransport,
+  LinkedErrors,
+} from '@sentry/browser';
 
 // New in v7:
 const client = new BrowserClient({
   transport: makeFetchTransport,
   stackParser: defaultStackParser,
-  integrations: [
-    new Integrations.Breadcrumbs(),
-    new Integrations.GlobalHandlers(),
-    new Integrations.LinkedErrors(),
-    new Integrations.Dedupe(),
-  ],
+  integrations: [new Breadcrumbs(), new GlobalHandlers(), new LinkedErrors(), new Dedupe()],
 });
 ```
 

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -41,6 +41,8 @@ export {
   setTags,
   setUser,
   withScope,
+  FunctionToString,
+  InboundFilters,
 } from '@sentry/core';
 
 export { BrowserClient } from './client';
@@ -56,3 +58,4 @@ export {
 } from './stack-parsers';
 export { defaultIntegrations, forceLoad, init, lastEventId, onLoad, showReportDialog, flush, close, wrap } from './sdk';
 export { SDK_NAME } from './version';
+export { GlobalHandlers, TryCatch, Breadcrumbs, LinkedErrors, UserAgent, Dedupe } from './integrations';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ export { initAndBind } from './sdk';
 export { createTransport } from './transports/base';
 export { SDK_VERSION } from './version';
 export { getIntegrationsToSetup } from './integration';
+export { FunctionToString, InboundFilters } from './integrations';
 
 import * as Integrations from './integrations';
 


### PR DESCRIPTION
Currently users consume integrations like so:

```ts
const INTEGRATIONS = {
  ...windowIntegrations,
  ...CoreIntegrations,
  ...BrowserIntegrations,
};

export { INTEGRATIONS as Integrations };
``` 

This cannot be tree-shaken because a new object is being constructed with multiple object spreads.

In this PR, we switch to exporting everything individually. This means users don't have import the entire `INTEGRATIONS` object in, allowing it to be treeshaken.