### PR TITLE
fix(remix): Clone erroneous responses not to consume their body streams.

### DIFF
--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -84,16 +84,19 @@ function isResponse(value: any): value is Response {
   );
 }
 
-// Taken from Remix Implementation
+// Based on Remix Implementation
 // https://github.com/remix-run/remix/blob/7688da5c75190a2e29496c78721456d6e12e3abe/packages/remix-server-runtime/data.ts#L131-L145
 function extractData(response: Response): Promise<unknown> {
   const contentType = response.headers.get('Content-Type');
 
+  // Cloning the response to avoid consuming the original body stream
+  const responseClone = response.clone();
+
   if (contentType && /\bapplication\/json\b/.test(contentType)) {
-    return response.json();
+    return responseClone.json();
   }
 
-  return response.text();
+  return responseClone.text();
 }
 
 function captureRemixServerException(err: Error, name: string): void {


### PR DESCRIPTION
Fixes: #5423

Ref: #5405 

We were extracting the bodies of 4xx/5xx responses to capture, but Remix also uses them, we should not consume their `body` streams, as they are only available once in response lifespans. 

This PR updates `extractData` to work on a clone response.