### PR TITLE
fix(nextjs): Pass request in sampling context of data fetchers wrapper transaction

### DIFF
--- a/packages/nextjs/src/config/wrappers/wrapperUtils.ts
+++ b/packages/nextjs/src/config/wrappers/wrapperUtils.ts
@@ -93,16 +93,19 @@ export function callTracedServerSideDataFetcher<F extends (...args: any[]) => Pr
 
       const dynamicSamplingContext = baggageHeaderToDynamicSamplingContext(rawBaggageString);
 
-      const newTransaction = startTransaction({
-        op: 'nextjs.data.server',
-        name: options.requestedRouteName,
-        ...traceparentData,
-        status: 'ok',
-        metadata: {
-          source: 'route',
-          dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,
+      const newTransaction = startTransaction(
+        {
+          op: 'nextjs.data.server',
+          name: options.requestedRouteName,
+          ...traceparentData,
+          status: 'ok',
+          metadata: {
+            source: 'route',
+            dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,
+          },
         },
-      });
+        { request: req },
+      );
 
       requestTransaction = newTransaction;
       autoEndTransactionOnResponseEnd(newTransaction, res);

--- a/packages/nextjs/test/config/wrappers.test.ts
+++ b/packages/nextjs/test/config/wrappers.test.ts
@@ -45,6 +45,11 @@ describe('data-fetching function wrappers', () => {
           op: 'nextjs.data.server',
           metadata: expect.objectContaining({ source: 'route' }),
         }),
+        {
+          request: expect.objectContaining({
+            url: 'http://dogs.are.great/tricks/kangaroo',
+          }),
+        },
       );
 
       expect(setMetadataSpy).toHaveBeenCalledWith({ request: req });
@@ -62,6 +67,11 @@ describe('data-fetching function wrappers', () => {
           op: 'nextjs.data.server',
           metadata: expect.objectContaining({ source: 'route' }),
         }),
+        {
+          request: expect.objectContaining({
+            url: 'http://dogs.are.great/tricks/kangaroo',
+          }),
+        },
       );
 
       expect(setMetadataSpy).toHaveBeenCalledWith({ request: req });


### PR DESCRIPTION
This adds the request to the sampling context passed to the `startTransaction` call in the data fetchers wrapper in nextjs, to bring it in line with the `startTransaction` calls elsewhere in the SDK.
