### PR TITLE
fix(remix): Make peer deps less restrictive

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -37,8 +37,8 @@
     "@remix-run/react": "^1.4.3"
   },
   "peerDependencies": {
-    "@remix-run/node": "^1.4.3",
-    "@remix-run/react": "^1.4.3",
+    "@remix-run/node": "1.x",
+    "@remix-run/react": "1.x",
     "react": "16.x || 17.x || 18.x"
   },
   "scripts": {


### PR DESCRIPTION
As I was dogfooding remix on https://github.com/getsentry/vanguard, I realized the remix peer deps are pretty restrictive. This opens it up so that we at least support `1.x` of remix - we can re-evaluate when a new major comes out!