### PR TITLE
ref(serverless): Add transaction source

### DIFF
--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -324,7 +324,7 @@ export function wrapHandler<TEvent, TResult>(
       name: context.functionName,
       op: 'awslambda.handler',
       ...traceparentData,
-      metadata: { baggage },
+      metadata: { baggage, source: 'component' },
     });
 
     const hub = getCurrentHub();

--- a/packages/serverless/src/gcpfunction/cloud_events.ts
+++ b/packages/serverless/src/gcpfunction/cloud_events.ts
@@ -33,6 +33,7 @@ function _wrapCloudEventFunction(
     const transaction = startTransaction({
       name: context.type || '<unknown>',
       op: 'gcp.function.cloud_event',
+      metadata: { source: 'component' },
     });
 
     // getCurrentHub() is expected to use current active domain as a carrier

--- a/packages/serverless/src/gcpfunction/events.ts
+++ b/packages/serverless/src/gcpfunction/events.ts
@@ -33,6 +33,7 @@ function _wrapEventFunction(
     const transaction = startTransaction({
       name: context.eventType,
       op: 'gcp.function.event',
+      metadata: { source: 'component' },
     });
 
     // getCurrentHub() is expected to use current active domain as a carrier

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -87,7 +87,7 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
       name: `${reqMethod} ${reqUrl}`,
       op: 'gcp.function.http',
       ...traceparentData,
-      metadata: { baggage, source: 'url' },
+      metadata: { baggage, source: 'route' },
     });
 
     // getCurrentHub() is expected to use current active domain as a carrier

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -87,7 +87,7 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
       name: `${reqMethod} ${reqUrl}`,
       op: 'gcp.function.http',
       ...traceparentData,
-      metadata: { baggage },
+      metadata: { baggage, source: 'url' },
     });
 
     // getCurrentHub() is expected to use current active domain as a carrier

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -190,7 +190,7 @@ describe('AWSLambda', () => {
       expect(Sentry.startTransaction).toBeCalledWith({
         name: 'functionName',
         op: 'awslambda.handler',
-        metadata: { baggage: [{}, '', true] },
+        metadata: { baggage: [{}, '', true], source: 'component' },
       });
       expectScopeSettings();
       // @ts-ignore see "Why @ts-ignore" note
@@ -213,7 +213,7 @@ describe('AWSLambda', () => {
         expect(Sentry.startTransaction).toBeCalledWith({
           name: 'functionName',
           op: 'awslambda.handler',
-          metadata: { baggage: [{}, '', true] },
+          metadata: { baggage: [{}, '', true], source: 'component' },
         });
         expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(error);
@@ -259,6 +259,7 @@ describe('AWSLambda', () => {
                 '',
                 false,
               ],
+              source: 'component',
             },
           }),
         );
@@ -289,7 +290,7 @@ describe('AWSLambda', () => {
           traceId: '12312012123120121231201212312012',
           parentSpanId: '1121201211212012',
           parentSampled: false,
-          metadata: { baggage: [{}, '', false] },
+          metadata: { baggage: [{}, '', false], source: 'component' },
         });
         expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(e);
@@ -313,7 +314,7 @@ describe('AWSLambda', () => {
       expect(Sentry.startTransaction).toBeCalledWith({
         name: 'functionName',
         op: 'awslambda.handler',
-        metadata: { baggage: [{}, '', true] },
+        metadata: { baggage: [{}, '', true], source: 'component' },
       });
       expectScopeSettings();
       // @ts-ignore see "Why @ts-ignore" note
@@ -347,7 +348,7 @@ describe('AWSLambda', () => {
         expect(Sentry.startTransaction).toBeCalledWith({
           name: 'functionName',
           op: 'awslambda.handler',
-          metadata: { baggage: [{}, '', true] },
+          metadata: { baggage: [{}, '', true], source: 'component' },
         });
         expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(error);
@@ -386,7 +387,7 @@ describe('AWSLambda', () => {
       expect(Sentry.startTransaction).toBeCalledWith({
         name: 'functionName',
         op: 'awslambda.handler',
-        metadata: { baggage: [{}, '', true] },
+        metadata: { baggage: [{}, '', true], source: 'component' },
       });
       expectScopeSettings();
       // @ts-ignore see "Why @ts-ignore" note
@@ -420,7 +421,7 @@ describe('AWSLambda', () => {
         expect(Sentry.startTransaction).toBeCalledWith({
           name: 'functionName',
           op: 'awslambda.handler',
-          metadata: { baggage: [{}, '', true] },
+          metadata: { baggage: [{}, '', true], source: 'component' },
         });
         expectScopeSettings();
         expect(Sentry.captureException).toBeCalledWith(error);

--- a/packages/serverless/test/gcpfunction.test.ts
+++ b/packages/serverless/test/gcpfunction.test.ts
@@ -113,7 +113,7 @@ describe('GCPFunction', () => {
       expect(Sentry.startTransaction).toBeCalledWith({
         name: 'POST /path',
         op: 'gcp.function.http',
-        metadata: { baggage: [{}, '', true] },
+        metadata: { baggage: [{}, '', true], source: 'url' },
       });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
@@ -153,6 +153,7 @@ describe('GCPFunction', () => {
               '',
               false,
             ],
+            source: 'url',
           },
         }),
       );
@@ -178,7 +179,7 @@ describe('GCPFunction', () => {
         traceId: '12312012123120121231201212312012',
         parentSpanId: '1121201211212012',
         parentSampled: false,
-        metadata: { baggage: [{}, '', false] },
+        metadata: { baggage: [{}, '', false], source: 'url' },
       });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
@@ -245,7 +246,11 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapEventFunction(func);
       await expect(handleEvent(wrappedHandler)).resolves.toBe(42);
-      expect(Sentry.startTransaction).toBeCalledWith({ name: 'event.type', op: 'gcp.function.event' });
+      expect(Sentry.startTransaction).toBeCalledWith({
+        name: 'event.type',
+        op: 'gcp.function.event',
+        metadata: { source: 'component' },
+      });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
@@ -262,7 +267,11 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapEventFunction(handler);
       await expect(handleEvent(wrappedHandler)).rejects.toThrowError(error);
-      expect(Sentry.startTransaction).toBeCalledWith({ name: 'event.type', op: 'gcp.function.event' });
+      expect(Sentry.startTransaction).toBeCalledWith({
+        name: 'event.type',
+        op: 'gcp.function.event',
+        metadata: { source: 'component' },
+      });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
       expect(Sentry.captureException).toBeCalledWith(error);
@@ -284,7 +293,11 @@ describe('GCPFunction', () => {
         });
       const wrappedHandler = wrapEventFunction(func);
       await expect(handleEvent(wrappedHandler)).resolves.toBe(42);
-      expect(Sentry.startTransaction).toBeCalledWith({ name: 'event.type', op: 'gcp.function.event' });
+      expect(Sentry.startTransaction).toBeCalledWith({
+        name: 'event.type',
+        op: 'gcp.function.event',
+        metadata: { source: 'component' },
+      });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
@@ -305,7 +318,11 @@ describe('GCPFunction', () => {
 
       const wrappedHandler = wrapEventFunction(handler);
       await expect(handleEvent(wrappedHandler)).rejects.toThrowError(error);
-      expect(Sentry.startTransaction).toBeCalledWith({ name: 'event.type', op: 'gcp.function.event' });
+      expect(Sentry.startTransaction).toBeCalledWith({
+        name: 'event.type',
+        op: 'gcp.function.event',
+        metadata: { source: 'component' },
+      });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
       expect(Sentry.captureException).toBeCalledWith(error);
@@ -324,7 +341,11 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapEventFunction(func);
       await expect(handleEvent(wrappedHandler)).resolves.toBe(42);
-      expect(Sentry.startTransaction).toBeCalledWith({ name: 'event.type', op: 'gcp.function.event' });
+      expect(Sentry.startTransaction).toBeCalledWith({
+        name: 'event.type',
+        op: 'gcp.function.event',
+        metadata: { source: 'component' },
+      });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
@@ -341,7 +362,11 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapEventFunction(handler);
       await expect(handleEvent(wrappedHandler)).rejects.toThrowError(error);
-      expect(Sentry.startTransaction).toBeCalledWith({ name: 'event.type', op: 'gcp.function.event' });
+      expect(Sentry.startTransaction).toBeCalledWith({
+        name: 'event.type',
+        op: 'gcp.function.event',
+        metadata: { source: 'component' },
+      });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
       expect(Sentry.captureException).toBeCalledWith(error);
@@ -359,7 +384,11 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapEventFunction(handler);
       await expect(handleEvent(wrappedHandler)).rejects.toThrowError(error);
-      expect(Sentry.startTransaction).toBeCalledWith({ name: 'event.type', op: 'gcp.function.event' });
+      expect(Sentry.startTransaction).toBeCalledWith({
+        name: 'event.type',
+        op: 'gcp.function.event',
+        metadata: { source: 'component' },
+      });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
       expect(Sentry.captureException).toBeCalledWith(error);
@@ -388,7 +417,11 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapCloudEventFunction(func);
       await expect(handleCloudEvent(wrappedHandler)).resolves.toBe(42);
-      expect(Sentry.startTransaction).toBeCalledWith({ name: 'event.type', op: 'gcp.function.cloud_event' });
+      expect(Sentry.startTransaction).toBeCalledWith({
+        name: 'event.type',
+        op: 'gcp.function.cloud_event',
+        metadata: { source: 'component' },
+      });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
@@ -405,7 +438,11 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapCloudEventFunction(handler);
       await expect(handleCloudEvent(wrappedHandler)).rejects.toThrowError(error);
-      expect(Sentry.startTransaction).toBeCalledWith({ name: 'event.type', op: 'gcp.function.cloud_event' });
+      expect(Sentry.startTransaction).toBeCalledWith({
+        name: 'event.type',
+        op: 'gcp.function.cloud_event',
+        metadata: { source: 'component' },
+      });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
       expect(Sentry.captureException).toBeCalledWith(error);
@@ -424,7 +461,11 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapCloudEventFunction(func);
       await expect(handleCloudEvent(wrappedHandler)).resolves.toBe(42);
-      expect(Sentry.startTransaction).toBeCalledWith({ name: 'event.type', op: 'gcp.function.cloud_event' });
+      expect(Sentry.startTransaction).toBeCalledWith({
+        name: 'event.type',
+        op: 'gcp.function.cloud_event',
+        metadata: { source: 'component' },
+      });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
@@ -441,7 +482,11 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapCloudEventFunction(handler);
       await expect(handleCloudEvent(wrappedHandler)).rejects.toThrowError(error);
-      expect(Sentry.startTransaction).toBeCalledWith({ name: 'event.type', op: 'gcp.function.cloud_event' });
+      expect(Sentry.startTransaction).toBeCalledWith({
+        name: 'event.type',
+        op: 'gcp.function.cloud_event',
+        metadata: { source: 'component' },
+      });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
       expect(Sentry.captureException).toBeCalledWith(error);
@@ -459,7 +504,11 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapCloudEventFunction(handler);
       await expect(handleCloudEvent(wrappedHandler)).rejects.toThrowError(error);
-      expect(Sentry.startTransaction).toBeCalledWith({ name: 'event.type', op: 'gcp.function.cloud_event' });
+      expect(Sentry.startTransaction).toBeCalledWith({
+        name: 'event.type',
+        op: 'gcp.function.cloud_event',
+        metadata: { source: 'component' },
+      });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
       expect(Sentry.captureException).toBeCalledWith(error);

--- a/packages/serverless/test/gcpfunction.test.ts
+++ b/packages/serverless/test/gcpfunction.test.ts
@@ -113,7 +113,7 @@ describe('GCPFunction', () => {
       expect(Sentry.startTransaction).toBeCalledWith({
         name: 'POST /path',
         op: 'gcp.function.http',
-        metadata: { baggage: [{}, '', true], source: 'url' },
+        metadata: { baggage: [{}, '', true], source: 'route' },
       });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
@@ -153,7 +153,7 @@ describe('GCPFunction', () => {
               '',
               false,
             ],
-            source: 'url',
+            source: 'route',
           },
         }),
       );
@@ -179,7 +179,7 @@ describe('GCPFunction', () => {
         traceId: '12312012123120121231201212312012',
         parentSpanId: '1121201211212012',
         parentSampled: false,
-        metadata: { baggage: [{}, '', false], source: 'url' },
+        metadata: { baggage: [{}, '', false], source: 'route' },
       });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry-javascript/issues/5345

Decided to go with `component` for the serverless functions as they are function names as transaction name.