### PR TITLE
feat: Remove tslib as a dependency

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -127,9 +127,6 @@
 
       "skipFiles": [
         "<node_internals>/**",
-        // this prevents us from landing in a neverending cycle of TS async-polyfill functions as we're stepping through
-        // our code
-        "${workspaceFolder}/node_modules/tslib/**/*"
       ],
       "sourceMaps": true,
       // this controls which files are sourcemapped

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "size-limit": "^4.5.5",
     "ts-jest": "^27.1.4",
     "ts-node": "^10.7.0",
-    "tslib": "^2.3.1",
     "typedoc": "^0.18.0",
     "typescript": "3.8.3"
   },

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "@sentry/core": "7.3.1",
     "@sentry/types": "7.3.1",
-    "@sentry/utils": "7.3.1",
-    "tslib": "^1.9.3"
+    "@sentry/utils": "7.3.1"
   },
   "devDependencies": {
     "@types/md5": "2.1.33",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "@sentry/hub": "7.3.1",
     "@sentry/types": "7.3.1",
-    "@sentry/utils": "7.3.1",
-    "tslib": "^1.9.3"
+    "@sentry/utils": "7.3.1"
   },
   "scripts": {
     "build": "run-p build:rollup build:types",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -17,8 +17,7 @@
   },
   "dependencies": {
     "@sentry/types": "7.3.1",
-    "@sentry/utils": "7.3.1",
-    "tslib": "^1.9.3"
+    "@sentry/utils": "7.3.1"
   },
   "scripts": {
     "build": "run-p build:rollup build:types",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "@sentry/types": "7.3.1",
     "@sentry/utils": "7.3.1",
-    "localforage": "^1.8.1",
-    "tslib": "^1.9.3"
+    "localforage": "^1.8.1"
   },
   "devDependencies": {
     "chai": "^4.1.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -25,8 +25,7 @@
     "@sentry/tracing": "7.3.1",
     "@sentry/types": "7.3.1",
     "@sentry/utils": "7.3.1",
-    "@sentry/webpack-plugin": "1.18.9",
-    "tslib": "^1.9.3"
+    "@sentry/webpack-plugin": "1.18.9"
   },
   "devDependencies": {
     "@types/webpack": "^4.41.31",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -22,8 +22,7 @@
     "@sentry/utils": "7.3.1",
     "cookie": "^0.4.1",
     "https-proxy-agent": "^5.0.0",
-    "lru_map": "^0.3.3",
-    "tslib": "^1.9.3"
+    "lru_map": "^0.3.3"
   },
   "devDependencies": {
     "@types/cookie": "0.3.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,7 @@
     "@sentry/browser": "7.3.1",
     "@sentry/types": "7.3.1",
     "@sentry/utils": "7.3.1",
-    "hoist-non-react-statics": "^3.3.2",
-    "tslib": "^1.9.3"
+    "hoist-non-react-statics": "^3.3.2"
   },
   "peerDependencies": {
     "react": "15.x || 16.x || 17.x || 18.x"

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -27,8 +27,7 @@
     "@sentry/tracing": "7.3.1",
     "@sentry/types": "7.3.1",
     "@sentry/utils": "7.3.1",
-    "@sentry/webpack-plugin": "1.18.9",
-    "tslib": "^1.9.3"
+    "@sentry/webpack-plugin": "1.18.9"
   },
   "devDependencies": {
     "@remix-run/node": "^1.4.3",

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -21,8 +21,7 @@
     "@sentry/types": "7.3.1",
     "@sentry/utils": "7.3.1",
     "@types/aws-lambda": "^8.10.62",
-    "@types/express": "^4.17.2",
-    "tslib": "^1.9.3"
+    "@types/express": "^4.17.2"
   },
   "devDependencies": {
     "@google-cloud/bigquery": "^5.3.0",

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "@sentry/hub": "7.3.1",
     "@sentry/types": "7.3.1",
-    "@sentry/utils": "7.3.1",
-    "tslib": "^1.9.3"
+    "@sentry/utils": "7.3.1"
   },
   "devDependencies": {
     "@sentry/browser": "7.3.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,8 +16,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/types": "7.3.1",
-    "tslib": "^1.9.3"
+    "@sentry/types": "7.3.1"
   },
   "devDependencies": {
     "@types/array.prototype.flat": "^1.2.1",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -19,8 +19,7 @@
     "@sentry/browser": "7.3.1",
     "@sentry/core": "7.3.1",
     "@sentry/types": "7.3.1",
-    "@sentry/utils": "7.3.1",
-    "tslib": "^1.9.3"
+    "@sentry/utils": "7.3.1"
   },
   "peerDependencies": {
     "vue": "2.x || 3.x"

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "@sentry/browser": "7.3.1",
     "@sentry/types": "7.3.1",
-    "@sentry/utils": "7.3.1",
-    "tslib": "^1.9.3"
+    "@sentry/utils": "7.3.1"
   },
   "devDependencies": {
     "@types/jest-environment-puppeteer": "^4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -25158,7 +25158,7 @@ tslib@2.0.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
We no longer use tslib as a dependency on the SDKs.

Only place tslib is left is in angular - not sure if we can remove that. If we can, we'll have removed `tslib` as a top level dependency in the SDKs.
