### PR TITLE
fix(remix): Do not capture 4xx codes from thrown responses.

### DIFF
--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -97,9 +97,9 @@ function extractData(response: Response): Promise<unknown> {
 }
 
 function captureRemixServerException(err: Error, name: string): void {
-  // Skip capturing if the thrown error is an OK Response
+  // Skip capturing if the thrown error is not a 5xx response
   // https://remix.run/docs/en/v1/api/conventions#throwing-responses-in-loaders
-  if (isResponse(err) && err.status < 400) {
+  if (isResponse(err) && err.status < 500) {
     return;
   }
 


### PR DESCRIPTION
Fixes: #5425 

Ref: #5429, #5405 

As per review https://github.com/getsentry/sentry-javascript/pull/5429#issuecomment-1189139234, we need to define how and when we should capture a 4xx error.

We will only capture thrown 5xx responses until then.