### PR TITLE
fix(ember): Restore ember package contents

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,8 @@ on:
         required: false
 
 env:
-  DEFAULT_NODE_VERSION: '16'
+  # We pin the exact version to enforce reproducable builds with node + npm.
+  DEFAULT_NODE_VERSION: '16.15.1'
 
   HEAD_COMMIT: ${{ github.event.inputs.commit || github.sha }}
 
@@ -58,7 +59,7 @@ jobs:
           echo "COMMIT_SHA=$COMMIT_SHA" >> $GITHUB_ENV
           echo "COMMIT_MESSAGE=$(git log -n 1 --pretty=format:%s $COMMIT_SHA)" >> $GITHUB_ENV
     outputs:
-      commit_label: "${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}"
+      commit_label: '${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}'
 
   job_install_deps:
     name: Install Dependencies
@@ -66,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: "Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})"
+      - name: 'Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})'
         uses: actions/checkout@v2
         with:
           ref: ${{ env.HEAD_COMMIT }}
@@ -93,7 +94,7 @@ jobs:
 
   job_build:
     name: Build
-    needs: [ job_get_metadata, job_install_deps ]
+    needs: [job_get_metadata, job_install_deps]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/packages/ember/.npmignore
+++ b/packages/ember/.npmignore
@@ -1,3 +1,6 @@
+# Disable rules of .npmignore in workspace root for this package
+!*
+
 # compiled output
 /dist/
 /tmp/
@@ -24,6 +27,7 @@
 /testem.js
 /tests/
 /yarn.lock
+/.npmignore
 .gitkeep
 
 # ember-try


### PR DESCRIPTION
### Problem Description

As reported in #5296, from version `7.1.1` to `7.2.0` of the Ember SDK, a majority of the contents of the npm packages suddenly disappeared.

We traced the issue back to a Node.js dependency change (in patch `v16.15.1`) that bumped npm from version `8.5.5` to `8.11.0`. That npm version bump included a fix (https://github.com/npm/cli/pull/4917 & https://github.com/npm/npm-packlist/pull/102, first appeared in npm `v8.11.0`) that restores the functionality that `npm pack` also looks at workspace roots for `.npmignore` files. For the ember SDK package, we actually depended on the bug that is now fixed, as a result messing up our package contents.

### Changes

To fix the ember package contents we simply override the workspace root `.npmignore` rules in the `.npmignore` file of the ember package. Essentially, for the ember package, this now works as if there were no `.npmignore` file in the workspace root.

Additionally, as of this PR, we pin the default node version (and implicitly the npm version). So we have reproducible builds.

---

Fixes #5296