### PR TITLE
fix(nextjs): Remove index signaure in `captureUnderscoreErrorException` argument type

### DIFF
--- a/packages/nextjs/src/utils/_error.ts
+++ b/packages/nextjs/src/utils/_error.ts
@@ -4,10 +4,10 @@ import { addExceptionMechanism, addRequestDataToEvent } from '@sentry/utils';
 import { NextPageContext } from 'next';
 
 type ContextOrProps = {
-  [key: string]: unknown;
   req?: NextPageContext['req'];
   res?: NextPageContext['res'];
   err?: NextPageContext['err'] | string;
+  pathname?: string;
   statusCode?: number;
 };
 


### PR DESCRIPTION
This removes the index signature in the `ContextOrProps` type in our nextjs `_error` helper function, `captureUnderscoreErrorException`, as it's causing build errors for people writing their `_error` page in TS.

Note: The [problem I anticipated](https://github.com/getsentry/sentry-javascript/issues/5448#issuecomment-1194786778), which led me to add it in the first place, hasn't materialized in my testing. 

Fixes https://github.com/getsentry/sentry-javascript/issues/5448.
