### PR TITLE
feat(tracing): Allow for spanId to be passed into startChild

### DIFF
--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -153,7 +153,7 @@ export class Span implements SpanInterface {
    * @inheritDoc
    */
   public startChild(
-    spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'spanId' | 'sampled' | 'traceId' | 'parentSpanId'>>,
+    spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'sampled' | 'traceId' | 'parentSpanId'>>,
   ): Span {
     const childSpan = new Span({
       ...spanContext,


### PR DESCRIPTION
For OpenTelemetry support in https://github.com/getsentry/sentry-javascript/pull/6023, we want to make sure to be able to pass in a `spanId` in the `startChild` constructor. This is as we want to use the otel `spanId`.