### PR TITLE
ref(nextjs): Consolidate to use single `setName` call

### DIFF
--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -332,8 +332,8 @@ function makeWrappedMethodForGettingParameterizedPath(
     // replace specific URL with parameterized version
     if (transaction && transaction.metadata.requestPath) {
       const origPath = transaction.metadata.requestPath;
-      transaction.name = transaction.name.replace(origPath, parameterizedPath);
-      transaction.setMetadata({ source: 'route' });
+      const newName = transaction.name.replace(origPath, parameterizedPath);
+      transaction.setName(newName, 'route');
     }
 
     return origMethod.call(this, parameterizedPath, ...args);


### PR DESCRIPTION
helps us get prepped for https://github.com/getsentry/sentry-javascript/issues/5679, related to https://github.com/getsentry/sentry-javascript/pull/5681 and https://github.com/getsentry/sentry-javascript/pull/5682

Please merge this in without me if I'm not available!