### PR TITLE
fix(tests): Limit Remix server integration test stacktrace length.

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -66,7 +66,7 @@
     "test:integration:clean": "(cd test/integration && rimraf .cache node_modules build)",
     "test:integration:client": "yarn playwright install-deps && yarn playwright test test/integration/test/client/",
     "test:integration:client:ci": "yarn test:integration:client --browser='all' --reporter='line'",
-    "test:integration:server": "jest --config=test/integration/jest.config.js test/integration/test/server/",
+    "test:integration:server": "export NODE_OPTIONS='--stack-trace-limit=25' && jest --config=test/integration/jest.config.js test/integration/test/server/",
     "test:unit": "jest",
     "test:watch": "jest --watch"
   },

--- a/packages/remix/test/integration/test/server/action.test.ts
+++ b/packages/remix/test/integration/test/server/action.test.ts
@@ -37,12 +37,15 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
     const env = await RemixTestEnv.init(adapter);
     const url = `${env.url}/action-json-response/-1`;
 
-    const [transaction, event] = await env.getMultipleEnvelopeRequest({
+    const envelopes = await env.getMultipleEnvelopeRequest({
       url,
       count: 2,
       method: 'post',
       envelopeType: ['transaction', 'event'],
     });
+
+    const [transaction] = envelopes.filter(envelope => envelope[1].type === 'transaction');
+    const [event] = envelopes.filter(envelope => envelope[1].type === 'event');
 
     assertSentryTransaction(transaction[2], {
       contexts: {
@@ -79,12 +82,15 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
     const env = await RemixTestEnv.init(adapter);
     const url = `${env.url}/action-json-response/-2`;
 
-    const [transaction_1, event, transaction_2] = await env.getMultipleEnvelopeRequest({
+    const envelopes = await env.getMultipleEnvelopeRequest({
       url,
       count: 3,
       method: 'post',
       envelopeType: ['transaction', 'event'],
     });
+
+    const [transaction_1, transaction_2] = envelopes.filter(envelope => envelope[1].type === 'transaction');
+    const [event] = envelopes.filter(envelope => envelope[1].type === 'event');
 
     assertSentryTransaction(transaction_1[2], {
       contexts: {

--- a/packages/remix/test/integration/test/server/loader.test.ts
+++ b/packages/remix/test/integration/test/server/loader.test.ts
@@ -77,11 +77,14 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
     const env = await RemixTestEnv.init(adapter);
     const url = `${env.url}/loader-json-response/-1`;
 
-    const [transaction_1, event, transaction_2] = await env.getMultipleEnvelopeRequest({
+    const envelopes = await env.getMultipleEnvelopeRequest({
       url,
       count: 3,
       envelopeType: ['transaction', 'event'],
     });
+
+    const [transaction_1, transaction_2] = envelopes.filter(envelope => envelope[1].type === 'transaction');
+    const [event] = envelopes.filter(envelope => envelope[1].type === 'event');
 
     assertSentryTransaction(transaction_1[2], {
       contexts: {


### PR DESCRIPTION
Related: https://github.com/getsentry/sentry-javascript/pull/5650

~Updated Remix server-side SDK to use the message of the thrown error instead of the whole object, when the error is not a response.~

Limited maximum stacktrace length for Remix server-side integration tests.

Also updated tests to filter by type and separate consecutive multi-type envelopes, and not to trust the capturing order.