### PR TITLE
chore(otel): Make @sentry/opentelemetry-node public

### DIFF
--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -2,7 +2,6 @@
   "name": "@sentry/opentelemetry-node",
   "version": "7.18.0",
   "description": "Official Sentry SDK for OpenTelemetry Node.js",
-  "private": true,
   "repository": "git://github.com/getsentry/sentry-javascript.git",
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/opentelemetry-node",
   "author": "Sentry",


### PR DESCRIPTION
Ah, just noticed, I forgot about this 😬 should be merged before https://github.com/getsentry/sentry-javascript/pull/6186 I guess!