### PR TITLE
fix(integration): Don't mangle localforage internals

### DIFF
--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -92,8 +92,15 @@ export function makeTerserPlugin() {
       properties: {
         // allow mangling of private field names...
         regex: /^_[^_]/,
-        // ...except for `_experiments`, which we want to remain usable from the outside
-        reserved: ['_experiments'],
+        reserved: [
+          // ...except for `_experiments`, which we want to remain usable from the outside
+          '_experiments',
+          // ...except for some localforage internals, which if we replaced them would break the localforage package
+          // with the error "Error: Custom driver not compliant": https://github.com/getsentry/sentry-javascript/issues/5527
+          '_driver',
+          '_initStorage',
+          '_support',
+        ],
       },
     },
     output: {

--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -96,7 +96,8 @@ export function makeTerserPlugin() {
           // ...except for `_experiments`, which we want to remain usable from the outside
           '_experiments',
           // ...except for some localforage internals, which if we replaced them would break the localforage package
-          // with the error "Error: Custom driver not compliant": https://github.com/getsentry/sentry-javascript/issues/5527
+          // with the error "Error: Custom driver not compliant": https://github.com/getsentry/sentry-javascript/issues/5527.
+          // Reference for which fields are affected: https://localforage.github.io/localForage/ (ctrl-f for "_")
           '_driver',
           '_initStorage',
           '_support',


### PR DESCRIPTION
The `localforage` library (used in offline integration) has some internal fields with a leading underscore (e.g. `_initStorage`). In our building process, we allow terser to mangle fields with a leading underscore to reduce bundle size when using classes with private fields. This causes internal breakage within the `localforage` package and throwing a `"Error: Custom driver not compliant"` error.

This PR marks some localforage-internal fields as reserved so they don't get mangled. The fields are taken from the [localforage docs](https://localforage.github.io/localForage/) by searching the page for "_".

Fixes https://github.com/getsentry/sentry-javascript/issues/5527
