### PR TITLE
fix(nextjs): Handle CJS API route exports

### DIFF
--- a/packages/nextjs/test/integration/pages/api/withSentryAPI/unwrapped/cjsExport.ts
+++ b/packages/nextjs/test/integration/pages/api/withSentryAPI/unwrapped/cjsExport.ts
@@ -1,0 +1,7 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+const handler = async (_req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+  res.status(200).json({ success: true });
+};
+
+module.exports = handler;

--- a/packages/nextjs/test/integration/pages/api/withSentryAPI/wrapped/cjsExport.ts
+++ b/packages/nextjs/test/integration/pages/api/withSentryAPI/wrapped/cjsExport.ts
@@ -1,0 +1,7 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+const handler = async (_req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+  res.status(200).json({ success: true });
+};
+
+module.exports = handler;

--- a/packages/nextjs/test/integration/test/server/cjsApiEndpoints.js
+++ b/packages/nextjs/test/integration/test/server/cjsApiEndpoints.js
@@ -1,12 +1,55 @@
 const assert = require('assert');
 
 const { sleep } = require('../utils/common');
-const { getAsync, interceptEventRequest, interceptTracingRequest } = require('../utils/server');
+const { getAsync, interceptTracingRequest } = require('../utils/server');
 
 module.exports = async ({ url: urlBase, argv }) => {
-  const responseUnwrapped = await getAsync(`${urlBase}/api/withSentryAPI/unwrapped/cjsExport`);
+  const unwrappedRoute = '/api/withSentryAPI/unwrapped/cjsExport';
+  const interceptedUnwrappedRequest = interceptTracingRequest(
+    {
+      contexts: {
+        trace: {
+          op: 'http.server',
+          status: 'ok',
+          tags: { 'http.status_code': '200' },
+        },
+      },
+      transaction: `GET ${unwrappedRoute}`,
+      type: 'transaction',
+      request: {
+        url: `${urlBase}${unwrappedRoute}`,
+      },
+    },
+    argv,
+    'unwrapped CJS route',
+  );
+  const responseUnwrapped = await getAsync(`${urlBase}${unwrappedRoute}`);
   assert.equal(responseUnwrapped, '{"success":true}');
 
-  const responseWrapped = await getAsync(`${urlBase}/api/withSentryAPI/wrapped/cjsExport`);
+  const wrappedRoute = '/api/withSentryAPI/wrapped/cjsExport';
+  const interceptedWrappedRequest = interceptTracingRequest(
+    {
+      contexts: {
+        trace: {
+          op: 'http.server',
+          status: 'ok',
+          tags: { 'http.status_code': '200' },
+        },
+      },
+      transaction: `GET ${wrappedRoute}`,
+      type: 'transaction',
+      request: {
+        url: `${urlBase}${wrappedRoute}`,
+      },
+    },
+    argv,
+    'wrapped CJS route',
+  );
+  const responseWrapped = await getAsync(`${urlBase}${wrappedRoute}`);
   assert.equal(responseWrapped, '{"success":true}');
+
+  await sleep(250);
+
+  assert.ok(interceptedUnwrappedRequest.isDone(), 'Did not intercept unwrapped request');
+  assert.ok(interceptedWrappedRequest.isDone(), 'Did not intercept wrapped request');
 };

--- a/packages/nextjs/test/integration/test/server/cjsApiEndpoints.js
+++ b/packages/nextjs/test/integration/test/server/cjsApiEndpoints.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+
+const { sleep } = require('../utils/common');
+const { getAsync, interceptEventRequest, interceptTracingRequest } = require('../utils/server');
+
+module.exports = async ({ url: urlBase, argv }) => {
+  const responseUnwrapped = await getAsync(`${urlBase}/api/withSentryAPI/unwrapped/cjsExport`);
+  assert.equal(responseUnwrapped, '{"success":true}');
+
+  const responseWrapped = await getAsync(`${urlBase}/api/withSentryAPI/wrapped/cjsExport`);
+  assert.equal(responseWrapped, '{"success":true}');
+};


### PR DESCRIPTION
Fixes #5863

The PR makes our auto wrapping of Next.js API routes able to handle CJS exports. Previously we only looked at `import.default` which is not defined in case the user exported via CJS export (e.g. `module.exports = myFunction;`)