### PR TITLE
fix(angular): Set `unknown` component name default in `TraceDirective`

### DIFF
--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -159,7 +159,7 @@ const UNKNOWN_COMPONENT = 'unknown';
  */
 @Directive({ selector: '[trace]' })
 export class TraceDirective implements OnInit, AfterViewInit {
-  @Input('trace') public componentName: string = UNKNOWN_COMPONENT;
+  @Input('trace') public componentName?: string;
 
   private _tracingSpan?: Span;
 
@@ -168,6 +168,10 @@ export class TraceDirective implements OnInit, AfterViewInit {
    * @inheritdoc
    */
   public ngOnInit(): void {
+    if (!this.componentName) {
+      this.componentName = UNKNOWN_COMPONENT;
+    }
+
     const activeTransaction = getActiveTransaction();
     if (activeTransaction) {
       this._tracingSpan = activeTransaction.startChild({


### PR DESCRIPTION
This PR fixes a bug in the Angular SDK's `TraceDirective` where previously, the fallback `UNKNOWN_COMPONENT` name wasn't correctly applied to the span description if users didn't specify a manual value for the directive:

```html
<!-- this adds <standalone1> as a span description  -->
<app-my-component trace="standalone1"></app-my-component>

<!-- this used to add <> as a span description  -->
<!-- With this fix, we now get <unknown> as a span description  -->
<app-my-component trace></app-my-component>
``` 

Stumbled across this while testing v15 standalone components so... ref #6219 

The reason for this bug is that Angular apparently doesn't entirely respect default values for inputs of directives that have the same name as the directive (but we def want this). 

Note: We do actually [have a test for this](https://github.com/getsentry/sentry-javascript/blob/0ee35f070927b47a37270d6037a3f004f3bce492/packages/angular/test/tracing.test.ts#L263-L265) and according to that test, everything worked fine before. This, however, was a problem with the test setup because creating a new instance of `TraceDirective` (which is what the test does) is different behaviour to specifying `trace` without a name in the component template. With this change now, also this test now fails, if the fallback would not be set correctly so I don't think we strictly need another test here.

Note2: There is [another way](https://plnkr.co/edit/IZn533jzlXRydwkIZNZB?p=preview&preview) how to set default values for inputs with the same name as the directive selector. However, I don't consider this particularly cleaner so I opted for this way instead which should also have less bundle size impact than the way above.