### PR TITLE
chore(nextjs/gatsby/remix): Bump webpack plugin to 1.19.0

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -24,7 +24,7 @@
     "@sentry/tracing": "7.7.0",
     "@sentry/types": "7.7.0",
     "@sentry/utils": "7.7.0",
-    "@sentry/webpack-plugin": "1.18.9"
+    "@sentry/webpack-plugin": "1.19.0"
   },
   "peerDependencies": {
     "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -25,7 +25,7 @@
     "@sentry/tracing": "7.7.0",
     "@sentry/types": "7.7.0",
     "@sentry/utils": "7.7.0",
-    "@sentry/webpack-plugin": "1.18.9",
+    "@sentry/webpack-plugin": "1.19.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -29,7 +29,7 @@
     "@sentry/tracing": "7.7.0",
     "@sentry/types": "7.7.0",
     "@sentry/utils": "7.7.0",
-    "@sentry/webpack-plugin": "1.18.9",
+    "@sentry/webpack-plugin": "1.19.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4445,10 +4445,10 @@
     proxy-from-env "^1.1.0"
     which "^2.0.2"
 
-"@sentry/webpack-plugin@1.18.9":
-  version "1.18.9"
-  resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-1.18.9.tgz#acb48c0f96fdb9e73f1e1db374ea31ded6d883a8"
-  integrity sha512-+TrenJrgFM0QTOwBnw0ZXWMvc0PiOebp6GN5EbGEx3JPCQqXOfXFzCaEjBtASKRgcNCL7zGly41S25YR6Hm+jw==
+"@sentry/webpack-plugin@1.19.0":
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/@sentry/webpack-plugin/-/webpack-plugin-1.19.0.tgz#2b134318f1552ba7f3e3f9c83c71a202095f7a44"
+  integrity sha512-qSpdgdGMtdzagGveSWgo2b+t8PdPUscuOjbOyWCsJme9jlTFnNk0rX7JEA55OUozikKHM/+vVh08USLBnPboZw==
   dependencies:
     "@sentry/cli" "^1.74.4"
 


### PR DESCRIPTION
This updates our dependency in order to take advantage of https://github.com/getsentry/sentry-webpack-plugin/pull/389.

Fixes https://github.com/getsentry/sentry-javascript/issues/5424
