### PR TITLE
fix(integrations): Don't add empty stack trace in `RewriteFrames`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 This release adds an environment check in `@sentry/nextjs` for Vercel deployments (using the `VERCEL_ENV` env variable), and only enables `SentryWebpackPlugin` if the environment is `production`. To override this, [setting `disableClientWebpackPlugin` or `disableServerWebpackPlugin` to `false`](https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#disable-sentrywebpackplugin) now takes precedence over other checks, rather than being a no-op. Note: Overriding this is not recommended! It can increase build time and clog Release Health data in Sentry with inaccurate noise.
 
-- fix(integration): exception.values.0.stacktrace.frames: Missing value for required attribute (?)
+- fix(integration): exception.values.0.stacktrace.frames: Missing value for required attribute (#5625)
 - fix(nextjs): Don't run webpack plugin on non-prod Vercel deployments (#5603)
 
 ## 7.11.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 This release adds an environment check in `@sentry/nextjs` for Vercel deployments (using the `VERCEL_ENV` env variable), and only enables `SentryWebpackPlugin` if the environment is `production`. To override this, [setting `disableClientWebpackPlugin` or `disableServerWebpackPlugin` to `false`](https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#disable-sentrywebpackplugin) now takes precedence over other checks, rather than being a no-op. Note: Overriding this is not recommended! It can increase build time and clog Release Health data in Sentry with inaccurate noise.
 
+- fix(integration): exception.values.0.stacktrace.frames: Missing value for required attribute (?)
 - fix(nextjs): Don't run webpack plugin on non-prod Vercel deployments (#5603)
 
 ## 7.11.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 This release adds an environment check in `@sentry/nextjs` for Vercel deployments (using the `VERCEL_ENV` env variable), and only enables `SentryWebpackPlugin` if the environment is `production`. To override this, [setting `disableClientWebpackPlugin` or `disableServerWebpackPlugin` to `false`](https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#disable-sentrywebpackplugin) now takes precedence over other checks, rather than being a no-op. Note: Overriding this is not recommended! It can increase build time and clog Release Health data in Sentry with inaccurate noise.
 
-- fix(integration): exception.values.0.stacktrace.frames: Missing value for required attribute (#5625)
+- fix(integrations): Don't add empty stack trace in `RewriteFrames` (#5625)
 - fix(nextjs): Don't run webpack plugin on non-prod Vercel deployments (#5603)
 
 ## 7.11.1

--- a/packages/integrations/src/rewriteframes.ts
+++ b/packages/integrations/src/rewriteframes.ts
@@ -77,8 +77,8 @@ export class RewriteFrames implements Integration {
     if (isWindowsFrame || startsWithSlash) {
       const filename = isWindowsFrame
         ? frame.filename
-            .replace(/^[A-Z]:/, '') // remove Windows-style prefix
-            .replace(/\\/g, '/') // replace all `\\` instances with `/`
+          .replace(/^[A-Z]:/, '') // remove Windows-style prefix
+          .replace(/\\/g, '/') // replace all `\\` instances with `/`
         : frame.filename;
       const base = this._root ? relative(this._root, filename) : basename(filename);
       frame.filename = `${this._prefix}${base}`;
@@ -108,9 +108,9 @@ export class RewriteFrames implements Integration {
 
   /** JSDoc */
   private _processStacktrace(stacktrace?: Stacktrace): Stacktrace {
-      return {
-        ...stacktrace,
-        frames: stacktrace && stacktrace.frames && stacktrace.frames.map(f => this._iteratee(f)),
-      };
+    return {
+      ...stacktrace,
+      frames: stacktrace && stacktrace.frames && stacktrace.frames.map(f => this._iteratee(f)),
+    };
   }
 }

--- a/packages/integrations/src/rewriteframes.ts
+++ b/packages/integrations/src/rewriteframes.ts
@@ -97,7 +97,7 @@ export class RewriteFrames implements Integration {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           values: event.exception!.values!.map(value => ({
             ...value,
-            stacktrace: value.stacktrace ? this._processStacktrace(value.stacktrace) : undefined, // Avoid creating an empty stacktrace if undefined.
+           ...(value.stacktrace && { stacktrace: this._processStacktrace(value.stacktrace) }),
           })),
         },
       };

--- a/packages/integrations/src/rewriteframes.ts
+++ b/packages/integrations/src/rewriteframes.ts
@@ -77,8 +77,8 @@ export class RewriteFrames implements Integration {
     if (isWindowsFrame || startsWithSlash) {
       const filename = isWindowsFrame
         ? frame.filename
-          .replace(/^[A-Z]:/, '') // remove Windows-style prefix
-          .replace(/\\/g, '/') // replace all `\\` instances with `/`
+            .replace(/^[A-Z]:/, '') // remove Windows-style prefix
+            .replace(/\\/g, '/') // replace all `\\` instances with `/`
         : frame.filename;
       const base = this._root ? relative(this._root, filename) : basename(filename);
       frame.filename = `${this._prefix}${base}`;

--- a/packages/integrations/src/rewriteframes.ts
+++ b/packages/integrations/src/rewriteframes.ts
@@ -97,7 +97,7 @@ export class RewriteFrames implements Integration {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           values: event.exception!.values!.map(value => ({
             ...value,
-            stacktrace: this._processStacktrace(value.stacktrace),
+            stacktrace: value.stacktrace ? this._processStacktrace(value.stacktrace) : undefined, // Avoid creating an empty stacktrace if undefined.
           })),
         },
       };
@@ -108,9 +108,9 @@ export class RewriteFrames implements Integration {
 
   /** JSDoc */
   private _processStacktrace(stacktrace?: Stacktrace): Stacktrace {
-    return {
-      ...stacktrace,
-      frames: stacktrace && stacktrace.frames && stacktrace.frames.map(f => this._iteratee(f)),
-    };
+      return {
+        ...stacktrace,
+        frames: stacktrace && stacktrace.frames && stacktrace.frames.map(f => this._iteratee(f)),
+      };
   }
 }

--- a/packages/integrations/src/rewriteframes.ts
+++ b/packages/integrations/src/rewriteframes.ts
@@ -97,7 +97,7 @@ export class RewriteFrames implements Integration {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           values: event.exception!.values!.map(value => ({
             ...value,
-           ...(value.stacktrace && { stacktrace: this._processStacktrace(value.stacktrace) }),
+            ...(value.stacktrace && { stacktrace: this._processStacktrace(value.stacktrace) }),
           })),
         },
       };

--- a/packages/integrations/test/rewriteframes.test.ts
+++ b/packages/integrations/test/rewriteframes.test.ts
@@ -4,6 +4,7 @@ import { RewriteFrames } from '../src/rewriteframes';
 
 let rewriteFrames: RewriteFrames;
 let exceptionEvent: Event;
+let exceptionWithoutStackTrace: Event;
 let windowsExceptionEvent: Event;
 let multipleStacktracesEvent: Event;
 
@@ -30,6 +31,14 @@ describe('RewriteFrames', () => {
           },
         ],
       },
+    };
+    exceptionWithoutStackTrace = {
+      exception: {
+        values: [
+          {
+          },
+        ],
+      }
     };
     multipleStacktracesEvent = {
       exception: {
@@ -64,6 +73,15 @@ describe('RewriteFrames', () => {
       expect(event.exception!.values![0].stacktrace!.frames![0].filename).toEqual('app:///file1.js');
       expect(event.exception!.values![0].stacktrace!.frames![1].filename).toEqual('app:///file2.js');
     });
+
+
+    it('ignore exception without StackTrace', () => {
+      //@ts-ignore Validates that the Stacktrace doesnt exist before validating the test.
+      expect(exceptionWithoutStackTrace.exception?.values[0].stacktrace).toEqual(undefined);
+      const event = rewriteFrames.process(exceptionWithoutStackTrace);
+      expect(event.exception!.values![0].stacktrace).toEqual(undefined);
+    });
+
   });
 
   describe('default iteratee prepends custom prefix to basename if frame starts with `/`', () => {

--- a/packages/integrations/test/rewriteframes.test.ts
+++ b/packages/integrations/test/rewriteframes.test.ts
@@ -76,7 +76,7 @@ describe('RewriteFrames', () => {
 
 
     it('ignore exception without StackTrace', () => {
-      //@ts-ignore Validates that the Stacktrace doesnt exist before validating the test.
+      //@ts-ignore Validates that the Stacktrace does not exist before validating the test.
       expect(exceptionWithoutStackTrace.exception?.values[0].stacktrace).toEqual(undefined);
       const event = rewriteFrames.process(exceptionWithoutStackTrace);
       expect(event.exception!.values![0].stacktrace).toEqual(undefined);

--- a/packages/integrations/test/rewriteframes.test.ts
+++ b/packages/integrations/test/rewriteframes.test.ts
@@ -34,11 +34,8 @@ describe('RewriteFrames', () => {
     };
     exceptionWithoutStackTrace = {
       exception: {
-        values: [
-          {
-          },
-        ],
-      }
+        values: [{}],
+      },
     };
     multipleStacktracesEvent = {
       exception: {
@@ -75,7 +72,7 @@ describe('RewriteFrames', () => {
     });
 
     it('ignore exception without StackTrace', () => {
-      //@ts-ignore Validates that the Stacktrace does not exist before validating the test.
+      // @ts-ignore Validates that the Stacktrace does not exist before validating the test.
       expect(exceptionWithoutStackTrace.exception?.values[0].stacktrace).toEqual(undefined);
       const event = rewriteFrames.process(exceptionWithoutStackTrace);
       expect(event.exception!.values![0].stacktrace).toEqual(undefined);

--- a/packages/integrations/test/rewriteframes.test.ts
+++ b/packages/integrations/test/rewriteframes.test.ts
@@ -74,14 +74,12 @@ describe('RewriteFrames', () => {
       expect(event.exception!.values![0].stacktrace!.frames![1].filename).toEqual('app:///file2.js');
     });
 
-
     it('ignore exception without StackTrace', () => {
       //@ts-ignore Validates that the Stacktrace does not exist before validating the test.
       expect(exceptionWithoutStackTrace.exception?.values[0].stacktrace).toEqual(undefined);
       const event = rewriteFrames.process(exceptionWithoutStackTrace);
       expect(event.exception!.values![0].stacktrace).toEqual(undefined);
     });
-
   });
 
   describe('default iteratee prepends custom prefix to basename if frame starts with `/`', () => {


### PR DESCRIPTION
This PR avoids adding an empty stack trace when a stack trace is not defined.
By doing that, you'll no longer see the following error message at Sentry:
![image](https://user-images.githubusercontent.com/8229322/185951169-525aff02-cd49-46e0-a6e4-6743046bb4c1.png)

Fixes #5609 and potentially fixes https://github.com/getsentry/sentry-react-native/issues/2429 

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [X] If you've added code that should be tested, please add tests.
- [X] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
