### PR TITLE
feat(browser): Add `__SENTRY_RELEASE__` magic string

### DIFF
--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -98,13 +98,14 @@ export function init(options: BrowserOptions = {}): void {
     options.defaultIntegrations = defaultIntegrations;
   }
   if (options.release === undefined) {
+    // This allows build tooling to find-and-replace __SENTRY_RELEASE__ to inject a release value
+    if (typeof __SENTRY_RELEASE__ === 'string') {
+      options.release = __SENTRY_RELEASE__;
+    }
+
     // This supports the variable that sentry-webpack-plugin injects
     if (WINDOW.SENTRY_RELEASE && WINDOW.SENTRY_RELEASE.id) {
       options.release = WINDOW.SENTRY_RELEASE.id;
-    }
-
-    if (typeof __SENTRY_RELEASE__ === 'string') {
-      options.release = __SENTRY_RELEASE__;
     }
   }
   if (options.autoSessionTracking === undefined) {

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -32,6 +32,11 @@ export const defaultIntegrations = [
 ];
 
 /**
+ * A magic string that build tooling can leverage in order to inject a release value into the SDK.
+ */
+declare const __SENTRY_RELEASE__: string | undefined;
+
+/**
  * The Sentry Browser SDK Client.
  *
  * To use this SDK, call the {@link init} function as early as possible when
@@ -96,6 +101,10 @@ export function init(options: BrowserOptions = {}): void {
     // This supports the variable that sentry-webpack-plugin injects
     if (WINDOW.SENTRY_RELEASE && WINDOW.SENTRY_RELEASE.id) {
       options.release = WINDOW.SENTRY_RELEASE.id;
+    }
+
+    if (typeof __SENTRY_RELEASE__ === 'string') {
+      options.release = __SENTRY_RELEASE__;
     }
   }
   if (options.autoSessionTracking === undefined) {

--- a/packages/gatsby/gatsby-browser.js
+++ b/packages/gatsby/gatsby-browser.js
@@ -26,8 +26,6 @@ exports.onClientEntry = function (_, pluginParams) {
 
   Sentry.init({
     // eslint-disable-next-line no-undef
-    release: __SENTRY_RELEASE__,
-    // eslint-disable-next-line no-undef
     dsn: __SENTRY_DSN__,
     ...pluginParams,
   });

--- a/packages/gatsby/test/gatsby-browser.test.ts
+++ b/packages/gatsby/test/gatsby-browser.test.ts
@@ -38,7 +38,7 @@ describe('onClientEntry', () => {
 
   it.each([
     [{}, ['dsn', 'release']],
-    [{ key: 'value' }, ['dsn', 'release', 'key']],
+    [{ key: 'value' }, ['dsn', 'key']],
   ])('inits Sentry by default', (pluginParams, expectedKeys) => {
     onClientEntry(undefined, pluginParams);
     expect(sentryInit).toHaveBeenCalledTimes(1);

--- a/packages/gatsby/test/gatsby-browser.test.ts
+++ b/packages/gatsby/test/gatsby-browser.test.ts
@@ -37,7 +37,7 @@ describe('onClientEntry', () => {
   });
 
   it.each([
-    [{}, ['dsn', 'release']],
+    [{}, ['dsn']],
     [{ key: 'value' }, ['dsn', 'key']],
   ])('inits Sentry by default', (pluginParams, expectedKeys) => {
     onClientEntry(undefined, pluginParams);


### PR DESCRIPTION
This adds a magic string in the browser code that can be used by build tooling to inject a release value into the SDK during build time.

This is not used right now but it makes sense to introduce something like it as early as possible because, in the future, we want to move our bundler plugins to use this approach instead of injecting a variable on `global`.