### PR TITLE
fix(react): Support root and wildcard routes in react router v6

### DIFF
--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -122,13 +122,17 @@ function getNormalizedName(
 
         const path = route.path;
         if (path) {
-          const newPath = path[0] === '/' ? path : `/${path}`;
+          const newPath = path[0] === '/' || pathBuilder[pathBuilder.length - 1] === '/' ? path : `/${path}`;
           pathBuilder += newPath;
           if (branch.pathname === location.pathname) {
-            // If the route defined on the element is something like
-            // <Route path="/stores/:storeId/products/:productId" element={<div>Product</div>} />
-            // We should check against the branch.pathname for the number of / seperators
-            if (getNumberOfUrlSegments(pathBuilder) !== getNumberOfUrlSegments(branch.pathname)) {
+            if (
+              // If the route defined on the element is something like
+              // <Route path="/stores/:storeId/products/:productId" element={<div>Product</div>} />
+              // We should check against the branch.pathname for the number of / seperators
+              getNumberOfUrlSegments(pathBuilder) !== getNumberOfUrlSegments(branch.pathname) &&
+              // We should not count wildcard operators in the url segments calculation
+              pathBuilder.slice(-2) !== '/*'
+            ) {
               return [newPath, 'route'];
             }
             return [pathBuilder, 'route'];


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/5965

This PR does two things for the react router v6 instrumentation.

1. Makes sure that routes don't appear with double slashes, like with `//example` or `//my-route`. This is done with a simple check for `pathBuilder[pathBuilder.length - 1] === '/'`.

2. Make sure that wildcard imports will generate proper transaction names. For example with `/tests/123` that loads a wildcard route, render `/tests/:testId/*`. Previously with wildcard routes we would only generate the wildcard portion, so it would render `:testId/*`.

I'm still undecided if we should even keep the wildcards, but I think they are fine for now.