### PR TITLE
fix(tracing): Align missing express span operation names

### DIFF
--- a/packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/packages/node-integration-tests/suites/express/tracing/test.ts
@@ -22,7 +22,7 @@ test('should create and send transactions for Express routes and spans for middl
     spans: [
       {
         description: 'corsMiddleware',
-        op: 'express.middleware.use',
+        op: 'middleware.express.use',
       },
     ],
   });

--- a/packages/tracing/src/integrations/node/express.ts
+++ b/packages/tracing/src/integrations/node/express.ts
@@ -159,7 +159,7 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
         const transaction = res.__sentry_transaction;
         const span = transaction?.startChild({
           description: fn.name,
-          op: `express.middleware.${method}`,
+          op: `middleware.express.${method}`,
         });
         fn.call(this, req, res, function (this: NodeJS.Global, ...args: unknown[]): void {
           span?.finish();
@@ -178,7 +178,7 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
         const transaction = res.__sentry_transaction;
         const span = transaction?.startChild({
           description: fn.name,
-          op: `express.middleware.${method}`,
+          op: `middleware.express.${method}`,
         });
         fn.call(this, err, req, res, function (this: NodeJS.Global, ...args: unknown[]): void {
           span?.finish();


### PR DESCRIPTION
I think this was missed when doing https://github.com/getsentry/sentry-javascript/issues/5837, there have been actually three occurrences of `express.middleware.xx`, only one of which was updated to `middleware.express.xx`.