### PR TITLE
chore(build): Only upload lambda layer when releasing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,6 +132,8 @@ jobs:
   job_pack_aws_lambda_layer:
     name: Pack and Upload AWS Lambda Layer
     needs: [job_get_metadata, job_build]
+    # only upload the zipped layer file if we're about to release
+    if: startsWith(github.ref, 'refs/heads/release/')
     runs-on: ubuntu-latest
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})


### PR DESCRIPTION
_Note: This is an exact duplicate of https://github.com/getsentry/sentry-javascript/pull/5167, which accidentally got merged into the 7.x branch rather than master._

This changes our GHA workflow to only zip and upload the lambda layer when the uploaded artifact is needed for a release. (This matches the behavior of other uploaded artifacts.)
