### PR TITLE
fix(mongo): when cursor is returned, track lifecycle until close

### DIFF
--- a/packages/tracing/src/integrations/node/mongo.ts
+++ b/packages/tracing/src/integrations/node/mongo.ts
@@ -94,8 +94,9 @@ interface MongoCursor {
 
 function isCursor(value: unknown): value is MongoCursor {
   return (
-    typeof value === 'function' &&
-    value?.constructor?.name.indexOf('Cursor') !== -1 &&
+    typeof value === 'object' &&
+    !!value &&
+    value.constructor.name.indexOf('Cursor') !== -1 &&
     'once' in value &&
     typeof (value as MongoCursor).once === 'function'
   );


### PR DESCRIPTION
This commit checks the return value of the collection operation, and if determined to be a cursor, it closes the span on the cursor 'close' event instead of immediately on the return

PR aims to fix https://github.com/getsentry/sentry-javascript/issues/4495 (similar to https://github.com/getsentry/sentry-javascript/pull/4563, but tracking the cursor as part of the original collection call)

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [X] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
