### PR TITLE
fix(node): Only set `DeviceContext.boot_time` if `os.uptime()` is valid

### DIFF
--- a/packages/node/src/integrations/context.ts
+++ b/packages/node/src/integrations/context.ts
@@ -189,10 +189,18 @@ function getAppContext(): AppContext {
   return { app_start_time, app_memory };
 }
 
-function getDeviceContext(deviceOpt: DeviceContextOptions | true): DeviceContext {
+/**
+ * Gets device information from os
+ */
+export function getDeviceContext(deviceOpt: DeviceContextOptions | true): DeviceContext {
   const device: DeviceContext = {};
 
-  device.boot_time = new Date(Date.now() - os.uptime() * 1000).toISOString();
+  // os.uptime or its return value seem to be undefined in certain environments (e.g. Azure functions).
+  // Hence, we only set boot time, if we get a valid uptime value.
+  // @see https://github.com/getsentry/sentry-javascript/issues/5856
+  const uptime = os.uptime && os.uptime();
+  device.boot_time = uptime !== undefined ? new Date(Date.now() - uptime * 1000).toISOString() : undefined;
+
   device.arch = os.arch();
 
   if (deviceOpt === true || deviceOpt.memory) {

--- a/packages/node/src/integrations/context.ts
+++ b/packages/node/src/integrations/context.ts
@@ -199,7 +199,9 @@ export function getDeviceContext(deviceOpt: DeviceContextOptions | true): Device
   // Hence, we only set boot time, if we get a valid uptime value.
   // @see https://github.com/getsentry/sentry-javascript/issues/5856
   const uptime = os.uptime && os.uptime();
-  device.boot_time = uptime !== undefined ? new Date(Date.now() - uptime * 1000).toISOString() : undefined;
+  if (typeof uptime === 'number') {
+    device.boot_time = new Date(Date.now() - uptime * 1000).toISOString();
+  }
 
   device.arch = os.arch();
 

--- a/packages/node/test/integrations/context.test.ts
+++ b/packages/node/test/integrations/context.test.ts
@@ -1,4 +1,5 @@
 import * as os from 'os';
+
 import { getDeviceContext } from '../../src/integrations/context';
 
 describe('Context', () => {

--- a/packages/node/test/integrations/context.test.ts
+++ b/packages/node/test/integrations/context.test.ts
@@ -1,0 +1,21 @@
+import * as os from 'os';
+import { getDeviceContext } from '../../src/integrations/context';
+
+describe('Context', () => {
+  describe('getDeviceContext', () => {
+    afterAll(() => {
+      jest.clearAllMocks();
+    });
+
+    it('returns boot time if os.uptime is defined and returns a valid uptime', () => {
+      const deviceCtx = getDeviceContext({});
+      expect(deviceCtx.boot_time).toEqual(expect.any(String));
+    });
+
+    it('returns no boot time if os.uptime() returns undefined', () => {
+      jest.spyOn(os, 'uptime').mockReturnValue(undefined as unknown as number);
+      const deviceCtx = getDeviceContext({});
+      expect(deviceCtx.boot_time).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
When[ creating the `DeviceContext` ](https://github.com/getsentry/sentry-javascript/blob/6b82415168f4d4eb33ae955dfef5b082f5adea3d/packages/node/src/integrations/context.ts#L195) in the Node SDK `Context` integration, we calculate the boot time based on `os.uptime`. However, as reported in #5856, `os.uptime` might not always be available or return undefined (I couldn't figure out which of the two cases actually was responsible).

This PR quickly fixes this bug by simply not setting the boot time in case we don't get a valid up time. It also adds two basic tests for this behaviour. I opted to not set the boot time instead of e.g. defaulting to `0` for uptime because IMO this creates a false boot time that probably causes more confusion than not having it. However, as my context on the Context integration (👀) is limited, I'm interested in other opinions on this. cc @timfish  

fixes #5856