### PR TITLE
fix(remix): Add `documentRequest` function name.

### DIFF
--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -120,7 +120,7 @@ function makeWrappedDocumentRequestFunction(
 
       span.finish();
     } catch (err) {
-      captureRemixServerException(err, name);
+      captureRemixServerException(err, 'documentRequest');
       throw err;
     }
 


### PR DESCRIPTION
Fixes: #5401 

I wonder why TS doesn't complain about that.

It's `const name: never` in that scope. Could not find a sign of a global type declaration though.