### PR TITLE
fix(remix): Rework dynamic imports of `react-router-dom`.

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -41,8 +41,7 @@
   "peerDependencies": {
     "@remix-run/node": "1.x",
     "@remix-run/react": "1.x",
-    "react": "16.x || 17.x || 18.x",
-    "react-router": "6.x"
+    "react": "16.x || 17.x || 18.x"
   },
   "scripts": {
     "build": "run-p build:rollup build:types",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -41,7 +41,8 @@
   "peerDependencies": {
     "@remix-run/node": "1.x",
     "@remix-run/react": "1.x",
-    "react": "16.x || 17.x || 18.x"
+    "react": "16.x || 17.x || 18.x",
+    "react-router": "6.x"
   },
   "scripts": {
     "build": "run-p build:rollup build:types",

--- a/packages/remix/rollup.npm.config.js
+++ b/packages/remix/rollup.npm.config.js
@@ -3,5 +3,11 @@ import { makeBaseNPMConfig, makeNPMConfigVariants } from '../../rollup/index.js'
 export default makeNPMConfigVariants(
   makeBaseNPMConfig({
     entrypoints: ['src/index.server.ts', 'src/index.client.tsx'],
+    packageSpecificConfig: {
+      output: {
+        // make it so Rollup calms down about the fact that we're combining default and named exports
+        exports: 'named',
+      },
+    },
   }),
 );

--- a/packages/remix/rollup.npm.config.js
+++ b/packages/remix/rollup.npm.config.js
@@ -4,6 +4,7 @@ export default makeNPMConfigVariants(
   makeBaseNPMConfig({
     entrypoints: ['src/index.server.ts', 'src/index.client.tsx'],
     packageSpecificConfig: {
+      external: ['react-router', 'react-router-dom'],
       output: {
         // make it so Rollup calms down about the fact that we're combining default and named exports
         exports: 'named',

--- a/packages/remix/src/utils/serverAdapters/express.ts
+++ b/packages/remix/src/utils/serverAdapters/express.ts
@@ -43,7 +43,15 @@ function wrapExpressRequestHandler(
     next: ExpressNextFunction,
   ): Promise<void> {
     if (!pkg) {
-      pkg = await import(`${cwd()}/node_modules/react-router-dom`);
+      try {
+        pkg = await import('react-router-dom');
+      } catch (e) {
+        pkg = await import(`${cwd()}/node_modules/react-router-dom`);
+      } finally {
+        if (!pkg) {
+          __DEBUG_BUILD__ && logger.error('Could not find `react-router-dom` package.');
+        }
+      }
     }
 
     // eslint-disable-next-line @typescript-eslint/unbound-method


### PR DESCRIPTION
Fixes: #5860
Ref: https://github.com/getsentry/sentry-javascript/pull/5810#discussion_r978866425

---

~~Added `react-router` as a peer dependency to flag it as `external`, so Rollup won't complain in `sentry-javascript`'s build time.~~

**Edit:** 
Defined `react-router` and `react-router-dom` as `external`s in Rollup configuration, without making them peer dependencies.

---

Added import by name as the first priority (which will work in monorepos) and relative imports as the second if the former fails. Logging error at the end if the latter fails too, without breaking the whole application.

This implementation is similar to the `loadModule` implementation below, only the priorities are swapped. (The other way works too)

https://github.com/getsentry/sentry-javascript/blob/69dfc3516896a60245ad616f33e4517902202581/packages/utils/src/node.ts#L46-L63

Which makes me wonder if we could implement this as a utility, and start using it as a fallback wherever `dynamicRequire` may not work? (like Deno?)