### PR TITLE
ref(node): Move request data functions back to`@sentry/node`

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -14,10 +14,11 @@ import * as domain from 'domain';
 import * as http from 'http';
 
 import { NodeClient } from './client';
+import { addRequestDataToEvent, extractRequestData } from './requestdata';
 // TODO (v8 / XXX) Remove these imports
 import type { ParseRequestOptions } from './requestDataDeprecated';
 import { parseRequest } from './requestDataDeprecated';
-import { addRequestDataToEvent, extractRequestData, flush, isAutoSessionTrackingEnabled } from './sdk';
+import { flush, isAutoSessionTrackingEnabled } from './sdk';
 
 /**
  * Express-compatible tracing handler.

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -46,17 +46,8 @@ export {
 
 export { NodeClient } from './client';
 export { makeNodeTransport } from './transports';
-export {
-  addRequestDataToEvent,
-  extractRequestData,
-  defaultIntegrations,
-  init,
-  defaultStackParser,
-  lastEventId,
-  flush,
-  close,
-  getSentryRelease,
-} from './sdk';
+export { defaultIntegrations, init, defaultStackParser, lastEventId, flush, close, getSentryRelease } from './sdk';
+export { addRequestDataToEvent, extractRequestData } from './requestdata';
 export { deepReadDirSync } from './utils';
 
 import { Integrations as CoreIntegrations } from '@sentry/core';

--- a/packages/node/src/requestDataDeprecated.ts
+++ b/packages/node/src/requestDataDeprecated.ts
@@ -7,13 +7,12 @@
 /* eslint-disable deprecation/deprecation */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Event, ExtractedNodeRequestData, PolymorphicRequest } from '@sentry/types';
+
 import {
   addRequestDataToEvent,
   AddRequestDataToEventOptions,
   extractRequestData as _extractRequestData,
-} from '@sentry/utils';
-import * as cookie from 'cookie';
-import * as url from 'url';
+} from './requestdata';
 
 /**
  * @deprecated `Handlers.ExpressRequest` is deprecated and will be removed in v8. Use `PolymorphicRequest` instead.
@@ -30,7 +29,7 @@ export type ExpressRequest = PolymorphicRequest;
  * @returns An object containing normalized request data
  */
 export function extractRequestData(req: { [key: string]: any }, keys?: string[]): ExtractedNodeRequestData {
-  return _extractRequestData(req, { include: keys, deps: { cookie, url } });
+  return _extractRequestData(req, { include: keys });
 }
 
 /**
@@ -55,5 +54,5 @@ export type ParseRequestOptions = AddRequestDataToEventOptions['include'] & {
  * @hidden
  */
 export function parseRequest(event: Event, req: ExpressRequest, options: ParseRequestOptions = {}): Event {
-  return addRequestDataToEvent(event, req, { include: options, deps: { cookie, url } });
+  return addRequestDataToEvent(event, req, { include: options });
 }

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -1,20 +1,15 @@
 /* eslint-disable max-lines */
 import { getCurrentHub, getIntegrationsToSetup, initAndBind, Integrations as CoreIntegrations } from '@sentry/core';
 import { getMainCarrier, setHubOnCarrier } from '@sentry/hub';
-import { Event, ExtractedNodeRequestData, PolymorphicRequest, SessionStatus, StackParser } from '@sentry/types';
+import { SessionStatus, StackParser } from '@sentry/types';
 import {
-  addRequestDataToEvent as _addRequestDataToEvent,
-  AddRequestDataToEventOptions,
   createStackParser,
-  extractRequestData as _extractRequestData,
   getGlobalObject,
   logger,
   nodeStackLineParser,
   stackParserFromStackParserOptions,
 } from '@sentry/utils';
-import * as cookie from 'cookie';
 import * as domain from 'domain';
-import * as url from 'url';
 
 import { NodeClient } from './client';
 import {
@@ -277,52 +272,4 @@ function startSessionTracking(): void {
     // Ref: https://develop.sentry.dev/sdk/sessions/
     if (session && !terminalStates.includes(session.status)) hub.endSession();
   });
-}
-
-/**
- * Add data from the given request to the given event
- *
- * (Note that there is no sister function to this one in `@sentry/browser`, because the whole point of this wrapper is
- * to pass along injected dependencies, which isn't necessary in a browser context. Isomorphic packages like
- * `@sentry/nextjs` should export directly from `@sentry/utils` in their browser index file.)
- *
- * @param event The event to which the request data will be added
- * @param req Request object
- * @param options.include Flags to control what data is included
- * @hidden
- */
-export function addRequestDataToEvent(
-  event: Event,
-  req: PolymorphicRequest,
-  options?: Omit<AddRequestDataToEventOptions, 'deps'>,
-): Event {
-  return _addRequestDataToEvent(event, req, {
-    ...options,
-    // We have to inject these node-only dependencies because we can't import them in `@sentry/utils`, where the
-    // original function lives
-    deps: { cookie, url },
-  });
-}
-
-/**
- * Normalize data from the request object, accounting for framework differences.
- *
- * (Note that there is no sister function to this one in `@sentry/browser`, because the whole point of this wrapper is
- * to inject dependencies, which isn't necessary in a browser context. Isomorphic packages like `@sentry/nextjs` should
- * export directly from `@sentry/utils` in their browser index file.)
- *
- * @param req The request object from which to extract data
- * @param options.keys An optional array of keys to include in the normalized data. Defaults to DEFAULT_REQUEST_KEYS if
- * not provided.
- * @returns An object containing normalized request data
- */
-export function extractRequestData(
-  req: PolymorphicRequest,
-  options?: {
-    include?: string[];
-  },
-): ExtractedNodeRequestData {
-  // We have to inject these node-only dependencies because we can't import them in `@sentry/utils`, where the original
-  // function lives
-  return _extractRequestData(req, { ...options, deps: { cookie, url } });
 }

--- a/packages/node/test/requestdata.test.ts
+++ b/packages/node/test/requestdata.test.ts
@@ -1,32 +1,24 @@
 /* eslint-disable deprecation/deprecation */
 
-/* Note: These tests (except for the ones related to cookies) should eventually live in `@sentry/utils`, and can be
- * moved there once the the backwards-compatibility-preserving wrappers in `handlers.ts` are removed.
- */
-
-// TODO (v8 / #5257): Remove everything above
+// TODO (v8 / #5257): Remove everything related to the deprecated functions
 
 import { Event, PolymorphicRequest, TransactionSource, User } from '@sentry/types';
+import * as net from 'net';
+
 import {
   addRequestDataToEvent,
   AddRequestDataToEventOptions,
   extractPathForTransaction,
   extractRequestData as newExtractRequestData,
-} from '@sentry/utils';
-import * as cookie from 'cookie';
-import * as net from 'net';
-import * as url from 'url';
-
+} from '../src/requestdata';
 import {
   ExpressRequest,
   extractRequestData as oldExtractRequestData,
   parseRequest,
 } from '../src/requestDataDeprecated';
 
-const mockCookieModule = { parse: jest.fn() };
-
-// TODO (v8 / #5257): Remove `describe.each` wrapper, remove `formatArgs` wrapper, reformat args in tests, use only
-// `addRequestDataToEvent`, and move these tests to @sentry/utils
+// TODO (v8 / #5257): Remove `describe.each` wrapper, remove `formatArgs` wrapper, reformat args in tests, and use only
+// `addRequestDataToEvent`
 describe.each([parseRequest, addRequestDataToEvent])(
   'backwards compatibility of `parseRequest` rename and move',
   fn => {
@@ -40,17 +32,7 @@ describe.each([parseRequest, addRequestDataToEvent])(
       if (fn.name === 'parseRequest') {
         return [event, req as ExpressRequest, include];
       } else {
-        return [
-          event,
-          req as PolymorphicRequest,
-          {
-            include,
-            deps: {
-              cookie: mockCookieModule,
-              url,
-            },
-          },
-        ];
+        return [event, req as PolymorphicRequest, { include }];
       }
     }
 
@@ -255,8 +237,7 @@ describe.each([parseRequest, addRequestDataToEvent])(
 );
 
 // TODO (v8 / #5257): Remove `describe.each` wrapper, remove `formatArgs` wrapper, reformat args in tests, use only
-// `newExtractRequestData`, rename `newExtractRequestData` to just `extractRequestData`, and move these tests (except
-// the ones involving cookies) to @sentry/utils (use `mockCookieModule` for others)
+// `newExtractRequestData`, and rename `newExtractRequestData` to just `extractRequestData`
 Object.defineProperty(oldExtractRequestData, 'name', {
   value: 'oldExtractRequestData',
 });
@@ -275,16 +256,7 @@ describe.each([oldExtractRequestData, newExtractRequestData])(
       if (fn.name === 'oldExtractRequestData') {
         return [req as ExpressRequest, include] as Parameters<typeof oldExtractRequestData>;
       } else {
-        return [
-          req as PolymorphicRequest,
-          {
-            include,
-            deps: {
-              cookie: include?.includes('cookies') ? cookie : mockCookieModule,
-              url,
-            },
-          },
-        ] as Parameters<typeof newExtractRequestData>;
+        return [req as PolymorphicRequest, { include }] as Parameters<typeof newExtractRequestData>;
       }
     }
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -12,6 +12,7 @@ export * from './normalize';
 export * from './object';
 export * from './path';
 export * from './promisebuffer';
+// TODO: Remove requestdata export once equivalent integration is used everywhere
 export * from './requestdata';
 export * from './severity';
 export * from './stacktrace';


### PR DESCRIPTION
As part of the work adding a `RequestData` integration, this moves the `requestdata` functions back into the node SDK. (The dependency injection makes things hard to follow, and soon the original reason for the move (so that they could be used in the `_error` helper in the nextjs SDK, which runs in both browser and node) will no longer apply (once https://github.com/getsentry/sentry-javascript/pull/5729 is merged).)

Once these functions are no longer needed, they can be deleted from `@sentry/utils`.

More details and a work plan are in https://github.com/getsentry/sentry-javascript/issues/5756.
