### PR TITLE
feat(tracing): Add `transaction.setContext` method

### DIFF
--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -55,21 +55,19 @@ describe('SentrySpanProcessor', () => {
   }
 
   function getContext(transaction: Transaction) {
-    const transactionWithContext = transaction as unknown as Transaction & { _contexts: Contexts };
+    const transactionWithContext = transaction as unknown as Transaction;
     return transactionWithContext._contexts;
   }
 
   // monkey-patch finish to store the context at finish time
   function monkeyPatchTransactionFinish(transaction: Transaction) {
-    const monkeyPatchedTransaction = transaction as Transaction & { _contexts: Contexts };
+    const monkeyPatchedTransaction = transaction as Transaction;
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const originalFinish = monkeyPatchedTransaction.finish;
     monkeyPatchedTransaction._contexts = {};
     monkeyPatchedTransaction.finish = function (endTimestamp?: number | undefined) {
-      monkeyPatchedTransaction._contexts = (
-        transaction._hub.getScope() as unknown as Scope & { _contexts: Contexts }
-      )._contexts;
+      monkeyPatchedTransaction._contexts = (transaction._hub.getScope() as unknown as Scope)._contexts;
 
       return originalFinish.apply(monkeyPatchedTransaction, [endTimestamp]);
     };

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -7,7 +7,7 @@ import { SemanticAttributes, SemanticResourceAttributes } from '@opentelemetry/s
 import { createTransport, Hub, makeMain } from '@sentry/core';
 import { NodeClient } from '@sentry/node';
 import { addExtensionMethods, Span as SentrySpan, SpanStatusType, Transaction } from '@sentry/tracing';
-import { Contexts, Scope } from '@sentry/types';
+import { Scope } from '@sentry/types';
 import { resolvedSyncPromise } from '@sentry/utils';
 
 import { SENTRY_SPAN_PROCESSOR_MAP, SentrySpanProcessor } from '../src/spanprocessor';
@@ -56,6 +56,7 @@ describe('SentrySpanProcessor', () => {
 
   function getContext(transaction: Transaction) {
     const transactionWithContext = transaction as unknown as Transaction;
+    // @ts-ignore accessing private property
     return transactionWithContext._contexts;
   }
 
@@ -65,8 +66,10 @@ describe('SentrySpanProcessor', () => {
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const originalFinish = monkeyPatchedTransaction.finish;
+    // @ts-ignore accessing private property
     monkeyPatchedTransaction._contexts = {};
     monkeyPatchedTransaction.finish = function (endTimestamp?: number | undefined) {
+      // @ts-ignore accessing private property
       monkeyPatchedTransaction._contexts = (transaction._hub.getScope() as unknown as Scope)._contexts;
 
       return originalFinish.apply(monkeyPatchedTransaction, [endTimestamp]);

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -117,7 +117,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete this._contexts[key];
     } else {
-      this._contexts = { ...this._contexts, [key]: context };
+      this._contexts[key] = context;
     }
   }
 

--- a/packages/tracing/test/transaction.test.ts
+++ b/packages/tracing/test/transaction.test.ts
@@ -1,7 +1,8 @@
-import { Transaction } from '../src/transaction';
-import { addExtensionMethods } from '../src';
-import { getDefaultBrowserClientOptions } from './testutils';
 import { BrowserClient, Hub } from '@sentry/browser';
+
+import { addExtensionMethods } from '../src';
+import { Transaction } from '../src/transaction';
+import { getDefaultBrowserClientOptions } from './testutils';
 
 describe('`Transaction` class', () => {
   beforeAll(() => {
@@ -268,7 +269,9 @@ describe('`Transaction` class', () => {
       transaction.setContext('foo', { key: 'val' });
       transaction.finish();
 
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(hub.captureEvent).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(hub.captureEvent).toHaveBeenLastCalledWith(
         expect.objectContaining({
           contexts: {
@@ -293,7 +296,9 @@ describe('`Transaction` class', () => {
       transaction.setContext('trace', { key: 'val' });
       transaction.finish();
 
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(hub.captureEvent).toHaveBeenCalledTimes(1);
+      // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(hub.captureEvent).toHaveBeenLastCalledWith(
         expect.objectContaining({
           contexts: {

--- a/packages/tracing/test/transaction.test.ts
+++ b/packages/tracing/test/transaction.test.ts
@@ -1,6 +1,13 @@
 import { Transaction } from '../src/transaction';
+import { addExtensionMethods } from '../src';
+import { getDefaultBrowserClientOptions } from './testutils';
+import { BrowserClient, Hub } from '@sentry/browser';
 
 describe('`Transaction` class', () => {
+  beforeAll(() => {
+    addExtensionMethods();
+  });
+
   describe('transaction name source', () => {
     it('sets source in constructor if provided', () => {
       const transaction = new Transaction({ name: 'dogpark', metadata: { source: 'route' } });
@@ -178,6 +185,125 @@ describe('`Transaction` class', () => {
           },
         ]);
       });
+    });
+  });
+
+  describe('setContext', () => {
+    it('sets context', () => {
+      const transaction = new Transaction({ name: 'dogpark' });
+      transaction.setContext('foo', {
+        key: 'val',
+        key2: 'val2',
+      });
+
+      // @ts-ignore accessing private property
+      expect(transaction._contexts).toEqual({
+        foo: {
+          key: 'val',
+          key2: 'val2',
+        },
+      });
+    });
+
+    it('overwrites context', () => {
+      const transaction = new Transaction({ name: 'dogpark' });
+      transaction.setContext('foo', {
+        key: 'val',
+        key2: 'val2',
+      });
+      transaction.setContext('foo', {
+        key3: 'val3',
+      });
+
+      // @ts-ignore accessing private property
+      expect(transaction._contexts).toEqual({
+        foo: {
+          key3: 'val3',
+        },
+      });
+    });
+
+    it('merges context', () => {
+      const transaction = new Transaction({ name: 'dogpark' });
+      transaction.setContext('foo', {
+        key: 'val',
+        key2: 'val2',
+      });
+      transaction.setContext('bar', {
+        anotherKey: 'anotherVal',
+      });
+
+      // @ts-ignore accessing private property
+      expect(transaction._contexts).toEqual({
+        foo: {
+          key: 'val',
+          key2: 'val2',
+        },
+        bar: {
+          anotherKey: 'anotherVal',
+        },
+      });
+    });
+
+    it('deletes context', () => {
+      const transaction = new Transaction({ name: 'dogpark' });
+      transaction.setContext('foo', {
+        key: 'val',
+        key2: 'val2',
+      });
+      transaction.setContext('foo', null);
+
+      // @ts-ignore accessing private property
+      expect(transaction._contexts).toEqual({});
+    });
+
+    it('sets contexts on the event', () => {
+      const options = getDefaultBrowserClientOptions({ tracesSampleRate: 1 });
+      const client = new BrowserClient(options);
+      const hub = new Hub(client);
+
+      jest.spyOn(hub, 'captureEvent');
+
+      const transaction = hub.startTransaction({ name: 'dogpark' });
+      transaction.setContext('foo', { key: 'val' });
+      transaction.finish();
+
+      expect(hub.captureEvent).toHaveBeenCalledTimes(1);
+      expect(hub.captureEvent).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          contexts: {
+            foo: { key: 'val' },
+            trace: {
+              span_id: transaction.spanId,
+              trace_id: transaction.traceId,
+            },
+          },
+        }),
+      );
+    });
+
+    it('does not override trace context', () => {
+      const options = getDefaultBrowserClientOptions({ tracesSampleRate: 1 });
+      const client = new BrowserClient(options);
+      const hub = new Hub(client);
+
+      jest.spyOn(hub, 'captureEvent');
+
+      const transaction = hub.startTransaction({ name: 'dogpark' });
+      transaction.setContext('trace', { key: 'val' });
+      transaction.finish();
+
+      expect(hub.captureEvent).toHaveBeenCalledTimes(1);
+      expect(hub.captureEvent).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          contexts: {
+            trace: {
+              span_id: transaction.spanId,
+              trace_id: transaction.traceId,
+            },
+          },
+        }),
+      );
     });
   });
 });

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -1,3 +1,4 @@
+import { Context } from './context';
 import { DynamicSamplingContext } from './envelope';
 import { MeasurementUnit } from './measurement';
 import { ExtractedNodeRequestData, Primitive, WorkerLocation } from './misc';
@@ -75,6 +76,11 @@ export interface Transaction extends TransactionContext, Span {
    * Set the name of the transaction
    */
   setName(name: string, source?: TransactionMetadata['source']): void;
+
+  /**
+   * Set the context of a transaction event
+   */
+  setContext(key: string, context: Context): void;
 
   /**
    * Set observed measurement for this transaction.


### PR DESCRIPTION
This is needed for the OpenTelemetry Span Processor. Same behaviour as `scope.setContext` here: https://github.com/getsentry/sentry-javascript/blob/351be067ac7ff280155c128011f79dac9caf6475/packages/core/src/scope.ts#L257-L270

One thing to note, we don't want users to override `trace` context, so we set that here.