### PR TITLE
fix(nextjs): Export `showReportDialog` from NextJS SDK

### DIFF
--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -15,7 +15,7 @@ export * from '@sentry/node';
 
 // Here we want to make sure to only include what doesn't have browser specifics
 // because or SSR of next.js we can only use this.
-export { ErrorBoundary, withErrorBoundary } from '@sentry/react';
+export { ErrorBoundary, showReportDialog, withErrorBoundary } from '@sentry/react';
 
 type GlobalWithDistDir = typeof global & { __rewriteFramesDistDir__: string };
 const domain = domainModule as typeof domainModule & { active: (domainModule.Domain & Carrier) | null };

--- a/packages/nextjs/test/integration/pages/reportDialog.tsx
+++ b/packages/nextjs/test/integration/pages/reportDialog.tsx
@@ -1,0 +1,13 @@
+import { showReportDialog } from '@sentry/nextjs';
+
+const ReportDialogPage = (): JSX.Element => (
+  <button
+    onClick={() => {
+      showReportDialog();
+    }}
+  >
+    Open Report Dialog
+  </button>
+);
+
+export default ReportDialogPage;

--- a/packages/nextjs/test/integration/test/client/reportDialog.js
+++ b/packages/nextjs/test/integration/test/client/reportDialog.js
@@ -1,4 +1,4 @@
-const { equal } = require('assert');
+const assert = require('assert');
 
 module.exports = async ({ page, url }) => {
   await page.goto(`${url}/reportDialog`);
@@ -10,5 +10,5 @@ module.exports = async ({ page, url }) => {
   const dialogScript = await page.waitForSelector(dialogScriptSelector, { state: 'attached' });
   const dialogScriptSrc = await (await dialogScript.getProperty('src')).jsonValue();
 
-  equal(dialogScriptSrc?.startsWith('https://dsn.ingest.sentry.io/api/embed/error-page/?'), true);
+  assert(dialogScriptSrc.startsWith('https://dsn.ingest.sentry.io/api/embed/error-page/?'));
 };

--- a/packages/nextjs/test/integration/test/client/reportDialog.js
+++ b/packages/nextjs/test/integration/test/client/reportDialog.js
@@ -1,0 +1,14 @@
+const { equal } = require('assert');
+
+module.exports = async ({ page, url }) => {
+  await page.goto(`${url}/reportDialog`);
+
+  await page.click('button');
+
+  const dialogScriptSelector = 'head > script[src^="https://dsn.ingest.sentry.io/api/embed/error-page"]';
+
+  const dialogScript = await page.waitForSelector(dialogScriptSelector, { state: 'attached' });
+  const dialogScriptSrc = await (await dialogScript.getProperty('src')).jsonValue();
+
+  equal(dialogScriptSrc?.startsWith('https://dsn.ingest.sentry.io/api/embed/error-page/?'), true);
+};


### PR DESCRIPTION
Resolves: #5240 

Exported from the `server` index, like the other SSR exports of `@sentry/react`.