### PR TITLE
fix(react): Set redux state context properly

### DIFF
--- a/packages/react/src/redux.ts
+++ b/packages/react/src/redux.ts
@@ -105,7 +105,7 @@ function createReduxEnhancer(enhancerOptions?: Partial<SentryEnhancerOptions>): 
           /* Set latest state to scope */
           const transformedState = options.stateTransformer(newState);
           if (typeof transformedState !== 'undefined' && transformedState !== null) {
-            scope.setContext('state', { type: 'redux', value: transformedState });
+            scope.setContext('state', { state: { type: 'redux', value: transformedState } });
           } else {
             scope.setContext('state', null);
           }

--- a/packages/react/test/redux.test.ts
+++ b/packages/react/test/redux.test.ts
@@ -64,9 +64,11 @@ describe('createReduxEnhancer', () => {
     store.dispatch(updateAction);
 
     expect(mockSetContext).toBeCalledWith('state', {
-      type: 'redux',
-      value: {
-        value: 'updated',
+      state: {
+        type: 'redux',
+        value: {
+          value: 'updated',
+        },
       },
     });
   });
@@ -88,10 +90,12 @@ describe('createReduxEnhancer', () => {
       Redux.createStore((state = initialState) => state, enhancer);
 
       expect(mockSetContext).toBeCalledWith('state', {
-        type: 'redux',
-        value: {
-          superSecret: 'REDACTED',
-          value: 123,
+        state: {
+          type: 'redux',
+          value: {
+            superSecret: 'REDACTED',
+            value: 123,
+          },
         },
       });
     });


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-javascript/issues/5536
ref: https://github.com/getsentry/sentry-javascript/pull/5471

It turns out I misunderstood the state spec for state context. This fixes the state setter to be correct - we do need a nested object for it to render correctly in Sentry. See the Sentry code here: https://github.com/getsentry/sentry/blob/master/static/app/components/events/contexts/state.tsx

@jennmueng do you think this is the correct approach? We can also try to adopt a different schema. 