### PR TITLE
chore: Add eslint rule to guard against optional chaining in browser SDKs

### DIFF
--- a/packages/browser/.eslintrc.js
+++ b/packages/browser/.eslintrc.js
@@ -4,4 +4,14 @@ module.exports = {
   },
   ignorePatterns: ['test/integration/**', 'src/loader.js'],
   extends: ['../../.eslintrc.js'],
+  rules: {
+    // Disallow optional chaining in browser SDKs
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'OptionalMemberExpression',
+        message: 'Optional Chaining is disallowed in packages that could be used by Browser SDKs',
+      },
+    ],
+  },
 };

--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -1,3 +1,13 @@
 module.exports = {
   extends: ['../../.eslintrc.js'],
+  rules: {
+    // Disallow optional chaining in browser SDKs
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'OptionalMemberExpression',
+        message: 'Optional Chaining is disallowed in packages that could be used by Browser SDKs',
+      },
+    ],
+  },
 };

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -291,7 +291,10 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
       for (const attachment of hint.attachments || []) {
         env = addItemToEnvelope(
           env,
-          createAttachmentEnvelopeItem(attachment, this._options.transportOptions?.textEncoder),
+          createAttachmentEnvelopeItem(
+            attachment,
+            this._options.transportOptions && this._options.transportOptions.textEncoder,
+          ),
         );
       }
 

--- a/packages/hub/.eslintrc.js
+++ b/packages/hub/.eslintrc.js
@@ -1,3 +1,13 @@
 module.exports = {
   extends: ['../../.eslintrc.js'],
+  rules: {
+    // Disallow optional chaining in browser SDKs
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'OptionalMemberExpression',
+        message: 'Optional Chaining is disallowed in packages that could be used by Browser SDKs',
+      },
+    ],
+  },
 };


### PR DESCRIPTION
Builds on top of https://github.com/getsentry/sentry-javascript/pull/5304