### PR TITLE
feat(Angular): Add URL Parameterization of Transaction Names

### DIFF
--- a/packages/angular/src/errorhandler.ts
+++ b/packages/angular/src/errorhandler.ts
@@ -1,7 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { ErrorHandler as AngularErrorHandler, Inject, Injectable } from '@angular/core';
 import * as Sentry from '@sentry/browser';
-import { ReportDialogOptions, showReportDialog } from '@sentry/browser';
 
 import { runOutsideAngular } from './zone';
 
@@ -11,7 +10,7 @@ import { runOutsideAngular } from './zone';
 export interface ErrorHandlerOptions {
   logErrors?: boolean;
   showDialog?: boolean;
-  dialogOptions?: ReportDialogOptions;
+  dialogOptions?: Sentry.ReportDialogOptions;
   /**
    * Custom implementation of error extraction from the raw value captured by the Angular.
    * @param error Value captured by Angular's ErrorHandler provider
@@ -51,7 +50,7 @@ class SentryErrorHandler implements AngularErrorHandler {
 
     // Optionally show user dialog to provide details on what happened.
     if (this._options.showDialog) {
-      showReportDialog({ ...this._options.dialogOptions, eventId });
+      Sentry.showReportDialog({ ...this._options.dialogOptions, eventId });
     }
   }
 

--- a/packages/angular/src/errorhandler.ts
+++ b/packages/angular/src/errorhandler.ts
@@ -1,6 +1,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { ErrorHandler as AngularErrorHandler, Inject, Injectable } from '@angular/core';
 import * as Sentry from '@sentry/browser';
+import { ReportDialogOptions, showReportDialog } from '@sentry/browser';
 
 import { runOutsideAngular } from './zone';
 
@@ -10,7 +11,7 @@ import { runOutsideAngular } from './zone';
 export interface ErrorHandlerOptions {
   logErrors?: boolean;
   showDialog?: boolean;
-  dialogOptions?: Sentry.ReportDialogOptions;
+  dialogOptions?: ReportDialogOptions;
   /**
    * Custom implementation of error extraction from the raw value captured by the Angular.
    * @param error Value captured by Angular's ErrorHandler provider
@@ -50,7 +51,7 @@ class SentryErrorHandler implements AngularErrorHandler {
 
     // Optionally show user dialog to provide details on what happened.
     if (this._options.showDialog) {
-      Sentry.showReportDialog({ ...this._options.dialogOptions, eventId });
+      showReportDialog({ ...this._options.dialogOptions, eventId });
     }
   }
 

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -120,7 +120,7 @@ export class TraceService implements OnDestroy {
   // are made from the new route.
   // In any case, this is the earliest stage where we can reliably get a resolved
   //
-  public resEnd: Observable<Event> = this._router.events.pipe(
+  public resEnd$: Observable<Event> = this._router.events.pipe(
     filter(event => event instanceof ResolveEnd),
     tap(event => {
       const ev = event as ResolveEnd;
@@ -163,7 +163,7 @@ export class TraceService implements OnDestroy {
 
   public constructor(private readonly _router: Router) {
     this._subscription.add(this.navStart$.subscribe());
-    this._subscription.add(this.resEnd.subscribe());
+    this._subscription.add(this.resEnd$.subscribe());
     this._subscription.add(this.navEnd$.subscribe());
   }
 

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -104,15 +104,14 @@ export class TraceService implements OnDestroy {
     }),
   );
 
-  // The ResolveEnd event is fired when the Angular router has resolved the URL
-  // and activated the route. It holds the new resolved router state and the
-  // new URL.
+  // The ResolveEnd event is fired when the Angular router has resolved the URL and
+  // the parameter<->value mapping. It holds the new resolved router state with
+  // the mapping and the new URL.
   // Only After this event, the route is activated, meaning that the transaction
   // can be updated with the parameterized route name before e.g. the route's root
   // component is initialized. This should be early enough before outgoing requests
-  // are made from the new route.
-  // In any case, this is the earliest stage where we can reliably get a resolved
-  //
+  // are made from the new route, with the exceptions of requests being made during
+  // a navigation.
   public resEnd$: Observable<Event> = this._router.events.pipe(
     filter(event => event instanceof ResolveEnd),
     tap(event => {

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -92,7 +92,6 @@ export class TraceService implements OnDestroy {
 
       if (activeTransaction) {
         this._activeTransaction = activeTransaction;
-
         if (this._routingSpan) {
           this._routingSpan.finish();
         }

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -136,7 +136,7 @@ export class TraceService implements OnDestroy {
       const route = getParameterizedRouteFromUrlAndParams(url, params);
 
       const transaction = this._activeTransaction;
-      if (transaction) {
+      if (transaction && transaction.metadata.source === 'url') {
         transaction.setName(route);
         transaction.setMetadata({ source: 'route' });
       }

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -132,6 +132,7 @@ export class TraceService implements OnDestroy {
       // we fall back to ev.url which holds the primarily resolved URL before a potential
       // redirect.
       const url = ev.urlAfterRedirects || ev.url;
+
       const route = getParameterizedRouteFromUrlAndParams(url, params);
 
       const transaction = getActiveTransaction();

--- a/packages/angular/test/tracing.test.ts
+++ b/packages/angular/test/tracing.test.ts
@@ -1,10 +1,17 @@
-import { NavigationStart, Router, RouterEvent } from '@angular/router';
+import { ActivatedRouteSnapshot, ActivationEnd, Event, NavigationStart, Router } from '@angular/router';
 import { Subject } from 'rxjs';
 
 import { instrumentAngularRouting, TraceService } from '../src/index';
 
+type MockedRouter = Router & {
+  setMockParams: (params: any) => void;
+  setMockUrl: (url: string) => void;
+  mockUrl: string;
+};
+
 describe('Angular Tracing', () => {
   const startTransaction = jest.fn();
+
   describe('instrumentAngularRouting', () => {
     it('should attach the transaction source on the pageload transaction', () => {
       instrumentAngularRouting(startTransaction);
@@ -18,15 +25,36 @@ describe('Angular Tracing', () => {
 
   describe('TraceService', () => {
     let traceService: TraceService;
-    const routerEvents$: Subject<RouterEvent> = new Subject();
+    const routerEvents$: Subject<Event> = new Subject();
+    const mockedRouter = {
+      events: routerEvents$,
+      routerState: {
+        snapshot: {
+          root: {
+            params: {},
+            children: [],
+          },
+        },
+      },
 
-    beforeAll(() => instrumentAngularRouting(startTransaction));
+      // router.url is readonly originally.Using a getter lets us return a previously changed URL
+      get url() {
+        return mockedRouter.mockUrl;
+      },
+
+      setMockParams: (params: any) => {
+        mockedRouter.routerState.snapshot.root.params = params;
+      },
+
+      setMockUrl: (url: string) => {
+        mockedRouter.mockUrl = url;
+      },
+    } as unknown as MockedRouter;
+
     beforeEach(() => {
+      instrumentAngularRouting(startTransaction);
       jest.resetAllMocks();
-
-      traceService = new TraceService({
-        events: routerEvents$,
-      } as unknown as Router);
+      traceService = new TraceService(mockedRouter);
     });
 
     afterEach(() => {
@@ -41,6 +69,71 @@ describe('Angular Tracing', () => {
         name: 'user/123/credentials',
         op: 'navigation',
         metadata: { source: 'url' },
+      });
+    });
+
+    describe('URL parameterization', () => {
+      // TODO: These tests are real unit tests in the sense that they only test TraceService
+      //       and we essentially just simulate a router navigation by firing the respective
+      //       routing events and providing the raw URL + the resolved route parameters.
+      //       In the future we should add more "wholesome" tests that let the Angular router
+      //       do its thing (e.g. by calling router.navigate) and we check how our service
+      //       reacts to it.
+      //       Once we set up Jest for testing Angular, we can use TestBed to inject an actual
+      //       router instance into TraceService and add more tests.
+      it.each([
+        ['does not parameterize static routes', '/books/', {}, '/books/'],
+        ['parameterizes number IDs in the URL', '/books/1/details', { bookId: '1' }, '/books/:bookId/details'],
+        [
+          'parameterizes string IDs in the URL',
+          '/books/asd123/details',
+          { bookId: 'asd123' },
+          '/books/:bookId/details',
+        ],
+        [
+          'parameterizes UUID4 IDs in the URL',
+          '/books/04bc6846-4a1e-4af5-984a-003258f33e31/details',
+          { bookId: '04bc6846-4a1e-4af5-984a-003258f33e31' },
+          '/books/:bookId/details',
+        ],
+        [
+          'parameterizes multiple IDs in the URL',
+          '/org/sentry/projects/1234/events/04bc6846-4a1e-4af5-984a-003258f33e31',
+          { orgId: 'sentry', projId: '1234', eventId: '04bc6846-4a1e-4af5-984a-003258f33e31' },
+          '/org/:orgId/projects/:projId/events/:eventId',
+        ],
+      ])('%s and sets the source to `route`', (_, url, params, result) => {
+        const transaction: any = {
+          setName: jest.fn(name => (transaction.name = name)),
+          setMetadata: jest.fn(metadata => (transaction.metadata = metadata)),
+        };
+
+        const customStartTransaction = jest.fn((ctx: any) => {
+          transaction.name = ctx.name;
+          transaction.op = ctx.op;
+          transaction.metadata = ctx.metadata;
+          return transaction;
+        });
+
+        instrumentAngularRouting(customStartTransaction);
+
+        mockedRouter.setMockParams(params);
+        mockedRouter.setMockUrl(url);
+
+        // this event starts the transaction
+        routerEvents$.next(new NavigationStart(0, url));
+
+        expect(customStartTransaction).toHaveBeenCalledWith({
+          name: url,
+          op: 'navigation',
+          metadata: { source: 'url' },
+        });
+
+        // this event starts the parameterization
+        routerEvents$.next(new ActivationEnd(new ActivatedRouteSnapshot()));
+
+        expect(transaction.setName).toHaveBeenCalledWith(result);
+        expect(transaction.setMetadata).toHaveBeenCalledWith({ source: 'route' });
       });
     });
   });

--- a/packages/angular/test/tracing.test.ts
+++ b/packages/angular/test/tracing.test.ts
@@ -5,8 +5,6 @@ import { Subject } from 'rxjs';
 import { instrumentAngularRouting, TraceService } from '../src/index';
 import { getParameterizedRouteFromUrlAndParams, getParamsOfRoute } from '../src/tracing';
 
-//import * as Sentry from '../src/index';
-// import { Transaction } from '@sentry/types';
 let transaction: any;
 let customStartTransaction: (context: any) => Transaction | undefined;
 

--- a/packages/angular/test/tracing.test.ts
+++ b/packages/angular/test/tracing.test.ts
@@ -190,13 +190,7 @@ describe('Angular Tracing', () => {
 
   describe('getParameterizedRouteFromSnapshot', () => {
     it.each([
-      [
-        'returns `/` empty object if the route no children',
-        {
-          firstChild: { routeConfig: null },
-        },
-        '/',
-      ],
+      ['returns `/` empty object if the route no children', {}, '/'],
       [
         'returns the route of a snapshot without children',
         {


### PR DESCRIPTION
This PR introduces URL Parameterization to our Angular SDK. With this change, the SDK will update transaction names coming from a URL with a paramterized version of the URL (e.g `GET /users/1235/details` will be parameterized to `GET /users/:userId/details/`).

This is done by listening to the `ResolveEnd` routing event in `TraceService`. When this event is fired, the Angular router has finished resolving the new URL and found the correct route. Besides the url, the event contains a snapshot of the resolved and soon-to-be activated route. This `ActivatedRouteSnapshot` instance is the root instance of the activated route. If the resolved route is something other than `''` or `'/'`, it will also points to its first child. This instance might again point to its (a possibly existing) child but it also holds its part of the resolved and parameterized route path (URL). 
By recursively concatenating the paths, we get a fully parameterized URL. 

The main advantage of this approach vs. a previously tried URL<->parameter interpolation approach is that we do not run into the danger of making interpolation mistakes or leaving parts of the route unparameterized. We now simply take what the Angular router has already resolved.

The potential disadvantage is that we rely on the assumption that there is only one child per route snapshot. While testing, I didn't come across a situation where a parent snapshot had more than one child. I believe that this is because the `ResolveEnd` event contains a snapshot of the newly activated route and not the complete router state. However, if we get reports of incorrect transaction names, we might want to revisit this parameterization approach.  

It should be noted that because there is a gap between transaction creation (where we initially set the unparameterized name) and URL parameterization, it is possible that parameterization might happen after an outgoing Http request is made. In that case, the dynamic sampling context will be populated and frozen without the `transaction` field because at this point the transaction name's source is still `url`. This means that we have a potential timing problem, similar to other routing instrumentations. 
At this point we're not yet sure how often such a timing problem would occur but it seems pretty unlikely for normal usage. For instance, DSC population will happen correctly (with the `transaction` field) when the first outgoing Http request is fired in the constructor of the component that is associated with the new route. This also means that hooks like `ngOnInit` which are frequently used for making requests (e.g. via Service calls) are called long after the `ResolveEnd` routing event.  

Additionally, this PR adds a few unit tests to test this new behaviour. However, these tests are really unit tests, meaning they only test our `TraceService` implementation. We currently simply mock the Angular router and fire the routing events manually. A more "wholesome" approach (e.g. calling `router.navigate` instead of manually firing events) would be better but for this we'd need to inject an actual Angular Router into `TraceService`. This is done best with Angular's `TestBed` feature but it currently doesn't work with our testing setup for the Angular SDK. Changing the setup is out of scope for this PR but we'll revisit this and make the necessary changes to improve the testing setup of our Angular SDK.

ref: #5342 
