### PR TITLE
fix(node): Fix default `transactionNamingScheme` value in `RequestData` integration

### DIFF
--- a/packages/node/src/integrations/requestdata.ts
+++ b/packages/node/src/integrations/requestdata.ts
@@ -44,7 +44,7 @@ const DEFAULT_OPTIONS = {
       email: true,
     },
   },
-  transactionNamingScheme: 'methodpath',
+  transactionNamingScheme: 'methodPath',
 };
 
 /** Add data about a request to an event. Primarily for use in Node-based SDKs, but included in `@sentry/integrations`


### PR DESCRIPTION
This fixes the casing of the default `transactionNamingScheme` value in the `RequestData` integration so that the default value is one of the accepted values.
