### PR TITLE
build: Add `build:dev:filter` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "build": "node ./scripts/verify-packages-versions.js && yarn run-p build:rollup build:types build:bundle && yarn build:extras",
     "build:bundle": "yarn ts-node scripts/ensure-bundle-deps.ts && yarn lerna run --parallel build:bundle",
     "build:dev": "run-p build:types build:rollup",
+    "build:dev:filter": "lerna run --stream --concurrency 1 --sort build:dev --include-filtered-dependencies --include-filtered-dependents --scope",
     "build:extras": "lerna run --parallel build:extras",
     "build:rollup": "lerna run --parallel build:rollup",
     "build:types": "lerna run --stream build:types",


### PR DESCRIPTION
Add `build:dev:filter` as per https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md#building-packages

Was originally added in https://github.com/getsentry/sentry-javascript/issues/4055, but somehow removed.