### PR TITLE
fix(remix): Skip capturing `ok` responses as errors.

### DIFF
--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -69,7 +69,6 @@ interface DataFunction {
   (args: DataFunctionArgs): Promise<Response> | Response | Promise<AppData> | AppData;
 }
 
-
 // Taken from Remix Implementation
 // https://github.com/remix-run/remix/blob/7688da5c75190a2e29496c78721456d6e12e3abe/packages/remix-server-runtime/responses.ts#L54-L62
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -85,14 +84,26 @@ function isResponse(value: any): value is Response {
   );
 }
 
+// Taken from Remix Implementation
+// https://github.com/remix-run/remix/blob/7688da5c75190a2e29496c78721456d6e12e3abe/packages/remix-server-runtime/data.ts#L131-L145
+function extractData(response: Response): Promise<unknown> {
+  const contentType = response.headers.get('Content-Type');
+
+  if (contentType && /\bapplication\/json\b/.test(contentType)) {
+    return response.json();
+  }
+
+  return response.text();
+}
+
 function captureRemixServerException(err: Error, name: string): void {
-  // Skip capturing if the thrown error is a Response
+  // Skip capturing if the thrown error is an OK Response
   // https://remix.run/docs/en/v1/api/conventions#throwing-responses-in-loaders
-  if (isResponse(err)) {
+  if (isResponse(err) && err.status < 400) {
     return;
   }
 
-  captureException(err, scope => {
+  captureException(isResponse(err) ? extractData(err) : err, scope => {
     scope.addEventProcessor(event => {
       addExceptionMechanism(event, {
         type: 'instrument',

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -69,7 +69,29 @@ interface DataFunction {
   (args: DataFunctionArgs): Promise<Response> | Response | Promise<AppData> | AppData;
 }
 
+
+// Taken from Remix Implementation
+// https://github.com/remix-run/remix/blob/7688da5c75190a2e29496c78721456d6e12e3abe/packages/remix-server-runtime/responses.ts#L54-L62
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isResponse(value: any): value is Response {
+  return (
+    value != null &&
+    /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+    typeof value.status === 'number' &&
+    typeof value.statusText === 'string' &&
+    typeof value.headers === 'object' &&
+    typeof value.body !== 'undefined'
+    /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+  );
+}
+
 function captureRemixServerException(err: Error, name: string): void {
+  // Skip capturing if the thrown error is a Response
+  // https://remix.run/docs/en/v1/api/conventions#throwing-responses-in-loaders
+  if (isResponse(err)) {
+    return;
+  }
+
   captureException(err, scope => {
     scope.addEventProcessor(event => {
       addExceptionMechanism(event, {


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry-javascript/issues/5362

[Remix supports throwing responses from `loader` and `action` functions for its internal `CatchBoundary`](https://remix.run/docs/en/v1/api/conventions#throwing-responses-in-loaders).

They are [catched on the caller level](https://github.com/remix-run/remix/blob/7688da5c75190a2e29496c78721456d6e12e3abe/packages/remix-server-runtime/data.ts#L41-L49), but as we wrap the callees, they are registered as exceptions in the SDK. Being http responses, they end up like `{size: 0}`, which is not meaningful.

This PR skips exception capturing for responses that are not `4xx` or `5xx`. 