### PR TITLE
chore: Delete @sentry/hub from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,6 @@ below:
 
 - [`@sentry/tracing`](https://github.com/getsentry/sentry-javascript/tree/master/packages/tracing): Provides
   Integrations and extensions for Performance Monitoring / Tracing
-- [`@sentry/hub`](https://github.com/getsentry/sentry-javascript/tree/master/packages/hub): Global state management of
-  SDKs
 - [`@sentry/core`](https://github.com/getsentry/sentry-javascript/tree/master/packages/core): The base for all
   JavaScript SDKs with interfaces, type definitions and base classes.
 - [`@sentry/utils`](https://github.com/getsentry/sentry-javascript/tree/master/packages/utils): A set of helpers and


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/5665

`@sentry/hub` is deprecated, so let us remove it from the README.