### PR TITLE
ref(utils): Remove `getGlobalObject()` usage from `@sentry/node` and `integrations`

### DIFF
--- a/packages/integrations/src/reportingobserver.ts
+++ b/packages/integrations/src/reportingobserver.ts
@@ -1,5 +1,5 @@
 import { EventProcessor, Hub, Integration } from '@sentry/types';
-import { getGlobalObject, supportsReportingObserver } from '@sentry/utils';
+import { supportsReportingObserver, WINDOW } from '@sentry/utils';
 
 interface Report {
   [key: string]: unknown;
@@ -76,7 +76,7 @@ export class ReportingObserver implements Integration {
     this._getCurrentHub = getCurrentHub;
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-    const observer = new (getGlobalObject<any>().ReportingObserver)(this.handler.bind(this), {
+    const observer = new (WINDOW as any).ReportingObserver(this.handler.bind(this), {
       buffered: true,
       types: this._options.types,
     });

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -10,7 +10,7 @@ import {
 import { SessionStatus, StackParser } from '@sentry/types';
 import {
   createStackParser,
-  getGlobalObject,
+  GLOBAL_OBJ,
   logger,
   nodeStackLineParser,
   stackParserFromStackParserOptions,
@@ -233,9 +233,8 @@ export function getSentryRelease(fallback?: string): string | undefined {
   }
 
   // This supports the variable that sentry-webpack-plugin injects
-  const global = getGlobalObject();
-  if (global.SENTRY_RELEASE && global.SENTRY_RELEASE.id) {
-    return global.SENTRY_RELEASE.id;
+  if (GLOBAL_OBJ.SENTRY_RELEASE && GLOBAL_OBJ.SENTRY_RELEASE.id) {
+    return GLOBAL_OBJ.SENTRY_RELEASE.id;
   }
 
   return (


### PR DESCRIPTION
Builds on top of #5831 and removes usages of `getGlobalObject` in node and integrations.
