### PR TITLE
feat(otel): Handle inconsistent `instrumenter` option

### DIFF
--- a/packages/opentelemetry-node/src/spanprocessor.ts
+++ b/packages/opentelemetry-node/src/spanprocessor.ts
@@ -45,7 +45,7 @@ export class SentrySpanProcessor implements OtelSpanProcessor {
     if (sentryParentSpan) {
       const sentryChildSpan = sentryParentSpan.startChild({
         description: otelSpan.name,
-        // instrumentor: 'otel',
+        instrumenter: 'otel',
         startTimestamp: convertOtelTimeToSeconds(otelSpan.startTime),
         spanId: otelSpanId,
       });
@@ -56,7 +56,7 @@ export class SentrySpanProcessor implements OtelSpanProcessor {
       const transaction = hub.startTransaction({
         name: otelSpan.name,
         ...traceCtx,
-        // instrumentor: 'otel',
+        instrumenter: 'otel',
         startTimestamp: convertOtelTimeToSeconds(otelSpan.startTime),
         spanId: otelSpanId,
       });

--- a/packages/tracing/src/hubextensions.ts
+++ b/packages/tracing/src/hubextensions.ts
@@ -166,6 +166,19 @@ function _startTransaction(
   const client = this.getClient();
   const options: Partial<ClientOptions> = (client && client.getOptions()) || {};
 
+  const configInstrumenter = options.instrumenter || 'sentry';
+  const transactionInstrumenter = transactionContext.instrumenter || 'sentry';
+
+  if (configInstrumenter !== transactionInstrumenter) {
+    __DEBUG_BUILD__ &&
+      logger.error(
+        `A transaction was started with instrumenter=\`${transactionInstrumenter}\`, but the SDK is configured with the \`${configInstrumenter}\` instrumenter.
+The transaction will not be sampled. Please use the ${configInstrumenter} instrumentation to start transactions.`,
+      );
+
+    transactionContext.sampled = false;
+  }
+
   let transaction = new Transaction(transactionContext, this);
   transaction = sample(transaction, options, {
     parentSampled: transactionContext.parentSampled,


### PR DESCRIPTION
This is the last piece for the otel integration. It relies on https://github.com/getsentry/sentry-javascript/pull/6144.

Basically, when a transaction is started with an instrumenter that does not match the configured instrumenter of the client, it will ensure it is never sampled, and log an error message.

ref https://github.com/getsentry/sentry-javascript/issues/6127