### PR TITLE
ref(tracing): Don't track transaction sampling method

### DIFF
--- a/packages/core/src/envelope.ts
+++ b/packages/core/src/envelope.ts
@@ -70,9 +70,6 @@ export function createEventEnvelope(
   const sdkInfo = getSdkMetadataForEnvelopeHeader(metadata);
   const eventType = event.type || 'event';
 
-  const { transactionSampling } = event.sdkProcessingMetadata || {};
-  const { method: samplingMethod, rate: sampleRate } = transactionSampling || {};
-
   enhanceEventWithSdkInfo(event, metadata && metadata.sdk);
 
   const envelopeHeaders = createEventEnvelopeHeaders(event, sdkInfo, tunnel, dsn);
@@ -83,13 +80,7 @@ export function createEventEnvelope(
   // of this `delete`, lest we miss putting it back in the next time the property is in use.)
   delete event.sdkProcessingMetadata;
 
-  const eventItem: EventItem = [
-    {
-      type: eventType,
-      sample_rates: [{ id: samplingMethod, rate: sampleRate }],
-    },
-    event,
-  ];
+  const eventItem: EventItem = [{ type: eventType }, event];
   return createEnvelope<EventEnvelope>(envelopeHeaders, [eventItem]);
 }
 

--- a/packages/tracing/src/hubextensions.ts
+++ b/packages/tracing/src/hubextensions.ts
@@ -55,10 +55,7 @@ function sample<T extends Transaction>(
   // if the user has forced a sampling decision by passing a `sampled` value in their transaction context, go with that
   if (transaction.sampled !== undefined) {
     transaction.setMetadata({
-      transactionSampling: {
-        method: 'explicitly_set',
-        rate: Number(transaction.sampled),
-      },
+      sampleRate: Number(transaction.sampled),
     });
     return transaction;
   }
@@ -69,25 +66,14 @@ function sample<T extends Transaction>(
   if (typeof options.tracesSampler === 'function') {
     sampleRate = options.tracesSampler(samplingContext);
     transaction.setMetadata({
-      transactionSampling: {
-        method: 'client_sampler',
-        // cast to number in case it's a boolean
-        rate: Number(sampleRate),
-      },
+      sampleRate: Number(sampleRate),
     });
   } else if (samplingContext.parentSampled !== undefined) {
     sampleRate = samplingContext.parentSampled;
-    transaction.setMetadata({
-      transactionSampling: { method: 'inheritance' },
-    });
   } else {
     sampleRate = options.tracesSampleRate;
     transaction.setMetadata({
-      transactionSampling: {
-        method: 'client_rate',
-        // cast to number in case it's a boolean
-        rate: Number(sampleRate),
-      },
+      sampleRate: Number(sampleRate),
     });
   }
 

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -244,7 +244,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
     const { environment, release } = client.getOptions() || {};
     const { publicKey: public_key } = client.getDsn() || {};
 
-    const maybeSampleRate = (this.metadata.transactionSampling || {}).rate;
+    const maybeSampleRate = this.metadata.sampleRate;
     const sample_rate = maybeSampleRate !== undefined ? maybeSampleRate.toString() : undefined;
 
     const scope = hub.getScope();

--- a/packages/tracing/test/hub.test.ts
+++ b/packages/tracing/test/hub.test.ts
@@ -243,7 +243,7 @@ describe('Hub', () => {
         hub.startTransaction({ name: 'dogpark', sampled: true });
 
         expect(Transaction.prototype.setMetadata).toHaveBeenCalledWith({
-          transactionSampling: { method: 'explicitly_set', rate: 1.0 },
+          sampleRate: 1.0,
         });
       });
 
@@ -255,7 +255,7 @@ describe('Hub', () => {
         hub.startTransaction({ name: 'dogpark' });
 
         expect(Transaction.prototype.setMetadata).toHaveBeenCalledWith({
-          transactionSampling: { method: 'client_sampler', rate: 0.1121 },
+          sampleRate: 0.1121,
         });
       });
 
@@ -265,9 +265,7 @@ describe('Hub', () => {
         makeMain(hub);
         hub.startTransaction({ name: 'dogpark', parentSampled: true });
 
-        expect(Transaction.prototype.setMetadata).toHaveBeenCalledWith({
-          transactionSampling: { method: 'inheritance' },
-        });
+        expect(Transaction.prototype.setMetadata).toHaveBeenCalledTimes(0);
       });
 
       it('should record sampling method and rate when sampling decision comes from traceSampleRate', () => {
@@ -277,7 +275,7 @@ describe('Hub', () => {
         hub.startTransaction({ name: 'dogpark' });
 
         expect(Transaction.prototype.setMetadata).toHaveBeenCalledWith({
-          transactionSampling: { method: 'client_rate', rate: 0.1121 },
+          sampleRate: 0.1121,
         });
       });
     });

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -424,7 +424,7 @@ describe('Span', () => {
         {
           name: 'tx',
           metadata: {
-            transactionSampling: { rate: 0.56, method: 'client_rate' },
+            sampleRate: 0.56,
           },
         },
         hub,

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -3,7 +3,7 @@ import { DsnComponents } from './dsn';
 import { Event } from './event';
 import { SdkInfo } from './sdkinfo';
 import { Session, SessionAggregates } from './session';
-import { Transaction, TransactionSamplingMethod } from './transaction';
+import { Transaction } from './transaction';
 import { UserFeedback } from './user';
 
 // Based on: https://develop.sentry.dev/sdk/envelopes/
@@ -49,7 +49,6 @@ type BaseEnvelope<EH extends BaseEnvelopeHeaders, I extends BaseEnvelopeItem<Bas
 
 type EventItemHeaders = {
   type: 'event' | 'transaction';
-  sample_rates?: [{ id?: TransactionSamplingMethod; rate?: number }];
 };
 type AttachmentItemHeaders = {
   type: 'attachment';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -70,7 +70,6 @@ export type {
   Transaction,
   TransactionContext,
   TransactionMetadata,
-  TransactionSamplingMethod,
   TransactionSource,
   TransactionNameChange,
 } from './transaction';

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -134,10 +134,9 @@ export interface SamplingContext extends CustomSamplingContext {
   request?: ExtractedNodeRequestData;
 }
 
-export type TransactionSamplingMethod = 'explicitly_set' | 'client_sampler' | 'client_rate' | 'inheritance';
-
 export interface TransactionMetadata {
-  transactionSampling?: { rate?: number; method: TransactionSamplingMethod };
+  /** The sample rate used when sampling this transaction */
+  sampleRate?: number;
 
   /**
    * The Dynamic Sampling Context of a transaction. If provided during transaction creation, its Dynamic Sampling


### PR DESCRIPTION
In our initial work on Dynamic Sampling (https://github.com/getsentry/sentry-javascript/pull/3068), we added the ability to track transaction sampling method.

https://github.com/getsentry/sentry-javascript/pull/3068/files#diff-337facb22f742f05b3326aed66ca6b0d5eb9c782c7c03c88ef0170fd97dc410dR104-R109

```ts
export enum TransactionSamplingMethod {
  Explicit = 'explicitly_set',
  Sampler = 'client_sampler',
  Rate = 'client_rate',
  Inheritance = 'inheritance',
}
```

To use this info, we set the transaction sampling method and sample rate on the transaction event header:

```ts
sample_rates: [{ id: samplingMethod, rate: sampleRate }],
```

In Relay this is used here: https://github.com/getsentry/relay/blob/4b16d279ccf21d3c1d975b652ffca01ebd72a500/relay-general/src/protocol/metrics.rs#L7-L16

This is no longer needed for dynamic sampling context with the introduction of Dynamic Sampling Context, so we can remove this code.