### PR TITLE
fix(build): Strip `eslint-enable` comments in rollup plugin

### DIFF
--- a/rollup/plugins/npmPlugins.js
+++ b/rollup/plugins/npmPlugins.js
@@ -104,7 +104,7 @@ export function makeRemoveESLintCommentsPlugin() {
   return regexReplace({
     patterns: [
       {
-        test: /\/[/*] eslint-disable.*\n/g,
+        test: /\/[/*] eslint-.*\n/g,
         replace: '',
       },
     ],


### PR DESCRIPTION
The `removeESLintCommentsPlugin` rollup plugin we use during build strips all comments beginning `eslint-disable`, but misses comments beginning `eslint-enable`. This makes the regex used in that plugin more general, so that it catches all comments beginning with `eslint-`.
