### PR TITLE
fix(types): Vendor in TextEncoderCommon type

### DIFF
--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -62,6 +62,7 @@ export type { Severity, SeverityLevel } from './severity';
 export type { Span, SpanContext } from './span';
 export type { StackFrame } from './stackframe';
 export type { Stacktrace, StackParser, StackLineParser, StackLineParserFn } from './stacktrace';
+export type { TextEncoderInternal } from './textencoder';
 export type {
   CustomSamplingContext,
   Measurements,

--- a/packages/types/src/textencoder.ts
+++ b/packages/types/src/textencoder.ts
@@ -1,0 +1,16 @@
+/**
+ * Vendored type from TS 3.8 `typescript/lib/lib.dom.d.ts`.
+ *
+ * Type is vendored in so that users don't have to opt-in to DOM types.
+ */
+export interface TextEncoderCommon {
+  /**
+   * Returns "utf-8".
+   */
+  readonly encoding: string;
+}
+
+// Combination of global TextEncoder and Node require('util').TextEncoder
+export interface TextEncoderInternal extends TextEncoderCommon {
+  encode(input?: string): Uint8Array;
+}

--- a/packages/types/src/transport.ts
+++ b/packages/types/src/transport.ts
@@ -1,6 +1,7 @@
 import { EventDropReason } from './clientreport';
 import { DataCategory } from './datacategory';
 import { Envelope } from './envelope';
+import { TextEncoderInternal } from './textencoder';
 
 export type TransportRequest = {
   body: string | Uint8Array;
@@ -14,11 +15,6 @@ export type TransportMakeRequestResponse = {
     'retry-after': string | null;
   };
 };
-
-// Combination of global TextEncoder and Node require('util').TextEncoder
-interface TextEncoderInternal extends TextEncoderCommon {
-  encode(input?: string): Uint8Array;
-}
 
 export interface InternalBaseTransportOptions {
   bufferSize?: number;

--- a/packages/utils/src/envelope.ts
+++ b/packages/utils/src/envelope.ts
@@ -1,4 +1,12 @@
-import { Attachment, AttachmentItem, DataCategory, Envelope, EnvelopeItem, EnvelopeItemType } from '@sentry/types';
+import {
+  Attachment,
+  AttachmentItem,
+  DataCategory,
+  Envelope,
+  EnvelopeItem,
+  EnvelopeItemType,
+  TextEncoderInternal,
+} from '@sentry/types';
 
 import { dropUndefinedKeys } from './object';
 
@@ -34,11 +42,6 @@ export function forEachEnvelopeItem<E extends Envelope>(
     const envelopeItemType = envelopeItem[0].type;
     callback(envelopeItem, envelopeItemType);
   });
-}
-
-// Combination of global TextEncoder and Node require('util').TextEncoder
-interface TextEncoderInternal extends TextEncoderCommon {
-  encode(input?: string): Uint8Array;
 }
 
 function encodeUTF8(input: string, textEncoder?: TextEncoderInternal): Uint8Array {


### PR DESCRIPTION
`TextEncoderCommon` is a type from `lib.dom.d.ts`. We don't want to
require users to set DOM types, so we vendor it in. It's a relatively
simple type, so we don't have to worry about potential conflicts or user
issues.

Fixes https://github.com/getsentry/sentry-javascript/issues/5199

Ref: https://getsentry.atlassian.net/browse/WEB-952
