### PR TITLE
fix(utils): Make empty traceparent string count as invalid

### DIFF
--- a/packages/tracing/test/utils.test.ts
+++ b/packages/tracing/test/utils.test.ts
@@ -60,6 +60,9 @@ describe('extractTraceparentData', () => {
   });
 
   test('invalid', () => {
+    // empty string
+    expect(extractTraceparentData('')).toBeUndefined();
+
     // trace id wrong length
     expect(extractTraceparentData('a-bbbbbbbbbbbbbbbb-1')).toBeUndefined();
 

--- a/packages/utils/src/tracing.ts
+++ b/packages/utils/src/tracing.ts
@@ -17,18 +17,22 @@ export const TRACEPARENT_REGEXP = new RegExp(
  */
 export function extractTraceparentData(traceparent: string): TraceparentData | undefined {
   const matches = traceparent.match(TRACEPARENT_REGEXP);
-  if (matches) {
-    let parentSampled: boolean | undefined;
-    if (matches[3] === '1') {
-      parentSampled = true;
-    } else if (matches[3] === '0') {
-      parentSampled = false;
-    }
-    return {
-      traceId: matches[1],
-      parentSampled,
-      parentSpanId: matches[2],
-    };
+
+  if (!traceparent || !matches) {
+    // empty string or no matches is invalid traceparent data
+    return undefined;
   }
-  return undefined;
+
+  let parentSampled: boolean | undefined;
+  if (matches[3] === '1') {
+    parentSampled = true;
+  } else if (matches[3] === '0') {
+    parentSampled = false;
+  }
+
+  return {
+    traceId: matches[1],
+    parentSampled,
+    parentSpanId: matches[2],
+  };
 }


### PR DESCRIPTION
So far, an empty `sentry-trace` header counted as valid in the SDK, in a sense that the `extractTraceparentData` function still returned an object instead of `undefined`.

This PR changes the behavior so that an empty string is not counted as valid.

Unblocks https://github.com/getsentry/sentry-javascript/pull/5710