### PR TITLE
fix(build): Fix express import in `gcpfunction`

### DIFF
--- a/packages/serverless/src/gcpfunction/general.ts
+++ b/packages/serverless/src/gcpfunction/general.ts
@@ -1,6 +1,6 @@
 import { Scope } from '@sentry/node';
 import { Context as SentryContext } from '@sentry/types';
-import { Request, Response } from 'express'; // eslint-disable-line import/no-extraneous-dependencies
+import type { Request, Response } from 'express';
 import { hostname } from 'os';
 
 export interface HttpFunction {


### PR DESCRIPTION
This fixes a spot where we're importing types only to _say_ that we're importing types only, in order to get rid of a warning in build. (If we don't say so, it gets mad because we only have `@types/express`, not `express`, as a listed dependency.)
