### PR TITLE
ref: Drop `no-plusplus` rule & refactor to use `++` / `--`

### DIFF
--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -25,9 +25,9 @@ export function shouldIgnoreOnError(): boolean {
  */
 export function ignoreNextOnError(): void {
   // onerror should trigger before setTimeout
-  ignoreOnError += 1;
+  ignoreOnError++;
   setTimeout(() => {
-    ignoreOnError -= 1;
+    ignoreOnError--;
   });
 }
 

--- a/packages/browser/test/integration/polyfills/promise.js
+++ b/packages/browser/test/integration/polyfills/promise.js
@@ -102,7 +102,6 @@
     observer.observe(node, { characterData: true });
 
     return function () {
-      // eslint-disable-next-line no-plusplus
       node.data = iterations = ++iterations % 2;
     };
   }

--- a/packages/browser/test/integration/polyfills/promise.js
+++ b/packages/browser/test/integration/polyfills/promise.js
@@ -467,11 +467,11 @@
 
   var id = 0;
   function nextId() {
-    return (id += 1);
+    return ++id;
   }
 
   function makePromise(promise) {
-    promise[PROMISE_ID] = id += 1;
+    promise[PROMISE_ID] = ++id;
     promise._state = undefined;
     promise._result = undefined;
     promise._subscribers = [];
@@ -534,7 +534,7 @@
         if (_then === then && entry._state !== PENDING) {
           this._settledAt(entry._state, i, entry._result);
         } else if (typeof _then !== 'function') {
-          this._remaining -= 1;
+          this._remaining--;
           this._result[i] = entry;
         } else if (c === Promise$2) {
           var promise = new c(noop);
@@ -561,7 +561,7 @@
       var promise = this.promise;
 
       if (promise._state === PENDING) {
-        this._remaining -= 1;
+        this._remaining--;
 
         if (state === REJECTED) {
           reject(promise, value);

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -714,14 +714,14 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    * Occupies the client with processing and event
    */
   protected _process<T>(promise: PromiseLike<T>): void {
-    this._numProcessing += 1;
+    this._numProcessing++;
     void promise.then(
       value => {
-        this._numProcessing -= 1;
+        this._numProcessing--;
         return value;
       },
       reason => {
-        this._numProcessing -= 1;
+        this._numProcessing--;
         return reason;
       },
     );

--- a/packages/core/test/mocks/transport.ts
+++ b/packages/core/test/mocks/transport.ts
@@ -18,10 +18,10 @@ export function makeFakeTransport(delay: number = 2000): {
   let sentCount = 0;
   const makeTransport = () =>
     createTransport({ recordDroppedEvent: () => undefined, textEncoder: new TextEncoder() }, () => {
-      sendCalled += 1;
+      sendCalled++;
       return new SyncPromise(async res => {
         await sleep(delay);
-        sentCount += 1;
+        sentCount++;
         res({});
       });
     });

--- a/packages/eslint-config-sdk/src/index.js
+++ b/packages/eslint-config-sdk/src/index.js
@@ -196,9 +196,6 @@ module.exports = {
   ],
 
   rules: {
-    // We want to prevent usage of unary operators outside of for loops
-    'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
-
     // Disallow usage of console and alert
     'no-console': 'error',
     'no-alert': 'error',

--- a/packages/gatsby/test/integration.test.tsx
+++ b/packages/gatsby/test/integration.test.tsx
@@ -22,7 +22,7 @@ describe('useEffect', () => {
     onClientEntry(undefined, {
       beforeSend: (event: any) => {
         expect(event).not.toBeUndefined();
-        calls += 1;
+        calls++;
 
         return null;
       },

--- a/packages/integration-tests/utils/helpers.ts
+++ b/packages/integration-tests/utils/helpers.ts
@@ -69,7 +69,7 @@ async function getMultipleRequests(
     function requestHandler(request: Request): void {
       if (urlRgx.test(request.url())) {
         try {
-          reqCount -= 1;
+          reqCount--;
           requestData.push(requestParser(request));
 
           if (reqCount === 0) {

--- a/packages/integration-tests/utils/web-vitals/cls.ts
+++ b/packages/integration-tests/utils/web-vitals/cls.ts
@@ -25,7 +25,7 @@ async function moveBy(elem: HTMLParagraphElement, percent: number): Promise<void
   if (elem.getAttribute('id') === 'partial') {
     const max = Number(elem.getAttribute('max-steps'));
     let current = Number(elem.getAttribute('steps'));
-    current += 1;
+    current++;
     if (current > max) {
       return;
     }
@@ -52,7 +52,7 @@ function howMany(desiredCls: number): { extraSteps: number; createParagraphs: nu
   const extraSteps = Math.round((desiredCls - fullRuns * 0.095) / 0.005);
   let create = fullRuns;
   if (extraSteps > 0) {
-    create += 1;
+    create++;
   }
 
   return { extraSteps: extraSteps, createParagraphs: create };

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -247,7 +247,7 @@ function _createWrappedRequestMethodFactory(
 
           const transaction = parentSpan.transaction;
           if (transaction) {
-            transaction.metadata.propagations += 1;
+            transaction.metadata.propagations++;
           }
         }
       }

--- a/packages/replay/.eslintrc.js
+++ b/packages/replay/.eslintrc.js
@@ -65,8 +65,6 @@ module.exports = {
         '@typescript-eslint/no-floating-promises': 'off',
         // TODO (medium-prio): Re-enable this after migration
         'jsdoc/require-jsdoc': 'off',
-        // TODO: Do we even want to turn this on? Why not enable ++?
-        'no-plusplus': 'off',
       },
     },
     {

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -216,7 +216,7 @@ export function fetchCallback(
         options,
       );
 
-      activeTransaction.metadata.propagations += 1;
+      activeTransaction.metadata.propagations++;
     }
   }
 }
@@ -351,7 +351,7 @@ export function xhrCallback(
           handlerData.xhr.setRequestHeader(BAGGAGE_HEADER_NAME, sentryBaggageHeader);
         }
 
-        activeTransaction.metadata.propagations += 1;
+        activeTransaction.metadata.propagations++;
       } catch (_) {
         // Error: InvalidStateError: Failed to execute 'setRequestHeader' on 'XMLHttpRequest': The object's state must be OPENED.
       }

--- a/packages/tracing/src/idletransaction.ts
+++ b/packages/tracing/src/idletransaction.ts
@@ -265,7 +265,7 @@ export class IdleTransaction extends Transaction {
     const heartbeatString = Object.keys(this.activities).join('');
 
     if (heartbeatString === this._prevHeartbeatString) {
-      this._heartbeatCounter += 1;
+      this._heartbeatCounter++;
     } else {
       this._heartbeatCounter = 1;
     }

--- a/packages/utils/src/browser.ts
+++ b/packages/utils/src/browser.ts
@@ -30,7 +30,6 @@ export function htmlTreeAsString(elem: unknown, keyAttrs?: string[]): string {
     const sepLength = separator.length;
     let nextStr;
 
-    // eslint-disable-next-line no-plusplus
     while (currentElem && height++ < MAX_TRAVERSE_HEIGHT) {
       nextStr = _htmlElementAsString(currentElem, keyAttrs);
       // bail out if

--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -526,7 +526,7 @@ function instrumentDOM(): void {
               originalAddEventListener.call(this, type, handler, options);
             }
 
-            handlerForType.refCount += 1;
+            handlerForType.refCount++;
           } catch (e) {
             // Accessing dom properties is always fragile.
             // Also allows us to skip `addEventListenrs` calls with no proper `this` context.
@@ -554,7 +554,7 @@ function instrumentDOM(): void {
               const handlerForType = handlers[type];
 
               if (handlerForType) {
-                handlerForType.refCount -= 1;
+                handlerForType.refCount--;
                 // If there are no longer any custom handlers of the current type on this element, we can remove ours, too.
                 if (handlerForType.refCount <= 0) {
                   originalRemoveEventListener.call(this, type, handlerForType.handler, options);

--- a/packages/utils/src/normalize.ts
+++ b/packages/utils/src/normalize.ts
@@ -147,7 +147,7 @@ function visit(
     const visitValue = visitable[visitKey];
     normalized[visitKey] = visit(visitKey, visitValue, depth - 1, maxProperties, memo);
 
-    numAdded += 1;
+    numAdded++;
   }
 
   // Once we've visited all the branches, remove the parent from memo storage

--- a/packages/utils/src/path.ts
+++ b/packages/utils/src/path.ts
@@ -11,18 +11,15 @@ function normalizeArray(parts: string[], allowAboveRoot?: boolean): string[] {
       parts.splice(i, 1);
     } else if (last === '..') {
       parts.splice(i, 1);
-      // eslint-disable-next-line no-plusplus
       up++;
     } else if (up) {
       parts.splice(i, 1);
-      // eslint-disable-next-line no-plusplus
       up--;
     }
   }
 
   // if the path is allowed to go above the root, restore leading ..s
   if (allowAboveRoot) {
-    // eslint-disable-next-line no-plusplus
     for (; up--; up) {
       parts.unshift('..');
     }

--- a/packages/utils/src/promisebuffer.ts
+++ b/packages/utils/src/promisebuffer.ts
@@ -90,7 +90,6 @@ export function makePromiseBuffer<T>(limit?: number): PromiseBuffer<T> {
       // if all promises resolve in time, cancel the timer and resolve to `true`
       buffer.forEach(item => {
         void resolvedSyncPromise(item).then(() => {
-          // eslint-disable-next-line no-plusplus
           if (!--counter) {
             clearTimeout(capturedSetTimeout);
             resolve(true);

--- a/packages/utils/src/stacktrace.ts
+++ b/packages/utils/src/stacktrace.ts
@@ -130,7 +130,6 @@ function node(getModule?: GetModuleFn): StackLineParserFn {
 
       let methodStart = functionName.lastIndexOf('.');
       if (functionName[methodStart - 1] === '.') {
-        // eslint-disable-next-line no-plusplus
         methodStart--;
       }
 

--- a/packages/vue/src/components.ts
+++ b/packages/vue/src/components.ts
@@ -61,7 +61,7 @@ export const generateComponentTrace = (vm?: ViewModel): string => {
         const last = tree[tree.length - 1] as any;
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         if (last.constructor === vm.constructor) {
-          currentRecursiveSequence += 1;
+          currentRecursiveSequence++;
           vm = vm.$parent; // eslint-disable-line no-param-reassign
           continue;
         } else if (currentRecursiveSequence > 0) {

--- a/scripts/ensure-bundle-deps.ts
+++ b/scripts/ensure-bundle-deps.ts
@@ -74,7 +74,7 @@ export async function ensureBundleBuildPrereqs(options: {
 
     while (retries < maxRetries && !checkForBundleDeps(packagesDir, dependencyDirs)) {
       console.log('Bundle dependencies not found. Trying again in 5 seconds.');
-      retries += 1;
+      retries++;
       await sleep(5000);
     }
 


### PR DESCRIPTION
This PR removes the `no-plusplus` eslint rule, as it doesn't really apply to us. By replacing usage of `a += 1` with `a++`, and `a -= 1` with `a--` we should actually be able to shave a few bytes off our bundles.