### PR TITLE
fix(tracing): Report the right units for CLS and TTFB [INGEST-1409]

### DIFF
--- a/packages/tracing/src/browser/metrics/index.ts
+++ b/packages/tracing/src/browser/metrics/index.ts
@@ -50,7 +50,7 @@ function _trackCLS(): void {
     }
 
     __DEBUG_BUILD__ && logger.log('[Measurements] Adding CLS');
-    _measurements['cls'] = { value: metric.value, unit: 'millisecond' };
+    _measurements['cls'] = { value: metric.value };
     _clsEntry = entry as LayoutShift;
   });
 }
@@ -172,7 +172,7 @@ export function addPerformanceEntries(transaction: Transaction): void {
         // This is the time between the start of the request and the start of the response in milliseconds.
         _measurements['ttfb.requestTime'] = {
           value: (responseStartTimestamp - requestStartTimestamp) * 1000,
-          unit: 'second',
+          unit: 'millisecond',
         };
       }
     }

--- a/packages/tracing/src/browser/metrics/index.ts
+++ b/packages/tracing/src/browser/metrics/index.ts
@@ -50,7 +50,7 @@ function _trackCLS(): void {
     }
 
     __DEBUG_BUILD__ && logger.log('[Measurements] Adding CLS');
-    _measurements['cls'] = { value: metric.value };
+    _measurements['cls'] = { value: metric.value, unit: 'none' };
     _clsEntry = entry as LayoutShift;
   });
 }


### PR DESCRIPTION
* ttfb.requestTime is multiplied times 1000 and is documented in a code comment as ms
* Cumulative Layout Shift does not have a unit. A layout cannot shift by 10 milliseconds