### PR TITLE
ref(build): Use sucrase for `watch` npm builds

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -55,7 +55,7 @@
     "build:bundle:watch": "rollup --config rollup.bundle.config.js --watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
-    "build:dev:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
+    "build:dev:watch": "run-p build:rollup:watch build:types:watch",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:rollup:watch": "rollup -c rollup.npm.config.js --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -51,7 +51,7 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:rollup": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",
-    "build:watch": "run-p build:cjs:watch build:esm:watch build:bundle:watch build:types:watch",
+    "build:watch": "run-p build:rollup:watch build:bundle:watch build:types:watch",
     "build:bundle:watch": "rollup --config rollup.bundle.config.js --watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,7 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:rollup": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",
-    "build:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
+    "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:dev:watch": "run-s build:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -43,7 +43,7 @@
     "build:plugin": "tsc -p tsconfig.plugin.json",
     "build:rollup": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",
-    "build:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
+    "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:dev:watch": "run-s build:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -28,7 +28,7 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:rollup": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",
-    "build:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
+    "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:dev:watch": "run-s build:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -33,7 +33,7 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:rollup": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",
-    "build:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
+    "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:dev:watch": "run-s build:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -50,7 +50,7 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:rollup": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",
-    "build:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
+    "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:dev:watch": "run-s build:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -41,7 +41,7 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:rollup": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",
-    "build:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
+    "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:dev:watch": "run-s build:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -55,7 +55,7 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:rollup": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",
-    "build:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
+    "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:dev:watch": "run-s build:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -46,7 +46,7 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:rollup": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",
-    "build:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
+    "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:dev:watch": "run-s build:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -34,7 +34,7 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:rollup": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",
-    "build:watch": "run-p build:cjs:watch build:esm:watch build:bundle:watch build:types:watch",
+    "build:watch": "run-p build:rollup:watch build:bundle:watch build:types:watch",
     "build:bundle:watch": "rollup --config rollup.bundle.config.js --watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:dev:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -37,7 +37,7 @@
     "build:watch": "run-p build:rollup:watch build:bundle:watch build:types:watch",
     "build:bundle:watch": "rollup --config rollup.bundle.config.js --watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
-    "build:dev:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
+    "build:dev:watch": "run-p build:rollup:watch build:types:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:rollup:watch": "rollup -c rollup.npm.config.js --watch",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -23,7 +23,7 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:rollup": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",
-    "build:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
+    "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:dev:watch": "run-s build:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -32,7 +32,7 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:rollup": "yarn ts-node scripts/buildRollup.ts",
     "build:types": "tsc -p tsconfig.types.json",
-    "build:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
+    "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:dev:watch": "run-s build:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -34,7 +34,7 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:rollup": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",
-    "build:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
+    "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:bundle:watch": "rollup --config --watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:dev:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -37,7 +37,7 @@
     "build:watch": "run-p build:rollup:watch build:types:watch",
     "build:bundle:watch": "rollup --config --watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
-    "build:dev:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
+    "build:dev:watch": "run-p build:rollup:watch build:types:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:rollup:watch": "rollup -c rollup.npm.config.js --watch",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -41,7 +41,7 @@
     "build:watch": "run-p build:rollup:watch build:bundle:watch build:types:watch",
     "build:bundle:watch": "rollup --config rollup.bundle.config.js --watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
-    "build:dev:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
+    "build:dev:watch": "run-p build:rollup:watch build:types:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:esm:watch": "tsc -p tsconfig.esm.json --watch",
     "build:rollup:watch": "rollup -c rollup.npm.config.js --watch",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -38,7 +38,7 @@
     "build:esm": "tsc -p tsconfig.esm.json",
     "build:rollup": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",
-    "build:watch": "run-p build:cjs:watch build:esm:watch build:bundle:watch build:types:watch",
+    "build:watch": "run-p build:rollup:watch build:bundle:watch build:types:watch",
     "build:bundle:watch": "rollup --config rollup.bundle.config.js --watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:dev:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",


### PR DESCRIPTION
This follows up on https://github.com/getsentry/sentry-javascript/pull/5035, which switched our main build commands to use rollup and sucrase instead of tsc, and brings that same change to our `build:watch` commands.

Note: Running either of these `watch` commands produces different feedback than the `tsc` watch commands we're used to, in that the `build:types` component auto-watches dependencies (and will trigger a cascading rebuild on change), but the `build:rollup` component doesn't (and therefore only rebuilds the changed package). The reason for this is that sucrase and rollup are truly only *trans*piling (IOW, smushing the code touching other packages around in a non-semantic way, only really worried about whether it's legal JS, not whether it plays the way it should with those other packages), not *com*piling (actually understanding the entire, cross-package AST and refusing to produce code if the interfaces between packages don't match up). The utility of `tsc`'s rebuild of dependent packages was never actually to change the built code of those packages, it was just that the rebuild attempt forced a cascading typecheck, so we could know what _we_ had to change in the dependent packages' code. The process building types still serves this function, but the process building code doesn't need to and therefore there's no need for the cascade. (As you'll see in the conversation below, I myself was fuzzy on this point at first, which is why I'm spelling it out here quite so explicitly, in case any future readers stumble into the same wrong assumptions I did.)