### PR TITLE
fix(core): Remove optional chaining usage

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -291,7 +291,10 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
       for (const attachment of hint.attachments || []) {
         env = addItemToEnvelope(
           env,
-          createAttachmentEnvelopeItem(attachment, this._options.transportOptions?.textEncoder),
+          createAttachmentEnvelopeItem(
+            attachment,
+            this._options.transportOptions && this._options.transportOptions.textEncoder,
+          ),
         );
       }
 


### PR DESCRIPTION
Remove optional chaining usage. This should mean we don't import the optional chaining polyfill into the browser bundle any more.

We really need to lint against this probably.

(proof it was pulling in the polyfill)
![image](https://user-images.githubusercontent.com/18689448/175389352-8265c1f8-0750-4166-b430-92a309ba0f68.png)

### Before

![image](https://user-images.githubusercontent.com/18689448/175389817-a13962f4-5fa5-4df1-938a-4308d1f4fc75.png)


### After

![image](https://user-images.githubusercontent.com/18689448/175389575-d1787a87-0e43-4510-a89c-b953e45ef5f5.png)