### PR TITLE
Sentry Node: do not exit process if the app added its own 'uncaughtException' or 'unhandledRejection' listener

### DIFF
--- a/packages/node-integration-tests/suites/public-api/integrations/OnUncaughtException/additional-listener-test-script.js
+++ b/packages/node-integration-tests/suites/public-api/integrations/OnUncaughtException/additional-listener-test-script.js
@@ -1,0 +1,16 @@
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+});
+
+process.on('uncaughtException', () => {
+  // do nothing - this will prevent the Error below from closing this process before the timeout resolves
+});
+
+setTimeout(() => {
+  process.stdout.write("I'm alive!");
+  process.exit(0);
+}, 500);
+
+throw new Error();

--- a/packages/node-integration-tests/suites/public-api/integrations/OnUncaughtException/mimic-behaviour-additional-listener-test-script.js
+++ b/packages/node-integration-tests/suites/public-api/integrations/OnUncaughtException/mimic-behaviour-additional-listener-test-script.js
@@ -1,0 +1,27 @@
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: integrations => {
+    return integrations.map(integration => {
+      if (integration.name === 'OnUncaughtException') {
+        return new Sentry.Integrations.OnUncaughtException({
+          mimicNativeBehaviour: true,
+        });
+      } else {
+        return integration;
+      }
+    });
+  },
+});
+
+process.on('uncaughtException', () => {
+  // do nothing - this will prevent the Error below from closing this process before the timeout resolves
+});
+
+setTimeout(() => {
+  process.stdout.write("I'm alive!");
+  process.exit(0);
+}, 500);
+
+throw new Error();

--- a/packages/node-integration-tests/suites/public-api/integrations/OnUncaughtException/mimic-behaviour-no-additional-listener-test-script.js
+++ b/packages/node-integration-tests/suites/public-api/integrations/OnUncaughtException/mimic-behaviour-no-additional-listener-test-script.js
@@ -1,0 +1,24 @@
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: integrations => {
+    return integrations.map(integration => {
+      if (integration.name === 'OnUncaughtException') {
+        return new Sentry.Integrations.OnUncaughtException({
+          mimicNativeBehaviour: true,
+        });
+      } else {
+        return integration;
+      }
+    });
+  },
+});
+
+setTimeout(() => {
+  // This should not be called because the script throws before this resolves
+  process.stdout.write("I'm alive!");
+  process.exit(0);
+}, 500);
+
+throw new Error();

--- a/packages/node-integration-tests/suites/public-api/integrations/OnUncaughtException/no-additional-listener-test-script.js
+++ b/packages/node-integration-tests/suites/public-api/integrations/OnUncaughtException/no-additional-listener-test-script.js
@@ -1,0 +1,13 @@
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+});
+
+setTimeout(() => {
+  // This should not be called because the script throws before this resolves
+  process.stdout.write("I'm alive!");
+  process.exit(0);
+}, 500);
+
+throw new Error();

--- a/packages/node-integration-tests/suites/public-api/integrations/OnUncaughtException/test.ts
+++ b/packages/node-integration-tests/suites/public-api/integrations/OnUncaughtException/test.ts
@@ -1,0 +1,29 @@
+import * as childProcess from 'child_process';
+import * as path from 'path';
+
+describe('OnUncaughtException integration', () => {
+  test('should close process on uncaught error with no additional listeners registered', done => {
+    expect.assertions(3);
+
+    const testScriptPath = path.resolve(__dirname, 'no-additional-listener-test-script.js');
+
+    childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout) => {
+      expect(err).not.toBeNull();
+      expect(err?.code).toBe(1);
+      expect(stdout).not.toBe("I'm alive!");
+      done();
+    });
+  });
+
+  test('should not close process on uncaught error when additional listeners are registered', done => {
+    expect.assertions(2);
+
+    const testScriptPath = path.resolve(__dirname, 'additional-listener-test-script.js');
+
+    childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout) => {
+      expect(err).toBeNull();
+      expect(stdout).toBe("I'm alive!");
+      done();
+    });
+  });
+});

--- a/packages/node-integration-tests/suites/public-api/integrations/OnUncaughtException/test.ts
+++ b/packages/node-integration-tests/suites/public-api/integrations/OnUncaughtException/test.ts
@@ -15,15 +15,43 @@ describe('OnUncaughtException integration', () => {
     });
   });
 
-  test('should not close process on uncaught error when additional listeners are registered', done => {
-    expect.assertions(2);
+  test('should close process on uncaught error when additional listeners are registered', done => {
+    expect.assertions(3);
 
     const testScriptPath = path.resolve(__dirname, 'additional-listener-test-script.js');
 
     childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout) => {
-      expect(err).toBeNull();
-      expect(stdout).toBe("I'm alive!");
+      expect(err).not.toBeNull();
+      expect(err?.code).toBe(1);
+      expect(stdout).not.toBe("I'm alive!");
       done();
+    });
+  });
+
+  describe('with `mimicNativeBehaviour` set to true', () => {
+    test('should close process on uncaught error with no additional listeners registered', done => {
+      expect.assertions(3);
+
+      const testScriptPath = path.resolve(__dirname, 'mimic-behaviour-no-additional-listener-test-script.js');
+
+      childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout) => {
+        expect(err).not.toBeNull();
+        expect(err?.code).toBe(1);
+        expect(stdout).not.toBe("I'm alive!");
+        done();
+      });
+    });
+
+    test('should not close process on uncaught error when additional listeners are registered', done => {
+      expect.assertions(2);
+
+      const testScriptPath = path.resolve(__dirname, 'mimic-behaviour-additional-listener-test-script.js');
+
+      childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout) => {
+        expect(err).toBeNull();
+        expect(stdout).toBe("I'm alive!");
+        done();
+      });
     });
   });
 });

--- a/packages/node-integration-tests/suites/public-api/integrations/OnUnhandledRejection/test-script.js
+++ b/packages/node-integration-tests/suites/public-api/integrations/OnUnhandledRejection/test-script.js
@@ -1,0 +1,29 @@
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: integrations => {
+    return integrations.map(integration => {
+      if (integration.name === 'OnUnhandledRejection') {
+        return new Sentry.Integrations.OnUnhandledRejection({
+          mode: process.env['PROMISE_REJECTION_MODE'],
+        });
+      } else {
+        return integration;
+      }
+    });
+  },
+});
+
+if (process.env['ATTACH_ADDITIONAL_HANDLER']) {
+  process.on('uncaughtException', () => {
+    // do nothing - this will prevent the rejected promise below from closing this process before the timeout resolves
+  });
+}
+
+setTimeout(() => {
+  process.stdout.write("I'm alive!");
+  process.exit(0);
+}, 500);
+
+Promise.reject();

--- a/packages/node-integration-tests/suites/public-api/integrations/OnUnhandledRejection/test.ts
+++ b/packages/node-integration-tests/suites/public-api/integrations/OnUnhandledRejection/test.ts
@@ -1,0 +1,36 @@
+import * as childProcess from 'child_process';
+import * as path from 'path';
+
+describe('OnUnhandledRejection integration', () => {
+  test.each([
+    { mode: 'none', additionalHandler: false, expectedErrorCode: 0 },
+    { mode: 'warn', additionalHandler: false, expectedErrorCode: 0 },
+    { mode: 'strict', additionalHandler: false, expectedErrorCode: 1 },
+
+    { mode: 'none', additionalHandler: true, expectedErrorCode: 0 },
+    { mode: 'warn', additionalHandler: true, expectedErrorCode: 0 },
+    { mode: 'strict', additionalHandler: true, expectedErrorCode: 1 },
+  ])(
+    'should cause process to exit with code $expectedErrorCode with `mode` set to $mode while having a handler attached (? - $additionalHandler)',
+    async ({ mode, additionalHandler, expectedErrorCode }) => {
+      const testScriptPath = path.resolve(__dirname, 'test-script.js');
+
+      await new Promise(resolve => {
+        childProcess.exec(
+          `node ${testScriptPath}`,
+          {
+            encoding: 'utf8',
+            env: {
+              PROMISE_REJECTION_MODE: mode ? String(mode) : undefined,
+              ATTACH_ADDITIONAL_HANDLER: additionalHandler ? String(additionalHandler) : undefined,
+            },
+          },
+          err => {
+            expect(err?.code).toBe(expectedErrorCode || undefined);
+            resolve();
+          },
+        );
+      });
+    },
+  );
+});

--- a/packages/node/src/integrations/onuncaughtexception.ts
+++ b/packages/node/src/integrations/onuncaughtexception.ts
@@ -13,7 +13,7 @@ interface OnUncaughtExceptionOptions {
   // Also, we can evaluate using https://nodejs.org/api/process.html#event-uncaughtexceptionmonitor per default, and
   // falling back to current behaviour when that's not available.
   /**
-   * Whether the SDK should mimic native behaviour when a global error occurs. Default: `false`.
+   * Whether the SDK should mimic native behaviour when a global error occurs. Default: `false`
    * - `false`: The SDK will exit the process on all uncaught errors.
    * - `true`: The SDK will only exit the process when there are no other 'uncaughtException' handlers attached.
    */

--- a/packages/node/src/integrations/onuncaughtexception.ts
+++ b/packages/node/src/integrations/onuncaughtexception.ts
@@ -8,6 +8,18 @@ import { logAndExitProcess } from './utils/errorhandling';
 
 type OnFatalErrorHandler = (firstError: Error, secondError?: Error) => void;
 
+interface OnUncaughtExceptionOptions {
+  /**
+   * This is called when an uncaught error would cause the process to exit.
+   *
+   * @param firstError Uncaught error causing the process to exit
+   * @param secondError Will be set if the handler was called multiple times. This can happen either because
+   * `onFatalError` itself threw, or because an independent error happened somewhere else while `onFatalError`
+   * was running.
+   */
+  onFatalError?(firstError: Error, secondError?: Error): void;
+}
+
 /** Global Promise Rejection handler */
 export class OnUncaughtException implements Integration {
   /**
@@ -28,16 +40,7 @@ export class OnUncaughtException implements Integration {
   /**
    * @inheritDoc
    */
-  public constructor(
-    private readonly _options: {
-      /**
-       * Default onFatalError handler
-       * @param firstError Error that has been thrown
-       * @param secondError If this was called multiple times this will be set
-       */
-      onFatalError?(firstError: Error, secondError?: Error): void;
-    } = {},
-  ) {}
+  public constructor(private readonly _options: OnUncaughtExceptionOptions = {}) {}
   /**
    * @inheritDoc
    */

--- a/packages/node/src/integrations/onunhandledrejection.ts
+++ b/packages/node/src/integrations/onunhandledrejection.ts
@@ -70,6 +70,10 @@ export class OnUnhandledRejection implements Integration {
       'or by rejecting a promise which was not handled with .catch().' +
       ' The promise rejected with the reason:';
 
+    // in order to honour Node's original behavior on unhandled rejections, we should not
+    // exit the process if the app added its own 'unhandledRejection' listener
+    const shouldExitProcess: boolean = global.process.listenerCount('unhandledRejection') === 1;
+
     /* eslint-disable no-console */
     if (this._options.mode === 'warn') {
       consoleSandbox(() => {
@@ -81,7 +85,9 @@ export class OnUnhandledRejection implements Integration {
       consoleSandbox(() => {
         console.warn(rejectionWarning);
       });
-      logAndExitProcess(reason);
+      if (shouldExitProcess) {
+        logAndExitProcess(reason);
+      }
     }
     /* eslint-enable no-console */
   }


### PR DESCRIPTION
- Fixes #1661

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Ref: https://getsentry.atlassian.net/browse/WEB-939