### PR TITLE
ci: Update size-limit-action to v5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,7 +208,7 @@ jobs:
           path: ${{ env.CACHED_BUILD_PATHS }}
           key: ${{ env.BUILD_CACHE_KEY }}
       - name: Check bundle sizes
-        uses: getsentry/size-limit-action@v4
+        uses: getsentry/size-limit-action@v5
         # Don't run size check on release branches - at that point, we're already committed
         if: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
         with:


### PR DESCRIPTION
This should address GitHub deprecation warnings
