### PR TITLE
feat(remix): Enable `RequestData` integration for server-side requests

### DIFF
--- a/packages/node/src/requestdata.ts
+++ b/packages/node/src/requestdata.ts
@@ -169,7 +169,7 @@ export function extractRequestData(
   //   koa, nextjs: req.url
   const originalUrl = req.originalUrl || req.url || '';
   // absolute url
-  const absoluteUrl = `${protocol}://${host}${originalUrl}`;
+  const absoluteUrl = originalUrl.startsWith(protocol) ? originalUrl : `${protocol}://${host}${originalUrl}`;
   include.forEach(key => {
     switch (key) {
       case 'headers': {

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -353,6 +353,11 @@ function wrapRequestHandler(origRequestHandler: RequestHandler, build: ServerBui
     return local.bind(async () => {
       const hub = getCurrentHub();
       const options = hub.getClient()?.getOptions();
+      const scope = hub.getScope();
+
+      if (scope) {
+        scope.setSDKProcessingMetadata({ request });
+      }
 
       if (!options || !hasTracingEnabled(options)) {
         return origRequestHandler.call(this, request, loadContext);

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -70,7 +70,7 @@ function extractData(response: Response): Promise<unknown> {
   return responseClone.text();
 }
 
-function captureRemixServerException(err: Error, name: string): void {
+function captureRemixServerException(err: Error, name: string, request: Request): void {
   // Skip capturing if the thrown error is not a 5xx response
   // https://remix.run/docs/en/v1/api/conventions#throwing-responses-in-loaders
   if (isResponse(err) && err.status < 500) {
@@ -78,6 +78,7 @@ function captureRemixServerException(err: Error, name: string): void {
   }
 
   captureException(isResponse(err) ? extractData(err) : err, scope => {
+    scope.setSDKProcessingMetadata({ request });
     scope.addEventProcessor(event => {
       addExceptionMechanism(event, {
         type: 'instrument',
@@ -127,7 +128,7 @@ function makeWrappedDocumentRequestFunction(
 
       span?.finish();
     } catch (err) {
-      captureRemixServerException(err, 'documentRequest');
+      captureRemixServerException(err, 'documentRequest', request);
       throw err;
     }
 
@@ -164,7 +165,7 @@ function makeWrappedDataFunction(origFn: DataFunction, id: string, name: 'action
       currentScope.setSpan(activeTransaction);
       span?.finish();
     } catch (err) {
-      captureRemixServerException(err, name);
+      captureRemixServerException(err, name, args.request);
       throw err;
     }
 

--- a/packages/remix/src/utils/serverAdapters/express.ts
+++ b/packages/remix/src/utils/serverAdapters/express.ts
@@ -60,6 +60,11 @@ function wrapExpressRequestHandler(
     const request = extractRequestData(req);
     const hub = getCurrentHub();
     const options = hub.getClient()?.getOptions();
+    const scope = hub.getScope();
+
+    if (scope) {
+      scope.setSDKProcessingMetadata({ request });
+    }
 
     if (!options || !hasTracingEnabled(options) || !request.url || !request.method) {
       return origRequestHandler.call(this, req, res, next);

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -175,4 +175,9 @@ export interface Scope {
    * Clears attachments from the scope
    */
   clearAttachments(): this;
+
+  /**
+   * Add data which will be accessible during event processing but won't get sent to Sentry
+   */
+  setSDKProcessingMetadata(newData: { [key: string]: unknown }): this;
 }


### PR DESCRIPTION
This enables the new `RequestData` integration in the remix SDK in order to add request data to server-side events. The integration itself is already installed automatically when the SDK initializes, because it's one of the underlying node SDK's default integrations, but without access to the request, it currently no-ops. This enables it to function as intended by storing the request object in the scope's `sdkProcessingMetadata`.
