### PR TITLE
types(node): add profilesSampleRate

### DIFF
--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -57,5 +57,8 @@ export interface NodeOptions extends Options<NodeTransportOptions>, BaseNodeOpti
  * @see NodeClient for more information.
  */
 export interface NodeClientOptions extends ClientOptions<NodeTransportOptions>, BaseNodeOptions {
+  /**
+   * Sets profiling sample rate when @sentry/profiling-node is installed
+   */
   profilesSampleRate?: number;
 }

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -56,4 +56,6 @@ export interface NodeOptions extends Options<NodeTransportOptions>, BaseNodeOpti
  * Configuration options for the Sentry Node SDK Client class
  * @see NodeClient for more information.
  */
-export interface NodeClientOptions extends ClientOptions<NodeTransportOptions>, BaseNodeOptions {}
+export interface NodeClientOptions extends ClientOptions<NodeTransportOptions>, BaseNodeOptions {
+  profilesSampleRate?: number;
+}

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -141,6 +141,14 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   normalizeMaxBreadth?: number;
 
   /**
+   * Sample rate to determine profile sampling.
+   *
+   * 0.0 = 0% chance of a given profile being sent (send no profiles) 1.0 = 100% chance of a given profile being sent (send
+   * all profiles)
+   */
+  profilesSampleRate?: number;
+
+  /**
    * Controls how many milliseconds to wait before shutting down. The default is
    * SDK-specific but typically around 2 seconds. Setting this too low can cause
    * problems for sending events from command line applications. Setting it too

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -141,14 +141,6 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   normalizeMaxBreadth?: number;
 
   /**
-   * Sample rate to determine profile sampling.
-   *
-   * 0.0 = 0% chance of a given profile being sent (send no profiles) 1.0 = 100% chance of a given profile being sent (send
-   * all profiles)
-   */
-  profilesSampleRate?: number;
-
-  /**
    * Controls how many milliseconds to wait before shutting down. The default is
    * SDK-specific but typically around 2 seconds. Setting this too low can cause
    * problems for sending events from command line applications. Setting it too


### PR DESCRIPTION
Adds profilesSampleRate to the Node SDK init options.

Adding this because we got 3 emails last week about the typescript error by our customers and asking them to @ts-expect-error is not really acceptable.