### PR TITLE
chore: Update craft config in preparation for otel release

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -21,9 +21,7 @@ targets:
           cacheControl: 'public, max-age=31536000'
   - name: github
     includeNames: /^sentry-.*$/
-    excludeNames: /^sentry-opentelemetry-node-.*$/
   - name: npm
-    excludeNames: /^sentry-opentelemetry-node-.*.tgz$/
   - name: registry
     sdks:
       'npm:@sentry/browser':


### PR DESCRIPTION
ref: #6000 

Stop excluding the otel package for release stuff.