### PR TITLE
ref(serverless): Use `RequestData` integration in GCP wrapper

### DIFF
--- a/packages/node/src/integrations/requestdata.ts
+++ b/packages/node/src/integrations/requestdata.ts
@@ -119,10 +119,11 @@ export class RequestData implements Integration {
       }
 
       // The Express request handler takes a similar `include` option to that which can be passed to this integration.
-      // If passed there, we store it in `sdkProcessingMetadata`. TODO(v8): Force express people to use this
+      // If passed there, we store it in `sdkProcessingMetadata`. TODO(v8): Force express and GCP people to use this
       // integration, so that all of this passing and conversion isn't necessary
       const addRequestDataOptions =
         sdkProcessingMetadata.requestDataOptionsFromExpressHandler ||
+        sdkProcessingMetadata.requestDataOptionsFromGCPWrapper ||
         convertReqDataIntegrationOptsToAddReqDataOpts(this._options);
 
       const processedEvent = this._addRequestData(event, req, addRequestDataOptions);

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -98,6 +98,10 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
     // So adding of event processors every time should not lead to memory bloat.
     hub.configureScope(scope => {
       scope.addEventProcessor(event => addRequestDataToEvent(event, req, options.addRequestDataToEventOptions));
+      scope.setSDKProcessingMetadata({
+        request: req,
+        requestDataOptionsFromGCPWrapper: options.addRequestDataToEventOptions,
+      });
       // We put the transaction on the scope so users can attach children to it
       scope.setSpan(transaction);
     });

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -1,10 +1,4 @@
-import {
-  addRequestDataToEvent,
-  AddRequestDataToEventOptions,
-  captureException,
-  flush,
-  getCurrentHub,
-} from '@sentry/node';
+import { AddRequestDataToEventOptions, captureException, flush, getCurrentHub } from '@sentry/node';
 import { extractTraceparentData } from '@sentry/tracing';
 import { baggageHeaderToDynamicSamplingContext, isString, logger, stripUrlQueryAndFragment } from '@sentry/utils';
 
@@ -97,7 +91,6 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
     // since functions-framework creates a domain for each incoming request.
     // So adding of event processors every time should not lead to memory bloat.
     hub.configureScope(scope => {
-      scope.addEventProcessor(event => addRequestDataToEvent(event, req, options.addRequestDataToEventOptions));
       scope.setSDKProcessingMetadata({
         request: req,
         requestDataOptionsFromGCPWrapper: options.addRequestDataToEventOptions,

--- a/packages/serverless/test/__mocks__/@sentry/node.ts
+++ b/packages/serverless/test/__mocks__/@sentry/node.ts
@@ -1,6 +1,7 @@
 const origSentry = jest.requireActual('@sentry/node');
 export const defaultIntegrations = origSentry.defaultIntegrations; // eslint-disable-line @typescript-eslint/no-unsafe-member-access
 export const Handlers = origSentry.Handlers; // eslint-disable-line @typescript-eslint/no-unsafe-member-access
+export const Integrations = origSentry.Integrations;
 export const addRequestDataToEvent = origSentry.addRequestDataToEvent;
 export const SDK_VERSION = '6.6.6';
 export const Severity = {
@@ -20,6 +21,7 @@ export const fakeScope = {
   setContext: jest.fn(),
   setSpan: jest.fn(),
   getTransaction: jest.fn(() => fakeTransaction),
+  setSDKProcessingMetadata: jest.fn(),
 };
 export const fakeSpan = {
   finish: jest.fn(),


### PR DESCRIPTION
This switches the GCP wrapper in the serverless SDK to use the new `RequestData` integration for adding request data to events rather than the current event processor. 

Ref: https://github.com/getsentry/sentry-javascript/issues/5756