### PR TITLE
ref(tracing): Deprecate `tracingOrigins`

### DIFF
--- a/packages/nextjs/src/index.client.ts
+++ b/packages/nextjs/src/index.client.ts
@@ -59,6 +59,7 @@ export function init(options: NextjsOptions): void {
 
 function createClientIntegrations(userIntegrations: UserIntegrations = []): UserIntegrations {
   const defaultBrowserTracingIntegration = new BrowserTracing({
+    // eslint-disable-next-line deprecation/deprecation
     tracingOrigins: [...defaultRequestInstrumentationOptions.tracingOrigins, /^(api\/)/],
     routingInstrumentation: nextRouterInstrumentation,
   });

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -147,23 +147,10 @@ export class BrowserTracing implements Integration {
 
   private _getCurrentHub?: () => Hub;
 
-  private readonly _emitOptionsWarning?: boolean;
-
   public constructor(_options?: Partial<BrowserTracingOptions>) {
-    let tracingOrigins = defaultRequestInstrumentationOptions.tracingOrigins;
-    // NOTE: Logger doesn't work in constructors, as it's initialized after integrations instances
-    if (_options) {
-      if (_options.tracingOrigins && Array.isArray(_options.tracingOrigins)) {
-        tracingOrigins = _options.tracingOrigins;
-      } else {
-        __DEBUG_BUILD__ && (this._emitOptionsWarning = true);
-      }
-    }
-
     this.options = {
       ...DEFAULT_BROWSER_TRACING_OPTIONS,
       ..._options,
-      tracingOrigins,
     };
 
     const { _metricOptions } = this.options;
@@ -179,17 +166,6 @@ export class BrowserTracing implements Integration {
   public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
     this._getCurrentHub = getCurrentHub;
 
-    if (this._emitOptionsWarning) {
-      __DEBUG_BUILD__ &&
-        logger.warn(
-          '[Tracing] You need to define `tracingOrigins` in the options. Set an array of urls or patterns to trace.',
-        );
-      __DEBUG_BUILD__ &&
-        logger.warn(
-          `[Tracing] We added a reasonable default for you: ${defaultRequestInstrumentationOptions.tracingOrigins}`,
-        );
-    }
-
     // eslint-disable-next-line @typescript-eslint/unbound-method
     const {
       routingInstrumentation: instrumentRouting,
@@ -198,6 +174,7 @@ export class BrowserTracing implements Integration {
       markBackgroundTransactions,
       traceFetch,
       traceXHR,
+      // eslint-disable-next-line deprecation/deprecation
       tracingOrigins,
       shouldCreateSpanForRequest,
     } = this.options;

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -17,10 +17,9 @@ export const DEFAULT_TRACE_PROPAGATION_TARGETS = ['localhost', /^\//];
 /** Options for Request Instrumentation */
 export interface RequestInstrumentationOptions {
   /**
-   * List of strings / regex where the integration should create Spans out of. Additionally this will be used
-   * to define which outgoing requests the `sentry-trace` header will be attached to.
-   *
-   * Default: ['localhost', /^\//] {@see DEFAULT_TRACING_ORIGINS}
+   * @deprecated Will be removed in v8.
+   * Use `shouldCreateSpanForRequest` to control span creation and `tracePropagationTargets` to control
+   * trace header attachment.
    */
   tracingOrigins: Array<string | RegExp>;
 
@@ -50,7 +49,7 @@ export interface RequestInstrumentationOptions {
    * This function will be called before creating a span for a request with the given url.
    * Return false if you don't want a span for the given url.
    *
-   * By default it uses the `tracingOrigins` options as a url match.
+   * Default: (url: string) => true
    */
   shouldCreateSpanForRequest?(url: string): boolean;
 }
@@ -114,6 +113,7 @@ export const defaultRequestInstrumentationOptions: RequestInstrumentationOptions
 
 /** Registers span creators for xhr and fetch requests  */
 export function instrumentOutgoingRequests(_options?: Partial<RequestInstrumentationOptions>): void {
+  // eslint-disable-next-line deprecation/deprecation
   const { traceFetch, traceXHR, tracingOrigins, tracePropagationTargets, shouldCreateSpanForRequest } = {
     ...defaultRequestInstrumentationOptions,
     ..._options,

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -34,9 +34,6 @@ jest.mock('@sentry/utils', () => {
 
 jest.mock('../../src/browser/metrics');
 
-const { logger } = jest.requireActual('@sentry/utils');
-const warnSpy = jest.spyOn(logger, 'warn');
-
 beforeAll(() => {
   const dom = new JSDOM();
   // @ts-ignore need to override global document
@@ -55,8 +52,6 @@ describe('BrowserTracing', () => {
     hub = new Hub(new BrowserClient(options));
     makeMain(hub);
     document.head.innerHTML = '';
-
-    warnSpy.mockClear();
   });
 
   afterEach(() => {
@@ -134,25 +129,6 @@ describe('BrowserTracing', () => {
     });
 
     describe('tracingOrigins', () => {
-      it('warns and uses default tracing origins if none are provided', () => {
-        const inst = createBrowserTracing(true, {
-          routingInstrumentation: customInstrumentRouting,
-        });
-
-        expect(warnSpy).toHaveBeenCalledTimes(2);
-        expect(inst.options.tracingOrigins).toEqual(defaultRequestInstrumentationOptions.tracingOrigins);
-      });
-
-      it('warns and uses default tracing origins if tracing origins are not defined', () => {
-        const inst = createBrowserTracing(true, {
-          routingInstrumentation: customInstrumentRouting,
-          tracingOrigins: undefined,
-        });
-
-        expect(warnSpy).toHaveBeenCalledTimes(2);
-        expect(inst.options.tracingOrigins).toEqual(defaultRequestInstrumentationOptions.tracingOrigins);
-      });
-
       it('sets tracing origins if provided and does not warn', () => {
         const sampleTracingOrigins = ['something'];
         const inst = createBrowserTracing(true, {
@@ -160,7 +136,6 @@ describe('BrowserTracing', () => {
           tracingOrigins: sampleTracingOrigins,
         });
 
-        expect(warnSpy).toHaveBeenCalledTimes(0);
         expect(inst.options.tracingOrigins).toEqual(sampleTracingOrigins);
       });
 
@@ -171,7 +146,6 @@ describe('BrowserTracing', () => {
           tracingOrigins: sampleTracingOrigins,
         });
 
-        expect(warnSpy).toHaveBeenCalledTimes(0);
         expect(inst.options.tracingOrigins).toEqual(sampleTracingOrigins);
       });
     });

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -136,6 +136,7 @@ describe('BrowserTracing', () => {
           tracingOrigins: sampleTracingOrigins,
         });
 
+        // eslint-disable-next-line deprecation/deprecation
         expect(inst.options.tracingOrigins).toEqual(sampleTracingOrigins);
       });
 
@@ -146,6 +147,7 @@ describe('BrowserTracing', () => {
           tracingOrigins: sampleTracingOrigins,
         });
 
+        // eslint-disable-next-line deprecation/deprecation
         expect(inst.options.tracingOrigins).toEqual(sampleTracingOrigins);
       });
     });


### PR DESCRIPTION
Ref #5285 

This PR:
- Deprecates `tracingOrigins` and points out the new properties that replace it
- Removes the warning for no supplied `tracingOrigins`
- Removes the tests for the warning

My best guess is the logged warning about no supplied `tracingOrigins` was due to the fact that it's default limited span creation and the default might not be relaxed enough. Since now span creation in controlled by `shouldCreateSpanForRequest` which defaults to always creating spans, this warning seems redundant.  Users are now only likely to seek out tracing options to reduce the number of spans or stop header attachment if it's causing them CORS issues.  



