### PR TITLE
fix(otel): Remove sampling decision in propagator

### DIFF
--- a/packages/opentelemetry-node/src/propagator.ts
+++ b/packages/opentelemetry-node/src/propagator.ts
@@ -62,12 +62,12 @@ export class SentryPropagator implements TextMapPropagator {
       const traceparentData = extractTraceparentData(header);
       newContext = newContext.setValue(SENTRY_TRACE_PARENT_CONTEXT_KEY, traceparentData);
       if (traceparentData) {
-        const traceFlags = traceparentData.parentSampled ? TraceFlags.SAMPLED : TraceFlags.NONE;
         const spanContext = {
           traceId: traceparentData.traceId || '',
           spanId: traceparentData.parentSpanId || '',
           isRemote: true,
-          traceFlags,
+          // Always sample if traceparent exists, we use SentrySpanProcessor to make sampling decisions with `startTransaction`.
+          traceFlags: TraceFlags.SAMPLED,
         };
         newContext = trace.setSpanContext(newContext, spanContext);
       }

--- a/packages/opentelemetry-node/src/spanprocessor.ts
+++ b/packages/opentelemetry-node/src/spanprocessor.ts
@@ -129,7 +129,7 @@ function getTraceData(otelSpan: OtelSpan, parentContext: Context): Partial<Trans
     | Partial<DynamicSamplingContext>
     | undefined;
 
-  return {
+  const context: Partial<TransactionContext> = {
     spanId,
     traceId,
     parentSpanId,
@@ -139,6 +139,13 @@ function getTraceData(otelSpan: OtelSpan, parentContext: Context): Partial<Trans
       source: 'custom',
     },
   };
+
+  // Only inherit sample rate if `traceId` is the same
+  if (traceparentData && traceId === traceparentData.traceId) {
+    context.parentSampled = traceparentData.parentSampled;
+  }
+
+  return context;
 }
 
 function finishTransactionWithContextFromOtelData(transaction: Transaction, otelSpan: OtelSpan): void {


### PR DESCRIPTION
Previously the Sentry Propagator was setting the sample rate on the opentelemetry span context based on the incoming traceparent from `sentry-trace`. This is problematic because it a span is unsampled, it does not enter a span processor. This means that we could create transactions erroneously (for example, unnecessarily promote a child span to a transaction).

To fix this, we move the sampling decision from the propagator to the span processor.