### PR TITLE
feat(meta): Send SDK source data

### DIFF
--- a/packages/core/src/envelope.ts
+++ b/packages/core/src/envelope.ts
@@ -35,6 +35,8 @@ function enhanceEventWithSdkInfo(event: Event, sdkInfo?: SdkInfo): Event {
   event.sdk.version = event.sdk.version || sdkInfo.version;
   event.sdk.integrations = [...(event.sdk.integrations || []), ...(sdkInfo.integrations || [])];
   event.sdk.packages = [...(event.sdk.packages || []), ...(sdkInfo.packages || [])];
+  // Either 'CDN', 'npm', or 'lambdaLayer'. This is hardcoded as part of our build process.
+  event.sdk.source = '__SDK_SOURCE__';
   return event;
 }
 

--- a/packages/serverless/rollup.aws.config.js
+++ b/packages/serverless/rollup.aws.config.js
@@ -5,7 +5,7 @@ export default [
   ...makeBundleConfigVariants(
     makeBaseBundleConfig({
       // this automatically sets it to be CJS
-      bundleType: 'node',
+      bundleType: 'lambdaLayer',
       entrypoints: ['src/index.awslambda.ts'],
       jsVersion: 'es6',
       licenseTitle: '@sentry/serverless',

--- a/packages/types/src/sdkinfo.ts
+++ b/packages/types/src/sdkinfo.ts
@@ -5,4 +5,6 @@ export interface SdkInfo {
   version?: string;
   integrations?: string[];
   packages?: Package[];
+  // Either 'CDN', 'npm', or 'lambdaLayer'. This is hardcoded as part of our build process.
+  source?: string;
 }

--- a/rollup/bundleHelpers.js
+++ b/rollup/bundleHelpers.js
@@ -83,7 +83,7 @@ export function makeBaseBundleConfig(options) {
   };
 
   // used by `@sentry/serverless`, when creating the lambda layer
-  const nodeBundleConfig = {
+  const lambdaLayerBundleConfig = {
     output: {
       format: 'cjs',
     },
@@ -113,7 +113,7 @@ export function makeBaseBundleConfig(options) {
   const bundleTypeConfigMap = {
     standalone: standAloneBundleConfig,
     addon: addOnBundleConfig,
-    node: nodeBundleConfig,
+    lambdaLayer: lambdaLayerBundleConfig,
   };
 
   return deepMerge.all([sharedBundleConfig, bundleTypeConfigMap[bundleType], packageSpecificConfig || {}], {

--- a/rollup/bundleHelpers.js
+++ b/rollup/bundleHelpers.js
@@ -10,6 +10,7 @@ import {
   makeBrowserBuildPlugin,
   makeCommonJSPlugin,
   makeIsDebugBuildPlugin,
+  makeSDKSourcePlugin,
   makeLicensePlugin,
   makeNodeResolvePlugin,
   makeCleanupPlugin,
@@ -28,6 +29,8 @@ export function makeBaseBundleConfig(options) {
   const sucrasePlugin = makeSucrasePlugin();
   const cleanupPlugin = makeCleanupPlugin();
   const markAsBrowserBuildPlugin = makeBrowserBuildPlugin(true);
+  const markAsCDNSourcePlugin = makeSDKSourcePlugin('CDN');
+  const markAsLambdaLayerSourcePlugin = makeSDKSourcePlugin('lambdaLayer');
   const licensePlugin = makeLicensePlugin(licenseTitle);
   const tsPlugin = makeTSPlugin(jsVersion.toLowerCase());
 
@@ -43,7 +46,7 @@ export function makeBaseBundleConfig(options) {
       name: 'Sentry',
     },
     context: 'window',
-    plugins: [markAsBrowserBuildPlugin],
+    plugins: [markAsBrowserBuildPlugin, markAsCDNSourcePlugin],
   };
 
   // used by `@sentry/integrations` and `@sentry/wasm` (bundles which need to be combined with a stand-alone SDK bundle)
@@ -76,7 +79,7 @@ export function makeBaseBundleConfig(options) {
       // code to add after the CJS wrapper
       footer: '}(window));',
     },
-    plugins: [markAsBrowserBuildPlugin],
+    plugins: [markAsBrowserBuildPlugin, markAsCDNSourcePlugin],
   };
 
   // used by `@sentry/serverless`, when creating the lambda layer
@@ -84,7 +87,7 @@ export function makeBaseBundleConfig(options) {
     output: {
       format: 'cjs',
     },
-    plugins: [commonJSPlugin],
+    plugins: [commonJSPlugin, markAsLambdaLayerSourcePlugin],
     // Don't bundle any of Node's core modules
     external: builtinModules,
   };

--- a/rollup/npmHelpers.js
+++ b/rollup/npmHelpers.js
@@ -13,6 +13,7 @@ import {
   makeCleanupPlugin,
   makeSucrasePlugin,
   makeDebugBuildStatementReplacePlugin,
+  makeSDKSourcePlugin,
 } from './plugins/index.js';
 import { mergePlugins } from './utils';
 
@@ -31,6 +32,7 @@ export function makeBaseNPMConfig(options = {}) {
   const debugBuildStatementReplacePlugin = makeDebugBuildStatementReplacePlugin();
   const cleanupPlugin = makeCleanupPlugin();
   const extractPolyfillsPlugin = makeExtractPolyfillsPlugin();
+  const markAsNPMSourcePlugin = makeSDKSourcePlugin('npm');
 
   const defaultBaseConfig = {
     input: entrypoints,
@@ -85,6 +87,7 @@ export function makeBaseNPMConfig(options = {}) {
       nodeResolvePlugin,
       sucrasePlugin,
       debugBuildStatementReplacePlugin,
+      markAsNPMSourcePlugin,
       cleanupPlugin,
       extractPolyfillsPlugin,
     ],

--- a/rollup/plugins/npmPlugins.js
+++ b/rollup/plugins/npmPlugins.js
@@ -104,4 +104,21 @@ export function makeDebugBuildStatementReplacePlugin() {
   });
 }
 
+/**
+ * Creates a plugin to replace all instances of "__SDK_SOURCE__" with either "CDN" or "npm".
+ *
+ * @returns A `@rollup/plugin-replace` instance.
+ */
+export function makeSDKSourcePlugin(source) {
+  return replace({
+    // TODO `preventAssignment` will default to true in version 5.x of the replace plugin, at which point we can get rid
+    // of this. (It actually makes no difference in this case whether it's true or false, since we never assign to
+    // `__SDK_SOURCE__`, but if we don't give it a value, it will spam with warnings.)
+    preventAssignment: true,
+    values: {
+      __SDK_SOURCE__: source,
+    },
+  });
+}
+
 export { makeExtractPolyfillsPlugin } from './extractPolyfillsPlugin.js';


### PR DESCRIPTION
NOTE: This is currently not fully working because right now only pre-ordained fields come through in the `sdk` object (relay just drops everything else). The procedures for getting new data to be accepted by relay, and for making sure that data is queryable are WIPs. Until that's figured out, this will stay in draft status.

----------------

We wonder sometimes how many people use our SDK via CDN, npm, and as a lambda layer. This adds it to the build so it can be hardcoded into the bundle/package. It also then includes that value in the `sdk` field for events.

Ref: https://github.com/getsentry/sentry-javascript/issues/6256