### PR TITLE
feat(build): Add option to build only specified bundle variants

### DIFF
--- a/rollup/bundleHelpers.js
+++ b/rollup/bundleHelpers.js
@@ -141,15 +141,6 @@ export function makeBundleConfigVariants(baseConfig) {
       },
       plugins: [includeDebuggingPlugin],
     },
-    // This variant isn't particularly helpful for an SDK user, as it strips logging while making no other minification
-    // changes, so by default we don't create it. It is however very useful when debugging rollup's treeshaking, so it's
-    // left here for that purpose.
-    // {
-    //   output: { file: `${baseConfig.output.file}.no-debug.js`,
-    //   },
-    //   plugins: [stripDebuggingPlugin],
-    // },
-    {
       output: {
         entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.min.js`,
       },

--- a/rollup/bundleHelpers.js
+++ b/rollup/bundleHelpers.js
@@ -20,6 +20,8 @@ import {
 } from './plugins/index.js';
 import { mergePlugins } from './utils';
 
+const BUNDLE_VARIANTS = ['.js', '.min.js', '.debug.min.js'];
+
 export function makeBaseBundleConfig(options) {
   const { bundleType, entrypoints, jsVersion, licenseTitle, outputFileBase, packageSpecificConfig } = options;
 
@@ -128,37 +130,45 @@ export function makeBaseBundleConfig(options) {
  * @param baseConfig The rollup config shared by the entire package
  * @returns An array of versions of that config
  */
-export function makeBundleConfigVariants(baseConfig) {
+export function makeBundleConfigVariants(baseConfig, options = {}) {
+  const { variants = BUNDLE_VARIANTS } = options;
+
   const includeDebuggingPlugin = makeIsDebugBuildPlugin(true);
   const stripDebuggingPlugin = makeIsDebugBuildPlugin(false);
   const terserPlugin = makeTerserPlugin();
 
-  // The additional options to use for each variant we're going to create
-  const variantSpecificConfigs = [
-    {
+  // The additional options to use for each variant we're going to create.
+  const variantSpecificConfigMap = {
+    '.js': {
       output: {
         entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.js`,
       },
       plugins: [includeDebuggingPlugin],
     },
+
+    '.min.js': {
       output: {
         entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.min.js`,
       },
       plugins: [stripDebuggingPlugin, terserPlugin],
     },
-    {
+
+    '.debug.min.js': {
       output: {
         entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.debug.min.js`,
       },
       plugins: [terserPlugin],
     },
-  ];
+  };
 
-  return variantSpecificConfigs.map(variant =>
-    deepMerge(baseConfig, variant, {
+  return variants.map(variant => {
+    if (!BUNDLE_VARIANTS.includes(variant)) {
+      throw new Error(`Unknown bundle variant requested: ${variant}`);
+    }
+    return deepMerge(baseConfig, variantSpecificConfigMap[variant], {
       // Merge the plugin arrays and make sure the end result is in the correct order. Everything else can use the
       // default merge strategy.
       customMerge: key => (key === 'plugins' ? mergePlugins : undefined),
-    }),
-  );
+    });
+  });
 }


### PR DESCRIPTION
There are situations in which we really only need one version of a bundle rather than all versions, but right now there's no way to build one without building all of them. This adds the option to specify which bundles you need, defaulting to the current behavior of building all three types (regular, minified, and minified with logging) if particular ones aren't requested.
