### PR TITLE
chore(dev): Remove redundant `prepublishOnly` build step in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,14 +92,6 @@ jobs:
         # this file) to a constant and skip rebuilding all of the packages each time CI runs.
         if: steps.cache_built_packages.outputs.cache-hit == ''
         run: yarn build
-        # We are performing a `prepublishOnly` step manually because build workflow is not responsible for publishing
-        # the actual release. It only creates artifacts which then are uploaded and used by another workflow.
-        # Because of that, any `prepublishOnly` script is skipped and files it produces are not included in the tarball.
-        # We also cannot use `prepare` script which would be more suited, because it's run only before `pack` is called,
-        # and it's done from a `release` workflow and not here.
-      - name: Run prepublishOnly script
-        if: startsWith(github.ref, 'refs/heads/release/')
-        run: yarn prepublishOnly
     outputs:
       # this needs to be passed on, because the `needs` context only looks at direct ancestors (so steps which depend on
       # `job_build` can't see `job_install_deps` and what it returned)

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "link:yarn": "lerna run --stream --concurrency 1 link:yarn",
     "lint": "lerna run --parallel lint",
     "lint:eslint": "lerna run --parallel lint:eslint",
-    "prepublishOnly": "lerna run --stream --concurrency 1 prepublishOnly",
     "postpublish": "make publish-docs && lerna run --stream --concurrency 1 postpublish",
     "test": "lerna run --ignore @sentry-internal/browser-integration-tests --ignore @sentry-internal/node-integration-tests --stream --concurrency 1 --sort test",
     "test-ci": "ts-node ./scripts/test.ts"


### PR DESCRIPTION
Based both on the description in the comment above it and the restrictions on when it is supposed to run, it appears that the `prepublishOnly` step of the `Build` job is meant to do the same thing as the `pack` step of the `Upload Artifacts` job. "Meant" is the operative word, however, because in reality, it doesn't actually do anything - though it calls the repo-level `prepublishOnly` script, which calls the `prepublishOnly` script in every package that has one... no package has one, so it's a no-op.

This removes the step and the associated repo-level yarn script, since they seem to have been replaced by the `build:npm` script called in `Upload Artifacts`.
