### PR TITLE
ref(tests): Refactor Node integration tests further.

### DIFF
--- a/packages/node-integration-tests/README.md
+++ b/packages/node-integration-tests/README.md
@@ -37,7 +37,7 @@ A custom server configuration can be used, supplying a script that exports a val
 
 The responsibility of ending the server is delegated to the test case. Data collection helpers such as `getEnvelopeRequest` and `getAPIResponse` expect the server instance to be available and finish it before their resolution. Tests that do not use those helpers will need to end the server manually.
 
-Nock interceptors are internally used to capture envelope requests by `getEnvelopeRequest` and `getMultipleEnvelopeRequest` helpers. After capturing required requests, the interceptors are removed. Nock can manually be used inside the test cases to intercept requests, but should be removed before the test ends, not to cause flakiness.
+Nock interceptors are internally used to capture envelope requests by `getEnvelopeRequest` and `getMultipleEnvelopeRequest` helpers. After capturing required requests, the interceptors are removed. Nock can manually be used inside the test cases to intercept requests but should be removed before the test ends, as not to cause flakiness.
 
 ## Running Tests Locally
 

--- a/packages/node-integration-tests/README.md
+++ b/packages/node-integration-tests/README.md
@@ -33,9 +33,12 @@ A custom server configuration can be used, supplying a script that exports a val
 
 `utils/` contains helpers and Sentry-specific assertions that can be used in (`test.ts`).
 
-`runServer` utility function returns an object containing `url`, [`http.Server`](https://nodejs.org/dist/latest-v16.x/docs/api/http.html#class-httpserver) and [`nock.Scope`](https://github.com/nock/nock#usage) instances for the created server. The `url` property is the base URL for the server. The `http.Server` instance is used to finish the server eventually, and the `nock.Scope` instance is used to bind / unbind interceptors for the test case.
+`runServer` utility function returns an object containing `url` and [`http.Server`](https://nodejs.org/dist/latest-v16.x/docs/api/http.html#class-httpserver)  instance for the created server. The `url` property is the base URL for the server. The `http.Server` instance is used to finish the server eventually.
 
-The responsibility of ending the server and interceptor is delegated to the test case. Data collection helpers such as `getEnvelopeRequest` and `getAPIResponse` expect those instances to be available and finish them before their resolution. Test that do not use those helpers will need to end the server and interceptors manually.
+The responsibility of ending the server is delegated to the test case. Data collection helpers such as `getEnvelopeRequest` and `getAPIResponse` expect the server instance to be available and finish it before their resolution. Test that do not use those helpers will need to end the server manually.
+
+Nock interceptors are internally used to capture envelope requests by `getEnvelopeRequest` and `getMultipleEnvelopeRequest` helpers. After capturing required requests, the interceptors are removed. Nock can manually be used inside the test cases to intercept requests, but should be removed before the test ends, not to cause flakiness.
+
 ## Running Tests Locally
 
 Tests can be run locally with:

--- a/packages/node-integration-tests/README.md
+++ b/packages/node-integration-tests/README.md
@@ -35,7 +35,7 @@ A custom server configuration can be used, supplying a script that exports a val
 
 `runServer` utility function returns an object containing `url` and [`http.Server`](https://nodejs.org/dist/latest-v16.x/docs/api/http.html#class-httpserver)  instance for the created server. The `url` property is the base URL for the server. The `http.Server` instance is used to finish the server eventually.
 
-The responsibility of ending the server is delegated to the test case. Data collection helpers such as `getEnvelopeRequest` and `getAPIResponse` expect the server instance to be available and finish it before their resolution. Test that do not use those helpers will need to end the server manually.
+The responsibility of ending the server is delegated to the test case. Data collection helpers such as `getEnvelopeRequest` and `getAPIResponse` expect the server instance to be available and finish it before their resolution. Tests that do not use those helpers will need to end the server manually.
 
 Nock interceptors are internally used to capture envelope requests by `getEnvelopeRequest` and `getMultipleEnvelopeRequest` helpers. After capturing required requests, the interceptors are removed. Nock can manually be used inside the test cases to intercept requests, but should be removed before the test ends, not to cause flakiness.
 

--- a/packages/node-integration-tests/suites/express/handle-error/test.ts
+++ b/packages/node-integration-tests/suites/express/handle-error/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../utils/index';
 
 test('should capture and send Express controller error.', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${__dirname}/server.ts`);
-  const event = await getEnvelopeRequest({ url: `${url}/express`, server, scope });
+  const { url, server } = await runServer(__dirname, `${__dirname}/server.ts`);
+  const event = await getEnvelopeRequest({ url: `${url}/express`, server });
 
   expect((event[2] as any).exception.values[0].stacktrace.frames.length).toBeGreaterThan(0);
 

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
@@ -4,10 +4,10 @@ import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('Should not overwrite baggage if the incoming request already has Sentry baggage data.', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const response = (await getAPIResponse(
-    { url: `${url}/express`, server, scope },
+    { url: `${url}/express`, server },
     {
       baggage: 'sentry-release=2.0.0,sentry-environment=myEnv',
     },
@@ -23,10 +23,10 @@ test('Should not overwrite baggage if the incoming request already has Sentry ba
 });
 
 test('Should propagate sentry trace baggage data from an incoming to an outgoing request.', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const response = (await getAPIResponse(
-    { url: `${url}/express`, server, scope },
+    { url: `${url}/express`, server },
     {
       'sentry-trace': '',
       baggage: 'sentry-release=2.0.0,sentry-environment=myEnv,dogs=great',
@@ -43,10 +43,10 @@ test('Should propagate sentry trace baggage data from an incoming to an outgoing
 });
 
 test('Should propagate empty baggage if sentry-trace header is present in incoming request but no baggage header', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const response = (await getAPIResponse(
-    { url: `${url}/express`, server, scope },
+    { url: `${url}/express`, server },
     {
       'sentry-trace': '',
     },
@@ -62,10 +62,10 @@ test('Should propagate empty baggage if sentry-trace header is present in incomi
 });
 
 test('Should propagate empty sentry and ignore original 3rd party baggage entries if sentry-trace header is present', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const response = (await getAPIResponse(
-    { url: `${url}/express`, server, scope },
+    { url: `${url}/express`, server },
     {
       'sentry-trace': '',
       baggage: 'foo=bar',
@@ -82,9 +82,9 @@ test('Should propagate empty sentry and ignore original 3rd party baggage entrie
 });
 
 test('Should populate and propagate sentry baggage if sentry-trace header does not exist', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse({ url: `${url}/express`, server, scope }, {})) as TestAPIResponse;
+  const response = (await getAPIResponse({ url: `${url}/express`, server }, {})) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
@@ -99,10 +99,10 @@ test('Should populate and propagate sentry baggage if sentry-trace header does n
 });
 
 test('Should populate Sentry and ignore 3rd party content if sentry-trace header does not exist', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const response = (await getAPIResponse(
-    { url: `${url}/express`, server, scope },
+    { url: `${url}/express`, server },
     {
       baggage: 'foo=bar,bar=baz',
     },

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out-bad-tx-name/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out-bad-tx-name/test.ts
@@ -4,9 +4,9 @@ import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('Does not include transaction name if transaction source is not set', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
-  const response = (await getAPIResponse({ url: `${url}/express`, server, scope })) as TestAPIResponse;
+  const response = (await getAPIResponse({ url: `${url}/express`, server })) as TestAPIResponse;
   const baggageString = response.test_data.baggage;
 
   expect(response).toBeDefined();

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/test.ts
@@ -4,9 +4,9 @@ import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('should attach a `baggage` header to an outgoing request.', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
-  const response = (await getAPIResponse({ url: `${url}/express`, server, scope })) as TestAPIResponse;
+  const response = (await getAPIResponse({ url: `${url}/express`, server })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/test.ts
@@ -4,10 +4,10 @@ import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('should ignore sentry-values in `baggage` header of a third party vendor and overwrite them with incoming DSC', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
   const response = (await getAPIResponse(
-    { url: `${url}/express`, server, scope },
+    { url: `${url}/express`, server },
     {
       'sentry-trace': '',
       baggage: 'sentry-release=2.1.0,sentry-environment=myEnv',
@@ -24,9 +24,9 @@ test('should ignore sentry-values in `baggage` header of a third party vendor an
 });
 
 test('should ignore sentry-values in `baggage` header of a third party vendor and overwrite them with new DSC', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
-  const response = (await getAPIResponse({ url: `${url}/express`, server, scope }, {})) as TestAPIResponse;
+  const response = (await getAPIResponse({ url: `${url}/express`, server }, {})) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/test.ts
@@ -4,10 +4,10 @@ import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('should merge `baggage` header of a third party vendor with the Sentry DSC baggage items', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
   const response = (await getAPIResponse(
-    { url: `${url}/express`, server, scope },
+    { url: `${url}/express`, server },
     {
       'sentry-trace': '',
       baggage: 'sentry-release=2.0.0,sentry-environment=myEnv',

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/test.ts
@@ -4,9 +4,9 @@ import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('Includes transaction in baggage if the transaction name is parameterized', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
-  const response = (await getAPIResponse({ url: `${url}/express`, server, scope })) as TestAPIResponse;
+  const response = (await getAPIResponse({ url: `${url}/express`, server })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/sentry-trace/trace-header-assign/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/trace-header-assign/test.ts
@@ -5,10 +5,10 @@ import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('Should assign `sentry-trace` header which sets parent trace id of an outgoing request.', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const response = (await getAPIResponse(
-    { url: `${url}/express`, server, scope },
+    { url: `${url}/express`, server },
     {
       'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
     },

--- a/packages/node-integration-tests/suites/express/sentry-trace/trace-header-out/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/trace-header-out/test.ts
@@ -5,9 +5,9 @@ import { getAPIResponse, runServer } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('should attach a `sentry-trace` header to an outgoing request.', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse({ url: `${url}/express`, server, scope })) as TestAPIResponse;
+  const response = (await getAPIResponse({ url: `${url}/express`, server })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/packages/node-integration-tests/suites/express/tracing/test.ts
@@ -1,8 +1,8 @@
 import { assertSentryTransaction, getEnvelopeRequest, runServer } from '../../../utils/index';
 
 test('should create and send transactions for Express routes and spans for middlewares.', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${__dirname}/server.ts`);
-  const envelope = await getEnvelopeRequest({ url: `${url}/express`, server, scope });
+  const { url, server } = await runServer(__dirname, `${__dirname}/server.ts`);
+  const envelope = await getEnvelopeRequest({ url: `${url}/express`, server }, { envelopeType: 'transaction' });
 
   expect(envelope).toHaveLength(3);
 
@@ -29,8 +29,8 @@ test('should create and send transactions for Express routes and spans for middl
 });
 
 test('should set a correct transaction name for routes specified in RegEx', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${__dirname}/server.ts`);
-  const envelope = await getEnvelopeRequest({ url: `${url}/regex`, server, scope });
+  const { url, server } = await runServer(__dirname, `${__dirname}/server.ts`);
+  const envelope = await getEnvelopeRequest({ url: `${url}/regex`, server }, { envelopeType: 'transaction' });
 
   expect(envelope).toHaveLength(3);
 
@@ -57,8 +57,8 @@ test('should set a correct transaction name for routes specified in RegEx', asyn
 test.each([['array1'], ['array5']])(
   'should set a correct transaction name for routes consisting of arrays of routes',
   async segment => {
-    const { url, server, scope } = await runServer(__dirname, `${__dirname}/server.ts`);
-    const envelope = await getEnvelopeRequest({ url: `${url}/${segment}`, server, scope });
+    const { url, server } = await runServer(__dirname, `${__dirname}/server.ts`);
+    const envelope = await getEnvelopeRequest({ url: `${url}/${segment}`, server }, { envelopeType: 'transaction' });
 
     expect(envelope).toHaveLength(3);
 
@@ -93,8 +93,8 @@ test.each([
   ['arr/requiredPath/optionalPath/'],
   ['arr/requiredPath/optionalPath/lastParam'],
 ])('should handle more complex regexes in route arrays correctly', async segment => {
-  const { url, server, scope } = await runServer(__dirname, `${__dirname}/server.ts`);
-  const envelope = await getEnvelopeRequest({ url: `${url}/${segment}`, server, scope });
+  const { url, server } = await runServer(__dirname, `${__dirname}/server.ts`);
+  const envelope = await getEnvelopeRequest({ url: `${url}/${segment}`, server }, { envelopeType: 'transaction' });
 
   expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/test.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/test.ts
@@ -1,13 +1,12 @@
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should add an empty breadcrumb, when an empty object is given', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
-  const errorEnvelope = envelopes[1];
+  const envelope = await getEnvelopeRequest(config);
 
-  expect(errorEnvelope).toHaveLength(3);
+  expect(envelope).toHaveLength(3);
 
-  assertSentryEvent(errorEnvelope[2], {
+  assertSentryEvent(envelope[2], {
     message: 'test-empty-obj',
   });
 });

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/test.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/test.ts
@@ -2,9 +2,9 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should add multiple breadcrumbs', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
+  const events = await getMultipleEnvelopeRequest(config, { count: 1 });
 
-  assertSentryEvent(envelopes[1][2], {
+  assertSentryEvent(events[0][2], {
     message: 'test_multi_breadcrumbs',
     breadcrumbs: [
       {

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/test.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/test.ts
@@ -1,10 +1,10 @@
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should add a simple breadcrumb', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
+  const event = await getEnvelopeRequest(config);
 
-  assertSentryEvent(envelopes[1][2], {
+  assertSentryEvent(event[2], {
     message: 'test_simple',
     breadcrumbs: [
       {

--- a/packages/node-integration-tests/suites/public-api/captureException/catched-error/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureException/catched-error/test.ts
@@ -1,11 +1,10 @@
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should work inside catch block', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
-  const errorEnvelope = envelopes[1];
+  const event = await getEnvelopeRequest(config);
 
-  assertSentryEvent(errorEnvelope[2], {
+  assertSentryEvent(event[2], {
     exception: {
       values: [
         {

--- a/packages/node-integration-tests/suites/public-api/captureException/empty-obj/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureException/empty-obj/test.ts
@@ -1,11 +1,10 @@
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should capture an empty object', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
-  const errorEnvelope = envelopes[1];
+  const event = await getEnvelopeRequest(config);
 
-  assertSentryEvent(errorEnvelope[2], {
+  assertSentryEvent(event[2], {
     exception: {
       values: [
         {

--- a/packages/node-integration-tests/suites/public-api/captureException/simple-error/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureException/simple-error/test.ts
@@ -1,11 +1,10 @@
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should capture a simple error with message', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
-  const errorEnvelope = envelopes[1];
+  const envelope = await getEnvelopeRequest(config);
 
-  assertSentryEvent(errorEnvelope[2], {
+  assertSentryEvent(envelope[2], {
     exception: {
       values: [
         {

--- a/packages/node-integration-tests/suites/public-api/captureMessage/simple_message/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureMessage/simple_message/test.ts
@@ -1,11 +1,10 @@
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should capture a simple message string', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
-  const errorEnvelope = envelopes[1];
+  const event = await getEnvelopeRequest(config);
 
-  assertSentryEvent(errorEnvelope[2], {
+  assertSentryEvent(event[2], {
     message: 'Message',
     level: 'info',
   });

--- a/packages/node-integration-tests/suites/public-api/captureMessage/with_level/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureMessage/with_level/test.ts
@@ -2,34 +2,34 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should capture with different severity levels', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 12 });
+  const events = await getMultipleEnvelopeRequest(config, { count: 6 });
 
-  assertSentryEvent(envelopes[1][2], {
+  assertSentryEvent(events[0][2], {
     message: 'debug_message',
     level: 'debug',
   });
 
-  assertSentryEvent(envelopes[3][2], {
+  assertSentryEvent(events[1][2], {
     message: 'info_message',
     level: 'info',
   });
 
-  assertSentryEvent(envelopes[5][2], {
+  assertSentryEvent(events[2][2], {
     message: 'warning_message',
     level: 'warning',
   });
 
-  assertSentryEvent(envelopes[7][2], {
+  assertSentryEvent(events[3][2], {
     message: 'error_message',
     level: 'error',
   });
 
-  assertSentryEvent(envelopes[9][2], {
+  assertSentryEvent(events[4][2], {
     message: 'fatal_message',
     level: 'fatal',
   });
 
-  assertSentryEvent(envelopes[11][2], {
+  assertSentryEvent(events[5][2], {
     message: 'log_message',
     level: 'log',
   });

--- a/packages/node-integration-tests/suites/public-api/configureScope/set_properties/test.ts
+++ b/packages/node-integration-tests/suites/public-api/configureScope/set_properties/test.ts
@@ -1,11 +1,10 @@
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should set different properties of a scope', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
-  const errorEnvelope = envelopes[1];
+  const envelope = await getEnvelopeRequest(config);
 
-  assertSentryEvent(errorEnvelope[2], {
+  assertSentryEvent(envelope[2], {
     message: 'configured_scope',
     tags: {
       foo: 'bar',

--- a/packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/test.ts
@@ -1,13 +1,12 @@
 import { Event } from '@sentry/node';
 
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should record multiple contexts', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
-  const errorEnvelope = envelopes[1];
+  const envelope = await getEnvelopeRequest(config, { count: 1 });
 
-  assertSentryEvent(errorEnvelope[2], {
+  assertSentryEvent(envelope[2], {
     message: 'multiple_contexts',
     contexts: {
       context_1: {
@@ -18,5 +17,5 @@ test('should record multiple contexts', async () => {
     },
   });
 
-  expect((errorEnvelope[2] as Event).contexts?.context_3).not.toBeDefined();
+  expect((envelope[2] as Event).contexts?.context_3).not.toBeDefined();
 });

--- a/packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/test.ts
@@ -1,16 +1,15 @@
 import { Event } from '@sentry/node';
 
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should normalize non-serializable context', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
-  const errorEnvelope = envelopes[1];
+  const event = await getEnvelopeRequest(config);
 
-  assertSentryEvent(errorEnvelope[2], {
+  assertSentryEvent(event[2], {
     message: 'non_serializable',
     contexts: {},
   });
 
-  expect((errorEnvelope[2] as Event).contexts?.context_3).not.toBeDefined();
+  expect((event as Event).contexts?.context_3).not.toBeDefined();
 });

--- a/packages/node-integration-tests/suites/public-api/setContext/simple-context/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/simple-context/test.ts
@@ -4,10 +4,9 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should set a simple context', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
-  const errorEnvelope = envelopes[1];
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 1 });
 
-  assertSentryEvent(errorEnvelope[2], {
+  assertSentryEvent(envelopes[0][2], {
     message: 'simple_context_object',
     contexts: {
       foo: {
@@ -16,5 +15,5 @@ test('should set a simple context', async () => {
     },
   });
 
-  expect((errorEnvelope[2] as Event).contexts?.context_3).not.toBeDefined();
+  expect((envelopes[0][2] as Event).contexts?.context_3).not.toBeDefined();
 });

--- a/packages/node-integration-tests/suites/public-api/setExtra/multiple-extras/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtra/multiple-extras/test.ts
@@ -1,11 +1,10 @@
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should record multiple extras of different types', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
-  const errorEnvelope = envelopes[1];
+  const event = await getEnvelopeRequest(config);
 
-  assertSentryEvent(errorEnvelope[2], {
+  assertSentryEvent(event[2], {
     message: 'multiple_extras',
     extra: {
       extra_1: { foo: 'bar', baz: { qux: 'quux' } },

--- a/packages/node-integration-tests/suites/public-api/setExtra/non-serializable-extra/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtra/non-serializable-extra/test.ts
@@ -1,11 +1,10 @@
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should normalize non-serializable extra', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
-  const errorEnvelope = envelopes[1];
+  const event = await getEnvelopeRequest(config);
 
-  assertSentryEvent(errorEnvelope[2], {
+  assertSentryEvent(event[2], {
     message: 'non_serializable',
     extra: {},
   });

--- a/packages/node-integration-tests/suites/public-api/setExtra/simple-extra/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtra/simple-extra/test.ts
@@ -1,11 +1,10 @@
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should set a simple extra', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
-  const errorEnvelope = envelopes[1];
+  const event = await getEnvelopeRequest(config);
 
-  assertSentryEvent(errorEnvelope[2], {
+  assertSentryEvent(event[2], {
     message: 'simple_extra',
     extra: {
       foo: {

--- a/packages/node-integration-tests/suites/public-api/setExtras/consecutive-calls/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtras/consecutive-calls/test.ts
@@ -2,10 +2,9 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should set extras from multiple consecutive calls', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
-  const errorEnvelope = envelopes[1];
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 1 });
 
-  assertSentryEvent(errorEnvelope[2], {
+  assertSentryEvent(envelopes[0][2], {
     message: 'consecutive_calls',
     extra: { extra: [], Infinity: 2, null: 0, obj: { foo: ['bar', 'baz', 1] } },
   });

--- a/packages/node-integration-tests/suites/public-api/setExtras/multiple-extras/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtras/multiple-extras/test.ts
@@ -2,10 +2,9 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should record an extras object', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
-  const errorEnvelope = envelopes[1];
+  const events = await getMultipleEnvelopeRequest(config, { count: 1 });
 
-  assertSentryEvent(errorEnvelope[2], {
+  assertSentryEvent(events[0][2], {
     message: 'multiple_extras',
     extra: {
       extra_1: [1, ['foo'], 'bar'],

--- a/packages/node-integration-tests/suites/public-api/setTag/with-primitives/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setTag/with-primitives/test.ts
@@ -1,11 +1,10 @@
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should set primitive tags', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
-  const envelope = envelopes[1];
+  const event = await getEnvelopeRequest(config);
 
-  assertSentryEvent(envelope[2], {
+  assertSentryEvent(event[2], {
     message: 'primitive_tags',
     tags: {
       tag_1: 'foo',

--- a/packages/node-integration-tests/suites/public-api/setTags/with-primitives/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setTags/with-primitives/test.ts
@@ -1,11 +1,10 @@
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
 
 test('should set primitive tags', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
-  const envelope = envelopes[1];
+  const event = await getEnvelopeRequest(config);
 
-  assertSentryEvent(envelope[2], {
+  assertSentryEvent(event[2], {
     message: 'primitive_tags',
     tags: {
       tag_1: 'foo',

--- a/packages/node-integration-tests/suites/public-api/setUser/unset_user/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setUser/unset_user/test.ts
@@ -4,15 +4,15 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should unset user', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 6 });
+  const events = await getMultipleEnvelopeRequest(config, { count: 3 });
 
-  assertSentryEvent(envelopes[1][2], {
+  assertSentryEvent(events[0][2], {
     message: 'no_user',
   });
 
-  expect((envelopes[0][2] as Event).user).not.toBeDefined();
+  expect((events[0][2] as Event).user).not.toBeDefined();
 
-  assertSentryEvent(envelopes[3][2], {
+  assertSentryEvent(events[1][2], {
     message: 'user',
     user: {
       id: 'foo',
@@ -21,9 +21,9 @@ test('should unset user', async () => {
     },
   });
 
-  assertSentryEvent(envelopes[5][2], {
+  assertSentryEvent(events[2][2], {
     message: 'unset_user',
   });
 
-  expect((envelopes[2][2] as Event).user).not.toBeDefined();
+  expect((events[2][2] as Event).user).not.toBeDefined();
 });

--- a/packages/node-integration-tests/suites/public-api/setUser/update_user/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setUser/update_user/test.ts
@@ -2,9 +2,9 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should update user', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 4 });
+  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
 
-  assertSentryEvent(envelopes[1][2], {
+  assertSentryEvent(envelopes[0][2], {
     message: 'first_user',
     user: {
       id: 'foo',
@@ -12,7 +12,7 @@ test('should update user', async () => {
     },
   });
 
-  assertSentryEvent(envelopes[3][2], {
+  assertSentryEvent(envelopes[1][2], {
     message: 'second_user',
     user: {
       id: 'baz',

--- a/packages/node-integration-tests/suites/public-api/startTransaction/basic-usage/test.ts
+++ b/packages/node-integration-tests/suites/public-api/startTransaction/basic-usage/test.ts
@@ -2,9 +2,7 @@ import { assertSentryTransaction, getEnvelopeRequest, runServer } from '../../..
 
 test('should send a manually started transaction when @sentry/tracing is imported using unnamed import.', async () => {
   const config = await runServer(__dirname);
-  const envelope = await getEnvelopeRequest(config);
-
-  expect(envelope).toHaveLength(3);
+  const envelope = await getEnvelopeRequest(config, { envelopeType: 'transaction' });
 
   assertSentryTransaction(envelope[2], {
     transaction: 'test_transaction_1',

--- a/packages/node-integration-tests/suites/public-api/startTransaction/with-nested-spans/test.ts
+++ b/packages/node-integration-tests/suites/public-api/startTransaction/with-nested-spans/test.ts
@@ -2,7 +2,7 @@ import { assertSentryTransaction, getEnvelopeRequest, runServer } from '../../..
 
 test('should report finished spans as children of the root transaction.', async () => {
   const config = await runServer(__dirname);
-  const envelope = await getEnvelopeRequest(config);
+  const envelope = await getEnvelopeRequest(config, { envelopeType: 'transaction' });
 
   expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/public-api/withScope/nested-scopes/test.ts
+++ b/packages/node-integration-tests/suites/public-api/withScope/nested-scopes/test.ts
@@ -4,16 +4,16 @@ import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../
 
 test('should allow nested scoping', async () => {
   const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 10 });
+  const events = await getMultipleEnvelopeRequest(config, { count: 5 });
 
-  assertSentryEvent(envelopes[1][2], {
+  assertSentryEvent(events[0][2], {
     message: 'root_before',
     user: {
       id: 'qux',
     },
   });
 
-  assertSentryEvent(envelopes[3][2], {
+  assertSentryEvent(events[1][2], {
     message: 'outer_before',
     user: {
       id: 'qux',
@@ -23,7 +23,7 @@ test('should allow nested scoping', async () => {
     },
   });
 
-  assertSentryEvent(envelopes[5][2], {
+  assertSentryEvent(events[2][2], {
     message: 'inner',
     tags: {
       foo: false,
@@ -31,9 +31,9 @@ test('should allow nested scoping', async () => {
     },
   });
 
-  expect((envelopes[4][2] as Event).user).toBeUndefined();
+  expect((events[2][2] as Event).user).toBeUndefined();
 
-  assertSentryEvent(envelopes[7][2], {
+  assertSentryEvent(events[3][2], {
     message: 'outer_after',
     user: {
       id: 'baz',
@@ -43,7 +43,7 @@ test('should allow nested scoping', async () => {
     },
   });
 
-  assertSentryEvent(envelopes[9][2], {
+  assertSentryEvent(events[4][2], {
     message: 'root_after',
     user: {
       id: 'qux',

--- a/packages/node-integration-tests/suites/sessions/exited-session-aggregate/test.ts
+++ b/packages/node-integration-tests/suites/sessions/exited-session-aggregate/test.ts
@@ -1,17 +1,18 @@
+import nock from 'nock';
 import path from 'path';
 
 import { getEnvelopeRequest, runServer } from '../../../utils';
 
 test('should aggregate successful sessions', async () => {
-  const { url, server, scope } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const envelope = await Promise.race([
-    getEnvelopeRequest({ url: `${url}/success`, server, scope }, { endServer: false }),
-    getEnvelopeRequest({ url: `${url}/success_next`, server, scope }, { endServer: false }),
-    getEnvelopeRequest({ url: `${url}/success_slow`, server, scope }, { endServer: false }),
+    getEnvelopeRequest({ url: `${url}/success`, server }, { endServer: false, envelopeType: 'sessions' }),
+    getEnvelopeRequest({ url: `${url}/success_next`, server }, { endServer: false, envelopeType: 'sessions' }),
+    getEnvelopeRequest({ url: `${url}/success_slow`, server }, { endServer: false, envelopeType: 'sessions' }),
   ]);
 
-  scope.persist(false);
+  nock.cleanAll();
   server.close();
 
   expect(envelope).toHaveLength(3);

--- a/packages/node-integration-tests/suites/tracing/apollo-graphql/test.ts
+++ b/packages/node-integration-tests/suites/tracing/apollo-graphql/test.ts
@@ -5,7 +5,7 @@ import { assertSentryTransaction, conditionalTest, getEnvelopeRequest, runServer
 conditionalTest({ min: 12 })('GraphQL/Apollo Tests', () => {
   test('should instrument GraphQL and Apollo Server.', async () => {
     const config = await runServer(__dirname);
-    const envelope = await getEnvelopeRequest(config);
+    const envelope = await getEnvelopeRequest(config, { envelopeType: 'transaction' });
 
     expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
@@ -19,7 +19,7 @@ conditionalTest({ min: 12 })('MongoDB Test', () => {
 
   test('should auto-instrument `mongodb` package.', async () => {
     const config = await runServer(__dirname);
-    const envelope = await getEnvelopeRequest(config);
+    const envelope = await getEnvelopeRequest(config, { envelopeType: 'transaction' });
 
     expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/tracing/auto-instrument/mysql/test.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/mysql/test.ts
@@ -2,7 +2,7 @@ import { assertSentryTransaction, getEnvelopeRequest, runServer } from '../../..
 
 test('should auto-instrument `mysql` package.', async () => {
   const config = await runServer(__dirname);
-  const envelope = await getEnvelopeRequest(config);
+  const envelope = await getEnvelopeRequest(config, { envelopeType: 'transaction' });
 
   expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/tracing/auto-instrument/pg/test.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/pg/test.ts
@@ -30,7 +30,7 @@ beforeAll(() => {
 
 test('should auto-instrument `pg` package.', async () => {
   const config = await runServer(__dirname);
-  const envelope = await getEnvelopeRequest(config);
+  const envelope = await getEnvelopeRequest(config, { envelopeType: 'transaction' });
 
   expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/tracing/prisma-orm/test.ts
+++ b/packages/node-integration-tests/suites/tracing/prisma-orm/test.ts
@@ -3,7 +3,7 @@ import { assertSentryTransaction, conditionalTest, getEnvelopeRequest, runServer
 conditionalTest({ min: 12 })('Prisma ORM Integration', () => {
   test('should instrument Prisma client for tracing.', async () => {
     const config = await runServer(__dirname);
-    const envelope = await getEnvelopeRequest(config);
+    const envelope = await getEnvelopeRequest(config, { envelopeType: 'transaction' });
 
     assertSentryTransaction(envelope[2], {
       transaction: 'Test Transaction',

--- a/packages/node-integration-tests/suites/tracing/tracePropagationTargets/test.ts
+++ b/packages/node-integration-tests/suites/tracing/tracePropagationTargets/test.ts
@@ -27,10 +27,12 @@ test('HttpIntegration should instrument correct requests when tracePropagationTa
     .matchHeader('sentry-trace', val => val === undefined)
     .reply(200);
 
-  const { url, scope, server } = await runServer(__dirname);
+  const { url, server } = await runServer(__dirname);
   await runScenario(url);
 
-  scope.persist(false);
+  server.close();
+  nock.cleanAll();
+
   await new Promise(resolve => server.close(resolve));
 
   expect(match1.isDone()).toBe(true);

--- a/packages/node-integration-tests/utils/index.ts
+++ b/packages/node-integration-tests/utils/index.ts
@@ -16,7 +16,7 @@ export type TestServerConfig = {
 
 export type DataCollectorOptions = {
   // The expected amount of requests to the envelope endpoint.
-  // If the amount of sentrequests is lower than`count`, this function will not resolve.
+  // If the amount of sent requests is lower than `count`, this function will not resolve.
   count?: number;
 
   // The method of the request.
@@ -90,7 +90,7 @@ export const parseEnvelope = (body: string): Array<Record<string, unknown>> => {
 /**
  * Intercepts and extracts up to a number of requests containing Sentry envelopes.
  *
- * @param {TestServerConfig} config The url, server instance and the nock scope.
+ * @param {TestServerConfig} config The url and the server instance.
  * @param {DataCollectorOptions} options
  * @returns The intercepted envelopes.
  */
@@ -174,9 +174,10 @@ const makeRequest = async (method: 'get' | 'post', url: string): Promise<void> =
 };
 
 /**
- * Sends a get request to given URL, with optional headers
+ * Sends a get request to given URL, with optional headers. Returns the response.
+ * Ends the server instance and flushes the Sentry event queue.
  *
- * @param {TestServerConfig} config The url, server instance and the nock scope.
+ * @param {TestServerConfig} config The url and the server instance.
  * @param {Record<string, string>} [headers]
  * @return {*}  {Promise<any>}
  */
@@ -192,7 +193,7 @@ export const getAPIResponse = async (config: TestServerConfig, headers?: Record<
 /**
  * Intercepts and extracts a single request containing a Sentry envelope
  *
- * @param {TestServerConfig} config The url, server instance and the nock scope.
+ * @param {TestServerConfig} config The url and the server instance.
  * @param {DataCollectorOptions} options
  * @returns The extracted envelope.
  */
@@ -240,6 +241,13 @@ export async function runServer(
   return { url, server };
 }
 
+/**
+ * Sends a get request to given URL.
+ * Flushes the Sentry event queue.
+ *
+ * @param {string} url
+ * @return {*}  {Promise<void>}
+ */
 export async function runScenario(url: string): Promise<void> {
   await axios.get(url);
   await Sentry.flush();

--- a/packages/remix/test/integration/test/server/action.test.ts
+++ b/packages/remix/test/integration/test/server/action.test.ts
@@ -13,7 +13,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
   it('correctly instruments a parameterized Remix API action', async () => {
     const config = await runServer(adapter);
     const url = `${config.url}/action-json-response/123123`;
-    const envelope = await getEnvelopeRequest({ ...config, url }, { method: 'post' });
+    const envelope = await getEnvelopeRequest({ ...config, url }, { method: 'post', envelopeType: 'transaction' });
     const transaction = envelope[2];
 
     assertSentryTransaction(transaction, {
@@ -43,7 +43,10 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
     const config = await runServer(adapter);
     const url = `${config.url}/action-json-response/-1`;
 
-    const [transaction, event] = await getMultipleEnvelopeRequest({ ...config, url }, { count: 2, method: 'post' });
+    const [transaction, event] = await getMultipleEnvelopeRequest(
+      { ...config, url },
+      { count: 2, method: 'post', envelopeType: ['transaction', 'event'] },
+    );
 
     assertSentryTransaction(transaction[2], {
       contexts: {
@@ -82,7 +85,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
 
     const [transaction_1, event, transaction_2] = await getMultipleEnvelopeRequest(
       { ...config, url },
-      { count: 3, method: 'post' },
+      { count: 3, method: 'post', envelopeType: ['transaction', 'event'] },
     );
 
     assertSentryTransaction(transaction_1[2], {

--- a/packages/remix/test/integration/test/server/utils/helpers.ts
+++ b/packages/remix/test/integration/test/server/utils/helpers.ts
@@ -3,7 +3,6 @@ import { createRequestHandler } from '@remix-run/express';
 import { getPortPromise } from 'portfinder';
 import { wrapExpressCreateRequestHandler } from '@sentry/remix';
 import type { TestServerConfig } from '../../../../../../node-integration-tests/utils';
-import nock from 'nock';
 import * as http from 'http';
 
 export * from '../../../../../../node-integration-tests/utils';
@@ -18,21 +17,18 @@ export async function runServer(adapter: string = 'builtin'): Promise<TestServer
 
   const port = await getPortPromise();
 
-  const { server, scope } = await new Promise<{ server: http.Server; scope: nock.Scope }>(resolve => {
+  const server = await new Promise<http.Server>(resolve => {
     const app = express();
 
     app.all('*', requestHandlerFactory({ build: require('../../../build') }));
 
     const server = app.listen(port, () => {
-      const scope = nock('https://dsn.ingest.sentry.io').persist();
-
-      resolve({ server, scope });
+      resolve(server);
     });
   });
 
   return {
     url: `http://localhost:${port}`,
     server,
-    scope,
   };
 }


### PR DESCRIPTION
Following up: #5579 

Apparently, the updates on #5579 were not enough to resolve leaking issues on #5512.

Debugging further, it seems that whenever a manual `http` request is initiated from a test (or test server) without waiting for / asserting on events or transactions, there are also transactions as side effects which may or may not finish before the test ends. This specifically happens with tests that assert request headers for `trace` and `baggage`, because they don't need to wait for the request / scenario to finish.

So it looks like the leakage to the next test doesn't come from the `nock` interceptor or an unclosed server, it comes from an unflushed Sentry transaction. The other tests using `getEnvelopeRequest` or `getMultipleEnvelopeRequest` finish wait for the events to be flushed.

While debugging this, I also made some more refactors in utilities, which I think will make them more concise.

Summary:

- [x] Making sure the events are flushed before tests that use `getAPIResponse` or `runScenario` complete.
- [x] Converted `http` usages in helpers to `axios` calls for simplicity and debuggability.
- [x] Moved `nock` initialization out of `runServer` so we don't need to carry `nock.Scope` around anymore. The `nock` instance is either manually initialized, or inside the `getMultipleEnvelopeRequest` function. The tests that are using manual `http` calls don't normally need nock anyways.
- [x] Filtering envelopes by their types on `nock` level, so if there is a need to filter them, we don't lose the expected `count`. Also, that makes the envelope indices inside tests simpler.
- [x] Switched to `nock.cleanAll()` and `nock.removeInterceptor(mock)` to end `nock` instead of `.persist(false)`.

I have tested this locally on #5512 and it seems to be working well.
🤞 

