### PR TITLE
feat(otel): Ignore outgoing Sentry HTTP requests from otel integration

### DIFF
--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -33,7 +33,8 @@
     "@opentelemetry/core": "^1.7.0",
     "@opentelemetry/sdk-trace-base": "^1.7.0",
     "@opentelemetry/sdk-trace-node": "^1.7.0",
-    "@opentelemetry/semantic-conventions": "^1.7.0"
+    "@opentelemetry/semantic-conventions": "^1.7.0",
+    "@sentry/node": "7.17.3"
   },
   "scripts": {
     "build": "run-p build:rollup build:types",

--- a/packages/opentelemetry-node/src/utils/is-sentry-request.ts
+++ b/packages/opentelemetry-node/src/utils/is-sentry-request.ts
@@ -1,0 +1,29 @@
+import { Span as OtelSpan } from '@opentelemetry/sdk-trace-base';
+import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
+import { getCurrentHub } from '@sentry/core';
+
+/**
+ *
+ * @param otelSpan Checks wheter a given OTEL Span is an http request to sentry.
+ * @returns boolean
+ */
+export function isSentryRequestSpan(otelSpan: OtelSpan): boolean {
+  const { attributes } = otelSpan;
+
+  const httpUrl = attributes[SemanticAttributes.HTTP_URL];
+
+  if (!httpUrl) {
+    return false;
+  }
+
+  return isSentryRequestUrl(httpUrl.toString());
+}
+
+/**
+ * Checks whether given url points to Sentry server
+ * @param url url to verify
+ */
+function isSentryRequestUrl(url: string): boolean {
+  const dsn = getCurrentHub().getClient()?.getDsn();
+  return dsn ? url.includes(dsn.host) : false;
+}

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -4,11 +4,15 @@ import { Resource } from '@opentelemetry/resources';
 import { Span as OtelSpan } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { SemanticAttributes, SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
-import { Hub, makeMain } from '@sentry/core';
+import { createTransport, Hub, makeMain } from '@sentry/core';
+import { NodeClient } from '@sentry/node';
 import { addExtensionMethods, Span as SentrySpan, SpanStatusType, Transaction } from '@sentry/tracing';
 import { Contexts, Scope } from '@sentry/types';
+import { resolvedSyncPromise } from '@sentry/utils';
 
 import { SentrySpanProcessor } from '../src/spanprocessor';
+
+const SENTRY_DSN = 'https://0@0.ingest.sentry.io/0';
 
 // Integration Test of SentrySpanProcessor
 
@@ -22,7 +26,13 @@ describe('SentrySpanProcessor', () => {
   let spanProcessor: SentrySpanProcessor;
 
   beforeEach(() => {
-    hub = new Hub();
+    const client = new NodeClient({
+      dsn: SENTRY_DSN,
+      integrations: [],
+      transport: () => createTransport({ recordDroppedEvent: () => undefined }, _ => resolvedSyncPromise({})),
+      stackParser: () => [],
+    });
+    hub = new Hub(client);
     makeMain(hub);
 
     spanProcessor = new SentrySpanProcessor();
@@ -558,6 +568,106 @@ describe('SentrySpanProcessor', () => {
 
         expect(transaction?.op).toBe('test faas trigger');
         expect(transaction?.name).toBe('test operation');
+      });
+    });
+  });
+
+  describe('skip sentry requests', () => {
+    it('does not finish transaction for Sentry request', async () => {
+      const otelSpan = provider.getTracer('default').startSpan('POST to sentry', {
+        attributes: {
+          [SemanticAttributes.HTTP_METHOD]: 'POST',
+          [SemanticAttributes.HTTP_URL]: `${SENTRY_DSN}/sub/route`,
+        },
+      }) as OtelSpan;
+
+      const sentrySpanTransaction = getSpanForOtelSpan(otelSpan) as Transaction | undefined;
+      expect(sentrySpanTransaction).toBeDefined();
+
+      otelSpan.end();
+
+      expect(sentrySpanTransaction?.endTimestamp).toBeUndefined();
+
+      // Ensure it is still removed from map!
+      expect(getSpanForOtelSpan(otelSpan)).toBeUndefined();
+    });
+
+    it('finishes transaction for non-Sentry request', async () => {
+      const otelSpan = provider.getTracer('default').startSpan('POST to sentry', {
+        attributes: {
+          [SemanticAttributes.HTTP_METHOD]: 'POST',
+          [SemanticAttributes.HTTP_URL]: 'https://other.sentry.io/sub/route',
+        },
+      }) as OtelSpan;
+
+      const sentrySpanTransaction = getSpanForOtelSpan(otelSpan) as Transaction | undefined;
+      expect(sentrySpanTransaction).toBeDefined();
+
+      otelSpan.end();
+
+      expect(sentrySpanTransaction?.endTimestamp).toBeDefined();
+    });
+
+    it('does not finish spans for Sentry request', async () => {
+      const tracer = provider.getTracer('default');
+
+      tracer.startActiveSpan('GET /users', () => {
+        tracer.startActiveSpan(
+          'SELECT * FROM users;',
+          {
+            attributes: {
+              [SemanticAttributes.HTTP_METHOD]: 'POST',
+              [SemanticAttributes.HTTP_URL]: `${SENTRY_DSN}/sub/route`,
+            },
+          },
+          child => {
+            const childOtelSpan = child as OtelSpan;
+
+            const sentrySpan = getSpanForOtelSpan(childOtelSpan);
+            expect(sentrySpan).toBeDefined();
+
+            childOtelSpan.end();
+
+            expect(sentrySpan?.endTimestamp).toBeUndefined();
+
+            // Ensure it is still removed from map!
+            expect(getSpanForOtelSpan(childOtelSpan)).toBeUndefined();
+          },
+        );
+      });
+    });
+
+    it('handles child spans of Sentry requests normally', async () => {
+      const tracer = provider.getTracer('default');
+
+      tracer.startActiveSpan('GET /users', () => {
+        tracer.startActiveSpan(
+          'SELECT * FROM users;',
+          {
+            attributes: {
+              [SemanticAttributes.HTTP_METHOD]: 'POST',
+              [SemanticAttributes.HTTP_URL]: `${SENTRY_DSN}/sub/route`,
+            },
+          },
+          child => {
+            const childOtelSpan = child as OtelSpan;
+
+            const grandchildSpan = tracer.startSpan('child 1');
+
+            const sentrySpan = getSpanForOtelSpan(childOtelSpan);
+            expect(sentrySpan).toBeDefined();
+
+            const sentryGrandchildSpan = getSpanForOtelSpan(grandchildSpan);
+            expect(sentryGrandchildSpan).toBeDefined();
+
+            grandchildSpan.end();
+
+            childOtelSpan.end();
+
+            expect(sentryGrandchildSpan?.endTimestamp).toBeDefined();
+            expect(sentrySpan?.endTimestamp).toBeUndefined();
+          },
+        );
       });
     });
   });


### PR DESCRIPTION
With the basic setup of the SpanProcessor, you can get into an infinite loop quickly:

* You have some OTEL auto-instrumentation set up
* This auto-instrumentation captures outgoing HTTP requests (e.g. `@opentelemetry/instrumentation-http`)
* You setup the Sentry<>OTEL integration
* For any OTEL span created, we capture this to Sentry
* This is sent to Sentry as an outgoing HTTP request
* Which again is captured by the OTEL auto-instrumentation, ....

The "cleanest" way to avoid this is to setup your auto-instrumentation to skip Sentry requests, e.g.:

```js
const sdk = new opentelemetry.NodeSDK({
  traceExporter: new OTLPTraceExporter(),
  instrumentations: [ 
    getNodeAutoInstrumentations({
      // load custom configuration for http instrumentation
      '@opentelemetry/instrumentation-http': {
        ignoreOutgoingRequestHook: (request) => {
          const host = request.host || request.hostname;
          // Ignore Sentry API calls
          return host.indexOf('.sentry.io') > -1;
        }
      },
    }), 
  ],
  spanProcessor: new SentrySpanProcessor()
})
```

However, this also means you need to make sure to cover any potential place where this is auto-instrumented, and it also makes the setup experience for users harder than necessary.

Instead, this PR adds some handling to handle these cases automatically.

## Actual solution

Any transaction/span that we identify as being an HTTP request to the configured Sentry DSN is never finished, and thus never sent to Sentry.

### Known downsides

Any theoretical child spans of the Sentry HTTP request span will also never be sent to Sentry. This _shouldn't_ actually happen that much, or be of high relevance if it happens, but it is theoretically possible.

### Explanation

At least as of now, there is simply no way in `onStart` of the SpanProcessor to access the attributes, as they are only set _after_ `onStart` has been called. Because of this, any behavior where we handle this/properly filter this out before the span ends is not possible to implement.

We will need to do some testing to ensure there are no memory leaks (it _should_ be fine, but to be sure...)

ref https://github.com/getsentry/sentry-javascript/issues/6112

## References

* [@opentelemetry/instrumentation-http](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation-http)
* [tracer.startSpan()](https://github.com/open-telemetry/opentelemetry-js/blob/0f178d1e2e9b3aed81789820944452c153543198/packages/opentelemetry-sdk-trace-base/src/Tracer.ts#L141)
* [calling of onStart hook](https://github.com/open-telemetry/opentelemetry-js/blob/0d4c71fc50f8be5fe85dc38eeb622580422d92cd/packages/opentelemetry-sdk-trace-base/src/Span.ts#L92)
