### PR TITLE
chore(nextjs): Increase client integration test timeout

### DIFF
--- a/packages/nextjs/test/integration/test/client.js
+++ b/packages/nextjs/test/integration/test/client.js
@@ -27,7 +27,7 @@ const execute = async (scenario, env) => {
 
   const page = (env.page = await env.browser.newPage());
   await page.setRequestInterception(true);
-  page.setDefaultTimeout(4000);
+  page.setDefaultTimeout(8000);
   page.on('request', createRequestInterceptor(env));
 
   return scenario(env);


### PR DESCRIPTION
Lately our nextjs integration tests seem to be flakey, because sometimes at least one of the client-side tests times out. This doubles the timeout in hopes of fixing that problem.
