### PR TITLE
feat(browser): support dom.maxStringLength configuration (#6175)

### DIFF
--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -123,7 +123,7 @@ function _domBreadcrumb(dom: BreadcrumbsOptions['dom']): (handlerData: { [key: s
   function _innerDomBreadcrumb(handlerData: { [key: string]: any }): void {
     let target;
     let keyAttrs = typeof dom === 'object' ? dom.serializeAttribute : undefined;
-    const customMaxStringLength =
+    const maxStringLength =
       typeof dom === 'object' && typeof dom.maxStringLength === 'number'
         ? Math.min(dom.maxStringLength, 1024)
         : undefined;
@@ -135,8 +135,8 @@ function _domBreadcrumb(dom: BreadcrumbsOptions['dom']): (handlerData: { [key: s
     // Accessing event.target can throw (see getsentry/raven-js#838, #768)
     try {
       target = handlerData.event.target
-        ? htmlTreeAsString(handlerData.event.target as Node, keyAttrs, customMaxStringLength)
-        : htmlTreeAsString(handlerData.event as unknown as Node, keyAttrs, customMaxStringLength);
+        ? htmlTreeAsString(handlerData.event.target as Node, { keyAttrs, maxStringLength })
+        : htmlTreeAsString(handlerData.event as unknown as Node, { keyAttrs, maxStringLength });
     } catch (e) {
       target = '<unknown>';
     }

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -130,11 +130,10 @@ function _domBreadcrumb(dom: BreadcrumbsOptions['dom']): (handlerData: { [key: s
     let maxStringLength =
       typeof dom === 'object' && typeof dom.maxStringLength === 'number' ? dom.maxStringLength : undefined;
     if (maxStringLength && maxStringLength > MAX_ALLOWED_STRING_LENGTH) {
-      if (__DEBUG_BUILD__) {
+      __DEBUG_BUILD__ &&
         logger.warn(
           `\`dom.maxStringLength\` cannot exceed ${MAX_ALLOWED_STRING_LENGTH}, but a value of ${maxStringLength} was configured. Sentry will use ${MAX_ALLOWED_STRING_LENGTH} instead.`,
         );
-      }
       maxStringLength = MAX_ALLOWED_STRING_LENGTH;
     }
 

--- a/packages/utils/src/browser.ts
+++ b/packages/utils/src/browser.ts
@@ -14,7 +14,7 @@ const DEFAULT_MAX_STRING_LENGTH = 80;
  */
 export function htmlTreeAsString(
   elem: unknown,
-  options: { keyAttrs?: string[]; maxStringLength?: number } = {},
+  options: string[] | { keyAttrs?: string[]; maxStringLength?: number } = {},
 ): string {
   type SimpleNode = {
     parentNode: SimpleNode;
@@ -33,7 +33,8 @@ export function htmlTreeAsString(
     const separator = ' > ';
     const sepLength = separator.length;
     let nextStr;
-    const { keyAttrs, maxStringLength = DEFAULT_MAX_STRING_LENGTH } = options;
+    const keyAttrs = Array.isArray(options) ? options : options.keyAttrs;
+    const maxStringLength = (!Array.isArray(options) && options.maxStringLength) || DEFAULT_MAX_STRING_LENGTH;
 
     while (currentElem && height++ < MAX_TRAVERSE_HEIGHT) {
       nextStr = _htmlElementAsString(currentElem, keyAttrs);

--- a/packages/utils/src/browser.ts
+++ b/packages/utils/src/browser.ts
@@ -4,13 +4,15 @@ import { getGlobalObject } from './worldwide';
 // eslint-disable-next-line deprecation/deprecation
 const WINDOW = getGlobalObject<Window>();
 
+const DEFAULT_MAX_STRING_LENGTH = 80;
+
 /**
  * Given a child DOM element, returns a query-selector statement describing that
  * and its ancestors
  * e.g. [HTMLElement] => body > div > input#foo.btn[name=baz]
  * @returns generated DOM path
  */
-export function htmlTreeAsString(elem: unknown, keyAttrs?: string[]): string {
+export function htmlTreeAsString(elem: unknown, keyAttrs?: string[], customMaxStringLength?: number): string {
   type SimpleNode = {
     parentNode: SimpleNode;
   } | null;
@@ -22,7 +24,7 @@ export function htmlTreeAsString(elem: unknown, keyAttrs?: string[]): string {
   try {
     let currentElem = elem as SimpleNode;
     const MAX_TRAVERSE_HEIGHT = 5;
-    const MAX_OUTPUT_LEN = 80;
+    const maxStringLength = customMaxStringLength || DEFAULT_MAX_STRING_LENGTH;
     const out = [];
     let height = 0;
     let len = 0;
@@ -34,9 +36,9 @@ export function htmlTreeAsString(elem: unknown, keyAttrs?: string[]): string {
       nextStr = _htmlElementAsString(currentElem, keyAttrs);
       // bail out if
       // - nextStr is the 'html' element
-      // - the length of the string that would be created exceeds MAX_OUTPUT_LEN
+      // - the length of the string that would be created exceeds maxStringLength
       //   (ignore this limit if we are on the first iteration)
-      if (nextStr === 'html' || (height > 1 && len + out.length * sepLength + nextStr.length >= MAX_OUTPUT_LEN)) {
+      if (nextStr === 'html' || (height > 1 && len + out.length * sepLength + nextStr.length >= maxStringLength)) {
         break;
       }
 

--- a/packages/utils/src/browser.ts
+++ b/packages/utils/src/browser.ts
@@ -12,7 +12,10 @@ const DEFAULT_MAX_STRING_LENGTH = 80;
  * e.g. [HTMLElement] => body > div > input#foo.btn[name=baz]
  * @returns generated DOM path
  */
-export function htmlTreeAsString(elem: unknown, keyAttrs?: string[], customMaxStringLength?: number): string {
+export function htmlTreeAsString(
+  elem: unknown,
+  options: { keyAttrs?: string[]; maxStringLength?: number } = {},
+): string {
   type SimpleNode = {
     parentNode: SimpleNode;
   } | null;
@@ -24,13 +27,13 @@ export function htmlTreeAsString(elem: unknown, keyAttrs?: string[], customMaxSt
   try {
     let currentElem = elem as SimpleNode;
     const MAX_TRAVERSE_HEIGHT = 5;
-    const maxStringLength = customMaxStringLength || DEFAULT_MAX_STRING_LENGTH;
     const out = [];
     let height = 0;
     let len = 0;
     const separator = ' > ';
     const sepLength = separator.length;
     let nextStr;
+    const { keyAttrs, maxStringLength = DEFAULT_MAX_STRING_LENGTH } = options;
 
     while (currentElem && height++ < MAX_TRAVERSE_HEIGHT) {
       nextStr = _htmlElementAsString(currentElem, keyAttrs);

--- a/packages/utils/test/browser.test.ts
+++ b/packages/utils/test/browser.test.ts
@@ -44,6 +44,10 @@ describe('htmlTreeAsString', () => {
     </li>`;
     document.body.appendChild(el);
 
+    // Two formats for specifying keyAttrs
+    expect(htmlTreeAsString(document.getElementById('cat-2'), ['test-id'])).toBe(
+      'body > ul > li.li-class[title="li-title"] > img[test-id="cat-2-test-id"]',
+    );
     expect(htmlTreeAsString(document.getElementById('cat-2'), { keyAttrs: ['test-id'] })).toBe(
       'body > ul > li.li-class[title="li-title"] > img[test-id="cat-2-test-id"]',
     );

--- a/packages/utils/test/browser.test.ts
+++ b/packages/utils/test/browser.test.ts
@@ -44,7 +44,7 @@ describe('htmlTreeAsString', () => {
     </li>`;
     document.body.appendChild(el);
 
-    expect(htmlTreeAsString(document.getElementById('cat-2'), ['test-id'])).toBe(
+    expect(htmlTreeAsString(document.getElementById('cat-2'), { keyAttrs: ['test-id'] })).toBe(
       'body > ul > li.li-class[title="li-title"] > img[test-id="cat-2-test-id"]',
     );
   });
@@ -61,7 +61,7 @@ describe('htmlTreeAsString', () => {
     expect(htmlTreeAsString(document.querySelector('button'))).toBe(
       'button.bg-blue-500.hover:bg-blue-700.text-white.hover:text-blue-100',
     );
-    expect(htmlTreeAsString(document.querySelector('button'), undefined, 100)).toBe(
+    expect(htmlTreeAsString(document.querySelector('button'), { maxStringLength: 100 })).toBe(
       'div#main-cta > div.container > button.bg-blue-500.hover:bg-blue-700.text-white.hover:text-blue-100',
     );
   });

--- a/packages/utils/test/browser.test.ts
+++ b/packages/utils/test/browser.test.ts
@@ -9,6 +9,10 @@ beforeAll(() => {
 });
 
 describe('htmlTreeAsString', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
   it('generates html tree for a simple element', () => {
     const el = document.createElement('ul');
     el.innerHTML = `<li class="container">
@@ -42,6 +46,23 @@ describe('htmlTreeAsString', () => {
 
     expect(htmlTreeAsString(document.getElementById('cat-2'), ['test-id'])).toBe(
       'body > ul > li.li-class[title="li-title"] > img[test-id="cat-2-test-id"]',
+    );
+  });
+
+  it('caps string output according to provided maxStringLength', () => {
+    const el = document.createElement('div');
+    el.innerHTML = `<div id="main-cta">
+      <div class="container">
+        <button class="bg-blue-500 hover:bg-blue-700 text-white hover:text-blue-100" />
+      </div>
+    </div>`;
+    document.body.appendChild(el);
+
+    expect(htmlTreeAsString(document.querySelector('button'))).toBe(
+      'button.bg-blue-500.hover:bg-blue-700.text-white.hover:text-blue-100',
+    );
+    expect(htmlTreeAsString(document.querySelector('button'), undefined, 100)).toBe(
+      'div#main-cta > div.container > button.bg-blue-500.hover:bg-blue-700.text-white.hover:text-blue-100',
     );
   });
 });


### PR DESCRIPTION
Implements the configuration feature described in #6175 . This lets sentry users opt in to having longer, potentially more helpful, UI breadcrumbs.

Closes https://github.com/getsentry/sentry-javascript/issues/6175