### PR TITLE
feat(nextjs): Make tracing package treeshakable

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -351,6 +351,8 @@ For our efforts to reduce bundle size of the SDK we had to remove and refactor p
 - Removed `eventStatusFromHttpCode` to save on bundle size.
 - Replace `BrowserTracing` `maxTransactionDuration` option with `finalTimeout` option
 - Removed `ignoreSentryErrors` option from AWS lambda SDK. Errors originating from the SDK will now *always* be caught internally.
+- Removed `Integrations.BrowserTracing` export from `@sentry/nextjs`. Please import `BrowserTracing` from `@sentry/nextjs` directly.
+- Removed static `id` property from `BrowserTracing` integration.
 
 ## Sentry Angular SDK Changes
 

--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -380,7 +380,22 @@ export async function instrumentForPerformance(appInstance: ApplicationInstance)
     }),
   ];
 
-  if (isTesting() && Sentry.getCurrentHub()?.getIntegration(tracing.Integrations.BrowserTracing)) {
+  class FakeBrowserTracingClass {
+    static id = tracing.BROWSER_TRACING_INTEGRATION_ID;
+    public name = FakeBrowserTracingClass.id;
+    setupOnce() {
+      // noop - We're just faking  this class for a lookup
+    }
+  }
+
+  if (
+    isTesting() &&
+    Sentry.getCurrentHub()?.getIntegration(
+      // This is a temporary hack because the BrowserTracing integration cannot have a static `id` field for tree
+      // shaking reasons. However, `getIntegration` needs that field.
+      FakeBrowserTracingClass,
+    )
+  ) {
     // Initializers are called more than once in tests, causing the integrations to not be setup correctly.
     return;
   }

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -15,6 +15,8 @@ import {
 } from './request';
 import { instrumentRoutingWithDefaults } from './router';
 
+export const BROWSER_TRACING_INTEGRATION_ID = 'BrowserTracing';
+
 /** Options for Browser Tracing integration */
 export interface BrowserTracingOptions extends RequestInstrumentationOptions {
   /**
@@ -111,10 +113,10 @@ const DEFAULT_BROWSER_TRACING_OPTIONS = {
  * any routing library. This integration uses {@see IdleTransaction} to create transactions.
  */
 export class BrowserTracing implements Integration {
-  /**
-   * @inheritDoc
-   */
-  public static id: string = 'BrowserTracing';
+  // This class currently doesn't have a static id field like the other classes, because it prevented @sentry/tracing
+  // from being treeshaken. Tree shaking does not like static fields because they behave like side effects.
+  // TODO: Come up with a better plan, than using static fields on integration classes, and use that plan on all
+  // integrations.
 
   /** Browser Tracing integration options */
   public options: BrowserTracingOptions;
@@ -122,7 +124,7 @@ export class BrowserTracing implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = BrowserTracing.id;
+  public name: string = BROWSER_TRACING_INTEGRATION_ID;
 
   private _getCurrentHub?: () => Hub;
 

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -113,8 +113,8 @@ const DEFAULT_BROWSER_TRACING_OPTIONS = {
  * any routing library. This integration uses {@see IdleTransaction} to create transactions.
  */
 export class BrowserTracing implements Integration {
-  // This class currently doesn't have a static id field like the other classes, because it prevented @sentry/tracing
-  // from being treeshaken. Tree shaking does not like static fields because they behave like side effects.
+  // This class currently doesn't have a static `id` field like the other integration classes, because it prevented
+  // @sentry/tracing from being treeshaken. Tree shakers do not like static fields, because they behave like side effects.
   // TODO: Come up with a better plan, than using static fields on integration classes, and use that plan on all
   // integrations.
 

--- a/packages/tracing/src/browser/index.ts
+++ b/packages/tracing/src/browser/index.ts
@@ -1,4 +1,4 @@
 export type { RequestInstrumentationOptions } from './request';
 
-export { BrowserTracing } from './browsertracing';
+export { BrowserTracing, BROWSER_TRACING_INTEGRATION_ID } from './browsertracing';
 export { instrumentOutgoingRequests, defaultRequestInstrumentationOptions } from './request';

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -22,7 +22,7 @@ export { Integrations };
 // const instance = new BrowserTracing();
 //
 // For an example of of the new usage of BrowserTracing, see @sentry/nextjs index.client.ts
-export { BrowserTracing } from './browser';
+export { BrowserTracing, BROWSER_TRACING_INTEGRATION_ID } from './browser';
 
 export { Span, spanStatusfromHttpCode } from './span';
 // eslint-disable-next-line deprecation/deprecation
@@ -32,8 +32,14 @@ export { instrumentOutgoingRequests, defaultRequestInstrumentationOptions } from
 export { IdleTransaction } from './idletransaction';
 export { startIdleTransaction } from './hubextensions';
 
-// We are patching the global object with our hub extension methods
-addExtensionMethods();
+// Treeshakable guard to remove all code related to tracing
+declare const __SENTRY_TRACING__: boolean;
+
+// Guard for tree
+if (typeof __SENTRY_TRACING__ === 'undefined' || __SENTRY_TRACING__) {
+  // We are patching the global object with our hub extension methods
+  addExtensionMethods();
+}
 
 export { addExtensionMethods };
 

--- a/packages/tracing/test/index.bundle.test.ts
+++ b/packages/tracing/test/index.bundle.test.ts
@@ -3,7 +3,14 @@ import { Integrations } from '../src/index.bundle';
 describe('Integrations export', () => {
   it('is exported correctly', () => {
     Object.keys(Integrations).forEach(key => {
-      expect(Integrations[key as keyof typeof Integrations].id).toStrictEqual(expect.any(String));
+      // Skip BrowserTracing because it doesn't have a static id field.
+      if (key === 'BrowserTracing') {
+        return;
+      }
+
+      expect(Integrations[key as keyof Omit<typeof Integrations, 'BrowserTracing'>].id).toStrictEqual(
+        expect.any(String),
+      );
     });
   });
 });

--- a/packages/tracing/test/index.test.ts
+++ b/packages/tracing/test/index.test.ts
@@ -13,7 +13,7 @@ describe('index', () => {
     it('is exported correctly', () => {
       Object.keys(Integrations).forEach(key => {
         // Skip BrowserTracing because it doesn't have a static id field.
-        if (key !== 'BrowserTracing') {
+        if (key === 'BrowserTracing') {
           return;
         }
 

--- a/packages/tracing/test/index.test.ts
+++ b/packages/tracing/test/index.test.ts
@@ -12,6 +12,11 @@ describe('index', () => {
   describe('Integrations', () => {
     it('is exported correctly', () => {
       Object.keys(Integrations).forEach(key => {
+        // Skip BrowserTracing because it doesn't have a static id field.
+        if (key !== 'BrowserTracing') {
+          return;
+        }
+
         expect(Integrations[key as keyof typeof Integrations].id).toStrictEqual(expect.any(String));
       });
     });

--- a/packages/tracing/test/index.test.ts
+++ b/packages/tracing/test/index.test.ts
@@ -17,7 +17,9 @@ describe('index', () => {
           return;
         }
 
-        expect(Integrations[key as keyof typeof Integrations].id).toStrictEqual(expect.any(String));
+        expect(Integrations[key as keyof Omit<typeof Integrations, 'BrowserTracing'>].id).toStrictEqual(
+          expect.any(String),
+        );
       });
     });
 


### PR DESCRIPTION
Makes `@sentry/tracing` treeshakable from `@sentry/nextjs`, by text-replacing `__SENTRY_TRACING__` with `false` in any bundler or pre-processor.

Ref: https://getsentry.atlassian.net/browse/WEB-713