### PR TITLE
ref(nextjs): Use new build process in vercel script

### DIFF
--- a/packages/nextjs/vercel/install-sentry-from-branch.sh
+++ b/packages/nextjs/vercel/install-sentry-from-branch.sh
@@ -53,7 +53,7 @@ PACKAGE_NAMES=$(ls $PACKAGES_DIR)
 for package in ${PACKAGE_NAMES[@]}; do
   # Within a given package.json file, search for each of the other packages in turn, and if found, make the replacement
   for package_dep in ${PACKAGE_NAMES[@]}; do
-    sed -Ei /"@sentry\/${package_dep}"/s/"[0-9]+\.[0-9]+\.[0-9]+"/"file:${ESCAPED_PACKAGES_DIR}\/${package_dep}"/ ${PACKAGES_DIR}/${package}/package.json
+    sed -Ei /"@sentry\/${package_dep}"/s/"[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?"/"file:${ESCAPED_PACKAGES_DIR}\/${package_dep}"/ ${PACKAGES_DIR}/${package}/package.json
   done
 done
 

--- a/packages/nextjs/vercel/install-sentry-from-branch.sh
+++ b/packages/nextjs/vercel/install-sentry-from-branch.sh
@@ -27,13 +27,8 @@ yarn --prod false
 
 echo " "
 echo "BUILDING SDK"
-# Types are required for any type of build to succeed
-yarn build:types
-# We need to build es5 versions because `next.config.js` calls `require` on the SDK (to get `withSentryConfig`) and
-# therefore it looks for `cjs/index.js`
-yarn build:cjs
-# We need to build esm versions because that's what `next` actually uses when it builds the app
-yarn build:esm
+# build types, cjs, and esm
+yarn build:dev
 
 # Set all packages in the repo to point to their siblings as file dependencies. That way, when we install the local copy
 # of @sentry/nextjs, it'll pull the local copy of each of its @sentry/* dependents. This mimics what Lerna does with


### PR DESCRIPTION
This updates the script for testing an SDK branch in Vercel to use the new build process. It also updates the regex used to match version numbers when updating monorepo dependencies' `package.json` files, to accept alpha and beta releases.
