### PR TITLE
ref(node): Add propagations to http integration

### DIFF
--- a/packages/nextjs/test/integration/test/server/tracingHttp.js
+++ b/packages/nextjs/test/integration/test/server/tracingHttp.js
@@ -32,7 +32,7 @@ module.exports = async ({ url: urlBase, argv }) => {
       transaction_info: {
         source: 'route',
         changes: [],
-        propagations: 0,
+        propagations: 1,
       },
       type: 'transaction',
       request: {

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -172,6 +172,11 @@ function _createWrappedRequestMethodFactory(
                 `[Tracing] Not adding sentry-trace header to outgoing request (${requestUrl}) due to mismatching tracePropagationTargets option.`,
               );
           }
+
+          const transaction = parentSpan.transaction;
+          if (transaction) {
+            transaction.metadata.propagations += 1;
+          }
         }
       }
 

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -172,6 +172,20 @@ describe('tracing', () => {
     expect(baggage).not.toBeDefined();
   });
 
+  it('records outgoing propagations on the transaction', () => {
+    nock('http://dogs.are.great').get('/').reply(200);
+
+    const transaction = createTransactionOnScope();
+
+    expect(transaction.metadata.propagations).toBe(0);
+
+    http.get('http://dogs.are.great/');
+    expect(transaction.metadata.propagations).toBe(1);
+
+    http.get('http://dogs.are.great/');
+    expect(transaction.metadata.propagations).toBe(2);
+  });
+
   describe('tracePropagationTargets option', () => {
     beforeEach(() => {
       // hacky way of restoring monkey patched functions


### PR DESCRIPTION
Part of https://github.com/getsentry/sentry-javascript/issues/5679

Dependent on https://github.com/getsentry/sentry-javascript/pull/5714 merging

This PR updates the propagations metadata field in the node SDK for the HTTP integration.