### PR TITLE
fix(tracing): Make `shouldAttachHeaders` not fall back to default values

### DIFF
--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -19,7 +19,7 @@ export interface RequestInstrumentationOptions {
    * Use `shouldCreateSpanForRequest` to control span creation and `tracePropagationTargets` to control
    * trace header attachment.
    */
-  tracingOrigins?: Array<string | RegExp>;
+  tracingOrigins: Array<string | RegExp>;
 
   /**
    * List of strings and/or regexes used to determine which outgoing requests will have `sentry-trace` and `baggage`
@@ -27,7 +27,7 @@ export interface RequestInstrumentationOptions {
    *
    * Default: ['localhost', /^\//] {@see DEFAULT_TRACE_PROPAGATION_TARGETS}
    */
-  tracePropagationTargets?: Array<string | RegExp>;
+  tracePropagationTargets: Array<string | RegExp>;
 
   /**
    * Flag to disable patching all together for fetch requests.
@@ -105,13 +105,17 @@ type PolymorphicRequestHeaders =
 export const defaultRequestInstrumentationOptions: RequestInstrumentationOptions = {
   traceFetch: true,
   traceXHR: true,
+  // TODO (v8): Remove this property
+  tracingOrigins: DEFAULT_TRACE_PROPAGATION_TARGETS,
+  tracePropagationTargets: DEFAULT_TRACE_PROPAGATION_TARGETS,
 };
 
 /** Registers span creators for xhr and fetch requests  */
 export function instrumentOutgoingRequests(_options?: Partial<RequestInstrumentationOptions>): void {
   // eslint-disable-next-line deprecation/deprecation
   const { traceFetch, traceXHR, tracingOrigins, tracePropagationTargets, shouldCreateSpanForRequest } = {
-    ...defaultRequestInstrumentationOptions,
+    traceFetch: defaultRequestInstrumentationOptions.traceFetch,
+    traceXHR: defaultRequestInstrumentationOptions.traceXHR,
     ..._options,
   };
 

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -10,8 +10,6 @@ import {
 
 import { getActiveTransaction, hasTracingEnabled } from '../utils';
 
-// TODO (v8): Remove `tracingOrigins`
-export const DEFAULT_TRACING_ORIGINS = ['localhost', /^\//];
 export const DEFAULT_TRACE_PROPAGATION_TARGETS = ['localhost', /^\//];
 
 /** Options for Request Instrumentation */
@@ -140,6 +138,7 @@ export function instrumentOutgoingRequests(_options?: Partial<RequestInstrumenta
 /**
  * Creates a function that determines whether to attach tracing headers to a request.
  * This was extracted from `instrumentOutgoingRequests` to make it easier to test shouldAttachHeaders.
+ * We only export this fuction for testing purposes.
  * TODO (v8): Remove `tracingOrigins` which should drastically simplify this function.
  */
 export function makeShouldAttachHeaders(
@@ -147,6 +146,8 @@ export function makeShouldAttachHeaders(
   tracingOrigins: (string | RegExp)[] | undefined,
 ) {
   return (url: string): boolean => {
+    // TODO (v8): Replace the code below with this one-liner:
+    // return stringMatchesSomePattern(url, tracePropagationTargets || DEFAULT_TRACE_PROPAGATION_TARGETS);
     if (tracePropagationTargets || tracingOrigins) {
       return stringMatchesSomePattern(url, tracePropagationTargets || tracingOrigins);
     }

--- a/packages/tracing/test/browser/request.test.ts
+++ b/packages/tracing/test/browser/request.test.ts
@@ -7,7 +7,7 @@ import {
   fetchCallback,
   FetchData,
   instrumentOutgoingRequests,
-  makeShouldAttachHeaders,
+  shouldAttachHeaders,
   xhrCallback,
   XHRData,
 } from '../../src/browser/request';
@@ -395,35 +395,29 @@ describe('callbacks', () => {
 describe('[pre-v8]: shouldAttachHeaders', () => {
   describe('prefer `tracePropagationTargets` over `tracingOrigins`', () => {
     it('should return `true` if the url matches the new tracePropagationTargets', () => {
-      const shouldAttachHeaders = makeShouldAttachHeaders(['example.com'], undefined);
-      expect(shouldAttachHeaders('http://example.com')).toBe(true);
+      expect(shouldAttachHeaders('http://example.com', ['example.com'], undefined)).toBe(true);
     });
 
     it('should return `false` if tracePropagationTargets array is empty', () => {
-      const shouldAttachHeaders = makeShouldAttachHeaders([], ['localhost']);
-      expect(shouldAttachHeaders('http://localhost:3000/test')).toBe(false);
+      expect(shouldAttachHeaders('http://localhost:3000/test', [], ['localhost'])).toBe(false);
     });
 
     it("should return `false` if tracePropagationTargets array doesn't match", () => {
-      const shouldAttachHeaders = makeShouldAttachHeaders(['example.com'], ['localhost']);
-      expect(shouldAttachHeaders('http://localhost:3000/test')).toBe(false);
+      expect(shouldAttachHeaders('http://localhost:3000/test', ['example.com'], ['localhost'])).toBe(false);
     });
   });
 
   describe('tracingOrigins backwards compatibility (tracePropagationTargets not defined)', () => {
     it('should return `true` if the url matches tracingOrigns', () => {
-      const shouldAttachHeaders = makeShouldAttachHeaders(undefined, ['example.com']);
-      expect(shouldAttachHeaders('http://example.com')).toBe(true);
+      expect(shouldAttachHeaders('http://example.com', undefined, ['example.com'])).toBe(true);
     });
 
     it('should return `false` if tracePropagationTargets array is empty', () => {
-      const shouldAttachHeaders = makeShouldAttachHeaders(undefined, []);
-      expect(shouldAttachHeaders('http://localhost:3000/test')).toBe(false);
+      expect(shouldAttachHeaders('http://localhost:3000/test', undefined, [])).toBe(false);
     });
 
     it("should return `false` if tracePropagationTargets array doesn't match", () => {
-      const shouldAttachHeaders = makeShouldAttachHeaders(undefined, ['example.com']);
-      expect(shouldAttachHeaders('http://localhost:3000/test')).toBe(false);
+      expect(shouldAttachHeaders('http://localhost:3000/test', undefined, ['example.com'])).toBe(false);
     });
   });
 
@@ -434,13 +428,11 @@ describe('[pre-v8]: shouldAttachHeaders', () => {
       'http://somewhere.com/test/localhost/123',
       'http://somewhere.com/test?url=localhost:3000&test=123',
     ])('return `true` for urls matching defaults (%s)', url => {
-      const shouldAttachHeaders = makeShouldAttachHeaders(undefined, undefined);
-      expect(shouldAttachHeaders(url)).toBe(true);
+      expect(shouldAttachHeaders(url, undefined, undefined)).toBe(true);
     });
 
     it.each(['notmydoman/api/test', 'example.com'])('return `false` for urls not matching defaults (%s)', url => {
-      const shouldAttachHeaders = makeShouldAttachHeaders(undefined, undefined);
-      expect(shouldAttachHeaders(url)).toBe(false);
+      expect(shouldAttachHeaders(url, undefined, undefined)).toBe(false);
     });
   });
 });

--- a/packages/tracing/test/browser/request.test.ts
+++ b/packages/tracing/test/browser/request.test.ts
@@ -398,10 +398,12 @@ describe('[pre-v8]: shouldAttachHeaders', () => {
       const shouldAttachHeaders = makeShouldAttachHeaders(['example.com'], undefined);
       expect(shouldAttachHeaders('http://example.com')).toBe(true);
     });
+
     it('should return `false` if tracePropagationTargets array is empty', () => {
       const shouldAttachHeaders = makeShouldAttachHeaders([], ['localhost']);
       expect(shouldAttachHeaders('http://localhost:3000/test')).toBe(false);
     });
+
     it("should return `false` if tracePropagationTargets array doesn't match", () => {
       const shouldAttachHeaders = makeShouldAttachHeaders(['example.com'], ['localhost']);
       expect(shouldAttachHeaders('http://localhost:3000/test')).toBe(false);
@@ -413,10 +415,12 @@ describe('[pre-v8]: shouldAttachHeaders', () => {
       const shouldAttachHeaders = makeShouldAttachHeaders(undefined, ['example.com']);
       expect(shouldAttachHeaders('http://example.com')).toBe(true);
     });
+
     it('should return `false` if tracePropagationTargets array is empty', () => {
       const shouldAttachHeaders = makeShouldAttachHeaders(undefined, []);
       expect(shouldAttachHeaders('http://localhost:3000/test')).toBe(false);
     });
+
     it("should return `false` if tracePropagationTargets array doesn't match", () => {
       const shouldAttachHeaders = makeShouldAttachHeaders(undefined, ['example.com']);
       expect(shouldAttachHeaders('http://localhost:3000/test')).toBe(false);
@@ -433,6 +437,7 @@ describe('[pre-v8]: shouldAttachHeaders', () => {
       const shouldAttachHeaders = makeShouldAttachHeaders(undefined, undefined);
       expect(shouldAttachHeaders(url)).toBe(true);
     });
+
     it.each(['notmydoman/api/test', 'example.com'])('return `false` for urls not matching defaults (%s)', url => {
       const shouldAttachHeaders = makeShouldAttachHeaders(undefined, undefined);
       expect(shouldAttachHeaders(url)).toBe(false);

--- a/packages/tracing/test/browser/request.test.ts
+++ b/packages/tracing/test/browser/request.test.ts
@@ -3,7 +3,14 @@ import { Hub, makeMain } from '@sentry/core';
 import * as utils from '@sentry/utils';
 
 import { Span, spanStatusfromHttpCode, Transaction } from '../../src';
-import { fetchCallback, FetchData, instrumentOutgoingRequests, xhrCallback, XHRData } from '../../src/browser/request';
+import {
+  fetchCallback,
+  FetchData,
+  instrumentOutgoingRequests,
+  makeShouldAttachHeaders,
+  xhrCallback,
+  XHRData,
+} from '../../src/browser/request';
 import { addExtensionMethods } from '../../src/hubextensions';
 import * as tracingUtils from '../../src/utils';
 import { getDefaultBrowserClientOptions } from '../testutils';
@@ -380,6 +387,55 @@ describe('callbacks', () => {
 
       xhrCallback(secondReqData, alwaysCreateSpan, alwaysAttachHeaders, {});
       expect(transaction.metadata.propagations).toBe(2);
+    });
+  });
+});
+
+// TODO (v8): Adapt these tests once we remove `tracingOrigins`
+describe('[pre-v8]: shouldAttachHeaders', () => {
+  describe('prefer `tracePropagationTargets` over `tracingOrigins`', () => {
+    it('should return `true` if the url matches the new tracePropagationTargets', () => {
+      const shouldAttachHeaders = makeShouldAttachHeaders(['example.com'], undefined);
+      expect(shouldAttachHeaders('http://example.com')).toBe(true);
+    });
+    it('should return `false` if tracePropagationTargets array is empty', () => {
+      const shouldAttachHeaders = makeShouldAttachHeaders([], ['localhost']);
+      expect(shouldAttachHeaders('http://localhost:3000/test')).toBe(false);
+    });
+    it("should return `false` if tracePropagationTargets array doesn't match", () => {
+      const shouldAttachHeaders = makeShouldAttachHeaders(['example.com'], ['localhost']);
+      expect(shouldAttachHeaders('http://localhost:3000/test')).toBe(false);
+    });
+  });
+
+  describe('tracingOrigins backwards compatibility (tracePropagationTargets not defined)', () => {
+    it('should return `true` if the url matches tracingOrigns', () => {
+      const shouldAttachHeaders = makeShouldAttachHeaders(undefined, ['example.com']);
+      expect(shouldAttachHeaders('http://example.com')).toBe(true);
+    });
+    it('should return `false` if tracePropagationTargets array is empty', () => {
+      const shouldAttachHeaders = makeShouldAttachHeaders(undefined, []);
+      expect(shouldAttachHeaders('http://localhost:3000/test')).toBe(false);
+    });
+    it("should return `false` if tracePropagationTargets array doesn't match", () => {
+      const shouldAttachHeaders = makeShouldAttachHeaders(undefined, ['example.com']);
+      expect(shouldAttachHeaders('http://localhost:3000/test')).toBe(false);
+    });
+  });
+
+  describe('should fall back to defaults if no options are specified', () => {
+    it.each([
+      '/api/test',
+      'http://localhost:3000/test',
+      'http://somewhere.com/test/localhost/123',
+      'http://somewhere.com/test?url=localhost:3000&test=123',
+    ])('return `true` for urls matching defaults (%s)', url => {
+      const shouldAttachHeaders = makeShouldAttachHeaders(undefined, undefined);
+      expect(shouldAttachHeaders(url)).toBe(true);
+    });
+    it.each(['notmydoman/api/test', 'example.com'])('return `false` for urls not matching defaults (%s)', url => {
+      const shouldAttachHeaders = makeShouldAttachHeaders(undefined, undefined);
+      expect(shouldAttachHeaders(url)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
This PR fixes a bug in our `shouldAttachHeaders` function that determines internally if outgoing requests should have headers attached or not. 

Previously, we assigned the default values to `tracingOrigins` as well as `tracePropagationTargets` and overwrote these defaults, if users provided one (or (unlikely) both) options. In `shouldAttachHeaders`, we then first tested `tracingOrigins` for a match and in case there was no match, we'd test `tracePropagationTargets`.  This, however, also meant that if users specified `tracingOrigins` and an URL didn't match them, there was still a chance that headers would be attached - in case the url matched the `tracePropagationTargets`' default values.

With this fix, we don't assign default values to either option but check for definedness of them and only if they're both undefined, well fall back to defaults. 

### Example:
url: `/api/test/123`
tracingOrigins: `[]`
tracePropTargets: `['localhost', /^\//]` // default values

`shouldAttachHeaders` returned `true` but should have returned `false`. This PR fixes this behaviour.

In case, both options are defined, we prefer `tracePropagationTargets` over `tracingOrigins`, as defined in the [dev specification](https://develop.sentry.dev/sdk/performance/#example).

Furthermore, this PR extracts the `shouldAttachHeaders` function by wrapping it in a factory function so that it's easier to test this behaviour. Also, the PR adds some tests to verify correct behaviour.
We can probably get rid of some code around this in v8 when we finally remove `tracingOrigins`.

possibly fixes the reopened issue #6077

Side-note: Because we're exporting `defaultRequestInstrumentationOptions` as public API, I decided to leave the optional value assignment in place but to simply not take the default values from it anymore in `instrumentOutgoingRequests` (see [aed40a6](https://github.com/getsentry/sentry-javascript/pull/6238/commits/aed40a61dcc4a96416e084a6a8cfb588576b389b)).
