### PR TITLE
fix(nextjs): Stop using `eval` when checking for `sentry-cli` binary

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -325,11 +325,17 @@ export function getWebpackPluginOptions(
 }
 
 /**
- * NOTE: `eval` usage is a workaround for @vercel/nft detecting the binary itself as the hard dependency
- *       and effectively always including it in the bundle, which is not what we want.
+ * NOTE: We're faking `require.resolve` here as a workaround for @vercel/nft detecting the binary itself as a hard
+ *       dependency and always including it in the bundle, which is not what we want.
+ *
  * ref: https://github.com/getsentry/sentry-javascript/issues/3865
  * ref: https://github.com/vercel/nft/issues/203
  */
 function ensureCLIBinaryExists(): boolean {
-  return eval("fs.existsSync(path.join(require.resolve('@sentry/cli'), '../../sentry-cli'))");
+  for (const node_modulesPath of module.paths) {
+    if (fs.existsSync(path.resolve(node_modulesPath, '@sentry/cli/sentry-cli'))) {
+      return true;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/4988, we switched to using `eval` in `ensureCLIBinaryExists` (called by our build-time config code in the nextjs SDK), in order to prevent Vercel's dependency-tracing algorithm from thinking the binary was a (n enormous) dependency and including it in people's serverless functions. (It was getting tricked by the `require.resolve()` call; turning that call into a string was the only way we could find to hide it from the algorithm.)

But `eval` is kind of gross. And Rollup, which agrees it's gross, keeps yelling at us for using it. In order to suppress the warnings and generally clean things up, this replaces the `eval` with real code again, and in that real code replaces the `require.resolve()` call with a manual check of all of the paths `require.resolve()` would consider. No `require` means no confused algorithm means no erroneously bundled cli binary in Vercel. And no `eval` means happy Rollup means happy us, because now it's easier to see when the build has legit errors. Wins all around.
