### PR TITLE
ref(core): Remove unnecessary nested `dropUndefinedKeys` call

### DIFF
--- a/packages/core/src/envelope.ts
+++ b/packages/core/src/envelope.ts
@@ -136,12 +136,10 @@ function createEventEnvelopeHeaders(
           environment: event.environment,
           release: event.release,
           transaction: event.transaction,
-          user:
-            event.user &&
-            dropUndefinedKeys({
-              id: event.user.id,
-              segment: event.user.segment,
-            }),
+          user: event.user && {
+            id: event.user.id,
+            segment: event.user.segment,
+          },
           public_key: dsn.publicKey,
         }),
       }),


### PR DESCRIPTION
This very small PR removes an unnecessary nested call to `dropUndefinedKeys` which we don't need because the function is already recursive (which could be causing a problem). 
