### PR TITLE
ci(replay): Ensure replay size limit excludes internal dependencies

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -69,6 +69,7 @@ module.exports = [
     path: 'packages/replay/build/npm/dist/index.js',
     gzip: true,
     limit: '100 KB',
+    ignore: ['@sentry/browser', '@sentry/utils', '@sentry/core', '@sentry/types'],
   },
   {
     name: '@sentry/replay - Webpack (gzipped + minified)',
@@ -76,6 +77,7 @@ module.exports = [
     import: '{ Replay }',
     gzip: true,
     limit: '100 KB',
+    ignore: ['@sentry/browser', '@sentry/utils', '@sentry/core', '@sentry/types'],
   },
   {
     name: '@sentry/replay - Webpack (minified)',
@@ -83,5 +85,6 @@ module.exports = [
     import: '{ Replay }',
     gzip: false,
     limit: '300 KB',
+    ignore: ['@sentry/browser', '@sentry/utils', '@sentry/core', '@sentry/types'],
   },
 ];


### PR DESCRIPTION
This gives us a more "correct" representation of the actual size increase to expect when using replay vs. not using it.

Note that we _do_ want to keep `rrweb` in there.