### PR TITLE
chore: Upgrade yarn to `1.22.19`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "volta": {
     "node": "14.17.0",
-    "yarn": "1.22.5"
+    "yarn": "1.22.19"
   },
   "workspaces": [
     "packages/angular",


### PR DESCRIPTION
Remove the error message that comes with running `yarn`.
