### PR TITLE
fix(browser): Change `UserAgent` export to `HttpContext`

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -58,4 +58,4 @@ export {
 } from './stack-parsers';
 export { defaultIntegrations, forceLoad, init, lastEventId, onLoad, showReportDialog, flush, close, wrap } from './sdk';
 export { SDK_NAME } from './version';
-export { GlobalHandlers, TryCatch, Breadcrumbs, LinkedErrors, UserAgent, Dedupe } from './integrations';
+export { GlobalHandlers, TryCatch, Breadcrumbs, LinkedErrors, HttpContext, Dedupe } from './integrations';


### PR DESCRIPTION
After merging #5027, I discovered that I didn't rebase the PR after the integrations exports change in #5028 exported `UserAgent`. Should have double checked before merging. Anyway, this PR renames the export of the `UserAgent` integration to `HttpContext` which should fix building.  