### PR TITLE
feat(build): Add ability to combine package-specific rollup config with standard options

### DIFF
--- a/packages/nextjs/rollup.npm.config.js
+++ b/packages/nextjs/rollup.npm.config.js
@@ -7,6 +7,6 @@ export default makeNPMConfigVariants(
     entrypoints: ['src/index.server.ts', 'src/index.client.ts', 'src/utils/instrumentServer.ts'],
     // prevent this nextjs code from ending up in our built package (this doesn't happen automatially because the name
     // doesn't match an SDK dependency)
-    externals: ['next/router'],
+    packageSpecificConfig: { external: ['next/router'] },
   }),
 );

--- a/rollup/bundleHelpers.js
+++ b/rollup/bundleHelpers.js
@@ -21,7 +21,7 @@ import {
 import { mergePlugins } from './utils';
 
 export function makeBaseBundleConfig(options) {
-  const { bundleType, entrypoints, jsVersion, licenseTitle, outputFileBase } = options;
+  const { bundleType, entrypoints, jsVersion, licenseTitle, outputFileBase, packageSpecificConfig } = options;
 
   const nodeResolvePlugin = makeNodeResolvePlugin();
   const sucrasePlugin = makeSucrasePlugin();
@@ -113,7 +113,7 @@ export function makeBaseBundleConfig(options) {
     node: nodeBundleConfig,
   };
 
-  return deepMerge(sharedBundleConfig, bundleTypeConfigMap[bundleType], {
+  return deepMerge.all([sharedBundleConfig, bundleTypeConfigMap[bundleType], packageSpecificConfig || {}], {
     // Plugins have to be in the correct order or everything breaks, so when merging we have to manually re-order them
     customMerge: key => (key === 'plugins' ? mergePlugins : undefined),
   });


### PR DESCRIPTION
Currently, the functions which we use to generate rollup configs accept a small handful of pre-defined options for customizing the output. For greater flexibility, this adds the option of passing arbitrary rollup options, which will get merged into what is currently being generated.