### PR TITLE
feat(node): Add integrations sdk information

### DIFF
--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -31,6 +31,7 @@ export class NodeClient extends BaseClient<NodeClientOptions> {
           version: SDK_VERSION,
         },
       ],
+      integrations: Object.keys(options.integrations).sort(),
       version: SDK_VERSION,
     };
 


### PR DESCRIPTION
### Summary
This adds 'integrations' to the sdk_info passed to ingest, mimics equivalent passing of integrations for python (see https://github.com/getsentry/sentry-python/blob/9fd938ed8762c06a8a1d355beb79f57c199ca92c/sentry_sdk/client.py\#L197).

Saw this was missing when trying to figure out which of our db integrations sees the most use.
