### PR TITLE
ref(hub): remove hard cap from maxBreadcrumbs

### DIFF
--- a/packages/hub/src/scope.ts
+++ b/packages/hub/src/scope.ts
@@ -34,10 +34,9 @@ import {
 import { updateSession } from './session';
 
 /**
- * Absolute maximum number of breadcrumbs added to an event.
- * The `maxBreadcrumbs` option cannot be higher than this value.
+ * Default value for maximum number of breadcrumbs added to an event.
  */
-const MAX_BREADCRUMBS = 100;
+const DEFAULT_MAX_BREADCRUMBS = 100;
 
 /**
  * Holds additional event information. {@link Scope.applyToEvent} will be
@@ -392,7 +391,7 @@ export class Scope implements ScopeInterface {
    * @inheritDoc
    */
   public addBreadcrumb(breadcrumb: Breadcrumb, maxBreadcrumbs?: number): this {
-    const maxCrumbs = typeof maxBreadcrumbs === 'number' ? Math.min(maxBreadcrumbs, MAX_BREADCRUMBS) : MAX_BREADCRUMBS;
+    const maxCrumbs = typeof maxBreadcrumbs === 'number' ? maxBreadcrumbs : DEFAULT_MAX_BREADCRUMBS;
 
     // No data has been changed, so don't notify scope listeners
     if (maxCrumbs <= 0) {

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -75,12 +75,12 @@ describe('Scope', () => {
       expect((scope as any)._breadcrumbs).toHaveLength(5);
     });
 
-    test('addBreadcrumb cannot go over MAX_BREADCRUMBS value', () => {
+    test('addBreadcrumb can go over DEFAULT_MAX_BREADCRUMBS value', () => {
       const scope = new Scope();
       for (let i = 0; i < 111; i++) {
         scope.addBreadcrumb({ message: 'test' }, 111);
       }
-      expect((scope as any)._breadcrumbs).toHaveLength(100);
+      expect((scope as any)._breadcrumbs).toHaveLength(111);
     });
 
     test('setLevel', () => {

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -77,7 +77,7 @@ describe('Scope', () => {
 
     test('addBreadcrumb can go over DEFAULT_MAX_BREADCRUMBS value', () => {
       const scope = new Scope();
-      for (let i = 0; i < 111; i++) {
+      for (let i = 0; i < 120; i++) {
         scope.addBreadcrumb({ message: 'test' }, 111);
       }
       expect((scope as any)._breadcrumbs).toHaveLength(111);

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -93,7 +93,7 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
 
   /**
    * The maximum number of breadcrumbs sent with events. Defaults to 100.
-   * Values over 100 will be ignored and 100 used instead.
+   * Sentry has a maximum payload size of 1MB and any events exceeding that payload size will be dropped.
    */
   maxBreadcrumbs?: number;
 


### PR DESCRIPTION
Fix #4693 

As decission in #4693, this PR remove hard cap from `maxBreadcrumbs`.