### PR TITLE
fix(remix): Use `require()` to get `react-router-dom` in Express wrapper.

### DIFF
--- a/packages/remix/src/utils/serverAdapters/express.ts
+++ b/packages/remix/src/utils/serverAdapters/express.ts
@@ -2,7 +2,8 @@ import { getCurrentHub } from '@sentry/hub';
 import { flush } from '@sentry/node';
 import { hasTracingEnabled } from '@sentry/tracing';
 import { Transaction } from '@sentry/types';
-import { extractRequestData, isString, loadModule, logger } from '@sentry/utils';
+import { extractRequestData, isString, logger } from '@sentry/utils';
+import { cwd } from 'process';
 
 import {
   createRoutes,
@@ -18,7 +19,6 @@ import {
   ExpressRequest,
   ExpressRequestHandler,
   ExpressResponse,
-  ReactRouterDomPkg,
   ServerBuild,
 } from '../types';
 
@@ -27,7 +27,6 @@ function wrapExpressRequestHandler(
   build: ServerBuild,
 ): ExpressRequestHandler {
   const routes = createRoutes(build.routes);
-  const pkg = loadModule<ReactRouterDomPkg>('react-router-dom');
 
   // If the core request handler is already wrapped, don't wrap Express handler which uses it.
   if (isRequestHandlerWrapped) {
@@ -52,6 +51,8 @@ function wrapExpressRequestHandler(
     }
 
     const url = new URL(request.url);
+    const pkg = await import(`${cwd()}/node_modules/react-router-dom`);
+
     const [name, source] = getTransactionName(routes, url, pkg);
     const transaction = startRequestHandlerTransaction(hub, name, source, {
       headers: {

--- a/packages/remix/src/utils/serverAdapters/express.ts
+++ b/packages/remix/src/utils/serverAdapters/express.ts
@@ -27,6 +27,8 @@ function wrapExpressRequestHandler(
   build: ServerBuild,
 ): ExpressRequestHandler {
   const routes = createRoutes(build.routes);
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const pkg = require(`${cwd()}/node_modules/react-router-dom`);
 
   // If the core request handler is already wrapped, don't wrap Express handler which uses it.
   if (isRequestHandlerWrapped) {
@@ -51,8 +53,6 @@ function wrapExpressRequestHandler(
     }
 
     const url = new URL(request.url);
-    const pkg = await import(`${cwd()}/node_modules/react-router-dom`);
-
     const [name, source] = getTransactionName(routes, url, pkg);
     const transaction = startRequestHandlerTransaction(hub, name, source, {
       headers: {


### PR DESCRIPTION
`loadModule` utility which we use to acquire `react-router-dom` can return `null` when called from Express wrapper.

I suspect the main reason is that we are not monkey-patching Remix core here, like we are doing in the base implementation, the package acquisition is not guaranteed to run when (or where?) `react-router-dom` is available.

Tried using dynamic imports, and it worked well on https://github.com/getsentry/vanguard

[Transaction Before](https://sentry.io/organizations/sentry-sdks/discover/results/?field=transaction&field=project&field=transaction.source&field=epm%28%29&field=p50%28%29&field=p95%28%29&name=Performance+-+Unparameterized+Transactions&project=6407073&query=event.type%3Atransaction+transaction.source%3A%22url%22&sort=-epm&statsPeriod=1h&yAxis=epm%28%29)

[Transaction After](https://sentry.io/organizations/sentry-sdks/performance/summary/?project=6407073&query=&statsPeriod=1h&transaction=root&unselectedSeries=p100%28%29) 

[Parameterized Route Transaction](https://sentry.io/organizations/sentry-sdks/performance/summary/?project=6407073&query=&statsPeriod=1h&transaction=routes%2Fp%2F%24postId%2Fedit&unselectedSeries=p100%28%29)