### PR TITLE
fix(browser): Parse Chrome stack frames without full paths

### DIFF
--- a/packages/browser/src/stack-parsers.ts
+++ b/packages/browser/src/stack-parsers.ts
@@ -31,7 +31,7 @@ function createFrame(filename: string, func: string, lineno?: number, colno?: nu
 
 // Chromium based browsers: Chrome, Brave, new Opera, new Edge
 const chromeRegex =
-  /^\s*at (?:(.*?) ?\((?:address at )?)?((?:file|https?|blob|chrome-extension|address|native|eval|webpack|<anonymous>|[-a-z]+:|.*bundle|\/).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i;
+  /^\s*at (?:(.*\).*?|.*?) ?\((?:address at )?)?((?:file|https?|blob|chrome-extension|address|native|eval|webpack|<anonymous>|[-a-z]+:|.*bundle|\/)?.*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i;
 const chromeEvalRegex = /\((\S*)(?::(\d+))(?::(\d+))\)/;
 
 const chrome: StackLineParserFn = line => {

--- a/packages/browser/test/unit/tracekit/chromium.test.ts
+++ b/packages/browser/test/unit/tracekit/chromium.test.ts
@@ -431,8 +431,8 @@ describe('Tracekit - Chrome Tests', () => {
     });
   });
 
-  it.only('should parse exceptions with bare filenames', () => {
-    const EDGE44_EVAL_EXCEPTION = {
+  it.only('should parse exceptions with frames without full paths', () => {
+    const EXCEPTION = {
       message: 'aha',
       name: 'Error',
       stack: `Error
@@ -444,7 +444,7 @@ describe('Tracekit - Chrome Tests', () => {
       at commitLayoutEffects (react-dom.development.js?f8c1:23426:1)`,
     };
 
-    const ex = exceptionFromError(parser, EDGE44_EVAL_EXCEPTION);
+    const ex = exceptionFromError(parser, EXCEPTION);
 
     expect(ex).toEqual({
       value: 'aha',

--- a/packages/browser/test/unit/tracekit/chromium.test.ts
+++ b/packages/browser/test/unit/tracekit/chromium.test.ts
@@ -431,7 +431,7 @@ describe('Tracekit - Chrome Tests', () => {
     });
   });
 
-  it.only('should parse exceptions with frames without full paths', () => {
+  it('should parse exceptions with frames without full paths', () => {
     const EXCEPTION = {
       message: 'aha',
       name: 'Error',

--- a/packages/browser/test/unit/tracekit/chromium.test.ts
+++ b/packages/browser/test/unit/tracekit/chromium.test.ts
@@ -430,4 +430,71 @@ describe('Tracekit - Chrome Tests', () => {
       },
     });
   });
+
+  it.only('should parse exceptions with bare filenames', () => {
+    const EDGE44_EVAL_EXCEPTION = {
+      message: 'aha',
+      name: 'Error',
+      stack: `Error
+      at Client.requestPromise (api.tsx:554:1)
+      at doDiscoverQuery (genericDiscoverQuery.tsx?33f8:328:1)
+      at _GenericDiscoverQuery.eval [as fetchData] (genericDiscoverQuery.tsx?33f8:256:1)
+      at _GenericDiscoverQuery.componentDidMount (genericDiscoverQuery.tsx?33f8:152:1)
+      at commitLifeCycles (react-dom.development.js?f8c1:20663:1)
+      at commitLayoutEffects (react-dom.development.js?f8c1:23426:1)`,
+    };
+
+    const ex = exceptionFromError(parser, EDGE44_EVAL_EXCEPTION);
+
+    expect(ex).toEqual({
+      value: 'aha',
+      type: 'Error',
+      stacktrace: {
+        frames: [
+          {
+            filename: 'react-dom.development.js?f8c1',
+            function: 'commitLayoutEffects',
+            in_app: true,
+            lineno: 23426,
+            colno: 1,
+          },
+          {
+            filename: 'react-dom.development.js?f8c1',
+            function: 'commitLifeCycles',
+            in_app: true,
+            lineno: 20663,
+            colno: 1,
+          },
+          {
+            filename: 'genericDiscoverQuery.tsx?33f8',
+            function: '_GenericDiscoverQuery.componentDidMount',
+            in_app: true,
+            lineno: 152,
+            colno: 1,
+          },
+          {
+            filename: 'genericDiscoverQuery.tsx?33f8',
+            function: '_GenericDiscoverQuery.eval [as fetchData]',
+            in_app: true,
+            lineno: 256,
+            colno: 1,
+          },
+          {
+            filename: 'genericDiscoverQuery.tsx?33f8',
+            function: 'doDiscoverQuery',
+            in_app: true,
+            lineno: 328,
+            colno: 1,
+          },
+          {
+            filename: 'api.tsx',
+            function: 'Client.requestPromise',
+            in_app: true,
+            lineno: 554,
+            colno: 1,
+          },
+        ],
+      },
+    });
+  });
 });


### PR DESCRIPTION
Fixes #5498
