### PR TITLE
fix(build): Fix regex in multiline-comment-removal Rollup plugin

### DIFF
--- a/rollup/plugins/npmPlugins.js
+++ b/rollup/plugins/npmPlugins.js
@@ -140,8 +140,11 @@ export function makeRemoveMultiLineCommentsPlugin() {
   return regexReplace({
     patterns: [
       {
-        // The `s` flag makes the dot match newlines
-        test: /^\/\*.*\*\//gs,
+        // If we ever want to remove all comments instead of just /* ... */ ones, the regex is
+        // /\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm. We also might consider a plugin like
+        // https://github.com/aMarCruz/rollup-plugin-cleanup (though to remove only multi-line comments we'd end up with
+        // a regex there, too).
+        test: /\/\*[\s\S]*?\*\//gm,
         replace: '',
       },
     ],


### PR DESCRIPTION
The existing regex, when presented with code like this:

```js
/* 
 * This is
 * a multiline
 * comment 
 */

const thisIs = "real code"

/* 
 * This is
 * another multiline
 * comment 
 */

const thisIsAlso = "real code"
```

matches everything between the initial `/*` on the first line and the final `*/` on the second-to-last line, and the plugin thus removes all but the last line of the file. This fixes the regex so that only the comments are removed.