### PR TITLE
ref(tracing): Add propagations to tracing SDK

### DIFF
--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -199,6 +199,7 @@ export function fetchCallback(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const options = (handlerData.args[1] = (handlerData.args[1] as { [key: string]: any }) || {});
     options.headers = addTracingHeaders(request, activeTransaction.getBaggage(), span, options);
+    activeTransaction.metadata.propagations += 1;
   }
 }
 
@@ -304,6 +305,7 @@ export function xhrCallback(
           BAGGAGE_HEADER_NAME,
           mergeAndSerializeBaggage(activeTransaction.getBaggage(), headerBaggageString),
         );
+        activeTransaction.metadata.propagations += 1;
       } catch (_) {
         // Error: InvalidStateError: Failed to execute 'setRequestHeader' on 'XMLHttpRequest': The object's state must be OPENED.
       }

--- a/packages/tracing/test/browser/request.test.ts
+++ b/packages/tracing/test/browser/request.test.ts
@@ -193,6 +193,19 @@ describe('callbacks', () => {
       expect(newSpan).toBeUndefined();
     });
 
+    it('records outgoing propogations', () => {
+      const firstReqData = { ...fetchHandlerData };
+      const secondReqData = { ...fetchHandlerData };
+
+      expect(transaction.metadata.propagations).toBe(0);
+
+      fetchCallback(firstReqData, alwaysCreateSpan, {});
+      expect(transaction.metadata.propagations).toBe(1);
+
+      fetchCallback(secondReqData, alwaysCreateSpan, {});
+      expect(transaction.metadata.propagations).toBe(2);
+    });
+
     it('adds sentry-trace header to fetch requests', () => {
       // TODO
     });
@@ -303,6 +316,19 @@ describe('callbacks', () => {
       const newSpan = transaction.spanRecorder?.spans[1];
 
       expect(newSpan).toBeUndefined();
+    });
+
+    it('records outgoing propogations', () => {
+      const firstReqData = { ...xhrHandlerData };
+      const secondReqData = { ...xhrHandlerData };
+
+      expect(transaction.metadata.propagations).toBe(0);
+
+      xhrCallback(firstReqData, alwaysCreateSpan, {});
+      expect(transaction.metadata.propagations).toBe(1);
+
+      xhrCallback(secondReqData, alwaysCreateSpan, {});
+      expect(transaction.metadata.propagations).toBe(2);
     });
   });
 });


### PR DESCRIPTION
Part of https://github.com/getsentry/sentry-javascript/issues/5679

Dependent on https://github.com/getsentry/sentry-javascript/pull/5714 merging

This PR updates the propagations metadata field in the tracing SDK for `BrowserTracing`. It does this by adding a propagations incrementor to the fetch and XHR instrumentation.

