### PR TITLE
fix(build): Fix references to `rollup.bundle.config.js`

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -52,7 +52,7 @@
     "build:rollup": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",
     "build:watch": "run-p build:cjs:watch build:esm:watch build:bundle:watch build:types:watch",
-    "build:bundle:watch": "rollup --config --watch",
+    "build:bundle:watch": "rollup --config rollup.bundle.config.js --watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",
     "build:dev:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",

--- a/packages/browser/test/integration/debugging.md
+++ b/packages/browser/test/integration/debugging.md
@@ -12,10 +12,10 @@ These tests are hard to debug, because the testing system is somewhat complex, s
 - `suites.yourTestFile.js`:
   - Use `it.only` to only run the single test you're interested in.
 
-- Repo-level `rollup.config.js`:
+- Repo-level `rollup/bundleHelpers.js`:
   - Comment out all bundle variants except whichever one `run.js` is turning into `artifacts/sdk.js`.
 
-- Browser-package-level `rollup.config.js`:
+- Browser-package-level `rollup.bundle.config.js`:
   - Build only one of `es5` and `es6`.
 
 - Run `build:bundle:watch` in a separate terminal tab, so that when you add `console.log`s to the SDK, they get picked up.

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -35,7 +35,7 @@
     "build:rollup": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",
     "build:watch": "run-p build:cjs:watch build:esm:watch build:bundle:watch build:types:watch",
-    "build:bundle:watch": "rollup --config --watch",
+    "build:bundle:watch": "rollup --config rollup.bundle.config.js --watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:dev:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -39,7 +39,7 @@
     "build:rollup": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",
     "build:watch": "run-p build:cjs:watch build:esm:watch build:bundle:watch build:types:watch",
-    "build:bundle:watch": "rollup --config --watch",
+    "build:bundle:watch": "rollup --config rollup.bundle.config.js --watch",
     "build:cjs:watch": "tsc -p tsconfig.cjs.json --watch",
     "build:dev:watch": "run-p build:cjs:watch build:esm:watch build:types:watch",
     "build:es5:watch": "yarn build:cjs:watch # *** backwards compatibility - remove in v7 ***",


### PR DESCRIPTION
This fixes a few spots where https://github.com/getsentry/sentry-javascript/pull/4950 missed changing references to the new name for our rollup config for CDN bundles, `rollup.bundle.config.js`.
