### PR TITLE
ref(nextjs): Simplify `rollupize` in proxy loader

### DIFF
--- a/packages/nextjs/src/config/loaders/rollup.ts
+++ b/packages/nextjs/src/config/loaders/rollup.ts
@@ -1,22 +1,15 @@
-import type { RollupSucraseOptions } from '@rollup/plugin-sucrase';
 import sucrase from '@rollup/plugin-sucrase';
 import * as path from 'path';
 import type { InputOptions as RollupInputOptions, OutputOptions as RollupOutputOptions } from 'rollup';
 import { rollup } from 'rollup';
 
-const getRollupInputOptions: (proxyPath: string, resourcePath: string) => RollupInputOptions = (
-  proxyPath,
-  resourcePath,
-) => ({
+const getRollupInputOptions = (proxyPath: string, resourcePath: string): RollupInputOptions => ({
   input: proxyPath,
+
   plugins: [
-    // For some reason, even though everything in `RollupSucraseOptions` besides `transforms` is supposed to be
-    // optional, TS complains that there are a bunch of missing properties (hence the typecast). Similar to
-    // https://github.com/microsoft/TypeScript/issues/20722, though that's been fixed. (In this case it's an interface
-    // exporting a `Pick` picking optional properties which is turning them required somehow.)'
     sucrase({
       transforms: ['jsx', 'typescript'],
-    } as unknown as RollupSucraseOptions),
+    }),
   ],
 
   // We want to process as few files as possible, so as not to slow down the build any more than we have to. We need the

--- a/packages/nextjs/src/config/loaders/rollup.ts
+++ b/packages/nextjs/src/config/loaders/rollup.ts
@@ -40,9 +40,8 @@ const getRollupInputOptions = (proxyPath: string, resourcePath: string): RollupI
   //     rather than the expected `export { helperFunc } from '../../utils/helper'`, thereby causing a build error in
   //     nextjs..
   //
-  // It's not 100% clear why, but telling it not to do the conversion back from absolute to relative (by setting
-  // `makeAbsoluteExternalsRelative` to `false`) seems to also prevent it from going from relative to absolute in the
-  // first place, with the result that the path remains untouched (which is what we want.)
+  // Setting `makeAbsoluteExternalsRelative` to `false` prevents all of the above by causing Rollup to ignore imports of
+  // externals entirely, with the result that their paths remain untouched (which is what we want).
   makeAbsoluteExternalsRelative: false,
 });
 


### PR DESCRIPTION
This makes a few small changes to the `rollupize` function used by the nextjs SDK's proxy loader:

- Consolidate error handling in the proxy loader, rather than handling errors inside of `rollupize` and then handling an undefined `rollupize` return value in the proxy loader.
- Slightly simplify explanation of `makeAbsoluteExternalsRelative`
- Remove type hack in `getRollupInputOptions` which seems no longer to be needed. (It was never clear why it was necessary in the first place, and TS no longer seems mad when it's removed.)
- Rename `resourcePath` to `userModulePath` for clarity

The latter two changes are drawn from https://github.com/getsentry/sentry-javascript/pull/5960, to preserve them even though it is being reverted.
