### PR TITLE
ref(utils): Deprecate `getGlobalObject` as it's no longer used

### DIFF
--- a/packages/utils/src/global.ts
+++ b/packages/utils/src/global.ts
@@ -73,15 +73,6 @@ export const GLOBAL_OBJ: InternalGlobal =
   {};
 
 /**
- * Safely get global scope object
- *
- * @returns Global scope object
- */
-export function getGlobalObject<T>(): T & InternalGlobal {
-  return GLOBAL_OBJ as T & InternalGlobal;
-}
-
-/**
  * Returns a global singleton contained in the global `__SENTRY__` object.
  *
  * If the singleton doesn't already exist in `__SENTRY__`, it will be created using the given factory

--- a/packages/utils/src/global.ts
+++ b/packages/utils/src/global.ts
@@ -73,6 +73,13 @@ export const GLOBAL_OBJ: InternalGlobal =
   {};
 
 /**
+ * @deprecated Use GLOBAL_OBJ instead. This will be removed in v8
+ */
+export function getGlobalObject<T>(): T & InternalGlobal {
+  return GLOBAL_OBJ as T & InternalGlobal;
+}
+
+/**
  * Returns a global singleton contained in the global `__SENTRY__` object.
  *
  * If the singleton doesn't already exist in `__SENTRY__`, it will be created using the given factory


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry-javascript/issues/5611

This PR wraps up the changes to the global object detection by removing `getGlobalObject` which is no longer used.
