### PR TITLE
log errors regardless of `ignoreSentryErrors`

### DIFF
--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -318,8 +318,10 @@ export function wrapHandler<TEvent, TResult>(
       transaction.finish();
       hub.popScope();
       await flush(options.flushTimeout).catch(e => {
+        // logging regardless of ignoreSentryErrors makes it possible to detect issues with sentry
+        // using logs; otherwise, things like oversized payloads fail completely silently.
+        logger.error(e)
         if (options.ignoreSentryErrors && e instanceof SentryError) {
-          IS_DEBUG_BUILD && logger.error(e);
           return;
         }
         throw e;

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -320,7 +320,7 @@ export function wrapHandler<TEvent, TResult>(
       await flush(options.flushTimeout).catch(e => {
         // logging regardless of ignoreSentryErrors makes it possible to detect issues with sentry
         // using logs; otherwise, things like oversized payloads fail completely silently.
-        logger.error(e)
+        logger.error(e);
         if (options.ignoreSentryErrors && e instanceof SentryError) {
           return;
         }


### PR DESCRIPTION
If we don't even log anything when `ignoreSentryErrors` is enabled, it is impossible to tell when there's something wrong with the integration. For example, when transaction payloads get too big and we start getting 413s from Sentry's service, the options are a. cause 500s in the service that's being monitored (worst possible outcome) or b. have zero way to tell it's happening. This introduces c. make it possible to add a warning alarm on occurences of sentry errors in the logs.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
