### PR TITLE
ref(browser): Lazy init fetchImpl in fetch transport

### DIFF
--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -8,11 +8,13 @@ import { clearCachedFetchImplementation, FetchImpl, getNativeFetchImplementation
 /**
  * Creates a Transport that uses the Fetch API to send events to Sentry.
  */
-export function makeFetchTransport(
-  options: BrowserTransportOptions,
-  nativeFetch: FetchImpl = getNativeFetchImplementation(),
-): Transport {
+export function makeFetchTransport(options: BrowserTransportOptions, maybeNativeFetch?: FetchImpl): Transport {
   function makeRequest(request: TransportRequest): PromiseLike<TransportMakeRequestResponse> {
+    // Lazy initialization of the native fetch implementation.
+    // So that if `getNativeFetchImplementation` causes DOM I/O it
+    // happens when request is made, not during Sentry initialization.
+    const nativeFetch = maybeNativeFetch || getNativeFetchImplementation();
+
     const requestOptions: RequestInit = {
       body: request.body,
       method: 'POST',


### PR DESCRIPTION
Partly addresses https://github.com/getsentry/sentry-javascript/issues/6177.

In the case of other 3rd parties monkey patching fetch, we run into some expensive I/O, which is blocking the main thread on initial load. Since this can be expensive, we instead defer this to when the first request is sent. From there, we should always be using the cached impl.