### PR TITLE
build(remix): Make remix package public

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -16,6 +16,9 @@
   "module": "build/esm/index.server.js",
   "browser": "build/esm/index.client.js",
   "types": "build/types/index.server.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@sentry/cli": "2.2.0",
     "@sentry/core": "7.3.1",


### PR DESCRIPTION
Publishing failed because we missed a flag in the package.json: https://github.com/getsentry/publish/runs/7147811439?check_suite_focus=true#step:10:1282