### PR TITLE
feat(nextjs): Add distDirOverride

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -59,6 +59,14 @@ export type UserSentryOptions = {
 
   // Automatically instrument Next.js data fetching methods and Next.js API routes
   autoInstrumentServerFunctions?: boolean;
+
+  // Override the distDir which is helpful if the if you're using a monorepo, such as Nx.
+  // Ultimately, directs the Sentry CLI to the correct directory.
+  // Monorepo example:
+  //    App Directory: `apps/my-next-app`
+  //    NextJS `distDir` is set to`../../dist/apps/my-next-app/.next`.
+  //    Sentry `distDirOverride` should be set to `dist/apps/my-next-app/.next`, as the CLI is run from the monorepo root.
+  distDirOverride?: string;
 };
 
 export type NextConfigFunction = (phase: string, defaults: { defaultConfig: NextConfigObject }) => NextConfigObject;

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -403,7 +403,7 @@ export function getWebpackPluginOptions(
   const { buildId, isServer, webpack, config, dev: isDev, dir: projectDir } = buildContext;
   const userNextConfig = config as NextConfigObject;
 
-  const distDir = userNextConfig.distDir ?? '.next'; // `.next` is the default directory
+  const distDir = userSentryOptions.distDirOverride ?? userNextConfig.distDir ?? '.next'; // `.next` is the default directory
 
   const isWebpack5 = webpack.version.startsWith('5');
   const isServerless = userNextConfig.target === 'experimental-serverless-trace';


### PR DESCRIPTION
## Problem
We're using a monorepo (Nx) and it runs the NextJS build process in `./apps/web` with the `distDir` set to `../../dist/apps/web/.next`. 

The CLI is being run at the root of the monorepo. As such, `../../dist/apps/web/.next` doesn't find anything when it goes to upload the source maps.

## Proposed Solution
This allows a developer to set the `distDir` for the CLI without compromising the Next `distDir`.

**Order of importance:**
1. `distDirOverride` in the Next `sentry` config object.
2. `distDir` in the Next config.
3. `.next`
----
Didn't really know what to name it so, in the interim, stuck with `distDirOverride`. 🤷 

![image](https://user-images.githubusercontent.com/26691/201433649-7f3df001-8b27-43be-ba5d-8856c787d585.png)