### PR TITLE
ref(tracing): Check and set mutability of baggage

### DIFF
--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -13,7 +13,7 @@ import {
   fill,
   isString,
   logger,
-  parseAndFreezeBaggageIfNecessary,
+  parseBaggageSetMutability,
   stripUrlQueryAndFragment,
 } from '@sentry/utils';
 import * as domain from 'domain';
@@ -258,7 +258,7 @@ function makeWrappedReqHandler(origReqHandler: ReqHandler): WrappedReqHandler {
           }
 
           const rawBaggageString = nextReq.headers && isString(nextReq.headers.baggage) && nextReq.headers.baggage;
-          const baggage = parseAndFreezeBaggageIfNecessary(rawBaggageString, traceparentData);
+          const baggage = parseBaggageSetMutability(rawBaggageString, traceparentData);
 
           // pull off query string, if any
           const reqPath = stripUrlQueryAndFragment(nextReq.url);

--- a/packages/nextjs/src/utils/withSentry.ts
+++ b/packages/nextjs/src/utils/withSentry.ts
@@ -7,7 +7,6 @@ import {
   logger,
   objectify,
   parseAndFreezeBaggageIfNecessary,
-  parseBaggageString,
   stripUrlQueryAndFragment,
 } from '@sentry/utils';
 import * as domain from 'domain';

--- a/packages/nextjs/src/utils/withSentry.ts
+++ b/packages/nextjs/src/utils/withSentry.ts
@@ -6,7 +6,7 @@ import {
   isString,
   logger,
   objectify,
-  parseAndFreezeBaggageIfNecessary,
+  parseBaggageSetMutability,
   stripUrlQueryAndFragment,
 } from '@sentry/utils';
 import * as domain from 'domain';
@@ -54,7 +54,7 @@ export const withSentry = (origHandler: NextApiHandler): WrappedNextApiHandler =
           }
 
           const rawBaggageString = req.headers && isString(req.headers.baggage) && req.headers.baggage;
-          const baggage = parseAndFreezeBaggageIfNecessary(rawBaggageString, traceparentData);
+          const baggage = parseBaggageSetMutability(rawBaggageString, traceparentData);
 
           const url = `${req.url}`;
           // pull off query string, if any

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
@@ -3,22 +3,6 @@ import * as path from 'path';
 import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
-test('Should assign `baggage` header which contains 3rd party trace baggage data to an outgoing request.', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
-
-  const response = (await getAPIResponse(new URL(`${url}/express`), {
-    baggage: 'foo=bar,bar=baz',
-  })) as TestAPIResponse;
-
-  expect(response).toBeDefined();
-  expect(response).toMatchObject({
-    test_data: {
-      host: 'somewhere.not.sentry',
-      baggage: 'foo=bar,bar=baz,sentry-environment=prod,sentry-release=1.0',
-    },
-  });
-});
-
 test('Should not overwrite baggage if the incoming request already has Sentry baggage data.', async () => {
   const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
@@ -47,6 +31,69 @@ test('Should pass along sentry and 3rd party trace baggage data from an incoming
     test_data: {
       host: 'somewhere.not.sentry',
       baggage: expect.stringContaining('dogs=great,sentry-version=2.0.0,sentry-environment=myEnv'),
+    },
+  });
+});
+
+test('Should propagate empty baggage if sentry-trace header is present in incoming request but no baggage header', async () => {
+  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+
+  const response = (await getAPIResponse(new URL(`${url}/express`), {
+    'sentry-trace': '',
+  })) as TestAPIResponse;
+
+  expect(response).toBeDefined();
+  expect(response).toMatchObject({
+    test_data: {
+      host: 'somewhere.not.sentry',
+      baggage: '',
+    },
+  });
+});
+
+test('Should propagate empty sentry and original 3rd party baggage if sentry-trace header is present', async () => {
+  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+
+  const response = (await getAPIResponse(new URL(`${url}/express`), {
+    'sentry-trace': '',
+    baggage: 'foo=bar',
+  })) as TestAPIResponse;
+
+  expect(response).toBeDefined();
+  expect(response).toMatchObject({
+    test_data: {
+      host: 'somewhere.not.sentry',
+      baggage: 'foo=bar',
+    },
+  });
+});
+
+test('Should populate and propagate sentry baggage if sentry-trace header does not exist', async () => {
+  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+
+  const response = (await getAPIResponse(new URL(`${url}/express`), {})) as TestAPIResponse;
+
+  expect(response).toBeDefined();
+  expect(response).toMatchObject({
+    test_data: {
+      host: 'somewhere.not.sentry',
+      baggage: 'sentry-environment=prod,sentry-release=1.0',
+    },
+  });
+});
+
+test('Should populate Sentry and propagate 3rd party content if sentry-trace header does not exist', async () => {
+  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+
+  const response = (await getAPIResponse(new URL(`${url}/express`), {
+    baggage: 'foo=bar,bar=baz',
+  })) as TestAPIResponse;
+
+  expect(response).toBeDefined();
+  expect(response).toMatchObject({
+    test_data: {
+      host: 'somewhere.not.sentry',
+      baggage: 'foo=bar,bar=baz,sentry-environment=prod,sentry-release=1.0',
     },
   });
 });

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -8,7 +8,7 @@ import {
   isString,
   logger,
   normalize,
-  parseAndFreezeBaggageIfNecessary,
+  parseBaggageSetMutability,
   stripUrlQueryAndFragment,
 } from '@sentry/utils';
 import * as cookie from 'cookie';
@@ -65,7 +65,7 @@ export function tracingHandler(): (
       req.headers && isString(req.headers['sentry-trace']) && extractTraceparentData(req.headers['sentry-trace']);
     const rawBaggageString = req.headers && isString(req.headers.baggage) && req.headers.baggage;
 
-    const baggage = parseAndFreezeBaggageIfNecessary(rawBaggageString, traceparentData);
+    const baggage = parseBaggageSetMutability(rawBaggageString, traceparentData);
 
     const transaction = startTransaction(
       {

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -369,8 +369,8 @@ describe('tracingHandler', () => {
     expect(transaction.parentSpanId).toEqual('1121201211212012');
     expect(transaction.sampled).toEqual(false);
     expect(transaction.metadata?.baggage).toBeDefined();
-    expect(isBaggageEmpty(transaction.metadata?.baggage)).toBeTruthy();
-    expect(isBaggageMutable(transaction.metadata?.baggage)).toBeFalsy();
+    expect(isBaggageEmpty(transaction.metadata?.baggage)).toBe(true);
+    expect(isBaggageMutable(transaction.metadata?.baggage)).toBe(false);
   });
 
   it("pulls parent's data from tracing and baggage headers on the request", () => {

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -3,7 +3,7 @@ import * as sentryHub from '@sentry/hub';
 import { Hub } from '@sentry/hub';
 import { Transaction } from '@sentry/tracing';
 import { Baggage, Runtime } from '@sentry/types';
-import { SentryError } from '@sentry/utils';
+import { isBaggageEmpty, isBaggageFrozen, SentryError } from '@sentry/utils';
 import * as http from 'http';
 import * as net from 'net';
 
@@ -368,7 +368,9 @@ describe('tracingHandler', () => {
     expect(transaction.traceId).toEqual('12312012123120121231201212312012');
     expect(transaction.parentSpanId).toEqual('1121201211212012');
     expect(transaction.sampled).toEqual(false);
-    expect(transaction.metadata?.baggage).toBeUndefined();
+    expect(transaction.metadata?.baggage).toBeDefined();
+    expect(isBaggageEmpty(transaction.metadata?.baggage)).toBeTruthy();
+    expect(isBaggageFrozen(transaction.metadata?.baggage)).toBeTruthy();
   });
 
   it("pulls parent's data from tracing and baggage headers on the request", () => {
@@ -386,7 +388,7 @@ describe('tracingHandler', () => {
     expect(transaction.parentSpanId).toEqual('1121201211212012');
     expect(transaction.sampled).toEqual(false);
     expect(transaction.metadata?.baggage).toBeDefined();
-    expect(transaction.metadata?.baggage).toEqual([{ version: '1.0', environment: 'production' }, ''] as Baggage);
+    expect(transaction.metadata?.baggage).toEqual([{ version: '1.0', environment: 'production' }, '', true] as Baggage);
   });
 
   it("pulls parent's baggage (sentry + third party entries) headers on the request", () => {
@@ -402,6 +404,7 @@ describe('tracingHandler', () => {
     expect(transaction.metadata?.baggage).toEqual([
       { version: '1.0', environment: 'production' },
       'dogs=great,cats=boring',
+      true,
     ] as Baggage);
   });
 

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -3,7 +3,7 @@ import * as sentryHub from '@sentry/hub';
 import { Hub } from '@sentry/hub';
 import { Transaction } from '@sentry/tracing';
 import { Baggage, Runtime } from '@sentry/types';
-import { isBaggageEmpty, isBaggageFrozen, SentryError } from '@sentry/utils';
+import { isBaggageEmpty, isBaggageMutable, SentryError } from '@sentry/utils';
 import * as http from 'http';
 import * as net from 'net';
 
@@ -370,7 +370,7 @@ describe('tracingHandler', () => {
     expect(transaction.sampled).toEqual(false);
     expect(transaction.metadata?.baggage).toBeDefined();
     expect(isBaggageEmpty(transaction.metadata?.baggage)).toBeTruthy();
-    expect(isBaggageFrozen(transaction.metadata?.baggage)).toBeTruthy();
+    expect(isBaggageMutable(transaction.metadata?.baggage)).toBeFalsy();
   });
 
   it("pulls parent's data from tracing and baggage headers on the request", () => {
@@ -388,7 +388,11 @@ describe('tracingHandler', () => {
     expect(transaction.parentSpanId).toEqual('1121201211212012');
     expect(transaction.sampled).toEqual(false);
     expect(transaction.metadata?.baggage).toBeDefined();
-    expect(transaction.metadata?.baggage).toEqual([{ version: '1.0', environment: 'production' }, '', true] as Baggage);
+    expect(transaction.metadata?.baggage).toEqual([
+      { version: '1.0', environment: 'production' },
+      '',
+      false,
+    ] as Baggage);
   });
 
   it("pulls parent's baggage (sentry + third party entries) headers on the request", () => {
@@ -404,7 +408,7 @@ describe('tracingHandler', () => {
     expect(transaction.metadata?.baggage).toEqual([
       { version: '1.0', environment: 'production' },
       'dogs=great,cats=boring',
-      true,
+      false,
     ] as Baggage);
   });
 

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -287,7 +287,7 @@ export function wrapHandler<TEvent, TResult>(
     }
 
     const rawBaggageString =
-      eventWithHeaders.headers && isString(eventWithHeaders.headers.baggage) && eventWithHeaders.headers.baggege;
+      eventWithHeaders.headers && isString(eventWithHeaders.headers.baggage) && eventWithHeaders.headers.baggage;
     const baggage = parseAndFreezeBaggageIfNecessary(rawBaggageString, traceparentData);
 
     const transaction = startTransaction({

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -11,7 +11,7 @@ import {
 } from '@sentry/node';
 import { extractTraceparentData } from '@sentry/tracing';
 import { Integration } from '@sentry/types';
-import { isString, logger, parseAndFreezeBaggageIfNecessary } from '@sentry/utils';
+import { isString, logger, parseBaggageSetMutability } from '@sentry/utils';
 // NOTE: I have no idea how to fix this right now, and don't want to waste more time, as it builds just fine — Kamil
 // eslint-disable-next-line import/no-unresolved
 import { Context, Handler } from 'aws-lambda';
@@ -288,7 +288,7 @@ export function wrapHandler<TEvent, TResult>(
 
     const rawBaggageString =
       eventWithHeaders.headers && isString(eventWithHeaders.headers.baggage) && eventWithHeaders.headers.baggage;
-    const baggage = parseAndFreezeBaggageIfNecessary(rawBaggageString, traceparentData);
+    const baggage = parseBaggageSetMutability(rawBaggageString, traceparentData);
 
     const transaction = startTransaction({
       name: context.functionName,

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -1,6 +1,6 @@
 import { captureException, flush, getCurrentHub, Handlers, startTransaction } from '@sentry/node';
 import { extractTraceparentData } from '@sentry/tracing';
-import { isString, logger, parseAndFreezeBaggageIfNecessary, stripUrlQueryAndFragment } from '@sentry/utils';
+import { isString, logger, parseBaggageSetMutability, stripUrlQueryAndFragment } from '@sentry/utils';
 
 import { domainify, getActiveDomain, proxyFunction } from './../utils';
 import { HttpFunction, WrapperOptions } from './general';
@@ -59,7 +59,7 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
     const rawBaggageString =
       reqWithHeaders.headers && isString(reqWithHeaders.headers.baggage) && reqWithHeaders.headers.baggage;
 
-    const baggage = parseAndFreezeBaggageIfNecessary(rawBaggageString, traceparentData);
+    const baggage = parseBaggageSetMutability(rawBaggageString, traceparentData);
 
     const transaction = startTransaction({
       name: `${reqMethod} ${reqUrl}`,

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -192,7 +192,7 @@ describe('AWSLambda', () => {
       expect(Sentry.startTransaction).toBeCalledWith({
         name: 'functionName',
         op: 'awslambda.handler',
-        metadata: { baggage: [{}, '', false] },
+        metadata: { baggage: [{}, '', true] },
       });
       expectScopeSettings();
       // @ts-ignore see "Why @ts-ignore" note
@@ -215,7 +215,7 @@ describe('AWSLambda', () => {
         expect(Sentry.startTransaction).toBeCalledWith({
           name: 'functionName',
           op: 'awslambda.handler',
-          metadata: { baggage: [{}, '', false] },
+          metadata: { baggage: [{}, '', true] },
         });
         expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(error);
@@ -259,7 +259,7 @@ describe('AWSLambda', () => {
                   release: '2.12.1',
                 },
                 'maisey=silly,charlie=goofy',
-                true,
+                false,
               ],
             },
           }),
@@ -291,7 +291,7 @@ describe('AWSLambda', () => {
           traceId: '12312012123120121231201212312012',
           parentSpanId: '1121201211212012',
           parentSampled: false,
-          metadata: { baggage: [{}, '', true] },
+          metadata: { baggage: [{}, '', false] },
         });
         expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(e);
@@ -315,7 +315,7 @@ describe('AWSLambda', () => {
       expect(Sentry.startTransaction).toBeCalledWith({
         name: 'functionName',
         op: 'awslambda.handler',
-        metadata: { baggage: [{}, '', false] },
+        metadata: { baggage: [{}, '', true] },
       });
       expectScopeSettings();
       // @ts-ignore see "Why @ts-ignore" note
@@ -349,7 +349,7 @@ describe('AWSLambda', () => {
         expect(Sentry.startTransaction).toBeCalledWith({
           name: 'functionName',
           op: 'awslambda.handler',
-          metadata: { baggage: [{}, '', false] },
+          metadata: { baggage: [{}, '', true] },
         });
         expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(error);
@@ -388,7 +388,7 @@ describe('AWSLambda', () => {
       expect(Sentry.startTransaction).toBeCalledWith({
         name: 'functionName',
         op: 'awslambda.handler',
-        metadata: { baggage: [{}, '', false] },
+        metadata: { baggage: [{}, '', true] },
       });
       expectScopeSettings();
       // @ts-ignore see "Why @ts-ignore" note
@@ -422,7 +422,7 @@ describe('AWSLambda', () => {
         expect(Sentry.startTransaction).toBeCalledWith({
           name: 'functionName',
           op: 'awslambda.handler',
-          metadata: { baggage: [{}, '', false] },
+          metadata: { baggage: [{}, '', true] },
         });
         expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(error);

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -189,7 +189,11 @@ describe('AWSLambda', () => {
       const wrappedHandler = wrapHandler(handler);
       const rv = await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       expect(rv).toStrictEqual(42);
-      expect(Sentry.startTransaction).toBeCalledWith({ name: 'functionName', op: 'awslambda.handler' });
+      expect(Sentry.startTransaction).toBeCalledWith({
+        name: 'functionName',
+        op: 'awslambda.handler',
+        metadata: { baggage: [{}, '', false] },
+      });
       expectScopeSettings();
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
@@ -208,7 +212,11 @@ describe('AWSLambda', () => {
       try {
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       } catch (e) {
-        expect(Sentry.startTransaction).toBeCalledWith({ name: 'functionName', op: 'awslambda.handler' });
+        expect(Sentry.startTransaction).toBeCalledWith({
+          name: 'functionName',
+          op: 'awslambda.handler',
+          metadata: { baggage: [{}, '', false] },
+        });
         expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(error);
         // @ts-ignore see "Why @ts-ignore" note
@@ -251,6 +259,7 @@ describe('AWSLambda', () => {
                   release: '2.12.1',
                 },
                 'maisey=silly,charlie=goofy',
+                true,
               ],
             },
           }),
@@ -282,6 +291,7 @@ describe('AWSLambda', () => {
           traceId: '12312012123120121231201212312012',
           parentSpanId: '1121201211212012',
           parentSampled: false,
+          metadata: { baggage: [{}, '', true] },
         });
         expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(e);
@@ -302,7 +312,11 @@ describe('AWSLambda', () => {
       const wrappedHandler = wrapHandler(handler);
       const rv = await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       expect(rv).toStrictEqual(42);
-      expect(Sentry.startTransaction).toBeCalledWith({ name: 'functionName', op: 'awslambda.handler' });
+      expect(Sentry.startTransaction).toBeCalledWith({
+        name: 'functionName',
+        op: 'awslambda.handler',
+        metadata: { baggage: [{}, '', false] },
+      });
       expectScopeSettings();
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
@@ -332,7 +346,11 @@ describe('AWSLambda', () => {
       try {
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       } catch (e) {
-        expect(Sentry.startTransaction).toBeCalledWith({ name: 'functionName', op: 'awslambda.handler' });
+        expect(Sentry.startTransaction).toBeCalledWith({
+          name: 'functionName',
+          op: 'awslambda.handler',
+          metadata: { baggage: [{}, '', false] },
+        });
         expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(error);
         // @ts-ignore see "Why @ts-ignore" note
@@ -367,7 +385,11 @@ describe('AWSLambda', () => {
       const wrappedHandler = wrapHandler(handler);
       const rv = await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       expect(rv).toStrictEqual(42);
-      expect(Sentry.startTransaction).toBeCalledWith({ name: 'functionName', op: 'awslambda.handler' });
+      expect(Sentry.startTransaction).toBeCalledWith({
+        name: 'functionName',
+        op: 'awslambda.handler',
+        metadata: { baggage: [{}, '', false] },
+      });
       expectScopeSettings();
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
@@ -397,7 +419,11 @@ describe('AWSLambda', () => {
       try {
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       } catch (e) {
-        expect(Sentry.startTransaction).toBeCalledWith({ name: 'functionName', op: 'awslambda.handler' });
+        expect(Sentry.startTransaction).toBeCalledWith({
+          name: 'functionName',
+          op: 'awslambda.handler',
+          metadata: { baggage: [{}, '', false] },
+        });
         expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(error);
         // @ts-ignore see "Why @ts-ignore" note

--- a/packages/serverless/test/gcpfunction.test.ts
+++ b/packages/serverless/test/gcpfunction.test.ts
@@ -113,7 +113,7 @@ describe('GCPFunction', () => {
       expect(Sentry.startTransaction).toBeCalledWith({
         name: 'POST /path',
         op: 'gcp.function.http',
-        metadata: { baggage: [{}, '', false] },
+        metadata: { baggage: [{}, '', true] },
       });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
@@ -151,7 +151,7 @@ describe('GCPFunction', () => {
                 release: '2.12.1',
               },
               'maisey=silly,charlie=goofy',
-              true,
+              false,
             ],
           },
         }),
@@ -178,7 +178,7 @@ describe('GCPFunction', () => {
         traceId: '12312012123120121231201212312012',
         parentSpanId: '1121201211212012',
         parentSampled: false,
-        metadata: { baggage: [{}, '', true] },
+        metadata: { baggage: [{}, '', false] },
       });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);

--- a/packages/serverless/test/gcpfunction.test.ts
+++ b/packages/serverless/test/gcpfunction.test.ts
@@ -110,7 +110,11 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapHttpFunction(handler);
       await handleHttp(wrappedHandler);
-      expect(Sentry.startTransaction).toBeCalledWith({ name: 'POST /path', op: 'gcp.function.http' });
+      expect(Sentry.startTransaction).toBeCalledWith({
+        name: 'POST /path',
+        op: 'gcp.function.http',
+        metadata: { baggage: [{}, '', false] },
+      });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
@@ -147,6 +151,7 @@ describe('GCPFunction', () => {
                 release: '2.12.1',
               },
               'maisey=silly,charlie=goofy',
+              true,
             ],
           },
         }),
@@ -173,6 +178,7 @@ describe('GCPFunction', () => {
         traceId: '12312012123120121231201212312012',
         parentSpanId: '1121201211212012',
         parentSampled: false,
+        metadata: { baggage: [{}, '', true] },
       });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);

--- a/packages/serverless/test/google-cloud-grpc.test.ts
+++ b/packages/serverless/test/google-cloud-grpc.test.ts
@@ -130,7 +130,7 @@ describe('GoogleCloudGrpc tracing', () => {
       expect(Sentry.fakeTransaction.startChild).toBeCalledWith({
         op: 'gcloud.grpc.pubsub',
         description: 'unary call publish',
-        metadata: { baggage: [{}, '', true] },
+        metadata: { baggage: [{}, '', false] },
       });
       await pubsub.close();
     });

--- a/packages/serverless/test/google-cloud-grpc.test.ts
+++ b/packages/serverless/test/google-cloud-grpc.test.ts
@@ -130,6 +130,7 @@ describe('GoogleCloudGrpc tracing', () => {
       expect(Sentry.fakeTransaction.startChild).toBeCalledWith({
         op: 'gcloud.grpc.pubsub',
         description: 'unary call publish',
+        metadata: { baggage: [{}, '', true] },
       });
       await pubsub.close();
     });

--- a/packages/serverless/test/google-cloud-grpc.test.ts
+++ b/packages/serverless/test/google-cloud-grpc.test.ts
@@ -130,7 +130,6 @@ describe('GoogleCloudGrpc tracing', () => {
       expect(Sentry.fakeTransaction.startChild).toBeCalledWith({
         op: 'gcloud.grpc.pubsub',
         description: 'unary call publish',
-        metadata: { baggage: [{}, '', false] },
       });
       await pubsub.close();
     });

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -1,6 +1,6 @@
 import { Hub } from '@sentry/hub';
 import { EventProcessor, Integration, Transaction, TransactionContext } from '@sentry/types';
-import { getGlobalObject, logger, parseBaggageString } from '@sentry/utils';
+import { getGlobalObject, logger, parseAndFreezeBaggageIfNecessary, parseBaggageString } from '@sentry/utils';
 
 import { startIdleTransaction } from '../hubextensions';
 import { DEFAULT_FINAL_TIMEOUT, DEFAULT_IDLE_TIMEOUT } from '../idletransaction';
@@ -255,7 +255,7 @@ export function extractTraceDataFromMetaTags(): Partial<TransactionContext> | un
   const baggageValue = getMetaContent('baggage');
 
   const sentrytraceData = sentrytraceValue ? extractTraceparentData(sentrytraceValue) : undefined;
-  const baggage = baggageValue ? parseBaggageString(baggageValue) : undefined;
+  const baggage = parseAndFreezeBaggageIfNecessary(baggageValue, sentrytraceValue);
 
   // TODO more extensive checks for baggage validity/emptyness?
   if (sentrytraceData || baggage) {

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -1,6 +1,6 @@
 import { Hub } from '@sentry/hub';
 import { EventProcessor, Integration, Transaction, TransactionContext } from '@sentry/types';
-import { getGlobalObject, logger, parseAndFreezeBaggageIfNecessary } from '@sentry/utils';
+import { getGlobalObject, logger, parseBaggageSetMutability } from '@sentry/utils';
 
 import { startIdleTransaction } from '../hubextensions';
 import { DEFAULT_FINAL_TIMEOUT, DEFAULT_IDLE_TIMEOUT } from '../idletransaction';
@@ -255,7 +255,7 @@ export function extractTraceDataFromMetaTags(): Partial<TransactionContext> | un
   const baggageValue = getMetaContent('baggage');
 
   const sentrytraceData = sentrytraceValue ? extractTraceparentData(sentrytraceValue) : undefined;
-  const baggage = parseAndFreezeBaggageIfNecessary(baggageValue, sentrytraceValue);
+  const baggage = parseBaggageSetMutability(baggageValue, sentrytraceValue);
 
   // TODO more extensive checks for baggage validity/emptyness?
   if (sentrytraceData || baggage) {

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -1,6 +1,6 @@
 import { Hub } from '@sentry/hub';
 import { EventProcessor, Integration, Transaction, TransactionContext } from '@sentry/types';
-import { getGlobalObject, logger, parseAndFreezeBaggageIfNecessary, parseBaggageString } from '@sentry/utils';
+import { getGlobalObject, logger, parseAndFreezeBaggageIfNecessary } from '@sentry/utils';
 
 import { startIdleTransaction } from '../hubextensions';
 import { DEFAULT_FINAL_TIMEOUT, DEFAULT_IDLE_TIMEOUT } from '../idletransaction';

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -356,9 +356,17 @@ export class Span implements SpanInterface {
   }
 
   /**
+   * Collects and adds data to the passed baggage object.
+   *
+   * Note: This function does not explicitly check if the passed baggage object is allowed
+   * to be modified. Implicitly, `setBaggageValue` will not make modification to the object
+   * if it was already set immutable.
+   *
+   * After adding the data, the baggage object is set immutable to prevent further modifications.
    *
    * @param baggage
-   * @returns
+   *
+   * @returns modified and immutable maggage object
    */
   private _getBaggageWithSentryValues(baggage: Baggage = createBaggage({})): Baggage {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -315,6 +315,8 @@ export class Span implements SpanInterface {
   public getBaggage(): Baggage | undefined {
     const existingBaggage = this.transaction && this.transaction.metadata.baggage;
 
+    // Only add Sentry baggage items to baggage, if baggage does not exist yet or it is still
+    // empty and not yet set immutable
     const finalBaggage =
       !existingBaggage || (!isBaggageFrozen(existingBaggage) && isSentryBaggageEmpty(existingBaggage))
         ? this._getBaggageWithSentryValues(existingBaggage)

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -4,10 +4,10 @@ import { Baggage, Hub, Primitive, Span as SpanInterface, SpanContext, Transactio
 import {
   createBaggage,
   dropUndefinedKeys,
-  freezeBaggage,
   isBaggageEmpty,
-  isBaggageFrozen,
+  isBaggageMutable,
   isSentryBaggageEmpty,
+  setBaggageImmutable,
   setBaggageValue,
   timestampWithMs,
   uuid4,
@@ -316,9 +316,9 @@ export class Span implements SpanInterface {
     const existingBaggage = this.transaction && this.transaction.metadata.baggage;
 
     // Only add Sentry baggage items to baggage, if baggage does not exist yet or it is still
-    // empty and not yet set immutable
+    // empty and mutable
     const finalBaggage =
-      !existingBaggage || (!isBaggageFrozen(existingBaggage) && isSentryBaggageEmpty(existingBaggage))
+      !existingBaggage || (isBaggageMutable(existingBaggage) && isSentryBaggageEmpty(existingBaggage))
         ? this._getBaggageWithSentryValues(existingBaggage)
         : existingBaggage;
 
@@ -378,7 +378,7 @@ export class Span implements SpanInterface {
     environment && setBaggageValue(baggage, 'environment', environment);
     release && setBaggageValue(baggage, 'release', release);
 
-    freezeBaggage(baggage);
+    setBaggageImmutable(baggage);
 
     return baggage;
   }

--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -5,7 +5,7 @@ import {
   createBaggage,
   dropUndefinedKeys,
   isBaggageEmpty,
-  isSentryBaggageEmpty,
+  isBaggageFrozen,
   setBaggageValue,
   timestampWithMs,
   uuid4,
@@ -313,10 +313,8 @@ export class Span implements SpanInterface {
   public getBaggage(): Baggage | undefined {
     const existingBaggage = this.transaction && this.transaction.metadata.baggage;
 
-    const finalBaggage =
-      !existingBaggage || isSentryBaggageEmpty(existingBaggage)
-        ? this._getBaggageWithSentryValues(existingBaggage)
-        : existingBaggage;
+    const canModifyBaggage = !(existingBaggage && isBaggageFrozen(existingBaggage));
+    const finalBaggage = canModifyBaggage ? this._getBaggageWithSentryValues(existingBaggage) : existingBaggage;
 
     return isBaggageEmpty(finalBaggage) ? undefined : finalBaggage;
   }

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -1,7 +1,13 @@
 import { BrowserClient } from '@sentry/browser';
 import { Hub, makeMain } from '@sentry/hub';
-import type { BaggageObj, BaseTransportOptions, ClientOptions } from '@sentry/types';
-import { getGlobalObject, InstrumentHandlerCallback, InstrumentHandlerType } from '@sentry/utils';
+import type { Baggage, BaggageObj, BaseTransportOptions, ClientOptions } from '@sentry/types';
+import {
+  getGlobalObject,
+  InstrumentHandlerCallback,
+  InstrumentHandlerType,
+  isBaggageEmpty,
+  isSentryBaggageEmpty,
+} from '@sentry/utils';
 import { JSDOM } from 'jsdom';
 
 import {
@@ -228,7 +234,7 @@ describe('BrowserTracing', () => {
           parentSpanId: 'b6e54397b12a2a0f',
           parentSampled: true,
           metadata: {
-            baggage: [{ release: '2.1.14' }, 'foo=bar'],
+            baggage: [{ release: '2.1.14' }, 'foo=bar', true],
           },
         }),
         expect.any(Number),
@@ -390,7 +396,9 @@ describe('BrowserTracing', () => {
 
         const headerContext = extractTraceDataFromMetaTags();
 
-        expect(headerContext).toBeUndefined();
+        expect(headerContext).toBeDefined();
+        expect(headerContext?.metadata?.baggage).toBeDefined();
+        expect(isBaggageEmpty(headerContext?.metadata?.baggage as Baggage)).toBeTruthy();
       });
 
       it('does not crash if the baggage header is malformed', () => {
@@ -406,12 +414,14 @@ describe('BrowserTracing', () => {
         expect(baggage && baggage[1]).toBeDefined();
       });
 
-      it("returns undefined if the header isn't there", () => {
+      it("returns default object if the header isn't there", () => {
         document.head.innerHTML = '<meta name="dogs" content="12312012123120121231201212312012-1121201211212012-0">';
 
         const headerContext = extractTraceDataFromMetaTags();
 
-        expect(headerContext).toBeUndefined();
+        expect(headerContext).toBeDefined();
+        expect(headerContext?.metadata?.baggage).toBeDefined();
+        expect(isBaggageEmpty(headerContext?.metadata?.baggage as Baggage)).toBeTruthy();
       });
     });
 
@@ -448,7 +458,7 @@ describe('BrowserTracing', () => {
         expect(baggage[1]).toEqual('foo=bar');
       });
 
-      it('adds Sentry baggage data to pageload transactions if not present in meta tags', () => {
+      it('does not add Sentry baggage data to pageload transactions if sentry-trace data is present but passes on 3rd party baggage', () => {
         // make sampled false here, so we can see that it's being used rather than the tracesSampleRate-dictated one
         document.head.innerHTML =
           '<meta name="sentry-trace" content="12312012123120121231201212312012-1121201211212012-0">' +
@@ -465,8 +475,7 @@ describe('BrowserTracing', () => {
         expect(transaction.parentSpanId).toEqual('1121201211212012');
         expect(transaction.sampled).toBe(false);
         expect(baggage).toBeDefined();
-        expect(baggage[0]).toBeDefined();
-        expect(baggage[0]).toEqual({ environment: 'production', release: '1.0.0' });
+        expect(isSentryBaggageEmpty(baggage)).toBeTruthy();
         expect(baggage[1]).toBeDefined();
         expect(baggage[1]).toEqual('foo=bar');
       });

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -398,7 +398,7 @@ describe('BrowserTracing', () => {
 
         expect(headerContext).toBeDefined();
         expect(headerContext?.metadata?.baggage).toBeDefined();
-        expect(isBaggageEmpty(headerContext?.metadata?.baggage as Baggage)).toBeTruthy();
+        expect(isBaggageEmpty(headerContext?.metadata?.baggage as Baggage)).toBe(true);
       });
 
       it('does not crash if the baggage header is malformed', () => {
@@ -421,7 +421,7 @@ describe('BrowserTracing', () => {
 
         expect(headerContext).toBeDefined();
         expect(headerContext?.metadata?.baggage).toBeDefined();
-        expect(isBaggageEmpty(headerContext?.metadata?.baggage as Baggage)).toBeTruthy();
+        expect(isBaggageEmpty(headerContext?.metadata?.baggage as Baggage)).toBe(true);
       });
     });
 
@@ -475,7 +475,7 @@ describe('BrowserTracing', () => {
         expect(transaction.parentSpanId).toEqual('1121201211212012');
         expect(transaction.sampled).toBe(false);
         expect(baggage).toBeDefined();
-        expect(isSentryBaggageEmpty(baggage)).toBeTruthy();
+        expect(isSentryBaggageEmpty(baggage)).toBe(true);
         expect(baggage[1]).toBeDefined();
         expect(baggage[1]).toEqual('foo=bar');
       });

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -234,7 +234,7 @@ describe('BrowserTracing', () => {
           parentSpanId: 'b6e54397b12a2a0f',
           parentSampled: true,
           metadata: {
-            baggage: [{ release: '2.1.14' }, 'foo=bar', true],
+            baggage: [{ release: '2.1.14' }, 'foo=bar', false],
           },
         }),
         expect.any(Number),

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -424,11 +424,11 @@ describe('Span', () => {
       expect(baggage && getThirdPartyBaggage(baggage)).toStrictEqual('');
     });
 
-    test('add Sentry baggage data to baggage if Sentry content is empty', () => {
+    test('add Sentry baggage data to baggage if Sentry content is empty and baggage is mutable', () => {
       const transaction = new Transaction(
         {
           name: 'tx',
-          metadata: { baggage: createBaggage({}, '') },
+          metadata: { baggage: createBaggage({}, '', false) },
         },
         hub,
       );

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -419,7 +419,7 @@ describe('Span', () => {
       const baggage = span.getBaggage();
 
       expect(hubSpy).toHaveBeenCalledTimes(0);
-      expect(baggage && isSentryBaggageEmpty(baggage)).toBeFalsy();
+      expect(baggage && isSentryBaggageEmpty(baggage)).toBe(false);
       expect(baggage && getSentryBaggageItems(baggage)).toStrictEqual({ environment: 'myEnv' });
       expect(baggage && getThirdPartyBaggage(baggage)).toStrictEqual('');
     });
@@ -440,7 +440,7 @@ describe('Span', () => {
       const baggage = span.getBaggage();
 
       expect(hubSpy).toHaveBeenCalledTimes(1);
-      expect(baggage && isSentryBaggageEmpty(baggage)).toBeFalsy();
+      expect(baggage && isSentryBaggageEmpty(baggage)).toBe(false);
       expect(baggage && getSentryBaggageItems(baggage)).toStrictEqual({ release: '1.0.1', environment: 'production' });
       expect(baggage && getThirdPartyBaggage(baggage)).toStrictEqual('');
     });

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -428,7 +428,7 @@ describe('Span', () => {
       const transaction = new Transaction(
         {
           name: 'tx',
-          metadata: { baggage: createBaggage({}, '', false) },
+          metadata: { baggage: createBaggage({}, '', true) },
         },
         hub,
       );

--- a/packages/types/src/baggage.ts
+++ b/packages/types/src/baggage.ts
@@ -13,7 +13,7 @@ export type BaggageObj = Partial<Record<AllowedBaggageKeys, string> & Record<str
  * set/used by sentry, they will be stored in an object to be easily accessed.
  * If they are not, they are kept as a string to be only accessed when serialized
  * at baggage propagation time.
- * The third tuple member controls the mutability of the baggage. If it is `true`,
- * the baggage can not be modified any longer (i.e. is immutable).
+ * The third tuple member controls the mutability of the baggage. If it is `false`,
+ * the baggage can no longer longer be modified (i.e. is immutable).
  */
 export type Baggage = [BaggageObj, string, boolean];

--- a/packages/types/src/baggage.ts
+++ b/packages/types/src/baggage.ts
@@ -8,10 +8,12 @@ export type BaggageObj = Partial<Record<AllowedBaggageKeys, string> & Record<str
  * It is expected that users interact with baggage using the helpers methods:
  * `createBaggage`, `getBaggageValue`, and `setBaggageValue`.
  *
- * Internally, the baggage data structure is a tuple of length 2, separating baggage values
+ * Internally, the baggage data structure is a tuple of length 3, separating baggage values
  * based on if they are related to Sentry or not. If the baggage values are
  * set/used by sentry, they will be stored in an object to be easily accessed.
  * If they are not, they are kept as a string to be only accessed when serialized
  * at baggage propagation time.
+ * The third tuple member controls the mutability of the baggage. If it is `true`,
+ * the baggage can not be modified any longer (i.e. is immutable).
  */
-export type Baggage = [BaggageObj, string];
+export type Baggage = [BaggageObj, string, boolean];

--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -145,20 +145,20 @@ export function mergeAndSerializeBaggage(incomingBaggage?: Baggage, headerBaggag
  * Helper function that takes a raw baggage string (if available) and the processed sentry-trace header
  * data (if available), parses the baggage string and creates a Baggage object
  * If there is no baggage string, it will create an empty Baggage object.
- * In a second step, this functions determines when the created Baggage object should be set immutable
+ * In a second step, this functions determines if the created Baggage object should be set immutable
  * to prevent mutation of the Sentry data.
  *
  * Extracted this logic to a function because it's duplicated in a lot of places.
  *
  * @param rawBaggageString
- * @param traceparentData
+ * @param sentryTraceData
  */
 export function parseBaggageSetMutability(
   rawBaggageString: string | false | undefined | null,
-  traceparentData: TraceparentData | string | false | undefined | null,
+  sentryTraceData: TraceparentData | string | false | undefined | null,
 ): Baggage {
   const baggage = parseBaggageString(rawBaggageString || '');
-  if (!isSentryBaggageEmpty(baggage) || (traceparentData && isSentryBaggageEmpty(baggage))) {
+  if (!isSentryBaggageEmpty(baggage) || (sentryTraceData && isSentryBaggageEmpty(baggage))) {
     setBaggageImmutable(baggage);
   }
   return baggage;

--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -153,7 +153,6 @@ export function mergeAndSerializeBaggage(incomingBaggage?: Baggage, headerBaggag
  * @param rawBaggageString
  * @param traceparentData
  */
-//              parseBaggagePlusMutability
 export function parseAndFreezeBaggageIfNecessary(
   rawBaggageString: string | false | undefined | null,
   traceparentData: TraceparentData | string | false | undefined | null,


### PR DESCRIPTION
This PR addresses the mutability aspect of baggage. It introduces a third item to our `Baggage` tuple which is a mutability  flag. The reason for adding this flag is to set the mutability of the baggage object when we receive one, either from incoming requests or `<meta>` tags in the browser. It's necessary to decide about mutability at this time because the decision depends on the `sentry-trace` header. Since we're lazily populating baggage when it gets sent (propagated), we have to know at that time, if we are allowed to add `sentry-` entries to it, or if we should just pass it along as is. The only way to cover all cases of when we're allowed to make changes is to set the flag at the incoming time and check it at population time. 

Specifically, we identify and handle mutability in the following cases:

* Incoming request w/ baggage that contains `sentry-*` items (and possibly 3rd party items): 
  * At incoming request time (IRT): Parse and store baggage on the span. Set it immutable
  * At baggage propagation time (BPT): Propagate baggage
* Incoming request w/o baggage header:
  * if `sentry-trace` is present
    * IRT: create empty baggage object and set it to immutable
    * BPT: propagate baggage
  * else, 
    * IRT: create empty baggage object (to be populated later) and leave it mutable
    * BPT: populate, set it immutable, propagate it
* Incoming request with baggage header that only contains 3rd party items: Same as above. In both cases, we propagate the 3rd party baggage.
* Incoming request w/o any of the two headers: 
    * IRT: create empty baggage object (to be populated later) and leave it mutable
    * BPT: populate, set it immutable, propagate it
* No baggage set on the span at BPT: populate, set it immutable, propagate it

Checking for the presence of the `sentry-trace` header is important because if it is present, we know that the trace was already started which means that whatever handler is receiving it, cannot modify baggage anymore. Getting a `sentry-trace` but no `baggage` header, can (and will) for example occur, when the SDK that started the trace does not yet support and propagate baggage.  

ref: https://getsentry.atlassian.net/browse/WEB-935