### PR TITLE
fix(nextjs): Reverse order of checks for instrumenting server

### DIFF
--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -142,7 +142,7 @@ export {
 // deployments, because the current method of doing the wrapping a) crashes Next 12 apps deployed to Vercel and
 // b) doesn't work on those apps anyway. We also don't do it during build, because there's no server running in that
 // phase.)
-if (!isVercel && !isBuild()) {
+if (!isBuild() && !isVercel) {
   // Dynamically require the file because even importing from it causes Next 12 to crash on Vercel.
   // In environments where the JS file doesn't exist, such as testing, import the TS file.
   try {


### PR DESCRIPTION
As it stands right now, when we check whether or not to require `instrumentServer`, our check short-circuits if the code is running on vercel. This is a problem, because the first run of `isBuild()` causes a side effect (it sets an env var) which then enables all future runs, so without that initial runs, future runs fail. This reverses the order of the check, so that `isBuild()` will always run.