### PR TITLE
chore(build): Move aws lambda build step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,11 +106,47 @@ jobs:
           echo "Saving SDK_VERSION for later"
           cat packages/core/src/version.ts | awk -F"'" '{print $2}' > dist-serverless/version
           [ ! -z $(cat dist-serverless/version) ] && echo SDK_VERSION=$(cat dist-serverless/version) || (echo "Version extraction failed" && exit 1)
-
     outputs:
       # this needs to be passed on, because the `needs` context only looks at direct ancestors (so steps which depend on
       # `job_build` can't see `job_install_deps` and what it returned)
       dependency_cache_key: ${{ needs.job_install_deps.outputs.dependency_cache_key }}
+
+  job_build_aws_lambda_layer:
+    name: Build AWS Lambda Layer
+    needs: job_build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out current commit (${{ env.HEAD_COMMIT }})
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.HEAD_COMMIT }}
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+      - name: Check dependency cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
+          key: ${{ needs.job_build.outputs.dependency_cache_key }}
+      - name: Check build cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.CACHED_BUILD_PATHS }}
+          key: ${{ env.BUILD_CACHE_KEY }}
+      - name: Get SDK version
+        run: |
+          export SDK_VERSION=$(cat dist-serverless/version)
+          echo "SDK_VERSION=$SDK_VERSION" | tee -a $GITHUB_ENV
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.HEAD_COMMIT }}
+          path: |
+            dist-serverless/*
+      - uses: getsentry/action-build-aws-lambda-extension@v1
+        with:
+          artifact_name: ${{ env.HEAD_COMMIT }}
+          zip_file_name: sentry-node-serverless-${{ env.SDK_VERSION }}.zip
 
   job_size_check:
     name: Size Check
@@ -508,40 +544,3 @@ jobs:
         run: |
           cd packages/node-integration-tests
           yarn test
-
-  job_build_aws_lambda_layer:
-    name: Build AWS Lambda Layer
-    needs: job_build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out current commit (${{ env.HEAD_COMMIT }})
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ env.HEAD_COMMIT }}
-      - name: Set up Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ env.DEFAULT_NODE_VERSION }}
-      - name: Check dependency cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
-          key: ${{ needs.job_build.outputs.dependency_cache_key }}
-      - name: Check build cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.CACHED_BUILD_PATHS }}
-          key: ${{ env.BUILD_CACHE_KEY }}
-      - name: Get SDK version
-        run: |
-          export SDK_VERSION=$(cat dist-serverless/version)
-          echo "SDK_VERSION=$SDK_VERSION" | tee -a $GITHUB_ENV
-      - uses: actions/upload-artifact@v3
-        with:
-          name: ${{ env.HEAD_COMMIT }}
-          path: |
-            dist-serverless/*
-      - uses: getsentry/action-build-aws-lambda-extension@v1
-        with:
-          artifact_name: ${{ env.HEAD_COMMIT }}
-          zip_file_name: sentry-node-serverless-${{ env.SDK_VERSION }}.zip


### PR DESCRIPTION
This moves, without making any changes, the aws lambda build job to live with the other build job in our CI workflow. (I'll admit that it's not totally obvious, but there is in fact a vague organizing principle to that doc.) Extracted from another PR to make it easier to see, in that PR, what actual changes are being made.