### PR TITLE
(feat:types) 🏷️ Add types for app hang functionality

### DIFF
--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -168,6 +168,23 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   sendDefaultPii?: boolean;
 
   /**
+   * When enabled, the SDK tracks when the application stops responding for a specific amount of
+   * time defined by the `appHangTimeoutInterval` option.
+   *
+   * Defaults to `false`.
+   */
+  enableAppHangTracking?: boolean;
+
+  /**
+   * The minimum amount of time an app should be unresponsive to be classified as an App Hanging.
+   * The actual amount may be a little longer.
+   * Avoid using values lower than 100ms, which may cause a lot of app hangs events being transmitted.
+   *
+   * Defaults to `2`.
+   */
+  appHangsTimeoutInterval?: number;
+
+  /**
    * Set of metadata about the SDK that can be internally used to enhance envelopes and events,
    * and provide additional data about every request.
    */


### PR DESCRIPTION
The sentry iOS sdk contains functionality to log a message to sentry when the app hangs.

This is not available in the types now. This pull requests adds the typings. 