### PR TITLE
feat(nextjs): Enable `autoInstrumentServerFunctions` per default

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -79,7 +79,7 @@ export function constructWebpackConfigFunction(
         ],
       };
 
-      if (userSentryOptions.autoInstrumentServerFunctions) {
+      if (userSentryOptions.autoInstrumentServerFunctions !== false) {
         const pagesDir = newConfig.resolve?.alias?.['private-next-pages'] as string;
 
         // Default page extensions per https://github.com/vercel/next.js/blob/f1dbc9260d48c7995f6c52f8fbcc65f08e627992/packages/next/server/config-shared.ts#L161

--- a/packages/nextjs/test/integration/next.config.js
+++ b/packages/nextjs/test/integration/next.config.js
@@ -6,7 +6,6 @@ const moduleExports = {
   },
   pageExtensions: ['jsx', 'js', 'tsx', 'ts', 'page.tsx'],
   sentry: {
-    autoInstrumentServerFunctions: true,
     // Suppress the warning message from `handleSourcemapHidingOptionWarning` in `src/config/webpack.ts`
     // TODO (v8): This can come out in v8, because this option will get a default value
     hideSourceMaps: false,

--- a/packages/nextjs/test/integration/next10.config.template
+++ b/packages/nextjs/test/integration/next10.config.template
@@ -7,7 +7,6 @@ const moduleExports = {
   },
   pageExtensions: ['jsx', 'js', 'tsx', 'ts', 'page.tsx'],
   sentry: {
-    autoInstrumentServerFunctions: true,
     // Suppress the warning message from `handleSourcemapHidingOptionWarning` in `src/config/webpack.ts`
     // TODO (v8): This can come out in v8, because this option will get a default value
     hideSourceMaps: false,

--- a/packages/nextjs/test/integration/next11.config.template
+++ b/packages/nextjs/test/integration/next11.config.template
@@ -8,7 +8,6 @@ const moduleExports = {
   },
   pageExtensions: ['jsx', 'js', 'tsx', 'ts', 'page.tsx'],
   sentry: {
-    autoInstrumentServerFunctions: true,
     // Suppress the warning message from `handleSourcemapHidingOptionWarning` in `src/config/webpack.ts`
     // TODO (v8): This can come out in v8, because this option will get a default value
     hideSourceMaps: false,


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/5505

Sets the default value of the `autoInstrumentServerFunctions` option in our Next.js SDK to `true`. This function automatically wraps any Next.js data fetching methods and user-defined API routes with Sentry error and performance monitoring during build-time.