### PR TITLE
fix(build): Revert unintended Replay `tsconfig` changes

### DIFF
--- a/packages/replay/.eslintrc.js
+++ b/packages/replay/.eslintrc.js
@@ -40,7 +40,7 @@ module.exports = {
     {
       files: ['worker/**/*.ts'],
       parserOptions: {
-        project: ['config/tsconfig.worker.json'],
+        project: ['./config/tsconfig.worker.json'],
       },
     },
     {

--- a/packages/replay/config/tsconfig.base.json
+++ b/packages/replay/config/tsconfig.base.json
@@ -1,4 +1,13 @@
 {
-  "compilerOptions": {},
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "noEmitOnError": false,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "target": "es5"
+  },
   "exclude": ["node_modules"]
 }

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -63,12 +63,6 @@
   "engines": {
     "node": ">=12"
   },
-  "size-limit": [
-    {
-      "path": "build/npm/index.js",
-      "limit": "4500ms"
-    }
-  ],
   "volta": {
     "node": "14.21.1",
     "yarn": "1.22.19"

--- a/packages/replay/tsconfig.json
+++ b/packages/replay/tsconfig.json
@@ -1,19 +1,11 @@
 {
   "extends": "./config/tsconfig.core.json",
   "compilerOptions": {
-    "module": "esnext",
-    "moduleResolution": "node",
-    "noImplicitAny": true,
-    "noEmitOnError": false,
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "types": ["node", "jest"],
-    "target": "es5",
     "paths": {
       "@test": ["./test"],
       "@test/*": ["./test/*"]
-    }
+    },
+    "types": ["node", "jest"]
   },
   "include": ["src/**/*.ts", "test/**/*.ts", "rollup.config.ts", "jest.config.ts", "jest.setup.ts"],
   "exclude": ["node_modules"]

--- a/packages/replay/worker/src/handleMessage.ts
+++ b/packages/replay/worker/src/handleMessage.ts
@@ -30,8 +30,10 @@ export function handleMessage(e: MessageEvent): void {
   const id = e.data.id as number;
   const [data] = e.data.args ? JSON.parse(e.data.args) : [];
 
+  // @ts-ignore this syntax is actually fine
   if (method in handlers && typeof handlers[method] === 'function') {
     try {
+      // @ts-ignore this syntax is actually fine
       const response = handlers[method](data);
       // @ts-ignore this syntax is actually fine
       postMessage({


### PR DESCRIPTION
This PR reverts a few changes I unintentionally comitted and merged in #6288. It caused build errors which for some reasons did not our CI's "build" step to fail but caused size-check fails in https://github.com/getsentry/sentry-javascript/actions/runs/3546454900