### PR TITLE
fix(utils): Handle `toJSON` methods that return circular references

### DIFF
--- a/packages/utils/test/normalize.test.ts
+++ b/packages/utils/test/normalize.test.ts
@@ -286,7 +286,7 @@ describe('normalize()', () => {
       expect(normalize([{ a }, { b: new B() }, c])).toEqual([{ a: 1 }, { b: 2 }, 3]);
     });
 
-    test('should return return normalized object even if toJSON throws', () => {
+    test('should return a normalized object even if toJSON throws', () => {
       const subject = { a: 1, foo: 'bar' } as any;
       subject.toJSON = () => {
         throw new Error("I'm faulty!");
@@ -294,7 +294,7 @@ describe('normalize()', () => {
       expect(normalize(subject)).toEqual({ a: 1, foo: 'bar', toJSON: '[Function: <anonymous>]' });
     });
 
-    test('should return return object without circular references when toJSON returns an object with circular references', () => {
+    test('should return an object without circular references when toJSON returns an object with circular references', () => {
       const subject: any = {};
       subject.toJSON = () => {
         const egg: any = {};

--- a/packages/utils/test/normalize.test.ts
+++ b/packages/utils/test/normalize.test.ts
@@ -285,6 +285,30 @@ describe('normalize()', () => {
       // @ts-ignore target lacks a construct signature
       expect(normalize([{ a }, { b: new B() }, c])).toEqual([{ a: 1 }, { b: 2 }, 3]);
     });
+
+    test('should return return normalized object even if toJSON throws', () => {
+      const subject = { a: 1, foo: 'bar' } as any;
+      subject.toJSON = () => {
+        throw new Error("I'm faulty!");
+      };
+      expect(normalize(subject)).toEqual({ a: 1, foo: 'bar', toJSON: '[Function: <anonymous>]' });
+    });
+
+    test('should return return object without circular references when toJSON returns an object with circular references', () => {
+      const subject: any = {};
+      subject.toJSON = () => {
+        const egg: any = {};
+        egg.chicken = egg;
+        return egg;
+      };
+      expect(normalize(subject)).toEqual({ chicken: '[Circular ~]' });
+    });
+
+    test('should detect circular reference when toJSON returns the original object', () => {
+      const subject: any = {};
+      subject.toJSON = () => subject;
+      expect(normalize(subject)).toEqual('[Circular ~]');
+    });
   });
 
   describe('changes unserializeable/global values/classes to its string representation', () => {


### PR DESCRIPTION
This PR handles a case in `normalize()` when a `.toJSON` method on an input value either returns an object with a circular reference or the input value itself, causing problems down the line.

#### Changes
- Normalize the return value from `toJSON`
- Add tests to check for edge cases

#### Compromise
To detect circular references we need to do a memoize call before normalizing the return value from `toJSON`. However, at the location we're currently calling the `toJSON` method, `value` could still be a primitive like `string` or `number` and we can't call `memoize` with primitives because the underlying `WeakSet` only takes `object`s.

As a compromise, we're moving the `toJSON` call down to where `value` is certainly an object or array and after the circ-ref-check. I believe it is ok for us to only call `toJSON` on values that are non-primitives since you can't even set a field on strings, numbers, symbols, etc. unless you modify their prototype.

If somebody has a better idea on how to tackle this best, feel free to make suggestions! - I myself am not *too* happy with this solution.

