### PR TITLE
feat(sdk): Add sendDefaultPii option to the JS SDKs

### DIFF
--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -440,6 +440,16 @@ export class Hub implements HubInterface {
   }
 
   /**
+   * Returns if default PII should be sent to Sentry and propagated in ourgoing requests
+   * when Tracing is used.
+   */
+  public shouldSendDefaultPii(): boolean {
+    const { client } = this.getStackTop();
+    const options = client && client.getOptions();
+    return Boolean(options && options.sendDefaultPii);
+  }
+
+  /**
    * Sends the current Session on the scope
    */
   private _sendSessionUpdate(): void {

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -153,6 +153,21 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   tunnel?: string;
 
   /**
+   * Currently controls if the user id (e.g. set by `Sentry.setUser`) should
+   * be used for dynamic sampling. Only if this flag is set to `true`, the user id
+   * will be propagated to outgoing requests in the `baggage` Http header.
+   *
+   * Note that in the next major version of this SDK, this option will not only
+   * control dynamic sampling data: As long as this flag is not set to `true`,
+   * the SDK will not send sensitive data by default.
+   *
+   * Defaults to `false`.
+   *
+   * @experimental (will be fully introduced in the next major version)
+   */
+  sendDefaultPii?: boolean;
+
+  /**
    * Set of metadata about the SDK that can be internally used to enhance envelopes and events,
    * and provide additional data about every request.
    */


### PR DESCRIPTION
This PR adds the `sendDefaultPii` option to the JS SDKs. It doesn't yet do anything for the reasons addressed in #5340. In a follow-up PR, we'll make sending the user id in the dynamic sampling context dependent on this flag. (Decided to do this in two PRs to keep DSC changes (+ test adjustments) separate from the introduction of this flag.

resolves #5340  
