### PR TITLE
fix(vue): align span operations to new operations

### DIFF
--- a/packages/vue/src/tracing.ts
+++ b/packages/vue/src/tracing.ts
@@ -75,7 +75,7 @@ export const createTracingMixins = (options: TracingOptions): Mixins => {
               this.$_sentryRootSpan ||
               activeTransaction.startChild({
                 description: 'Application Render',
-                op: 'ui.vue.render',
+                op: `${VUE_OP}.render`,
               });
           }
         }

--- a/packages/vue/src/tracing.ts
+++ b/packages/vue/src/tracing.ts
@@ -75,7 +75,7 @@ export const createTracingMixins = (options: TracingOptions): Mixins => {
               this.$_sentryRootSpan ||
               activeTransaction.startChild({
                 description: 'Application Render',
-                op: VUE_OP,
+                op: 'ui.vue.render',
               });
           }
         }


### PR DESCRIPTION
Ref: #5837

For `packages/vue`, I changed span operations to new operations.