### PR TITLE
fix(integrations): Remove erroneous WINDOW exports

### DIFF
--- a/packages/integrations/src/offline.ts
+++ b/packages/integrations/src/offline.ts
@@ -4,7 +4,7 @@ import { Event, EventProcessor, Hub, Integration } from '@sentry/types';
 import { GLOBAL_OBJ, logger, normalize, uuid4 } from '@sentry/utils';
 import localForage from 'localforage';
 
-export const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
+const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
 
 type LocalForage = {
   setItem<T>(key: string, value: T, callback?: (err: any, value: T) => void): Promise<T>;

--- a/packages/integrations/src/reportingobserver.ts
+++ b/packages/integrations/src/reportingobserver.ts
@@ -1,7 +1,7 @@
 import { EventProcessor, Hub, Integration } from '@sentry/types';
 import { GLOBAL_OBJ, supportsReportingObserver } from '@sentry/utils';
 
-export const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
+const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
 
 interface Report {
   [key: string]: unknown;


### PR DESCRIPTION
Fixes #6183

These ended up in the TypeScript definitions because they are exported but they should never have been exported!
