### PR TITLE
build: Install dependencies in CI with frozen lockfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
           key: ${{ steps.compute_lockfile_hash.outputs.hash }}
       - name: Install dependencies
         if: steps.cache_dependencies.outputs.cache-hit == ''
-        run: yarn install --ignore-engines
+        run: yarn install --ignore-engines --frozen-lockfile
     outputs:
       dependency_cache_key: ${{ steps.compute_lockfile_hash.outputs.hash }}
 
@@ -332,7 +332,7 @@ jobs:
         env:
           NODE_VERSION: ${{ matrix.node }}
         run: |
-          [[ $NODE_VERSION == 8 ]] && yarn add --dev --ignore-engines --ignore-scripts --ignore-workspace-root-check ts-node@8.x
+          [[ $NODE_VERSION == 8 ]] && yarn add --dev --ignore-engines --ignore-scripts --ignore-workspace-root-check ts-node@8.10.2
           yarn test-ci
       - name: Compute test coverage
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
Because we keep running into situations where our builds fail out of the blue (https://github.com/getsentry/sentry-javascript/pull/5327#issuecomment-1171603041, https://github.com/getsentry/sentry-javascript/issues/5296#issuecomment-1165625869), I propose we install our dependencies in CI with `--frozen-lockfile` which simply installs packages exactly as described in `yarn.lock`. Additionally, we want to pin as many dependencies in our CI as possible, just so we can have reproducible builds.

This PR:
- adds a `--frozen-lockfile` flag to `yarn install` in our CI
- Pins a `ts-node` dependency version in CI
