### PR TITLE
ref(tracing): Move `getBaggage()` from `Span` to `Transaction` class

### DIFF
--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -123,12 +123,13 @@ function _createWrappedRequestMethodFactory(
               `[Tracing] Adding sentry-trace header ${sentryTraceHeader} to outgoing request to ${requestUrl}: `,
             );
 
+          const baggage = parentSpan.transaction && parentSpan.transaction.getBaggage();
           const headerBaggageString = requestOptions.headers && requestOptions.headers.baggage;
 
           requestOptions.headers = {
             ...requestOptions.headers,
             'sentry-trace': sentryTraceHeader,
-            baggage: mergeAndSerializeBaggage(span.getBaggage(), headerBaggageString),
+            baggage: mergeAndSerializeBaggage(baggage, headerBaggageString),
           };
         }
       }

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -188,6 +188,8 @@ export class Transaction extends SpanClass implements TransactionInterface {
 
   /**
    * @inheritdoc
+   *
+   * @experimental
    */
   public getBaggage(): Baggage {
     const existingBaggage = this.metadata.baggage;

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -414,9 +414,7 @@ describe('Span', () => {
 
       const hubSpy = jest.spyOn(hub.getClient()!, 'getOptions');
 
-      const span = transaction.startChild();
-
-      const baggage = span.getBaggage();
+      const baggage = transaction.getBaggage();
 
       expect(hubSpy).toHaveBeenCalledTimes(0);
       expect(baggage && isSentryBaggageEmpty(baggage)).toBe(false);
@@ -438,9 +436,7 @@ describe('Span', () => {
 
       const hubSpy = jest.spyOn(hub.getClient()!, 'getOptions');
 
-      const span = transaction.startChild();
-
-      const baggage = span.getBaggage();
+      const baggage = transaction.getBaggage();
 
       expect(hubSpy).toHaveBeenCalledTimes(1);
       expect(baggage && isSentryBaggageEmpty(baggage)).toBe(false);

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -1,4 +1,3 @@
-import { Baggage } from './baggage';
 import { Primitive } from './misc';
 import { Transaction } from './transaction';
 
@@ -162,6 +161,7 @@ export interface Span extends SpanContext {
     tags?: { [key: string]: Primitive };
     trace_id: string;
   };
+
   /** Convert the object to JSON */
   toJSON(): {
     data?: { [key: string]: any };
@@ -175,7 +175,4 @@ export interface Span extends SpanContext {
     timestamp?: number;
     trace_id: string;
   };
-
-  /** return the baggage for dynamic sampling and trace propagation */
-  getBaggage(): Baggage | undefined;
 }

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -87,6 +87,9 @@ export interface Transaction extends TransactionContext, Span {
 
   /** Updates the current transaction with a new `TransactionContext` */
   updateWithContext(transactionContext: TransactionContext): this;
+
+  /** return the baggage for dynamic sampling and trace propagation */
+  getBaggage(): Baggage;
 }
 
 /**

--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -1,5 +1,4 @@
-import { Baggage, BaggageObj, TraceparentData } from '@sentry/types';
-import { HttpHeaderValue } from '@sentry/types';
+import { Baggage, BaggageObj, HttpHeaderValue, TraceparentData } from '@sentry/types';
 
 import { isString } from './is';
 import { logger } from './logger';


### PR DESCRIPTION
As already discussed in #5292, this PR moves the `getBaggage()` method from the `Span` class, to the `Transaction` class. This change is good for two reasons:

1. It conceptually makes more sense to store DSC on the transaction rather than the span because we're always talking about transactions in DS
2. We can get rid of a sketchy type cast and avoid a circular dependency situation (transaction -> span -> transaction) entirely