### PR TITLE
fix(nextjs): Don't assert existence of `req` and `res` in data-fetching wrappers

### DIFF
--- a/packages/nextjs/src/config/wrappers/withSentryServerSideAppGetInitialProps.ts
+++ b/packages/nextjs/src/config/wrappers/withSentryServerSideAppGetInitialProps.ts
@@ -28,27 +28,23 @@ export function withSentryServerSideAppGetInitialProps(origAppGetInitialProps: A
 
     const errorWrappedAppGetInitialProps = withErrorInstrumentation(origAppGetInitialProps);
 
-    if (hasTracingEnabled()) {
-      // Since this wrapper is only applied to `getInitialProps` running on the server, we can assert that `req` and
-      // `res` are always defined: https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#context-object
+    // Generally we can assume that `req` and `res` are always defined on the server:
+    // https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#context-object
+    // This does not seem to be the case in dev mode. Because we have no clean way of associating the the data fetcher
+    // span with eachother when there are no req or res objects, we simply do not trace them at all here.
+    if (hasTracingEnabled() && req && res) {
       const appGetInitialProps: {
         pageProps: {
           _sentryTraceData?: string;
           _sentryBaggage?: string;
         };
-      } = await callTracedServerSideDataFetcher(
-        errorWrappedAppGetInitialProps,
-        appGetInitialPropsArguments,
-        req!,
-        res!,
-        {
-          dataFetcherRouteName: '/_app',
-          requestedRouteName: context.ctx.pathname,
-          dataFetchingMethodName: 'getInitialProps',
-        },
-      );
+      } = await callTracedServerSideDataFetcher(errorWrappedAppGetInitialProps, appGetInitialPropsArguments, req, res, {
+        dataFetcherRouteName: '/_app',
+        requestedRouteName: context.ctx.pathname,
+        dataFetchingMethodName: 'getInitialProps',
+      });
 
-      const requestTransaction = getTransactionFromRequest(req!);
+      const requestTransaction = getTransactionFromRequest(req);
       if (requestTransaction) {
         appGetInitialProps.pageProps._sentryTraceData = requestTransaction.toTraceparent();
 

--- a/packages/nextjs/src/config/wrappers/withSentryServerSideAppGetInitialProps.ts
+++ b/packages/nextjs/src/config/wrappers/withSentryServerSideAppGetInitialProps.ts
@@ -31,7 +31,7 @@ export function withSentryServerSideAppGetInitialProps(origAppGetInitialProps: A
     // Generally we can assume that `req` and `res` are always defined on the server:
     // https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#context-object
     // This does not seem to be the case in dev mode. Because we have no clean way of associating the the data fetcher
-    // span with eachother when there are no req or res objects, we simply do not trace them at all here.
+    // span with each other when there are no req or res objects, we simply do not trace them at all here.
     if (hasTracingEnabled() && req && res) {
       const appGetInitialProps: {
         pageProps: {

--- a/packages/nextjs/src/config/wrappers/withSentryServerSideDocumentGetInitialProps.ts
+++ b/packages/nextjs/src/config/wrappers/withSentryServerSideDocumentGetInitialProps.ts
@@ -32,7 +32,7 @@ export function withSentryServerSideDocumentGetInitialProps(
     // Generally we can assume that `req` and `res` are always defined on the server:
     // https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#context-object
     // This does not seem to be the case in dev mode. Because we have no clean way of associating the the data fetcher
-    // span with eachother when there are no req or res objects, we simply do not trace them at all here.
+    // span with each other when there are no req or res objects, we simply do not trace them at all here.
     if (hasTracingEnabled() && req && res) {
       return callTracedServerSideDataFetcher(errorWrappedGetInitialProps, documentGetInitialPropsArguments, req, res, {
         dataFetcherRouteName: '/_document',

--- a/packages/nextjs/src/config/wrappers/withSentryServerSideErrorGetInitialProps.ts
+++ b/packages/nextjs/src/config/wrappers/withSentryServerSideErrorGetInitialProps.ts
@@ -34,7 +34,7 @@ export function withSentryServerSideErrorGetInitialProps(
     // Generally we can assume that `req` and `res` are always defined on the server:
     // https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#context-object
     // This does not seem to be the case in dev mode. Because we have no clean way of associating the the data fetcher
-    // span with eachother when there are no req or res objects, we simply do not trace them at all here.
+    // span with each other when there are no req or res objects, we simply do not trace them at all here.
     if (hasTracingEnabled() && req && res) {
       const errorGetInitialProps: ErrorProps & {
         _sentryTraceData?: string;

--- a/packages/nextjs/src/config/wrappers/withSentryServerSideErrorGetInitialProps.ts
+++ b/packages/nextjs/src/config/wrappers/withSentryServerSideErrorGetInitialProps.ts
@@ -31,25 +31,21 @@ export function withSentryServerSideErrorGetInitialProps(
 
     const errorWrappedGetInitialProps = withErrorInstrumentation(origErrorGetInitialProps);
 
-    if (hasTracingEnabled()) {
-      // Since this wrapper is only applied to `getInitialProps` running on the server, we can assert that `req` and
-      // `res` are always defined: https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#context-object
+    // Generally we can assume that `req` and `res` are always defined on the server:
+    // https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#context-object
+    // This does not seem to be the case in dev mode. Because we have no clean way of associating the the data fetcher
+    // span with eachother when there are no req or res objects, we simply do not trace them at all here.
+    if (hasTracingEnabled() && req && res) {
       const errorGetInitialProps: ErrorProps & {
         _sentryTraceData?: string;
         _sentryBaggage?: string;
-      } = await callTracedServerSideDataFetcher(
-        errorWrappedGetInitialProps,
-        errorGetInitialPropsArguments,
-        req!,
-        res!,
-        {
-          dataFetcherRouteName: '/_error',
-          requestedRouteName: context.pathname,
-          dataFetchingMethodName: 'getInitialProps',
-        },
-      );
+      } = await callTracedServerSideDataFetcher(errorWrappedGetInitialProps, errorGetInitialPropsArguments, req, res, {
+        dataFetcherRouteName: '/_error',
+        requestedRouteName: context.pathname,
+        dataFetchingMethodName: 'getInitialProps',
+      });
 
-      const requestTransaction = getTransactionFromRequest(req!);
+      const requestTransaction = getTransactionFromRequest(req);
       if (requestTransaction) {
         errorGetInitialProps._sentryTraceData = requestTransaction.toTraceparent();
 

--- a/packages/nextjs/src/config/wrappers/withSentryServerSideGetInitialProps.ts
+++ b/packages/nextjs/src/config/wrappers/withSentryServerSideGetInitialProps.ts
@@ -30,7 +30,7 @@ export function withSentryServerSideGetInitialProps(origGetInitialProps: GetInit
     // Generally we can assume that `req` and `res` are always defined on the server:
     // https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#context-object
     // This does not seem to be the case in dev mode. Because we have no clean way of associating the the data fetcher
-    // span with eachother when there are no req or res objects, we simply do not trace them at all here.
+    // span with each other when there are no req or res objects, we simply do not trace them at all here.
     if (hasTracingEnabled() && req && res) {
       const initialProps: {
         _sentryTraceData?: string;


### PR DESCRIPTION
Fixes #5864

Next.js' `getInitialProps` functions generally are passed request and response objects on the server side. This does not seem to hold in development mode where there are cases that they're undefined.

This PR simply stops tracing `getInitialProps` functions when there are no request or response objects, because we have no clean way of grouping data fetchers under a transaction when there are no `req` and `res` objects.

Disclaimer: I am still not entirely sure if this is the right approach and how the exact behavior for `getInitialProps` and `next dev` is, but this is a forward fix to quickly unblock users.