### PR TITLE
fix(types): Export SerializedSession

### DIFF
--- a/packages/hub/src/session.ts
+++ b/packages/hub/src/session.ts
@@ -1,5 +1,4 @@
-import { Session, SessionContext, SessionStatus } from '@sentry/types';
-import { SerializedSession } from '@sentry/types/build/types/session';
+import { SerializedSession, Session, SessionContext, SessionStatus } from '@sentry/types';
 import { dropUndefinedKeys, timestampInSeconds, uuid4 } from '@sentry/utils';
 
 /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -40,6 +40,7 @@ export type { SdkMetadata } from './sdkmetadata';
 export type {
   SessionAggregates,
   AggregationCounts,
+  SerializedSession,
   Session,
   SessionContext,
   SessionStatus,


### PR DESCRIPTION
Fix so we don't import `SerializedSession` from `build` folder directly.