### PR TITLE
ref(tracing): Update long task description

### DIFF
--- a/packages/integration-tests/suites/tracing/browsertracing/long-tasks-enabled/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/long-tasks-enabled/test.ts
@@ -23,7 +23,7 @@ sentryTest('should capture long task.', async ({ browserName, getLocalTestPath, 
   expect(firstUISpan).toEqual(
     expect.objectContaining({
       op: 'ui.long-task',
-      description: 'Long Task',
+      description: 'Main UI thread blocked',
       parent_span_id: eventData.contexts?.trace.span_id,
     }),
   );

--- a/packages/tracing/src/browser/metrics/index.ts
+++ b/packages/tracing/src/browser/metrics/index.ts
@@ -52,7 +52,7 @@ export function startTrackingLongTasks(): void {
     const startTime = msToSec((browserPerformanceTimeOrigin as number) + entry.startTime);
     const duration = msToSec(entry.duration);
     transaction.startChild({
-      description: 'Long Task',
+      description: 'Main UI thread blocked',
       op: 'ui.long-task',
       startTimestamp: startTime,
       endTimestamp: startTime + duration,


### PR DESCRIPTION
Update the `ui.long-task` span description to explain what is happening while the span is occuring.

https://developer.mozilla.org/en-US/docs/Web/API/Long_Tasks_API