### PR TITLE
meta: CHANGELOG for 7.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This release introduces updates the [`tracingOrigins` option](https://docs.sentr
 - feat(nextjs): Add spans and route parameterization in data fetching wrappers (#5564)
 - feat(nextjs): Create spans and route parameterization in server-side `getInitialProps` (#5587)
 - fix(remix): Use domains to prevent scope bleed (#5570)
+- fix(remix): Wrap domains properly on instrumentServer (#5590)
 - feat(remix): Add route ID to remix routes (#5568)
 - feat(remix): Export a manual wrapper for custom Express servers (#5524)
 - feat(tracing): Add long task collection (#5529)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+## 7.11.0
+
+This release introduces updates the [`tracingOrigins` option](https://docs.sentry.io/platforms/javascript/performance/instrumentation/automatic-instrumentation/#tracingorigins) to not attach any headers/create an spans when supplied with an empty array (`[]`). Previously, we would supply the default `tracingOrigins` if an empty array was set as the `tracingOrigins` option.
+
+- fix(core): Suppress stack when `SentryError` isn't an error (#5562)
+- feat(nextjs): Wrap server-side getInitialProps (#5546)
+- feat(nextjs): Improve pageload transaction creation (#5574)
+- feat(nextjs): Add spans and route parameterization in data fetching wrappers (#5564)
+- feat(nextjs): Create spans and route parameterization in server-side `getInitialProps` (#5587)
+- fix(remix): Use domains to prevent scope bleed (#5570)
+- feat(remix): Add route ID to remix routes (#5568)
+- feat(remix): Export a manual wrapper for custom Express servers (#5524)
+- feat(tracing): Add long task collection (#5529)
+- feat(tracing): Allow for setting of an empty array (#5583)
+
 ## 7.10.0
 
 This release introduces the first alpha version of `@sentry/svelte`, our newest JavaScript SDK! For details on how to use it, please see the [README](./packages/svelte/README.md) and [the tracking GitHub issue](https://github.com/getsentry/sentry-javascript/issues/5492).


### PR DESCRIPTION
Blocked on ~https://github.com/getsentry/sentry-javascript/pull/5564~, ~https://github.com/getsentry/sentry-javascript/pull/5570~, ~https://github.com/getsentry/sentry-javascript/pull/5587~ and ~https://github.com/getsentry/sentry-javascript/pull/5590~