### PR TITLE
fix(core): Only generate eventIds in client

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -127,8 +127,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
       return;
     }
 
-    let eventId: string | undefined = hint && hint.event_id;
-
+    let eventId: string | undefined;
     this._process(
       this.eventFromException(exception, hint)
         .then(event => this._captureEvent(event, hint, scope))
@@ -150,7 +149,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
     hint?: EventHint,
     scope?: Scope,
   ): string | undefined {
-    let eventId: string | undefined = hint && hint.event_id;
+    let eventId: string | undefined;
 
     const promisedEvent = isPrimitive(message)
       ? this.eventFromMessage(String(message), level, hint)
@@ -177,7 +176,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
       return;
     }
 
-    let eventId: string | undefined = hint && hint.event_id;
+    let eventId: string | undefined;
 
     this._process(
       this._captureEvent(event, hint, scope).then(result => {

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -186,7 +186,7 @@ export class Hub implements HubInterface {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
   public captureException(exception: any, hint?: EventHint): string {
     const syntheticException = new Error('Sentry syntheticException');
-    return (this._lastEventId =
+    this._lastEventId =
       this._withClient((client, scope) => {
         return client.captureException(
           exception,
@@ -197,7 +197,8 @@ export class Hub implements HubInterface {
           },
           scope,
         );
-      }) || NIL_EVENT_ID);
+      }) || NIL_EVENT_ID;
+    return this._lastEventId;
   }
 
   /**
@@ -210,7 +211,7 @@ export class Hub implements HubInterface {
     hint?: EventHint,
   ): string {
     const syntheticException = new Error(message);
-    return (this._lastEventId =
+    this._lastEventId =
       this._withClient((client, scope) => {
         return client.captureMessage(
           message,
@@ -222,7 +223,8 @@ export class Hub implements HubInterface {
           },
           scope,
         );
-      }) || NIL_EVENT_ID);
+      }) || NIL_EVENT_ID;
+    return this._lastEventId;
   }
 
   /**

--- a/packages/hub/test/hub.test.ts
+++ b/packages/hub/test/hub.test.ts
@@ -7,11 +7,13 @@ import { getCurrentHub, Hub, Scope } from '../src';
 
 const clientFn: any = jest.fn();
 
+const MOCK_EVENT_ID = '7bab5137428b4de29891fb8bd34a31cb';
+
 function makeClient() {
   return {
     getOptions: jest.fn(),
     captureEvent: jest.fn(),
-    captureException: jest.fn(),
+    captureException: jest.fn().mockReturnValue(MOCK_EVENT_ID),
     close: jest.fn(),
     flush: jest.fn(),
     getDsn: jest.fn(),
@@ -224,16 +226,6 @@ describe('Hub', () => {
       expect(args[0]).toBe('a');
     });
 
-    test('should set event_id in hint', () => {
-      const testClient = makeClient();
-      const hub = new Hub(testClient);
-
-      hub.captureException('a');
-      const args = getPassedArgs(testClient.captureException);
-
-      expect(args[1].event_id).toBeTruthy();
-    });
-
     test('should keep event_id from hint', () => {
       const testClient = makeClient();
       const hub = new Hub(testClient);
@@ -270,14 +262,12 @@ describe('Hub', () => {
       expect(args[0]).toBe('a');
     });
 
-    test('should set event_id in hint', () => {
+    test('should get event_id from client', () => {
       const testClient = makeClient();
       const hub = new Hub(testClient);
 
-      hub.captureMessage('a');
-      const args = getPassedArgs(testClient.captureMessage);
-
-      expect(args[2].event_id).toBeTruthy();
+      const id = hub.captureMessage('a');
+      expect(id).toBeTruthy();
     });
 
     test('should keep event_id from hint', () => {
@@ -318,17 +308,15 @@ describe('Hub', () => {
       expect(args[0]).toBe(event);
     });
 
-    test('should set event_id in hint', () => {
+    test('should get event_id from client', () => {
       const event: Event = {
         extra: { b: 3 },
       };
       const testClient = makeClient();
       const hub = new Hub(testClient);
 
-      hub.captureEvent(event);
-      const args = getPassedArgs(testClient.captureEvent);
-
-      expect(args[1].event_id).toBeTruthy();
+      const id = hub.captureEvent(event);
+      expect(id).toBeTruthy();
     });
 
     test('should keep event_id from hint', () => {
@@ -352,10 +340,8 @@ describe('Hub', () => {
       const testClient = makeClient();
       const hub = new Hub(testClient);
 
-      hub.captureEvent(event);
-      const args = getPassedArgs(testClient.captureEvent);
-
-      expect(args[1].event_id).toEqual(hub.lastEventId());
+      const id = hub.captureEvent(event);
+      expect(id).toEqual(hub.lastEventId());
     });
 
     test('transactions do not set lastEventId', () => {
@@ -366,10 +352,8 @@ describe('Hub', () => {
       const testClient = makeClient();
       const hub = new Hub(testClient);
 
-      hub.captureEvent(event);
-      const args = getPassedArgs(testClient.captureEvent);
-
-      expect(args[1].event_id).not.toEqual(hub.lastEventId());
+      const id = hub.captureEvent(event);
+      expect(id).not.toEqual(hub.lastEventId());
     });
   });
 

--- a/packages/hub/test/hub.test.ts
+++ b/packages/hub/test/hub.test.ts
@@ -226,6 +226,14 @@ describe('Hub', () => {
       expect(args[0]).toBe('a');
     });
 
+    test('should get event_id from client', () => {
+      const testClient = makeClient();
+      const hub = new Hub(testClient);
+
+      const id = hub.captureException('a');
+      expect(id).toBeDefined();
+    });
+
     test('should keep event_id from hint', () => {
       const testClient = makeClient();
       const hub = new Hub(testClient);
@@ -267,7 +275,7 @@ describe('Hub', () => {
       const hub = new Hub(testClient);
 
       const id = hub.captureMessage('a');
-      expect(id).toBeTruthy();
+      expect(id).toBeDefined();
     });
 
     test('should keep event_id from hint', () => {
@@ -316,7 +324,7 @@ describe('Hub', () => {
       const hub = new Hub(testClient);
 
       const id = hub.captureEvent(event);
-      expect(id).toBeTruthy();
+      expect(id).toBeDefined();
     });
 
     test('should keep event_id from hint', () => {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/6244

This changes moves all generation of eventId uuids to the client. Since we can't change the signature of `hub.captureException` and similar, we return a event id of zeros, `00000000000000000000000000000000`, if the client method returns undefined.

This should improve the performance of the SDKs!