### PR TITLE
fix(tracing): Set sample rate in transaction metadata and DSC

### DIFF
--- a/packages/tracing/src/hubextensions.ts
+++ b/packages/tracing/src/hubextensions.ts
@@ -55,7 +55,10 @@ function sample<T extends Transaction>(
   // if the user has forced a sampling decision by passing a `sampled` value in their transaction context, go with that
   if (transaction.sampled !== undefined) {
     transaction.setMetadata({
-      transactionSampling: { method: 'explicitly_set' },
+      transactionSampling: {
+        method: 'explicitly_set',
+        rate: Number(transaction.sampled),
+      },
     });
     return transaction;
   }

--- a/packages/tracing/test/hub.test.ts
+++ b/packages/tracing/test/hub.test.ts
@@ -243,7 +243,7 @@ describe('Hub', () => {
         hub.startTransaction({ name: 'dogpark', sampled: true });
 
         expect(Transaction.prototype.setMetadata).toHaveBeenCalledWith({
-          transactionSampling: { method: 'explicitly_set' },
+          transactionSampling: { method: 'explicitly_set', rate: 1.0 },
         });
       });
 


### PR DESCRIPTION
Set the `transaction.metadata.transactionSampling.rate` field to 1 or 0 depending on `transaction.sampled` (if it is defined)

Fixes #5690 