### PR TITLE
test(e2e): Don't run E2E tests on fork PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -622,6 +622,8 @@ jobs:
 
   job_e2e_tests:
     name: E2E Tests
+    # We only run E2E tests for non-fork PRs because the E2E tests require secrets to work and they can't be accessed from forks
+    if: github.repository == 'getsentry/sentry-javascript'
     needs: [job_get_metadata, job_build]
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
The E2E tests need secrets to work (DSN and auth token), however, fork PRs don't have access to the secrets we define in this repository.

To unblock external contributions, this PR simply skips the E2E tests if the PR comes from a different repository. After merging a PR, the tests will run on master anyways.