### PR TITLE
chore(build): Remove redundant `tsconfig` settings

### DIFF
--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -9,7 +9,6 @@
     "isolatedModules": true,
     "lib": ["es6", "dom"],
     "moduleResolution": "node",
-    "noEmitHelpers": true,
     "noErrorTruncation": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,5 @@
     "declaration": false,
     "declarationMap": false,
     "skipLibCheck": true,
-    "types": ["node"],
   }
 }


### PR DESCRIPTION
This removes two `tsconfig` settings which don't have any effect given settings elsewhere in the repo:

- `noEmitHelpers`: The [TS config docs](https://www.typescriptlang.org/tsconfig#noEmitHelpers) aren't super clear in saying this explicitly, but `noEmitHelpers` has no effect in the presence of `importHelpers: true`, because the latter means that no helper implementations will be emitted in any case, instead being imported from `tslib`.

- Node types: We've had Node types in our repo-level `tsconfig` for a long time, but all packages which need Node types already specify it themselves. Removing it in our top-level tsconfig also has the advantage that it means we won't accidentally use Node types where we shouldn't (like in browser-based and cross-platform packages).