### PR TITLE
ref(utils): Clean up dangerous type casts in object helper file

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -31,6 +31,7 @@ export type { Mechanism } from './mechanism';
 export type { ExtractedNodeRequestData, Primitive, WorkerLocation } from './misc';
 export type { ClientOptions, Options } from './options';
 export type { Package } from './package';
+export type { PolymorphicEvent } from './polymorphics';
 export type { QueryParams, Request } from './request';
 export type { Runtime } from './runtime';
 export type { CaptureContext, Scope, ScopeContext } from './scope';

--- a/packages/types/src/polymorphics.ts
+++ b/packages/types/src/polymorphics.ts
@@ -1,0 +1,11 @@
+/**
+ * Event-like interface that's usable in browser and node.
+ *
+ * Property availability taken from https://developer.mozilla.org/en-US/docs/Web/API/Event#browser_compatibility
+ */
+export interface PolymorphicEvent {
+  [key: string]: unknown;
+  readonly type: string;
+  readonly target?: unknown;
+  readonly currentTarget?: unknown;
+}

--- a/packages/utils/src/is.ts
+++ b/packages/utils/src/is.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 
-import { Primitive } from '@sentry/types';
+import { PolymorphicEvent, Primitive } from '@sentry/types';
 
 // eslint-disable-next-line @typescript-eslint/unbound-method
 const objectToString = Object.prototype.toString;
@@ -101,7 +101,7 @@ export function isPlainObject(wat: unknown): wat is Record<string, unknown> {
  * @param wat A value to be checked.
  * @returns A boolean representing the result.
  */
-export function isEvent(wat: unknown): boolean {
+export function isEvent(wat: unknown): wat is PolymorphicEvent {
   return typeof Event !== 'undefined' && isInstanceOf(wat, Event);
 }
 

--- a/packages/utils/src/normalize.ts
+++ b/packages/utils/src/normalize.ts
@@ -1,6 +1,6 @@
 import { Primitive } from '@sentry/types';
 
-import { isError, isEvent, isNaN, isSyntheticEvent } from './is';
+import { isNaN, isSyntheticEvent } from './is';
 import { memoBuilder, MemoFunc } from './memo';
 import { convertToPlainObject } from './object';
 import { getFunctionName } from './stacktrace';
@@ -117,7 +117,7 @@ function visit(
 
   // Before we begin, convert`Error` and`Event` instances into plain objects, since some of each of their relevant
   // properties are non-enumerable and otherwise would get missed.
-  const visitable = (isError(value) || isEvent(value) ? convertToPlainObject(value) : value) as ObjOrArray<unknown>;
+  const visitable = convertToPlainObject(value as ObjOrArray<unknown>);
 
   for (const visitKey in visitable) {
     // Avoid iterating over fields in the prototype if they've somehow been exposed to enumeration.

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -99,7 +99,23 @@ export function urlEncode(object: { [key: string]: any }): string {
  * @returns An Event or Error turned into an object - or the value argurment itself, when value is neither an Event nor
  *  an Error.
  */
-export function convertToPlainObject<V extends unknown>(value: V): Record<string, unknown> | V {
+export function convertToPlainObject<V extends unknown>(
+  value: V,
+):
+  | {
+      [ownProps: string]: unknown;
+      type: string;
+      target: string;
+      currentTarget: string;
+      detail?: unknown;
+    }
+  | {
+      [ownProps: string]: unknown;
+      message: string;
+      name: string;
+      stack?: string;
+    }
+  | V {
   if (isError(value)) {
     return {
       message: value.message,
@@ -108,7 +124,13 @@ export function convertToPlainObject<V extends unknown>(value: V): Record<string
       ...getOwnProperties(value),
     };
   } else if (isEvent(value)) {
-    const newObj: Record<string, unknown> = {
+    const newObj: {
+      [ownProps: string]: unknown;
+      type: string;
+      target: string;
+      currentTarget: string;
+      detail?: unknown;
+    } = {
       type: value.type,
       target: serializeEventTarget(value.target),
       currentTarget: serializeEventTarget(value.currentTarget),


### PR DESCRIPTION
While trying to understand what `convertToPlainObject` does, I noticed that it had some pretty dangerous type signatures. This PR tries to clean that up a bit.

This PR intends not change any behaviour.