### PR TITLE
ref(tracing): Remove mark measurements

### DIFF
--- a/packages/integration-tests/suites/tracing/metrics/web-vitals-fid/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/web-vitals-fid/test.ts
@@ -20,7 +20,6 @@ sentryTest('should capture a FID vital.', async ({ browserName, getLocalTestPath
 
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.fid?.value).toBeDefined();
-  expect(eventData.measurements?.['mark.fid']?.value).toBeDefined();
 
   const fidSpan = eventData.spans?.filter(({ description }) => description === 'first input delay')[0];
 

--- a/packages/integration-tests/suites/tracing/metrics/web-vitals-fp-fcp/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/web-vitals-fp-fcp/test.ts
@@ -16,8 +16,6 @@ sentryTest('should capture FP vital.', async ({ browserName, getLocalTestPath, p
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.fp?.value).toBeDefined();
 
-  expect(eventData.measurements?.['mark.fp']?.value).toBeDefined();
-
   const fpSpan = eventData.spans?.filter(({ description }) => description === 'first-paint')[0];
 
   expect(fpSpan).toBeDefined();
@@ -31,8 +29,6 @@ sentryTest('should capture FCP vital.', async ({ getLocalTestPath, page }) => {
 
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.fcp?.value).toBeDefined();
-
-  expect(eventData.measurements?.['mark.fcp']?.value).toBeDefined();
 
   const fcpSpan = eventData.spans?.filter(({ description }) => description === 'first-contentful-paint')[0];
 

--- a/packages/integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -22,7 +22,6 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
 
   expect(eventData.measurements).toBeDefined();
   expect(eventData.measurements?.lcp?.value).toBeDefined();
-  expect(eventData.measurements?.['mark.lcp']?.value).toBeDefined();
 
   expect(eventData.tags?.['lcp.element']).toBe('body > img');
   expect(eventData.tags?.['lcp.size']).toBe(107400);


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry/pull/38023

fixes https://getsentry.atlassian.net/browse/PERF-1700

https://www.notion.so/sentry/Stop-sending-mark-X-measurements-from-JavaScript-SDK-66d26d45e860419280ec853377195305

Currently the JS SDK sends extra measurements though, specifically `mark.lcp`, `mark.fid`, `mark.fp`, `mark.fcp`. This is done because these measurements are being used in the Sentry front-end UI to draw these lines:

![image](https://user-images.githubusercontent.com/18689448/185432413-fe8be9c2-423d-4fb8-976a-3fdac8bfe1e9.png)

These measurements should be removed, as they count toward a user’s custom measurement quota - hence we would be reducing the amount of custom measurements they can send and use because the SDK is setting them automatically. In addition, there is no way these measurements are ever going to be indexed, so we can’t move them to be built-in.

To remove these `mark.X` measurements, we’ll need to first adjust the Sentry front-end UI to stop using them, and then delete them from the SDK.

@0Calories