### PR TITLE
Adds request data to transaction first, to allow downstream changes

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -56,6 +56,9 @@ export function tracingHandler(): (
       scope.setSpan(transaction);
     });
 
+    // Add the request data to the transaction first, so others can override downstream if necessary
+    addRequestDataToTransaction(transaction, req);
+
     // We also set __sentry_transaction on the response so people can grab the transaction there to add
     // spans to it later.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -65,7 +68,6 @@ export function tracingHandler(): (
       // Push `transaction.finish` to the next event loop so open spans have a chance to finish before the transaction
       // closes
       setImmediate(() => {
-        addRequestDataToTransaction(transaction, req);
         transaction.setHttpStatus(res.statusCode);
         transaction.finish();
       });

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -305,6 +305,22 @@ describe('tracingHandler', () => {
     });
   });
 
+  it('allows downstream functions to override transaction values', done => {
+    const transaction = new Transaction({ name: 'mockTransaction' });
+    jest.spyOn(sentryCore, 'startTransaction').mockReturnValue(transaction as Transaction);
+    const finishTransaction = jest.spyOn(transaction, 'finish');
+
+    sentryTracingMiddleware(req, res, next);
+    transaction.name = 'overriddenName';
+    res.emit('finish');
+
+    setImmediate(() => {
+      expect(finishTransaction).toHaveBeenCalled();
+      expect(transaction.name).toBe('overriddenName');
+      done();
+    });
+  });
+
   it('strips query string from request path', () => {
     req.url = `${path}?${queryString}`;
 


### PR DESCRIPTION
We are using the express handler in our app, but I was puzzled as to why setting the name of the transaction downstream wasn't being respected. Turns out `addRequestDataToTransaction` was running just before the transaction was sent.

This changes the behaviour to add the data after the transaction is started