### PR TITLE
fix(tracing): Remove `connection.downlink` measurement

### DIFF
--- a/packages/tracing/src/browser/metrics/index.ts
+++ b/packages/tracing/src/browser/metrics/index.ts
@@ -395,10 +395,6 @@ function _trackNavigator(transaction: Transaction): void {
     if (isMeasurementValue(connection.rtt)) {
       _measurements['connection.rtt'] = { value: connection.rtt, unit: 'millisecond' };
     }
-
-    if (isMeasurementValue(connection.downlink)) {
-      _measurements['connection.downlink'] = { value: connection.downlink, unit: '' }; // unit is empty string for now, while relay doesn't support download speed units
-    }
   }
 
   if (isMeasurementValue(navigator.deviceMemory)) {


### PR DESCRIPTION
As per RFC: https://github.com/getsentry/rfcs/blob/main/text/0003-browser-js-built-in-metrics.md we have decided to remove `connection.downlink` from as a recorded performance metrics in the `BrowserTracing` integration
