### PR TITLE
feat(angular): Auto-detect component name in `TraceDirective`

### DIFF
--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -2,6 +2,7 @@
 import {
   AfterViewInit,
   Directive,
+  Inject,
   Injectable,
   Input,
   NgModule,
@@ -173,7 +174,7 @@ export class TraceDirective implements OnInit, AfterViewInit {
 
   private _tracingSpan?: Span;
 
-  public constructor(@Optional() private readonly _vcRef: ViewContainerRef) {}
+  public constructor(@Optional() @Inject(ViewContainerRef) private readonly _vcRef: ViewContainerRef) {}
 
   /**
    * Implementation of OnInit lifecycle method
@@ -181,7 +182,7 @@ export class TraceDirective implements OnInit, AfterViewInit {
    */
   public ngOnInit(): void {
     if (!this.componentName) {
-      this.componentName = detectComponentName(this._vcRef as EnhancedVieContainerRef);
+      this.componentName = detectComponentName(this._vcRef as EnhancedViewContainerRef);
     }
 
     const activeTransaction = getActiveTransaction();
@@ -204,7 +205,7 @@ export class TraceDirective implements OnInit, AfterViewInit {
   }
 }
 
-type EnhancedVieContainerRef = ViewContainerRef & {
+type EnhancedViewContainerRef = ViewContainerRef & {
   _lContainer?: {
     localName?: string;
   }[][];
@@ -215,10 +216,9 @@ type EnhancedVieContainerRef = ViewContainerRef & {
  * Specifically, it looks up the selector of the component (e.g. `app-my-component`) or
  * falls back to the default component name if the selector is not available.
  */
-function detectComponentName(vcRef: EnhancedVieContainerRef | undefined): string {
+function detectComponentName(vcRef: EnhancedViewContainerRef | undefined): string {
   if (vcRef && vcRef._lContainer && vcRef._lContainer[0] && vcRef._lContainer[0][0]) {
-    // TODO: is this preferrable?
-    // Alternative: We could get the class name like so:
+    // Alternatively, we could get the class name like so:
     // const className = Object.getPrototypeOf(vcRef._lContainer[0][8]).constructor.name;
 
     const selectorName = vcRef._lContainer[0][0].localName;

--- a/packages/angular/test/tracing.test.ts
+++ b/packages/angular/test/tracing.test.ts
@@ -256,12 +256,50 @@ describe('Angular Tracing', () => {
 
   describe('TraceDirective', () => {
     it('should create an instance', () => {
-      const directive = new TraceDirective();
+      const directive = new TraceDirective({} as unknown as any);
       expect(directive).toBeTruthy();
     });
 
+    it('should create a child tracingSpan on init (WIP)', async () => {
+      const customStartTransaction = jest.fn(defaultStartTransaction);
+
+      @Component({
+        selector: 'app-component',
+        template: `<app-child trace></app-child>`,
+      })
+      class AppComponent {
+        public constructor() {}
+      }
+
+      @Component({
+        selector: 'app-child',
+        template: `<p>Hi</p>`,
+      })
+      class ChildComponent {
+        public constructor() {}
+      }
+
+      const env = await TestEnv.setup({
+        components: [AppComponent, ChildComponent, TraceDirective],
+        defaultComponent: AppComponent,
+        customStartTransaction,
+        useTraceService: false,
+      });
+
+      transaction.startChild = jest.fn();
+
+      //directive.ngOnInit();
+
+      expect(transaction.startChild).toHaveBeenCalledWith({
+        op: 'ui.angular.init',
+        description: '<unknown>',
+      });
+
+      env.destroy();
+    });
+
     it('should create a child tracingSpan on init', async () => {
-      const directive = new TraceDirective();
+      //const directive = new TraceDirective({} as unknown as any);
       const customStartTransaction = jest.fn(defaultStartTransaction);
 
       const env = await TestEnv.setup({
@@ -272,7 +310,7 @@ describe('Angular Tracing', () => {
 
       transaction.startChild = jest.fn();
 
-      directive.ngOnInit();
+      //directive.ngOnInit();
 
       expect(transaction.startChild).toHaveBeenCalledWith({
         op: 'ui.angular.init',
@@ -283,7 +321,7 @@ describe('Angular Tracing', () => {
     });
 
     it('should use component name as span description', async () => {
-      const directive = new TraceDirective();
+      const directive = new TraceDirective({} as unknown as any);
       const finishMock = jest.fn();
       const customStartTransaction = jest.fn(defaultStartTransaction);
 
@@ -309,7 +347,7 @@ describe('Angular Tracing', () => {
     });
 
     it('should finish tracingSpan after view init', async () => {
-      const directive = new TraceDirective();
+      const directive = new TraceDirective({} as unknown as any);
       const finishMock = jest.fn();
       const customStartTransaction = jest.fn(defaultStartTransaction);
 

--- a/packages/angular/test/tracing.test.ts
+++ b/packages/angular/test/tracing.test.ts
@@ -4,7 +4,7 @@ import { Hub } from '@sentry/types';
 
 import { instrumentAngularRouting, TraceClassDecorator, TraceDirective, TraceMethodDecorator } from '../src';
 import { getParameterizedRouteFromSnapshot } from '../src/tracing';
-import { AppComponent, TestEnv } from './utils/index';
+import { AppComponent, TestEnv, TestViewContainerRef } from './utils/index';
 
 let transaction: any;
 
@@ -265,7 +265,7 @@ describe('Angular Tracing', () => {
 
       @Component({
         selector: 'app-component',
-        template: `<app-child trace></app-child>`,
+        template: '<app-child trace></app-child>',
       })
       class AppComponent {
         public constructor() {}
@@ -273,7 +273,7 @@ describe('Angular Tracing', () => {
 
       @Component({
         selector: 'app-child',
-        template: `<p>Hi</p>`,
+        template: '<p>Hi</p>',
       })
       class ChildComponent {
         public constructor() {}
@@ -288,7 +288,7 @@ describe('Angular Tracing', () => {
 
       transaction.startChild = jest.fn();
 
-      //directive.ngOnInit();
+      // directive.ngOnInit();
 
       expect(transaction.startChild).toHaveBeenCalledWith({
         op: 'ui.angular.init',
@@ -299,7 +299,7 @@ describe('Angular Tracing', () => {
     });
 
     it('should create a child tracingSpan on init', async () => {
-      //const directive = new TraceDirective({} as unknown as any);
+      // const directive = new TraceDirective({} as unknown as any);
       const customStartTransaction = jest.fn(defaultStartTransaction);
 
       const env = await TestEnv.setup({
@@ -310,7 +310,7 @@ describe('Angular Tracing', () => {
 
       transaction.startChild = jest.fn();
 
-      //directive.ngOnInit();
+      // directive.ngOnInit();
 
       expect(transaction.startChild).toHaveBeenCalledWith({
         op: 'ui.angular.init',
@@ -347,7 +347,8 @@ describe('Angular Tracing', () => {
     });
 
     it('should finish tracingSpan after view init', async () => {
-      const directive = new TraceDirective({} as unknown as any);
+      // @ts-ignore - we don't need to pass a param here
+      const directive = new TraceDirective(new TestViewContainerRef());
       const finishMock = jest.fn();
       const customStartTransaction = jest.fn(defaultStartTransaction);
 

--- a/packages/angular/test/utils/index.ts
+++ b/packages/angular/test/utils/index.ts
@@ -1,4 +1,4 @@
-import { Component, NgModule } from '@angular/core';
+import { Component, NgModule, ViewContainerRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router, Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -65,7 +65,12 @@ export class TestEnv {
               deps: [Router],
             },
           ]
-        : [],
+        : [
+            {
+              provide: ViewContainerRef,
+              useValue: new TestViewContainerRef(),
+            },
+          ],
     });
 
     const router: Router = TestBed.inject(Router);
@@ -92,5 +97,58 @@ export class TestEnv {
     }
 
     jest.clearAllMocks();
+  }
+}
+
+// create the test class
+export class TestViewContainerRef extends ViewContainerRef {
+  get element(): import('@angular/core').ElementRef<any> {
+    throw new Error('Method not implemented.');
+  }
+  get injector(): import('@angular/core').Injector {
+    throw new Error('Method not implemented.');
+  }
+  get parentInjector(): import('@angular/core').Injector {
+    throw new Error('Method not implemented.');
+  }
+  clear(): void {
+    throw new Error('Method not implemented.');
+  }
+  get(_index: number): import('@angular/core').ViewRef {
+    throw new Error('Method not implemented.');
+  }
+  get length(): number {
+    throw new Error('Method not implemented.');
+  }
+  createEmbeddedView<C>(
+    _templateRef: import('@angular/core').TemplateRef<C>,
+    _context?: C,
+    _index?: number,
+  ): import('@angular/core').EmbeddedViewRef<C> {
+    throw new Error('Method not implemented.');
+  }
+  createComponent<C>(
+    _componentFactory: import('@angular/core').ComponentFactory<C>,
+    _index?: number,
+    _injector?: import('@angular/core').Injector,
+    _projectableNodes?: any[][],
+    _ngModule?: import('@angular/core').NgModuleRef<any>,
+  ): import('@angular/core').ComponentRef<C> {
+    throw new Error('Method not implemented.');
+  }
+  insert(_viewRef: import('@angular/core').ViewRef, _index?: number): import('@angular/core').ViewRef {
+    throw new Error('Method not implemented.');
+  }
+  move(_viewRef: import('@angular/core').ViewRef, _currentIndex: number): import('@angular/core').ViewRef {
+    throw new Error('Method not implemented.');
+  }
+  indexOf(_viewRef: import('@angular/core').ViewRef): number {
+    throw new Error('Method not implemented.');
+  }
+  remove(_index?: number): void {
+    throw new Error('Method not implemented.');
+  }
+  detach(_index?: number): import('@angular/core').ViewRef {
+    throw new Error('Method not implemented.');
   }
 }

--- a/packages/angular/test/utils/index.ts
+++ b/packages/angular/test/utils/index.ts
@@ -1,4 +1,4 @@
-import { Component, NgModule, ViewContainerRef } from '@angular/core';
+import { Component, NgModule } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router, Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -65,12 +65,7 @@ export class TestEnv {
               deps: [Router],
             },
           ]
-        : [
-            {
-              provide: ViewContainerRef,
-              useValue: new TestViewContainerRef(),
-            },
-          ],
+        : [],
     });
 
     const router: Router = TestBed.inject(Router);
@@ -97,58 +92,5 @@ export class TestEnv {
     }
 
     jest.clearAllMocks();
-  }
-}
-
-// create the test class
-export class TestViewContainerRef extends ViewContainerRef {
-  get element(): import('@angular/core').ElementRef<any> {
-    throw new Error('Method not implemented.');
-  }
-  get injector(): import('@angular/core').Injector {
-    throw new Error('Method not implemented.');
-  }
-  get parentInjector(): import('@angular/core').Injector {
-    throw new Error('Method not implemented.');
-  }
-  clear(): void {
-    throw new Error('Method not implemented.');
-  }
-  get(_index: number): import('@angular/core').ViewRef {
-    throw new Error('Method not implemented.');
-  }
-  get length(): number {
-    throw new Error('Method not implemented.');
-  }
-  createEmbeddedView<C>(
-    _templateRef: import('@angular/core').TemplateRef<C>,
-    _context?: C,
-    _index?: number,
-  ): import('@angular/core').EmbeddedViewRef<C> {
-    throw new Error('Method not implemented.');
-  }
-  createComponent<C>(
-    _componentFactory: import('@angular/core').ComponentFactory<C>,
-    _index?: number,
-    _injector?: import('@angular/core').Injector,
-    _projectableNodes?: any[][],
-    _ngModule?: import('@angular/core').NgModuleRef<any>,
-  ): import('@angular/core').ComponentRef<C> {
-    throw new Error('Method not implemented.');
-  }
-  insert(_viewRef: import('@angular/core').ViewRef, _index?: number): import('@angular/core').ViewRef {
-    throw new Error('Method not implemented.');
-  }
-  move(_viewRef: import('@angular/core').ViewRef, _currentIndex: number): import('@angular/core').ViewRef {
-    throw new Error('Method not implemented.');
-  }
-  indexOf(_viewRef: import('@angular/core').ViewRef): number {
-    throw new Error('Method not implemented.');
-  }
-  remove(_index?: number): void {
-    throw new Error('Method not implemented.');
-  }
-  detach(_index?: number): import('@angular/core').ViewRef {
-    throw new Error('Method not implemented.');
   }
 }


### PR DESCRIPTION
WIP (Still fighting tests, will come back to it later)
(Also, if we merge this, we'll need to adjust docs)

Thought I'd give this a quick try after working on #6222 

This PR adds auto detection of the component name in which `TraceDirective` is used. This makes it unnecessary for users in the future to specifiy a name in the trace directive unless they want to: 

```html
<!-- span description: <CustomName> -->
<app-sample-component trace="CustomName"></app-sample-component>
<!-- New: span description: <app-sample-component>, previously <unknown> -->
<app-sample-component trace></app-sample-component>
```

The auto detection currently takes the component selector name (`app-sample-component` in the example above). We could theoretically also take the class name (see TODO in code). Both approaches are admittedly quite hacky but the selector one is a little bit less hacky, which is why I opted for it right now.

In case we cannot auto-obtain the selector, we still fall back to `the UNKNONW_COMPONENT` default. 

Tested this with all Angular versions from 10 to 15 and it seems to work in my test apps.