### PR TITLE
ref(vue): expose Vue and VueRouter interface

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -4,3 +4,5 @@ export { init } from './sdk';
 export { vueRouterInstrumentation } from './router';
 export { attachErrorHandler } from './errorhandler';
 export { createTracingMixins } from './tracing';
+export type { VueRouter } from "./router";
+export type { Vue } from "./types";

--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -25,7 +25,7 @@ export type Route = {
   matched: { path: string }[];
 };
 
-interface VueRouter {
+export interface VueRouter {
   onError: (fn: (err: Error) => void) => void;
   beforeEach: (fn: (to: Route, from: Route, next: () => void) => void) => void;
 }


### PR DESCRIPTION
This pull request simply expose the `Vue` and `VueRouter` interface to be easier to wrap Sentry into a standalone library to be used cross-project within a company.

In my company we have a few frontend projects and in all of them, we have replicated a util called `bu-reporter`, which uses Sentry under the hood to do the heavy work!
This util is just to add some standards, control global tags and ensure the instrumentation we do for one project, can be easily used in another one.

As we have already these 2 types available within the `@sentry/vue` package, it's pointless to dev-install `vue` and `vue-router` into this standalone bug reporter just to get its types, and for that, I hope this PR goes through.
