### PR TITLE
fix(utils): Fix faulty references in `dropUndefinedKeys`

### DIFF
--- a/packages/utils/test/object.test.ts
+++ b/packages/utils/test/object.test.ts
@@ -200,28 +200,34 @@ describe('dropUndefinedKeys()', () => {
     });
   });
 
-  test('objects with circular reference', () => {
-    const dog: any = {
+  test('should not throw on objects with circular reference', () => {
+    const chicken: any = {
       food: undefined,
     };
 
-    const human = {
-      brain: undefined,
-      pets: dog,
+    const egg = {
+      edges: undefined,
+      contains: chicken,
     };
 
-    const rat = {
-      scares: human,
-      weight: '4kg',
-    };
+    chicken.lays = egg;
 
-    dog.chases = rat;
+    const droppedChicken = dropUndefinedKeys(chicken);
 
-    expect(dropUndefinedKeys(human)).toStrictEqual({
-      pets: {
-        chases: rat,
-      },
-    });
+    // Removes undefined keys
+    expect(Object.keys(droppedChicken)).toEqual(['lays']);
+    expect(Object.keys(droppedChicken.lays)).toEqual(['contains']);
+
+    // Returns new object
+    expect(chicken === droppedChicken).toBe(false);
+    expect(chicken.lays === droppedChicken.lays).toBe(false);
+
+    // Returns new references within objects
+    expect(chicken === droppedChicken.lays.contains).toBe(false);
+    expect(egg === droppedChicken.lays.contains.lays).toBe(false);
+
+    // Keeps circular reference
+    expect(droppedChicken.lays.contains === droppedChicken).toBe(true);
   });
 
   test('arrays with circular reference', () => {
@@ -235,10 +241,22 @@ describe('dropUndefinedKeys()', () => {
 
     egg[0] = chicken;
 
-    expect(dropUndefinedKeys(chicken)).toStrictEqual({
-      lays: egg,
-      weight: '1kg',
-    });
+    const droppedChicken = dropUndefinedKeys(chicken);
+
+    // Removes undefined keys
+    expect(Object.keys(droppedChicken)).toEqual(['weight', 'lays']);
+    expect(Object.keys(droppedChicken.lays)).toEqual(['0']);
+
+    // Returns new objects
+    expect(chicken === droppedChicken).toBe(false);
+    expect(egg === droppedChicken.lays).toBe(false);
+
+    // Returns new references within objects
+    expect(chicken === droppedChicken.lays[0]).toBe(false);
+    expect(egg === droppedChicken.lays[0].lays).toBe(false);
+
+    // Keeps circular reference
+    expect(droppedChicken.lays[0] === droppedChicken).toBe(true);
   });
 });
 


### PR DESCRIPTION
For a long time, our helper function `dropUndefinedKeys` (which might more accurately be named `dropKeysWithUndefinedValues`) had a bug: when presented with an object containing a circular reference, it was perfectly happy to follow that cycle and recurse infinitely right along with the object. This was fixed in https://github.com/getsentry/sentry-javascript/pull/5163 using a memoizer - we keep a reference to each value we process, and if we hit one we've seen before, we stop recursing. No more infinite loops, yay!

Unfortunately, that change introduced a new bug. By design, `dropUndefinedKeys` doesn't mutate the object it's given, instead performing a deep copy which just skips over any keys whose value is `undefined`, eventually returning an object wholely separate from the original. If there's a circular reference in the original, its copy thus points from one spot in the new object to another spot in the new object and then back again. The cycle might be longer than two nodes, of course, but the overall point stands: every member of the cycle in the new object must itself be contained in (or equal to) the new object.

The problem with the fix in https://github.com/getsentry/sentry-javascript/pull/5163 is that it violates that rule. Before that change, when `dropUndefinedKeys` recursed infinitely, it wasn't creating a circular reference in the new object. Instead, it was creating infinitely nested copies of the members of the cycle. In other words, when presented with

`hen = { egg: { chicken: hen }}`,

it was creating

`henCopy = { egg: { chicken: { egg: { chicken: { egg: { chicken: { egg: ... }}}}}}}` .


Since that change, and continuing with the same example, it processes `hen` and `hen.egg`, but when it goes to process `hen.egg.chicken`, it recognizes it as the same `hen` it's already seen and instead of recursing into it just returns the existing one to complete the cycle. Unfortunately, that means it ends up creating

`henCopy = { egg: { chicken: hen }}`

rather than

`henCopy = { egg: { chicken: henCopy }}` ,

thereby violating the "all members of the new cycle must be part of the new object" rule.

This fixes that by using a map to store the new version of each value alongside its original. Now when a cycle is detected, instead of the original being returned, the copy is returned, completing the cycle entirely within the new object.

---

PR description courtesy of @lobsterkatie 

Ref: https://getsentry.atlassian.net/browse/WEB-940

This PR should be followed up by: https://github.com/getsentry/sentry-javascript/pull/5171