### PR TITLE
7.4.0-alpha.0 branch - testing Remix SDK

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -25,9 +25,7 @@ targets:
           cacheControl: 'public, max-age=31536000'
   - name: github
     includeNames: /^sentry-.*$/
-    excludeNames: /^sentry-remix-.*$/
   - name: npm
-    excludeNames: /^sentry-remix-.*.tgz$/
   - name: registry
     sdks:
       'npm:@sentry/browser':

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+## 7.4.0-alpha.0
+
+- feat(remix): Add release / sourcemap upload script. (#5312)
+- feat(remix): Add Remix server SDK (#5269)
+- feat(remix): Add Remix client SDK (#5264)
+- feat(remix): Add Remix SDK package boilerplate (#5256)
+
 ## 7.3.1
 
 - feat(react): expose FallbackRender as top-level type (#5307)

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -16,7 +16,6 @@
   "module": "build/esm/index.server.js",
   "browser": "build/esm/index.client.js",
   "types": "build/types/index.server.d.ts",
-  "private": true,
   "dependencies": {
     "@sentry/cli": "2.2.0",
     "@sentry/core": "7.3.1",


### PR DESCRIPTION
Built on top of https://github.com/getsentry/sentry-javascript/pull/5327

This PR represents the state of `7.4.0-alpha.0`, which will be used to test the new `@sentry/remix` SDK.

After we've tested the alpha, we'll cut a full `7.4.0` release including the remix SDK.