### PR TITLE
ref(nextjs): Use`RequestData` integration for errors

### DIFF
--- a/packages/nextjs/src/config/wrappers/wrapperUtils.ts
+++ b/packages/nextjs/src/config/wrappers/wrapperUtils.ts
@@ -1,5 +1,4 @@
 import { captureException, getCurrentHub, startTransaction } from '@sentry/core';
-import { addRequestDataToEvent } from '@sentry/node';
 import { getActiveTransaction } from '@sentry/tracing';
 import { Transaction } from '@sentry/types';
 import { baggageHeaderToDynamicSamplingContext, extractTraceparentData, fill } from '@sentry/utils';
@@ -124,18 +123,6 @@ export function callTracedServerSideDataFetcher<F extends (...args: any[]) => Pr
     if (currentScope) {
       currentScope.setSpan(dataFetcherSpan);
       currentScope.setSDKProcessingMetadata({ request: req });
-      currentScope.addEventProcessor(event =>
-        event.type !== 'transaction'
-          ? addRequestDataToEvent(event, req, {
-              include: {
-                // When the `transaction` option is set to true, it tries to extract a transaction name from the request
-                // object. We don't want this since we already have a high-quality transaction name with a parameterized
-                // route. Setting `transaction` to `true` will clobber that transaction name.
-                transaction: false,
-              },
-            })
-          : event,
-      );
     }
 
     try {

--- a/packages/nextjs/src/config/wrappers/wrapperUtils.ts
+++ b/packages/nextjs/src/config/wrappers/wrapperUtils.ts
@@ -123,6 +123,7 @@ export function callTracedServerSideDataFetcher<F extends (...args: any[]) => Pr
     const currentScope = getCurrentHub().getScope();
     if (currentScope) {
       currentScope.setSpan(dataFetcherSpan);
+      currentScope.setSDKProcessingMetadata({ request: req });
       currentScope.addEventProcessor(event =>
         event.type !== 'transaction'
           ? addRequestDataToEvent(event, req, {

--- a/packages/nextjs/src/utils/_error.ts
+++ b/packages/nextjs/src/utils/_error.ts
@@ -1,6 +1,6 @@
 import { captureException, withScope } from '@sentry/core';
 import { getCurrentHub } from '@sentry/hub';
-import { addExceptionMechanism, addRequestDataToEvent } from '@sentry/utils';
+import { addExceptionMechanism } from '@sentry/utils';
 import { NextPageContext } from 'next';
 
 type ContextOrProps = {
@@ -55,7 +55,6 @@ export async function captureUnderscoreErrorException(contextOrProps: ContextOrP
     });
 
     if (req) {
-      scope.addEventProcessor(event => addRequestDataToEvent(event, req));
       scope.setSDKProcessingMetadata({ request: req });
     }
 

--- a/packages/nextjs/src/utils/_error.ts
+++ b/packages/nextjs/src/utils/_error.ts
@@ -56,6 +56,7 @@ export async function captureUnderscoreErrorException(contextOrProps: ContextOrP
 
     if (req) {
       scope.addEventProcessor(event => addRequestDataToEvent(event, req));
+      scope.setSDKProcessingMetadata({ request: req });
     }
 
     // If third-party libraries (or users themselves) throw something falsy, we want to capture it as a message (which

--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -247,6 +247,7 @@ function makeWrappedReqHandler(origReqHandler: ReqHandler): WrappedReqHandler {
         currentScope.addEventProcessor(event =>
           event.type !== 'transaction' ? addRequestDataToEvent(event, nextReq) : event,
         );
+        currentScope.setSDKProcessingMetadata({ request: req });
 
         // We only want to record page and API requests
         if (hasTracingEnabled() && shouldTraceRequest(nextReq.url, publicDirFiles)) {

--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -1,12 +1,5 @@
 /* eslint-disable max-lines */
-import {
-  addRequestDataToEvent,
-  captureException,
-  configureScope,
-  deepReadDirSync,
-  getCurrentHub,
-  startTransaction,
-} from '@sentry/node';
+import { captureException, configureScope, deepReadDirSync, getCurrentHub, startTransaction } from '@sentry/node';
 import { extractTraceparentData, getActiveTransaction, hasTracingEnabled } from '@sentry/tracing';
 import {
   addExceptionMechanism,
@@ -244,9 +237,7 @@ function makeWrappedReqHandler(origReqHandler: ReqHandler): WrappedReqHandler {
       const currentScope = getCurrentHub().getScope();
 
       if (currentScope) {
-        currentScope.addEventProcessor(event =>
-          event.type !== 'transaction' ? addRequestDataToEvent(event, nextReq) : event,
-        );
+        // Store the request on the scope so we can pull data from it and add it to the event
         currentScope.setSDKProcessingMetadata({ request: req });
 
         // We only want to record page and API requests
@@ -297,10 +288,6 @@ function makeWrappedReqHandler(origReqHandler: ReqHandler): WrappedReqHandler {
             const transaction = getActiveTransaction();
             if (transaction) {
               transaction.setHttpStatus(res.statusCode);
-
-              // we'll collect this data in a more targeted way in the event processor we added above,
-              // `addRequestDataToEvent`
-              delete transaction.metadata.requestPath;
 
               // Push `transaction.finish` to the next event loop so open spans have a chance to finish before the
               // transaction closes

--- a/packages/nextjs/src/utils/withSentry.ts
+++ b/packages/nextjs/src/utils/withSentry.ts
@@ -59,6 +59,7 @@ export const withSentry = (origHandler: NextApiHandler): WrappedNextApiHandler =
         currentScope.addEventProcessor(event =>
           event.type !== 'transaction' ? addRequestDataToEvent(event, req) : event,
         );
+        currentScope.setSDKProcessingMetadata({ request: req });
 
         if (hasTracingEnabled()) {
           // If there is a trace header set, extract the data from it (parentSpanId, traceId, and sampling decision)

--- a/packages/nextjs/src/utils/withSentry.ts
+++ b/packages/nextjs/src/utils/withSentry.ts
@@ -1,4 +1,4 @@
-import { addRequestDataToEvent, captureException, flush, getCurrentHub, startTransaction } from '@sentry/node';
+import { captureException, flush, getCurrentHub, startTransaction } from '@sentry/node';
 import { extractTraceparentData, hasTracingEnabled } from '@sentry/tracing';
 import { Transaction } from '@sentry/types';
 import {
@@ -56,9 +56,6 @@ export const withSentry = (origHandler: NextApiHandler): WrappedNextApiHandler =
       const currentScope = getCurrentHub().getScope();
 
       if (currentScope) {
-        currentScope.addEventProcessor(event =>
-          event.type !== 'transaction' ? addRequestDataToEvent(event, req) : event,
-        );
         currentScope.setSDKProcessingMetadata({ request: req });
 
         if (hasTracingEnabled()) {


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/5703, a new integration, `RequestData`, was added to take the place of the request-specific event processors we've been using to add request data to transaction events in the nextjs SDK. This builds on that work by making the same switch for error events.

Notes:

- Because of https://github.com/getsentry/sentry-javascript/issues/5718, it's hard to reason about the potential side effects of making major changes to the logic in `@sentry/utils/requestData`. Therefore, the majority of the new logic in this PR has been added to the integration, and just overwrites the `transaction` value added by the functions in `requestData`. Once we've cleaned up the request data code, we can consolidate the logic.
