### PR TITLE
fix(browser): update Request checks to be valid in Deno

### DIFF
--- a/packages/browser/test/integration/common/utils.js
+++ b/packages/browser/test/integration/common/utils.js
@@ -7,7 +7,7 @@ function supportsFetch() {
 
   try {
     new Headers();
-    new Request('');
+    new Request('http://www.example.com');
     new Response();
     return true;
   } catch (e) {

--- a/packages/utils/src/supports.ts
+++ b/packages/utils/src/supports.ts
@@ -62,7 +62,7 @@ export function supportsFetch(): boolean {
 
   try {
     new Headers();
-    new Request('');
+    new Request('http://www.example.com');
     new Response();
     return true;
   } catch (e) {


### PR DESCRIPTION
In Deno `@sentry/browser` is almost usable, but the check `new Request('')` fails silently because Deno throws a `TypeError: invalid URL` that goes to a catch block. This changes the Request call to include a valid URL `http://www.example.com` so that `@sentry/browser` can be imported in Deno without this issue.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
