### PR TITLE
test: Run node integration tests in isolation

### DIFF
--- a/packages/node-integration-tests/package.json
+++ b/packages/node-integration-tests/package.json
@@ -17,7 +17,7 @@
     "fix:prettier": "prettier --write \"{suites,utils}/**/*.ts\"",
     "type-check": "tsc",
     "pretest": "run-s --silent prisma:init",
-    "test": "jest --forceExit",
+    "test": "ts-node ./utils/run-tests.ts",
     "test:watch": "yarn test --watch"
   },
   "dependencies": {

--- a/packages/node-integration-tests/package.json
+++ b/packages/node-integration-tests/package.json
@@ -34,8 +34,7 @@
     "mongodb-memory-server-global": "^7.6.3",
     "mysql": "^2.18.1",
     "nock": "^13.1.0",
-    "pg": "^8.7.3",
-    "portfinder": "^1.0.28"
+    "pg": "^8.7.3"
   },
   "config": {
     "mongodbMemoryServer": {

--- a/packages/node-integration-tests/utils/index.ts
+++ b/packages/node-integration-tests/utils/index.ts
@@ -5,9 +5,9 @@ import { logger, parseSemver } from '@sentry/utils';
 import axios, { AxiosRequestConfig } from 'axios';
 import { Express } from 'express';
 import * as http from 'http';
+import { AddressInfo } from 'net';
 import nock from 'nock';
 import * as path from 'path';
-import { getPorts } from 'portfinder';
 
 export type TestServerConfig = {
   url: string;
@@ -151,20 +151,9 @@ export class TestEnv {
         }
       });
 
-      getPorts(50, {}, (err, ports) => {
-        if (err) {
-          throw err;
-        }
-
-        const port = ports.find(
-          // Only allow ports that do not overlap with other workers - this is done to avoid race-conditions
-          p => p % Number(process.env.TEST_WORKERS_AMOUNT) === Number(process.env.TEST_PORT_MODULO),
-        );
-
-        const url = `http://localhost:${port}/test`;
-        const server = app.listen(port, () => {
-          resolve([server, url]);
-        });
+      const server = app.listen(0, () => {
+        const url = `http://localhost:${(server.address() as AddressInfo).port}/test`;
+        resolve([server, url]);
       });
     });
 

--- a/packages/node-integration-tests/utils/run-tests.ts
+++ b/packages/node-integration-tests/utils/run-tests.ts
@@ -59,7 +59,7 @@ void Promise.all(threads).then(() => {
     });
     process.exit(1);
   } else {
-    console.log('All testcases returned the expected results.');
+    console.log('All tests succeeded.');
     process.exit(0);
   }
 });

--- a/packages/node-integration-tests/utils/run-tests.ts
+++ b/packages/node-integration-tests/utils/run-tests.ts
@@ -5,7 +5,7 @@ import os from 'os';
 const testPaths = childProcess.execSync('jest --listTests', { encoding: 'utf8' }).trim().split('\n');
 
 let testsSucceeded = true;
-const testAmount = testPaths.length;
+const numTests = testPaths.length;
 const fails: string[] = [];
 
 const threads = os.cpus().map(async (_, i) => {
@@ -46,7 +46,7 @@ const threads = os.cpus().map(async (_, i) => {
 
 void Promise.all(threads).then(() => {
   console.log('-------------------');
-  console.log(`Successfully ran ${testAmount} tests.`);
+  console.log(`Successfully ran ${numTests} tests.`);
   if (!testsSucceeded) {
     console.log('Not all tests succeeded:\n');
     fails.forEach(fail => {

--- a/packages/node-integration-tests/utils/run-tests.ts
+++ b/packages/node-integration-tests/utils/run-tests.ts
@@ -16,8 +16,8 @@ const workers = os.cpus().map(async (_, i) => {
     await new Promise(resolve => {
       const jestProcess = childProcess.spawn('jest', ['--runTestsByPath', testPath as string, '--forceExit']);
 
-      // We're collecting the output and logging it all at once instead of inheriting stdout and stderr, so that the
-      // test outputs aren't interwoven.
+      // We're collecting the output and logging it all at once instead of inheriting stdout and stderr, so that
+      // test outputs of the individual workers aren't interwoven, in case they print at the same time.
       let output = '';
 
       jestProcess.stdout.on('data', (data: Buffer) => {

--- a/packages/node-integration-tests/utils/run-tests.ts
+++ b/packages/node-integration-tests/utils/run-tests.ts
@@ -9,29 +9,29 @@ const testAmount = testPaths.length;
 const fails: string[] = [];
 
 const threads = os.cpus().map(async (_, i) => {
-  let testPath = testPaths.pop();
-  while (testPath !== undefined) {
+  while (testPaths.length > 0) {
+    const testPath = testPaths.pop();
     console.log(`(Worker ${i}) Running test "${testPath}"`);
     await new Promise(resolve => {
-      const p = childProcess.spawn('jest', ['--runTestsByPath', testPath as string, '--forceExit']);
+      const jestProcess = childProcess.spawn('jest', ['--runTestsByPath', testPath as string, '--forceExit']);
 
       let output = '';
 
-      p.stdout.on('data', (data: Buffer) => {
+      jestProcess.stdout.on('data', (data: Buffer) => {
         output = output + data.toString();
       });
 
-      p.stderr.on('data', (data: Buffer) => {
+      jestProcess.stderr.on('data', (data: Buffer) => {
         output = output + data.toString();
       });
 
-      p.on('error', error => {
+      jestProcess.on('error', error => {
         console.log(`(Worker ${i}) Error in test "${testPath}"`, error);
         console.log(output);
         resolve();
       });
 
-      p.on('exit', exitcode => {
+      jestProcess.on('exit', exitcode => {
         console.log(`(Worker ${i}) Finished test "${testPath}"`);
         console.log(output);
         if (exitcode !== 0) {
@@ -41,7 +41,6 @@ const threads = os.cpus().map(async (_, i) => {
         resolve();
       });
     });
-    testPath = testPaths.pop();
   }
 });
 

--- a/packages/node-integration-tests/utils/run-tests.ts
+++ b/packages/node-integration-tests/utils/run-tests.ts
@@ -13,7 +13,11 @@ const threads = os.cpus().map(async (_, i) => {
   while (testPath !== undefined) {
     console.log(`(Worker ${i}) Running test "${testPath}"`);
     await new Promise(resolve => {
-      const p = childProcess.spawn('jest', ['--runTestsByPath', testPath as string, '--forceExit']);
+      const p = childProcess.spawn('jest', ['--runTestsByPath', testPath as string, '--forceExit'], {
+        // These env vars are used to give workers a limited, non-overlapping set of ports to occupy.
+        // This is done to avoid race-conditions during port reservation.
+        env: { ...process.env, TEST_WORKERS_AMOUNT: String(os.cpus().length), TEST_PORT_MODULO: String(i) },
+      });
 
       let output = '';
 

--- a/packages/node-integration-tests/utils/run-tests.ts
+++ b/packages/node-integration-tests/utils/run-tests.ts
@@ -1,0 +1,61 @@
+/* eslint-disable no-console */
+import childProcess from 'child_process';
+import os from 'os';
+
+const testPaths = childProcess.execSync('jest --listTests', { encoding: 'utf8' }).trim().split('\n');
+
+let testsSucceeded = true;
+const testAmount = testPaths.length;
+const fails: string[] = [];
+
+const threads = os.cpus().map(async (_, i) => {
+  let testPath = testPaths.pop();
+  while (testPath !== undefined) {
+    console.log(`(Worker ${i}) Running test "${testPath}"`);
+    await new Promise(resolve => {
+      const p = childProcess.spawn('jest', ['--runTestsByPath', testPath as string, '--forceExit']);
+
+      let output = '';
+
+      p.stdout.on('data', (data: Buffer) => {
+        output = output + data.toString();
+      });
+
+      p.stderr.on('data', (data: Buffer) => {
+        output = output + data.toString();
+      });
+
+      p.on('error', error => {
+        console.log(`(Worker ${i}) Error in test "${testPath}"`, error);
+        console.log(output);
+        resolve();
+      });
+
+      p.on('exit', exitcode => {
+        console.log(`(Worker ${i}) Finished test "${testPath}"`);
+        console.log(output);
+        if (exitcode !== 0) {
+          fails.push(`FAILED: "${testPath}"`);
+          testsSucceeded = false;
+        }
+        resolve();
+      });
+    });
+    testPath = testPaths.pop();
+  }
+});
+
+void Promise.all(threads).then(() => {
+  console.log('-------------------');
+  console.log(`Successfully ran ${testAmount} tests.`);
+  if (!testsSucceeded) {
+    console.log('Not all tests succeeded:\n');
+    fails.forEach(fail => {
+      console.log(`● ${fail}`);
+    });
+    process.exit(1);
+  } else {
+    console.log('All testcases returned the expected results.');
+    process.exit(0);
+  }
+});

--- a/packages/node-integration-tests/utils/run-tests.ts
+++ b/packages/node-integration-tests/utils/run-tests.ts
@@ -13,11 +13,7 @@ const threads = os.cpus().map(async (_, i) => {
   while (testPath !== undefined) {
     console.log(`(Worker ${i}) Running test "${testPath}"`);
     await new Promise(resolve => {
-      const p = childProcess.spawn('jest', ['--runTestsByPath', testPath as string, '--forceExit'], {
-        // These env vars are used to give workers a limited, non-overlapping set of ports to occupy.
-        // This is done to avoid race-conditions during port reservation.
-        env: { ...process.env, TEST_WORKERS_AMOUNT: String(os.cpus().length), TEST_PORT_MODULO: String(i) },
-      });
+      const p = childProcess.spawn('jest', ['--runTestsByPath', testPath as string, '--forceExit']);
 
       let output = '';
 

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -34,7 +34,8 @@
   },
   "devDependencies": {
     "@remix-run/node": "^1.4.3",
-    "@remix-run/react": "^1.4.3"
+    "@remix-run/react": "^1.4.3",
+    "portfinder": "^1.0.28"
   },
   "peerDependencies": {
     "@remix-run/node": "1.x",


### PR DESCRIPTION
Since even after merging https://github.com/getsentry/sentry-javascript/pull/5715 I have trouble with the global context being shared across tests we should definitely isolate the individual node integration tests before something slips though because of it.

This PR adds a quick and dirty script that runs all the test files with an individual `jest` command. It doesn't do anything fancy except for creating a worker sharing work for each CPU core available.

Also removes the `portfinder` package from the integration tests as it was a bit inconsistent - we now let the OS choose a port on its own.

This PR admittedly doesn't contain a lot of effort but was done to unblock https://github.com/getsentry/sentry-javascript/pull/5710
