### PR TITLE
fix(remix): Paramaterize server side transactions

### DIFF
--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -274,8 +274,9 @@ function createRoutes(manifest: ServerRouteManifest, parentId?: string): ServerR
 
 function wrapRequestHandler(origRequestHandler: RequestHandler, build: ServerBuild): RequestHandler {
   const routes = createRoutes(build.routes);
-  const pkg = loadModule<{ matchRoutes: (routes: ServerRoute[], pathname: string) => any[] }>('react-router-dom');
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const pkg = loadModule<{
+    matchRoutes: (routes: ServerRoute[], pathname: string) => RouteMatch<ServerRoute>[] | null;
+  }>('react-router-dom');
   // https://github.com/remix-run/remix/blob/38e127b1d97485900b9c220d93503de0deb1fc81/packages/remix-server-runtime/routeMatching.ts#L12-L24
   function matchServerRoutes(routes: ServerRoute[], pathname: string): RouteMatch<ServerRoute>[] | null {
     if (!pkg) {

--- a/packages/remix/test/integration/test/server/loader.test.ts
+++ b/packages/remix/test/integration/test/server/loader.test.ts
@@ -8,13 +8,14 @@ describe('Remix API Loaders', () => {
     const transaction = envelope[2];
 
     assertSentryTransaction(transaction, {
+      name: 'routes/loader-json-response/$id',
       spans: [
         {
-          description: url,
+          description: 'routes/loader-json-response/$id',
           op: 'remix.server.loader',
         },
         {
-          description: url,
+          description: 'routes/loader-json-response/$id',
           op: 'remix.server.documentRequest',
         },
       ],

--- a/packages/remix/test/integration/test/server/loader.test.ts
+++ b/packages/remix/test/integration/test/server/loader.test.ts
@@ -8,7 +8,10 @@ describe('Remix API Loaders', () => {
     const transaction = envelope[2];
 
     assertSentryTransaction(transaction, {
-      name: 'routes/loader-json-response/$id',
+      transaction: 'routes/loader-json-response/$id',
+      transaction_info: {
+        source: 'route',
+      },
       spans: [
         {
           description: 'routes/loader-json-response/$id',


### PR DESCRIPTION
This makes sure server side transactions are parameterized correctly in Remix.

We do this by matching the server routes the same way Remix does under the hood, by reconciling the routes and URL pathname - https://github.com/remix-run/remix/blob/97999d02493e8114c39d48b76944069d58526e8d/packages/remix-server-runtime/server.ts#L36

Copied over a bunch of code from Remix to make this happen (and attributed accordingly).