### PR TITLE
feat(remix): Add `RequestData` integration to `captureRemixServerException`

### DIFF
--- a/packages/node/src/requestdata.ts
+++ b/packages/node/src/requestdata.ts
@@ -169,7 +169,7 @@ export function extractRequestData(
   //   koa, nextjs: req.url
   const originalUrl = req.originalUrl || req.url || '';
   // absolute url
-  const absoluteUrl = `${protocol}://${host}${originalUrl}`;
+  const absoluteUrl = originalUrl.startsWith(protocol) ? originalUrl : `${protocol}://${host}${originalUrl}`;
   include.forEach(key => {
     switch (key) {
       case 'headers': {

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -353,6 +353,11 @@ function wrapRequestHandler(origRequestHandler: RequestHandler, build: ServerBui
     return local.bind(async () => {
       const hub = getCurrentHub();
       const options = hub.getClient()?.getOptions();
+      const scope = hub.getScope();
+
+      if (scope) {
+        scope.setSDKProcessingMetadata({ request });
+      }
 
       if (!options || !hasTracingEnabled(options)) {
         return origRequestHandler.call(this, request, loadContext);

--- a/packages/remix/src/utils/serverAdapters/express.ts
+++ b/packages/remix/src/utils/serverAdapters/express.ts
@@ -60,6 +60,11 @@ function wrapExpressRequestHandler(
     const request = extractRequestData(req);
     const hub = getCurrentHub();
     const options = hub.getClient()?.getOptions();
+    const scope = hub.getScope();
+
+    if (scope) {
+      scope.setSDKProcessingMetadata({ request });
+    }
 
     if (!options || !hasTracingEnabled(options) || !request.url || !request.method) {
       return origRequestHandler.call(this, req, res, next);

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -175,4 +175,9 @@ export interface Scope {
    * Clears attachments from the scope
    */
   clearAttachments(): this;
+
+  /**
+   * Add data which will be accessible during event processing but won't get sent to Sentry
+   */
+  setSDKProcessingMetadata(newData: { [key: string]: unknown }): this;
 }


### PR DESCRIPTION
@lobsterkatie -- I'm not sure if this patch is valid (or complete), but it fixes `event`s missing `request` objects in tests of #6007.

- Adds `setSDKProcessingMetadata` to Remix exception capturing utility.
- Also adds it to the wrapper for Express adapters.
