### PR TITLE
fix(build): Prevent redundant typechecking

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "allowSyntheticDefaultImports": true,
     "declaration": false,
     "declarationMap": false,
+    "skipLibCheck": true,
     "types": ["node"],
   }
 }


### PR DESCRIPTION
When the tsconfig option`skipLibCheck` is false (as it is by default), TS typechecks not only your code, and not only the code you use from dependencies, but the entire codebase of all of your dependencies. Not only does this seem like overkill, in our case it's actually largely redundant, because our packages have very few dependencies other than each other. Turning this off speeds up the build and prevents us from, for example, typechecking the entire `utils` package 15 times (once for its own sake, and once for every one of the 14 packages which depend on it). 