### PR TITLE
test(nextjs): Attempt to make Next.js integration tests less flakey

### DIFF
--- a/packages/nextjs/test/integration/test/client/tracingClientGetInitialProps.js
+++ b/packages/nextjs/test/integration/test/client/tracingClientGetInitialProps.js
@@ -7,8 +7,9 @@ const {
 const assert = require('assert').strict;
 
 module.exports = async ({ page, url, requests }) => {
+  const requestPromise = page.waitForRequest(isTransactionRequest);
   await page.goto(`${url}/42/withInitialProps`);
-  await page.waitForRequest(isTransactionRequest);
+  await requestPromise;
 
   const transactionEnvelope = extractEnvelopeFromRequest(requests.transactions[0]);
 

--- a/packages/nextjs/test/integration/test/client/tracingClientGetServerSideProps.js
+++ b/packages/nextjs/test/integration/test/client/tracingClientGetServerSideProps.js
@@ -7,8 +7,9 @@ const {
 const assert = require('assert').strict;
 
 module.exports = async ({ page, url, requests }) => {
+  const requestPromise = page.waitForRequest(isTransactionRequest);
   await page.goto(`${url}/1337/withServerSideProps`);
-  await page.waitForRequest(isTransactionRequest);
+  await requestPromise;
 
   const transactionEnvelope = extractEnvelopeFromRequest(requests.transactions[0]);
 

--- a/packages/nextjs/test/integration/test/client/tracingDynamicRoute.js
+++ b/packages/nextjs/test/integration/test/client/tracingDynamicRoute.js
@@ -1,8 +1,9 @@
 const { expectRequestCount, isTransactionRequest, expectTransaction } = require('../utils/client');
 
 module.exports = async ({ page, url, requests }) => {
+  const requestPromise = page.waitForRequest(isTransactionRequest);
   await page.goto(`${url}/users/102`);
-  await page.waitForRequest(isTransactionRequest);
+  await requestPromise;
 
   expectTransaction(requests.transactions[0], {
     transaction: '/users/[id]',

--- a/packages/nextjs/test/integration/test/client/tracingFetch.js
+++ b/packages/nextjs/test/integration/test/client/tracingFetch.js
@@ -6,9 +6,10 @@ const {
 } = require('../utils/client');
 
 module.exports = async ({ page, url, requests }) => {
+  const requestPromise = page.waitForRequest(isTransactionRequest);
   await page.goto(`${url}/fetch`);
   await page.click('button');
-  await page.waitForRequest(isTransactionRequest);
+  await requestPromise;
 
   expectTransaction(requests.transactions[0], {
     transaction: '/fetch',

--- a/packages/nextjs/test/integration/test/client/tracingNavigate.js
+++ b/packages/nextjs/test/integration/test/client/tracingNavigate.js
@@ -2,8 +2,9 @@ const { sleep } = require('../utils/common');
 const { expectRequestCount, isTransactionRequest, expectTransaction } = require('../utils/client');
 
 module.exports = async ({ page, url, requests }) => {
+  const requestPromise = page.waitForRequest(isTransactionRequest);
   await page.goto(`${url}/42/withInitialProps/`);
-  await page.waitForRequest(isTransactionRequest);
+  await requestPromise;
 
   expectTransaction(requests.transactions[0], {
     transaction: '/[id]/withInitialProps',

--- a/packages/nextjs/test/integration/test/client/tracingPageLoad.js
+++ b/packages/nextjs/test/integration/test/client/tracingPageLoad.js
@@ -1,8 +1,9 @@
 const { expectRequestCount, isTransactionRequest, expectTransaction } = require('../utils/client');
 
 module.exports = async ({ page, url, requests }) => {
+  const requestPromise = page.waitForRequest(isTransactionRequest);
   await page.goto(`${url}/healthy`);
-  await page.waitForRequest(isTransactionRequest);
+  await requestPromise;
 
   expectTransaction(requests.transactions[0], {
     contexts: {


### PR DESCRIPTION
Partly adresses https://github.com/getsentry/sentry-javascript/issues/6053

I guess there is a possibility that requests go out in between the `page.goto()` calls and the `page.waitForRequest()`, causing us to wait for the latter indefinitely.
If we await the request before we go to the page, there is no way a request is sent before `page.waitForRequest()` is called.