### PR TITLE
fix(utils): Consider 429 responses in transports

### DIFF
--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -23,6 +23,7 @@ export function makeFetchTransport(
     };
 
     return nativeFetch(options.url, requestOptions).then(response => ({
+      statusCode: response.status,
       headers: {
         'x-sentry-rate-limits': response.headers.get('X-Sentry-Rate-Limits'),
         'retry-after': response.headers.get('Retry-After'),

--- a/packages/browser/src/transports/xhr.ts
+++ b/packages/browser/src/transports/xhr.ts
@@ -28,13 +28,13 @@ export function makeXHRTransport(options: XHRTransportOptions): Transport {
 
       xhr.onreadystatechange = (): void => {
         if (xhr.readyState === XHR_READYSTATE_DONE) {
-          const response = {
+          resolve({
+            statusCode: xhr.status,
             headers: {
               'x-sentry-rate-limits': xhr.getResponseHeader('X-Sentry-Rate-Limits'),
               'retry-after': xhr.getResponseHeader('Retry-After'),
             },
-          };
-          resolve(response);
+          });
         }
       };
 

--- a/packages/core/src/transports/base.ts
+++ b/packages/core/src/transports/base.ts
@@ -70,10 +70,8 @@ export function createTransport(
 
     const requestTask = (): PromiseLike<void> =>
       makeRequest({ body: serializeEnvelope(filteredEnvelope) }).then(
-        ({ headers, statusCode }): void => {
-          if (headers) {
-            rateLimits = updateRateLimits(rateLimits, { statusCode, headers });
-          }
+        response => {
+          rateLimits = updateRateLimits(rateLimits, response);
         },
         error => {
           IS_DEBUG_BUILD && logger.error('Failed while sending event:', error);

--- a/packages/core/src/transports/base.ts
+++ b/packages/core/src/transports/base.ts
@@ -70,13 +70,13 @@ export function createTransport(
 
     const requestTask = (): PromiseLike<void> =>
       makeRequest({ body: serializeEnvelope(filteredEnvelope) }).then(
-        ({ headers }): void => {
+        ({ headers, statusCode }): void => {
           if (headers) {
-            rateLimits = updateRateLimits(rateLimits, headers);
+            rateLimits = updateRateLimits(rateLimits, { statusCode, headers });
           }
         },
         error => {
-          IS_DEBUG_BUILD && logger.error('Failed while recording event:', error);
+          IS_DEBUG_BUILD && logger.error('Failed while sending event:', error);
           recordEnvelopeLoss('network_error');
         },
       );

--- a/packages/node/src/transports/http.ts
+++ b/packages/node/src/transports/http.ts
@@ -113,6 +113,7 @@ function createRequestExecutor(
           const rateLimitsHeader = res.headers['x-sentry-rate-limits'] ?? null;
 
           resolve({
+            statusCode: res.statusCode,
             headers: {
               'retry-after': retryAfterHeader,
               'x-sentry-rate-limits': Array.isArray(rateLimitsHeader) ? rateLimitsHeader[0] : rateLimitsHeader,

--- a/packages/node/test/transports/http.test.ts
+++ b/packages/node/test/transports/http.test.ts
@@ -237,10 +237,7 @@ describe('makeNewHttpTransport()', () => {
   it('should register TransportRequestExecutor that returns the correct object from server response (rate limit)', async () => {
     await setupTestServer({
       statusCode: RATE_LIMIT,
-      responseHeaders: {
-        'Retry-After': '2700',
-        'X-Sentry-Rate-Limits': '60::organization, 2700::organization',
-      },
+      responseHeaders: {},
     });
 
     makeNodeTransport(defaultOptions);
@@ -253,10 +250,7 @@ describe('makeNewHttpTransport()', () => {
 
     await expect(executorResult).resolves.toEqual(
       expect.objectContaining({
-        headers: {
-          'retry-after': '2700',
-          'x-sentry-rate-limits': '60::organization, 2700::organization',
-        },
+        statusCode: RATE_LIMIT,
       }),
     );
   });
@@ -276,6 +270,7 @@ describe('makeNewHttpTransport()', () => {
 
     await expect(executorResult).resolves.toEqual(
       expect.objectContaining({
+        statusCode: SUCCESS,
         headers: {
           'retry-after': null,
           'x-sentry-rate-limits': null,
@@ -303,6 +298,7 @@ describe('makeNewHttpTransport()', () => {
 
     await expect(executorResult).resolves.toEqual(
       expect.objectContaining({
+        statusCode: SUCCESS,
         headers: {
           'retry-after': '2700',
           'x-sentry-rate-limits': '60::organization, 2700::organization',
@@ -330,6 +326,7 @@ describe('makeNewHttpTransport()', () => {
 
     await expect(executorResult).resolves.toEqual(
       expect.objectContaining({
+        statusCode: RATE_LIMIT,
         headers: {
           'retry-after': '2700',
           'x-sentry-rate-limits': '60::organization, 2700::organization',

--- a/packages/node/test/transports/https.test.ts
+++ b/packages/node/test/transports/https.test.ts
@@ -290,10 +290,7 @@ describe('makeNewHttpsTransport()', () => {
   it('should register TransportRequestExecutor that returns the correct object from server response (rate limit)', async () => {
     await setupTestServer({
       statusCode: RATE_LIMIT,
-      responseHeaders: {
-        'Retry-After': '2700',
-        'X-Sentry-Rate-Limits': '60::organization, 2700::organization',
-      },
+      responseHeaders: {},
     });
 
     makeNodeTransport(defaultOptions);
@@ -306,10 +303,7 @@ describe('makeNewHttpsTransport()', () => {
 
     await expect(executorResult).resolves.toEqual(
       expect.objectContaining({
-        headers: {
-          'retry-after': '2700',
-          'x-sentry-rate-limits': '60::organization, 2700::organization',
-        },
+        statusCode: RATE_LIMIT,
       }),
     );
   });
@@ -329,6 +323,7 @@ describe('makeNewHttpsTransport()', () => {
 
     await expect(executorResult).resolves.toEqual(
       expect.objectContaining({
+        statusCode: SUCCESS,
         headers: {
           'retry-after': null,
           'x-sentry-rate-limits': null,
@@ -356,6 +351,7 @@ describe('makeNewHttpsTransport()', () => {
 
     await expect(executorResult).resolves.toEqual(
       expect.objectContaining({
+        statusCode: SUCCESS,
         headers: {
           'retry-after': '2700',
           'x-sentry-rate-limits': '60::organization, 2700::organization',
@@ -383,6 +379,7 @@ describe('makeNewHttpsTransport()', () => {
 
     await expect(executorResult).resolves.toEqual(
       expect.objectContaining({
+        statusCode: RATE_LIMIT,
         headers: {
           'retry-after': '2700',
           'x-sentry-rate-limits': '60::organization, 2700::organization',

--- a/packages/types/src/transport.ts
+++ b/packages/types/src/transport.ts
@@ -7,6 +7,7 @@ export type TransportRequest = {
 };
 
 export type TransportMakeRequestResponse = {
+  statusCode?: number;
   headers?: {
     [key: string]: string | null;
     'x-sentry-rate-limits': string | null;

--- a/packages/utils/src/ratelimit.ts
+++ b/packages/utils/src/ratelimit.ts
@@ -1,3 +1,5 @@
+import { TransportMakeRequestResponse } from '@sentry/types';
+
 // Intentionally keeping the key broad, as we don't know for sure what rate limit headers get returned from backend
 export type RateLimits = Record<string, number>;
 
@@ -43,13 +45,10 @@ export function isRateLimited(limits: RateLimits, category: string, now: number 
  */
 export function updateRateLimits(
   limits: RateLimits,
-  newRateLimitParameters: {
-    statusCode?: number;
-    headers?: Record<string, string | null | undefined>;
-  },
+  newRateLimitParameters: TransportMakeRequestResponse,
   now: number = Date.now(),
 ): RateLimits {
-  const { statusCode, headers = {} } = newRateLimitParameters;
+  const { statusCode, headers } = newRateLimitParameters;
 
   const updatedRateLimits: RateLimits = {
     ...limits,
@@ -57,8 +56,8 @@ export function updateRateLimits(
 
   // "The name is case-insensitive."
   // https://developer.mozilla.org/en-US/docs/Web/API/Headers/get
-  const rateLimitHeader = headers['x-sentry-rate-limits'];
-  const retryAfterHeader = headers['retry-after'];
+  const rateLimitHeader = headers && headers['x-sentry-rate-limits'];
+  const retryAfterHeader = headers && headers['retry-after'];
 
   if (rateLimitHeader) {
     /**

--- a/packages/utils/src/ratelimit.ts
+++ b/packages/utils/src/ratelimit.ts
@@ -45,11 +45,9 @@ export function isRateLimited(limits: RateLimits, category: string, now: number 
  */
 export function updateRateLimits(
   limits: RateLimits,
-  newRateLimitParameters: TransportMakeRequestResponse,
+  { statusCode, headers }: TransportMakeRequestResponse,
   now: number = Date.now(),
 ): RateLimits {
-  const { statusCode, headers } = newRateLimitParameters;
-
   const updatedRateLimits: RateLimits = {
     ...limits,
   };

--- a/packages/utils/test/ratelimit.test.ts
+++ b/packages/utils/test/ratelimit.test.ts
@@ -72,7 +72,7 @@ describe('updateRateLimits()', () => {
     const headers = {
       'retry-after': '42',
     };
-    const updatedRateLimits = updateRateLimits(rateLimits, headers, 0);
+    const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
     expect(updatedRateLimits.all).toEqual(42 * 1000);
   });
 
@@ -81,7 +81,7 @@ describe('updateRateLimits()', () => {
     const headers = {
       'x-sentry-rate-limits': '13:error',
     };
-    const updatedRateLimits = updateRateLimits(rateLimits, headers, 0);
+    const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
     expect(updatedRateLimits.error).toEqual(13 * 1000);
   });
 
@@ -90,7 +90,7 @@ describe('updateRateLimits()', () => {
     const headers = {
       'x-sentry-rate-limits': '13:error;transaction',
     };
-    const updatedRateLimits = updateRateLimits(rateLimits, headers, 0);
+    const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
     expect(updatedRateLimits.error).toEqual(13 * 1000);
     expect(updatedRateLimits.transaction).toEqual(13 * 1000);
   });
@@ -100,7 +100,7 @@ describe('updateRateLimits()', () => {
     const headers = {
       'x-sentry-rate-limits': '13:error,15:transaction',
     };
-    const updatedRateLimits = updateRateLimits(rateLimits, headers, 0);
+    const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
     expect(updatedRateLimits.error).toEqual(13 * 1000);
     expect(updatedRateLimits.transaction).toEqual(15 * 1000);
   });
@@ -110,7 +110,7 @@ describe('updateRateLimits()', () => {
     const headers = {
       'x-sentry-rate-limits': '13:error,15:transaction;error',
     };
-    const updatedRateLimits = updateRateLimits(rateLimits, headers, 0);
+    const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
     expect(updatedRateLimits.error).toEqual(15 * 1000);
     expect(updatedRateLimits.transaction).toEqual(15 * 1000);
   });
@@ -120,7 +120,7 @@ describe('updateRateLimits()', () => {
     const headers = {
       'x-sentry-rate-limits': '13',
     };
-    const updatedRateLimits = updateRateLimits(rateLimits, headers, 0);
+    const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
     expect(updatedRateLimits.all).toEqual(13 * 1000);
   });
 
@@ -129,7 +129,7 @@ describe('updateRateLimits()', () => {
     const headers = {
       'x-sentry-rate-limits': 'x',
     };
-    const updatedRateLimits = updateRateLimits(rateLimits, headers, 0);
+    const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
     expect(updatedRateLimits.all).toEqual(60 * 1000);
   });
 
@@ -140,7 +140,7 @@ describe('updateRateLimits()', () => {
     const headers = {
       'x-sentry-rate-limits': '13:transaction',
     };
-    const updatedRateLimits = updateRateLimits(rateLimits, headers, 0);
+    const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
     expect(updatedRateLimits.error).toEqual(1337);
     expect(updatedRateLimits.transaction).toEqual(13 * 1000);
   });
@@ -151,7 +151,7 @@ describe('updateRateLimits()', () => {
       'retry-after': '42',
       'x-sentry-rate-limits': '13:error',
     };
-    const updatedRateLimits = updateRateLimits(rateLimits, headers, 0);
+    const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
     expect(updatedRateLimits.error).toEqual(13 * 1000);
     expect(updatedRateLimits.all).toBeUndefined();
   });

--- a/packages/utils/test/ratelimit.test.ts
+++ b/packages/utils/test/ratelimit.test.ts
@@ -155,4 +155,28 @@ describe('updateRateLimits()', () => {
     expect(updatedRateLimits.error).toEqual(13 * 1000);
     expect(updatedRateLimits.all).toBeUndefined();
   });
+
+  test('should apply a global rate limit of 60s when no headers are provided on a 429 status code', () => {
+    const rateLimits: RateLimits = {};
+    const headers = {};
+    const updatedRateLimits = updateRateLimits(rateLimits, { statusCode: 429, headers }, 0);
+    expect(updatedRateLimits.all).toBe(60_000);
+  });
+
+  test('should not apply a global rate limit specific headers are provided on a 429 status code', () => {
+    const rateLimits: RateLimits = {};
+    const headers = {
+      'x-sentry-rate-limits': '13:error',
+    };
+    const updatedRateLimits = updateRateLimits(rateLimits, { statusCode: 429, headers }, 0);
+    expect(updatedRateLimits.error).toEqual(13 * 1000);
+    expect(updatedRateLimits.all).toBeUndefined();
+  });
+
+  test('should not apply a default rate limit on a non-429 status code', () => {
+    const rateLimits: RateLimits = {};
+    const headers = {};
+    const updatedRateLimits = updateRateLimits(rateLimits, { statusCode: 200, headers }, 0);
+    expect(updatedRateLimits).toEqual(rateLimits);
+  });
 });

--- a/packages/utils/test/ratelimit.test.ts
+++ b/packages/utils/test/ratelimit.test.ts
@@ -70,6 +70,7 @@ describe('updateRateLimits()', () => {
   test('should update the `all` category based on `retry-after` header ', () => {
     const rateLimits: RateLimits = {};
     const headers = {
+      'x-sentry-rate-limits': null,
       'retry-after': '42',
     };
     const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
@@ -79,6 +80,7 @@ describe('updateRateLimits()', () => {
   test('should update a single category based on `x-sentry-rate-limits` header', () => {
     const rateLimits: RateLimits = {};
     const headers = {
+      'retry-after': null,
       'x-sentry-rate-limits': '13:error',
     };
     const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
@@ -88,6 +90,7 @@ describe('updateRateLimits()', () => {
   test('should update multiple categories based on `x-sentry-rate-limits` header', () => {
     const rateLimits: RateLimits = {};
     const headers = {
+      'retry-after': null,
       'x-sentry-rate-limits': '13:error;transaction',
     };
     const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
@@ -98,6 +101,7 @@ describe('updateRateLimits()', () => {
   test('should update multiple categories with different values based on multi `x-sentry-rate-limits` header', () => {
     const rateLimits: RateLimits = {};
     const headers = {
+      'retry-after': null,
       'x-sentry-rate-limits': '13:error,15:transaction',
     };
     const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
@@ -108,6 +112,7 @@ describe('updateRateLimits()', () => {
   test('should use last entry from multi `x-sentry-rate-limits` header for a given category', () => {
     const rateLimits: RateLimits = {};
     const headers = {
+      'retry-after': null,
       'x-sentry-rate-limits': '13:error,15:transaction;error',
     };
     const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
@@ -118,6 +123,7 @@ describe('updateRateLimits()', () => {
   test('should fallback to `all` if `x-sentry-rate-limits` header is missing a category', () => {
     const rateLimits: RateLimits = {};
     const headers = {
+      'retry-after': null,
       'x-sentry-rate-limits': '13',
     };
     const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
@@ -127,6 +133,7 @@ describe('updateRateLimits()', () => {
   test('should use 60s default if delay in `x-sentry-rate-limits` header is malformed', () => {
     const rateLimits: RateLimits = {};
     const headers = {
+      'retry-after': null,
       'x-sentry-rate-limits': 'x',
     };
     const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
@@ -138,6 +145,7 @@ describe('updateRateLimits()', () => {
       error: 1337,
     };
     const headers = {
+      'retry-after': null,
       'x-sentry-rate-limits': '13:transaction',
     };
     const updatedRateLimits = updateRateLimits(rateLimits, { headers }, 0);
@@ -158,14 +166,14 @@ describe('updateRateLimits()', () => {
 
   test('should apply a global rate limit of 60s when no headers are provided on a 429 status code', () => {
     const rateLimits: RateLimits = {};
-    const headers = {};
-    const updatedRateLimits = updateRateLimits(rateLimits, { statusCode: 429, headers }, 0);
+    const updatedRateLimits = updateRateLimits(rateLimits, { statusCode: 429 }, 0);
     expect(updatedRateLimits.all).toBe(60_000);
   });
 
   test('should not apply a global rate limit specific headers are provided on a 429 status code', () => {
     const rateLimits: RateLimits = {};
     const headers = {
+      'retry-after': null,
       'x-sentry-rate-limits': '13:error',
     };
     const updatedRateLimits = updateRateLimits(rateLimits, { statusCode: 429, headers }, 0);
@@ -175,8 +183,7 @@ describe('updateRateLimits()', () => {
 
   test('should not apply a default rate limit on a non-429 status code', () => {
     const rateLimits: RateLimits = {};
-    const headers = {};
-    const updatedRateLimits = updateRateLimits(rateLimits, { statusCode: 200, headers }, 0);
+    const updatedRateLimits = updateRateLimits(rateLimits, { statusCode: 200 }, 0);
     expect(updatedRateLimits).toEqual(rateLimits);
   });
 });


### PR DESCRIPTION
Fixes rate limiting by conforming to the rate limiting spec: https://develop.sentry.dev/sdk/rate-limiting/#stage-1-parse-response-headers

Ref: https://getsentry.atlassian.net/browse/WEB-908