### PR TITLE
ref(node): Improve Node manual test logging

### DIFF
--- a/packages/node/test/manual/colorize.js
+++ b/packages/node/test/manual/colorize.js
@@ -1,0 +1,16 @@
+const COLOR_RESET = '\x1b[0m';
+const COLORS = {
+  green: '\x1b[32m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+};
+
+function colorize(str, color) {
+  if (!(color in COLORS)) {
+    throw new Error(`Unknown color. Available colors: ${Object.keys(COLORS).join(', ')}`);
+  }
+
+  return `${COLORS[color]}${str}${COLOR_RESET}`;
+}
+
+module.exports = { colorize };

--- a/packages/node/test/manual/express-scope-separation/start.js
+++ b/packages/node/test/manual/express-scope-separation/start.js
@@ -2,13 +2,14 @@ const http = require('http');
 const express = require('express');
 const app = express();
 const Sentry = require('../../../build/cjs');
+const { colorize } = require('../colorize');
 
 // don't log the test errors we're going to throw, so at a quick glance it doesn't look like the test itself has failed
 global.console.error = () => null;
 
 function assertTags(actual, expected) {
   if (JSON.stringify(actual) !== JSON.stringify(expected)) {
-    console.error('FAILED: Scope contains incorrect tags');
+    console.log(colorize('FAILED: Scope contains incorrect tags\n', 'red'));
     process.exit(1);
   }
 }
@@ -20,7 +21,7 @@ function makeDummyTransport() {
     --remaining;
 
     if (!remaining) {
-      console.error('SUCCESS: All scopes contain correct tags');
+      console.log(colorize('PASSED: All scopes contain correct tags\n', 'green'));
       server.close();
       process.exit(0);
     }

--- a/packages/node/test/manual/release-health/runner.js
+++ b/packages/node/test/manual/release-health/runner.js
@@ -1,21 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { spawn } = require('child_process');
-
-const COLOR_RESET = '\x1b[0m';
-const COLORS = {
-  green: '\x1b[32m',
-  red: '\x1b[31m',
-  yellow: '\x1b[33m',
-};
-
-const colorize = (str, color) => {
-  if (!(color in COLORS)) {
-    throw new Error(`Unknown color. Available colors: ${Object.keys(COLORS).join(', ')}`);
-  }
-
-  return `${COLORS[color]}${str}${COLOR_RESET}`;
-};
+const { colorize } = require('../colorize');
 
 const scenariosDirs = ['session-aggregates', 'single-session'];
 const scenarios = [];

--- a/packages/node/test/manual/webpack-domain/index.js
+++ b/packages/node/test/manual/webpack-domain/index.js
@@ -1,4 +1,5 @@
 const Sentry = require('../../../build/cjs');
+const { colorize } = require('../colorize');
 
 let remaining = 2;
 
@@ -7,7 +8,7 @@ function makeDummyTransport() {
     --remaining;
 
     if (!remaining) {
-      console.error('SUCCESS: Webpack Node Domain test OK!');
+      console.log(colorize('PASSED: Webpack Node Domain test OK!\n', 'green'));
       process.exit(0);
     }
 
@@ -23,13 +24,13 @@ Sentry.init({
   beforeSend(event) {
     if (event.message === 'inside') {
       if (event.tags.a !== 'x' && event.tags.b !== 'c') {
-        console.error('FAILED: Scope contains incorrect tags');
+        console.log(colorize('FAILED: Scope contains incorrect tags\n', 'red'));
         process.exit(1);
       }
     }
     if (event.message === 'outside') {
       if (event.tags.a !== 'b') {
-        console.error('FAILED: Scope contains incorrect tags');
+        console.log(colorize('FAILED: Scope contains incorrect tags\n', 'red'));
         process.exit(1);
       }
     }

--- a/packages/node/test/manual/webpack-domain/npm-build.js
+++ b/packages/node/test/manual/webpack-domain/npm-build.js
@@ -39,7 +39,7 @@ webpack(
 
 function runTests() {
   try {
-    execSync('node ' + path.resolve(__dirname, 'dist', 'bundle.js'));
+    execSync('node ' + path.resolve(__dirname, 'dist', 'bundle.js'), { stdio: 'inherit' });
   } catch (_) {
     process.exit(1);
   }


### PR DESCRIPTION
This makes some small changes to the logs emitted by the manual tests in the node package, to make it a little cleaner and easier to see what's what.

Included changes:
- Use `colorize` function from release health tests in all test suites.
- Capture and display console logs in express test.
- Standardize success message across test suites.
- Use whitespace to separate each suite's logs from the next.

Before:

![image](https://user-images.githubusercontent.com/14812505/168014606-0631bec5-f08f-46c3-aadf-95ac93e36fb9.png)

After:

![image](https://user-images.githubusercontent.com/14812505/168014668-15f1ccb9-e586-4c72-99b4-2320d49627e2.png)
