### PR TITLE
ref(node): Explicitly pass down node transport options

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -218,8 +218,6 @@ Sentry.init({
   ...
 })
 
-
-
 // Before:
 class MyCustomTransport extends BaseTransport {
   constructor(options: TransportOptions) {
@@ -251,6 +249,30 @@ We recommend calling using the `createTransport` function from `@sentry/core` as
 object with your custom logic, will also take care of rate limiting and flushing.
 
 For a complete v7 transport implementation, take a look at our [browser fetch transport](https://github.com/getsentry/sentry-javascript/blob/ebc938a03d6efe7d0c4bbcb47714e84c9a566a9c/packages/browser/src/transports/fetch.ts#L1-L34).
+
+### Node Transport Changes
+
+To clean up the options interface, we now require users to pass down transport related options under the `transportOptions` key. The options that
+were changed were `caCerts`, `httpProxy`, and `httpsProxy`. In addition, `httpProxy` and `httpsProxy` were unified to a single option under
+the `transportOptions` key, `proxy`.
+
+```ts
+// New in v7:
+Sentry.init({
+  dsn: '...',
+  transportOptions: {
+    caCerts: getMyCaCert(),
+    proxy: 'http://example.com',
+  },
+});
+
+// Before:
+Sentry.init({
+  dsn: '...',
+  caCerts: getMyCaCert(),
+  httpsProxy: 'http://example.com',
+})
+```
 
 ## Enum Changes
 

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -1,17 +1,10 @@
 import { ClientOptions, Options } from '@sentry/types';
 
+import { NodeTransportOptions } from './transports';
+
 export interface BaseNodeOptions {
   /** Sets an optional server name (device name) */
   serverName?: string;
-
-  /** Set a HTTP proxy that should be used for outbound requests. */
-  httpProxy?: string;
-
-  /** Set a HTTPS proxy that should be used for outbound requests. */
-  httpsProxy?: string;
-
-  /** HTTPS proxy certificates path */
-  caCerts?: string;
 
   /** Callback that is executed when a fatal global error occurs. */
   onFatalError?(error: Error): void;
@@ -21,10 +14,10 @@ export interface BaseNodeOptions {
  * Configuration options for the Sentry Node SDK
  * @see @sentry/types Options for more information.
  */
-export interface NodeOptions extends Options, BaseNodeOptions {}
+export interface NodeOptions extends Options<NodeTransportOptions>, BaseNodeOptions {}
 
 /**
  * Configuration options for the Sentry Node SDK Client class
  * @see NodeClient for more information.
  */
-export interface NodeClientOptions extends ClientOptions, BaseNodeOptions {}
+export interface NodeClientOptions extends ClientOptions<NodeTransportOptions>, BaseNodeOptions {}


### PR DESCRIPTION
We enforce the transport types by assigning the generic when typing the
Node Client class (we use `ClientOptions<NodeTransportOptions>`).

To further refine the transport types, we remove the transport options
from the top level of the sdk init and instead require users to pass it
in under the `transportOptions` key explicitly.

Resolves https://getsentry.atlassian.net/browse/WEB-914
