### PR TITLE
ref(typescript): Remove `dom` lib types from `types`/`hub`/`core`/`node`

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
     // package-specific options
+    "lib": [
+      "ES6"
+    ]
   }
 }

--- a/packages/hub/tsconfig.json
+++ b/packages/hub/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
     // package-specific options
+    "lib": [
+      "ES6"
+    ]
   }
 }

--- a/packages/node/src/requestdata.ts
+++ b/packages/node/src/requestdata.ts
@@ -308,11 +308,5 @@ function extractQueryParams(req: PolymorphicRequest): string | Record<string, un
     originalUrl = `http://dogs.are.great${originalUrl}`;
   }
 
-  return (
-    req.query ||
-    (typeof URL !== undefined && new URL(originalUrl).search.replace('?', '')) ||
-    // In Node 8, `URL` isn't in the global scope, so we have to use the built-in module from Node
-    url.parse(originalUrl).query ||
-    undefined
-  );
+  return req.query || new url.URL(originalUrl).search.replace('?', '') || url.parse(originalUrl).query || undefined;
 }

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
     // package-specific options
+    "lib": [
+      "ES6"
+    ]
   }
 }

--- a/packages/node/tsconfig.test.json
+++ b/packages/node/tsconfig.test.json
@@ -1,12 +1,18 @@
 {
   "extends": "./tsconfig.json",
-
-  "include": ["test/**/*"],
-
+  "include": [
+    "test/**/*"
+  ],
   "compilerOptions": {
+    "lib": [
+      "ES6",
+      "DOM"
+    ],
     // should include all types from `./tsconfig.json` plus types for all test frameworks used
-    "types": ["node", "jest"]
-
+    "types": [
+      "node",
+      "jest"
+    ]
     // other package-specific, test-specific options
   }
 }

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "extends": "../../tsconfig.json",
-
-  "include": ["src/**/*"],
-
+  "include": [
+    "src/**/*"
+  ],
   "compilerOptions": {
     // package-specific options
+    "lib": [
+      "ES6"
+    ]
   }
 }


### PR DESCRIPTION
This PR is an alternative to #5816 which rather than changing the default, overrides the lib types in the packages that shouldn't have dom types.
