### PR TITLE
feat(nextjs): Add `excludedServersideEntrypoints` option

### DIFF
--- a/packages/nextjs/src/config/loaders/proxyLoader.ts
+++ b/packages/nextjs/src/config/loaders/proxyLoader.ts
@@ -38,7 +38,7 @@ export default async function proxyLoader(this: LoaderThis<LoaderOptions>, userC
 
   // For the `excludedServersideEntrypoints` option we need the calculate the relative path to the file in question without file extension.
   const relativePagePath = path
-    .join('path', path.relative(pagesDir, this.resourcePath))
+    .join('pages', path.relative(pagesDir, this.resourcePath))
     // Pull off the file extension
     .replace(new RegExp(`\\.(${pageExtensionRegex})`), '');
 

--- a/packages/nextjs/src/config/loaders/proxyLoader.ts
+++ b/packages/nextjs/src/config/loaders/proxyLoader.ts
@@ -37,16 +37,19 @@ export default async function proxyLoader(this: LoaderThis<LoaderOptions>, userC
     .replace(/^$/, '/');
 
   // For the `excludedServersideEntrypoints` option we need the calculate the relative path to the file in question without file extension.
-  const relativePagePath = path
+  const relativePosixPagePath = path
     .join('pages', path.relative(pagesDir, this.resourcePath))
+    // Make sure that path is in posix style - this should make it easiser for users to configure and copy & paste from docs
+    .split(path.sep)
+    .join(path.posix.sep)
     // Pull off the file extension
     .replace(new RegExp(`\\.(${pageExtensionRegex})`), '');
 
   const isExcluded = excludedServersideEntrypoints.some(exludeEntry => {
     if (typeof exludeEntry === 'string') {
-      return relativePagePath === exludeEntry;
+      return relativePosixPagePath === exludeEntry;
     } else {
-      return relativePagePath.match(exludeEntry);
+      return relativePosixPagePath.match(exludeEntry);
     }
   });
 

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -62,7 +62,7 @@ export type UserSentryOptions = {
 
   // Used to exclude certain serverside API routes or pages from being instrumented with Sentry. This option takes an
   // array of strings or regular expressions - strings will exactly match a route. Matches are made against routes in
-  // the follwoing form:
+  // the following form:
   // - "pages/home/index"
   // - "pages/about"
   // - "pages/posts/[postId]"

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -59,6 +59,15 @@ export type UserSentryOptions = {
 
   // Automatically instrument Next.js data fetching methods and Next.js API routes
   autoInstrumentServerFunctions?: boolean;
+
+  // Used to exclude certain serverside API routes or pages from being instrumented with Sentry. This option takes an
+  // array of strings or regular expressions - strings will exactly match a route. Matches are made against routes in
+  // the follwoing form:
+  // - "pages/home/index"
+  // - "pages/about"
+  // - "pages/posts/[postId]"
+  // - "pages/posts/[postId]/comments"
+  excludedServersideEntrypoints?: (RegExp | string)[];
 };
 
 export type NextConfigFunction = (phase: string, defaults: { defaultConfig: NextConfigObject }) => NextConfigObject;

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -94,7 +94,7 @@ export function constructWebpackConfigFunction(
               options: {
                 pagesDir,
                 pageExtensionRegex,
-                excludedServersideEntrypoints: userSentryOptions.excludedServersideEntrypoints ?? [],
+                excludedServersideEntrypoints: userSentryOptions.excludedServersideEntrypoints,
               },
             },
           ],
@@ -388,7 +388,7 @@ function checkWebpackPluginOverrides(
 function shouldAddSentryToEntryPoint(
   entryPointName: string,
   isServer: boolean,
-  excludedServersideEntrypoints: (string | RegExp)[],
+  excludedServersideEntrypoints: (string | RegExp)[] = [],
 ): boolean {
   if (isServer) {
     const isExcluded = excludedServersideEntrypoints.some(serverSideExclude => {
@@ -467,7 +467,7 @@ export function getWebpackPluginOptions(
     stripPrefix: ['webpack://_N_E/'],
     urlPrefix,
     entries: (entryPointName: string) =>
-      shouldAddSentryToEntryPoint(entryPointName, isServer, userSentryOptions.excludedServersideEntrypoints ?? []),
+      shouldAddSentryToEntryPoint(entryPointName, isServer, userSentryOptions.excludedServersideEntrypoints),
     release: getSentryRelease(buildId),
     dryRun: isDev,
   });

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -390,20 +390,31 @@ function shouldAddSentryToEntryPoint(
   isServer: boolean,
   excludedServersideEntrypoints: (string | RegExp)[],
 ): boolean {
-  const isServerSideExcluded = excludedServersideEntrypoints.some(serverSideExclude => {
-    if (typeof serverSideExclude === 'string') {
-      return entryPointName === serverSideExclude;
-    } else {
-      return entryPointName.match(serverSideExclude);
-    }
-  });
+  if (isServer) {
+    const isExcluded = excludedServersideEntrypoints.some(serverSideExclude => {
+      if (typeof serverSideExclude === 'string') {
+        return entryPointName === serverSideExclude;
+      } else {
+        return entryPointName.match(serverSideExclude);
+      }
+    });
 
-  return (
-    (!isServer || !isServerSideExcluded) &&
-    (entryPointName === 'pages/_app' ||
-      (entryPointName.includes('pages/api') && !entryPointName.includes('_middleware')) ||
-      (isServer && entryPointName === 'pages/_error'))
-  );
+    if (isExcluded) {
+      return false;
+    } else if (entryPointName === 'pages/_error') {
+      return true;
+    }
+  }
+
+  if (entryPointName === 'pages/_app') {
+    return true;
+  }
+
+  if (entryPointName.includes('pages/api') && !entryPointName.includes('_middleware')) {
+    return true;
+  }
+
+  return false;
 }
 
 /**

--- a/packages/nextjs/test/integration/next.config.js
+++ b/packages/nextjs/test/integration/next.config.js
@@ -9,6 +9,10 @@ const moduleExports = {
     // Suppress the warning message from `handleSourcemapHidingOptionWarning` in `src/config/webpack.ts`
     // TODO (v8): This can come out in v8, because this option will get a default value
     hideSourceMaps: false,
+    excludedServersideEntrypoints: [
+      'pages/api/excludedEndpoints/excludedWithString',
+      /pages\/api\/excludedEndpoints\/excludedWithRegExp/,
+    ],
   },
 };
 const SentryWebpackPluginOptions = {

--- a/packages/nextjs/test/integration/next10.config.template
+++ b/packages/nextjs/test/integration/next10.config.template
@@ -10,6 +10,10 @@ const moduleExports = {
     // Suppress the warning message from `handleSourcemapHidingOptionWarning` in `src/config/webpack.ts`
     // TODO (v8): This can come out in v8, because this option will get a default value
     hideSourceMaps: false,
+    excludedServersideEntrypoints: [
+      'pages/api/excludedEndpoints/excludedWithString',
+      /pages\/api\/excludedEndpoints\/excludedWithRegExp/,
+    ],
   },
 };
 

--- a/packages/nextjs/test/integration/next11.config.template
+++ b/packages/nextjs/test/integration/next11.config.template
@@ -11,6 +11,10 @@ const moduleExports = {
     // Suppress the warning message from `handleSourcemapHidingOptionWarning` in `src/config/webpack.ts`
     // TODO (v8): This can come out in v8, because this option will get a default value
     hideSourceMaps: false,
+    excludedServersideEntrypoints: [
+      'pages/api/excludedEndpoints/excludedWithString',
+      /pages\/api\/excludedEndpoints\/excludedWithRegExp/,
+    ],
   },
 };
 

--- a/packages/nextjs/test/integration/pages/api/excludedEndpoints/excludedWithRegExp.tsx
+++ b/packages/nextjs/test/integration/pages/api/excludedEndpoints/excludedWithRegExp.tsx
@@ -1,0 +1,6 @@
+// This file will test the `excludedServersideEntrypoints` option when a route is provided as a RegExp.
+const handler = async (): Promise<void> => {
+  throw new Error('API Error');
+};
+
+export default handler;

--- a/packages/nextjs/test/integration/pages/api/excludedEndpoints/excludedWithString.tsx
+++ b/packages/nextjs/test/integration/pages/api/excludedEndpoints/excludedWithString.tsx
@@ -1,0 +1,6 @@
+// This file will test the `excludedServersideEntrypoints` option when a route is provided as a string.
+const handler = async (): Promise<void> => {
+  throw new Error('API Error');
+};
+
+export default handler;

--- a/packages/nextjs/test/integration/test/server/excludedApiEndpoints.js
+++ b/packages/nextjs/test/integration/test/server/excludedApiEndpoints.js
@@ -1,0 +1,67 @@
+const assert = require('assert');
+
+const { sleep } = require('../utils/common');
+const { getAsync, interceptEventRequest, interceptTracingRequest } = require('../utils/server');
+
+module.exports = async ({ url: urlBase, argv }) => {
+  const regExpUrl = `${urlBase}/api/excludedEndpoints/excludedWithRegExp`;
+  const stringUrl = `${urlBase}/api/excludedEndpoints/excludedWithString`;
+
+  const capturedRegExpErrorRequest = interceptEventRequest(
+    {
+      exception: {
+        values: [
+          {
+            type: 'Error',
+            value: 'API Error',
+          },
+        ],
+      },
+      tags: {
+        runtime: 'node',
+      },
+      request: {
+        url: regExpUrl,
+        method: 'GET',
+      },
+      transaction: 'GET /api/excludedEndpoints/excludedWithRegExp',
+    },
+    argv,
+    'excluded API endpoint via RegExp',
+  );
+
+  const capturedStringErrorRequest = interceptEventRequest(
+    {
+      exception: {
+        values: [
+          {
+            type: 'Error',
+            value: 'API Error',
+          },
+        ],
+      },
+      tags: {
+        runtime: 'node',
+      },
+      request: {
+        url: regExpUrl,
+        method: 'GET',
+      },
+      transaction: 'GET /api/excludedEndpoints/excludedWithString',
+    },
+    argv,
+    'excluded API endpoint via String',
+  );
+
+  await Promise.all([getAsync(regExpUrl), getAsync(stringUrl)]);
+  await sleep(250);
+
+  assert.ok(
+    !capturedRegExpErrorRequest.isDone(),
+    'Did intercept error request even though route should be excluded (RegExp)',
+  );
+  assert.ok(
+    !capturedStringErrorRequest.isDone(),
+    'Did intercept error request even though route should be excluded (String)',
+  );
+};


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/6119

This PR adds a `excludedServersideEntrypoints` to our `withSentryConfig` Next.js config wrapper. It allows users to opt specific routes out of Sentry instrumentation, meaning the Sentry SDK won't be initialized for these routes.

The reason for this change is that we want to allow users to use different JavaScript runtimes for their Next.js routes. Up until now we just crashed the route.

The option takes an array containing strings or RegExes - strings match exactly, and RegExes match like they usually do.

