### PR TITLE
feat(build): Allow for multiple bundle entrypoints

### DIFF
--- a/packages/browser/rollup.bundle.config.js
+++ b/packages/browser/rollup.bundle.config.js
@@ -5,10 +5,10 @@ const builds = [];
 ['es5', 'es6'].forEach(jsVersion => {
   const baseBundleConfig = makeBaseBundleConfig({
     bundleType: 'standalone',
-    input: 'src/index.ts',
+    entrypoints: ['src/index.ts'],
     jsVersion,
     licenseTitle: '@sentry/browser',
-    outputFileBase: `bundles/bundle${jsVersion === 'es5' ? '.es5' : ''}`,
+    outputFileBase: () => `bundles/bundle${jsVersion === 'es5' ? '.es5' : ''}`,
   });
 
   builds.push(...makeBundleConfigVariants(baseBundleConfig));

--- a/packages/integrations/rollup.bundle.config.js
+++ b/packages/integrations/rollup.bundle.config.js
@@ -9,10 +9,10 @@ const jsVersion = process.env.JS_VERSION;
 
 const baseBundleConfig = makeBaseBundleConfig({
   bundleType: 'addon',
-  input: `src/${file}`,
+  entrypoints: [`src/${file}`],
   jsVersion,
   licenseTitle: '@sentry/integrations',
-  outputFileBase: `bundles/${file.replace('.ts', '')}${jsVersion === 'ES5' ? '.es5' : ''}`,
+  outputFileBase: ({ name: entrypoint }) => `bundles/${entrypoint}${jsVersion === 'ES5' ? '.es5' : ''}`,
 });
 
 // TODO We only need `commonjs` for localforage (used in the offline plugin). Once that's fixed, this can come out.

--- a/packages/tracing/rollup.bundle.config.js
+++ b/packages/tracing/rollup.bundle.config.js
@@ -5,10 +5,10 @@ const builds = [];
 ['es5', 'es6'].forEach(jsVersion => {
   const baseBundleConfig = makeBaseBundleConfig({
     bundleType: 'standalone',
-    input: 'src/index.bundle.ts',
+    entrypoints: ['src/index.bundle.ts'],
     jsVersion,
     licenseTitle: '@sentry/tracing & @sentry/browser',
-    outputFileBase: `bundles/bundle.tracing${jsVersion === 'es5' ? '.es5' : ''}`,
+    outputFileBase: () => `bundles/bundle.tracing${jsVersion === 'es5' ? '.es5' : ''}`,
   });
 
   builds.push(...makeBundleConfigVariants(baseBundleConfig));

--- a/packages/vue/rollup.bundle.config.js
+++ b/packages/vue/rollup.bundle.config.js
@@ -2,10 +2,10 @@ import { makeBaseBundleConfig, makeBundleConfigVariants } from '../../rollup/ind
 
 const baseBundleConfig = makeBaseBundleConfig({
   bundleType: 'standalone',
-  input: 'src/index.bundle.ts',
+  entrypoints: ['src/index.bundle.ts'],
   jsVersion: 'es6',
   licenseTitle: '@sentry/vue',
-  outputFileBase: 'bundle.vue',
+  outputFileBase: () => 'bundle.vue',
 });
 
 export default makeBundleConfigVariants(baseBundleConfig);

--- a/packages/wasm/rollup.bundle.config.js
+++ b/packages/wasm/rollup.bundle.config.js
@@ -2,10 +2,10 @@ import { makeBaseBundleConfig, makeBundleConfigVariants } from '../../rollup/ind
 
 const baseBundleConfig = makeBaseBundleConfig({
   bundleType: 'addon',
-  input: 'src/index.ts',
+  entrypoints: ['src/index.ts'],
   jsVersion: 'es6',
   licenseTitle: '@sentry/wasm',
-  outputFileBase: 'bundles/wasm',
+  outputFileBase: () => 'bundles/wasm',
 });
 
 export default makeBundleConfigVariants(baseBundleConfig);

--- a/rollup/bundleHelpers.js
+++ b/rollup/bundleHelpers.js
@@ -21,7 +21,7 @@ import {
 import { mergePlugins } from './utils';
 
 export function makeBaseBundleConfig(options) {
-  const { bundleType, input, jsVersion, licenseTitle, outputFileBase } = options;
+  const { bundleType, entrypoints, jsVersion, licenseTitle, outputFileBase } = options;
 
   const nodeResolvePlugin = makeNodeResolvePlugin();
   const sucrasePlugin = makeSucrasePlugin();
@@ -91,10 +91,11 @@ export function makeBaseBundleConfig(options) {
 
   // used by all bundles
   const sharedBundleConfig = {
-    input,
+    input: entrypoints,
     output: {
       // a file extension will be added to this base value when we specify either a minified or non-minified build
-      file: `build/${outputFileBase}`,
+      entryFileNames: outputFileBase,
+      dir: 'build',
       sourcemap: true,
       strict: false,
       esModule: false,
@@ -136,7 +137,7 @@ export function makeBundleConfigVariants(baseConfig) {
   const variantSpecificConfigs = [
     {
       output: {
-        file: `${baseConfig.output.file}.js`,
+        entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.js`,
       },
       plugins: [includeDebuggingPlugin],
     },
@@ -150,13 +151,13 @@ export function makeBundleConfigVariants(baseConfig) {
     // },
     {
       output: {
-        file: `${baseConfig.output.file}.min.js`,
+        entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.min.js`,
       },
       plugins: [stripDebuggingPlugin, terserPlugin],
     },
     {
       output: {
-        file: `${baseConfig.output.file}.debug.min.js`,
+        entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.debug.min.js`,
       },
       plugins: [terserPlugin],
     },


### PR DESCRIPTION
This adds the ability to create more than one bundle with a single bundle rollup config, by specifying multiple entrypoints. Because multiple files can now be output, the way they're named also needed to be switched, from providing a static string to providing a function to determine the name of each bundle. Finally, the name of the option (`input`) was changed to match the corresponding option used in the building of npm packages (`entryponts`).