### PR TITLE
fix(remix): Use cjs for main entry point

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -12,7 +12,7 @@
   "engines": {
     "node": ">=14"
   },
-  "main": "build/esm/index.server.js",
+  "main": "build/cjs/index.server.js",
   "module": "build/esm/index.server.js",
   "browser": "build/esm/index.client.js",
   "types": "build/types/index.server.d.ts",


### PR DESCRIPTION
Fixes #5351 

Looks like just a typo exporting an esm module under main