### PR TITLE
fix(core): Include `_sdkProcessingMetadata` when cloning scope

### DIFF
--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -95,6 +95,8 @@ export class Scope implements ScopeInterface {
   /** Request Mode Session Status */
   protected _requestSession?: RequestSession;
 
+  // NOTE: Any field which gets added here should get added not only to the constructor but also to the `clone` method.
+
   public constructor() {
     this._notifyingListeners = false;
     this._scopeListeners = [];
@@ -128,6 +130,7 @@ export class Scope implements ScopeInterface {
       newScope._eventProcessors = [...scope._eventProcessors];
       newScope._requestSession = scope._requestSession;
       newScope._attachments = [...scope._attachments];
+      newScope._sdkProcessingMetadata = { ...scope._sdkProcessingMetadata };
     }
     return newScope;
   }


### PR DESCRIPTION
When I added the `_sdkProcessingMetadata` field to `Scope`, I missed adding it to the `clone` method. This fixes that.

Addresses the `withScope` problem mentioned in https://github.com/getsentry/sentry-javascript/issues/6139#issuecomment-1310839406. (TL;DR - the stored request upon which the `RequestData` integration relies was getting lost when `withScope` was called, which in turn meant that no request data was coming through.)