### PR TITLE
fix(node): Use `normalizeDepth` when creating an event from unknown input

### DIFF
--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -118,7 +118,9 @@ export class NodeClient extends BaseClient<NodeClientOptions> {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   public eventFromException(exception: any, hint?: EventHint): PromiseLike<Event> {
-    return resolvedSyncPromise(eventFromUnknownInput(this._options.stackParser, exception, hint));
+    return resolvedSyncPromise(
+      eventFromUnknownInput(this._options.stackParser, exception, hint, this._options.normalizeDepth),
+    );
   }
 
   /**

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -118,9 +118,7 @@ export class NodeClient extends BaseClient<NodeClientOptions> {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   public eventFromException(exception: any, hint?: EventHint): PromiseLike<Event> {
-    return resolvedSyncPromise(
-      eventFromUnknownInput(this._options.stackParser, exception, hint, this._options.normalizeDepth),
-    );
+    return resolvedSyncPromise(eventFromUnknownInput(this._options.stackParser, exception, hint));
   }
 
   /**

--- a/packages/node/src/eventbuilder.ts
+++ b/packages/node/src/eventbuilder.ts
@@ -46,12 +46,7 @@ export function exceptionFromError(stackParser: StackParser, error: Error): Exce
  * Builds and Event from a Exception
  * @hidden
  */
-export function eventFromUnknownInput(
-  stackParser: StackParser,
-  exception: unknown,
-  hint?: EventHint,
-  normalizeDepth?: number,
-): Event {
+export function eventFromUnknownInput(stackParser: StackParser, exception: unknown, hint?: EventHint): Event {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let ex: unknown = exception;
   const providedMechanism: Mechanism | undefined =
@@ -67,7 +62,10 @@ export function eventFromUnknownInput(
       // which is much better than creating new group when any key/value change
       const message = `Non-Error exception captured with keys: ${extractExceptionKeysForMessage(exception)}`;
 
-      getCurrentHub().configureScope(scope => {
+      const hub = getCurrentHub();
+      const client = hub.getClient();
+      const normalizeDepth = client && client.getOptions().normalizeDepth;
+      hub.configureScope(scope => {
         scope.setExtra('__serialized__', normalizeToSize(exception, normalizeDepth));
       });
 

--- a/packages/node/src/eventbuilder.ts
+++ b/packages/node/src/eventbuilder.ts
@@ -46,7 +46,12 @@ export function exceptionFromError(stackParser: StackParser, error: Error): Exce
  * Builds and Event from a Exception
  * @hidden
  */
-export function eventFromUnknownInput(stackParser: StackParser, exception: unknown, hint?: EventHint): Event {
+export function eventFromUnknownInput(
+  stackParser: StackParser,
+  exception: unknown,
+  hint?: EventHint,
+  normalizeDepth?: number,
+): Event {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let ex: unknown = exception;
   const providedMechanism: Mechanism | undefined =
@@ -63,7 +68,7 @@ export function eventFromUnknownInput(stackParser: StackParser, exception: unkno
       const message = `Non-Error exception captured with keys: ${extractExceptionKeysForMessage(exception)}`;
 
       getCurrentHub().configureScope(scope => {
-        scope.setExtra('__serialized__', normalizeToSize(exception));
+        scope.setExtra('__serialized__', normalizeToSize(exception, normalizeDepth));
       });
 
       ex = (hint && hint.syntheticException) || new Error(message);

--- a/packages/node/test/eventbuilders.test.ts
+++ b/packages/node/test/eventbuilders.test.ts
@@ -1,4 +1,5 @@
 import { Client } from '@sentry/types';
+
 import { defaultStackParser, Scope } from '../src';
 import { eventFromUnknownInput } from '../src/eventbuilder';
 
@@ -24,7 +25,7 @@ jest.mock('@sentry/hub', () => {
         getScope(): Scope {
           return new Scope();
         },
-        configureScope(scopeFunction): void {
+        configureScope(scopeFunction: (scope: Scope) => void): void {
           scopeFunction(testScope);
         },
       };

--- a/packages/node/test/eventbuilders.test.ts
+++ b/packages/node/test/eventbuilders.test.ts
@@ -1,0 +1,75 @@
+import { Client } from '@sentry/types';
+import { defaultStackParser, Scope } from '../src';
+import { eventFromUnknownInput } from '../src/eventbuilder';
+
+const testScope = new Scope();
+
+jest.mock('@sentry/hub', () => {
+  const original = jest.requireActual('@sentry/hub');
+  return {
+    ...original,
+    getCurrentHub(): {
+      getClient(): Client;
+      getScope(): Scope;
+      configureScope(scopeFunction: (scope: Scope) => void): void;
+    } {
+      return {
+        getClient(): any {
+          return {
+            getOptions(): any {
+              return { normalizeDepth: 6 };
+            },
+          };
+        },
+        getScope(): Scope {
+          return new Scope();
+        },
+        configureScope(scopeFunction): void {
+          scopeFunction(testScope);
+        },
+      };
+    },
+  };
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('eventFromUnknownInput', () => {
+  test('uses normalizeDepth from init options', () => {
+    const deepObject = {
+      a: {
+        b: {
+          c: {
+            d: {
+              e: {
+                f: {
+                  g: 'foo',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    eventFromUnknownInput(defaultStackParser, deepObject);
+
+    const serializedObject = (testScope as any)._extra.__serialized__;
+    expect(serializedObject).toBeDefined();
+    expect(serializedObject).toEqual({
+      a: {
+        b: {
+          c: {
+            d: {
+              e: {
+                f: '[Object]',
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
This PR makes use of the `normalizeDepth` init option when creating events from an unknown input. It potentially fixes #5687 where a user reported that calling `Sentry.captureException` with a deep custom object, the `normalizeDepth` isn't respected but the depth defaults to 3. 

Note: I'm not sure if this behaviour was intentional or if we have a bug. Opened this quick PR with an idea how to fix it. Since I'm gone for the next weeks, reviewer(s) please feel free to change, close or merge this PR! Was just a quick idea.
If we decide to go with this, we might want to apply the same fix to the Browser SDKs event builder.