### PR TITLE
ref(core): Move `allowUrls` and `denyUrls` options into core

### DIFF
--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -8,33 +8,17 @@ import { Breadcrumbs } from './integrations';
 import { BREADCRUMB_INTEGRATION_ID } from './integrations/breadcrumbs';
 import { BrowserTransportOptions } from './transports/types';
 
-export interface BaseBrowserOptions {
-  /**
-   * A pattern for error URLs which should exclusively be sent to Sentry.
-   * This is the opposite of {@link Options.denyUrls}.
-   * By default, all errors will be sent.
-   */
-  allowUrls?: Array<string | RegExp>;
-
-  /**
-   * A pattern for error URLs which should not be sent to Sentry.
-   * To allow certain errors instead, use {@link Options.allowUrls}.
-   * By default, all errors will be sent.
-   */
-  denyUrls?: Array<string | RegExp>;
-}
-
 /**
  * Configuration options for the Sentry Browser SDK.
  * @see @sentry/types Options for more information.
  */
-export interface BrowserOptions extends Options<BrowserTransportOptions>, BaseBrowserOptions {}
+export type BrowserOptions = Options<BrowserTransportOptions>;
 
 /**
  * Configuration options for the Sentry Browser SDK Client class
  * @see BrowserClient for more information.
  */
-export interface BrowserClientOptions extends ClientOptions<BrowserTransportOptions>, BaseBrowserOptions {}
+export type BrowserClientOptions = ClientOptions<BrowserTransportOptions>;
 
 /**
  * The Sentry Browser SDK Client.

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -191,6 +191,24 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   };
 
   /**
+   * A pattern for error URLs which should exclusively be sent to Sentry.
+   * This is the opposite of {@link Options.denyUrls}.
+   * By default, all errors will be sent.
+   *
+   * Requires the use of the `InboundFilters` integration.
+   */
+  allowUrls?: Array<string | RegExp>;
+
+  /**
+   * A pattern for error URLs which should not be sent to Sentry.
+   * To allow certain errors instead, use {@link Options.allowUrls}.
+   * By default, all errors will be sent.
+   *
+   * Requires the use of the `InboundFilters` integration.
+   */
+  denyUrls?: Array<string | RegExp>;
+
+  /**
    * Function to compute tracing sample rate dynamically and filter unwanted traces.
    *
    * Tracing is enabled if either this or `tracesSampleRate` is defined. If both are defined, `tracesSampleRate` is


### PR DESCRIPTION
`InboundFilters` is a default integration, so `allowUrls` and `denyUrls` should be part of the base client options - not just on the browser client only.