### PR TITLE
ci: Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
     commit-message:
       prefix: ci
       prefix-development: ci
-      include: deps
+      include: scope


### PR DESCRIPTION
Apparently, github only validates the dependabot config _after_ merging it 🤦 

See https://github.com/getsentry/sentry-javascript/pull/6227/checks?check_run_id=9569642709. Apparently there is no real way to check this beforehand.