### PR TITLE
Revert "ref(browser): Remove top level eventbuilder exports (#4887)"

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -56,5 +56,6 @@ export {
   opera11StackLineParser,
   winjsStackLineParser,
 } from './stack-parsers';
+export { eventFromException, eventFromMessage } from './eventbuilder';
 export { defaultIntegrations, forceLoad, init, lastEventId, onLoad, showReportDialog, flush, close, wrap } from './sdk';
 export { GlobalHandlers, TryCatch, Breadcrumbs, LinkedErrors, HttpContext, Dedupe } from './integrations';


### PR DESCRIPTION
This reverts commit c3ffa2af57e5fdfb5dd9479bd077369daeaa382f.

Removing an export like this is a breaking change.

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
