### PR TITLE
feat(nextjs): Enable Sentry in allowed preview branches

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -37,6 +37,10 @@ export type NextConfigObject = {
 };
 
 export type UserSentryOptions = {
+  // Override the automatic disabling of Sentry when `VERCEL_ENV` is `preview`.
+  // Useful for `preview` -> `staging` -> `production` workflows.
+  allowedPreviewBranches?: string[];
+
   // Override the SDK's default decision about whether or not to enable to the webpack plugin. Note that `false` forces
   // the plugin to be enabled, even in situations where it's not recommended.
   disableServerWebpackPlugin?: boolean;

--- a/packages/nextjs/test/config/webpack/sentryWebpackPlugin.test.ts
+++ b/packages/nextjs/test/config/webpack/sentryWebpackPlugin.test.ts
@@ -306,7 +306,6 @@ describe('Sentry webpack plugin config', () => {
         true,
         false,
       ],
-
       [
         'obeys `disableServerWebpackPlugin = true`',
         {
@@ -323,6 +322,16 @@ describe('Sentry webpack plugin config', () => {
         { VERCEL_ENV: 'preview' },
         false,
         false,
+      ],
+      [
+        'allows the plugin in Vercel `preview` environment with a branch of `staging`',
+        {
+          ...exportedNextConfig,
+          sentry: { allowedPreviewBranches: ['staging'] },
+        },
+        { VERCEL_ENV: 'preview', VERCEL_GIT_COMMIT_REF: 'staging' },
+        true,
+        true,
       ],
       [
         'disables the plugin in Vercel `development` environment',


### PR DESCRIPTION
There are cases where you can have one, or more, preview branches which don't act like normal preview branches. As-is, though, Sentry doesn't initialize on **any**  preview `VERCEL_ENV`.

Take a `staging` branch, for example, as instructed by Vercel: [Vercel Docs](https://vercel.com/guides/set-up-a-staging-environment-on-vercel)

This PR enables the ability to define `preview` environments, via `allowedPreviewBranches`,  where Sentry should still be initialized. It uses another system environment variable, `VERCEL_GIT_COMMIT_REF`, to determine if it should be initialized, which is similar to how they determine which custom domain should be set and environment variables served up.