### PR TITLE
feat(nextjs): Promote option to automatically wrap data fetchers and API routes to non-experimental

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -55,10 +55,8 @@ export type UserSentryOptions = {
   // up uploading too many files, which is why this defaults to `false`.
   widenClientFileUpload?: boolean;
 
-  experiments?: {
-    // Automatically wrap `getInitialProps`, `getServerSideProps`, and `getStaticProps` in order to instrument them for tracing.
-    autoWrapDataFetchers?: boolean;
-  };
+  // Automatically instrument Next.js data fetching methods and Next.js API routes
+  autoInstrumentServerFunctions?: boolean;
 };
 
 export type NextConfigFunction = (phase: string, defaults: { defaultConfig: NextConfigObject }) => NextConfigObject;

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -79,7 +79,7 @@ export function constructWebpackConfigFunction(
         ],
       };
 
-      if (userSentryOptions.experiments?.autoWrapDataFetchers) {
+      if (userSentryOptions.autoInstrumentServerFunctions) {
         const pagesDir = newConfig.resolve?.alias?.['private-next-pages'] as string;
 
         newConfig.module.rules.push({

--- a/packages/nextjs/test/integration/next.config.js
+++ b/packages/nextjs/test/integration/next.config.js
@@ -5,7 +5,7 @@ const moduleExports = {
     ignoreDuringBuilds: true,
   },
   sentry: {
-    experiments: { autoWrapDataFetchers: true },
+    autoInstrumentServerFunctions: true,
     // Suppress the warning message from `handleSourcemapHidingOptionWarning` in `src/config/webpack.ts`
     // TODO (v8): This can come out in v8, because this option will get a default value
     hideSourceMaps: false,

--- a/packages/nextjs/test/integration/next10.config.template
+++ b/packages/nextjs/test/integration/next10.config.template
@@ -6,7 +6,7 @@ const moduleExports = {
     webpack5: %RUN_WEBPACK_5%,
   },
   sentry: {
-    experiments: { autoWrapDataFetchers: true },
+    autoInstrumentServerFunctions: true,
     // Suppress the warning message from `handleSourcemapHidingOptionWarning` in `src/config/webpack.ts`
     // TODO (v8): This can come out in v8, because this option will get a default value
     hideSourceMaps: false,

--- a/packages/nextjs/test/integration/next11.config.template
+++ b/packages/nextjs/test/integration/next11.config.template
@@ -7,7 +7,7 @@ const moduleExports = {
     ignoreDuringBuilds: true,
   },
   sentry: {
-    experiments: { autoWrapDataFetchers: true },
+    autoInstrumentServerFunctions: true,
     // Suppress the warning message from `handleSourcemapHidingOptionWarning` in `src/config/webpack.ts`
     // TODO (v8): This can come out in v8, because this option will get a default value
     hideSourceMaps: false,


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/5505

Promotes `experiments.autoWrapDataFetchers` option in the Sentry Next.js config to a proper option called `autoInstrumentServerFunctions`.

---

Other names I considered naming this option:
- `instrumentServerRequests`
- `autoInstrumentServerMethods`
