### PR TITLE
feat(build): Add args and templates to rollup debugger plugin

### DIFF
--- a/rollup/plugins/npmPlugins.js
+++ b/rollup/plugins/npmPlugins.js
@@ -50,10 +50,39 @@ export function makeConstToVarPlugin() {
 /**
  * Create a plugin which can be used to pause the build process at the given hook.
  *
- * Hooks can be found here: https://rollupjs.org/guide/en/#build-hooks
+ * Hooks can be found here: https://rollupjs.org/guide/en/#build-hooks.
  *
  * @param hookName The name of the hook at which to pause.
  * @returns A plugin which inserts a debugger statement in the phase represented by the given hook
+ *
+ * For convenience, here are pre-built debuggers for every hook:
+ *
+ *  makeDebuggerPlugin('buildStart'),
+ *  makeDebuggerPlugin('options'),
+ *  makeDebuggerPlugin('resolveId'),
+ *  makeDebuggerPlugin('resolveDynamicImport'),
+ *  makeDebuggerPlugin('load'),
+ *  makeDebuggerPlugin('transform'),
+ *  makeDebuggerPlugin('shouldTransformCachedModule'),
+ *  makeDebuggerPlugin('moduleParsed'),
+ *  makeDebuggerPlugin('buildEnd'),
+ *  makeDebuggerPlugin('watchChange'),
+ *  makeDebuggerPlugin('closeWatcher'),
+ *  makeDebuggerPlugin('outputOptions'),
+ *  makeDebuggerPlugin('renderStart'),
+ *  makeDebuggerPlugin('banner'),
+ *  makeDebuggerPlugin('footer'),
+ *  makeDebuggerPlugin('intro'),
+ *  makeDebuggerPlugin('outro'),
+ *  makeDebuggerPlugin('augmentChunkHash'),
+ *  makeDebuggerPlugin('renderDynamicImport'),
+ *  makeDebuggerPlugin('resolveFileUrl'),
+ *  makeDebuggerPlugin('resolveImportMeta'),
+ *  makeDebuggerPlugin('renderChunk'),
+ *  makeDebuggerPlugin('renderError'),
+ *  makeDebuggerPlugin('generateBundle'),
+ *  makeDebuggerPlugin('writeBundle'),
+ *  makeDebuggerPlugin('closeBundle'),
  */
 export function makeDebuggerPlugin(hookName) {
   return {

--- a/rollup/plugins/npmPlugins.js
+++ b/rollup/plugins/npmPlugins.js
@@ -58,7 +58,7 @@ export function makeConstToVarPlugin() {
 export function makeDebuggerPlugin(hookName) {
   return {
     name: 'debugger-plugin',
-    [hookName]: () => {
+    [hookName]: (..._args) => {
       // eslint-disable-next-line no-debugger
       debugger;
       return null;


### PR DESCRIPTION
This makes two improvements to the rollup debugging plugin, which allows you to stick a breakpoint into any phase of the build process:
- It now collects the arguments passed to the hook function for that phase, so they can be examined in the debugger.
- The docstring now includes pre-built copies of the plugin (or, rather, calls to the plugin factory function) for every hook, so you can just copy any that you need over into the helper functions which create the rollup config.
