### PR TITLE
ref(node): Improve Express URL Parameterization

### DIFF
--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
@@ -80,7 +80,7 @@ test('Should populate and propagate sentry baggage if sentry-trace header does n
       host: 'somewhere.not.sentry',
       // TraceId changes, hence we only expect that the string contains the traceid key
       baggage: expect.stringContaining(
-        'sentry-environment=prod,sentry-release=1.0,sentry-public_key=public,sentry-trace_id=',
+        'sentry-environment=prod,sentry-release=1.0,sentry-transaction=GET%20%2Ftest%2Fexpress,sentry-public_key=public,sentry-trace_id=',
       ),
     },
   });
@@ -99,7 +99,7 @@ test('Should populate Sentry and ignore 3rd party content if sentry-trace header
       host: 'somewhere.not.sentry',
       // TraceId changes, hence we only expect that the string contains the traceid key
       baggage: expect.stringContaining(
-        'sentry-environment=prod,sentry-release=1.0,sentry-public_key=public,sentry-trace_id=',
+        'sentry-environment=prod,sentry-release=1.0,sentry-transaction=GET%20%2Ftest%2Fexpress,sentry-public_key=public,sentry-trace_id=',
       ),
     },
   });

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out-bad-tx-name/server.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out-bad-tx-name/server.ts
@@ -27,6 +27,7 @@ app.get('/test/express', (_req, res) => {
   const transaction = Sentry.getCurrentHub().getScope()?.getTransaction();
   if (transaction) {
     transaction.traceId = '86f39e84263a4de99c326acab3bfe3bd';
+    transaction.metadata.source = undefined;
   }
   const headers = http.get('http://somewhere.not.sentry/').getHeaders();
 

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out-bad-tx-name/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out-bad-tx-name/test.ts
@@ -3,18 +3,17 @@ import * as path from 'path';
 import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
-test('should attach a `baggage` header to an outgoing request.', async () => {
+test('Does not include transaction name if transaction source is not set', async () => {
   const url = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
   const response = (await getAPIResponse(new URL(`${url}/express`))) as TestAPIResponse;
+  const baggageString = response.test_data.baggage;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
     test_data: {
       host: 'somewhere.not.sentry',
-      baggage:
-        'sentry-environment=prod,sentry-release=1.0,sentry-transaction=GET%20%2Ftest%2Fexpress,sentry-user_segment=SegmentA' +
-        ',sentry-public_key=public,sentry-trace_id=86f39e84263a4de99c326acab3bfe3bd,sentry-sample_rate=1',
     },
   });
+  expect(baggageString).not.toContain('sentry-transaction=');
 });

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/server.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/server.ts
@@ -27,6 +27,7 @@ app.get('/test/express', (_req, res) => {
   const transaction = Sentry.getCurrentHub().getScope()?.getTransaction();
   if (transaction) {
     transaction.traceId = '86f39e84263a4de99c326acab3bfe3bd';
+    transaction.metadata.source = undefined;
   }
   const headers = http.get('http://somewhere.not.sentry/').getHeaders();
 

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/test.ts
@@ -30,7 +30,7 @@ test('should ignore sentry-values in `baggage` header of a third party vendor an
     test_data: {
       host: 'somewhere.not.sentry',
       baggage: expect.stringContaining(
-        'other=vendor,foo=bar,third=party,last=item,sentry-environment=prod,sentry-release=1.0,sentry-public_key=public',
+        'other=vendor,foo=bar,third=party,last=item,sentry-environment=prod,sentry-release=1.0,sentry-transaction=GET%20%2Ftest%2Fexpress,sentry-public_key=public',
       ),
     },
   });

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -65,7 +65,9 @@ export function tracingHandler(): (
       // Push `transaction.finish` to the next event loop so open spans have a chance to finish before the transaction
       // closes
       setImmediate(() => {
-        addRequestDataToTransaction(transaction, req);
+        if (!transaction.metadata.source || transaction.metadata.source === 'url') {
+          addRequestDataToTransaction(transaction, req);
+        }
         transaction.setHttpStatus(res.statusCode);
         transaction.finish();
       });

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -40,12 +40,13 @@ export function tracingHandler(): (
 
     const baggage = parseBaggageSetMutability(rawBaggageString, traceparentData);
 
+    const [name, source] = extractPathForTransaction(req, { path: true, method: true });
     const transaction = startTransaction(
       {
-        name: extractPathForTransaction(req, { path: true, method: true }),
+        name,
         op: 'http.server',
         ...traceparentData,
-        metadata: { baggage },
+        metadata: { baggage, source },
       },
       // extra context passed to the tracesSampler
       { request: extractRequestData(req) },

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -65,9 +65,7 @@ export function tracingHandler(): (
       // Push `transaction.finish` to the next event loop so open spans have a chance to finish before the transaction
       // closes
       setImmediate(() => {
-        if (!transaction.metadata.source || transaction.metadata.source === 'url') {
-          addRequestDataToTransaction(transaction, req);
-        }
+        addRequestDataToTransaction(transaction, req);
         transaction.setHttpStatus(res.statusCode);
         transaction.finish();
       });

--- a/packages/node/test/requestdata.test.ts
+++ b/packages/node/test/requestdata.test.ts
@@ -572,7 +572,11 @@ describe('extractPathForTransaction', () => {
       originalUrl: '/api/users/123/details',
     } as CrossPlatformRequest;
 
-    const [route, source] = extractPathForTransaction(req, { path: true, method: true }, '/other/path/:id/details');
+    const [route, source] = extractPathForTransaction(req, {
+      path: true,
+      method: true,
+      customRoute: '/other/path/:id/details',
+    });
 
     expect(route).toEqual('GET /other/path/:id/details');
     expect(source).toEqual('route');

--- a/packages/tracing/src/integrations/node/express.ts
+++ b/packages/tracing/src/integrations/node/express.ts
@@ -1,5 +1,4 @@
 /* eslint-disable max-lines */
-import { getCurrentHub } from '@sentry/hub';
 import { Integration, Transaction } from '@sentry/types';
 import { CrossPlatformRequest, extractPathForTransaction, logger } from '@sentry/utils';
 
@@ -266,7 +265,7 @@ function instrumentRouter(appOrRouter: ExpressRouter): void {
     layer: Layer,
     called: unknown,
     req: PatchedRequest,
-    res: ExpressResponse,
+    res: ExpressResponse & SentryTracingResponse,
     done: () => unknown,
   ) {
     // Base case: We're in the first part of the URL (thus we start with the root '/')
@@ -298,7 +297,7 @@ function instrumentRouter(appOrRouter: ExpressRouter): void {
     const urlLength = req.originalUrl?.split('/').filter(s => s.length > 0).length;
     const routeLength = req._reconstructedRoute.split('/').filter(s => s.length > 0).length;
     if (urlLength === routeLength) {
-      const transaction = getCurrentHub().getScope()?.getTransaction();
+      const transaction = res.__sentry_transaction;
       if (transaction && transaction.metadata.source !== 'custom') {
         const finalRoute = req._reconstructedRoute.replace(/\/$/, '');
         transaction.setName(...extractPathForTransaction(req, { path: true, method: true }, finalRoute));

--- a/packages/tracing/src/integrations/node/express.ts
+++ b/packages/tracing/src/integrations/node/express.ts
@@ -304,7 +304,7 @@ function instrumentRouter(appOrRouter: ExpressRouter): void {
         // Therefore, we fall back to setting the final route to '/' in this case.
         const finalRoute = req._reconstructedRoute || '/';
 
-        transaction.setName(...extractPathForTransaction(req, { path: true, method: true }, finalRoute));
+        transaction.setName(...extractPathForTransaction(req, { path: true, method: true, customRoute: finalRoute }));
       }
     }
 

--- a/packages/tracing/src/integrations/node/express.ts
+++ b/packages/tracing/src/integrations/node/express.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 import { getCurrentHub } from '@sentry/hub';
 import { Integration, Transaction } from '@sentry/types';
-import { CrossPlatformRequest, logger } from '@sentry/utils';
+import { CrossPlatformRequest, extractPathForTransaction, logger } from '@sentry/utils';
 
 type Method =
   | 'all'
@@ -301,9 +301,7 @@ function instrumentRouter(appOrRouter: ExpressRouter): void {
       const transaction = getCurrentHub().getScope()?.getTransaction();
       if (transaction && transaction.metadata.source !== 'custom') {
         const finalRoute = req._reconstructedRoute.replace(/\/$/, '');
-        const method = req.method && req.method.toUpperCase();
-        transaction.setName(`${method} ${finalRoute}`, 'route');
-        logger.debug('TX is now called', transaction.name);
+        transaction.setName(...extractPathForTransaction(req, { path: true, method: true }, finalRoute));
       }
     }
 

--- a/packages/utils/src/requestdata.ts
+++ b/packages/utils/src/requestdata.ts
@@ -113,7 +113,9 @@ export function addRequestDataToTransaction(
   deps?: InjectedNodeDeps,
 ): void {
   if (!transaction) return;
-  transaction.name = extractPathForTransaction(req, { path: true, method: true });
+  if (!transaction.metadata.source || transaction.metadata.source === 'url') {
+    transaction.name = extractPathForTransaction(req, { path: true, method: true });
+  }
   transaction.setData('url', req.originalUrl || req.url);
   if (req.baseUrl) {
     transaction.setData('baseUrl', req.baseUrl);

--- a/packages/utils/src/requestdata.ts
+++ b/packages/utils/src/requestdata.ts
@@ -114,6 +114,7 @@ export function addRequestDataToTransaction(
 ): void {
   if (!transaction) return;
   if (!transaction.metadata.source || transaction.metadata.source === 'url') {
+    // Attempt to grab a parameterized route off of the request
     transaction.setName(...extractPathForTransaction(req, { path: true, method: true }));
   }
   transaction.setData('url', req.originalUrl || req.url);

--- a/packages/utils/src/requestdata.ts
+++ b/packages/utils/src/requestdata.ts
@@ -133,15 +133,14 @@ export function addRequestDataToTransaction(
  * eg. GET /mountpoint/user/:id
  *
  * @param req A request object
- * @param options What to include in the transaction name (method, path, or both)
- * @param customRoute An optional string that should be used as transaction name instead of the requests path
+ * @param options What to include in the transaction name (method, path, or a custom route name to be
+ *                used instead of the request's route)
  *
- * @returns A tuple of the fully constructed transaction name [0] and its source [1] (can be either route or url)
+ * @returns A tuple of the fully constructed transaction name [0] and its source [1] (can be either 'route' or 'url')
  */
 export function extractPathForTransaction(
   req: CrossPlatformRequest,
-  options: { path?: boolean; method?: boolean } = {},
-  customRoute?: string,
+  options: { path?: boolean; method?: boolean; customRoute?: string } = {},
 ): [string, TransactionSource] {
   const method = req.method && req.method.toUpperCase();
 
@@ -149,8 +148,8 @@ export function extractPathForTransaction(
   let source: TransactionSource = 'url';
 
   // Check to see if there's a parameterized route we can use (as there is in Express)
-  if (customRoute || req.route) {
-    path = customRoute || `${req.baseUrl || ''}${req.route && req.route.path}`;
+  if (options.customRoute || req.route) {
+    path = options.customRoute || `${req.baseUrl || ''}${req.route && req.route.path}`;
     source = 'route';
   }
 


### PR DESCRIPTION
This PR improves the URL parameterization for transaction names in our Express integration.

Previously, we would only obtain a parameterized version of the incoming request's URL **after** the registered handler(s) finished their job, right before we called `transaction.finish()`. This is definitely too late for DSC propagation, if the handlers made any outgoing request. In that case, the DSC (propagated via the `baggage` header) would not contain a transaction name.

As of this PR, we patch the `Express.Router` prototype, more precisely the `process_params` function. This function contains a reference to the incoming `req` object as well as to the `layer` that matched the route. We hook into the function to extract the matched and parameterized partial route of the layer and we attach it to the `req` object. This happens for every matched layer, until the entire route is resolved, in which stichtched together the entire parameterized route. 

For the time being, we deliberately ignore route registrations with wildcards (e.g. `app.get('/*', ...)`) when stitching together the parameterized route. After we added a new part to the reconstructed route, we check if it has the same number of segments as the original (raw) URL. In case it has, we assume that the parameterized route is complete and we update the active transaction with the parameterized name. Additionally, we set the transaction source to `route` at this point. In case we never get to the point where we have an equal amount of URL segments, the transaction name is never updated, meaning its source stays `url` (and therefore, it's not added to the DSC). In that case, we continue to update the transaction name like before right before the end of the transaction.

After reading the Express source code, we confirmed that the process for resolving parts of a route and handling it is performed sequentially **for each matched route segment**. This means that each matched layer's handle function is invoked before the next part of the URL is matched. We therefore still have timing issues around DSC population if any of those intermediate handler functions make outgoing requests. A simple example:

The incoming request is `/api/users/123`
* We intercept the request and start the transaction with the name `/api/users/123` and source `url`
* The first layer that matches is matches the route `/*`.
  * We start reconstructing the parameterized route with `/`
  * The handle function of this layer is invoked (e.g. to check authentication)
    *  the handler makes an XHR request 
      * at this point, we populate and freeze the DSC (without transaction name)
* The second handler matches the route `/api/users/123`
  * We obtain the parameterized route and our reconstructed route is now `/api/users/:id`
  * Now we have 3 segments in the original and in the reconstructed route
  * We update the transaction name with `/api/users/:id` and set its source to `route`
  * The handle function of this layer is invoked
    * every request that might happen here will still propagate the DSC from layer 1 because it can't be modified
* We finish the transaction

This example shows that we still have timing issues w.r.t DSC propagation. That is, assuming that the Node SDK is in this case the head of the trace and it didn't intercept incoming DSC from the incoming request.
However, with this PR we now at least have the chance to get the correct transaction name early enough.

ref: #5342 