### PR TITLE
chore(ci): Only run CI tests when related files changed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,8 @@ jobs:
   job_get_metadata:
     name: Get Metadata
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Check out current commit
         uses: actions/checkout@v3
@@ -64,8 +66,35 @@ jobs:
           COMMIT_SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.event.head_commit.id || env.HEAD_COMMIT }})
           echo "COMMIT_SHA=$COMMIT_SHA" >> $GITHUB_ENV
           echo "COMMIT_MESSAGE=$(git log -n 1 --pretty=format:%s $COMMIT_SHA)" >> $GITHUB_ENV
+      - uses: getsentry/paths-filter@v2.11.1
+        id: changed
+        with:
+          filters: |
+            shared: &shared
+              - '/*.{js,ts,json,yml,lock}'
+              - '/.github/**'
+              - '/jest/**'
+              - '/rollup/**'
+              - '/packages/core/**'
+              - '/packages/tracing/**'
+              - '/packages/utils/**'
+              - '/packages/types/**'
+            ember:
+              - *shared
+              - '/packages/ember/**'
+              - '/packages/browser/**'
+            nextjs:
+              - *shared
+              - '/packages/nextjs/**'
+              - '/packages/node/**'
+              - '/packages/react/**'
+              - '/packages/intergrations/**'
+              - '/packages/browser/**'
+
     outputs:
       commit_label: '${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}'
+      changed_nextjs: ${{ steps.changed.outputs.nextjs }}
+      changed_ember: ${{ steps.changed.outputs.ember }}
 
   job_install_deps:
     name: Install Dependencies
@@ -348,6 +377,7 @@ jobs:
   job_nextjs_integration_test:
     name: Test @sentry/nextjs on (Node ${{ matrix.node }})
     needs: [job_get_metadata, job_build]
+    if: ${{ needs.job_get_metadata.outputs.changed_nextjs == 'true' }}
     continue-on-error: true
     timeout-minutes: 30
     runs-on: ubuntu-latest
@@ -385,6 +415,7 @@ jobs:
   job_ember_tests:
     name: Test @sentry/ember
     needs: [job_get_metadata, job_build]
+    if: ${{ needs.job_get_metadata.outputs.changed_ember == 'true' }}
     continue-on-error: true
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,7 @@ jobs:
               - 'packages/tracing/**'
               - 'packages/utils/**'
               - 'packages/types/**'
+              - 'packages/integrations/**'
             browser:
               - *shared
               - 'packages/browser/**'
@@ -97,14 +98,12 @@ jobs:
               - 'packages/nextjs/**'
               - 'packages/node/**'
               - 'packages/react/**'
-              - 'packages/intergrations/**'
               - 'packages/browser/**'
             remix:
               - *shared
               - 'packages/remix/**'
               - 'packages/node/**'
               - 'packages/react/**'
-              - 'packages/intergrations/**'
               - 'packages/browser/**'
             node:
               - *shared

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
           COMMIT_SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.event.head_commit.id || env.HEAD_COMMIT }})
           echo "COMMIT_SHA=$COMMIT_SHA" >> $GITHUB_ENV
           echo "COMMIT_MESSAGE=$(git log -n 1 --pretty=format:%s $COMMIT_SHA)" >> $GITHUB_ENV
+
       - name: Determine changed packages
         uses: getsentry/paths-filter@v2.11.1
         id: changed
@@ -73,6 +74,7 @@ jobs:
           filters: |
             shared: &shared
               - '*.{js,ts,json,yml,lock}'
+              - 'CHANGELOG.md'
               - '.github/**'
               - 'jest/**'
               - 'rollup/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -402,7 +402,7 @@ jobs:
   job_nextjs_integration_test:
     name: Test @sentry/nextjs on (Node ${{ matrix.node }})
     needs: [job_get_metadata, job_build]
-    if: ${{ needs.job_get_metadata.outputs.changed_nextjs == 'true' }}
+    if: ${{ needs.job_get_metadata.outputs.changed_nextjs == 'true' }} || ${{ github.event_name != 'pull_request' }}
     continue-on-error: true
     timeout-minutes: 30
     runs-on: ubuntu-latest
@@ -440,7 +440,7 @@ jobs:
   job_ember_tests:
     name: Test @sentry/ember
     needs: [job_get_metadata, job_build]
-    if: ${{ needs.job_get_metadata.outputs.changed_ember == 'true' }}
+    if: ${{ needs.job_get_metadata.outputs.changed_ember == 'true' }} || ${{ github.event_name != 'pull_request' }}
     continue-on-error: true
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -482,7 +482,9 @@ jobs:
   job_browser_playwright_tests:
     name: Playwright - ${{ (matrix.tracing_only && 'Browser + Tracing') || 'Browser' }} (${{ matrix.bundle }})
     needs: [job_get_metadata, job_build]
-    if: ${{ needs.job_get_metadata.outputs.changed_browser_integration == 'true' }}
+    if:
+      ${{ needs.job_get_metadata.outputs.changed_browser_integration == 'true' }} || ${{ github.event_name !=
+      'pull_request' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -534,7 +536,7 @@ jobs:
   job_browser_integration_tests:
     name: Old Browser Integration Tests (${{ matrix.browser }})
     needs: [job_get_metadata, job_build]
-    if: ${{ needs.job_get_metadata.outputs.changed_browser == 'true' }}
+    if: ${{ needs.job_get_metadata.outputs.changed_browser == 'true' }} || ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true
@@ -608,7 +610,7 @@ jobs:
   job_node_integration_tests:
     name: Node SDK Integration Tests (${{ matrix.node }})
     needs: [job_get_metadata, job_build]
-    if: ${{ needs.job_get_metadata.outputs.changed_node == 'true' }}
+    if: ${{ needs.job_get_metadata.outputs.changed_node == 'true' }} || ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true
@@ -644,7 +646,7 @@ jobs:
   job_remix_integration_tests:
     name: Remix SDK Integration Tests (${{ matrix.node }})
     needs: [job_get_metadata, job_build]
-    if: ${{ needs.job_get_metadata.outputs.changed_remix == 'true' }}
+    if: ${{ needs.job_get_metadata.outputs.changed_remix == 'true' }} || ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,25 +71,25 @@ jobs:
         with:
           filters: |
             shared: &shared
-              - '/*.{js,ts,json,yml,lock}'
-              - '/.github/**'
-              - '/jest/**'
-              - '/rollup/**'
-              - '/packages/core/**'
-              - '/packages/tracing/**'
-              - '/packages/utils/**'
-              - '/packages/types/**'
+              - '*.{js,ts,json,yml,lock}'
+              - '.github/**'
+              - 'jest/**'
+              - 'rollup/**'
+              - 'packages/core/**'
+              - 'packages/tracing/**'
+              - 'packages/utils/**'
+              - 'packages/types/**'
             ember:
               - *shared
-              - '/packages/ember/**'
-              - '/packages/browser/**'
+              - 'packages/ember/**'
+              - 'packages/browser/**'
             nextjs:
               - *shared
-              - '/packages/nextjs/**'
-              - '/packages/node/**'
-              - '/packages/react/**'
-              - '/packages/intergrations/**'
-              - '/packages/browser/**'
+              - 'packages/nextjs/**'
+              - 'packages/node/**'
+              - 'packages/react/**'
+              - 'packages/intergrations/**'
+              - 'packages/browser/**'
 
     outputs:
       commit_label: '${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,7 @@ jobs:
               - '.github/**'
               - 'jest/**'
               - 'rollup/**'
+              - 'scripts/**'
               - 'packages/core/**'
               - 'packages/tracing/**'
               - 'packages/utils/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -402,7 +402,7 @@ jobs:
   job_nextjs_integration_test:
     name: Test @sentry/nextjs on (Node ${{ matrix.node }})
     needs: [job_get_metadata, job_build]
-    if: ${{ needs.job_get_metadata.outputs.changed_nextjs == 'true' }} || ${{ github.event_name != 'pull_request' }}
+    if: needs.job_get_metadata.outputs.changed_nextjs == 'true' || github.event_name != 'pull_request'
     continue-on-error: true
     timeout-minutes: 30
     runs-on: ubuntu-latest
@@ -440,7 +440,7 @@ jobs:
   job_ember_tests:
     name: Test @sentry/ember
     needs: [job_get_metadata, job_build]
-    if: ${{ needs.job_get_metadata.outputs.changed_ember == 'true' }} || ${{ github.event_name != 'pull_request' }}
+    if: needs.job_get_metadata.outputs.changed_ember == 'true' || github.event_name != 'pull_request'
     continue-on-error: true
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -482,9 +482,7 @@ jobs:
   job_browser_playwright_tests:
     name: Playwright - ${{ (matrix.tracing_only && 'Browser + Tracing') || 'Browser' }} (${{ matrix.bundle }})
     needs: [job_get_metadata, job_build]
-    if:
-      ${{ needs.job_get_metadata.outputs.changed_browser_integration == 'true' }} || ${{ github.event_name !=
-      'pull_request' }}
+    if: needs.job_get_metadata.outputs.changed_browser_integration == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -536,7 +534,7 @@ jobs:
   job_browser_integration_tests:
     name: Old Browser Integration Tests (${{ matrix.browser }})
     needs: [job_get_metadata, job_build]
-    if: ${{ needs.job_get_metadata.outputs.changed_browser == 'true' }} || ${{ github.event_name != 'pull_request' }}
+    if: needs.job_get_metadata.outputs.changed_browser == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true
@@ -610,7 +608,7 @@ jobs:
   job_node_integration_tests:
     name: Node SDK Integration Tests (${{ matrix.node }})
     needs: [job_get_metadata, job_build]
-    if: ${{ needs.job_get_metadata.outputs.changed_node == 'true' }} || ${{ github.event_name != 'pull_request' }}
+    if: needs.job_get_metadata.outputs.changed_node == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true
@@ -646,7 +644,7 @@ jobs:
   job_remix_integration_tests:
     name: Remix SDK Integration Tests (${{ matrix.node }})
     needs: [job_get_metadata, job_build]
-    if: ${{ needs.job_get_metadata.outputs.changed_remix == 'true' }} || ${{ github.event_name != 'pull_request' }}
+    if: needs.job_get_metadata.outputs.changed_remix == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,8 @@ jobs:
           COMMIT_SHA=$(git rev-parse --short ${{ github.event.pull_request.head.sha || github.event.head_commit.id || env.HEAD_COMMIT }})
           echo "COMMIT_SHA=$COMMIT_SHA" >> $GITHUB_ENV
           echo "COMMIT_MESSAGE=$(git log -n 1 --pretty=format:%s $COMMIT_SHA)" >> $GITHUB_ENV
-      - uses: getsentry/paths-filter@v2.11.1
+      - name: Determine changed packages
+        uses: getsentry/paths-filter@v2.11.1
         id: changed
         with:
           filters: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,13 @@ jobs:
               - 'packages/tracing/**'
               - 'packages/utils/**'
               - 'packages/types/**'
+            browser:
+              - *shared
+              - 'packages/browser/**'
+            browser_integration:
+              - *shared
+              - 'packages/browser/**'
+              - 'packages/integration-tests/**'
             ember:
               - *shared
               - 'packages/ember/**'
@@ -109,6 +116,8 @@ jobs:
       changed_ember: ${{ steps.changed.outputs.ember }}
       changed_remix: ${{ steps.changed.outputs.remix }}
       changed_node: ${{ steps.changed.outputs.node }}
+      changed_browser: ${{ steps.changed.outputs.browser }}
+      changed_browser_integration: ${{ steps.changed.outputs.browser_integration }}
 
   job_install_deps:
     name: Install Dependencies
@@ -471,6 +480,7 @@ jobs:
   job_browser_playwright_tests:
     name: Playwright - ${{ (matrix.tracing_only && 'Browser + Tracing') || 'Browser' }} (${{ matrix.bundle }})
     needs: [job_get_metadata, job_build]
+    if: ${{ needs.job_get_metadata.outputs.changed_browser_integration == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -522,6 +532,7 @@ jobs:
   job_browser_integration_tests:
     name: Old Browser Integration Tests (${{ matrix.browser }})
     needs: [job_get_metadata, job_build]
+    if: ${{ needs.job_get_metadata.outputs.changed_browser == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,22 +79,28 @@ jobs:
               - 'packages/tracing/**'
               - 'packages/utils/**'
               - 'packages/types/**'
+              - 'packages/browser/**'
             ember:
               - *shared
               - 'packages/ember/**'
-              - 'packages/browser/**'
             nextjs:
               - *shared
               - 'packages/nextjs/**'
               - 'packages/node/**'
               - 'packages/react/**'
               - 'packages/intergrations/**'
-              - 'packages/browser/**'
+            remix:
+              - *shared
+              - 'packages/remix/**'
+              - 'packages/node/**'
+              - 'packages/react/**'
+              - 'packages/intergrations/**'
 
     outputs:
       commit_label: '${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}'
       changed_nextjs: ${{ steps.changed.outputs.nextjs }}
       changed_ember: ${{ steps.changed.outputs.ember }}
+      changed_remix: ${{ steps.changed.outputs.remix }}
 
   job_install_deps:
     name: Install Dependencies
@@ -616,6 +622,7 @@ jobs:
   job_remix_integration_tests:
     name: Remix SDK Integration Tests (${{ matrix.node }})
     needs: [job_get_metadata, job_build]
+    if: ${{ needs.job_get_metadata.outputs.changed_remix == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,28 +80,35 @@ jobs:
               - 'packages/tracing/**'
               - 'packages/utils/**'
               - 'packages/types/**'
-              - 'packages/browser/**'
             ember:
               - *shared
               - 'packages/ember/**'
+              - 'packages/browser/**'
             nextjs:
               - *shared
               - 'packages/nextjs/**'
               - 'packages/node/**'
               - 'packages/react/**'
               - 'packages/intergrations/**'
+              - 'packages/browser/**'
             remix:
               - *shared
               - 'packages/remix/**'
               - 'packages/node/**'
               - 'packages/react/**'
               - 'packages/intergrations/**'
+              - 'packages/browser/**'
+            node:
+              - *shared
+              - 'packages/node/**'
+              - 'packages/node-integration-tests/**'
 
     outputs:
       commit_label: '${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}'
       changed_nextjs: ${{ steps.changed.outputs.nextjs }}
       changed_ember: ${{ steps.changed.outputs.ember }}
       changed_remix: ${{ steps.changed.outputs.remix }}
+      changed_node: ${{ steps.changed.outputs.node }}
 
   job_install_deps:
     name: Install Dependencies
@@ -588,6 +595,7 @@ jobs:
   job_node_integration_tests:
     name: Node SDK Integration Tests (${{ matrix.node }})
     needs: [job_get_metadata, job_build]
+    if: ${{ needs.job_get_metadata.outputs.changed_node == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: true


### PR DESCRIPTION
This PR updates the build to only run the "special" CI test jobs when the respective packages have actually changed.

This is done using https://github.com/getsentry/paths-filter with a simple list of directories to watch. We can use the handy `shared` functionality to avoid duplicating the "global" dependencies.

Note that we _do_ need to keep the internal dependencies in sync (e.g. if nextjs starts to depend on another internal package, we need to add it), but IMHO that is acceptable.

This is how that looks:

![Screenshot 2022-11-07 at 15 23 51](https://user-images.githubusercontent.com/2411343/200333862-59577636-2eef-49de-b67e-c1a060e187b1.png)

Replaces https://github.com/getsentry/sentry-javascript/pull/6067