### PR TITLE
ref(tracing): Simplify sample_rate serialization for DSC

### DIFF
--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -246,10 +246,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
     const { publicKey: public_key } = client.getDsn() || {};
 
     const rate = this.metadata && this.metadata.transactionSampling && this.metadata.transactionSampling.rate;
-    const sample_rate =
-      rate !== undefined
-        ? rate.toLocaleString('fullwide', { useGrouping: false, maximumFractionDigits: 16 })
-        : undefined;
+    const sample_rate = rate !== undefined ? JSON.stringify(rate) : undefined;
 
     const scope = hub.getScope();
     const { segment: user_segment } = (scope && scope.getUser()) || {};

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -245,7 +245,11 @@ export class Transaction extends SpanClass implements TransactionInterface {
     const { environment, release } = client.getOptions() || {};
     const { publicKey: public_key } = client.getDsn() || {};
 
-    const sample_rate = this.metadata && this.metadata.transactionSampling && this.metadata.transactionSampling.rate;
+    const sample_rate =
+      this.metadata &&
+      this.metadata.transactionSampling &&
+      this.metadata.transactionSampling.rate &&
+      this.metadata.transactionSampling.rate.toString();
 
     const scope = hub.getScope();
     const { segment: user_segment } = (scope && scope.getUser()) || {};

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -245,8 +245,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
     const { environment, release } = client.getOptions() || {};
     const { publicKey: public_key } = client.getDsn() || {};
 
-    const rate = this.metadata && this.metadata.transactionSampling && this.metadata.transactionSampling.rate;
-    const sample_rate = rate !== undefined ? JSON.stringify(rate) : undefined;
+    const sample_rate = this.metadata && this.metadata.transactionSampling && this.metadata.transactionSampling.rate;
 
     const scope = hub.getScope();
     const { segment: user_segment } = (scope && scope.getUser()) || {};

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -449,30 +449,6 @@ describe('Span', () => {
       expect(baggage && getThirdPartyBaggage(baggage)).toStrictEqual('');
     });
 
-    test('exponential sample rate notation is converted to decimal notation', () => {
-      const transaction = new Transaction(
-        {
-          name: 'tx',
-          metadata: {
-            transactionSampling: { rate: 1.45e-14, method: 'client_rate' },
-          },
-        },
-        hub,
-      );
-
-      const baggage = transaction.getBaggage();
-
-      expect(baggage && isSentryBaggageEmpty(baggage)).toBe(false);
-      expect(baggage && getSentryBaggageItems(baggage)).toStrictEqual({
-        release: '1.0.1',
-        environment: 'production',
-        // transaction: 'tx',
-        sample_rate: '0.0000000000000145',
-        trace_id: expect.any(String),
-      });
-      expect(baggage && getThirdPartyBaggage(baggage)).toStrictEqual('');
-    });
-
     describe('Including transaction name in DSC', () => {
       test.each([
         ['is not included if transaction source is not set', undefined],


### PR DESCRIPTION
This PR changes our formatting logic of the `sample_rate` value when the dynamic sampling context (DSC) is populated. Instead of using `Number.toLocaleString` with a bunch of options (which theoretically is supported by all browsers; but it turns out that IE11 doesn't support the `fullwide` locale we use), we now simply convert the number `toString` to do the job. Given that Relay now supports parsing the sample_rate from JSON format, we can drop our previous formatting logic. 

Deleted a test that's IMO no longer necessary, covering the conversion of exponential to decimal notation.

Fixes #5466
