### PR TITLE
fix(node): Correctly handle Windows paths when resolving module name

### DIFF
--- a/packages/node/src/module.ts
+++ b/packages/node/src/module.ts
@@ -1,20 +1,29 @@
 import { basename, dirname } from '@sentry/utils';
 
+/** normalizes Windows paths */
+function normalisePath(path: string): string {
+  return path
+    .replace(/^[A-Z]:/, '') // remove Windows-style prefix
+    .replace(/\\/g, '/'); // replace all `\` instances with `/`
+}
+
 /** Gets the module from a filename */
 export function getModule(filename: string | undefined): string | undefined {
   if (!filename) {
     return;
   }
 
+  const normalizedFilename = normalisePath(filename);
+
   // We could use optional chaining here but webpack does like that mixed with require
-  const base = `${
-    (require && require.main && require.main.filename && dirname(require.main.filename)) || global.process.cwd()
-  }/`;
+  const base = normalisePath(
+    `${(require && require.main && require.main.filename && dirname(require.main.filename)) || global.process.cwd()}/`,
+  );
 
   // It's specifically a module
-  const file = basename(filename, '.js');
+  const file = basename(normalizedFilename, '.js');
 
-  const path = dirname(filename);
+  const path = dirname(normalizedFilename);
   let n = path.lastIndexOf('/node_modules/');
   if (n > -1) {
     // /node_modules/ is 14 chars

--- a/packages/node/src/module.ts
+++ b/packages/node/src/module.ts
@@ -1,7 +1,7 @@
 import { basename, dirname } from '@sentry/utils';
 
 /** normalizes Windows paths */
-function normalisePath(path: string): string {
+function normalizePath(path: string): string {
   return path
     .replace(/^[A-Z]:/, '') // remove Windows-style prefix
     .replace(/\\/g, '/'); // replace all `\` instances with `/`
@@ -13,10 +13,10 @@ export function getModule(filename: string | undefined): string | undefined {
     return;
   }
 
-  const normalizedFilename = normalisePath(filename);
+  const normalizedFilename = normalizePath(filename);
 
   // We could use optional chaining here but webpack does like that mixed with require
-  const base = normalisePath(
+  const base = normalizePath(
     `${(require && require.main && require.main.filename && dirname(require.main.filename)) || global.process.cwd()}/`,
   );
 

--- a/packages/node/test/module.test.ts
+++ b/packages/node/test/module.test.ts
@@ -1,0 +1,15 @@
+import { getModule } from '../src/module';
+
+describe('getModule', () => {
+  test('Windows', async () => {
+    (require.main as any) = { filename: 'C:\\Users\\Tim\\app.js' };
+
+    expect(getModule('C:\\Users\\users\\Tim\\Desktop\\node_modules\\module.js')).toEqual('module');
+  });
+
+  test('POSIX', async () => {
+    (require.main as any) = { filename: '/Users/Tim/app.js' };
+
+    expect(getModule('/Users/users/Tim/Desktop/node_modules/module.js')).toEqual('module');
+  });
+});

--- a/packages/node/test/module.test.ts
+++ b/packages/node/test/module.test.ts
@@ -16,13 +16,13 @@ function withFilename(fn: () => void, filename: string) {
 }
 
 describe('getModule', () => {
-  test('Windows', async () => {
+  test('Windows', () => {
     withFilename(() => {
       expect(getModule('C:\\Users\\users\\Tim\\Desktop\\node_modules\\module.js')).toEqual('module');
     }, 'C:\\Users\\Tim\\app.js');
   });
 
-  test('POSIX', async () => {
+  test('POSIX', () => {
     withFilename(() => {
       expect(getModule('/Users/users/Tim/Desktop/node_modules/module.js')).toEqual('module');
     }, '/Users/Tim/app.js');

--- a/packages/node/test/module.test.ts
+++ b/packages/node/test/module.test.ts
@@ -1,6 +1,6 @@
 import { getModule } from '../src/module';
 
-function reaplaceFilename(fn: () => void, filename: string) {
+function withFilename(fn: () => void, filename: string) {
   const prevFilename = require.main?.filename;
   if (require.main?.filename) {
     require.main.filename = filename;
@@ -17,13 +17,13 @@ function reaplaceFilename(fn: () => void, filename: string) {
 
 describe('getModule', () => {
   test('Windows', async () => {
-    reaplaceFilename(() => {
+    withFilename(() => {
       expect(getModule('C:\\Users\\users\\Tim\\Desktop\\node_modules\\module.js')).toEqual('module');
     }, 'C:\\Users\\Tim\\app.js');
   });
 
   test('POSIX', async () => {
-    reaplaceFilename(() => {
+    withFilename(() => {
       expect(getModule('/Users/users/Tim/Desktop/node_modules/module.js')).toEqual('module');
     }, '/Users/Tim/app.js');
   });

--- a/packages/node/test/module.test.ts
+++ b/packages/node/test/module.test.ts
@@ -1,15 +1,30 @@
 import { getModule } from '../src/module';
 
+function reaplaceFilename(fn: () => void, filename: string) {
+  const prevFilename = require.main?.filename;
+  if (require.main?.filename) {
+    require.main.filename = filename;
+  }
+
+  try {
+    fn();
+  } finally {
+    if (require.main && prevFilename) {
+      require.main.filename = prevFilename;
+    }
+  }
+}
+
 describe('getModule', () => {
   test('Windows', async () => {
-    (require.main as any) = { filename: 'C:\\Users\\Tim\\app.js' };
-
-    expect(getModule('C:\\Users\\users\\Tim\\Desktop\\node_modules\\module.js')).toEqual('module');
+    reaplaceFilename(() => {
+      expect(getModule('C:\\Users\\users\\Tim\\Desktop\\node_modules\\module.js')).toEqual('module');
+    }, 'C:\\Users\\Tim\\app.js');
   });
 
   test('POSIX', async () => {
-    (require.main as any) = { filename: '/Users/Tim/app.js' };
-
-    expect(getModule('/Users/users/Tim/Desktop/node_modules/module.js')).toEqual('module');
+    reaplaceFilename(() => {
+      expect(getModule('/Users/users/Tim/Desktop/node_modules/module.js')).toEqual('module');
+    }, '/Users/Tim/app.js');
   });
 });


### PR DESCRIPTION
This was causing https://github.com/getsentry/sentry-electron/issues/503

It looks like this was never handled correctly and we don't CI test on Windows so this was never noticed!
