### PR TITLE
fix(node): Compression headers leak between requests

### DIFF
--- a/packages/node/src/transports/http.ts
+++ b/packages/node/src/transports/http.ts
@@ -105,12 +105,10 @@ function createRequestExecutor(
     return new Promise((resolve, reject) => {
       let body = streamFromBody(request.body);
 
-      if (request.body.length > GZIP_THRESHOLD) {
-        options.headers = {
-          ...options.headers,
-          'content-encoding': 'gzip',
-        };
+      const headers: Record<string, string> = { ...options.headers };
 
+      if (request.body.length > GZIP_THRESHOLD) {
+        headers['content-encoding'] = 'gzip';
         body = body.pipe(createGzip());
       }
 
@@ -118,7 +116,7 @@ function createRequestExecutor(
         {
           method: 'POST',
           agent,
-          headers: options.headers,
+          headers,
           hostname,
           path: `${pathname}${search}`,
           port,

--- a/packages/node/test/transports/http.test.ts
+++ b/packages/node/test/transports/http.test.ts
@@ -42,8 +42,6 @@ function setupTestServer(
 
     const stream = req.headers['content-encoding'] === 'gzip' ? req.pipe(createGunzip({})) : req;
 
-    stream.on('error', () => {});
-
     stream.on('data', data => {
       chunks.push(data);
     });


### PR DESCRIPTION
#5139 introduced a subtle bug where `options.headers` was modified which causes headers to leak between requests. This means requests after a compressed request will be incorrectly marked with `content-encoding: gzip`.
