### PR TITLE
feat(core): auto set release when Sentry.init without release

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -23,6 +23,7 @@ import {
   checkOrSetAlreadyCaught,
   createAttachmentEnvelopeItem,
   dateTimestampInSeconds,
+  getGlobalObject,
   isPlainObject,
   isPrimitive,
   isThenable,
@@ -216,6 +217,12 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    * @inheritDoc
    */
   public getOptions(): O {
+    const _global = getGlobalObject();
+
+    if (this._options.release === undefined && _global.SENTRY_RELEASE && _global.SENTRY_RELEASE.id) {
+      this._options.release = _global.SENTRY_RELEASE.id;
+    }
+
     return this._options;
   }
 


### PR DESCRIPTION
There is such a usage scenario that the event reported by sentry cannot be associated with the sourcemap file:

1. Import sentry using cdn link in index.html
2. Use ```@sentry/webpack-plugin``` to upload the sourcemap file
3. The ```release``` is not provided when using ```Sentry.init``` in index.html

And i read the source code of ```@sentry/webpack-plugin``` which injects the commitId into the SENTRY_RELEASE under the window, hence this pr.

