### PR TITLE
feat(node): Add Modules integration to default integrations

### DIFF
--- a/packages/node/src/integrations/modules.ts
+++ b/packages/node/src/integrations/modules.ts
@@ -87,7 +87,10 @@ export class Modules implements Integration {
       }
       return {
         ...event,
-        modules: this._getModules(),
+        modules: {
+          ...event.modules,
+          ...this._getModules(),
+        },
       };
     });
   }

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -24,6 +24,7 @@ import {
   ContextLines,
   Http,
   LinkedErrors,
+  Modules,
   OnUncaughtException,
   OnUnhandledRejection,
 } from './integrations';
@@ -35,16 +36,18 @@ export const defaultIntegrations = [
   // Common
   new CoreIntegrations.InboundFilters(),
   new CoreIntegrations.FunctionToString(),
-  new ContextLines(),
   // Native Wrappers
   new Console(),
   new Http(),
   // Global Handlers
   new OnUncaughtException(),
   new OnUnhandledRejection(),
+  // Event Info
+  new ContextLines(),
+  new Context(),
+  new Modules(),
   // Misc
   new LinkedErrors(),
-  new Context(),
 ];
 
 /**


### PR DESCRIPTION
Start adding module information to NodeJS events. This is important so we can start understanding what kind of packages people use, and better inform strategies around future integration development + opentelemetry.