### PR TITLE
fix(replay): Temporarily build Replay after other packages

### DIFF
--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "bootstrap": "yarn && cd demo && yarn #TODO: change after migration",
     "build": "yarn build:rollup",
-    "build:rollup": "NODE_ENV=production yarn build:all",
+    "build:extras": "NODE_ENV=production yarn build:all",
     "build:dev": "NODE_ENV=development yarn build:all",
     "build:all": "run-s clean build:worker build:core",
     "build:core": "yarn build:actualRollup --config config/rollup.config.core.ts",

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -8,7 +8,7 @@
   "sideEffects": false,
   "scripts": {
     "bootstrap": "yarn && cd demo && yarn #TODO: change after migration",
-    "build": "yarn build:rollup",
+    "build": "yarn build:extras",
     "build:extras": "NODE_ENV=production yarn build:all",
     "build:dev": "NODE_ENV=development yarn build:all",
     "build:all": "run-s clean build:worker build:core",


### PR DESCRIPTION
This PR fixes a build error in Replay process by building it after all other packages (including their type declarations) were built. We have to do this temporarily because `@rollup/plugin-typescript` expects type declarations of the `@sentry/*` dependencies of the replay package. Because we're building types in parallel to transpiling JS, type declarations were not yet (reliably) built before replay's `build:rollup` commands was executed.

To unblock us, we for now build the package via `build:extras` so that it only runs after all other packages were fully built.

We should revert this change as soon as we use our transpilation process (sucrase) where we don't care about type declarations.

This might also fix the size-limit action on the master branch.   