### PR TITLE
feat(angular): Add Angular 14 support

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -15,9 +15,9 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@angular/common": "10.x || 11.x || 12.x || 13.x",
-    "@angular/core": "10.x || 11.x || 12.x || 13.x",
-    "@angular/router": "10.x || 11.x || 12.x || 13.x",
+    "@angular/common": "10.x || 11.x || 12.x || 13.x || 14.x",
+    "@angular/core": "10.x || 11.x || 12.x || 13.x || 14.x",
+    "@angular/router": "10.x || 11.x || 12.x || 13.x || 14.x",
     "rxjs": "^6.5.5 || ^7.x"
   },
   "dependencies": {


### PR DESCRIPTION
This PR adds Angular 14 peer dependencies to `package.json` to make our SDK compatible with the recently released version 14 of Angular. Tested on an NG14 sample projects - Errors, transaction and component instrumentation work as expected.

Fixes #5215