### PR TITLE
fix(node): Check if router exists before it is instrumented

### DIFF
--- a/packages/tracing/src/integrations/node/express.ts
+++ b/packages/tracing/src/integrations/node/express.ts
@@ -263,7 +263,7 @@ function instrumentRouter(appOrRouter: ExpressRouter): void {
   if (!router) {
     /*
     If we end up here, this means likely that this integration is used with Express 3 or Express 5.
-    For now, we don't support these version (3 is very old and 5 is still in beta). To support Express 5,
+    For now, we don't support these versions (3 is very old and 5 is still in beta). To support Express 5,
     we'd need to make more changes to the routing instrumentation because the router is no longer part of
     the Express core package but maintained in its own package. The new router has different function
     signatures and works slightly differently, demanding more changes than just taking the router from

--- a/packages/tracing/src/integrations/node/express.ts
+++ b/packages/tracing/src/integrations/node/express.ts
@@ -259,6 +259,24 @@ function instrumentRouter(appOrRouter: ExpressRouter): void {
   }
 
   const router = isApp ? appOrRouter._router : appOrRouter;
+
+  if (!router) {
+    /*
+    If we end up here, this means likely that this integration is used with Express 3 or Express 5.
+    For now, we don't support these version (3 is very old and 5 is still in beta). To support Express 5,
+    we'd need to make more changes to the routing instrumentation because the router is no longer part of
+    the Express core package but maintained in its own package. The new router has different function
+    signatures and works slightly differently, demanding more changes than just taking the router from
+    `app.router` instead of `app._router`.
+    @see https://github.com/pillarjs/router
+
+    TODO: Proper Express 5 support
+    */
+    __DEBUG_BUILD__ && logger.debug('Cannot instrument router for URL Parameterization (did not find a valid router).');
+    __DEBUG_BUILD__ && logger.debug('Routing instrumentation is currently only supported in Express 4.');
+    return;
+  }
+
   const routerProto = Object.getPrototypeOf(router) as ExpressRouter;
 
   const originalProcessParams = routerProto.process_params;


### PR DESCRIPTION
This PR hotfixes a problem in our router instrumentation introduced in #5450 which would cause Express 5 Node apps to crash on startup. Because the internals of Express 5 (which is still in beta) have changed quite a bit compared to Express 4, there is unfortunately no quick way of supporting the new version in our current router instrumentation. 

Therefore, this PR simply checks if the router we retrieve from Express 4 apps (which we get from `app._router`) exists. In case it does, we can patch it; in case it doesn't, we know that the integration is either used with Express 3 or 5. In both cases, we early return and do not patch the router.

We can revisit adding proper support for early URL parameterization of Express 5 apps but for now, this PR will unblock Express 5 users by skipping instrumentation. This means that for Express 5, we fall back to our old way of instrumenting routes (which means we get paramterized routes for transaction names but only after the route handler was executed and the transaction is finished).

fixes #5501