### PR TITLE
chore(svelte): Temporarily remove Svelte SDK as a Release Registry target

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -46,5 +46,3 @@ targets:
         onlyIfPresent: /^sentry-nextjs-.*\.tgz$/
       'npm:@sentry/remix':
         onlyIfPresent: /^sentry-remix-.*\.tgz$/
-      'npm:@sentry/svelte':
-        onlyIfPresent: /^sentry-svelte-.*\.tgz$/


### PR DESCRIPTION
Let's tmp remove the Svelte SDK as a target to repair RR 7.10.0 entries for the other SDKs and then revert this
