### PR TITLE
fix(remix): Fix express `Request` and `Response` types

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
     "typescript": "3.8.3"
   },
   "resolutions": {
-    "**/agent-base": "5"
+    "**/agent-base": "5",
+    "@types/express-serve-static-core": "4.17.30"
   },
   "version": "0.0.0",
   "dependencies": {}

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/cookie": "0.3.2",
-    "@types/express": "^4.17.2",
+    "@types/express": "^4.17.14",
     "@types/lru-cache": "^5.1.0",
     "@types/node": "~10.17.0",
     "express": "^4.17.1",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@remix-run/node": "^1.4.3",
     "@remix-run/react": "^1.4.3",
+    "@types/express": "^4.17.14",
     "portfinder": "^1.0.28"
   },
   "peerDependencies": {

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -21,7 +21,7 @@
     "@sentry/types": "7.13.0",
     "@sentry/utils": "7.13.0",
     "@types/aws-lambda": "^8.10.62",
-    "@types/express": "^4.17.2",
+    "@types/express": "^4.17.14",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@sentry/browser": "7.13.0",
-    "@types/express": "^4.17.1"
+    "@types/express": "^4.17.14"
   },
   "scripts": {
     "build": "run-p build:rollup build:types build:bundle && yarn build:extras #necessary for integration tests",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5102,19 +5102,10 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.50.tgz#1e0caa9364d3fccd2931c3ed96fdbeaa5d4cca83"
   integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
 
-"@types/express-serve-static-core@4.17.28":
-  version "4.17.28"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz#c47def9f34ec81dc6328d0b1b5303d1ec98d86b8"
-  integrity sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==
-  dependencies:
-    "@types/node" "*"
-    "@types/qs" "*"
-    "@types/range-parser" "*"
-
-"@types/express-serve-static-core@^4.17.18":
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz#00acfc1632e729acac4f1530e9e16f6dd1508a1d"
-  integrity sha512-DJOSHzX7pCiSElWaGR8kCprwibCB/3yW6vcT8VG3P0SJjnv19gnWG/AZMfM60Xj/YJIp/YCaDHyvzsFVeniARA==
+"@types/express-serve-static-core@4.17.28", "@types/express-serve-static-core@4.17.30", "@types/express-serve-static-core@^4.17.18":
+  version "4.17.30"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.30.tgz#0f2f99617fa8f9696170c46152ccf7500b34ac04"
+  integrity sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -5130,10 +5121,10 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/express@^4.17.1", "@types/express@^4.17.2":
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.11.tgz#debe3caa6f8e5fcda96b47bd54e2f40c4ee59545"
-  integrity sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==
+"@types/express@^4.17.14", "@types/express@^4.17.2":
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.14.tgz#143ea0557249bc1b3b54f15db4c81c3d4eb3569c"
+  integrity sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "^4.17.18"


### PR DESCRIPTION
Recently, [this issue](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/40138) flared up in our remix tests, and it turns out the culprit was that DefinitelyTyped [removed TS 4.0 support from a number of packages](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62240), among them `@types/express-serve-static-core` (upon which `@types/express` depends).

Key changes in this fix:

- Lock `@types/express-serve-static-core` to the last version before this change.
- Add `@types/express` to `@sentry/remix`'s dev dependencies (where it should have been all along).
- Update all usages of `@types/express` to latest. (Not strictly necessary, but done as part of my debugging. Doesn't seem to break anything, and we might as well be up to date.)