### PR TITLE
ci: Ignore sentry-remix for publishing

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -25,7 +25,7 @@ targets:
           cacheControl: 'public, max-age=31536000'
   - name: github
     includeNames: /^sentry-.*$/
-    excludeNames: /^sentry-remix-.$/
+    excludeNames: /^sentry-remix-.*$/
   - name: npm
     excludeNames: /^sentry-remix-.*.tgz$/
   - name: registry

--- a/.craft.yml
+++ b/.craft.yml
@@ -25,6 +25,7 @@ targets:
           cacheControl: 'public, max-age=31536000'
   - name: github
     includeNames: /^sentry-.*$/
+    excludeNames: /^sentry-remix-.$/
   - name: npm
     excludeNames: /^sentry-remix-.*.tgz$/
   - name: registry

--- a/.craft.yml
+++ b/.craft.yml
@@ -26,6 +26,7 @@ targets:
   - name: github
     includeNames: /^sentry-.*$/
   - name: npm
+    excludeNames: /^sentry-remix-.*.tgz$/
   - name: registry
     sdks:
       'npm:@sentry/browser':


### PR DESCRIPTION
Its currently `private`, so we dont want `npm` to pick it up, as it will fail whole build workflow.