### PR TITLE
fix(build): Narrow scope of build cache in GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,15 +24,16 @@ env:
 
   # DEPENDENCY_CACHE_KEY: can't be set here because we don't have access to yarn.lock
 
+  # packages/utils/cjs and packages/utils/esm: Symlinks to the folders inside of `build`, needed for tests
   CACHED_BUILD_PATHS: |
-    ${{ github.workspace }}/packages/**/build
-    ${{ github.workspace }}/packages/**/cjs
-    ${{ github.workspace }}/packages/**/esm
+    ${{ github.workspace }}/packages/*/build
     ${{ github.workspace }}/packages/ember/*.d.ts
     ${{ github.workspace }}/packages/ember/instance-initializers
     ${{ github.workspace }}/packages/gatsby/*.d.ts
     ${{ github.workspace }}/packages/core/src/version.ts
     ${{ github.workspace }}/dist-serverless
+    ${{ github.workspace }}/packages/utils/cjs
+    ${{ github.workspace }}/packages/utils/esm
 
   BUILD_CACHE_KEY: ${{ github.event.inputs.commit || github.sha }}
 


### PR DESCRIPTION
Currently, as part of caching our built files in GHA, we cache any directory named `build`, `cjs`, or `esm`, no matter how deeply nested. As a result, we end up caching files from any number of node modules which happen to contain directories of the same name(s). Since we have a separate dependency cache, this is redundant and only serves to slow down our CI checks.

This fixes that problem by narrowing the scope to the `build` folder at the top level of each package, so that now we upload ~2700 files rather than ~4000. Two legitimate files which would otherwise be excluded as a result of this change have also been added to the cache.