### PR TITLE
chore(deps): Remove `tslib` dependency

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -131,9 +131,6 @@
 
       "skipFiles": [
         "<node_internals>/**",
-        // this prevents us from landing in a neverending cycle of TS async-polyfill functions as we're stepping through
-        // our code
-        "${workspaceFolder}/node_modules/tslib/**/*"
       ],
       "sourceMaps": true,
       // this controls which files are sourcemapped

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "size-limit": "^4.5.5",
     "ts-jest": "^27.1.4",
     "ts-node": "^10.7.0",
-    "tslib": "^2.3.1",
     "typedoc": "^0.18.0",
     "typescript": "3.8.3"
   },

--- a/packages/angular/ng-package.json
+++ b/packages/angular/ng-package.json
@@ -8,6 +8,6 @@
       "@sentry/utils": "Sentry.util"
     }
   },
-  "whitelistedNonPeerDependencies": ["@sentry/browser", "@sentry/utils", "@sentry/types", "tslib"],
+  "whitelistedNonPeerDependencies": ["@sentry/browser", "@sentry/utils", "@sentry/types"],
   "assets": ["README.md", "LICENSE"]
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -23,8 +23,7 @@
   "dependencies": {
     "@sentry/browser": "7.13.0",
     "@sentry/types": "7.13.0",
-    "@sentry/utils": "7.13.0",
-    "tslib": "^2.0.0"
+    "@sentry/utils": "7.13.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1002.4",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "@sentry/core": "7.13.0",
     "@sentry/types": "7.13.0",
-    "@sentry/utils": "7.13.0",
-    "tslib": "^1.9.3"
+    "@sentry/utils": "7.13.0"
   },
   "devDependencies": {
     "@types/md5": "2.1.33",

--- a/packages/browser/test/package/npm-build.js
+++ b/packages/browser/test/package/npm-build.js
@@ -52,11 +52,6 @@ function runTests() {
 
   const myLibrary = fs.readFileSync(bundlePath, { encoding: 'utf-8' });
 
-  if (myLibrary.indexOf('tslib_1__default') !== -1) {
-    console.log('"tslib_1__default" reappeared...');
-    process.exit(1);
-  }
-
   const scriptEl = window.document.createElement('script');
   scriptEl.textContent = myLibrary;
   window.document.body.appendChild(scriptEl);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "@sentry/hub": "7.13.0",
     "@sentry/types": "7.13.0",
-    "@sentry/utils": "7.13.0",
-    "tslib": "^1.9.3"
+    "@sentry/utils": "7.13.0"
   },
   "scripts": {
     "build": "run-p build:rollup build:types",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -17,8 +17,7 @@
   },
   "dependencies": {
     "@sentry/types": "7.13.0",
-    "@sentry/utils": "7.13.0",
-    "tslib": "^1.9.3"
+    "@sentry/utils": "7.13.0"
   },
   "scripts": {
     "build": "run-p build:rollup build:types",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "@sentry/types": "7.13.0",
     "@sentry/utils": "7.13.0",
-    "localforage": "^1.8.1",
-    "tslib": "^1.9.3"
+    "localforage": "^1.8.1"
   },
   "devDependencies": {
     "chai": "^4.1.2"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -28,8 +28,7 @@
     "@sentry/utils": "7.13.0",
     "@sentry/webpack-plugin": "1.19.0",
     "chalk": "3.0.0",
-    "rollup": "2.78.0",
-    "tslib": "^1.9.3"
+    "rollup": "2.78.0"
   },
   "devDependencies": {
     "@sentry/nextjs": "7.13.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -22,8 +22,7 @@
     "@sentry/utils": "7.13.0",
     "cookie": "^0.4.1",
     "https-proxy-agent": "^5.0.0",
-    "lru_map": "^0.3.3",
-    "tslib": "^1.9.3"
+    "lru_map": "^0.3.3"
   },
   "devDependencies": {
     "@types/cookie": "0.3.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,7 @@
     "@sentry/browser": "7.13.0",
     "@sentry/types": "7.13.0",
     "@sentry/utils": "7.13.0",
-    "hoist-non-react-statics": "^3.3.2",
-    "tslib": "^1.9.3"
+    "hoist-non-react-statics": "^3.3.2"
   },
   "peerDependencies": {
     "react": "15.x || 16.x || 17.x || 18.x"

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -29,8 +29,7 @@
     "@sentry/tracing": "7.13.0",
     "@sentry/types": "7.13.0",
     "@sentry/utils": "7.13.0",
-    "@sentry/webpack-plugin": "1.19.0",
-    "tslib": "^1.9.3"
+    "@sentry/webpack-plugin": "1.19.0"
   },
   "devDependencies": {
     "@remix-run/node": "^1.4.3",

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -21,8 +21,7 @@
     "@sentry/types": "7.13.0",
     "@sentry/utils": "7.13.0",
     "@types/aws-lambda": "^8.10.62",
-    "@types/express": "^4.17.14",
-    "tslib": "^1.9.3"
+    "@types/express": "^4.17.14"
   },
   "devDependencies": {
     "@google-cloud/bigquery": "^5.3.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -19,8 +19,7 @@
     "@sentry/browser": "7.13.0",
     "@sentry/types": "7.13.0",
     "@sentry/utils": "7.13.0",
-    "magic-string": "^0.26.2",
-    "tslib": "^1.9.3"
+    "magic-string": "^0.26.2"
   },
   "peerDependencies": {
     "svelte": "3.x"

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "@sentry/hub": "7.13.0",
     "@sentry/types": "7.13.0",
-    "@sentry/utils": "7.13.0",
-    "tslib": "^1.9.3"
+    "@sentry/utils": "7.13.0"
   },
   "devDependencies": {
     "@sentry/browser": "7.13.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,8 +16,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/types": "7.13.0",
-    "tslib": "^1.9.3"
+    "@sentry/types": "7.13.0"
   },
   "devDependencies": {
     "@types/array.prototype.flat": "^1.2.1",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -19,8 +19,7 @@
     "@sentry/browser": "7.13.0",
     "@sentry/core": "7.13.0",
     "@sentry/types": "7.13.0",
-    "@sentry/utils": "7.13.0",
-    "tslib": "^1.9.3"
+    "@sentry/utils": "7.13.0"
   },
   "peerDependencies": {
     "vue": "2.x || 3.x"

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "@sentry/browser": "7.13.0",
     "@sentry/types": "7.13.0",
-    "@sentry/utils": "7.13.0",
-    "tslib": "^1.9.3"
+    "@sentry/utils": "7.13.0"
   },
   "devDependencies": {
     "@types/jest-environment-puppeteer": "^4.4.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,12 @@
     "declarationMap": false,
     "skipLibCheck": true,
     "types": ["node"],
+    // Setting this to `false` causes TS to include the full code for each helper it injects, which allows us to remove
+    // `tslib` as a dependency, with the advantage that it means we don't have to worry about `tslib` version
+    // compatibility with our version of TS. Since we now use Sucrase and Rollup for our main builds, this only affects
+    // our ES5 bundles (which would pull in the helper code in any case, even if specified in an import) and tests
+    // (where the built files last only long enough to run tests againt), so it's safe to include it here in the root
+    // tsconfig.
+    "importHelpers": false,
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25309,7 +25309,7 @@ tslib@2.0.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
NOTE: Though most of the the problems the change causes have been solved, I'm leaving this in draft form until I can figure out why the `tracePropogationTargets` tests (and only the `tracePropogationTargets` tests) consistently fail. Very mysterious...

------------------------

Now that we use Sucrase and Rollup for transpiling in our main build process, we no longer need `tslib` as a runtime dependency. (Sucrase and Rollup have their own ES6 polyfills, which we vendor.) 

We do still use `tsc` when creating ES5 bundles, but we do so through `rollup-plugin-typescript-2`, which includes `tslib` among its own dependencies. 

We've also been using it (indirectly) in our tests. `ts-jest` works by transpiling relevant TS files on the fly before running `jest`, and it's set to use the local `tsconfig.test.json` when it does so. Because all of our tsconfig files inherit from the tsconfig in `@sentry/typescript`, they've all been running with `importHelpers` set to `true`, which makes our testing dependent on `tslib`. But since we have no other reason to depend on 	`tslib` (and since we obviously don't care about bundle size when it comes to the temporary files `ts-jest` creates), it's fine to let TS just include the helper implementations alongside their use. Thus we can turn `importHelpers` off , which means we no longer need `tslib` as a direct dev dependency, either.

This therefore removes it from our dependencies, both at the repo and package levels.

Notes:

- The change to `importHelpers` is done at the repo level, rather than being done directly in `@sentry/typescript`, because other packages (like `sentry-capacitor` and `craft`, among others) also depend on `@sentry/typescript` (and use our old build infrastructure, which needed the setting).

- An old test testing for the inclusion of `tslib` code in our build files, and the `skipFiles` setting in one of our `launch.json` profiles have also been removed, as they are now moot.