### PR TITLE
feat(nextjs): Record transaction name source when creating transactions

### DIFF
--- a/packages/nextjs/src/performance/client.ts
+++ b/packages/nextjs/src/performance/client.ts
@@ -35,11 +35,16 @@ export function nextRouterInstrumentation(
     // route name. Setting the transaction name after the transaction is started could lead
     // to possible race conditions with the router, so this approach was taken.
     if (startTransactionOnPageLoad) {
-      prevTransactionName = Router.route !== null ? stripUrlQueryAndFragment(Router.route) : global.location.pathname;
+      const pathIsRoute = Router.route !== null;
+
+      prevTransactionName = pathIsRoute ? stripUrlQueryAndFragment(Router.route) : global.location.pathname;
       activeTransaction = startTransactionCb({
         name: prevTransactionName,
         op: 'pageload',
         tags: DEFAULT_TAGS,
+        metadata: {
+          source: pathIsRoute ? 'route' : 'url',
+        },
       });
     }
 
@@ -105,6 +110,7 @@ function changeStateWrapper(originalChangeStateWrapper: RouterChangeState): Wrap
         name: prevTransactionName,
         op: 'navigation',
         tags,
+        metadata: { source: 'route' },
       });
     }
     return originalChangeStateWrapper.call(this, method, url, as, options, ...args);

--- a/packages/nextjs/src/utils/withSentry.ts
+++ b/packages/nextjs/src/utils/withSentry.ts
@@ -60,7 +60,7 @@ export const withSentry = (origHandler: NextApiHandler): WrappedNextApiHandler =
           // Replace with placeholder
           if (req.query) {
             // TODO get this from next if possible, to avoid accidentally replacing non-dynamic parts of the path if
-            // they match dynamic parts
+            // they happen to match the values of any of the dynamic parts
             for (const [key, value] of Object.entries(req.query)) {
               reqPath = reqPath.replace(`${value}`, `[${key}]`);
             }
@@ -72,7 +72,7 @@ export const withSentry = (origHandler: NextApiHandler): WrappedNextApiHandler =
               name: `${reqMethod}${reqPath}`,
               op: 'http.server',
               ...traceparentData,
-              metadata: { baggage },
+              metadata: { baggage, source: 'route' },
             },
             // extra context passed to the `tracesSampler`
             { request: req },

--- a/packages/nextjs/test/integration/test/server/tracing200.js
+++ b/packages/nextjs/test/integration/test/server/tracing200.js
@@ -16,6 +16,9 @@ module.exports = async ({ url: urlBase, argv }) => {
         },
       },
       transaction: 'GET /api/users',
+      transaction_info: {
+        source: 'route',
+      },
       type: 'transaction',
       request: {
         url,

--- a/packages/nextjs/test/integration/test/server/tracing500.js
+++ b/packages/nextjs/test/integration/test/server/tracing500.js
@@ -15,6 +15,9 @@ module.exports = async ({ url: urlBase, argv }) => {
         },
       },
       transaction: 'GET /api/broken',
+      transaction_info: {
+        source: 'route',
+      },
       type: 'transaction',
       request: {
         url,

--- a/packages/nextjs/test/integration/test/server/tracingHttp.js
+++ b/packages/nextjs/test/integration/test/server/tracingHttp.js
@@ -29,6 +29,9 @@ module.exports = async ({ url: urlBase, argv }) => {
         },
       ],
       transaction: 'GET /api/http',
+      transaction_info: {
+        source: 'route',
+      },
       type: 'transaction',
       request: {
         url,

--- a/packages/nextjs/test/performance/client.test.ts
+++ b/packages/nextjs/test/performance/client.test.ts
@@ -45,6 +45,9 @@ describe('client', () => {
         tags: {
           'routing.instrumentation': 'next-router',
         },
+        metadata: {
+          source: 'route',
+        },
       });
     });
 
@@ -68,6 +71,9 @@ describe('client', () => {
               method: 'pushState',
               'routing.instrumentation': 'next-router',
             },
+            metadata: {
+              source: 'route',
+            },
           },
         ],
         [
@@ -81,6 +87,9 @@ describe('client', () => {
               method: 'replaceState',
               'routing.instrumentation': 'next-router',
             },
+            metadata: {
+              source: 'route',
+            },
           },
         ],
         [
@@ -93,6 +102,9 @@ describe('client', () => {
               from: '/[user]/posts/[id]',
               method: 'pushState',
               'routing.instrumentation': 'next-router',
+            },
+            metadata: {
+              source: 'route',
             },
           },
         ],
@@ -120,6 +132,9 @@ describe('client', () => {
         name: '/login',
         op: 'navigation',
         tags: { from: '/[user]/posts/[id]', method: 'pushState', 'routing.instrumentation': 'next-router' },
+        metadata: {
+          source: 'route',
+        },
       });
 
       Router.router?.changeState('pushState', '/login', '/login', {});
@@ -131,6 +146,9 @@ describe('client', () => {
         name: '/posts/[id]',
         op: 'navigation',
         tags: { from: '/login', method: 'pushState', 'routing.instrumentation': 'next-router' },
+        metadata: {
+          source: 'route',
+        },
       });
     });
   });


### PR DESCRIPTION
This adds information about the source of the transaction name to all transactions created by the nextjs SDK.
