### PR TITLE
ref(eslint): Fix max lines eslint rule

### DIFF
--- a/packages/eslint-config-sdk/src/index.js
+++ b/packages/eslint-config-sdk/src/index.js
@@ -212,7 +212,7 @@ module.exports = {
     'prefer-template': 'error',
 
     // Limit maximum file size to reduce complexity. Turned off in tests.
-    'max-lines': ["error", {"max": 300, "skipComments": true, "skipBlankLines": true}],
+    'max-lines': ['error', {'max': 300, 'skipComments': true, 'skipBlankLines': true}],
 
     // We should require a whitespace beginning a comment
     'spaced-comment': [

--- a/packages/eslint-config-sdk/src/index.js
+++ b/packages/eslint-config-sdk/src/index.js
@@ -212,7 +212,7 @@ module.exports = {
     'prefer-template': 'error',
 
     // Limit maximum file size to reduce complexity. Turned off in tests.
-    'max-lines': ['error', {'max': 300, 'skipComments': true, 'skipBlankLines': true}],
+    'max-lines': ['error', { max: 300, skipComments: true, skipBlankLines: true }],
 
     // We should require a whitespace beginning a comment
     'spaced-comment': [

--- a/packages/eslint-config-sdk/src/index.js
+++ b/packages/eslint-config-sdk/src/index.js
@@ -212,7 +212,7 @@ module.exports = {
     'prefer-template': 'error',
 
     // Limit maximum file size to reduce complexity. Turned off in tests.
-    'max-lines': 'error',
+    'max-lines': ["error", {"max": 300, "skipComments": true, "skipBlankLines": true}],
 
     // We should require a whitespace beginning a comment
     'spaced-comment': [


### PR DESCRIPTION
It's debatable whether this should be enabled at all, but at the very least we should relax the conditions that don't affect bundle size, such as blank lines and comments since it leads towards either disabling the rule entirely (as you can see in a lot of sdk files) or people not writing comments (again, not ideal).
