### PR TITLE
ref(dev): Remove stacktrace limit on node errors in yarn scripts

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,3 @@
 workspaces-experimental true
+env:
+  NODE_OPTIONS --stack-trace-limit=10000


### PR DESCRIPTION
By default, Node errors [only include the top 10 stackframes](https://nodejs.org/api/errors.html#errorstacktracelimit). Given the number of frames taken up by internal node code (especially when async functions are involved), this very often means that frames which might actually tell us something are cut off.

This solves that problem by removing the 10-frame limit for all errors thrown by node processes run through yarn. Note that this is a change which only affects our dev environment, not the SDK itself.
