### PR TITLE
chore(event): Add threads to browser events

### DIFF
--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -278,6 +278,9 @@ export function eventFromString(
       event.exception = {
         values: [{ value: input, stacktrace: { frames } }],
       };
+      event.threads = {
+        values: [{ stacktrace: { frames } }],
+      };
     }
   }
 

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -11,6 +11,7 @@ import { CaptureContext } from './scope';
 import { SdkInfo } from './sdkinfo';
 import { Severity, SeverityLevel } from './severity';
 import { Span } from './span';
+import { Thread } from './thread';
 import { TransactionNameChange, TransactionSource } from './transaction';
 import { User } from './user';
 
@@ -51,6 +52,9 @@ export interface Event {
     source: TransactionSource;
     changes: TransactionNameChange[];
     propagations: number;
+  };
+  threads?: {
+    values: Thread[];
   };
 }
 


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-javascript/issues/5879

Relates to: https://github.com/getsentry/sentry-react-native/issues/2131

Haven't tested it yet. I'm having trouble with the browser example.

![Screenshot 2022-10-25 at 13 49 00](https://user-images.githubusercontent.com/31292499/197767341-16b8c7b7-df15-4611-acf1-5e052da31448.png)
