### PR TITLE
feat(tracing): Allow to set `instrumenter` on Span & Transaction

### DIFF
--- a/packages/tracing/src/span.ts
+++ b/packages/tracing/src/span.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { Primitive, Span as SpanInterface, SpanContext, Transaction } from '@sentry/types';
+import { Instrumenter, Primitive, Span as SpanInterface, SpanContext, Transaction } from '@sentry/types';
 import { dropUndefinedKeys, logger, timestampWithMs, uuid4 } from '@sentry/utils';
 
 /**
@@ -103,6 +103,11 @@ export class Span implements SpanInterface {
   public transaction?: Transaction;
 
   /**
+   * The instrumenter that created this span.
+   */
+  public instrumenter: Instrumenter = 'sentry';
+
+  /**
    * You should never call the constructor manually, always use `Sentry.startTransaction()`
    * or call `startChild()` on an existing span.
    * @internal
@@ -146,6 +151,9 @@ export class Span implements SpanInterface {
     }
     if (spanContext.endTimestamp) {
       this.endTimestamp = spanContext.endTimestamp;
+    }
+    if (spanContext.instrumenter) {
+      this.instrumenter = spanContext.instrumenter;
     }
   }
 

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -24,6 +24,18 @@ describe('Span', () => {
       expect((span2 as any).traceId).toBe((span as any).traceId);
       expect((span2 as any).sampled).toBe((span as any).sampled);
     });
+
+    test('sets instrumenter to `sentry` if not specified in constructor', () => {
+      const span = new Span({});
+
+      expect(span.instrumenter).toBe('sentry');
+    });
+
+    test('allows to set instrumenter in constructor', () => {
+      const span = new Span({ instrumenter: 'otel' });
+
+      expect(span.instrumenter).toBe('otel');
+    });
   });
 
   describe('new Transaction', () => {

--- a/packages/tracing/test/transaction.test.ts
+++ b/packages/tracing/test/transaction.test.ts
@@ -24,6 +24,18 @@ describe('`Transaction` class', () => {
       expect(transaction.metadata.source).toEqual('custom');
     });
 
+    it('sets instrumenter to be `sentry` in constructor if not provided', () => {
+      const transaction = new Transaction({ name: 'dogpark' });
+
+      expect(transaction.instrumenter).toEqual('sentry');
+    });
+
+    it('allows to set instrumenter', () => {
+      const transaction = new Transaction({ name: 'dogpark', instrumenter: 'otel' });
+
+      expect(transaction.instrumenter).toEqual('otel');
+    });
+
     it('updates transaction name changes with correct variables needed', () => {
       const transaction = new Transaction({ name: 'dogpark', metadata: { source: 'url' } });
       expect(transaction.metadata.changes).toEqual([]);

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -1,3 +1,4 @@
+import { Instrumenter } from './instrumenter';
 import { Primitive } from './misc';
 import { Transaction } from './transaction';
 
@@ -58,6 +59,11 @@ export interface SpanContext {
    * Timestamp in seconds (epoch time) indicating when the span ended.
    */
   endTimestamp?: number;
+
+  /**
+   * The instrumenter that created this span.
+   */
+  instrumenter?: Instrumenter;
 }
 
 /** Span holding trace_id, span_id */
@@ -91,6 +97,11 @@ export interface Span extends SpanContext {
    * The transaction containing this span
    */
   transaction?: Transaction;
+
+  /**
+   * The instrumenter that created this span.
+   */
+  instrumenter: Instrumenter;
 
   /**
    * Sets the finish timestamp on the current span.

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -1,4 +1,5 @@
 import { DynamicSamplingContext } from './envelope';
+import { Instrumenter } from './instrumenter';
 import { MeasurementUnit } from './measurement';
 import { ExtractedNodeRequestData, Primitive, WorkerLocation } from './misc';
 import { PolymorphicRequest } from './polymorphics';
@@ -70,6 +71,11 @@ export interface Transaction extends TransactionContext, Span {
    * Metadata about the transaction
    */
   metadata: TransactionMetadata;
+
+  /**
+   * The instrumenter that created this transaction.
+   */
+  instrumenter: Instrumenter;
 
   /**
    * Set the name of the transaction


### PR DESCRIPTION
A span & transaction now have a field `instrumenter` that can be used to check where a the span/transaction was created.
This defaults to `sentry`.

In later steps, we can use this information to react internally based on SDK config.

ref https://github.com/getsentry/sentry-javascript/issues/6127
