### PR TITLE
Revert "fix(remix): Use `require()` to get `react-router-dom` in Express wrapper."

### DIFF
--- a/packages/remix/src/utils/serverAdapters/express.ts
+++ b/packages/remix/src/utils/serverAdapters/express.ts
@@ -2,8 +2,7 @@ import { getCurrentHub } from '@sentry/hub';
 import { flush } from '@sentry/node';
 import { hasTracingEnabled } from '@sentry/tracing';
 import { Transaction } from '@sentry/types';
-import { extractRequestData, isString, logger } from '@sentry/utils';
-import { cwd } from 'process';
+import { extractRequestData, isString, loadModule, logger } from '@sentry/utils';
 
 import {
   createRoutes,
@@ -19,6 +18,7 @@ import {
   ExpressRequest,
   ExpressRequestHandler,
   ExpressResponse,
+  ReactRouterDomPkg,
   ServerBuild,
 } from '../types';
 
@@ -27,8 +27,7 @@ function wrapExpressRequestHandler(
   build: ServerBuild,
 ): ExpressRequestHandler {
   const routes = createRoutes(build.routes);
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const pkg = require(`${cwd()}/node_modules/react-router-dom`);
+  const pkg = loadModule<ReactRouterDomPkg>('react-router-dom');
 
   // If the core request handler is already wrapped, don't wrap Express handler which uses it.
   if (isRequestHandlerWrapped) {


### PR DESCRIPTION
Reverts getsentry/sentry-javascript#5796

Fixes broken master.