### PR TITLE
ref(nextjs): Move `autoWrapDataFetchers` option into `experiments` object

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -50,9 +50,11 @@ export type UserSentryOptions = {
   // up uploading too many files, which is why this defaults to `false`.
   widenClientFileUpload?: boolean;
 
-  // Automatically wrap `getServerSideProps`, `getStaticProps`, and `getStaticPaths` in order to instrument them for
-  // tracing.
-  autoWrapDataFetchers?: boolean;
+  experiments?: {
+    // Automatically wrap `getServerSideProps`, `getStaticProps`, and `getStaticPaths` in order to instrument them for
+    // tracing.
+    autoWrapDataFetchers?: boolean;
+  };
 };
 
 export type NextConfigFunction = (phase: string, defaults: { defaultConfig: NextConfigObject }) => NextConfigObject;

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -77,7 +77,7 @@ export function constructWebpackConfigFunction(
         ],
       };
 
-      if (userSentryOptions.autoWrapDataFetchers) {
+      if (userSentryOptions.experiments?.autoWrapDataFetchers) {
         newConfig.module.rules.push({
           test: pageRegex,
           use: [


### PR DESCRIPTION
This nests the new `autoWrapDataFetchers` option in `next.config.js` in an `experiments` object, to make it clear that it's not necessarily a stable option yet.
