### PR TITLE
fix(nextjs): Rename `nextjs.data.server` ops

### DIFF
--- a/packages/nextjs/src/config/wrappers/wrapperUtils.ts
+++ b/packages/nextjs/src/config/wrappers/wrapperUtils.ts
@@ -117,7 +117,7 @@ export function callTracedServerSideDataFetcher<F extends (...args: any[]) => Pr
     }
 
     const dataFetcherSpan = requestTransaction.startChild({
-      op: 'nextjs.data.server',
+      op: 'function.nextjs',
       description: `${options.dataFetchingMethodName} (${options.dataFetcherRouteName})`,
       status: 'ok',
     });
@@ -180,7 +180,7 @@ export async function callDataFetcherTraced<F extends (...args: any[]) => Promis
   // Capture the route, since pre-loading, revalidation, etc might mean that this span may happen during another
   // route's transaction
   const span = transaction.startChild({
-    op: 'nextjs.data.server',
+    op: 'function.nextjs',
     description: `${dataFetchingMethodName} (${parameterizedRoute})`,
     status: 'ok',
   });

--- a/packages/nextjs/src/config/wrappers/wrapperUtils.ts
+++ b/packages/nextjs/src/config/wrappers/wrapperUtils.ts
@@ -95,7 +95,7 @@ export function callTracedServerSideDataFetcher<F extends (...args: any[]) => Pr
 
       const newTransaction = startTransaction(
         {
-          op: 'nextjs.data.server',
+          op: 'http.server',
           name: options.requestedRouteName,
           ...traceparentData,
           status: 'ok',

--- a/packages/nextjs/test/config/wrappers.test.ts
+++ b/packages/nextjs/test/config/wrappers.test.ts
@@ -42,7 +42,7 @@ describe('data-fetching function wrappers', () => {
       expect(startTransactionSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           name: '/tricks/[trickName]',
-          op: 'nextjs.data.server',
+          op: 'http.server',
           metadata: expect.objectContaining({ source: 'route' }),
         }),
         {
@@ -64,7 +64,7 @@ describe('data-fetching function wrappers', () => {
       expect(startTransactionSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           name: '/tricks/[trickName]',
-          op: 'nextjs.data.server',
+          op: 'http.server',
           metadata: expect.objectContaining({ source: 'route' }),
         }),
         {

--- a/packages/nextjs/test/integration/test/server/errorServerSideProps.js
+++ b/packages/nextjs/test/integration/test/server/errorServerSideProps.js
@@ -32,7 +32,7 @@ module.exports = async ({ url: urlBase, argv }) => {
     {
       contexts: {
         trace: {
-          op: 'nextjs.data.server',
+          op: 'http.server',
           status: 'internal_error',
         },
       },

--- a/packages/nextjs/test/integration/test/server/tracingServerGetInitialProps.js
+++ b/packages/nextjs/test/integration/test/server/tracingServerGetInitialProps.js
@@ -10,7 +10,7 @@ module.exports = async ({ url: urlBase, argv }) => {
     {
       contexts: {
         trace: {
-          op: 'nextjs.data.server',
+          op: 'http.server',
           status: 'ok',
         },
       },

--- a/packages/nextjs/test/integration/test/server/tracingServerGetServerSideProps.js
+++ b/packages/nextjs/test/integration/test/server/tracingServerGetServerSideProps.js
@@ -10,7 +10,7 @@ module.exports = async ({ url: urlBase, argv }) => {
     {
       contexts: {
         trace: {
-          op: 'nextjs.data.server',
+          op: 'http.server',
           status: 'ok',
         },
       },


### PR DESCRIPTION
As per the span operation audit, this transaction is a http request processed on the server, so we should rename the span op.

https://www.notion.so/sentry/Set-up-an-audit-for-SDK-consistency-for-span-operations-to-enable-performance-issues-addf02a8fa234dda8acf48d4ff9b8efb?d=b852bdd1e9914d2ca74c1052296081f3#d04af01302604881999b1bd29c837b1f

ref: https://github.com/getsentry/sentry-javascript/issues/5837

`nextjs.data.server` -> `http.server` for transactions, and `nextjs.data.server` -> `function.nextjs` for spans.