### PR TITLE
test(angular): Increase Angular SDK test coverage.

### DIFF
--- a/packages/angular/.eslintrc.js
+++ b/packages/angular/.eslintrc.js
@@ -3,4 +3,5 @@ module.exports = {
     browser: true,
   },
   extends: ['../../.eslintrc.js'],
+  ignorePatterns: ['setup-jest.ts'],
 };

--- a/packages/angular/jest.config.js
+++ b/packages/angular/jest.config.js
@@ -3,4 +3,5 @@ const baseConfig = require('../../jest/jest.config.js');
 module.exports = {
   ...baseConfig,
   testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],
 };

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1002.4",
-    "@angular/animations": "~10.2.5",
     "@angular/cli": "^10.2.4",
     "@angular/common": "~10.2.5",
     "@angular/compiler": "^10.2.5",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -28,14 +28,18 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.1002.4",
+    "@angular/animations": "~10.2.5",
     "@angular/cli": "^10.2.4",
     "@angular/common": "~10.2.5",
     "@angular/compiler": "^10.2.5",
     "@angular/compiler-cli": "~10.2.5",
     "@angular/core": "~10.2.5",
+    "@angular/platform-browser": "~10.2.5",
+    "@angular/platform-browser-dynamic": "~10.2.5",
     "@angular/router": "~10.2.5",
     "ng-packagr": "^10.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "zone.js": "^0.11.8"
   },
   "scripts": {
     "build": "yarn build:ngc",

--- a/packages/angular/setup-jest.ts
+++ b/packages/angular/setup-jest.ts
@@ -1,0 +1,7 @@
+import 'zone.js';
+
+import { TestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+
+TestBed.resetTestEnvironment();
+TestBed.initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());

--- a/packages/angular/test/errorhandler.test.ts
+++ b/packages/angular/test/errorhandler.test.ts
@@ -121,4 +121,28 @@ describe('SentryErrorHandler', () => {
       expect.any(Function),
     );
   });
+
+  it('handleError method shows report dialog', () => {
+    const showReportDialogSpy = jest.spyOn(SentryBrowser, 'showReportDialog');
+
+    const errorHandler = createErrorHandler({ showDialog: true });
+    errorHandler.handleError(new Error('test'));
+
+    expect(showReportDialogSpy).toBeCalledTimes(1);
+  });
+
+  it('handleError method extracts error with a custom extractor', () => {
+    const customExtractor = (error: unknown) => {
+      if (typeof error === 'string') {
+        return new Error(`custom ${error}`);
+      }
+      return error;
+    };
+
+    const errorHandler = createErrorHandler({ extractor: customExtractor });
+    errorHandler.handleError('error');
+
+    expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
+    expect(captureExceptionSpy).toHaveBeenCalledWith(new Error('custom error'), expect.any(Function));
+  });
 });

--- a/packages/angular/test/tracing.test.ts
+++ b/packages/angular/test/tracing.test.ts
@@ -1,12 +1,21 @@
-import { ActivatedRouteSnapshot, Event, NavigationStart, ResolveEnd, Router } from '@angular/router';
-import { Hub, Transaction } from '@sentry/types';
-import { Subject } from 'rxjs';
+import { Component } from '@angular/core';
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { Hub } from '@sentry/types';
 
-import { instrumentAngularRouting, TraceService } from '../src/index';
+import { instrumentAngularRouting, TraceClassDecorator, TraceDirective, TraceMethodDecorator } from '../src';
 import { getParameterizedRouteFromSnapshot } from '../src/tracing';
+import { AppComponent, TestEnv } from './utils/index';
 
 let transaction: any;
-let customStartTransaction: (context: any) => Transaction | undefined;
+
+const defaultStartTransaction = (ctx: any) => {
+  transaction = {
+    ...ctx,
+    setName: jest.fn(name => (transaction.name = name)),
+  };
+
+  return transaction;
+};
 
 jest.mock('@sentry/browser', () => {
   const original = jest.requireActual('@sentry/browser');
@@ -27,160 +36,19 @@ jest.mock('@sentry/browser', () => {
 });
 
 describe('Angular Tracing', () => {
-  const startTransaction = jest.fn();
+  beforeEach(() => {
+    transaction = undefined;
+  });
 
   describe('instrumentAngularRouting', () => {
     it('should attach the transaction source on the pageload transaction', () => {
+      const startTransaction = jest.fn();
       instrumentAngularRouting(startTransaction);
+
       expect(startTransaction).toHaveBeenCalledWith({
         name: '/',
         op: 'pageload',
         metadata: { source: 'url' },
-      });
-    });
-  });
-
-  describe('TraceService', () => {
-    let traceService: TraceService;
-    const routerEvents$: Subject<Event> = new Subject();
-    const mockedRouter: Partial<Router> = {
-      events: routerEvents$,
-    };
-
-    beforeEach(() => {
-      instrumentAngularRouting(startTransaction);
-      jest.resetAllMocks();
-      traceService = new TraceService(mockedRouter as Router);
-    });
-
-    afterEach(() => {
-      traceService.ngOnDestroy();
-    });
-
-    it('attaches the transaction source on a navigation change', () => {
-      routerEvents$.next(new NavigationStart(0, 'user/123/credentials'));
-
-      expect(startTransaction).toHaveBeenCalledTimes(1);
-      expect(startTransaction).toHaveBeenCalledWith({
-        name: 'user/123/credentials',
-        op: 'navigation',
-        metadata: { source: 'url' },
-      });
-    });
-
-    describe('URL parameterization', () => {
-      // TODO: These tests are real unit tests in the sense that they only test TraceService
-      //       and we essentially just simulate a router navigation by firing the respective
-      //       routing events and providing the raw URL + the resolved route parameters.
-      //       In the future we should add more "wholesome" tests that let the Angular router
-      //       do its thing (e.g. by calling router.navigate) and we check how our service
-      //       reacts to it.
-      //       Once we set up Jest for testing Angular, we can use TestBed to inject an actual
-      //       router instance into TraceService and add more tests.
-
-      beforeEach(() => {
-        transaction = undefined;
-        customStartTransaction = jest.fn((ctx: any) => {
-          transaction = {
-            ...ctx,
-            setName: jest.fn(name => (transaction.name = name)),
-          };
-          return transaction;
-        });
-      });
-
-      it.each([
-        [
-          'handles the root URL correctly',
-          '',
-          {
-            root: { firstChild: { routeConfig: null } },
-          },
-          '/',
-        ],
-        [
-          'does not alter static routes',
-          '/books/',
-          {
-            root: { firstChild: { routeConfig: { path: 'books' } } },
-          },
-          '/books/',
-        ],
-        [
-          'parameterizes IDs in the URL',
-          '/books/1/details',
-          {
-            root: { firstChild: { routeConfig: { path: 'books/:bookId/details' } } },
-          },
-          '/books/:bookId/details/',
-        ],
-        [
-          'parameterizes multiple IDs in the URL',
-          '/org/sentry/projects/1234/events/04bc6846-4a1e-4af5-984a-003258f33e31',
-          {
-            root: { firstChild: { routeConfig: { path: 'org/:orgId/projects/:projId/events/:eventId' } } },
-          },
-          '/org/:orgId/projects/:projId/events/:eventId/',
-        ],
-        [
-          'parameterizes URLs from route with child routes',
-          '/org/sentry/projects/1234/events/04bc6846-4a1e-4af5-984a-003258f33e31',
-          {
-            root: {
-              firstChild: {
-                routeConfig: { path: 'org/:orgId' },
-                firstChild: {
-                  routeConfig: { path: 'projects/:projId' },
-                  firstChild: { routeConfig: { path: 'events/:eventId' } },
-                },
-              },
-            },
-          },
-          '/org/:orgId/projects/:projId/events/:eventId/',
-        ],
-      ])('%s and sets the source to `route`', (_, url, routerState, result) => {
-        instrumentAngularRouting(customStartTransaction, false, true);
-
-        // this event starts the transaction
-        routerEvents$.next(new NavigationStart(0, url));
-
-        expect(customStartTransaction).toHaveBeenCalledWith({
-          name: url,
-          op: 'navigation',
-          metadata: { source: 'url' },
-        });
-
-        // this event starts the parameterization
-        routerEvents$.next(new ResolveEnd(1, url, url, routerState as any));
-
-        expect(transaction.setName).toHaveBeenCalledWith(result, 'route');
-      });
-
-      it('does not change the transaction name if the source is something other than `url`', () => {
-        instrumentAngularRouting(customStartTransaction, false, true);
-
-        const url = '/user/12345/test';
-
-        routerEvents$.next(new NavigationStart(0, url));
-
-        expect(customStartTransaction).toHaveBeenCalledWith({
-          name: url,
-          op: 'navigation',
-          metadata: { source: 'url' },
-        });
-
-        // Simulate that this transaction has a custom name:
-        transaction.metadata.source = 'custom';
-
-        // this event starts the parameterization
-        routerEvents$.next(
-          new ResolveEnd(1, url, url, {
-            root: { firstChild: { routeConfig: { path: 'org/:orgId/projects/:projId/events/:eventId' } } },
-          } as any),
-        );
-
-        expect(transaction.setName).toHaveBeenCalledTimes(0);
-        expect(transaction.name).toEqual(url);
       });
     });
   });
@@ -212,6 +80,364 @@ describe('Angular Tracing', () => {
       expect(getParameterizedRouteFromSnapshot(routeSnapshot as unknown as ActivatedRouteSnapshot)).toEqual(
         expectedParams,
       );
+    });
+  });
+
+  describe('TraceService', () => {
+    it('does not change the transaction name if the source is something other than `url`', async () => {
+      const customStartTransaction = jest.fn((ctx: any) => {
+        transaction = {
+          ...ctx,
+          metadata: {
+            ...ctx.metadata,
+            source: 'custom',
+          },
+          setName: jest.fn(name => (transaction.name = name)),
+        };
+
+        return transaction;
+      });
+
+      const env = await TestEnv.setup({
+        customStartTransaction,
+        routes: [
+          {
+            path: '',
+            component: AppComponent,
+          },
+        ],
+      });
+
+      const url = '/';
+
+      await env.navigateInAngular(url);
+
+      expect(customStartTransaction).toHaveBeenCalledWith({
+        name: url,
+        op: 'pageload',
+        metadata: { source: 'url' },
+      });
+
+      expect(transaction.setName).toHaveBeenCalledTimes(0);
+      expect(transaction.name).toEqual(url);
+
+      env.destroy();
+    });
+
+    it('re-assigns routing span on navigation start with active transaction.', async () => {
+      const customStartTransaction = jest.fn(defaultStartTransaction);
+
+      const env = await TestEnv.setup({
+        customStartTransaction,
+      });
+
+      const finishMock = jest.fn();
+      transaction.startChild = jest.fn(() => ({
+        finish: finishMock,
+      }));
+
+      await env.navigateInAngular('/');
+
+      expect(finishMock).toHaveBeenCalledTimes(1);
+
+      env.destroy();
+    });
+
+    it('finishes routing span on navigation end', async () => {
+      const customStartTransaction = jest.fn(defaultStartTransaction);
+
+      const env = await TestEnv.setup({
+        customStartTransaction,
+      });
+
+      const finishMock = jest.fn();
+      transaction.startChild = jest.fn(() => ({
+        finish: finishMock,
+      }));
+
+      await env.navigateInAngular('/');
+
+      expect(finishMock).toHaveBeenCalledTimes(1);
+
+      env.destroy();
+    });
+
+    describe('URL parameterization', () => {
+      it.each([
+        [
+          'handles the root URL correctly',
+          '/',
+          {
+            root: { firstChild: { routeConfig: null } },
+          },
+          '/',
+          [
+            {
+              path: '',
+              component: AppComponent,
+            },
+          ],
+        ],
+        [
+          'does not alter static routes',
+          '/books',
+          {
+            root: { firstChild: { routeConfig: { path: 'books' } } },
+          },
+          '/books/',
+          [
+            {
+              path: 'books',
+              component: AppComponent,
+            },
+          ],
+        ],
+        [
+          'parameterizes IDs in the URL',
+          '/books/1/details',
+          {
+            root: { firstChild: { routeConfig: { path: 'books/:bookId/details' } } },
+          },
+          '/books/:bookId/details/',
+          [
+            {
+              path: 'books/:bookId/details',
+              component: AppComponent,
+            },
+          ],
+        ],
+        [
+          'parameterizes multiple IDs in the URL',
+          '/org/sentry/projects/1234/events/04bc6846-4a1e-4af5-984a-003258f33e31',
+          {
+            root: { firstChild: { routeConfig: { path: 'org/:orgId/projects/:projId/events/:eventId' } } },
+          },
+          '/org/:orgId/projects/:projId/events/:eventId/',
+          [
+            {
+              path: 'org/:orgId/projects/:projId/events/:eventId',
+              component: AppComponent,
+            },
+          ],
+        ],
+        [
+          'parameterizes URLs from route with child routes',
+          '/org/sentry/projects/1234/events/04bc6846-4a1e-4af5-984a-003258f33e31',
+          {
+            root: {
+              firstChild: {
+                routeConfig: { path: 'org/:orgId' },
+                firstChild: {
+                  routeConfig: { path: 'projects/:projId' },
+                  firstChild: { routeConfig: { path: 'events/:eventId' } },
+                },
+              },
+            },
+          },
+          '/org/:orgId/projects/:projId/events/:eventId/',
+          [
+            {
+              path: 'org/:orgId',
+              component: AppComponent,
+              children: [
+                {
+                  path: 'projects/:projId',
+                  component: AppComponent,
+                  children: [
+                    {
+                      path: 'events/:eventId',
+                      component: AppComponent,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        ],
+      ])('%s and sets the source to `route`', async (_, url, routerState, result, routes) => {
+        const customStartTransaction = jest.fn(defaultStartTransaction);
+        const env = await TestEnv.setup({
+          customStartTransaction,
+          routes,
+          startTransactionOnPageLoad: false,
+        });
+
+        await env.navigateInAngular(url, routerState);
+
+        expect(customStartTransaction).toHaveBeenCalledWith({
+          name: url,
+          op: 'navigation',
+          metadata: { source: 'url' },
+        });
+        expect(transaction.setName).toHaveBeenCalledWith(result, 'route');
+
+        env.destroy();
+      });
+    });
+  });
+
+  describe('TraceDirective', () => {
+    it('should create an instance', () => {
+      const directive = new TraceDirective();
+      expect(directive).toBeTruthy();
+    });
+
+    it('should create a child tracingSpan on init', async () => {
+      const directive = new TraceDirective();
+      const customStartTransaction = jest.fn(defaultStartTransaction);
+
+      const env = await TestEnv.setup({
+        components: [TraceDirective],
+        customStartTransaction,
+        useTraceService: false,
+      });
+
+      transaction.startChild = jest.fn();
+
+      directive.ngOnInit();
+
+      expect(transaction.startChild).toHaveBeenCalledWith({
+        op: 'ui.angular.init',
+        description: '<unknown>',
+      });
+
+      env.destroy();
+    });
+
+    it('should finish tracingSpan after view init', async () => {
+      const directive = new TraceDirective();
+      const finishMock = jest.fn();
+      const customStartTransaction = jest.fn(defaultStartTransaction);
+
+      const env = await TestEnv.setup({
+        components: [TraceDirective],
+        customStartTransaction,
+        useTraceService: false,
+      });
+
+      transaction.startChild = jest.fn(() => ({
+        finish: finishMock,
+      }));
+
+      directive.ngOnInit();
+      directive.ngAfterViewInit();
+
+      expect(finishMock).toHaveBeenCalledTimes(1);
+
+      env.destroy();
+    });
+  });
+
+  describe('TraceClassDecorator', () => {
+    const origNgOnInitMock = jest.fn();
+    const origNgAfterViewInitMock = jest.fn();
+
+    @Component({
+      selector: 'layout-header',
+      template: '<router-outlet></router-outlet>',
+    })
+    @TraceClassDecorator()
+    class DecoratedComponent {
+      public ngOnInit() {
+        origNgOnInitMock();
+      }
+      public ngAfterViewInit() {
+        origNgAfterViewInitMock();
+      }
+    }
+
+    it('Instruments `ngOnInit` and `ngAfterViewInit` methods of the decorated class', async () => {
+      const finishMock = jest.fn();
+      const startChildMock = jest.fn(() => ({
+        finish: finishMock,
+      }));
+
+      const customStartTransaction = jest.fn((ctx: any) => {
+        transaction = {
+          ...ctx,
+          startChild: startChildMock,
+        };
+
+        return transaction;
+      });
+
+      const env = await TestEnv.setup({
+        customStartTransaction,
+        components: [DecoratedComponent],
+        defaultComponent: DecoratedComponent,
+        useTraceService: false,
+      });
+
+      expect(transaction.startChild).toHaveBeenCalledWith({
+        description: '<DecoratedComponent>',
+        op: 'ui.angular.init',
+      });
+
+      expect(origNgOnInitMock).toHaveBeenCalledTimes(1);
+      expect(origNgAfterViewInitMock).toHaveBeenCalledTimes(1);
+      expect(finishMock).toHaveBeenCalledTimes(1);
+
+      env.destroy();
+    });
+  });
+
+  describe('TraceMethodDecorator', () => {
+    const origNgOnInitMock = jest.fn();
+    const origNgAfterViewInitMock = jest.fn();
+
+    @Component({
+      selector: 'layout-header',
+      template: '<router-outlet></router-outlet>',
+    })
+    class DecoratedComponent {
+      @TraceMethodDecorator()
+      public ngOnInit() {
+        origNgOnInitMock();
+      }
+      @TraceMethodDecorator()
+      public ngAfterViewInit() {
+        origNgAfterViewInitMock();
+      }
+    }
+
+    it('Instruments `ngOnInit` and `ngAfterViewInit` methods of the decorated class', async () => {
+      const startChildMock = jest.fn();
+
+      const customStartTransaction = jest.fn((ctx: any) => {
+        transaction = {
+          ...ctx,
+          startChild: startChildMock,
+        };
+
+        return transaction;
+      });
+
+      const env = await TestEnv.setup({
+        customStartTransaction,
+        components: [DecoratedComponent],
+        defaultComponent: DecoratedComponent,
+        useTraceService: false,
+      });
+
+      expect(transaction.startChild).toHaveBeenCalledTimes(2);
+      expect(transaction.startChild.mock.calls[0][0]).toEqual({
+        description: '<DecoratedComponent>',
+        op: 'ui.angular.ngOnInit',
+        startTimestamp: expect.any(Number),
+        endTimestamp: expect.any(Number),
+      });
+
+      expect(transaction.startChild.mock.calls[1][0]).toEqual({
+        description: '<DecoratedComponent>',
+        op: 'ui.angular.ngAfterViewInit',
+        startTimestamp: expect.any(Number),
+        endTimestamp: expect.any(Number),
+      });
+
+      expect(origNgOnInitMock).toHaveBeenCalledTimes(1);
+      expect(origNgAfterViewInitMock).toHaveBeenCalledTimes(1);
+
+      env.destroy();
     });
   });
 });

--- a/packages/angular/test/utils/index.ts
+++ b/packages/angular/test/utils/index.ts
@@ -1,0 +1,96 @@
+import { Component, NgModule } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router, Routes } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Transaction } from '@sentry/types';
+
+import { instrumentAngularRouting, TraceService } from '../../src';
+
+@Component({
+  template: '<router-outlet></router-outlet>',
+})
+export class AppComponent {}
+
+@NgModule({
+  providers: [
+    {
+      provide: TraceService,
+      deps: [Router],
+    },
+  ],
+})
+export class AppModule {}
+
+const defaultRoutes = [
+  {
+    path: '',
+    component: AppComponent,
+  },
+];
+
+export class TestEnv {
+  constructor(
+    public router: Router,
+    public fixture: ComponentFixture<unknown>,
+    public traceService: TraceService | null,
+  ) {
+    fixture.detectChanges();
+  }
+
+  public static async setup(conf: {
+    routes?: Routes;
+    components?: any[];
+    defaultComponent?: any;
+    customStartTransaction?: (context: any) => Transaction | undefined;
+    startTransactionOnPageLoad?: boolean;
+    startTransactionOnNavigation?: boolean;
+    useTraceService?: boolean;
+  }): Promise<TestEnv> {
+    instrumentAngularRouting(
+      conf.customStartTransaction || jest.fn(),
+      conf.startTransactionOnPageLoad !== undefined ? conf.startTransactionOnPageLoad : true,
+      conf.startTransactionOnNavigation !== undefined ? conf.startTransactionOnNavigation : true,
+    );
+
+    const useTraceService = conf.useTraceService !== undefined ? conf.useTraceService : true;
+    const routes = conf.routes === undefined ? defaultRoutes : conf.routes;
+
+    TestBed.configureTestingModule({
+      imports: [AppModule, RouterTestingModule.withRoutes(routes)],
+      declarations: [...(conf.components || []), AppComponent],
+      providers: useTraceService
+        ? [
+            {
+              provide: TraceService,
+              deps: [Router],
+            },
+          ]
+        : [],
+    });
+
+    const router: Router = TestBed.inject(Router);
+    const traceService = useTraceService ? new TraceService(router) : null;
+    const fixture = TestBed.createComponent(conf.defaultComponent || AppComponent);
+
+    return new TestEnv(router, fixture, traceService);
+  }
+
+  public async navigateInAngular(url: string, routerState?: { [k: string]: any }): Promise<void> {
+    return new Promise(resolve => {
+      return this.fixture.ngZone?.run(() => {
+        void this.router.navigateByUrl(url, { state: routerState }).then(() => {
+          this.fixture.detectChanges();
+          resolve();
+        });
+      });
+    });
+  }
+
+  public destroy(): void {
+    if (this.traceService) {
+      this.traceService.ngOnDestroy();
+    }
+
+    jest.clearAllMocks();
+  }
+}

--- a/packages/angular/test/utils/index.ts
+++ b/packages/angular/test/utils/index.ts
@@ -75,10 +75,10 @@ export class TestEnv {
     return new TestEnv(router, fixture, traceService);
   }
 
-  public async navigateInAngular(url: string, routerState?: { [k: string]: any }): Promise<void> {
+  public async navigateInAngular(url: string): Promise<void> {
     return new Promise(resolve => {
       return this.fixture.ngZone?.run(() => {
-        void this.router.navigateByUrl(url, { state: routerState }).then(() => {
+        void this.router.navigateByUrl(url).then(() => {
           this.fixture.detectChanges();
           resolve();
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,6 +128,13 @@
     ora "5.0.0"
     rxjs "6.6.2"
 
+"@angular/animations@~10.2.5":
+  version "10.2.5"
+  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-10.2.5.tgz#9b4aaa2a2f88f848decb5a03f2ddaa2aed37642d"
+  integrity sha512-lIMwjY1pAqpCM4Ayndf2RsvOWRUc5QV7W82XNou6pIBv2T1i1XV6H72I5Sk9Z4sxxBYCWncEaEub+C6NcS8QRg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@angular/cli@^10.2.4":
   version "10.2.4"
   resolved "https://registry.yarnpkg.com/@angular/cli/-/cli-10.2.4.tgz#f8899eee8f774cd805b1831a8f2f865024e9f4e1"
@@ -191,6 +198,20 @@
   version "10.2.5"
   resolved "https://registry.yarnpkg.com/@angular/core/-/core-10.2.5.tgz#2050b0dbb180aa98c2ec46bba6d4827565ba2a2d"
   integrity sha512-krhOKNTj5XE92Rk9ASX5KmgTF72j7qT2PLVxrGEVjuUKjBY2XaK3TV0Kotq9zI3qa9WgeCrP/Njn6jlKQCCAEQ==
+  dependencies:
+    tslib "^2.0.0"
+
+"@angular/platform-browser-dynamic@~10.2.5":
+  version "10.2.5"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-10.2.5.tgz#c9eea9e076a9fc8f80d7c041ba9766465613bb96"
+  integrity sha512-7z443I80K2CeqzczlSJ8BlABj0uRgnHUrABE8yLlU2BgifJrriBawzSXEV7UMEN7k7ezbc6NhpOn6Q6BrCKEOA==
+  dependencies:
+    tslib "^2.0.0"
+
+"@angular/platform-browser@~10.2.5":
+  version "10.2.5"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-10.2.5.tgz#40dd88c937af7af56e3fb246608c7001e4ac09c7"
+  integrity sha512-3JDFRGNxr0IUkjSdGK2Q1BvqnSDpy9YWo0DJP+TEpgW578R84m4X7/wI3jJmFSC2yyouMWrHsot2vcBPAQj89g==
   dependencies:
     tslib "^2.0.0"
 
@@ -26984,3 +27005,10 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zone.js@^0.11.8:
+  version "0.11.8"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.11.8.tgz#40dea9adc1ad007b5effb2bfed17f350f1f46a21"
+  integrity sha512-82bctBg2hKcEJ21humWIkXRlLBBmrc3nN7DFh5LGGhcyycO2S7FN8NmdvlcKaGFDNVL4/9kFLmwmInTavdJERA==
+  dependencies:
+    tslib "^2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,13 +128,6 @@
     ora "5.0.0"
     rxjs "6.6.2"
 
-"@angular/animations@~10.2.5":
-  version "10.2.5"
-  resolved "https://registry.yarnpkg.com/@angular/animations/-/animations-10.2.5.tgz#9b4aaa2a2f88f848decb5a03f2ddaa2aed37642d"
-  integrity sha512-lIMwjY1pAqpCM4Ayndf2RsvOWRUc5QV7W82XNou6pIBv2T1i1XV6H72I5Sk9Z4sxxBYCWncEaEub+C6NcS8QRg==
-  dependencies:
-    tslib "^2.0.0"
-
 "@angular/cli@^10.2.4":
   version "10.2.4"
   resolved "https://registry.yarnpkg.com/@angular/cli/-/cli-10.2.4.tgz#f8899eee8f774cd805b1831a8f2f865024e9f4e1"


### PR DESCRIPTION
Resolves: #4143

This PR increases unit test coverage of Angular SDK by integrating [`TestBed`](https://angular.io/api/core/testing/TestBed).

The main work here is done on [`tracing.ts`](https://github.com/getsentry/sentry-javascript/blob/12c19d051eca4fcef316ba6ee512f1221ae92ef0/packages/angular/src/tracing.ts) which had low test coverage, and the previous tests were [faking the angular router](https://github.com/getsentry/sentry-javascript/blob/12c19d051eca4fcef316ba6ee512f1221ae92ef0/packages/angular/test/tracing.test.ts#L72-L79).

I attempted to use `@testing-library/angular` to be consistent with other SDK tests like `@sentry/react` and `@sentry/svelte`, but it was not possible as [it doesn't support renders without compiled components](https://github.com/testing-library/angular-testing-library/blob/36648c4b431a9e17efa1f59cc2d83710c17a42ee/projects/testing-library/src/lib/testing-library.ts#L43-L89) which we need while testing [`TraceService`](https://github.com/getsentry/sentry-javascript/pull/5790/files#diff-d46ba52093e0179db0bc8dfa1887658374319ebf783602153a45f0e4f4b06e72R55-R72). 

Coverage before:

```
-----------------|---------|----------|---------|---------|-----------------------------------------
File             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                       
-----------------|---------|----------|---------|---------|-----------------------------------------
All files        |    76.5 |    68.57 |   52.27 |   75.43 |                                         
 constants.ts    |     100 |      100 |     100 |     100 |                                         
 errorhandler.ts |   90.24 |    88.23 |     100 |   89.74 | 68,78-79,120                            
 flags.ts        |     100 |       50 |     100 |     100 | 13                                      
 index.ts        |     100 |      100 |   18.18 |     100 |                                         
 sdk.ts          |   93.33 |       60 |     100 |   93.33 | 33                                      
 tracing.ts      |   63.46 |    64.86 |   45.45 |   61.85 | ...1,87,128-133,173-188,210-233,245-264 
 zone.ts         |     100 |       50 |     100 |     100 | 12-27                                   
-----------------|---------|----------|---------|---------|-----------------------------------------
```

Coverage after:

```
------------------|---------|----------|---------|---------|-------------------
File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------------|---------|----------|---------|---------|-------------------
All files         |   97.22 |    86.02 |   88.23 |      97 |                   
 src              |   96.72 |    85.71 |   86.36 |   96.49 |                   
  constants.ts    |     100 |      100 |     100 |     100 |                   
  errorhandler.ts |   97.56 |      100 |     100 |   97.43 | 120               
  flags.ts        |     100 |       50 |     100 |     100 | 13                
  index.ts        |     100 |      100 |   45.45 |     100 |                   
  sdk.ts          |   93.33 |       60 |     100 |   93.33 | 33                
  tracing.ts      |   96.15 |    89.18 |     100 |   95.87 | 56,69-71,87       
  zone.ts         |     100 |       75 |     100 |     100 | 27                
 test/utils       |     100 |    86.95 |     100 |     100 |                   
  index.ts        |     100 |    86.95 |     100 |     100 | 50,52,80          
------------------|---------|----------|---------|---------|-------------------
```
