### PR TITLE
misc: Remove new lines from changelog lists to make rendering unified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ If you are a regular consumer of the Sentry JavaScript SDK you only need to focu
 - Replaced `BrowserTracing` integration's `maxTransactionDuration` option with `finalTimeout` option in the `@sentry/tracing` package and reset `idleTimeout` based on activities count. This should improve accuracy of web-vitals like LCP by 20-30%. (#5044)
 - [Updated `@sentry/angular` to be compiled by the angular compiler](./MIGRATION.md#sentry-angular-sdk-changes). (#4641)
 - Made tracing package treeshakable (#5166)
-
 - Removed support for [Node v6](./MIGRATION.md#dropping-support-for-nodejs-v6). (#4851)
 - Removed `@sentry/minimal` package in favour of using [`@sentry/hub`](./MIGRATION.md#removal-of-sentryminimal). (#4971)
 - Removed support for Opera browser pre v15 (#4923)
@@ -78,7 +77,6 @@ If you are a regular consumer of the Sentry JavaScript SDK you only need to focu
 - feat(tracing): Add Prisma ORM integration. (#4931)
 - feat(react): Add react-router-v6 integration (#5042)
 - feat: Add attachments API (#5004)
-
 - feat: Add `name` field to `EventProcessor` (#4932)
 - feat: Expose configurable stack parser (#4902)
 - feat(tracing): Make `setMeasurement` public API (#4933)


### PR DESCRIPTION
Before:

<img width="589" alt="image" src="https://user-images.githubusercontent.com/1523305/171011613-7f8f9a35-b149-4d99-9fe2-6193eeb5ed46.png">

After:

<img width="559" alt="image" src="https://user-images.githubusercontent.com/1523305/171011671-1f7e0506-691a-4bd1-9a27-ae8c32d4cb33.png">
