### PR TITLE
fix(nextjs): Match loader files exactly

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -94,9 +94,9 @@ export function constructWebpackConfigFunction(
         newConfig.module.rules.push({
           // Nextjs allows the `pages` folder to optionally live inside a `src` folder
           test: new RegExp(
-            `${escapeStringForRegex(projectDir)}${
+            `^${escapeStringForRegex(projectDir)}${
               shouldIncludeSrcDirectory ? '/src' : ''
-            }/pages/.*\\.(${pageExtensionRegex})`,
+            }/pages/.*\\.(${pageExtensionRegex})$`,
           ),
           use: [
             {

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -86,6 +86,9 @@ export function constructWebpackConfigFunction(
         // if `pages` is present in the root directory"
         // - https://nextjs.org/docs/advanced-features/src-directory
         const shouldIncludeSrcDirectory = !fs.existsSync(path.resolve(projectDir, 'pages'));
+        const pagesDirectory = shouldIncludeSrcDirectory // We're intentionally not including slashes in the paths because we wanne let node do the path resolution for Windows
+          ? path.resolve(projectDir, 'src', 'pages')
+          : path.resolve(projectDir, 'pages');
 
         // Default page extensions per https://github.com/vercel/next.js/blob/f1dbc9260d48c7995f6c52f8fbcc65f08e627992/packages/next/server/config-shared.ts#L161
         const pageExtensions = userNextConfig.pageExtensions || ['tsx', 'ts', 'jsx', 'js'];
@@ -93,11 +96,7 @@ export function constructWebpackConfigFunction(
 
         newConfig.module.rules.push({
           // Nextjs allows the `pages` folder to optionally live inside a `src` folder
-          test: new RegExp(
-            `^${escapeStringForRegex(projectDir)}${
-              shouldIncludeSrcDirectory ? '/src' : ''
-            }/pages/.*\\.(${pageExtensionRegex})$`,
-          ),
+          test: new RegExp(`^${escapeStringForRegex(pagesDirectory)}.*\\.(${pageExtensionRegex})$`),
           use: [
             {
               loader: path.resolve(__dirname, 'loaders/proxyLoader.js'),


### PR DESCRIPTION
Probably resolves https://github.com/getsentry/sentry-javascript/issues/6012

I couldn't really reproduce https://github.com/getsentry/sentry-javascript/issues/6012 but I noticed that we're applying our proxy loader to JSON files because our loader regex matches on `.js` and `.js` happens to be a substring of `.json`.

In this PR we attempt to fix this by making the loader RegExp an exact match.