### PR TITLE
Declare hub as peer dependency of tracing

### DIFF
--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -16,10 +16,12 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/hub": "7.3.1",
     "@sentry/types": "7.3.1",
     "@sentry/utils": "7.3.1",
     "tslib": "^1.9.3"
+  },
+  "peerDependencies": {
+    "@sentry/hub": "7.3.1"
   },
   "devDependencies": {
     "@sentry/browser": "7.3.1",


### PR DESCRIPTION
This makes it dependency update tools such as Dependabot will
update dependencies like @sentry/node and @sentry/tracing
together.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
