### PR TITLE
fix(tracing): Remove circular dep warning in build with `GLOBAL`

### DIFF
--- a/packages/tracing/src/browser/backgroundtab.ts
+++ b/packages/tracing/src/browser/backgroundtab.ts
@@ -3,7 +3,7 @@ import { logger } from '@sentry/utils';
 import { IdleTransaction } from '../idletransaction';
 import { SpanStatusType } from '../span';
 import { getActiveTransaction } from '../utils';
-import { WINDOW } from '.';
+import { WINDOW } from './types';
 
 /**
  * Add a listener that cancels and finishes a transaction when the global

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -6,7 +6,6 @@ import { baggageHeaderToDynamicSamplingContext, getDomElement, logger } from '@s
 import { startIdleTransaction } from '../hubextensions';
 import { DEFAULT_FINAL_TIMEOUT, DEFAULT_HEARTBEAT_INTERVAL, DEFAULT_IDLE_TIMEOUT } from '../idletransaction';
 import { extractTraceparentData } from '../utils';
-import { WINDOW } from '.';
 import { registerBackgroundTabDetection } from './backgroundtab';
 import { addPerformanceEntries, startTrackingLongTasks, startTrackingWebVitals } from './metrics';
 import {
@@ -15,6 +14,7 @@ import {
   RequestInstrumentationOptions,
 } from './request';
 import { instrumentRoutingWithDefaults } from './router';
+import { WINDOW } from './types';
 
 export const BROWSER_TRACING_INTEGRATION_ID = 'BrowserTracing';
 

--- a/packages/tracing/src/browser/index.ts
+++ b/packages/tracing/src/browser/index.ts
@@ -1,8 +1,4 @@
-import { GLOBAL_OBJ } from '@sentry/utils';
-
 export type { RequestInstrumentationOptions } from './request';
 
 export { BrowserTracing, BROWSER_TRACING_INTEGRATION_ID } from './browsertracing';
 export { instrumentOutgoingRequests, defaultRequestInstrumentationOptions } from './request';
-
-export const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;

--- a/packages/tracing/src/browser/metrics/index.ts
+++ b/packages/tracing/src/browser/metrics/index.ts
@@ -2,10 +2,10 @@
 import { Measurements } from '@sentry/types';
 import { browserPerformanceTimeOrigin, htmlTreeAsString, logger } from '@sentry/utils';
 
-import { WINDOW } from '..';
 import { IdleTransaction } from '../../idletransaction';
 import { Transaction } from '../../transaction';
 import { getActiveTransaction, msToSec } from '../../utils';
+import { WINDOW } from '../types';
 import { onCLS } from '../web-vitals/getCLS';
 import { onFID } from '../web-vitals/getFID';
 import { onLCP } from '../web-vitals/getLCP';

--- a/packages/tracing/src/browser/router.ts
+++ b/packages/tracing/src/browser/router.ts
@@ -1,7 +1,7 @@
 import { Transaction, TransactionContext } from '@sentry/types';
 import { addInstrumentationHandler, logger } from '@sentry/utils';
 
-import { WINDOW } from '.';
+import { WINDOW } from './types';
 
 /**
  * Default function implementing pageload and navigation transactions

--- a/packages/tracing/src/browser/types.ts
+++ b/packages/tracing/src/browser/types.ts
@@ -1,0 +1,3 @@
+import { GLOBAL_OBJ } from '@sentry/utils';
+
+export const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;

--- a/packages/tracing/src/browser/web-vitals/lib/getNavigationEntry.ts
+++ b/packages/tracing/src/browser/web-vitals/lib/getNavigationEntry.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { WINDOW } from '../..';
+import { WINDOW } from '../../types';
 import { NavigationTimingPolyfillEntry } from '../types';
 
 const getNavigationEntryFromPerformanceTiming = (): NavigationTimingPolyfillEntry => {

--- a/packages/tracing/src/browser/web-vitals/lib/getVisibilityWatcher.ts
+++ b/packages/tracing/src/browser/web-vitals/lib/getVisibilityWatcher.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { WINDOW } from '../..';
+import { WINDOW } from '../../types';
 import { onHidden } from './onHidden';
 
 let firstHiddenTime = -1;

--- a/packages/tracing/src/browser/web-vitals/lib/initMetric.ts
+++ b/packages/tracing/src/browser/web-vitals/lib/initMetric.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { WINDOW } from '../..';
+import { WINDOW } from '../../types';
 import { Metric } from '../types';
 import { generateUniqueID } from './generateUniqueID';
 import { getActivationStart } from './getActivationStart';

--- a/packages/tracing/src/browser/web-vitals/lib/onHidden.ts
+++ b/packages/tracing/src/browser/web-vitals/lib/onHidden.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { WINDOW } from '../..';
+import { WINDOW } from '../../types';
 
 export interface OnHiddenCallback {
   (event: Event): void;


### PR DESCRIPTION
Extract `WINDOW` declaration from `index.ts` to remove circular dependency warning when building with rollup.