### PR TITLE
ref(test): Refactor Node integration tests to prevent nock leaks.

### DIFF
--- a/packages/node-integration-tests/README.md
+++ b/packages/node-integration-tests/README.md
@@ -33,6 +33,9 @@ A custom server configuration can be used, supplying a script that exports a val
 
 `utils/` contains helpers and Sentry-specific assertions that can be used in (`test.ts`).
 
+`runServer` utility function returns an object containing `url`, [`http.Server`](https://nodejs.org/dist/latest-v16.x/docs/api/http.html#class-httpserver) and [`nock.Scope`](https://github.com/nock/nock#usage) instances for the created server. The `url` property is the base URL for the server. The `http.Server` instance is used to finish the server eventually, and the `nock.Scope` instance is used to bind / unbind interceptors for the test case.
+
+The responsibility of ending the server and interceptor is delegated to the test case. Data collection helpers such as `getEnvelopeRequest` and `getAPIResponse` expect those instances to be available and finish them before their resolution. Test that do not use those helpers will need to end the server and interceptors manually.
 ## Running Tests Locally
 
 Tests can be run locally with:

--- a/packages/node-integration-tests/jest.config.js
+++ b/packages/node-integration-tests/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   globalSetup: '<rootDir>/utils/setup-tests.ts',
   ...baseConfig,
   testMatch: ['**/test.ts'],
+  testTimeout: 10000,
 };

--- a/packages/node-integration-tests/jest.config.js
+++ b/packages/node-integration-tests/jest.config.js
@@ -4,5 +4,4 @@ module.exports = {
   globalSetup: '<rootDir>/utils/setup-tests.ts',
   ...baseConfig,
   testMatch: ['**/test.ts'],
-  testTimeout: 10000,
 };

--- a/packages/node-integration-tests/suites/express/handle-error/test.ts
+++ b/packages/node-integration-tests/suites/express/handle-error/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../utils/index';
 
 test('should capture and send Express controller error.', async () => {
-  const url = await runServer(__dirname, `${__dirname}/server.ts`);
-  const event = await getEnvelopeRequest(`${url}/express`);
+  const { url, server, scope } = await runServer(__dirname, `${__dirname}/server.ts`);
+  const event = await getEnvelopeRequest({ url: `${url}/express`, server, scope });
 
   expect((event[2] as any).exception.values[0].stacktrace.frames.length).toBeGreaterThan(0);
 

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
@@ -4,11 +4,14 @@ import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('Should not overwrite baggage if the incoming request already has Sentry baggage data.', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse(new URL(`${url}/express`), {
-    baggage: 'sentry-release=2.0.0,sentry-environment=myEnv',
-  })) as TestAPIResponse;
+  const response = (await getAPIResponse(
+    { url: `${url}/express`, server, scope },
+    {
+      baggage: 'sentry-release=2.0.0,sentry-environment=myEnv',
+    },
+  )) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
@@ -20,12 +23,15 @@ test('Should not overwrite baggage if the incoming request already has Sentry ba
 });
 
 test('Should propagate sentry trace baggage data from an incoming to an outgoing request.', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse(new URL(`${url}/express`), {
-    'sentry-trace': '',
-    baggage: 'sentry-release=2.0.0,sentry-environment=myEnv,dogs=great',
-  })) as TestAPIResponse;
+  const response = (await getAPIResponse(
+    { url: `${url}/express`, server, scope },
+    {
+      'sentry-trace': '',
+      baggage: 'sentry-release=2.0.0,sentry-environment=myEnv,dogs=great',
+    },
+  )) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
@@ -37,11 +43,14 @@ test('Should propagate sentry trace baggage data from an incoming to an outgoing
 });
 
 test('Should propagate empty baggage if sentry-trace header is present in incoming request but no baggage header', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse(new URL(`${url}/express`), {
-    'sentry-trace': '',
-  })) as TestAPIResponse;
+  const response = (await getAPIResponse(
+    { url: `${url}/express`, server, scope },
+    {
+      'sentry-trace': '',
+    },
+  )) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
@@ -53,12 +62,15 @@ test('Should propagate empty baggage if sentry-trace header is present in incomi
 });
 
 test('Should propagate empty sentry and ignore original 3rd party baggage entries if sentry-trace header is present', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse(new URL(`${url}/express`), {
-    'sentry-trace': '',
-    baggage: 'foo=bar',
-  })) as TestAPIResponse;
+  const response = (await getAPIResponse(
+    { url: `${url}/express`, server, scope },
+    {
+      'sentry-trace': '',
+      baggage: 'foo=bar',
+    },
+  )) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
@@ -70,9 +82,9 @@ test('Should propagate empty sentry and ignore original 3rd party baggage entrie
 });
 
 test('Should populate and propagate sentry baggage if sentry-trace header does not exist', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse(new URL(`${url}/express`), {})) as TestAPIResponse;
+  const response = (await getAPIResponse({ url: `${url}/express`, server, scope }, {})) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
@@ -87,11 +99,14 @@ test('Should populate and propagate sentry baggage if sentry-trace header does n
 });
 
 test('Should populate Sentry and ignore 3rd party content if sentry-trace header does not exist', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse(new URL(`${url}/express`), {
-    baggage: 'foo=bar,bar=baz',
-  })) as TestAPIResponse;
+  const response = (await getAPIResponse(
+    { url: `${url}/express`, server, scope },
+    {
+      baggage: 'foo=bar,bar=baz',
+    },
+  )) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out-bad-tx-name/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out-bad-tx-name/test.ts
@@ -4,9 +4,9 @@ import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('Does not include transaction name if transaction source is not set', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
-  const response = (await getAPIResponse(new URL(`${url}/express`))) as TestAPIResponse;
+  const response = (await getAPIResponse({ url: `${url}/express`, server, scope })) as TestAPIResponse;
   const baggageString = response.test_data.baggage;
 
   expect(response).toBeDefined();

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/test.ts
@@ -4,9 +4,9 @@ import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('should attach a `baggage` header to an outgoing request.', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
-  const response = (await getAPIResponse(new URL(`${url}/express`))) as TestAPIResponse;
+  const response = (await getAPIResponse({ url: `${url}/express`, server, scope })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/test.ts
@@ -4,12 +4,15 @@ import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('should ignore sentry-values in `baggage` header of a third party vendor and overwrite them with incoming DSC', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
-  const response = (await getAPIResponse(new URL(`${url}/express`), {
-    'sentry-trace': '',
-    baggage: 'sentry-release=2.1.0,sentry-environment=myEnv',
-  })) as TestAPIResponse;
+  const response = (await getAPIResponse(
+    { url: `${url}/express`, server, scope },
+    {
+      'sentry-trace': '',
+      baggage: 'sentry-release=2.1.0,sentry-environment=myEnv',
+    },
+  )) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
@@ -21,9 +24,9 @@ test('should ignore sentry-values in `baggage` header of a third party vendor an
 });
 
 test('should ignore sentry-values in `baggage` header of a third party vendor and overwrite them with new DSC', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
-  const response = (await getAPIResponse(new URL(`${url}/express`), {})) as TestAPIResponse;
+  const response = (await getAPIResponse({ url: `${url}/express`, server, scope }, {})) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/test.ts
@@ -4,12 +4,15 @@ import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('should merge `baggage` header of a third party vendor with the Sentry DSC baggage items', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
-  const response = (await getAPIResponse(new URL(`${url}/express`), {
-    'sentry-trace': '',
-    baggage: 'sentry-release=2.0.0,sentry-environment=myEnv',
-  })) as TestAPIResponse;
+  const response = (await getAPIResponse(
+    { url: `${url}/express`, server, scope },
+    {
+      'sentry-trace': '',
+      baggage: 'sentry-release=2.0.0,sentry-environment=myEnv',
+    },
+  )) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/test.ts
@@ -4,9 +4,9 @@ import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('Includes transaction in baggage if the transaction name is parameterized', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
-  const response = (await getAPIResponse(new URL(`${url}/express`))) as TestAPIResponse;
+  const response = (await getAPIResponse({ url: `${url}/express`, server, scope })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/sentry-trace/trace-header-assign/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/trace-header-assign/test.ts
@@ -5,11 +5,14 @@ import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('Should assign `sentry-trace` header which sets parent trace id of an outgoing request.', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse(new URL(`${url}/express`), {
-    'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
-  })) as TestAPIResponse;
+  const response = (await getAPIResponse(
+    { url: `${url}/express`, server, scope },
+    {
+      'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
+    },
+  )) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/sentry-trace/trace-header-out/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/trace-header-out/test.ts
@@ -5,9 +5,9 @@ import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('should attach a `sentry-trace` header to an outgoing request.', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse(new URL(`${url}/express`))) as TestAPIResponse;
+  const response = (await getAPIResponse({ url: `${url}/express`, server, scope })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/packages/node-integration-tests/suites/express/tracing/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryTransaction, getEnvelopeRequest, runServer } from '../../../utils/index';
 
 test('should create and send transactions for Express routes and spans for middlewares.', async () => {
-  const url = await runServer(__dirname, `${__dirname}/server.ts`);
-  const envelope = await getEnvelopeRequest(`${url}/express`);
+  const { url, server, scope } = await runServer(__dirname, `${__dirname}/server.ts`);
+  const envelope = await getEnvelopeRequest({ url: `${url}/express`, server, scope });
 
   expect(envelope).toHaveLength(3);
 
@@ -29,8 +29,8 @@ test('should create and send transactions for Express routes and spans for middl
 });
 
 test('should set a correct transaction name for routes specified in RegEx', async () => {
-  const url = await runServer(__dirname, `${__dirname}/server.ts`);
-  const envelope = await getEnvelopeRequest(`${url}/regex`);
+  const { url, server, scope } = await runServer(__dirname, `${__dirname}/server.ts`);
+  const envelope = await getEnvelopeRequest({ url: `${url}/regex`, server, scope });
 
   expect(envelope).toHaveLength(3);
 
@@ -57,8 +57,8 @@ test('should set a correct transaction name for routes specified in RegEx', asyn
 test.each([['array1'], ['array5']])(
   'should set a correct transaction name for routes consisting of arrays of routes',
   async segment => {
-    const url = await runServer(__dirname, `${__dirname}/server.ts`);
-    const envelope = await getEnvelopeRequest(`${url}/${segment}`);
+    const { url, server, scope } = await runServer(__dirname, `${__dirname}/server.ts`);
+    const envelope = await getEnvelopeRequest({ url: `${url}/${segment}`, server, scope });
 
     expect(envelope).toHaveLength(3);
 
@@ -93,8 +93,8 @@ test.each([
   ['arr/requiredPath/optionalPath/'],
   ['arr/requiredPath/optionalPath/lastParam'],
 ])('should handle more complex regexes in route arrays correctly', async segment => {
-  const url = await runServer(__dirname, `${__dirname}/server.ts`);
-  const envelope = await getEnvelopeRequest(`${url}/${segment}`);
+  const { url, server, scope } = await runServer(__dirname, `${__dirname}/server.ts`);
+  const envelope = await getEnvelopeRequest({ url: `${url}/${segment}`, server, scope });
 
   expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/test.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should add an empty breadcrumb, when an empty object is given', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
   const errorEnvelope = envelopes[1];
 
   expect(errorEnvelope).toHaveLength(3);

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/test.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should add an empty breadcrumb, when an empty object is given', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
   const errorEnvelope = envelopes[1];
 
   expect(errorEnvelope).toHaveLength(3);

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/test.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should add multiple breadcrumbs', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
 
   assertSentryEvent(envelopes[1][2], {
     message: 'test_multi_breadcrumbs',

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/test.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should add multiple breadcrumbs', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
 
   assertSentryEvent(envelopes[1][2], {
     message: 'test_multi_breadcrumbs',

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/test.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should add a simple breadcrumb', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
 
   assertSentryEvent(envelopes[1][2], {
     message: 'test_simple',

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/test.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should add a simple breadcrumb', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
 
   assertSentryEvent(envelopes[1][2], {
     message: 'test_simple',

--- a/packages/node-integration-tests/suites/public-api/captureException/catched-error/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureException/catched-error/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should work inside catch block', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/captureException/catched-error/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureException/catched-error/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should work inside catch block', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/captureException/empty-obj/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureException/empty-obj/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should capture an empty object', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/captureException/empty-obj/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureException/empty-obj/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should capture an empty object', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/captureException/simple-error/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureException/simple-error/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should capture a simple error with message', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/captureException/simple-error/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureException/simple-error/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should capture a simple error with message', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/captureMessage/simple_message/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureMessage/simple_message/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should capture a simple message string', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/captureMessage/simple_message/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureMessage/simple_message/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should capture a simple message string', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/captureMessage/with_level/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureMessage/with_level/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should capture with different severity levels', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 12);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 12);
 
   assertSentryEvent(envelopes[1][2], {
     message: 'debug_message',

--- a/packages/node-integration-tests/suites/public-api/captureMessage/with_level/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureMessage/with_level/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should capture with different severity levels', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 12);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 12 });
 
   assertSentryEvent(envelopes[1][2], {
     message: 'debug_message',

--- a/packages/node-integration-tests/suites/public-api/configureScope/clear_scope/test.ts
+++ b/packages/node-integration-tests/suites/public-api/configureScope/clear_scope/test.ts
@@ -3,8 +3,8 @@ import { Event } from '@sentry/node';
 import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should clear previously set properties of a scope', async () => {
-  const url = await runServer(__dirname);
-  const envelope = await getEnvelopeRequest(url);
+  const config = await runServer(__dirname);
+  const envelope = await getEnvelopeRequest(config);
 
   assertSentryEvent(envelope[2], {
     message: 'cleared_scope',

--- a/packages/node-integration-tests/suites/public-api/configureScope/set_properties/test.ts
+++ b/packages/node-integration-tests/suites/public-api/configureScope/set_properties/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should set different properties of a scope', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/configureScope/set_properties/test.ts
+++ b/packages/node-integration-tests/suites/public-api/configureScope/set_properties/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should set different properties of a scope', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/test.ts
@@ -4,7 +4,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should record multiple contexts', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/test.ts
@@ -3,8 +3,8 @@ import { Event } from '@sentry/node';
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should record multiple contexts', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/test.ts
@@ -3,8 +3,8 @@ import { Event } from '@sentry/node';
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should normalize non-serializable context', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/test.ts
@@ -4,7 +4,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should normalize non-serializable context', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setContext/simple-context/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/simple-context/test.ts
@@ -4,7 +4,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should set a simple context', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setContext/simple-context/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/simple-context/test.ts
@@ -3,8 +3,8 @@ import { Event } from '@sentry/node';
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should set a simple context', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setExtra/multiple-extras/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtra/multiple-extras/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should record multiple extras of different types', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setExtra/multiple-extras/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtra/multiple-extras/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should record multiple extras of different types', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setExtra/non-serializable-extra/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtra/non-serializable-extra/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should normalize non-serializable extra', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setExtra/non-serializable-extra/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtra/non-serializable-extra/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should normalize non-serializable extra', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setExtra/simple-extra/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtra/simple-extra/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should set a simple extra', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setExtra/simple-extra/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtra/simple-extra/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should set a simple extra', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setExtras/consecutive-calls/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtras/consecutive-calls/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should set extras from multiple consecutive calls', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setExtras/consecutive-calls/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtras/consecutive-calls/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should set extras from multiple consecutive calls', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setExtras/multiple-extras/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtras/multiple-extras/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should record an extras object', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setExtras/multiple-extras/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtras/multiple-extras/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should record an extras object', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
   const errorEnvelope = envelopes[1];
 
   assertSentryEvent(errorEnvelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setTag/with-primitives/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setTag/with-primitives/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should set primitive tags', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
   const envelope = envelopes[1];
 
   assertSentryEvent(envelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setTag/with-primitives/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setTag/with-primitives/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should set primitive tags', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
   const envelope = envelopes[1];
 
   assertSentryEvent(envelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setTags/with-primitives/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setTags/with-primitives/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should set primitive tags', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 2);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 2);
   const envelope = envelopes[1];
 
   assertSentryEvent(envelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setTags/with-primitives/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setTags/with-primitives/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should set primitive tags', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 2);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
   const envelope = envelopes[1];
 
   assertSentryEvent(envelope[2], {

--- a/packages/node-integration-tests/suites/public-api/setUser/unset_user/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setUser/unset_user/test.ts
@@ -4,7 +4,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should unset user', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 6);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 6 });
 
   assertSentryEvent(envelopes[1][2], {
     message: 'no_user',

--- a/packages/node-integration-tests/suites/public-api/setUser/unset_user/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setUser/unset_user/test.ts
@@ -3,8 +3,8 @@ import { Event } from '@sentry/node';
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should unset user', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 6);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 6);
 
   assertSentryEvent(envelopes[1][2], {
     message: 'no_user',

--- a/packages/node-integration-tests/suites/public-api/setUser/update_user/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setUser/update_user/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should update user', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 4);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 4);
 
   assertSentryEvent(envelopes[1][2], {
     message: 'first_user',

--- a/packages/node-integration-tests/suites/public-api/setUser/update_user/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setUser/update_user/test.ts
@@ -2,7 +2,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should update user', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 4);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 4 });
 
   assertSentryEvent(envelopes[1][2], {
     message: 'first_user',

--- a/packages/node-integration-tests/suites/public-api/startTransaction/basic-usage/test.ts
+++ b/packages/node-integration-tests/suites/public-api/startTransaction/basic-usage/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryTransaction, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should send a manually started transaction when @sentry/tracing is imported using unnamed import.', async () => {
-  const url = await runServer(__dirname);
-  const envelope = await getEnvelopeRequest(url);
+  const config = await runServer(__dirname);
+  const envelope = await getEnvelopeRequest(config);
 
   expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/public-api/startTransaction/with-nested-spans/test.ts
+++ b/packages/node-integration-tests/suites/public-api/startTransaction/with-nested-spans/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryTransaction, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should report finished spans as children of the root transaction.', async () => {
-  const url = await runServer(__dirname);
-  const envelope = await getEnvelopeRequest(url);
+  const config = await runServer(__dirname);
+  const envelope = await getEnvelopeRequest(config);
 
   expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/public-api/withScope/nested-scopes/test.ts
+++ b/packages/node-integration-tests/suites/public-api/withScope/nested-scopes/test.ts
@@ -3,8 +3,8 @@ import { Event } from '@sentry/node';
 import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should allow nested scoping', async () => {
-  const url = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(url, 10);
+  const config = await runServer(__dirname);
+  const envelopes = await getMultipleEnvelopeRequest(config, 10);
 
   assertSentryEvent(envelopes[1][2], {
     message: 'root_before',

--- a/packages/node-integration-tests/suites/public-api/withScope/nested-scopes/test.ts
+++ b/packages/node-integration-tests/suites/public-api/withScope/nested-scopes/test.ts
@@ -4,7 +4,7 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should allow nested scoping', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, 10);
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 10 });
 
   assertSentryEvent(envelopes[1][2], {
     message: 'root_before',

--- a/packages/node-integration-tests/suites/sessions/crashed-session-aggregate/test.ts
+++ b/packages/node-integration-tests/suites/sessions/crashed-session-aggregate/test.ts
@@ -6,9 +6,9 @@ test('should aggregate successful and crashed sessions', async () => {
   const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const envelopes = await Promise.race([
-    getMultipleEnvelopeRequest({ url: `${url}/success`, server, scope }, 2, 'get', false),
-    getMultipleEnvelopeRequest({ url: `${url}/error_unhandled`, server, scope }, 2, 'get', false),
-    getMultipleEnvelopeRequest({ url: `${url}/success_next`, server, scope }, 2, 'get', false),
+    getMultipleEnvelopeRequest({ url: `${url}/success`, server, scope }, { count: 2, endServer: false }),
+    getMultipleEnvelopeRequest({ url: `${url}/error_unhandled`, server, scope }, { count: 2, endServer: false }),
+    getMultipleEnvelopeRequest({ url: `${url}/success_next`, server, scope }, { count: 2, endServer: false }),
   ]);
 
   scope.persist(false);

--- a/packages/node-integration-tests/suites/sessions/crashed-session-aggregate/test.ts
+++ b/packages/node-integration-tests/suites/sessions/crashed-session-aggregate/test.ts
@@ -3,13 +3,17 @@ import path from 'path';
 import { getMultipleEnvelopeRequest, runServer } from '../../../utils';
 
 test('should aggregate successful and crashed sessions', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const envelopes = await Promise.race([
-    getMultipleEnvelopeRequest(`${url}/success`, 2),
-    getMultipleEnvelopeRequest(`${url}/error_unhandled`, 2),
-    getMultipleEnvelopeRequest(`${url}/success_next`, 2),
+    getMultipleEnvelopeRequest({ url: `${url}/success`, server, scope }, 2, 'get', false),
+    getMultipleEnvelopeRequest({ url: `${url}/error_unhandled`, server, scope }, 2, 'get', false),
+    getMultipleEnvelopeRequest({ url: `${url}/success_next`, server, scope }, 2, 'get', false),
   ]);
+
+  scope.persist(false);
+  server.close();
+
   const envelope = envelopes[1];
 
   expect(envelope[0]).toMatchObject({

--- a/packages/node-integration-tests/suites/sessions/errored-session-aggregate/test.ts
+++ b/packages/node-integration-tests/suites/sessions/errored-session-aggregate/test.ts
@@ -6,9 +6,9 @@ test('should aggregate successful, crashed and erroneous sessions', async () => 
   const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const envelopes = await Promise.race([
-    getMultipleEnvelopeRequest({ url: `${url}/success`, server, scope }, 3, 'get', false),
-    getMultipleEnvelopeRequest({ url: `${url}/error_handled`, server, scope }, 3, 'get', false),
-    getMultipleEnvelopeRequest({ url: `${url}/error_unhandled`, server, scope }, 3, 'get', false),
+    getMultipleEnvelopeRequest({ url: `${url}/success`, server, scope }, { count: 3, endServer: false }),
+    getMultipleEnvelopeRequest({ url: `${url}/error_handled`, server, scope }, { count: 3, endServer: false }),
+    getMultipleEnvelopeRequest({ url: `${url}/error_unhandled`, server, scope }, { count: 3, endServer: false }),
   ]);
 
   scope.persist(false);

--- a/packages/node-integration-tests/suites/sessions/exited-session-aggregate/test.ts
+++ b/packages/node-integration-tests/suites/sessions/exited-session-aggregate/test.ts
@@ -6,9 +6,9 @@ test('should aggregate successful sessions', async () => {
   const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const envelope = await Promise.race([
-    getEnvelopeRequest({ url: `${url}/success`, server, scope }, 'get', false),
-    getEnvelopeRequest({ url: `${url}/success_next`, server, scope }, 'get', false),
-    getEnvelopeRequest({ url: `${url}/success_slow`, server, scope }, 'get', false),
+    getEnvelopeRequest({ url: `${url}/success`, server, scope }, { endServer: false }),
+    getEnvelopeRequest({ url: `${url}/success_next`, server, scope }, { endServer: false }),
+    getEnvelopeRequest({ url: `${url}/success_slow`, server, scope }, { endServer: false }),
   ]);
 
   scope.persist(false);

--- a/packages/node-integration-tests/suites/sessions/exited-session-aggregate/test.ts
+++ b/packages/node-integration-tests/suites/sessions/exited-session-aggregate/test.ts
@@ -3,13 +3,16 @@ import path from 'path';
 import { getEnvelopeRequest, runServer } from '../../../utils';
 
 test('should aggregate successful sessions', async () => {
-  const url = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const envelope = await Promise.race([
-    getEnvelopeRequest(`${url}/success`),
-    getEnvelopeRequest(`${url}/success_next`),
-    getEnvelopeRequest(`${url}/success_slow`),
+    getEnvelopeRequest({ url: `${url}/success`, server, scope }, 'get', false),
+    getEnvelopeRequest({ url: `${url}/success_next`, server, scope }, 'get', false),
+    getEnvelopeRequest({ url: `${url}/success_slow`, server, scope }, 'get', false),
   ]);
+
+  scope.persist(false);
+  server.close();
 
   expect(envelope).toHaveLength(3);
   expect(envelope[0]).toMatchObject({

--- a/packages/node-integration-tests/suites/tracing/apollo-graphql/test.ts
+++ b/packages/node-integration-tests/suites/tracing/apollo-graphql/test.ts
@@ -4,8 +4,8 @@ import { assertSentryTransaction, conditionalTest, getEnvelopeRequest, runServer
 // Ref: https://github.com/graphql/graphql-js/blob/main/package.json
 conditionalTest({ min: 12 })('GraphQL/Apollo Tests', () => {
   test('should instrument GraphQL and Apollo Server.', async () => {
-    const url = await runServer(__dirname);
-    const envelope = await getEnvelopeRequest(url);
+    const config = await runServer(__dirname);
+    const envelope = await getEnvelopeRequest(config);
 
     expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
@@ -18,9 +18,8 @@ conditionalTest({ min: 12 })('MongoDB Test', () => {
   });
 
   test('should auto-instrument `mongodb` package.', async () => {
-    const url = await runServer(__dirname);
-
-    const envelope = await getEnvelopeRequest(url);
+    const config = await runServer(__dirname);
+    const envelope = await getEnvelopeRequest(config);
 
     expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/tracing/auto-instrument/mysql/test.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/mysql/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryTransaction, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should auto-instrument `mysql` package.', async () => {
-  const url = await runServer(__dirname);
-  const envelope = await getEnvelopeRequest(url);
+  const config = await runServer(__dirname);
+  const envelope = await getEnvelopeRequest(config);
 
   expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/tracing/auto-instrument/pg/test.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/pg/test.ts
@@ -29,8 +29,8 @@ beforeAll(() => {
 });
 
 test('should auto-instrument `pg` package.', async () => {
-  const url = await runServer(__dirname);
-  const envelope = await getEnvelopeRequest(url);
+  const config = await runServer(__dirname);
+  const envelope = await getEnvelopeRequest(config);
 
   expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/tracing/prisma-orm/test.ts
+++ b/packages/node-integration-tests/suites/tracing/prisma-orm/test.ts
@@ -2,8 +2,8 @@ import { assertSentryTransaction, conditionalTest, getEnvelopeRequest, runServer
 
 conditionalTest({ min: 12 })('Prisma ORM Integration', () => {
   test('should instrument Prisma client for tracing.', async () => {
-    const url = await runServer(__dirname);
-    const envelope = await getEnvelopeRequest(url);
+    const config = await runServer(__dirname);
+    const envelope = await getEnvelopeRequest(config);
 
     assertSentryTransaction(envelope[2], {
       transaction: 'Test Transaction',

--- a/packages/node-integration-tests/suites/tracing/tracePropagationTargets/test.ts
+++ b/packages/node-integration-tests/suites/tracing/tracePropagationTargets/test.ts
@@ -27,8 +27,11 @@ test('HttpIntegration should instrument correct requests when tracePropagationTa
     .matchHeader('sentry-trace', val => val === undefined)
     .reply(200);
 
-  const serverUrl = await runServer(__dirname);
-  await runScenario(serverUrl);
+  const { url, scope, server } = await runServer(__dirname);
+  await runScenario(url);
+
+  scope.persist(false);
+  await new Promise(resolve => server.close(resolve));
 
   expect(match1.isDone()).toBe(true);
   expect(match2.isDone()).toBe(true);

--- a/packages/node-integration-tests/utils/index.ts
+++ b/packages/node-integration-tests/utils/index.ts
@@ -7,6 +7,13 @@ import { RequestOptions } from 'https';
 import nock from 'nock';
 import * as path from 'path';
 import { getPortPromise } from 'portfinder';
+
+type TestServerConfig = {
+  url: string;
+  server: http.Server;
+  scope: nock.Scope;
+};
+
 /**
  * Returns`describe` or `describe.skip` depending on allowed major versions of Node.
  *
@@ -68,48 +75,69 @@ export const parseEnvelope = (body: string): Array<Record<string, unknown>> => {
 /**
  * Intercepts and extracts up to a number of requests containing Sentry envelopes.
  *
- * @param url The url the intercepted requests will be directed to.
+ * @param config The url, server instance and the nock scope.
  * @param count The expected amount of requests to the envelope endpoint. If
  * the amount of sentrequests is lower than`count`, this function will not resolve.
  * @param method The method of the request. Defaults to `GET`.
+ * @param endServer: Whether to stop the server after the requests have been intercepted.
  * @returns The intercepted envelopes.
  */
 export const getMultipleEnvelopeRequest = async (
-  url: string,
+  config: TestServerConfig,
   count: number,
   method: 'get' | 'post' = 'get',
+  endServer: boolean = true,
 ): Promise<Record<string, unknown>[][]> => {
-  const envelopes: Record<string, unknown>[][] = [];
-
   // eslint-disable-next-line no-async-promise-executor
-  return new Promise(async resolve => {
-    nock('https://dsn.ingest.sentry.io')
+  return (
+    await Promise.all([setupNock(config.scope, config.server, count, endServer), makeRequest(method, config.url)])
+  )[0];
+};
+
+const setupNock = async (
+  scope: nock.Scope,
+  server: http.Server,
+  count: number,
+  endServer: boolean,
+): Promise<Record<string, unknown>[][]> => {
+  return new Promise(resolve => {
+    const envelopes: Record<string, unknown>[][] = [];
+
+    scope
       .post('/api/1337/envelope/', body => {
         const envelope = parseEnvelope(body);
+
         envelopes.push(envelope);
 
         if (count === envelopes.length) {
+          if (endServer) {
+            scope.persist(false);
+            server.close(() => {
+              resolve(envelopes);
+            });
+          }
           resolve(envelopes);
         }
 
         return true;
       })
-      .times(count)
       .query(true) // accept any query params - used for sentry_key param
       .reply(200);
-
-    try {
-      if (method === 'get') {
-        await axios.get(url);
-      } else {
-        await axios.post(url);
-      }
-    } catch (e) {
-      // We sometimes expect the request to fail, but not the test.
-      // So, we do nothing.
-      logger.warn(e);
-    }
   });
+};
+
+const makeRequest = async (method: 'get' | 'post', url: string): Promise<void> => {
+  try {
+    if (method === 'get') {
+      await axios.get(url);
+    } else {
+      await axios.post(url);
+    }
+  } catch (e) {
+    // We sometimes expect the request to fail, but not the test.
+    // So, we do nothing.
+    logger.warn(e);
+  }
 };
 
 /**
@@ -119,8 +147,10 @@ export const getMultipleEnvelopeRequest = async (
  * @param {Record<string, string>} [headers]
  * @return {*}  {Promise<any>}
  */
-export const getAPIResponse = async (url: URL, headers?: Record<string, string>): Promise<unknown> => {
+export const getAPIResponse = async (config: TestServerConfig, headers?: Record<string, string>): Promise<unknown> => {
   return new Promise(resolve => {
+    const url = new URL(config.url);
+
     http.get(
       headers
         ? ({
@@ -138,7 +168,10 @@ export const getAPIResponse = async (url: URL, headers?: Record<string, string>)
           body += chunk;
         });
         response.on('end', function () {
-          resolve(JSON.parse(body));
+          config.scope.persist(false);
+          config.server.close(() => {
+            resolve(JSON.parse(body));
+          });
         });
       },
     );
@@ -153,10 +186,11 @@ export const getAPIResponse = async (url: URL, headers?: Record<string, string>)
  * @returns The extracted envelope.
  */
 export const getEnvelopeRequest = async (
-  url: string,
+  config: TestServerConfig,
   method: 'get' | 'post' = 'get',
+  endServer: boolean = true,
 ): Promise<Array<Record<string, unknown>>> => {
-  return (await getMultipleEnvelopeRequest(url, 1, method))[0];
+  return (await getMultipleEnvelopeRequest(config, 1, method, endServer))[0];
 };
 
 /**
@@ -167,12 +201,16 @@ export const getEnvelopeRequest = async (
  * @param {string} [scenarioPath]
  * @return {*}  {Promise<string>}
  */
-export async function runServer(testDir: string, serverPath?: string, scenarioPath?: string): Promise<string> {
+export async function runServer(
+  testDir: string,
+  serverPath?: string,
+  scenarioPath?: string,
+): Promise<TestServerConfig> {
   const port = await getPortPromise();
   const url = `http://localhost:${port}/test`;
   const defaultServerPath = path.resolve(process.cwd(), 'utils', 'defaults', 'server');
 
-  await new Promise<void>(resolve => {
+  const { server, scope } = await new Promise<{ server: http.Server; scope: nock.Scope }>(resolve => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-member-access
     const app = require(serverPath || defaultServerPath).default as Express;
 
@@ -185,14 +223,13 @@ export async function runServer(testDir: string, serverPath?: string, scenarioPa
     });
 
     const server = app.listen(port, () => {
-      resolve();
-      setTimeout(() => {
-        server.close();
-      }, 4000);
+      const scope = nock('https://dsn.ingest.sentry.io').persist();
+
+      resolve({ server, scope });
     });
   });
 
-  return url;
+  return { url, server, scope };
 }
 
 export async function runScenario(serverUrl: string): Promise<void> {

--- a/packages/node-integration-tests/utils/index.ts
+++ b/packages/node-integration-tests/utils/index.ts
@@ -8,7 +8,7 @@ import nock from 'nock';
 import * as path from 'path';
 import { getPortPromise } from 'portfinder';
 
-type TestServerConfig = {
+export type TestServerConfig = {
   url: string;
   server: http.Server;
   scope: nock.Scope;

--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -19,6 +19,7 @@
     "@remix-run/dev": "^1.6.5",
     "@types/react": "^17.0.47",
     "@types/react-dom": "^17.0.17",
+    "nock": "^13.1.0",
     "typescript": "^4.2.4"
   },
   "resolutions": {

--- a/packages/remix/test/integration/test/server/action.test.ts
+++ b/packages/remix/test/integration/test/server/action.test.ts
@@ -11,9 +11,9 @@ jest.spyOn(console, 'error').mockImplementation();
 // Repeat tests for each adapter
 describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', adapter => {
   it('correctly instruments a parameterized Remix API action', async () => {
-    const baseURL = await runServer(adapter);
-    const url = `${baseURL}/action-json-response/123123`;
-    const envelope = await getEnvelopeRequest(url, 'post');
+    const config = await runServer(adapter);
+    const url = `${config.url}/action-json-response/123123`;
+    const envelope = await getEnvelopeRequest({ ...config, url }, 'post');
     const transaction = envelope[2];
 
     assertSentryTransaction(transaction, {
@@ -40,10 +40,10 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
   });
 
   it('reports an error thrown from the action', async () => {
-    const baseURL = await runServer(adapter);
-    const url = `${baseURL}/action-json-response/-1`;
+    const config = await runServer(adapter);
+    const url = `${config.url}/action-json-response/-1`;
 
-    const [transaction, event] = await getMultipleEnvelopeRequest(url, 2, 'post');
+    const [transaction, event] = await getMultipleEnvelopeRequest({ ...config, url }, 2, 'post');
 
     assertSentryTransaction(transaction[2], {
       contexts: {
@@ -77,10 +77,10 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
   });
 
   it('handles a thrown 500 response', async () => {
-    const baseURL = await runServer(adapter);
-    const url = `${baseURL}/action-json-response/-2`;
+    const config = await runServer(adapter);
+    const url = `${config.url}/action-json-response/-2`;
 
-    const [transaction_1, event, transaction_2] = await getMultipleEnvelopeRequest(url, 3, 'post');
+    const [transaction_1, event, transaction_2] = await getMultipleEnvelopeRequest({ ...config, url }, 3, 'post');
 
     assertSentryTransaction(transaction_1[2], {
       contexts: {

--- a/packages/remix/test/integration/test/server/action.test.ts
+++ b/packages/remix/test/integration/test/server/action.test.ts
@@ -13,7 +13,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
   it('correctly instruments a parameterized Remix API action', async () => {
     const config = await runServer(adapter);
     const url = `${config.url}/action-json-response/123123`;
-    const envelope = await getEnvelopeRequest({ ...config, url }, 'post');
+    const envelope = await getEnvelopeRequest({ ...config, url }, { method: 'post' });
     const transaction = envelope[2];
 
     assertSentryTransaction(transaction, {
@@ -43,7 +43,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
     const config = await runServer(adapter);
     const url = `${config.url}/action-json-response/-1`;
 
-    const [transaction, event] = await getMultipleEnvelopeRequest({ ...config, url }, 2, 'post');
+    const [transaction, event] = await getMultipleEnvelopeRequest({ ...config, url }, { count: 2, method: 'post' });
 
     assertSentryTransaction(transaction[2], {
       contexts: {
@@ -80,7 +80,10 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
     const config = await runServer(adapter);
     const url = `${config.url}/action-json-response/-2`;
 
-    const [transaction_1, event, transaction_2] = await getMultipleEnvelopeRequest({ ...config, url }, 3, 'post');
+    const [transaction_1, event, transaction_2] = await getMultipleEnvelopeRequest(
+      { ...config, url },
+      { count: 3, method: 'post' },
+    );
 
     assertSentryTransaction(transaction_1[2], {
       contexts: {

--- a/packages/remix/test/integration/test/server/loader.test.ts
+++ b/packages/remix/test/integration/test/server/loader.test.ts
@@ -14,7 +14,7 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
     const config = await runServer(adapter);
     const url = `${config.url}/loader-json-response/-2`;
 
-    let [transaction, event] = await getMultipleEnvelopeRequest({ ...config, url }, 2);
+    let [transaction, event] = await getMultipleEnvelopeRequest({ ...config, url }, { count: 2 });
 
     // The event envelope is returned before the transaction envelope when using express adapter.
     // We can update this when we merge the envelope filtering utility.
@@ -83,7 +83,7 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
     const config = await runServer(adapter);
     const url = `${config.url}/loader-json-response/-1`;
 
-    const [transaction_1, event, transaction_2] = await getMultipleEnvelopeRequest({ ...config, url }, 3);
+    const [transaction_1, event, transaction_2] = await getMultipleEnvelopeRequest({ ...config, url }, { count: 3 });
 
     assertSentryTransaction(transaction_1[2], {
       contexts: {

--- a/packages/remix/test/integration/test/server/loader.test.ts
+++ b/packages/remix/test/integration/test/server/loader.test.ts
@@ -11,10 +11,10 @@ jest.spyOn(console, 'error').mockImplementation();
 // Repeat tests for each adapter
 describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', adapter => {
   it('reports an error thrown from the loader', async () => {
-    const baseURL = await runServer(adapter);
-    const url = `${baseURL}/loader-json-response/-2`;
+    const config = await runServer(adapter);
+    const url = `${config.url}/loader-json-response/-2`;
 
-    let [transaction, event] = await getMultipleEnvelopeRequest(url, 2);
+    let [transaction, event] = await getMultipleEnvelopeRequest({ ...config, url }, 2);
 
     // The event envelope is returned before the transaction envelope when using express adapter.
     // We can update this when we merge the envelope filtering utility.
@@ -52,9 +52,9 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
   });
 
   it('correctly instruments a parameterized Remix API loader', async () => {
-    const baseURL = await runServer(adapter);
-    const url = `${baseURL}/loader-json-response/123123`;
-    const envelope = await getEnvelopeRequest(url);
+    const config = await runServer(adapter);
+    const url = `${config.url}/loader-json-response/123123`;
+    const envelope = await getEnvelopeRequest({ ...config, url });
     const transaction = envelope[2];
 
     assertSentryTransaction(transaction, {
@@ -80,10 +80,10 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
   });
 
   it('handles a thrown 500 response', async () => {
-    const baseURL = await runServer(adapter);
-    const url = `${baseURL}/loader-json-response/-1`;
+    const config = await runServer(adapter);
+    const url = `${config.url}/loader-json-response/-1`;
 
-    const [transaction_1, event, transaction_2] = await getMultipleEnvelopeRequest(url, 3);
+    const [transaction_1, event, transaction_2] = await getMultipleEnvelopeRequest({ ...config, url }, 3);
 
     assertSentryTransaction(transaction_1[2], {
       contexts: {

--- a/packages/remix/test/integration/test/server/utils/helpers.ts
+++ b/packages/remix/test/integration/test/server/utils/helpers.ts
@@ -2,6 +2,9 @@ import express from 'express';
 import { createRequestHandler } from '@remix-run/express';
 import { getPortPromise } from 'portfinder';
 import { wrapExpressCreateRequestHandler } from '@sentry/remix';
+import type { TestServerConfig } from '../../../../../../node-integration-tests/utils';
+import nock from 'nock';
+import * as http from 'http';
 
 export * from '../../../../../../node-integration-tests/utils';
 
@@ -9,20 +12,27 @@ export * from '../../../../../../node-integration-tests/utils';
  * Runs a test server
  * @returns URL
  */
-export async function runServer(adapter: string = 'builtin'): Promise<string> {
+export async function runServer(adapter: string = 'builtin'): Promise<TestServerConfig> {
   const requestHandlerFactory =
     adapter === 'express' ? wrapExpressCreateRequestHandler(createRequestHandler) : createRequestHandler;
 
-  const app = express();
   const port = await getPortPromise();
 
-  app.all('*', requestHandlerFactory({ build: require('../../../build') }));
+  const { server, scope } = await new Promise<{ server: http.Server; scope: nock.Scope }>(resolve => {
+    const app = express();
 
-  const server = app.listen(port, () => {
-    setTimeout(() => {
-      server.close();
-    }, 4000);
+    app.all('*', requestHandlerFactory({ build: require('../../../build') }));
+
+    const server = app.listen(port, () => {
+      const scope = nock('https://dsn.ingest.sentry.io').persist();
+
+      resolve({ server, scope });
+    });
   });
 
-  return `http://localhost:${port}`;
+  return {
+    url: `http://localhost:${port}`,
+    server,
+    scope,
+  };
 }


### PR DESCRIPTION
Currently, Node integration tests initialize nock interceptors on server initialization and end them after a certain timeout. This recently created problems with asynchronous event processors, and caused random cases of envelope leaks between tests.

To resolve it, this approach returns `http.Server` and `nock.Scope` instances back to the test, to eventually be provided to a helper that either collects envelopes or makes requests. The responsibility of ending those two instances is moved to the collection helpers like `getEnvelopeRequest` or `getAPIResponse`.

Tests that do not use those helpers should close the server and nock interceptors manually. 
This way, we ensure that we do not lose the context of the server and the nock interceptors between tests. 

Needs to be tested on #5512