### PR TITLE
fix(browser): Strip webpack wrapping from stack frames

### DIFF
--- a/packages/browser/test/unit/tracekit/chromium.test.ts
+++ b/packages/browser/test/unit/tracekit/chromium.test.ts
@@ -497,4 +497,54 @@ describe('Tracekit - Chrome Tests', () => {
       },
     });
   });
+
+  it('should parse webpack wrapped exceptions', () => {
+    const EXCEPTION = {
+      message: 'aha',
+      name: 'ChunkLoadError',
+      stack: `ChunkLoadError: Loading chunk app_bootstrap_initializeLocale_tsx failed.
+      (error: https://s1.sentry-cdn.com/_static/dist/sentry/chunks/app_bootstrap_initializeLocale_tsx.abcdefg.js)
+        at (error: (/_static/dist/sentry/chunks/app_bootstrap_initializeLocale_tsx.abcdefg.js))
+        at key(webpack/runtime/jsonp chunk loading:27:18)
+        at ? (webpack/runtime/ensure chunk:6:25)
+        at Array.reduce(<anonymous>)`,
+    };
+
+    const ex = exceptionFromError(parser, EXCEPTION);
+
+    expect(ex).toEqual({
+      value: 'aha',
+      type: 'ChunkLoadError',
+      stacktrace: {
+        frames: [
+          { filename: '<anonymous>', function: 'Array.reduce', in_app: true },
+          {
+            filename: 'webpack/runtime/ensure chunk',
+            function: '?',
+            in_app: true,
+            lineno: 6,
+            colno: 25,
+          },
+          {
+            filename: 'webpack/runtime/jsonp chunk loading',
+            function: 'key',
+            in_app: true,
+            lineno: 27,
+            colno: 18,
+          },
+          {
+            filename: '/_static/dist/sentry/chunks/app_bootstrap_initializeLocale_tsx.abcdefg.js',
+            function: '?',
+            in_app: true,
+          },
+          {
+            filename:
+              'https://s1.sentry-cdn.com/_static/dist/sentry/chunks/app_bootstrap_initializeLocale_tsx.abcdefg.js',
+            function: '?',
+            in_app: true,
+          },
+        ],
+      },
+    });
+  });
 });

--- a/packages/utils/src/stacktrace.ts
+++ b/packages/utils/src/stacktrace.ts
@@ -16,8 +16,12 @@ export function createStackParser(...parsers: StackLineParser[]): StackParser {
     const frames: StackFrame[] = [];
 
     for (const line of stack.split('\n').slice(skipFirst)) {
+      // https://github.com/getsentry/sentry-javascript/issues/5459
+      // Remove webpack (error: *) wrappers
+      const cleanedLine = line.replace(/\(error: (.*)\)/, '$1');
+
       for (const parser of sortedParsers) {
-        const frame = parser(line);
+        const frame = parser(cleanedLine);
 
         if (frame) {
           frames.push(frame);


### PR DESCRIPTION
Fixes #5459

I did try and solve this via the Chrome regex but found that the 2nd line (`(error: https://s1.sentry-cdn.com/_static/dist/sentry/chunks/app_bootstrap_initializeLocale_tsx.abcdefg.js)`) was picked up by the gecko parser. This change just strips the `(error: *)` wrapper from all lines before parsing proper. Line 2 is still parsed by the gecko parser but the resulting frame seems sensible even if it doesn't contain much useful info. 

The following stack string:
```
ChunkLoadError: Loading chunk app_bootstrap_initializeLocale_tsx failed.
      (error: https://s1.sentry-cdn.com/_static/dist/sentry/chunks/app_bootstrap_initializeLocale_tsx.abcdefg.js)
        at (error: (/_static/dist/sentry/chunks/app_bootstrap_initializeLocale_tsx.abcdefg.js))
        at key(webpack/runtime/jsonp chunk loading:27:18)
        at ? (webpack/runtime/ensure chunk:6:25)
        at Array.reduce(<anonymous>)
```
Now results in the following frames:
```ts
        [ 
          { 
            filename: '<anonymous>', 
            function: 'Array.reduce', 
            in_app: true 
          },
          {
            filename: 'webpack/runtime/ensure chunk',
            function: '?',
            in_app: true,
            lineno: 6,
            colno: 25,
          },
          {
            filename: 'webpack/runtime/jsonp chunk loading',
            function: 'key',
            in_app: true,
            lineno: 27,
            colno: 18,
          },
          {
            filename: '/_static/dist/sentry/chunks/app_bootstrap_initializeLocale_tsx.abcdefg.js',
            function: '?',
            in_app: true,
          },
          {
            filename: 'https://s1.sentry-cdn.com/_static/dist/sentry/chunks/app_bootstrap_initializeLocale_tsx.abcdefg.js',
            function: '?',
            in_app: true,
          },
        ]
```