### PR TITLE
chore(ci): Only run ember tests when ember files are affected

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,8 +64,22 @@ jobs:
           COMMIT_SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.event.head_commit.id || env.HEAD_COMMIT }})
           echo "COMMIT_SHA=$COMMIT_SHA" >> $GITHUB_ENV
           echo "COMMIT_MESSAGE=$(git log -n 1 --pretty=format:%s $COMMIT_SHA)" >> $GITHUB_ENV
+      - name: Get changed files in common folders
+        id: changed-files-root
+        uses: tj-actions/changed-files@v34
+        with:
+          files: |
+            ./!(packages/)**
+      - name: Get changes in ember package
+        uses: julien-capellari/is-workspace-affected@v1.0
+        id: ember-changed
+        with:
+          workspace: ember
+          base: ${{ github.base_ref || 'master' }}
     outputs:
       commit_label: '${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}'
+      ember_changed:
+        ${{ steps.changed-files-root.outputs.any_changed == 'true' || steps.ember-changed.outputs.affected }}
 
   job_install_deps:
     name: Install Dependencies
@@ -385,6 +399,7 @@ jobs:
   job_ember_tests:
     name: Test @sentry/ember
     needs: [job_get_metadata, job_build]
+    if: ${{ needs.job_get_metadata.outputs.ember_changed }}
     continue-on-error: true
     timeout-minutes: 10
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a draft of an idea to only run CI for a package if that package was actually affected by changes.

Basically, the logic is:

* If anything _outside_ of `./packages` has changed (e.g. yarn.lock, ...)
* If a given package or any of its dependencies has changed (using https://github.com/neoxia/is-workspace-affected)

If this is something we'd like to explore, I need to actually verify that this works as expected 😅 But in theory it appears straightforward.