### PR TITLE
feat(utils): Add `isEmpty` helper

### DIFF
--- a/packages/tracing/src/idletransaction.ts
+++ b/packages/tracing/src/idletransaction.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 import { Hub } from '@sentry/hub';
 import { TransactionContext } from '@sentry/types';
-import { logger, timestampWithMs } from '@sentry/utils';
+import { isEmptyObj, logger, timestampWithMs } from '@sentry/utils';
 
 import { Span, SpanRecorder } from './span';
 import { Transaction } from './transaction';
@@ -214,7 +214,7 @@ export class IdleTransaction extends Transaction {
   private _startIdleTimeout(endTimestamp?: Parameters<IdleTransaction['finish']>[0]): void {
     this._cancelIdleTimeout();
     this._idleTimeoutID = setTimeout(() => {
-      if (!this._finished && Object.keys(this.activities).length === 0) {
+      if (!this._finished && isEmptyObj(this.activities)) {
         this.finish(endTimestamp);
       }
     }, this._idleTimeout);
@@ -243,7 +243,7 @@ export class IdleTransaction extends Transaction {
       __DEBUG_BUILD__ && logger.log('[Tracing] new activities count', Object.keys(this.activities).length);
     }
 
-    if (Object.keys(this.activities).length === 0) {
+    if (isEmptyObj(this.activities)) {
       // We need to add the timeout here to have the real endtimestamp of the transaction
       // Remember timestampWithMs is in seconds, timeout is in ms
       const endTimestamp = timestampWithMs() + this._idleTimeout / 1000;

--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -1,6 +1,6 @@
 import { DynamicSamplingContext } from '@sentry/types';
 
-import { isString } from './is';
+import { isEmptyObj, isString } from './is';
 import { logger } from './logger';
 
 export const BAGGAGE_HEADER_NAME = 'baggage';
@@ -123,7 +123,7 @@ function baggageHeaderToObject(baggageHeader: string): Record<string, string> {
  * is not spec compliant.
  */
 function objectToBaggageHeader(object: Record<string, string>): string | undefined {
-  if (Object.keys(object).length === 0) {
+  if (isEmptyObj(object)) {
     // An empty baggage header is not spec compliant: We return undefined.
     return undefined;
   }

--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -4,7 +4,7 @@
 import { WrappedFunction } from '@sentry/types';
 
 import { getGlobalObject } from './global';
-import { isInstanceOf, isString } from './is';
+import { isEmptyObj, isInstanceOf, isString } from './is';
 import { CONSOLE_LEVELS, logger } from './logger';
 import { fill } from './object';
 import { getFunctionName } from './stacktrace';
@@ -562,7 +562,7 @@ function instrumentDOM(): void {
                 }
 
                 // If there are no longer any custom handlers of any type on this element, cleanup everything.
-                if (Object.keys(handlers).length === 0) {
+                if (isEmptyObj(handlers)) {
                   delete el.__sentry_instrumentation_handlers__;
                 }
               }

--- a/packages/utils/src/is.ts
+++ b/packages/utils/src/is.ts
@@ -179,3 +179,13 @@ export function isInstanceOf(wat: any, base: any): boolean {
     return false;
   }
 }
+
+/**
+ * Determine if an object is empty
+ *
+ * @param obj A plain object
+ * @returns True if object has none of its own properties
+ */
+export function isEmptyObj(obj: Record<string, unknown>): boolean {
+  return Object.keys(obj).length === 0;
+}


### PR DESCRIPTION
~This adds an `isEmpty` helper to `@sentry/utils`, which can be used on both objects and arrays.~

~(I wanted something to save me from having to write `if (Object.keys(someObj).length === 0)` just to check if there was stuff in an object Then it occurred to me that it'd save a few bytes if applied to arrays as well - when minified, it's the difference between `if (x.length === 0)` and `if (y(x))` - so I added those in, too.)~

Orrrrr.... not. Believe it or not, this actually makes the bundles bigger, because a) it inlines the function implementation wherever the function is called, and b) it creates a variable to store the results of the function, which it then has to return. (The numbers in the size-limit comment are for a scaled-down version of this PR which only included objects. With arrays included, it was significantly worse.)

So, I guess my laziness at not wanting to type out `Object.keys(someObj).length === 0` does not win out. Closing this.