### PR TITLE
feat(remix): Wrap root with `ErrorBoundary`.

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,7 +2,7 @@ export * from '@sentry/browser';
 
 export { init } from './sdk';
 export { Profiler, withProfiler, useProfiler } from './profiler';
-export type { FallbackRender } from './errorboundary';
+export type { ErrorBoundaryProps, FallbackRender } from './errorboundary';
 export { ErrorBoundary, withErrorBoundary } from './errorboundary';
 export { createReduxEnhancer } from './redux';
 export { reactRouterV3Instrumentation } from './reactrouterv3';

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -90,7 +90,12 @@ function App() {
   );
 }
 
-export default withSentryRouteTracing(App);
+export default withSentryRouteTracing(App, {
+  wrapWithErrorBoundary: false // default: true
+  errorBoundaryOptions: {
+    fallback: <p>An error has occurred</p>
+  } // optional
+});
 ```
 
 To set context information or send manual events, use the exported functions of `@sentry/remix`.

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -57,7 +57,7 @@ Sentry.init({
 });
 ```
 
-Also, wrap your Remix root with `withSentryRouteTracing` to catch React component errors and to get parameterized router transactions.
+Also, wrap your Remix root with `withSentry` to catch React component errors and to get parameterized router transactions.
 
 ```ts
 // root.tsx
@@ -71,7 +71,7 @@ import {
   ScrollRestoration,
 } from "@remix-run/react";
 
-import { withSentryRouteTracing } from "@sentry/remix";
+import { withSentry } from "@sentry/remix";
 
 function App() {
   return (
@@ -90,20 +90,20 @@ function App() {
   );
 }
 
-export default withSentryRouteTracing(App);
+export default withSentry(App);
 ```
 
-You can disable or configure `ErrorBoundary` using a second parameter to `withSentryRouteTracing`.
+You can disable or configure `ErrorBoundary` using a second parameter to `withSentry`.
 
 ```ts
 
-withSentryRouteTracing(App, {
+withSentry(App, {
   wrapWithErrorBoundary: false
 });
 
 // or
 
-withSentryRouteTracing(App, {
+withSentry(App, {
   errorBoundaryOptions: {
     fallback: <p>An error has occurred</p>
   }

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -90,11 +90,23 @@ function App() {
   );
 }
 
-export default withSentryRouteTracing(App, {
-  wrapWithErrorBoundary: false // default: true
+export default withSentryRouteTracing(App);
+```
+
+You can disable or configure `ErrorBoundary` using a second parameter to `withSentryRouteTracing`.
+
+```ts
+
+withSentryRouteTracing(App, {
+  wrapWithErrorBoundary: false
+});
+
+// or
+
+withSentryRouteTracing(App, {
   errorBoundaryOptions: {
     fallback: <p>An error has occurred</p>
-  } // optional
+  }
 });
 ```
 

--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -57,7 +57,7 @@ Sentry.init({
 });
 ```
 
-Also, wrap your Remix root, with Sentry's `ErrorBoundary` component to catch React component errors, and `withSentryRouteTracing` to get parameterized router transactions.
+Also, wrap your Remix root with `withSentryRouteTracing` to catch React component errors and to get parameterized router transactions.
 
 ```ts
 // root.tsx
@@ -71,24 +71,22 @@ import {
   ScrollRestoration,
 } from "@remix-run/react";
 
-import { ErrorBoundary, withSentryRouteTracing } from "@sentry/remix";
+import { withSentryRouteTracing } from "@sentry/remix";
 
 function App() {
   return (
-    <ErrorBoundary>
-      <html>
-        <head>
-          <Meta />
-          <Links />
-        </head>
-        <body>
-          <Outlet />
-          <ScrollRestoration />
-          <Scripts />
-          <LiveReload />
-        </body>
-      </html>
-    </ErrorBoundary>
+    <html>
+      <head>
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+        <LiveReload />
+      </body>
+    </html>
   );
 }
 

--- a/packages/remix/src/index.client.tsx
+++ b/packages/remix/src/index.client.tsx
@@ -3,8 +3,7 @@ import { configureScope, init as reactInit, Integrations } from '@sentry/react';
 
 import { buildMetadata } from './utils/metadata';
 import { RemixOptions } from './utils/remixOptions';
-// eslint-disable-next-line deprecation/deprecation
-export { remixRouterInstrumentation, withSentry, withSentryRouteTracing } from './performance/client';
+export { remixRouterInstrumentation, withSentry } from './performance/client';
 export { BrowserTracing } from '@sentry/tracing';
 export * from '@sentry/react';
 

--- a/packages/remix/src/index.client.tsx
+++ b/packages/remix/src/index.client.tsx
@@ -3,6 +3,7 @@ import { configureScope, init as reactInit, Integrations } from '@sentry/react';
 
 import { buildMetadata } from './utils/metadata';
 import { RemixOptions } from './utils/remixOptions';
+// eslint-disable-next-line deprecation/deprecation
 export { remixRouterInstrumentation, withSentry, withSentryRouteTracing } from './performance/client';
 export { BrowserTracing } from '@sentry/tracing';
 export * from '@sentry/react';

--- a/packages/remix/src/index.client.tsx
+++ b/packages/remix/src/index.client.tsx
@@ -3,7 +3,7 @@ import { configureScope, init as reactInit, Integrations } from '@sentry/react';
 
 import { buildMetadata } from './utils/metadata';
 import { RemixOptions } from './utils/remixOptions';
-export { remixRouterInstrumentation, withSentryRouteTracing } from './performance/client';
+export { remixRouterInstrumentation, withSentry, withSentryRouteTracing } from './performance/client';
 export { BrowserTracing } from '@sentry/tracing';
 export * from '@sentry/react';
 

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -7,6 +7,7 @@ import { buildMetadata } from './utils/metadata';
 import { RemixOptions } from './utils/remixOptions';
 
 export { ErrorBoundary, withErrorBoundary } from '@sentry/react';
+// eslint-disable-next-line deprecation/deprecation
 export { remixRouterInstrumentation, withSentry, withSentryRouteTracing } from './performance/client';
 export { BrowserTracing, Integrations } from '@sentry/tracing';
 export * from '@sentry/node';

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -7,8 +7,7 @@ import { buildMetadata } from './utils/metadata';
 import { RemixOptions } from './utils/remixOptions';
 
 export { ErrorBoundary, withErrorBoundary } from '@sentry/react';
-// eslint-disable-next-line deprecation/deprecation
-export { remixRouterInstrumentation, withSentry, withSentryRouteTracing } from './performance/client';
+export { remixRouterInstrumentation, withSentry } from './performance/client';
 export { BrowserTracing, Integrations } from '@sentry/tracing';
 export * from '@sentry/node';
 

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -7,7 +7,7 @@ import { buildMetadata } from './utils/metadata';
 import { RemixOptions } from './utils/remixOptions';
 
 export { ErrorBoundary, withErrorBoundary } from '@sentry/react';
-export { remixRouterInstrumentation, withSentryRouteTracing } from './performance/client';
+export { remixRouterInstrumentation, withSentry, withSentryRouteTracing } from './performance/client';
 export { BrowserTracing, Integrations } from '@sentry/tracing';
 export * from '@sentry/node';
 

--- a/packages/remix/src/performance/client.tsx
+++ b/packages/remix/src/performance/client.tsx
@@ -1,3 +1,4 @@
+import { withErrorBoundary } from '@sentry/react';
 import { Transaction, TransactionContext } from '@sentry/types';
 import { getGlobalObject, logger } from '@sentry/utils';
 import * as React from 'react';
@@ -91,6 +92,7 @@ export function withSentryRouteTracing<P extends Record<string, unknown>, R exte
       // will break advanced type inference done by react router params
       return <OrigApp {...props} />;
     }
+
     let isBaseLocation: boolean = false;
 
     const location = _useLocation();
@@ -135,5 +137,5 @@ export function withSentryRouteTracing<P extends Record<string, unknown>, R exte
 
   // @ts-ignore Setting more specific React Component typing for `R` generic above
   // will break advanced type inference done by react router params
-  return SentryRoot;
+  return withErrorBoundary(SentryRoot);
 }

--- a/packages/remix/src/performance/client.tsx
+++ b/packages/remix/src/performance/client.tsx
@@ -79,18 +79,6 @@ export function remixRouterInstrumentation(useEffect: UseEffect, useLocation: Us
 }
 
 /**
- * @deprecated Please use `withSentry` instead.
- *
- * Wraps a remix `root` (see: https://remix.run/docs/en/v1/guides/migrating-react-router-app#creating-the-root-route)
- * To enable pageload/navigation tracing on every route.
- */
-export function withSentryRouteTracing<P extends Record<string, unknown>, R extends React.FC<P>>(App: R): R {
-  // @ts-ignore Setting more specific React Component typing for `R` generic above
-  // will break advanced type inference done by react router params
-  return withSentry(App);
-}
-
-/**
  * Wraps a remix `root` (see: https://remix.run/docs/en/v1/guides/migrating-react-router-app#creating-the-root-route)
  * To enable pageload/navigation tracing on every route.
  * Also wraps the application with `ErrorBoundary`.

--- a/packages/remix/src/performance/client.tsx
+++ b/packages/remix/src/performance/client.tsx
@@ -79,10 +79,26 @@ export function remixRouterInstrumentation(useEffect: UseEffect, useLocation: Us
 }
 
 /**
+ * @deprecated Please use `withSentry` instead.
+ *
  * Wraps a remix `root` (see: https://remix.run/docs/en/v1/guides/migrating-react-router-app#creating-the-root-route)
  * To enable pageload/navigation tracing on every route.
  */
-export function withSentryRouteTracing<P extends Record<string, unknown>, R extends React.FC<P>>(
+export function withSentryRouteTracing<P extends Record<string, unknown>, R extends React.FC<P>>(App: R): R {
+  // @ts-ignore Setting more specific React Component typing for `R` generic above
+  // will break advanced type inference done by react router params
+  return withSentry(App);
+}
+
+/**
+ * Wraps a remix `root` (see: https://remix.run/docs/en/v1/guides/migrating-react-router-app#creating-the-root-route)
+ * To enable pageload/navigation tracing on every route.
+ * Also wraps the application with `ErrorBoundary`.
+ *
+ * @param OrigApp The Remix root to wrap
+ * @param options The options for ErrorBoundary wrapper.
+ */
+export function withSentry<P extends Record<string, unknown>, R extends React.FC<P>>(
   OrigApp: R,
   options: {
     wrapWithErrorBoundary?: boolean;


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/4894

Wraps the Remix root with `ErrorBoundary` while wrapping it with the router instrumentation. 

`withSentryRouteTracing` can be renamed to something like `withSentry` from this point, but it is a breaking change, so I left it out.