### PR TITLE
feat(utils): Use consts rather than `getGlobalObject` function

### DIFF
--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -3,7 +3,7 @@ import { AfterViewInit, Directive, Injectable, Input, NgModule, OnDestroy, OnIni
 import { ActivatedRouteSnapshot, Event, NavigationEnd, NavigationStart, ResolveEnd, Router } from '@angular/router';
 import { getCurrentHub } from '@sentry/browser';
 import { Span, Transaction, TransactionContext } from '@sentry/types';
-import { getGlobalObject, logger, stripUrlQueryAndFragment, timestampWithMs } from '@sentry/utils';
+import { logger, stripUrlQueryAndFragment, timestampWithMs, WINDOW } from '@sentry/utils';
 import { Observable, Subscription } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
 
@@ -14,8 +14,6 @@ import { runOutsideAngular } from './zone';
 let instrumentationInitialized: boolean;
 let stashedStartTransaction: (context: TransactionContext) => Transaction | undefined;
 let stashedStartTransactionOnLocationChange: boolean;
-
-const global = getGlobalObject<Window>();
 
 /**
  * Creates routing instrumentation for Angular Router.
@@ -29,9 +27,9 @@ export function routingInstrumentation(
   stashedStartTransaction = customStartTransaction;
   stashedStartTransactionOnLocationChange = startTransactionOnLocationChange;
 
-  if (startTransactionOnPageLoad && global && global.location) {
+  if (startTransactionOnPageLoad && WINDOW && WINDOW.location) {
     customStartTransaction({
-      name: global.location.pathname,
+      name: WINDOW.location.pathname,
       op: 'pageload',
       metadata: { source: 'url' },
     });

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -1,16 +1,15 @@
 export * from './exports';
 
 import { Integrations as CoreIntegrations } from '@sentry/core';
-import { getGlobalObject } from '@sentry/utils';
+import { WINDOW } from '@sentry/utils';
 
 import * as BrowserIntegrations from './integrations';
 
 let windowIntegrations = {};
 
 // This block is needed to add compatibility with the integrations packages when used with a CDN
-const _window = getGlobalObject<Window>();
-if (_window.Sentry && _window.Sentry.Integrations) {
-  windowIntegrations = _window.Sentry.Integrations;
+if (WINDOW.Sentry && WINDOW.Sentry.Integrations) {
+  windowIntegrations = WINDOW.Sentry.Integrations;
 }
 
 const INTEGRATIONS = {

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -4,11 +4,11 @@ import { getCurrentHub } from '@sentry/core';
 import { Integration } from '@sentry/types';
 import {
   addInstrumentationHandler,
-  getGlobalObject,
   htmlTreeAsString,
   parseUrl,
   safeJoin,
   severityLevelFromString,
+  WINDOW,
 } from '@sentry/utils';
 
 /** JSDoc */
@@ -245,10 +245,9 @@ function _fetchBreadcrumb(handlerData: { [key: string]: any }): void {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function _historyBreadcrumb(handlerData: { [key: string]: any }): void {
-  const global = getGlobalObject<Window>();
   let from = handlerData.from;
   let to = handlerData.to;
-  const parsedLoc = parseUrl(global.location.href);
+  const parsedLoc = parseUrl(WINDOW.location.href);
   let parsedFrom = parseUrl(from);
   const parsedTo = parseUrl(to);
 

--- a/packages/browser/src/integrations/httpcontext.ts
+++ b/packages/browser/src/integrations/httpcontext.ts
@@ -1,8 +1,6 @@
 import { addGlobalEventProcessor, getCurrentHub } from '@sentry/core';
 import { Event, Integration } from '@sentry/types';
-import { getGlobalObject } from '@sentry/utils';
-
-const global = getGlobalObject<Window>();
+import { WINDOW } from '@sentry/utils';
 
 /** HttpContext integration collects information about HTTP request headers */
 export class HttpContext implements Integration {
@@ -23,14 +21,14 @@ export class HttpContext implements Integration {
     addGlobalEventProcessor((event: Event) => {
       if (getCurrentHub().getIntegration(HttpContext)) {
         // if none of the information we want exists, don't bother
-        if (!global.navigator && !global.location && !global.document) {
+        if (!WINDOW.navigator && !WINDOW.location && !WINDOW.document) {
           return event;
         }
 
         // grab as much info as exists and add it to the event
-        const url = (event.request && event.request.url) || (global.location && global.location.href);
-        const { referrer } = global.document || {};
-        const { userAgent } = global.navigator || {};
+        const url = (event.request && event.request.url) || (WINDOW.location && WINDOW.location.href);
+        const { referrer } = WINDOW.document || {};
+        const { userAgent } = WINDOW.navigator || {};
 
         const headers = {
           ...(event.request && event.request.headers),

--- a/packages/browser/src/integrations/trycatch.ts
+++ b/packages/browser/src/integrations/trycatch.ts
@@ -1,5 +1,5 @@
 import { Integration, WrappedFunction } from '@sentry/types';
-import { fill, getFunctionName, getGlobalObject, getOriginalFunction } from '@sentry/utils';
+import { fill, getFunctionName, getOriginalFunction, WINDOW } from '@sentry/utils';
 
 import { wrap } from '../helpers';
 
@@ -80,21 +80,19 @@ export class TryCatch implements Integration {
    * and provide better metadata.
    */
   public setupOnce(): void {
-    const global = getGlobalObject();
-
     if (this._options.setTimeout) {
-      fill(global, 'setTimeout', _wrapTimeFunction);
+      fill(WINDOW, 'setTimeout', _wrapTimeFunction);
     }
 
     if (this._options.setInterval) {
-      fill(global, 'setInterval', _wrapTimeFunction);
+      fill(WINDOW, 'setInterval', _wrapTimeFunction);
     }
 
     if (this._options.requestAnimationFrame) {
-      fill(global, 'requestAnimationFrame', _wrapRAF);
+      fill(WINDOW, 'requestAnimationFrame', _wrapRAF);
     }
 
-    if (this._options.XMLHttpRequest && 'XMLHttpRequest' in global) {
+    if (this._options.XMLHttpRequest && 'XMLHttpRequest' in WINDOW) {
       fill(XMLHttpRequest.prototype, 'send', _wrapXHR);
     }
 
@@ -185,7 +183,7 @@ function _wrapXHR(originalSend: () => void): () => void {
 /** JSDoc */
 function _wrapEventTarget(target: string): void {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const global = getGlobalObject() as { [key: string]: any };
+  const global = WINDOW as { [key: string]: any };
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const proto = global[target] && global[target].prototype;
 

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -8,11 +8,11 @@ import {
 } from '@sentry/core';
 import {
   addInstrumentationHandler,
-  getGlobalObject,
   logger,
   resolvedSyncPromise,
   stackParserFromStackParserOptions,
   supportsFetch,
+  WINDOW,
 } from '@sentry/utils';
 
 import { BrowserClient, BrowserClientOptions, BrowserOptions } from './client';
@@ -94,10 +94,9 @@ export function init(options: BrowserOptions = {}): void {
     options.defaultIntegrations = defaultIntegrations;
   }
   if (options.release === undefined) {
-    const window = getGlobalObject<Window>();
     // This supports the variable that sentry-webpack-plugin injects
-    if (window.SENTRY_RELEASE && window.SENTRY_RELEASE.id) {
-      options.release = window.SENTRY_RELEASE.id;
+    if (WINDOW.SENTRY_RELEASE && WINDOW.SENTRY_RELEASE.id) {
+      options.release = WINDOW.SENTRY_RELEASE.id;
     }
   }
   if (options.autoSessionTracking === undefined) {
@@ -128,8 +127,7 @@ export function init(options: BrowserOptions = {}): void {
  */
 export function showReportDialog(options: ReportDialogOptions = {}, hub: Hub = getCurrentHub()): void {
   // doesn't work without a document (React Native)
-  const global = getGlobalObject<Window>();
-  if (!global.document) {
+  if (!WINDOW.document) {
     __DEBUG_BUILD__ && logger.error('Global document not defined in showReportDialog call');
     return;
   }
@@ -152,7 +150,7 @@ export function showReportDialog(options: ReportDialogOptions = {}, hub: Hub = g
     options.eventId = hub.lastEventId();
   }
 
-  const script = global.document.createElement('script');
+  const script = WINDOW.document.createElement('script');
   script.async = true;
   script.src = getReportDialogEndpoint(dsn, options);
 
@@ -161,7 +159,7 @@ export function showReportDialog(options: ReportDialogOptions = {}, hub: Hub = g
     script.onload = options.onLoad;
   }
 
-  const injectionPoint = global.document.head || global.document.body;
+  const injectionPoint = WINDOW.document.head || WINDOW.document.body;
   if (injectionPoint) {
     injectionPoint.appendChild(script);
   } else {
@@ -249,10 +247,7 @@ function startSessionOnHub(hub: Hub): void {
  * Enable automatic Session Tracking for the initial page load.
  */
 function startSessionTracking(): void {
-  const window = getGlobalObject<Window>();
-  const document = window.document;
-
-  if (typeof document === 'undefined') {
+  if (typeof WINDOW.document === 'undefined') {
     __DEBUG_BUILD__ &&
       logger.warn('Session tracking in non-browser environment with @sentry/browser is not supported.');
     return;

--- a/packages/browser/src/transports/utils.ts
+++ b/packages/browser/src/transports/utils.ts
@@ -1,6 +1,5 @@
-import { getGlobalObject, isNativeFetch, logger } from '@sentry/utils';
+import { isNativeFetch, logger, WINDOW } from '@sentry/utils';
 
-const global = getGlobalObject<Window>();
 let cachedFetchImpl: FetchImpl;
 
 export type FetchImpl = typeof fetch;
@@ -51,12 +50,12 @@ export function getNativeFetchImplementation(): FetchImpl {
   /* eslint-disable @typescript-eslint/unbound-method */
 
   // Fast path to avoid DOM I/O
-  if (isNativeFetch(global.fetch)) {
-    return (cachedFetchImpl = global.fetch.bind(global));
+  if (isNativeFetch(WINDOW.fetch)) {
+    return (cachedFetchImpl = WINDOW.fetch.bind(WINDOW));
   }
 
-  const document = global.document;
-  let fetchImpl = global.fetch;
+  const document = WINDOW.document;
+  let fetchImpl = WINDOW.fetch;
   // eslint-disable-next-line deprecation/deprecation
   if (document && typeof document.createElement === 'function') {
     try {
@@ -74,6 +73,6 @@ export function getNativeFetchImplementation(): FetchImpl {
     }
   }
 
-  return (cachedFetchImpl = fetchImpl.bind(global));
+  return (cachedFetchImpl = fetchImpl.bind(WINDOW));
   /* eslint-enable @typescript-eslint/unbound-method */
 }

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -22,20 +22,18 @@ jest.mock('@sentry/utils', () => {
     uuid4(): string {
       return '42';
     },
-    getGlobalObject(): any {
-      return {
-        console: {
-          log(): void {
-            // no-empty
-          },
-          warn(): void {
-            // no-empty
-          },
-          error(): void {
-            // no-empty
-          },
+    GLOBAL_OBJ: {
+      console: {
+        log(): void {
+          // no-empty
         },
-      };
+        warn(): void {
+          // no-empty
+        },
+        error(): void {
+          // no-empty
+        },
+      },
     },
     consoleSandbox(cb: () => any): any {
       return cb();

--- a/packages/core/test/lib/hint.test.ts
+++ b/packages/core/test/lib/hint.test.ts
@@ -1,5 +1,5 @@
 import { captureEvent, configureScope } from '@sentry/hub';
-import { getGlobalObject } from '@sentry/utils';
+import { GLOBAL_OBJ } from '@sentry/utils';
 
 import { initAndBind } from '../../src/sdk';
 import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
@@ -16,7 +16,7 @@ describe('Hint', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    delete getGlobalObject().__SENTRY__;
+    delete GLOBAL_OBJ.__SENTRY__;
   });
 
   describe('attachments', () => {

--- a/packages/ember/addon/index.ts
+++ b/packages/ember/addon/index.ts
@@ -4,12 +4,11 @@ import { macroCondition, isDevelopingApp, getOwnConfig } from '@embroider/macros
 import { next } from '@ember/runloop';
 import { assert, warn } from '@ember/debug';
 import Ember from 'ember';
-import { timestampWithMs } from '@sentry/utils';
+import { timestampWithMs, GLOBAL_OBJ } from '@sentry/utils';
 import { GlobalConfig, OwnConfig } from './types';
-import { getGlobalObject } from '@sentry/utils';
 
 function _getSentryInitConfig() {
-  const _global = getGlobalObject<GlobalConfig>();
+  const _global = GLOBAL_OBJ as typeof GLOBAL_OBJ & GlobalConfig;
   _global.__sentryEmberConfig = _global.__sentryEmberConfig ?? {};
   return _global.__sentryEmberConfig;
 }

--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -6,12 +6,12 @@ import { ExtendedBackburner } from '@sentry/ember/runloop';
 import { Span, Transaction, Integration } from '@sentry/types';
 import { EmberRunQueues } from '@ember/runloop/-private/types';
 import { getActiveTransaction } from '..';
-import { browserPerformanceTimeOrigin, getGlobalObject, timestampWithMs } from '@sentry/utils';
+import { browserPerformanceTimeOrigin, GLOBAL_OBJ, timestampWithMs } from '@sentry/utils';
 import { macroCondition, isTesting, getOwnConfig } from '@embroider/macros';
 import { EmberSentryConfig, GlobalConfig, OwnConfig } from '../types';
 
 function getSentryConfig() {
-  const _global = getGlobalObject<GlobalConfig>();
+  const _global = GLOBAL_OBJ as typeof GLOBAL_OBJ & GlobalConfig;
   _global.__sentryEmberConfig = _global.__sentryEmberConfig ?? {};
   const environmentConfig = getOwnConfig<OwnConfig>().sentryConfig;
   if (!environmentConfig.sentry) {

--- a/packages/hub/src/hub.ts
+++ b/packages/hub/src/hub.ts
@@ -23,8 +23,8 @@ import {
 import {
   consoleSandbox,
   dateTimestampInSeconds,
-  getGlobalObject,
   getGlobalSingleton,
+  GLOBAL_OBJ,
   isNodeEnv,
   logger,
   uuid4,
@@ -413,8 +413,7 @@ export class Hub implements HubInterface {
     const { release, environment } = (client && client.getOptions()) || {};
 
     // Will fetch userAgent if called from browser sdk
-    const global = getGlobalObject<{ navigator?: { userAgent?: string } }>();
-    const { userAgent } = global.navigator || {};
+    const { userAgent } = GLOBAL_OBJ.navigator || {};
 
     const session = makeSession({
       release,
@@ -500,12 +499,11 @@ export class Hub implements HubInterface {
  * at the call-site. We always access the carrier through this function, so we can guarantee that `__SENTRY__` is there.
  **/
 export function getMainCarrier(): Carrier {
-  const carrier = getGlobalObject();
-  carrier.__SENTRY__ = carrier.__SENTRY__ || {
+  GLOBAL_OBJ.__SENTRY__ = GLOBAL_OBJ.__SENTRY__ || {
     extensions: {},
     hub: undefined,
   };
-  return carrier;
+  return GLOBAL_OBJ;
 }
 
 /**

--- a/packages/hub/test/global.test.ts
+++ b/packages/hub/test/global.test.ts
@@ -1,13 +1,11 @@
-import { getGlobalObject } from '@sentry/utils';
+import { GLOBAL_OBJ } from '@sentry/utils';
 
 import { getCurrentHub, getHubFromCarrier, Hub } from '../src';
-
-const global = getGlobalObject();
 
 describe('global', () => {
   test('getGlobalHub', () => {
     expect(getCurrentHub()).toBeTruthy();
-    expect((global as any).__SENTRY__.hub).toBeTruthy();
+    expect(GLOBAL_OBJ.__SENTRY__.hub).toBeTruthy();
   });
 
   test('getHubFromCarrier', () => {
@@ -20,22 +18,21 @@ describe('global', () => {
 
   test('getGlobalHub', () => {
     const newestHub = new Hub(undefined, undefined, 999999);
-    (global as any).__SENTRY__.hub = newestHub;
+    GLOBAL_OBJ.__SENTRY__.hub = newestHub;
     expect(getCurrentHub()).toBe(newestHub);
   });
 
   test('hub extension methods receive correct hub instance', () => {
     const newestHub = new Hub(undefined, undefined, 999999);
-    (global as any).__SENTRY__.hub = newestHub;
+    GLOBAL_OBJ.__SENTRY__.hub = newestHub;
     const fn = jest.fn().mockImplementation(function (...args: []) {
       // @ts-ignore typescript complains that this can be `any`
       expect(this).toBe(newestHub);
       expect(args).toEqual([1, 2, 3]);
     });
-    (global as any).__SENTRY__.extensions = {};
-    (global as any).__SENTRY__.extensions.testy = fn;
+    GLOBAL_OBJ.__SENTRY__.extensions = {};
+    GLOBAL_OBJ.__SENTRY__.extensions.testy = fn;
     (getCurrentHub() as any)._callExtensionMethod('testy', 1, 2, 3);
     expect(fn).toBeCalled();
   });
-  // (global as any).__SENTRY__
 });

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -1,5 +1,5 @@
 import { Event, EventHint, RequestSessionStatus } from '@sentry/types';
-import { getGlobalObject } from '@sentry/utils';
+import { GLOBAL_OBJ } from '@sentry/utils';
 
 import { addGlobalEventProcessor, Scope } from '../src';
 
@@ -7,7 +7,7 @@ describe('Scope', () => {
   afterEach(() => {
     jest.resetAllMocks();
     jest.useRealTimers();
-    getGlobalObject<any>().__SENTRY__.globalEventProcessors = undefined;
+    GLOBAL_OBJ.__SENTRY__.globalEventProcessors = undefined;
   });
 
   describe('attributes modification', () => {

--- a/packages/integrations/src/reportingobserver.ts
+++ b/packages/integrations/src/reportingobserver.ts
@@ -1,5 +1,5 @@
 import { EventProcessor, Hub, Integration } from '@sentry/types';
-import { getGlobalObject, supportsReportingObserver } from '@sentry/utils';
+import { supportsReportingObserver, WINDOW } from '@sentry/utils';
 
 interface Report {
   [key: string]: unknown;
@@ -76,7 +76,7 @@ export class ReportingObserver implements Integration {
     this._getCurrentHub = getCurrentHub;
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-    const observer = new (getGlobalObject<any>().ReportingObserver)(this.handler.bind(this), {
+    const observer = new (WINDOW as any).ReportingObserver(this.handler.bind(this), {
       buffered: true,
       types: this._options.types,
     });

--- a/packages/nextjs/src/performance/client.ts
+++ b/packages/nextjs/src/performance/client.ts
@@ -3,21 +3,19 @@ import { Primitive, TraceparentData, Transaction, TransactionContext, Transactio
 import {
   baggageHeaderToDynamicSamplingContext,
   extractTraceparentData,
-  getGlobalObject,
   logger,
   stripUrlQueryAndFragment,
+  WINDOW,
 } from '@sentry/utils';
 import type { NEXT_DATA as NextData } from 'next/dist/next-server/lib/utils';
 import { default as Router } from 'next/router';
 import type { ParsedUrlQuery } from 'querystring';
 
-const global = getGlobalObject<
-  Window & {
-    __BUILD_MANIFEST?: {
-      sortedPages?: string[];
-    };
-  }
->();
+const global = WINDOW as typeof WINDOW & {
+  __BUILD_MANIFEST?: {
+    sortedPages?: string[];
+  };
+};
 
 type StartTransactionCb = (context: TransactionContext) => Transaction | undefined;
 

--- a/packages/nextjs/test/index.client.test.ts
+++ b/packages/nextjs/test/index.client.test.ts
@@ -3,15 +3,13 @@ import { getCurrentHub } from '@sentry/hub';
 import * as SentryReact from '@sentry/react';
 import { Integrations as TracingIntegrations } from '@sentry/tracing';
 import { Integration } from '@sentry/types';
-import { getGlobalObject, logger } from '@sentry/utils';
+import { logger, WINDOW } from '@sentry/utils';
 import { JSDOM } from 'jsdom';
 
 import { init, Integrations, nextRouterInstrumentation } from '../src/index.client';
 import { UserIntegrationsFunction } from '../src/utils/userIntegrations';
 
 const { BrowserTracing } = TracingIntegrations;
-
-const global = getGlobalObject();
 
 const reactInit = jest.spyOn(SentryReact, 'init');
 const captureEvent = jest.spyOn(BaseClient.prototype, 'captureEvent');
@@ -24,12 +22,12 @@ const dom = new JSDOM(undefined, { url: 'https://example.com/' });
 Object.defineProperty(global, 'document', { value: dom.window.document, writable: true });
 Object.defineProperty(global, 'location', { value: dom.window.document.location, writable: true });
 
-const originalGlobalDocument = getGlobalObject<Window>().document;
-const originalGlobalLocation = getGlobalObject<Window>().location;
+const originalGlobalDocument = WINDOW.document;
+const originalGlobalLocation = WINDOW.location;
 afterAll(() => {
   // Clean up JSDom
-  Object.defineProperty(global, 'document', { value: originalGlobalDocument });
-  Object.defineProperty(global, 'location', { value: originalGlobalLocation });
+  Object.defineProperty(WINDOW, 'document', { value: originalGlobalDocument });
+  Object.defineProperty(WINDOW, 'location', { value: originalGlobalLocation });
 });
 
 function findIntegrationByName(integrations: Integration[] = [], name: string): Integration | undefined {
@@ -39,7 +37,7 @@ function findIntegrationByName(integrations: Integration[] = [], name: string): 
 describe('Client init()', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    global.__SENTRY__.hub = undefined;
+    WINDOW.__SENTRY__.hub = undefined;
   });
 
   it('inits the React SDK', () => {

--- a/packages/nextjs/test/index.server.test.ts
+++ b/packages/nextjs/test/index.server.test.ts
@@ -1,17 +1,15 @@
 import * as SentryNode from '@sentry/node';
 import { getCurrentHub, NodeClient } from '@sentry/node';
 import { Integration } from '@sentry/types';
-import { getGlobalObject, logger } from '@sentry/utils';
+import { GLOBAL_OBJ, logger } from '@sentry/utils';
 import * as domain from 'domain';
 
 import { init } from '../src/index.server';
 
 const { Integrations } = SentryNode;
 
-const global = getGlobalObject();
-
 // normally this is set as part of the build process, so mock it here
-(global as typeof global & { __rewriteFramesDistDir__: string }).__rewriteFramesDistDir__ = '.next';
+(GLOBAL_OBJ as typeof GLOBAL_OBJ & { __rewriteFramesDistDir__: string }).__rewriteFramesDistDir__ = '.next';
 
 const nodeInit = jest.spyOn(SentryNode, 'init');
 const loggerLogSpy = jest.spyOn(logger, 'log');
@@ -23,7 +21,7 @@ function findIntegrationByName(integrations: Integration[] = [], name: string): 
 describe('Server init()', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    global.__SENTRY__.hub = undefined;
+    GLOBAL_OBJ.__SENTRY__.hub = undefined;
     delete process.env.VERCEL;
   });
 

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -4,7 +4,7 @@ import { getMainCarrier, setHubOnCarrier } from '@sentry/hub';
 import { SessionStatus, StackParser } from '@sentry/types';
 import {
   createStackParser,
-  getGlobalObject,
+  GLOBAL_OBJ,
   logger,
   nodeStackLineParser,
   stackParserFromStackParserOptions,
@@ -227,9 +227,8 @@ export function getSentryRelease(fallback?: string): string | undefined {
   }
 
   // This supports the variable that sentry-webpack-plugin injects
-  const global = getGlobalObject();
-  if (global.SENTRY_RELEASE && global.SENTRY_RELEASE.id) {
-    return global.SENTRY_RELEASE.id;
+  if (GLOBAL_OBJ.SENTRY_RELEASE && GLOBAL_OBJ.SENTRY_RELEASE.id) {
+    return GLOBAL_OBJ.SENTRY_RELEASE.id;
   }
 
   return (

--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -1,5 +1,5 @@
 import { Transaction, TransactionSource } from '@sentry/types';
-import { getGlobalObject } from '@sentry/utils';
+import { WINDOW } from '@sentry/utils';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
 
@@ -25,8 +25,6 @@ export type RouteConfig = {
 
 type MatchPath = (pathname: string, props: string | string[] | any, parent?: Match | null) => Match | null;
 /* eslint-enable @typescript-eslint/no-explicit-any */
-
-const global = getGlobalObject<Window>();
 
 let activeTransaction: Transaction | undefined;
 
@@ -57,8 +55,8 @@ function createReactRouterInstrumentation(
       return history.location.pathname;
     }
 
-    if (global && global.location) {
-      return global.location.pathname;
+    if (WINDOW && WINDOW.location) {
+      return WINDOW.location.pathname;
     }
 
     return undefined;

--- a/packages/react/src/reactrouterv3.ts
+++ b/packages/react/src/reactrouterv3.ts
@@ -1,5 +1,5 @@
 import { Primitive, Transaction, TransactionContext, TransactionSource } from '@sentry/types';
-import { getGlobalObject } from '@sentry/utils';
+import { WINDOW } from '@sentry/utils';
 
 import { Location, ReactRouterInstrumentation } from './types';
 
@@ -20,8 +20,6 @@ export type Match = (
 ) => void;
 
 type ReactRouterV3TransactionSource = Extract<TransactionSource, 'url' | 'route'>;
-
-const global = getGlobalObject<Window>();
 
 /**
  * Creates routing instrumentation for React Router v3
@@ -44,11 +42,11 @@ export function reactRouterV3Instrumentation(
     let activeTransaction: Transaction | undefined;
     let prevName: string | undefined;
 
-    // Have to use global.location because history.location might not be defined.
-    if (startTransactionOnPageLoad && global && global.location) {
+    // Have to use window.location because history.location might not be defined.
+    if (startTransactionOnPageLoad && WINDOW && WINDOW.location) {
       normalizeTransactionName(
         routes,
-        global.location as unknown as Location,
+        WINDOW.location as unknown as Location,
         match,
         (localName: string, source: ReactRouterV3TransactionSource = 'url') => {
           prevName = localName;

--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -2,7 +2,7 @@
 // https://gist.github.com/wontondon/e8c4bdf2888875e4c755712e99279536
 
 import { Transaction, TransactionContext, TransactionSource } from '@sentry/types';
-import { getGlobalObject, getNumberOfUrlSegments, logger } from '@sentry/utils';
+import { getNumberOfUrlSegments, logger, WINDOW } from '@sentry/utils';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import React from 'react';
 
@@ -58,8 +58,6 @@ let _matchRoutes: MatchRoutes;
 let _customStartTransaction: (context: TransactionContext) => Transaction | undefined;
 let _startTransactionOnLocationChange: boolean;
 
-const global = getGlobalObject<Window>();
-
 const SENTRY_TAGS = {
   'routing.instrumentation': 'react-router-v6',
 };
@@ -76,7 +74,7 @@ export function reactRouterV6Instrumentation(
     startTransactionOnPageLoad = true,
     startTransactionOnLocationChange = true,
   ): void => {
-    const initPathName = global && global.location && global.location.pathname;
+    const initPathName = WINDOW && WINDOW.location && WINDOW.location.pathname;
     if (startTransactionOnPageLoad && initPathName) {
       activeTransaction = customStartTransaction({
         name: initPathName,

--- a/packages/remix/src/performance/client.tsx
+++ b/packages/remix/src/performance/client.tsx
@@ -1,7 +1,7 @@
 import type { ErrorBoundaryProps } from '@sentry/react';
 import { withErrorBoundary } from '@sentry/react';
 import { Transaction, TransactionContext } from '@sentry/types';
-import { getGlobalObject, logger } from '@sentry/utils';
+import { logger, WINDOW } from '@sentry/utils';
 import * as React from 'react';
 
 const DEFAULT_TAGS = {
@@ -38,11 +38,9 @@ let _useMatches: UseMatches;
 let _customStartTransaction: (context: TransactionContext) => Transaction | undefined;
 let _startTransactionOnLocationChange: boolean;
 
-const global = getGlobalObject<Window>();
-
 function getInitPathName(): string | undefined {
-  if (global && global.location) {
-    return global.location.pathname;
+  if (WINDOW && WINDOW.location) {
+    return WINDOW.location.pathname;
   }
 
   return undefined;

--- a/packages/remix/test/index.client.test.ts
+++ b/packages/remix/test/index.client.test.ts
@@ -1,17 +1,15 @@
 import { getCurrentHub } from '@sentry/hub';
 import * as SentryReact from '@sentry/react';
-import { getGlobalObject } from '@sentry/utils';
+import { GLOBAL_OBJ } from '@sentry/utils';
 
 import { init } from '../src/index.client';
-
-const global = getGlobalObject();
 
 const reactInit = jest.spyOn(SentryReact, 'init');
 
 describe('Client init()', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    global.__SENTRY__.hub = undefined;
+    GLOBAL_OBJ.__SENTRY__.hub = undefined;
   });
 
   it('inits the React SDK', () => {

--- a/packages/remix/test/index.server.test.ts
+++ b/packages/remix/test/index.server.test.ts
@@ -1,17 +1,15 @@
 import * as SentryNode from '@sentry/node';
 import { getCurrentHub } from '@sentry/node';
-import { getGlobalObject } from '@sentry/utils';
+import { GLOBAL_OBJ } from '@sentry/utils';
 
 import { init } from '../src/index.server';
-
-const global = getGlobalObject();
 
 const nodeInit = jest.spyOn(SentryNode, 'init');
 
 describe('Server init()', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    global.__SENTRY__.hub = undefined;
+    GLOBAL_OBJ.__SENTRY__.hub = undefined;
   });
 
   it('inits the Node SDK', () => {

--- a/packages/tracing/src/browser/backgroundtab.ts
+++ b/packages/tracing/src/browser/backgroundtab.ts
@@ -1,20 +1,18 @@
-import { getGlobalObject, logger } from '@sentry/utils';
+import { logger, WINDOW } from '@sentry/utils';
 
 import { IdleTransaction } from '../idletransaction';
 import { SpanStatusType } from '../span';
 import { getActiveTransaction } from '../utils';
-
-const global = getGlobalObject<Window>();
 
 /**
  * Add a listener that cancels and finishes a transaction when the global
  * document is hidden.
  */
 export function registerBackgroundTabDetection(): void {
-  if (global && global.document) {
-    global.document.addEventListener('visibilitychange', () => {
+  if (WINDOW && WINDOW.document) {
+    WINDOW.document.addEventListener('visibilitychange', () => {
       const activeTransaction = getActiveTransaction() as IdleTransaction;
-      if (global.document.hidden && activeTransaction) {
+      if (WINDOW.document.hidden && activeTransaction) {
         const statusType: SpanStatusType = 'cancelled';
 
         __DEBUG_BUILD__ &&

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 import { Hub } from '@sentry/hub';
 import { EventProcessor, Integration, Transaction, TransactionContext } from '@sentry/types';
-import { baggageHeaderToDynamicSamplingContext, getDomElement, getGlobalObject, logger } from '@sentry/utils';
+import { baggageHeaderToDynamicSamplingContext, getDomElement, logger, WINDOW } from '@sentry/utils';
 
 import { startIdleTransaction } from '../hubextensions';
 import { DEFAULT_FINAL_TIMEOUT, DEFAULT_IDLE_TIMEOUT } from '../idletransaction';
@@ -255,7 +255,7 @@ export class BrowserTracing implements Integration {
     __DEBUG_BUILD__ && logger.log(`[Tracing] Starting ${finalContext.op} transaction on scope`);
 
     const hub = this._getCurrentHub();
-    const { location } = getGlobalObject() as WindowOrWorkerGlobalScope & { location: Location };
+    const { location } = WINDOW;
 
     const idleTransaction = startIdleTransaction(
       hub,

--- a/packages/tracing/src/browser/metrics/index.ts
+++ b/packages/tracing/src/browser/metrics/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import { Measurements } from '@sentry/types';
-import { browserPerformanceTimeOrigin, getGlobalObject, htmlTreeAsString, logger } from '@sentry/utils';
+import { browserPerformanceTimeOrigin, htmlTreeAsString, logger, WINDOW } from '@sentry/utils';
 
 import { IdleTransaction } from '../../idletransaction';
 import { Transaction } from '../../transaction';
@@ -13,10 +13,8 @@ import { observe, PerformanceEntryHandler } from '../web-vitals/lib/observe';
 import { NavigatorDeviceMemory, NavigatorNetworkInformation } from '../web-vitals/types';
 import { _startChild, isMeasurementValue } from './utils';
 
-const global = getGlobalObject<Window>();
-
 function getBrowserPerformanceAPI(): Performance | undefined {
-  return global && global.addEventListener && global.performance;
+  return WINDOW && WINDOW.addEventListener && WINDOW.performance;
 }
 
 let _performanceCursor: number = 0;
@@ -32,7 +30,7 @@ export function startTrackingWebVitals(reportAllChanges: boolean = false): void 
   const performance = getBrowserPerformanceAPI();
   if (performance && browserPerformanceTimeOrigin) {
     if (performance.mark) {
-      global.performance.mark('sentry-tracing-init');
+      WINDOW.performance.mark('sentry-tracing-init');
     }
     _trackCLS();
     _trackLCP(reportAllChanges);
@@ -112,7 +110,7 @@ function _trackFID(): void {
 /** Add performance related spans to a transaction */
 export function addPerformanceEntries(transaction: Transaction): void {
   const performance = getBrowserPerformanceAPI();
-  if (!performance || !global.performance.getEntries || !browserPerformanceTimeOrigin) {
+  if (!performance || !WINDOW.performance.getEntries || !browserPerformanceTimeOrigin) {
     // Gatekeeper if performance API not available
     return;
   }
@@ -162,7 +160,7 @@ export function addPerformanceEntries(transaction: Transaction): void {
         break;
       }
       case 'resource': {
-        const resourceName = (entry.name as string).replace(global.location.origin, '');
+        const resourceName = (entry.name as string).replace(WINDOW.location.origin, '');
         _addResourceSpans(transaction, entry, resourceName, startTime, duration, timeOrigin);
         break;
       }
@@ -376,7 +374,7 @@ export function _addResourceSpans(
  * Capture the information of the user agent.
  */
 function _trackNavigator(transaction: Transaction): void {
-  const navigator = global.navigator as null | (Navigator & NavigatorNetworkInformation & NavigatorDeviceMemory);
+  const navigator = WINDOW.navigator as null | (Navigator & NavigatorNetworkInformation & NavigatorDeviceMemory);
   if (!navigator) {
     return;
   }

--- a/packages/tracing/src/browser/router.ts
+++ b/packages/tracing/src/browser/router.ts
@@ -1,7 +1,5 @@
 import { Transaction, TransactionContext } from '@sentry/types';
-import { addInstrumentationHandler, getGlobalObject, logger } from '@sentry/utils';
-
-const global = getGlobalObject<Window>();
+import { addInstrumentationHandler, logger, WINDOW } from '@sentry/utils';
 
 /**
  * Default function implementing pageload and navigation transactions
@@ -11,17 +9,17 @@ export function instrumentRoutingWithDefaults<T extends Transaction>(
   startTransactionOnPageLoad: boolean = true,
   startTransactionOnLocationChange: boolean = true,
 ): void {
-  if (!global || !global.location) {
+  if (!WINDOW || !WINDOW.location) {
     __DEBUG_BUILD__ && logger.warn('Could not initialize routing instrumentation due to invalid location');
     return;
   }
 
-  let startingUrl: string | undefined = global.location.href;
+  let startingUrl: string | undefined = WINDOW.location.href;
 
   let activeTransaction: T | undefined;
   if (startTransactionOnPageLoad) {
     activeTransaction = customStartTransaction({
-      name: global.location.pathname,
+      name: WINDOW.location.pathname,
       op: 'pageload',
       metadata: { source: 'url' },
     });
@@ -51,7 +49,7 @@ export function instrumentRoutingWithDefaults<T extends Transaction>(
           activeTransaction.finish();
         }
         activeTransaction = customStartTransaction({
-          name: global.location.pathname,
+          name: WINDOW.location.pathname,
           op: 'navigation',
           metadata: { source: 'url' },
         });

--- a/packages/tracing/src/browser/web-vitals/lib/getVisibilityWatcher.ts
+++ b/packages/tracing/src/browser/web-vitals/lib/getVisibilityWatcher.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { getGlobalObject } from '@sentry/utils';
+import { WINDOW } from '@sentry/utils';
 
 import { onHidden } from './onHidden';
 
 let firstHiddenTime = -1;
 
 const initHiddenTime = (): number => {
-  return getGlobalObject<Window>().document.visibilityState === 'hidden' ? 0 : Infinity;
+  return WINDOW.document.visibilityState === 'hidden' ? 0 : Infinity;
 };
 
 const trackChanges = (): void => {

--- a/packages/tracing/src/browser/web-vitals/lib/onHidden.ts
+++ b/packages/tracing/src/browser/web-vitals/lib/onHidden.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { getGlobalObject } from '@sentry/utils';
+import { WINDOW } from '@sentry/utils';
 
 export interface OnHiddenCallback {
   (event: Event): void;
@@ -22,7 +22,7 @@ export interface OnHiddenCallback {
 
 export const onHidden = (cb: OnHiddenCallback, once?: boolean): void => {
   const onHiddenOrPageHide = (event: Event): void => {
-    if (event.type === 'pagehide' || getGlobalObject<Window>().document.visibilityState === 'hidden') {
+    if (event.type === 'pagehide' || WINDOW.document.visibilityState === 'hidden') {
       cb(event);
       if (once) {
         removeEventListener('visibilitychange', onHiddenOrPageHide, true);

--- a/packages/tracing/src/index.bundle.ts
+++ b/packages/tracing/src/index.bundle.ts
@@ -53,7 +53,7 @@ export {
 export { SDK_VERSION } from '@sentry/browser';
 
 import { Integrations as BrowserIntegrations } from '@sentry/browser';
-import { getGlobalObject } from '@sentry/utils';
+import { GLOBAL_OBJ } from '@sentry/utils';
 
 import { BrowserTracing } from './browser';
 import { addExtensionMethods } from './hubextensions';
@@ -63,9 +63,8 @@ export { Span } from './span';
 let windowIntegrations = {};
 
 // This block is needed to add compatibility with the integrations packages when used with a CDN
-const _window = getGlobalObject<Window>();
-if (_window.Sentry && _window.Sentry.Integrations) {
-  windowIntegrations = _window.Sentry.Integrations;
+if (GLOBAL_OBJ.Sentry && GLOBAL_OBJ.Sentry.Integrations) {
+  windowIntegrations = GLOBAL_OBJ.Sentry.Integrations;
 }
 
 const INTEGRATIONS = {

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -1,7 +1,7 @@
 import { BrowserClient } from '@sentry/browser';
 import { Hub, makeMain } from '@sentry/hub';
 import type { BaseTransportOptions, ClientOptions, DsnComponents } from '@sentry/types';
-import { getGlobalObject, InstrumentHandlerCallback, InstrumentHandlerType } from '@sentry/utils';
+import { InstrumentHandlerCallback, InstrumentHandlerType, WINDOW } from '@sentry/utils';
 import { JSDOM } from 'jsdom';
 
 import { BrowserTracing, BrowserTracingOptions, getMetaContent } from '../../src/browser/browsertracing';
@@ -35,11 +35,11 @@ const warnSpy = jest.spyOn(logger, 'warn');
 beforeAll(() => {
   const dom = new JSDOM();
   // @ts-ignore need to override global document
-  global.document = dom.window.document;
+  WINDOW.document = dom.window.document;
   // @ts-ignore need to override global document
-  global.window = dom.window;
+  WINDOW.window = dom.window;
   // @ts-ignore need to override global document
-  global.location = dom.window.location;
+  WINDOW.location = dom.window.location;
 });
 
 describe('BrowserTracing', () => {
@@ -484,7 +484,7 @@ describe('BrowserTracing', () => {
     };
 
     it('extracts window.location/self.location for sampling context in pageload transactions', () => {
-      getGlobalObject<Window>().location = dogParkLocation as any;
+      WINDOW.location = dogParkLocation as any;
 
       const tracesSampler = jest.fn();
       const options = getDefaultBrowserClientOptions({ tracesSampler });
@@ -501,7 +501,7 @@ describe('BrowserTracing', () => {
     });
 
     it('extracts window.location/self.location for sampling context in navigation transactions', () => {
-      getGlobalObject<Window>().location = dogParkLocation as any;
+      WINDOW.location = dogParkLocation as any;
 
       const tracesSampler = jest.fn();
       const options = getDefaultBrowserClientOptions({ tracesSampler });

--- a/packages/tracing/test/hub.test.ts
+++ b/packages/tracing/test/hub.test.ts
@@ -23,8 +23,6 @@ jest.spyOn(logger, 'warn');
 jest.spyOn(logger, 'log');
 jest.spyOn(utilsModule, 'isNodeEnv');
 
-// we have to add things into the real global object (rather than mocking the return value of getGlobalObject) because
-// there are modules which call getGlobalObject as they load, which is seemingly too early for jest to intervene
 addDOMPropertiesToGlobal(['XMLHttpRequest', 'Event', 'location', 'document']);
 
 describe('Hub', () => {

--- a/packages/tracing/test/testutils.ts
+++ b/packages/tracing/test/testutils.ts
@@ -1,6 +1,6 @@
 import { createTransport } from '@sentry/browser';
 import { ClientOptions } from '@sentry/types';
-import { getGlobalObject, resolvedSyncPromise } from '@sentry/utils';
+import { GLOBAL_OBJ, resolvedSyncPromise } from '@sentry/utils';
 import { JSDOM } from 'jsdom';
 
 /**
@@ -13,14 +13,13 @@ import { JSDOM } from 'jsdom';
  * @param properties The names of the properties to add
  */
 export function addDOMPropertiesToGlobal(properties: string[]): void {
-  // we have to add things into the real global object (rather than mocking the return value of getGlobalObject)
-  // because there are modules which call getGlobalObject as they load, which is too early for jest to intervene
+  // we have to add things into the real global object
+  // because there are modules which call GLOBAL_OBJ as they load, which is too early for jest to intervene
   const { window } = new JSDOM('', { url: 'http://dogs.are.great/' });
-  const global = getGlobalObject<NodeJS.Global & Window>();
 
   properties.forEach(prop => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    (global as any)[prop] = window[prop];
+    (GLOBAL_OBJ as any)[prop] = window[prop];
   });
 }
 

--- a/packages/utils/src/browser.ts
+++ b/packages/utils/src/browser.ts
@@ -1,5 +1,10 @@
-import { getGlobalObject } from './global';
+import { GLOBAL_OBJ } from './global';
 import { isString } from './is';
+
+/**
+ * TODO: Move me to @sentry/browser when @sentry/utils no longer contains any browser code
+ */
+export const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
 
 /**
  * Given a child DOM element, returns a query-selector statement describing that
@@ -115,9 +120,8 @@ function _htmlElementAsString(el: unknown, keyAttrs?: string[]): string {
  * A safe form of location.href
  */
 export function getLocationHref(): string {
-  const global = getGlobalObject<Window>();
   try {
-    return global.document.location.href;
+    return WINDOW.document.location.href;
   } catch (oO) {
     return '';
   }
@@ -141,9 +145,8 @@ export function getLocationHref(): string {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function getDomElement<E = any>(selector: string): E | null {
-  const global = getGlobalObject<Window>();
-  if (global.document && global.document.querySelector) {
-    return global.document.querySelector(selector) as unknown as E;
+  if (WINDOW.document && WINDOW.document.querySelector) {
+    return WINDOW.document.querySelector(selector) as unknown as E;
   }
   return null;
 }

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -1,20 +1,19 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Event, Exception, Mechanism, StackFrame } from '@sentry/types';
 
-import { getGlobalObject } from './global';
+import { GLOBAL_OBJ } from './global';
 import { addNonEnumerableProperty } from './object';
 import { snipLine } from './string';
 
-/**
- * Extended Window interface that allows for Crypto API usage in IE browsers
- */
-interface MsCryptoWindow extends Window {
-  msCrypto?: Crypto;
+interface CryptoInternal {
+  getRandomValues(array: Uint8Array): Uint8Array;
+  randomUUID?(): string;
 }
 
-/** Many browser now support native uuid v4 generation */
-interface CryptoWithRandomUUID extends Crypto {
-  randomUUID?(): string;
+/** An interface for common properties on global */
+interface CryptoGlobal {
+  msCrypto?: CryptoInternal;
+  crypto?: CryptoInternal;
 }
 
 /**
@@ -23,8 +22,8 @@ interface CryptoWithRandomUUID extends Crypto {
  * @returns string Generated UUID4.
  */
 export function uuid4(): string {
-  const global = getGlobalObject() as MsCryptoWindow;
-  const crypto = (global.crypto || global.msCrypto) as CryptoWithRandomUUID;
+  const gbl = GLOBAL_OBJ as typeof GLOBAL_OBJ & CryptoGlobal;
+  const crypto = gbl.crypto || gbl.msCrypto;
 
   if (crypto && crypto.randomUUID) {
     return crypto.randomUUID().replace(/-/g, '');

--- a/packages/utils/src/supports.ts
+++ b/packages/utils/src/supports.ts
@@ -1,4 +1,4 @@
-import { getGlobalObject } from './global';
+import { WINDOW } from './browser';
 import { logger } from './logger';
 
 /**
@@ -56,7 +56,7 @@ export function supportsDOMException(): boolean {
  * @returns Answer to the given question.
  */
 export function supportsFetch(): boolean {
-  if (!('fetch' in getGlobalObject<Window>())) {
+  if (!('fetch' in WINDOW)) {
     return false;
   }
 
@@ -88,18 +88,16 @@ export function supportsNativeFetch(): boolean {
     return false;
   }
 
-  const global = getGlobalObject<Window>();
-
   // Fast path to avoid DOM I/O
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  if (isNativeFetch(global.fetch)) {
+  if (isNativeFetch(WINDOW.fetch)) {
     return true;
   }
 
   // window.fetch is implemented, but is polyfilled or already wrapped (e.g: by a chrome extension)
   // so create a "pure" iframe to see if that has native fetch
   let result = false;
-  const doc = global.document;
+  const doc = WINDOW.document;
   // eslint-disable-next-line deprecation/deprecation
   if (doc && typeof (doc.createElement as unknown) === 'function') {
     try {
@@ -127,7 +125,7 @@ export function supportsNativeFetch(): boolean {
  * @returns Answer to the given question.
  */
 export function supportsReportingObserver(): boolean {
-  return 'ReportingObserver' in getGlobalObject();
+  return 'ReportingObserver' in WINDOW;
 }
 
 /**
@@ -166,13 +164,12 @@ export function supportsHistory(): boolean {
   // NOTE: in Chrome App environment, touching history.pushState, *even inside
   //       a try/catch block*, will cause Chrome to output an error to console.error
   // borrowed from: https://github.com/angular/angular.js/pull/13945/files
-  const global = getGlobalObject<Window>();
   /* eslint-disable @typescript-eslint/no-unsafe-member-access */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const chrome = (global as any).chrome;
+  const chrome = (WINDOW as any).chrome;
   const isChromePackagedApp = chrome && chrome.app && chrome.app.runtime;
   /* eslint-enable @typescript-eslint/no-unsafe-member-access */
-  const hasHistoryApi = 'history' in global && !!global.history.pushState && !!global.history.replaceState;
+  const hasHistoryApi = 'history' in WINDOW && !!WINDOW.history.pushState && !!WINDOW.history.replaceState;
 
   return !isChromePackagedApp && hasHistoryApi;
 }

--- a/packages/utils/src/time.ts
+++ b/packages/utils/src/time.ts
@@ -1,4 +1,4 @@
-import { getGlobalObject } from './global';
+import { WINDOW } from './browser';
 import { dynamicRequire, isNodeEnv } from './node';
 
 /**
@@ -41,7 +41,7 @@ interface Performance {
  * Wrapping the native API works around differences in behavior from different browsers.
  */
 function getBrowserPerformance(): Performance | undefined {
-  const { performance } = getGlobalObject<Window>();
+  const { performance } = WINDOW;
   if (!performance || !performance.now) {
     return undefined;
   }
@@ -140,7 +140,7 @@ export const browserPerformanceTimeOrigin = ((): number | undefined => {
   // performance.timing.navigationStart, which results in poor results in performance data. We only treat time origin
   // data as reliable if they are within a reasonable threshold of the current time.
 
-  const { performance } = getGlobalObject<Window>();
+  const { performance } = WINDOW;
   if (!performance || !performance.now) {
     _browserPerformanceTimeOriginMode = 'none';
     return undefined;

--- a/packages/utils/test/global.test.ts
+++ b/packages/utils/test/global.test.ts
@@ -1,11 +1,11 @@
-import { getGlobalObject } from '../src/global';
+import { GLOBAL_OBJ } from '../src/global';
 
-describe('getGlobalObject()', () => {
+describe('WINDOW', () => {
   test('should return the same object', () => {
     const backup = global.process;
     delete global.process;
-    const first = getGlobalObject();
-    const second = getGlobalObject();
+    const first = GLOBAL_OBJ;
+    const second = GLOBAL_OBJ;
     expect(first).toEqual(second);
     global.process = backup;
   });

--- a/packages/vue/src/index.bundle.ts
+++ b/packages/vue/src/index.bundle.ts
@@ -47,7 +47,7 @@ export {
 } from '@sentry/browser';
 
 import { Integrations as BrowserIntegrations } from '@sentry/browser';
-import { getGlobalObject } from '@sentry/utils';
+import { WINDOW } from '@sentry/utils';
 
 export { init } from './sdk';
 export { vueRouterInstrumentation } from './router';
@@ -57,9 +57,8 @@ export { createTracingMixins } from './tracing';
 let windowIntegrations = {};
 
 // This block is needed to add compatibility with the integrations packages when used with a CDN
-const _window = getGlobalObject<Window>();
-if (_window.Sentry && _window.Sentry.Integrations) {
-  windowIntegrations = _window.Sentry.Integrations;
+if (WINDOW.Sentry && WINDOW.Sentry.Integrations) {
+  windowIntegrations = WINDOW.Sentry.Integrations;
 }
 
 const INTEGRATIONS = {

--- a/packages/vue/src/sdk.ts
+++ b/packages/vue/src/sdk.ts
@@ -1,13 +1,15 @@
 import { init as browserInit, SDK_VERSION } from '@sentry/browser';
-import { arrayify, getGlobalObject, logger } from '@sentry/utils';
+import { arrayify, GLOBAL_OBJ, logger } from '@sentry/utils';
 
 import { DEFAULT_HOOKS } from './constants';
 import { attachErrorHandler } from './errorhandler';
 import { createTracingMixins } from './tracing';
 import { Options, TracingOptions, Vue } from './types';
 
+const globalWithVue = GLOBAL_OBJ as typeof GLOBAL_OBJ & { Vue: Vue };
+
 const DEFAULT_CONFIG: Options = {
-  Vue: getGlobalObject<{ Vue: Vue }>().Vue,
+  Vue: globalWithVue.Vue,
   attachProps: true,
   logErrors: false,
   hooks: DEFAULT_HOOKS,


### PR DESCRIPTION
As discussed [here](https://github.com/getsentry/sentry-javascript/pull/5809#issuecomment-1257290748), this PR:
-  Replaces  `getGlobalObject` with a const `GLOBAL_OBJ` which retains the runtime detection from #5809 
- Also includes a `WINDOW` const which returns `GLOBAL_OBJ` but with `typeof GLOBAL_OBJ & Window` type.
  - This will eventually move to `@sentry/browser` to ensure stricter typing around the global object 
  - Maybe this should be called `WINDOW_GLOBAL` to remove any ambiguity?

It's worth noting that `@sentry/node` and downstream node code doesn't seem to make use of `getGlobalObject` and is already using `global` and I'm not sure if anything is gained by modifying these.