### PR TITLE
fix(otel): Add transaction source logic to otel spans

### DIFF
--- a/packages/opentelemetry-node/src/spanprocessor.ts
+++ b/packages/opentelemetry-node/src/spanprocessor.ts
@@ -171,9 +171,9 @@ function updateSpanWithOtelData(sentrySpan: SentrySpan, otelSpan: OtelSpan): voi
 function updateTransactionWithOtelData(transaction: Transaction, otelSpan: OtelSpan): void {
   transaction.setStatus(mapOtelStatus(otelSpan));
 
-  const { op, description } = parseSpanDescription(otelSpan);
+  const { op, description, source } = parseSpanDescription(otelSpan);
   transaction.op = op;
-  transaction.name = description;
+  transaction.setName(description, source);
 }
 
 function convertOtelTimeToSeconds([seconds, nano]: [number, number]): number {

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -462,6 +462,36 @@ describe('SentrySpanProcessor', () => {
       });
     });
 
+    it('adds transaction source `url` for HTTP_TARGET', async () => {
+      const tracer = provider.getTracer('default');
+
+      tracer.startActiveSpan('GET /users', otelSpan => {
+        const sentrySpan = getSpanForOtelSpan(otelSpan);
+
+        otelSpan.setAttribute(SemanticAttributes.HTTP_METHOD, 'GET');
+        otelSpan.setAttribute(SemanticAttributes.HTTP_TARGET, '/my/route/123');
+
+        otelSpan.end();
+
+        expect(sentrySpan?.transaction?.metadata.source).toBe('url');
+      });
+    });
+
+    it('adds transaction source `url` for HTTP_ROUTE', async () => {
+      const tracer = provider.getTracer('default');
+
+      tracer.startActiveSpan('GET /users', otelSpan => {
+        const sentrySpan = getSpanForOtelSpan(otelSpan);
+
+        otelSpan.setAttribute(SemanticAttributes.HTTP_METHOD, 'GET');
+        otelSpan.setAttribute(SemanticAttributes.HTTP_ROUTE, '/my/route/:id');
+
+        otelSpan.end();
+
+        expect(sentrySpan?.transaction?.metadata.source).toBe('route');
+      });
+    });
+
     it('updates based on attributes for DB_SYSTEM', async () => {
       const tracer = provider.getTracer('default');
 


### PR DESCRIPTION
Define transaction source on transactions depending on what semantic attributes are being used. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-server-semantic-conventions.

Related: https://github.com/open-telemetry/opentelemetry-demo/pull/566