### PR TITLE
fix(node): Remove trailing slash in `@sentry/utils` import

### DIFF
--- a/packages/node/src/requestdata.ts
+++ b/packages/node/src/requestdata.ts
@@ -1,5 +1,5 @@
 import { Event, ExtractedNodeRequestData, PolymorphicRequest, Transaction, TransactionSource } from '@sentry/types';
-import { isPlainObject, isString, normalize, stripUrlQueryAndFragment } from '@sentry/utils/';
+import { isPlainObject, isString, normalize, stripUrlQueryAndFragment } from '@sentry/utils';
 import * as cookie from 'cookie';
 import * as url from 'url';
 


### PR DESCRIPTION
This removes a trailing slash which somehow crept into an `@sentry/utils` import when the request-data-adding functions were moved back to node. As a result of the trailing slash, Rollup doesn't recognize the import as external, which leads to the inclusion of files from the utils package in the node build, as well as an incorrect file structure (the root which is used for `build/cjs` and `build/esm` becomes `packages` rather than `packages/node/src`).

(I think that the reason this wasn't caught by our tests is that both our unit and integration tests do their own building of the SDK, using `tsc` and `webpack`, respectively, which must have handled the trailing slash more gracefully than `rollup` does. We've talked before about having tests for our build process, and this is a good example of a time they would have been helpful.)
