### PR TITLE
fix(utils): Check if function before using `toString`

### DIFF
--- a/packages/utils/src/supports.ts
+++ b/packages/utils/src/supports.ts
@@ -74,7 +74,7 @@ export function supportsFetch(): boolean {
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
 export function isNativeFetch(func: Function): boolean {
-  return func && /^function fetch\(\)\s+\{\s+\[native code\]\s+\}$/.test(func.toString());
+  return func && typeof func === 'function' && /^function fetch\(\)\s+\{\s+\[native code\]\s+\}$/.test(func.toString());
 }
 
 /**


### PR DESCRIPTION
i use vconsole and sentry-vue in my application

`UA:
Mozilla/5.0 (Linux; Android 8.1.0; 16th Build/OPM1.171019.026; wv)
AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0
.3325.110 Mobile Safari/537.36`

and get error from @sentry-utils 

`Uncaught TypeError: Function prototype. toString requires that this
be a Function
/assets/index.f256a6e6.js:21:11553
TypeError: Function.prototype. toString requires that 'this' be a Functi
on
at Proxy.toString(<anonymous>)\n
at .inspectSource `

i find vconsole will proxy fetch when i init my vue app.
next to sentry init it will chrash 

`Function.prototype.toString.call(Proxy({},{}))`

we must ensure 'func' is function~

- [ ] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

