### PR TITLE
ref(angular): Consolidate to use single `setName` call

### DIFF
--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -117,8 +117,7 @@ export class TraceService implements OnDestroy {
       const transaction = getActiveTransaction();
       // TODO (v8 / #5416): revisit the source condition. Do we want to make the parameterized route the default?
       if (transaction && transaction.metadata.source === 'url') {
-        transaction.setName(route);
-        transaction.setMetadata({ source: 'route' });
+        transaction.setName(route, 'route');
       }
     }),
   );

--- a/packages/angular/test/tracing.test.ts
+++ b/packages/angular/test/tracing.test.ts
@@ -84,7 +84,6 @@ describe('Angular Tracing', () => {
           transaction = {
             ...ctx,
             setName: jest.fn(name => (transaction.name = name)),
-            setMetadata: jest.fn(metadata => (transaction.metadata = metadata)),
           };
           return transaction;
         });
@@ -154,8 +153,7 @@ describe('Angular Tracing', () => {
         // this event starts the parameterization
         routerEvents$.next(new ResolveEnd(1, url, url, routerState as any));
 
-        expect(transaction.setName).toHaveBeenCalledWith(result);
-        expect(transaction.setMetadata).toHaveBeenCalledWith({ source: 'route' });
+        expect(transaction.setName).toHaveBeenCalledWith(result, 'route');
       });
 
       it('does not change the transaction name if the source is something other than `url`', () => {
@@ -182,7 +180,6 @@ describe('Angular Tracing', () => {
         );
 
         expect(transaction.setName).toHaveBeenCalledTimes(0);
-        expect(transaction.setMetadata).toHaveBeenCalledTimes(0);
         expect(transaction.name).toEqual(url);
       });
     });


### PR DESCRIPTION
Remove usage `setMetadata` in favour of adding the source to `setName`

helps us get prepped for https://github.com/getsentry/sentry-javascript/issues/5679, related to https://github.com/getsentry/sentry-javascript/pull/5681

Please merge this in without me if I'm not available!
