### PR TITLE
feat(browser): Use fetch `keepalive` flag

### DIFF
--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -17,6 +17,16 @@ export function makeFetchTransport(
       method: 'POST',
       referrerPolicy: 'origin',
       headers: options.headers,
+      // Outgoing requests are usually cancelled when navigating to a different page, causing a "TypeError: Failed to
+      // fetch" error and sending a "network_error" client-outcome - in Chrome, the request status shows "(cancelled)".
+      // The `keepalive` flag keeps outgoing requests alive, even when switching pages. We want this since we're
+      // frequently sending events right before the user is switching pages (eg. whenfinishing navigation transactions).
+      // Gotchas:
+      // - `keepalive` isn't supported by Firefox
+      // - As per spec (https://fetch.spec.whatwg.org/#http-network-or-cache-fetch), a request with `keepalive: true`
+      //   and a content length of > 64 kibibytes returns a network error. We will therefore only activate the flag wnen
+      //   we're below that limit.
+      keepalive: request.body.length <= 65536,
       ...options.fetchOptions,
     };
 

--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -24,7 +24,7 @@ export function makeFetchTransport(
       // Gotchas:
       // - `keepalive` isn't supported by Firefox
       // - As per spec (https://fetch.spec.whatwg.org/#http-network-or-cache-fetch), a request with `keepalive: true`
-      //   and a content length of > 64 kibibytes returns a network error. We will therefore only activate the flag wnen
+      //   and a content length of > 64 kibibytes returns a network error. We will therefore only activate the flag when
       //   we're below that limit.
       keepalive: request.body.length <= 65536,
       ...options.fetchOptions,

--- a/packages/browser/test/unit/transports/fetch.test.ts
+++ b/packages/browser/test/unit/transports/fetch.test.ts
@@ -44,6 +44,7 @@ describe('NewFetchTransport', () => {
     expect(mockFetch).toHaveBeenLastCalledWith(DEFAULT_FETCH_TRANSPORT_OPTIONS.url, {
       body: serializeEnvelope(ERROR_ENVELOPE, new TextEncoder()),
       method: 'POST',
+      keepalive: true,
       referrerPolicy: 'origin',
     });
   });
@@ -81,7 +82,7 @@ describe('NewFetchTransport', () => {
 
     const REQUEST_OPTIONS: RequestInit = {
       referrerPolicy: 'strict-origin',
-      keepalive: true,
+      keepalive: false,
       referrer: 'http://example.org',
     };
 


### PR DESCRIPTION
While working on https://github.com/getsentry/sentry-javascript/pull/5676 I noticed some navigation transactions don't show up in Sentry. I found out that when navigating between pages, Chrome cancels any outgoing requests - including requests to Sentry.

Events not being sent because of a page navigation probably happens the most with navigation transactions, since we usually finish the transaction right before we navigate (finishing happens implicitly on navigation). To requests being cancelled, we can use `fetch`'s `keepalive` flag to keep outgoing requests alive, even when we're switching pages.

https://github.com/getsentry/sentry-javascript/issues/2547 has an excellent writeup on the pros and cons of this flag. In short:
- `keepalive` isn't supported by Firefox
- As per [specification](https://fetch.spec.whatwg.org/#http-network-or-cache-fetch), a fetch request with `keepalive: true` and a content length of > 64 kibibytes returns a network error

This change definitely isn't a solution to solve this problem in 100% of the cases but it is our best effort to improve the status quo.

---

Resolves https://github.com/getsentry/sentry-javascript/issues/2547