### PR TITLE
ref(nextjs): Remove redundant `pagesDirectory` variable in webpack config

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -82,21 +82,12 @@ export function constructWebpackConfigFunction(
       if (userSentryOptions.autoInstrumentServerFunctions !== false) {
         const pagesDir = newConfig.resolve?.alias?.['private-next-pages'] as string;
 
-        // Next.js allows users to have the `pages` folder inside a `src` folder, however "`src/pages` will be ignored
-        // if `pages` is present in the root directory"
-        // - https://nextjs.org/docs/advanced-features/src-directory
-        const shouldIncludeSrcDirectory = !fs.existsSync(path.resolve(projectDir, 'pages'));
-        const pagesDirectory = shouldIncludeSrcDirectory // We're intentionally not including slashes in the paths because we wanne let node do the path resolution for Windows
-          ? path.resolve(projectDir, 'src', 'pages')
-          : path.resolve(projectDir, 'pages');
-
         // Default page extensions per https://github.com/vercel/next.js/blob/f1dbc9260d48c7995f6c52f8fbcc65f08e627992/packages/next/server/config-shared.ts#L161
         const pageExtensions = userNextConfig.pageExtensions || ['tsx', 'ts', 'jsx', 'js'];
         const pageExtensionRegex = pageExtensions.map(escapeStringForRegex).join('|');
 
         newConfig.module.rules.push({
-          // Nextjs allows the `pages` folder to optionally live inside a `src` folder
-          test: new RegExp(`^${escapeStringForRegex(pagesDirectory)}.*\\.(${pageExtensionRegex})$`),
+          test: new RegExp(`^${escapeStringForRegex(pagesDir)}.*\\.(${pageExtensionRegex})$`),
           use: [
             {
               loader: path.resolve(__dirname, 'loaders/proxyLoader.js'),

--- a/packages/nextjs/test/config/fixtures.ts
+++ b/packages/nextjs/test/config/fixtures.ts
@@ -56,6 +56,7 @@ export const serverWebpackConfig: WebpackConfigObject = {
   output: { filename: '[name].js', path: '/Users/Maisey/projects/squirrelChasingSimulator/.next' },
   target: 'node',
   context: '/Users/Maisey/projects/squirrelChasingSimulator',
+  resolve: { alias: { 'private-next-pages': '/Users/Maisey/projects/squirrelChasingSimulator/pages' } },
 };
 export const clientWebpackConfig: WebpackConfigObject = {
   entry: () =>

--- a/packages/nextjs/test/config/webpack/constructWebpackConfig.test.ts
+++ b/packages/nextjs/test/config/webpack/constructWebpackConfig.test.ts
@@ -50,7 +50,11 @@ describe('constructWebpackConfigFunction()', () => {
   it("doesn't set devtool if webpack plugin is disabled", () => {
     const finalNextConfig = materializeFinalNextConfig({
       ...exportedNextConfig,
-      webpack: () => ({ devtool: 'something-besides-source-map' } as any),
+      webpack: () =>
+        ({
+          ...serverWebpackConfig,
+          devtool: 'something-besides-source-map',
+        } as any),
       sentry: { disableServerWebpackPlugin: true },
     });
     const finalWebpackConfig = finalNextConfig.webpack?.(serverWebpackConfig, serverBuildContext);


### PR DESCRIPTION
This removes the `pagesDirectory` variable in the nextjs SDK's `constructWebpackConfigFunction` function, as its computed value matches that of `pagesDir` a few lines above, which we read from nextjs config.
