### PR TITLE
fix(node): Adjust Express URL parameterization for array routes

### DIFF
--- a/packages/node-integration-tests/suites/express/tracing/server.ts
+++ b/packages/node-integration-tests/suites/express/tracing/server.ts
@@ -25,6 +25,10 @@ app.get(/\/test\/regex/, (_req, res) => {
   res.send({ response: 'response 2' });
 });
 
+app.get(['/test/array1', /\/test\/array[2-9]/], (_req, res) => {
+  res.send({ response: 'response 3' });
+});
+
 app.use(Sentry.Handlers.errorHandler());
 
 export default app;

--- a/packages/node-integration-tests/suites/express/tracing/server.ts
+++ b/packages/node-integration-tests/suites/express/tracing/server.ts
@@ -29,6 +29,10 @@ app.get(['/test/array1', /\/test\/array[2-9]/], (_req, res) => {
   res.send({ response: 'response 3' });
 });
 
+app.get(['/test/arr/:id', /\/test\/arr[0-9]*\/required(path)?(\/optionalPath)?\/(lastParam)?/], (_req, res) => {
+  res.send({ response: 'response 4' });
+});
+
 app.use(Sentry.Handlers.errorHandler());
 
 export default app;

--- a/packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/packages/node-integration-tests/suites/express/tracing/test.ts
@@ -53,3 +53,32 @@ test('should set a correct transaction name for routes specified in RegEx', asyn
     },
   });
 });
+
+test.each([
+  ['', 'array1'],
+  ['', 'array5'],
+])('%s should set a correct transaction name for routes consisting of arrays of routes', async (_, segment) => {
+  const url = await runServer(__dirname, `${__dirname}/server.ts`);
+  const envelope = await getEnvelopeRequest(`${url}/${segment}`);
+
+  expect(envelope).toHaveLength(3);
+
+  assertSentryTransaction(envelope[2], {
+    transaction: 'GET /test/array1,/\\/test\\/array[2-9]',
+    transaction_info: {
+      source: 'route',
+    },
+    contexts: {
+      trace: {
+        data: {
+          url: `/test/${segment}`,
+        },
+        op: 'http.server',
+        status: 'ok',
+        tags: {
+          'http.status_code': '200',
+        },
+      },
+    },
+  });
+});

--- a/packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/packages/node-integration-tests/suites/express/tracing/test.ts
@@ -82,3 +82,36 @@ test.each([['array1'], ['array5']])(
     });
   },
 );
+
+test.each([
+  ['arr/545'],
+  ['arr/required'],
+  ['arr/requiredPath'],
+  ['arr/required/lastParam'],
+  ['arr/requiredPath/optionalPath/'],
+  ['arr/requiredPath/optionalPath/lastParam'],
+])('should handle more complex regexes in route arrays correctly', async segment => {
+  const url = await runServer(__dirname, `${__dirname}/server.ts`);
+  const envelope = await getEnvelopeRequest(`${url}/${segment}`);
+
+  expect(envelope).toHaveLength(3);
+
+  assertSentryTransaction(envelope[2], {
+    transaction: 'GET /test/arr/:id,/\\/test\\/arr[0-9]*\\/required(path)?(\\/optionalPath)?\\/(lastParam)?',
+    transaction_info: {
+      source: 'route',
+    },
+    contexts: {
+      trace: {
+        data: {
+          url: `/test/${segment}`,
+        },
+        op: 'http.server',
+        status: 'ok',
+        tags: {
+          'http.status_code': '200',
+        },
+      },
+    },
+  });
+});

--- a/packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/packages/node-integration-tests/suites/express/tracing/test.ts
@@ -86,8 +86,10 @@ test.each([['array1'], ['array5']])(
 test.each([
   ['arr/545'],
   ['arr/required'],
+  ['arr/required'],
   ['arr/requiredPath'],
   ['arr/required/lastParam'],
+  ['arr55/required/lastParam'],
   ['arr/requiredPath/optionalPath/'],
   ['arr/requiredPath/optionalPath/lastParam'],
 ])('should handle more complex regexes in route arrays correctly', async segment => {

--- a/packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/packages/node-integration-tests/suites/express/tracing/test.ts
@@ -54,31 +54,31 @@ test('should set a correct transaction name for routes specified in RegEx', asyn
   });
 });
 
-test.each([
-  ['', 'array1'],
-  ['', 'array5'],
-])('%s should set a correct transaction name for routes consisting of arrays of routes', async (_, segment) => {
-  const url = await runServer(__dirname, `${__dirname}/server.ts`);
-  const envelope = await getEnvelopeRequest(`${url}/${segment}`);
+test.each([['array1'], ['array5']])(
+  'should set a correct transaction name for routes consisting of arrays of routes',
+  async segment => {
+    const url = await runServer(__dirname, `${__dirname}/server.ts`);
+    const envelope = await getEnvelopeRequest(`${url}/${segment}`);
 
-  expect(envelope).toHaveLength(3);
+    expect(envelope).toHaveLength(3);
 
-  assertSentryTransaction(envelope[2], {
-    transaction: 'GET /test/array1,/\\/test\\/array[2-9]',
-    transaction_info: {
-      source: 'route',
-    },
-    contexts: {
-      trace: {
-        data: {
-          url: `/test/${segment}`,
-        },
-        op: 'http.server',
-        status: 'ok',
-        tags: {
-          'http.status_code': '200',
+    assertSentryTransaction(envelope[2], {
+      transaction: 'GET /test/array1,/\\/test\\/array[2-9]',
+      transaction_info: {
+        source: 'route',
+      },
+      contexts: {
+        trace: {
+          data: {
+            url: `/test/${segment}`,
+          },
+          op: 'http.server',
+          status: 'ok',
+          tags: {
+            'http.status_code': '200',
+          },
         },
       },
-    },
-  });
-});
+    });
+  },
+);

--- a/packages/tracing/src/integrations/node/express.ts
+++ b/packages/tracing/src/integrations/node/express.ts
@@ -339,9 +339,19 @@ function getLayerRoutePathString(layer: Layer): LayerRoutePathInfo {
   const isRegex = isRegExp(lrp);
   const isArray = Array.isArray(lrp);
 
-  const numExtraSegments = isArray ? getNumberOfArrayUrlSegments(lrp) - getNumberOfUrlSegments(layer.path || '') : 0;
+  if (!lrp) {
+    return { isRegex, numExtraSegments: 0 };
+  }
 
-  const layerRoutePath = isArray ? lrp.join(',') : isRegex ? lrp?.toString() : (lrp as string | undefined);
+  const numExtraSegments = isArray
+    ? getNumberOfArrayUrlSegments(lrp as RouteType[]) - getNumberOfUrlSegments(layer.path || '')
+    : 0;
+
+  const layerRoutePath = isArray
+    ? (lrp as RouteType[]).map((r: RouteType) => r.toString()).join(',')
+    : isRegex
+    ? lrp.toString()
+    : (lrp as string | undefined);
 
   return { layerRoutePath, isRegex, numExtraSegments };
 }

--- a/packages/tracing/src/integrations/node/express.ts
+++ b/packages/tracing/src/integrations/node/express.ts
@@ -344,7 +344,7 @@ function getLayerRoutePathString(layer: Layer): LayerRoutePathInfo {
   }
 
   const numExtraSegments = isArray
-    ? getNumberOfArrayUrlSegments(lrp as RouteType[]) - getNumberOfUrlSegments(layer.path || '')
+    ? Math.max(getNumberOfArrayUrlSegments(lrp as RouteType[]) - getNumberOfUrlSegments(layer.path || ''), 0)
     : 0;
 
   const layerRoutePath = isArray

--- a/packages/tracing/src/integrations/node/express.ts
+++ b/packages/tracing/src/integrations/node/express.ts
@@ -348,7 +348,7 @@ function getLayerRoutePathString(layer: Layer): LayerRoutePathInfo {
     : 0;
 
   const layerRoutePath = isArray
-    ? (lrp as RouteType[]).map((r: RouteType) => r.toString()).join(',')
+    ? (lrp as RouteType[]).map(r => r.toString()).join(',')
     : isRegex
     ? lrp.toString()
     : (lrp as string | undefined);

--- a/packages/tracing/src/integrations/node/express.ts
+++ b/packages/tracing/src/integrations/node/express.ts
@@ -275,7 +275,7 @@ function instrumentRouter(appOrRouter: ExpressRouter): void {
     }
 
     // If the layer's partial route has params, is a regex or an array, the route is stored in layer.route.
-    const { layerRoutePath, isRegex, numExtraSegments }: LayerRoutePathInfo = getLayerRoutePathInfo(layer);
+    const { layerRoutePath, isRegex, isArray, numExtraSegments }: LayerRoutePathInfo = getLayerRoutePathInfo(layer);
 
     // Otherwise, the hardcoded path (i.e. a partial route without params) is stored in layer.path
     const partialRoute = layerRoutePath || layer.path || '';
@@ -287,7 +287,7 @@ function instrumentRouter(appOrRouter: ExpressRouter): void {
     // We want to end up with the parameterized URL of the incoming request without any extraneous path segments.
     const finalPartialRoute = partialRoute
       .split('/')
-      .filter(segment => segment.length > 0 && !segment.includes('*'))
+      .filter(segment => segment.length > 0 && (isRegex || isArray || !segment.includes('*')))
       .join('/');
 
     // If we found a valid partial URL, we append it to the reconstructed route
@@ -320,6 +320,7 @@ function instrumentRouter(appOrRouter: ExpressRouter): void {
 type LayerRoutePathInfo = {
   layerRoutePath?: string;
   isRegex: boolean;
+  isArray: boolean;
   numExtraSegments: number;
 };
 
@@ -341,7 +342,7 @@ function getLayerRoutePathInfo(layer: Layer): LayerRoutePathInfo {
   const isArray = Array.isArray(lrp);
 
   if (!lrp) {
-    return { isRegex, numExtraSegments: 0 };
+    return { isRegex, isArray, numExtraSegments: 0 };
   }
 
   const numExtraSegments = isArray
@@ -350,7 +351,7 @@ function getLayerRoutePathInfo(layer: Layer): LayerRoutePathInfo {
 
   const layerRoutePath = getLayerRoutePathString(isArray, lrp);
 
-  return { layerRoutePath, isRegex, numExtraSegments };
+  return { layerRoutePath, isRegex, isArray, numExtraSegments };
 }
 
 /**

--- a/packages/tracing/src/integrations/node/express.ts
+++ b/packages/tracing/src/integrations/node/express.ts
@@ -36,7 +36,7 @@ type Router = {
 /* Extend the CrossPlatformRequest type with a patched parameter to build a reconstructed route */
 type PatchedRequest = CrossPlatformRequest & { _reconstructedRoute?: string };
 
-/* Type used for pathing the express router prototype */
+/* Types used for patching the express router prototype */
 type ExpressRouter = Router & {
   _router?: ExpressRouter;
   stack?: Layer[];
@@ -51,15 +51,14 @@ type ExpressRouter = Router & {
   ) => unknown;
 };
 
-type RouteType = string | RegExp;
-
-/* Type used for pathing the express router prototype */
 type Layer = {
   match: (path: string) => boolean;
   handle_request: (req: PatchedRequest, res: ExpressResponse, next: () => void) => void;
   route?: { path: RouteType | RouteType[] };
   path?: string;
 };
+
+type RouteType = string | RegExp;
 
 interface ExpressResponse {
   once(name: string, callback: () => void): void;


### PR DESCRIPTION
This PR fixes an error thrown from our Node SDK that  when our Express router parameterization logic (introduced in #5450) would try to parameterize a route consisting of an array of paths (which could be strings or RegExes). 

Previously, before #5450, the transaction name for a route such as
```js
app.get(['/test/array1', /\/test\/array[2-9]/], (_req, res) => {});
```

would be `GET /test/array1,/\/test\/array[2-9]/`. This is because internally, express does not care about which item in the array matched successfully. Express simply combines all items into one regex and matches the incoming path against this regex. It then stores the whole, concatenated array as the matched route.

While it might be worth revisiting our transaction name strategy for array routes at a later time, this is out of scope for this PR and the bugfix. Therefore, transaction names (for now) stay the same but, the patch fixes the error that was thrown as well as adding URL parameterization in time for DSC population (well, mostly; see #5450 for more details on that).

Since a crucial part of our parameterization approach is to determine if the currently resolved layer is the "last" part of the route (in which case we update the transaction name and source), this patch also makes a few modifications to determine this correctly for arrays. In order to do so, we check for the number of URL segments in the original URL vs. that of the parameterized URL. In the case of arrays, we'll likely have more segments than in the raw URL path. Therefore, we balance this out by determining the number of extra segments we got from the array.

Additionally, added tests for array routes.

fixes #5489 
