### PR TITLE
ref(tracing): Ignore third party baggage entries from incoming requests

### DIFF
--- a/packages/nextjs/src/utils/withSentry.ts
+++ b/packages/nextjs/src/utils/withSentry.ts
@@ -72,7 +72,7 @@ export const withSentry = (origHandler: NextApiHandler): WrappedNextApiHandler =
               name: `${reqMethod}${reqPath}`,
               op: 'http.server',
               ...traceparentData,
-              metadata: { baggage: baggage },
+              metadata: { baggage },
             },
             // extra context passed to the `tracesSampler`
             { request: req },

--- a/packages/node-integration-tests/package.json
+++ b/packages/node-integration-tests/package.json
@@ -13,7 +13,6 @@
     "lint:eslint": "eslint . --cache --cache-location '../../eslintcache/' --format stylish",
     "lint:prettier": "prettier --check \"{suites,utils}/**/*.ts\"",
     "type-check": "tsc",
-    "pretest": "run-s --silent prisma:init",
     "test": "jest --runInBand --forceExit",
     "test:watch": "yarn test --watch"
   },

--- a/packages/node-integration-tests/package.json
+++ b/packages/node-integration-tests/package.json
@@ -13,6 +13,7 @@
     "lint:eslint": "eslint . --cache --cache-location '../../eslintcache/' --format stylish",
     "lint:prettier": "prettier --check \"{suites,utils}/**/*.ts\"",
     "type-check": "tsc",
+    "pretest": "run-s --silent prisma:init",
     "test": "jest --runInBand --forceExit",
     "test:watch": "yarn test --watch"
   },

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
@@ -7,7 +7,6 @@ test('Should not overwrite baggage if the incoming request already has Sentry ba
   const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const response = (await getAPIResponse(new URL(`${url}/express`), {
-    'sentry-trace': '',
     baggage: 'sentry-release=2.0.0,sentry-environment=myEnv',
   })) as TestAPIResponse;
 

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
@@ -7,30 +7,32 @@ test('Should not overwrite baggage if the incoming request already has Sentry ba
   const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const response = (await getAPIResponse(new URL(`${url}/express`), {
-    baggage: 'sentry-version=2.0.0,sentry-environment=myEnv',
+    'sentry-trace': '',
+    baggage: 'sentry-release=2.0.0,sentry-environment=myEnv',
   })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
     test_data: {
       host: 'somewhere.not.sentry',
-      baggage: 'sentry-version=2.0.0,sentry-environment=myEnv',
+      baggage: 'sentry-release=2.0.0,sentry-environment=myEnv',
     },
   });
 });
 
-test('Should pass along sentry and 3rd party trace baggage data from an incoming to an outgoing request.', async () => {
+test('Should propagate sentry trace baggage data from an incoming to an outgoing request.', async () => {
   const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const response = (await getAPIResponse(new URL(`${url}/express`), {
-    baggage: 'sentry-version=2.0.0,sentry-environment=myEnv,dogs=great',
+    'sentry-trace': '',
+    baggage: 'sentry-release=2.0.0,sentry-environment=myEnv,dogs=great',
   })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
     test_data: {
       host: 'somewhere.not.sentry',
-      baggage: expect.stringContaining('dogs=great,sentry-version=2.0.0,sentry-environment=myEnv'),
+      baggage: 'sentry-release=2.0.0,sentry-environment=myEnv',
     },
   });
 });
@@ -51,7 +53,7 @@ test('Should propagate empty baggage if sentry-trace header is present in incomi
   });
 });
 
-test('Should propagate empty sentry and original 3rd party baggage if sentry-trace header is present', async () => {
+test('Should propagate empty sentry and ignore original 3rd party baggage entries if sentry-trace header is present', async () => {
   const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const response = (await getAPIResponse(new URL(`${url}/express`), {
@@ -63,7 +65,7 @@ test('Should propagate empty sentry and original 3rd party baggage if sentry-tra
   expect(response).toMatchObject({
     test_data: {
       host: 'somewhere.not.sentry',
-      baggage: 'foo=bar',
+      baggage: '',
     },
   });
 });
@@ -85,7 +87,7 @@ test('Should populate and propagate sentry baggage if sentry-trace header does n
   });
 });
 
-test('Should populate Sentry and propagate 3rd party content if sentry-trace header does not exist', async () => {
+test('Should populate Sentry and ignore 3rd party content if sentry-trace header does not exist', async () => {
   const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const response = (await getAPIResponse(new URL(`${url}/express`), {
@@ -98,7 +100,7 @@ test('Should populate Sentry and propagate 3rd party content if sentry-trace hea
       host: 'somewhere.not.sentry',
       // TraceId changes, hence we only expect that the string contains the traceid key
       baggage: expect.stringContaining(
-        'foo=bar,bar=baz,sentry-environment=prod,sentry-release=1.0,sentry-transaction=GET%20%2Ftest%2Fexpress,' +
+        'sentry-environment=prod,sentry-release=1.0,sentry-transaction=GET%20%2Ftest%2Fexpress,' +
           'sentry-public_key=public,sentry-trace_id=',
       ),
     },

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/server.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/server.ts
@@ -1,0 +1,42 @@
+import * as Sentry from '@sentry/node';
+import * as Tracing from '@sentry/tracing';
+import cors from 'cors';
+import express from 'express';
+import http from 'http';
+
+const app = express();
+
+export type TestAPIResponse = { test_data: { host: string; 'sentry-trace': string; baggage: string } };
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  environment: 'prod',
+  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  tracesSampleRate: 1.0,
+});
+
+app.use(Sentry.Handlers.requestHandler());
+app.use(Sentry.Handlers.tracingHandler());
+
+app.use(cors());
+
+app.get('/test/express', (_req, res) => {
+  // simulate setting a "third party" baggage header which the Sentry SDK should merge with Sentry DSC entries
+  const headers = http
+    .get({
+      hostname: 'somewhere.not.sentry',
+      headers: {
+        baggage:
+          'other=vendor,foo=bar,third=party,sentry-release=9.9.9,sentry-environment=staging,sentry-sample_rate=0.54,last=item',
+      },
+    })
+    .getHeaders();
+
+  // Responding with the headers outgoing request headers back to the assertions.
+  res.send({ test_data: headers });
+});
+
+app.use(Sentry.Handlers.errorHandler());
+
+export default app;

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/test.ts
@@ -1,0 +1,38 @@
+import * as path from 'path';
+
+import { getAPIResponse, runServer } from '../../../../utils/index';
+import { TestAPIResponse } from '../server';
+
+test('should ignore sentry-values in `baggage` header of a third party vendor and overwrite them with incoming DSC', async () => {
+  const url = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+
+  const response = (await getAPIResponse(new URL(`${url}/express`), {
+    'sentry-trace': '',
+    baggage: 'sentry-release=2.1.0,sentry-environment=myEnv',
+  })) as TestAPIResponse;
+
+  expect(response).toBeDefined();
+  expect(response).toMatchObject({
+    test_data: {
+      host: 'somewhere.not.sentry',
+      baggage: 'other=vendor,foo=bar,third=party,last=item,sentry-release=2.1.0,sentry-environment=myEnv',
+    },
+  });
+});
+
+test('should ignore sentry-values in `baggage` header of a third party vendor and overwrite them with new DSC', async () => {
+  const url = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+
+  const response = (await getAPIResponse(new URL(`${url}/express`), {})) as TestAPIResponse;
+
+  expect(response).toBeDefined();
+  expect(response).toMatchObject({
+    test_data: {
+      host: 'somewhere.not.sentry',
+      baggage: expect.stringContaining(
+        'other=vendor,foo=bar,third=party,last=item,sentry-environment=prod,sentry-release=1.0,' +
+          'sentry-transaction=GET%20%2Ftest%2Fexpress,sentry-public_key=public',
+      ),
+    },
+  });
+});

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/server.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/server.ts
@@ -1,0 +1,36 @@
+import * as Sentry from '@sentry/node';
+import * as Tracing from '@sentry/tracing';
+import cors from 'cors';
+import express from 'express';
+import http from 'http';
+
+const app = express();
+
+export type TestAPIResponse = { test_data: { host: string; 'sentry-trace': string; baggage: string } };
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  environment: 'prod',
+  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  tracesSampleRate: 1.0,
+});
+
+app.use(Sentry.Handlers.requestHandler());
+app.use(Sentry.Handlers.tracingHandler());
+
+app.use(cors());
+
+app.get('/test/express', (_req, res) => {
+  // simulate setting a "third party" baggage header which the Sentry SDK should merge with Sentry DSC entries
+  const headers = http
+    .get({ hostname: 'somewhere.not.sentry', headers: { baggage: 'other=vendor,foo=bar,third=party' } })
+    .getHeaders();
+
+  // Responding with the headers outgoing request headers back to the assertions.
+  res.send({ test_data: headers });
+});
+
+app.use(Sentry.Handlers.errorHandler());
+
+export default app;

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/test.ts
@@ -1,0 +1,21 @@
+import * as path from 'path';
+
+import { getAPIResponse, runServer } from '../../../../utils/index';
+import { TestAPIResponse } from '../server';
+
+test('should merge `baggage` header of a third party vendor with the Sentry DSC baggage items', async () => {
+  const url = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+
+  const response = (await getAPIResponse(new URL(`${url}/express`), {
+    'sentry-trace': '',
+    baggage: 'sentry-release=2.0.0,sentry-environment=myEnv',
+  })) as TestAPIResponse;
+
+  expect(response).toBeDefined();
+  expect(response).toMatchObject({
+    test_data: {
+      host: 'somewhere.not.sentry',
+      baggage: 'other=vendor,foo=bar,third=party,sentry-release=2.0.0,sentry-environment=myEnv',
+    },
+  });
+});

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -45,7 +45,7 @@ export function tracingHandler(): (
         name: extractPathForTransaction(req, { path: true, method: true }),
         op: 'http.server',
         ...traceparentData,
-        metadata: { baggage: baggage },
+        metadata: { baggage },
       },
       // extra context passed to the tracesSampler
       { request: extractRequestData(req) },

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -3,7 +3,7 @@ import * as sentryHub from '@sentry/hub';
 import { Hub } from '@sentry/hub';
 import { Transaction } from '@sentry/tracing';
 import { Baggage, Event } from '@sentry/types';
-import { isBaggageEmpty, isBaggageMutable, SentryError } from '@sentry/utils';
+import { getThirdPartyBaggage, isBaggageMutable, isSentryBaggageEmpty, SentryError } from '@sentry/utils';
 import * as http from 'http';
 
 import { NodeClient } from '../src/client';
@@ -193,7 +193,8 @@ describe('tracingHandler', () => {
     expect(transaction.parentSpanId).toEqual('1121201211212012');
     expect(transaction.sampled).toEqual(false);
     expect(transaction.metadata?.baggage).toBeDefined();
-    expect(isBaggageEmpty(transaction.metadata?.baggage)).toBe(true);
+    expect(isSentryBaggageEmpty(transaction.metadata?.baggage)).toBe(true);
+    expect(getThirdPartyBaggage(transaction.metadata?.baggage)).toEqual('');
     expect(isBaggageMutable(transaction.metadata?.baggage)).toBe(false);
   });
 

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -219,8 +219,9 @@ describe('tracingHandler', () => {
     ] as Baggage);
   });
 
-  it("pulls parent's baggage (sentry + third party entries) headers on the request", () => {
+  it('ignores 3rd party entries in incoming baggage header', () => {
     req.headers = {
+      'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
       baggage: 'sentry-version=1.0,sentry-environment=production,dogs=great,cats=boring',
     };
 
@@ -231,7 +232,7 @@ describe('tracingHandler', () => {
     expect(transaction.metadata?.baggage).toBeDefined();
     expect(transaction.metadata?.baggage).toEqual([
       { version: '1.0', environment: 'production' },
-      'dogs=great,cats=boring',
+      '',
       false,
     ] as Baggage);
   });

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -289,7 +289,7 @@ export function wrapHandler<TEvent, TResult>(
       name: context.functionName,
       op: 'awslambda.handler',
       ...traceparentData,
-      metadata: { baggage: baggage },
+      metadata: { baggage },
     });
 
     const hub = getCurrentHub();

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -87,7 +87,7 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
       name: `${reqMethod} ${reqUrl}`,
       op: 'gcp.function.http',
       ...traceparentData,
-      metadata: { baggage: baggage },
+      metadata: { baggage },
     });
 
     // getCurrentHub() is expected to use current active domain as a carrier

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -256,7 +256,7 @@ describe('AWSLambda', () => {
                 {
                   release: '2.12.1',
                 },
-                'maisey=silly,charlie=goofy',
+                '',
                 false,
               ],
             },

--- a/packages/serverless/test/gcpfunction.test.ts
+++ b/packages/serverless/test/gcpfunction.test.ts
@@ -150,7 +150,7 @@ describe('GCPFunction', () => {
               {
                 release: '2.12.1',
               },
-              'maisey=silly,charlie=goofy',
+              '',
               false,
             ],
           },

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -8,15 +8,7 @@ import {
   TransactionContext,
   TransactionMetadata,
 } from '@sentry/types';
-import {
-  createBaggage,
-  dropUndefinedKeys,
-  getSentryBaggageItems,
-  getThirdPartyBaggage,
-  isBaggageMutable,
-  isSentryBaggageEmpty,
-  logger,
-} from '@sentry/utils';
+import { createBaggage, dropUndefinedKeys, getSentryBaggageItems, isBaggageMutable, logger } from '@sentry/utils';
 
 import { Span as SpanClass, SpanRecorder } from './span';
 
@@ -197,17 +189,13 @@ export class Transaction extends SpanClass implements TransactionInterface {
 
     // Only add Sentry baggage items to baggage, if baggage does not exist yet or it is still
     // empty and mutable
-    // TODO: we might want to ditch the isSentryBaggageEmpty condition because it prevents
-    //       custom sentry-values in DSC (added by users in the future)
     const finalBaggage =
-      !existingBaggage || (isBaggageMutable(existingBaggage) && isSentryBaggageEmpty(existingBaggage))
+      !existingBaggage || isBaggageMutable(existingBaggage)
         ? this._populateBaggageWithSentryValues(existingBaggage)
         : existingBaggage;
 
-    // In case, we poulated the DSC, we have update the stored one on the transaction.
-    if (existingBaggage !== finalBaggage) {
-      this.metadata.baggage = finalBaggage;
-    }
+    // Update the baggage stored on the transaction.
+    this.metadata.baggage = finalBaggage;
 
     return finalBaggage;
   }
@@ -255,7 +243,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
         sample_rate,
         ...getSentryBaggageItems(baggage), // keep user-added values
       } as BaggageObj),
-      getThirdPartyBaggage(baggage), // TODO: remove once we ignore 3rd party baggage
+      '',
       false, // set baggage immutable
     );
   }

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -234,7 +234,7 @@ describe('BrowserTracing', () => {
           parentSpanId: 'b6e54397b12a2a0f',
           parentSampled: true,
           metadata: {
-            baggage: [{ release: '2.1.14' }, 'foo=bar', false],
+            baggage: [{ release: '2.1.14' }, '', false],
           },
         }),
         expect.any(Number),
@@ -375,7 +375,7 @@ describe('BrowserTracing', () => {
         expect(headerContext!.parentSampled).toEqual(false);
       });
 
-      it('correctly parses a valid baggage meta header', () => {
+      it('correctly parses a valid baggage meta header and ignored 3rd party entries', () => {
         document.head.innerHTML = '<meta name="baggage" content="sentry-release=2.1.12,foo=bar">';
 
         const headerContext = extractTraceDataFromMetaTags();
@@ -388,7 +388,7 @@ describe('BrowserTracing', () => {
           release: '2.1.12',
         } as BaggageObj);
         expect(baggage && baggage[1]).toBeDefined();
-        expect(baggage && baggage[1]).toEqual('foo=bar');
+        expect(baggage && baggage[1]).toEqual('');
       });
 
       it('returns undefined if the sentry-trace header is malformed', () => {
@@ -461,7 +461,7 @@ describe('BrowserTracing', () => {
         expect(baggage[0]).toBeDefined();
         expect(baggage[0]).toEqual({ release: '2.1.14' });
         expect(baggage[1]).toBeDefined();
-        expect(baggage[1]).toEqual('foo=bar');
+        expect(baggage[1]).toEqual('');
       });
 
       it('does not add Sentry baggage data to pageload transactions if sentry-trace data is present but passes on 3rd party baggage', () => {
@@ -483,7 +483,7 @@ describe('BrowserTracing', () => {
         expect(baggage).toBeDefined();
         expect(isSentryBaggageEmpty(baggage)).toBe(true);
         expect(baggage[1]).toBeDefined();
-        expect(baggage[1]).toEqual('foo=bar');
+        expect(baggage[1]).toEqual('');
       });
 
       it('ignores the data for navigation transactions', () => {

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -3,9 +3,9 @@ import { Hub, makeMain } from '@sentry/hub';
 import type { Baggage, BaggageObj, BaseTransportOptions, ClientOptions, DsnComponents } from '@sentry/types';
 import {
   getGlobalObject,
+  getThirdPartyBaggage,
   InstrumentHandlerCallback,
   InstrumentHandlerType,
-  isBaggageEmpty,
   isSentryBaggageEmpty,
 } from '@sentry/utils';
 import { JSDOM } from 'jsdom';
@@ -398,7 +398,8 @@ describe('BrowserTracing', () => {
 
         expect(headerContext).toBeDefined();
         expect(headerContext?.metadata?.baggage).toBeDefined();
-        expect(isBaggageEmpty(headerContext?.metadata?.baggage as Baggage)).toBe(true);
+        expect(isSentryBaggageEmpty(headerContext?.metadata?.baggage as Baggage)).toBe(true);
+        expect(getThirdPartyBaggage(headerContext?.metadata?.baggage as Baggage)).toEqual('');
       });
 
       it('does not crash if the baggage header is malformed', () => {
@@ -421,7 +422,8 @@ describe('BrowserTracing', () => {
 
         expect(headerContext).toBeDefined();
         expect(headerContext?.metadata?.baggage).toBeDefined();
-        expect(isBaggageEmpty(headerContext?.metadata?.baggage as Baggage)).toBe(true);
+        expect(isSentryBaggageEmpty(headerContext?.metadata?.baggage as Baggage)).toBe(true);
+        expect(getThirdPartyBaggage(headerContext?.metadata?.baggage as Baggage)).toEqual('');
       });
     });
 

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -403,11 +403,11 @@ describe('Span', () => {
       };
     });
 
-    test('leave baggage content untouched and just return baggage if there already is Sentry content in it', () => {
+    test('leave baggage content untouched and just return baggage if it is immutable', () => {
       const transaction = new Transaction(
         {
           name: 'tx',
-          metadata: { baggage: createBaggage({ environment: 'myEnv' }, '') },
+          metadata: { baggage: createBaggage({ environment: 'myEnv' }, '', false) },
         },
         hub,
       );

--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -185,7 +185,12 @@ export function parseBaggageSetMutability(
   // we only need to check if we have a sentry-trace header or not. As soon as we have it,
   // we set baggage immutable. In case we don't get a sentry-trace header, we can assume that
   // this SDK is the head of the trace and thus we still permit mutation at this time.
-  sentryTraceHeader && setBaggageImmutable(baggage);
+  // There is one exception though, which is that we get a baggage-header with `sentry-`
+  // items but NO sentry-trace header. In this case we also set the baggage immutable for now
+  // but if smoething like this would ever happen, we should revisit this and determine
+  // what this would actually mean for the trace (i.e. is this SDK the head?, what happened
+  // before that we don't have a sentry-trace header?, etc)
+  (sentryTraceHeader || !isSentryBaggageEmpty(baggage)) && setBaggageImmutable(baggage);
 
   return baggage;
 }

--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -38,12 +38,6 @@ export function isSentryBaggageEmpty(baggage: Baggage): boolean {
   return Object.keys(baggage[0]).length === 0;
 }
 
-/** Check if the Sentry part of the passed baggage (i.e. the first element in the tuple) is empty */
-export function isBaggageEmpty(baggage: Baggage): boolean {
-  const thirdPartyBaggage = getThirdPartyBaggage(baggage);
-  return isSentryBaggageEmpty(baggage) && (thirdPartyBaggage == undefined || thirdPartyBaggage.length === 0);
-}
-
 /** Returns Sentry specific baggage values */
 export function getSentryBaggageItems(baggage: Baggage): BaggageObj {
   return baggage[0];

--- a/packages/utils/test/baggage.test.ts
+++ b/packages/utils/test/baggage.test.ts
@@ -3,7 +3,6 @@ import { Baggage } from '@sentry/types';
 import {
   createBaggage,
   getBaggageValue,
-  isBaggageEmpty,
   isBaggageMutable,
   isSentryBaggageEmpty,
   mergeAndSerializeBaggage,
@@ -152,17 +151,6 @@ describe('Baggage', () => {
       ['ignorese other input types than string and string[]', 42, undefined, createBaggage({}, '')],
     ])('%s', (_: string, baggageValue, includeThirPartyEntries, expectedBaggage) => {
       expect(parseBaggageHeader(baggageValue, includeThirPartyEntries)).toEqual(expectedBaggage);
-    });
-  });
-
-  describe('isBaggageEmpty', () => {
-    it.each([
-      ['returns true if the entire baggage tuple is empty', createBaggage({}), true],
-      ['returns false if the Sentry part of baggage is not empty', createBaggage({ release: '10.0.2' }), false],
-      ['returns false if the 3rd party part of baggage is not empty', createBaggage({}, 'foo=bar'), false],
-      ['returns false if both parts of baggage are not empty', createBaggage({ release: '10.0.2' }, 'foo=bar'), false],
-    ])('%s', (_: string, baggage, outcome) => {
-      expect(isBaggageEmpty(baggage)).toEqual(outcome);
     });
   });
 

--- a/packages/utils/test/baggage.test.ts
+++ b/packages/utils/test/baggage.test.ts
@@ -99,24 +99,33 @@ describe('Baggage', () => {
 
   describe('parseBaggageHeader', () => {
     it.each([
-      ['parses an empty string', '', createBaggage({})],
-      ['parses a blank string', '     ', createBaggage({})],
+      ['parses an empty string', '', undefined, createBaggage({})],
+      ['parses a blank string', '     ', undefined, createBaggage({})],
       [
         'parses sentry values into baggage',
         'sentry-environment=production,sentry-release=10.0.2',
+        undefined,
         createBaggage({ environment: 'production', release: '10.0.2' }),
       ],
       [
-        'parses arbitrary baggage headers',
+        'ignores 3rd party entries by default',
         'userId=alice,serverNode=DF%2028,isProduction=false,sentry-environment=production,sentry-release=10.0.2',
+        undefined,
+        createBaggage({ environment: 'production', release: '10.0.2' }, ''),
+      ],
+      [
+        'parses sentry- and arbitrary 3rd party values if the 3rd party entries flag is set to true',
+        'userId=alice,serverNode=DF%2028,isProduction=false,sentry-environment=production,sentry-release=10.0.2',
+        true,
         createBaggage(
           { environment: 'production', release: '10.0.2' },
           'userId=alice,serverNode=DF%2028,isProduction=false',
         ),
       ],
       [
-        'parses arbitrary baggage headers from string with empty and blank entries',
+        'parses arbitrary baggage entries from string with empty and blank entries',
         'userId=alice,    serverNode=DF%2028   , isProduction=false,   ,,sentry-environment=production,,sentry-release=10.0.2',
+        true,
         createBaggage(
           { environment: 'production', release: '10.0.2' },
           'userId=alice,serverNode=DF%2028,isProduction=false',
@@ -125,21 +134,24 @@ describe('Baggage', () => {
       [
         'parses a string array',
         ['userId=alice', 'sentry-environment=production', 'foo=bar'],
+        true,
         createBaggage({ environment: 'production' }, 'userId=alice,foo=bar'),
       ],
       [
         'parses a string array with items containing multiple entries',
         ['userId=alice,   userName=bob', 'sentry-environment=production,sentry-release=1.0.1', 'foo=bar'],
+        true,
         createBaggage({ environment: 'production', release: '1.0.1' }, 'userId=alice,userName=bob,foo=bar'),
       ],
       [
         'parses a string array with empty/blank entries',
         ['', 'sentry-environment=production,sentry-release=1.0.1', '    ', 'foo=bar'],
+        true,
         createBaggage({ environment: 'production', release: '1.0.1' }, 'foo=bar'),
       ],
-      ['ignorese other input types than string and string[]', 42, createBaggage({}, '')],
-    ])('%s', (_: string, baggageValue, baggage) => {
-      expect(parseBaggageHeader(baggageValue)).toEqual(baggage);
+      ['ignorese other input types than string and string[]', 42, undefined, createBaggage({}, '')],
+    ])('%s', (_: string, baggageValue, includeThirPartyEntries, expectedBaggage) => {
+      expect(parseBaggageHeader(baggageValue, includeThirPartyEntries)).toEqual(expectedBaggage);
     });
   });
 
@@ -166,18 +178,24 @@ describe('Baggage', () => {
   describe('mergeAndSerializeBaggage', () => {
     it.each([
       [
-        'returns original baggage when there is no additional baggage',
-        createBaggage({ release: '1.1.1', userid: '1234' }, 'foo=bar'),
+        'returns original baggage when there is no additional baggage header',
+        createBaggage({ release: '1.1.1', user_id: '1234' }),
         undefined,
-        'foo=bar,sentry-release=1.1.1,sentry-userid=1234',
+        'sentry-release=1.1.1,sentry-user_id=1234',
       ],
       [
         'returns merged baggage when there is a 3rd party header added',
-        createBaggage({ release: '1.1.1', userid: '1234' }, 'foo=bar'),
+        createBaggage({ release: '1.1.1', user_id: '1234' }, 'foo=bar'),
         'bar=baz,key=value',
-        'bar=baz,key=value,sentry-release=1.1.1,sentry-userid=1234',
+        'bar=baz,key=value,sentry-release=1.1.1,sentry-user_id=1234',
       ],
       ['returns merged baggage original baggage is empty', createBaggage({}), 'bar=baz,key=value', 'bar=baz,key=value'],
+      [
+        'ignores sentry- items in 3rd party baggage header',
+        createBaggage({}),
+        'bar=baz,sentry-user_id=abc,key=value,sentry-sample_rate=0.76',
+        'bar=baz,key=value',
+      ],
       ['returns empty string when original and 3rd party baggage are empty', createBaggage({}), '', ''],
       ['returns merged baggage original baggage is undefined', undefined, 'bar=baz,key=value', 'bar=baz,key=value'],
       ['returns empty string when both params are undefined', undefined, undefined, ''],
@@ -207,22 +225,16 @@ describe('Baggage', () => {
         [{}, '', false] as Baggage,
       ],
       [
-        'returns a non-empty, mutable baggage object if sentry-trace is not defined and only 3rd party baggage items are passed',
+        'returns a non-empty, mutable baggage object if sentry-trace is not defined and ignores 3rd party baggage items',
         'foo=bar',
         undefined,
-        [{}, 'foo=bar', true] as Baggage,
-      ],
-      [
-        'returns a non-empty, immutable baggage object if sentry-trace is not defined and Sentry baggage items are passed',
-        'sentry-environment=production,foo=bar',
-        undefined,
-        [{ environment: 'production' }, 'foo=bar', false] as Baggage,
+        [{}, '', true] as Baggage,
       ],
       [
         'returns a non-empty, immutable baggage object if sentry-trace is defined',
-        'foo=bar',
+        'foo=bar,sentry-environment=production,sentry-sample_rate=0.96',
         {},
-        [{}, 'foo=bar', false] as Baggage,
+        [{ environment: 'production', sample_rate: '0.96' }, '', false] as Baggage,
       ],
     ])(
       '%s',


### PR DESCRIPTION
This PR makes changes to how we handle third party content in the `baggage` Http header: On incoming requests we no longer parse and put non-`sentry-` baggage entries into the `Baggage` object but we ignore them and instead store an empty third party string. The reason for this change is that - as we discussed and agreed upon - the Sentry SDK should not be responsible for propagating other vendors' data. If users want to propagate that data as well on the service where the Sentry SDK is installed, they should add the other vendors' propagation mechanisms. In fact, this is the only way we can ensure that baggage content that should _not_ be propagated further is really stopped. 

It's important to note that this only concerns _incoming_ 3rd party baggage items. If other vendors (or the users themselves) add a `baggage` header to the outgoing request before the Sentry SDK adds its `baggage` header, we continue to merge the two headers such that the 3rd party baggage as well as this SDK's DSC entries are still in the final header. In (the edge) case that this 3rd party `baggage` header already contains `sentry-` entries, they will be ignored and overwritten with this SDK's `sentry-` entries. 

With this PR, our DSC propagation behaviour conforms with [our DSC specification](https://develop.sentry.dev/sdk/performance/dynamic-sampling-context/).

In addition of these changes, this PR also contains a few small cleanups and improvements:
* removed `isBaggageEmpty` helper function (+ tests) as it was not used anymore except for in tests
* simplified mutability check: Because of how we parse incoming baggage headers, we can make the check slightly simpler than the pseudo code in the spec. Reviewer(s): Would appreciate a careful look here. Happy to discuss changing this.
* adjusted tests to new 3rd party handling
* added node integration tests to check for correct handling of `baggage` header merging in case another vendor injects a baggage header before the Sentry SDK

fixes  #5297 


