### PR TITLE
fix(serverless): align span operations to new operations

### DIFF
--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -315,7 +315,7 @@ export function wrapHandler<TEvent, TResult>(
 
     const transaction = hub.startTransaction({
       name: context.functionName,
-      op: 'awslambda.handler',
+      op: 'function.aws.lambda',
       ...traceparentData,
       metadata: {
         dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,

--- a/packages/serverless/src/awsservices.ts
+++ b/packages/serverless/src/awsservices.ts
@@ -65,7 +65,7 @@ function wrapMakeRequest<TService extends AWSService, TResult>(
       if (transaction) {
         span = transaction.startChild({
           description: describe(this, operation, params),
-          op: 'aws.request',
+          op: 'http.client',
         });
       }
     });

--- a/packages/serverless/src/gcpfunction/cloud_events.ts
+++ b/packages/serverless/src/gcpfunction/cloud_events.ts
@@ -34,7 +34,7 @@ function _wrapCloudEventFunction(
 
     const transaction = hub.startTransaction({
       name: context.type || '<unknown>',
-      op: 'gcp.function.cloud_event',
+      op: 'function.gcp.cloud_event',
       metadata: { source: 'component' },
     });
 

--- a/packages/serverless/src/gcpfunction/events.ts
+++ b/packages/serverless/src/gcpfunction/events.ts
@@ -36,7 +36,7 @@ function _wrapEventFunction<F extends EventFunction | EventFunctionWithCallback>
 
     const transaction = hub.startTransaction({
       name: context.eventType,
-      op: 'gcp.function.event',
+      op: 'function.gcp.event',
       metadata: { source: 'component' },
     });
 

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -85,7 +85,7 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
 
     const transaction = hub.startTransaction({
       name: `${reqMethod} ${reqUrl}`,
-      op: 'gcp.function.http',
+      op: 'function.gcp.http',
       ...traceparentData,
       metadata: {
         dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,

--- a/packages/serverless/src/google-cloud-grpc.ts
+++ b/packages/serverless/src/google-cloud-grpc.ts
@@ -114,7 +114,7 @@ function fillGrpcFunction(stub: Stub, serviceIdentifier: string, methodName: str
         if (transaction) {
           span = transaction.startChild({
             description: `${callType} ${methodName}`,
-            op: `gcloud.grpc.${serviceIdentifier}`,
+            op: `grpc.${serviceIdentifier}`,
           });
         }
         ret.on('status', () => {

--- a/packages/serverless/src/google-cloud-http.ts
+++ b/packages/serverless/src/google-cloud-http.ts
@@ -59,7 +59,7 @@ function wrapRequestFunction(orig: RequestFunction): RequestFunction {
       const httpMethod = reqOpts.method || 'GET';
       span = transaction.startChild({
         description: `${httpMethod} ${reqOpts.uri}`,
-        op: `gcloud.http.${identifyService(this.apiEndpoint)}`,
+        op: `http.client.${identifyService(this.apiEndpoint)}`,
       });
     }
     orig.call(this, reqOpts, (...args: Parameters<ResponseCallback>) => {

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -191,7 +191,7 @@ describe('AWSLambda', () => {
 
       const fakeTransactionContext = {
         name: 'functionName',
-        op: 'awslambda.handler',
+        op: 'function.aws.lambda',
         metadata: { source: 'component' },
       };
 
@@ -218,7 +218,7 @@ describe('AWSLambda', () => {
       } catch (e) {
         const fakeTransactionContext = {
           name: 'functionName',
-          op: 'awslambda.handler',
+          op: 'function.aws.lambda',
           metadata: { source: 'component' },
         };
 
@@ -258,7 +258,7 @@ describe('AWSLambda', () => {
           expect.objectContaining({
             parentSpanId: '1121201211212012',
             parentSampled: false,
-            op: 'awslambda.handler',
+            op: 'function.aws.lambda',
             name: 'functionName',
             traceId: '12312012123120121231201212312012',
             metadata: {
@@ -292,7 +292,7 @@ describe('AWSLambda', () => {
       } catch (e) {
         const fakeTransactionContext = {
           name: 'functionName',
-          op: 'awslambda.handler',
+          op: 'function.aws.lambda',
           traceId: '12312012123120121231201212312012',
           parentSpanId: '1121201211212012',
           parentSampled: false,
@@ -322,7 +322,7 @@ describe('AWSLambda', () => {
 
       const fakeTransactionContext = {
         name: 'functionName',
-        op: 'awslambda.handler',
+        op: 'function.aws.lambda',
         metadata: { source: 'component' },
       };
 
@@ -360,7 +360,7 @@ describe('AWSLambda', () => {
       } catch (e) {
         const fakeTransactionContext = {
           name: 'functionName',
-          op: 'awslambda.handler',
+          op: 'function.aws.lambda',
           metadata: { source: 'component' },
         };
 
@@ -402,7 +402,7 @@ describe('AWSLambda', () => {
 
       const fakeTransactionContext = {
         name: 'functionName',
-        op: 'awslambda.handler',
+        op: 'function.aws.lambda',
         metadata: { source: 'component' },
       };
 
@@ -440,7 +440,7 @@ describe('AWSLambda', () => {
       } catch (e) {
         const fakeTransactionContext = {
           name: 'functionName',
-          op: 'awslambda.handler',
+          op: 'function.aws.lambda',
           metadata: { source: 'component' },
         };
 

--- a/packages/serverless/test/awsservices.test.ts
+++ b/packages/serverless/test/awsservices.test.ts
@@ -32,7 +32,7 @@ describe('AWSServices', () => {
       expect(data.Body?.toString('utf-8')).toEqual('contents');
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.startChild).toBeCalledWith({
-        op: 'aws.request',
+        op: 'http.client',
         description: 'aws.s3.getObject foo',
       });
       // @ts-ignore see "Why @ts-ignore" note
@@ -49,7 +49,7 @@ describe('AWSServices', () => {
       });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.startChild).toBeCalledWith({
-        op: 'aws.request',
+        op: 'http.client',
         description: 'aws.s3.getObject foo',
       });
     });
@@ -64,7 +64,7 @@ describe('AWSServices', () => {
       expect(data.Payload?.toString('utf-8')).toEqual('reply');
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.startChild).toBeCalledWith({
-        op: 'aws.request',
+        op: 'http.client',
         description: 'aws.lambda.invoke foo',
       });
     });

--- a/packages/serverless/test/gcpfunction.test.ts
+++ b/packages/serverless/test/gcpfunction.test.ts
@@ -113,7 +113,7 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'POST /path',
-        op: 'gcp.function.http',
+        op: 'function.gcp.http',
         metadata: { source: 'route' },
       };
       // @ts-ignore see "Why @ts-ignore" note
@@ -146,7 +146,7 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'POST /path',
-        op: 'gcp.function.http',
+        op: 'function.gcp.http',
         traceId: '12312012123120121231201212312012',
         parentSpanId: '1121201211212012',
         parentSampled: false,
@@ -182,7 +182,7 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'POST /path',
-        op: 'gcp.function.http',
+        op: 'function.gcp.http',
         traceId: '12312012123120121231201212312012',
         parentSpanId: '1121201211212012',
         parentSampled: false,
@@ -261,7 +261,7 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'gcp.function.event',
+        op: 'function.gcp.event',
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
@@ -288,7 +288,7 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'gcp.function.event',
+        op: 'function.gcp.event',
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
@@ -320,7 +320,7 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'gcp.function.event',
+        op: 'function.gcp.event',
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
@@ -351,7 +351,7 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'gcp.function.event',
+        op: 'function.gcp.event',
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
@@ -380,7 +380,7 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'gcp.function.event',
+        op: 'function.gcp.event',
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
@@ -407,7 +407,7 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'gcp.function.event',
+        op: 'function.gcp.event',
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
@@ -435,7 +435,7 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'gcp.function.event',
+        op: 'function.gcp.event',
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
@@ -474,7 +474,7 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'gcp.function.cloud_event',
+        op: 'function.gcp.cloud_event',
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
@@ -501,7 +501,7 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'gcp.function.cloud_event',
+        op: 'function.gcp.cloud_event',
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
@@ -530,7 +530,7 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'gcp.function.cloud_event',
+        op: 'function.gcp.cloud_event',
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
@@ -557,7 +557,7 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'gcp.function.cloud_event',
+        op: 'function.gcp.cloud_event',
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
@@ -585,7 +585,7 @@ describe('GCPFunction', () => {
 
       const fakeTransactionContext = {
         name: 'event.type',
-        op: 'gcp.function.cloud_event',
+        op: 'function.gcp.cloud_event',
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note

--- a/packages/serverless/test/google-cloud-grpc.test.ts
+++ b/packages/serverless/test/google-cloud-grpc.test.ts
@@ -128,7 +128,7 @@ describe('GoogleCloudGrpc tracing', () => {
       expect(resp).toEqual('1637084156623860');
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.startChild).toBeCalledWith({
-        op: 'gcloud.grpc.pubsub',
+        op: 'grpc.pubsub',
         description: 'unary call publish',
       });
       await pubsub.close();

--- a/packages/serverless/test/google-cloud-http.test.ts
+++ b/packages/serverless/test/google-cloud-http.test.ts
@@ -59,12 +59,12 @@ describe('GoogleCloudHttp tracing', () => {
       expect(resp).toEqual([[{ foo: true }]]);
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.startChild).toBeCalledWith({
-        op: 'gcloud.http.bigquery',
+        op: 'http.client.bigquery',
         description: 'POST /jobs',
       });
       // @ts-ignore see "Why @ts-ignore" note
       expect(Sentry.fakeTransaction.startChild).toBeCalledWith({
-        op: 'gcloud.http.bigquery',
+        op: 'http.client.bigquery',
         description: expect.stringMatching(new RegExp('^GET /queries/.+')),
       });
     });


### PR DESCRIPTION
Ref: #5837

For `packages/serverless`, I changed span operations to new operations.