### PR TITLE
feat(tracing): Record transaction name source when name set directly

### DIFF
--- a/packages/hub/src/exports.ts
+++ b/packages/hub/src/exports.ts
@@ -168,6 +168,9 @@ export function withScope(callback: (scope: Scope) => void): ReturnType<Hub['wit
  * The transaction must be finished with a call to its `.finish()` method, at which point the transaction with all its
  * finished child spans will be sent to Sentry.
  *
+ * NOTE: This function should only be used for *manual* instrumentation. Auto-instrumentation should call
+ * `startTransaction` directly on the hub.
+ *
  * @param context Properties of the new `Transaction`.
  * @param customSamplingContext Information given to the transaction sampling function (along with context-dependent
  * default values). See {@link Options.tracesSampler}.
@@ -178,5 +181,11 @@ export function startTransaction(
   context: TransactionContext,
   customSamplingContext?: CustomSamplingContext,
 ): ReturnType<Hub['startTransaction']> {
-  return getCurrentHub().startTransaction({ ...context }, customSamplingContext);
+  return getCurrentHub().startTransaction(
+    {
+      metadata: { source: 'custom' },
+      ...context,
+    },
+    customSamplingContext,
+  );
 }

--- a/packages/hub/test/exports.test.ts
+++ b/packages/hub/test/exports.test.ts
@@ -10,6 +10,7 @@ import {
   setTag,
   setTags,
   setUser,
+  startTransaction,
   withScope,
 } from '../src/exports';
 
@@ -181,6 +182,35 @@ describe('Top Level API', () => {
       getCurrentHub().bindClient(client);
       scope.setLevel('warning');
       expect(global.__SENTRY__.hub._stack[1].scope._level).toEqual('warning');
+    });
+  });
+
+  describe('startTransaction', () => {
+    beforeEach(() => {
+      global.__SENTRY__ = {
+        hub: undefined,
+        extensions: {
+          startTransaction: (context: any) => ({
+            name: context.name,
+            // Spread rather than assign in case it's undefined
+            metadata: { ...context.metadata },
+          }),
+        },
+      };
+    });
+
+    it("sets source to `'custom'` if no source provided", () => {
+      const transaction = startTransaction({ name: 'dogpark' });
+
+      expect(transaction.name).toEqual('dogpark');
+      expect(transaction.metadata.source).toEqual('custom');
+    });
+
+    it('uses given `source` value', () => {
+      const transaction = startTransaction({ name: 'dogpark', metadata: { source: 'route' } });
+
+      expect(transaction.name).toEqual('dogpark');
+      expect(transaction.metadata.source).toEqual('route');
     });
   });
 

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -1,4 +1,4 @@
-import { captureException, getCurrentHub, startTransaction } from '@sentry/node';
+import { captureException, getCurrentHub } from '@sentry/node';
 import { getActiveTransaction } from '@sentry/tracing';
 import { addExceptionMechanism, fill, loadModule, logger, stripUrlQueryAndFragment } from '@sentry/utils';
 
@@ -175,8 +175,9 @@ function makeWrappedLoader(origAction: DataFunction): DataFunction {
 
 function wrapRequestHandler(origRequestHandler: RequestHandler): RequestHandler {
   return async function (this: unknown, request: Request, loadContext?: unknown): Promise<Response> {
-    const currentScope = getCurrentHub().getScope();
-    const transaction = startTransaction({
+    const hub = getCurrentHub();
+    const currentScope = hub.getScope();
+    const transaction = hub.startTransaction({
       name: stripUrlQueryAndFragment(request.url),
       op: 'http.server',
       tags: {

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -1,14 +1,6 @@
 /* eslint-disable max-lines */
 import * as Sentry from '@sentry/node';
-import {
-  captureException,
-  captureMessage,
-  flush,
-  getCurrentHub,
-  Scope,
-  startTransaction,
-  withScope,
-} from '@sentry/node';
+import { captureException, captureMessage, flush, getCurrentHub, Scope, withScope } from '@sentry/node';
 import { extractTraceparentData } from '@sentry/tracing';
 import { Integration } from '@sentry/types';
 import { dsnFromString, dsnToString, isString, logger, parseBaggageSetMutability } from '@sentry/utils';
@@ -320,14 +312,15 @@ export function wrapHandler<TEvent, TResult>(
       eventWithHeaders.headers && isString(eventWithHeaders.headers.baggage) && eventWithHeaders.headers.baggage;
     const baggage = parseBaggageSetMutability(rawBaggageString, traceparentData);
 
-    const transaction = startTransaction({
+    const hub = getCurrentHub();
+
+    const transaction = hub.startTransaction({
       name: context.functionName,
       op: 'awslambda.handler',
       ...traceparentData,
       metadata: { baggage, source: 'component' },
     });
 
-    const hub = getCurrentHub();
     const scope = hub.pushScope();
     let rv: TResult;
     try {

--- a/packages/serverless/src/gcpfunction/events.ts
+++ b/packages/serverless/src/gcpfunction/events.ts
@@ -1,4 +1,4 @@
-import { captureException, flush, getCurrentHub, startTransaction } from '@sentry/node';
+import { captureException, flush, getCurrentHub } from '@sentry/node';
 import { logger } from '@sentry/utils';
 
 import { domainify, getActiveDomain, proxyFunction } from '../utils';
@@ -30,7 +30,9 @@ function _wrapEventFunction(
     ...wrapOptions,
   };
   return (data, context, callback) => {
-    const transaction = startTransaction({
+    const hub = getCurrentHub();
+
+    const transaction = hub.startTransaction({
       name: context.eventType,
       op: 'gcp.function.event',
       metadata: { source: 'component' },
@@ -39,7 +41,7 @@ function _wrapEventFunction(
     // getCurrentHub() is expected to use current active domain as a carrier
     // since functions-framework creates a domain for each incoming request.
     // So adding of event processors every time should not lead to memory bloat.
-    getCurrentHub().configureScope(scope => {
+    hub.configureScope(scope => {
       scope.setContext('gcp.function.context', { ...context });
       // We put the transaction on the scope so users can attach children to it
       scope.setSpan(transaction);

--- a/packages/serverless/test/__mocks__/@sentry/node.ts
+++ b/packages/serverless/test/__mocks__/@sentry/node.ts
@@ -11,6 +11,7 @@ export const fakeHub = {
   pushScope: jest.fn(() => fakeScope),
   popScope: jest.fn(),
   getScope: jest.fn(() => fakeScope),
+  startTransaction: jest.fn(context => ({ ...fakeTransaction, ...context })),
 };
 export const fakeScope = {
   addEventProcessor: jest.fn(),

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -38,9 +38,11 @@ const fakeCallback: Callback = (err, result) => {
   return err;
 };
 
-function expectScopeSettings() {
+function expectScopeSettings(fakeTransactionContext: any) {
   // @ts-ignore see "Why @ts-ignore" note
-  expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+  const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+  // @ts-ignore see "Why @ts-ignore" note
+  expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
   // @ts-ignore see "Why @ts-ignore" note
   expect(Sentry.fakeScope.setTag).toBeCalledWith('server_name', expect.anything());
   // @ts-ignore see "Why @ts-ignore" note
@@ -186,13 +188,17 @@ describe('AWSLambda', () => {
       };
       const wrappedHandler = wrapHandler(handler);
       const rv = await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
-      expect(rv).toStrictEqual(42);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'functionName',
         op: 'awslambda.handler',
         metadata: { baggage: [{}, '', true], source: 'component' },
-      });
-      expectScopeSettings();
+      };
+
+      expect(rv).toStrictEqual(42);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expectScopeSettings(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
       expect(Sentry.flush).toBeCalledWith(2000);
@@ -210,12 +216,15 @@ describe('AWSLambda', () => {
       try {
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       } catch (e) {
-        expect(Sentry.startTransaction).toBeCalledWith({
+        const fakeTransactionContext = {
           name: 'functionName',
           op: 'awslambda.handler',
           metadata: { baggage: [{}, '', true], source: 'component' },
-        });
-        expectScopeSettings();
+        };
+
+        // @ts-ignore see "Why @ts-ignore" note
+        expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+        expectScopeSettings(fakeTransactionContext);
         expect(Sentry.captureException).toBeCalledWith(error);
         // @ts-ignore see "Why @ts-ignore" note
         expect(Sentry.fakeTransaction.finish).toBeCalled();
@@ -244,7 +253,8 @@ describe('AWSLambda', () => {
       };
 
       const handler: Handler = (_event, _context, callback) => {
-        expect(Sentry.startTransaction).toBeCalledWith(
+        // @ts-ignore see "Why @ts-ignore" note
+        expect(Sentry.fakeHub.startTransaction).toBeCalledWith(
           expect.objectContaining({
             parentSpanId: '1121201211212012',
             parentSampled: false,
@@ -284,15 +294,18 @@ describe('AWSLambda', () => {
         fakeEvent.headers = { 'sentry-trace': '12312012123120121231201212312012-1121201211212012-0' };
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       } catch (e) {
-        expect(Sentry.startTransaction).toBeCalledWith({
+        const fakeTransactionContext = {
           name: 'functionName',
           op: 'awslambda.handler',
           traceId: '12312012123120121231201212312012',
           parentSpanId: '1121201211212012',
           parentSampled: false,
           metadata: { baggage: [{}, '', false], source: 'component' },
-        });
-        expectScopeSettings();
+        };
+
+        // @ts-ignore see "Why @ts-ignore" note
+        expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+        expectScopeSettings(fakeTransactionContext);
         expect(Sentry.captureException).toBeCalledWith(e);
         // @ts-ignore see "Why @ts-ignore" note
         expect(Sentry.fakeTransaction.finish).toBeCalled();
@@ -310,13 +323,17 @@ describe('AWSLambda', () => {
       };
       const wrappedHandler = wrapHandler(handler);
       const rv = await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
-      expect(rv).toStrictEqual(42);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'functionName',
         op: 'awslambda.handler',
         metadata: { baggage: [{}, '', true], source: 'component' },
-      });
-      expectScopeSettings();
+      };
+
+      expect(rv).toStrictEqual(42);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expectScopeSettings(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
       expect(Sentry.flush).toBeCalled();
@@ -345,12 +362,15 @@ describe('AWSLambda', () => {
       try {
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       } catch (e) {
-        expect(Sentry.startTransaction).toBeCalledWith({
+        const fakeTransactionContext = {
           name: 'functionName',
           op: 'awslambda.handler',
           metadata: { baggage: [{}, '', true], source: 'component' },
-        });
-        expectScopeSettings();
+        };
+
+        // @ts-ignore see "Why @ts-ignore" note
+        expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+        expectScopeSettings(fakeTransactionContext);
         expect(Sentry.captureException).toBeCalledWith(error);
         // @ts-ignore see "Why @ts-ignore" note
         expect(Sentry.fakeTransaction.finish).toBeCalled();
@@ -383,13 +403,17 @@ describe('AWSLambda', () => {
       };
       const wrappedHandler = wrapHandler(handler);
       const rv = await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
-      expect(rv).toStrictEqual(42);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'functionName',
         op: 'awslambda.handler',
         metadata: { baggage: [{}, '', true], source: 'component' },
-      });
-      expectScopeSettings();
+      };
+
+      expect(rv).toStrictEqual(42);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expectScopeSettings(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
       expect(Sentry.flush).toBeCalled();
@@ -418,12 +442,15 @@ describe('AWSLambda', () => {
       try {
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
       } catch (e) {
-        expect(Sentry.startTransaction).toBeCalledWith({
+        const fakeTransactionContext = {
           name: 'functionName',
           op: 'awslambda.handler',
           metadata: { baggage: [{}, '', true], source: 'component' },
-        });
-        expectScopeSettings();
+        };
+
+        // @ts-ignore see "Why @ts-ignore" note
+        expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+        expectScopeSettings(fakeTransactionContext);
         expect(Sentry.captureException).toBeCalledWith(error);
         // @ts-ignore see "Why @ts-ignore" note
         expect(Sentry.fakeTransaction.finish).toBeCalled();

--- a/packages/serverless/test/gcpfunction.test.ts
+++ b/packages/serverless/test/gcpfunction.test.ts
@@ -110,13 +110,19 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapHttpFunction(handler);
       await handleHttp(wrappedHandler);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'POST /path',
         op: 'gcp.function.http',
         metadata: { baggage: [{}, '', true], source: 'route' },
-      });
+      };
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.setHttpStatus).toBeCalledWith(200);
       // @ts-ignore see "Why @ts-ignore" note
@@ -138,25 +144,29 @@ describe('GCPFunction', () => {
       };
       await handleHttp(wrappedHandler, traceHeaders);
 
-      expect(Sentry.startTransaction).toBeCalledWith(
-        expect.objectContaining({
-          name: 'POST /path',
-          op: 'gcp.function.http',
-          traceId: '12312012123120121231201212312012',
-          parentSpanId: '1121201211212012',
-          parentSampled: false,
-          metadata: {
-            baggage: [
-              {
-                release: '2.12.1',
-              },
-              '',
-              false,
-            ],
-            source: 'route',
-          },
-        }),
-      );
+      const fakeTransactionContext = {
+        name: 'POST /path',
+        op: 'gcp.function.http',
+        traceId: '12312012123120121231201212312012',
+        parentSpanId: '1121201211212012',
+        parentSampled: false,
+        metadata: {
+          baggage: [
+            {
+              release: '2.12.1',
+            },
+            '',
+            false,
+          ],
+          source: 'route',
+        },
+      };
+
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+
+      // @ts-ignore see "Why @ts-ignore" note
+      // expect(Sentry.fakeHub.startTransaction).toBeCalledWith(expect.objectContaining(fakeTransactionContext));
     });
 
     test('capture error', async () => {
@@ -173,16 +183,22 @@ describe('GCPFunction', () => {
       };
 
       await handleHttp(wrappedHandler, trace_headers);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'POST /path',
         op: 'gcp.function.http',
         traceId: '12312012123120121231201212312012',
         parentSpanId: '1121201211212012',
         parentSampled: false,
         metadata: { baggage: [{}, '', false], source: 'route' },
-      });
+      };
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(Sentry.captureException).toBeCalledWith(error);
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
@@ -246,13 +262,19 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapEventFunction(func);
       await expect(handleEvent(wrappedHandler)).resolves.toBe(42);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'event.type',
         op: 'gcp.function.event',
         metadata: { source: 'component' },
-      });
+      };
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
       expect(Sentry.flush).toBeCalledWith(2000);
@@ -267,13 +289,19 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapEventFunction(handler);
       await expect(handleEvent(wrappedHandler)).rejects.toThrowError(error);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'event.type',
         op: 'gcp.function.event',
         metadata: { source: 'component' },
-      });
+      };
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(Sentry.captureException).toBeCalledWith(error);
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
@@ -293,13 +321,19 @@ describe('GCPFunction', () => {
         });
       const wrappedHandler = wrapEventFunction(func);
       await expect(handleEvent(wrappedHandler)).resolves.toBe(42);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'event.type',
         op: 'gcp.function.event',
         metadata: { source: 'component' },
-      });
+      };
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
       expect(Sentry.flush).toBeCalledWith(2000);
@@ -318,13 +352,19 @@ describe('GCPFunction', () => {
 
       const wrappedHandler = wrapEventFunction(handler);
       await expect(handleEvent(wrappedHandler)).rejects.toThrowError(error);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'event.type',
         op: 'gcp.function.event',
         metadata: { source: 'component' },
-      });
+      };
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(Sentry.captureException).toBeCalledWith(error);
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
@@ -341,13 +381,19 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapEventFunction(func);
       await expect(handleEvent(wrappedHandler)).resolves.toBe(42);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'event.type',
         op: 'gcp.function.event',
         metadata: { source: 'component' },
-      });
+      };
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
       expect(Sentry.flush).toBeCalledWith(2000);
@@ -362,13 +408,19 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapEventFunction(handler);
       await expect(handleEvent(wrappedHandler)).rejects.toThrowError(error);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'event.type',
         op: 'gcp.function.event',
         metadata: { source: 'component' },
-      });
+      };
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(Sentry.captureException).toBeCalledWith(error);
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
@@ -384,13 +436,19 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapEventFunction(handler);
       await expect(handleEvent(wrappedHandler)).rejects.toThrowError(error);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'event.type',
         op: 'gcp.function.event',
         metadata: { source: 'component' },
-      });
+      };
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(Sentry.captureException).toBeCalledWith(error);
     });
   });
@@ -417,13 +475,19 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapCloudEventFunction(func);
       await expect(handleCloudEvent(wrappedHandler)).resolves.toBe(42);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'event.type',
         op: 'gcp.function.cloud_event',
         metadata: { source: 'component' },
-      });
+      };
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
       expect(Sentry.flush).toBeCalledWith(2000);
@@ -438,13 +502,19 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapCloudEventFunction(handler);
       await expect(handleCloudEvent(wrappedHandler)).rejects.toThrowError(error);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'event.type',
         op: 'gcp.function.cloud_event',
         metadata: { source: 'component' },
-      });
+      };
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(Sentry.captureException).toBeCalledWith(error);
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
@@ -461,13 +531,19 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapCloudEventFunction(func);
       await expect(handleCloudEvent(wrappedHandler)).resolves.toBe(42);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'event.type',
         op: 'gcp.function.cloud_event',
         metadata: { source: 'component' },
-      });
+      };
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
       expect(Sentry.flush).toBeCalledWith(2000);
@@ -482,13 +558,19 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapCloudEventFunction(handler);
       await expect(handleCloudEvent(wrappedHandler)).rejects.toThrowError(error);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'event.type',
         op: 'gcp.function.cloud_event',
         metadata: { source: 'component' },
-      });
+      };
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(Sentry.captureException).toBeCalledWith(error);
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.finish).toBeCalled();
@@ -504,13 +586,20 @@ describe('GCPFunction', () => {
       };
       const wrappedHandler = wrapCloudEventFunction(handler);
       await expect(handleCloudEvent(wrappedHandler)).rejects.toThrowError(error);
-      expect(Sentry.startTransaction).toBeCalledWith({
+
+      const fakeTransactionContext = {
         name: 'event.type',
         op: 'gcp.function.cloud_event',
         metadata: { source: 'component' },
-      });
+      };
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(Sentry.fakeTransaction);
+      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      // @ts-ignore see "Why @ts-ignore" note
+      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
+
       expect(Sentry.captureException).toBeCalledWith(error);
     });
   });

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -222,6 +222,12 @@ export class BrowserTracing implements Integration {
     // from being sent to Sentry).
     const finalContext = modifiedContext === undefined ? { ...expandedContext, sampled: false } : modifiedContext;
 
+    // If `beforeNavigate` set a custom name, record that fact
+    finalContext.metadata =
+      finalContext.name !== expandedContext.name
+        ? { ...finalContext.metadata, source: 'custom' }
+        : finalContext.metadata;
+
     if (finalContext.sampled === false) {
       __DEBUG_BUILD__ &&
         logger.log(`[Tracing] Will not send ${finalContext.op} transaction because of beforeNavigate.`);

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -15,14 +15,14 @@ import { Span as SpanClass, SpanRecorder } from './span';
 
 /** JSDoc */
 export class Transaction extends SpanClass implements TransactionInterface {
-  public name: string;
-
   public metadata: TransactionMetadata;
 
   /**
    * The reference to the current hub.
    */
   public readonly _hub: Hub;
+
+  private _name: string;
 
   private _measurements: Measurements = {};
 
@@ -40,7 +40,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
 
     this._hub = hub || getCurrentHub();
 
-    this.name = transactionContext.name || '';
+    this._name = transactionContext.name || '';
 
     this.metadata = transactionContext.metadata || {};
     this._trimEnd = transactionContext.trimEnd;
@@ -49,11 +49,23 @@ export class Transaction extends SpanClass implements TransactionInterface {
     this.transaction = this;
   }
 
+  /** Getter for `name` property */
+  public get name(): string {
+    return this._name;
+  }
+
+  /** Setter for `name` property, which also sets `source` */
+  public set name(newName: string) {
+    this._name = newName;
+    this.metadata.source = 'custom';
+  }
+
   /**
    * JSDoc
    */
-  public setName(name: string): void {
+  public setName(name: string, source: TransactionMetadata['source'] = 'custom'): void {
     this.name = name;
+    this.metadata.source = source;
   }
 
   /**

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -216,6 +216,39 @@ describe('BrowserTracing', () => {
 
         expect(mockBeforeNavigation).toHaveBeenCalledTimes(1);
       });
+
+      it("sets transaction name source to `'custom'` if name is changed", () => {
+        const mockBeforeNavigation = jest.fn(ctx => ({
+          ...ctx,
+          name: 'newName',
+        }));
+        createBrowserTracing(true, {
+          beforeNavigate: mockBeforeNavigation,
+          routingInstrumentation: customInstrumentRouting,
+        });
+        const transaction = getActiveTransaction(hub) as IdleTransaction;
+        expect(transaction).toBeDefined();
+        expect(transaction.name).toBe('newName');
+        expect(transaction.metadata.source).toBe('custom');
+
+        expect(mockBeforeNavigation).toHaveBeenCalledTimes(1);
+      });
+
+      it("doesn't set transaction name source if name is not changed", () => {
+        const mockBeforeNavigation = jest.fn(ctx => ({
+          ...ctx,
+        }));
+        createBrowserTracing(true, {
+          beforeNavigate: mockBeforeNavigation,
+          routingInstrumentation: customInstrumentRouting,
+        });
+        const transaction = getActiveTransaction(hub) as IdleTransaction;
+        expect(transaction).toBeDefined();
+        expect(transaction.name).toBe('a/path');
+        expect(transaction.metadata.source).toBeUndefined();
+
+        expect(mockBeforeNavigation).toHaveBeenCalledTimes(1);
+      });
     });
 
     it('sets transaction context from sentry-trace header', () => {

--- a/packages/tracing/test/transaction.test.ts
+++ b/packages/tracing/test/transaction.test.ts
@@ -1,0 +1,45 @@
+import { Transaction } from '../src/transaction';
+
+describe('`Transaction` class', () => {
+  describe('transaction name source', () => {
+    it('sets source in constructor if provided', () => {
+      const transaction = new Transaction({ name: 'dogpark', metadata: { source: 'route' } });
+
+      expect(transaction.name).toEqual('dogpark');
+      expect(transaction.metadata.source).toEqual('route');
+    });
+
+    it("doesn't set source in constructor if not provided", () => {
+      const transaction = new Transaction({ name: 'dogpark' });
+
+      expect(transaction.name).toEqual('dogpark');
+      expect(transaction.metadata.source).toBeUndefined();
+    });
+
+    it("sets source to `'custom'` when assigning to `name` property", () => {
+      const transaction = new Transaction({ name: 'dogpark' });
+      transaction.name = 'ballpit';
+
+      expect(transaction.name).toEqual('ballpit');
+      expect(transaction.metadata.source).toEqual('custom');
+    });
+
+    describe('`setName` method', () => {
+      it("sets source to `'custom'` if no source provided", () => {
+        const transaction = new Transaction({ name: 'dogpark' });
+        transaction.setName('ballpit');
+
+        expect(transaction.name).toEqual('ballpit');
+        expect(transaction.metadata.source).toEqual('custom');
+      });
+
+      it('uses given `source` value', () => {
+        const transaction = new Transaction({ name: 'dogpark' });
+        transaction.setName('ballpit', 'route');
+
+        expect(transaction.name).toEqual('ballpit');
+        expect(transaction.metadata.source).toEqual('route');
+      });
+    });
+  });
+});


### PR DESCRIPTION
This adds transaction name source to transaction metadata in various situations in which the name is set directly: starting a manual transaction, assigning to the `name` property of a transaction, calling a transaction's `setName` method, and changing the name using `beforeNavigate`.

In order to distinguish manually-created transactions from automatically-created ones, all internal uses of `startTransaction` have been changed so that they are happening directly on the hub, rather than through the top-level `Sentry.startTransaction()` wrapper.