### PR TITLE
fix(nextjs): Fix typing issue with `withSentryConfig` and `NextConfig`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # dependencies
 node_modules/
 packages/*/package-lock.json
-packages/**/test/**/yarn.lock
 package-lock.json
 
 # build and test

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # dependencies
 node_modules/
 packages/*/package-lock.json
+packages/**/test/**/yarn.lock
 package-lock.json
 
 # build and test

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -67,7 +67,7 @@
     "test:all": "run-s test:unit test:integration",
     "test:unit": "jest",
     "test:integration": "test/run-integration-tests.sh && yarn test:types",
-    "test:types": "cd test/types/ && yarn && tsc",
+    "test:types": "cd test/types && yarn test",
     "test:watch": "jest --watch",
     "vercel:branch": "source vercel/set-up-branch-for-test-app-use.sh",
     "vercel:project": "source vercel/make-project-use-current-branch.sh"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -66,7 +66,8 @@
     "test": "run-s test:unit",
     "test:all": "run-s test:unit test:integration",
     "test:unit": "jest",
-    "test:integration": "test/run-integration-tests.sh",
+    "test:integration": "test/run-integration-tests.sh && yarn test:types",
+    "test:types": "cd test/types/ && yarn && tsc",
     "test:watch": "jest --watch",
     "vercel:branch": "source vercel/set-up-branch-for-test-app-use.sh",
     "vercel:project": "source vercel/make-project-use-current-branch.sh"

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -97,7 +97,7 @@ export type BuildContext = {
   config: any;
   webpack: { version: string };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  defaultLoaders: { babel: any };
+  defaultLoaders: any;
   totalPages: number;
   nextRuntime?: 'nodejs' | 'edge';
 };

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -23,7 +23,7 @@ export type NextConfigFunctionWithSentry = (
 
 export type NextConfigObject = {
   // Custom webpack options
-  webpack?: WebpackConfigFunction;
+  webpack?: WebpackConfigFunction | null;
   // Whether to build serverless functions for all pages, not just API routes. Removed in nextjs 12+.
   target?: 'server' | 'experimental-serverless-trace';
   // The output directory for the built app (defaults to ".next")
@@ -93,8 +93,13 @@ export type BuildContext = {
   isServer: boolean;
   buildId: string;
   dir: string;
-  config: NextConfigObject;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  config: any;
   webpack: { version: string };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  defaultLoaders: { babel: any };
+  totalPages: number;
+  nextRuntime?: 'nodejs' | 'edge';
 };
 
 /**

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -401,7 +401,9 @@ export function getWebpackPluginOptions(
   userPluginOptions: Partial<SentryWebpackPluginOptions>,
   userSentryOptions: UserSentryOptions,
 ): SentryWebpackPluginOptions {
-  const { buildId, isServer, webpack, config: userNextConfig, dev: isDev, dir: projectDir } = buildContext;
+  const { buildId, isServer, webpack, config, dev: isDev, dir: projectDir } = buildContext;
+  const userNextConfig = config as NextConfigObject;
+
   const distDir = userNextConfig.distDir ?? '.next'; // `.next` is the default directory
 
   const isWebpack5 = webpack.version.startsWith('5');

--- a/packages/nextjs/test/config/fixtures.ts
+++ b/packages/nextjs/test/config/fixtures.ts
@@ -93,6 +93,8 @@ export function getBuildContext(
       ...materializedNextConfig,
     } as NextConfigObject,
     webpack: { version: webpackVersion },
+    defaultLoaders: true,
+    totalPages: 2,
     isServer: buildTarget === 'server',
   };
 }

--- a/packages/nextjs/test/types/.gitignore
+++ b/packages/nextjs/test/types/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+yarn.lock

--- a/packages/nextjs/test/types/next.config.ts
+++ b/packages/nextjs/test/types/next.config.ts
@@ -1,0 +1,17 @@
+import { withSentryConfig } from '../../src/config';
+import { NextConfig } from 'next';
+
+const config: NextConfig = {
+  hideSourceMaps: true,
+  webpack: config => ({
+    ...config,
+    module: {
+      ...config.module,
+      rules: [...config.module.rules],
+    },
+  }),
+};
+
+module.exports = withSentryConfig(config, {
+  validate: true,
+});

--- a/packages/nextjs/test/types/next.config.ts
+++ b/packages/nextjs/test/types/next.config.ts
@@ -1,5 +1,6 @@
-import { withSentryConfig } from '../../src/config';
 import { NextConfig } from 'next';
+
+import { withSentryConfig } from '../../src/config';
 
 const config: NextConfig = {
   hideSourceMaps: true,

--- a/packages/nextjs/test/types/package.json
+++ b/packages/nextjs/test/types/package.json
@@ -1,5 +1,8 @@
 {
-  "description": "This is only used to install the nextjs v12 package so we can test against those types",
+  "description": "This is used to install the nextjs v12 so we can test against those types",
+  "scripts": {
+    "test": "ts-node test.ts"
+  },
   "dependencies": {
     "next": "12.3.1"
   }

--- a/packages/nextjs/test/types/package.json
+++ b/packages/nextjs/test/types/package.json
@@ -1,0 +1,6 @@
+{
+  "description": "This is only used to install the nextjs v12 package so we can test against those types",
+  "dependencies": {
+    "next": "12.3.1"
+  }
+}

--- a/packages/nextjs/test/types/test.ts
+++ b/packages/nextjs/test/types/test.ts
@@ -1,0 +1,12 @@
+/* eslint-disable no-console */
+import { parseSemver } from '@sentry/utils';
+import { execSync } from 'child_process';
+
+const NODE_VERSION = parseSemver(process.versions.node);
+
+if (NODE_VERSION.major && NODE_VERSION.major >= 12) {
+  console.log('Installing next@v12...');
+  execSync('yarn install', { stdio: 'inherit' });
+  console.log('Testing some types...');
+  execSync('tsc --noEmit --project tsconfig.json', { stdio: 'inherit' });
+}

--- a/packages/nextjs/test/types/tsconfig.json
+++ b/packages/nextjs/test/types/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.json",
+  "include": [
+    "./**/*"
+  ]
+}


### PR DESCRIPTION
Closes #4560

This was super nasty to fix!

I managed to fix the reported `null` issue and a couple of other minor differences too, I finally get stuck on this horror: 
```
Argument of type 'NextConfig' is not assignable to parameter of type 'NextConfigObjectWithSentry | NextConfigFunctionWithSentry | undefined'.
  Type 'NextConfig' is not assignable to type 'NextConfigObjectWithSentry'.
    Type 'NextConfig' is not assignable to type '{ webpack?: WebpackConfigFunction | null | undefined; target?: "server" | "experimental-serverless-trace" | undefined; distDir?: string | undefined; basePath?: string | undefined; publicRuntimeConfig?: { [key: string]: unknown; } | undefined; pageExtensions?: string[] | undefined; }'.
      Types of property 'webpack' are incompatible.
        Type 'NextJsWebpackConfig | null | undefined' is not assignable to type 'WebpackConfigFunction | null | undefined'.
          Type 'NextJsWebpackConfig' is not assignable to type 'WebpackConfigFunction'.
            Types of parameters 'context' and 'options' are incompatible.
              Type 'BuildContext' is not assignable to type 'WebpackConfigContext'.
                Types of property 'config' are incompatible.
                  Type 'NextConfigObject' is not assignable to type 'NextConfigComplete'.
                    Type 'NextConfigObject' is missing the following properties from type 'Required<NextConfig>': exportPathMap, i18n, eslint, typescript, and 33 more.  ts(2345)
```

The issue is that `NextJsWebpackConfig` has the property `config: NextConfigComplete` and `NextConfigComplete` is `Required<NextConfig>`. I could go through and add the 33 missing properties to the vendored `NextConfigObject` but it will get broken as soon as new properties get added.

I spent an age trying to work out how to fix this and it basically comes down to the fact that `Required` is evil and makes creating vendored types close to impossible, especially when you rely on the detail of those vendored types in your own code. 

I resigned myself to making the smallest change somewhere to `any` and found that I could do that with the `config` in `BuildContext`. So we don't lose type safety in the Sentry code, I had to add `config as NextConfigObject` where appropriate. 

This PR also adds a `test:types` script which runs after the integration tests and ensures that this doesn't get broken in the future. It has a `package.json` that means that we can test against the next v12 types. I did try updating `@sentry/nextjs` to devDepend on v12 but it threw up a few errors and I wasn't convinced this was a good idea.

