### PR TITLE
ref(replay): Extract sticky session handling

### DIFF
--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -21,6 +21,7 @@ import {
 } from './session/constants';
 import { deleteSession } from './session/deleteSession';
 import { getSession } from './session/getSession';
+import { saveSession } from './session/saveSession';
 import { Session } from './session/Session';
 import type {
   AllPerformanceEntry,
@@ -637,6 +638,7 @@ export class Replay implements Integration {
       // checkout.
       if (this.waitForError && this.session && this.context.earliestEvent) {
         this.session.started = this.context.earliestEvent;
+        this._maybeSaveSession();
       }
 
       // If the full snapshot is due to an initial load, we will not have
@@ -893,6 +895,7 @@ export class Replay implements Integration {
   updateSessionActivity(lastActivity: number = new Date().getTime()): void {
     if (this.session) {
       this.session.lastActivity = lastActivity;
+      this._maybeSaveSession();
     }
   }
 
@@ -1104,6 +1107,7 @@ export class Replay implements Integration {
       const eventContext = this.popEventContext();
       // Always increment segmentId regardless of outcome of sending replay
       const segmentId = this.session.segmentId++;
+      this._maybeSaveSession();
 
       await this.sendReplay({
         replayId,
@@ -1340,6 +1344,13 @@ export class Replay implements Integration {
           }
         }, this.retryInterval);
       });
+    }
+  }
+
+  /** Save the session, if it is sticky */
+  private _maybeSaveSession(): void {
+    if (this.session && this.options.stickySession) {
+      saveSession(this.session);
     }
   }
 }

--- a/packages/replay/src/session/createSession.ts
+++ b/packages/replay/src/session/createSession.ts
@@ -11,7 +11,6 @@ import { Session } from './Session';
  */
 export function createSession({ sessionSampleRate, errorSampleRate, stickySession = false }: SessionOptions): Session {
   const session = new Session(undefined, {
-    stickySession,
     errorSampleRate,
     sessionSampleRate,
   });

--- a/packages/replay/src/session/fetchSession.ts
+++ b/packages/replay/src/session/fetchSession.ts
@@ -24,12 +24,7 @@ export function fetchSession({ sessionSampleRate, errorSampleRate }: SampleRates
 
     const sessionObj = JSON.parse(sessionStringFromStorage);
 
-    return new Session(
-      sessionObj,
-      // We are assuming that if there is a saved item, then the session is sticky,
-      // however this could break down if we used a different storage mechanism (e.g. localstorage)
-      { stickySession: true, sessionSampleRate, errorSampleRate },
-    );
+    return new Session(sessionObj, { sessionSampleRate, errorSampleRate });
   } catch {
     return null;
   }

--- a/packages/replay/test/mocks/mockSdk.ts
+++ b/packages/replay/test/mocks/mockSdk.ts
@@ -36,7 +36,7 @@ class MockTransport implements Transport {
 
 export async function mockSdk({
   replayOptions = {
-    stickySession: true,
+    stickySession: false,
     sessionSampleRate: 1.0,
     errorSampleRate: 0.0,
   },

--- a/packages/replay/test/unit/session/Session.test.ts
+++ b/packages/replay/test/unit/session/Session.test.ts
@@ -26,7 +26,6 @@ jest.mock('@sentry/utils', () => {
 import * as Sentry from '@sentry/browser';
 import { WINDOW } from '@sentry/browser';
 
-import { saveSession } from '../../../src/session/saveSession';
 import { Session } from '../../../src/session/Session';
 
 type CaptureEventMockType = jest.MockedFunction<typeof Sentry.captureEvent>;
@@ -39,48 +38,8 @@ afterEach(() => {
   (Sentry.getCurrentHub().captureEvent as CaptureEventMockType).mockReset();
 });
 
-it('non-sticky Session does not save to local storage', function () {
-  const newSession = new Session(undefined, {
-    stickySession: false,
-    sessionSampleRate: 1.0,
-    errorSampleRate: 0,
-  });
-
-  expect(saveSession).not.toHaveBeenCalled();
-  expect(newSession.id).toBe('test_session_id');
-  expect(newSession.segmentId).toBe(0);
-
-  newSession.segmentId++;
-  expect(saveSession).not.toHaveBeenCalled();
-  expect(newSession.segmentId).toBe(1);
-});
-
-it('sticky Session saves to local storage', function () {
-  const newSession = new Session(undefined, {
-    stickySession: true,
-    sessionSampleRate: 1.0,
-    errorSampleRate: 0,
-  });
-
-  expect(saveSession).toHaveBeenCalledTimes(0);
-  expect(newSession.id).toBe('test_session_id');
-  expect(newSession.segmentId).toBe(0);
-
-  (saveSession as jest.Mock).mockClear();
-
-  newSession.segmentId++;
-  expect(saveSession).toHaveBeenCalledTimes(1);
-  expect(saveSession).toHaveBeenCalledWith(
-    expect.objectContaining({
-      segmentId: 1,
-    }),
-  );
-  expect(newSession.segmentId).toBe(1);
-});
-
 it('does not sample', function () {
   const newSession = new Session(undefined, {
-    stickySession: true,
     sessionSampleRate: 0.0,
     errorSampleRate: 0.0,
   });
@@ -90,7 +49,6 @@ it('does not sample', function () {
 
 it('samples using `sessionSampleRate`', function () {
   const newSession = new Session(undefined, {
-    stickySession: true,
     sessionSampleRate: 1.0,
     errorSampleRate: 0.0,
   });
@@ -100,7 +58,6 @@ it('samples using `sessionSampleRate`', function () {
 
 it('samples using `errorSampleRate`', function () {
   const newSession = new Session(undefined, {
-    stickySession: true,
     sessionSampleRate: 0,
     errorSampleRate: 1.0,
   });
@@ -114,7 +71,6 @@ it('does not run sampling function if existing session was sampled', function ()
       sampled: 'session',
     },
     {
-      stickySession: true,
       sessionSampleRate: 0,
       errorSampleRate: 0,
     },

--- a/packages/replay/test/unit/session/getSession.test.ts
+++ b/packages/replay/test/unit/session/getSession.test.ts
@@ -27,7 +27,7 @@ function createMockSession(when: number = new Date().getTime()) {
       started: when,
       sampled: 'session',
     },
-    { stickySession: false, ...SAMPLE_RATES },
+    { ...SAMPLE_RATES },
   );
 }
 
@@ -92,7 +92,7 @@ it('creates a non-sticky session, when one is expired', function () {
         started: new Date().getTime() - 1001,
         segmentId: 0,
       },
-      { stickySession: false, ...SAMPLE_RATES },
+      { ...SAMPLE_RATES },
     ),
   });
 
@@ -188,7 +188,7 @@ it('fetches a non-expired non-sticky session', function () {
         started: +new Date() - 500,
         segmentId: 0,
       },
-      { stickySession: false, ...SAMPLE_RATES },
+      { ...SAMPLE_RATES },
     ),
   });
 

--- a/packages/replay/test/unit/session/saveSession.test.ts
+++ b/packages/replay/test/unit/session/saveSession.test.ts
@@ -21,7 +21,7 @@ it('saves a valid session', function () {
       lastActivity: 1648827162658,
       sampled: 'session',
     },
-    { stickySession: true, sessionSampleRate: 1.0, errorSampleRate: 0 },
+    { sessionSampleRate: 1.0, errorSampleRate: 0 },
   );
   saveSession(session);
 

--- a/packages/replay/test/unit/util/isSessionExpired.test.ts
+++ b/packages/replay/test/unit/util/isSessionExpired.test.ts
@@ -9,7 +9,7 @@ function createSession(extra?: Record<string, any>) {
       segmentId: 0,
       ...extra,
     },
-    { stickySession: false, sessionSampleRate: 1.0, errorSampleRate: 0 },
+    { sessionSampleRate: 1.0, errorSampleRate: 0 },
   );
 }
 


### PR DESCRIPTION
Currently, a `Session` in replay receives `stickySession` as argument, and conditionally saves itself in its setters.

IMHO this responsibility is better placed outside of the session class. This also allows us to streamline the Session class quite a lot. 