### PR TITLE
feat(svelte): Add Error and Performance Instrumentation from Browser SDK

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -43,7 +43,7 @@
     "lint": "run-s lint:prettier lint:eslint",
     "lint:eslint": "eslint . --cache --cache-location '../../eslintcache/' --format stylish",
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/*.ts\"",
-    "test": "jest --passWithNoTests",
+    "test": "jest",
     "test:watch": "jest --watch"
   },
   "volta": {

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,1 +1,3 @@
-export default null;
+export * from '@sentry/browser';
+
+export { init } from './sdk';

--- a/packages/svelte/src/sdk.ts
+++ b/packages/svelte/src/sdk.ts
@@ -1,0 +1,20 @@
+import { BrowserOptions, init as browserInit, SDK_VERSION } from '@sentry/browser';
+
+/**
+ * Inits the Svelte SDK
+ */
+export function init(options: BrowserOptions): void {
+  options._metadata = options._metadata || {};
+  options._metadata.sdk = {
+    name: 'sentry.javascript.svelte',
+    packages: [
+      {
+        name: 'npm:@sentry/svelte',
+        version: SDK_VERSION,
+      },
+    ],
+    version: SDK_VERSION,
+  };
+
+  browserInit(options);
+}

--- a/packages/svelte/test/sdk.test.ts
+++ b/packages/svelte/test/sdk.test.ts
@@ -1,5 +1,6 @@
-import { init as svelteInit } from '../src/sdk';
 import { init as browserInitRaw, SDK_VERSION } from '@sentry/browser';
+
+import { init as svelteInit } from '../src/sdk';
 
 const browserInit = browserInitRaw as jest.Mock;
 jest.mock('@sentry/browser');

--- a/packages/svelte/test/sdk.test.ts
+++ b/packages/svelte/test/sdk.test.ts
@@ -1,0 +1,30 @@
+import { init as svelteInit } from '../src/sdk';
+import { init as browserInitRaw, SDK_VERSION } from '@sentry/browser';
+
+const browserInit = browserInitRaw as jest.Mock;
+jest.mock('@sentry/browser');
+
+describe('Initialize Svelte SDk', () => {
+  afterAll(() => {
+    jest.clearAllMocks();
+  });
+
+  it('has the correct metadata', () => {
+    svelteInit({
+      dsn: 'https://public@dsn.ingest.sentry.io/1337',
+    });
+
+    const expectedMetadata = {
+      _metadata: {
+        sdk: {
+          name: 'sentry.javascript.svelte',
+          packages: [{ name: 'npm:@sentry/svelte', version: SDK_VERSION }],
+          version: SDK_VERSION,
+        },
+      },
+    };
+
+    expect(browserInit).toHaveBeenCalledTimes(1);
+    expect(browserInit).toHaveBeenCalledWith(expect.objectContaining(expectedMetadata));
+  });
+});


### PR DESCRIPTION
This PR adds basic error and performance monitoring to the new Svelte SDK. For the moment, we only wrap the Browser SDK and overwrite its default config with the Svelte SDK metadata.

Additionally, this PR adds a small unit test to ensure that SDK name and version are set correctly.

ref: #5520