### PR TITLE
chore(deps): Add `@types/rimraf`

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/jsdom": "^16.2.3",
     "@types/mocha": "^5.2.0",
     "@types/node": "~10.17.0",
+    "@types/rimraf": "^3.0.2",
     "@types/sinon": "^7.0.11",
     "acorn": "^8.7.0",
     "chai": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5477,6 +5477,14 @@
     "@types/glob" "*"
     "@types/node" "*"
 
+"@types/rimraf@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-3.0.2.tgz#a63d175b331748e5220ad48c901d7bbf1f44eef8"
+  integrity sha512-F3OznnSLAUxFrCEu/L5PY8+ny8DtcFRjx7fZZ9bycvXRi3KPTRS9HOitGZwvPg0juRhXFWIeKX58cnX5YqLohQ==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
+
 "@types/rsvp@*", "@types/rsvp@~4.0.3":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@types/rsvp/-/rsvp-4.0.4.tgz#55e93e7054027f1ad4b4ebc1e60e59eb091e2d32"


### PR DESCRIPTION
We list `rimraf` as a top-level dev dependency, but have been relying on a hoisted sub-dependency for the types. This adds them as a first-class dev dependency.
