### PR TITLE
chore(otel): Add missing imports to otel readme

### DIFF
--- a/packages/opentelemetry-node/README.md
+++ b/packages/opentelemetry-node/README.md
@@ -36,8 +36,10 @@ You need to register the `SentrySpanProcessor` and `SentryPropagator` with your 
 
 ```js
 import * as Sentry from '@sentry/node';
-import * as otelApi from '@opentelemetry/api';
 import { SentrySpanProcessor } from '@sentry/opentelemetry-node';
+import * as otelApi from '@opentelemetry/api';
+import { getNodeAutoInstrumentations } from  '@opentelemetry/auto-instrumentations-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 
 // Make sure to call `Sentry.init` BEFORE initializing the OpenTelemetry SDK
 Sentry.init({


### PR DESCRIPTION
The otel docs are missing some imports, for better clarity.
