### PR TITLE
draft: Add metadata around transaction name changes

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -671,7 +671,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
                 name: processedEvent.transaction,
                 source,
                 timestamp: timestampInSeconds(),
-                propagations: transactionInfo.num_propagations,
+                propagations: transactionInfo.propagations,
               },
             ],
           };

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -29,7 +29,6 @@ import {
   isThenable,
   logger,
   SyncPromise,
-  timestampWithMs,
 } from '@sentry/utils';
 
 import { updateSession } from './session';

--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -29,6 +29,7 @@ import {
   isThenable,
   logger,
   SyncPromise,
+  timestampWithMs,
 } from '@sentry/utils';
 
 import { updateSession } from './session';

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -187,7 +187,7 @@ function _createWrappedRequestMethodFactory(
           if (tracingEnabled && span) {
             const transaction = span.transaction;
             if (transaction) {
-              transaction.metadata.numPropagations += 1;
+              transaction.metadata.propagations += 1;
             }
 
             if (res.statusCode) {

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -185,6 +185,11 @@ function _createWrappedRequestMethodFactory(
             addRequestBreadcrumb('response', requestUrl, req, res);
           }
           if (tracingEnabled && span) {
+            const transaction = span.transaction;
+            if (transaction) {
+              transaction.metadata.numPropagations += 1;
+            }
+
             if (res.statusCode) {
               span.setHttpStatus(res.statusCode);
             }

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -199,7 +199,7 @@ export function fetchCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const options = (handlerData.args[1] = (handlerData.args[1] as { [key: string]: any }) || {});
     options.headers = addTracingHeaders(request, activeTransaction.getBaggage(), span, options);
-    activeTransaction.metadata.numPropagations += 1;
+    activeTransaction.metadata.propagations += 1;
   }
 }
 
@@ -305,7 +305,7 @@ export function xhrCallback(
           BAGGAGE_HEADER_NAME,
           mergeAndSerializeBaggage(activeTransaction.getBaggage(), headerBaggageString),
         );
-        activeTransaction.metadata.numPropagations += 1;
+        activeTransaction.metadata.propagations += 1;
       } catch (_) {
         // Error: InvalidStateError: Failed to execute 'setRequestHeader' on 'XMLHttpRequest': The object's state must be OPENED.
       }

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -199,6 +199,7 @@ export function fetchCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const options = (handlerData.args[1] = (handlerData.args[1] as { [key: string]: any }) || {});
     options.headers = addTracingHeaders(request, activeTransaction.getBaggage(), span, options);
+    activeTransaction.metadata.numPropagations += 1;
   }
 }
 
@@ -304,6 +305,7 @@ export function xhrCallback(
           BAGGAGE_HEADER_NAME,
           mergeAndSerializeBaggage(activeTransaction.getBaggage(), headerBaggageString),
         );
+        activeTransaction.metadata.numPropagations += 1;
       } catch (_) {
         // Error: InvalidStateError: Failed to execute 'setRequestHeader' on 'XMLHttpRequest': The object's state must be OPENED.
       }

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -27,7 +27,7 @@ export { BrowserTracing, BROWSER_TRACING_INTEGRATION_ID } from './browser';
 export { Span, spanStatusfromHttpCode } from './span';
 // eslint-disable-next-line deprecation/deprecation
 export { SpanStatus } from './spanstatus';
-export { Transaction } from './transaction';
+export { Transaction, generateTransactionNameChange } from './transaction';
 export { instrumentOutgoingRequests, defaultRequestInstrumentationOptions } from './browser';
 export { IdleTransaction } from './idletransaction';
 export { startIdleTransaction } from './hubextensions';

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -55,7 +55,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
       ...transactionContext.metadata,
       spanMetadata: {},
       nameChanges: [],
-      numPropagations: 0,
+      propagations: 0,
     };
 
     this._trimEnd = transactionContext.trimEnd;
@@ -74,7 +74,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
     this._name = newName;
     const source = 'custom';
     this.metadata.source = source;
-    this.metadata.nameChanges.push(generateTransactionNameChange(source, this.metadata.numPropagations));
+    this.metadata.nameChanges.push(generateTransactionNameChange(source, this.metadata.propagations));
   }
 
   /**
@@ -83,7 +83,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
   public setName(name: string, source: TransactionMetadata['source'] = 'custom'): void {
     this.name = name;
     this.metadata.source = source;
-    this.metadata.nameChanges.push(generateTransactionNameChange(source, this.metadata.numPropagations));
+    this.metadata.nameChanges.push(generateTransactionNameChange(source, this.metadata.propagations));
   }
 
   /**
@@ -171,7 +171,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
         transaction_info: {
           source: metadata.source,
           name_changes: metadata.nameChanges,
-          num_propagations: metadata.numPropagations,
+          propagations: metadata.propagations,
         },
       }),
     };

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -74,7 +74,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
     this._name = newName;
     const source = 'custom';
     this.metadata.source = source;
-    this.metadata.nameChanges.push(generateTransactionNameChange(newName, source, this.metadata.numPropagations));
+    this.metadata.nameChanges.push(generateTransactionNameChange(source, this.metadata.numPropagations));
   }
 
   /**
@@ -83,7 +83,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
   public setName(name: string, source: TransactionMetadata['source'] = 'custom'): void {
     this.name = name;
     this.metadata.source = source;
-    this.metadata.nameChanges.push(generateTransactionNameChange(name, source, this.metadata.numPropagations));
+    this.metadata.nameChanges.push(generateTransactionNameChange(source, this.metadata.numPropagations));
   }
 
   /**
@@ -291,13 +291,8 @@ export class Transaction extends SpanClass implements TransactionInterface {
 }
 
 /** Generate objects representing a transaction name change */
-export function generateTransactionNameChange(
-  name: string,
-  source: TransactionSource,
-  propagations: number,
-): TransactionNameChange {
+export function generateTransactionNameChange(source: TransactionSource, propagations: number): TransactionNameChange {
   return {
-    name,
     source,
     timestamp: timestampWithMs(),
     propagations,

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -11,7 +11,7 @@ import { CaptureContext } from './scope';
 import { SdkInfo } from './sdkinfo';
 import { Severity, SeverityLevel } from './severity';
 import { Span } from './span';
-import { TransactionSource } from './transaction';
+import { TransactionNameChange, TransactionSource } from './transaction';
 import { User } from './user';
 
 /** JSDoc */
@@ -49,6 +49,9 @@ export interface Event {
   sdkProcessingMetadata?: { [key: string]: any };
   transaction_info?: {
     source: TransactionSource;
+    name_changes: TransactionNameChange[];
+    // The total number of propagations that happened
+    num_propagations: number;
   };
 }
 

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -51,7 +51,7 @@ export interface Event {
     source: TransactionSource;
     name_changes: TransactionNameChange[];
     // The total number of propagations that happened
-    num_propagations: number;
+    propagations: number;
   };
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -73,6 +73,7 @@ export type {
   TransactionMetadata,
   TransactionSamplingMethod,
   TransactionSource,
+  TransactionNameChange,
 } from './transaction';
 export type {
   DurationUnit,

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -150,6 +150,12 @@ export interface TransactionMetadata {
 
   /** Metadata for the transaction's spans, keyed by spanId */
   spanMetadata: { [spanId: string]: { [key: string]: unknown } };
+
+  /** Metadata representing information about transaction name changes  */
+  nameChanges: TransactionNameChange[];
+
+  /** The total number of propagations that happened */
+  numPropagations: number;
 }
 
 /**
@@ -169,3 +175,17 @@ export type TransactionSource =
   | 'component'
   /** Name of a background task (e.g. a Celery task) */
   | 'task';
+
+/**
+ * Object representing metadata about when a transaction name was changed.
+ */
+export interface TransactionNameChange {
+  // new name
+  name: string;
+  // unix timestamp when the name was changed
+  timestamp: number;
+  // new source
+  source: TransactionSource;
+  // number of propagations since start of transaction.
+  propagations: number;
+}

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -155,7 +155,7 @@ export interface TransactionMetadata {
   nameChanges: TransactionNameChange[];
 
   /** The total number of propagations that happened */
-  numPropagations: number;
+  propagations: number;
 }
 
 /**

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -180,8 +180,6 @@ export type TransactionSource =
  * Object representing metadata about when a transaction name was changed.
  */
 export interface TransactionNameChange {
-  // new name
-  name: string;
   // unix timestamp when the name was changed
   timestamp: number;
   // new source


### PR DESCRIPTION
This is a draft PR that adds metadata around transaction name changes for https://github.com/getsentry/sentry-javascript/issues/5679. It's mainly being used to get feedback around the data being sent, and the general approach being used.

If folks are fine with this, I'll split this up into smaller PRs with test changes.

The schema looks like this:

```ts
/**
 * Object representing metadata about when a transaction name was changed.
 */
export interface TransactionNameChange {
  // new name
  name: string;
  // unix timestamp when the name was changed
  timestamp: number;
  // new source
  source: TransactionSource;
  // number of propagations since start of transaction.
  propagations: number;
}
```

In addition to an array of these transaction name changes, we also store the total amount of propagations, which should help understand the relative nature of the propagations.