### PR TITLE
ci(e2e): Don't run E2E tests on forked PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -620,7 +620,7 @@ jobs:
   job_e2e_tests:
     name: E2E Tests
     # We only run E2E tests for non-fork PRs because the E2E tests require secrets to work and they can't be accessed from forks
-    if: github.repository == 'getsentry/sentry-javascript'
+    if: github.event.pull_request.head.repo.full_name == github.repository
     needs: [job_get_metadata, job_build]
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
Previous attempts to not run E2E tests on PRs didn't work so here we go again. We do this because we cannot run the E2E tests on forks because they require secrets that GitHub doesn't provide in fork actions.

This PR was done via fork so we can actually confirm this is working. 