### PR TITLE
fix(dev): Add placeholder tsconfigs for tests

### DIFF
--- a/packages/angular/test/tsconfig.json
+++ b/packages/angular/test/tsconfig.json
@@ -1,0 +1,8 @@
+// TODO Once https://github.com/microsoft/TypeScript/issues/33094 is done (if it ever is), this file can disappear, as
+// it's purely a placeholder to satisfy VSCode.
+
+{
+  "extends": "../tsconfig.test.json",
+
+  "include": ["./**/*"]
+}

--- a/packages/browser/test/tsconfig.json
+++ b/packages/browser/test/tsconfig.json
@@ -1,0 +1,8 @@
+// TODO Once https://github.com/microsoft/TypeScript/issues/33094 is done (if it ever is), this file can disappear, as
+// it's purely a placeholder to satisfy VSCode.
+
+{
+  "extends": "../tsconfig.test.json",
+
+  "include": ["./**/*"]
+}

--- a/packages/core/test/tsconfig.json
+++ b/packages/core/test/tsconfig.json
@@ -1,0 +1,8 @@
+// TODO Once https://github.com/microsoft/TypeScript/issues/33094 is done (if it ever is), this file can disappear, as
+// it's purely a placeholder to satisfy VSCode.
+
+{
+  "extends": "../tsconfig.test.json",
+
+  "include": ["./**/*"]
+}

--- a/packages/gatsby/test/tsconfig.json
+++ b/packages/gatsby/test/tsconfig.json
@@ -1,0 +1,8 @@
+// TODO Once https://github.com/microsoft/TypeScript/issues/33094 is done (if it ever is), this file can disappear, as
+// it's purely a placeholder to satisfy VSCode.
+
+{
+  "extends": "../tsconfig.test.json",
+
+  "include": ["./**/*"]
+}

--- a/packages/hub/test/tsconfig.json
+++ b/packages/hub/test/tsconfig.json
@@ -1,0 +1,8 @@
+// TODO Once https://github.com/microsoft/TypeScript/issues/33094 is done (if it ever is), this file can disappear, as
+// it's purely a placeholder to satisfy VSCode.
+
+{
+  "extends": "../tsconfig.test.json",
+
+  "include": ["./**/*"]
+}

--- a/packages/integrations/test/tsconfig.json
+++ b/packages/integrations/test/tsconfig.json
@@ -1,0 +1,8 @@
+// TODO Once https://github.com/microsoft/TypeScript/issues/33094 is done (if it ever is), this file can disappear, as
+// it's purely a placeholder to satisfy VSCode.
+
+{
+  "extends": "../tsconfig.test.json",
+
+  "include": ["./**/*"]
+}

--- a/packages/nextjs/test/tsconfig.json
+++ b/packages/nextjs/test/tsconfig.json
@@ -1,0 +1,8 @@
+// TODO Once https://github.com/microsoft/TypeScript/issues/33094 is done (if it ever is), this file can disappear, as
+// it's purely a placeholder to satisfy VSCode.
+
+{
+  "extends": "../tsconfig.test.json",
+
+  "include": ["./**/*"]
+}

--- a/packages/node-integration-tests/suites/tsconfig.json
+++ b/packages/node-integration-tests/suites/tsconfig.json
@@ -1,0 +1,8 @@
+// TODO Once https://github.com/microsoft/TypeScript/issues/33094 is done (if it ever is), this file can disappear, as
+// it's purely a placeholder to satisfy VSCode.
+
+{
+  "extends": "../tsconfig.test.json",
+
+  "include": ["./**/*"]
+}

--- a/packages/node/test/tsconfig.json
+++ b/packages/node/test/tsconfig.json
@@ -1,0 +1,8 @@
+// TODO Once https://github.com/microsoft/TypeScript/issues/33094 is done (if it ever is), this file can disappear, as
+// it's purely a placeholder to satisfy VSCode.
+
+{
+  "extends": "../tsconfig.test.json",
+
+  "include": ["./**/*"]
+}

--- a/packages/react/test/tsconfig.json
+++ b/packages/react/test/tsconfig.json
@@ -1,0 +1,8 @@
+// TODO Once https://github.com/microsoft/TypeScript/issues/33094 is done (if it ever is), this file can disappear, as
+// it's purely a placeholder to satisfy VSCode.
+
+{
+  "extends": "../tsconfig.test.json",
+
+  "include": ["./**/*"]
+}

--- a/packages/serverless/test/tsconfig.json
+++ b/packages/serverless/test/tsconfig.json
@@ -1,0 +1,8 @@
+// TODO Once https://github.com/microsoft/TypeScript/issues/33094 is done (if it ever is), this file can disappear, as
+// it's purely a placeholder to satisfy VSCode.
+
+{
+  "extends": "../tsconfig.test.json",
+
+  "include": ["./**/*"]
+}

--- a/packages/tracing/test/tsconfig.json
+++ b/packages/tracing/test/tsconfig.json
@@ -1,0 +1,8 @@
+// TODO Once https://github.com/microsoft/TypeScript/issues/33094 is done (if it ever is), this file can disappear, as
+// it's purely a placeholder to satisfy VSCode.
+
+{
+  "extends": "../tsconfig.test.json",
+
+  "include": ["./**/*"]
+}

--- a/packages/utils/test/tsconfig.json
+++ b/packages/utils/test/tsconfig.json
@@ -1,0 +1,8 @@
+// TODO Once https://github.com/microsoft/TypeScript/issues/33094 is done (if it ever is), this file can disappear, as
+// it's purely a placeholder to satisfy VSCode.
+
+{
+  "extends": "../tsconfig.test.json",
+
+  "include": ["./**/*"]
+}

--- a/packages/vue/test/tsconfig.json
+++ b/packages/vue/test/tsconfig.json
@@ -1,0 +1,8 @@
+// TODO Once https://github.com/microsoft/TypeScript/issues/33094 is done (if it ever is), this file can disappear, as
+// it's purely a placeholder to satisfy VSCode.
+
+{
+  "extends": "../tsconfig.test.json",
+
+  "include": ["./**/*"]
+}

--- a/packages/wasm/test/tsconfig.json
+++ b/packages/wasm/test/tsconfig.json
@@ -1,0 +1,8 @@
+// TODO Once https://github.com/microsoft/TypeScript/issues/33094 is done (if it ever is), this file can disappear, as
+// it's purely a placeholder to satisfy VSCode.
+
+{
+  "extends": "../tsconfig.test.json",
+
+  "include": ["./**/*"]
+}

--- a/tsconfig-templates/README.md
+++ b/tsconfig-templates/README.md
@@ -1,5 +1,7 @@
 # `tsconfig` Templates
 
-Every package should get its own copy of these three files. Package-specific options should go in `tsconfig.json` and
-test-specific options in `tsconfig.test.json`. The `types` file shouldn't need to be modified, and only exists because
-tsconfigs don't support multiple inheritence.
+Every package should get its own copy of the three files in this directory and the one in `test/` (which should go in an
+analogous spot in the package). Package-specific options should go in `tsconfig.json` and test-specific options in
+`tsconfig.test.json`. The `types` file shouldn't need to be modified, and only exists because tsconfigs don't support
+multiple inheritence. The same goes for the file in `test/`, which only exists because VSCode only knows to look for a
+file named (exactly) `tsconfig.json`.

--- a/tsconfig-templates/test/tsconfig.json
+++ b/tsconfig-templates/test/tsconfig.json
@@ -1,0 +1,8 @@
+// TODO Once https://github.com/microsoft/TypeScript/issues/33094 is done (if it ever is), this file can disappear, as
+// it's purely a placeholder to satisfy VSCode.
+
+{
+  "extends": "../tsconfig.test.json",
+
+  "include": ["./**/*"]
+}


### PR DESCRIPTION
It is well-documented ([1](https://github.com/angular/angular-cli/issues/5175), [2](https://github.com/microsoft/TypeScript/issues/49210), [3](https://github.com/microsoft/vscode/issues/107750), [4](https://github.com/Microsoft/vscode/issues/12463), [5](https://github.com/mseag/bible-karaoke/issues/175), [6](https://github.com/microsoft/TypeScript/issues/8435)) that VSCode doesn't support setups like ours, where multiple tsconfig files coexist in a single directory. Strangely, though, it is only recently that this has become a problem, with VSCode at random intervals forgetting that it's ever heard of `expect` or `describe` (because it's not seeing `tsconfig.test.json`, but taking a while to realize it).

There is an [open issue](https://github.com/microsoft/TypeScript/issues/33094) tracking the addition of support for this, but it's been open for a long time, with little movement. In the meantime, this solves the problem by adding placeholder `test/tsconfig.json` files to each package, each pointing to its corresponding `tsconfig.test.ts` file. I went with this approach over simply moving and renaming the existing test tsconfigs because this allows us to stay consistent in having all flavors of tsconfig for a package live at the package root level, and provides an easy way to reverse this workaround, should VSCode ever fix the underlying problem.
