### PR TITLE
fix(aws): Move relay to port 5333 to avoid collisions

### DIFF
--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -64,7 +64,7 @@ function extensionRelayDSN(originalDsn: string | undefined): string | undefined 
 
   const dsn = dsnFromString(originalDsn);
   dsn.host = 'localhost';
-  dsn.port = '3000';
+  dsn.port = '5333';
   dsn.protocol = 'http';
 
   return dsnToString(dsn);


### PR DESCRIPTION
fixes #5412 
goes with https://github.com/getsentry/action-build-aws-lambda-extension/pull/6
