### PR TITLE
fix(nextjs): Log false positive warning only if request is unfinished.

### DIFF
--- a/packages/nextjs/src/config/wrappers/withSentryAPI.ts
+++ b/packages/nextjs/src/config/wrappers/withSentryAPI.ts
@@ -134,11 +134,17 @@ export function withSentry(origHandler: NextApiHandler, parameterizedRoute?: str
       try {
         const handlerResult = await origHandler(req, res);
 
-        if (process.env.NODE_ENV === 'development' && !process.env.SENTRY_IGNORE_API_RESOLUTION_ERROR) {
+        if (
+          process.env.NODE_ENV === 'development' &&
+          !process.env.SENTRY_IGNORE_API_RESOLUTION_ERROR &&
+          !res.finished
+          // This can only happen (not always) when the user is using `withSentry` manually, which we're deprecating.
+          // Warning suppression on Next.JS is only necessary in that case.
+        ) {
           // eslint-disable-next-line no-console
           console.warn(
-            `[sentry] If Next.js logs a warning "API resolved without sending a response", it's a false positive, which we're working to rectify.
-            In the meantime, to suppress this warning, set \`SENTRY_IGNORE_API_RESOLUTION_ERROR\` to 1 in your env.
+            `[sentry] If Next.js logs a warning "API resolved without sending a response", it's a false positive, which may happen when you use \`withSentry\` manually to wrap your routes.
+            To suppress this warning, set \`SENTRY_IGNORE_API_RESOLUTION_ERROR\` to 1 in your env.
             To suppress the nextjs warning, use the \`externalResolver\` API route option (see https://nextjs.org/docs/api-routes/api-middlewares#custom-config for details).`,
           );
         }


### PR DESCRIPTION
Closes: #3852 

Looks like #3852 is resolved by #5778, which is published with [`7.14.0`](https://github.com/getsentry/sentry-javascript/releases/tag/7.14.0).

We have been logging a warning to point out that Next.JS's warning is a false positive, but it seems not necessary anymore unless the user prefers disabling auto-wrapping and uses `withSentry` wrapper manually.

This PR updates the warning message and ensures it's only logged when the request is not yet finished, before the result is returned.