### PR TITLE
ref(dev): Add `dev-utils` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "packages/angular",
     "packages/browser",
     "packages/core",
+    "packages/dev-utils",
     "packages/ember",
     "packages/eslint-config-sdk",
     "packages/eslint-plugin-sdk",

--- a/packages/dev-utils/.eslintrc.js
+++ b/packages/dev-utils/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['../../.eslintrc.js'],
+};

--- a/packages/dev-utils/LICENSE
+++ b/packages/dev-utils/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2019, Sentry
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/dev-utils/README.md
+++ b/packages/dev-utils/README.md
@@ -1,0 +1,17 @@
+<p align="center">
+  <a href="https://sentry.io" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <br />
+</p>
+
+# Sentry JavaScript SDK Developer Utilities
+
+## Links
+
+- [Contribution Guide](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md)
+- [SDK Developer Docs](https://develop.sentry.dev/sdk/)
+
+## General
+
+Common utilities used during development of the Sentry JavaScript SDKs. Internal only, does not follow semver.

--- a/packages/dev-utils/jest.config.js
+++ b/packages/dev-utils/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest/jest.config.js');

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@sentry-internal/dev-utils",
+  "version": "7.0.0-beta.0",
+  "description": "Development utilities for all Sentry JavaScript SDKs",
+  "repository": "git://github.com/getsentry/sentry-javascript.git",
+  "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/dev-utils",
+  "author": "Sentry",
+  "license": "BSD-3-Clause",
+  "engines": {
+    "node": ">=8"
+  },
+  "main": "build/cjs/index.js",
+  "module": "build/esm/index.js",
+  "types": "build/types/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "run-p build:rollup build:types",
+    "build:dev": "run-s build",
+    "build:rollup": "rollup -c rollup.npm.config.js",
+    "build:types": "tsc -p tsconfig.types.json",
+    "build:watch": "run-p build:rollup:watch build:types:watch",
+    "build:dev:watch": "run-s build:watch",
+    "build:rollup:watch": "rollup -c rollup.npm.config.js --watch",
+    "build:types:watch": "tsc -p tsconfig.types.json --watch",
+    "build:npm": "ts-node ../../scripts/prepack.ts && npm pack ./build",
+    "circularDepCheck": "madge --circular src/index.ts",
+    "clean": "rimraf build coverage cjs esm sentry-dev-utils-*.tgz",
+    "fix": "run-s fix:eslint fix:prettier",
+    "fix:eslint": "eslint . --format stylish --fix",
+    "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",
+    "link:yarn": "yarn link",
+    "lint": "run-s lint:prettier lint:eslint",
+    "lint:eslint": "eslint . --cache --cache-location '../../eslintcache/' --format stylish",
+    "lint:prettier": "prettier --check \"{src,test,scripts}/**/*.ts\"",
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "sideEffects": false
+}

--- a/packages/dev-utils/rollup.npm.config.js
+++ b/packages/dev-utils/rollup.npm.config.js
@@ -1,0 +1,8 @@
+import { makeBaseNPMConfig, makeNPMConfigVariants } from '../../rollup/index.js';
+
+export default makeNPMConfigVariants(
+  makeBaseNPMConfig({
+    // This way we don't have to worry about whether third-party packages have updated to ESM yet.
+    esModuleInterop: true,
+  }),
+);

--- a/packages/dev-utils/src/index.ts
+++ b/packages/dev-utils/src/index.ts
@@ -1,0 +1,2 @@
+// we need some import or export to exist, to satisfy the tsconfig --isolatedModules setting
+export const dummyExport = {};

--- a/packages/dev-utils/test/placeholder.test.ts
+++ b/packages/dev-utils/test/placeholder.test.ts
@@ -1,0 +1,8 @@
+// we need some import or export to exist, to satisfy the tsconfig --isolatedModules setting
+import { dummyExport } from '../src';
+
+describe('placeholder tests', () => {
+  it('holds a place', () => {
+    expect(dummyExport).toEqual({});
+  });
+});

--- a/packages/dev-utils/tsconfig.json
+++ b/packages/dev-utils/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+
+  "include": ["src/**/*"],
+
+  "compilerOptions": {
+    // package-specific options
+  }
+}

--- a/packages/dev-utils/tsconfig.test.json
+++ b/packages/dev-utils/tsconfig.test.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+
+  "include": ["test/**/*"],
+
+  "compilerOptions": {
+    // should include all types from `./tsconfig.json` plus types for all test frameworks used
+    "types": ["node", "jest"],
+
+    // other package-specific, test-specific options
+
+    // `es2020` is the recommended `lib` and `target` for Node 14
+    // see https://github.com/tsconfig/bases/blob/main/bases/node14.json
+    "lib": ["dom", "es2020"],
+    "target": "es2020",
+
+    // so we don't have to worry about how libraries we use export things
+    "esModuleInterop": true
+  }
+}

--- a/packages/dev-utils/tsconfig.types.json
+++ b/packages/dev-utils/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "build/types"
+  }
+}


### PR DESCRIPTION
Since we're not using it immediately, I'm going to wait to merge this until a few other structural changes have gone through. Moving back to draft.

-------------


This adds the skeleton of a new `dev-utils` package, which will eventually hold a lot of the stuff that's started to litter the top level of our repo (rollup helpers, jest transformers, etc), as well as give us a place to put, for example, testing helpers which right now have to be copied across packages.

Work to move things into the package (and update anything that points to the old locations) will happen in follow-up PRs.

Note: There is a little cruft here, of the kind from which all of our packages suffer, which I left alone (for the moment) for simplicity's sake. When we do the work to clean up this junk repo-wide, these crufty areas will get taken care of.
