### PR TITLE
fix(core): Add guard against `scope.getAttachments`

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -437,7 +437,12 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
 
     // This should be the last thing called, since we want that
     // {@link Hub.addEventProcessor} gets the finished prepared event.
-    if (finalScope) {
+    //
+    // We need to check for the existence of `finalScope.getAttachments`
+    // because `getAttachments` can be undefined if users are using an older version
+    // of `@sentry/core` that does not have the `getAttachments` method.
+    // See: https://github.com/getsentry/sentry-javascript/issues/5229
+    if (finalScope && finalScope.getAttachments) {
       // Collect attachments from the hint and scope
       const attachments = [...(hint.attachments || []), ...finalScope.getAttachments()];
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/5229#issuecomment-1322748113

We need to check for the existence of `finalScope.getAttachments` because `getAttachments` can be undefined if users are using an older version of `@sentry/core` that does not have the `getAttachments` method.