### PR TITLE
docs(migration): Add upgrading information for multiple Sentry packages to TL;DR section

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,6 +4,8 @@ The main goal of version 7 is to reduce bundle size. This version is breaking be
 Below we will outline all the breaking changes you should consider when upgrading.
 
 **TL;DR** If you only use basic features of Sentry, or you simply copy & pasted the setup examples from our docs, here's what changed for you:
+- If you installed `@sentry/tracing` alongside your Sentry SDK (e.g. `@sentry/react` or `@sentry/node`), make
+sure to upgrade both packages to version 7.
 - Our CDN bundles are now ES6 - you will need to [reconfigure your script tags](#renaming-of-cdn-bundles) if you want to keep supporting ES5 and IE11 on the new SDK version.
 - Distributed CommonJS files will be ES6. Use a transpiler if you need to support old node versions.
 - We bumped the TypeScript version we generate our types with to 3.8.3. Please check if your TypeScript projects using TypeScript version 3.7 or lower still compile. Otherwise, upgrade your TypeScript version.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,8 +4,7 @@ The main goal of version 7 is to reduce bundle size. This version is breaking be
 Below we will outline all the breaking changes you should consider when upgrading.
 
 **TL;DR** If you only use basic features of Sentry, or you simply copy & pasted the setup examples from our docs, here's what changed for you:
-- If you installed `@sentry/tracing` alongside your Sentry SDK (e.g. `@sentry/react` or `@sentry/node`), make
-sure to upgrade both packages to version 7.
+- If you installed additional Sentry packages, such as`@sentry/tracing` alongside your Sentry SDK (e.g. `@sentry/react` or `@sentry/node`), make sure to upgrade all of them to version 7.
 - Our CDN bundles are now ES6 - you will need to [reconfigure your script tags](#renaming-of-cdn-bundles) if you want to keep supporting ES5 and IE11 on the new SDK version.
 - Distributed CommonJS files will be ES6. Use a transpiler if you need to support old node versions.
 - We bumped the TypeScript version we generate our types with to 3.8.3. Please check if your TypeScript projects using TypeScript version 3.7 or lower still compile. Otherwise, upgrade your TypeScript version.


### PR DESCRIPTION
This mini PR just adds a point to the TL;DR section stating that other Sentry packages like `@sentry/tracing` should be upgraded alongside the used Sentry SDK. Got the idea to add this after I saw that people were just upgrading the SDK to v7 beta but left tracing at v6.