### PR TITLE
feat: fix vue3 render warning loop

### DIFF
--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -135,6 +135,12 @@ function _domBreadcrumb(dom: BreadcrumbsOptions['dom']): (handlerData: { [key: s
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function _consoleBreadcrumb(handlerData: { [key: string]: any }): void {
+  // This is a hack to fix a Vue3-specific bug that causes an infinite loop of 
+  // console warnings. This happens when a Vue template is rendered with 
+  // an undeclared variable, which we try to stringify, ultimately causing 
+  // Vue to issue another warning which repeats indefinitely. 
+  // see: https://github.com/getsentry/sentry-javascript/pull/6010
+  // see: https://github.com/getsentry/sentry-javascript/issues/5916
   for (let i = 0; i < handlerData.args.length; i++) {
     if (handlerData.args[i] === 'ref=Ref<') {
       handlerData.args[i + 1] = 'viewRef';

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -135,6 +135,12 @@ function _domBreadcrumb(dom: BreadcrumbsOptions['dom']): (handlerData: { [key: s
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function _consoleBreadcrumb(handlerData: { [key: string]: any }): void {
+  for (let i = 0; i < handlerData.args.length; i++) {
+    if (handlerData.args[i] === 'ref=Ref<') {
+      handlerData.args[i + 1] = 'viewRef'
+      break;
+    }
+  }
   const breadcrumb = {
     category: 'console',
     data: {

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -137,7 +137,7 @@ function _domBreadcrumb(dom: BreadcrumbsOptions['dom']): (handlerData: { [key: s
 function _consoleBreadcrumb(handlerData: { [key: string]: any }): void {
   for (let i = 0; i < handlerData.args.length; i++) {
     if (handlerData.args[i] === 'ref=Ref<') {
-      handlerData.args[i + 1] = 'viewRef'
+      handlerData.args[i + 1] = 'viewRef';
       break;
     }
   }


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

fix issues:
https://github.com/getsentry/sentry-javascript/issues/5916
https://github.com/getsentry/sentry-javascript/issues/4743

why this happens:
1. vue3 support the property `ref` in the second arg of `h` method, to support this feature: https://cn.vuejs.org/guide/essentials/template-refs.html
2. when a template render with a undecalred variable, vue3 will call `console.warn` to print error stacks.
3. sentry hijacked `console`, and add the message to `breadcrumb` with `safeJoin`
4. `safeJoin` will transfer variables to string. The ref variable is a proxied object via `Proxy`. so, when called `String(value)`, will trigger the getter of Proxy, and got undefined, so again vue3 will call `console.warn` to print error stacks
5. just loop infinitely.

solutions:
1. tried to test the variable is Proxy. No matter how you test, will trigger proxy getter or other handlers, so it loops.
2. the only way can test is the stack information from vue3 