### PR TITLE
feat(react): expose FallbackRender as top-level type

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,7 +2,7 @@ export * from '@sentry/browser';
 
 export { init } from './sdk';
 export { Profiler, withProfiler, useProfiler } from './profiler';
-export { ErrorBoundary, withErrorBoundary } from './errorboundary';
+export { ErrorBoundary, FallbackRender, withErrorBoundary } from './errorboundary';
 export { createReduxEnhancer } from './redux';
 export { reactRouterV3Instrumentation } from './reactrouterv3';
 export { reactRouterV4Instrumentation, reactRouterV5Instrumentation, withSentryRouting } from './reactrouter';


### PR DESCRIPTION
This PR exposes the `FallbackRender` type at the root level of `@sentry/react` package. Currently, to use the type and so get type info on the passed error object., we need to do:

```ts
import { FallbackRender } from '@sentry/react/types/errorboundary.d';
// v6: import { FallbackRender } from '@sentry/react/dist/errorboundary';

export const ErrorOverlay: FallbackRender = (error) => {
});
```

which feels wrong, as reaching into the package internals is clearly asking for unannounced breaking changes (as seen going from v6->v7).

------

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
