### PR TITLE
fix(remix): Provide `sentry-trace` and `baggage` via root loader.

### DIFF
--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -260,9 +260,7 @@ function makeWrappedRootLoader(origLoader: DataFunction): DataFunction {
 
     const res = await origLoader.call(this, args);
 
-    Object.assign(res, { sentryTrace, sentryBaggage });
-
-    return res;
+    return { ...res, sentryTrace, sentryBaggage };
   };
 }
 

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -381,6 +381,10 @@ function makeWrappedCreateRequestHandler(
         fill(wrappedRoute.module, 'action', makeWrappedAction);
       }
 
+      if (wrappedRoute.module.loader) {
+        fill(wrappedRoute.module, 'loader', makeWrappedLoader);
+      }
+
       // Entry module should have a loader function to provide `sentry-trace` and `baggage`
       // They will be available for the root `meta` function as `data.sentryTrace` and `data.sentryBaggage`
       if (!wrappedRoute.parentId) {
@@ -389,10 +393,6 @@ function makeWrappedCreateRequestHandler(
         }
 
         fill(wrappedRoute.module, 'loader', makeWrappedRootLoader);
-      }
-
-      if (wrappedRoute.module.loader) {
-        fill(wrappedRoute.module, 'loader', makeWrappedLoader);
       }
 
       routes[id] = wrappedRoute;

--- a/packages/remix/test/integration/app/root.tsx
+++ b/packages/remix/test/integration/app/root.tsx
@@ -2,10 +2,12 @@ import type { MetaFunction } from '@remix-run/node';
 import { Links, LiveReload, Meta, Outlet, Scripts, ScrollRestoration } from '@remix-run/react';
 import { withSentry } from '@sentry/remix';
 
-export const meta: MetaFunction = () => ({
+export const meta: MetaFunction = ({ data }) => ({
   charset: 'utf-8',
   title: 'New Remix App',
   viewport: 'width=device-width,initial-scale=1',
+  'sentry-trace': data.sentryTrace,
+  baggage: data.sentryBaggage,
 });
 
 function App() {


### PR DESCRIPTION
Fixes: #5490 

We are currently wrapping [`meta` functions](https://remix.run/docs/en/v1/api/conventions#meta) to create `sentry-trace` and `baggage` `<meta>` tags in the server-side rendered HTML.

It all seems convenient to use that facility (not bothering users to configure anything through the whole process), but turns out it's breaking the hydration. While on React 17, it's just a warning (and `<meta>` tags are still available at the end). On React 18, hydration logic fails and falls back to client-side rendering. 

The problem is that the HTML template for hydration is generated on build time, and uses the `meta` functions before we wrap them. And when we finally wrap it on initial runtime (we are wrapping `createRequestHandler`), the updated template doesn't match.

But we also have `loader` functions available for us that can pass data from server to client-side, and their return values are also available in `meta` functions. Furthermore, using a `loader` data in `meta` seems to spare it from hydration and let it add `<meta>` tags whenever the data is available (which is `handleDocumentRequest` in this case, so just before the start of our `pageload` transaction).

Also, it turns out we don't need to add `<meta>` tags to every sub-route. If we add them to the `root` route, they will be available on the sub-routes. 

So, this PR removes the monkey patching logic for `meta` functions. Instead, introduces a special `loader` wrapper for `root`. This will require the users to set `sentry-trace` and `baggage` in `meta` functions in `root.tsx`.

It will look like:

```typescript
// root.tsx
export const meta: MetaFunction = ({data}) => {
    return {
        charset: "utf-8",
        title: "New Remix App",
        viewport: "width=device-width,initial-scale=1",
        'sentry-trace': data.sentryTrace,
        baggage: data.sentryBaggage,
    };
};
```

Will need to update the docs if this approach sounds good to the team.

Update:
Depending on the resolutions of: https://github.com/remix-run/remix/issues/2947 and https://github.com/facebook/react/issues/24430, we may be able to switch back to the current approach in the future.