### PR TITLE
ref(nextjs): Add @sentry/cli as a dependency

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -17,6 +17,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@sentry/cli": "^1.73.0",
     "@sentry/core": "6.19.7",
     "@sentry/hub": "6.19.7",
     "@sentry/integrations": "6.19.7",


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [X] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Since @sentry/cli is included to grab its binary, I believe it should also be added explicitly as a dependency.