### PR TITLE
ci(deps): Setup dependabot for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    commit-message:
+      prefix: ci
+      prefix-development: ci
+      include: deps


### PR DESCRIPTION
While it makes sense for us to not run dependabot for general dependencies, we should be able to run it for Github Actions at least. This will create PRs once a month for any GHA that has a newer version available. (e.g. update `@actions/checkout@v3` to `@actions/checkout@v4` or similar stuff).

See: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot