### PR TITLE
ref(serverless): Deactivate deployment of Lambda Layer

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -2,16 +2,20 @@ minVersion: '0.23.1'
 changelogPolicy: simple
 preReleaseCommand: bash scripts/craft-pre-release.sh
 targets:
-  - name: aws-lambda-layer
-    includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha)\.\d+)?\.zip$/
-    layerName: SentryNodeServerlessSDK
-    compatibleRuntimes:
-      - name: node
-        versions:
-          - nodejs10.x
-          - nodejs12.x
-          - nodejs14.x
-    license: MIT
+  #
+  # Deactivated for now. This needs to be reactivated if the new Sentry Lambda Extension is deployed to production.
+  # (ask Anton Pirker if you have questions.)
+  #
+  # - name: aws-lambda-layer
+  #   includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha)\.\d+)?\.zip$/
+  #   layerName: SentryNodeServerlessSDK
+  #   compatibleRuntimes:
+  #     - name: node
+  #       versions:
+  #         - nodejs10.x
+  #         - nodejs12.x
+  #         - nodejs14.x
+  #   license: MIT
   - name: gcs
     includeNames: /.*\.js.*$/
     bucket: sentry-js-sdk


### PR DESCRIPTION
Deactivated deployment of Lambda Layer until new Lambda Extension is production ready.
With this we make sure, that we do not break existing Lambda Layer users.