### PR TITLE
chore(remix): Update badge links in Remix README

### DIFF
--- a/packages/remix/README.md
+++ b/packages/remix/README.md
@@ -6,9 +6,9 @@
 
 # Official Sentry SDK for Remix
 
-[![npm version](https://img.shields.io/npm/v/@sentry/nextjs.svg)](https://www.npmjs.com/package/@sentry/remix)
-[![npm dm](https://img.shields.io/npm/dm/@sentry/nextjs.svg)](https://www.npmjs.com/package/@sentry/remix)
-[![npm dt](https://img.shields.io/npm/dt/@sentry/nextjs.svg)](https://www.npmjs.com/package/@sentry/remix)
+[![npm version](https://img.shields.io/npm/v/@sentry/remix.svg)](https://www.npmjs.com/package/@sentry/remix)
+[![npm dm](https://img.shields.io/npm/dm/@sentry/remix.svg)](https://www.npmjs.com/package/@sentry/remix)
+[![npm dt](https://img.shields.io/npm/dt/@sentry/remix.svg)](https://www.npmjs.com/package/@sentry/remix)
 [![typedoc](https://img.shields.io/badge/docs-typedoc-blue.svg)](http://getsentry.github.io/sentry-javascript/)
 
 This SDK is considered experimental and in an alpha state. It may experience breaking changes. Please reach out on [GitHub](https://github.com/getsentry/sentry-javascript/issues/new/choose) if you have any feedback/concerns.


### PR DESCRIPTION
While working on #5544, I noticed that the badges in our Remix SDK README.md still link to the NextJS NPM package stats. This PR changes the badge links to the Remix SDK NPM badges to get more accurate stats. Tested it locally and it seems to work.