### PR TITLE
build(ember): Remove unused `build:extras` for ember package

### DIFF
--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -18,7 +18,6 @@
   },
   "scripts": {
     "build": "ember build --environment=production",
-    "build:extras": "yarn build",
     "build:npm": "ember ts:precompile && npm pack && ember ts:clean",
     "clean": "yarn rimraf sentry-ember-*.tgz",
     "lint": "run-p lint:js lint:hbs lint:ts",


### PR DESCRIPTION
This removes `build:extra` from the ember package. It is not really needed at this stage, as far as I can tell. 

For reference: What `ember build` in the context of an addon (=package) does is not really related to the library, but it builds the test app. Ember addons don't need to be built in any way, they are always built by the host app. 