### PR TITLE
fix(node): Improve logging in express scope tag match test

### DIFF
--- a/packages/node/test/manual/express-scope-separation/start.js
+++ b/packages/node/test/manual/express-scope-separation/start.js
@@ -11,6 +11,8 @@ global.console.error = () => null;
 function assertTags(actual, expected) {
   if (JSON.stringify(actual) !== JSON.stringify(expected)) {
     console.log(colorize('FAILED: Scope contains incorrect tags\n', 'red'));
+    console.log(colorize(`Got: ${JSON.stringify(actual)}\n`, 'red'));
+    console.log(colorize(`Expected: ${JSON.stringify(expected)}\n`, 'red'));
     process.exit(1);
   }
 }

--- a/packages/node/test/manual/webpack-domain/index.js
+++ b/packages/node/test/manual/webpack-domain/index.js
@@ -26,12 +26,16 @@ Sentry.init({
     if (event.message === 'inside') {
       if (event.tags.a !== 'x' && event.tags.b !== 'c') {
         console.log(colorize('FAILED: Scope contains incorrect tags\n', 'red'));
+        console.log(colorize(`Got: ${JSON.stringify(event.tags)}\n`, 'red'));
+        console.log(colorize(`Expected: Object including { a: 'x', b: 'c' }\n`, 'red'));
         process.exit(1);
       }
     }
     if (event.message === 'outside') {
       if (event.tags.a !== 'b') {
         console.log(colorize('FAILED: Scope contains incorrect tags\n', 'red'));
+        console.log(colorize(`Got: ${JSON.stringify(event.tags)}\n`, 'red'));
+        console.log(colorize(`Expected: Object including { a: 'b' }\n`, 'red'));
         process.exit(1);
       }
     }


### PR DESCRIPTION
This adds logging of the received and expected values when the tags in the express scope separation test don't match, for easier debugging.
