### PR TITLE
fix(build): Add missing debug logger plugin in `debug.min` bundle variant config

### DIFF
--- a/rollup/bundleHelpers.js
+++ b/rollup/bundleHelpers.js
@@ -157,7 +157,7 @@ export function makeBundleConfigVariants(baseConfig, options = {}) {
       output: {
         entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.debug.min.js`,
       },
-      plugins: [terserPlugin],
+      plugins: [includeDebuggingPlugin, terserPlugin],
     },
   };
 


### PR DESCRIPTION
This restores the plugin which includes debug logging in the configuration for our `.debug.min` bundles. (It was accidentally dropped in https://github.com/getsentry/sentry-javascript/pull/5142.)