### PR TITLE
fix(browser): Handle case where fetch can be undefined

### DIFF
--- a/packages/browser/test/unit/transports/fetch.test.ts
+++ b/packages/browser/test/unit/transports/fetch.test.ts
@@ -98,4 +98,13 @@ describe('NewFetchTransport', () => {
       ...REQUEST_OPTIONS,
     });
   });
+
+  it.only('handles when `getNativeFetchImplementation` is undefined', async () => {
+    const mockFetch = jest.fn(() => undefined) as unknown as FetchImpl;
+    const transport = makeFetchTransport(DEFAULT_FETCH_TRANSPORT_OPTIONS, mockFetch);
+
+    expect(mockFetch).toHaveBeenCalledTimes(0);
+    await expect(() => transport.send(ERROR_ENVELOPE)).not.toThrow();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/browser/test/unit/transports/fetch.test.ts
+++ b/packages/browser/test/unit/transports/fetch.test.ts
@@ -99,7 +99,7 @@ describe('NewFetchTransport', () => {
     });
   });
 
-  it.only('handles when `getNativeFetchImplementation` is undefined', async () => {
+  it('handles when `getNativeFetchImplementation` is undefined', async () => {
     const mockFetch = jest.fn(() => undefined) as unknown as FetchImpl;
     const transport = makeFetchTransport(DEFAULT_FETCH_TRANSPORT_OPTIONS, mockFetch);
 


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-javascript/issues/5792.

Some users reported cases where the `nativeFetch` call was returning undefined. I have no idea how this happens, but in order for us to not send unnecessary errors to Sentry, let's be a little defensive in the usage of fetch.

Draft because I would like to chat about this with the team.