### PR TITLE
build: Cancel in-progress jobs for CodeQL action

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,12 +13,18 @@ name: 'CodeQL'
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
   schedule:
     - cron: '40 3 * * 0'
+
+# Cancel in progress workflows on pull_requests.
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   analyze:


### PR DESCRIPTION
Cancel any pending actions running on a pull request when a new commit is pushed. This should help improve CI times generally.

ref: https://github.com/getsentry/sentry-javascript/pull/5899

See: 
- https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
- https://vanguard.getsentry.net/p/cl8kjy5ed162880ls6gwjs6a63 
- https://github.com/getsentry/sentry/pull/38889