### PR TITLE
chore: Update discussion link to point to github discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question
-    url: https://github.com/getsentry/sentry-javascript/issues
+    url: https://github.com/getsentry/sentry-javascript/discussions
     about: Ask questions and discuss with other community members


### PR DESCRIPTION
I noticed when creating an issue in github, the link to the community discussion points to the issues tab again, where it should probably point at the github discussions since I'd imagine that's where the question or post should go if it doesn't fall under a bug or feature request
