### PR TITLE
ref(utils): Remove `getGlobalObject()` usage from all framework specific SDKs

### DIFF
--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -3,7 +3,7 @@ import { AfterViewInit, Directive, Injectable, Input, NgModule, OnDestroy, OnIni
 import { ActivatedRouteSnapshot, Event, NavigationEnd, NavigationStart, ResolveEnd, Router } from '@angular/router';
 import { getCurrentHub } from '@sentry/browser';
 import { Span, Transaction, TransactionContext } from '@sentry/types';
-import { getGlobalObject, logger, stripUrlQueryAndFragment, timestampWithMs } from '@sentry/utils';
+import { logger, stripUrlQueryAndFragment, timestampWithMs, WINDOW } from '@sentry/utils';
 import { Observable, Subscription } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
 
@@ -14,8 +14,6 @@ import { runOutsideAngular } from './zone';
 let instrumentationInitialized: boolean;
 let stashedStartTransaction: (context: TransactionContext) => Transaction | undefined;
 let stashedStartTransactionOnLocationChange: boolean;
-
-const global = getGlobalObject<Window>();
 
 /**
  * Creates routing instrumentation for Angular Router.
@@ -29,9 +27,9 @@ export function routingInstrumentation(
   stashedStartTransaction = customStartTransaction;
   stashedStartTransactionOnLocationChange = startTransactionOnLocationChange;
 
-  if (startTransactionOnPageLoad && global && global.location) {
+  if (startTransactionOnPageLoad && WINDOW && WINDOW.location) {
     customStartTransaction({
-      name: global.location.pathname,
+      name: WINDOW.location.pathname,
       op: 'pageload',
       metadata: { source: 'url' },
     });

--- a/packages/ember/addon/index.ts
+++ b/packages/ember/addon/index.ts
@@ -4,12 +4,11 @@ import { macroCondition, isDevelopingApp, getOwnConfig } from '@embroider/macros
 import { next } from '@ember/runloop';
 import { assert, warn } from '@ember/debug';
 import Ember from 'ember';
-import { timestampWithMs } from '@sentry/utils';
+import { timestampWithMs, GLOBAL_OBJ } from '@sentry/utils';
 import { GlobalConfig, OwnConfig } from './types';
-import { getGlobalObject } from '@sentry/utils';
 
 function _getSentryInitConfig() {
-  const _global = getGlobalObject<GlobalConfig>();
+  const _global = GLOBAL_OBJ as typeof GLOBAL_OBJ & GlobalConfig;
   _global.__sentryEmberConfig = _global.__sentryEmberConfig ?? {};
   return _global.__sentryEmberConfig;
 }

--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -6,12 +6,12 @@ import { ExtendedBackburner } from '@sentry/ember/runloop';
 import { Span, Transaction, Integration } from '@sentry/types';
 import { EmberRunQueues } from '@ember/runloop/-private/types';
 import { getActiveTransaction } from '..';
-import { browserPerformanceTimeOrigin, getGlobalObject, timestampWithMs } from '@sentry/utils';
+import { browserPerformanceTimeOrigin, GLOBAL_OBJ, timestampWithMs } from '@sentry/utils';
 import { macroCondition, isTesting, getOwnConfig } from '@embroider/macros';
 import { EmberSentryConfig, GlobalConfig, OwnConfig } from '../types';
 
 function getSentryConfig() {
-  const _global = getGlobalObject<GlobalConfig>();
+  const _global = GLOBAL_OBJ as typeof GLOBAL_OBJ & GlobalConfig;
   _global.__sentryEmberConfig = _global.__sentryEmberConfig ?? {};
   const environmentConfig = getOwnConfig<OwnConfig>().sentryConfig;
   if (!environmentConfig.sentry) {

--- a/packages/nextjs/src/performance/client.ts
+++ b/packages/nextjs/src/performance/client.ts
@@ -3,21 +3,19 @@ import { Primitive, TraceparentData, Transaction, TransactionContext, Transactio
 import {
   baggageHeaderToDynamicSamplingContext,
   extractTraceparentData,
-  getGlobalObject,
   logger,
   stripUrlQueryAndFragment,
+  WINDOW,
 } from '@sentry/utils';
 import type { NEXT_DATA as NextData } from 'next/dist/next-server/lib/utils';
 import { default as Router } from 'next/router';
 import type { ParsedUrlQuery } from 'querystring';
 
-const global = getGlobalObject<
-  Window & {
-    __BUILD_MANIFEST?: {
-      sortedPages?: string[];
-    };
-  }
->();
+const global = WINDOW as typeof WINDOW & {
+  __BUILD_MANIFEST?: {
+    sortedPages?: string[];
+  };
+};
 
 type StartTransactionCb = (context: TransactionContext) => Transaction | undefined;
 

--- a/packages/nextjs/test/index.client.test.ts
+++ b/packages/nextjs/test/index.client.test.ts
@@ -2,15 +2,13 @@ import { BaseClient, getCurrentHub } from '@sentry/core';
 import * as SentryReact from '@sentry/react';
 import { Integrations as TracingIntegrations } from '@sentry/tracing';
 import { Integration } from '@sentry/types';
-import { getGlobalObject, logger } from '@sentry/utils';
+import { logger, WINDOW } from '@sentry/utils';
 import { JSDOM } from 'jsdom';
 
 import { init, Integrations, nextRouterInstrumentation } from '../src/index.client';
 import { UserIntegrationsFunction } from '../src/utils/userIntegrations';
 
 const { BrowserTracing } = TracingIntegrations;
-
-const global = getGlobalObject();
 
 const reactInit = jest.spyOn(SentryReact, 'init');
 const captureEvent = jest.spyOn(BaseClient.prototype, 'captureEvent');
@@ -23,12 +21,12 @@ const dom = new JSDOM(undefined, { url: 'https://example.com/' });
 Object.defineProperty(global, 'document', { value: dom.window.document, writable: true });
 Object.defineProperty(global, 'location', { value: dom.window.document.location, writable: true });
 
-const originalGlobalDocument = getGlobalObject<Window>().document;
-const originalGlobalLocation = getGlobalObject<Window>().location;
+const originalGlobalDocument = WINDOW.document;
+const originalGlobalLocation = WINDOW.location;
 afterAll(() => {
   // Clean up JSDom
-  Object.defineProperty(global, 'document', { value: originalGlobalDocument });
-  Object.defineProperty(global, 'location', { value: originalGlobalLocation });
+  Object.defineProperty(WINDOW, 'document', { value: originalGlobalDocument });
+  Object.defineProperty(WINDOW, 'location', { value: originalGlobalLocation });
 });
 
 function findIntegrationByName(integrations: Integration[] = [], name: string): Integration | undefined {
@@ -38,7 +36,7 @@ function findIntegrationByName(integrations: Integration[] = [], name: string): 
 describe('Client init()', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    global.__SENTRY__.hub = undefined;
+    WINDOW.__SENTRY__.hub = undefined;
   });
 
   it('inits the React SDK', () => {

--- a/packages/nextjs/test/index.server.test.ts
+++ b/packages/nextjs/test/index.server.test.ts
@@ -1,17 +1,15 @@
 import * as SentryNode from '@sentry/node';
 import { getCurrentHub, NodeClient } from '@sentry/node';
 import { Integration } from '@sentry/types';
-import { getGlobalObject, logger } from '@sentry/utils';
+import { GLOBAL_OBJ, logger } from '@sentry/utils';
 import * as domain from 'domain';
 
 import { init } from '../src/index.server';
 
 const { Integrations } = SentryNode;
 
-const global = getGlobalObject();
-
 // normally this is set as part of the build process, so mock it here
-(global as typeof global & { __rewriteFramesDistDir__: string }).__rewriteFramesDistDir__ = '.next';
+(GLOBAL_OBJ as typeof GLOBAL_OBJ & { __rewriteFramesDistDir__: string }).__rewriteFramesDistDir__ = '.next';
 
 const nodeInit = jest.spyOn(SentryNode, 'init');
 const loggerLogSpy = jest.spyOn(logger, 'log');
@@ -23,7 +21,7 @@ function findIntegrationByName(integrations: Integration[] = [], name: string): 
 describe('Server init()', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    global.__SENTRY__.hub = undefined;
+    GLOBAL_OBJ.__SENTRY__.hub = undefined;
     delete process.env.VERCEL;
   });
 

--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -1,5 +1,5 @@
 import { Transaction, TransactionSource } from '@sentry/types';
-import { getGlobalObject } from '@sentry/utils';
+import { WINDOW } from '@sentry/utils';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
 
@@ -25,8 +25,6 @@ export type RouteConfig = {
 
 type MatchPath = (pathname: string, props: string | string[] | any, parent?: Match | null) => Match | null;
 /* eslint-enable @typescript-eslint/no-explicit-any */
-
-const global = getGlobalObject<Window>();
 
 let activeTransaction: Transaction | undefined;
 
@@ -57,8 +55,8 @@ function createReactRouterInstrumentation(
       return history.location.pathname;
     }
 
-    if (global && global.location) {
-      return global.location.pathname;
+    if (WINDOW && WINDOW.location) {
+      return WINDOW.location.pathname;
     }
 
     return undefined;

--- a/packages/react/src/reactrouterv3.ts
+++ b/packages/react/src/reactrouterv3.ts
@@ -1,5 +1,5 @@
 import { Primitive, Transaction, TransactionContext, TransactionSource } from '@sentry/types';
-import { getGlobalObject } from '@sentry/utils';
+import { WINDOW } from '@sentry/utils';
 
 import { Location, ReactRouterInstrumentation } from './types';
 
@@ -20,8 +20,6 @@ export type Match = (
 ) => void;
 
 type ReactRouterV3TransactionSource = Extract<TransactionSource, 'url' | 'route'>;
-
-const global = getGlobalObject<Window>();
 
 /**
  * Creates routing instrumentation for React Router v3
@@ -44,11 +42,11 @@ export function reactRouterV3Instrumentation(
     let activeTransaction: Transaction | undefined;
     let prevName: string | undefined;
 
-    // Have to use global.location because history.location might not be defined.
-    if (startTransactionOnPageLoad && global && global.location) {
+    // Have to use window.location because history.location might not be defined.
+    if (startTransactionOnPageLoad && WINDOW && WINDOW.location) {
       normalizeTransactionName(
         routes,
-        global.location as unknown as Location,
+        WINDOW.location as unknown as Location,
         match,
         (localName: string, source: ReactRouterV3TransactionSource = 'url') => {
           prevName = localName;

--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -2,7 +2,7 @@
 // https://gist.github.com/wontondon/e8c4bdf2888875e4c755712e99279536
 
 import { Transaction, TransactionContext, TransactionSource } from '@sentry/types';
-import { getGlobalObject, getNumberOfUrlSegments, logger } from '@sentry/utils';
+import { getNumberOfUrlSegments, logger, WINDOW } from '@sentry/utils';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import React from 'react';
 
@@ -58,8 +58,6 @@ let _matchRoutes: MatchRoutes;
 let _customStartTransaction: (context: TransactionContext) => Transaction | undefined;
 let _startTransactionOnLocationChange: boolean;
 
-const global = getGlobalObject<Window>();
-
 const SENTRY_TAGS = {
   'routing.instrumentation': 'react-router-v6',
 };
@@ -76,7 +74,7 @@ export function reactRouterV6Instrumentation(
     startTransactionOnPageLoad = true,
     startTransactionOnLocationChange = true,
   ): void => {
-    const initPathName = global && global.location && global.location.pathname;
+    const initPathName = WINDOW && WINDOW.location && WINDOW.location.pathname;
     if (startTransactionOnPageLoad && initPathName) {
       activeTransaction = customStartTransaction({
         name: initPathName,

--- a/packages/remix/src/performance/client.tsx
+++ b/packages/remix/src/performance/client.tsx
@@ -1,7 +1,7 @@
 import type { ErrorBoundaryProps } from '@sentry/react';
 import { withErrorBoundary } from '@sentry/react';
 import { Transaction, TransactionContext } from '@sentry/types';
-import { getGlobalObject, logger } from '@sentry/utils';
+import { logger, WINDOW } from '@sentry/utils';
 import * as React from 'react';
 
 const DEFAULT_TAGS = {
@@ -38,11 +38,9 @@ let _useMatches: UseMatches;
 let _customStartTransaction: (context: TransactionContext) => Transaction | undefined;
 let _startTransactionOnLocationChange: boolean;
 
-const global = getGlobalObject<Window>();
-
 function getInitPathName(): string | undefined {
-  if (global && global.location) {
-    return global.location.pathname;
+  if (WINDOW && WINDOW.location) {
+    return WINDOW.location.pathname;
   }
 
   return undefined;

--- a/packages/remix/test/index.client.test.ts
+++ b/packages/remix/test/index.client.test.ts
@@ -1,17 +1,15 @@
 import { getCurrentHub } from '@sentry/core';
 import * as SentryReact from '@sentry/react';
-import { getGlobalObject } from '@sentry/utils';
+import { GLOBAL_OBJ } from '@sentry/utils';
 
 import { init } from '../src/index.client';
-
-const global = getGlobalObject();
 
 const reactInit = jest.spyOn(SentryReact, 'init');
 
 describe('Client init()', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    global.__SENTRY__.hub = undefined;
+    GLOBAL_OBJ.__SENTRY__.hub = undefined;
   });
 
   it('inits the React SDK', () => {

--- a/packages/remix/test/index.server.test.ts
+++ b/packages/remix/test/index.server.test.ts
@@ -1,17 +1,15 @@
 import * as SentryNode from '@sentry/node';
 import { getCurrentHub } from '@sentry/node';
-import { getGlobalObject } from '@sentry/utils';
+import { GLOBAL_OBJ } from '@sentry/utils';
 
 import { init } from '../src/index.server';
-
-const global = getGlobalObject();
 
 const nodeInit = jest.spyOn(SentryNode, 'init');
 
 describe('Server init()', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    global.__SENTRY__.hub = undefined;
+    GLOBAL_OBJ.__SENTRY__.hub = undefined;
   });
 
   it('inits the Node SDK', () => {

--- a/packages/vue/src/index.bundle.ts
+++ b/packages/vue/src/index.bundle.ts
@@ -47,7 +47,7 @@ export {
 } from '@sentry/browser';
 
 import { Integrations as BrowserIntegrations } from '@sentry/browser';
-import { getGlobalObject } from '@sentry/utils';
+import { WINDOW } from '@sentry/utils';
 
 export { init } from './sdk';
 export { vueRouterInstrumentation } from './router';
@@ -57,9 +57,8 @@ export { createTracingMixins } from './tracing';
 let windowIntegrations = {};
 
 // This block is needed to add compatibility with the integrations packages when used with a CDN
-const _window = getGlobalObject<Window>();
-if (_window.Sentry && _window.Sentry.Integrations) {
-  windowIntegrations = _window.Sentry.Integrations;
+if (WINDOW.Sentry && WINDOW.Sentry.Integrations) {
+  windowIntegrations = WINDOW.Sentry.Integrations;
 }
 
 const INTEGRATIONS = {

--- a/packages/vue/src/sdk.ts
+++ b/packages/vue/src/sdk.ts
@@ -1,13 +1,15 @@
 import { init as browserInit, SDK_VERSION } from '@sentry/browser';
-import { arrayify, getGlobalObject, logger } from '@sentry/utils';
+import { arrayify, GLOBAL_OBJ, logger } from '@sentry/utils';
 
 import { DEFAULT_HOOKS } from './constants';
 import { attachErrorHandler } from './errorhandler';
 import { createTracingMixins } from './tracing';
 import { Options, TracingOptions, Vue } from './types';
 
+const globalWithVue = GLOBAL_OBJ as typeof GLOBAL_OBJ & { Vue: Vue };
+
 const DEFAULT_CONFIG: Options = {
-  Vue: getGlobalObject<{ Vue: Vue }>().Vue,
+  Vue: globalWithVue.Vue,
   attachProps: true,
   logErrors: false,
   hooks: DEFAULT_HOOKS,


### PR DESCRIPTION
Builds on top of #5831 and removes usages of `getGlobalObject` from all the framework specific SDKs.
