### PR TITLE
feat(utils): Introduce Baggage API

### DIFF
--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -8,11 +8,11 @@ export type BaggageObj = Partial<Record<AllowedBaggageKeys, string> & Record<str
  * It is expected that users interact with baggage using the helpers methods:
  * `createBaggage`, `getBaggageValue`, and `setBaggageValue`.
  *
- * Internally, the baggage data structure is a tuple of length 2, seperating baggage values
+ * Internally, the baggage data structure is a tuple of length 2, separating baggage values
  * based on if they are related to Sentry or not. If the baggage values are
  * set/used by sentry, they will be stored in an object to be easily accessed.
  * If they are not, they are kept as a string to be only accessed when serialized
- * at baggage propogation time.
+ * at baggage propagation time.
  */
 export type Baggage = [BaggageObj, string];
 

--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -1,0 +1,54 @@
+export type AllowedBaggageKeys = 'environment' | 'release'; // TODO: Add remaining allowed baggage keys | 'transaction' | 'userid' | 'usersegment';
+export type Baggage = Partial<Record<AllowedBaggageKeys, string> & Record<string, string>>;
+
+export const BAGGAGE_HEADER_NAME = 'baggage';
+
+/**
+ * Max length of a serialized baggage string
+ *
+ * https://www.w3.org/TR/baggage/#limits
+ */
+export const MAX_BAGGAGE_STRING_LENGTH = 8192;
+
+/** Create an instance of Baggage */
+export function createBaggage(initItems: Baggage): Baggage {
+  return { ...initItems };
+}
+
+/** Add a value to baggage */
+export function getBaggageValue(baggage: Baggage, key: keyof Baggage): Baggage[keyof Baggage] {
+  return baggage[key];
+}
+
+/** Add a value to baggage */
+export function setBaggageValue(baggage: Baggage, key: keyof Baggage, value: Baggage[keyof Baggage]): void {
+  baggage[key] = value;
+}
+
+/** remove a value from baggage */
+// TODO: Is this even useful?
+// export function removeBaggageValue(baggage: Baggage, key: keyof Baggage): void {
+//   // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+//   delete baggage[key];
+// }
+
+/** Serialize a baggage object */
+export function serializeBaggage(baggage: Baggage): string {
+  return Object.keys(baggage).reduce((prev, key) => {
+    const newVal = `${prev};${key}=${baggage[key as keyof Baggage]}`;
+    return newVal.length > MAX_BAGGAGE_STRING_LENGTH ? prev : newVal;
+  }, '');
+}
+
+/** Parse a baggage header to a string */
+export function parseBaggageString(baggageString: string): Baggage {
+  // TODO: Should we check validity with regex? How much should we check for malformed baggage keys?
+  // Perhaps we shouldn't worry about this being used in the frontend, so bundle size isn't that much of a concern
+  return baggageString.split(';').reduce((prevBaggage, curr) => {
+    const [key, val] = curr.split('=');
+    return {
+      ...prevBaggage,
+      [key]: val,
+    };
+  }, {} as Baggage);
+}

--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -1,7 +1,14 @@
 export type AllowedBaggageKeys = 'environment' | 'release'; // TODO: Add remaining allowed baggage keys | 'transaction' | 'userid' | 'usersegment';
-export type Baggage = Partial<Record<AllowedBaggageKeys, string> & Record<string, string>>;
+export type BaggageObj = Partial<Record<AllowedBaggageKeys, string> & Record<string, string>>;
+export type Baggage = [BaggageObj, string];
 
 export const BAGGAGE_HEADER_NAME = 'baggage';
+
+export const SENTRY_BAGGAGE_KEY_PREFIX = 'sentry-';
+
+export const SENTRY_BAGGAGE_KEY_PREFIX_REGEX = /^sentry-/;
+
+// baggage = sentry-environment=prod;my-info=true;
 
 /**
  * Max length of a serialized baggage string
@@ -11,44 +18,46 @@ export const BAGGAGE_HEADER_NAME = 'baggage';
 export const MAX_BAGGAGE_STRING_LENGTH = 8192;
 
 /** Create an instance of Baggage */
-export function createBaggage(initItems: Baggage): Baggage {
-  return { ...initItems };
+export function createBaggage(initItems: BaggageObj, baggageString: string = ''): Baggage {
+  return [{ ...initItems }, baggageString];
 }
 
 /** Add a value to baggage */
-export function getBaggageValue(baggage: Baggage, key: keyof Baggage): Baggage[keyof Baggage] {
-  return baggage[key];
+export function getBaggageValue(baggage: Baggage, key: keyof BaggageObj): BaggageObj[keyof BaggageObj] {
+  return baggage[0][key];
 }
 
 /** Add a value to baggage */
-export function setBaggageValue(baggage: Baggage, key: keyof Baggage, value: Baggage[keyof Baggage]): void {
-  baggage[key] = value;
+export function setBaggageValue(baggage: Baggage, key: keyof BaggageObj, value: BaggageObj[keyof BaggageObj]): void {
+  baggage[0][key] = value;
 }
-
-/** remove a value from baggage */
-// TODO: Is this even useful?
-// export function removeBaggageValue(baggage: Baggage, key: keyof Baggage): void {
-//   // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-//   delete baggage[key];
-// }
 
 /** Serialize a baggage object */
 export function serializeBaggage(baggage: Baggage): string {
-  return Object.keys(baggage).reduce((prev, key) => {
-    const newVal = `${prev};${key}=${baggage[key as keyof Baggage]}`;
+  return Object.keys(baggage[0]).reduce((prev, key) => {
+    const baggageEntry = `${SENTRY_BAGGAGE_KEY_PREFIX}${key}=${baggage[0][key as keyof BaggageObj]}`;
+    const newVal = prev === '' ? baggageEntry : `${prev},${baggageEntry}`;
     return newVal.length > MAX_BAGGAGE_STRING_LENGTH ? prev : newVal;
-  }, '');
+  }, baggage[1]);
 }
 
 /** Parse a baggage header to a string */
 export function parseBaggageString(baggageString: string): Baggage {
-  // TODO: Should we check validity with regex? How much should we check for malformed baggage keys?
-  // Perhaps we shouldn't worry about this being used in the frontend, so bundle size isn't that much of a concern
-  return baggageString.split(';').reduce((prevBaggage, curr) => {
-    const [key, val] = curr.split('=');
-    return {
-      ...prevBaggage,
-      [key]: val,
-    };
-  }, {} as Baggage);
+  return baggageString.split(',').reduce(
+    ([baggageObj, baggageString], curr) => {
+      const [key, val] = curr.split('=');
+      if (SENTRY_BAGGAGE_KEY_PREFIX_REGEX.test(key)) {
+        return [
+          {
+            ...baggageObj,
+            [key.split('-')[1]]: val,
+          },
+          baggageString,
+        ];
+      } else {
+        return [baggageObj, baggageString === '' ? curr : `${baggageString},${curr}`];
+      }
+    },
+    [{}, ''],
+  );
 }

--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -1,5 +1,19 @@
 export type AllowedBaggageKeys = 'environment' | 'release'; // TODO: Add remaining allowed baggage keys | 'transaction' | 'userid' | 'usersegment';
 export type BaggageObj = Partial<Record<AllowedBaggageKeys, string> & Record<string, string>>;
+
+/**
+ * The baggage data structure represents key,value pairs based on the baggage
+ * spec: https://www.w3.org/TR/baggage
+ *
+ * It is expected that users interact with baggage using the helpers methods:
+ * `createBaggage`, `getBaggageValue`, and `setBaggageValue`.
+ *
+ * Internally, the baggage data structure is a tuple of length 2, seperating baggage values
+ * based on if they are related to Sentry or not. If the baggage values are
+ * set/used by sentry, they will be stored in an object to be easily accessed.
+ * If they are not, they are kept as a string to be only accessed when serialized
+ * at baggage propogation time.
+ */
 export type Baggage = [BaggageObj, string];
 
 export const BAGGAGE_HEADER_NAME = 'baggage';
@@ -7,8 +21,6 @@ export const BAGGAGE_HEADER_NAME = 'baggage';
 export const SENTRY_BAGGAGE_KEY_PREFIX = 'sentry-';
 
 export const SENTRY_BAGGAGE_KEY_PREFIX_REGEX = /^sentry-/;
-
-// baggage = sentry-environment=prod;my-info=true;
 
 /**
  * Max length of a serialized baggage string
@@ -35,7 +47,8 @@ export function setBaggageValue(baggage: Baggage, key: keyof BaggageObj, value: 
 /** Serialize a baggage object */
 export function serializeBaggage(baggage: Baggage): string {
   return Object.keys(baggage[0]).reduce((prev, key) => {
-    const baggageEntry = `${SENTRY_BAGGAGE_KEY_PREFIX}${key}=${baggage[0][key as keyof BaggageObj]}`;
+    const val = baggage[0][key as keyof BaggageObj] as string;
+    const baggageEntry = `${SENTRY_BAGGAGE_KEY_PREFIX}${encodeURIComponent(key)}=${encodeURIComponent(val)}`;
     const newVal = prev === '' ? baggageEntry : `${prev},${baggageEntry}`;
     return newVal.length > MAX_BAGGAGE_STRING_LENGTH ? prev : newVal;
   }, baggage[1]);
@@ -47,10 +60,11 @@ export function parseBaggageString(baggageString: string): Baggage {
     ([baggageObj, baggageString], curr) => {
       const [key, val] = curr.split('=');
       if (SENTRY_BAGGAGE_KEY_PREFIX_REGEX.test(key)) {
+        const baggageKey = decodeURIComponent(key.split('-')[1]);
         return [
           {
             ...baggageObj,
-            [key.split('-')[1]]: val,
+            [baggageKey]: decodeURIComponent(val),
           },
           baggageString,
         ];

--- a/packages/utils/test/baggage.test.ts
+++ b/packages/utils/test/baggage.test.ts
@@ -1,0 +1,25 @@
+import { createBaggage, getBaggageValue } from '../src/baggage';
+
+describe('Baggage', () => {
+  describe('createBaggage', () => {
+    it.each([
+      ['creates an empty baggage instance', {}, {}],
+      [
+        'creates a baggage instance with initial values',
+        { environment: 'production', anyKey: 'anyValue' },
+        { environment: 'production', anyKey: 'anyValue' },
+      ],
+    ])('%s', (_: string, input, output) => {
+      expect(createBaggage(input)).toEqual(output);
+    });
+  });
+
+  describe('getBaggageValue', () => {
+    it.each([
+      ['gets a baggage item', { environment: 'production', anyKey: 'anyValue' }, 'environment', 'production'],
+      ['finds undefined items', {}, 'environment', undefined],
+    ])('%s', (_: string, baggage, key, value) => {
+      expect(getBaggageValue(baggage, key)).toEqual(value);
+    });
+  });
+});

--- a/packages/utils/test/baggage.test.ts
+++ b/packages/utils/test/baggage.test.ts
@@ -1,13 +1,13 @@
-import { createBaggage, getBaggageValue } from '../src/baggage';
+import { createBaggage, getBaggageValue, parseBaggageString, serializeBaggage, setBaggageValue } from '../src/baggage';
 
 describe('Baggage', () => {
   describe('createBaggage', () => {
     it.each([
-      ['creates an empty baggage instance', {}, {}],
+      ['creates an empty baggage instance', {}, [{}, '']],
       [
         'creates a baggage instance with initial values',
         { environment: 'production', anyKey: 'anyValue' },
-        { environment: 'production', anyKey: 'anyValue' },
+        [{ environment: 'production', anyKey: 'anyValue' }, ''],
       ],
     ])('%s', (_: string, input, output) => {
       expect(createBaggage(input)).toEqual(output);
@@ -16,10 +16,77 @@ describe('Baggage', () => {
 
   describe('getBaggageValue', () => {
     it.each([
-      ['gets a baggage item', { environment: 'production', anyKey: 'anyValue' }, 'environment', 'production'],
-      ['finds undefined items', {}, 'environment', undefined],
+      [
+        'gets a baggage item',
+        createBaggage({ environment: 'production', anyKey: 'anyValue' }),
+        'environment',
+        'production',
+      ],
+      ['finds undefined items', createBaggage({}), 'environment', undefined],
     ])('%s', (_: string, baggage, key, value) => {
       expect(getBaggageValue(baggage, key)).toEqual(value);
+    });
+  });
+
+  describe('setBaggageValue', () => {
+    it.each([
+      ['sets a baggage item', createBaggage({}), 'environment', 'production'],
+      ['overwrites a baggage item', createBaggage({ environment: 'development' }), 'environment', 'production'],
+    ])('%s', (_: string, baggage, key, value) => {
+      setBaggageValue(baggage, key, value);
+      expect(getBaggageValue(baggage, key)).toEqual(value);
+    });
+  });
+
+  describe('serializeBaggage', () => {
+    it.each([
+      ['serializes empty baggage', createBaggage({}), ''],
+      [
+        'serializes baggage with a single value',
+        createBaggage({ environment: 'production' }),
+        'sentry-environment=production',
+      ],
+      [
+        'serializes baggage with multiple values',
+        createBaggage({ environment: 'production', release: '10.0.2' }),
+        'sentry-environment=production,sentry-release=10.0.2',
+      ],
+      [
+        'keeps non-sentry prefixed baggage items',
+        createBaggage(
+          { environment: 'production', release: '10.0.2' },
+          'userId=alice,serverNode=DF%2028,isProduction=false',
+        ),
+        'userId=alice,serverNode=DF%2028,isProduction=false,sentry-environment=production,sentry-release=10.0.2',
+      ],
+      [
+        'can only use non-sentry prefixed baggage items',
+        createBaggage({}, 'userId=alice,serverNode=DF%2028,isProduction=false'),
+        'userId=alice,serverNode=DF%2028,isProduction=false',
+      ],
+    ])('%s', (_: string, baggage, serializedBaggage) => {
+      expect(serializeBaggage(baggage)).toEqual(serializedBaggage);
+    });
+  });
+
+  describe('parseBaggageString', () => {
+    it.each([
+      ['parses an empty string', '', createBaggage({})],
+      [
+        'parses sentry values into baggage',
+        'sentry-environment=production,sentry-release=10.0.2',
+        createBaggage({ environment: 'production', release: '10.0.2' }),
+      ],
+      [
+        'parses arbitrary baggage headers',
+        'userId=alice,serverNode=DF%2028,isProduction=false,sentry-environment=production,sentry-release=10.0.2',
+        createBaggage(
+          { environment: 'production', release: '10.0.2' },
+          'userId=alice,serverNode=DF%2028,isProduction=false',
+        ),
+      ],
+    ])('%s', (_: string, baggageString, baggage) => {
+      expect(parseBaggageString(baggageString)).toEqual(baggage);
     });
   });
 });


### PR DESCRIPTION
This patch introduced a basic data structure for baggage, as well as controls to create, manipulate and serialize the baggage data structure.

The baggage data structure represents key,value pairs based on the baggage spec: https://www.w3.org/TR/baggage

It is expected that users interact with baggage using the helpers methods: `createBaggage`, `getBaggageValue`, and `setBaggageValue`.

Internally, the baggage data structure is a tuple of length 2, separating baggage values based on if they are related to Sentry or not. If the baggage values are set/used by sentry, they will be stored in an object to be easily accessed. If they are not, they are kept as a string to be only accessed when serialized at baggage propagation time.

As a next step, let's add the baggage values to the envelope header so they can be processed and used by relay - this will allow us to do some early validations of our assumptions.

Resolves https://getsentry.atlassian.net/browse/WEB-910