### PR TITLE
feat(svelte): Add Component Tracking

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -19,6 +19,7 @@
     "@sentry/browser": "7.11.1",
     "@sentry/types": "7.11.1",
     "@sentry/utils": "7.11.1",
+    "magic-string": "^0.26.2",
     "tslib": "^1.9.3"
   },
   "peerDependencies": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -24,6 +24,9 @@
   "peerDependencies": {
     "svelte": "3.x"
   },
+  "devDependencies": {
+    "svelte": "3.49.0"
+  },
   "scripts": {
     "build": "run-p build:rollup build:types",
     "build:dev": "run-s build",

--- a/packages/svelte/rollup.npm.config.js
+++ b/packages/svelte/rollup.npm.config.js
@@ -1,3 +1,8 @@
 import { makeBaseNPMConfig, makeNPMConfigVariants } from '../../rollup/index.js';
 
-export default makeNPMConfigVariants(makeBaseNPMConfig());
+export default makeNPMConfigVariants(
+  makeBaseNPMConfig({
+    // Prevent 'svelte/internal' stuff from being included in the built JS
+    packageSpecificConfig: { external: ['svelte/internal'] },
+  }),
+);

--- a/packages/svelte/src/constants.ts
+++ b/packages/svelte/src/constants.ts
@@ -1,7 +1,4 @@
-// TODO: we might want to call this ui.svelte.init instead because
-// it doesn't only track mounting time (there's no before-/afterMount)
-// but component init to mount time.
-export const UI_SVELTE_MOUNT = 'ui.svelte.mount';
+export const UI_SVELTE_INIT = 'ui.svelte.init';
 
 export const UI_SVELTE_UPDATE = 'ui.svelte.update';
 

--- a/packages/svelte/src/constants.ts
+++ b/packages/svelte/src/constants.ts
@@ -1,0 +1,8 @@
+// TODO: we might want to call this ui.svelte.init instead because
+// it doesn't only track mounting time (there's no before-/afterMount)
+// but component init to mount time.
+export const UI_SVELTE_MOUNT = 'ui.svelte.mount';
+
+export const UI_SVELTE_UPDATE = 'ui.svelte.update';
+
+export const DEFAULT_COMPONENT_NAME = 'Svelte Component';

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,4 +1,7 @@
-export type { ComponentTrackingInitOptions as ComponentTrackingOptions, TrackingOptions } from './types';
+export type {
+  ComponentTrackingInitOptions as ComponentTrackingOptions,
+  TrackComponentOptions as TrackingOptions,
+} from './types';
 
 export * from '@sentry/browser';
 

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,3 +1,8 @@
+export type { ComponentTrackingInitOptions as ComponentTrackingOptions, TrackingOptions } from './types';
+
 export * from '@sentry/browser';
 
 export { init } from './sdk';
+
+export { componentTrackingPreprocessor } from './preprocessors';
+export { trackComponent } from './performance';

--- a/packages/svelte/src/performance.ts
+++ b/packages/svelte/src/performance.ts
@@ -15,7 +15,8 @@ const defaultOptions: TrackingOptions = {
  * Tracks the Svelte component's intialization and mounting operation as well as
  * updates and records them as spans.
  * This function is injected automatically into your Svelte components' code
- * if you are using the Sentry componentTrackingPreprocessor
+ * if you are using the Sentry componentTrackingPreprocessor.
+ * Alternatively, you can call it yourself if you don't want to use the preprocessor.
  */
 export function trackComponent(options: TrackingOptions = defaultOptions): void {
   const transaction = getActiveTransaction();
@@ -29,8 +30,13 @@ export function trackComponent(options: TrackingOptions = defaultOptions): void 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const componentName = `<${customComponentName || current_component.constructor.name || DEFAULT_COMPONENT_NAME}>`;
 
-  options.trackMount && recordMountSpan(transaction, componentName);
-  options.trackUpdates && recordUpdateSpans(componentName);
+  if (options.trackMount) {
+    recordMountSpan(transaction, componentName);
+  }
+
+  if (options.trackUpdates) {
+    recordUpdateSpans(componentName);
+  }
 }
 
 function recordMountSpan(transaction: Transaction, componentName: string): void {

--- a/packages/svelte/src/performance.ts
+++ b/packages/svelte/src/performance.ts
@@ -1,0 +1,76 @@
+import { getCurrentHub } from '@sentry/browser';
+import { Span, Transaction } from '@sentry/types';
+import { afterUpdate, beforeUpdate, onMount } from 'svelte';
+import { current_component } from 'svelte/internal';
+
+import { DEFAULT_COMPONENT_NAME, UI_SVELTE_MOUNT, UI_SVELTE_UPDATE } from './constants';
+import { TrackingOptions } from './types';
+
+const defaultOptions: TrackingOptions = {
+  trackMount: true,
+  trackUpdates: true,
+};
+
+/**
+ * Tracks the Svelte component's intialization and mounting operation as well as
+ * updates and records them as spans.
+ * This function is injected automatically into your Svelte components' code
+ * if you are using the Sentry componentTrackingPreprocessor
+ */
+export function trackComponent(options: TrackingOptions = defaultOptions): void {
+  const transaction = getActiveTransaction();
+  if (!transaction) {
+    return;
+  }
+
+  const customComponentName = options && options.componentName;
+
+  // current_component.ctor.name is likely to give us the component's name automatically
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const componentName = `<${customComponentName || current_component.constructor.name || DEFAULT_COMPONENT_NAME}>`;
+
+  options.trackMount && recordMountSpan(transaction, componentName);
+  options.trackUpdates && recordUpdateSpans(componentName);
+}
+
+function recordMountSpan(transaction: Transaction, componentName: string): void {
+  const mountSpan = transaction.startChild({
+    op: UI_SVELTE_MOUNT,
+    description: componentName,
+  });
+
+  onMount(() => {
+    mountSpan.finish();
+  });
+}
+
+function recordUpdateSpans(componentName: string): void {
+  let updateSpan: Span | undefined;
+  beforeUpdate(() => {
+    // We need to get the active transaction again because the initial one could
+    // already be finished or there is no transaction going on, currently.
+    const transaction = getActiveTransaction();
+    if (!transaction) {
+      return;
+    }
+
+    updateSpan = transaction.startChild({
+      op: UI_SVELTE_UPDATE,
+      description: componentName,
+    });
+  });
+
+  afterUpdate(() => {
+    if (!updateSpan) {
+      return;
+    }
+    updateSpan.finish();
+    updateSpan = undefined;
+  });
+}
+
+function getActiveTransaction(): Transaction | undefined {
+  const currentHub = getCurrentHub();
+  const scope = currentHub && currentHub.getScope();
+  return scope && scope.getTransaction();
+}

--- a/packages/svelte/src/performance.ts
+++ b/packages/svelte/src/performance.ts
@@ -6,8 +6,11 @@ import { current_component } from 'svelte/internal';
 import { DEFAULT_COMPONENT_NAME, UI_SVELTE_INIT, UI_SVELTE_UPDATE } from './constants';
 import { TrackComponentOptions } from './types';
 
-const defaultOptions: Required<Pick<TrackComponentOptions, 'trackInit' | 'trackUpdates'>> &
-  Pick<TrackComponentOptions, 'componentName'> = {
+const defaultTrackComponentOptions: {
+  trackInit: boolean;
+  trackUpdates: boolean;
+  componentName?: string;
+} = {
   trackInit: true,
   trackUpdates: true,
 };
@@ -20,7 +23,7 @@ const defaultOptions: Required<Pick<TrackComponentOptions, 'trackInit' | 'trackU
  * Alternatively, you can call it yourself if you don't want to use the preprocessor.
  */
 export function trackComponent(options?: TrackComponentOptions): void {
-  const mergedOptions = { ...defaultOptions, ...options };
+  const mergedOptions = { ...defaultTrackComponentOptions, ...options };
 
   const transaction = getActiveTransaction();
   if (!transaction) {

--- a/packages/svelte/src/preprocessors.ts
+++ b/packages/svelte/src/preprocessors.ts
@@ -28,7 +28,7 @@ export function componentTrackingPreprocessor(options?: ComponentTrackingInitOpt
       const trackComponentOptions: TrackComponentOptions = {
         trackMount,
         trackUpdates,
-        componentName: getComponentName(filename || ''),
+        componentName: getBaseName(filename || ''),
       };
 
       const importStmt = 'import { trackComponent } from "@sentry/svelte";\n';
@@ -54,12 +54,13 @@ function shouldInjectFunction(
   }
   if (Array.isArray(trackComponents)) {
     // TODO: this probably needs to be a little more robust
-    const componentName = getComponentName(filename);
+    const componentName = getBaseName(filename);
     return trackComponents.some(allowed => allowed === componentName);
   }
   return true;
 }
-function getComponentName(filename: string): string {
+
+function getBaseName(filename: string): string {
   const segments = filename.split('/');
   const componentName = segments[segments.length - 1].replace('.svelte', '');
   return componentName;

--- a/packages/svelte/src/preprocessors.ts
+++ b/packages/svelte/src/preprocessors.ts
@@ -1,3 +1,5 @@
+import MagicString from 'magic-string';
+
 import { ComponentTrackingInitOptions, PreprocessorGroup, TrackingOptions } from './types';
 
 const defaultComponentTrackingOptions: ComponentTrackingInitOptions = {
@@ -29,12 +31,16 @@ export function componentTrackingPreprocessor(
         componentName: getComponentName(filename || ''),
       };
 
-      const importStmt = 'import { trackComponent } from "@sentry/svelte"\n';
+      const importStmt = 'import { trackComponent } from "@sentry/svelte";\n';
       const functionCall = `trackComponent(${JSON.stringify(trackOptions)});\n`;
-      console.log(functionCall);
 
-      const updatedCode = `${importStmt}${functionCall}${content}`;
-      return { code: updatedCode };
+      const s = new MagicString(content);
+      s.prepend(functionCall).prepend(importStmt).append('console.log()');
+
+      const updatedCode = s.toString();
+      const updatedSourceMap = s.generateMap().toString();
+
+      return { code: updatedCode, map: updatedSourceMap };
     },
   };
 }

--- a/packages/svelte/src/preprocessors.ts
+++ b/packages/svelte/src/preprocessors.ts
@@ -1,0 +1,60 @@
+import { ComponentTrackingInitOptions, PreprocessorGroup, TrackingOptions } from './types';
+
+const defaultComponentTrackingOptions: ComponentTrackingInitOptions = {
+  trackComponents: true,
+  trackMount: true,
+  trackUpdates: true,
+};
+
+/**
+ * Svelte Preprocessor to inject performance monitoring related code
+ * into Svelte components.
+ */
+export function componentTrackingPreprocessor(
+  options: ComponentTrackingInitOptions = defaultComponentTrackingOptions,
+): PreprocessorGroup {
+  return {
+    // This script hook is called whenever a Svelte component's <script>
+    // content is preprocessed.
+    // `content` contains the script code as a string
+    script: ({ content, filename }) => {
+      if (!shouldInjectFunction(options.trackComponents, filename)) {
+        return { code: content };
+      }
+
+      const { trackMount, trackUpdates } = options;
+      const trackOptions: TrackingOptions = {
+        trackMount: trackMount === undefined ? true : trackMount,
+        trackUpdates: trackUpdates === undefined ? true : trackUpdates,
+        componentName: getComponentName(filename || ''),
+      };
+
+      const importStmt = 'import { trackComponent } from "@sentry/svelte"\n';
+      const functionCall = `trackComponent(${JSON.stringify(trackOptions)});\n`;
+      console.log(functionCall);
+
+      const updatedCode = `${importStmt}${functionCall}${content}`;
+      return { code: updatedCode };
+    },
+  };
+}
+
+function shouldInjectFunction(
+  trackComponents: ComponentTrackingInitOptions['trackComponents'],
+  filename: string | undefined,
+): boolean {
+  if (!trackComponents || !filename) {
+    return false;
+  }
+  if (Array.isArray(trackComponents)) {
+    // TODO: this probably needs to be a little more robust
+    const componentName = getComponentName(filename);
+    return trackComponents.some(allowed => allowed === componentName);
+  }
+  return true;
+}
+function getComponentName(filename: string): string {
+  const segments = filename.split('/');
+  const componentName = segments[segments.length - 1].replace('.svelte', '');
+  return componentName;
+}

--- a/packages/svelte/src/preprocessors.ts
+++ b/packages/svelte/src/preprocessors.ts
@@ -85,6 +85,5 @@ function shouldInjectFunction(
 
 function getBaseName(filename: string): string {
   const segments = filename.split('/');
-  const componentName = segments[segments.length - 1].replace('.svelte', '');
-  return componentName;
+  return segments[segments.length - 1].replace('.svelte', '');
 }

--- a/packages/svelte/src/preprocessors.ts
+++ b/packages/svelte/src/preprocessors.ts
@@ -2,7 +2,7 @@ import MagicString from 'magic-string';
 
 import { ComponentTrackingInitOptions, PreprocessorGroup, TrackComponentOptions } from './types';
 
-const defaultComponentTrackingOptions: Required<ComponentTrackingInitOptions> = {
+export const defaultComponentTrackingOptions: Required<ComponentTrackingInitOptions> = {
   trackComponents: true,
   trackMount: true,
   trackUpdates: true,

--- a/packages/svelte/src/preprocessors.ts
+++ b/packages/svelte/src/preprocessors.ts
@@ -4,7 +4,7 @@ import { ComponentTrackingInitOptions, PreprocessorGroup, TrackComponentOptions 
 
 export const defaultComponentTrackingOptions: Required<ComponentTrackingInitOptions> = {
   trackComponents: true,
-  trackMount: true,
+  trackInit: true,
   trackUpdates: true,
 };
 
@@ -29,9 +29,9 @@ export function componentTrackingPreprocessor(options?: ComponentTrackingInitOpt
         return { code: content };
       }
 
-      const { trackMount, trackUpdates } = mergedOptions;
+      const { trackInit, trackUpdates } = mergedOptions;
       const trackComponentOptions: TrackComponentOptions = {
-        trackMount,
+        trackInit,
         trackUpdates,
         componentName: getBaseName(finalFilename),
       };

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -38,15 +38,16 @@ export interface PreprocessorGroup {
 
 export type SpanOptions = {
   /**
-   * If true, spans are be recorded between component intialization and its
-   * onMount lifecycle hook.
+   * If true, a span is recorded between a component's intialization and its
+   * onMount lifecycle hook. This span tells how long it takes a component
+   * to be created and inserted into the DOM.
    *
    * Defaults to true if component tracking is enabled
    */
-  trackMount?: boolean;
+  trackInit?: boolean;
 
   /**
-   * If true, spans are recorded between each component's beforeUpdate and afterUpdate
+   * If true, a span is recorded between a component's beforeUpdate and afterUpdate
    * lifecycle hooks.
    *
    * Defaults to true if component tracking is enabled

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -1,0 +1,76 @@
+// The following types were copied from 'svelte/compiler'-internal
+// type definitions
+// see: https://github.com/sveltejs/svelte/blob/master/src/compiler/preprocess/types.ts
+interface Processed {
+  code: string;
+  map?: string | Record<string, unknown>;
+  dependencies?: string[];
+  toString?: () => string;
+}
+
+type MarkupPreprocessor = (options: {
+  content: string;
+  filename?: string;
+}) => Processed | void | Promise<Processed | void>;
+
+type Preprocessor = (options: {
+  /**
+   * The script/style tag content
+   */
+  content: string;
+  attributes: Record<string, string | boolean>;
+  /**
+   * The whole Svelte file content
+   */
+  markup: string;
+  filename?: string;
+}) => Processed | void | Promise<Processed | void>;
+
+export interface PreprocessorGroup {
+  markup?: MarkupPreprocessor;
+  style?: Preprocessor;
+  script?: Preprocessor;
+}
+
+// Alternatively, we could use a direct from svelte/compiler/preprocess
+// TODO: figure out what's better and roll with that
+// import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
+
+export type SpanOptions = {
+  /**
+   * If true, spans are be recorded between component intialization and Svellte's
+   * onMount lifecycle hook
+   *
+   * defaults to true if component tracking is enabled
+   */
+  trackMount?: boolean;
+
+  /**
+   * If true, spans are recorded between each component's beforeUpdate and afterUpdate
+   * lifecycle hooks
+   *
+   * defaults to true if component tracking is enabled
+   */
+  trackUpdates?: boolean;
+};
+
+/**
+ * Control which components and which operations should be tracked
+ * and recorded as spans
+ */
+export type ComponentTrackingInitOptions = {
+  /**
+   * Control if all your Svelte components should be tracked or only a specified list
+   * of components.
+   * If set to true, all components will be tracked.
+   * If you only want to track a selection of components, specify the component names
+   * as an array.
+   *
+   * defaults to: true
+   */
+  trackComponents: boolean | string[];
+} & SpanOptions;
+
+export type TrackingOptions = {
+  componentName?: string;
+} & SpanOptions;

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -38,18 +38,18 @@ export interface PreprocessorGroup {
 
 export type SpanOptions = {
   /**
-   * If true, spans are be recorded between component intialization and Svellte's
-   * onMount lifecycle hook
+   * If true, spans are be recorded between component intialization and its
+   * onMount lifecycle hook.
    *
-   * defaults to true if component tracking is enabled
+   * Defaults to true if component tracking is enabled
    */
   trackMount?: boolean;
 
   /**
    * If true, spans are recorded between each component's beforeUpdate and afterUpdate
-   * lifecycle hooks
+   * lifecycle hooks.
    *
-   * defaults to true if component tracking is enabled
+   * Defaults to true if component tracking is enabled
    */
   trackUpdates?: boolean;
 };
@@ -66,11 +66,11 @@ export type ComponentTrackingInitOptions = {
    * If you only want to track a selection of components, specify the component names
    * as an array.
    *
-   * defaults to: true
+   * Defaults to true if the preprocessor is used
    */
-  trackComponents: boolean | string[];
+  trackComponents?: boolean | string[];
 } & SpanOptions;
 
-export type TrackingOptions = {
+export type TrackComponentOptions = {
   componentName?: string;
 } & SpanOptions;

--- a/packages/svelte/test/preprocessors.test.ts
+++ b/packages/svelte/test/preprocessors.test.ts
@@ -1,0 +1,109 @@
+import { componentTrackingPreprocessor, defaultComponentTrackingOptions } from '../src/preprocessors';
+
+function expectComponentCodeToBeModified(
+  preprocessedComponents: {
+    originalCode: string;
+    filename: string;
+    name: string;
+    newCode: string;
+    map: any;
+  }[],
+  options: any,
+) {
+  const expectedImportStmt = 'import { trackComponent } from "@sentry/svelte";\n';
+
+  preprocessedComponents.forEach(cmp => {
+    const expectedFunctionCallOptions = {
+      trackMount: options?.trackMount ?? true,
+      trackUpdates: options?.trackUpdates ?? true,
+      componentName: cmp.name,
+    };
+    const expectedFunctionCall = `trackComponent(${JSON.stringify(expectedFunctionCallOptions)});\n`;
+    expect(cmp.newCode).toBeDefined();
+    expect(cmp.map).toBeDefined();
+    expect(cmp.newCode).toEqual(`${expectedImportStmt}${expectedFunctionCall}${cmp.originalCode}`);
+  });
+}
+
+describe('componentTrackingPreprocessor', () => {
+  it('correctly inits the script preprocessor', () => {
+    const preProc = componentTrackingPreprocessor();
+    expect(preProc.script).toBeDefined();
+    expect(preProc.markup).toBeUndefined();
+    expect(preProc.style).toBeUndefined();
+  });
+
+  it.each([
+    ['no options', undefined],
+    ['default options', defaultComponentTrackingOptions],
+    ['custom options (mount 0, updates 0)', { trackMount: false, trackUpdates: false }],
+    ['custom options (mount 0, updates 1)', { trackMount: false, trackUpdates: true }],
+    ['custom options (mount 1, updates 0)', { trackMount: true, trackUpdates: false }],
+    ['custom options (mount 1, updates 1)', { trackMount: true, trackUpdates: true }],
+  ])('adds the function call to all components if %s are set', (_, options) => {
+    const preProc = componentTrackingPreprocessor(options);
+    const components = [
+      { originalCode: 'console.log(cmp1);', filename: 'components/Cmp1.svelte', name: 'Cmp1' },
+      { originalCode: 'console.log(cmp2);', filename: 'components/Cmp2.svelte', name: 'Cmp2' },
+      { originalCode: 'console.log(cmp3);', filename: 'components/Cmp3.svelte', name: 'Cmp3' },
+    ];
+
+    const preprocessedComponents = components.map(cmp => {
+      const res: any = preProc.script!!({
+        content: cmp.originalCode,
+        filename: cmp.filename,
+        attributes: {},
+        markup: '',
+      });
+      return { ...cmp, newCode: res.code, map: res.map };
+    });
+
+    expectComponentCodeToBeModified(preprocessedComponents, options);
+  });
+
+  it('does not add the function call to any component if `trackComponents` is set to `false`', () => {
+    const preProc = componentTrackingPreprocessor({ trackComponents: false });
+    const components = [
+      { originalCode: 'console.log(cmp1)', filename: 'components/Cmp1.svelte', name: 'Cmp1' },
+      { originalCode: 'console.log(cmp2)', filename: 'components/Cmp2.svelte', name: 'Cmp2' },
+      { originalCode: 'console.log(cmp3)', filename: 'components/Cmp3.svelte', name: 'Cmp3' },
+    ];
+
+    const preprocessedComponents = components.map(cmp => {
+      const res: any = preProc.script!!({
+        content: cmp.originalCode,
+        filename: cmp.filename,
+        attributes: {},
+        markup: '',
+      });
+      return { ...cmp, newCode: res.code, map: res.map };
+    });
+
+    preprocessedComponents.forEach(cmp => {
+      expect(cmp.newCode).toEqual(cmp.originalCode);
+    });
+  });
+
+  it('adds the function call to specific components if specified in `trackComponents`', () => {
+    const preProc = componentTrackingPreprocessor({ trackComponents: ['Cmp1', 'Cmp3'] });
+    const components = [
+      { originalCode: 'console.log(cmp1)', filename: 'components/Cmp1.svelte', name: 'Cmp1' },
+      { originalCode: 'console.log(cmp2)', filename: 'lib/Cmp2.svelte', name: 'Cmp2' },
+      { originalCode: 'console.log(cmp3)', filename: 'lib/subdir/sub/Cmp3.svelte', name: 'Cmp3' },
+    ];
+
+    const [cmp1, cmp2, cmp3] = components.map(cmp => {
+      const res: any = preProc.script!!({
+        content: cmp.originalCode,
+        filename: cmp.filename,
+        attributes: {},
+        markup: '',
+      });
+      return { ...cmp, newCode: res.code, map: res.map };
+    });
+
+    expect(cmp2.newCode).toEqual(cmp2.originalCode);
+
+    expectComponentCodeToBeModified([cmp1, cmp3], { trackMount: true, trackUpdates: true });
+  });
+});

--- a/packages/svelte/test/preprocessors.test.ts
+++ b/packages/svelte/test/preprocessors.test.ts
@@ -49,12 +49,14 @@ describe('componentTrackingPreprocessor', () => {
     ];
 
     const preprocessedComponents = components.map(cmp => {
-      const res: any = preProc.script!!({
-        content: cmp.originalCode,
-        filename: cmp.filename,
-        attributes: {},
-        markup: '',
-      });
+      const res: any =
+        preProc.script &&
+        preProc.script({
+          content: cmp.originalCode,
+          filename: cmp.filename,
+          attributes: {},
+          markup: '',
+        });
       return { ...cmp, newCode: res.code, map: res.map };
     });
 
@@ -70,12 +72,14 @@ describe('componentTrackingPreprocessor', () => {
     ];
 
     const preprocessedComponents = components.map(cmp => {
-      const res: any = preProc.script!!({
-        content: cmp.originalCode,
-        filename: cmp.filename,
-        attributes: {},
-        markup: '',
-      });
+      const res: any =
+        preProc.script &&
+        preProc.script({
+          content: cmp.originalCode,
+          filename: cmp.filename,
+          attributes: {},
+          markup: '',
+        });
       return { ...cmp, newCode: res.code, map: res.map };
     });
 
@@ -93,12 +97,14 @@ describe('componentTrackingPreprocessor', () => {
     ];
 
     const [cmp1, cmp2, cmp3] = components.map(cmp => {
-      const res: any = preProc.script!!({
-        content: cmp.originalCode,
-        filename: cmp.filename,
-        attributes: {},
-        markup: '',
-      });
+      const res: any =
+        preProc.script &&
+        preProc.script({
+          content: cmp.originalCode,
+          filename: cmp.filename,
+          attributes: {},
+          markup: '',
+        });
       return { ...cmp, newCode: res.code, map: res.map };
     });
 

--- a/packages/svelte/test/preprocessors.test.ts
+++ b/packages/svelte/test/preprocessors.test.ts
@@ -14,7 +14,7 @@ function expectComponentCodeToBeModified(
 
   preprocessedComponents.forEach(cmp => {
     const expectedFunctionCallOptions = {
-      trackMount: options?.trackMount ?? true,
+      trackInit: options?.trackInit ?? true,
       trackUpdates: options?.trackUpdates ?? true,
       componentName: cmp.name,
     };
@@ -36,10 +36,10 @@ describe('componentTrackingPreprocessor', () => {
   it.each([
     ['no options', undefined],
     ['default options', defaultComponentTrackingOptions],
-    ['custom options (mount 0, updates 0)', { trackMount: false, trackUpdates: false }],
-    ['custom options (mount 0, updates 1)', { trackMount: false, trackUpdates: true }],
-    ['custom options (mount 1, updates 0)', { trackMount: true, trackUpdates: false }],
-    ['custom options (mount 1, updates 1)', { trackMount: true, trackUpdates: true }],
+    ['custom options (init 0, updates 0)', { trackInit: false, trackUpdates: false }],
+    ['custom options (init 0, updates 1)', { trackInit: false, trackUpdates: true }],
+    ['custom options (init 1, updates 0)', { trackInit: true, trackUpdates: false }],
+    ['custom options (init 1, updates 1)', { trackInit: true, trackUpdates: true }],
   ])('adds the function call to all components if %s are set', (_, options) => {
     const preProc = componentTrackingPreprocessor(options);
     const components = [
@@ -104,6 +104,6 @@ describe('componentTrackingPreprocessor', () => {
 
     expect(cmp2.newCode).toEqual(cmp2.originalCode);
 
-    expectComponentCodeToBeModified([cmp1, cmp3], { trackMount: true, trackUpdates: true });
+    expectComponentCodeToBeModified([cmp1, cmp3], { trackInit: true, trackUpdates: true });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -24837,6 +24837,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+svelte@3.49.0:
+  version "3.49.0"
+  resolved "https://registry.yarnpkg.com/svelte/-/svelte-3.49.0.tgz#5baee3c672306de1070c3b7888fc2204e36a4029"
+  integrity sha512-+lmjic1pApJWDfPCpUUTc1m8azDqYCG1JN9YEngrx/hUyIcFJo6VZhj0A1Ai0wqoHcEIuQy+e9tk+4uDgdtsFA==
+
 svgo@^1.0.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-1.3.2.tgz#b6dc511c063346c9e415b81e43401145b96d4167"


### PR DESCRIPTION
## Summary

This PR introduces component tracking to the Sentry Svelte SDK. I'm currently trying to implement an approach for users that is simple and only requires minimal configuration on their end. The idea is to let them specify once if and which  components they actually want to track (like we do it in Vue for example). 

Because Svelte components are compiled into plain JS at build time, we cannot reliably hook into a Svelte runtime or do similar approaches monkey patching approaches. What we can however do, is to hook into the component compilation by using an official Svelte compiler feature: [preprocessors](https://svelte.dev/docs#compile-time-svelte-preprocess). 

With this PR, we add a Svelte preprocessor that injects a function call (+ the necessary import) into the top of the `<script>` part of Svelte components. The called function takes care creating the lifecycle spans and putting them onto a transaction.

## Usage

In your `svelte.config.js`, import and add the Sentry `componentTrackingPreprocessor`:

```js
import sveltePreprocess from "svelte-preprocess";
import { componentTrackingPreprocessor } from "@sentry/svelte";

const config = {
  compilerOptions: {
    enableSourcemap: true,
  },
  preprocess: [
    componentTrackingPreprocessor({
      trackComponents: ["Component1", "Component2"],
      trackInit: true,
      trackUpdates: true, 
    }),
    sveltePreprocess({
      sourceMap: true,
    }),
  ],
};

export default config;
```

### Under the Hood

In the compiled JS (after the Svelte compiler is done), this function call translates to the following code for `Component1.svelte`:

```js
function instance$1($$self, $$props, $$invalidate) {
  let $count;
  component_subscribe($$self, count, ($$value) => $$invalidate(0, $count = $$value));
  // --> here we are:
  trackComponent({
    "trackInit": true,
    "trackUpdates": true,
    "componentName": "Component1"
  });
  // ...
}
```

### Alternative Usage

If you don't want to use our Preprocessor to automatically track components, you can call our tracking function in every component you would like to see tracked yourself:

```ts
<script>
  import * as Sentry from "@sentry/svelte";
  Sentry.trackComponent({trackInit: true, trackUpdates: false})
  // rest of your code
</script>
``` 

## Result

This is the result of the PR:
![image](https://user-images.githubusercontent.com/8420481/187656765-72f258d3-4fa6-4b3d-bbf2-c1b0a59f8a1b.png)


## Compatibility with SvelteKit

If users are using the Svelte SDK in a SvelteKit app, they can use this preprocessor (or make the manual function call). I tested component tracking with the Realworld SvelteKit app and it seems to work normally, as long as the SDK is only initialized on the browser end (which is how it is supposed to be used, if at all). There might be weird edge cases but generally, the lifecycle hooks are called on the client-side and the spans are recorded correctly. We can revisit this, if we get bug reports.

## To Do

* [x] revisit types and naming ([81d1213](https://github.com/getsentry/sentry-javascript/pull/5612/commits/81d12132f0c0baf90e3a1713959c50f4a2053d1f))
* [x] Discuss if code injection approach is ok
* [x] Check if this is a good approach DevEx-wise
* [x] Check if/how this works w/ Sveltekit apps
* [x] Add Unit tests
