### PR TITLE
chore(angular): Add Angular version to event contexts

### DIFF
--- a/packages/angular/jest.config.js
+++ b/packages/angular/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require('../../jest/jest.config.js');
+
+module.exports = {
+  ...baseConfig,
+  testEnvironment: 'jsdom',
+};

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -52,7 +52,10 @@
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/*.ts\"",
     "lint": "run-s lint:prettier lint:eslint",
     "lint:eslint": "eslint . --cache --cache-location '../../eslintcache/' --format stylish",
-    "lint:prettier": "prettier --check \"{src,test,scripts}/**/*.ts\""
+    "lint:prettier": "prettier --check \"{src,test,scripts}/**/*.ts\"",
+    "test": "run-s test:unit",
+    "test:unit": "jest",
+    "test:unit:watch": "jest --watch"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/angular/src/errorhandler.ts
+++ b/packages/angular/src/errorhandler.ts
@@ -32,6 +32,7 @@ class SentryErrorHandler implements AngularErrorHandler {
       ...options,
     };
   }
+
   /**
    * Method called for every value captured through the ErrorHandler
    */

--- a/packages/angular/src/errorhandler.ts
+++ b/packages/angular/src/errorhandler.ts
@@ -1,5 +1,5 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { ErrorHandler as AngularErrorHandler, Inject, Injectable } from '@angular/core';
+import { ErrorHandler as AngularErrorHandler, Inject, Injectable, VERSION } from '@angular/core';
 import * as Sentry from '@sentry/browser';
 
 import { runOutsideAngular } from './zone';
@@ -32,7 +32,6 @@ class SentryErrorHandler implements AngularErrorHandler {
       ...options,
     };
   }
-
   /**
    * Method called for every value captured through the ErrorHandler
    */
@@ -40,7 +39,10 @@ class SentryErrorHandler implements AngularErrorHandler {
     const extractedError = this._extractError(error) || 'Handled unknown error';
 
     // Capture handled exception and send it to Sentry.
-    const eventId = runOutsideAngular(() => Sentry.captureException(extractedError));
+    const angularVersion = VERSION && VERSION.major ? parseInt(VERSION.major, 10) : 0;
+    const eventId = runOutsideAngular(() =>
+      Sentry.captureException(extractedError, { contexts: { angular: { version: angularVersion } } }),
+    );
 
     // When in development mode, log the error to console for immediate feedback.
     if (this._options.logErrors) {

--- a/packages/angular/src/errorhandler.ts
+++ b/packages/angular/src/errorhandler.ts
@@ -1,5 +1,5 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { ErrorHandler as AngularErrorHandler, Inject, Injectable, VERSION } from '@angular/core';
+import { ErrorHandler as AngularErrorHandler, Inject, Injectable } from '@angular/core';
 import * as Sentry from '@sentry/browser';
 
 import { runOutsideAngular } from './zone';
@@ -39,10 +39,7 @@ class SentryErrorHandler implements AngularErrorHandler {
     const extractedError = this._extractError(error) || 'Handled unknown error';
 
     // Capture handled exception and send it to Sentry.
-    const angularVersion = VERSION && VERSION.major ? parseInt(VERSION.major, 10) : 0;
-    const eventId = runOutsideAngular(() =>
-      Sentry.captureException(extractedError, { contexts: { angular: { version: angularVersion } } }),
-    );
+    const eventId = runOutsideAngular(() => Sentry.captureException(extractedError));
 
     // When in development mode, log the error to console for immediate feedback.
     if (this._options.logErrors) {

--- a/packages/angular/src/sdk.ts
+++ b/packages/angular/src/sdk.ts
@@ -1,5 +1,5 @@
 import { VERSION } from '@angular/core';
-import { BrowserOptions, init as browserInit, SDK_VERSION } from '@sentry/browser';
+import { BrowserOptions, init as browserInit, SDK_VERSION, setContext } from '@sentry/browser';
 import { logger } from '@sentry/utils';
 
 import { ANGULAR_MINIMUM_VERSION } from './constants';
@@ -20,20 +20,23 @@ export function init(options: BrowserOptions): void {
     ],
     version: SDK_VERSION,
   };
-  checkAngularVersion();
+
+  checkAndSetAngularVersion();
   browserInit(options);
 }
 
-function checkAngularVersion(): void {
-  if (VERSION && VERSION.major) {
-    const major = parseInt(VERSION.major, 10);
-    if (major < ANGULAR_MINIMUM_VERSION) {
+function checkAndSetAngularVersion(): void {
+  const angularVersion = VERSION && VERSION.major ? parseInt(VERSION.major, 10) : undefined;
+
+  if (angularVersion) {
+    if (angularVersion < ANGULAR_MINIMUM_VERSION) {
       IS_DEBUG_BUILD &&
         logger.warn(
-          `The Sentry SDK does not officially support Angular ${major}.`,
+          `The Sentry SDK does not officially support Angular ${angularVersion}.`,
           `This version of the Sentry SDK supports Angular ${ANGULAR_MINIMUM_VERSION} and above.`,
           'Please consider upgrading your Angular version or downgrading the Sentry SDK.',
         );
     }
+    setContext('angular', { version: angularVersion });
   }
 }

--- a/packages/angular/test/sdk.test.ts
+++ b/packages/angular/test/sdk.test.ts
@@ -1,0 +1,16 @@
+import * as SentryBrowser from '@sentry/browser';
+
+import { init } from '../src/sdk';
+
+describe('init', () => {
+  it('sets the Angular version (if available) in the global scope', () => {
+    const setContextSpy = jest.spyOn(SentryBrowser, 'setContext');
+
+    init({});
+
+    // In our case, the Angular version is 10 because that's the version we use for compilation
+    // (and hence the dependency version of Angular core we installed (see package.json))
+    expect(setContextSpy).toHaveBeenCalledTimes(1);
+    expect(setContextSpy).toHaveBeenCalledWith('angular', { version: 10 });
+  });
+});


### PR DESCRIPTION
Query and send the Angular version in events to Sentry to let us know which Angular versions are used by our users. This should help us make data-based Angular version support decisions in the future.
