### PR TITLE
chore(svelte): Remove private field from package.json

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -12,7 +12,6 @@
   "main": "build/cjs/index.js",
   "module": "build/esm/index.js",
   "types": "build/types/index.d.ts",
-  "private": "true",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
This PR removes the `"private": "true"` field from the Svelte SDK's `package.json` to get it ready for the first public alpha release

ref: #5520 