### PR TITLE
ref(hub): Convert `Session` class to object and functions

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -292,6 +292,32 @@ changes in v7. They will be removed in the next major release which is why we st
 corresponding string literals. Here's how to adjust [`Severity`](#severity-severitylevel-and-severitylevels) and
 [`SpanStatus`](#spanstatus).
 
+## Session Changes
+
+Note: These changes are not relevant for the majority of Sentry users but if you are building an
+SDK on top of the Javascript SDK, you might need to make some adaptions.
+The internal `Session` class was refactored and replaced with a more functional approach in
+[#5054](https://github.com/getsentry/sentry-javascript/pull/5054).
+Instead of the class, we now export a `Session` interface from `@sentry/types` and three utility functions
+to create and update a `Session` object from `@sentry/hub`.
+This short example shows what has changed and how to deal with the new functions:
+
+```js
+// New in v7:
+import { makeSession, updateSession, closeSession } from '@sentry/hub';
+
+const session = makeSession({ release: 'v1.0' });
+updateSession(session, { environment: 'prod' });
+closeSession(session, 'ok');
+
+// Before:
+import { Session } from '@sentry/hub';
+
+const session = new Session({ release: 'v1.0' });
+session.update({ environment: 'prod' });
+session.close('ok');
+```
+
 ## General API Changes
 
 For our efforts to reduce bundle size of the SDK we had to remove and refactor parts of the package which introduced a few changes to the API:
@@ -313,8 +339,11 @@ For our efforts to reduce bundle size of the SDK we had to remove and refactor p
 - Rename `UserAgent` integration to `HttpContext`. (see [#5027](https://github.com/getsentry/sentry-javascript/pull/5027))
 - Remove `SDK_NAME` export from `@sentry/browser`, `@sentry/node`, `@sentry/tracing` and `@sentry/vue` packages.
 - Removed `eventStatusFromHttpCode` to save on bundle size.
+<<<<<<< HEAD
 - Replace `BrowserTracing` `maxTransactionDuration` option with `finalTimeout` option
 - Replace `Session` class with a session object and functions (see [#5054](https://github.com/getsentry/sentry-javascript/pull/5054)).
+=======
+>>>>>>> 5c81e32c4 (Add "Session Changes" section to Migration docs)
 
 ## Sentry Angular SDK Changes
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -314,6 +314,7 @@ For our efforts to reduce bundle size of the SDK we had to remove and refactor p
 - Remove `SDK_NAME` export from `@sentry/browser`, `@sentry/node`, `@sentry/tracing` and `@sentry/vue` packages.
 - Removed `eventStatusFromHttpCode` to save on bundle size.
 - Replace `BrowserTracing` `maxTransactionDuration` option with `finalTimeout` option
+- Replace `Session` class with a session object and functions (see [#5054](https://github.com/getsentry/sentry-javascript/pull/5054)).
 
 ## Sentry Angular SDK Changes
 

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -13,6 +13,7 @@ export type {
   Stacktrace,
   Thread,
   User,
+  Session,
 } from '@sentry/types';
 
 export type { BrowserOptions } from './client';
@@ -31,7 +32,6 @@ export {
   Hub,
   makeMain,
   Scope,
-  Session,
   startTransaction,
   SDK_VERSION,
   setContext,

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -200,11 +200,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
     } else {
       this.sendSession(session);
       // After sending, we set init false to indicate it's not the first occurrence
-
-      // TODO(v7) this does not have any consequence b/c we don't write the update after the session change
-      // disabling for now
-      // session.update({ init: false });
-      // updateSession(session, { init: false });
+      updateSession(session, { init: false });
     }
   }
 
@@ -348,11 +344,11 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
     const shouldUpdateAndSend = (sessionNonTerminal && session.errors === 0) || (sessionNonTerminal && crashed);
 
     if (shouldUpdateAndSend) {
-      const updatedSession = updateSession(session, {
+      updateSession(session, {
         ...(crashed && { status: 'crashed' }),
         errors: session.errors || Number(errored || crashed),
       });
-      this.captureSession(updatedSession);
+      this.captureSession(session);
     }
   }
 

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { Scope, Session } from '@sentry/hub';
+import { Scope, updateSession } from '@sentry/hub';
 import {
   Client,
   ClientOptions,
@@ -12,6 +12,7 @@ import {
   Integration,
   IntegrationClass,
   Outcome,
+  Session,
   SessionAggregates,
   Severity,
   SeverityLevel,
@@ -199,7 +200,10 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
     } else {
       this.sendSession(session);
       // After sending, we set init false to indicate it's not the first occurrence
-      session.update({ init: false });
+      // TODO this does not have any consequence b/c we don't write the update after the session change
+      // disabling for now
+      // session.update({ init: false });
+      updateSession(ses);
     }
   }
 
@@ -343,11 +347,11 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
     const shouldUpdateAndSend = (sessionNonTerminal && session.errors === 0) || (sessionNonTerminal && crashed);
 
     if (shouldUpdateAndSend) {
-      session.update({
+      const updatedSession = updateSession(session, {
         ...(crashed && { status: 'crashed' }),
         errors: session.errors || Number(errored || crashed),
       });
-      this.captureSession(session);
+      this.captureSession(updatedSession);
     }
   }
 

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -200,10 +200,11 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
     } else {
       this.sendSession(session);
       // After sending, we set init false to indicate it's not the first occurrence
-      // TODO this does not have any consequence b/c we don't write the update after the session change
+
+      // TODO(v7) this does not have any consequence b/c we don't write the update after the session change
       // disabling for now
       // session.update({ init: false });
-      updateSession(ses);
+      // updateSession(session, { init: false });
     }
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,7 +20,6 @@ export {
   Hub,
   makeMain,
   Scope,
-  Session,
 } from '@sentry/hub';
 export { getEnvelopeEndpointWithUrlEncodedAuth, getReportDialogEndpoint } from './api';
 export { BaseClient } from './baseclient';

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -1,4 +1,5 @@
-import { Hub, Scope, Session } from '@sentry/hub';
+import { Hub, Scope } from '@sentry/hub';
+import { makeSession } from '@sentry/hub/src/session';
 import { Event, Span } from '@sentry/types';
 import { dsnToString, logger, SentryError, SyncPromise } from '@sentry/utils';
 
@@ -1327,7 +1328,7 @@ describe('BaseClient', () => {
 
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
       const client = new TestClient(options);
-      const session = new Session({ release: 'test' });
+      const session = makeSession({ release: 'test' });
 
       client.captureSession(session);
 
@@ -1339,7 +1340,7 @@ describe('BaseClient', () => {
 
       const options = getDefaultTestClientOptions({ enabled: false, dsn: PUBLIC_DSN });
       const client = new TestClient(options);
-      const session = new Session({ release: 'test' });
+      const session = makeSession({ release: 'test' });
 
       client.captureSession(session);
 

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -1,5 +1,4 @@
-import { Hub, Scope } from '@sentry/hub';
-import { makeSession } from '@sentry/hub/src/session';
+import { Hub, Scope, makeSession } from '@sentry/hub';
 import { Event, Span } from '@sentry/types';
 import { dsnToString, logger, SentryError, SyncPromise } from '@sentry/utils';
 

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -1,4 +1,4 @@
-import { Hub, Scope, makeSession } from '@sentry/hub';
+import { Hub, makeSession, Scope } from '@sentry/hub';
 import { Event, Span } from '@sentry/types';
 import { dsnToString, logger, SentryError, SyncPromise } from '@sentry/utils';
 

--- a/packages/core/test/mocks/client.ts
+++ b/packages/core/test/mocks/client.ts
@@ -1,5 +1,4 @@
-import { Session } from '@sentry/hub';
-import { ClientOptions, Event, Integration, Outcome, Severity, SeverityLevel } from '@sentry/types';
+import { ClientOptions, Event, Integration, Outcome, Session, Severity, SeverityLevel } from '@sentry/types';
 import { resolvedSyncPromise } from '@sentry/utils';
 
 import { BaseClient } from '../../src/baseclient';

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -396,8 +396,7 @@ export class Hub implements HubInterface {
     const scope = layer && layer.scope;
     const session = scope && scope.getSession();
     if (session) {
-      const closedSession = closeSession(session);
-      scope && scope.setSession(closedSession);
+      closeSession(session);
     }
     this._sendSessionUpdate();
 
@@ -430,8 +429,7 @@ export class Hub implements HubInterface {
       // End existing session if there's one
       const currentSession = scope.getSession && (scope.getSession() as Session);
       if (currentSession && currentSession.status === 'ok') {
-        const updatedSession = updateSession({ status: 'exited' });
-        scope.setSession(updatedSession);
+        updateSession(currentSession, { status: 'exited' });
       }
       this.endSession();
 

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -447,7 +447,7 @@ export class Hub implements HubInterface {
     const { scope, client } = this.getStackTop();
     if (!scope) return;
 
-    const session = scope.getSession && scope.getSession();
+    const session = scope.getSession();
     if (session) {
       if (client && client.captureSession) {
         client.captureSession(session);

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -427,7 +427,7 @@ export class Hub implements HubInterface {
 
     if (scope) {
       // End existing session if there's one
-      const currentSession = scope.getSession && (scope.getSession() as Session);
+      const currentSession = scope.getSession && scope.getSession();
       if (currentSession && currentSession.status === 'ok') {
         updateSession(currentSession, { status: 'exited' });
       }

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -1,7 +1,7 @@
 export type { Carrier, Layer } from './hub';
 
 export { addGlobalEventProcessor, Scope } from './scope';
-export { Session } from './session';
+export { updateSession, closeSession, sessionToJSON } from './session';
 export { SessionFlusher } from './sessionflusher';
 export { getCurrentHub, getHubFromCarrier, getMainCarrier, Hub, makeMain, setHubOnCarrier } from './hub';
 export {

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -1,7 +1,7 @@
 export type { Carrier, Layer } from './hub';
 
 export { addGlobalEventProcessor, Scope } from './scope';
-export { updateSession, closeSession, sessionToJSON } from './session';
+export { updateSession, closeSession } from './session';
 export { SessionFlusher } from './sessionflusher';
 export { getCurrentHub, getHubFromCarrier, getMainCarrier, Hub, makeMain, setHubOnCarrier } from './hub';
 export {

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -1,7 +1,7 @@
 export type { Carrier, Layer } from './hub';
 
 export { addGlobalEventProcessor, Scope } from './scope';
-export { updateSession, closeSession } from './session';
+export { closeSession, makeSession, updateSession } from './session';
 export { SessionFlusher } from './sessionflusher';
 export { getCurrentHub, getHubFromCarrier, getMainCarrier, Hub, makeMain, setHubOnCarrier } from './hub';
 export {

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -137,7 +137,7 @@ export class Scope implements ScopeInterface {
   public setUser(user: User | null): this {
     this._user = user || {};
     if (this._session) {
-      this._session = updateSession(this._session, { user });
+      updateSession(this._session, { user });
     }
     this._notifyScopeListeners();
     return this;

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -13,6 +13,7 @@ import {
   RequestSession,
   Scope as ScopeInterface,
   ScopeContext,
+  Session,
   Severity,
   SeverityLevel,
   Span,
@@ -29,7 +30,7 @@ import {
 } from '@sentry/utils';
 
 import { IS_DEBUG_BUILD } from './flags';
-import { Session } from './session';
+import { updateSession } from './session';
 
 /**
  * Absolute maximum number of breadcrumbs added to an event.
@@ -136,7 +137,7 @@ export class Scope implements ScopeInterface {
   public setUser(user: User | null): this {
     this._user = user || {};
     if (this._session) {
-      this._session.update({ user });
+      this._session = updateSession(this._session, { user });
     }
     this._notifyScopeListeners();
     return this;

--- a/packages/hub/src/session.ts
+++ b/packages/hub/src/session.ts
@@ -10,14 +10,20 @@ export function makeSession(context?: Omit<SessionContext, 'started' | 'status'>
   // Both timestamp and started are in seconds since the UNIX epoch.
   const startingTime = timestampInSeconds();
 
-  const basicSession = {
+  const basicSession: Session = {
+    errors: 0,
+    sid: uuid4(),
     timestamp: startingTime,
     started: startingTime,
+    duration: 0,
+    status: 'ok',
+    init: true,
+    ignoreDuration: false,
   };
 
   return {
     ...basicSession,
-    ...(context ? updateSession(basicSession, context) : undefined),
+    ...(context ? updateSession(basicSession, context) : {}),
   };
 }
 
@@ -97,7 +103,7 @@ export function closeSession(session: Session, status?: Exclude<SessionStatus, '
   let context = {};
   if (status) {
     context = { status };
-  } else if (session === 'ok') {
+  } else if (session.status === 'ok') {
     context = { status: 'exited' };
   }
 
@@ -133,7 +139,7 @@ export function sessionToJSON(session: Session): {
     status: session.status || 'ok',
     errors: session.errors || 0,
     did: typeof session.did === 'number' || typeof session.did === 'string' ? `${session.did}` : undefined,
-    duration: session.duration || 0,
+    duration: session.duration,
     attrs: {
       release: session.release,
       environment: session.environment,

--- a/packages/hub/src/session.ts
+++ b/packages/hub/src/session.ts
@@ -133,7 +133,7 @@ export function closeSession(session: Session, status?: Exclude<SessionStatus, '
  *
  * @returns a JSON object of the passed session
  */
-export function sessionToJSON(session: Session): SerializedSession {
+function sessionToJSON(session: Session): SerializedSession {
   return dropUndefinedKeys({
     sid: `${session.sid}`,
     init: session.init !== undefined ? session.init : true,

--- a/packages/hub/src/session.ts
+++ b/packages/hub/src/session.ts
@@ -15,13 +15,13 @@ export function makeSession(context?: Omit<SessionContext, 'started' | 'status'>
   const startingTime = timestampInSeconds();
 
   const session: Session = {
-    errors: 0,
     sid: uuid4(),
+    init: true,
     timestamp: startingTime,
     started: startingTime,
     duration: 0,
     status: 'ok',
-    init: true,
+    errors: 0,
     ignoreDuration: false,
     toJSON: () => sessionToJSON(session),
   };
@@ -79,7 +79,7 @@ export function updateSession(session: Session, context: SessionContext = {}): v
   } else if (typeof context.duration === 'number') {
     session.duration = context.duration;
   } else {
-    const duration = session.timestamp - (session.started || 0);
+    const duration = session.timestamp - session.started;
     session.duration = duration >= 0 ? duration : 0;
   }
   if (context.release) {
@@ -138,10 +138,10 @@ export function sessionToJSON(session: Session): SerializedSession {
     sid: `${session.sid}`,
     init: session.init !== undefined ? session.init : true,
     // Make sure that sec is converted to ms for date constructor
-    started: new Date((session.started || 0) * 1000).toISOString(),
-    timestamp: new Date((session.timestamp || 0) * 1000).toISOString(),
-    status: session.status || 'ok',
-    errors: session.errors || 0,
+    started: new Date(session.started * 1000).toISOString(),
+    timestamp: new Date(session.timestamp * 1000).toISOString(),
+    status: session.status,
+    errors: session.errors,
     did: typeof session.did === 'number' || typeof session.did === 'string' ? `${session.did}` : undefined,
     duration: session.duration,
     attrs: {

--- a/packages/hub/src/session.ts
+++ b/packages/hub/src/session.ts
@@ -1,136 +1,144 @@
-import { Session as SessionInterface, SessionContext, SessionStatus } from '@sentry/types';
+import { Session, SessionContext, SessionStatus } from '@sentry/types';
 import { dropUndefinedKeys, timestampInSeconds, uuid4 } from '@sentry/utils';
 
 /**
- * @inheritdoc
+ * TODO jsdoc
+ * @param context
+ * @returns
  */
-export class Session implements SessionInterface {
-  public userAgent?: string;
-  public errors: number = 0;
-  public release?: string;
-  public sid: string = uuid4();
-  public did?: string;
-  public timestamp: number;
-  public started: number;
-  public duration?: number = 0;
-  public status: SessionStatus = 'ok';
-  public environment?: string;
-  public ipAddress?: string;
-  public init: boolean = true;
-  public ignoreDuration: boolean = false;
+export function makeSession(context?: Omit<SessionContext, 'started' | 'status'>): Session {
+  // Both timestamp and started are in seconds since the UNIX epoch.
+  const startingTime = timestampInSeconds();
 
-  public constructor(context?: Omit<SessionContext, 'started' | 'status'>) {
-    // Both timestamp and started are in seconds since the UNIX epoch.
-    const startingTime = timestampInSeconds();
-    this.timestamp = startingTime;
-    this.started = startingTime;
-    if (context) {
-      this.update(context);
+  const basicSession = {
+    timestamp: startingTime,
+    started: startingTime,
+  };
+
+  return {
+    ...basicSession,
+    ...(context ? updateSession(basicSession, context) : undefined),
+  };
+}
+
+/**
+ * TODO jsdoc
+ * @param session
+ * @param context
+ * @returns
+ */
+// eslint-disable-next-line complexity
+export function updateSession(originalSession: Session, context: SessionContext = {}): Session {
+  const session = { ...originalSession };
+
+  if (context.user) {
+    if (!session.ipAddress && context.user.ip_address) {
+      session.ipAddress = context.user.ip_address;
+    }
+
+    if (!session.did && !context.did) {
+      session.did = context.user.id || context.user.email || context.user.username;
     }
   }
 
-  /** JSDoc */
-  // eslint-disable-next-line complexity
-  public update(context: SessionContext = {}): void {
-    if (context.user) {
-      if (!this.ipAddress && context.user.ip_address) {
-        this.ipAddress = context.user.ip_address;
-      }
+  session.timestamp = context.timestamp || timestampInSeconds();
 
-      if (!this.did && !context.did) {
-        this.did = context.user.id || context.user.email || context.user.username;
-      }
-    }
-
-    this.timestamp = context.timestamp || timestampInSeconds();
-    if (context.ignoreDuration) {
-      this.ignoreDuration = context.ignoreDuration;
-    }
-    if (context.sid) {
-      // Good enough uuid validation. — Kamil
-      this.sid = context.sid.length === 32 ? context.sid : uuid4();
-    }
-    if (context.init !== undefined) {
-      this.init = context.init;
-    }
-    if (!this.did && context.did) {
-      this.did = `${context.did}`;
-    }
-    if (typeof context.started === 'number') {
-      this.started = context.started;
-    }
-    if (this.ignoreDuration) {
-      this.duration = undefined;
-    } else if (typeof context.duration === 'number') {
-      this.duration = context.duration;
-    } else {
-      const duration = this.timestamp - this.started;
-      this.duration = duration >= 0 ? duration : 0;
-    }
-    if (context.release) {
-      this.release = context.release;
-    }
-    if (context.environment) {
-      this.environment = context.environment;
-    }
-    if (!this.ipAddress && context.ipAddress) {
-      this.ipAddress = context.ipAddress;
-    }
-    if (!this.userAgent && context.userAgent) {
-      this.userAgent = context.userAgent;
-    }
-    if (typeof context.errors === 'number') {
-      this.errors = context.errors;
-    }
-    if (context.status) {
-      this.status = context.status;
-    }
+  if (context.ignoreDuration) {
+    session.ignoreDuration = context.ignoreDuration;
+  }
+  if (context.sid) {
+    // Good enough uuid validation. — Kamil
+    session.sid = context.sid.length === 32 ? context.sid : uuid4();
+  }
+  if (context.init !== undefined) {
+    session.init = context.init;
+  }
+  if (!session.did && context.did) {
+    session.did = `${context.did}`;
+  }
+  if (typeof context.started === 'number') {
+    session.started = context.started;
+  }
+  if (session.ignoreDuration) {
+    session.duration = undefined;
+  } else if (typeof context.duration === 'number') {
+    session.duration = context.duration;
+  } else {
+    const duration = session.timestamp - (session.started || 0);
+    session.duration = duration >= 0 ? duration : 0;
+  }
+  if (context.release) {
+    session.release = context.release;
+  }
+  if (context.environment) {
+    session.environment = context.environment;
+  }
+  if (!session.ipAddress && context.ipAddress) {
+    session.ipAddress = context.ipAddress;
+  }
+  if (!session.userAgent && context.userAgent) {
+    session.userAgent = context.userAgent;
+  }
+  if (typeof context.errors === 'number') {
+    session.errors = context.errors;
+  }
+  if (context.status) {
+    session.status = context.status;
   }
 
-  /** JSDoc */
-  public close(status?: Exclude<SessionStatus, 'ok'>): void {
-    if (status) {
-      this.update({ status });
-    } else if (this.status === 'ok') {
-      this.update({ status: 'exited' });
-    } else {
-      this.update();
-    }
+  return session;
+}
+
+/**
+ * TODO doc
+ * @param status
+ */
+export function closeSession(session: Session, status?: Exclude<SessionStatus, 'ok'>): Session {
+  let context = {};
+  if (status) {
+    context = { status };
+  } else if (session === 'ok') {
+    context = { status: 'exited' };
   }
 
-  /** JSDoc */
-  public toJSON(): {
-    init: boolean;
-    sid: string;
-    did?: string;
-    timestamp: string;
-    started: string;
-    duration?: number;
-    status: SessionStatus;
-    errors: number;
-    attrs?: {
-      release?: string;
-      environment?: string;
-      user_agent?: string;
-      ip_address?: string;
-    };
-  } {
-    return dropUndefinedKeys({
-      sid: `${this.sid}`,
-      init: this.init,
-      // Make sure that sec is converted to ms for date constructor
-      started: new Date(this.started * 1000).toISOString(),
-      timestamp: new Date(this.timestamp * 1000).toISOString(),
-      status: this.status,
-      errors: this.errors,
-      did: typeof this.did === 'number' || typeof this.did === 'string' ? `${this.did}` : undefined,
-      duration: this.duration,
-      attrs: {
-        release: this.release,
-        environment: this.environment,
-        ip_address: this.ipAddress,
-        user_agent: this.userAgent,
-      },
-    });
-  }
+  return updateSession(session, context);
+}
+
+/**
+ * TODO doc
+ * @returns
+ */
+export function sessionToJSON(session: Session): {
+  init: boolean;
+  sid: string;
+  did?: string;
+  timestamp: string;
+  started: string;
+  duration?: number;
+  status: SessionStatus;
+  errors: number;
+  attrs?: {
+    release?: string;
+    environment?: string;
+    user_agent?: string;
+    ip_address?: string;
+  };
+} {
+  return dropUndefinedKeys({
+    sid: `${session.sid}`,
+    init: session.init !== undefined ? session.init : true,
+    // Make sure that sec is converted to ms for date constructor
+    started: new Date((session.started || 0) * 1000).toISOString(),
+    timestamp: new Date((session.timestamp || 0) * 1000).toISOString(),
+    status: session.status || 'ok',
+    errors: session.errors || 0,
+    did: typeof session.did === 'number' || typeof session.did === 'string' ? `${session.did}` : undefined,
+    duration: session.duration || 0,
+    attrs: {
+      release: session.release,
+      environment: session.environment,
+      ip_address: session.ipAddress,
+      user_agent: session.userAgent,
+    },
+  });
 }

--- a/packages/hub/src/session.ts
+++ b/packages/hub/src/session.ts
@@ -136,7 +136,7 @@ export function closeSession(session: Session, status?: Exclude<SessionStatus, '
 function sessionToJSON(session: Session): SerializedSession {
   return dropUndefinedKeys({
     sid: `${session.sid}`,
-    init: session.init !== undefined ? session.init : true,
+    init: session.init,
     // Make sure that sec is converted to ms for date constructor
     started: new Date(session.started * 1000).toISOString(),
     timestamp: new Date(session.timestamp * 1000).toISOString(),

--- a/packages/hub/test/session.test.ts
+++ b/packages/hub/test/session.test.ts
@@ -1,12 +1,12 @@
 import { SessionContext } from '@sentry/types';
 import { timestampInSeconds } from '@sentry/utils';
 
-import { closeSession, makeSession, sessionToJSON, updateSession } from '../src/session';
+import { closeSession, makeSession, updateSession } from '../src/session';
 
 describe('Session', () => {
   it('initializes with the proper defaults', () => {
     const newSession = makeSession();
-    const session = sessionToJSON(newSession);
+    const session = newSession.toJSON();
 
     // Grab current year to check if we are converting from sec -> ms correctly
     const currentYear = new Date(timestampInSeconds() * 1000).toISOString().slice(0, 4);
@@ -84,10 +84,10 @@ describe('Session', () => {
       const DEFAULT_OUT = { duration: expect.any(Number), timestamp: expect.any(String) };
 
       const session = makeSession();
-      const initSessionProps = sessionToJSON(session);
+      const initSessionProps = session.toJSON();
 
       updateSession(session, test[1]);
-      const updatedSessionProps = sessionToJSON(session);
+      const updatedSessionProps = session.toJSON();
 
       expect(updatedSessionProps).toEqual({ ...initSessionProps, ...DEFAULT_OUT, ...test[2] });
     });

--- a/packages/hub/test/session.test.ts
+++ b/packages/hub/test/session.test.ts
@@ -112,7 +112,7 @@ describe('Session', () => {
       const updatedSession = updateSession(session, { status: 'crashed' });
       expect(updatedSession.status).toEqual('crashed');
 
-      const closedSession = closeSession(session, 'abnormal');
+      const closedSession = closeSession(session, 'crashed');
       expect(closedSession.status).toEqual('crashed');
     });
   });

--- a/packages/hub/test/session.test.ts
+++ b/packages/hub/test/session.test.ts
@@ -1,5 +1,6 @@
 import { SessionContext } from '@sentry/types';
 import { timestampInSeconds } from '@sentry/utils';
+
 import { closeSession, makeSession, sessionToJSON, updateSession } from '../src/session';
 
 describe('Session', () => {

--- a/packages/hub/test/session.test.ts
+++ b/packages/hub/test/session.test.ts
@@ -85,8 +85,9 @@ describe('Session', () => {
       const session = makeSession();
       const initSessionProps = sessionToJSON(session);
 
-      const updatedSession = updateSession(session, test[1]);
-      const updatedSessionProps = sessionToJSON(updatedSession);
+      updateSession(session, test[1]);
+      const updatedSessionProps = sessionToJSON(session);
+
       expect(updatedSessionProps).toEqual({ ...initSessionProps, ...DEFAULT_OUT, ...test[2] });
     });
   });
@@ -95,25 +96,26 @@ describe('Session', () => {
     it('exits a normal session', () => {
       const session = makeSession();
       expect(session.status).toEqual('ok');
-      const closedSession = closeSession(session);
-      expect(closedSession.status).toEqual('exited');
+
+      closeSession(session);
+      expect(session.status).toEqual('exited');
     });
 
     it('updates session status when give status', () => {
       const session = makeSession();
       expect(session.status).toEqual('ok');
 
-      const closedSession = closeSession(session, 'abnormal');
-      expect(closedSession.status).toEqual('abnormal');
+      closeSession(session, 'abnormal');
+      expect(session.status).toEqual('abnormal');
     });
 
     it('only changes status ok to exited', () => {
       const session = makeSession();
-      const updatedSession = updateSession(session, { status: 'crashed' });
-      expect(updatedSession.status).toEqual('crashed');
+      updateSession(session, { status: 'crashed' });
+      expect(session.status).toEqual('crashed');
 
-      const closedSession = closeSession(session, 'crashed');
-      expect(closedSession.status).toEqual('crashed');
+      closeSession(session, 'crashed');
+      expect(session.status).toEqual('crashed');
     });
   });
 });

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -7,6 +7,7 @@ export type {
   EventHint,
   Exception,
   // eslint-disable-next-line deprecation/deprecation
+  Session,
   Severity,
   SeverityLevel,
   StackFrame,
@@ -30,7 +31,6 @@ export {
   Hub,
   makeMain,
   Scope,
-  Session,
   startTransaction,
   SDK_VERSION,
   setContext,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -6,8 +6,8 @@ export type {
   Event,
   EventHint,
   Exception,
-  // eslint-disable-next-line deprecation/deprecation
   Session,
+  // eslint-disable-next-line deprecation/deprecation
   Severity,
   SeverityLevel,
   StackFrame,

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -249,6 +249,6 @@ function startSessionTracking(): void {
     // Terminal Status i.e. Exited or Crashed because
     // "When a session is moved away from ok it must not be updated anymore."
     // Ref: https://develop.sentry.dev/sdk/sessions/
-    if (session && session.status && !terminalStates.includes(session.status)) hub.endSession();
+    if (session && !terminalStates.includes(session.status)) hub.endSession();
   });
 }

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -249,6 +249,6 @@ function startSessionTracking(): void {
     // Terminal Status i.e. Exited or Crashed because
     // "When a session is moved away from ok it must not be updated anymore."
     // Ref: https://develop.sentry.dev/sdk/sessions/
-    if (session && !terminalStates.includes(session.status)) hub.endSession();
+    if (session && session.status && !terminalStates.includes(session.status)) hub.endSession();
   });
 }

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -5,7 +5,7 @@ import { Extra, Extras } from './extra';
 import { Integration, IntegrationClass } from './integration';
 import { Primitive } from './misc';
 import { Scope } from './scope';
-import { Session, SessionContext } from './session';
+import { Session } from './session';
 import { Severity, SeverityLevel } from './severity';
 import { CustomSamplingContext, Transaction, TransactionContext } from './transaction';
 import { User } from './user';
@@ -215,7 +215,7 @@ export interface Hub {
    *
    * @returns The session which was just started
    */
-  startSession(context?: SessionContext): Session;
+  startSession(context?: Session): Session;
 
   /**
    * Ends the session that lives on the current scope and sends it to Sentry

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -7,6 +7,7 @@ export interface RequestSession {
 /**
  * Session Context
  */
+// TODO: make properties required that were set by ctor
 export interface Session {
   sid?: string;
   did?: string;
@@ -24,6 +25,13 @@ export interface Session {
   errors?: number;
   user?: User | null;
   ignoreDuration?: boolean;
+
+  /**
+   * Overrides default JSON serialization of the Session because
+   * the Sentry servers expect a slightly different schema of a session
+   * which is described in the interface @see SerializedSession in this file.
+   */
+  toJSON(): SerializedSession;
 }
 
 export type SessionContext = Partial<Session>;
@@ -59,4 +67,21 @@ export interface AggregationCounts {
   errored?: number;
   exited?: number;
   crashed?: number;
+}
+
+export interface SerializedSession {
+  init: boolean;
+  sid: string;
+  did?: string;
+  timestamp: string;
+  started: string;
+  duration?: number;
+  status: SessionStatus;
+  errors: number;
+  attrs?: {
+    release?: string;
+    environment?: string;
+    user_agent?: string;
+    ip_address?: string;
+  };
 }

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -1,34 +1,5 @@
 import { User } from './user';
 
-/**
- * @inheritdoc
- */
-export interface Session extends SessionContext {
-  /** JSDoc */
-  update(context?: SessionContext): void;
-
-  /** JSDoc */
-  close(status?: SessionStatus): void;
-
-  /** JSDoc */
-  toJSON(): {
-    init: boolean;
-    sid: string;
-    did?: string;
-    timestamp: string;
-    started: string;
-    duration?: number;
-    status: SessionStatus;
-    errors: number;
-    attrs?: {
-      release?: string;
-      environment?: string;
-      user_agent?: string;
-      ip_address?: string;
-    };
-  };
-}
-
 export interface RequestSession {
   status?: RequestSessionStatus;
 }
@@ -36,7 +7,7 @@ export interface RequestSession {
 /**
  * Session Context
  */
-export interface SessionContext {
+export interface Session {
   sid?: string;
   did?: string;
   init?: boolean;
@@ -54,6 +25,8 @@ export interface SessionContext {
   user?: User | null;
   ignoreDuration?: boolean;
 }
+
+export type SessionContext = Partial<Session>;
 
 export type SessionStatus = 'ok' | 'exited' | 'crashed' | 'abnormal';
 export type RequestSessionStatus = 'ok' | 'errored' | 'crashed';

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -9,22 +9,22 @@ export interface RequestSession {
  */
 // TODO: make properties required that were set by ctor
 export interface Session {
-  sid?: string;
+  sid: string;
   did?: string;
-  init?: boolean;
+  init: boolean;
   // seconds since the UNIX epoch
-  timestamp?: number;
+  timestamp: number;
   // seconds since the UNIX epoch
-  started?: number;
+  started: number;
   duration?: number;
-  status?: SessionStatus;
+  status: SessionStatus;
   release?: string;
   environment?: string;
   userAgent?: string;
   ipAddress?: string;
-  errors?: number;
+  errors: number;
   user?: User | null;
-  ignoreDuration?: boolean;
+  ignoreDuration: boolean;
 
   /**
    * Overrides default JSON serialization of the Session because

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -4,10 +4,6 @@ export interface RequestSession {
   status?: RequestSessionStatus;
 }
 
-/**
- * Session Context
- */
-// TODO: make properties required that were set by ctor
 export interface Session {
   sid: string;
   did?: string;
@@ -30,6 +26,8 @@ export interface Session {
    * Overrides default JSON serialization of the Session because
    * the Sentry servers expect a slightly different schema of a session
    * which is described in the interface @see SerializedSession in this file.
+   *
+   * @return a Sentry-backend conforming JSON object of the session
    */
   toJSON(): SerializedSession;
 }


### PR DESCRIPTION
This PR converts the `Session` class to a more FP style `Session` object with additional functions that replace the methods of the class.

API-wise, This PR makes the following changes:
* `new Session(context)` => `makeSession(context)`
* `session.update(context)` => `updateSession(session, context)`
* `session.close(status)` => `closeSession(session, status)`

 `session.toJSON()` is left untouched because this method is called when the Session object is serialized to the JSON object that's sent to the Sentry servers.

Additionally, this PR modifies the session-related interfaces. Interface `Session` now describes the session object while the `SessionContext` interface is used to make modifications to the session by calling `updateSession`.

Note that `updateSession` and `closeSession` mutate the session object that's passed in as a parameter. I originally wanted to return a new, mutated, object and leave the original one untouched instead of changing it. However this is unfortunately not possible (without bigger modifications) as `BaseClient` makes a modification to a session after it's already passed to `sendSession` to keep it from getting re-sent as a new session.

ref: https://getsentry.atlassian.net/browse/WEB-815