### PR TITLE
feat(utils): Add function for ensuring input is an array

### DIFF
--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -22,6 +22,7 @@ import {
   User,
 } from '@sentry/types';
 import {
+  arrayify,
   dateTimestampInSeconds,
   getGlobalSingleton,
   isPlainObject,
@@ -553,11 +554,7 @@ export class Scope implements ScopeInterface {
    */
   private _applyFingerprint(event: Event): void {
     // Make sure it's an array first and we actually have something in place
-    event.fingerprint = event.fingerprint
-      ? Array.isArray(event.fingerprint)
-        ? event.fingerprint
-        : [event.fingerprint]
-      : [];
+    event.fingerprint = event.fingerprint ? arrayify(event.fingerprint) : [];
 
     // If we have something on the scope, then merge it with event
     if (this._fingerprint) {

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import { getSentryRelease } from '@sentry/node';
-import { dropUndefinedKeys, escapeStringForRegex, logger } from '@sentry/utils';
+import { arrayify, dropUndefinedKeys, escapeStringForRegex, logger } from '@sentry/utils';
 import { default as SentryWebpackPlugin } from '@sentry/webpack-plugin';
 import * as chalk from 'chalk';
 import * as fs from 'fs';
@@ -186,7 +186,7 @@ function isMatchingRule(rule: WebpackModuleRule, projectDir: string): boolean {
   }
 
   // `rule.use` can be an object or an array of objects. For simplicity, force it to be an array.
-  const useEntries = Array.isArray(rule.use) ? rule.use : [rule.use];
+  const useEntries = arrayify(rule.use);
 
   // Depending on the version of nextjs we're talking about, the loader which does the transpiling is either
   //

--- a/packages/tracing/src/integrations/node/apollo.ts
+++ b/packages/tracing/src/integrations/node/apollo.ts
@@ -1,6 +1,6 @@
 import { Hub } from '@sentry/hub';
 import { EventProcessor, Integration } from '@sentry/types';
-import { fill, isThenable, loadModule, logger } from '@sentry/utils';
+import { arrayify, fill, isThenable, loadModule, logger } from '@sentry/utils';
 
 type ApolloResolverGroup = {
   [key: string]: () => unknown;
@@ -44,7 +44,7 @@ export class Apollo implements Integration {
      */
     fill(pkg.ApolloServerBase.prototype, 'constructSchema', function (orig: () => unknown) {
       return function (this: { config: { resolvers: ApolloModelResolvers[] } }) {
-        const resolvers = Array.isArray(this.config.resolvers) ? this.config.resolvers : [this.config.resolvers];
+        const resolvers = arrayify(this.config.resolvers);
 
         this.config.resolvers = resolvers.map(model => {
           Object.keys(model).forEach(resolverGroupName => {

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -200,3 +200,13 @@ export function checkOrSetAlreadyCaught(exception: unknown): boolean {
 
   return false;
 }
+
+/**
+ * Checks whether the given input is already an array, and if it isn't, wraps it in one.
+ *
+ * @param maybeArray Input to turn into an array, if necessary
+ * @returns The input, if already an array, or an array with the input as the only element, if not
+ */
+export function arrayify<T = unknown>(maybeArray: T | T[]): T[] {
+  return Array.isArray(maybeArray) ? maybeArray : [maybeArray];
+}

--- a/packages/utils/test/misc.test.ts
+++ b/packages/utils/test/misc.test.ts
@@ -3,6 +3,7 @@ import { Event, Mechanism, StackFrame } from '@sentry/types';
 import {
   addContextToFrame,
   addExceptionMechanism,
+  arrayify,
   checkOrSetAlreadyCaught,
   getEventDescription,
   uuid4,
@@ -307,5 +308,21 @@ describe('uuid4 generation', () => {
     for (let index = 0; index < 1_000; index++) {
       expect(uuid4()).toMatch(/^[0-9A-F]{12}[4][0-9A-F]{3}[89AB][0-9A-F]{15}$/i);
     }
+  });
+});
+
+describe('arrayify()', () => {
+  it('returns arrays untouched', () => {
+    expect(arrayify([])).toEqual([]);
+    expect(arrayify(['dogs', 'are', 'great'])).toEqual(['dogs', 'are', 'great']);
+  });
+
+  it('wraps non-arrays with an array', () => {
+    expect(arrayify(1231)).toEqual([1231]);
+    expect(arrayify('dogs are great')).toEqual(['dogs are great']);
+    expect(arrayify(true)).toEqual([true]);
+    expect(arrayify({})).toEqual([{}]);
+    expect(arrayify(null)).toEqual([null]);
+    expect(arrayify(undefined)).toEqual([undefined]);
   });
 });

--- a/packages/vue/src/sdk.ts
+++ b/packages/vue/src/sdk.ts
@@ -1,5 +1,5 @@
 import { init as browserInit, SDK_VERSION } from '@sentry/browser';
-import { getGlobalObject, logger } from '@sentry/utils';
+import { arrayify, getGlobalObject, logger } from '@sentry/utils';
 
 import { DEFAULT_HOOKS } from './constants';
 import { attachErrorHandler } from './errorhandler';
@@ -51,7 +51,7 @@ export function init(
   }
 
   if (options.app) {
-    const apps = Array.isArray(options.app) ? options.app : [options.app];
+    const apps = arrayify(options.app);
     apps.forEach(app => vueInit(app, options));
   } else if (options.Vue) {
     vueInit(options.Vue, options);


### PR DESCRIPTION
In a number of places in our codebase, we have the pattern `const something = Array.isArray(somethingElse) ? somethingElse : [ somethingElse ];`, where we need something (which might already be an array) to be an array. 

This introduces a utility function, `arrayify`, which does that work for us, mostly because I just got tired of typing it. (As a bonus, it's slightly shorter and therefore might save a few bytes on bundle size.)