### PR TITLE
fix(nextjs): Add `transpileClientSDK` option

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -22,6 +22,9 @@ export type NextConfigObject = {
     disableClientWebpackPlugin?: boolean;
     hideSourceMaps?: boolean;
 
+    // Force webpack to apply the same transpilation rules to the SDK code as apply to user code. Helpful when targeting
+    // older browsers which don't support ES6 (and ES6+ features like object spread).
+    transpileClientSDK?: boolean;
     // Upload files from `<distDir>/static/chunks` rather than `<distDir>/static/chunks/pages`. Usually files outside of
     // `pages/` only contain third-party code, but in cases where they contain user code, restricting the webpack
     // plugin's upload breaks sourcemaps for those user-code-containing files, because it keeps them from being

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -57,13 +57,7 @@ export type WebpackConfigObject = {
     alias?: { [key: string]: string | boolean };
   };
   module?: {
-    rules: Array<{
-      test: string | RegExp;
-      use: Array<{
-        loader: string;
-        options: Record<string, unknown>;
-      }>;
-    }>;
+    rules: Array<WebpackModuleRule>;
   };
 } & {
   // other webpack options
@@ -98,3 +92,20 @@ export type EntryPropertyFunction = () => Promise<EntryPropertyObject>;
 // listed under the key `import`.
 export type EntryPointValue = string | Array<string> | EntryPointObject;
 export type EntryPointObject = { import: string | Array<string> };
+
+/**
+ * Webpack `module.rules` entry
+ */
+
+export type WebpackModuleRule = {
+  test?: string | RegExp;
+  include?: Array<string | RegExp> | RegExp;
+  exclude?: (filepath: string) => boolean;
+  use?: ModuleRuleUseProperty | Array<ModuleRuleUseProperty>;
+  oneOf?: Array<WebpackModuleRule>;
+};
+
+export type ModuleRuleUseProperty = {
+  loader?: string;
+  options?: Record<string, unknown>;
+};

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -23,7 +23,7 @@ export type NextConfigObject = {
     hideSourceMaps?: boolean;
 
     // Force webpack to apply the same transpilation rules to the SDK code as apply to user code. Helpful when targeting
-    // older browsers which don't support ES6 (and ES6+ features like object spread).
+    // older browsers which don't support ES6 (or ES6+ features like object spread).
     transpileClientSDK?: boolean;
     // Upload files from `<distDir>/static/chunks` rather than `<distDir>/static/chunks/pages`. Usually files outside of
     // `pages/` only contain third-party code, but in cases where they contain user code, restricting the webpack


### PR DESCRIPTION
As of version 7.0, our SDK publishes code which isn't natively compatible with older browsers (ones which can't handle ES6 or certain ES6+ features like object spread). If users control the build process of their apps, they can make sure that our SDK code is included in the transpilation they apply to their own code. In nextjs, however, the build process is controlled by the framework, and while users _can_ make modifications to it, they're modifying a webpack config they didn't create, making it a more challenging task.

Fortunately, our SDK can also modify the build process, and that's what this PR does. Nextjs does its transpiling using a loader (either `next-babel-loader` or `next-swc-loader`, depending on the nextjs version), controlled by entries in the `module.rules` section of the webpack config. Normally this transpiling excludes all of `node_modules`, but we can make it not ignore the SDK by wrapping the `exclude` function so that it checks first for SDK code (and doesn't exclude it), before applying the normal checks.

Notes:

- In order to do the wrapping, we first have to find the correct `module.rules` entries. The default value of `module.rules` varies by nextjs version, so instead of looking in a known location, we look at all entries. In order to determine which ones to modify, we match on `test` (a regex for the type of file upon which the rule acts), `include` (a list of paths upon which the rule will act), and `loader` (the name of the module actually doing the transpiling). Any rule which would apply `next-babel-loader` or `next-swc-loader` to user files gets modified to also apply the loader to SDK code.

- Because this is only a browser concern, this modification is only made during the client-side build.

- This only applies to folks trying to support older browsers, and it noticeably increases bundle size, so it's an opt-in process, controlled by a new `next.config.js` option called `transpileClientSDK`.

- While it would theoretically be possible to figure out which builds need this (someone with `target: 'es5'` in their `tsconfig` would be a good candidate, for example), the number of locations and ways in which a user can configure that is prohibitively large (a tsconfig with the default name, a tsconfig with a configured name, babel config in webpack config, babel config in `package.json`, babel config in a file with any one of [nine possible names](https://babeljs.io/docs/en/config-files), using a babel preset, using any of a number of different `target` values, and on  and on and on). The option is thus only enabled if a user does so directly.

- There will be a follow-up docs PR once this option is released in the SDK.

This addresses part of https://github.com/getsentry/sentry-javascript/issues/5452. Non-nextjs users will need to do a similar adjustment on their own, which we will also need to document.