### PR TITLE
feat(dev): Add default Node version for CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,8 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+          # ember won't build under node 16, at least not with the versions of the ember build tools we use
+          node-version: '14'
       - name: Check dependency cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ on:
         required: false
 
 env:
+  DEFAULT_NODE_VERSION: '16'
+
   HEAD_COMMIT: ${{ github.event.inputs.commit || github.sha }}
 
   CACHED_DEPENDENCY_PATHS: |
@@ -45,6 +47,8 @@ jobs:
           ref: ${{ env.HEAD_COMMIT }}
       - name: Set up Node
         uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
         # we use a hash of yarn.lock as our cache key, because if it hasn't changed, our dependencies haven't changed,
         # so no need to reinstall them
       - name: Compute dependency cache key
@@ -74,6 +78,8 @@ jobs:
           ref: ${{ env.HEAD_COMMIT }}
       - name: Set up Node
         uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
       - name: Check dependency cache
         uses: actions/cache@v2
         with:
@@ -118,7 +124,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12'
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
       - name: Check dependency cache
         uses: actions/cache@v2
         with:
@@ -149,6 +155,8 @@ jobs:
           ref: ${{ env.HEAD_COMMIT }}
       - name: Set up Node
         uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
       - name: Check dependency cache
         uses: actions/cache@v2
         with:
@@ -174,6 +182,8 @@ jobs:
           ref: ${{ env.HEAD_COMMIT }}
       - name: Set up Node
         uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
       - name: Check dependency cache
         uses: actions/cache@v2
         with:
@@ -200,6 +210,8 @@ jobs:
           ref: ${{ env.HEAD_COMMIT }}
       - name: Set up Node
         uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
       - name: Check dependency cache
         uses: actions/cache@v2
         with:
@@ -367,7 +379,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '16'
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
       - name: Check dependency cache
         uses: actions/cache@v2
         with:
@@ -406,6 +418,8 @@ jobs:
           ref: ${{ env.HEAD_COMMIT }}
       - name: Set up Node
         uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
       - name: Check dependency cache
         uses: actions/cache@v2
         with:
@@ -438,7 +452,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: '16'
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
       - name: Check dependency cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
In our CI workflow, we currently use version 1 of GHA's `setup-node` action, whose default Node version is 10. Though we could (and should) update to version 3 of the action, whose default is Node 16, [the `setup-node` docs recommend](https://github.com/actions/setup-node#usage) explicitly setting a version for greater control and clarity. This does so, by adding the default Node version as an env variable and using it in all jobs which don't otherwise specify their version. 
