### PR TITLE
fix(core): Stop clobbering existing transaction name with scope value

### DIFF
--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -465,7 +465,11 @@ export class Scope implements ScopeInterface {
       event.level = this._level;
     }
     if (this._transactionName) {
-      event.transaction = this._transactionName;
+      // This runs before any event processors, so the only way that the event would already have a `transaction` value
+      // at this point is if either a) it's a transaction (they have a `transaction` value - their name - from the
+      // get-go, which we take great pains to ensure is as high-quality as possible), or b) it's a custom event in which
+      // the user has set the `transaction` value (and in that case we should respect that).
+      event.transaction = event.transaction || this._transactionName;
     }
 
     // We want to set the trace context for normal events only if there isn't already

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -302,14 +302,14 @@ describe('Scope', () => {
       });
     });
 
-    test('scope transaction should have priority over event transaction', async () => {
+    test("scope transaction shouldn't overwrite existing event transaction", async () => {
       expect.assertions(1);
       const scope = new Scope();
       scope.setTransactionName('/abc');
       const event: Event = {};
       event.transaction = '/cdf';
       return scope.applyToEvent(event).then(processedEvent => {
-        expect(processedEvent!.transaction).toEqual('/abc');
+        expect(processedEvent!.transaction).toEqual('/cdf');
       });
     });
 


### PR DESCRIPTION
Draft until we figure out if this is actually what we want to do.

-----------------------------------------

This prevents the transaction name stored on the scope from overwriting an event's existing `transaction` value. Since the code in question runs before either event processors or `beforeSend`, the only way for an event to already have a `transaction` value at that point are 

a) to be a transaction, or 
b) to be a custom event captured by the user.

In the case of a), we don't want to overwrite the existing `transaction` value because we've just done a bunch of work to make sure that it's a good, parameterized value coming in. In the case of b), the user has actively provided a name, which we should respect.

Resolves https://github.com/getsentry/sentry-javascript/issues/5660
