### PR TITLE
fix(tracing): add new transaction source

### DIFF
--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -44,7 +44,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
     this._name = transactionContext.name || '';
 
     this.metadata = {
-      source: 'custom',
+      source: 'initialize',
       ...transactionContext.metadata,
       spanMetadata: {},
       changes: [],

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -177,6 +177,8 @@ export interface TransactionMetadata {
  * whether or not to scrub identifiers from the transaction name, or replace the entire name with a placeholder.
  */
 export type TransactionSource =
+  /** initialize name */
+  | 'initialize'
   /** User-defined name */
   | 'custom'
   /** Raw URL, potentially containing identifiers */

--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -92,7 +92,7 @@ export function vueRouterInstrumentation(router: VueRouter): VueRouterInstrument
       if (startTransactionOnPageLoad && isPageLoadNavigation) {
         const pageloadTransaction = getActiveTransaction();
         if (pageloadTransaction) {
-          if (pageloadTransaction.metadata.source !== 'custom') {
+          if (pageloadTransaction.metadata.source !== 'initialize') {
             pageloadTransaction.setName(transactionName, transactionSource);
           }
           pageloadTransaction.setData('params', data.params);


### PR DESCRIPTION
In my opinion, the source value of customer should not be used directly, which will result in the user being unable to customize the value, so a new initialization value is required to distinguish whether it is modified or not.

Finally, the user can use the source of customer when he wants to modify context.name.

```javascript
new Integrations.BrowserTracing({
        beforeNavigate: context => {
          context.name = 'test-transaction-name'
          context.metadata = {
            source: 'custom'
          }
          return context
        },
        routingInstrumentation: Sentry.vueRouterInstrumentation(router)
}),
```
