### PR TITLE
fix(build): Use Node 14 in "Size Check" job to fix CI runs on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,10 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+          # The size limit action runs `yarn` and `yarn build` when this job is executed on
+          # `master`. We can't change this without making changes to the action, so we'll
+          # use Node 14 for now.
+          node-version: '14'
       - name: Check dependency cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Since we re-enabled the "Size Check" job for GHA runs on `master` in #5314, our CI runs were failing because the "Size Check" job was failing. The reason is that our [size-limit-action](https://github.com/getsentry/size-limit-action) is not passing on the `skip_step` option we set here

https://github.com/getsentry/sentry-javascript/blob/05cb748bdaba970eacf40b62405090688eeac7bc/.github/workflows/build.yml#L210

if it is [executed on the master branch](https://github.com/getsentry/size-limit-action/blob/3f9e584f47175f7f2ac742569ac16b7a8c05ad82/src/main.ts#L68-L74). Instead, `null` is passed to the execution function of the action which makes the action first call `yarn install` followed by `yarn build`. This fails because the Ember SDK cannot be built with Node 16.  

While the best option to fix this is to make changes to the actions to respect the `skip_step` option on master runs, we want to fix things on our end for now which should work by setting the Node version to 14. 

