### PR TITLE
fix(node): Ensure that `self._handler` exists before calling it in LinkedErrors

### DIFF
--- a/packages/node/src/integrations/linkederrors.ts
+++ b/packages/node/src/integrations/linkederrors.ts
@@ -47,7 +47,7 @@ export class LinkedErrors implements Integration {
       const hub = getCurrentHub();
       const self = hub.getIntegration(LinkedErrors);
       const client = hub.getClient<NodeClient>();
-      if (client && self) {
+      if (client && self && self._handler && typeof self._handler === 'function') {
         await self._handler(client.getOptions().stackParser, event, hint);
       }
       return event;


### PR DESCRIPTION
This patch brings back a check for `self._handler` in the global event processor of the LinkedErrors integration for Node. 
The check was removed in #4902 but apparently it is still necessary.

fixes #5493