### PR TITLE
feat(react): Use state context for Redux integration

### DIFF
--- a/packages/react/src/redux.ts
+++ b/packages/react/src/redux.ts
@@ -68,7 +68,6 @@ export interface SentryEnhancerOptions<S = any> {
 
 const ACTION_BREADCRUMB_CATEGORY = 'redux.action';
 const ACTION_BREADCRUMB_TYPE = 'info';
-const STATE_CONTEXT_KEY = 'redux.state';
 
 const defaultOptions: SentryEnhancerOptions = {
   actionTransformer: action => action,
@@ -106,9 +105,9 @@ function createReduxEnhancer(enhancerOptions?: Partial<SentryEnhancerOptions>): 
           /* Set latest state to scope */
           const transformedState = options.stateTransformer(newState);
           if (typeof transformedState !== 'undefined' && transformedState !== null) {
-            scope.setContext(STATE_CONTEXT_KEY, transformedState);
+            scope.setContext('state', { type: 'redux', value: transformedState });
           } else {
-            scope.setContext(STATE_CONTEXT_KEY, null);
+            scope.setContext('state', null);
           }
 
           /* Allow user to configure scope with latest state */

--- a/packages/react/test/redux.test.ts
+++ b/packages/react/test/redux.test.ts
@@ -63,8 +63,11 @@ describe('createReduxEnhancer', () => {
     const updateAction = { type: ACTION_TYPE, newValue: 'updated' };
     store.dispatch(updateAction);
 
-    expect(mockSetContext).toBeCalledWith('redux.state', {
-      value: 'updated',
+    expect(mockSetContext).toBeCalledWith('state', {
+      type: 'redux',
+      value: {
+        value: 'updated',
+      },
     });
   });
 
@@ -84,9 +87,12 @@ describe('createReduxEnhancer', () => {
 
       Redux.createStore((state = initialState) => state, enhancer);
 
-      expect(mockSetContext).toBeCalledWith('redux.state', {
-        superSecret: 'REDACTED',
-        value: 123,
+      expect(mockSetContext).toBeCalledWith('state', {
+        type: 'redux',
+        value: {
+          superSecret: 'REDACTED',
+          value: 123,
+        },
       });
     });
 
@@ -103,7 +109,7 @@ describe('createReduxEnhancer', () => {
       Redux.createStore((state = initialState) => state, enhancer);
 
       // Check that state is cleared
-      expect(mockSetContext).toBeCalledWith('redux.state', null);
+      expect(mockSetContext).toBeCalledWith('state', null);
     });
 
     it('transforms actions', () => {


### PR DESCRIPTION
Switch to using state context as outlined by
https://develop.sentry.dev/sdk/event-payloads/contexts/#state-context

More context here: https://github.com/getsentry/sentry-javascript/issues/5430#issuecomment-1195882729

cc @thanaen