### PR TITLE
fix(remix): Prevent capturing pending `Promise`s as exceptions.

### DIFF
--- a/packages/remix/test/integration/app/routes/action-json-response/$id.tsx
+++ b/packages/remix/test/integration/app/routes/action-json-response/$id.tsx
@@ -17,6 +17,22 @@ export const action: ActionFunction = async ({ params: { id } }) => {
     throw redirect('/action-json-response/-1');
   }
 
+  if (id === '-3') {
+    throw json({}, { status: 500, statusText: 'Sentry Test Error' });
+  }
+
+  if (id === '-4') {
+    throw json({ data: 1234 }, { status: 500 });
+  }
+
+  if (id === '-5') {
+    throw json('Sentry Test Error [string body]', { status: 500 });
+  }
+
+  if (id === '-6') {
+    throw json({}, { status: 500 });
+  }
+
   return json({ test: 'test' });
 };
 

--- a/packages/remix/test/integration/test/server/action.test.ts
+++ b/packages/remix/test/integration/test/server/action.test.ts
@@ -185,4 +185,204 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
       },
     });
   });
+
+  it('handles a thrown `json()` error response with `statusText`', async () => {
+    const env = await RemixTestEnv.init(adapter);
+    const url = `${env.url}/action-json-response/-3`;
+
+    const envelopes = await env.getMultipleEnvelopeRequest({
+      url,
+      count: 2,
+      method: 'post',
+      envelopeType: ['transaction', 'event'],
+    });
+
+    const [transaction] = envelopes.filter(envelope => envelope[1].type === 'transaction');
+    const [event] = envelopes.filter(envelope => envelope[1].type === 'event');
+
+    assertSentryTransaction(transaction[2], {
+      contexts: {
+        trace: {
+          op: 'http.server',
+          status: 'internal_error',
+          tags: {
+            method: 'POST',
+            'http.status_code': '500',
+          },
+        },
+      },
+      tags: {
+        transaction: 'routes/action-json-response/$id',
+      },
+    });
+
+    assertSentryEvent(event[2], {
+      exception: {
+        values: [
+          {
+            type: 'Error',
+            value: 'Sentry Test Error',
+            stacktrace: expect.any(Object),
+            mechanism: {
+              data: {
+                function: 'action',
+              },
+              handled: true,
+              type: 'instrument',
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('handles a thrown `json()` error response without `statusText`', async () => {
+    const env = await RemixTestEnv.init(adapter);
+    const url = `${env.url}/action-json-response/-4`;
+
+    const envelopes = await env.getMultipleEnvelopeRequest({
+      url,
+      count: 2,
+      method: 'post',
+      envelopeType: ['transaction', 'event'],
+    });
+
+    const [transaction] = envelopes.filter(envelope => envelope[1].type === 'transaction');
+    const [event] = envelopes.filter(envelope => envelope[1].type === 'event');
+
+    assertSentryTransaction(transaction[2], {
+      contexts: {
+        trace: {
+          op: 'http.server',
+          status: 'internal_error',
+          tags: {
+            method: 'POST',
+            'http.status_code': '500',
+          },
+        },
+      },
+      tags: {
+        transaction: 'routes/action-json-response/$id',
+      },
+    });
+
+    assertSentryEvent(event[2], {
+      exception: {
+        values: [
+          {
+            type: 'Error',
+            value: 'Non-Error exception captured with keys: data',
+            stacktrace: expect.any(Object),
+            mechanism: {
+              data: {
+                function: 'action',
+              },
+              handled: true,
+              type: 'instrument',
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('handles a thrown `json()` error response with string body', async () => {
+    const env = await RemixTestEnv.init(adapter);
+    const url = `${env.url}/action-json-response/-5`;
+
+    const envelopes = await env.getMultipleEnvelopeRequest({
+      url,
+      count: 2,
+      method: 'post',
+      envelopeType: ['transaction', 'event'],
+    });
+
+    const [transaction] = envelopes.filter(envelope => envelope[1].type === 'transaction');
+    const [event] = envelopes.filter(envelope => envelope[1].type === 'event');
+
+    assertSentryTransaction(transaction[2], {
+      contexts: {
+        trace: {
+          op: 'http.server',
+          status: 'internal_error',
+          tags: {
+            method: 'POST',
+            'http.status_code': '500',
+          },
+        },
+      },
+      tags: {
+        transaction: 'routes/action-json-response/$id',
+      },
+    });
+
+    assertSentryEvent(event[2], {
+      exception: {
+        values: [
+          {
+            type: 'Error',
+            value: 'Sentry Test Error [string body]',
+            stacktrace: expect.any(Object),
+            mechanism: {
+              data: {
+                function: 'action',
+              },
+              handled: true,
+              type: 'instrument',
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  it('handles a thrown `json()` error response with an empty object', async () => {
+    const env = await RemixTestEnv.init(adapter);
+    const url = `${env.url}/action-json-response/-6`;
+
+    const envelopes = await env.getMultipleEnvelopeRequest({
+      url,
+      count: 2,
+      method: 'post',
+      envelopeType: ['transaction', 'event'],
+    });
+
+    const [transaction] = envelopes.filter(envelope => envelope[1].type === 'transaction');
+    const [event] = envelopes.filter(envelope => envelope[1].type === 'event');
+
+    assertSentryTransaction(transaction[2], {
+      contexts: {
+        trace: {
+          op: 'http.server',
+          status: 'internal_error',
+          tags: {
+            method: 'POST',
+            'http.status_code': '500',
+          },
+        },
+      },
+      tags: {
+        transaction: 'routes/action-json-response/$id',
+      },
+    });
+
+    assertSentryEvent(event[2], {
+      exception: {
+        values: [
+          {
+            type: 'Error',
+            value: 'Non-Error exception captured with keys: [object has no keys]',
+            stacktrace: expect.any(Object),
+            mechanism: {
+              data: {
+                function: 'action',
+              },
+              handled: true,
+              type: 'instrument',
+            },
+          },
+        ],
+      },
+    });
+  });
 });


### PR DESCRIPTION
Closes: #5963

The reason we have been getting exceptions from Remix SDK captured as, `{}` even if the response is not an empty object (see: #5963) was apparently the pending Promises returned from `extractData`.

Implemented the async logic and added another abstraction specifically for error responses, to make sure the errors do not end up misnamed.

Based on Remix examples of [how to throw a `json(...)`](https://github.com/remix-run/remix/blob/471ab259fba5adbdd70de71ee7bc7e874c1f4db9/docs/api/conventions.md), this implementation favours:

1 - `response` (if `response` is a `string`)
2 - `response.statusText`
3 - The extracted `response` object, which will eventually be handled by [Node SDK's `eventbuilder`](https://github.com/getsentry/sentry-javascript/blob/4aff9f14bee54a65105c2ec65170ecef19c05b33/packages/node/src/eventbuilder.ts#L60-L63)

While extracting data from an error response.
