### PR TITLE
test(e2e): Validate test app setup

### DIFF
--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -13,9 +13,10 @@
     "lint": "run-s lint:prettier lint:eslint",
     "lint:eslint": "eslint . --cache --cache-location '../../eslintcache/' --format stylish",
     "lint:prettier": "prettier --config ../../.prettierrc.json --check .",
-    "test:e2e": "run-s test:validate-configuration test:run",
+    "test:e2e": "run-s test:validate-configuration test:test-app-setups test:run",
     "test:run": "ts-node run.ts",
-    "test:validate-configuration": "ts-node validate-verdaccio-configuration.ts"
+    "test:validate-configuration": "ts-node validate-verdaccio-configuration.ts",
+    "test:test-app-setups": "ts-node validate-test-app-setups.ts"
   },
   "devDependencies": {
     "@types/glob": "8.0.0",

--- a/packages/e2e-tests/validate-test-app-setups.ts
+++ b/packages/e2e-tests/validate-test-app-setups.ts
@@ -1,0 +1,46 @@
+/* eslint-disable no-console */
+import * as fs from 'fs';
+import * as glob from 'glob';
+import * as path from 'path';
+
+const testRecipePaths = glob.sync('test-applications/*/test-recipe.json', {
+  cwd: __dirname,
+  absolute: true,
+});
+
+testRecipePaths.forEach(testRecipePath => {
+  const testAppPath = path.dirname(testRecipePath);
+  const npmrcPath = path.resolve(testAppPath, '.npmrc');
+
+  if (!fs.existsSync(npmrcPath)) {
+    console.log(
+      `No .npmrc found in test application "${testAppPath}". Please add a .npmrc to this test application that uses the fake test registry. (More info in packages/e2e-tests/README.md)`,
+    );
+    process.exit(1);
+  }
+
+  const npmrcContents = fs.readFileSync(npmrcPath, 'utf-8');
+  if (!npmrcContents.includes('http://localhost:4873')) {
+    console.log(
+      `.npmrc in test application "${testAppPath} doesn't contain a reference to the fake test registry at "http://localhost:4873". Please add a .npmrc to this test application that uses the fake test registry. (More info in packages/e2e-tests/README.md)`,
+    );
+    process.exit(1);
+  }
+
+  const gitignorePath = path.resolve(testAppPath, '.gitignore');
+
+  if (!fs.existsSync(gitignorePath)) {
+    console.log(
+      `No .gitignore found in test application "${testAppPath}". Please add a .gitignore to this test application that ignores any kind of lockfiles. (More info in packages/e2e-tests/README.md)`,
+    );
+    process.exit(1);
+  }
+
+  const gitignoreContents = fs.readFileSync(gitignorePath, 'utf-8');
+  if (!gitignoreContents.includes('lock')) {
+    console.log(
+      `.gitignore in test application "${testAppPath} doesn't contain an entry for a lockfile. Please add a .gitignore to this test application that ignores any kind of lockfiles. (More info in packages/e2e-tests/README.md)`,
+    );
+    process.exit(1);
+  }
+});


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/5506

Adds a validation script to the E2E test package that does a plausibility check if E2E test apps have a correct setup (i.e. they use the test registry and ignore lockfiles).