### PR TITLE
fix(tracing): Baggage parsing fails when input is not of type string

### DIFF
--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -123,7 +123,7 @@ function _createWrappedRequestMethodFactory(
               `[Tracing] Adding sentry-trace header ${sentryTraceHeader} to outgoing request to ${requestUrl}: `,
             );
 
-          const headerBaggageString = requestOptions.headers && (requestOptions.headers.baggage as string);
+          const headerBaggageString = requestOptions.headers && requestOptions.headers.baggage;
 
           requestOptions.headers = {
             ...requestOptions.headers,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -36,7 +36,7 @@ export type {} from './globals';
 export type { Hub } from './hub';
 export type { Integration, IntegrationClass } from './integration';
 export type { Mechanism } from './mechanism';
-export type { ExtractedNodeRequestData, Primitive, WorkerLocation } from './misc';
+export type { ExtractedNodeRequestData, HttpHeaderValue, Primitive, WorkerLocation } from './misc';
 export type { ClientOptions, Options } from './options';
 export type { Package } from './package';
 export type { PolymorphicEvent } from './polymorphics';

--- a/packages/types/src/misc.ts
+++ b/packages/types/src/misc.ts
@@ -63,3 +63,5 @@ export interface WorkerLocation {
 }
 
 export type Primitive = number | string | boolean | bigint | symbol | null | undefined;
+
+export type HttpHeaderValue = string | string[] | number | null;

--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -1,5 +1,5 @@
 import { Baggage, BaggageObj, TraceparentData } from '@sentry/types';
-import { HttpHeaderValue } from '@sentry/types/build/types/misc';
+import { HttpHeaderValue } from '@sentry/types';
 
 import { isString } from './is';
 import { logger } from './logger';

--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -1,6 +1,6 @@
 import { Baggage, BaggageObj, TraceparentData } from '@sentry/types';
-import { isString } from './is';
 
+import { isString } from './is';
 import { logger } from './logger';
 
 export const BAGGAGE_HEADER_NAME = 'baggage';

--- a/packages/utils/test/baggage.test.ts
+++ b/packages/utils/test/baggage.test.ts
@@ -100,6 +100,7 @@ describe('Baggage', () => {
   describe('parseBaggageString', () => {
     it.each([
       ['parses an empty string', '', createBaggage({})],
+      ['parses a blank string', '     ', createBaggage({})],
       [
         'parses sentry values into baggage',
         'sentry-environment=production,sentry-release=10.0.2',
@@ -108,6 +109,14 @@ describe('Baggage', () => {
       [
         'parses arbitrary baggage headers',
         'userId=alice,serverNode=DF%2028,isProduction=false,sentry-environment=production,sentry-release=10.0.2',
+        createBaggage(
+          { environment: 'production', release: '10.0.2' },
+          'userId=alice,serverNode=DF%2028,isProduction=false',
+        ),
+      ],
+      [
+        'parses arbitrary baggage headers from string with empty and blank entries',
+        'userId=alice,    serverNode=DF%2028   , isProduction=false,   ,,sentry-environment=production,,sentry-release=10.0.2',
         createBaggage(
           { environment: 'production', release: '10.0.2' },
           'userId=alice,serverNode=DF%2028,isProduction=false',

--- a/packages/utils/test/baggage.test.ts
+++ b/packages/utils/test/baggage.test.ts
@@ -7,8 +7,8 @@ import {
   isBaggageMutable,
   isSentryBaggageEmpty,
   mergeAndSerializeBaggage,
+  parseBaggageHeader,
   parseBaggageSetMutability,
-  parseBaggageString,
   serializeBaggage,
   setBaggageImmutable,
   setBaggageValue,
@@ -97,7 +97,7 @@ describe('Baggage', () => {
     });
   });
 
-  describe('parseBaggageString', () => {
+  describe('parseBaggageHeader', () => {
     it.each([
       ['parses an empty string', '', createBaggage({})],
       ['parses a blank string', '     ', createBaggage({})],
@@ -137,8 +137,9 @@ describe('Baggage', () => {
         ['', 'sentry-environment=production,sentry-release=1.0.1', '    ', 'foo=bar'],
         createBaggage({ environment: 'production', release: '1.0.1' }, 'foo=bar'),
       ],
-    ])('%s', (_: string, baggageString, baggage) => {
-      expect(parseBaggageString(baggageString)).toEqual(baggage);
+      ['ignorese other input types than string and string[]', 42, createBaggage({}, '')],
+    ])('%s', (_: string, baggageValue, baggage) => {
+      expect(parseBaggageHeader(baggageValue)).toEqual(baggage);
     });
   });
 

--- a/packages/utils/test/baggage.test.ts
+++ b/packages/utils/test/baggage.test.ts
@@ -113,6 +113,21 @@ describe('Baggage', () => {
           'userId=alice,serverNode=DF%2028,isProduction=false',
         ),
       ],
+      [
+        'parses a string array',
+        ['userId=alice', 'sentry-environment=production', 'foo=bar'],
+        createBaggage({ environment: 'production' }, 'userId=alice,foo=bar'),
+      ],
+      [
+        'parses a string array with items containing multiple entries',
+        ['userId=alice,   userName=bob', 'sentry-environment=production,sentry-release=1.0.1', 'foo=bar'],
+        createBaggage({ environment: 'production', release: '1.0.1' }, 'userId=alice,userName=bob,foo=bar'),
+      ],
+      [
+        'parses a string array with empty/blank entries',
+        ['', 'sentry-environment=production,sentry-release=1.0.1', '    ', 'foo=bar'],
+        createBaggage({ environment: 'production', release: '1.0.1' }, 'foo=bar'),
+      ],
     ])('%s', (_: string, baggageString, baggage) => {
       expect(parseBaggageString(baggageString)).toEqual(baggage);
     });


### PR DESCRIPTION
This PR attempts to fix a bug reported in #5250 where the input parameter for `parseBaggageString` was not a string and hence the `string.split` function call would throw an error. This PR now checks for the type of the input and makes the function

* return an empty baggage object if the input is neither a string, nor an array. In this case we log a warning to get more information on what is actually passed in.
* parse the baggage string if the input is a string
* join and then split the array if the input is an array

Additionally, the parser now ignores empty or blank baggage entries (e.g. `foo=bar,   ,,alice=bob`).

This is far from a proper, complete bugfix because we're missing an actual reproduction of the exact error but we got similar errors when experimenting with a Node/Express test app that would yield an array of baggage items rather than a string. However, it has the potential to fix it, or at least keep an error from emerging. Additionally, it makes the parser a little more robust.

Added some tests to describe/test how the parser now handles different input values. 
 