### PR TITLE
fix(nextjs): Remove sentry property from returned next config

### DIFF
--- a/packages/nextjs/src/config/index.ts
+++ b/packages/nextjs/src/config/index.ts
@@ -17,16 +17,26 @@ export function withSentryConfig(
   if (typeof userNextConfig === 'function') {
     return function (phase: string, defaults: { defaultConfig: NextConfigObject }): Partial<NextConfigObject> {
       const materializedUserNextConfig = userNextConfig(phase, defaults);
+      const webpack = constructWebpackConfigFunction(materializedUserNextConfig, userSentryWebpackPluginOptions);
+      
+      // Next 12.2.3+ warns about additional properties on the config
+      delete materializedUserNextConfig.sentry;
+      
       return {
         ...materializedUserNextConfig,
-        webpack: constructWebpackConfigFunction(materializedUserNextConfig, userSentryWebpackPluginOptions),
+        webpack,
       };
     };
   }
 
   // Otherwise, we can just merge their config with ours and return an object.
+  const webpack = constructWebpackConfigFunction(userNextConfig, userSentryWebpackPluginOptions);
+
+  // Next 12.2.3+ warns about additional properties on the config
+  delete userNextConfig.sentry
+  
   return {
     ...userNextConfig,
-    webpack: constructWebpackConfigFunction(userNextConfig, userSentryWebpackPluginOptions),
+    webpack,
   };
 }


### PR DESCRIPTION
Next recently added config validation https://github.com/vercel/next.js/pull/38498 so `withSentryConfig` should remove the additional `sentry` property to avoid these warnings.

Fixes https://github.com/getsentry/sentry-javascript/issues/5449

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
