### PR TITLE
feat(tracing): Add interaction transaction as an experiment

### DIFF
--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/assets/script.js
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/assets/script.js
@@ -1,0 +1,12 @@
+(() => {
+  const startTime = Date.now();
+
+  function getElasped() {
+    const time = Date.now();
+    return time - startTime;
+  }
+
+  while (getElasped() < 105) {
+    //
+  }
+})();

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/init.js
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/init.js
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/browser';
+import { Integrations } from '@sentry/tracing';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [
+    new Integrations.BrowserTracing({
+      idleTimeout: 1000,
+      _experiments: {
+        interactionSampleRate: 1.0,
+      },
+    }),
+  ],
+  tracesSampleRate: 1,
+});

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/init.js
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/init.js
@@ -9,7 +9,7 @@ Sentry.init({
     new Integrations.BrowserTracing({
       idleTimeout: 1000,
       _experiments: {
-        interactionSampleRate: 1.0,
+        enableInteractions: true,
       },
     }),
   ],

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/template.html
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/template.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <div>Rendered Before Long Task</div>
+    <script src="https://example.com/path/to/script.js"></script>
+    <button data-test-id="interaction-button">Click Me</button>
+  </body>
+</html>

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
@@ -1,0 +1,36 @@
+import { expect, Route } from '@playwright/test';
+import { Event } from '@sentry/types';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest, getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
+
+sentryTest('should capture interaction transaction.', async ({ browserName, getLocalTestPath, page }) => {
+  if (browserName !== 'chromium') {
+    sentryTest.skip();
+  }
+
+  await page.route('**/path/to/script.js', (route: Route) => route.fulfill({ path: `${__dirname}/assets/script.js` }));
+
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  await getFirstSentryEnvelopeRequest<Event>(page, url);
+
+  await page.locator('[data-test-id=interaction-button]').click();
+
+  const envelopes = await getMultipleSentryEnvelopeRequests<Event>(page, 2);
+  const eventData = envelopes[1];
+
+  expect(eventData).toEqual(
+    expect.objectContaining({
+      contexts: expect.objectContaining({
+        trace: expect.objectContaining({
+          op: 'ui.action.click',
+        }),
+      }),
+      platform: 'javascript',
+      spans: [],
+      tags: {},
+      type: 'transaction',
+    }),
+  );
+});

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
@@ -17,8 +17,8 @@ sentryTest('should capture interaction transaction.', async ({ browserName, getL
 
   await page.locator('[data-test-id=interaction-button]').click();
 
-  const envelopes = await getMultipleSentryEnvelopeRequests<Event>(page, 2);
-  const eventData = envelopes[1];
+  const envelopes = await getMultipleSentryEnvelopeRequests<Event>(page, 1);
+  const eventData = envelopes[0];
 
   expect(eventData).toEqual(
     expect.objectContaining({

--- a/packages/integration-tests/utils/generatePlugin.ts
+++ b/packages/integration-tests/utils/generatePlugin.ts
@@ -49,6 +49,7 @@ const BUNDLE_PATHS: Record<string, Record<string, string>> = {
 function generateSentryAlias(): Record<string, string> {
   const packageNames = readdirSync(PACKAGES_DIR, { withFileTypes: true })
     .filter(dirent => dirent.isDirectory())
+    .filter(dir => !['apm', 'minimal', 'next-plugin-sentry'].includes(dir.name))
     .map(dir => dir.name);
 
   return Object.fromEntries(

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -89,6 +89,7 @@ describe('BrowserTracing', () => {
     expect(browserTracing.options).toEqual({
       _experiments: {
         enableLongTask: true,
+        enableInteractions: false,
       },
       idleTimeout: DEFAULT_IDLE_TIMEOUT,
       finalTimeout: DEFAULT_FINAL_TIMEOUT,


### PR DESCRIPTION
### Summary
This adds interactions as an experiment so we can try it out with Sentry SaaS before tuning it for general release. It's behind a rate as an experiment option and only makes idleTransactions on 'click' for now. Future considerations include us likely having differing idleTimeout settings, and being more clever with which data we include, but this should be enough to start experimenting.

For rollout, we can potentially release this as a branch / beta for our SaaS experiment first.

#### Other:
- re: playwright tests I'll need to fix them since they seem to work in debug but not regularly, I think it's a timeout issue.
- refs earlier convos I've had with @AbhiPrasad about interactions, https://github.com/getsentry/sentry-javascript/issues/5750
- We're planning on introducing the INP web vital via interaction transactions hopefully, if it makes sense. That might change which interaction transactions we choose to send, or we might need dynamic sampling work to bias towards interactions with INP. Otherwise our other main option will be out-of-transaction metrics, which will be a larger amount of work. 