### PR TITLE
fix: Don't publish @sentry/opentelemetry-node on NPM

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -21,7 +21,9 @@ targets:
           cacheControl: 'public, max-age=31536000'
   - name: github
     includeNames: /^sentry-.*$/
+    excludeNames: /^sentry-opentelemetry-node-.*$/
   - name: npm
+    excludeNames: /^sentry-opentelemetry-node-.*.tgz$/
   - name: registry
     sdks:
       'npm:@sentry/browser':


### PR DESCRIPTION
As per https://github.com/getsentry/sentry-javascript/pull/6065#discussion_r1006863672