### PR TITLE
fix: Add otel-node package to craft

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -48,3 +48,5 @@ targets:
         onlyIfPresent: /^sentry-remix-.*\.tgz$/
       'npm:@sentry/svelte':
         onlyIfPresent: /^sentry-svelte-.*\.tgz$/
+      'npm:@sentry/opentelemetry-node':
+        onlyIfPresent: /^sentry-opentelemetry-node-.*\.tgz$/


### PR DESCRIPTION
This should make it so we only publish `@sentry/opentelemetry-node` if it is marked as public.