### PR TITLE
fix(nextjs): Await Next.js server in patched `getServerRequestHandler`

### DIFF
--- a/packages/nextjs/src/utils/instrumentServer.ts
+++ b/packages/nextjs/src/utils/instrumentServer.ts
@@ -22,6 +22,7 @@ type PlainObject<T = any> = { [key: string]: T };
 // https://github.com/vercel/next.js/blob/4443d6f3d36b107e833376c2720c1e206eee720d/packages/next/server/next.ts#L32
 interface NextServer {
   server: Server;
+  getServer: () => Promise<Server>;
   createServer: (options: PlainObject) => Server;
 }
 
@@ -131,7 +132,7 @@ function makeWrappedHandlerGetter(origHandlerGetter: HandlerGetter): WrappedHand
   const wrappedHandlerGetter = async function (this: NextServer): Promise<ReqHandler> {
     if (!sdkSetupComplete) {
       // stash this in the closure so that `makeWrappedReqHandler` can use it
-      liveServer = this.server;
+      liveServer = await this.getServer();
       const serverPrototype = Object.getPrototypeOf(liveServer);
 
       // Wrap for error capturing (`logError` gets called by `next` for all server-side errors)


### PR DESCRIPTION
Fixes #6059

Attempts to fix a bug where we try to grab the prototype of the Next.js server even though it hasn't been created yet. I couldn't repro this locally - I think this might be due to a race condition.

I believe (emphasis on "believe") it is safe to call `getServer` inside of the `getServerRequestHandler` function because Next.js itself calls it in there: https://github.com/vercel/next.js/blob/0beed3563cdab846fd6b683f1ed5586de3e7d96d/packages/next/server/next.ts#L175