### PR TITLE
ref(tracing): Reduce metrics bundle size

### DIFF
--- a/packages/tracing/src/browser/metrics/utils.ts
+++ b/packages/tracing/src/browser/metrics/utils.ts
@@ -1,0 +1,26 @@
+import { Span, SpanContext } from '@sentry/types';
+
+import { Transaction } from '../../transaction';
+
+/**
+ * Checks if a given value is a valid measurement value.
+ */
+export function isMeasurementValue(value: unknown): value is number {
+  return typeof value === 'number' && isFinite(value);
+}
+
+/**
+ * Helper function to start child on transactions. This function will make sure that the transaction will
+ * use the start timestamp of the created child span if it is earlier than the transactions actual
+ * start timestamp.
+ */
+export function _startChild(transaction: Transaction, { startTimestamp, ...ctx }: SpanContext): Span {
+  if (startTimestamp && transaction.startTimestamp > startTimestamp) {
+    transaction.startTimestamp = startTimestamp;
+  }
+
+  return transaction.startChild({
+    startTimestamp,
+    ...ctx,
+  });
+}

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -9,7 +9,6 @@ import {
   getHeaderContext,
   getMetaContent,
 } from '../../src/browser/browsertracing';
-import { MetricsInstrumentation } from '../../src/browser/metrics';
 import { defaultRequestInstrumentationOptions } from '../../src/browser/request';
 import { instrumentRoutingWithDefaults } from '../../src/browser/router';
 import * as hubExtensions from '../../src/hubextensions';
@@ -464,31 +463,6 @@ describe('BrowserTracing', () => {
           transactionContext: expect.objectContaining({ op: 'navigation' }),
         }),
       );
-    });
-  });
-
-  describe('metrics', () => {
-    beforeEach(() => {
-      // @ts-ignore mock clear
-      MetricsInstrumentation.mockClear();
-    });
-
-    it('creates metrics instrumentation', () => {
-      createBrowserTracing(true, {});
-
-      expect(MetricsInstrumentation).toHaveBeenCalledTimes(1);
-      expect(MetricsInstrumentation).toHaveBeenLastCalledWith(undefined);
-    });
-
-    it('creates metrics instrumentation with custom options', () => {
-      createBrowserTracing(true, {
-        _metricOptions: {
-          _reportAllChanges: true,
-        },
-      });
-
-      expect(MetricsInstrumentation).toHaveBeenCalledTimes(1);
-      expect(MetricsInstrumentation).toHaveBeenLastCalledWith(true);
     });
   });
 });

--- a/packages/tracing/test/browser/metrics/index.test.ts
+++ b/packages/tracing/test/browser/metrics/index.test.ts
@@ -1,5 +1,5 @@
 import { Transaction } from '../../../src';
-import { _addResourceSpans, _addMeasureSpans, ResourceEntry } from '../../../src/browser/metrics';
+import { _addMeasureSpans, _addResourceSpans, ResourceEntry } from '../../../src/browser/metrics';
 
 describe('_addMeasureSpans', () => {
   const transaction = new Transaction({ op: 'pageload', name: '/' });
@@ -19,9 +19,12 @@ describe('_addMeasureSpans', () => {
     const startTime = 23;
     const duration = 356;
 
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(transaction.startChild).toHaveBeenCalledTimes(0);
     _addMeasureSpans(transaction, entry, startTime, duration, timeOrigin);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(transaction.startChild).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(transaction.startChild).toHaveBeenLastCalledWith({
       description: 'measure-1',
       startTimestamp: timeOrigin + startTime,

--- a/packages/tracing/test/browser/metrics/utils.test.ts
+++ b/packages/tracing/test/browser/metrics/utils.test.ts
@@ -1,0 +1,40 @@
+import { Span, Transaction } from '../../../src';
+import { _startChild } from '../../../src/browser/metrics/utils';
+
+describe('_startChild()', () => {
+  it('creates a span with given properties', () => {
+    const transaction = new Transaction({ name: 'test' });
+    const span = _startChild(transaction, {
+      description: 'evaluation',
+      op: 'script',
+    });
+
+    expect(span).toBeInstanceOf(Span);
+    expect(span.description).toBe('evaluation');
+    expect(span.op).toBe('script');
+  });
+
+  it('adjusts the start timestamp if child span starts before transaction', () => {
+    const transaction = new Transaction({ name: 'test', startTimestamp: 123 });
+    const span = _startChild(transaction, {
+      description: 'script.js',
+      op: 'resource',
+      startTimestamp: 100,
+    });
+
+    expect(transaction.startTimestamp).toEqual(span.startTimestamp);
+    expect(transaction.startTimestamp).toEqual(100);
+  });
+
+  it('does not adjust start timestamp if child span starts after transaction', () => {
+    const transaction = new Transaction({ name: 'test', startTimestamp: 123 });
+    const span = _startChild(transaction, {
+      description: 'script.js',
+      op: 'resource',
+      startTimestamp: 150,
+    });
+
+    expect(transaction.startTimestamp).not.toEqual(span.startTimestamp);
+    expect(transaction.startTimestamp).toEqual(123);
+  });
+});


### PR DESCRIPTION
This PR reduces metrics bundle size by converting the `MetricsInstrumentation` class into a set of functions.

The `MetricsInstrumentation` class constructor was turned into the `startTrackingWebVitals` function. The internal class state was turned into a set of global variables that get mutated.

Resolves https://getsentry.atlassian.net/browse/WEB-816