### PR TITLE
feat(otel): Disable node tracing auto instrumentation when using otel

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -37,7 +37,12 @@ export function tracingHandler(): (
     const hub = getCurrentHub();
     const options = hub.getClient()?.getOptions();
 
-    if (!options || req.method?.toUpperCase() === 'OPTIONS' || req.method?.toUpperCase() === 'HEAD') {
+    if (
+      !options ||
+      options.instrumenter !== 'sentry' ||
+      req.method?.toUpperCase() === 'OPTIONS' ||
+      req.method?.toUpperCase() === 'HEAD'
+    ) {
       return next();
     }
 

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -72,6 +72,7 @@ export class Http implements Integration {
 
     // Do not auto-instrument for other instrumenter
     if (clientOptions && clientOptions.instrumenter !== 'sentry') {
+      __DEBUG_BUILD__ && logger.log('HTTP Integration is skipped because of instrumenter configuration.');
       return;
     }
 

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -69,6 +69,12 @@ export class Http implements Integration {
     }
 
     const clientOptions = setupOnceGetCurrentHub().getClient<NodeClient>()?.getOptions();
+
+    // Do not auto-instrument for other instrumenter
+    if (clientOptions && clientOptions.instrumenter !== 'sentry') {
+      return;
+    }
+
     const wrappedHandlerMaker = _createWrappedRequestMethodFactory(this._breadcrumbs, this._tracing, clientOptions);
 
     // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/packages/node/test/helper/node-client-options.ts
+++ b/packages/node/test/helper/node-client-options.ts
@@ -8,6 +8,7 @@ export function getDefaultNodeClientOptions(options: Partial<NodeClientOptions> 
     integrations: [],
     transport: () => createTransport({ recordDroppedEvent: () => undefined }, _ => resolvedSyncPromise({})),
     stackParser: () => [],
+    instrumenter: 'sentry',
     ...options,
   };
 }

--- a/packages/tracing/src/integrations/node/apollo.ts
+++ b/packages/tracing/src/integrations/node/apollo.ts
@@ -2,6 +2,8 @@ import { Hub } from '@sentry/core';
 import { EventProcessor, Integration } from '@sentry/types';
 import { arrayify, fill, isThenable, loadModule, logger } from '@sentry/utils';
 
+import { shouldDisableAutoInstrumentation } from './utils/node-utils';
+
 type ApolloResolverGroup = {
   [key: string]: () => unknown;
 };
@@ -36,6 +38,11 @@ export class Apollo implements Integration {
 
     if (!pkg) {
       __DEBUG_BUILD__ && logger.error('Apollo Integration was unable to require apollo-server-core package.');
+      return;
+    }
+
+    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
+      __DEBUG_BUILD__ && logger.log('Apollo Integration is skipped because of instrumenter configuration.');
       return;
     }
 

--- a/packages/tracing/src/integrations/node/graphql.ts
+++ b/packages/tracing/src/integrations/node/graphql.ts
@@ -2,6 +2,8 @@ import { Hub } from '@sentry/core';
 import { EventProcessor, Integration } from '@sentry/types';
 import { fill, isThenable, loadModule, logger } from '@sentry/utils';
 
+import { shouldDisableAutoInstrumentation } from './utils/node-utils';
+
 /** Tracing integration for graphql package */
 export class GraphQL implements Integration {
   /**
@@ -24,6 +26,11 @@ export class GraphQL implements Integration {
 
     if (!pkg) {
       __DEBUG_BUILD__ && logger.error('GraphQL Integration was unable to require graphql/execution package.');
+      return;
+    }
+
+    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
+      __DEBUG_BUILD__ && logger.log('GraphQL Integration is skipped because of instrumenter configuration.');
       return;
     }
 

--- a/packages/tracing/src/integrations/node/mongo.ts
+++ b/packages/tracing/src/integrations/node/mongo.ts
@@ -2,6 +2,8 @@ import { Hub } from '@sentry/core';
 import { EventProcessor, Integration, SpanContext } from '@sentry/types';
 import { fill, isThenable, loadModule, logger } from '@sentry/utils';
 
+import { shouldDisableAutoInstrumentation } from './utils/node-utils';
+
 // This allows us to use the same array for both defaults options and the type itself.
 // (note `as const` at the end to make it a union of string literal types (i.e. "a" | "b" | ... )
 // and not just a string[])
@@ -122,6 +124,11 @@ export class Mongo implements Integration {
 
     if (!pkg) {
       __DEBUG_BUILD__ && logger.error(`Mongo Integration was unable to require \`${moduleName}\` package.`);
+      return;
+    }
+
+    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
+      __DEBUG_BUILD__ && logger.log('Mongo Integration is skipped because of instrumenter configuration.');
       return;
     }
 

--- a/packages/tracing/src/integrations/node/mysql.ts
+++ b/packages/tracing/src/integrations/node/mysql.ts
@@ -2,6 +2,8 @@ import { Hub } from '@sentry/core';
 import { EventProcessor, Integration } from '@sentry/types';
 import { fill, loadModule, logger } from '@sentry/utils';
 
+import { shouldDisableAutoInstrumentation } from './utils/node-utils';
+
 interface MysqlConnection {
   createQuery: () => void;
 }
@@ -26,6 +28,11 @@ export class Mysql implements Integration {
 
     if (!pkg) {
       __DEBUG_BUILD__ && logger.error('Mysql Integration was unable to require `mysql` package.');
+      return;
+    }
+
+    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
+      __DEBUG_BUILD__ && logger.log('Mysql Integration is skipped because of instrumenter configuration.');
       return;
     }
 

--- a/packages/tracing/src/integrations/node/postgres.ts
+++ b/packages/tracing/src/integrations/node/postgres.ts
@@ -2,6 +2,8 @@ import { Hub } from '@sentry/core';
 import { EventProcessor, Integration } from '@sentry/types';
 import { fill, isThenable, loadModule, logger } from '@sentry/utils';
 
+import { shouldDisableAutoInstrumentation } from './utils/node-utils';
+
 interface PgClient {
   prototype: {
     query: () => void | Promise<unknown>;
@@ -38,6 +40,11 @@ export class Postgres implements Integration {
 
     if (!pkg) {
       __DEBUG_BUILD__ && logger.error('Postgres Integration was unable to require `pg` package.');
+      return;
+    }
+
+    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
+      __DEBUG_BUILD__ && logger.log('Postgres Integration is skipped because of instrumenter configuration.');
       return;
     }
 

--- a/packages/tracing/src/integrations/node/prisma.ts
+++ b/packages/tracing/src/integrations/node/prisma.ts
@@ -2,6 +2,8 @@ import { Hub } from '@sentry/core';
 import { EventProcessor, Integration } from '@sentry/types';
 import { isThenable, logger } from '@sentry/utils';
 
+import { shouldDisableAutoInstrumentation } from './utils/node-utils';
+
 type PrismaAction =
   | 'findUnique'
   | 'findMany'
@@ -77,6 +79,11 @@ export class Prisma implements Integration {
   public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
     if (!this._client) {
       __DEBUG_BUILD__ && logger.error('PrismaIntegration is missing a Prisma Client Instance');
+      return;
+    }
+
+    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
+      __DEBUG_BUILD__ && logger.log('Prisma Integration is skipped because of instrumenter configuration.');
       return;
     }
 

--- a/packages/tracing/src/integrations/node/utils/node-utils.ts
+++ b/packages/tracing/src/integrations/node/utils/node-utils.ts
@@ -1,0 +1,14 @@
+import { Hub } from '@sentry/types';
+
+/**
+ * Check if Sentry auto-instrumentation should be disabled.
+ *
+ * @param getCurrentHub A method to fetch the current hub
+ * @returns boolean
+ */
+export function shouldDisableAutoInstrumentation(getCurrentHub: () => Hub): boolean {
+  const clientOptions = getCurrentHub().getClient()?.getOptions();
+  const instrumenter = clientOptions?.instrumenter || 'sentry';
+
+  return instrumenter !== 'sentry';
+}

--- a/packages/tracing/test/integrations/node/mongo.test.ts
+++ b/packages/tracing/test/integrations/node/mongo.test.ts
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Hub, Scope } from '@sentry/core';
+import { logger } from '@sentry/utils';
 
 import { Mongo } from '../../../src/integrations/node/mongo';
 import { Span } from '../../../src/span';
+import { getTestClient } from '../../testutils';
 
 class Collection {
   public collectionName: string = 'mockedCollectionName';
@@ -110,5 +112,20 @@ describe('patchOperation()', () => {
       description: 'initializeOrderedBulkOp',
     });
     expect(childSpan.finish).toBeCalled();
+  });
+
+  it("doesn't attach when using otel instrumenter", () => {
+    const loggerLogSpy = jest.spyOn(logger, 'log');
+
+    const client = getTestClient({ instrumenter: 'otel' });
+    const hub = new Hub(client);
+
+    const integration = new Mongo();
+    integration.setupOnce(
+      () => {},
+      () => hub,
+    );
+
+    expect(loggerLogSpy).toBeCalledWith('Mongo Integration is skipped because of instrumenter configuration.');
   });
 });

--- a/packages/tracing/test/integrations/node/postgres.test.ts
+++ b/packages/tracing/test/integrations/node/postgres.test.ts
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Hub, Scope } from '@sentry/core';
+import { logger } from '@sentry/utils';
 
 import { Postgres } from '../../../src/integrations/node/postgres';
 import { Span } from '../../../src/span';
+import { getTestClient } from '../../testutils';
 
 class PgClient {
   // https://node-postgres.com/api/client#clientquery
@@ -93,5 +95,20 @@ describe('setupOnce', () => {
       });
       expect(childSpan.finish).toBeCalled();
     });
+  });
+
+  it("doesn't attach when using otel instrumenter", () => {
+    const loggerLogSpy = jest.spyOn(logger, 'log');
+
+    const client = getTestClient({ instrumenter: 'otel' });
+    const hub = new Hub(client);
+
+    const integration = new Postgres();
+    integration.setupOnce(
+      () => {},
+      () => hub,
+    );
+
+    expect(loggerLogSpy).toBeCalledWith('Postgres Integration is skipped because of instrumenter configuration.');
   });
 });

--- a/packages/tracing/test/testutils.ts
+++ b/packages/tracing/test/testutils.ts
@@ -1,5 +1,5 @@
 import { createTransport } from '@sentry/browser';
-import { ClientOptions } from '@sentry/types';
+import { Client, ClientOptions } from '@sentry/types';
 import { GLOBAL_OBJ, resolvedSyncPromise } from '@sentry/utils';
 import { JSDOM } from 'jsdom';
 
@@ -65,4 +65,20 @@ export function getDefaultBrowserClientOptions(options: Partial<ClientOptions> =
     stackParser: () => [],
     ...options,
   };
+}
+
+export function getTestClient(options: Partial<ClientOptions>): Client {
+  class TestClient {
+    _options: Partial<ClientOptions>;
+
+    constructor(options: Partial<ClientOptions>) {
+      this._options = options;
+    }
+
+    getOptions(): Partial<ClientOptions> {
+      return this._options;
+    }
+  }
+
+  return new TestClient(options) as unknown as Client;
 }


### PR DESCRIPTION
With this PR, when `instrumenter: 'otel'` is configured in the Node SDK, any auto-instrumentation that generates transactions is skipped.

This is a bit tricky to test, so I created a separate PR for the tests, if we don't like the approach: https://github.com/getsentry/sentry-javascript/pull/6143

ref https://github.com/getsentry/sentry-javascript/issues/6127