### PR TITLE
build: Cancel in-progress workflows to free up concurrent groups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,12 @@ on:
         description: If the commit you want to test isn't the head of a branch, provide its SHA here
         required: false
 
+# Cancel in progress workflows on pull_requests.
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   # We pin the exact version to enforce reproducable builds with node + npm.
   DEFAULT_NODE_VERSION: '16.15.1'


### PR DESCRIPTION
Cancel any pending actions running on a pull request when a new commit is pushed. This should help improve CI times generally.

See: https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

Based on @mattgauntseo-sentry's work in https://vanguard.getsentry.net/p/cl8kjy5ed162880ls6gwjs6a63 - https://github.com/getsentry/sentry/pull/38889