### PR TITLE
fix: Always use `?` for anonymous function name

### DIFF
--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -9,6 +9,7 @@ import {
   isPrimitive,
   isString,
   logger,
+  UNKNOWN_FUNCTION,
 } from '@sentry/utils';
 
 import { BrowserClient } from '../client';
@@ -227,7 +228,7 @@ function _enhanceEventWithInitialFrame(event: Event, url: any, line: any, column
     ev0sf.push({
       colno,
       filename,
-      function: '?',
+      function: UNKNOWN_FUNCTION,
       in_app: true,
       lineno,
     });

--- a/packages/browser/src/stack-parsers.ts
+++ b/packages/browser/src/stack-parsers.ts
@@ -1,8 +1,5 @@
 import { StackFrame, StackLineParser, StackLineParserFn } from '@sentry/types';
-import { createStackParser } from '@sentry/utils';
-
-// global reference to slice
-const UNKNOWN_FUNCTION = '?';
+import { createStackParser, UNKNOWN_FUNCTION } from '@sentry/utils';
 
 const OPERA10_PRIORITY = 10;
 const OPERA11_PRIORITY = 20;

--- a/packages/browser/test/integration/suites/builtins.js
+++ b/packages/browser/test/integration/suites/builtins.js
@@ -287,7 +287,7 @@ describe('wrapped built-ins', function () {
   });
 
   it(
-    optional('should fallback to <anonymous> fn name in mechanism data if one is unavailable', IS_LOADER),
+    optional('should fallback to "?" fn name in mechanism data if one is unavailable', IS_LOADER),
     function () {
       return runInSandbox(sandbox, function () {
         var div = document.createElement('div');
@@ -316,7 +316,7 @@ describe('wrapped built-ins', function () {
             handled: true,
             data: {
               function: 'addEventListener',
-              handler: '<anonymous>',
+              handler: '?',
             },
           });
         }

--- a/packages/integrations/src/transaction.ts
+++ b/packages/integrations/src/transaction.ts
@@ -1,4 +1,5 @@
 import { Event, EventProcessor, Hub, Integration, StackFrame } from '@sentry/types';
+import { UNKNOWN_FUNCTION } from '@sentry/utils';
 
 /** Add node transaction to the event */
 export class Transaction implements Integration {
@@ -52,6 +53,8 @@ export class Transaction implements Integration {
 
   /** JSDoc */
   private _getTransaction(frame: StackFrame): string {
-    return frame.module || frame.function ? `${frame.module || '?'}/${frame.function || '?'}` : '<unknown>';
+    return frame.module || frame.function
+      ? `${frame.module || UNKNOWN_FUNCTION}/${frame.function || UNKNOWN_FUNCTION}`
+      : '<unknown>';
   }
 }

--- a/packages/node/test/stacktrace.test.ts
+++ b/packages/node/test/stacktrace.test.ts
@@ -192,7 +192,7 @@ describe('Stack parsing', () => {
       {
         filename: '/Users/felix/code/node-fast-or-slow/lib/test_case.js',
         module: 'test_case',
-        function: '<anonymous>',
+        function: '?',
         lineno: 80,
         colno: 10,
         in_app: true,
@@ -212,7 +212,7 @@ describe('Stack parsing', () => {
       {
         filename: '/Users/felix/code/node-fast-or-slow/lib/test_case.js',
         module: 'test_case',
-        function: '<anonymous>',
+        function: '?',
         lineno: 80,
         colno: 10,
         in_app: true,
@@ -289,7 +289,7 @@ describe('Stack parsing', () => {
       {
         filename: '/code/node_modules/kafkajs/src/consumer/runner.js',
         module: 'kafkajs.src.consumer:runner',
-        function: '<anonymous>',
+        function: '?',
         lineno: 376,
         colno: 15,
         in_app: false,

--- a/packages/utils/src/stacktrace.ts
+++ b/packages/utils/src/stacktrace.ts
@@ -1,6 +1,7 @@
 import { StackFrame, StackLineParser, StackLineParserFn, StackParser } from '@sentry/types';
 
 const STACKTRACE_LIMIT = 50;
+export const UNKNOWN_FUNCTION = '?';
 
 /**
  * Creates a stack parser with the supplied line parsers
@@ -76,12 +77,10 @@ export function stripSentryFramesAndReverse(stack: StackFrame[]): StackFrame[] {
     .map(frame => ({
       ...frame,
       filename: frame.filename || localStack[0].filename,
-      function: frame.function || '?',
+      function: frame.function || UNKNOWN_FUNCTION,
     }))
     .reverse();
 }
-
-const defaultFunctionName = '<anonymous>';
 
 /**
  * Safely extract function name from itself
@@ -89,13 +88,13 @@ const defaultFunctionName = '<anonymous>';
 export function getFunctionName(fn: unknown): string {
   try {
     if (!fn || typeof fn !== 'function') {
-      return defaultFunctionName;
+      return UNKNOWN_FUNCTION;
     }
-    return fn.name || defaultFunctionName;
+    return fn.name || UNKNOWN_FUNCTION;
   } catch (e) {
     // Just accessing custom props in some Selenium environments
     // can cause a "Permission denied" exception (see raven-js#495).
-    return defaultFunctionName;
+    return UNKNOWN_FUNCTION;
   }
 }
 
@@ -151,13 +150,13 @@ function node(getModule?: GetModuleFn): StackLineParserFn {
       methodName = method;
     }
 
-    if (method === '<anonymous>') {
+    if (method === UNKNOWN_FUNCTION) {
       methodName = undefined;
       functionName = undefined;
     }
 
     if (functionName === undefined) {
-      methodName = methodName || '<anonymous>';
+      methodName = methodName || UNKNOWN_FUNCTION;
       functionName = typeName ? `${typeName}.${methodName}` : methodName;
     }
 

--- a/packages/utils/test/normalize.test.ts
+++ b/packages/utils/test/normalize.test.ts
@@ -291,7 +291,7 @@ describe('normalize()', () => {
       subject.toJSON = () => {
         throw new Error("I'm faulty!");
       };
-      expect(normalize(subject)).toEqual({ a: 1, foo: 'bar', toJSON: '[Function: <anonymous>]' });
+      expect(normalize(subject)).toEqual({ a: 1, foo: 'bar', toJSON: '[Function: ?]' });
     });
 
     test('should return an object without circular references when toJSON returns an object with circular references', () => {
@@ -327,7 +327,7 @@ describe('normalize()', () => {
         normalize(() => {
           /* no-empty */
         }),
-      ).toEqual('[Function: <anonymous>]');
+      ).toEqual('[Function: ?]');
       const foo = () => {
         /* no-empty */
       };


### PR DESCRIPTION
Closes #5523 

This moves the `'?'` string to `@sentry/utils` so it only exists once in the bundle.