### PR TITLE
feat(react): Track duration of React component updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,5 @@
   },
   "yaml.schemas": {
     "https://json.schemastore.org/github-workflow.json": ".github/workflows/**.yml"
-  },
-  "prettier.configPath": "/Users/ash/code/sentry-javascript/.prettierrc.json"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,5 @@
   },
   "yaml.schemas": {
     "https://json.schemastore.org/github-workflow.json": ".github/workflows/**.yml"
-  }
+  },
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,4 +21,5 @@
   "yaml.schemas": {
     "https://json.schemastore.org/github-workflow.json": ".github/workflows/**.yml"
   },
+  "prettier.configPath": "/Users/ash/code/sentry-javascript/.prettierrc.json"
 }

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -34,6 +34,9 @@ class Profiler extends React.Component<ProfilerProps> {
    * Made protected for the React Native SDK to access
    */
   protected _mountSpan: Span | undefined = undefined;
+  /**
+   * The span that represents the duration of time between shouldComponentUpdate and componentDidUpdate
+   */
   protected _updateSpan: Span | undefined = undefined;
 
   // eslint-disable-next-line @typescript-eslint/member-ordering
@@ -76,8 +79,6 @@ class Profiler extends React.Component<ProfilerProps> {
       // set as data on the span. We just store the prop keys as the values could be potenially very large.
       const changedProps = Object.keys(updateProps).filter(k => updateProps[k] !== this.props.updateProps[k]);
       if (changedProps.length > 0) {
-        // The update span is a point in time span with 0 duration, just signifying that the component
-        // has been updated.
         const now = timestampWithMs();
         this._updateSpan = this._mountSpan.startChild({
           data: {

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { getCurrentHub, Hub } from '@sentry/browser';
-import { Span, Transaction } from '@sentry/types';
-import { timestampWithMs } from '@sentry/utils';
+import {getCurrentHub, Hub} from '@sentry/browser';
+import {Span, Transaction} from '@sentry/types';
+import {timestampWithMs} from '@sentry/utils';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
 
-import { REACT_MOUNT_OP, REACT_RENDER_OP, REACT_UPDATE_OP } from './constants';
+import {REACT_MOUNT_OP, REACT_RENDER_OP, REACT_UPDATE_OP} from './constants';
 
 export const UNKNOWN_COMPONENT = 'unknown';
 
@@ -21,7 +21,7 @@ export type ProfilerProps = {
   // If component updates should be displayed as spans. True by default.
   includeUpdates?: boolean;
   // props given to component being profiled.
-  updateProps: { [key: string]: unknown };
+  updateProps: {[key: string]: unknown};
 };
 
 /**
@@ -45,7 +45,7 @@ class Profiler extends React.Component<ProfilerProps> {
 
   public constructor(props: ProfilerProps) {
     super(props);
-    const { name, disabled = false } = this.props;
+    const {name, disabled = false} = this.props;
 
     if (disabled) {
       return;
@@ -67,11 +67,19 @@ class Profiler extends React.Component<ProfilerProps> {
     }
   }
 
-  public shouldComponentUpdate({ updateProps, includeUpdates = true }: ProfilerProps): boolean {
+  public shouldComponentUpdate({
+    updateProps,
+    includeUpdates = true,
+  }: ProfilerProps): boolean {
+    // Only generate an update span if includeUpdates is true, if there is a valid mountSpan,
+    // and if the updateProps have changed. It is ok to not do a deep equality check here as it is expensive.
+    // We are just trying to give baseline clues for further investigation.
     if (includeUpdates && this._mountSpan && updateProps !== this.props.updateProps) {
       // See what props haved changed between the previous props, and the current props. This is
       // set as data on the span. We just store the prop keys as the values could be potenially very large.
-      const changedProps = Object.keys(updateProps).filter(k => updateProps[k] !== this.props.updateProps[k]);
+      const changedProps = Object.keys(updateProps).filter(
+        k => updateProps[k] !== this.props.updateProps[k]
+      );
       if (changedProps.length > 0) {
         // The update span is a point in time span with 0 duration, just signifying that the component
         // has been updated.
@@ -91,9 +99,6 @@ class Profiler extends React.Component<ProfilerProps> {
   }
 
   public componentDidUpdate(): void {
-    // Only generate an update span if hasUpdateSpan is true, if there is a valid mountSpan,
-    // and if the updateProps have changed. It is ok to not do a deep equality check here as it is expensive.
-    // We are just trying to give baseline clues for further investigation.
     if (this._updateSpan) {
       this._updateSpan.finish();
       this._updateSpan = undefined;
@@ -103,7 +108,7 @@ class Profiler extends React.Component<ProfilerProps> {
   // If a component is unmounted, we can say it is no longer on the screen.
   // This means we can finish the span representing the component render.
   public componentWillUnmount(): void {
-    const { name, includeRender = true } = this.props;
+    const {name, includeRender = true} = this.props;
 
     if (this._mountSpan && includeRender) {
       // If we were able to obtain the spanId of the mount activity, we should set the
@@ -133,10 +138,13 @@ class Profiler extends React.Component<ProfilerProps> {
 function withProfiler<P extends Record<string, any>>(
   WrappedComponent: React.ComponentType<P>,
   // We do not want to have `updateProps` given in options, it is instead filled through the HOC.
-  options?: Pick<Partial<ProfilerProps>, Exclude<keyof ProfilerProps, 'updateProps'>>,
+  options?: Pick<Partial<ProfilerProps>, Exclude<keyof ProfilerProps, 'updateProps'>>
 ): React.FC<P> {
   const componentDisplayName =
-    (options && options.name) || WrappedComponent.displayName || WrappedComponent.name || UNKNOWN_COMPONENT;
+    (options && options.name) ||
+    WrappedComponent.displayName ||
+    WrappedComponent.name ||
+    UNKNOWN_COMPONENT;
 
   const Wrapped: React.FC<P> = (props: P) => (
     <Profiler {...options} name={componentDisplayName} updateProps={props}>
@@ -161,10 +169,10 @@ function withProfiler<P extends Record<string, any>>(
  */
 function useProfiler(
   name: string,
-  options: { disabled?: boolean; hasRenderSpan?: boolean } = {
+  options: {disabled?: boolean; hasRenderSpan?: boolean} = {
     disabled: false,
     hasRenderSpan: true,
-  },
+  }
 ): void {
   const [mountSpan] = React.useState(() => {
     if (options && options.disabled) {
@@ -202,10 +210,12 @@ function useProfiler(
   }, []);
 }
 
-export { withProfiler, Profiler, useProfiler };
+export {withProfiler, Profiler, useProfiler};
 
 /** Grabs active transaction off scope */
-export function getActiveTransaction<T extends Transaction>(hub: Hub = getCurrentHub()): T | undefined {
+export function getActiveTransaction<T extends Transaction>(
+  hub: Hub = getCurrentHub()
+): T | undefined {
   if (hub) {
     const scope = hub.getScope();
     if (scope) {

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {getCurrentHub, Hub} from '@sentry/browser';
-import {Span, Transaction} from '@sentry/types';
-import {timestampWithMs} from '@sentry/utils';
+import { getCurrentHub, Hub } from '@sentry/browser';
+import { Span, Transaction } from '@sentry/types';
+import { timestampWithMs } from '@sentry/utils';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
 
-import {REACT_MOUNT_OP, REACT_RENDER_OP, REACT_UPDATE_OP} from './constants';
+import { REACT_MOUNT_OP, REACT_RENDER_OP, REACT_UPDATE_OP } from './constants';
 
 export const UNKNOWN_COMPONENT = 'unknown';
 
@@ -21,7 +21,7 @@ export type ProfilerProps = {
   // If component updates should be displayed as spans. True by default.
   includeUpdates?: boolean;
   // props given to component being profiled.
-  updateProps: {[key: string]: unknown};
+  updateProps: { [key: string]: unknown };
 };
 
 /**
@@ -45,7 +45,7 @@ class Profiler extends React.Component<ProfilerProps> {
 
   public constructor(props: ProfilerProps) {
     super(props);
-    const {name, disabled = false} = this.props;
+    const { name, disabled = false } = this.props;
 
     if (disabled) {
       return;
@@ -67,19 +67,14 @@ class Profiler extends React.Component<ProfilerProps> {
     }
   }
 
-  public shouldComponentUpdate({
-    updateProps,
-    includeUpdates = true,
-  }: ProfilerProps): boolean {
+  public shouldComponentUpdate({ updateProps, includeUpdates = true }: ProfilerProps): boolean {
     // Only generate an update span if includeUpdates is true, if there is a valid mountSpan,
     // and if the updateProps have changed. It is ok to not do a deep equality check here as it is expensive.
     // We are just trying to give baseline clues for further investigation.
     if (includeUpdates && this._mountSpan && updateProps !== this.props.updateProps) {
       // See what props haved changed between the previous props, and the current props. This is
       // set as data on the span. We just store the prop keys as the values could be potenially very large.
-      const changedProps = Object.keys(updateProps).filter(
-        k => updateProps[k] !== this.props.updateProps[k]
-      );
+      const changedProps = Object.keys(updateProps).filter(k => updateProps[k] !== this.props.updateProps[k]);
       if (changedProps.length > 0) {
         // The update span is a point in time span with 0 duration, just signifying that the component
         // has been updated.
@@ -108,7 +103,7 @@ class Profiler extends React.Component<ProfilerProps> {
   // If a component is unmounted, we can say it is no longer on the screen.
   // This means we can finish the span representing the component render.
   public componentWillUnmount(): void {
-    const {name, includeRender = true} = this.props;
+    const { name, includeRender = true } = this.props;
 
     if (this._mountSpan && includeRender) {
       // If we were able to obtain the spanId of the mount activity, we should set the
@@ -138,13 +133,10 @@ class Profiler extends React.Component<ProfilerProps> {
 function withProfiler<P extends Record<string, any>>(
   WrappedComponent: React.ComponentType<P>,
   // We do not want to have `updateProps` given in options, it is instead filled through the HOC.
-  options?: Pick<Partial<ProfilerProps>, Exclude<keyof ProfilerProps, 'updateProps'>>
+  options?: Pick<Partial<ProfilerProps>, Exclude<keyof ProfilerProps, 'updateProps'>>,
 ): React.FC<P> {
   const componentDisplayName =
-    (options && options.name) ||
-    WrappedComponent.displayName ||
-    WrappedComponent.name ||
-    UNKNOWN_COMPONENT;
+    (options && options.name) || WrappedComponent.displayName || WrappedComponent.name || UNKNOWN_COMPONENT;
 
   const Wrapped: React.FC<P> = (props: P) => (
     <Profiler {...options} name={componentDisplayName} updateProps={props}>
@@ -169,10 +161,10 @@ function withProfiler<P extends Record<string, any>>(
  */
 function useProfiler(
   name: string,
-  options: {disabled?: boolean; hasRenderSpan?: boolean} = {
+  options: { disabled?: boolean; hasRenderSpan?: boolean } = {
     disabled: false,
     hasRenderSpan: true,
-  }
+  },
 ): void {
   const [mountSpan] = React.useState(() => {
     if (options && options.disabled) {
@@ -210,12 +202,10 @@ function useProfiler(
   }, []);
 }
 
-export {withProfiler, Profiler, useProfiler};
+export { withProfiler, Profiler, useProfiler };
 
 /** Grabs active transaction off scope */
-export function getActiveTransaction<T extends Transaction>(
-  hub: Hub = getCurrentHub()
-): T | undefined {
+export function getActiveTransaction<T extends Transaction>(hub: Hub = getCurrentHub()): T | undefined {
   if (hub) {
     const scope = hub.getScope();
     if (scope) {

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {getCurrentHub, Hub} from '@sentry/browser';
-import {Span, Transaction} from '@sentry/types';
-import {timestampWithMs} from '@sentry/utils';
+import { getCurrentHub, Hub } from '@sentry/browser';
+import { Span, Transaction } from '@sentry/types';
+import { timestampWithMs } from '@sentry/utils';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
 
-import {REACT_MOUNT_OP, REACT_RENDER_OP, REACT_UPDATE_OP} from './constants';
+import { REACT_MOUNT_OP, REACT_RENDER_OP, REACT_UPDATE_OP } from './constants';
 
 export const UNKNOWN_COMPONENT = 'unknown';
 
@@ -21,7 +21,7 @@ export type ProfilerProps = {
   // If component updates should be displayed as spans. True by default.
   includeUpdates?: boolean;
   // props given to component being profiled.
-  updateProps: {[key: string]: unknown};
+  updateProps: { [key: string]: unknown };
 };
 
 /**
@@ -45,7 +45,7 @@ class Profiler extends React.Component<ProfilerProps> {
 
   public constructor(props: ProfilerProps) {
     super(props);
-    const {name, disabled = false} = this.props;
+    const { name, disabled = false } = this.props;
 
     if (disabled) {
       return;
@@ -67,16 +67,11 @@ class Profiler extends React.Component<ProfilerProps> {
     }
   }
 
-  public shouldComponentUpdate({
-    updateProps,
-    includeUpdates = true,
-  }: ProfilerProps): boolean {
+  public shouldComponentUpdate({ updateProps, includeUpdates = true }: ProfilerProps): boolean {
     if (includeUpdates && this._mountSpan && updateProps !== this.props.updateProps) {
       // See what props haved changed between the previous props, and the current props. This is
       // set as data on the span. We just store the prop keys as the values could be potenially very large.
-      const changedProps = Object.keys(updateProps).filter(
-        k => updateProps[k] !== this.props.updateProps[k]
-      );
+      const changedProps = Object.keys(updateProps).filter(k => updateProps[k] !== this.props.updateProps[k]);
       if (changedProps.length > 0) {
         // The update span is a point in time span with 0 duration, just signifying that the component
         // has been updated.
@@ -108,7 +103,7 @@ class Profiler extends React.Component<ProfilerProps> {
   // If a component is unmounted, we can say it is no longer on the screen.
   // This means we can finish the span representing the component render.
   public componentWillUnmount(): void {
-    const {name, includeRender = true} = this.props;
+    const { name, includeRender = true } = this.props;
 
     if (this._mountSpan && includeRender) {
       // If we were able to obtain the spanId of the mount activity, we should set the
@@ -138,13 +133,10 @@ class Profiler extends React.Component<ProfilerProps> {
 function withProfiler<P extends Record<string, any>>(
   WrappedComponent: React.ComponentType<P>,
   // We do not want to have `updateProps` given in options, it is instead filled through the HOC.
-  options?: Pick<Partial<ProfilerProps>, Exclude<keyof ProfilerProps, 'updateProps'>>
+  options?: Pick<Partial<ProfilerProps>, Exclude<keyof ProfilerProps, 'updateProps'>>,
 ): React.FC<P> {
   const componentDisplayName =
-    (options && options.name) ||
-    WrappedComponent.displayName ||
-    WrappedComponent.name ||
-    UNKNOWN_COMPONENT;
+    (options && options.name) || WrappedComponent.displayName || WrappedComponent.name || UNKNOWN_COMPONENT;
 
   const Wrapped: React.FC<P> = (props: P) => (
     <Profiler {...options} name={componentDisplayName} updateProps={props}>
@@ -169,10 +161,10 @@ function withProfiler<P extends Record<string, any>>(
  */
 function useProfiler(
   name: string,
-  options: {disabled?: boolean; hasRenderSpan?: boolean} = {
+  options: { disabled?: boolean; hasRenderSpan?: boolean } = {
     disabled: false,
     hasRenderSpan: true,
-  }
+  },
 ): void {
   const [mountSpan] = React.useState(() => {
     if (options && options.disabled) {
@@ -210,12 +202,10 @@ function useProfiler(
   }, []);
 }
 
-export {withProfiler, Profiler, useProfiler};
+export { withProfiler, Profiler, useProfiler };
 
 /** Grabs active transaction off scope */
-export function getActiveTransaction<T extends Transaction>(
-  hub: Hub = getCurrentHub()
-): T | undefined {
+export function getActiveTransaction<T extends Transaction>(hub: Hub = getCurrentHub()): T | undefined {
   if (hub) {
     const scope = hub.getScope();
     if (scope) {

--- a/packages/react/test/profiler.test.tsx
+++ b/packages/react/test/profiler.test.tsx
@@ -1,12 +1,12 @@
-import {SpanContext} from '@sentry/types';
-import {render} from '@testing-library/react';
-import {renderHook} from '@testing-library/react-hooks';
+import { SpanContext } from '@sentry/types';
+import { render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
 import * as React from 'react';
 
-import {REACT_MOUNT_OP, REACT_RENDER_OP, REACT_UPDATE_OP} from '../src/constants';
-import {UNKNOWN_COMPONENT, useProfiler, withProfiler} from '../src/profiler';
+import { REACT_MOUNT_OP, REACT_RENDER_OP, REACT_UPDATE_OP } from '../src/constants';
+import { UNKNOWN_COMPONENT, useProfiler, withProfiler } from '../src/profiler';
 
-const mockStartChild = jest.fn((spanArgs: SpanContext) => ({...spanArgs}));
+const mockStartChild = jest.fn((spanArgs: SpanContext) => ({ ...spanArgs }));
 const mockFinish = jest.fn();
 
 // @sent
@@ -37,7 +37,7 @@ jest.mock('@sentry/browser', () => ({
 beforeEach(() => {
   mockStartChild.mockClear();
   mockFinish.mockClear();
-  activeTransaction = new MockSpan({op: 'pageload'});
+  activeTransaction = new MockSpan({ op: 'pageload' });
 });
 
 describe('withProfiler', () => {
@@ -51,7 +51,7 @@ describe('withProfiler', () => {
   it('sets a custom displayName', () => {
     const TestComponent = () => <h1>Hello World</h1>;
 
-    const ProfiledComponent = withProfiler(TestComponent, {name: 'BestComponent'});
+    const ProfiledComponent = withProfiler(TestComponent, { name: 'BestComponent' });
     expect(ProfiledComponent.displayName).toBe('profiler(BestComponent)');
   });
 
@@ -62,7 +62,7 @@ describe('withProfiler', () => {
 
   describe('mount span', () => {
     it('does not get created if Profiler is disabled', () => {
-      const ProfiledComponent = withProfiler(() => <h1>Testing</h1>, {disabled: true});
+      const ProfiledComponent = withProfiler(() => <h1>Testing</h1>, { disabled: true });
       expect(mockStartChild).toHaveBeenCalledTimes(0);
       render(<ProfiledComponent />);
       expect(mockStartChild).toHaveBeenCalledTimes(0);
@@ -115,17 +115,15 @@ describe('withProfiler', () => {
 
   describe('update span', () => {
     it('is created when component is updated', () => {
-      const ProfiledComponent = withProfiler((props: {num: number}) => (
-        <div>{props.num}</div>
-      ));
-      const {rerender} = render(<ProfiledComponent num={0} />);
+      const ProfiledComponent = withProfiler((props: { num: number }) => <div>{props.num}</div>);
+      const { rerender } = render(<ProfiledComponent num={0} />);
       expect(mockStartChild).toHaveBeenCalledTimes(1);
 
       // Dispatch new props
       rerender(<ProfiledComponent num={1} />);
       expect(mockStartChild).toHaveBeenCalledTimes(2);
       expect(mockStartChild).toHaveBeenLastCalledWith({
-        data: {changedProps: ['num']},
+        data: { changedProps: ['num'] },
         description: `<${UNKNOWN_COMPONENT}>`,
         op: REACT_UPDATE_OP,
         startTimestamp: expect.any(Number),
@@ -135,7 +133,7 @@ describe('withProfiler', () => {
       rerender(<ProfiledComponent num={2} />);
       expect(mockStartChild).toHaveBeenCalledTimes(3);
       expect(mockStartChild).toHaveBeenLastCalledWith({
-        data: {changedProps: ['num']},
+        data: { changedProps: ['num'] },
         description: `<${UNKNOWN_COMPONENT}>`,
         op: REACT_UPDATE_OP,
         startTimestamp: expect.any(Number),
@@ -148,13 +146,10 @@ describe('withProfiler', () => {
     });
 
     it('does not get created if hasUpdateSpan is false', () => {
-      const ProfiledComponent = withProfiler(
-        (props: {num: number}) => <div>{props.num}</div>,
-        {
-          includeUpdates: false,
-        }
-      );
-      const {rerender} = render(<ProfiledComponent num={0} />);
+      const ProfiledComponent = withProfiler((props: { num: number }) => <div>{props.num}</div>, {
+        includeUpdates: false,
+      });
+      const { rerender } = render(<ProfiledComponent num={0} />);
       expect(mockStartChild).toHaveBeenCalledTimes(1);
 
       // Dispatch new props
@@ -167,7 +162,7 @@ describe('withProfiler', () => {
 describe('useProfiler()', () => {
   describe('mount span', () => {
     it('does not get created if Profiler is disabled', () => {
-      renderHook(() => useProfiler('Example', {disabled: true}));
+      renderHook(() => useProfiler('Example', { disabled: true }));
       expect(mockStartChild).toHaveBeenCalledTimes(0);
     });
 
@@ -184,7 +179,7 @@ describe('useProfiler()', () => {
 
   describe('render span', () => {
     it('does not get created when hasRenderSpan is false', () => {
-      const component = renderHook(() => useProfiler('Example', {hasRenderSpan: false}));
+      const component = renderHook(() => useProfiler('Example', { hasRenderSpan: false }));
       expect(mockStartChild).toHaveBeenCalledTimes(1);
       component.unmount();
       expect(mockStartChild).toHaveBeenCalledTimes(1);
@@ -200,7 +195,7 @@ describe('useProfiler()', () => {
         expect.objectContaining({
           description: '<Example>',
           op: REACT_RENDER_OP,
-        })
+        }),
       );
     });
   });

--- a/packages/react/test/profiler.test.tsx
+++ b/packages/react/test/profiler.test.tsx
@@ -1,12 +1,12 @@
-import { SpanContext } from '@sentry/types';
-import { render } from '@testing-library/react';
-import { renderHook } from '@testing-library/react-hooks';
+import {SpanContext} from '@sentry/types';
+import {render} from '@testing-library/react';
+import {renderHook} from '@testing-library/react-hooks';
 import * as React from 'react';
 
-import { REACT_MOUNT_OP, REACT_RENDER_OP, REACT_UPDATE_OP } from '../src/constants';
-import { UNKNOWN_COMPONENT, useProfiler, withProfiler } from '../src/profiler';
+import {REACT_MOUNT_OP, REACT_RENDER_OP, REACT_UPDATE_OP} from '../src/constants';
+import {UNKNOWN_COMPONENT, useProfiler, withProfiler} from '../src/profiler';
 
-const mockStartChild = jest.fn((spanArgs: SpanContext) => ({ ...spanArgs }));
+const mockStartChild = jest.fn((spanArgs: SpanContext) => ({...spanArgs}));
 const mockFinish = jest.fn();
 
 // @sent
@@ -36,7 +36,8 @@ jest.mock('@sentry/browser', () => ({
 
 beforeEach(() => {
   mockStartChild.mockClear();
-  activeTransaction = new MockSpan({ op: 'pageload' });
+  mockFinish.mockClear();
+  activeTransaction = new MockSpan({op: 'pageload'});
 });
 
 describe('withProfiler', () => {
@@ -50,7 +51,7 @@ describe('withProfiler', () => {
   it('sets a custom displayName', () => {
     const TestComponent = () => <h1>Hello World</h1>;
 
-    const ProfiledComponent = withProfiler(TestComponent, { name: 'BestComponent' });
+    const ProfiledComponent = withProfiler(TestComponent, {name: 'BestComponent'});
     expect(ProfiledComponent.displayName).toBe('profiler(BestComponent)');
   });
 
@@ -61,7 +62,7 @@ describe('withProfiler', () => {
 
   describe('mount span', () => {
     it('does not get created if Profiler is disabled', () => {
-      const ProfiledComponent = withProfiler(() => <h1>Testing</h1>, { disabled: true });
+      const ProfiledComponent = withProfiler(() => <h1>Testing</h1>, {disabled: true});
       expect(mockStartChild).toHaveBeenCalledTimes(0);
       render(<ProfiledComponent />);
       expect(mockStartChild).toHaveBeenCalledTimes(0);
@@ -100,7 +101,9 @@ describe('withProfiler', () => {
     });
 
     it('is not created if hasRenderSpan is false', () => {
-      const ProfiledComponent = withProfiler(() => <h1>Testing</h1>, { includeRender: false });
+      const ProfiledComponent = withProfiler(() => <h1>Testing</h1>, {
+        includeRender: false,
+      });
       expect(mockStartChild).toHaveBeenCalledTimes(0);
 
       const component = render(<ProfiledComponent />);
@@ -112,28 +115,28 @@ describe('withProfiler', () => {
 
   describe('update span', () => {
     it('is created when component is updated', () => {
-      const ProfiledComponent = withProfiler((props: { num: number }) => <div>{props.num}</div>);
-      const { rerender } = render(<ProfiledComponent num={0} />);
+      const ProfiledComponent = withProfiler((props: {num: number}) => (
+        <div>{props.num}</div>
+      ));
+      const {rerender} = render(<ProfiledComponent num={0} />);
       expect(mockStartChild).toHaveBeenCalledTimes(1);
 
       // Dispatch new props
       rerender(<ProfiledComponent num={1} />);
       expect(mockStartChild).toHaveBeenCalledTimes(2);
       expect(mockStartChild).toHaveBeenLastCalledWith({
-        data: { changedProps: ['num'] },
+        data: {changedProps: ['num']},
         description: `<${UNKNOWN_COMPONENT}>`,
-        endTimestamp: expect.any(Number),
         op: REACT_UPDATE_OP,
         startTimestamp: expect.any(Number),
       });
-
+      expect(mockFinish).toHaveBeenCalledTimes(2);
       // New props yet again
       rerender(<ProfiledComponent num={2} />);
       expect(mockStartChild).toHaveBeenCalledTimes(3);
       expect(mockStartChild).toHaveBeenLastCalledWith({
-        data: { changedProps: ['num'] },
+        data: {changedProps: ['num']},
         description: `<${UNKNOWN_COMPONENT}>`,
-        endTimestamp: expect.any(Number),
         op: REACT_UPDATE_OP,
         startTimestamp: expect.any(Number),
       });
@@ -141,13 +144,17 @@ describe('withProfiler', () => {
       // Should not create spans if props haven't changed
       rerender(<ProfiledComponent num={2} />);
       expect(mockStartChild).toHaveBeenCalledTimes(3);
+      expect(mockFinish).toHaveBeenCalledTimes(3);
     });
 
     it('does not get created if hasUpdateSpan is false', () => {
-      const ProfiledComponent = withProfiler((props: { num: number }) => <div>{props.num}</div>, {
-        includeUpdates: false,
-      });
-      const { rerender } = render(<ProfiledComponent num={0} />);
+      const ProfiledComponent = withProfiler(
+        (props: {num: number}) => <div>{props.num}</div>,
+        {
+          includeUpdates: false,
+        }
+      );
+      const {rerender} = render(<ProfiledComponent num={0} />);
       expect(mockStartChild).toHaveBeenCalledTimes(1);
 
       // Dispatch new props
@@ -160,7 +167,7 @@ describe('withProfiler', () => {
 describe('useProfiler()', () => {
   describe('mount span', () => {
     it('does not get created if Profiler is disabled', () => {
-      renderHook(() => useProfiler('Example', { disabled: true }));
+      renderHook(() => useProfiler('Example', {disabled: true}));
       expect(mockStartChild).toHaveBeenCalledTimes(0);
     });
 
@@ -177,7 +184,7 @@ describe('useProfiler()', () => {
 
   describe('render span', () => {
     it('does not get created when hasRenderSpan is false', () => {
-      const component = renderHook(() => useProfiler('Example', { hasRenderSpan: false }));
+      const component = renderHook(() => useProfiler('Example', {hasRenderSpan: false}));
       expect(mockStartChild).toHaveBeenCalledTimes(1);
       component.unmount();
       expect(mockStartChild).toHaveBeenCalledTimes(1);
@@ -193,7 +200,7 @@ describe('useProfiler()', () => {
         expect.objectContaining({
           description: '<Example>',
           op: REACT_RENDER_OP,
-        }),
+        })
       );
     });
   });

--- a/packages/react/test/profiler.test.tsx
+++ b/packages/react/test/profiler.test.tsx
@@ -118,6 +118,7 @@ describe('withProfiler', () => {
       const ProfiledComponent = withProfiler((props: { num: number }) => <div>{props.num}</div>);
       const { rerender } = render(<ProfiledComponent num={0} />);
       expect(mockStartChild).toHaveBeenCalledTimes(1);
+      expect(mockFinish).toHaveBeenCalledTimes(1);
 
       // Dispatch new props
       rerender(<ProfiledComponent num={1} />);
@@ -138,6 +139,7 @@ describe('withProfiler', () => {
         op: REACT_UPDATE_OP,
         startTimestamp: expect.any(Number),
       });
+      expect(mockFinish).toHaveBeenCalledTimes(3);
 
       // Should not create spans if props haven't changed
       rerender(<ProfiledComponent num={2} />);


### PR DESCRIPTION
This PR gives the React SDK the ability to track the duration of `ui.react.update` spans by calling `startChild` within the `shouldComponentUpdate` lifecycle method, and then calling `finish` in `componentDidUpdate`

This will allow Performance users to see in their transactions how long it is taking their components to update

### Before
![image](https://user-images.githubusercontent.com/16740047/183150905-5b489a4b-d907-418f-8864-cb4fa96b4376.png)


### After
![image](https://user-images.githubusercontent.com/16740047/183150809-4c55c49b-650f-45ef-85ce-401657913083.png)
