### PR TITLE
ref(utils): `window` and `self` are no longer required for global object detection?

### DIFF
--- a/packages/utils/src/global.ts
+++ b/packages/utils/src/global.ts
@@ -53,15 +53,10 @@ function isGlobalObj(obj: { Math?: Math }): any | undefined {
   return obj && obj.Math == Math ? obj : undefined;
 }
 
+// When our minimum supported version of node.js is v12 this can become simply globalThis
 const GLOBAL =
   (typeof globalThis == 'object' && isGlobalObj(globalThis)) ||
-  // eslint-disable-next-line no-restricted-globals
-  (typeof window == 'object' && isGlobalObj(window)) ||
-  (typeof self == 'object' && isGlobalObj(self)) ||
   (typeof global == 'object' && isGlobalObj(global)) ||
-  (function (this: any) {
-    return this;
-  })() ||
   {};
 
 /**


### PR DESCRIPTION
As per [this comment](https://github.com/getsentry/sentry-javascript/issues/5611#issuecomment-1271712639), we probably no longer require `window` and `self` since all supported browsers (apart from IE) now support `globalThis`.

This is a breaking change since supporting IE will require a polyfill to continue working.
