### PR TITLE
feat(tracing): Propagate environment and release values in baggage Http headers

### DIFF
--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
@@ -19,7 +19,7 @@ test('Should assign `baggage` header which contains 3rd party trace baggage data
   });
 });
 
-test('Should assign `baggage` header which contains sentry trace baggage data to an outgoing request.', async () => {
+test('Should not overwrite baggage if the incoming request already has Sentry baggage data.', async () => {
   const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const response = (await getAPIResponse(new URL(`${url}/express`), {
@@ -35,7 +35,7 @@ test('Should assign `baggage` header which contains sentry trace baggage data to
   });
 });
 
-test('Should assign `baggage` header which contains sentry and 3rd party trace baggage data to an outgoing request.', async () => {
+test('Should pass along sentry and 3rd party trace baggage data from an incoming to an outgoing request.', async () => {
   const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const response = (await getAPIResponse(new URL(`${url}/express`), {

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
-test('Should assign `baggage` header which contains 3rd party trace baggage data of an outgoing request.', async () => {
+test('Should assign `baggage` header which contains 3rd party trace baggage data to an outgoing request.', async () => {
   const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const response = (await getAPIResponse(new URL(`${url}/express`), {
@@ -14,39 +14,39 @@ test('Should assign `baggage` header which contains 3rd party trace baggage data
   expect(response).toMatchObject({
     test_data: {
       host: 'somewhere.not.sentry',
-      baggage: expect.stringContaining('foo=bar,bar=baz'),
+      baggage: 'foo=bar,bar=baz,sentry-environment=prod,sentry-release=1.0',
     },
   });
 });
 
-test('Should assign `baggage` header which contains sentry trace baggage data of an outgoing request.', async () => {
+test('Should assign `baggage` header which contains sentry trace baggage data to an outgoing request.', async () => {
   const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const response = (await getAPIResponse(new URL(`${url}/express`), {
-    baggage: 'sentry-version=1.0.0,sentry-environment=production',
+    baggage: 'sentry-version=2.0.0,sentry-environment=myEnv',
   })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
     test_data: {
       host: 'somewhere.not.sentry',
-      baggage: expect.stringContaining('sentry-version=1.0.0,sentry-environment=production'),
+      baggage: 'sentry-version=2.0.0,sentry-environment=myEnv',
     },
   });
 });
 
-test('Should assign `baggage` header which contains sentry and 3rd party trace baggage data of an outgoing request.', async () => {
+test('Should assign `baggage` header which contains sentry and 3rd party trace baggage data to an outgoing request.', async () => {
   const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const response = (await getAPIResponse(new URL(`${url}/express`), {
-    baggage: 'sentry-version=1.0.0,sentry-environment=production,dogs=great',
+    baggage: 'sentry-version=2.0.0,sentry-environment=myEnv,dogs=great',
   })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
     test_data: {
       host: 'somewhere.not.sentry',
-      baggage: expect.stringContaining('dogs=great,sentry-version=1.0.0,sentry-environment=production'),
+      baggage: expect.stringContaining('dogs=great,sentry-version=2.0.0,sentry-environment=myEnv'),
     },
   });
 });

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/test.ts
@@ -12,8 +12,7 @@ test('should attach a `baggage` header to an outgoing request.', async () => {
   expect(response).toMatchObject({
     test_data: {
       host: 'somewhere.not.sentry',
-      // TODO this is currently still empty but eventually it should contain sentry data
-      baggage: expect.stringMatching(''),
+      baggage: expect.stringMatching('sentry-environment=prod,sentry-release=1.0'),
     },
   });
 });

--- a/packages/node-integration-tests/suites/express/sentry-trace/server.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/server.ts
@@ -11,6 +11,7 @@ export type TestAPIResponse = { test_data: { host: string; 'sentry-trace': strin
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
+  environment: 'prod',
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
 });

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -40,7 +40,7 @@ describe('tracing', () => {
     nock('http://dogs.are.great').get('/').reply(200);
 
     const transaction = createTransactionOnScope();
-    const spans = (transaction as Span).spanRecorder?.spans as Span[];
+    const spans = (transaction as unknown as Span).spanRecorder?.spans as Span[];
 
     http.get('http://dogs.are.great/');
 
@@ -55,7 +55,7 @@ describe('tracing', () => {
     nock('http://squirrelchasers.ingest.sentry.io').get('/api/12312012/store/').reply(200);
 
     const transaction = createTransactionOnScope();
-    const spans = (transaction as Span).spanRecorder?.spans as Span[];
+    const spans = (transaction as unknown as Span).spanRecorder?.spans as Span[];
 
     http.get('http://squirrelchasers.ingest.sentry.io/api/12312012/store/');
 

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -21,6 +21,8 @@ describe('tracing', () => {
       dsn: 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012',
       tracesSampleRate: 1.0,
       integrations: [new HttpIntegration({ tracing: true })],
+      release: '1.0.0',
+      environment: 'production',
     });
     const hub = new Hub(new NodeClient(options));
     addExtensionMethods();
@@ -96,8 +98,7 @@ describe('tracing', () => {
     const baggageHeader = request.getHeader('baggage') as string;
 
     expect(baggageHeader).toBeDefined();
-    // this might change once we actually add our baggage data to the header
-    expect(baggageHeader).toEqual('');
+    expect(baggageHeader).toEqual('sentry-environment=production,sentry-release=1.0.0');
   });
 
   it('propagates 3rd party baggage header data to outgoing non-sentry requests', async () => {
@@ -109,8 +110,7 @@ describe('tracing', () => {
     const baggageHeader = request.getHeader('baggage') as string;
 
     expect(baggageHeader).toBeDefined();
-    // this might change once we actually add our baggage data to the header
-    expect(baggageHeader).toEqual('dog=great');
+    expect(baggageHeader).toEqual('dog=great,sentry-environment=production,sentry-release=1.0.0');
   });
 
   it("doesn't attach the sentry-trace header to outgoing sentry requests", () => {

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+import type { Span } from '@sentry/types';
 import {
   addInstrumentationHandler,
   BAGGAGE_HEADER_NAME,
@@ -7,7 +8,6 @@ import {
   mergeAndSerializeBaggage,
 } from '@sentry/utils';
 
-import { Span } from '../span';
 import { getActiveTransaction, hasTracingEnabled } from '../utils';
 
 export const DEFAULT_TRACING_ORIGINS = ['localhost', /^\//];

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -17,12 +17,12 @@ export class Transaction extends SpanClass implements TransactionInterface {
 
   public metadata: TransactionMetadata;
 
-  private _measurements: Measurements = {};
-
   /**
    * The reference to the current hub.
    */
-  private readonly _hub: Hub;
+  protected readonly _hub: Hub;
+
+  private _measurements: Measurements = {};
 
   private _trimEnd?: boolean;
 

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -1,11 +1,11 @@
 import { BrowserClient } from '@sentry/browser';
 import { Hub, makeMain, Scope } from '@sentry/hub';
+import { BaseTransportOptions, ClientOptions } from '@sentry/types';
 import { createBaggage, getSentryBaggageItems, getThirdPartyBaggage, isSentryBaggageEmpty } from '@sentry/utils';
 
 import { Span, Transaction } from '../src';
 import { TRACEPARENT_REGEXP } from '../src/utils';
 import { getDefaultBrowserClientOptions } from './testutils';
-import { BaseTransportOptions, ClientOptions } from '@sentry/types';
 
 describe('Span', () => {
   let hub: Hub;
@@ -395,7 +395,7 @@ describe('Span', () => {
 
   describe('getBaggage and _getBaggageWithSentryValues', () => {
     beforeEach(() => {
-      hub.getClient()!!.getOptions = () => {
+      hub.getClient()!.getOptions = () => {
         return {
           release: '1.0.1',
           environment: 'production',
@@ -412,7 +412,7 @@ describe('Span', () => {
         hub,
       );
 
-      const hubSpy = jest.spyOn(hub.getClient()!!, 'getOptions');
+      const hubSpy = jest.spyOn(hub.getClient()!, 'getOptions');
 
       const span = transaction.startChild();
 
@@ -433,7 +433,7 @@ describe('Span', () => {
         hub,
       );
 
-      const hubSpy = jest.spyOn(hub.getClient()!!, 'getOptions');
+      const hubSpy = jest.spyOn(hub.getClient()!, 'getOptions');
 
       const span = transaction.startChild();
 

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -178,4 +178,6 @@ export interface Span extends SpanContext {
 
   /** return the baggage for dynamic sampling and trace propagation */
   getBaggage(): Baggage | undefined;
+
+  //_getBaggageWithSentryValues(baggage: Baggage): Baggage;
 }

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -178,6 +178,4 @@ export interface Span extends SpanContext {
 
   /** return the baggage for dynamic sampling and trace propagation */
   getBaggage(): Baggage | undefined;
-
-  //_getBaggageWithSentryValues(baggage: Baggage): Baggage;
 }

--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -31,9 +31,15 @@ export function setBaggageValue(baggage: Baggage, key: keyof BaggageObj, value: 
   baggage[0][key] = value;
 }
 
-/** Check if the baggage object (i.e. the first element in the tuple) is empty */
-export function isBaggageEmpty(baggage: Baggage): boolean {
+/** Check if the Sentry part of the passed baggage (i.e. the first element in the tuple) is empty */
+export function isSentryBaggageEmpty(baggage: Baggage): boolean {
   return Object.keys(baggage[0]).length === 0;
+}
+
+/** Check if the Sentry part of the passed baggage (i.e. the first element in the tuple) is empty */
+export function isBaggageEmpty(baggage: Baggage): boolean {
+  const thirdPartyBaggage = getThirdPartyBaggage(baggage);
+  return isSentryBaggageEmpty(baggage) && (thirdPartyBaggage == undefined || thirdPartyBaggage.length === 0);
 }
 
 /** Returns Sentry specific baggage values */

--- a/packages/utils/test/baggage.test.ts
+++ b/packages/utils/test/baggage.test.ts
@@ -1,7 +1,7 @@
 import {
   createBaggage,
   getBaggageValue,
-  isBaggageEmpty,
+  isSentryBaggageEmpty,
   mergeAndSerializeBaggage,
   parseBaggageString,
   serializeBaggage,
@@ -98,12 +98,12 @@ describe('Baggage', () => {
     });
   });
 
-  describe('isBaggageEmpty', () => {
+  describe('isSentryBaggageEmpty', () => {
     it.each([
       ['returns true if the modifyable part of baggage is empty', createBaggage({}), true],
       ['returns false if the modifyable part of baggage is not empty', createBaggage({ release: '10.0.2' }), false],
     ])('%s', (_: string, baggage, outcome) => {
-      expect(isBaggageEmpty(baggage)).toEqual(outcome);
+      expect(isSentryBaggageEmpty(baggage)).toEqual(outcome);
     });
   });
 


### PR DESCRIPTION
Following #5133, this PR adds the `sentry-environment` and `sentry-release` values to the `baggage` HTTP headers of outgoing requests. We add these values to baggage as late as possible with the rationale that other baggage values (to be added in the future) will not be available right away, e.g. when intercepting baggage from incoming requests. 

As a result, the flow described below happens, when the first call to `span.getBaggage` is made (e.g. in callbacks of instrumented outgoing requests): 

1. In `span.getBaggage`, check if there is baggage present in the span (in which case it was intercepted from incoming headers/meta tags) and it is empty (or only includes 3rd party data) OR if there is no baggage yet
2. In both of these cases, populate the baggage with Sentry data (and leave 3rd party content untouched). Else do nothing
3. Add this baggage to outgoing headers (and merge with possible 3rd party header) 

Furthermore, the PR adds and improves tests to check correct handling and propagation of baggage

This PR does not yet sync the Http header baggage information with the one that's sent in the `trace` envelope header. This will be addressed in a follow-up PR.

EDIT: As discussed with the team, this PR does not fully address all (im)mutability cases. Will open up a separate PR soon to fix this.

ref: https://getsentry.atlassian.net/browse/WEB-936