### PR TITLE
ref(core): Move sentry breadcrumb logic into integration

### DIFF
--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable max-lines */
 import { getCurrentHub } from '@sentry/core';
-import { Integration } from '@sentry/types';
+import { Event, Integration } from '@sentry/types';
 import {
   addInstrumentationHandler,
+  getEventDescription,
   htmlTreeAsString,
   parseUrl,
   safeJoin,
@@ -83,6 +84,25 @@ export class Breadcrumbs implements Integration {
     }
     if (this.options.history) {
       addInstrumentationHandler('history', _historyBreadcrumb);
+    }
+  }
+
+  /**
+   * Adds a breadcrumb for Sentry events or transactions if this option is enabled.
+   */
+  public addSentryBreadcrumb(event: Event): void {
+    if (this.options.sentry) {
+      getCurrentHub().addBreadcrumb(
+        {
+          category: `sentry.${event.type === 'transaction' ? 'transaction' : 'event'}`,
+          event_id: event.event_id,
+          level: event.level,
+          message: getEventDescription(event),
+        },
+        {
+          event,
+        },
+      );
     }
   }
 }

--- a/packages/browser/test/unit/integrations/breadcrumbs.test.ts
+++ b/packages/browser/test/unit/integrations/breadcrumbs.test.ts
@@ -1,0 +1,34 @@
+import { BrowserClient, Breadcrumbs, Hub, flush } from '../../../src';
+import { getCurrentHub } from '@sentry/core';
+import { getDefaultBrowserClientOptions } from '../helper/browser-client-options';
+
+const hub = new Hub();
+
+jest.mock('@sentry/core', () => {
+  const original = jest.requireActual('@sentry/core');
+  return {
+    ...original,
+    getCurrentHub: () => hub,
+  };
+});
+
+describe('Breadcrumbs', () => {
+  it('Should add sentry breadcrumb', async () => {
+    const addBreadcrumb = jest.fn();
+    hub.addBreadcrumb = addBreadcrumb;
+
+    const client = new BrowserClient({
+      ...getDefaultBrowserClientOptions(),
+      dsn: 'https://username@domain/123',
+      integrations: [new Breadcrumbs()],
+    });
+
+    getCurrentHub().bindClient(client);
+
+    client.captureMessage('test');
+    await flush(2000);
+
+    expect(addBreadcrumb.mock.calls[0][0].category).toEqual('sentry.event');
+    expect(addBreadcrumb.mock.calls[0][0].message).toEqual('test');
+  });
+});

--- a/packages/browser/test/unit/integrations/breadcrumbs.test.ts
+++ b/packages/browser/test/unit/integrations/breadcrumbs.test.ts
@@ -1,5 +1,6 @@
-import { BrowserClient, Breadcrumbs, Hub, flush } from '../../../src';
 import { getCurrentHub } from '@sentry/core';
+
+import { Breadcrumbs, BrowserClient, flush, Hub } from '../../../src';
 import { getDefaultBrowserClientOptions } from '../helper/browser-client-options';
 
 const hub = new Hub();


### PR DESCRIPTION
`getIntegrationById` is used to ensure that the `Breadcrumbs` integration is not included in the bundle when it's not used. 

Moving this logic from the `BaseClient` into the integration should save further bundle size when the `Breadcrumbs` integration is not used, especially since `getEventDescription` will no longer be included too.