### PR TITLE
ref(tests): Add `TestEnv` class to Node integration tests.

### DIFF
--- a/packages/node-integration-tests/README.md
+++ b/packages/node-integration-tests/README.md
@@ -33,9 +33,9 @@ A custom server configuration can be used, supplying a script that exports a val
 
 `utils/` contains helpers and Sentry-specific assertions that can be used in (`test.ts`).
 
-`runServer` utility function returns an object containing `url` and [`http.Server`](https://nodejs.org/dist/latest-v16.x/docs/api/http.html#class-httpserver)  instance for the created server. The `url` property is the base URL for the server. The `http.Server` instance is used to finish the server eventually.
+`TestEnv` class contains methods to create and execute requests on a test server instance. `TestEnv.init()` which starts a test server and returns a `TestEnv` instance must be called by each test. The test server is automatically shut down after each test, if a data collection helper method such as `getEnvelopeRequest` and `getAPIResponse` is used. Tests that do not use those helper methods will need to end the server manually.
 
-The responsibility of ending the server is delegated to the test case. Data collection helpers such as `getEnvelopeRequest` and `getAPIResponse` expect the server instance to be available and finish it before their resolution. Tests that do not use those helpers will need to end the server manually.
+`TestEnv` instance has two public properties: `url` and `server`. The `url` property is the base URL for the server. The `http.Server` instance is used to finish the server eventually.
 
 Nock interceptors are internally used to capture envelope requests by `getEnvelopeRequest` and `getMultipleEnvelopeRequest` helpers. After capturing required requests, the interceptors are removed. Nock can manually be used inside the test cases to intercept requests but should be removed before the test ends, as not to cause flakiness.
 

--- a/packages/node-integration-tests/suites/express/handle-error/test.ts
+++ b/packages/node-integration-tests/suites/express/handle-error/test.ts
@@ -1,8 +1,8 @@
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../utils/index';
+import { assertSentryEvent, TestEnv } from '../../../utils/index';
 
 test('should capture and send Express controller error.', async () => {
-  const { url, server } = await runServer(__dirname, `${__dirname}/server.ts`);
-  const event = await getEnvelopeRequest({ url: `${url}/express`, server });
+  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
+  const event = await env.getEnvelopeRequest({ url: `${env.url}/express` });
 
   expect((event[2] as any).exception.values[0].stacktrace.frames.length).toBeGreaterThan(0);
 

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-assign/test.ts
@@ -1,17 +1,13 @@
 import * as path from 'path';
 
-import { getAPIResponse, runServer } from '../../../../utils/index';
+import { TestEnv } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('Should not overwrite baggage if the incoming request already has Sentry baggage data.', async () => {
-  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
-
-  const response = (await getAPIResponse(
-    { url: `${url}/express`, server },
-    {
-      baggage: 'sentry-release=2.0.0,sentry-environment=myEnv',
-    },
-  )) as TestAPIResponse;
+  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const response = (await env.getAPIResponse(`${env.url}/express`, {
+    baggage: 'sentry-release=2.0.0,sentry-environment=myEnv',
+  })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
@@ -23,15 +19,12 @@ test('Should not overwrite baggage if the incoming request already has Sentry ba
 });
 
 test('Should propagate sentry trace baggage data from an incoming to an outgoing request.', async () => {
-  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse(
-    { url: `${url}/express`, server },
-    {
-      'sentry-trace': '',
-      baggage: 'sentry-release=2.0.0,sentry-environment=myEnv,dogs=great',
-    },
-  )) as TestAPIResponse;
+  const response = (await env.getAPIResponse(`${env.url}/express`, {
+    'sentry-trace': '',
+    baggage: 'sentry-release=2.0.0,sentry-environment=myEnv,dogs=great',
+  })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
@@ -43,14 +36,11 @@ test('Should propagate sentry trace baggage data from an incoming to an outgoing
 });
 
 test('Should propagate empty baggage if sentry-trace header is present in incoming request but no baggage header', async () => {
-  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse(
-    { url: `${url}/express`, server },
-    {
-      'sentry-trace': '',
-    },
-  )) as TestAPIResponse;
+  const response = (await env.getAPIResponse(`${env.url}/express`, {
+    'sentry-trace': '',
+  })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
@@ -62,15 +52,12 @@ test('Should propagate empty baggage if sentry-trace header is present in incomi
 });
 
 test('Should propagate empty sentry and ignore original 3rd party baggage entries if sentry-trace header is present', async () => {
-  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse(
-    { url: `${url}/express`, server },
-    {
-      'sentry-trace': '',
-      baggage: 'foo=bar',
-    },
-  )) as TestAPIResponse;
+  const response = (await env.getAPIResponse(`${env.url}/express`, {
+    'sentry-trace': '',
+    baggage: 'foo=bar',
+  })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
@@ -82,9 +69,9 @@ test('Should propagate empty sentry and ignore original 3rd party baggage entrie
 });
 
 test('Should populate and propagate sentry baggage if sentry-trace header does not exist', async () => {
-  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse({ url: `${url}/express`, server }, {})) as TestAPIResponse;
+  const response = (await env.getAPIResponse(`${env.url}/express`, {})) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
@@ -99,14 +86,11 @@ test('Should populate and propagate sentry baggage if sentry-trace header does n
 });
 
 test('Should populate Sentry and ignore 3rd party content if sentry-trace header does not exist', async () => {
-  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse(
-    { url: `${url}/express`, server },
-    {
-      baggage: 'foo=bar,bar=baz',
-    },
-  )) as TestAPIResponse;
+  const response = (await env.getAPIResponse(`${env.url}/express`, {
+    baggage: 'foo=bar,bar=baz',
+  })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out-bad-tx-name/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out-bad-tx-name/test.ts
@@ -1,12 +1,12 @@
 import * as path from 'path';
 
-import { getAPIResponse, runServer } from '../../../../utils/index';
+import { TestEnv } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('Does not include transaction name if transaction source is not set', async () => {
-  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
-  const response = (await getAPIResponse({ url: `${url}/express`, server })) as TestAPIResponse;
+  const response = (await env.getAPIResponse(`${env.url}/express`)) as TestAPIResponse;
   const baggageString = response.test_data.baggage;
 
   expect(response).toBeDefined();

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/test.ts
@@ -1,12 +1,12 @@
 import * as path from 'path';
 
-import { getAPIResponse, runServer } from '../../../../utils/index';
+import { TestEnv } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('should attach a `baggage` header to an outgoing request.', async () => {
-  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
-  const response = (await getAPIResponse({ url: `${url}/express`, server })) as TestAPIResponse;
+  const response = (await env.getAPIResponse(`${env.url}/express`)) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/test.ts
@@ -1,18 +1,15 @@
 import * as path from 'path';
 
-import { getAPIResponse, runServer } from '../../../../utils/index';
+import { TestEnv } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('should ignore sentry-values in `baggage` header of a third party vendor and overwrite them with incoming DSC', async () => {
-  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
-  const response = (await getAPIResponse(
-    { url: `${url}/express`, server },
-    {
-      'sentry-trace': '',
-      baggage: 'sentry-release=2.1.0,sentry-environment=myEnv',
-    },
-  )) as TestAPIResponse;
+  const response = (await env.getAPIResponse(`${env.url}/express`, {
+    'sentry-trace': '',
+    baggage: 'sentry-release=2.1.0,sentry-environment=myEnv',
+  })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
@@ -24,9 +21,9 @@ test('should ignore sentry-values in `baggage` header of a third party vendor an
 });
 
 test('should ignore sentry-values in `baggage` header of a third party vendor and overwrite them with new DSC', async () => {
-  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
-  const response = (await getAPIResponse({ url: `${url}/express`, server }, {})) as TestAPIResponse;
+  const response = (await env.getAPIResponse(`${env.url}/express`, {})) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/test.ts
@@ -1,18 +1,15 @@
 import * as path from 'path';
 
-import { getAPIResponse, runServer } from '../../../../utils/index';
+import { TestEnv } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('should merge `baggage` header of a third party vendor with the Sentry DSC baggage items', async () => {
-  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
-  const response = (await getAPIResponse(
-    { url: `${url}/express`, server },
-    {
-      'sentry-trace': '',
-      baggage: 'sentry-release=2.0.0,sentry-environment=myEnv',
-    },
-  )) as TestAPIResponse;
+  const response = (await env.getAPIResponse(`${env.url}/express`, {
+    'sentry-trace': '',
+    baggage: 'sentry-release=2.0.0,sentry-environment=myEnv',
+  })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/test.ts
@@ -1,12 +1,12 @@
 import * as path from 'path';
 
-import { getAPIResponse, runServer } from '../../../../utils/index';
+import { TestEnv } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('Includes transaction in baggage if the transaction name is parameterized', async () => {
-  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
 
-  const response = (await getAPIResponse({ url: `${url}/express`, server })) as TestAPIResponse;
+  const response = (await env.getAPIResponse(`${env.url}/express`)) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/sentry-trace/trace-header-assign/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/trace-header-assign/test.ts
@@ -1,18 +1,15 @@
 import { TRACEPARENT_REGEXP } from '@sentry/utils';
 import * as path from 'path';
 
-import { getAPIResponse, runServer } from '../../../../utils/index';
+import { TestEnv } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('Should assign `sentry-trace` header which sets parent trace id of an outgoing request.', async () => {
-  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse(
-    { url: `${url}/express`, server },
-    {
-      'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
-    },
-  )) as TestAPIResponse;
+  const response = (await env.getAPIResponse(`${env.url}/express`, {
+    'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
+  })) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/sentry-trace/trace-header-out/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/trace-header-out/test.ts
@@ -1,13 +1,13 @@
 import { TRACEPARENT_REGEXP } from '@sentry/utils';
 import * as path from 'path';
 
-import { getAPIResponse, runServer } from '../../../../utils/index';
+import { TestEnv } from '../../../../utils/index';
 import { TestAPIResponse } from '../server';
 
 test('should attach a `sentry-trace` header to an outgoing request.', async () => {
-  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
-  const response = (await getAPIResponse({ url: `${url}/express`, server })) as TestAPIResponse;
+  const response = (await env.getAPIResponse(`${env.url}/express`)) as TestAPIResponse;
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/packages/node-integration-tests/suites/express/tracing/test.ts
@@ -1,8 +1,8 @@
-import { assertSentryTransaction, getEnvelopeRequest, runServer } from '../../../utils/index';
+import { assertSentryTransaction, TestEnv } from '../../../utils/index';
 
 test('should create and send transactions for Express routes and spans for middlewares.', async () => {
-  const { url, server } = await runServer(__dirname, `${__dirname}/server.ts`);
-  const envelope = await getEnvelopeRequest({ url: `${url}/express`, server }, { envelopeType: 'transaction' });
+  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
+  const envelope = await env.getEnvelopeRequest({ url: `${env.url}/express`, envelopeType: 'transaction' });
 
   expect(envelope).toHaveLength(3);
 
@@ -29,8 +29,8 @@ test('should create and send transactions for Express routes and spans for middl
 });
 
 test('should set a correct transaction name for routes specified in RegEx', async () => {
-  const { url, server } = await runServer(__dirname, `${__dirname}/server.ts`);
-  const envelope = await getEnvelopeRequest({ url: `${url}/regex`, server }, { envelopeType: 'transaction' });
+  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
+  const envelope = await env.getEnvelopeRequest({ url: `${env.url}/regex`, envelopeType: 'transaction' });
 
   expect(envelope).toHaveLength(3);
 
@@ -57,8 +57,8 @@ test('should set a correct transaction name for routes specified in RegEx', asyn
 test.each([['array1'], ['array5']])(
   'should set a correct transaction name for routes consisting of arrays of routes',
   async segment => {
-    const { url, server } = await runServer(__dirname, `${__dirname}/server.ts`);
-    const envelope = await getEnvelopeRequest({ url: `${url}/${segment}`, server }, { envelopeType: 'transaction' });
+    const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
+    const envelope = await env.getEnvelopeRequest({ url: `${env.url}/${segment}`, envelopeType: 'transaction' });
 
     expect(envelope).toHaveLength(3);
 
@@ -93,8 +93,8 @@ test.each([
   ['arr/requiredPath/optionalPath/'],
   ['arr/requiredPath/optionalPath/lastParam'],
 ])('should handle more complex regexes in route arrays correctly', async segment => {
-  const { url, server } = await runServer(__dirname, `${__dirname}/server.ts`);
-  const envelope = await getEnvelopeRequest({ url: `${url}/${segment}`, server }, { envelopeType: 'transaction' });
+  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
+  const envelope = await env.getEnvelopeRequest({ url: `${env.url}/${segment}`, envelopeType: 'transaction' });
 
   expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/test.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/empty-obj/test.ts
@@ -1,8 +1,8 @@
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should add an empty breadcrumb, when an empty object is given', async () => {
-  const config = await runServer(__dirname);
-  const envelope = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const envelope = await env.getEnvelopeRequest();
 
   expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/test.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/multiple_breadcrumbs/test.ts
@@ -1,8 +1,8 @@
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should add multiple breadcrumbs', async () => {
-  const config = await runServer(__dirname);
-  const events = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const events = await env.getEnvelopeRequest();
 
   assertSentryEvent(events[2], {
     message: 'test_multi_breadcrumbs',

--- a/packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/test.ts
+++ b/packages/node-integration-tests/suites/public-api/addBreadcrumb/simple_breadcrumb/test.ts
@@ -1,8 +1,8 @@
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should add a simple breadcrumb', async () => {
-  const config = await runServer(__dirname);
-  const event = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const event = await env.getEnvelopeRequest();
 
   assertSentryEvent(event[2], {
     message: 'test_simple',

--- a/packages/node-integration-tests/suites/public-api/captureException/catched-error/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureException/catched-error/test.ts
@@ -1,10 +1,10 @@
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should work inside catch block', async () => {
-  const config = await runServer(__dirname);
-  const events = await getMultipleEnvelopeRequest(config, { count: 1 });
+  const env = await TestEnv.init(__dirname);
+  const event = await env.getEnvelopeRequest();
 
-  assertSentryEvent(events[0][2], {
+  assertSentryEvent(event[2], {
     exception: {
       values: [
         {

--- a/packages/node-integration-tests/suites/public-api/captureException/empty-obj/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureException/empty-obj/test.ts
@@ -1,10 +1,10 @@
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should capture an empty object', async () => {
-  const config = await runServer(__dirname);
-  const events = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const event = await env.getEnvelopeRequest();
 
-  assertSentryEvent(events[2], {
+  assertSentryEvent(event[2], {
     exception: {
       values: [
         {

--- a/packages/node-integration-tests/suites/public-api/captureException/simple-error/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureException/simple-error/test.ts
@@ -1,10 +1,10 @@
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should capture a simple error with message', async () => {
-  const config = await runServer(__dirname);
-  const events = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const envelope = await env.getEnvelopeRequest();
 
-  assertSentryEvent(events[2], {
+  assertSentryEvent(envelope[2], {
     exception: {
       values: [
         {

--- a/packages/node-integration-tests/suites/public-api/captureMessage/simple_message/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureMessage/simple_message/test.ts
@@ -1,10 +1,10 @@
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should capture a simple message string', async () => {
-  const config = await runServer(__dirname);
-  const events = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const event = await env.getEnvelopeRequest();
 
-  assertSentryEvent(events[2], {
+  assertSentryEvent(event[2], {
     message: 'Message',
     level: 'info',
   });

--- a/packages/node-integration-tests/suites/public-api/captureMessage/with_level/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureMessage/with_level/test.ts
@@ -1,8 +1,8 @@
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should capture with different severity levels', async () => {
-  const config = await runServer(__dirname);
-  const events = await getMultipleEnvelopeRequest(config, { count: 6 });
+  const env = await TestEnv.init(__dirname);
+  const events = await env.getMultipleEnvelopeRequest({ count: 6 });
 
   assertSentryEvent(events[0][2], {
     message: 'debug_message',

--- a/packages/node-integration-tests/suites/public-api/configureScope/clear_scope/test.ts
+++ b/packages/node-integration-tests/suites/public-api/configureScope/clear_scope/test.ts
@@ -1,10 +1,10 @@
 import { Event } from '@sentry/node';
 
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should clear previously set properties of a scope', async () => {
-  const config = await runServer(__dirname);
-  const envelope = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const envelope = await env.getEnvelopeRequest();
 
   assertSentryEvent(envelope[2], {
     message: 'cleared_scope',

--- a/packages/node-integration-tests/suites/public-api/configureScope/set_properties/test.ts
+++ b/packages/node-integration-tests/suites/public-api/configureScope/set_properties/test.ts
@@ -1,8 +1,8 @@
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should set different properties of a scope', async () => {
-  const config = await runServer(__dirname);
-  const envelope = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const envelope = await env.getEnvelopeRequest();
 
   assertSentryEvent(envelope[2], {
     message: 'configured_scope',

--- a/packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/multiple-contexts/test.ts
@@ -1,12 +1,12 @@
 import { Event } from '@sentry/node';
 
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should record multiple contexts', async () => {
-  const config = await runServer(__dirname);
-  const events = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const envelope = await env.getEnvelopeRequest();
 
-  assertSentryEvent(events[2], {
+  assertSentryEvent(envelope[2], {
     message: 'multiple_contexts',
     contexts: {
       context_1: {
@@ -17,5 +17,5 @@ test('should record multiple contexts', async () => {
     },
   });
 
-  expect((events[0] as Event).contexts?.context_3).not.toBeDefined();
+  expect((envelope[0] as Event).contexts?.context_3).not.toBeDefined();
 });

--- a/packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/non-serializable-context/test.ts
@@ -1,15 +1,15 @@
 import { Event } from '@sentry/node';
 
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should normalize non-serializable context', async () => {
-  const config = await runServer(__dirname);
-  const events = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const event = await env.getEnvelopeRequest();
 
-  assertSentryEvent(events[2], {
+  assertSentryEvent(event[2], {
     message: 'non_serializable',
     contexts: {},
   });
 
-  expect((events[0] as Event).contexts?.context_3).not.toBeDefined();
+  expect((event[0] as Event).contexts?.context_3).not.toBeDefined();
 });

--- a/packages/node-integration-tests/suites/public-api/setContext/simple-context/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setContext/simple-context/test.ts
@@ -1,12 +1,12 @@
 import { Event } from '@sentry/node';
 
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should set a simple context', async () => {
-  const config = await runServer(__dirname);
-  const envelopes = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const envelope = await env.getEnvelopeRequest();
 
-  assertSentryEvent(envelopes[2], {
+  assertSentryEvent(envelope[2], {
     message: 'simple_context_object',
     contexts: {
       foo: {
@@ -15,5 +15,5 @@ test('should set a simple context', async () => {
     },
   });
 
-  expect((envelopes[2] as Event).contexts?.context_3).not.toBeDefined();
+  expect((envelope[2] as Event).contexts?.context_3).not.toBeDefined();
 });

--- a/packages/node-integration-tests/suites/public-api/setExtra/multiple-extras/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtra/multiple-extras/test.ts
@@ -1,10 +1,10 @@
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should record multiple extras of different types', async () => {
-  const config = await runServer(__dirname);
-  const events = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const event = await env.getEnvelopeRequest();
 
-  assertSentryEvent(events[2], {
+  assertSentryEvent(event[2], {
     message: 'multiple_extras',
     extra: {
       extra_1: { foo: 'bar', baz: { qux: 'quux' } },

--- a/packages/node-integration-tests/suites/public-api/setExtra/non-serializable-extra/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtra/non-serializable-extra/test.ts
@@ -1,10 +1,10 @@
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should normalize non-serializable extra', async () => {
-  const config = await runServer(__dirname);
-  const events = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const event = await env.getEnvelopeRequest();
 
-  assertSentryEvent(events[2], {
+  assertSentryEvent(event[2], {
     message: 'non_serializable',
     extra: {},
   });

--- a/packages/node-integration-tests/suites/public-api/setExtra/simple-extra/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtra/simple-extra/test.ts
@@ -1,10 +1,10 @@
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should set a simple extra', async () => {
-  const config = await runServer(__dirname);
-  const events = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const event = await env.getEnvelopeRequest();
 
-  assertSentryEvent(events[2], {
+  assertSentryEvent(event[2], {
     message: 'simple_extra',
     extra: {
       foo: {

--- a/packages/node-integration-tests/suites/public-api/setExtras/consecutive-calls/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtras/consecutive-calls/test.ts
@@ -1,10 +1,10 @@
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should set extras from multiple consecutive calls', async () => {
-  const config = await runServer(__dirname);
-  const envelopes = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const envelope = await env.getEnvelopeRequest();
 
-  assertSentryEvent(envelopes[2], {
+  assertSentryEvent(envelope[2], {
     message: 'consecutive_calls',
     extra: { extra: [], Infinity: 2, null: 0, obj: { foo: ['bar', 'baz', 1] } },
   });

--- a/packages/node-integration-tests/suites/public-api/setExtras/multiple-extras/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setExtras/multiple-extras/test.ts
@@ -1,10 +1,10 @@
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should record an extras object', async () => {
-  const config = await runServer(__dirname);
-  const events = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const event = await env.getEnvelopeRequest();
 
-  assertSentryEvent(events[2], {
+  assertSentryEvent(event[2], {
     message: 'multiple_extras',
     extra: {
       extra_1: [1, ['foo'], 'bar'],

--- a/packages/node-integration-tests/suites/public-api/setTag/with-primitives/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setTag/with-primitives/test.ts
@@ -1,10 +1,10 @@
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should set primitive tags', async () => {
-  const config = await runServer(__dirname);
-  const events = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const event = await env.getEnvelopeRequest();
 
-  assertSentryEvent(events[2], {
+  assertSentryEvent(event[2], {
     message: 'primitive_tags',
     tags: {
       tag_1: 'foo',

--- a/packages/node-integration-tests/suites/public-api/setTags/with-primitives/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setTags/with-primitives/test.ts
@@ -1,10 +1,10 @@
-import { assertSentryEvent, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should set primitive tags', async () => {
-  const config = await runServer(__dirname);
-  const events = await getEnvelopeRequest(config);
+  const env = await TestEnv.init(__dirname);
+  const event = await env.getEnvelopeRequest();
 
-  assertSentryEvent(events[2], {
+  assertSentryEvent(event[2], {
     message: 'primitive_tags',
     tags: {
       tag_1: 'foo',

--- a/packages/node-integration-tests/suites/public-api/setUser/unset_user/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setUser/unset_user/test.ts
@@ -1,10 +1,10 @@
 import { Event } from '@sentry/node';
 
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should unset user', async () => {
-  const config = await runServer(__dirname);
-  const events = await getMultipleEnvelopeRequest(config, { count: 3 });
+  const env = await TestEnv.init(__dirname);
+  const events = await env.getMultipleEnvelopeRequest({ count: 3 });
 
   assertSentryEvent(events[0][2], {
     message: 'no_user',

--- a/packages/node-integration-tests/suites/public-api/setUser/update_user/test.ts
+++ b/packages/node-integration-tests/suites/public-api/setUser/update_user/test.ts
@@ -1,8 +1,8 @@
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should update user', async () => {
-  const config = await runServer(__dirname);
-  const envelopes = await getMultipleEnvelopeRequest(config, { count: 2 });
+  const env = await TestEnv.init(__dirname);
+  const envelopes = await env.getMultipleEnvelopeRequest({ count: 2 });
 
   assertSentryEvent(envelopes[0][2], {
     message: 'first_user',

--- a/packages/node-integration-tests/suites/public-api/startTransaction/basic-usage/test.ts
+++ b/packages/node-integration-tests/suites/public-api/startTransaction/basic-usage/test.ts
@@ -1,8 +1,8 @@
-import { assertSentryTransaction, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryTransaction, TestEnv } from '../../../../utils';
 
 test('should send a manually started transaction when @sentry/tracing is imported using unnamed import.', async () => {
-  const config = await runServer(__dirname);
-  const envelope = await getEnvelopeRequest(config, { envelopeType: 'transaction' });
+  const env = await TestEnv.init(__dirname);
+  const envelope = await env.getEnvelopeRequest({ envelopeType: 'transaction' });
 
   assertSentryTransaction(envelope[2], {
     transaction: 'test_transaction_1',

--- a/packages/node-integration-tests/suites/public-api/startTransaction/with-nested-spans/test.ts
+++ b/packages/node-integration-tests/suites/public-api/startTransaction/with-nested-spans/test.ts
@@ -1,8 +1,8 @@
-import { assertSentryTransaction, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryTransaction, TestEnv } from '../../../../utils';
 
 test('should report finished spans as children of the root transaction.', async () => {
-  const config = await runServer(__dirname);
-  const envelope = await getEnvelopeRequest(config, { envelopeType: 'transaction' });
+  const env = await TestEnv.init(__dirname);
+  const envelope = await env.getEnvelopeRequest({ envelopeType: 'transaction' });
 
   expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/public-api/withScope/nested-scopes/test.ts
+++ b/packages/node-integration-tests/suites/public-api/withScope/nested-scopes/test.ts
@@ -1,10 +1,10 @@
 import { Event } from '@sentry/node';
 
-import { assertSentryEvent, getMultipleEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryEvent, TestEnv } from '../../../../utils';
 
 test('should allow nested scoping', async () => {
-  const config = await runServer(__dirname);
-  const events = await getMultipleEnvelopeRequest(config, { count: 5 });
+  const env = await TestEnv.init(__dirname);
+  const events = await env.getMultipleEnvelopeRequest({ count: 5 });
 
   assertSentryEvent(events[0][2], {
     message: 'root_before',

--- a/packages/node-integration-tests/suites/sessions/errored-session-aggregate/test.ts
+++ b/packages/node-integration-tests/suites/sessions/errored-session-aggregate/test.ts
@@ -1,17 +1,17 @@
 import path from 'path';
 
-import { getEnvelopeRequest, runServer } from '../../../utils';
+import { TestEnv } from '../../../utils';
 
 test('should aggregate successful, crashed and erroneous sessions', async () => {
-  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const aggregateSessionEnvelope = await Promise.race([
-    getEnvelopeRequest({ url: `${url}/success`, server }, { endServer: false, envelopeType: 'sessions' }),
-    getEnvelopeRequest({ url: `${url}/error_handled`, server }, { endServer: false, envelopeType: 'sessions' }),
-    getEnvelopeRequest({ url: `${url}/error_unhandled`, server }, { endServer: false, envelopeType: 'sessions' }),
+    env.getEnvelopeRequest({ url: `${env.url}/success`, endServer: false, envelopeType: 'sessions' }),
+    env.getEnvelopeRequest({ url: `${env.url}/error_handled`, endServer: false, envelopeType: 'sessions' }),
+    env.getEnvelopeRequest({ url: `${env.url}/error_unhandled`, endServer: false, envelopeType: 'sessions' }),
   ]);
 
-  await new Promise(resolve => server.close(resolve));
+  await new Promise(resolve => env.server.close(resolve));
 
   expect(aggregateSessionEnvelope[0]).toMatchObject({
     sent_at: expect.any(String),

--- a/packages/node-integration-tests/suites/sessions/exited-session-aggregate/test.ts
+++ b/packages/node-integration-tests/suites/sessions/exited-session-aggregate/test.ts
@@ -1,19 +1,19 @@
 import nock from 'nock';
 import path from 'path';
 
-import { getEnvelopeRequest, runServer } from '../../../utils';
+import { TestEnv } from '../../../utils';
 
 test('should aggregate successful sessions', async () => {
-  const { url, server } = await runServer(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
 
   const envelope = await Promise.race([
-    getEnvelopeRequest({ url: `${url}/success`, server }, { endServer: false, envelopeType: 'sessions' }),
-    getEnvelopeRequest({ url: `${url}/success_next`, server }, { endServer: false, envelopeType: 'sessions' }),
-    getEnvelopeRequest({ url: `${url}/success_slow`, server }, { endServer: false, envelopeType: 'sessions' }),
+    env.getEnvelopeRequest({ url: `${env.url}/success`, endServer: false, envelopeType: 'sessions' }),
+    env.getEnvelopeRequest({ url: `${env.url}/success_next`, endServer: false, envelopeType: 'sessions' }),
+    env.getEnvelopeRequest({ url: `${env.url}/success_slow`, endServer: false, envelopeType: 'sessions' }),
   ]);
 
   nock.cleanAll();
-  server.close();
+  env.server.close();
 
   expect(envelope).toHaveLength(3);
   expect(envelope[0]).toMatchObject({

--- a/packages/node-integration-tests/suites/tracing/apollo-graphql/test.ts
+++ b/packages/node-integration-tests/suites/tracing/apollo-graphql/test.ts
@@ -1,11 +1,11 @@
-import { assertSentryTransaction, conditionalTest, getEnvelopeRequest, runServer } from '../../../utils';
+import { assertSentryTransaction, conditionalTest, TestEnv } from '../../../utils';
 
 // Node 10 is not supported by `graphql-js`
 // Ref: https://github.com/graphql/graphql-js/blob/main/package.json
 conditionalTest({ min: 12 })('GraphQL/Apollo Tests', () => {
   test('should instrument GraphQL and Apollo Server.', async () => {
-    const config = await runServer(__dirname);
-    const envelope = await getEnvelopeRequest(config, { envelopeType: 'transaction' });
+    const env = await TestEnv.init(__dirname);
+    const envelope = await env.getEnvelopeRequest({ envelopeType: 'transaction' });
 
     expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
@@ -1,6 +1,6 @@
 import { MongoMemoryServer } from 'mongodb-memory-server-global';
 
-import { assertSentryTransaction, conditionalTest, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryTransaction, conditionalTest, TestEnv } from '../../../../utils';
 
 // This test can take longer.
 jest.setTimeout(15000);
@@ -20,8 +20,8 @@ conditionalTest({ min: 12 })('MongoDB Test', () => {
   });
 
   test('should auto-instrument `mongodb` package.', async () => {
-    const config = await runServer(__dirname);
-    const envelope = await getEnvelopeRequest(config, { envelopeType: 'transaction' });
+    const env = await TestEnv.init(__dirname);
+    const envelope = await env.getEnvelopeRequest({ envelopeType: 'transaction' });
 
     expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/tracing/auto-instrument/mysql/test.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/mysql/test.ts
@@ -1,8 +1,8 @@
-import { assertSentryTransaction, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryTransaction, TestEnv } from '../../../../utils';
 
 test('should auto-instrument `mysql` package.', async () => {
-  const config = await runServer(__dirname);
-  const envelope = await getEnvelopeRequest(config, { envelopeType: 'transaction' });
+  const env = await TestEnv.init(__dirname);
+  const envelope = await env.getEnvelopeRequest({ envelopeType: 'transaction' });
 
   expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/tracing/auto-instrument/pg/test.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/pg/test.ts
@@ -1,4 +1,4 @@
-import { assertSentryTransaction, getEnvelopeRequest, runServer } from '../../../../utils';
+import { assertSentryTransaction, TestEnv } from '../../../../utils';
 
 class PgClient {
   // https://node-postgres.com/api/client#clientquery
@@ -29,8 +29,8 @@ beforeAll(() => {
 });
 
 test('should auto-instrument `pg` package.', async () => {
-  const config = await runServer(__dirname);
-  const envelope = await getEnvelopeRequest(config, { envelopeType: 'transaction' });
+  const env = await TestEnv.init(__dirname);
+  const envelope = await env.getEnvelopeRequest({ envelopeType: 'transaction' });
 
   expect(envelope).toHaveLength(3);
 

--- a/packages/node-integration-tests/suites/tracing/prisma-orm/test.ts
+++ b/packages/node-integration-tests/suites/tracing/prisma-orm/test.ts
@@ -1,9 +1,9 @@
-import { assertSentryTransaction, conditionalTest, getEnvelopeRequest, runServer } from '../../../utils';
+import { assertSentryTransaction, conditionalTest, TestEnv } from '../../../utils';
 
 conditionalTest({ min: 12 })('Prisma ORM Integration', () => {
   test('should instrument Prisma client for tracing.', async () => {
-    const config = await runServer(__dirname);
-    const envelope = await getEnvelopeRequest(config, { envelopeType: 'transaction' });
+    const env = await TestEnv.init(__dirname);
+    const envelope = await env.getEnvelopeRequest({ envelopeType: 'transaction' });
 
     assertSentryTransaction(envelope[2], {
       transaction: 'Test Transaction',

--- a/packages/node-integration-tests/suites/tracing/tracePropagationTargets/test.ts
+++ b/packages/node-integration-tests/suites/tracing/tracePropagationTargets/test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 
-import { TestEnv, runScenario } from '../../../utils';
+import { runScenario, TestEnv } from '../../../utils';
 
 test('HttpIntegration should instrument correct requests when tracePropagationTargets option is provided', async () => {
   const match1 = nock('http://match-this-url.com')

--- a/packages/node-integration-tests/suites/tracing/tracePropagationTargets/test.ts
+++ b/packages/node-integration-tests/suites/tracing/tracePropagationTargets/test.ts
@@ -1,6 +1,6 @@
 import nock from 'nock';
 
-import { runScenario, runServer } from '../../../utils';
+import { TestEnv, runScenario } from '../../../utils';
 
 test('HttpIntegration should instrument correct requests when tracePropagationTargets option is provided', async () => {
   const match1 = nock('http://match-this-url.com')
@@ -27,13 +27,13 @@ test('HttpIntegration should instrument correct requests when tracePropagationTa
     .matchHeader('sentry-trace', val => val === undefined)
     .reply(200);
 
-  const { url, server } = await runServer(__dirname);
-  await runScenario(url);
+  const env = await TestEnv.init(__dirname);
+  await runScenario(env.url);
 
-  server.close();
+  env.server.close();
   nock.cleanAll();
 
-  await new Promise(resolve => server.close(resolve));
+  await new Promise(resolve => env.server.close(resolve));
 
   expect(match1.isDone()).toBe(true);
   expect(match2.isDone()).toBe(true);


### PR DESCRIPTION
Following up: #5579 and #5596
Ref: https://github.com/getsentry/sentry-javascript/pull/5579#pullrequestreview-1072740393

Refactored Node integration test helpers, to use a `TestEnv` instance for each test. This will help avoid explicitly passing `server` and `url` back and forth.

Remix server-side tests also extend the `TestEnv` class to implement Remix-specific initialization logic.