### PR TITLE
ref(node): Make `RequestData` integration default

### DIFF
--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -118,9 +118,6 @@ function addServerIntegrations(options: NextjsOptions): void {
   });
   integrations = addOrUpdateIntegration(defaultRewriteFramesIntegration, integrations);
 
-  const defaultRequestDataIntegration = new Integrations.RequestData();
-  integrations = addOrUpdateIntegration(defaultRequestDataIntegration, integrations);
-
   if (hasTracingEnabled(options)) {
     const defaultHttpTracingIntegration = new Integrations.Http({ tracing: true });
     integrations = addOrUpdateIntegration(defaultHttpTracingIntegration, integrations, {

--- a/packages/nextjs/test/index.server.test.ts
+++ b/packages/nextjs/test/index.server.test.ts
@@ -148,10 +148,8 @@ describe('Server init()', () => {
 
       const nodeInitOptions = nodeInit.mock.calls[0][0] as ModifiedInitOptions;
       const rewriteFramesIntegration = findIntegrationByName(nodeInitOptions.integrations, 'RewriteFrames');
-      const requestDataIntegration = findIntegrationByName(nodeInitOptions.integrations, 'RequestData');
 
       expect(rewriteFramesIntegration).toBeDefined();
-      expect(requestDataIntegration).toBeDefined();
     });
 
     it('supports passing unrelated integrations through options', () => {

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -27,6 +27,7 @@ import {
   Modules,
   OnUncaughtException,
   OnUnhandledRejection,
+  RequestData,
 } from './integrations';
 import { getModule } from './module';
 import { makeNodeTransport } from './transports';
@@ -46,6 +47,7 @@ export const defaultIntegrations = [
   new ContextLines(),
   new Context(),
   new Modules(),
+  new RequestData(),
   // Misc
   new LinkedErrors(),
 ];


### PR DESCRIPTION
This adds the new `RequestData` integration to the node SDK's default integrations, in order to be able to use it in SDKs besides just nextjs. (It therefore also removes it from the nextjs SDK's specific defaults.) In cases where we haven't yet set up our request handlers to use the integration, the event processor it adds will no-op because it won't find a request object in `sdkProcessingMetadata`. 
