### PR TITLE
ref(nextjs): Update vercel testing script

### DIFF
--- a/packages/nextjs/vercel/set-up-branch-for-test-app-use.sh
+++ b/packages/nextjs/vercel/set-up-branch-for-test-app-use.sh
@@ -4,31 +4,41 @@
 
 echo " "
 
-NEXTJS_SDK_DIR=$(pwd)
+# This puts us in the packages directory
+cd ..
 
-# this puts us in the repo root
-cd ../..
-
-# make sure we're dealing with a clean SDK repo
+# Make sure we're dealing with a clean SDK repo
 STASHED_CHANGES=$(git status --porcelain)
 if [ -n "${STASHED_CHANGES}" ]; then
   echo "Found uncommitted changes. Stashing them."
   git stash --quiet --include-untracked
 fi
 
-# if this hasn't already been done, get rid of irrelevant packages to speed up deploy process
+# If this hasn't already been done, get rid of irrelevant packages to speed up deploy process
 PACKAGES_DELETED=false
-for package in "angular" "ember" "eslint-config-sdk" "eslint-plugin-sdk" "gatsby" "serverless" "vue" "wasm"; do
-  if [ -d packages/${package} ]; then
+for package in *; do
+  # Delete all packages which aren't either runtime or dev dependencies of the nextjs SDK
+  case $package in
+  # Runtime depependencies
+  "nextjs" | "core" | "hub" | "browser" | "node" | "react" | "tracing" | "utils" | "integrations")
+    continue
+    ;;
+    # Dev dependencies
+  "eslint-config-sdk" | "eslint-plugin-sdk" | "types" | "typescript")
+    continue
+    ;;
+    # Everything else
+  *)
     echo "Deleting ${package}"
-    rm -rf packages/${package}
+    rm -rf ${package}
     PACKAGES_DELETED=true
-  fi
+    ;;
+  esac
 done
 
 echo " "
 
-# if we deleted anything, commit the result
+# If we deleted anything, commit the result
 if [ "$PACKAGES_DELETED" = true ]; then
   echo "Committing deletions. Don't forget to push this commit before you deploy."
   git add .
@@ -37,7 +47,7 @@ else
   echo "Branch already set up for vercel deployment"
 fi
 
-# restore working directory, if necessary
+# Restore working directory, if necessary
 if [ -n "${STASHED_CHANGES}" ]; then
   echo " "
   echo "Restoring changes from earlier stash:"
@@ -46,4 +56,4 @@ if [ -n "${STASHED_CHANGES}" ]; then
   echo " "
 fi
 
-cd $NEXTJS_SDK_DIR
+cd nextjs


### PR DESCRIPTION
This is a small refactor to our `set-up-branch-for-test-app-use.sh` vercel script, which prepares the current branch to be tested on vercel by deleting packages unrelated to the nextjs SDK, thereby speeding up the vercel build.

The only consequential change is a switch from specifying which packages should get deleted to specifying which packages shouldn't. (The list of deletion targets kept falling out of date, each time we added a new package. With this change, it should in theory be evergreen.)