### PR TITLE
chore(svelte): Add entry for Svelte SDK in craft.yml

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -46,3 +46,5 @@ targets:
         onlyIfPresent: /^sentry-nextjs-.*\.tgz$/
       'npm:@sentry/remix':
         onlyIfPresent: /^sentry-remix-.*\.tgz$/
+      'npm:@sentry/svelte':
+        onlyIfPresent: /^sentry-svelte-.*\.tgz$/


### PR DESCRIPTION
This PR adds an entry to `craft.yml` in the release registry section. 

ref: #5520 