### PR TITLE
fix(dev): Restrict size check action to PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,8 @@ jobs:
     needs: job_build
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    # Size Check will error out outside of the context of a PR
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Check out current commit (${{ env.HEAD_COMMIT }})
         uses: actions/checkout@v2


### PR DESCRIPTION
The size check action we use in our main CI workflow will throw an error if run outside of the context of a PR (as when running CI manually, for example). As a result, the overall run is always marked as a failure, even when all other jobs passed. This restricts the action to running on PRs, to avoid that problem.
