### PR TITLE
feat(core): Pass `event` as third argument to `recordDroppedEvent`

### DIFF
--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -1237,7 +1237,9 @@ describe('BaseClient', () => {
       client.captureEvent({ message: 'hello' }, {});
 
       expect(beforeSend).toHaveBeenCalled();
-      expect(recordLostEventSpy).toHaveBeenCalledWith('before_send', 'error');
+      expect(recordLostEventSpy).toHaveBeenCalledWith('before_send', 'error', {
+        message: 'hello',
+      });
     });
 
     test('`beforeSendTransaction` records dropped events', () => {
@@ -1257,7 +1259,10 @@ describe('BaseClient', () => {
       client.captureEvent({ transaction: '/dogs/are/great', type: 'transaction' });
 
       expect(beforeSendTransaction).toHaveBeenCalled();
-      expect(recordLostEventSpy).toHaveBeenCalledWith('before_send', 'transaction');
+      expect(recordLostEventSpy).toHaveBeenCalledWith('before_send', 'transaction', {
+        transaction: '/dogs/are/great',
+        type: 'transaction',
+      });
     });
 
     test('event processor drops error event when it returns `null`', () => {
@@ -1309,7 +1314,9 @@ describe('BaseClient', () => {
 
       client.captureEvent({ message: 'hello' }, {}, scope);
 
-      expect(recordLostEventSpy).toHaveBeenCalledWith('event_processor', 'error');
+      expect(recordLostEventSpy).toHaveBeenCalledWith('event_processor', 'error', {
+        message: 'hello',
+      });
     });
 
     test('event processor records dropped transaction events', () => {
@@ -1325,7 +1332,10 @@ describe('BaseClient', () => {
 
       client.captureEvent({ transaction: '/dogs/are/great', type: 'transaction' }, {}, scope);
 
-      expect(recordLostEventSpy).toHaveBeenCalledWith('event_processor', 'transaction');
+      expect(recordLostEventSpy).toHaveBeenCalledWith('event_processor', 'transaction', {
+        transaction: '/dogs/are/great',
+        type: 'transaction',
+      });
     });
 
     test('mutating transaction name with event processors sets transaction-name-change metadata', () => {
@@ -1434,7 +1444,9 @@ describe('BaseClient', () => {
       const recordLostEventSpy = jest.spyOn(client, 'recordDroppedEvent');
 
       client.captureEvent({ message: 'hello' }, {});
-      expect(recordLostEventSpy).toHaveBeenCalledWith('sample_rate', 'error');
+      expect(recordLostEventSpy).toHaveBeenCalledWith('sample_rate', 'error', {
+        message: 'hello',
+      });
     });
   });
 

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -126,6 +126,7 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    *
    * @param reason The reason why the event got dropped.
    * @param category The data category of the dropped event.
+   * @param event The dropped event.
    */
-  recordDroppedEvent(reason: EventDropReason, category: DataCategory): void;
+  recordDroppedEvent(reason: EventDropReason, dataCategory: DataCategory, event?: Event): void;
 }

--- a/packages/types/src/transport.ts
+++ b/packages/types/src/transport.ts
@@ -1,5 +1,4 @@
-import { EventDropReason } from './clientreport';
-import { DataCategory } from './datacategory';
+import { Client } from './client';
 import { Envelope } from './envelope';
 import { TextEncoderInternal } from './textencoder';
 
@@ -18,7 +17,7 @@ export type TransportMakeRequestResponse = {
 
 export interface InternalBaseTransportOptions {
   bufferSize?: number;
-  recordDroppedEvent: (reason: EventDropReason, dataCategory: DataCategory) => void;
+  recordDroppedEvent: Client['recordDroppedEvent'];
   textEncoder?: TextEncoderInternal;
 }
 


### PR DESCRIPTION
For replay, we want to provide an easy (internal) way to strip out dropped events.
Our idea is to monkey patch `recordDroppedEvent` in replay, and use it to get notified of which events have been dropped, and handle that internally. This requires the `recordDroppedEvent` callback to actually receive the event as argument.

This PR changes the signature so that it receives an error/transaction event as optional third argument. For other types of dropped events (e.g. attachments), undefined is passed.

ref https://github.com/getsentry/sentry-javascript/issues/6285
