### PR TITLE
ref(core): Use timestamp of processed event in name change

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -33,7 +33,6 @@ import {
   resolvedSyncPromise,
   SentryError,
   SyncPromise,
-  timestampInSeconds,
   truncate,
   uuid4,
 } from '@sentry/utils';
@@ -672,7 +671,8 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
               ...transactionInfo.changes,
               {
                 source,
-                timestamp: timestampInSeconds(),
+                // use the same timestamp as the processed event.
+                timestamp: processedEvent.timestamp as number,
                 propagations: transactionInfo.propagations,
               },
             ],


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/5679

Instead of setting a timestamp to a number that is larger than the transaction's end timestamp, set the transaction name change timestamp to be the transaction's end timestamp.