### PR TITLE
fix(nextjs): Add default `distDir` value back into `index.server.ts`

### DIFF
--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -93,8 +93,9 @@ function sdkAlreadyInitialized(): boolean {
 }
 
 function addServerIntegrations(options: NextjsOptions): void {
-  // This value is injected at build time, based on the output directory specified in the build config
-  const distDirName = (global as GlobalWithDistDir).__rewriteFramesDistDir__;
+  // This value is injected at build time, based on the output directory specified in the build config. Though a default
+  // is set there, we set it here as well, just in case something has gone wrong with the injection.
+  const distDirName = (global as GlobalWithDistDir).__rewriteFramesDistDir__ || '.next';
   // nextjs always puts the build directory at the project root level, which is also where you run `next start` from, so
   // we can read in the project directory from the currently running process
   const distDirAbsPath = path.resolve(process.cwd(), distDirName);


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/5445, a change was made to the way the global `RewriteFrames` helper value is handled. Specifically, setting the default value (using the `||` operator) was moved to the place where the value is set rather than where it's retrieved. But if something goes wrong and for whatever reason the value never gets set globally, it now causes errors when the value is later used, because it has nothing to default to.

This fixes that by restoring the default value to the old location, so that when it's used, it will never be undefined.

Fixes https://github.com/getsentry/sentry-javascript/issues/5478.
