### PR TITLE
feat(types): Add `TransactionNameChange` interface

### DIFF
--- a/packages/nextjs/test/integration/test/server/tracing200.js
+++ b/packages/nextjs/test/integration/test/server/tracing200.js
@@ -18,6 +18,8 @@ module.exports = async ({ url: urlBase, argv }) => {
       transaction: 'GET /api/users',
       transaction_info: {
         source: 'route',
+        name_changes: [],
+        propagations: 0,
       },
       type: 'transaction',
       request: {

--- a/packages/nextjs/test/integration/test/server/tracing200.js
+++ b/packages/nextjs/test/integration/test/server/tracing200.js
@@ -18,7 +18,7 @@ module.exports = async ({ url: urlBase, argv }) => {
       transaction: 'GET /api/users',
       transaction_info: {
         source: 'route',
-        name_changes: [],
+        changes: [],
         propagations: 0,
       },
       type: 'transaction',

--- a/packages/nextjs/test/integration/test/server/tracing500.js
+++ b/packages/nextjs/test/integration/test/server/tracing500.js
@@ -17,7 +17,7 @@ module.exports = async ({ url: urlBase, argv }) => {
       transaction: 'GET /api/broken',
       transaction_info: {
         source: 'route',
-        name_changes: [],
+        changes: [],
         propagations: 0,
       },
       type: 'transaction',

--- a/packages/nextjs/test/integration/test/server/tracing500.js
+++ b/packages/nextjs/test/integration/test/server/tracing500.js
@@ -17,6 +17,8 @@ module.exports = async ({ url: urlBase, argv }) => {
       transaction: 'GET /api/broken',
       transaction_info: {
         source: 'route',
+        name_changes: [],
+        propagations: 0,
       },
       type: 'transaction',
       request: {

--- a/packages/nextjs/test/integration/test/server/tracingHttp.js
+++ b/packages/nextjs/test/integration/test/server/tracingHttp.js
@@ -31,6 +31,8 @@ module.exports = async ({ url: urlBase, argv }) => {
       transaction: 'GET /api/http',
       transaction_info: {
         source: 'route',
+        name_changes: [],
+        propagations: 0,
       },
       type: 'transaction',
       request: {

--- a/packages/nextjs/test/integration/test/server/tracingHttp.js
+++ b/packages/nextjs/test/integration/test/server/tracingHttp.js
@@ -31,7 +31,7 @@ module.exports = async ({ url: urlBase, argv }) => {
       transaction: 'GET /api/http',
       transaction_info: {
         source: 'route',
-        name_changes: [],
+        changes: [],
         propagations: 0,
       },
       type: 'transaction',

--- a/packages/nextjs/test/integration/test/server/tracingServerGetInitialProps.js
+++ b/packages/nextjs/test/integration/test/server/tracingServerGetInitialProps.js
@@ -16,6 +16,8 @@ module.exports = async ({ url: urlBase, argv }) => {
       transaction: '/[id]/withInitialProps',
       transaction_info: {
         source: 'route',
+        name_changes: [],
+        propagations: 0,
       },
       type: 'transaction',
       request: {

--- a/packages/nextjs/test/integration/test/server/tracingServerGetInitialProps.js
+++ b/packages/nextjs/test/integration/test/server/tracingServerGetInitialProps.js
@@ -16,7 +16,7 @@ module.exports = async ({ url: urlBase, argv }) => {
       transaction: '/[id]/withInitialProps',
       transaction_info: {
         source: 'route',
-        name_changes: [],
+        changes: [],
         propagations: 0,
       },
       type: 'transaction',

--- a/packages/nextjs/test/integration/test/server/tracingServerGetServerSideProps.js
+++ b/packages/nextjs/test/integration/test/server/tracingServerGetServerSideProps.js
@@ -16,7 +16,7 @@ module.exports = async ({ url: urlBase, argv }) => {
       transaction: '/[id]/withServerSideProps',
       transaction_info: {
         source: 'route',
-        name_changes: [],
+        changes: [],
         propagations: 0,
       },
       type: 'transaction',

--- a/packages/nextjs/test/integration/test/server/tracingServerGetServerSideProps.js
+++ b/packages/nextjs/test/integration/test/server/tracingServerGetServerSideProps.js
@@ -16,6 +16,8 @@ module.exports = async ({ url: urlBase, argv }) => {
       transaction: '/[id]/withServerSideProps',
       transaction_info: {
         source: 'route',
+        name_changes: [],
+        propagations: 0,
       },
       type: 'transaction',
       request: {

--- a/packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/packages/node-integration-tests/suites/express/tracing/test.ts
@@ -38,6 +38,8 @@ test('should set a correct transaction name for routes specified in RegEx', asyn
     transaction: 'GET /\\/test\\/regex/',
     transaction_info: {
       source: 'route',
+      name_changes: [],
+      propagations: 0,
     },
     contexts: {
       trace: {
@@ -66,6 +68,8 @@ test.each([['array1'], ['array5']])(
       transaction: 'GET /test/array1,/\\/test\\/array[2-9]',
       transaction_info: {
         source: 'route',
+        name_changes: [],
+        propagations: 0,
       },
       contexts: {
         trace: {
@@ -102,6 +106,8 @@ test.each([
     transaction: 'GET /test/arr/:id,/\\/test\\/arr[0-9]*\\/required(path)?(\\/optionalPath)?\\/(lastParam)?',
     transaction_info: {
       source: 'route',
+      name_changes: [],
+      propagations: 0,
     },
     contexts: {
       trace: {

--- a/packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/packages/node-integration-tests/suites/express/tracing/test.ts
@@ -38,7 +38,7 @@ test('should set a correct transaction name for routes specified in RegEx', asyn
     transaction: 'GET /\\/test\\/regex/',
     transaction_info: {
       source: 'route',
-      name_changes: [],
+      changes: [],
       propagations: 0,
     },
     contexts: {
@@ -68,7 +68,7 @@ test.each([['array1'], ['array5']])(
       transaction: 'GET /test/array1,/\\/test\\/array[2-9]',
       transaction_info: {
         source: 'route',
-        name_changes: [],
+        changes: [],
         propagations: 0,
       },
       contexts: {
@@ -106,7 +106,7 @@ test.each([
     transaction: 'GET /test/arr/:id,/\\/test\\/arr[0-9]*\\/required(path)?(\\/optionalPath)?\\/(lastParam)?',
     transaction_info: {
       source: 'route',
-      name_changes: [],
+      changes: [],
       propagations: 0,
     },
     contexts: {

--- a/packages/remix/test/integration/test/server/loader.test.ts
+++ b/packages/remix/test/integration/test/server/loader.test.ts
@@ -55,7 +55,7 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
       transaction: 'routes/loader-json-response/$id',
       transaction_info: {
         source: 'route',
-        name_changes: [],
+        changes: [],
         propagations: 0,
       },
       spans: [

--- a/packages/remix/test/integration/test/server/loader.test.ts
+++ b/packages/remix/test/integration/test/server/loader.test.ts
@@ -55,6 +55,8 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
       transaction: 'routes/loader-json-response/$id',
       transaction_info: {
         source: 'route',
+        name_changes: [],
+        propagations: 0,
       },
       spans: [
         {

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -45,6 +45,8 @@ export class Transaction extends SpanClass implements TransactionInterface {
     this.metadata = {
       ...transactionContext.metadata,
       spanMetadata: {},
+      nameChanges: [],
+      propagations: 0,
     };
 
     this._trimEnd = transactionContext.trimEnd;
@@ -156,6 +158,8 @@ export class Transaction extends SpanClass implements TransactionInterface {
       ...(metadata.source && {
         transaction_info: {
           source: metadata.source,
+          name_changes: metadata.nameChanges,
+          propagations: metadata.propagations,
         },
       }),
     };

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -158,7 +158,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
       ...(metadata.source && {
         transaction_info: {
           source: metadata.source,
-          name_changes: metadata.nameChanges,
+          changes: metadata.nameChanges,
           propagations: metadata.propagations,
         },
       }),

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -45,7 +45,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
     this.metadata = {
       ...transactionContext.metadata,
       spanMetadata: {},
-      nameChanges: [],
+      changes: [],
       propagations: 0,
     };
 
@@ -158,7 +158,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
       ...(metadata.source && {
         transaction_info: {
           source: metadata.source,
-          changes: metadata.nameChanges,
+          changes: metadata.changes,
           propagations: metadata.propagations,
         },
       }),

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -503,7 +503,7 @@ describe('Span', () => {
         expect.not.objectContaining({
           transaction_info: {
             source: expect.any(String),
-            name_changes: [],
+            changes: [],
             propagations: 0,
           },
         }),
@@ -524,7 +524,7 @@ describe('Span', () => {
         expect.objectContaining({
           transaction_info: {
             source: 'url',
-            name_changes: [],
+            changes: [],
             propagations: 0,
           },
         }),

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -503,6 +503,8 @@ describe('Span', () => {
         expect.not.objectContaining({
           transaction_info: {
             source: expect.any(String),
+            name_changes: [],
+            propagations: 0,
           },
         }),
       );
@@ -522,6 +524,8 @@ describe('Span', () => {
         expect.objectContaining({
           transaction_info: {
             source: 'url',
+            name_changes: [],
+            propagations: 0,
           },
         }),
       );

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -11,7 +11,7 @@ import { CaptureContext } from './scope';
 import { SdkInfo } from './sdkinfo';
 import { Severity, SeverityLevel } from './severity';
 import { Span } from './span';
-import { TransactionSource } from './transaction';
+import { TransactionNameChange, TransactionSource } from './transaction';
 import { User } from './user';
 
 /** JSDoc */
@@ -49,6 +49,8 @@ export interface Event {
   sdkProcessingMetadata?: { [key: string]: any };
   transaction_info?: {
     source: TransactionSource;
+    name_changes: TransactionNameChange[];
+    propagations: number;
   };
 }
 

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -49,7 +49,7 @@ export interface Event {
   sdkProcessingMetadata?: { [key: string]: any };
   transaction_info?: {
     source: TransactionSource;
-    name_changes: TransactionNameChange[];
+    changes: TransactionNameChange[];
     propagations: number;
   };
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -73,6 +73,7 @@ export type {
   TransactionMetadata,
   TransactionSamplingMethod,
   TransactionSource,
+  TransactionNameChange,
 } from './transaction';
 export type {
   DurationUnit,

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -150,6 +150,12 @@ export interface TransactionMetadata {
 
   /** Metadata for the transaction's spans, keyed by spanId */
   spanMetadata: { [spanId: string]: { [key: string]: unknown } };
+
+  /** Metadata representing information about transaction name changes  */
+  nameChanges: TransactionNameChange[];
+
+  /** The total number of propagations that happened */
+  propagations: number;
 }
 
 /**
@@ -169,3 +175,20 @@ export type TransactionSource =
   | 'component'
   /** Name of a background task (e.g. a Celery task) */
   | 'task';
+
+/**
+ * Object representing metadata about when a transaction name was changed.
+ */
+export interface TransactionNameChange {
+  /**
+   * Unix timestamp when the name was changed. Same type as the start and
+   * end timestamps of a transaction and span.
+   */
+  timestamp: number;
+
+  /** New source applied for transaction name change */
+  source: TransactionSource;
+
+  /** Number of propagations since start of transaction */
+  propagations: number;
+}

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -152,7 +152,7 @@ export interface TransactionMetadata {
   spanMetadata: { [spanId: string]: { [key: string]: unknown } };
 
   /** Metadata representing information about transaction name changes  */
-  nameChanges: TransactionNameChange[];
+  changes: TransactionNameChange[];
 
   /** The total number of propagations that happened */
   propagations: number;


### PR DESCRIPTION
Part of https://github.com/getsentry/sentry-javascript/issues/5679

This PR adds types for the `TransactionNameChange` interface:

```ts
export interface TransactionInfo {
    source: TransactionSource;
    changes: TransactionNameChange[];
    propagations: number;
};

/**
 * Object representing metadata about when a transaction name was changed.
 */
export interface TransactionNameChange {
  /**
   * Unix timestamp when the name was changed. Same type as the start and
   * end timestamps of a transaction and span.
   */
  timestamp: number;

  /** New source applied for transaction name change */
  source: TransactionSource;

  /** Number of propagations since start of transaction */
  propagations: number;
}
```

`TransactionNameChange` is an object that describes a point in time when a transaction name was changed. It contains a Unix timestamp (matching with span/transaction start/end timestamps), the transaction source for the changed name, and the number of propagations (when dynamic sampling context was sent to another SDK - through meta tag/http header) that happened since that transaction name change.

 Next steps are described in https://github.com/getsentry/sentry-javascript/issues/5679.