### PR TITLE
chore(nextjs): pin @types/react version to fix integration tests

### DIFF
--- a/packages/nextjs/test/integration/package.json
+++ b/packages/nextjs/test/integration/package.json
@@ -16,9 +16,8 @@
   "devDependencies": {
     "@types/node": "^15.3.1",
     "@types/puppeteer": "^5.4.3",
-    // Hard-pinning @types/react because 17.0.48 causes build failures
     "@types/react": "17.0.47",
-    "@types/react-dom": "^17.0.5",
+    "@types/react-dom": "17.0.17",
     "nock": "^13.1.0",
     "puppeteer": "^9.1.1",
     "typescript": "^4.2.4",

--- a/packages/nextjs/test/integration/package.json
+++ b/packages/nextjs/test/integration/package.json
@@ -16,7 +16,8 @@
   "devDependencies": {
     "@types/node": "^15.3.1",
     "@types/puppeteer": "^5.4.3",
-    "@types/react": "^17.0.6",
+    // Hard-pinning @types/react because 17.0.48 causes build failures
+    "@types/react": "17.0.47",
     "@types/react-dom": "^17.0.5",
     "nock": "^13.1.0",
     "puppeteer": "^9.1.1",


### PR DESCRIPTION
Hard-pins `@types/react` to version `17.0.47` (`@types/react-dom` to version `17.0.17`)  because the latest patch (`@types/react@17.0.48`) caused our NextJs Integration tests to fail. 

Caused by: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/61457

