### PR TITLE
ref(build): Use sucrase for es6 bundles

### DIFF
--- a/rollup/bundleHelpers.js
+++ b/rollup/bundleHelpers.js
@@ -11,6 +11,9 @@ import {
   makeIsDebugBuildPlugin,
   makeLicensePlugin,
   makeNodeResolvePlugin,
+  makeRemoveBlankLinesPlugin,
+  makeRemoveESLintCommentsPlugin,
+  makeSucrasePlugin,
   makeTerserPlugin,
   makeTSPlugin,
 } from './plugins/index.js';
@@ -20,6 +23,9 @@ export function makeBaseBundleConfig(options) {
   const { input, isAddOn, jsVersion, licenseTitle, outputFileBase } = options;
 
   const nodeResolvePlugin = makeNodeResolvePlugin();
+  const sucrasePlugin = makeSucrasePlugin();
+  const removeBlankLinesPlugin = makeRemoveBlankLinesPlugin();
+  const removeESLintCommentsPlugin = makeRemoveESLintCommentsPlugin();
   const markAsBrowserBuildPlugin = makeBrowserBuildPlugin(true);
   const licensePlugin = makeLicensePlugin(licenseTitle);
   const tsPlugin = makeTSPlugin(jsVersion.toLowerCase());
@@ -75,7 +81,17 @@ export function makeBaseBundleConfig(options) {
       strict: false,
       esModule: false,
     },
-    plugins: [tsPlugin, markAsBrowserBuildPlugin, nodeResolvePlugin, licensePlugin],
+    plugins:
+      jsVersion === 'es5'
+        ? [tsPlugin, markAsBrowserBuildPlugin, nodeResolvePlugin, licensePlugin]
+        : [
+            sucrasePlugin,
+            removeBlankLinesPlugin,
+            removeESLintCommentsPlugin,
+            markAsBrowserBuildPlugin,
+            nodeResolvePlugin,
+            licensePlugin,
+          ],
     treeshake: 'smallest',
   };
 


### PR DESCRIPTION
This switches the building of our es6 CDN bundles to use sucrase instead of tsc (or, more accurately, to use the sucrase rollup plugin rather than the typescript rollup plugin), in order both to build more quickly (in a time trial of multiple runs on GHA, this change brings the average `yarn build` run down from ~8 minutes to ~4 minutes) and to ensure that we have exact code parity between our CDN bundles and our npm packages.

Because sucrase doesn't down-compile the way `tsc` will, the building of the es5 bundles hasn't been changed, and that build still uses the typescript plugin. 
