### PR TITLE
ci(e2e): Run E2E tests on non-PR triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -620,7 +620,7 @@ jobs:
   job_e2e_tests:
     name: E2E Tests
     # We only run E2E tests for non-fork PRs because the E2E tests require secrets to work and they can't be accessed from forks
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     needs: [job_get_metadata, job_build]
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
This PR corrects for the fact that E2E tests didn't run on anything other than PRs.