### PR TITLE
test(nextjs): Make `tracingFetch` integration test not use UI elements

### DIFF
--- a/packages/nextjs/test/integration/pages/fetch.tsx
+++ b/packages/nextjs/test/integration/pages/fetch.tsx
@@ -1,14 +1,14 @@
-const ButtonPage = (): JSX.Element => (
-  <button
-    onClick={() => {
-      // test that a span is created in the pageload transaction for this fetch request
-      fetch('http://example.com').catch(() => {
-        // no-empty
-      });
-    }}
-  >
-    Send Request
-  </button>
-);
+import { useEffect } from 'react';
 
-export default ButtonPage;
+const FetchPage = (): JSX.Element => {
+  useEffect(() => {
+    // test that a span is created in the pageload transaction for this fetch request
+    fetch('http://example.com').catch(() => {
+      // no-empty
+    });
+  }, []);
+
+  return <p>Hello world!</p>;
+};
+
+export default FetchPage;

--- a/packages/nextjs/test/integration/test/client/tracingFetch.js
+++ b/packages/nextjs/test/integration/test/client/tracingFetch.js
@@ -8,7 +8,6 @@ const {
 module.exports = async ({ page, url, requests }) => {
   const requestPromise = page.waitForRequest(isTransactionRequest);
   await page.goto(`${url}/fetch`);
-  await page.click('button');
   await requestPromise;
 
   expectTransaction(requests.transactions[0], {


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-javascript/issues/6281

This PR attempts to fix a flakey Next.js integration test that seems to be flakey because the UI thread was blocking a button-click interaction, causing the page load transaction to terminate before we get the chance to trigger a fetch request via the button click.

We try to fix this by conducting the fetch request on page mount, so we decouple the request from a UI interaction.