### PR TITLE
perf(core): Prevent creation of new contexts object on scope

### DIFF
--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -262,7 +262,7 @@ export class Scope implements ScopeInterface {
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete this._contexts[key];
     } else {
-      this._contexts = { ...this._contexts, [key]: context };
+      this._contexts[key] = context;
     }
 
     this._notifyScopeListeners();


### PR DESCRIPTION
Based on feedback from https://github.com/getsentry/sentry-javascript/pull/6154#discussion_r1016704391

Remove spread operator usage when setting new context so we mutate the current reference instead of creating a new object. Should reduce bundle size and be slightly more performant.