### PR TITLE
docs(remix): Add missing comma in README

### DIFF
--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -66,7 +66,7 @@ import {
   LiveReload,
   Meta,
   Outlet,
-  Scripts
+  Scripts,
   ScrollRestoration,
 } from "@remix-run/react";
 


### PR DESCRIPTION
There's a typo in the example for `root.tsx`.