### PR TITLE
fix(tracing): Fix missing page load metrics in Electron renderer

### DIFF
--- a/packages/tracing/src/browser/metrics/index.ts
+++ b/packages/tracing/src/browser/metrics/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import { Measurements } from '@sentry/types';
-import { browserPerformanceTimeOrigin, getGlobalObject, htmlTreeAsString, isNodeEnv, logger } from '@sentry/utils';
+import { browserPerformanceTimeOrigin, getGlobalObject, htmlTreeAsString, logger } from '@sentry/utils';
 
 import { IS_DEBUG_BUILD } from '../../flags';
 import { Transaction } from '../../transaction';
@@ -14,8 +14,8 @@ import { _startChild, isMeasurementValue } from './utils';
 
 const global = getGlobalObject<Window>();
 
-function getBrowserPerformanceAPI(): false | Performance {
-  return !isNodeEnv() && global && global.document && global.performance;
+function getBrowserPerformanceAPI(): Performance | undefined {
+  return global && global.document && global.performance;
 }
 
 let _performanceCursor: number = 0;

--- a/packages/tracing/src/browser/metrics/index.ts
+++ b/packages/tracing/src/browser/metrics/index.ts
@@ -15,7 +15,7 @@ import { _startChild, isMeasurementValue } from './utils';
 const global = getGlobalObject<Window>();
 
 function getBrowserPerformanceAPI(): Performance | undefined {
-  return global && global.document && global.performance;
+  return global && global.addEventListener && global.performance;
 }
 
 let _performanceCursor: number = 0;


### PR DESCRIPTION
Electron renderers can have a combined Chrome and node.js context which can cause it to be detected as node.js when in fact it has full browser features.

This PR simplifies the detection of the browser `performance` API so that it doesn't fail to record page load metrics when running in an Electron renderer with mixed context.
