### PR TITLE
fix(browser): Use `normalizeDepth` option when creating an event from a plain object

### DIFF
--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -1,3 +1,4 @@
+import { getCurrentHub } from '@sentry/core';
 import { Event, EventHint, Exception, Severity, SeverityLevel, StackFrame, StackParser } from '@sentry/types';
 import {
   addExceptionMechanism,
@@ -45,6 +46,10 @@ export function eventFromPlainObject(
   syntheticException?: Error,
   isUnhandledRejection?: boolean,
 ): Event {
+  const hub = getCurrentHub();
+  const client = hub.getClient();
+  const normalizeDepth = client && client.getOptions().normalizeDepth;
+
   const event: Event = {
     exception: {
       values: [
@@ -57,7 +62,7 @@ export function eventFromPlainObject(
       ],
     },
     extra: {
-      __serialized__: normalizeToSize(exception),
+      __serialized__: normalizeToSize(exception, normalizeDepth),
     },
   };
 

--- a/packages/browser/test/unit/eventbuilder.test.ts
+++ b/packages/browser/test/unit/eventbuilder.test.ts
@@ -3,8 +3,8 @@ import { Client } from '@sentry/types';
 import { defaultStackParser } from '../../src';
 import { eventFromPlainObject } from '../../src/eventbuilder';
 
-jest.mock('@sentry/hub', () => {
-  const original = jest.requireActual('@sentry/hub');
+jest.mock('@sentry/core', () => {
+  const original = jest.requireActual('@sentry/core');
   return {
     ...original,
     getCurrentHub(): {

--- a/packages/browser/test/unit/eventbuilder.test.ts
+++ b/packages/browser/test/unit/eventbuilder.test.ts
@@ -1,0 +1,64 @@
+import { Client } from '@sentry/types';
+
+import { defaultStackParser } from '../../src';
+import { eventFromPlainObject } from '../../src/eventbuilder';
+
+jest.mock('@sentry/hub', () => {
+  const original = jest.requireActual('@sentry/hub');
+  return {
+    ...original,
+    getCurrentHub(): {
+      getClient(): Client;
+    } {
+      return {
+        getClient(): any {
+          return {
+            getOptions(): any {
+              return { normalizeDepth: 6 };
+            },
+          };
+        },
+      };
+    },
+  };
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('eventFromPlainObject', () => {
+  it('should use normalizeDepth from init options', () => {
+    const deepObject = {
+      a: {
+        b: {
+          c: {
+            d: {
+              e: {
+                f: {
+                  g: 'foo',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const event = eventFromPlainObject(defaultStackParser, deepObject);
+
+    expect(event?.extra?.__serialized__).toEqual({
+      a: {
+        b: {
+          c: {
+            d: {
+              e: {
+                f: '[Object]',
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
Analogous change to https://github.com/getsentry/sentry-javascript/pull/5689

Raised by https://github.com/getsentry/sentry-javascript/pull/5689#issuecomment-1238699465
