### PR TITLE
fix(nextjs): Move `userNextConfig.sentry` to closure

### DIFF
--- a/packages/nextjs/src/config/index.ts
+++ b/packages/nextjs/src/config/index.ts
@@ -17,16 +17,33 @@ export function withSentryConfig(
   if (typeof userNextConfig === 'function') {
     return function (phase: string, defaults: { defaultConfig: NextConfigObject }): Partial<NextConfigObject> {
       const materializedUserNextConfig = userNextConfig(phase, defaults);
+
+      // Next 12.2.3+ warns about non-canonical properties on `userNextConfig`, so grab and then remove the `sentry`
+      // property there. Where we actually need it is in the webpack config function we're going to create, so pass it
+      // to `constructWebpackConfigFunction` so that it will be in the created function's closure.
+      const { sentry: userSentryOptions } = materializedUserNextConfig;
+      delete materializedUserNextConfig.sentry;
+
       return {
         ...materializedUserNextConfig,
-        webpack: constructWebpackConfigFunction(materializedUserNextConfig, userSentryWebpackPluginOptions),
+        webpack: constructWebpackConfigFunction(
+          materializedUserNextConfig,
+          userSentryWebpackPluginOptions,
+          userSentryOptions,
+        ),
       };
     };
   }
 
   // Otherwise, we can just merge their config with ours and return an object.
+
+  // Prevent nextjs from getting mad about having a non-standard config property in `userNextConfig`. (See note above
+  // for a more thorough explanation of what we're doing here.)
+  const { sentry: userSentryOptions } = userNextConfig;
+  delete userNextConfig.sentry;
+
   return {
     ...userNextConfig,
-    webpack: constructWebpackConfigFunction(userNextConfig, userSentryWebpackPluginOptions),
+    webpack: constructWebpackConfigFunction(userNextConfig, userSentryWebpackPluginOptions, userSentryOptions),
   };
 }

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -17,24 +17,27 @@ export type NextConfigObject = {
   target: 'server' | 'experimental-serverless-trace';
   // the output directory for the built app (defaults to ".next")
   distDir: string;
-  sentry?: {
-    disableServerWebpackPlugin?: boolean;
-    disableClientWebpackPlugin?: boolean;
-    hideSourceMaps?: boolean;
-
-    // Force webpack to apply the same transpilation rules to the SDK code as apply to user code. Helpful when targeting
-    // older browsers which don't support ES6 (or ES6+ features like object spread).
-    transpileClientSDK?: boolean;
-    // Upload files from `<distDir>/static/chunks` rather than `<distDir>/static/chunks/pages`. Usually files outside of
-    // `pages/` only contain third-party code, but in cases where they contain user code, restricting the webpack
-    // plugin's upload breaks sourcemaps for those user-code-containing files, because it keeps them from being
-    // uploaded. At the same time, we don't want to widen the scope if we don't have to, because we're guaranteed to end
-    // up uploading too many files, which is why this defaults to `false`.
-    widenClientFileUpload?: boolean;
-  };
+  sentry?: UserSentryOptions;
 } & {
   // other `next.config.js` options
   [key: string]: unknown;
+};
+
+export type UserSentryOptions = {
+  disableServerWebpackPlugin?: boolean;
+  disableClientWebpackPlugin?: boolean;
+  hideSourceMaps?: boolean;
+
+  // Force webpack to apply the same transpilation rules to the SDK code as apply to user code. Helpful when targeting
+  // older browsers which don't support ES6 (or ES6+ features like object spread).
+  transpileClientSDK?: boolean;
+
+  // Upload files from `<distDir>/static/chunks` rather than `<distDir>/static/chunks/pages`. Usually files outside of
+  // `pages/` only contain third-party code, but in cases where they contain user code, restricting the webpack
+  // plugin's upload breaks sourcemaps for those user-code-containing files, because it keeps them from being
+  // uploaded. At the same time, we don't want to widen the scope if we don't have to, because we're guaranteed to end
+  // up uploading too many files, which is why this defaults to `false`.
+  widenClientFileUpload?: boolean;
 };
 
 export type NextConfigFunction = (

--- a/packages/nextjs/test/config.test.ts
+++ b/packages/nextjs/test/config.test.ts
@@ -200,6 +200,7 @@ async function materializeFinalWebpackConfig(options: {
   const webpackConfigFunction = constructWebpackConfigFunction(
     materializedUserNextConfig,
     userSentryWebpackPluginConfig,
+    materializedUserNextConfig.sentry,
   );
 
   // call it to get concrete values for comparison
@@ -870,9 +871,11 @@ describe('Sentry webpack plugin config', () => {
       [getBuildContext('server', {}, '4'), '.next'],
       [getBuildContext('server', {}, '5'), '.next'],
     ])('`distDir` is not defined', (buildContext: BuildContext, expectedDistDir) => {
-      const includePaths = getWebpackPluginOptions(buildContext, {
-        /** userPluginOptions */
-      }).include as { paths: [] }[];
+      const includePaths = getWebpackPluginOptions(
+        buildContext,
+        {}, // userPluginOptions
+        {}, // userSentryOptions
+      ).include as { paths: [] }[];
 
       for (const pathDescriptor of includePaths) {
         for (const path of pathDescriptor.paths) {
@@ -887,9 +890,11 @@ describe('Sentry webpack plugin config', () => {
       [getBuildContext('server', { distDir: 'tmpDir' }, '4'), 'tmpDir'],
       [getBuildContext('server', { distDir: 'tmpDir' }, '5'), 'tmpDir'],
     ])('`distDir` is defined', (buildContext: BuildContext, expectedDistDir) => {
-      const includePaths = getWebpackPluginOptions(buildContext, {
-        /** userPluginOptions */
-      }).include as { paths: [] }[];
+      const includePaths = getWebpackPluginOptions(
+        buildContext,
+        {}, // userPluginOptions
+        {}, // userSentryOptions
+      ).include as { paths: [] }[];
 
       for (const pathDescriptor of includePaths) {
         for (const path of pathDescriptor.paths) {


### PR DESCRIPTION
_h/t to @mitchheddles for the research and [initial idea](https://github.com/getsentry/sentry-javascript/pull/5456) - thanks!_

As of https://github.com/vercel/next.js/pull/38498, nextjs now warns (voluminously) if the config exported from `next.config.js` contains properties it doesn't recognize, including the `sentry` property we've been having people use to do things like [disable the webpack plugin](https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#disable-sentrywebpackplugin). In order to prevent these warnings, the final config returned from `withSentryConfig` must not have such a property, so this deletes the property from the `userNextConfig` object before returning it. 

If we were to stop there, the warning would be gone, but so would the data `userNextConfig.sentry` contains. (This is true even if we run `constructWebpackConfigFunction` before doing the deletion, because the place we need the `userNextConfig.sentry` data is not in `constructWebpackConfigFunction` itself but in the function it returns. By the time that function is called by nextjs, the deletion will already have gone through and the data will be gone unless we keep a reference to it elsewhere.) Therefore, in order to allow the returned function to retain access the `userNextConfig.sentry` data, this captures it before it's deleted and passes it to `constructWebpackConfigFunction`, where it lives in a closure around the returned function.


