### PR TITLE
feat(angular): Add Angular 15 Peer Dependencies

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -15,9 +15,9 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@angular/common": "10.x || 11.x || 12.x || 13.x || 14.x",
-    "@angular/core": "10.x || 11.x || 12.x || 13.x || 14.x",
-    "@angular/router": "10.x || 11.x || 12.x || 13.x || 14.x",
+    "@angular/common": "10.x || 11.x || 12.x || 13.x || 14.x || 15.x",
+    "@angular/core": "10.x || 11.x || 12.x || 13.x || 14.x || 15.x",
+    "@angular/router": "10.x || 11.x || 12.x || 13.x || 14.x || 15.x",
     "rxjs": "^6.5.5 || ^7.x"
   },
   "dependencies": {


### PR DESCRIPTION
This PR adds Angular 15 support by adding `15.x` as a peer dependency version for the Angular packages. A quick test suggests that all previous features seem to work as usual. Still have to do some experiments with new NG15 features but for now we can at least add basic support and unblock anyone who wants to update to v15. 

ref #6219 