### PR TITLE
feat(otel): Add base SentryPropagator class

### DIFF
--- a/packages/opentelemetry-node/src/constants.ts
+++ b/packages/opentelemetry-node/src/constants.ts
@@ -1,0 +1,3 @@
+export const SENTRY_TRACE_HEADER = 'sentry-trace';
+
+export const SENTRY_BAGGAGE_HEADER = 'baggage';

--- a/packages/opentelemetry-node/src/index.ts
+++ b/packages/opentelemetry-node/src/index.ts
@@ -1,3 +1,4 @@
 import '@sentry/tracing';
 
 export { SentrySpanProcessor } from './spanprocessor';
+export { SentryPropagator } from './propagator';

--- a/packages/opentelemetry-node/src/propagator.ts
+++ b/packages/opentelemetry-node/src/propagator.ts
@@ -1,0 +1,29 @@
+import { Context, TextMapGetter, TextMapPropagator, TextMapSetter } from '@opentelemetry/api';
+
+import { SENTRY_BAGGAGE_HEADER, SENTRY_TRACE_HEADER } from './constants';
+
+/**
+ * Injects and extracts `sentry-trace` and `baggage` headers from carriers.
+ */
+export class SentryPropagator implements TextMapPropagator {
+  /**
+   * @inheritDoc
+   */
+  public inject(_context: Context, _carrier: unknown, _setter: TextMapSetter): void {
+    // no-op
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public extract(context: Context, _carrier: unknown, _getter: TextMapGetter): Context {
+    return context;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public fields(): string[] {
+    return [SENTRY_TRACE_HEADER, SENTRY_BAGGAGE_HEADER];
+  }
+}

--- a/packages/opentelemetry-node/test/propagator.test.ts
+++ b/packages/opentelemetry-node/test/propagator.test.ts
@@ -1,0 +1,10 @@
+import { SENTRY_BAGGAGE_HEADER, SENTRY_TRACE_HEADER } from '../src/constants';
+import { SentryPropagator } from '../src/propagator';
+
+describe('SentryPropagator', () => {
+  const propogator = new SentryPropagator();
+
+  it('returns fields set', () => {
+    expect(propogator.fields()).toEqual([SENTRY_TRACE_HEADER, SENTRY_BAGGAGE_HEADER]);
+  });
+});


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry-javascript/issues/6107

Previous implementation: https://github.com/getsentry/sentry-javascript/issues/6107 (yes propagator is spelled wrong everywhere in that PR lol)

Adds base `SentryPropagator` class. In the PRs after this we will add implementations for `inherit` and `extract`
