### PR TITLE
ref(dev): Improve labeling of checkout step in GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,28 @@ env:
   BUILD_CACHE_KEY: ${{ github.event.inputs.commit || github.sha }}
 
 jobs:
+  job_get_metadata:
+    name: Get Metadata
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out current commit
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.HEAD_COMMIT }}
+          # We need to check out not only the fake merge commit between the PR and the base branch which GH creates, but
+          # also its parents, so that we can pull the commit message from the head commit of the PR
+          fetch-depth: 2
+      - name: Get metadata
+        id: get_metadata
+        # We need to try a number of different options for finding the head commit, because each kind of trigger event
+        # stores it in a different location
+        run: |
+          COMMIT_SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.event.head_commit.id || env.HEAD_COMMIT }})
+          echo "COMMIT_SHA=$COMMIT_SHA" >> $GITHUB_ENV
+          echo "COMMIT_MESSAGE=$(git log -n 1 --pretty=format:%s $COMMIT_SHA)" >> $GITHUB_ENV
+    outputs:
+      commit_label: "${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}"
+
   job_install_deps:
     name: Install Dependencies
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,10 +62,11 @@ jobs:
 
   job_install_deps:
     name: Install Dependencies
+    needs: job_get_metadata
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Check out current commit (${{ env.HEAD_COMMIT }})
+      - name: "Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})"
         uses: actions/checkout@v2
         with:
           ref: ${{ env.HEAD_COMMIT }}
@@ -92,11 +93,11 @@ jobs:
 
   job_build:
     name: Build
-    needs: job_install_deps
+    needs: [ job_get_metadata, job_install_deps ]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Check out current commit (${{ env.HEAD_COMMIT }})
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v2
         with:
           ref: ${{ env.HEAD_COMMIT }}
@@ -172,13 +173,13 @@ jobs:
 
   job_size_check:
     name: Size Check
-    needs: job_build
+    needs: [job_get_metadata, job_build]
     timeout-minutes: 15
     runs-on: ubuntu-latest
     # Size Check will error out outside of the context of a PR
     if: ${{ github.event_name == 'pull_request' }}
     steps:
-      - name: Check out current commit (${{ env.HEAD_COMMIT }})
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v2
         with:
           ref: ${{ env.HEAD_COMMIT }}
@@ -206,11 +207,11 @@ jobs:
 
   job_lint:
     name: Lint
-    needs: job_build
+    needs: [job_get_metadata, job_build]
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: Check out current commit (${{ env.HEAD_COMMIT }})
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v2
         with:
           ref: ${{ env.HEAD_COMMIT }}
@@ -233,11 +234,11 @@ jobs:
 
   job_circular_dep_check:
     name: Circular Dependency Check
-    needs: job_build
+    needs: [job_get_metadata, job_build]
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - name: Check out current commit (${{ env.HEAD_COMMIT }})
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v2
         with:
           ref: ${{ env.HEAD_COMMIT }}
@@ -260,12 +261,12 @@ jobs:
 
   job_artifacts:
     name: Upload Artifacts
-    needs: job_build
+    needs: [job_get_metadata, job_build]
     runs-on: ubuntu-latest
     # Build artifacts are only needed for releasing workflow.
     if: startsWith(github.ref, 'refs/heads/release/')
     steps:
-      - name: Check out current commit (${{ github.sha }})
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v2
         with:
           ref: ${{ env.HEAD_COMMIT }}
@@ -297,7 +298,7 @@ jobs:
 
   job_unit_test:
     name: Test (Node ${{ matrix.node }})
-    needs: job_build
+    needs: [job_get_metadata, job_build]
     continue-on-error: true
     timeout-minutes: 30
     runs-on: ubuntu-latest
@@ -305,7 +306,7 @@ jobs:
       matrix:
         node: [8, 10, 12, 14, 16, 18]
     steps:
-      - name: Check out current commit (${{ env.HEAD_COMMIT }})
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v2
         with:
           ref: ${{ env.HEAD_COMMIT }}
@@ -334,7 +335,7 @@ jobs:
 
   job_nextjs_integration_test:
     name: Test @sentry/nextjs on (Node ${{ matrix.node }})
-    needs: job_build
+    needs: [job_get_metadata, job_build]
     continue-on-error: true
     timeout-minutes: 30
     runs-on: ubuntu-latest
@@ -342,7 +343,7 @@ jobs:
       matrix:
         node: [10, 12, 14, 16, 18]
     steps:
-      - name: Check out current commit (${{ env.HEAD_COMMIT }})
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v2
         with:
           ref: ${{ env.HEAD_COMMIT }}
@@ -371,12 +372,12 @@ jobs:
   # separate job allows them to run in parallel with the other tests.
   job_ember_tests:
     name: Test @sentry/ember
-    needs: job_build
+    needs: [job_get_metadata, job_build]
     continue-on-error: true
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - name: Check out current commit (${{ env.HEAD_COMMIT }})
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v2
         with:
           ref: ${{ env.HEAD_COMMIT }}
@@ -410,7 +411,7 @@ jobs:
 
   job_browser_playwright_tests:
     name: Playwright - ${{ (matrix.tracing_only && 'Browser + Tracing') || 'Browser' }} (${{ matrix.bundle }})
-    needs: job_build
+    needs: [job_get_metadata, job_build]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -432,7 +433,7 @@ jobs:
           - bundle: cjs
             tracing_only: false
     steps:
-      - name: Check out current commit (${{ env.HEAD_COMMIT }})
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v2
         with:
           ref: ${{ env.HEAD_COMMIT }}
@@ -461,7 +462,7 @@ jobs:
 
   job_browser_integration_tests:
     name: Old Browser Integration Tests (${{ matrix.browser }})
-    needs: job_build
+    needs: [job_get_metadata, job_build]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true
@@ -472,7 +473,7 @@ jobs:
           - FirefoxHeadless
           - WebkitHeadless
     steps:
-      - name: Check out current commit (${{ env.HEAD_COMMIT }})
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v2
         with:
           ref: ${{ env.HEAD_COMMIT }}
@@ -500,12 +501,12 @@ jobs:
 
   job_browser_build_tests:
     name: Browser Build Tests
-    needs: job_build
+    needs: [job_get_metadata, job_build]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true
     steps:
-      - name: Check out current commit (${ env.HEAD_COMMIT }})
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v2
         with:
           ref: ${{ env.HEAD_COMMIT }}
@@ -534,7 +535,7 @@ jobs:
 
   job_node_integration_tests:
     name: Node SDK Integration Tests (${{ matrix.node }})
-    needs: job_build
+    needs: [job_get_metadata, job_build]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true
@@ -542,7 +543,7 @@ jobs:
       matrix:
         node: [10, 12, 14, 16, 18]
     steps:
-      - name: Check out current commit (${{ github.sha }})
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v2
         with:
           ref: ${{ env.HEAD_COMMIT }}


### PR DESCRIPTION
Currently, when looking at runs of our `Build & Test` GHA workflow, it's often hard to tell exactly what commit is being used. When the workflow is triggered by a push to a PR, the PR title ends up as the label, which can be pretty uninformative:

![image](https://user-images.githubusercontent.com/14812505/169982107-bfde875b-ea03-4c81-b6df-e5b1a5659e32.png)

Runs triggered manually are no better:

![image](https://user-images.githubusercontent.com/14812505/169981878-6d19206f-fdaa-46da-b0f8-0a61d3753bff.png)

Runs triggered by pushes _are_ better...

![image](https://user-images.githubusercontent.com/14812505/169966520-1887820a-b56c-4582-87a4-7765af138cd3.png)

 ...at least from the outisde, but once you're in one, it's not obvious from the logs which commit is being used:

![image](https://user-images.githubusercontent.com/14812505/169967481-71f9cf27-79c0-40f6-b29f-521dffba1629.png)

(That SHA listed in the checkout step isn't even that helpful, because by default it's not the branch's `HEAD` commit but rather a made-up merge commit between `HEAD` and the base branch, making it useless for identifying `HEAD`.)

This fixes that problem, by adding a preliminary GHA job to gather and store the SHA of the actual branch head (along with its commit message). Subsequent jobs can then use that information to label their checkout step, making it much easier to tell where in the commit history the job falls:

![image](https://user-images.githubusercontent.com/14812505/169969513-ce0c8016-fbf1-441c-aac6-7de9ec87ffaf.png)
