### PR TITLE
fix: Update MIGRATION for SeverityLevel

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -478,11 +478,9 @@ const status = SpanStatus.fromHttpCode(403);
 
 We deprecated the `Severity` enum in `@sentry/types` and it will be removed in the next major release. We recommend using string literals (typed as `SeverityLevel`) to save on bundle size.
 
-`SeverityLevel` and `SeverityLevels` will continue to exist in v7, but they will live in `@sentry/utils` rather than `@sentry/types`. Currently, they live in both, for ease of migration. (`SeverityLevels` isn't included in the examples below because it is only useful internally.)
-
 ```js
 // New in 6.17.5:
-import { SeverityLevel } from '@sentry/utils';
+import { SeverityLevel } from '@sentry/types';
 
 const levelA = "error" as SeverityLevel;
 


### PR DESCRIPTION
Change the import for `SeverityLevel` from utils -> types to better reflect how it actually works.