### PR TITLE
fix(vue): Start pageload transaction earlier to capture missing spans

### DIFF
--- a/packages/vue/src/tracing.ts
+++ b/packages/vue/src/tracing.ts
@@ -29,7 +29,7 @@ const HOOKS: { [key in Operation]: Hook[] } = {
 };
 
 /** Grabs active transaction off scope, if any */
-function getActiveTransaction(): Transaction | undefined {
+export function getActiveTransaction(): Transaction | undefined {
   return getCurrentHub().getScope()?.getTransaction();
 }
 
@@ -117,8 +117,8 @@ export const createTracingMixins = (options: TracingOptions): Mixins => {
           // The before hook did not start the tracking span, so the span was not added.
           // This is probably because it happened before there is an active transaction
           if (!span) return;
-
           span.finish();
+
           finishRootSpan(this, timestampInSeconds(), options.timeout);
         }
       };

--- a/packages/vue/test/router.test.ts
+++ b/packages/vue/test/router.test.ts
@@ -3,7 +3,6 @@ import { Transaction } from '@sentry/types';
 
 import { vueRouterInstrumentation } from '../src';
 import { Route } from '../src/router';
-
 import * as vueTracing from '../src/tracing';
 
 const captureExceptionSpy = jest.spyOn(SentryBrowser, 'captureException');

--- a/packages/vue/test/router.test.ts
+++ b/packages/vue/test/router.test.ts
@@ -1,7 +1,10 @@
 import * as SentryBrowser from '@sentry/browser';
+import { Transaction } from '@sentry/types';
 
 import { vueRouterInstrumentation } from '../src';
 import { Route } from '../src/router';
+
+import * as vueTracing from '../src/tracing';
 
 const captureExceptionSpy = jest.spyOn(SentryBrowser, 'captureException');
 
@@ -74,13 +77,12 @@ describe('vueRouterInstrumentation()', () => {
   });
 
   it.each([
-    ['initialPageloadRoute', 'normalRoute1', 'pageload', '/books/:bookId/chapter/:chapterId', 'route'],
-    ['normalRoute1', 'normalRoute2', 'navigation', '/accounts/:accountId', 'route'],
-    ['normalRoute2', 'namedRoute', 'navigation', 'login-screen', 'custom'],
-    ['normalRoute2', 'unmatchedRoute', 'navigation', '/e8733846-20ac-488c-9871-a5cbcb647294', 'url'],
+    ['normalRoute1', 'normalRoute2', '/accounts/:accountId', 'route'],
+    ['normalRoute2', 'namedRoute', 'login-screen', 'custom'],
+    ['normalRoute2', 'unmatchedRoute', '/e8733846-20ac-488c-9871-a5cbcb647294', 'url'],
   ])(
-    'should return instrumentation that instruments VueRouter.beforeEach(%s, %s)',
-    (fromKey, toKey, op, transactionName, transactionSource) => {
+    'should return instrumentation that instruments VueRouter.beforeEach(%s, %s) for navigations',
+    (fromKey, toKey, transactionName, transactionSource) => {
       // create instrumentation
       const instrument = vueRouterInstrumentation(mockVueRouter);
 
@@ -95,7 +97,8 @@ describe('vueRouterInstrumentation()', () => {
       const to = testRoutes[toKey];
       beforeEachCallback(to, from, mockNext);
 
-      expect(mockStartTransaction).toHaveBeenCalledTimes(1);
+      // first startTx call happens when the instrumentation is initialized (for pageloads)
+      expect(mockStartTransaction).toHaveBeenCalledTimes(2);
       expect(mockStartTransaction).toHaveBeenCalledWith({
         name: transactionName,
         metadata: {
@@ -105,11 +108,62 @@ describe('vueRouterInstrumentation()', () => {
           params: to.params,
           query: to.query,
         },
-        op: op,
+        op: 'navigation',
         tags: {
           'routing.instrumentation': 'vue-router',
         },
       });
+
+      expect(mockNext).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([
+    ['initialPageloadRoute', 'normalRoute1', '/books/:bookId/chapter/:chapterId', 'route'],
+    ['initialPageloadRoute', 'namedRoute', 'login-screen', 'custom'],
+    ['initialPageloadRoute', 'unmatchedRoute', '/e8733846-20ac-488c-9871-a5cbcb647294', 'url'],
+  ])(
+    'should return instrumentation that instruments VueRouter.beforeEach(%s, %s) for pageloads',
+    (fromKey, toKey, _transactionName, _transactionSource) => {
+      const mockedTxn = {
+        setName: jest.fn(),
+        setData: jest.fn(),
+      };
+      const customMockStartTxn = { ...mockStartTransaction }.mockImplementation(_ => {
+        return mockedTxn;
+      });
+      jest.spyOn(vueTracing, 'getActiveTransaction').mockImplementation(() => mockedTxn as unknown as Transaction);
+
+      // create instrumentation
+      const instrument = vueRouterInstrumentation(mockVueRouter);
+
+      // instrument
+      instrument(customMockStartTxn, true, true);
+
+      // check for transaction start
+      expect(customMockStartTxn).toHaveBeenCalledTimes(1);
+      expect(customMockStartTxn).toHaveBeenCalledWith({
+        name: '/',
+        metadata: {
+          source: 'url',
+        },
+        op: 'pageload',
+        tags: {
+          'routing.instrumentation': 'vue-router',
+        },
+      });
+
+      const beforeEachCallback = mockVueRouter.beforeEach.mock.calls[0][0];
+
+      const from = testRoutes[fromKey];
+      const to = testRoutes[toKey];
+
+      beforeEachCallback(to, from, mockNext);
+      expect(mockVueRouter.beforeEach).toHaveBeenCalledTimes(1);
+
+      expect(mockedTxn.setName).toHaveBeenCalledWith(_transactionName, _transactionSource);
+      expect(mockedTxn.setData).toHaveBeenNthCalledWith(1, 'params', to.params);
+      expect(mockedTxn.setData).toHaveBeenNthCalledWith(2, 'query', to.query);
 
       expect(mockNext).toHaveBeenCalledTimes(1);
     },
@@ -148,7 +202,7 @@ describe('vueRouterInstrumentation()', () => {
       // create instrumentation
       const instrument = vueRouterInstrumentation(mockVueRouter);
 
-      // instrument
+      // instrument (this will call startTrransaction once for pageloads but we can ignore that)
       instrument(mockStartTransaction, true, startTransactionOnLocationChange);
 
       // check
@@ -157,7 +211,7 @@ describe('vueRouterInstrumentation()', () => {
       const beforeEachCallback = mockVueRouter.beforeEach.mock.calls[0][0];
       beforeEachCallback(testRoutes['normalRoute2'], testRoutes['normalRoute1'], mockNext);
 
-      expect(mockStartTransaction).toHaveBeenCalledTimes(expectedCallsAmount);
+      expect(mockStartTransaction).toHaveBeenCalledTimes(expectedCallsAmount + 1);
     },
   );
 });


### PR DESCRIPTION
This PR makes the `pageload` transaction start a little earlier in the Vue routing instrumentation, allowing our SDK to add the root `ui.vue.render` span and a few missed child component spans to the now available and active transaction.

Previously, in our Vue routing instrumentation, the `pageload` transaction would only be created when the `beforeEach` hook of the Vue router was called for the first time. This worked reasonably well in Vue 2 apps where this hook was called before any components were rendered. However, in Vue 3 (Vue router v3 and v4) it seems like the routing/rendering process was changed so that the root component would be rendered before the initial `beforeEach` router hook call. 

To be clear, this change makes the `pageload` transaction always start with a `url` transaction source (because we don't yet have a matched route at this stage). However, it is updated to a more high-quality source later on - exactly at the time where we previously used to start the transaction. IMO this is fine because by now we've realized that the timing problem of transaction names in DSC propagation requires more fundamental changes. Furthermore, this increases the quality of the pageload transaction, as it is now showing a more representative starting time. This matches the behaviour of other routing instrumentations, such as Angular or Express. 

fixes #5910 
