### PR TITLE
fix(utils): Normalize when serializing envelope

### DIFF
--- a/packages/utils/test/envelope.test.ts
+++ b/packages/utils/test/envelope.test.ts
@@ -58,6 +58,21 @@ describe('envelope', () => {
         Uint8Array.from([7, 8, 9, 10, 11, 12]),
       ]);
     });
+
+    it("doesn't throw when being passed a an envelope that contains a circular item payload", () => {
+      const chicken: { egg?: unknown } = {};
+      const egg = { chicken };
+      chicken.egg = chicken;
+
+      const env = createEnvelope<EventEnvelope>({ event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2', sent_at: '123' }, [
+        [{ type: 'event' }, egg],
+      ]);
+
+      const serializedEnvelope = serializeEnvelope(env, new TextEncoder());
+      const [, , serializedBody] = serializedEnvelope.toString().split('\n');
+
+      expect(serializedBody).toBe('{"chicken":{"egg":"[Circular ~]"}}');
+    });
   });
 
   describe('addItemToEnvelope()', () => {


### PR DESCRIPTION
Since https://github.com/getsentry/sentry-javascript/issues/2809 keeps being necrobumped I decided to look into it once more.

Apparently unnormalized data keeps slipping through up until we serialize envelopes. This causes the `JSON.stringify` call to fail and throw, right before we were about to report an error event. Not ideal.

My proposed fix for now - and I am definitely *not* all for it - is to simply wrap the `JSON.stringify` call in a try-catch and normalize the entire payload with infinite recursion depth once more, in case that call fails.

This has an obvious performance impact, especially since we know that when `JSON.stringify` fails, it has some unnormalized data that might be very big and recursive - potentially even sending payloads that are too big.
