### PR TITLE
fix(tracing): Add an extra conditional check to web vitals `onCLS()`

### DIFF
--- a/packages/tracing/src/browser/web-vitals/getCLS.ts
+++ b/packages/tracing/src/browser/web-vitals/getCLS.ts
@@ -61,6 +61,7 @@ export const onCLS = (onReport: ReportCallback, opts: ReportOpts = {}): void => 
         // entry in the current session. Otherwise, start a new session.
         if (
           sessionValue &&
+          sessionEntries.length !== 0 &&
           entry.startTime - lastSessionEntry.startTime < 1000 &&
           entry.startTime - firstSessionEntry.startTime < 5000
         ) {


### PR DESCRIPTION
It's still not immediately clear what causes #6083 since I've been unable to reproduce this locally however it's been reported by numerous users.

Before the upgrade to web vitals v3, there was [an additional check](https://github.com/getsentry/sentry-javascript/blob/5386ce73e4ffa897bfe0ab039552f745066e92ea/packages/tracing/src/browser/web-vitals/getCLS.ts#L54-L59) here so this PR adds that back. 
