### PR TITLE
chore(ci): Add new Ci job that runs after required test jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -715,7 +715,16 @@ jobs:
 
   job_required_tests:
     name: All required tests passed or skipped
-    needs: [job_unit_test, job_nextjs_integration_test, job_node_integration_tests]
+    needs:
+      [
+        job_unit_test,
+        job_nextjs_integration_test,
+        job_node_integration_tests,
+        job_browser_playwright_tests,
+        job_browser_integration_tests,
+        job_remix_integration_tests,
+        job_ember_tests,
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: All required tests passed!

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -712,3 +712,11 @@ jobs:
         run: |
           cd packages/e2e-tests
           yarn test:e2e
+
+  job_required_tests:
+    name: All required tests passed or skipped
+    needs: [job_unit_test, job_nextjs_integration_test, job_node_integration_tests]
+    runs-on: ubuntu-latest
+    steps:
+      - name: All required tests passed!
+        run: echo "OK"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -365,10 +365,10 @@ jobs:
   job_unit_test:
     name: Test (Node ${{ matrix.node }})
     needs: [job_get_metadata, job_build]
-    continue-on-error: true
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node: [8, 10, 12, 14, 16, 18]
     steps:
@@ -403,10 +403,10 @@ jobs:
     name: Test @sentry/nextjs on (Node ${{ matrix.node }})
     needs: [job_get_metadata, job_build]
     # Currently always runs because it is required for merging PRs
-    continue-on-error: true
     timeout-minutes: 30
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node: [10, 12, 14, 16, 18]
     steps:
@@ -441,10 +441,10 @@ jobs:
     name: Test @sentry/ember
     needs: [job_get_metadata, job_build]
     if: needs.job_get_metadata.outputs.changed_ember == 'true' || github.event_name != 'pull_request'
-    continue-on-error: true
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         scenario: [ember-release, embroider-optimized, ember-4.0]
     steps:
@@ -537,8 +537,8 @@ jobs:
     if: needs.job_get_metadata.outputs.changed_browser == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         browser:
           - ChromeHeadless
@@ -576,7 +576,6 @@ jobs:
     needs: [job_get_metadata, job_build]
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    continue-on-error: true
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3
@@ -611,8 +610,8 @@ jobs:
     # Currently always runs because it is required for merging PRs
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         node: [10, 12, 14, 16, 18]
     steps:
@@ -647,8 +646,8 @@ jobs:
     if: needs.job_get_metadata.outputs.changed_remix == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         node: [14, 16, 18]
     steps:
@@ -684,7 +683,6 @@ jobs:
     needs: [job_get_metadata, job_build]
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -723,7 +723,11 @@ jobs:
         job_remix_integration_tests,
         job_ember_tests,
       ]
+    # Always run this, even if a dependent job failed
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: All required tests passed!
-        run: echo "OK"
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,7 +238,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     # Size Check will error out outside of the context of a PR
-    if: ${{ github.event_name == 'pull_request' }} || ${{ startsWith(github.ref, 'refs/heads/master/') }}
+    if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/master/')
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3


### PR DESCRIPTION
This adds a new job that doesn't do anything, that runs after all required test matrix jobs.

With this in place, we can remove the requirement of the nextjs, test & node integration matrix tests, and instead only make this one job required. This should then also handle skipped jobs (hopefully).

We can start with making _both_ required (so just add requirement on this new job), then when we see it works remove the requirement on the specific matrix jobs.

## Update 

After some trial and error, we figured out that we need some further adjustments for this to work as expected.

### How GitHub Actions interprets failed vs. skipped

* A job that is marked as required counts as passed whenever it is not failed
* This means that if the job is skipped, it will pass the required check
* A job that depends on another job will be considered skipped when the dependent job fails.
* This means that we cannot rely on the normal `needs` notation to ensure that all dependent jobs have either succeeded or skipped

Instead, we took some inspiration from: https://github.com/getsentry/sentry/pull/33784

By marking the follow-up job with `if: always()`, it will _always_ run, even if the dependent jobs failed.
Then, we check if any dependent job resulted in failure, and error out if that's the case.

ref https://github.com/getsentry/sentry-javascript/issues/6170