### PR TITLE
fix(remix): Attempt to extract user IP from request headers.

### DIFF
--- a/packages/remix/src/utils/getIpAddress.ts
+++ b/packages/remix/src/utils/getIpAddress.ts
@@ -30,29 +30,29 @@ import { isIP } from 'net';
 export function getClientIPAddress(headers: Headers): string | null {
   // The headers to check, in priority order
   const headerNames = [
-    "X-Client-IP",
-    "X-Forwarded-For",
-    "Fly-Client-IP",
-    "CF-Connecting-IP",
-    "Fastly-Client-Ip",
-    "True-Client-Ip",
-    "X-Real-IP",
-    "X-Cluster-Client-IP",
-    "X-Forwarded",
-    "Forwarded-For",
-    "Forwarded",
+    'X-Client-IP',
+    'X-Forwarded-For',
+    'Fly-Client-IP',
+    'CF-Connecting-IP',
+    'Fastly-Client-Ip',
+    'True-Client-Ip',
+    'X-Real-IP',
+    'X-Cluster-Client-IP',
+    'X-Forwarded',
+    'Forwarded-For',
+    'Forwarded',
   ];
 
   // This will end up being Array<string | string[] | undefined | null> because of the various possible values a header
   // can take
   const headerValues = headerNames.map((headerName: string) => {
     const value = headers.get(headerName);
-    
-    if (headerName === "Forwarded") {
+
+    if (headerName === 'Forwarded') {
       return parseForwardedHeader(value);
     }
-    
-    return value?.split(", ");
+
+    return value?.split(', ');
   });
 
   // Flatten the array and filter out any falsy entries
@@ -65,7 +65,7 @@ export function getClientIPAddress(headers: Headers): string | null {
   }, []);
 
   // Find the first value which is a valid IP address, if any
-  const ipAddress = flattenedHeaderValues.find((ip) => ip !== null && isIP(ip));
+  const ipAddress = flattenedHeaderValues.find(ip => ip !== null && isIP(ip));
 
   return ipAddress || null;
 }
@@ -75,8 +75,8 @@ function parseForwardedHeader(value: string | null): string | null {
     return null;
   }
 
-  for (const part of value.split(";")) {
-    if (part.startsWith("for=")) {
+  for (const part of value.split(';')) {
+    if (part.startsWith('for=')) {
       return part.slice(4);
     }
   }

--- a/packages/remix/src/utils/getIpAddress.ts
+++ b/packages/remix/src/utils/getIpAddress.ts
@@ -1,0 +1,79 @@
+// Vendored / modified from @sergiodxa/remix-utils
+// https://github.com/sergiodxa/remix-utils/blob/02af80e12829a53696bfa8f3c2363975cf59f55e/src/server/get-client-ip-address.ts
+
+import { isIP } from 'net';
+
+/**
+ * This is the list of headers, in order of preference, that will be used to
+ * determine the client's IP address.
+ */
+const headerNames = [
+  'X-Client-IP',
+  'X-Forwarded-For',
+  'Fly-Client-IP',
+  'CF-Connecting-IP',
+  'Fastly-Client-Ip',
+  'True-Client-Ip',
+  'X-Real-IP',
+  'X-Cluster-Client-IP',
+  'X-Forwarded',
+  'Forwarded-For',
+  'Forwarded',
+];
+/**
+ * Get the IP address of the client sending a request.
+ *
+ * It receives a Request headers object and use it to get the
+ * IP address from one of the following headers in order.
+ *
+ * - X-Client-IP
+ * - X-Forwarded-For
+ * - Fly-Client-IP
+ * - CF-Connecting-IP
+ * - Fastly-Client-Ip
+ * - True-Client-Ip
+ * - X-Real-IP
+ * - X-Cluster-Client-IP
+ * - X-Forwarded
+ * - Forwarded-For
+ * - Forwarded
+ *
+ * If the IP address is valid, it will be returned. Otherwise, null will be
+ * returned.
+ *
+ * If the header values contains more than one IP address, the first valid one
+ * will be returned.
+ */
+export function getClientIPAddress(headers: Headers): string | null {
+  const ipAddress = headerNames
+    .map((headerName: string) => {
+      const value = headers.get(headerName);
+      if (headerName === 'Forwarded') {
+        return parseForwardedHeader(value);
+      }
+      if (!value?.includes(', ')) return value;
+      return value.split(', ');
+    })
+    .reduce((acc: string[], val) => {
+      if (!val) {
+        return acc;
+      }
+
+      return acc.concat(val);
+    }, [])
+    .find(ip => {
+      if (ip === null) return false;
+      return isIP(ip);
+    });
+
+  return ipAddress ?? null;
+}
+
+function parseForwardedHeader(value: string | null): string | null {
+  if (!value) return null;
+  for (const part of value.split(';')) {
+    if (part.startsWith('for=')) return part.slice(4);
+    continue;
+  }
+  return null;
+}

--- a/packages/remix/src/utils/getIpAddress.ts
+++ b/packages/remix/src/utils/getIpAddress.ts
@@ -4,23 +4,6 @@
 import { isIP } from 'net';
 
 /**
- * This is the list of headers, in order of preference, that will be used to
- * determine the client's IP address.
- */
-const headerNames = [
-  'X-Client-IP',
-  'X-Forwarded-For',
-  'Fly-Client-IP',
-  'CF-Connecting-IP',
-  'Fastly-Client-Ip',
-  'True-Client-Ip',
-  'X-Real-IP',
-  'X-Cluster-Client-IP',
-  'X-Forwarded',
-  'Forwarded-For',
-  'Forwarded',
-];
-/**
  * Get the IP address of the client sending a request.
  *
  * It receives a Request headers object and use it to get the
@@ -45,35 +28,58 @@ const headerNames = [
  * will be returned.
  */
 export function getClientIPAddress(headers: Headers): string | null {
-  const ipAddress = headerNames
-    .map((headerName: string) => {
-      const value = headers.get(headerName);
-      if (headerName === 'Forwarded') {
-        return parseForwardedHeader(value);
-      }
-      if (!value?.includes(', ')) return value;
-      return value.split(', ');
-    })
-    .reduce((acc: string[], val) => {
-      if (!val) {
-        return acc;
-      }
+  // The headers to check, in priority order
+  const headerNames = [
+    "X-Client-IP",
+    "X-Forwarded-For",
+    "Fly-Client-IP",
+    "CF-Connecting-IP",
+    "Fastly-Client-Ip",
+    "True-Client-Ip",
+    "X-Real-IP",
+    "X-Cluster-Client-IP",
+    "X-Forwarded",
+    "Forwarded-For",
+    "Forwarded",
+  ];
 
-      return acc.concat(val);
-    }, [])
-    .find(ip => {
-      if (ip === null) return false;
-      return isIP(ip);
-    });
+  // This will end up being Array<string | string[] | undefined | null> because of the various possible values a header
+  // can take
+  const headerValues = headerNames.map((headerName: string) => {
+    const value = headers.get(headerName);
+    
+    if (headerName === "Forwarded") {
+      return parseForwardedHeader(value);
+    }
+    
+    return value?.split(", ");
+  });
 
-  return ipAddress ?? null;
+  // Flatten the array and filter out any falsy entries
+  const flattenedHeaderValues = headerValues.reduce((acc: string[], val) => {
+    if (!val) {
+      return acc;
+    }
+
+    return acc.concat(val);
+  }, []);
+
+  // Find the first value which is a valid IP address, if any
+  const ipAddress = flattenedHeaderValues.find((ip) => ip !== null && isIP(ip));
+
+  return ipAddress || null;
 }
 
 function parseForwardedHeader(value: string | null): string | null {
-  if (!value) return null;
-  for (const part of value.split(';')) {
-    if (part.startsWith('for=')) return part.slice(4);
-    continue;
+  if (!value) {
+    return null;
   }
+
+  for (const part of value.split(";")) {
+    if (part.startsWith("for=")) {
+      return part.slice(4);
+    }
+  }
+
   return null;
 }

--- a/packages/remix/src/utils/web-fetch.ts
+++ b/packages/remix/src/utils/web-fetch.ts
@@ -1,6 +1,7 @@
 // Based on Remix's implementation of Fetch API
 // https://github.com/remix-run/web-std-io/tree/main/packages/fetch
 
+import { getClientIPAddress } from './getIpAddress';
 import { RemixRequest } from './types';
 
 /*
@@ -92,6 +93,15 @@ export const normalizeRemixRequest = (request: RemixRequest): Record<string, any
     headers.set('Connection', 'close');
   }
 
+  let ip;
+
+  // Using a try block here just to stay on the safe side
+  try {
+    ip = getClientIPAddress(headers);
+  } catch (e) {
+    // ignore
+  }
+
   // HTTP-network fetch step 4.2
   // chunked encoding is handled by Node.js
   const search = getSearch(parsedURL);
@@ -116,6 +126,9 @@ export const normalizeRemixRequest = (request: RemixRequest): Record<string, any
 
     // [SENTRY] For compatibility with Sentry SDK RequestData parser, adding `originalUrl` property.
     originalUrl: parsedURL.href,
+
+    // [SENTRY] Adding `ip` property if found inside headers.
+    ip,
   };
 
   return requestOptions;


### PR DESCRIPTION
Ref: #6139 - https://github.com/getsentry/sentry-javascript/issues/6139#issuecomment-1323887582

Remix requests don't contain client IP addresses in `req.ip` or `req.socket.*`.
To extract them, we need to iterate over a set of request headers that may contain that info.

I have vendored / modified an implementation of that function from third-party utility set [`remix-utils`](https://github.com/sergiodxa/remix-utils#getclientipaddress). (Using as a dependency is not possible because of incompatible TS syntax.)

It's still the best effort and may also need improvements over header key prioritization.