### PR TITLE
chore(dev): Fix ts-node compatibility issues

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,3 @@
 workspaces-experimental true
+env:
+  TS_NODE_PROJECT tsconfig.dev.json

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -6,5 +6,12 @@
 
   "compilerOptions": {
     "types": ["node", "jest"],
+
+    // Setting `commonjs` here is necessary so ts-node will convert everything to CJS, which is all that will run on
+    // older versions of Node. See https://github.com/TypeStrong/ts-node#commonjs-vs-native-ecmascript-modules.
+    "module": "commonjs",
+
+    // This lets us use any package in our scripts, no matter how it's set up, using normal `import` syntax
+    "esModuleInterop": true,
   }
 }


### PR DESCRIPTION
WIP

Moving this back to draft because it's going to take a little more work than I thought to fix the currently failing tests.

-----------------

This fixes two compatibility issues with `ts-node`:
- Older versions of Node need the `module` tsconfig option to be set to `commonjs`, so that ts-node will do that conversion before running a script, since those old Node versions can't handle ESM modules.
- Certain third-party packages (ones which use the `exports = <some function>` pattern, for example) can't be accessed using `import * as ____`, `import { default as ___ }`, or `import ____` syntax, and need to be required instead. Setting `esModuleInterop` fixes that, though, so we don't have to worry about the implementation details of the package when we import it.

These options are both set in the dev tsconfig, but that's only helpful if `ts-node` knows to use it. In order to not have to specify in every yarn script which uses `ts-node` which config to use, this takes advantage of yarn's (bizarrely undocumented) ability to set environment variables in order to point to the correct config file globally.
