### PR TITLE
fix(serverless) Do not change DSN in Serverless integration

### DIFF
--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -11,7 +11,7 @@ import {
 } from '@sentry/node';
 import { extractTraceparentData } from '@sentry/tracing';
 import { Integration } from '@sentry/types';
-import { extensionRelayDSN, isString, logger, parseBaggageString } from '@sentry/utils';
+import { isString, logger, parseBaggageString } from '@sentry/utils';
 // NOTE: I have no idea how to fix this right now, and don't want to waste more time, as it builds just fine — Kamil
 // eslint-disable-next-line import/no-unresolved
 import { Context, Handler } from 'aws-lambda';
@@ -77,8 +77,6 @@ export function init(options: Sentry.NodeOptions = {}): void {
     ],
     version: Sentry.SDK_VERSION,
   };
-
-  options.dsn = extensionRelayDSN(options.dsn);
 
   Sentry.init(options);
   Sentry.addGlobalEventProcessor(serverlessEventProcessor);


### PR DESCRIPTION
In AWS Lambda Integration of V7 the DSN of the user is changed to point to `localhost:3000` (that is the URL of the Lambda Extension, that is not yet released)

This breaks the Serverless AWS Lambda Integration, so I disabled "changing the DSN" until the Lambda Extension is released. 

Was reported by a user in this PR: https://github.com/getsentry/sentry-javascript/pull/5126

Fixes https://github.com/getsentry/sentry-javascript/issues/5211