### PR TITLE
ref(nextjs): Simplify adding default integrations when initializing SDK

### DIFF
--- a/packages/nextjs/src/index.client.ts
+++ b/packages/nextjs/src/index.client.ts
@@ -5,7 +5,7 @@ import { EventProcessor } from '@sentry/types';
 import { nextRouterInstrumentation } from './performance/client';
 import { buildMetadata } from './utils/metadata';
 import { NextjsOptions } from './utils/nextjsOptions';
-import { addIntegration, UserIntegrations } from './utils/userIntegrations';
+import { addOrUpdateIntegration, UserIntegrations } from './utils/userIntegrations';
 
 export * from '@sentry/react';
 export { nextRouterInstrumentation } from './performance/client';
@@ -57,14 +57,14 @@ export function init(options: NextjsOptions): void {
   });
 }
 
-function createClientIntegrations(integrations?: UserIntegrations): UserIntegrations {
+function createClientIntegrations(userIntegrations?: UserIntegrations): UserIntegrations {
   const defaultBrowserTracingIntegration = new BrowserTracing({
     tracingOrigins: [...defaultRequestInstrumentationOptions.tracingOrigins, /^(api\/)/],
     routingInstrumentation: nextRouterInstrumentation,
   });
 
-  if (integrations) {
-    return addIntegration(defaultBrowserTracingIntegration, integrations, {
+  if (userIntegrations) {
+    return addOrUpdateIntegration(defaultBrowserTracingIntegration, userIntegrations, {
       BrowserTracing: { keyPath: 'options.routingInstrumentation', value: nextRouterInstrumentation },
     });
   } else {

--- a/packages/nextjs/src/index.client.ts
+++ b/packages/nextjs/src/index.client.ts
@@ -57,17 +57,13 @@ export function init(options: NextjsOptions): void {
   });
 }
 
-function createClientIntegrations(userIntegrations?: UserIntegrations): UserIntegrations {
+function createClientIntegrations(userIntegrations: UserIntegrations = []): UserIntegrations {
   const defaultBrowserTracingIntegration = new BrowserTracing({
     tracingOrigins: [...defaultRequestInstrumentationOptions.tracingOrigins, /^(api\/)/],
     routingInstrumentation: nextRouterInstrumentation,
   });
 
-  if (userIntegrations) {
-    return addOrUpdateIntegration(defaultBrowserTracingIntegration, userIntegrations, {
-      BrowserTracing: { keyPath: 'options.routingInstrumentation', value: nextRouterInstrumentation },
-    });
-  } else {
-    return [defaultBrowserTracingIntegration];
-  }
+  return addOrUpdateIntegration(defaultBrowserTracingIntegration, userIntegrations, {
+    'options.routingInstrumentation': nextRouterInstrumentation,
+  });
 }

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import { isBuild } from './utils/isBuild';
 import { buildMetadata } from './utils/metadata';
 import { NextjsOptions } from './utils/nextjsOptions';
-import { addIntegration } from './utils/userIntegrations';
+import { addOrUpdateIntegration } from './utils/userIntegrations';
 
 export * from '@sentry/node';
 export { captureUnderscoreErrorException } from './utils/_error';
@@ -109,14 +109,14 @@ function addServerIntegrations(options: NextjsOptions): void {
   });
 
   if (options.integrations) {
-    options.integrations = addIntegration(defaultRewriteFramesIntegration, options.integrations);
+    options.integrations = addOrUpdateIntegration(defaultRewriteFramesIntegration, options.integrations);
   } else {
     options.integrations = [defaultRewriteFramesIntegration];
   }
 
   if (hasTracingEnabled(options)) {
     const defaultHttpTracingIntegration = new Integrations.Http({ tracing: true });
-    options.integrations = addIntegration(defaultHttpTracingIntegration, options.integrations, {
+    options.integrations = addOrUpdateIntegration(defaultHttpTracingIntegration, options.integrations, {
       Http: { keyPath: '_tracing', value: true },
     });
   }

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -93,6 +93,8 @@ function sdkAlreadyInitialized(): boolean {
 }
 
 function addServerIntegrations(options: NextjsOptions): void {
+  let integrations = options.integrations || [];
+
   // This value is injected at build time, based on the output directory specified in the build config. Though a default
   // is set there, we set it here as well, just in case something has gone wrong with the injection.
   const distDirName = (global as GlobalWithDistDir).__rewriteFramesDistDir__ || '.next';
@@ -107,19 +109,16 @@ function addServerIntegrations(options: NextjsOptions): void {
       return frame;
     },
   });
-
-  if (options.integrations) {
-    options.integrations = addOrUpdateIntegration(defaultRewriteFramesIntegration, options.integrations);
-  } else {
-    options.integrations = [defaultRewriteFramesIntegration];
-  }
+  integrations = addOrUpdateIntegration(defaultRewriteFramesIntegration, integrations);
 
   if (hasTracingEnabled(options)) {
     const defaultHttpTracingIntegration = new Integrations.Http({ tracing: true });
-    options.integrations = addOrUpdateIntegration(defaultHttpTracingIntegration, options.integrations, {
-      Http: { keyPath: '_tracing', value: true },
+    integrations = addOrUpdateIntegration(defaultHttpTracingIntegration, integrations, {
+      _tracing: true,
     });
   }
+
+  options.integrations = integrations;
 }
 
 export type { SentryWebpackPluginOptions } from './config/types';

--- a/packages/nextjs/src/utils/userIntegrations.ts
+++ b/packages/nextjs/src/utils/userIntegrations.ts
@@ -1,9 +1,9 @@
 import { Integration } from '@sentry/types';
 
-export type UserFunctionIntegrations = (integrations: Integration[]) => Integration[];
-export type UserIntegrations = Integration[] | UserFunctionIntegrations;
+export type UserIntegrationsFunction = (integrations: Integration[]) => Integration[];
+export type UserIntegrations = Integration[] | UserIntegrationsFunction;
 
-type Options = {
+type ForcedIntegrationOptions = {
   [integrationName: string]:
     | {
         keyPath: string;
@@ -25,69 +25,72 @@ type Options = {
 function setNestedKey(obj: Record<string, any>, keyPath: string, value: unknown): void {
   // Ex. foo.bar.zoop will extract foo and bar.zoop
   const match = keyPath.match(/([a-z]+)\.(.*)/i);
+  // The match will be null when there's no more recursing to do, i.e., when we've reached the right level of the object
   if (match === null) {
     obj[keyPath] = value;
   } else {
+    // `match[1]` is the initial segment of the path, and `match[2]` is the remainder of the path
     setNestedKey(obj[match[1]], match[2], value);
   }
 }
 
 /**
- * Retrieves the patched integrations with the provided integration.
+ * Enforces inclusion of a given integration with specified options in an integration array originally determined by the
+ * user, by either including the given default instance or by patching an existing user instance with the given options.
  *
- * The integration must be present in the final user integrations, and they are compared
- * by integration name. If the user has defined one, there's nothing to patch; if not,
- * the provided integration is added.
+ * Ideally this would happen when integrations are set up, but there isn't currently a mechanism there for merging
+ * options from a default integration instance with those from a user-provided instance of the same integration, only
+ * for allowing the user to override a default instance entirely. (TODO: Fix that.)
  *
- * @param integration The integration to patch, if necessary.
+ * @param defaultIntegrationInstance An instance of the integration with the correct options already set
  * @param userIntegrations Integrations defined by the user.
- * @param options options to update for a particular integration
- * @returns Final integrations, patched if necessary.
+ * @param forcedOptions Options with which to patch an existing user-derived instance on the integration.
+ * @returns A final integrations array.
  */
-export function addIntegration(
-  integration: Integration,
+export function addOrUpdateIntegration(
+  defaultIntegrationInstance: Integration,
   userIntegrations: UserIntegrations,
-  options: Options = {},
+  forcedOptions: ForcedIntegrationOptions = {},
 ): UserIntegrations {
   if (Array.isArray(userIntegrations)) {
-    return addIntegrationToArray(integration, userIntegrations, options);
+    return addOrUpdateIntegrationInArray(defaultIntegrationInstance, userIntegrations, forcedOptions);
   } else {
-    return addIntegrationToFunction(integration, userIntegrations, options);
+    return addOrUpdateIntegrationInFunction(defaultIntegrationInstance, userIntegrations, forcedOptions);
   }
 }
 
-function addIntegrationToArray(
-  integration: Integration,
+function addOrUpdateIntegrationInArray(
+  defaultIntegrationInstance: Integration,
   userIntegrations: Integration[],
-  options: Options,
+  forcedOptions: ForcedIntegrationOptions,
 ): Integration[] {
   let includesName = false;
   // eslint-disable-next-line @typescript-eslint/prefer-for-of
   for (let x = 0; x < userIntegrations.length; x++) {
-    if (userIntegrations[x].name === integration.name) {
+    if (userIntegrations[x].name === defaultIntegrationInstance.name) {
       includesName = true;
     }
 
-    const op = options[userIntegrations[x].name];
-    if (op) {
-      setNestedKey(userIntegrations[x], op.keyPath, op.value);
+    const optionToSet = forcedOptions[userIntegrations[x].name];
+    if (optionToSet) {
+      setNestedKey(userIntegrations[x], optionToSet.keyPath, optionToSet.value);
     }
   }
 
   if (includesName) {
     return userIntegrations;
   }
-  return [...userIntegrations, integration];
+  return [...userIntegrations, defaultIntegrationInstance];
 }
 
-function addIntegrationToFunction(
-  integration: Integration,
-  userIntegrationsFunc: UserFunctionIntegrations,
-  options: Options,
-): UserFunctionIntegrations {
-  const wrapper: UserFunctionIntegrations = defaultIntegrations => {
+function addOrUpdateIntegrationInFunction(
+  defaultIntegrationInstance: Integration,
+  userIntegrationsFunc: UserIntegrationsFunction,
+  forcedOptions: ForcedIntegrationOptions,
+): UserIntegrationsFunction {
+  const wrapper: UserIntegrationsFunction = defaultIntegrations => {
     const userFinalIntegrations = userIntegrationsFunc(defaultIntegrations);
-    return addIntegrationToArray(integration, userFinalIntegrations, options);
+    return addOrUpdateIntegrationInArray(defaultIntegrationInstance, userFinalIntegrations, forcedOptions);
   };
   return wrapper;
 }

--- a/packages/nextjs/src/utils/userIntegrations.ts
+++ b/packages/nextjs/src/utils/userIntegrations.ts
@@ -19,7 +19,7 @@ type ForcedIntegrationOptions = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function setNestedKey(obj: Record<string, any>, keyPath: string, value: unknown): void {
   // Ex. foo.bar.zoop will extract foo and bar.zoop
-  const match = keyPath.match(/([a-z]+)\.(.*)/i);
+  const match = keyPath.match(/([a-z_]+)\.(.*)/i);
   // The match will be null when there's no more recursing to do, i.e., when we've reached the right level of the object
   if (match === null) {
     obj[keyPath] = value;

--- a/packages/nextjs/test/utils/userIntegrations.test.ts
+++ b/packages/nextjs/test/utils/userIntegrations.test.ts
@@ -1,7 +1,7 @@
 import { RewriteFrames } from '@sentry/integrations';
 import { Integration } from '@sentry/types';
 
-import { addIntegration, UserFunctionIntegrations } from '../../src/utils/userIntegrations';
+import { addOrUpdateIntegration, UserIntegrationsFunction } from '../../src/utils/userIntegrations';
 
 const testIntegration = new RewriteFrames();
 
@@ -9,7 +9,7 @@ describe('user integrations without any integrations', () => {
   test('as an array', () => {
     const userIntegrations: Integration[] = [];
     // Should get a single integration
-    let finalIntegrations = addIntegration(testIntegration, userIntegrations);
+    let finalIntegrations = addOrUpdateIntegration(testIntegration, userIntegrations);
     expect(finalIntegrations).toBeInstanceOf(Array);
     finalIntegrations = finalIntegrations as Integration[];
     expect(finalIntegrations).toHaveLength(1);
@@ -17,11 +17,11 @@ describe('user integrations without any integrations', () => {
   });
 
   test('as a function', () => {
-    const userIntegrationFnc: UserFunctionIntegrations = (): Integration[] => [];
+    const userIntegrationFnc: UserIntegrationsFunction = (): Integration[] => [];
     // Should get a single integration
-    const integrationWrapper = addIntegration(testIntegration, userIntegrationFnc);
+    const integrationWrapper = addOrUpdateIntegration(testIntegration, userIntegrationFnc);
     expect(integrationWrapper).toBeInstanceOf(Function);
-    const finalIntegrations = (integrationWrapper as UserFunctionIntegrations)([]);
+    const finalIntegrations = (integrationWrapper as UserIntegrationsFunction)([]);
     expect(finalIntegrations).toHaveLength(1);
     expect(finalIntegrations[0]).toMatchObject(testIntegration);
   });
@@ -31,20 +31,20 @@ describe('user integrations with integrations', () => {
   test('as an array', () => {
     const userIntegrations = [new RewriteFrames()];
     // Should get the same array (with no patches)
-    const finalIntegrations = addIntegration(testIntegration, userIntegrations);
+    const finalIntegrations = addOrUpdateIntegration(testIntegration, userIntegrations);
     expect(finalIntegrations).toMatchObject(userIntegrations);
   });
 
   test('as a function', () => {
     const userIntegrations = [new RewriteFrames()];
-    const integrationsFnc: UserFunctionIntegrations = (_integrations: Integration[]): Integration[] => {
+    const integrationsFnc: UserIntegrationsFunction = (_integrations: Integration[]): Integration[] => {
       return userIntegrations;
     };
     // Should get a function that returns the test integration
-    let finalIntegrations = addIntegration(testIntegration, integrationsFnc);
+    let finalIntegrations = addOrUpdateIntegration(testIntegration, integrationsFnc);
     expect(typeof finalIntegrations === 'function').toBe(true);
     expect(finalIntegrations).toBeInstanceOf(Function);
-    finalIntegrations = finalIntegrations as UserFunctionIntegrations;
+    finalIntegrations = finalIntegrations as UserIntegrationsFunction;
     expect(finalIntegrations([])).toMatchObject(userIntegrations);
   });
 });


### PR DESCRIPTION
While working on adding a `RequestData` integration to the nextjs SDK, I found that the functions we use to set default integrations in the SDK were a little hard to parse, primarily because of a docstring that didn't make any sense and vague and/or slightly inaccurate function and variable names. We also have been making things more complicated than necessary, in that

a) The existing functions in `utils/userIntegrations.ts` use the given default integration instance if no user instance is found. Meanwhile, the two index files do the same in the case that no user integrations are provided at all. But those two conditions aren't logically independent, so by simply providing a default (empty) value for the second case, we can rely on the first check to ensure the default instance is used. (See the now-removed `if (options.integrations)` check in both of the index files.)

b) The options we want to force onto any user instance we find have been living in a nested object which really doesn’t need to be nested. (See the `Options` - now `ForcedIntegrationOptions` - type in `utils/userIntegrations.ts`.)

c) We've essentially been manually implementing `Array.find`, which there's no reason for us to do. (See the `for`-loop in `addIntegrationToArray` - now `addOrUpdateIntegrationInArray` - in `utils/userIntegrations.ts`.)

This fixes those problems, rewrites the docstring, and renames a bunch of variables. It also

- Reorganizes the tests testing the adding of default integrations and refactors them to stop depending on the order or size of the eventual `integrations` array when testing an individual integration type.
- Fixes a small regex bug in `setNestedKey`.

For ease of reviewing, the docstring/renaming changes have been separated into a separate commit from the logic changes, test reorg, and bugfix.