### PR TITLE
fix(remix): Wrap domains properly on instrumentServer

### DIFF
--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -320,22 +320,25 @@ function wrapRequestHandler(origRequestHandler: RequestHandler, build: ServerBui
   const routes = createRoutes(build.routes);
   const pkg = loadModule<ReactRouterDomPkg>('react-router-dom');
   return async function (this: unknown, request: Request, loadContext?: unknown): Promise<Response> {
-    const hub = getCurrentHub();
-    const options = hub.getClient()?.getOptions();
+    const local = domain.create();
+    return local.bind(async () => {
+      const hub = getCurrentHub();
+      const options = hub.getClient()?.getOptions();
 
-    if (!options || !hasTracingEnabled(options)) {
-      return origRequestHandler.call(this, request, loadContext);
-    }
+      if (!options || !hasTracingEnabled(options)) {
+        return origRequestHandler.call(this, request, loadContext);
+      }
 
-    const url = new URL(request.url);
-    const transaction = startRequestHandlerTransaction(url, request.method, routes, hub, pkg);
+      const url = new URL(request.url);
+      const transaction = startRequestHandlerTransaction(url, request.method, routes, hub, pkg);
 
-    const res = (await origRequestHandler.call(this, request, loadContext)) as Response;
+      const res = (await origRequestHandler.call(this, request, loadContext)) as Response;
 
-    transaction.setHttpStatus(res.status);
-    transaction.finish();
+      transaction.setHttpStatus(res.status);
+      transaction.finish();
 
-    return res;
+      return res;
+    })();
   };
 }
 
@@ -421,8 +424,7 @@ function makeWrappedCreateRequestHandler(
     const newBuild = instrumentBuild(build);
     const requestHandler = origCreateRequestHandler.call(this, newBuild, ...args);
 
-    const local = domain.create();
-    return local.bind(() => wrapRequestHandler(requestHandler, newBuild))();
+    return wrapRequestHandler(requestHandler, newBuild);
   };
 }
 

--- a/packages/remix/test/integration/test/server/loader.test.ts
+++ b/packages/remix/test/integration/test/server/loader.test.ts
@@ -5,6 +5,7 @@ import {
   getMultipleEnvelopeRequest,
   assertSentryEvent,
 } from './utils/helpers';
+import { Event } from '@sentry/types';
 
 jest.spyOn(console, 'error').mockImplementation();
 
@@ -136,39 +137,27 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
     });
   });
 
-  // TODO: This test flakes. Let's fix it.
-  // it('makes sure scope does not bleed between requests', async () => {
-  //   const { url, server, scope } = await runServer(adapter);
+  it('makes sure scope does not bleed between requests', async () => {
+    const { url, server, scope } = await runServer(adapter);
 
-  //   const envelopes = await Promise.all([
-  //     getEnvelopeRequest({ url: `${url}/scope-bleed/1`, server, scope }, { endServer: false }),
-  //     getEnvelopeRequest({ url: `${url}/scope-bleed/2`, server, scope }, { endServer: false }),
-  //     getEnvelopeRequest({ url: `${url}/scope-bleed/3`, server, scope }, { endServer: false }),
-  //     getEnvelopeRequest({ url: `${url}/scope-bleed/4`, server, scope }, { endServer: false }),
-  //   ]);
+    const envelopes = await Promise.all([
+      getEnvelopeRequest({ url: `${url}/scope-bleed/1`, server, scope }, { endServer: false }),
+      getEnvelopeRequest({ url: `${url}/scope-bleed/2`, server, scope }, { endServer: false }),
+      getEnvelopeRequest({ url: `${url}/scope-bleed/3`, server, scope }, { endServer: false }),
+      getEnvelopeRequest({ url: `${url}/scope-bleed/4`, server, scope }, { endServer: false }),
+    ]);
 
-  //   scope.persist(false);
-  //   await new Promise(resolve => server.close(resolve));
+    scope.persist(false);
+    await new Promise(resolve => server.close(resolve));
 
-  //   assertSentryTransaction(envelopes[0][2], {
-  //     tags: {
-  //       tag4: '4',
-  //     },
-  //   });
-  //   assertSentryTransaction(envelopes[1][2], {
-  //     tags: {
-  //       tag3: '3',
-  //     },
-  //   });
-  //   assertSentryTransaction(envelopes[2][2], {
-  //     tags: {
-  //       tag2: '2',
-  //     },
-  //   });
-  //   assertSentryTransaction(envelopes[3][2], {
-  //     tags: {
-  //       tag1: '1',
-  //     },
-  //   });
-  // });
+    envelopes.forEach(envelope => {
+      const tags = envelope[2].tags as NonNullable<Event['tags']>;
+      const customTagArr = Object.keys(tags).filter(t => t.startsWith('tag'));
+      expect(customTagArr).toHaveLength(1);
+
+      const key = customTagArr[0];
+      const val = key[key.length - 1];
+      expect(tags[key]).toEqual(val);
+    });
+  });
 });

--- a/packages/remix/test/integration/test/server/loader.test.ts
+++ b/packages/remix/test/integration/test/server/loader.test.ts
@@ -136,38 +136,39 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
     });
   });
 
-  it('makes sure scope does not bleed between requests', async () => {
-    const { url, server, scope } = await runServer(adapter);
+  // TODO: This test flakes. Let's fix it.
+  // it('makes sure scope does not bleed between requests', async () => {
+  //   const { url, server, scope } = await runServer(adapter);
 
-    const envelopes = await Promise.all([
-      getEnvelopeRequest({ url: `${url}/scope-bleed/1`, server, scope }, { endServer: false }),
-      getEnvelopeRequest({ url: `${url}/scope-bleed/2`, server, scope }, { endServer: false }),
-      getEnvelopeRequest({ url: `${url}/scope-bleed/3`, server, scope }, { endServer: false }),
-      getEnvelopeRequest({ url: `${url}/scope-bleed/4`, server, scope }, { endServer: false }),
-    ]);
+  //   const envelopes = await Promise.all([
+  //     getEnvelopeRequest({ url: `${url}/scope-bleed/1`, server, scope }, { endServer: false }),
+  //     getEnvelopeRequest({ url: `${url}/scope-bleed/2`, server, scope }, { endServer: false }),
+  //     getEnvelopeRequest({ url: `${url}/scope-bleed/3`, server, scope }, { endServer: false }),
+  //     getEnvelopeRequest({ url: `${url}/scope-bleed/4`, server, scope }, { endServer: false }),
+  //   ]);
 
-    scope.persist(false);
-    await new Promise(resolve => server.close(resolve));
+  //   scope.persist(false);
+  //   await new Promise(resolve => server.close(resolve));
 
-    assertSentryTransaction(envelopes[0][2], {
-      tags: {
-        tag4: '4',
-      },
-    });
-    assertSentryTransaction(envelopes[1][2], {
-      tags: {
-        tag3: '3',
-      },
-    });
-    assertSentryTransaction(envelopes[2][2], {
-      tags: {
-        tag2: '2',
-      },
-    });
-    assertSentryTransaction(envelopes[3][2], {
-      tags: {
-        tag1: '1',
-      },
-    });
-  });
+  //   assertSentryTransaction(envelopes[0][2], {
+  //     tags: {
+  //       tag4: '4',
+  //     },
+  //   });
+  //   assertSentryTransaction(envelopes[1][2], {
+  //     tags: {
+  //       tag3: '3',
+  //     },
+  //   });
+  //   assertSentryTransaction(envelopes[2][2], {
+  //     tags: {
+  //       tag2: '2',
+  //     },
+  //   });
+  //   assertSentryTransaction(envelopes[3][2], {
+  //     tags: {
+  //       tag1: '1',
+  //     },
+  //   });
+  // });
 });


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/pull/5570 merged, but the tests were being very flaky. I took another look and figured out that we only needed to wrap our instrumentation with a domain once. Wrapping twice (for both express and built-in) was causing problems. In addition, I moved the wrapping down to the request handling phase, which makes the behaviour more correct.

This supercedes https://github.com/getsentry/sentry-javascript/pull/5589