### PR TITLE
test: Fix node integration tests sharing SDK initializations

### DIFF
--- a/packages/node-integration-tests/jest.config.js
+++ b/packages/node-integration-tests/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   globalSetup: '<rootDir>/utils/setup-tests.ts',
   ...baseConfig,
   testMatch: ['**/test.ts'],
+  setupFilesAfterEnv: ['./jest.setup.js'],
 };

--- a/packages/node-integration-tests/jest.setup.js
+++ b/packages/node-integration-tests/jest.setup.js
@@ -1,0 +1,2 @@
+// Increases test timeout from 5s to 45s
+jest.setTimeout(45000);

--- a/packages/node-integration-tests/package.json
+++ b/packages/node-integration-tests/package.json
@@ -17,7 +17,7 @@
     "fix:prettier": "prettier --write \"{suites,utils}/**/*.ts\"",
     "type-check": "tsc",
     "pretest": "run-s --silent prisma:init",
-    "test": "jest",
+    "test": "jest --forceExit",
     "test:watch": "yarn test --watch"
   },
   "dependencies": {

--- a/packages/node-integration-tests/package.json
+++ b/packages/node-integration-tests/package.json
@@ -17,7 +17,7 @@
     "fix:prettier": "prettier --write \"{suites,utils}/**/*.ts\"",
     "type-check": "tsc",
     "pretest": "run-s --silent prisma:init",
-    "test": "jest --runInBand --forceExit",
+    "test": "jest",
     "test:watch": "yarn test --watch"
   },
   "dependencies": {

--- a/packages/node-integration-tests/utils/index.ts
+++ b/packages/node-integration-tests/utils/index.ts
@@ -137,11 +137,9 @@ export class TestEnv {
    * @return {*}  {Promise<string>}
    */
   public static async init(testDir: string, serverPath?: string, scenarioPath?: string): Promise<TestEnv> {
-    const port = await getPortPromise();
-    const url = `http://localhost:${port}/test`;
     const defaultServerPath = path.resolve(process.cwd(), 'utils', 'defaults', 'server');
 
-    const server = await new Promise<http.Server>(resolve => {
+    const [server, url] = await new Promise<[http.Server, string]>(resolve => {
       // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-member-access
       const app = require(serverPath || defaultServerPath).default as Express;
 
@@ -153,8 +151,11 @@ export class TestEnv {
         }
       });
 
-      const server = app.listen(port, () => {
-        resolve(server);
+      void getPortPromise().then(port => {
+        const url = `http://localhost:${port}/test`;
+        const server = app.listen(port, () => {
+          resolve([server, url]);
+        });
       });
     });
 


### PR DESCRIPTION
While working on baggage changes and running the Node.js integration tests, I noticed that integrations were set up N times where N is the number of test suites there were.

I believe we do not want to share global context (i.e. SDK inits) across integration tests since that is not really simulating a real-world scenario.

By removing the `--runInBand` we will not run the tests in a single process anymore but in multiple worker processes. This is a bit slower so I also increased the test timeout. I raised it by quite a lot, hoping to reduce test flakes in the future.

Also, there was some weird race condition/deadlock in the logic where we get a free port on the machine I aim to fix with this PR. TBH I don't quite know why it works but it seems to improve things when running locally.