### PR TITLE
feat(otel): Map otel span data to Sentry transaction/span/context

### DIFF
--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -24,7 +24,8 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "1.x",
-    "@opentelemetry/sdk-trace-base": "1.x"
+    "@opentelemetry/sdk-trace-base": "1.x",
+    "@opentelemetry/semantic-conventions": "1.x"
   },
   "devDependencies": {
     "@opentelemetry/api": "^1.2.0",

--- a/packages/opentelemetry-node/src/spanprocessor.ts
+++ b/packages/opentelemetry-node/src/spanprocessor.ts
@@ -77,8 +77,7 @@ export class SentrySpanProcessor implements OtelSpanProcessor {
     if (sentrySpan instanceof Transaction) {
       updateContextWithOtelData(otelSpan);
     } else {
-      // TODO:
-      // updateSpanWithOtelData(sentrySpan, otelSpan);
+      updateSpanWithOtelData(sentrySpan, otelSpan);
     }
 
     sentrySpan.finish(otelSpan.endTime[0]);
@@ -118,5 +117,17 @@ function updateContextWithOtelData(otelSpan: OtelSpan): void {
   setContext('otel', {
     attributes: otelSpan.attributes,
     resource: otelSpan.resource.attributes,
+  });
+}
+
+function updateSpanWithOtelData(sentrySpan: SentrySpan, otelSpan: OtelSpan): void {
+  const { attributes, kind } = otelSpan;
+
+  // TODO: Set status
+  sentrySpan.setData('otel.kind', kind.valueOf());
+
+  Object.keys(attributes).forEach(prop => {
+    const value = attributes[prop];
+    sentrySpan.setData(prop, value);
   });
 }

--- a/packages/opentelemetry-node/src/utils/map-otel-status.ts
+++ b/packages/opentelemetry-node/src/utils/map-otel-status.ts
@@ -1,0 +1,77 @@
+import { Span as OtelSpan } from '@opentelemetry/sdk-trace-base';
+import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { SpanStatusType as SentryStatus } from '@sentry/tracing';
+
+// canonicalCodesHTTPMap maps some HTTP codes to Sentry's span statuses. See possible mapping in https://develop.sentry.dev/sdk/event-payloads/span/
+const canonicalCodesHTTPMap: Record<string, SentryStatus> = {
+  '400': 'failed_precondition',
+  '401': 'unauthenticated',
+  '403': 'permission_denied',
+  '404': 'not_found',
+  '409': 'aborted',
+  '429': 'resource_exhausted',
+  '499': 'cancelled',
+  '500': 'internal_error',
+  '501': 'unimplemented',
+  '503': 'unavailable',
+  '504': 'deadline_exceeded',
+} as const;
+
+// canonicalCodesGrpcMap maps some GRPC codes to Sentry's span statuses. See description in grpc documentation.
+const canonicalCodesGrpcMap: Record<string, SentryStatus> = {
+  '1': 'cancelled',
+  '2': 'unknown_error',
+  '3': 'invalid_argument',
+  '4': 'deadline_exceeded',
+  '5': 'not_found',
+  '6': 'already_exists',
+  '7': 'permission_denied',
+  '8': 'resource_exhausted',
+  '9': 'failed_precondition',
+  '10': 'aborted',
+  '11': 'out_of_range',
+  '12': 'unimplemented',
+  '13': 'internal_error',
+  '14': 'unavailable',
+  '15': 'data_loss',
+  '16': 'unauthenticated',
+} as const;
+
+/**
+ * Get a Sentry span status from an otel span.
+ *
+ * @param otelSpan An otel span to generate a sentry status for.
+ * @returns The Sentry span status
+ */
+export function mapOtelStatus(otelSpan: OtelSpan): SentryStatus {
+  const { status, attributes } = otelSpan;
+
+  const statusCode = status.code;
+
+  if (statusCode < 0 || statusCode > 2) {
+    return 'unknown_error';
+  }
+
+  if (statusCode === 0 || statusCode === 1) {
+    return 'ok';
+  }
+
+  const httpCode = attributes[SemanticAttributes.HTTP_STATUS_CODE];
+  const grpcCode = attributes[SemanticAttributes.RPC_GRPC_STATUS_CODE];
+
+  if (typeof httpCode === 'string') {
+    const sentryStatus = canonicalCodesHTTPMap[httpCode];
+    if (sentryStatus) {
+      return sentryStatus;
+    }
+  }
+
+  if (typeof grpcCode === 'string') {
+    const sentryStatus = canonicalCodesGrpcMap[grpcCode];
+    if (sentryStatus) {
+      return sentryStatus;
+    }
+  }
+
+  return 'unknown_error';
+}

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -2,9 +2,9 @@ import * as OpenTelemetry from '@opentelemetry/api';
 import { Resource } from '@opentelemetry/resources';
 import { Span as OtelSpan } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { SemanticAttributes, SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { Hub, makeMain } from '@sentry/core';
-import { addExtensionMethods, Span as SentrySpan, Transaction } from '@sentry/tracing';
+import { addExtensionMethods, Span as SentrySpan, SpanStatusType, Transaction } from '@sentry/tracing';
 import { Contexts, Scope } from '@sentry/types';
 
 import { SentrySpanProcessor } from '../src/spanprocessor';
@@ -220,6 +220,102 @@ describe('SentrySpanProcessor', () => {
       parentOtelSpan.end();
     });
   });
+
+  it('sets status for transaction', async () => {
+    const otelSpan = provider.getTracer('default').startSpan('GET /users');
+
+    const transaction = getSpanForOtelSpan(otelSpan) as Transaction;
+
+    // status is only set after end
+    expect(transaction?.status).toBe(undefined);
+
+    otelSpan.end();
+
+    expect(transaction?.status).toBe('ok');
+  });
+
+  it('sets status for span', async () => {
+    const tracer = provider.getTracer('default');
+
+    tracer.startActiveSpan('GET /users', parentOtelSpan => {
+      tracer.startActiveSpan('SELECT * FROM users;', child => {
+        const sentrySpan = getSpanForOtelSpan(child);
+
+        expect(sentrySpan?.status).toBe(undefined);
+
+        child.end();
+
+        expect(sentrySpan?.status).toBe('ok');
+
+        parentOtelSpan.end();
+      });
+    });
+  });
+
+  const statusTestTable: [number, undefined | string, undefined | string, SpanStatusType][] = [
+    [-1, undefined, undefined, 'unknown_error'],
+    [3, undefined, undefined, 'unknown_error'],
+    [0, undefined, undefined, 'ok'],
+    [1, undefined, undefined, 'ok'],
+    [2, undefined, undefined, 'unknown_error'],
+
+    // http codes
+    [2, '400', undefined, 'failed_precondition'],
+    [2, '401', undefined, 'unauthenticated'],
+    [2, '403', undefined, 'permission_denied'],
+    [2, '404', undefined, 'not_found'],
+    [2, '409', undefined, 'aborted'],
+    [2, '429', undefined, 'resource_exhausted'],
+    [2, '499', undefined, 'cancelled'],
+    [2, '500', undefined, 'internal_error'],
+    [2, '501', undefined, 'unimplemented'],
+    [2, '503', undefined, 'unavailable'],
+    [2, '504', undefined, 'deadline_exceeded'],
+    [2, '999', undefined, 'unknown_error'],
+
+    // grpc codes
+    [2, undefined, '1', 'cancelled'],
+    [2, undefined, '2', 'unknown_error'],
+    [2, undefined, '3', 'invalid_argument'],
+    [2, undefined, '4', 'deadline_exceeded'],
+    [2, undefined, '5', 'not_found'],
+    [2, undefined, '6', 'already_exists'],
+    [2, undefined, '7', 'permission_denied'],
+    [2, undefined, '8', 'resource_exhausted'],
+    [2, undefined, '9', 'failed_precondition'],
+    [2, undefined, '10', 'aborted'],
+    [2, undefined, '11', 'out_of_range'],
+    [2, undefined, '12', 'unimplemented'],
+    [2, undefined, '13', 'internal_error'],
+    [2, undefined, '14', 'unavailable'],
+    [2, undefined, '15', 'data_loss'],
+    [2, undefined, '16', 'unauthenticated'],
+    [2, undefined, '999', 'unknown_error'],
+
+    // http takes precedence over grpc
+    [2, '400', '2', 'failed_precondition'],
+  ];
+
+  it.each(statusTestTable)(
+    'correctly converts otel span status to sentry status with otelStatus=%i, httpCode=%s, grpcCode=%s',
+    (otelStatus, httpCode, grpcCode, expected) => {
+      const otelSpan = provider.getTracer('default').startSpan('GET /users');
+      const transaction = getSpanForOtelSpan(otelSpan) as Transaction;
+
+      otelSpan.setStatus({ code: otelStatus });
+
+      if (httpCode) {
+        otelSpan.setAttribute(SemanticAttributes.HTTP_STATUS_CODE, httpCode);
+      }
+
+      if (grpcCode) {
+        otelSpan.setAttribute(SemanticAttributes.RPC_GRPC_STATUS_CODE, grpcCode);
+      }
+
+      otelSpan.end();
+      expect(transaction?.status).toBe(expected);
+    },
+  );
 });
 
 // OTEL expects a custom date format


### PR DESCRIPTION
Enhance sentry transactions/spans/context with data from OpenTelemetry spans, when using otel-integration.

Summary:

* otel `attributes`, `resource` for transaction --> sentry `context`
* otel `attributes`, `kind` for span --> sentry `data`
* otel `status` + data from `attributes` --> sentry `status` (for both transactions & spans)

Part of https://github.com/getsentry/sentry-javascript/issues/6000