### PR TITLE
fix(tracing): Warn if `resolvers` is not defined in `ApolloServer` config

### DIFF
--- a/packages/tracing/src/integrations/node/apollo.ts
+++ b/packages/tracing/src/integrations/node/apollo.ts
@@ -35,7 +35,7 @@ export class Apollo implements Integration {
     }>('apollo-server-core');
 
     if (!pkg) {
-      logger.error('Apollo Integration was unable to require apollo-server-core package.');
+      __DEBUG_BUILD__ && logger.error('Apollo Integration was unable to require apollo-server-core package.');
       return;
     }
 
@@ -45,17 +45,20 @@ export class Apollo implements Integration {
     fill(pkg.ApolloServerBase.prototype, 'constructSchema', function (orig: () => unknown) {
       return function (this: { config: { resolvers?: ApolloModelResolvers[]; schema?: unknown; modules?: unknown } }) {
         if (!this.config.resolvers) {
-          if (this.config.schema) {
-            logger.warn(
-              'Apollo integration is not able to trace `ApolloServer` instances constructed via `schema` property.',
-            );
-          } else if (this.config.modules) {
-            logger.warn(
-              'Apollo integration is not able to trace `ApolloServer` instances constructed via `modules` property.',
-            );
+          if (__DEBUG_BUILD__) {
+            if (this.config.schema) {
+              logger.warn(
+                'Apollo integration is not able to trace `ApolloServer` instances constructed via `schema` property.',
+              );
+            } else if (this.config.modules) {
+              logger.warn(
+                'Apollo integration is not able to trace `ApolloServer` instances constructed via `modules` property.',
+              );
+            }
+
+            logger.error('Skipping tracing as no resolvers found on the `ApolloServer` instance.');
           }
 
-          logger.error('Skipping tracing as no resolvers found on the `ApolloServer` instance.');
           return orig.call(this);
         }
 

--- a/packages/tracing/src/integrations/node/graphql.ts
+++ b/packages/tracing/src/integrations/node/graphql.ts
@@ -23,7 +23,7 @@ export class GraphQL implements Integration {
     }>('graphql/execution/execute.js');
 
     if (!pkg) {
-      logger.error('GraphQL Integration was unable to require graphql/execution package.');
+      __DEBUG_BUILD__ && logger.error('GraphQL Integration was unable to require graphql/execution package.');
       return;
     }
 


### PR DESCRIPTION
ref #5808

This PR actually doesn't solve the source of #5808 (supporting `ApolloServer` instances configured by a pre-constructed `schema`).

But logs a warning instead of breaking the application when `resolvers` array is not defined in the `ApolloServer` configuration.