### PR TITLE
chore(otel): Add opentelemetry-node to craft config

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -48,3 +48,5 @@ targets:
         onlyIfPresent: /^sentry-remix-.*\.tgz$/
       'npm:@sentry/svelte':
         onlyIfPresent: /^sentry-svelte-.*\.tgz$/
+      'npm:@sentry/opentelemetry-node':
+        onlyIfPresent: /^sentry-opentelemetry-node-.*\.tgz$/


### PR DESCRIPTION
Add the new @sentry/opentelemetry-node package to the craft config.