### PR TITLE
fix(remix): align span operations to new operations

### DIFF
--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -115,7 +115,7 @@ function makeWrappedDocumentRequestFunction(
 
     try {
       const span = activeTransaction?.startChild({
-        op: 'remix.server.documentRequest',
+        op: 'function.remix.document_request',
         description: activeTransaction.name,
         tags: {
           method: request.method,
@@ -147,7 +147,7 @@ function makeWrappedDataFunction(origFn: DataFunction, id: string, name: 'action
 
     try {
       const span = activeTransaction?.startChild({
-        op: `remix.server.${name}`,
+        op: `function.remix.${name}`,
         description: id,
         tags: {
           name,

--- a/packages/remix/test/integration/test/server/action.test.ts
+++ b/packages/remix/test/integration/test/server/action.test.ts
@@ -15,19 +15,19 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
       spans: [
         {
           description: 'routes/action-json-response/$id',
-          op: 'remix.server.action',
+          op: 'function.remix.action',
         },
         {
           description: 'root',
-          op: 'remix.server.loader',
+          op: 'function.remix.loader',
         },
         {
           description: 'routes/action-json-response/$id',
-          op: 'remix.server.loader',
+          op: 'function.remix.loader',
         },
         {
           description: 'routes/action-json-response/$id',
-          op: 'remix.server.documentRequest',
+          op: 'function.remix.document_request',
         },
       ],
     });

--- a/packages/remix/test/integration/test/server/loader.test.ts
+++ b/packages/remix/test/integration/test/server/loader.test.ts
@@ -61,15 +61,15 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
       spans: [
         {
           description: 'root',
-          op: 'remix.server.loader',
+          op: 'function.remix.loader',
         },
         {
           description: 'routes/loader-json-response/$id',
-          op: 'remix.server.loader',
+          op: 'function.remix.loader',
         },
         {
           description: 'routes/loader-json-response/$id',
-          op: 'remix.server.documentRequest',
+          op: 'function.remix.document_request',
         },
       ],
     });


### PR DESCRIPTION
Ref: #5837

For `packages/remix`, I changed span operations to new operations.