### PR TITLE
feat(svelte): Add `withSentryConfig` function to wrap User Svelte Configuration

### DIFF
--- a/packages/svelte/src/config.ts
+++ b/packages/svelte/src/config.ts
@@ -36,14 +36,14 @@ export function withSentryConfig(
     // TODO(v8): Remove eslint rule
     // eslint-disable-next-line deprecation/deprecation
     const firstPassPreproc: SentryPreprocessorGroup = componentTrackingPreprocessor(mergedOptions.componentTracking);
-    sentryPreprocessors.set(firstPassPreproc.sentry_id || '', firstPassPreproc);
+    sentryPreprocessors.set(firstPassPreproc.sentryId || '', firstPassPreproc);
   }
 
   // We prioritize user-added preprocessors, so we don't insert sentry processors if they
   // have already been added by users.
   originalPreprocessors.forEach((p: SentryPreprocessorGroup) => {
-    if (p.sentry_id) {
-      sentryPreprocessors.delete(p.sentry_id);
+    if (p.sentryId) {
+      sentryPreprocessors.delete(p.sentryId);
     }
   });
 

--- a/packages/svelte/src/config.ts
+++ b/packages/svelte/src/config.ts
@@ -67,6 +67,7 @@ function dedupePreprocessors(
 ): PreprocessorGroup[] {
   return sentryPreprocessors.filter(
     sentryPreproc =>
-      originalPreprocessors.find(p => (p as SentryPreprocessorGroup).id === sentryPreproc.id) === undefined,
+      originalPreprocessors.find(p => (p as SentryPreprocessorGroup).sentry_id === sentryPreproc.sentry_id) ===
+      undefined,
   );
 }

--- a/packages/svelte/src/config.ts
+++ b/packages/svelte/src/config.ts
@@ -1,0 +1,76 @@
+import { CompileOptions } from 'svelte/types/compiler';
+import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
+
+import { componentTrackingPreprocessor, defaultComponentTrackingOptions } from './preprocessors';
+import { ComponentTrackingInitOptions, SentryPreprocessorGroup } from './types';
+
+export type SvelteConfig = {
+  [key: string]: unknown;
+  preprocess?: PreprocessorGroup[] | PreprocessorGroup;
+  compilerOptions?: CompileOptions;
+};
+
+export type SentrySvelteConfigOptions = {
+  componentTracking?: ComponentTrackingInitOptions;
+};
+
+const DEFAULT_SENTRY_OPTIONS: SentrySvelteConfigOptions = {
+  componentTracking: defaultComponentTrackingOptions,
+};
+
+/**
+ * Add Sentry options to the Svelte config to be exported from the user's `svelte.config.js` file.
+ *
+ * @param originalConfig The existing config to be exported prior to adding Sentry
+ * @param sentryOptions The configuration of the Sentry-added options
+ *
+ * @return The wrapped and modified config to be exported
+ */
+export function withSentryConfig(
+  originalConfig: SvelteConfig,
+  sentryOptions?: SentrySvelteConfigOptions,
+): SvelteConfig {
+  const mergedOptions = {
+    ...DEFAULT_SENTRY_OPTIONS,
+    ...sentryOptions,
+  };
+
+  const originalPreprocessors = getOriginalPreprocessorArray(originalConfig);
+  const sentryPreprocessors: SentryPreprocessorGroup[] = [];
+
+  const shouldTrackComponents = mergedOptions.componentTracking && mergedOptions.componentTracking.trackComponents;
+  if (shouldTrackComponents) {
+    // TODO(v8): Remove eslint rule
+    // eslint-disable-next-line deprecation/deprecation
+    sentryPreprocessors.push(componentTrackingPreprocessor(mergedOptions.componentTracking));
+  }
+
+  const dedupedSentryPreprocessors = sentryPreprocessors.filter(
+    sentryPreproc =>
+      originalPreprocessors.find(p => (p as SentryPreprocessorGroup).id === sentryPreproc.id) === undefined,
+  );
+
+  const mergedPreprocessors = [...dedupedSentryPreprocessors, ...originalPreprocessors];
+
+  return {
+    ...originalConfig,
+    preprocess: mergedPreprocessors,
+  };
+}
+
+/**
+ * Standardizes the different ways the user-provided preprocessor option can be specified.
+ * Users can specify an array of preprocessors, one single one or nothing at all.
+ *
+ * @param originalConfig the user-provided svelte config oject
+ * @return an array of preprocessors or an empty array if no preprocessors were specified
+ */
+function getOriginalPreprocessorArray(originalConfig: SvelteConfig): PreprocessorGroup[] {
+  if (originalConfig.preprocess) {
+    if (Array.isArray(originalConfig.preprocess)) {
+      return originalConfig.preprocess;
+    }
+    return [originalConfig.preprocess];
+  }
+  return [];
+}

--- a/packages/svelte/src/config.ts
+++ b/packages/svelte/src/config.ts
@@ -1,18 +1,7 @@
-import { CompileOptions } from 'svelte/types/compiler';
 import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 
 import { componentTrackingPreprocessor, defaultComponentTrackingOptions } from './preprocessors';
-import { ComponentTrackingInitOptions, SentryPreprocessorGroup } from './types';
-
-export type SvelteConfig = {
-  [key: string]: unknown;
-  preprocess?: PreprocessorGroup[] | PreprocessorGroup;
-  compilerOptions?: CompileOptions;
-};
-
-export type SentrySvelteConfigOptions = {
-  componentTracking?: ComponentTrackingInitOptions;
-};
+import { SentryPreprocessorGroup, SentrySvelteConfigOptions, SvelteConfig } from './types';
 
 const DEFAULT_SENTRY_OPTIONS: SentrySvelteConfigOptions = {
   componentTracking: defaultComponentTrackingOptions,
@@ -36,19 +25,16 @@ export function withSentryConfig(
   };
 
   const originalPreprocessors = getOriginalPreprocessorArray(originalConfig);
-  const sentryPreprocessors: SentryPreprocessorGroup[] = [];
+  const allSentryPreprocessors: SentryPreprocessorGroup[] = [];
 
   const shouldTrackComponents = mergedOptions.componentTracking && mergedOptions.componentTracking.trackComponents;
   if (shouldTrackComponents) {
     // TODO(v8): Remove eslint rule
     // eslint-disable-next-line deprecation/deprecation
-    sentryPreprocessors.push(componentTrackingPreprocessor(mergedOptions.componentTracking));
+    allSentryPreprocessors.push(componentTrackingPreprocessor(mergedOptions.componentTracking));
   }
 
-  const dedupedSentryPreprocessors = sentryPreprocessors.filter(
-    sentryPreproc =>
-      originalPreprocessors.find(p => (p as SentryPreprocessorGroup).id === sentryPreproc.id) === undefined,
-  );
+  const dedupedSentryPreprocessors = dedupePreprocessors(allSentryPreprocessors, originalPreprocessors);
 
   const mergedPreprocessors = [...dedupedSentryPreprocessors, ...originalPreprocessors];
 
@@ -60,7 +46,7 @@ export function withSentryConfig(
 
 /**
  * Standardizes the different ways the user-provided preprocessor option can be specified.
- * Users can specify an array of preprocessors, one single one or nothing at all.
+ * Users can specify an array of preprocessors, a single one or no preprocessor.
  *
  * @param originalConfig the user-provided svelte config oject
  * @return an array of preprocessors or an empty array if no preprocessors were specified
@@ -73,4 +59,14 @@ function getOriginalPreprocessorArray(originalConfig: SvelteConfig): Preprocesso
     return [originalConfig.preprocess];
   }
   return [];
+}
+
+function dedupePreprocessors(
+  sentryPreprocessors: SentryPreprocessorGroup[],
+  originalPreprocessors: PreprocessorGroup[],
+): PreprocessorGroup[] {
+  return sentryPreprocessors.filter(
+    sentryPreproc =>
+      originalPreprocessors.find(p => (p as SentryPreprocessorGroup).id === sentryPreproc.id) === undefined,
+  );
 }

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -8,6 +8,7 @@ export * from '@sentry/browser';
 export { init } from './sdk';
 
 // TODO(v8): Remove this export
+// eslint-disable-next-line deprecation/deprecation
 export { componentTrackingPreprocessor } from './preprocessors';
 
 export { trackComponent } from './performance';

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -7,5 +7,9 @@ export * from '@sentry/browser';
 
 export { init } from './sdk';
 
+// TODO(v8): Remove this export
 export { componentTrackingPreprocessor } from './preprocessors';
+
 export { trackComponent } from './performance';
+
+export { withSentryConfig } from './config';

--- a/packages/svelte/src/preprocessors.ts
+++ b/packages/svelte/src/preprocessors.ts
@@ -56,7 +56,7 @@ export function componentTrackingPreprocessor(options?: ComponentTrackingInitOpt
 
   const sentryPreprocessor: SentryPreprocessorGroup = {
     ...preprocessor,
-    id: FIRST_PASS_COMPONENT_TRACKING_PREPROC_ID,
+    sentry_id: FIRST_PASS_COMPONENT_TRACKING_PREPROC_ID,
   };
 
   return sentryPreprocessor;

--- a/packages/svelte/src/preprocessors.ts
+++ b/packages/svelte/src/preprocessors.ts
@@ -1,6 +1,7 @@
 import MagicString from 'magic-string';
+import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 
-import { ComponentTrackingInitOptions, PreprocessorGroup, TrackComponentOptions } from './types';
+import { ComponentTrackingInitOptions, SentryPreprocessorGroup, TrackComponentOptions } from './types';
 
 export const defaultComponentTrackingOptions: Required<ComponentTrackingInitOptions> = {
   trackComponents: true,
@@ -8,18 +9,22 @@ export const defaultComponentTrackingOptions: Required<ComponentTrackingInitOpti
   trackUpdates: true,
 };
 
+export const FIRST_PASS_COMPONENT_TRACKING_PREPROC_ID = 'FIRST_PASS_COMPONENT_TRACKING_PREPROCESSOR';
+
 /**
  * Svelte Preprocessor to inject Sentry performance monitoring related code
  * into Svelte components.
+ *
+ * @deprecated Use `withSentryConfig` which is the new way of making compile-time modifications
+ *             to Svelte apps going forward.
  */
 export function componentTrackingPreprocessor(options?: ComponentTrackingInitOptions): PreprocessorGroup {
   const mergedOptions = { ...defaultComponentTrackingOptions, ...options };
 
   const visitedFiles = new Set<string>();
 
-  return {
-    // This script hook is called whenever a Svelte component's <script>
-    // content is preprocessed.
+  const preprocessor: PreprocessorGroup = {
+    // This script hook is called whenever a Svelte component's <script> content is preprocessed.
     // `content` contains the script code as a string
     script: ({ content, filename, attributes }) => {
       // TODO: Not sure when a filename could be undefined. Using this 'unknown' fallback for the time being
@@ -48,6 +53,13 @@ export function componentTrackingPreprocessor(options?: ComponentTrackingInitOpt
       return { code: updatedCode, map: updatedSourceMap };
     },
   };
+
+  const sentryPreprocessor: SentryPreprocessorGroup = {
+    ...preprocessor,
+    id: FIRST_PASS_COMPONENT_TRACKING_PREPROC_ID,
+  };
+
+  return sentryPreprocessor;
 }
 
 function shouldInjectFunction(

--- a/packages/svelte/src/preprocessors.ts
+++ b/packages/svelte/src/preprocessors.ts
@@ -56,7 +56,7 @@ export function componentTrackingPreprocessor(options?: ComponentTrackingInitOpt
 
   const sentryPreprocessor: SentryPreprocessorGroup = {
     ...preprocessor,
-    sentry_id: FIRST_PASS_COMPONENT_TRACKING_PREPROC_ID,
+    sentryId: FIRST_PASS_COMPONENT_TRACKING_PREPROC_ID,
   };
 
   return sentryPreprocessor;

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -4,7 +4,7 @@ import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 // Adds an id property to the preprocessor object we can use to check for duplication
 // in the preprocessors array
 export interface SentryPreprocessorGroup extends PreprocessorGroup {
-  id?: string;
+  sentry_id?: string;
 }
 
 /**

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -1,3 +1,4 @@
+import { CompileOptions } from 'svelte/types/compiler';
 import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 
 // Adds an id property to the preprocessor object we can use to check for duplication
@@ -6,8 +7,21 @@ export interface SentryPreprocessorGroup extends PreprocessorGroup {
   id?: string;
 }
 
-// Alternatively, we could use a direct from svelte/compiler/preprocess
-// TODO: figure out what's better and roll with that
+/**
+ * The object exported from `svelte.config.js`
+ */
+export type SvelteConfig = {
+  [key: string]: unknown;
+  preprocess?: PreprocessorGroup[] | PreprocessorGroup;
+  compilerOptions?: CompileOptions;
+};
+
+/**
+ * Options users can provide to `withSentryConfig` to customize what Sentry adds too the Svelte config
+ */
+export type SentrySvelteConfigOptions = {
+  componentTracking?: ComponentTrackingInitOptions;
+};
 
 export type SpanOptions = {
   /**

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -4,7 +4,7 @@ import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 // Adds an id property to the preprocessor object we can use to check for duplication
 // in the preprocessors array
 export interface SentryPreprocessorGroup extends PreprocessorGroup {
-  sentry_id?: string;
+  sentryId?: string;
 }
 
 /**

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -1,40 +1,13 @@
-// The following types were copied from 'svelte/compiler'-internal
-// type definitions
-// see: https://github.com/sveltejs/svelte/blob/master/src/compiler/preprocess/types.ts
-interface Processed {
-  code: string;
-  map?: string | Record<string, unknown>;
-  dependencies?: string[];
-  toString?: () => string;
-}
+import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 
-type MarkupPreprocessor = (options: {
-  content: string;
-  filename?: string;
-}) => Processed | void | Promise<Processed | void>;
-
-type Preprocessor = (options: {
-  /**
-   * The script/style tag content
-   */
-  content: string;
-  attributes: Record<string, string | boolean>;
-  /**
-   * The whole Svelte file content
-   */
-  markup: string;
-  filename?: string;
-}) => Processed | void | Promise<Processed | void>;
-
-export interface PreprocessorGroup {
-  markup?: MarkupPreprocessor;
-  style?: Preprocessor;
-  script?: Preprocessor;
+// Adds an id property to the preprocessor object we can use to check for duplication
+// in the preprocessors array
+export interface SentryPreprocessorGroup extends PreprocessorGroup {
+  id?: string;
 }
 
 // Alternatively, we could use a direct from svelte/compiler/preprocess
 // TODO: figure out what's better and roll with that
-// import { PreprocessorGroup } from 'svelte/types/compiler/preprocess';
 
 export type SpanOptions = {
   /**

--- a/packages/svelte/test/config.test.ts
+++ b/packages/svelte/test/config.test.ts
@@ -48,18 +48,18 @@ describe('withSentryConfig', () => {
   });
 
   it("doesn't add Sentry preprocessors that were already added by the users", () => {
+    const sentryPreproc = componentTrackingPreprocessor();
     const originalConfig = {
       compilerOptions: {
         enableSourcemap: true,
       },
       // eslint-disable-next-line deprecation/deprecation
-      preprocess: componentTrackingPreprocessor(),
+      preprocess: sentryPreproc,
     };
 
     const wrappedConfig = withSentryConfig(originalConfig);
 
-    expect(wrappedConfig).toEqual({ ...originalConfig, preprocess: expect.any(Array) });
-    expect(wrappedConfig.preprocess).toHaveLength(1);
+    expect(wrappedConfig).toEqual({ ...originalConfig, preprocess: [sentryPreproc] });
   });
 
   it('handles multiple wraps correctly by only adding our preprocessors once', () => {

--- a/packages/svelte/test/config.test.ts
+++ b/packages/svelte/test/config.test.ts
@@ -1,6 +1,6 @@
-import { withSentryConfig, SvelteConfig, SentrySvelteConfigOptions } from '../src/config';
+import { withSentryConfig } from '../src/config';
 import { componentTrackingPreprocessor, FIRST_PASS_COMPONENT_TRACKING_PREPROC_ID } from '../src/preprocessors';
-import { SentryPreprocessorGroup } from '../src/types';
+import { SentryPreprocessorGroup, SentrySvelteConfigOptions, SvelteConfig } from '../src/types';
 
 describe('withSentryConfig', () => {
   it.each([
@@ -53,6 +53,7 @@ describe('withSentryConfig', () => {
       compilerOptions: {
         enableSourcemap: true,
       },
+      // eslint-disable-next-line deprecation/deprecation
       preprocess: componentTrackingPreprocessor(),
     };
 

--- a/packages/svelte/test/config.test.ts
+++ b/packages/svelte/test/config.test.ts
@@ -32,7 +32,6 @@ describe('withSentryConfig', () => {
     ],
   ])('adds our preprocessors by default to the provided svelte config with %s', (_, originalConfig: SvelteConfig) => {
     const wrappedConfig = withSentryConfig(originalConfig);
-
     const originalPreprocs = originalConfig.preprocess;
     const originalNumberOfPreprocs = originalPreprocs
       ? Array.isArray(originalPreprocs)
@@ -43,7 +42,7 @@ describe('withSentryConfig', () => {
     expect(Array.isArray(wrappedConfig.preprocess)).toBe(true);
     expect(wrappedConfig).toEqual({ ...originalConfig, preprocess: expect.any(Array) });
     expect(wrappedConfig.preprocess).toHaveLength(originalNumberOfPreprocs + 1);
-    expect((wrappedConfig.preprocess as SentryPreprocessorGroup[])[0].id).toEqual(
+    expect((wrappedConfig.preprocess as SentryPreprocessorGroup[])[0].sentry_id).toEqual(
       FIRST_PASS_COMPONENT_TRACKING_PREPROC_ID,
     );
   });

--- a/packages/svelte/test/config.test.ts
+++ b/packages/svelte/test/config.test.ts
@@ -42,7 +42,7 @@ describe('withSentryConfig', () => {
     expect(Array.isArray(wrappedConfig.preprocess)).toBe(true);
     expect(wrappedConfig).toEqual({ ...originalConfig, preprocess: expect.any(Array) });
     expect(wrappedConfig.preprocess).toHaveLength(originalNumberOfPreprocs + 1);
-    expect((wrappedConfig.preprocess as SentryPreprocessorGroup[])[0].sentry_id).toEqual(
+    expect((wrappedConfig.preprocess as SentryPreprocessorGroup[])[0].sentryId).toEqual(
       FIRST_PASS_COMPONENT_TRACKING_PREPROC_ID,
     );
   });

--- a/packages/svelte/test/config.test.ts
+++ b/packages/svelte/test/config.test.ts
@@ -48,12 +48,12 @@ describe('withSentryConfig', () => {
   });
 
   it("doesn't add Sentry preprocessors that were already added by the users", () => {
+    // eslint-disable-next-line deprecation/deprecation
     const sentryPreproc = componentTrackingPreprocessor();
     const originalConfig = {
       compilerOptions: {
         enableSourcemap: true,
       },
-      // eslint-disable-next-line deprecation/deprecation
       preprocess: sentryPreproc,
     };
 

--- a/packages/svelte/test/config.test.ts
+++ b/packages/svelte/test/config.test.ts
@@ -1,0 +1,91 @@
+import { withSentryConfig, SvelteConfig, SentrySvelteConfigOptions } from '../src/config';
+import { componentTrackingPreprocessor, FIRST_PASS_COMPONENT_TRACKING_PREPROC_ID } from '../src/preprocessors';
+import { SentryPreprocessorGroup } from '../src/types';
+
+describe('withSentryConfig', () => {
+  it.each([
+    [
+      'no preprocessors specified',
+      {
+        compilerOptions: {
+          enableSourcemap: true,
+        },
+      },
+    ],
+    [
+      'a single preprocessor specified',
+      {
+        compilerOptions: {
+          enableSourcemap: true,
+        },
+        preprocess: {},
+      },
+    ],
+    [
+      'an array of preprocessors specified',
+      {
+        compilerOptions: {
+          enableSourcemap: true,
+        },
+        preprocess: [{}, {}, {}],
+      },
+    ],
+  ])('adds our preprocessors by default to the provided svelte config with %s', (_, originalConfig: SvelteConfig) => {
+    const wrappedConfig = withSentryConfig(originalConfig);
+
+    const originalPreprocs = originalConfig.preprocess;
+    const originalNumberOfPreprocs = originalPreprocs
+      ? Array.isArray(originalPreprocs)
+        ? originalPreprocs.length
+        : 1
+      : 0;
+
+    expect(Array.isArray(wrappedConfig.preprocess)).toBe(true);
+    expect(wrappedConfig).toEqual({ ...originalConfig, preprocess: expect.any(Array) });
+    expect(wrappedConfig.preprocess).toHaveLength(originalNumberOfPreprocs + 1);
+    expect((wrappedConfig.preprocess as SentryPreprocessorGroup[])[0].id).toEqual(
+      FIRST_PASS_COMPONENT_TRACKING_PREPROC_ID,
+    );
+  });
+
+  it("doesn't add Sentry preprocessors that were already added by the users", () => {
+    const originalConfig = {
+      compilerOptions: {
+        enableSourcemap: true,
+      },
+      preprocess: componentTrackingPreprocessor(),
+    };
+
+    const wrappedConfig = withSentryConfig(originalConfig);
+
+    expect(wrappedConfig).toEqual({ ...originalConfig, preprocess: expect.any(Array) });
+    expect(wrappedConfig.preprocess).toHaveLength(1);
+  });
+
+  it('handles multiple wraps correctly by only adding our preprocessors once', () => {
+    const originalConfig = {
+      compilerOptions: {
+        enableSourcemap: true,
+      },
+    };
+
+    const wrappedConfig = withSentryConfig(withSentryConfig(withSentryConfig(originalConfig)));
+
+    expect(wrappedConfig).toEqual({ ...originalConfig, preprocess: expect.any(Array) });
+    expect(wrappedConfig.preprocess).toHaveLength(1);
+  });
+
+  it("doesn't add component tracking preprocessors if the feature is deactivated", () => {
+    const originalConfig = {
+      compilerOptions: {
+        enableSourcemap: true,
+      },
+      preprocess: [{}],
+    };
+
+    const sentryOptions: SentrySvelteConfigOptions = { componentTracking: { trackComponents: false } };
+    const wrappedConfig = withSentryConfig(originalConfig, sentryOptions);
+
+    expect(wrappedConfig).toEqual(originalConfig);
+  });
+});

--- a/packages/svelte/test/preprocessors.test.ts
+++ b/packages/svelte/test/preprocessors.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import { componentTrackingPreprocessor, defaultComponentTrackingOptions } from '../src/preprocessors';
 
 function expectComponentCodeToBeModified(


### PR DESCRIPTION
This PR adds the `withSentryConfig` wrapper function to our Svelte SDK which can be used to automatically add Sentry-specific svelte configuration options to our users' configuration in `svelte.config.js`. Going forward, this function will allow us to add more sentry-specific config items, such as additional preprocessors to the config without having to ask our users to adjust their config stuff every time we introduce changes.

We already have a concrete use case for adding another preprocessor to fix #5923 which will be addressed in a follow-up PR. 

The change is fully backward-compatible with how we previously instructed users to add the `componentTrackingPreprocessor` explicitly to their set of preprocessors in their config. However, to make it clear that `withSentryConfig` is the way forward, this PR deprecates `componentTrackingPreprocessor` and in v8, we'll remove it from our public exports.  

Additionally, this PR 
- adds tests for `withSentryConfig`.
-  removes the svelte-internal types we previously copied from Svelte source code into our types file. I think it doesn't do us any harm to switch to the actual types because if they ever change we'd have problems either way. Happy to revert this though if reviewers think this might cause issues. 