### PR TITLE
fix(tracing): Remove `isInstanceOf` check in Hub constructor

### DIFF
--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -6,7 +6,7 @@ import {
   TransactionContext,
   TransactionMetadata,
 } from '@sentry/types';
-import { dropUndefinedKeys, isInstanceOf, logger } from '@sentry/utils';
+import { dropUndefinedKeys, logger } from '@sentry/utils';
 
 import { IS_DEBUG_BUILD } from './flags';
 import { Span as SpanClass, SpanRecorder } from './span';
@@ -22,7 +22,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
   /**
    * The reference to the current hub.
    */
-  private readonly _hub: Hub = getCurrentHub() as unknown as Hub;
+  private readonly _hub: Hub;
 
   private _trimEnd?: boolean;
 
@@ -36,9 +36,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
   public constructor(transactionContext: TransactionContext, hub?: Hub) {
     super(transactionContext);
 
-    if (isInstanceOf(hub, Hub)) {
-      this._hub = hub as Hub;
-    }
+    this._hub = hub || getCurrentHub();
 
     this.name = transactionContext.name || '';
 


### PR DESCRIPTION
This PR fixes a bug which assigned the wrong `Hub` instance to a `Transaction` in the `Transaction` constructor. It removes the `isInstanceOf` check which incorrectly failed when passing a user-created `Hub` the constructor. Overall, the PR simplifies the hub initialization by deciding in the constructor if the passed `Hub` should be used. As a fallback, the `Hub` returned from `getCurrentHub` is used.

This fix was originally created by @lobsterkatie in https://github.com/getsentry/sentry-javascript/compare/7.x...temp-5-5-fix-hub-in-transaction-constructor.

ref: https://getsentry.atlassian.net/browse/ISSUE-1402