### PR TITLE
feat(tracing): Allow empty array as `tracingOrigins`

### DIFF
--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -133,7 +133,7 @@ export class BrowserTracing implements Integration {
     let tracingOrigins = defaultRequestInstrumentationOptions.tracingOrigins;
     // NOTE: Logger doesn't work in constructors, as it's initialized after integrations instances
     if (_options) {
-      if (_options.tracingOrigins && Array.isArray(_options.tracingOrigins) && _options.tracingOrigins.length !== 0) {
+      if (_options.tracingOrigins && Array.isArray(_options.tracingOrigins)) {
         tracingOrigins = _options.tracingOrigins;
       } else {
         __DEBUG_BUILD__ && (this._emitOptionsWarning = true);

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -145,16 +145,6 @@ describe('BrowserTracing', () => {
         expect(inst.options.tracingOrigins).toEqual(defaultRequestInstrumentationOptions.tracingOrigins);
       });
 
-      it('warns and uses default tracing origins if empty array given', () => {
-        const inst = createBrowserTracing(true, {
-          routingInstrumentation: customInstrumentRouting,
-          tracingOrigins: [],
-        });
-
-        expect(warnSpy).toHaveBeenCalledTimes(2);
-        expect(inst.options.tracingOrigins).toEqual(defaultRequestInstrumentationOptions.tracingOrigins);
-      });
-
       it('warns and uses default tracing origins if tracing origins are not defined', () => {
         const inst = createBrowserTracing(true, {
           routingInstrumentation: customInstrumentRouting,
@@ -166,13 +156,25 @@ describe('BrowserTracing', () => {
       });
 
       it('sets tracing origins if provided and does not warn', () => {
+        const sampleTracingOrigins = ['something'];
         const inst = createBrowserTracing(true, {
           routingInstrumentation: customInstrumentRouting,
-          tracingOrigins: ['something'],
+          tracingOrigins: sampleTracingOrigins,
         });
 
         expect(warnSpy).toHaveBeenCalledTimes(0);
-        expect(inst.options.tracingOrigins).toEqual(['something']);
+        expect(inst.options.tracingOrigins).toEqual(sampleTracingOrigins);
+      });
+
+      it('sets tracing origins to an empty array and does not warn', () => {
+        const sampleTracingOrigins: string[] = [];
+        const inst = createBrowserTracing(true, {
+          routingInstrumentation: customInstrumentRouting,
+          tracingOrigins: sampleTracingOrigins,
+        });
+
+        expect(warnSpy).toHaveBeenCalledTimes(0);
+        expect(inst.options.tracingOrigins).toEqual(sampleTracingOrigins);
       });
     });
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/5393

Allow for users to set an empty array as `tracingOrigins` option if they do not want to attach outgoing headers to any request. Previously we would just set the default tracing origins if users supplied an empty array.

This is technically a breaking change - but moves us toward the correct behaviour so I don't mind rolling this out in a minor. Thoughts?