### PR TITLE
chore(nextjs): Suppress warning message about `hideSourceMaps` option in tests

### DIFF
--- a/packages/nextjs/test/config/mocks.ts
+++ b/packages/nextjs/test/config/mocks.ts
@@ -54,3 +54,18 @@ export const mkdtempSyncSpy = jest.spyOn(fs, 'mkdtempSync');
 afterEach(() => {
   mkdtempSyncSpy.mockClear();
 });
+
+// TODO (v8): This shouldn't be necessary once `hideSourceMaps` gets a default value, even for the updated error message
+// eslint-disable-next-line @typescript-eslint/unbound-method
+const realConsoleWarn = global.console.warn;
+global.console.warn = (...args: unknown[]) => {
+  // Suppress the warning message about the `hideSourceMaps` option. This is better than forcing a value for
+  // `hideSourceMaps` because that would mean we couldn't test it easily and would muddy the waters of other tests. Note
+  // that doing this here, as a side effect, only works because the tests which trigger this warning are the same tests
+  // which need other mocks from this file.
+  if (typeof args[0] === 'string' && args[0].includes('your original code may be visible in browser devtools')) {
+    return;
+  }
+
+  return realConsoleWarn(...args);
+};

--- a/packages/nextjs/test/integration/next.config.js
+++ b/packages/nextjs/test/integration/next.config.js
@@ -6,6 +6,9 @@ const moduleExports = {
   },
   sentry: {
     experiments: { autoWrapDataFetchers: true },
+    // Suppress the warning message from `handleSourcemapHidingOptionWarning` in `src/config/webpack.ts`
+    // TODO (v8): This can come out in v8, because this option will get a default value
+    hideSourceMaps: false,
   },
 };
 const SentryWebpackPluginOptions = {

--- a/packages/nextjs/test/integration/next10.config.template
+++ b/packages/nextjs/test/integration/next10.config.template
@@ -7,6 +7,9 @@ const moduleExports = {
   },
   sentry: {
     experiments: { autoWrapDataFetchers: true },
+    // Suppress the warning message from `handleSourcemapHidingOptionWarning` in `src/config/webpack.ts`
+    // TODO (v8): This can come out in v8, because this option will get a default value
+    hideSourceMaps: false,
   },
 };
 

--- a/packages/nextjs/test/integration/next11.config.template
+++ b/packages/nextjs/test/integration/next11.config.template
@@ -8,6 +8,9 @@ const moduleExports = {
   },
   sentry: {
     experiments: { autoWrapDataFetchers: true },
+    // Suppress the warning message from `handleSourcemapHidingOptionWarning` in `src/config/webpack.ts`
+    // TODO (v8): This can come out in v8, because this option will get a default value
+    hideSourceMaps: false,
   },
 };
 


### PR DESCRIPTION
The warning added in https://github.com/getsentry/sentry-javascript/pull/5649 isn't relevant to our overall nextjs test suite. This therefore suppresses it in both unit and integration tests.