### PR TITLE
chore(build): Handle npm tarballs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ scratch/
 scenarios/*/dist/
 # transpiled transformers
 jest/transformers/*.js
+# node tarballs
+packages/*/sentry-*.tgz
 
 # logs
 yarn-error.log

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -45,7 +45,7 @@
     "build:ngc:watch": "ng build --prod --watch",
     "build:npm": "npm pack ./build",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf build coverage",
+    "clean": "rimraf build coverage sentry-angular-*.tgz",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -61,7 +61,7 @@
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "ts-node ../../scripts/prepack.ts --bundles && npm pack ./build/npm",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf build coverage .rpt2_cache",
+    "clean": "rimraf build coverage .rpt2_cache sentry-browser-*.tgz",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "ts-node ../../scripts/prepack.ts && npm pack ./build",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf build coverage",
+    "clean": "rimraf build coverage sentry-core-*.tgz",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "build": "ember build --environment=production",
     "build:npm": "ember ts:precompile && npm pack && ember ts:clean",
+    "clean": "yarn rimraf sentry-ember-*.tgz",
     "link:yarn": "yarn link",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
     "lint:hbs": "ember-template-lint .",

--- a/packages/eslint-config-sdk/package.json
+++ b/packages/eslint-config-sdk/package.json
@@ -36,6 +36,7 @@
     "eslint": "7.32.0"
   },
   "scripts": {
+    "clean": "yarn rimraf sentry-internal-eslint-config-sdk-*.tgz",
     "link:yarn": "yarn link",
     "lint": "prettier --check \"**/*.js\"",
     "fix": "prettier --write \"**/*.js\"",

--- a/packages/eslint-plugin-sdk/package.json
+++ b/packages/eslint-plugin-sdk/package.json
@@ -25,6 +25,7 @@
     "mocha": "^6.2.0"
   },
   "scripts": {
+    "clean": "yarn rimraf sentry-internal-eslint-plugin-sdk-*.tgz",
     "link:yarn": "yarn link",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -52,7 +52,7 @@
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "ts-node ../../scripts/prepack.ts && npm pack ./build",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf build coverage *.d.ts",
+    "clean": "rimraf build coverage *.d.ts sentry-gatsby-*.tgz",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -37,7 +37,7 @@
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "ts-node ../../scripts/prepack.ts && npm pack ./build",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf build coverage",
+    "clean": "rimraf build coverage sentry-hub-*.tgz",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -42,7 +42,7 @@
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "ts-node ../../scripts/prepack.ts --bundles && npm pack ./build/npm",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf build coverage .rpt2_cache",
+    "clean": "rimraf build coverage .rpt2_cache sentry-integrations-*.tgz",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -59,7 +59,7 @@
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "ts-node ../../scripts/prepack.ts && npm pack ./build",
     "circularDepCheck": "madge --circular src/index.client.ts && madge --circular --exclude 'config/types\\.ts' src/index.server.ts # see https://github.com/pahen/madge/issues/306",
-    "clean": "rimraf build coverage",
+    "clean": "rimraf build coverage sentry-nextjs-*.tgz",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -50,7 +50,7 @@
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "ts-node ../../scripts/prepack.ts && npm pack ./build",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf build coverage",
+    "clean": "rimraf build coverage sentry-node-*.tgz",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,7 +63,7 @@
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "ts-node ../../scripts/prepack.ts && npm pack ./build",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf build coverage",
+    "clean": "rimraf build coverage sentry-react-*.tgz",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -55,7 +55,7 @@
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "ts-node ../../scripts/prepack.ts && npm pack ./build",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf build dist-awslambda-layer coverage",
+    "clean": "rimraf build dist-awslambda-layer coverage sentry-serverless-*.tgz",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -43,7 +43,7 @@
     "build:rollup:watch": "rollup -c rollup.npm.config.js --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "ts-node ../../scripts/prepack.ts --bundles && npm pack ./build/npm",
-    "clean": "rimraf build coverage",
+    "clean": "rimraf build coverage sentry-tracing-*.tgz",
     "circularDepCheck": "madge --circular src/index.ts",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -31,7 +31,7 @@
     "build:rollup:watch": "rollup -c rollup.npm.config.js --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "ts-node ../../scripts/prepack.ts && npm pack ./build",
-    "clean": "rimraf build",
+    "clean": "rimraf build sentry-types-*.tgz",
     "link:yarn": "yarn link",
     "lint": "run-s lint:prettier lint:eslint",
     "lint:eslint": "eslint . --cache --cache-location '../../eslintcache/' --format stylish",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -14,6 +14,7 @@
     "typescript": "3.8.3"
   },
   "scripts": {
+    "clean": "yarn rimraf sentry-internal-typescript-*.tgz",
     "link:yarn": "yarn link",
     "build:npm": "npm pack"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -41,7 +41,7 @@
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "ts-node ../../scripts/prepack.ts && npm pack ./build",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf build coverage cjs esm",
+    "clean": "rimraf build coverage cjs esm sentry-utils-*.tgz",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -44,7 +44,7 @@
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "ts-node ../../scripts/prepack.ts && npm pack ./build",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf build coverage",
+    "clean": "rimraf build coverage sentry-vue-*.tgz",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -48,7 +48,7 @@
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:npm": "ts-node ../../scripts/prepack.ts --bundles && npm pack ./build/npm",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf build coverage",
+    "clean": "rimraf build coverage sentry-wasm-*.tgz",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",


### PR DESCRIPTION
Running `yarn build:npm` at the root level of the repo (which one might do while testing out build changes) creates a tarball in every package directory. This adds them to `.gitignore` and removes them when `yarn clean` is run.
