### PR TITLE
ci: Do not run E2E tests for dependabot PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -679,7 +679,10 @@ jobs:
   job_e2e_tests:
     name: E2E Tests
     # We only run E2E tests for non-fork PRs because the E2E tests require secrets to work and they can't be accessed from forks
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # Dependabot PRs sadly also don't have access to secrets, so we skip them as well
+    if:
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      github.actor != 'dependabot[bot]'
     needs: [job_get_metadata, job_build]
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
As they lack access to secrets, we have to skip the E2E tests when running on a dependabot PR.