### PR TITLE
fix(remix): Sourcemaps upload script is missing in the tarball

### DIFF
--- a/packages/remix/.eslintrc.js
+++ b/packages/remix/.eslintrc.js
@@ -10,4 +10,12 @@ module.exports = {
   rules: {
     '@sentry-internal/sdk/no-async-await': 'off',
   },
+  overrides: [
+    {
+      files: ['scripts/**/*.ts'],
+      parserOptions: {
+        project: ['../../tsconfig.dev.json'],
+      },
+    },
+  ],
 };

--- a/packages/remix/.npmignore
+++ b/packages/remix/.npmignore
@@ -1,9 +1,4 @@
 # The paths in this file are specified so that they align with the file structure in `./build` after this file is copied
 # into it by the prepack script `scripts/prepack.ts`.
 
-*
-
-!/cjs/**/*
-!/esm/**/*
-!/types/**/*
 !/scripts/**/*

--- a/packages/remix/.npmignore
+++ b/packages/remix/.npmignore
@@ -1,0 +1,9 @@
+# The paths in this file are specified so that they align with the file structure in `./build` after this file is copied
+# into it by the prepack script `scripts/prepack.ts`.
+
+*
+
+!/cjs/**/*
+!/esm/**/*
+!/types/**/*
+!/scripts/**/*

--- a/packages/remix/scripts/prepack.ts
+++ b/packages/remix/scripts/prepack.ts
@@ -1,0 +1,34 @@
+/* eslint-disable no-console */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const PACKAGE_ASSETS = ['scripts/sentry-upload-sourcemaps.js', 'scripts/createRelease.js'];
+
+export function prepack(buildDir: string): boolean {
+  // copy package-specific assets to build dir
+  return PACKAGE_ASSETS.every(asset => {
+    const assetPath = path.resolve(asset);
+    const destinationPath = path.resolve(buildDir, asset);
+    try {
+      if (!fs.existsSync(assetPath)) {
+        console.error(`\nERROR: Asset '${asset}' does not exist.`);
+        return false;
+      }
+      const scriptsDir = path.resolve(buildDir, 'scripts');
+      if (!fs.existsSync(scriptsDir)) {
+        console.log('Creating missing directory', scriptsDir);
+        fs.mkdirSync(scriptsDir);
+      }
+      console.log(`Copying ${path.basename(asset)} to ${path.relative('../..', destinationPath)}.`);
+      fs.copyFileSync(assetPath, destinationPath);
+    } catch (error) {
+      console.error(
+        `\nERROR: Error while copying ${path.basename(asset)} to ${path.relative('../..', destinationPath)}:\n`,
+        error,
+      );
+      return false;
+    }
+    return true;
+  });
+}


### PR DESCRIPTION
To upload source maps to Sentry, the Remix SDK includes a script that wraps around Sentry CLI to make uploading sourcemaps easier for our users. However, due to the way how we package our NPM tarballs, this script didn't make it into the Remix SDK tarball.

This PR adds the script to the tarball, which required the following changes:
* Added a package-specific `prepack.ts` script which is invoked by the main `prepack.ts` script. This is similar to how we do it with the Gatsby SDK where - just as with Remix - we need to copy over additional files to the `build` directory that are not part of our other packages. The newly added files are:
  * `scripts/sentry-upload-sourcemaps.js`
  * `scripts/createRelease.js`
* Added a package-specific `.npmignore` which extends the root level `.npmignore` file to not ignore the `scripts` directory in the `build` directory. 

Fixes #5355