### PR TITLE
feat(node): Add `tracePropagationTargets` option

### DIFF
--- a/packages/node-integration-tests/suites/tracing/tracePropagationTargets/scenario.ts
+++ b/packages/node-integration-tests/suites/tracing/tracePropagationTargets/scenario.ts
@@ -1,0 +1,26 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import '@sentry/tracing';
+
+import * as Sentry from '@sentry/node';
+import * as http from 'http';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  tracePropagationTargets: [/\/v0/, 'v1'],
+  integrations: [new Sentry.Integrations.Http({ tracing: true })],
+});
+
+const transaction = Sentry.startTransaction({ name: 'test_transaction' });
+
+Sentry.configureScope(scope => {
+  scope.setSpan(transaction);
+});
+
+http.get('http://match-this-url.com/api/v0');
+http.get('http://match-this-url.com/api/v1');
+http.get('http://dont-match-this-url.com/api/v2');
+http.get('http://dont-match-this-url.com/api/v3');
+
+transaction.finish();

--- a/packages/node-integration-tests/suites/tracing/tracePropagationTargets/test.ts
+++ b/packages/node-integration-tests/suites/tracing/tracePropagationTargets/test.ts
@@ -1,0 +1,37 @@
+import nock from 'nock';
+
+import { runScenario, runServer } from '../../../utils';
+
+test('HttpIntegration should instrument correct requests when tracePropagationTargets option is provided', async () => {
+  const match1 = nock('http://match-this-url.com')
+    .get('/api/v0')
+    .matchHeader('baggage', val => typeof val === 'string')
+    .matchHeader('sentry-trace', val => typeof val === 'string')
+    .reply(200);
+
+  const match2 = nock('http://match-this-url.com')
+    .get('/api/v1')
+    .matchHeader('baggage', val => typeof val === 'string')
+    .matchHeader('sentry-trace', val => typeof val === 'string')
+    .reply(200);
+
+  const match3 = nock('http://dont-match-this-url.com')
+    .get('/api/v2')
+    .matchHeader('baggage', val => val === undefined)
+    .matchHeader('sentry-trace', val => val === undefined)
+    .reply(200);
+
+  const match4 = nock('http://dont-match-this-url.com')
+    .get('/api/v3')
+    .matchHeader('baggage', val => val === undefined)
+    .matchHeader('sentry-trace', val => val === undefined)
+    .reply(200);
+
+  const serverUrl = await runServer(__dirname);
+  await runScenario(serverUrl);
+
+  expect(match1.isDone()).toBe(true);
+  expect(match2.isDone()).toBe(true);
+  expect(match3.isDone()).toBe(true);
+  expect(match4.isDone()).toBe(true);
+});

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -1,9 +1,10 @@
-import { getCurrentHub } from '@sentry/core';
-import { Integration, Span } from '@sentry/types';
-import { fill, logger, mergeAndSerializeBaggage, parseSemver } from '@sentry/utils';
+import { getCurrentHub, Hub } from '@sentry/core';
+import { EventProcessor, Integration, Span } from '@sentry/types';
+import { fill, isMatchingPattern, logger, mergeAndSerializeBaggage, parseSemver } from '@sentry/utils';
 import * as http from 'http';
 import * as https from 'https';
 
+import { NodeClientOptions } from '../types';
 import {
   cleanSpanDescription,
   extractUrl,
@@ -15,7 +16,10 @@ import {
 
 const NODE_VERSION = parseSemver(process.versions.node);
 
-/** http module integration */
+/**
+ * The http module integration instruments nodes internal http module. It creates breadcrumbs, transactions for outgoing
+ * http requests and attaches trace data when tracing is enabled via its `tracing` option.
+ */
 export class Http implements Integration {
   /**
    * @inheritDoc
@@ -48,13 +52,22 @@ export class Http implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(): void {
+  public setupOnce(
+    _addGlobalEventProcessor: (callback: EventProcessor) => void,
+    setupOnceGetCurrentHub: () => Hub,
+  ): void {
     // No need to instrument if we don't want to track anything
     if (!this._breadcrumbs && !this._tracing) {
       return;
     }
 
-    const wrappedHandlerMaker = _createWrappedRequestMethodFactory(this._breadcrumbs, this._tracing);
+    const clientOptions = setupOnceGetCurrentHub().getClient()?.getOptions() as NodeClientOptions | undefined;
+
+    const wrappedHandlerMaker = _createWrappedRequestMethodFactory(
+      this._breadcrumbs,
+      this._tracing,
+      clientOptions?.tracePropagationTargets,
+    );
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const httpModule = require('http');
@@ -90,7 +103,26 @@ type WrappedRequestMethodFactory = (original: OriginalRequestMethod) => WrappedR
 function _createWrappedRequestMethodFactory(
   breadcrumbsEnabled: boolean,
   tracingEnabled: boolean,
+  tracePropagationTargets: (string | RegExp)[] | undefined,
 ): WrappedRequestMethodFactory {
+  // We're caching results so we dont have to recompute regexp everytime we create a request.
+  const urlMap: Record<string, boolean> = {};
+  const shouldAttachTraceData = (url: string): boolean => {
+    if (tracePropagationTargets === undefined) {
+      return true;
+    }
+
+    if (urlMap[url]) {
+      return urlMap[url];
+    }
+
+    urlMap[url] = tracePropagationTargets.some(tracePropagationTarget =>
+      isMatchingPattern(url, tracePropagationTarget),
+    );
+
+    return urlMap[url];
+  };
+
   return function wrappedRequestMethodFactory(originalRequestMethod: OriginalRequestMethod): WrappedRequestMethod {
     return function wrappedMethod(this: typeof http | typeof https, ...args: RequestMethodArgs): http.ClientRequest {
       // eslint-disable-next-line @typescript-eslint/no-this-alias
@@ -109,28 +141,37 @@ function _createWrappedRequestMethodFactory(
       let parentSpan: Span | undefined;
 
       const scope = getCurrentHub().getScope();
+
       if (scope && tracingEnabled) {
         parentSpan = scope.getSpan();
+
         if (parentSpan) {
           span = parentSpan.startChild({
             description: `${requestOptions.method || 'GET'} ${requestUrl}`,
             op: 'http.client',
           });
 
-          const sentryTraceHeader = span.toTraceparent();
-          __DEBUG_BUILD__ &&
-            logger.log(
-              `[Tracing] Adding sentry-trace header ${sentryTraceHeader} to outgoing request to ${requestUrl}: `,
-            );
+          if (shouldAttachTraceData(requestUrl)) {
+            const sentryTraceHeader = span.toTraceparent();
+            __DEBUG_BUILD__ &&
+              logger.log(
+                `[Tracing] Adding sentry-trace header ${sentryTraceHeader} to outgoing request to "${requestUrl}": `,
+              );
 
-          const baggage = parentSpan.transaction && parentSpan.transaction.getBaggage();
-          const headerBaggageString = requestOptions.headers && requestOptions.headers.baggage;
+            const baggage = parentSpan.transaction && parentSpan.transaction.getBaggage();
+            const headerBaggageString = requestOptions.headers && requestOptions.headers.baggage;
 
-          requestOptions.headers = {
-            ...requestOptions.headers,
-            'sentry-trace': sentryTraceHeader,
-            baggage: mergeAndSerializeBaggage(baggage, headerBaggageString),
-          };
+            requestOptions.headers = {
+              ...requestOptions.headers,
+              'sentry-trace': sentryTraceHeader,
+              baggage: mergeAndSerializeBaggage(baggage, headerBaggageString),
+            };
+          } else {
+            __DEBUG_BUILD__ &&
+              logger.log(
+                `[Tracing] Not adding sentry-trace header to outgoing request (${requestUrl}) due to mismatching tracePropagationTargets option.`,
+              );
+          }
         }
       }
 

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -1,5 +1,5 @@
 import { getCurrentHub, Hub } from '@sentry/core';
-import { EventProcessor, Integration, Span } from '@sentry/types';
+import { EventProcessor, Integration, Span, TracePropagationTargets } from '@sentry/types';
 import { fill, isMatchingPattern, logger, mergeAndSerializeBaggage, parseSemver } from '@sentry/utils';
 import * as http from 'http';
 import * as https from 'https';
@@ -103,7 +103,7 @@ type WrappedRequestMethodFactory = (original: OriginalRequestMethod) => WrappedR
 function _createWrappedRequestMethodFactory(
   breadcrumbsEnabled: boolean,
   tracingEnabled: boolean,
-  tracePropagationTargets: (string | RegExp)[] | undefined,
+  tracePropagationTargets: TracePropagationTargets | undefined,
 ): WrappedRequestMethodFactory {
   // We're caching results so we dont have to recompute regexp everytime we create a request.
   const urlMap: Record<string, boolean> = {};

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -17,7 +17,7 @@ import {
 const NODE_VERSION = parseSemver(process.versions.node);
 
 /**
- * The http module integration instruments nodes internal http module. It creates breadcrumbs, transactions for outgoing
+ * The http module integration instruments Node's internal http module. It creates breadcrumbs, transactions for outgoing
  * http requests and attaches trace data when tracing is enabled via its `tracing` option.
  */
 export class Http implements Integration {

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -1,4 +1,4 @@
-import { ClientOptions, Options } from '@sentry/types';
+import { ClientOptions, Options, TracePropagationTargets } from '@sentry/types';
 
 import { NodeTransportOptions } from './transports';
 
@@ -17,7 +17,7 @@ export interface BaseNodeOptions {
    * request URL of outgoing requests against the items in this
    * array, and only attach tracing headers if a match was found.
    */
-  tracePropagationTargets?: (string | RegExp)[];
+  tracePropagationTargets?: TracePropagationTargets;
 
   /** Callback that is executed when a fatal global error occurs. */
   onFatalError?(error: Error): void;

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -6,6 +6,19 @@ export interface BaseNodeOptions {
   /** Sets an optional server name (device name) */
   serverName?: string;
 
+  // We have this option seperately in both the node options and the browser options, so that we can have different JSDoc
+  // comments, since this has different behaviour in the Browser and Node SDKs.
+  /**
+   * List of strings/regex controlling to which outgoing requests
+   * the SDK will attach tracing headers.
+   *
+   * By default the SDK will attach those headers to all outgoing
+   * requests. If this option is provided, the SDK will match the
+   * request URL of outgoing requests against the items in this
+   * array, and only attach tracing headers if a match was found.
+   */
+  tracePropagationTargets?: (string | RegExp)[];
+
   /** Callback that is executed when a fatal global error occurs. */
   onFatalError?(error: Error): void;
 }

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -6,7 +6,7 @@ export interface BaseNodeOptions {
   /** Sets an optional server name (device name) */
   serverName?: string;
 
-  // We have this option seperately in both the node options and the browser options, so that we can have different JSDoc
+  // We have this option separately in both, the node options and the browser options, so that we can have different JSDoc
   // comments, since this has different behaviour in the Browser and Node SDKs.
   /**
    * List of strings/regex controlling to which outgoing requests

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -37,7 +37,7 @@ export type { Hub } from './hub';
 export type { Integration, IntegrationClass } from './integration';
 export type { Mechanism } from './mechanism';
 export type { ExtractedNodeRequestData, HttpHeaderValue, Primitive, WorkerLocation } from './misc';
-export type { ClientOptions, Options, TracePropagationTargets } from './options';
+export type { ClientOptions, Options } from './options';
 export type { Package } from './package';
 export type { PolymorphicEvent } from './polymorphics';
 export type { QueryParams, Request } from './request';
@@ -63,6 +63,7 @@ export type { Span, SpanContext } from './span';
 export type { StackFrame } from './stackframe';
 export type { Stacktrace, StackParser, StackLineParser, StackLineParserFn } from './stacktrace';
 export type { TextEncoderInternal } from './textencoder';
+export type { TracePropagationTargets } from './tracing';
 export type {
   CustomSamplingContext,
   SamplingContext,

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -37,7 +37,7 @@ export type { Hub } from './hub';
 export type { Integration, IntegrationClass } from './integration';
 export type { Mechanism } from './mechanism';
 export type { ExtractedNodeRequestData, HttpHeaderValue, Primitive, WorkerLocation } from './misc';
-export type { ClientOptions, Options } from './options';
+export type { ClientOptions, Options, TracePropagationTargets } from './options';
 export type { Package } from './package';
 export type { PolymorphicEvent } from './polymorphics';
 export type { QueryParams, Request } from './request';

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -7,6 +7,8 @@ import { StackLineParser, StackParser } from './stacktrace';
 import { SamplingContext } from './transaction';
 import { BaseTransportOptions, Transport } from './transport';
 
+export type TracePropagationTargets = (string | RegExp)[];
+
 export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOptions> {
   /**
    * Enable debug functionality in the SDK itself

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -7,8 +7,6 @@ import { StackLineParser, StackParser } from './stacktrace';
 import { SamplingContext } from './transaction';
 import { BaseTransportOptions, Transport } from './transport';
 
-export type TracePropagationTargets = (string | RegExp)[];
-
 export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOptions> {
   /**
    * Enable debug functionality in the SDK itself

--- a/packages/types/src/tracing.ts
+++ b/packages/types/src/tracing.ts
@@ -1,0 +1,1 @@
+export type TracePropagationTargets = (string | RegExp)[];


### PR DESCRIPTION
This PR adds the `tracePropagationTargets` option as outlined in https://github.com/getsentry/sentry-javascript/issues/5403,  https://github.com/getsentry/develop/issues/636, and [DACI](https://www.notion.so/sentry/DACI-Control-Sending-Trace-Data-63fd04ea885443ee99514c15a1e91499) (internal)  to the node SDK init options.

The `tracePropagationTargets` option can be used to control to which request the SDK should attach trace data (at the time of writing via `sentry-trace` and `baggage` headers).

Its behavior (at least for node) is as follows: If not provided, the SDK will attach tracing data to *all* outgoing requests. If provided, the SDK will only attach trace data when the request's URL matches one of the items in the `tracePropagationTargets` array.

Resolves https://github.com/getsentry/sentry-javascript/issues/5403

---
Notes:

- Since the option has a different meaning in the node SDK vs the browser SDK, I suggest we have the option types separated so we can have different JSDoc for each of them.
