### PR TITLE
fix(node): Avoid catching domain errors in request handler

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -153,7 +153,6 @@ export function requestHandler(
     const local = domain.create();
     local.add(req);
     local.add(res);
-    local.on('error', next);
 
     local.run(() => {
       const currentHub = getCurrentHub();


### PR DESCRIPTION
According to the Node.js docs, domain errors are equivalent to an uncaught exception and therefore should not really be caught except to do some cleanup and then exit the process. Not doing so causes the process to potentially linger without being able to handle any request. Currently, the behavior is also erroneous because `next` can end up be called twice. This issue was discovered via fastify/middie#158.

Fixes #1922.

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
