### PR TITLE
feat(tracing): Add empty baggage header propagation to outgoing requests

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,7 +9,9 @@ Below we will outline all the breaking changes you should consider when upgradin
 - Distributed CommonJS files will be ES6. Use a transpiler if you need to support old node versions.
 - We bumped the TypeScript version we generate our types with to 3.8.3. Please check if your TypeScript projects using TypeScript version 3.7 or lower still compile. Otherwise, upgrade your TypeScript version.
 - `whitelistUrls` and `blacklistUrls` have been renamed to `allowUrls` and `denyUrls` in the `Sentry.init()` options.
-- The `UserAgent` integration is now called `HttpContext`.
+- The `UserAgent` integration is now called `HttpContext`.#
+- If you are using Performance Monitoring and with tracing enabled, you might have to [make adjustments to
+your server's CORS settings](#-propagation-of-baggage-header)
 
 ## Dropping Support for Node.js v6
 
@@ -319,6 +321,11 @@ session.update({ environment: 'prod' });
 session.close('ok');
 ```
 
+## Propagation of Baggage Header
+
+We introduced a new way of propagating tracing and transaction-related information between services. This
+change adds the [`baggage` HTTP header](https://www.w3.org/TR/baggage/) to outgoing requests if the instrumentation of requests is enabled. Since this adds a header to your HTTP requests, you might need
+to adjust your Server's CORS settings to allow this additional header.
 ## General API Changes
 
 For our efforts to reduce bundle size of the SDK we had to remove and refactor parts of the package which introduced a few changes to the API:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -327,6 +327,7 @@ We introduced a new way of propagating tracing and transaction-related informati
 change adds the [`baggage` HTTP header](https://www.w3.org/TR/baggage/) to outgoing requests if the instrumentation of requests is enabled. Since this adds a header to your HTTP requests, you might need
 to adjust your Server's CORS settings to allow this additional header. Take a look at the [Sentry docs](https://docs.sentry.io/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests)
 for more in-depth instructions what to change.
+
 ## General API Changes
 
 For our efforts to reduce bundle size of the SDK we had to remove and refactor parts of the package which introduced a few changes to the API:

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -9,7 +9,7 @@ Below we will outline all the breaking changes you should consider when upgradin
 - Distributed CommonJS files will be ES6. Use a transpiler if you need to support old node versions.
 - We bumped the TypeScript version we generate our types with to 3.8.3. Please check if your TypeScript projects using TypeScript version 3.7 or lower still compile. Otherwise, upgrade your TypeScript version.
 - `whitelistUrls` and `blacklistUrls` have been renamed to `allowUrls` and `denyUrls` in the `Sentry.init()` options.
-- The `UserAgent` integration is now called `HttpContext`.#
+- The `UserAgent` integration is now called `HttpContext`.
 - If you are using Performance Monitoring and with tracing enabled, you might have to [make adjustments to
 your server's CORS settings](#-propagation-of-baggage-header)
 
@@ -325,7 +325,8 @@ session.close('ok');
 
 We introduced a new way of propagating tracing and transaction-related information between services. This
 change adds the [`baggage` HTTP header](https://www.w3.org/TR/baggage/) to outgoing requests if the instrumentation of requests is enabled. Since this adds a header to your HTTP requests, you might need
-to adjust your Server's CORS settings to allow this additional header.
+to adjust your Server's CORS settings to allow this additional header. Take a look at the [Sentry docs](https://docs.sentry.io/platforms/javascript/performance/connect-services/#navigation-and-other-xhr-requests)
+for more in-depth instructions what to change.
 ## General API Changes
 
 For our efforts to reduce bundle size of the SDK we had to remove and refactor parts of the package which introduced a few changes to the API:

--- a/packages/core/test/lib/envelope.test.ts
+++ b/packages/core/test/lib/envelope.test.ts
@@ -1,5 +1,4 @@
-import { DsnComponents, Event } from '@sentry/types';
-import { EventTraceContext } from '@sentry/types/build/types/envelope';
+import { DsnComponents, Event, EventTraceContext } from '@sentry/types';
 
 import { createEventEnvelope } from '../../src/envelope';
 

--- a/packages/integration-tests/suites/tracing/browsertracing/meta/template.html
+++ b/packages/integration-tests/suites/tracing/browsertracing/meta/template.html
@@ -2,5 +2,6 @@
   <head>
     <meta charset="utf-8" />
     <meta name="sentry-trace" content="12312012123120121231201212312012-1121201211212012-1" />
+    <meta name="baggage" content="sentry-version=2.1.12" />
   </head>
 </html>

--- a/packages/integration-tests/suites/tracing/browsertracing/meta/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/meta/test.ts
@@ -30,8 +30,8 @@ sentryTest.skip(
 
     const envHeader = await getFirstSentryEnvelopeRequest<EventEnvelopeHeaders>(page, url, envelopeHeaderRequestParser);
 
-    expect(envHeader.baggage).toBeDefined();
-    expect(envHeader.baggage).toEqual('{version:2.1.12}');
+    expect(envHeader.trace).toBeDefined();
+    expect(envHeader.trace).toEqual('{version:2.1.12}');
   },
 );
 

--- a/packages/integration-tests/suites/tracing/browsertracing/meta/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/meta/test.ts
@@ -1,8 +1,8 @@
 import { expect } from '@playwright/test';
-import { Event } from '@sentry/types';
+import { Event, EventEnvelopeHeaders } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
-import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
+import { envelopeHeaderRequestParser, getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
 sentryTest(
   'should create a pageload transaction based on `sentry-trace` <meta>',
@@ -18,6 +18,20 @@ sentryTest(
     });
 
     expect(eventData.spans?.length).toBeGreaterThan(0);
+  },
+);
+
+// TODO this we can't really test until we actually propagate sentry- entries in baggage
+// skipping for now but this must be adjusted later on
+sentryTest.skip(
+  'should pick up `baggage` <meta> tag and propagate the content in transaction',
+  async ({ getLocalTestPath, page }) => {
+    const url = await getLocalTestPath({ testDir: __dirname });
+
+    const envHeader = await getFirstSentryEnvelopeRequest<EventEnvelopeHeaders>(page, url, envelopeHeaderRequestParser);
+
+    expect(envHeader.baggage).toBeDefined();
+    expect(envHeader.baggage).toEqual('{version:2.1.12}');
   },
 );
 

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
@@ -1,0 +1,52 @@
+import * as path from 'path';
+
+import { getAPIResponse, runServer } from '../../../../utils/index';
+import { TestAPIResponse } from '../server';
+
+test('Should assign `baggage` header which contains 3rd party trace baggage data of an outgoing request.', async () => {
+  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+
+  const response = (await getAPIResponse(new URL(`${url}/express`), {
+    baggage: 'foo=bar,bar=baz',
+  })) as TestAPIResponse;
+
+  expect(response).toBeDefined();
+  expect(response).toMatchObject({
+    test_data: {
+      host: 'somewhere.not.sentry',
+      baggage: expect.stringContaining('foo=bar,bar=baz'),
+    },
+  });
+});
+
+test('Should assign `baggage` header which contains sentry trace baggage data of an outgoing request.', async () => {
+  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+
+  const response = (await getAPIResponse(new URL(`${url}/express`), {
+    baggage: 'sentry-version=1.0.0,sentry-environment=production',
+  })) as TestAPIResponse;
+
+  expect(response).toBeDefined();
+  expect(response).toMatchObject({
+    test_data: {
+      host: 'somewhere.not.sentry',
+      baggage: expect.stringContaining('sentry-version=1.0.0,sentry-environment=production'),
+    },
+  });
+});
+
+test('Should assign `baggage` header which contains sentry and 3rd party trace baggage data of an outgoing request.', async () => {
+  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+
+  const response = (await getAPIResponse(new URL(`${url}/express`), {
+    baggage: 'sentry-version=1.0.0,sentry-environment=production,dogs=great',
+  })) as TestAPIResponse;
+
+  expect(response).toBeDefined();
+  expect(response).toMatchObject({
+    test_data: {
+      host: 'somewhere.not.sentry',
+      baggage: expect.stringContaining('dogs=great,sentry-version=1.0.0,sentry-environment=production'),
+    },
+  });
+});

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/test.ts
@@ -1,0 +1,19 @@
+import * as path from 'path';
+
+import { getAPIResponse, runServer } from '../../../../utils/index';
+import { TestAPIResponse } from '../server';
+
+test('should attach a `baggage` header to an outgoing request.', async () => {
+  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+
+  const response = (await getAPIResponse(new URL(`${url}/express`))) as TestAPIResponse;
+
+  expect(response).toBeDefined();
+  expect(response).toMatchObject({
+    test_data: {
+      host: 'somewhere.not.sentry',
+      // TODO this is currently still empty but eventually it should contain sentry data
+      baggage: expect.stringMatching(''),
+    },
+  });
+});

--- a/packages/node-integration-tests/suites/express/sentry-trace/server.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/server.ts
@@ -6,7 +6,7 @@ import http from 'http';
 
 const app = express();
 
-export type TestAPIResponse = { test_data: { host: string; 'sentry-trace': string } };
+export type TestAPIResponse = { test_data: { host: string; 'sentry-trace': string; baggage: string } };
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -1,6 +1,6 @@
 import { getCurrentHub } from '@sentry/core';
 import { Integration, Span } from '@sentry/types';
-import { fill, logger, parseSemver } from '@sentry/utils';
+import { fill, logger, mergeAndSerializeBaggage, parseSemver } from '@sentry/utils';
 import * as http from 'http';
 import * as https from 'https';
 
@@ -123,7 +123,14 @@ function _createWrappedRequestMethodFactory(
             logger.log(
               `[Tracing] Adding sentry-trace header ${sentryTraceHeader} to outgoing request to ${requestUrl}: `,
             );
-          requestOptions.headers = { ...requestOptions.headers, 'sentry-trace': sentryTraceHeader };
+
+          const headerBaggageString = requestOptions.headers && (requestOptions.headers.baggage as string);
+
+          requestOptions.headers = {
+            ...requestOptions.headers,
+            'sentry-trace': sentryTraceHeader,
+            baggage: mergeAndSerializeBaggage(span.getBaggage(), headerBaggageString),
+          };
         }
       }
 

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -11,7 +11,7 @@ import {
 } from '@sentry/node';
 import { extractTraceparentData } from '@sentry/tracing';
 import { Integration } from '@sentry/types';
-import { extensionRelayDSN, isString, logger } from '@sentry/utils';
+import { extensionRelayDSN, isString, logger, parseBaggageString } from '@sentry/utils';
 // NOTE: I have no idea how to fix this right now, and don't want to waste more time, as it builds just fine — Kamil
 // eslint-disable-next-line import/no-unresolved
 import { Context, Handler } from 'aws-lambda';
@@ -288,10 +288,17 @@ export function wrapHandler<TEvent, TResult>(
     if (eventWithHeaders.headers && isString(eventWithHeaders.headers['sentry-trace'])) {
       traceparentData = extractTraceparentData(eventWithHeaders.headers['sentry-trace']);
     }
+
+    const baggage =
+      eventWithHeaders.headers &&
+      isString(eventWithHeaders.headers.baggage) &&
+      parseBaggageString(eventWithHeaders.headers.baggage);
+
     const transaction = startTransaction({
       name: context.functionName,
       op: 'awslambda.handler',
       ...traceparentData,
+      ...(baggage && { metadata: { baggage: baggage } }),
     });
 
     const hub = getCurrentHub();

--- a/packages/serverless/test/gcpfunction.test.ts
+++ b/packages/serverless/test/gcpfunction.test.ts
@@ -120,6 +120,39 @@ describe('GCPFunction', () => {
       expect(Sentry.flush).toBeCalledWith(2000);
     });
 
+    test('incoming trace headers are correctly parsed and used', async () => {
+      expect.assertions(1);
+
+      const handler: HttpFunction = (_req, res) => {
+        res.statusCode = 200;
+        res.end();
+      };
+      const wrappedHandler = wrapHttpFunction(handler);
+      const traceHeaders = {
+        'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
+        baggage: 'sentry-release=2.12.1,maisey=silly,charlie=goofy',
+      };
+      await handleHttp(wrappedHandler, traceHeaders);
+
+      expect(Sentry.startTransaction).toBeCalledWith(
+        expect.objectContaining({
+          name: 'POST /path',
+          op: 'gcp.function.http',
+          traceId: '12312012123120121231201212312012',
+          parentSpanId: '1121201211212012',
+          parentSampled: false,
+          metadata: {
+            baggage: [
+              {
+                release: '2.12.1',
+              },
+              'maisey=silly,charlie=goofy',
+            ],
+          },
+        }),
+      );
+    });
+
     test('capture error', async () => {
       expect.assertions(5);
 

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -243,20 +243,6 @@ export class BrowserTracing implements Integration {
 }
 
 /**
- * Gets transaction context from a sentry-trace meta.
- *
- * @returns Transaction context data from the header or undefined if there's no header or the header is malformed
- */
-export function getHeaderContext(): Partial<TransactionContext> | undefined {
-  const header = getMetaContent('sentry-trace');
-  if (header) {
-    return extractTraceparentData(header);
-  }
-
-  return undefined;
-}
-
-/**
  * Gets transaction context data from `sentry-trace` and `baggage` <meta> tags.
  * @returns Transaction context data or undefined neither tag exists or has valid data
  */

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -256,7 +256,7 @@ export function extractTraceDataFromMetaTags(): Partial<TransactionContext> | un
   // TODO more extensive checks for baggage validity/emptyness?
   if (sentrytraceData || baggage) {
     return {
-      ...sentrytraceData,
+      ...(sentrytraceData && { sentrytraceData }),
       ...(baggage && { metadata: { baggage } }),
     };
   }

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -256,7 +256,7 @@ export function extractTraceDataFromMetaTags(): Partial<TransactionContext> | un
   // TODO more extensive checks for baggage validity/emptyness?
   if (sentrytraceData || baggage) {
     return {
-      ...(sentrytraceData && { sentrytraceData }),
+      ...(sentrytraceData && sentrytraceData),
       ...(baggage && { metadata: { baggage } }),
     };
   }

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -1,4 +1,10 @@
-import { addInstrumentationHandler, BAGGAGE_HEADER_NAME, isInstanceOf, isMatchingPattern,serializeBaggage  } from '@sentry/utils';
+import {
+  addInstrumentationHandler,
+  BAGGAGE_HEADER_NAME,
+  isInstanceOf,
+  isMatchingPattern,
+  serializeBaggage,
+} from '@sentry/utils';
 
 import { Span } from '../span';
 import { getActiveTransaction, hasTracingEnabled } from '../utils';

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -1,5 +1,4 @@
-import { BAGGAGE_HEADER_NAME, serializeBaggage } from '@sentry/utils';
-import { addInstrumentationHandler, isInstanceOf, isMatchingPattern } from '@sentry/utils';
+import { addInstrumentationHandler, BAGGAGE_HEADER_NAME, isInstanceOf, isMatchingPattern,serializeBaggage  } from '@sentry/utils';
 
 import { Span } from '../span';
 import { getActiveTransaction, hasTracingEnabled } from '../utils';

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -1,14 +1,10 @@
 /* eslint-disable max-lines */
-import { Baggage } from '@sentry/types';
 import {
   addInstrumentationHandler,
   BAGGAGE_HEADER_NAME,
-  createBaggage,
-  getThirdPartyBaggage,
   isInstanceOf,
   isMatchingPattern,
-  parseBaggageString,
-  serializeBaggage,
+  mergeAndSerializeBaggage,
 } from '@sentry/utils';
 
 import { Span } from '../span';
@@ -313,31 +309,4 @@ export function xhrCallback(
       }
     }
   }
-}
-
-/**
- * Merges the baggage header we saved from the incoming request (or meta tag) with
- * a possibly created or modified baggage header by a third party that's been added
- * to the outgoing request header.
- *
- * In case @param headerBaggage exists, we can safely add the the 3rd party part of @param headerBaggage
- * with our @param incomingBaggage. This is possible because if we modified anything beforehand,
- * it would only affect parts of the sentry baggage (@see Baggage interface).
- *
- * @param incomingBaggage the baggage header of the incoming request that might contain sentry entries
- * @param headerBaggageString possibly existing baggage header string added from a third party to request headers
- *
- * @return a merged and serialized baggage string to be propagated with the outgoing request
- */
-function mergeAndSerializeBaggage(incomingBaggage?: Baggage, headerBaggageString?: string): string {
-  if (!incomingBaggage && !headerBaggageString) {
-    return '';
-  }
-
-  const headerBaggage = (headerBaggageString && parseBaggageString(headerBaggageString)) || undefined;
-  const thirdPartyHeaderBaggage = headerBaggage && getThirdPartyBaggage(headerBaggage);
-
-  const finalBaggage = createBaggage((incomingBaggage && incomingBaggage[0]) || {}, thirdPartyHeaderBaggage || '');
-
-  return serializeBaggage(finalBaggage);
 }

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { Primitive, Span as SpanInterface, SpanContext, Transaction } from '@sentry/types';
+import { Baggage, Primitive, Span as SpanInterface, SpanContext, Transaction } from '@sentry/types';
 import { dropUndefinedKeys, timestampWithMs, uuid4 } from '@sentry/utils';
 
 /**
@@ -296,6 +296,13 @@ export class Span implements SpanInterface {
       tags: Object.keys(this.tags).length > 0 ? this.tags : undefined,
       trace_id: this.traceId,
     });
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public getBaggage(): Baggage | undefined {
+    return this.transaction && this.transaction.metadata.baggage;
   }
 
   /**

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -377,13 +377,13 @@ describe('BrowserTracing', () => {
 
         expect(headerContext).toBeDefined();
         expect(headerContext?.metadata?.baggage).toBeDefined();
-        const baggage = headerContext?.metadata?.baggage!;
-        expect(baggage[0]).toBeDefined();
-        expect(baggage[0]).toEqual({
+        const baggage = headerContext?.metadata?.baggage;
+        expect(baggage && baggage[0]).toBeDefined();
+        expect(baggage && baggage[0]).toEqual({
           release: '2.1.12',
         } as BaggageObj);
-        expect(baggage[1]).toBeDefined();
-        expect(baggage[1]).toEqual('foo=bar');
+        expect(baggage && baggage[1]).toBeDefined();
+        expect(baggage && baggage[1]).toEqual('foo=bar');
       });
 
       it('returns undefined if the sentry-trace header is malformed', () => {
@@ -402,10 +402,9 @@ describe('BrowserTracing', () => {
         // TODO currently this creates invalid baggage. This must be adressed in a follow-up PR
         expect(headerContext).toBeDefined();
         expect(headerContext?.metadata?.baggage).toBeDefined();
-        const baggage = headerContext?.metadata?.baggage!;
-        expect(baggage[0]).toBeDefined();
-        //expect(baggage[0]).toEqual);
-        expect(baggage[1]).toBeDefined();
+        const baggage = headerContext?.metadata?.baggage;
+        expect(baggage && baggage[0]).toBeDefined();
+        expect(baggage && baggage[1]).toBeDefined();
       });
 
       it("returns undefined if the header isn't there", () => {

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -1,12 +1,13 @@
 import { BrowserClient } from '@sentry/browser';
 import { Hub, makeMain } from '@sentry/hub';
+import { BaggageObj } from '@sentry/types';
 import { getGlobalObject, InstrumentHandlerCallback, InstrumentHandlerType } from '@sentry/utils';
 import { JSDOM } from 'jsdom';
 
 import {
   BrowserTracing,
   BrowserTracingOptions,
-  getHeaderContext,
+  extractTraceDataFromMetaTags,
   getMetaContent,
 } from '../../src/browser/browsertracing';
 import { MetricsInstrumentation } from '../../src/browser/metrics';
@@ -215,7 +216,8 @@ describe('BrowserTracing', () => {
     it('sets transaction context from sentry-trace header', () => {
       const name = 'sentry-trace';
       const content = '126de09502ae4e0fb26c6967190756a4-b6e54397b12a2a0f-1';
-      document.head.innerHTML = `<meta name="${name}" content="${content}">`;
+      document.head.innerHTML =
+        `<meta name="${name}" content="${content}">` + '<meta name="baggage" content="sentry-release=2.1.14,foo=bar">';
       const startIdleTransaction = jest.spyOn(hubExtensions, 'startIdleTransaction');
 
       createBrowserTracing(true, { routingInstrumentation: customInstrumentRouting });
@@ -226,6 +228,9 @@ describe('BrowserTracing', () => {
           traceId: '126de09502ae4e0fb26c6967190756a4',
           parentSpanId: 'b6e54397b12a2a0f',
           parentSampled: true,
+          metadata: {
+            baggage: [{ release: '2.1.14' }, 'foo=bar'],
+          },
         }),
         expect.any(Number),
         expect.any(Number),
@@ -322,7 +327,7 @@ describe('BrowserTracing', () => {
     });
   });
 
-  describe('sentry-trace <meta> element', () => {
+  describe('sentry-trace and baggage <meta> elements', () => {
     describe('getMetaContent', () => {
       it('finds the specified tag and extracts the value', () => {
         const name = 'sentry-trace';
@@ -352,12 +357,12 @@ describe('BrowserTracing', () => {
       });
     });
 
-    describe('getHeaderContext', () => {
+    describe('extractTraceDataFromMetaTags()', () => {
       it('correctly parses a valid sentry-trace meta header', () => {
         document.head.innerHTML =
           '<meta name="sentry-trace" content="12312012123120121231201212312012-1121201211212012-0">';
 
-        const headerContext = getHeaderContext();
+        const headerContext = extractTraceDataFromMetaTags();
 
         expect(headerContext).toBeDefined();
         expect(headerContext!.traceId).toEqual('12312012123120121231201212312012');
@@ -365,54 +370,94 @@ describe('BrowserTracing', () => {
         expect(headerContext!.parentSampled).toEqual(false);
       });
 
-      it('returns undefined if the header is malformed', () => {
+      it('correctly parses a valid baggage meta header', () => {
+        document.head.innerHTML = '<meta name="baggage" content="sentry-release=2.1.12,foo=bar">';
+
+        const headerContext = extractTraceDataFromMetaTags();
+
+        expect(headerContext).toBeDefined();
+        expect(headerContext?.metadata?.baggage).toBeDefined();
+        const baggage = headerContext?.metadata?.baggage!;
+        expect(baggage[0]).toBeDefined();
+        expect(baggage[0]).toEqual({
+          release: '2.1.12',
+        } as BaggageObj);
+        expect(baggage[1]).toBeDefined();
+        expect(baggage[1]).toEqual('foo=bar');
+      });
+
+      it('returns undefined if the sentry-trace header is malformed', () => {
         document.head.innerHTML = '<meta name="sentry-trace" content="12312012-112120121-0">';
 
-        const headerContext = getHeaderContext();
+        const headerContext = extractTraceDataFromMetaTags();
 
         expect(headerContext).toBeUndefined();
+      });
+
+      it('does not crash if the baggage header is malformed', () => {
+        document.head.innerHTML = '<meta name="baggage" content="sentry-relase:2.1.13;foo-bar">';
+
+        const headerContext = extractTraceDataFromMetaTags();
+
+        // TODO currently this creates invalid baggage. This must be adressed in a follow-up PR
+        expect(headerContext).toBeDefined();
+        expect(headerContext?.metadata?.baggage).toBeDefined();
+        const baggage = headerContext?.metadata?.baggage!;
+        expect(baggage[0]).toBeDefined();
+        //expect(baggage[0]).toEqual);
+        expect(baggage[1]).toBeDefined();
       });
 
       it("returns undefined if the header isn't there", () => {
         document.head.innerHTML = '<meta name="dogs" content="12312012123120121231201212312012-1121201211212012-0">';
 
-        const headerContext = getHeaderContext();
+        const headerContext = extractTraceDataFromMetaTags();
 
         expect(headerContext).toBeUndefined();
       });
     });
 
     describe('using the data', () => {
-      it('uses the data for pageload transactions', () => {
+      it('uses the tracing data for pageload transactions', () => {
         // make sampled false here, so we can see that it's being used rather than the tracesSampleRate-dictated one
         document.head.innerHTML =
-          '<meta name="sentry-trace" content="12312012123120121231201212312012-1121201211212012-0">';
+          '<meta name="sentry-trace" content="12312012123120121231201212312012-1121201211212012-0">' +
+          '<meta name="baggage" content="sentry-release=2.1.14,foo=bar">';
 
         // pageload transactions are created as part of the BrowserTracing integration's initialization
         createBrowserTracing(true);
         const transaction = getActiveTransaction(hub) as IdleTransaction;
+        const baggage = transaction.getBaggage()!;
 
         expect(transaction).toBeDefined();
         expect(transaction.op).toBe('pageload');
         expect(transaction.traceId).toEqual('12312012123120121231201212312012');
         expect(transaction.parentSpanId).toEqual('1121201211212012');
         expect(transaction.sampled).toBe(false);
+        expect(baggage).toBeDefined();
+        expect(baggage[0]).toBeDefined();
+        expect(baggage[0]).toEqual({ release: '2.1.14' });
+        expect(baggage[1]).toBeDefined();
+        expect(baggage[1]).toEqual('foo=bar');
       });
 
       it('ignores the data for navigation transactions', () => {
         mockChangeHistory = () => undefined;
         document.head.innerHTML =
-          '<meta name="sentry-trace" content="12312012123120121231201212312012-1121201211212012-0">';
+          '<meta name="sentry-trace" content="12312012123120121231201212312012-1121201211212012-0">' +
+          '<meta name="baggage" content="sentry-release=2.1.14,foo=bar">';
 
         createBrowserTracing(true);
 
         mockChangeHistory({ to: 'here', from: 'there' });
         const transaction = getActiveTransaction(hub) as IdleTransaction;
+        const baggage = transaction.getBaggage()!;
 
         expect(transaction).toBeDefined();
         expect(transaction.op).toBe('navigation');
         expect(transaction.traceId).not.toEqual('12312012123120121231201212312012');
         expect(transaction.parentSpanId).toBeUndefined();
+        expect(baggage).toBeUndefined();
       });
     });
   });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -19,6 +19,7 @@ export type {
   EventEnvelope,
   EventEnvelopeHeaders,
   EventItem,
+  EventTraceContext,
   SessionEnvelope,
   SessionItem,
   UserFeedbackItem,

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -1,3 +1,4 @@
+import { Baggage } from './baggage';
 import { Primitive } from './misc';
 import { Transaction } from './transaction';
 
@@ -174,4 +175,7 @@ export interface Span extends SpanContext {
     timestamp?: number;
     trace_id: string;
   };
+
+  /** return the baggage for dynamic sampling and trace propagation */
+  getBaggage(): Baggage | undefined;
 }

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -1,6 +1,6 @@
+import { Baggage } from './baggage';
 import { ExtractedNodeRequestData, Primitive, WorkerLocation } from './misc';
 import { Span, SpanContext } from './span';
-
 /**
  * Interface holding Transaction-specific properties
  */
@@ -131,11 +131,8 @@ export type TransactionSamplingMethod = 'explicitly_set' | 'client_sampler' | 'c
 export interface TransactionMetadata {
   transactionSampling?: { rate?: number; method: TransactionSamplingMethod };
 
-  /** The two halves (sentry and third-party) of a transaction's tracestate header, used for dynamic sampling */
-  tracestate?: {
-    sentry?: string;
-    thirdparty?: string;
-  };
+  /** The baggage object of a transaction's baggage header, used for dynamic sampling  */
+  baggage?: Baggage;
 
   /** For transactions tracing server-side request handling, the path of the request being tracked. */
   requestPath?: string;

--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -109,7 +109,9 @@ export function mergeAndSerializeBaggage(incomingBaggage?: Baggage, headerBaggag
   const headerBaggage = (headerBaggageString && parseBaggageString(headerBaggageString)) || undefined;
   const thirdPartyHeaderBaggage = headerBaggage && getThirdPartyBaggage(headerBaggage);
 
-  const finalBaggage = createBaggage((incomingBaggage && incomingBaggage[0]) || {}, thirdPartyHeaderBaggage || '');
-
+  const finalBaggage = createBaggage(
+    (incomingBaggage && incomingBaggage[0]) || {},
+    thirdPartyHeaderBaggage || (incomingBaggage && incomingBaggage[1]) || '',
+  );
   return serializeBaggage(finalBaggage);
 }

--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -92,7 +92,7 @@ export function parseBaggageString(inputBaggageString: string): Baggage {
  * a possibly created or modified baggage header by a third party that's been added
  * to the outgoing request header.
  *
- * In case @param headerBaggage exists, we can safely add the the 3rd party part of @param headerBaggage
+ * In case @param headerBaggageString exists, we can safely add the the 3rd party part of @param headerBaggage
  * with our @param incomingBaggage. This is possible because if we modified anything beforehand,
  * it would only affect parts of the sentry baggage (@see Baggage interface).
  *

--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -41,6 +41,14 @@ export function getSentryBaggageItems(baggage: Baggage): BaggageObj {
   return baggage[0];
 }
 
+/**
+ * Returns 3rd party baggage string of @param baggage
+ * @param baggage
+ */
+export function getThirdPartyBaggage(baggage: Baggage): string {
+  return baggage[1];
+}
+
 /** Serialize a baggage object */
 export function serializeBaggage(baggage: Baggage): string {
   return Object.keys(baggage[0]).reduce((prev, key: keyof BaggageObj) => {


### PR DESCRIPTION
This PR adds the propagation of an "empty" baggage header. The word "empty" is however kind of misleading as the header is not necessarily empty. In order to comply with the baggage spec, as of this PR, we propagate incoming (3rd party) baggage to outgoing requests. The important part of this PR is that we actually add the `baggage` HTTP header to outgoing requests which is a breaking change in terms of CORS rules having to be adjusted.

We don't yet add `sentry-` baggage entries to the propagated baggage. This will come in a follow up PR which does not necessarily have to be part of the initial v7 release as it is no longer a breaking change. 

Overall, the PR is heavily inspired from #3945 (thanks @lobsterkatie for doing the hard work)

More specifically, this PR does the following things:

1. Extract incoming baggage headers and store them in the created transaction's metadata. Incoming baggage data is intercepted at:
* Node SDK: TracingHandler
* Serverless SDK: AWS wrapHandler
* Serverless SDK: GCP wrapHttpFunction
* Next.js: SDK makeWrappedReqHandler
* Next.js: SDK withSentry
* BrowserTracing Integration: by parsing the `<meta>` tags (analogously to the `sentry-trace` header)

2. Add the extracted baggage data to outgoing requests we instrument at:
* Node SDK: HTTP integration
* Tracing: instrumented Fetch and XHR callbacks

Note that there is still a lot to be done until we have a properly working baggage propagation. This PR should add much of the necessary groundwork but it is far from complete. I'm very open for improvement suggestions (also I might have missed something) and already added a few TODOs to follow up on in future PRs. We will iterate on baggage in upcoming PRs (potentially post-v7.0.0).

Also commented out lambda stuff because it's broken with the changed GH action.

ref: https://getsentry.atlassian.net/browse/WEB-925