### PR TITLE
ref: Delete unneeded `SDK_NAME`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -281,8 +281,9 @@ For our efforts to reduce bundle size of the SDK we had to remove and refactor p
   [#4919](https://github.com/getsentry/sentry-javascript/pull/4919)). `Backend` was an unnecessary abstraction which is
   not present in other Sentry SDKs. For the sake of reducing complexity, increasing consistency with other Sentry SDKs and
   decreasing bundle-size, `Backend` was removed.
-- Remove support for Opera browser pre v15
-- Rename `UserAgent` integration to `HttpContext` (see [#5027](https://github.com/getsentry/sentry-javascript/pull/5027))
+- Remove support for Opera browser pre v15.
+- Rename `UserAgent` integration to `HttpContext`. (see [#5027](https://github.com/getsentry/sentry-javascript/pull/5027))
+- Remove `SDK_NAME` export from `@sentry/browser`, `@sentry/node`, `@sentry/tracing` and `@sentry/vue` packages.
 
 ## Sentry Angular SDK Changes
 

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -57,5 +57,4 @@ export {
   winjsStackLineParser,
 } from './stack-parsers';
 export { defaultIntegrations, forceLoad, init, lastEventId, onLoad, showReportDialog, flush, close, wrap } from './sdk';
-export { SDK_NAME } from './version';
 export { GlobalHandlers, TryCatch, Breadcrumbs, LinkedErrors, HttpContext, Dedupe } from './integrations';

--- a/packages/browser/src/version.ts
+++ b/packages/browser/src/version.ts
@@ -1,2 +1,0 @@
-// TODO: Remove in the next major release and rely only on @sentry/core SDK_VERSION and SdkInfo metadata
-export const SDK_NAME = 'sentry.javascript.browser';

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -46,7 +46,6 @@ export { NodeClient } from './client';
 export { makeNodeTransport } from './transports';
 export { defaultIntegrations, init, lastEventId, flush, close, getSentryRelease } from './sdk';
 export { deepReadDirSync } from './utils';
-export { SDK_NAME } from './version';
 export { defaultStackParser } from './stack-parser';
 
 import { Integrations as CoreIntegrations } from '@sentry/core';

--- a/packages/node/src/version.ts
+++ b/packages/node/src/version.ts
@@ -1,2 +1,0 @@
-// TODO: Remove in the next major release and rely only on @sentry/core SDK_VERSION and SdkMetadata
-export const SDK_NAME = 'sentry.javascript.node';

--- a/packages/tracing/src/index.bundle.ts
+++ b/packages/tracing/src/index.bundle.ts
@@ -50,7 +50,7 @@ export {
   close,
   wrap,
 } from '@sentry/browser';
-export { SDK_NAME, SDK_VERSION } from '@sentry/browser';
+export { SDK_VERSION } from '@sentry/browser';
 
 import { Integrations as BrowserIntegrations } from '@sentry/browser';
 import { getGlobalObject } from '@sentry/utils';

--- a/packages/vue/src/index.bundle.ts
+++ b/packages/vue/src/index.bundle.ts
@@ -43,7 +43,6 @@ export {
   makeFetchTransport,
   makeXHRTransport,
   withScope,
-  SDK_NAME,
   SDK_VERSION,
 } from '@sentry/browser';
 


### PR DESCRIPTION
Removes `SDK_NAME` export from from `@sentry/browser`, `@sentry/node`, `@sentry/tracing` and `@sentry/vue` packages.

This const contained the name of the sdk in the form of `'sentry.javascript.browser'` which was used internally but is now unused because we define the sdk name in the clients directly.

Ref: https://getsentry.atlassian.net/browse/WEB-823