### PR TITLE
fix(dev): Clarify issue template framework field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -45,15 +45,15 @@ body:
     attributes:
       label: SDK Version
       description: What version of the SDK are you using?
-      placeholder: ex. 1.5.2
+      placeholder: ex. 7.8.0
     validations:
       required: true
   - type: input
     id: framework-version
     attributes:
       label: Framework Version
-      description: If you're using one of our framework-specific SDKs (`@sentry/react`, for example), what version of the framework are you using?
-      placeholder: ex. 1.5.2
+      description: If you're using one of our framework-specific SDKs (`@sentry/react`, for example), what version of the _framework_ (not SDK) are you using?
+      placeholder: ex. React 17.0.0
   - type: input
     id: link-to-sentry
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 name: 🐞 Bug Report
 description: Tell us about something that's not working the way we (probably) intend.
-labels: "Type: Bug"
+labels: ["Type: Bug"]
 body:
   - type: checkboxes
     attributes:
@@ -88,5 +88,3 @@ body:
     attributes:
       value: |-
         ## Thanks 🙏
-    validations:
-      required: false


### PR DESCRIPTION
In our bug template, we ask users for their SDK version and, if they're using a framework SDK (react, etc), the version of the framework. Users often misunderstand, however, and just provide the SDK version twice. This aims to clarify the distinction, by making three changes:
- Adding clarifying language to the Framework Version field description.
- Changing the placeholder example for the field to include the name of the framework, and a recent IRL version.
- Changing the placeholder example for the SDK field to be the current version, to further emphasize which one is which.

It also fixes two schema errors highlighted by the linter.
