### PR TITLE
ref(utils): Improve uuid generation

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -12,6 +12,11 @@ interface MsCryptoWindow extends Window {
   msCrypto?: Crypto;
 }
 
+/** Many browser now support native uuid v4 generation */
+interface CryptoWithRandomUUID extends Crypto {
+  randomUUID?(): string;
+}
+
 /**
  * UUID4 generator
  *
@@ -19,40 +24,21 @@ interface MsCryptoWindow extends Window {
  */
 export function uuid4(): string {
   const global = getGlobalObject() as MsCryptoWindow;
-  const crypto = global.crypto || global.msCrypto;
+  const crypto = (global.crypto || global.msCrypto) as CryptoWithRandomUUID;
 
-  if (!(crypto === void 0) && crypto.getRandomValues) {
-    // Use window.crypto API if available
-    const arr = new Uint16Array(8);
-    crypto.getRandomValues(arr);
-
-    // set 4 in byte 7
-    // eslint-disable-next-line no-bitwise
-    arr[3] = (arr[3] & 0xfff) | 0x4000;
-    // set 2 most significant bits of byte 9 to '10'
-    // eslint-disable-next-line no-bitwise
-    arr[4] = (arr[4] & 0x3fff) | 0x8000;
-
-    const pad = (num: number): string => {
-      let v = num.toString(16);
-      while (v.length < 4) {
-        v = `0${v}`;
-      }
-      return v;
-    };
-
-    return (
-      pad(arr[0]) + pad(arr[1]) + pad(arr[2]) + pad(arr[3]) + pad(arr[4]) + pad(arr[5]) + pad(arr[6]) + pad(arr[7])
-    );
+  if (crypto && crypto.randomUUID) {
+    return crypto.randomUUID().replace(/-/g, '');
   }
+
+  const getRandomByte =
+    crypto && crypto.getRandomValues ? () => crypto.getRandomValues(new Uint8Array(1))[0] : () => Math.random() * 16;
+
   // http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript/2117523#2117523
-  return 'xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx'.replace(/[xy]/g, c => {
+  // Concatenating the following numbers as strings results in '10000000100040008000100000000000'
+  return (([1e7] as unknown as string) + 1e3 + 4e3 + 8e3 + 1e11).replace(/[018]/g, c =>
     // eslint-disable-next-line no-bitwise
-    const r = (Math.random() * 16) | 0;
-    // eslint-disable-next-line no-bitwise
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
+    ((c as unknown as number) ^ ((getRandomByte() & 15) >> ((c as unknown as number) / 4))).toString(16),
+  );
 }
 
 /**

--- a/packages/utils/test/misc.test.ts
+++ b/packages/utils/test/misc.test.ts
@@ -6,6 +6,7 @@ import {
   checkOrSetAlreadyCaught,
   getEventDescription,
   stripUrlQueryAndFragment,
+  uuid4,
 } from '../src/misc';
 
 describe('getEventDescription()', () => {
@@ -296,5 +297,13 @@ describe('checkOrSetAlreadyCaught()', () => {
 
     expect(checkOrSetAlreadyCaught(exception)).toBe(false);
     expect((exception as any).__sentry_captured__).toBe(true);
+  });
+});
+
+describe('uuid4 generation', () => {
+  it('returns valid uuid v4 ids', () => {
+    for (let index = 0; index < 1_000; index++) {
+      expect(uuid4()).toMatch(/^[0-9A-F]{12}[4][0-9A-F]{3}[89AB][0-9A-F]{15}$/i);
+    }
   });
 });

--- a/packages/utils/test/misc.test.ts
+++ b/packages/utils/test/misc.test.ts
@@ -310,6 +310,7 @@ describe('uuid4 generation', () => {
   });
 
   it('returns valid uuid v4 ids via crypto.getRandomValues', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const cryptoMod = require('crypto');
 
     (global as any).crypto = { getRandomValues: cryptoMod.getRandomValues };
@@ -320,6 +321,7 @@ describe('uuid4 generation', () => {
   });
 
   it('returns valid uuid v4 ids via crypto.randomUUID', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const cryptoMod = require('crypto');
 
     (global as any).crypto = { randomUUID: cryptoMod.randomUUID };

--- a/packages/utils/test/misc.test.ts
+++ b/packages/utils/test/misc.test.ts
@@ -301,7 +301,29 @@ describe('checkOrSetAlreadyCaught()', () => {
 });
 
 describe('uuid4 generation', () => {
-  it('returns valid uuid v4 ids', () => {
+  // Jest messes with the global object, so there is no global crypto object in any node version
+  // For this reason we need to create our own crypto object for each test to cover all the code paths
+  it('returns valid uuid v4 ids via Math.random', () => {
+    for (let index = 0; index < 1_000; index++) {
+      expect(uuid4()).toMatch(/^[0-9A-F]{12}[4][0-9A-F]{3}[89AB][0-9A-F]{15}$/i);
+    }
+  });
+
+  it('returns valid uuid v4 ids via crypto.getRandomValues', () => {
+    const cryptoMod = require('crypto');
+
+    (global as any).crypto = { getRandomValues: cryptoMod.getRandomValues };
+
+    for (let index = 0; index < 1_000; index++) {
+      expect(uuid4()).toMatch(/^[0-9A-F]{12}[4][0-9A-F]{3}[89AB][0-9A-F]{15}$/i);
+    }
+  });
+
+  it('returns valid uuid v4 ids via crypto.randomUUID', () => {
+    const cryptoMod = require('crypto');
+
+    (global as any).crypto = { randomUUID: cryptoMod.randomUUID };
+
     for (let index = 0; index < 1_000; index++) {
       expect(uuid4()).toMatch(/^[0-9A-F]{12}[4][0-9A-F]{3}[89AB][0-9A-F]{15}$/i);
     }


### PR DESCRIPTION
Since [modern browsers](https://caniuse.com/mdn-api_crypto_randomuuid) support `crypto.randomUUID()` it's probably a good idea to use that when available. 
Rather than let this impact bundle size, I also took some of the recent updates from the linked stackoverflow question.

- Shaves ~160 bytes off the browser bundle
- I have validated that all code paths do in fact return valid uuidv4 ids with hyphens removed!
- Modern platforms bail out quickly with `crypto.randomUUID()`
- Less modern browsers (including IE11 and Safari < v15.4) use `crypto.getRandomValues()`
- Node.js 
  - `< v15` uses `Math.random()`
  - `v15 > v16.7 uses` `crypto.getRandomValues()`
  - `>= v16.7 uses` `crypto.randomUUID()`


Downsides vs previous code:
- The "code golf" style code is nasty but since this is a utility function that will likely go untouched until it's replaced on all platforms with `crypto.randomUUID()`, this may be less of a concern. I added a comment for the most confusing number+string concat part.
- When using `crypto.getRandomValues()`, it's called multiple times rather than a single time with `new Uint16Array(8)` which could marginally affect performance.