### PR TITLE
feat(ci): Add Node 18 to test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [8, 10, 12, 14, 16]
+        node: [8, 10, 12, 14, 16, 18]
     steps:
       - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2
@@ -318,7 +318,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [10, 12, 14, 16, 18]
     steps:
       - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2
@@ -518,7 +518,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        node: [10, 12, 14, 16]
+        node: [10, 12, 14, 16, 18]
     steps:
       - name: Check out current commit (${{ github.sha }})
         uses: actions/checkout@v2

--- a/packages/nextjs/test/run-integration-tests.sh
+++ b/packages/nextjs/test/run-integration-tests.sh
@@ -78,6 +78,19 @@ for NEXTJS_VERSION in 10 11 12; do
       WEBPACK_VERSION=5 ||
       WEBPACK_VERSION=4
 
+    # Node v18 only with Webpack 5 and above
+    # https://github.com/webpack/webpack/issues/14532#issuecomment-947513562
+    # Context: https://github.com/vercel/next.js/issues/30078#issuecomment-947338268
+    if [ "$NODE_MAJOR" -gt "17" ] && [ "$WEBPACK_VERSION" -eq "4" ]; then
+      echo "[nextjs$NEXTJS_VERSION | webpack@$WEBPACK_VERSION] Node $NODE_MAJOR not compatible with Webpack $WEBPACK_VERSION"
+      exit 0
+    fi
+    if [ "$NODE_MAJOR" -gt "17" ] && [ "$NEXTJS_VERSION" -eq "10" ]; then
+      echo "[nextjs$NEXTJS_VERSION | webpack@$WEBPACK_VERSION] Node $NODE_MAJOR not compatible with Webpack $WEBPACK_VERSION"
+      exit 0
+    fi
+
+
     # next 10 defaults to webpack 4 and next 11 defaults to webpack 5, but each can use either based on settings
     if [ "$NEXTJS_VERSION" -eq "10" ]; then
       sed "s/%RUN_WEBPACK_5%/$RUN_WEBPACK_5/g" <next10.config.template >next.config.js

--- a/packages/node/test/manual/webpack-domain/npm-build.js
+++ b/packages/node/test/manual/webpack-domain/npm-build.js
@@ -2,6 +2,11 @@ const path = require('path');
 const webpack = require('webpack');
 const { execSync } = require('child_process');
 
+// Webpack test does not work in Node 18 and above.
+if (Number(process.versions.node.split('.')[0]) >= 18) {
+  return;
+}
+
 // prettier-ignore
 webpack(
   {
@@ -13,7 +18,7 @@ webpack(
     target: 'node',
     mode: 'development',
   },
-  function(err, stats) {
+  function (err, stats) {
     if (err) {
       console.error(err.stack || err);
       if (err.details) {

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -79,7 +79,7 @@ export function init(options: Sentry.NodeOptions = {}): void {
     version: Sentry.SDK_VERSION,
   };
 
-  options.dsn = extensionRelayDSN(options.dsn)
+  options.dsn = extensionRelayDSN(options.dsn);
 
   Sentry.init(options);
   Sentry.addGlobalEventProcessor(serverlessEventProcessor);

--- a/packages/utils/src/dsn.ts
+++ b/packages/utils/src/dsn.ts
@@ -108,7 +108,6 @@ export function makeDsn(from: DsnLike): DsnComponents {
   return components;
 }
 
-
 /**
  * Changes a Dsn to point to the `relay` server running in the Lambda Extension.
  *

--- a/packages/utils/src/normalize.ts
+++ b/packages/utils/src/normalize.ts
@@ -31,6 +31,7 @@ type ObjOrArray<T> = { [key: string]: T };
  * object in the normallized output..
  * @returns A normalized version of the object, or `"**non-serializable**"` if any errors are thrown during normalization.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function normalize(input: unknown, depth: number = +Infinity, maxProperties: number = +Infinity): any {
   try {
     // since we're at the outermost level, we don't provide a key
@@ -42,6 +43,7 @@ export function normalize(input: unknown, depth: number = +Infinity, maxProperti
 
 /** JSDoc */
 export function normalizeToSize<T>(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   object: { [key: string]: any },
   // Default Node.js REPL depth
   depth: number = 3,
@@ -241,6 +243,7 @@ function utf8Length(value: string): number {
 }
 
 /** Calculates bytes size of input object */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function jsonSize(value: any): number {
   return utf8Length(JSON.stringify(value));
 }


### PR DESCRIPTION
https://nodejs.org/en/blog/announcements/v18-release-announce/

From reviewing the CHANGELOG (https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V18.md), there seems to be no changes that will affect us in the code.

See v17 CHANGELOG: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V17.md

Notable things we can maybe pursue:
- Make a Node 18 only fetch transport: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V18.md#fetch-experimental

Resolves https://getsentry.atlassian.net/browse/WEB-870