### PR TITLE
fix(node): Only set contexts runtime if not set.

### DIFF
--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -142,7 +142,7 @@ export class NodeClient extends BaseClient<NodeClientOptions> {
     event.platform = event.platform || 'node';
     event.contexts = {
       ...event.contexts,
-      runtime: {
+      runtime: event.contexts?.runtime || {
         name: 'node',
         version: global.process.version,
       },

--- a/packages/node/test/client.test.ts
+++ b/packages/node/test/client.test.ts
@@ -216,6 +216,24 @@ describe('NodeClient', () => {
       });
     });
 
+    test('does not add runtime context to event if already defined on event', () => {
+      const options = getDefaultNodeClientOptions({ dsn: PUBLIC_DSN });
+      client = new NodeClient(options);
+
+      const event: Event = {
+        contexts: {
+          runtime: {
+            name: 'Electron',
+            version: '19.0.0',
+          },
+        },
+      };
+      const hint: EventHint = {};
+      (client as any)._prepareEvent(event, hint);
+
+      expect(event.contexts?.runtime).toEqual(event.contexts?.runtime);
+    });
+
     test('adds server name to event when value passed in options', () => {
       const options = getDefaultNodeClientOptions({ dsn: PUBLIC_DSN, serverName: 'foo' });
       client = new NodeClient(options);


### PR DESCRIPTION
Make sure we don't overwrite contexts runtime if it has already been set.

Fixes issue addressed in https://github.com/getsentry/sentry-javascript/pull/5190#issuecomment-1149149462.

cc @timfish 