### PR TITLE
fix(nextjs): Don't run webpack plugin on non-prod Vercel deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+This release adds an environment check in `@sentry/nextjs` for Vercel deployments (using the `VERCEL_ENV` env variable), and only enables `SentryWebpackPlugin` if the environment is `production`. To override this, [setting `disableClientWebpackPlugin` or `disableServerWebpackPlugin` to `false`](https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#disable-sentrywebpackplugin) now takes precedence over other checks, rather than being a no-op. Note: Overriding this is not recommended! It can increase build time and clog Release Health data in Sentry with inaccurate noise.
+
+- fix(nextjs): Don't run webpack plugin on non-prod Vercel deployments (#5603)
+
 ## 7.11.1
 
 - fix(remix): Store transaction on express req (#5595)

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -35,6 +35,8 @@ export type NextConfigObject = {
 };
 
 export type UserSentryOptions = {
+  // Override the SDK's default decision about whether or not to enable to the webpack plugin. Note that `false` forces
+  // the plugin to be enabled, even in situations where it's not recommended.
   disableServerWebpackPlugin?: boolean;
   disableClientWebpackPlugin?: boolean;
   hideSourceMaps?: boolean;

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -487,6 +487,10 @@ function shouldEnableWebpackPlugin(buildContext: BuildContext, userSentryOptions
     // return false
   }
 
+  if (process.env.VERCEL_ENV === 'preview' || process.env.VERCEL_ENV === 'development') {
+    return false;
+  }
+
   // We've passed all of the tests!
   return true;
 }

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -134,17 +134,7 @@ export function constructWebpackConfigFunction(
     newConfig.entry = async () => addSentryToEntryProperty(origEntryProperty, buildContext);
 
     // Enable the Sentry plugin (which uploads source maps to Sentry when not in dev) by default
-    const enableWebpackPlugin =
-      // TODO: this is a hack to fix https://github.com/getsentry/sentry-cli/issues/1085, which is caused by
-      // https://github.com/getsentry/sentry-cli/issues/915. Once the latter is addressed, this existence check can come
-      // out. (The check is necessary because currently, `@sentry/cli` uses a post-install script to download an
-      // architecture-specific version of the `sentry-cli` binary. If `yarn install`, `npm install`, or `npm ci` are run
-      // with the `--ignore-scripts` option, this will be blocked and the missing binary will cause an error when users
-      // try to build their apps.)
-      ensureCLIBinaryExists() &&
-      (isServer ? !userSentryOptions.disableServerWebpackPlugin : !userSentryOptions.disableClientWebpackPlugin);
-
-    if (enableWebpackPlugin) {
+    if (shouldEnableWebpackPlugin(buildContext, userSentryOptions)) {
       // TODO Handle possibility that user is using `SourceMapDevToolPlugin` (see
       // https://webpack.js.org/plugins/source-map-dev-tool-plugin/)
 
@@ -459,4 +449,42 @@ function ensureCLIBinaryExists(): boolean {
     }
   }
   return false;
+}
+
+/** Check various conditions to decide if we should run the plugin */
+function shouldEnableWebpackPlugin(buildContext: BuildContext, userSentryOptions: UserSentryOptions): boolean {
+  const { isServer, dev: isDev } = buildContext;
+  const { disableServerWebpackPlugin, disableClientWebpackPlugin } = userSentryOptions;
+
+  /** Non-negotiable */
+
+  // TODO: this is a hack to fix https://github.com/getsentry/sentry-cli/issues/1085, which is caused by
+  // https://github.com/getsentry/sentry-cli/issues/915. Once the latter is addressed, this existence check can come
+  // out. (The check is necessary because currently, `@sentry/cli` uses a post-install script to download an
+  // architecture-specific version of the `sentry-cli` binary. If `yarn install`, `npm install`, or `npm ci` are run
+  // with the `--ignore-scripts` option, this will be blocked and the missing binary will cause an error when users
+  // try to build their apps.)
+  if (!ensureCLIBinaryExists()) {
+    return false;
+  }
+
+  /** User override */
+
+  if ((isServer && disableServerWebpackPlugin) || (!isServer && disableClientWebpackPlugin)) {
+    return false;
+  }
+
+  /** Situations where the default is to disable the plugin */
+
+  // TODO: Are there analogs to Vercel's preveiw and dev modes on other deployment platforms?
+
+  if (isDev || process.env.NODE_ENV === 'development') {
+    // TODO (v8): Right now in dev we set the plugin to dryrun mode, and our boilerplate includes setting the plugin to
+    // `silent`, so for the vast majority of users, it's as if the plugin doesn't run at all in dev. Making that
+    // official is technically a breaking change, though, so we probably should wait until v8.
+    // return false
+  }
+
+  // We've passed all of the tests!
+  return true;
 }

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -470,8 +470,10 @@ function shouldEnableWebpackPlugin(buildContext: BuildContext, userSentryOptions
 
   /** User override */
 
-  if ((isServer && disableServerWebpackPlugin) || (!isServer && disableClientWebpackPlugin)) {
-    return false;
+  if (isServer && disableServerWebpackPlugin !== undefined) {
+    return !disableServerWebpackPlugin;
+  } else if (!isServer && disableClientWebpackPlugin !== undefined) {
+    return !disableClientWebpackPlugin;
   }
 
   /** Situations where the default is to disable the plugin */

--- a/packages/nextjs/test/config/webpack/constructWebpackConfig.test.ts
+++ b/packages/nextjs/test/config/webpack/constructWebpackConfig.test.ts
@@ -12,7 +12,7 @@ import {
   serverWebpackConfig,
   userNextConfig,
 } from '../fixtures';
-import { materializeFinalWebpackConfig } from '../testUtils';
+import { materializeFinalNextConfig, materializeFinalWebpackConfig } from '../testUtils';
 
 describe('constructWebpackConfigFunction()', () => {
   it('includes expected properties', async () => {
@@ -45,6 +45,17 @@ describe('constructWebpackConfigFunction()', () => {
     delete materializedUserWebpackConfig.entry;
 
     expect(finalWebpackConfig).toEqual(expect.objectContaining(materializedUserWebpackConfig));
+  });
+
+  it("doesn't set devtool if webpack plugin is disabled", () => {
+    const finalNextConfig = materializeFinalNextConfig({
+      ...exportedNextConfig,
+      webpack: () => ({ devtool: 'something-besides-source-map' } as any),
+      sentry: { disableServerWebpackPlugin: true },
+    });
+    const finalWebpackConfig = finalNextConfig.webpack?.(serverWebpackConfig, serverBuildContext);
+
+    expect(finalWebpackConfig?.devtool).not.toEqual('source-map');
   });
 
   it('allows for the use of `hidden-source-map` as `devtool` value for client-side builds', async () => {


### PR DESCRIPTION
When someone adds our Vercel integration, it only adds sentry-cli-relevant environment variables to production deployments. This can cause non-production deployments to fail, because when the webpack loader tries to run, it doesn't find the information it needs. That said, there's a reason we only set the env variables for prod - we really shouldn't be creating releases or uploading sourcemaps for dev or preview deployments in any case. 

This adds an environment check for vercel deployments (using [the `VERCEL_ENV` env variable](https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables)), and only enables the webpack plugin if the environment is `production`. To give users a way to override this, setting `disableClientWebpackPlugin` or `disableServerWebpackPlugin` to `false` now takes precedence over other checks, rather than being a no-op. Finally, given that the number of enablement checks is likely to grow, this pulls them into a separate function.

This supersedes https://github.com/getsentry/sentry/pull/37649.