### PR TITLE
ci: Fix size check action to run on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,7 +228,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     # Size Check will error out outside of the context of a PR
-    if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/master/')
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/master'
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3


### PR DESCRIPTION
As pointed out by @AbhiPrasad, the size check action on CI has not been properly running since we merged https://github.com/getsentry/sentry-javascript/pull/6180.

After some investigation, I think I've pinned the culprit down:

Basically, in that PR I "fixed" an `if` condition for the size limit action job. Previously, because the condition had a wrong syntax, it was _always_ running.

```
if: ${{ github.event_name == 'pull_request' }} || ${{ startsWith(github.ref, 'refs/heads/master/') }}
```

This was incorrect because either we need to wrap the _whole_ expression with `${{ }}`, or none of it (as `if` auto-wraps it). With the original statement, it always evaluated to a truthy expression.

So I "fixed" the syntax, however didn't notice that one part of the check was incorrect:

```
if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/master/')
```

Actually, `refs/heads/master/` never matches - the trailing `/` is incorrect, I believe - should be:

```
if: github.event_name == 'pull_request' || github.ref == 'refs/heads/master'
```

So this PR actually fixes that statement with the proper branch name (hopefully). Also, as far as I can tell from github docs, we don't actually need the `startsWith` stuff here.