### PR TITLE
fix(nextjs): Correctly apply auto-instrumentation to pages in `src` folder

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -95,7 +95,7 @@ export function constructWebpackConfigFunction(
           // Nextjs allows the `pages` folder to optionally live inside a `src` folder
           test: new RegExp(
             `${escapeStringForRegex(projectDir)}${
-              shouldIncludeSrcDirectory ? '(/src)?' : ''
+              shouldIncludeSrcDirectory ? '/src' : ''
             }/pages/.*\\.(${pageExtensionRegex})`,
           ),
           use: [

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -82,13 +82,22 @@ export function constructWebpackConfigFunction(
       if (userSentryOptions.autoInstrumentServerFunctions !== false) {
         const pagesDir = newConfig.resolve?.alias?.['private-next-pages'] as string;
 
+        // Next.js allows users to have the `pages` folder inside a `src` folder, however "`src/pages` will be ignored
+        // if `pages` is present in the root directory"
+        // - https://nextjs.org/docs/advanced-features/src-directory
+        const shouldIncludeSrcDirectory = !fs.existsSync(path.resolve(projectDir, 'pages'));
+
         // Default page extensions per https://github.com/vercel/next.js/blob/f1dbc9260d48c7995f6c52f8fbcc65f08e627992/packages/next/server/config-shared.ts#L161
         const pageExtensions = userNextConfig.pageExtensions || ['tsx', 'ts', 'jsx', 'js'];
         const pageExtensionRegex = pageExtensions.map(escapeStringForRegex).join('|');
 
         newConfig.module.rules.push({
           // Nextjs allows the `pages` folder to optionally live inside a `src` folder
-          test: new RegExp(`${escapeStringForRegex(projectDir)}(/src)?/pages/.*\\.(${pageExtensionRegex})`),
+          test: new RegExp(
+            `${escapeStringForRegex(projectDir)}${
+              shouldIncludeSrcDirectory ? '(/src)?' : ''
+            }/pages/.*\\.(${pageExtensionRegex})`,
+          ),
           use: [
             {
               loader: path.resolve(__dirname, 'loaders/proxyLoader.js'),

--- a/packages/nextjs/test/integration/src/pages/someNamedComponent.tsx
+++ b/packages/nextjs/test/integration/src/pages/someNamedComponent.tsx
@@ -1,0 +1,6 @@
+export const MyNamedPage = () => (
+  <h1>
+    This page exists to test the compatibility of our auto-wrapper with the option of having the `pages` directory
+    inside a `src` directory (https://nextjs.org/docs/advanced-features/src-directory)
+  </h1>
+);


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/5978

Next.js allows users to have their `pages` directory inside a `src` directory. So far, the regex that tests if we wanna apply our auto instrumentation loader to a file, didn't consider that if a `pages` directory exists we don't want to wrap anything inside `src/pages`, because these files don't count as "pages" anymore.

This PR introduces a check if there is a root-level `pages` directory - if so, we don't wrap anything inside `src/pages`.

https://nextjs.org/docs/advanced-features/src-directory
