### PR TITLE
build: Run size-limit action on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           echo "COMMIT_SHA=$COMMIT_SHA" >> $GITHUB_ENV
           echo "COMMIT_MESSAGE=$(git log -n 1 --pretty=format:%s $COMMIT_SHA)" >> $GITHUB_ENV
     outputs:
-      commit_label: "${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}"
+      commit_label: '${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}'
 
   job_install_deps:
     name: Install Dependencies
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: "Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})"
+      - name: 'Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})'
         uses: actions/checkout@v2
         with:
           ref: ${{ env.HEAD_COMMIT }}
@@ -93,7 +93,7 @@ jobs:
 
   job_build:
     name: Build
-    needs: [ job_get_metadata, job_install_deps ]
+    needs: [job_get_metadata, job_install_deps]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -177,7 +177,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     # Size Check will error out outside of the context of a PR
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' }} || ${{ startsWith(github.ref, 'refs/heads/master/') }}
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v2


### PR DESCRIPTION
We need to run size-limit on master so that we upload size assets that we can do comparisons with.

Some formatting fixes climbed in, but `${{ github.event_name == 'pull_request' }} || ${{ startsWith(github.ref, 'refs/heads/master/') }}` is the line to care about.
