### PR TITLE
ref(replay): Improve `isBrowser` check

### DIFF
--- a/packages/replay/jest.setup.ts
+++ b/packages/replay/jest.setup.ts
@@ -10,6 +10,12 @@ global.__SENTRY_REPLAY_VERSION__ = 'version:Test';
 
 type MockTransport = jest.MockedFunction<Transport['send']>;
 
+jest.mock('./src/util/isBrowser', () => {
+  return {
+    isBrowser: () => true,
+  };
+});
+
 afterEach(() => {
   const hub = getCurrentHub();
   if (typeof hub?.getClient !== 'function') {

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -38,6 +38,7 @@ import { captureInternalException } from './util/captureInternalException';
 import { createBreadcrumb } from './util/createBreadcrumb';
 import { createPayload } from './util/createPayload';
 import { dedupePerformanceEntries } from './util/dedupePerformanceEntries';
+import { isBrowser } from './util/isBrowser';
 import { isExpired } from './util/isExpired';
 import { isSessionExpired } from './util/isSessionExpired';
 
@@ -52,8 +53,6 @@ const UNABLE_TO_SEND_REPLAY = 'Unable to send Replay';
 const MEDIA_SELECTORS = 'img,image,svg,path,rect,area,video,object,picture,embed,map,audio';
 
 let _initialized = false;
-
-const isBrowser = typeof window !== 'undefined';
 
 export class Replay implements Integration {
   /**
@@ -210,7 +209,7 @@ export class Replay implements Integration {
       maxWait: this.options.flushMaxDelay,
     });
 
-    if (isBrowser && _initialized) {
+    if (isBrowser() && _initialized) {
       const error = new Error('Multiple Sentry Session Replay instances are not supported');
       captureInternalException(error);
       throw error;
@@ -229,7 +228,7 @@ export class Replay implements Integration {
    * here to avoid any future issues.
    */
   setupOnce(): void {
-    if (!isBrowser) {
+    if (!isBrowser()) {
       return;
     }
     // XXX: See method comments above
@@ -243,7 +242,7 @@ export class Replay implements Integration {
    * PerformanceObserver, Recording, Sentry SDK, etc)
    */
   start(): void {
-    if (!isBrowser) {
+    if (!isBrowser()) {
       return;
     }
 
@@ -309,7 +308,7 @@ export class Replay implements Integration {
    * does not support a teardown
    */
   stop(): void {
-    if (!isBrowser) {
+    if (!isBrowser()) {
       return;
     }
 

--- a/packages/replay/src/util/isBrowser.ts
+++ b/packages/replay/src/util/isBrowser.ts
@@ -1,0 +1,5 @@
+import { isNodeEnv } from '@sentry/utils';
+
+export function isBrowser(): boolean {
+  return typeof window !== 'undefined' && !isNodeEnv();
+}

--- a/packages/replay/src/util/isInternal.ts
+++ b/packages/replay/src/util/isInternal.ts
@@ -1,9 +1,9 @@
-const isBrowser = typeof window !== 'undefined';
+import { isBrowser } from './isBrowser';
 
 /**
  * Returns true if we are currently recording an internal to Sentry replay
  * (e.g. on https://sentry.io )
  */
 export function isInternal(): boolean {
-  return isBrowser && ['sentry.io', 'dev.getsentry.net'].includes(window.location.host);
+  return isBrowser() && ['sentry.io', 'dev.getsentry.net'].includes(window.location.host);
 }


### PR DESCRIPTION
Extracted out of https://github.com/getsentry/sentry-javascript/pull/6316, as these are only semi-related. This should allow us to better evaluate bundle size changes due to `WINDOW`

For now, just changed the logic a bit to use `isNodeEnv` under the hood. In a next step we should evaluate if we can remove some of these checks.