### PR TITLE
feat(core): Add `instrumenter` option to `ClientOptions`

### DIFF
--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -148,6 +148,10 @@ export function init(options: NodeOptions = {}): void {
     options.autoSessionTracking = true;
   }
 
+  if (options.instrumenter === undefined) {
+    options.instrumenter = 'sentry';
+  }
+
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
   if ((domain as any).active) {
     setHubOnCarrier(carrier, getCurrentHub());

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -1,4 +1,4 @@
-import { ClientOptions, Instrumenter, Options, TracePropagationTargets } from '@sentry/types';
+import { ClientOptions, Options, TracePropagationTargets } from '@sentry/types';
 
 import { NodeTransportOptions } from './transports';
 
@@ -18,15 +18,6 @@ export interface BaseNodeOptions {
    * array, and only attach tracing headers if a match was found.
    */
   tracePropagationTargets?: TracePropagationTargets;
-
-  /**
-   * The instrumenter to use. Defaults to `sentry`.
-   * When not set to `sentry`, auto-instrumentation inside of Sentry will be disabled,
-   * in favor of using external auto instrumentation.
-   *
-   * NOTE: Any option except for `sentry` is highly experimental and subject to change!
-   */
-  instrumenter?: Instrumenter;
 
   /** Callback that is executed when a fatal global error occurs. */
   onFatalError?(error: Error): void;

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -2,6 +2,8 @@ import { ClientOptions, Options, TracePropagationTargets } from '@sentry/types';
 
 import { NodeTransportOptions } from './transports';
 
+type SentryNodeInstrumenter = 'sentry' | 'otel';
+
 export interface BaseNodeOptions {
   /** Sets an optional server name (device name) */
   serverName?: string;
@@ -18,6 +20,15 @@ export interface BaseNodeOptions {
    * array, and only attach tracing headers if a match was found.
    */
   tracePropagationTargets?: TracePropagationTargets;
+
+  /**
+   * The instrumenter to use. Defaults to `sentry`.
+   * When not set to `sentry`, auto-instrumentation inside of Sentry will be disabled,
+   * in favor of using external auto instrumentation.
+   *
+   * NOTE: Any option except for `sentry` is highly experimental and subject to change!
+   */
+  instrumenter?: SentryNodeInstrumenter;
 
   /** Callback that is executed when a fatal global error occurs. */
   onFatalError?(error: Error): void;

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -1,8 +1,6 @@
-import { ClientOptions, Options, TracePropagationTargets } from '@sentry/types';
+import { ClientOptions, Instrumenter, Options, TracePropagationTargets } from '@sentry/types';
 
 import { NodeTransportOptions } from './transports';
-
-type SentryNodeInstrumenter = 'sentry' | 'otel';
 
 export interface BaseNodeOptions {
   /** Sets an optional server name (device name) */
@@ -28,7 +26,7 @@ export interface BaseNodeOptions {
    *
    * NOTE: Any option except for `sentry` is highly experimental and subject to change!
    */
-  instrumenter?: SentryNodeInstrumenter;
+  instrumenter?: Instrumenter;
 
   /** Callback that is executed when a fatal global error occurs. */
   onFatalError?(error: Error): void;

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../src';
 import { ContextLines, LinkedErrors } from '../src/integrations';
 import { defaultStackParser } from '../src/sdk';
+import { NodeClientOptions } from '../src/types';
 import { getDefaultNodeClientOptions } from './helper/node-client-options';
 
 jest.mock('@sentry/core', () => {
@@ -464,6 +465,24 @@ describe('SentryNode initialization', () => {
 
       const options = (initAndBind as jest.Mock).mock.calls[0][1];
       expect(options.autoSessionTracking).toBe(undefined);
+    });
+  });
+
+  describe('instrumenter', () => {
+    it('defaults to sentry instrumenter', () => {
+      init({ dsn });
+
+      const instrumenter = (getCurrentHub()?.getClient()?.getOptions() as NodeClientOptions).instrumenter;
+
+      expect(instrumenter).toEqual('sentry');
+    });
+
+    it('allows to set instrumenter', () => {
+      init({ dsn, instrumenter: 'otel' });
+
+      const instrumenter = (getCurrentHub()?.getClient()?.getOptions() as NodeClientOptions).instrumenter;
+
+      expect(instrumenter).toEqual('otel');
     });
   });
 });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -92,3 +92,4 @@ export type {
 } from './transport';
 export type { User, UserFeedback } from './user';
 export type { WrappedFunction } from './wrappedfunction';
+export type { Instrumenter } from './instrumenter';

--- a/packages/types/src/instrumenter.ts
+++ b/packages/types/src/instrumenter.ts
@@ -1,0 +1,1 @@
+export type Instrumenter = 'sentry' | 'otel';

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -1,5 +1,6 @@
 import { Breadcrumb, BreadcrumbHint } from './breadcrumb';
 import { Event, EventHint } from './event';
+import { Instrumenter } from './instrumenter';
 import { Integration } from './integration';
 import { CaptureContext } from './scope';
 import { SdkMetadata } from './sdkmetadata';
@@ -57,6 +58,15 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
    * List of integrations that should be installed after SDK was initialized.
    */
   integrations: Integration[];
+
+  /**
+   * The instrumenter to use. Defaults to `sentry`.
+   * When not set to `sentry`, auto-instrumentation inside of Sentry will be disabled,
+   * in favor of using external auto instrumentation.
+   *
+   * NOTE: Any option except for `sentry` is highly experimental and subject to change!
+   */
+  instrumenter?: Instrumenter;
 
   /**
    * A function that takes transport options and returns the Transport object which is used to send events to Sentry.


### PR DESCRIPTION
Add a new option `instrumenter` to the the client options, which can be `sentry` or `otel` and defaults to `otel`.

Nothing is done with that option _yet_, this will happen in follow up PRs.

It will only have an effect when being set in the node SDK.

ref https://github.com/getsentry/sentry-javascript/issues/6127