### PR TITLE
fix(node): Handle colons in stack trace paths

### DIFF
--- a/packages/node/test/stacktrace.test.ts
+++ b/packages/node/test/stacktrace.test.ts
@@ -362,8 +362,6 @@ describe('Stack parsing', () => {
 
     const frames = parseStackFrames(stackParser, err);
 
-    console.log(frames);
-
     expect(frames).toEqual([
       {
         filename: '/Users/felix/code/node-fast-or-slow/lib/test_case.js',

--- a/packages/node/test/stacktrace.test.ts
+++ b/packages/node/test/stacktrace.test.ts
@@ -120,33 +120,6 @@ describe('Stack parsing', () => {
     ]);
   });
 
-  test('parses with missing column numbers', () => {
-    const err = new Error();
-    err.stack =
-      'AssertionError: true == false\n' +
-      '    at Test.fn (/Users/felix/code/node-fast-or-slow/test/fast/example/test-example.js:6)\n' +
-      '    at Test.run (/Users/felix/code/node-fast-or-slow/lib/test.js:45)';
-
-    const frames = parseStackFrames(stackParser, err);
-
-    expect(frames).toEqual([
-      {
-        filename: '/Users/felix/code/node-fast-or-slow/lib/test.js',
-        module: 'test',
-        function: 'Test.run',
-        lineno: 45,
-        in_app: true,
-      },
-      {
-        filename: '/Users/felix/code/node-fast-or-slow/test/fast/example/test-example.js',
-        module: 'test-example',
-        function: 'Test.fn',
-        lineno: 6,
-        in_app: true,
-      },
-    ]);
-  });
-
   test('parses with native methods', () => {
     const err = new Error();
     err.stack =
@@ -376,6 +349,37 @@ describe('Stack parsing', () => {
         lineno: 17,
         colno: 73,
         in_app: false,
+      },
+    ]);
+  });
+
+  test('parses with colons in paths', () => {
+    const err = new Error();
+    err.stack =
+      'AssertionError: true == false\n' +
+      '    at Test.run (/Users/felix/code/node-fast-or-slow/lib/20:20:20/test.js:45:10)\n' +
+      '    at TestCase.run (/Users/felix/code/node-fast-or-slow/lib/test_case.js:61:8)\n';
+
+    const frames = parseStackFrames(stackParser, err);
+
+    console.log(frames);
+
+    expect(frames).toEqual([
+      {
+        filename: '/Users/felix/code/node-fast-or-slow/lib/test_case.js',
+        module: 'test_case',
+        function: 'TestCase.run',
+        lineno: 61,
+        colno: 8,
+        in_app: true,
+      },
+      {
+        filename: '/Users/felix/code/node-fast-or-slow/lib/20:20:20/test.js',
+        module: 'test',
+        function: 'Test.run',
+        lineno: 45,
+        colno: 10,
+        in_app: true,
       },
     ]);
   });

--- a/packages/utils/src/stacktrace.ts
+++ b/packages/utils/src/stacktrace.ts
@@ -100,7 +100,7 @@ type GetModuleFn = (filename: string | undefined) => string | undefined;
 // eslint-disable-next-line complexity
 function node(getModule?: GetModuleFn): StackLineParserFn {
   const FILENAME_MATCH = /^\s*[-]{4,}$/;
-  const FULL_MATCH = /at (?:async )?(?:(.+?)\s+\()?(?:(.+?):(\d+)(?::(\d+))?|([^)]+))\)?/;
+  const FULL_MATCH = /at (?:async )?(?:(.+?)\s+\()?(?:(.+):(\d+):(\d+)?|([^)]+))\)?/;
 
   // eslint-disable-next-line complexity
   return (line: string) => {


### PR DESCRIPTION
Closes #5151

So the regex doesn't just keep growing in complexity, this change drops the ability to parse stack frames that don't have column numbers. It's my understanding that modern versions of v8/node always have column numbers and this was left over for legacy support.
