### PR TITLE
fix: remove otel from the registry

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -50,5 +50,3 @@ targets:
         onlyIfPresent: /^sentry-remix-.*\.tgz$/
       'npm:@sentry/svelte':
         onlyIfPresent: /^sentry-svelte-.*\.tgz$/
-      'npm:@sentry/opentelemetry-node':
-        onlyIfPresent: /^sentry-opentelemetry-node-.*\.tgz$/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
-## 7.17.0
+## 7.17.1
 
 This release standardizes our SDKs to use the MIT License, which is our [standard license for Sentry SDKs](https://open.sentry.io/licensing/). We were previously using the BSD 3-Clause License in `@sentry/browser`,`@sentry/core`, `@sentry/gatsby`, `@sentry/hub`, `@sentry/integrations`, `@sentry/node`, `@sentry/react`, `@sentry/types`, `@sentry/typescript`, and `@sentry/utils`.
 


### PR DESCRIPTION
We need to do this to stop the registry release from failing, but waiting till NPM publishes on https://github.com/getsentry/publish/issues/1513

This also updates the changelog to `7.17.1` to prep another release.