### PR TITLE
feat(tracing): Allow storing span metadata

### DIFF
--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -89,7 +89,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
   /**
    * @inheritDoc
    */
-  public setMetadata(newMetadata: TransactionMetadata): void {
+  public setMetadata(newMetadata: Partial<TransactionMetadata>): void {
     this.metadata = { ...this.metadata, ...newMetadata };
   }
 

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -42,7 +42,11 @@ export class Transaction extends SpanClass implements TransactionInterface {
 
     this._name = transactionContext.name || '';
 
-    this.metadata = transactionContext.metadata || {};
+    this.metadata = {
+      ...transactionContext.metadata,
+      spanMetadata: {},
+    };
+
     this._trimEnd = transactionContext.trimEnd;
 
     // this is because transactions are also spans, and spans have a transaction pointer

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -147,6 +147,9 @@ export interface TransactionMetadata {
 
   /** Information on how a transaction name was generated. */
   source?: TransactionSource;
+
+  /** Metadata for the transaction's spans, keyed by spanId */
+  spanMetadata: { [spanId: string]: { [key: string]: unknown } };
 }
 
 /**

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -27,7 +27,7 @@ export interface TransactionContext extends SpanContext {
   /**
    * Metadata associated with the transaction, for internal SDK use.
    */
-  metadata?: TransactionMetadata;
+  metadata?: Partial<TransactionMetadata>;
 }
 
 /**
@@ -93,7 +93,7 @@ export interface Transaction extends TransactionContext, Span {
    * Set metadata for this transaction.
    * @hidden
    */
-  setMetadata(newMetadata: TransactionMetadata): void;
+  setMetadata(newMetadata: Partial<TransactionMetadata>): void;
 
   /** return the baggage for dynamic sampling and trace propagation */
   getBaggage(): Baggage;


### PR DESCRIPTION
This adds span metadata to the `TransactionMetadata` type and the default value given to the `metadata` property in the `Transaction` constructor. I chose to add a property to `TransactionMetadata` rather than create a new `SpanMetadata` type/property which would live on the `Span` class because by doing the former, we don't have to worry about looping over the spans and deleting the metadata before the transaction is sent - everything in `transaction.metadata` (which becomes `event.sdkProcessingMetadata`) [is already cleared when the envelope is created](https://github.com/getsentry/sentry-javascript/blob/8a06b16d605ca3a1fa6c9af2a701f332e39799ed/packages/core/src/envelope.ts#L86).

In order to not have to assert on its existence every time it's used, I made `spanMetadata` a required property of `TransactionMetadata`. In order to satisfy that required-ness, a few other things had to happen:
- It had to be initialized in the `Transaction` constructor. (Note that there should never be incoming span metadata because the only span at that point is the transaction itself, and its metadata can and does already live in the main `metadata` object. This means there's no need to do `span: metadata.span || {}` when initializing it. )
- The metadata passed to the constructor in the transaction context needed to become a partial (which it effectively already was, since until now all properties have been optional).
- The metadata passed to `setMetadata` similarly had to become a partial.