### PR TITLE
ref(typescript): Remove `DOM` from default `lib` types

### DIFF
--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -1,10 +1,13 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
-    // package-specific options
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "lib": [
+      "ES6",
+      "DOM"
+    ]
   }
 }

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
-    // package-specific options
+    "lib": [
+      "ES6",
+      "DOM"
+    ]
   }
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
     // package-specific options
   }

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -1,12 +1,18 @@
 {
   "extends": "./tsconfig.json",
-
-  "include": ["test/**/*"],
-
+  "include": [
+    "test/**/*"
+  ],
   "compilerOptions": {
     // should include all types from `./tsconfig.json` plus types for all test frameworks used
-    "types": ["node", "jest"]
-
+    "types": [
+      "node",
+      "jest"
+    ],
+    "lib": [
+      "ES6",
+      "DOM"
+    ]
     // other package-specific, test-specific options
   }
 }

--- a/packages/ember/tsconfig.json
+++ b/packages/ember/tsconfig.json
@@ -13,6 +13,7 @@
     "noEmit": true,
     "baseUrl": ".",
     "module": "esnext",
+    "lib": ["ES6", "DOM"],
     "experimentalDecorators": true,
     "paths": {
       "dummy/tests/*": ["tests/*"],

--- a/packages/gatsby/tsconfig.json
+++ b/packages/gatsby/tsconfig.json
@@ -1,10 +1,13 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
-    // package-specific options
-    "jsx": "react"
+    "jsx": "react",
+    "lib": [
+      "ES6",
+      "DOM"
+    ]
   }
 }

--- a/packages/hub/tsconfig.test.json
+++ b/packages/hub/tsconfig.test.json
@@ -1,12 +1,17 @@
 {
   "extends": "./tsconfig.json",
-
-  "include": ["test/**/*"],
-
+  "include": [
+    "test/**/*"
+  ],
   "compilerOptions": {
     // should include all types from `./tsconfig.json` plus types for all test frameworks used
-    "types": ["jest"]
-
+    "types": [
+      "jest"
+    ],
+    "lib": [
+      "ES6",
+      "DOM"
+    ]
     // other package-specific, test-specific options
   }
 }

--- a/packages/integrations/tsconfig.json
+++ b/packages/integrations/tsconfig.json
@@ -1,10 +1,13 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
-    // package-specific options
     "esModuleInterop": true,
+    "lib": [
+      "ES6",
+      "DOM"
+    ]
   }
 }

--- a/packages/nextjs/tsconfig.json
+++ b/packages/nextjs/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
-    // package-specific options
+    "lib": [
+      "ES6",
+      "DOM"
+    ]
   }
 }

--- a/packages/node/src/requestdata.ts
+++ b/packages/node/src/requestdata.ts
@@ -310,8 +310,8 @@ function extractQueryParams(req: PolymorphicRequest): string | Record<string, un
 
   return (
     req.query ||
-    (typeof URL !== undefined && new URL(originalUrl).search.replace('?', '')) ||
     // In Node 8, `URL` isn't in the global scope, so we have to use the built-in module from Node
+    new url.URL(originalUrl).search.replace('?', '') ||
     url.parse(originalUrl).query ||
     undefined
   );

--- a/packages/node/test/domain.test.ts
+++ b/packages/node/test/domain.test.ts
@@ -49,7 +49,6 @@ describe('domains', () => {
       expect(hub.getStack()[1]).toEqual({ client: 'process' });
       // Just in case so we don't have to worry which one finishes first
       // (although it always should be d2)
-      // setImmediate
       setTimeout(() => {
         d1done = true;
         if (d2done) {

--- a/packages/node/test/domain.test.ts
+++ b/packages/node/test/domain.test.ts
@@ -49,12 +49,13 @@ describe('domains', () => {
       expect(hub.getStack()[1]).toEqual({ client: 'process' });
       // Just in case so we don't have to worry which one finishes first
       // (although it always should be d2)
+      // setImmediate
       setTimeout(() => {
         d1done = true;
         if (d2done) {
           done();
         }
-      });
+      }, 0);
     });
 
     d2.run(() => {
@@ -66,7 +67,7 @@ describe('domains', () => {
         if (d1done) {
           done();
         }
-      });
+      }, 0);
     });
   });
 });

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,11 +1,14 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
-    // package-specific options
     "esModuleInterop": true,
-    "jsx": "react"
+    "jsx": "react",
+    "lib": [
+      "ES6",
+      "DOM"
+    ]
   }
 }

--- a/packages/remix/tsconfig.json
+++ b/packages/remix/tsconfig.json
@@ -1,10 +1,14 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
     "jsx": "react",
-    "module": "es2020"
+    "module": "es2020",
+    "lib": [
+      "ES6",
+      "DOM"
+    ]
   }
 }

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
-  "compilerOptions": {}
+  "include": [
+    "src/**/*"
+  ],
+  "compilerOptions": {
+    "lib": [
+      "ES6",
+      "DOM"
+    ]
+  }
 }

--- a/packages/tracing/tsconfig.json
+++ b/packages/tracing/tsconfig.json
@@ -1,9 +1,13 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
     // package-specific options
+    "lib": [
+      "ES6",
+      "DOM"
+    ]
   }
 }

--- a/packages/typescript/tsconfig.json
+++ b/packages/typescript/tsconfig.json
@@ -7,7 +7,7 @@
     "importHelpers": true,
     "inlineSources": true,
     "isolatedModules": true,
-    "lib": ["es6", "dom"],
+    "lib": ["es6"],
     "moduleResolution": "node",
     "noErrorTruncation": true,
     "noFallthroughCasesInSwitch": true,

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,9 +1,13 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
     // package-specific options
+    "lib": [
+      "ES6",
+      "DOM"
+    ]
   }
 }

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,9 +1,13 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
     // package-specific options
+    "lib": [
+      "ES6",
+      "DOM"
+    ]
   }
 }

--- a/packages/wasm/tsconfig.json
+++ b/packages/wasm/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
-    // package-specific options
+    "lib": [
+      "ES6",
+      "DOM"
+    ]
   }
 }


### PR DESCRIPTION
The base TypeScript config currently includes DOM types:
https://github.com/getsentry/sentry-javascript/blob/a5bfa8013ab84c6e43a7d48b9a0da197d2b32443/packages/typescript/tsconfig.json#L10

In the spirit of supporting other JavaScript runtimes (#5611), we need to keep these types out of the core packages.

This PR removes `DOM` from the base tsconfig lib types and adds it back to all the packages where it's required. For now this effectively removes the DOM types from `@sentry/types`, `@sentry/core`, `@sentry/hub` and `@sentry/node`. 

`@sentry/utils` will follow later when all the browser code has been moved!

This PR also formats the `tsconfig.json` files.

## Pros
- Keeps DOM types out of the core packages and node.js

## Cons
- `@sentry/electron`, `@sentry/react-native`, `sentry-cordova` and `@sentry/capacitor` may need to add `"lib": ["ES6", "DOM"]` to their `tsconfig.json`.

### Alternatives
Override with `"lib": ["ES6"]` in the packages where there shouldn't be any DOM types. 


