### PR TITLE
fix(nextjs): Start navigation transactions on same-route navigations

### DIFF
--- a/packages/nextjs/src/performance/client.ts
+++ b/packages/nextjs/src/performance/client.ts
@@ -8,7 +8,6 @@ import {
   getGlobalObject,
   logger,
   parseBaggageHeader,
-  stripUrlFragment,
   stripUrlQueryAndFragment,
 } from '@sentry/utils';
 import type { NEXT_DATA as NextData } from 'next/dist/next-server/lib/utils';

--- a/packages/utils/src/url.ts
+++ b/packages/utils/src/url.ts
@@ -44,6 +44,17 @@ export function stripUrlQueryAndFragment(urlPath: string): string {
 }
 
 /**
+ * Strip the URL fragment off of a given URL or path (if present)
+ *
+ * @param urlPath Full URL or path, including possible fragment
+ * @returns URL or path without fragment
+ */
+export function stripUrlFragment(urlPath: string): string {
+  // eslint-disable-next-line no-useless-escape
+  return urlPath.split('#')[0];
+}
+
+/**
  * Returns number of URL segments of a passed string URL.
  */
 export function getNumberOfUrlSegments(url: string): number {

--- a/packages/utils/src/url.ts
+++ b/packages/utils/src/url.ts
@@ -44,16 +44,6 @@ export function stripUrlQueryAndFragment(urlPath: string): string {
 }
 
 /**
- * Strip the URL fragment off of a given URL or path (if present)
- *
- * @param urlPath Full URL or path, including possible fragment
- * @returns URL or path without fragment
- */
-export function stripUrlFragment(urlPath: string): string {
-  return urlPath.split('#')[0];
-}
-
-/**
  * Returns number of URL segments of a passed string URL.
  */
 export function getNumberOfUrlSegments(url: string): number {

--- a/packages/utils/src/url.ts
+++ b/packages/utils/src/url.ts
@@ -50,7 +50,6 @@ export function stripUrlQueryAndFragment(urlPath: string): string {
  * @returns URL or path without fragment
  */
 export function stripUrlFragment(urlPath: string): string {
-  // eslint-disable-next-line no-useless-escape
   return urlPath.split('#')[0];
 }
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/5641

Currently we are not starting transactions in Next.js when navigating from one page to another, but within the same route (eg. from `/users/42` to `/users/1337`, both are on the same route `/users/[id]`).

This PR fixes this by starting a transaction for those navigations by looking at the window pathname instead. (See code changes for reason why we're not starting transactions when *just* the query string changes)