### PR TITLE
ci: Make `job_build` required to pass

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -698,6 +698,7 @@ jobs:
     name: All required tests passed or skipped
     needs:
       [
+        job_build,
         job_unit_test,
         job_nextjs_integration_test,
         job_node_integration_tests,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -699,6 +699,7 @@ jobs:
     needs:
       [
         job_build,
+        job_browser_build_tests,
         job_unit_test,
         job_nextjs_integration_test,
         job_node_integration_tests,


### PR DESCRIPTION
Currently, because of the logic of the "required jobs passed" meta-CI-job, we only check direct dependends of this job for success. This means that if the `build` job fails, and all the jobs following this are skipped because of this, it pretends to be "OK", which it is not:

![Screenshot 2022-11-21 at 11 04 30](https://user-images.githubusercontent.com/2411343/203022870-6dfe443e-3b57-4122-8d22-0e909d1a1a39.png)


The solution is to add the build job to `needs` for the required job.

