### PR TITLE
fix(core): Suppress stack when `SentryError` isn't an error

### DIFF
--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -920,13 +920,13 @@ describe('BaseClient', () => {
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, beforeSend });
       const client = new TestClient(options);
       const captureExceptionSpy = jest.spyOn(client, 'captureException');
-      const loggerWarnSpy = jest.spyOn(logger, 'warn');
+      const loggerWarnSpy = jest.spyOn(logger, 'log');
 
       client.captureEvent({ message: 'hello' });
 
       expect(TestClient.instance!.event).toBeUndefined();
       expect(captureExceptionSpy).not.toBeCalled();
-      expect(loggerWarnSpy).toBeCalledWith(new SentryError('`beforeSend` returned `null`, will not send event.'));
+      expect(loggerWarnSpy).toBeCalledWith('`beforeSend` returned `null`, will not send event.');
     });
 
     test('calls beforeSend and log info about invalid return value', () => {
@@ -1065,7 +1065,7 @@ describe('BaseClient', () => {
 
       const client = new TestClient(getDefaultTestClientOptions({ dsn: PUBLIC_DSN }));
       const captureExceptionSpy = jest.spyOn(client, 'captureException');
-      const loggerWarnSpy = jest.spyOn(logger, 'warn');
+      const loggerLogSpy = jest.spyOn(logger, 'log');
       const scope = new Scope();
       scope.addEventProcessor(() => null);
 
@@ -1073,7 +1073,7 @@ describe('BaseClient', () => {
 
       expect(TestClient.instance!.event).toBeUndefined();
       expect(captureExceptionSpy).not.toBeCalled();
-      expect(loggerWarnSpy).toBeCalledWith(new SentryError('An event processor returned null, will not send event.'));
+      expect(loggerLogSpy).toBeCalledWith('An event processor returned null, will not send event.');
     });
 
     test('eventProcessor records dropped events', () => {

--- a/packages/nextjs/test/index.client.test.ts
+++ b/packages/nextjs/test/index.client.test.ts
@@ -3,7 +3,7 @@ import { getCurrentHub } from '@sentry/hub';
 import * as SentryReact from '@sentry/react';
 import { Integrations as TracingIntegrations } from '@sentry/tracing';
 import { Integration } from '@sentry/types';
-import { getGlobalObject, logger, SentryError } from '@sentry/utils';
+import { getGlobalObject, logger } from '@sentry/utils';
 
 import { init, Integrations, nextRouterInstrumentation } from '../src/index.client';
 import { NextjsOptions } from '../src/utils/nextjsOptions';
@@ -14,7 +14,7 @@ const global = getGlobalObject();
 
 const reactInit = jest.spyOn(SentryReact, 'init');
 const captureEvent = jest.spyOn(BaseClient.prototype, 'captureEvent');
-const logWarn = jest.spyOn(logger, 'warn');
+const loggerLogSpy = jest.spyOn(logger, 'log');
 
 describe('Client init()', () => {
   afterEach(() => {
@@ -75,7 +75,7 @@ describe('Client init()', () => {
 
     expect(transportSend).not.toHaveBeenCalled();
     expect(captureEvent.mock.results[0].value).toBeUndefined();
-    expect(logWarn).toHaveBeenCalledWith(new SentryError('An event processor returned null, will not send event.'));
+    expect(loggerLogSpy).toHaveBeenCalledWith('An event processor returned null, will not send event.');
   });
 
   describe('integrations', () => {

--- a/packages/nextjs/test/index.server.test.ts
+++ b/packages/nextjs/test/index.server.test.ts
@@ -2,7 +2,7 @@ import { RewriteFrames } from '@sentry/integrations';
 import * as SentryNode from '@sentry/node';
 import { getCurrentHub, NodeClient } from '@sentry/node';
 import { Integration } from '@sentry/types';
-import { getGlobalObject, logger, SentryError } from '@sentry/utils';
+import { getGlobalObject, logger } from '@sentry/utils';
 import * as domain from 'domain';
 
 import { init } from '../src/index.server';
@@ -16,7 +16,7 @@ const global = getGlobalObject();
 (global as typeof global & { __rewriteFramesDistDir__: string }).__rewriteFramesDistDir__ = '.next';
 
 const nodeInit = jest.spyOn(SentryNode, 'init');
-const logWarn = jest.spyOn(logger, 'warn');
+const loggerLogSpy = jest.spyOn(logger, 'log');
 
 describe('Server init()', () => {
   afterEach(() => {
@@ -104,7 +104,7 @@ describe('Server init()', () => {
     await SentryNode.flush();
 
     expect(transportSend).not.toHaveBeenCalled();
-    expect(logWarn).toHaveBeenCalledWith(new SentryError('An event processor returned null, will not send event.'));
+    expect(loggerLogSpy).toHaveBeenCalledWith('An event processor returned null, will not send event.');
   });
 
   it("initializes both global hub and domain hub when there's an active domain", () => {

--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -11,6 +11,9 @@ export class SentryError extends Error {
     super(message);
 
     this.name = new.target.prototype.constructor.name;
+    // This sets the prototype to be `Error`, not `SentryError`. It's unclear why we do this, but commenting this line
+    // out causes various (seemingly totally unrelated) playwright tests consistently time out. FYI, this makes
+    // instances of `SentryError` fail `obj instanceof SentryError` checks.
     Object.setPrototypeOf(this, new.target.prototype);
     this.logLevel = logLevel;
   }

--- a/packages/utils/src/error.ts
+++ b/packages/utils/src/error.ts
@@ -1,12 +1,17 @@
+import type { ConsoleLevel } from './logger';
+
 /** An error emitted by Sentry SDKs and related utilities. */
 export class SentryError extends Error {
   /** Display name of this error instance. */
   public name: string;
 
-  public constructor(public message: string) {
+  public logLevel: ConsoleLevel;
+
+  public constructor(public message: string, logLevel: ConsoleLevel = 'warn') {
     super(message);
 
     this.name = new.target.prototype.constructor.name;
     Object.setPrototypeOf(this, new.target.prototype);
+    this.logLevel = logLevel;
   }
 }

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -9,6 +9,7 @@ const global = getGlobalObject<Window | NodeJS.Global>();
 const PREFIX = 'Sentry Logger ';
 
 export const CONSOLE_LEVELS = ['debug', 'info', 'warn', 'error', 'log', 'assert', 'trace'] as const;
+export type ConsoleLevel = typeof CONSOLE_LEVELS[number];
 
 type LoggerMethod = (...args: unknown[]) => void;
 type LoggerConsoleMethods = Record<typeof CONSOLE_LEVELS[number], LoggerMethod>;


### PR DESCRIPTION
We use `SentryError`s in our event processing and sending pipeline both when something has gone legitimately wrong and when we just want to bail on a promise chain. In all cases, however, we log both the message and the stack, at a warning log level, which both clutters the logs and unnecessarily alarms anyone who has logging on.

This fixes that by adding a `logLevel` property to the `SentryError` class, which can be read before we log to the console. The default behavior remains the same (log the full error, using `logger.warn`), but now we have the option of passing `'log'` as a second constructor parameter, in order to mark a given `SentryError` as something which should only be `logger.log`ged and whose stack should be suppressed.

(To answer the inevitable _Why now?_ question, it's because it was making my test app logs really hard to read and it finally drove me one banana too far.)