### PR TITLE
fix(types): Make `@sentry/types` a runtime dependency in gatsby and nextjs

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@sentry/react": "7.0.0-beta.0",
     "@sentry/tracing": "7.0.0-beta.0",
+    "@sentry/types": "7.0.0-beta.0",
     "@sentry/utils": "7.0.0-beta.0",
     "@sentry/webpack-plugin": "1.18.9"
   },
@@ -30,7 +31,6 @@
     "react": "15.x || 16.x || 17.x || 18.x"
   },
   "devDependencies": {
-    "@sentry/types": "7.0.0-beta.0",
     "@testing-library/react": "^13.0.0",
     "react": "^18.0.0"
   },

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -25,10 +25,10 @@
     "@sentry/tracing": "7.0.0-beta.0",
     "@sentry/utils": "7.0.0-beta.0",
     "@sentry/webpack-plugin": "1.18.9",
+    "@sentry/types": "7.0.0-beta.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@sentry/types": "7.0.0-beta.0",
     "@types/webpack": "^4.41.31",
     "next": "10.1.3"
   },


### PR DESCRIPTION
In order that it be installed with the SDK, we make the types package a runtime/regular dependency of all of our other packages, so it's there for anyone using the SDK in a TS app. In the gatsby and nextjs packages, though, it's listed as a dev dependency, and therefore won't be installed. This corrects that by moving it to be a regular dependency in both packages.
