### PR TITLE
feat(core): Set custom transaction source for event processors

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -33,9 +33,9 @@ import {
   resolvedSyncPromise,
   SentryError,
   SyncPromise,
+  timestampInSeconds,
   truncate,
   uuid4,
-  timestampInSeconds,
 } from '@sentry/utils';
 
 import { getEnvelopeEndpointWithUrlEncodedAuth } from './api';

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -35,6 +35,7 @@ import {
   SyncPromise,
   truncate,
   uuid4,
+  timestampInSeconds,
 } from '@sentry/utils';
 
 import { getEnvelopeEndpointWithUrlEncodedAuth } from './api';
@@ -656,6 +657,26 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
         const session = scope && scope.getSession();
         if (!isTransaction && session) {
           this._updateSessionFromEvent(session, processedEvent);
+        }
+
+        // None of the Sentry built event processor will update transaction name,
+        // so if the transaction name has been changed by an event processor, we know
+        // it has to come from custom event processor added by a user
+        const transactionInfo = processedEvent.transaction_info;
+        if (isTransaction && transactionInfo && processedEvent.transaction !== event.transaction) {
+          const source = 'custom';
+          processedEvent.transaction_info = {
+            ...transactionInfo,
+            source,
+            changes: [
+              ...transactionInfo.changes,
+              {
+                source,
+                timestamp: timestampInSeconds(),
+                propagations: transactionInfo.propagations,
+              },
+            ],
+          };
         }
 
         this.sendEvent(processedEvent, hint);


### PR DESCRIPTION
Part of https://github.com/getsentry/sentry-javascript/issues/5679

Dependent on https://github.com/getsentry/sentry-javascript/pull/5714 merging

This PR updates `BaseClient` class to set a custom transaction source if event processors change the transaction name. It also adds metadata around a transaction name change when this is done.