### PR TITLE
ref(node): Small `RequestData` integration tweaks

### DIFF
--- a/packages/node/src/integrations/requestdata.ts
+++ b/packages/node/src/integrations/requestdata.ts
@@ -6,7 +6,7 @@ import { extractPathForTransaction } from '@sentry/utils';
 
 import { addRequestDataToEvent, AddRequestDataToEventOptions, TransactionNamingScheme } from '../requestdata';
 
-type RequestDataIntegrationOptions = {
+export type RequestDataIntegrationOptions = {
   /**
    * Controls what data is pulled from the request and added to the event
    */

--- a/packages/node/src/integrations/requestdata.ts
+++ b/packages/node/src/integrations/requestdata.ts
@@ -10,7 +10,7 @@ type RequestDataIntegrationOptions = {
   /**
    * Controls what data is pulled from the request and added to the event
    */
-  include: {
+  include?: {
     cookies?: boolean;
     data?: boolean;
     headers?: boolean;
@@ -27,7 +27,7 @@ type RequestDataIntegrationOptions = {
   };
 
   /** Whether to identify transactions by parameterized path, parameterized path with method, or handler name */
-  transactionNamingScheme: TransactionNamingScheme;
+  transactionNamingScheme?: TransactionNamingScheme;
 };
 
 const DEFAULT_OPTIONS = {
@@ -67,12 +67,12 @@ export class RequestData implements Integration {
    */
   protected _addRequestData: (event: Event, req: PolymorphicRequest, options?: { [key: string]: unknown }) => Event;
 
-  private _options: RequestDataIntegrationOptions;
+  private _options: Required<RequestDataIntegrationOptions>;
 
   /**
    * @inheritDoc
    */
-  public constructor(options: Partial<RequestDataIntegrationOptions> = {}) {
+  public constructor(options: RequestDataIntegrationOptions = {}) {
     this._addRequestData = addRequestDataToEvent;
     this._options = {
       ...DEFAULT_OPTIONS,
@@ -155,7 +155,7 @@ export class RequestData implements Integration {
 /** Convert this integration's options to match what `addRequestDataToEvent` expects */
 /** TODO: Can possibly be deleted once https://github.com/getsentry/sentry-javascript/issues/5718 is fixed */
 function convertReqDataIntegrationOptsToAddReqDataOpts(
-  integrationOptions: RequestDataIntegrationOptions,
+  integrationOptions: Required<RequestDataIntegrationOptions>,
 ): AddRequestDataToEventOptions {
   const {
     transactionNamingScheme,

--- a/packages/node/src/integrations/requestdata.ts
+++ b/packages/node/src/integrations/requestdata.ts
@@ -158,7 +158,10 @@ export class RequestData implements Integration {
 function convertReqDataIntegrationOptsToAddReqDataOpts(
   integrationOptions: RequestDataIntegrationOptions,
 ): AddRequestDataToEventOptions {
-  const { ip, user, ...requestOptions } = integrationOptions.include;
+  const {
+    transactionNamingScheme,
+    include: { ip, user, ...requestOptions },
+  } = integrationOptions;
 
   const requestIncludeKeys: string[] = [];
   for (const [key, value] of Object.entries(requestOptions)) {
@@ -187,6 +190,7 @@ function convertReqDataIntegrationOptsToAddReqDataOpts(
       ip,
       user: addReqDataUserOpt,
       request: requestIncludeKeys.length !== 0 ? requestIncludeKeys : undefined,
+      transaction: transactionNamingScheme,
     },
   };
 }

--- a/packages/node/src/integrations/requestdata.ts
+++ b/packages/node/src/integrations/requestdata.ts
@@ -6,7 +6,7 @@ import { extractPathForTransaction } from '@sentry/utils';
 
 import { addRequestDataToEvent, AddRequestDataToEventOptions, TransactionNamingScheme } from '../requestdata';
 
-type RequestDataOptions = {
+type RequestDataIntegrationOptions = {
   /**
    * Controls what data is pulled from the request and added to the event
    */
@@ -69,12 +69,12 @@ export class RequestData implements Integration {
    */
   public name: string = RequestData.id;
 
-  private _options: RequestDataOptions;
+  private _options: RequestDataIntegrationOptions;
 
   /**
    * @inheritDoc
    */
-  public constructor(options: Partial<RequestDataOptions> = {}) {
+  public constructor(options: Partial<RequestDataIntegrationOptions> = {}) {
     this._options = {
       ...DEFAULT_OPTIONS,
       ...options,
@@ -154,7 +154,7 @@ export class RequestData implements Integration {
 /** Convert `include` option to match what `addRequestDataToEvent` expects */
 /** TODO: Can possibly be deleted once https://github.com/getsentry/sentry-javascript/issues/5718 is fixed */
 function formatIncludeOption(
-  integrationInclude: RequestDataOptions['include'] = {},
+  integrationInclude: RequestDataIntegrationOptions['include'] = {},
 ): AddRequestDataToEventOptions['include'] {
   const { ip, user, ...requestOptions } = integrationInclude;
 

--- a/packages/node/src/requestdata.ts
+++ b/packages/node/src/requestdata.ts
@@ -15,7 +15,7 @@ export const DEFAULT_USER_INCLUDES = ['id', 'username', 'email'];
 /**
  * Options deciding what parts of the request to use when enhancing an event
  */
-export interface AddRequestDataToEventOptions {
+export type AddRequestDataToEventOptions = {
   /** Flags controlling whether each type of data should be added to the event */
   include?: {
     ip?: boolean;
@@ -23,7 +23,7 @@ export interface AddRequestDataToEventOptions {
     transaction?: boolean | TransactionNamingScheme;
     user?: boolean | Array<typeof DEFAULT_USER_INCLUDES[number]>;
   };
-}
+};
 
 export type TransactionNamingScheme = 'path' | 'methodPath' | 'handler';
 

--- a/packages/node/test/integrations/requestdata.test.ts
+++ b/packages/node/test/integrations/requestdata.test.ts
@@ -1,0 +1,103 @@
+import { getCurrentHub, Hub, makeMain } from '@sentry/core';
+import { Event, EventProcessor } from '@sentry/types';
+import * as http from 'http';
+
+import { NodeClient } from '../../src/client';
+import { RequestData, RequestDataIntegrationOptions } from '../../src/integrations/requestdata';
+import * as requestDataModule from '../../src/requestdata';
+import { getDefaultNodeClientOptions } from '../helper/node-client-options';
+
+const addRequestDataToEventSpy = jest.spyOn(requestDataModule, 'addRequestDataToEvent');
+const requestDataEventProcessor = jest.fn();
+
+const headers = { ears: 'furry', nose: 'wet', tongue: 'spotted', cookie: 'favorite=zukes' };
+const method = 'wagging';
+const protocol = 'mutualsniffing';
+const hostname = 'the.dog.park';
+const path = '/by/the/trees/';
+const queryString = 'chase=me&please=thankyou';
+
+function initWithRequestDataIntegrationOptions(integrationOptions: RequestDataIntegrationOptions): void {
+  const setMockEventProcessor = (eventProcessor: EventProcessor) =>
+    requestDataEventProcessor.mockImplementationOnce(eventProcessor);
+
+  const requestDataIntegration = new RequestData({
+    ...integrationOptions,
+  });
+
+  const client = new NodeClient(
+    getDefaultNodeClientOptions({
+      dsn: 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012',
+      integrations: [requestDataIntegration],
+    }),
+  );
+  client.setupIntegrations = () => requestDataIntegration.setupOnce(setMockEventProcessor, getCurrentHub);
+  client.getIntegration = () => requestDataIntegration as any;
+
+  const hub = new Hub(client);
+
+  makeMain(hub);
+}
+
+describe('`RequestData` integration', () => {
+  let req: http.IncomingMessage, event: Event;
+
+  beforeEach(() => {
+    req = {
+      headers,
+      method,
+      protocol,
+      hostname,
+      originalUrl: `${path}?${queryString}`,
+    } as unknown as http.IncomingMessage;
+    event = { sdkProcessingMetadata: { request: req } };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('option conversion', () => {
+    it('leaves `ip` and `user` at top level of `include`', () => {
+      initWithRequestDataIntegrationOptions({ include: { ip: false, user: true } });
+
+      requestDataEventProcessor(event);
+
+      const passedOptions = addRequestDataToEventSpy.mock.calls[0][2];
+
+      expect(passedOptions?.include).toEqual(expect.objectContaining({ ip: false, user: true }));
+    });
+
+    it('moves `transactionNamingScheme` to `transaction` include', () => {
+      initWithRequestDataIntegrationOptions({ transactionNamingScheme: 'path' });
+
+      requestDataEventProcessor(event);
+
+      const passedOptions = addRequestDataToEventSpy.mock.calls[0][2];
+
+      expect(passedOptions?.include).toEqual(expect.objectContaining({ transaction: 'path' }));
+    });
+
+    it('moves `true` request keys into `request` include, but omits `false` ones', async () => {
+      initWithRequestDataIntegrationOptions({ include: { data: true, cookies: false } });
+
+      requestDataEventProcessor(event);
+
+      const passedOptions = addRequestDataToEventSpy.mock.calls[0][2];
+
+      expect(passedOptions?.include?.request).toEqual(expect.arrayContaining(['data']));
+      expect(passedOptions?.include?.request).not.toEqual(expect.arrayContaining(['cookies']));
+    });
+
+    it('moves `true` user keys into `user` include, but omits `false` ones', async () => {
+      initWithRequestDataIntegrationOptions({ include: { user: { id: true, email: false } } });
+
+      requestDataEventProcessor(event);
+
+      const passedOptions = addRequestDataToEventSpy.mock.calls[0][2];
+
+      expect(passedOptions?.include?.user).toEqual(expect.arrayContaining(['id']));
+      expect(passedOptions?.include?.user).not.toEqual(expect.arrayContaining(['email']));
+    });
+  });
+});


### PR DESCRIPTION
This makes a few small revisions to the new `RequestData` integration:

- Switch to using booleans rather than an array of keys when specifying what user data to include. This makes it match all of the other options, and is something I should have just done from the get-go. Given that the integration is new and thus far entirely undocumented, IMHO it feels safe to make what is technically a breaking change here.

- Rename the integration's internal `RequestDataOptions` type to `RequestDataIntegrationOptions`, to help distinguish it from the many other flavors of request data functions and types floating around.

- Make all properties in `RequestDataIntegrationOptions` optional, rather than using the `Partial` helper type.

- Switch the callback which actually does the data adding from being an option to being a protected property, in order to make it less public but still leave open the option of subclassing and setting it to a different value if we ever get around to using this in browser-based SDKs. Because I also made the property's type slightly more generic and used an index signature to do it, I also had to switch `AddRequestDataToEventOptions` from being an interface to being a type. See https://github.com/microsoft/TypeScript/issues/15300.

- Rename the helper function which formats the `include` option for use in `addRequestDataToEvent` to more specifically indicate that it's converting from integration-style options to `addRequestDataToEvent`-style options.

- Refactor the aforementioned helper function to act upon and return an entire options object rather than just the `include` property, in order to have access to the `transactionNamingScheme` option.

- Add missing `transaction` property in helper function's output.

- Add tests for the helper function.