### PR TITLE
chore: Ensure volta is setup for all packages

### DIFF
--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -25,5 +25,8 @@
     "ts-node": "10.9.1",
     "typescript": "3.8.3",
     "yaml": "2.1.1"
+  },
+  "volta": {
+    "extends": "../../package.json"
   }
 }

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -32,5 +32,8 @@
     "playwright": "^1.17.1",
     "typescript": "^4.5.2",
     "webpack": "^5.52.0"
+  },
+  "volta": {
+    "extends": "../../package.json"
   }
 }

--- a/packages/node-integration-tests/package.json
+++ b/packages/node-integration-tests/package.json
@@ -41,5 +41,8 @@
       "preferGlobalPath": true,
       "runtimeDownload": false
     }
+  },
+  "volta": {
+    "extends": "../../package.json"
   }
 }


### PR DESCRIPTION
Some packages did not have a volta setup, leading to potential issues when running e.g. tests there locally when a different yarn version or similar is installed globally.
