### PR TITLE
fix(otel): Set root transaction name to be route

### DIFF
--- a/packages/opentelemetry-node/src/utils/parse-otel-span-description.ts
+++ b/packages/opentelemetry-node/src/utils/parse-otel-span-description.ts
@@ -98,7 +98,9 @@ function descriptionForHttpMethod(otelSpan: OtelSpan, httpMethod: AttributeValue
 
   // Ex. description="GET /api/users".
   const description = `${httpMethod} ${httpPath}`;
-  const source: TransactionSource = httpRoute ? 'route' : 'url';
+
+  // If `httpPath` is a root path, then we can categorize the transaction source as route.
+  const source: TransactionSource = httpRoute || httpPath === '/' ? 'route' : 'url';
 
   return { op: opParts.join('.'), description, source };
 }

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -458,6 +458,21 @@ describe('SentrySpanProcessor', () => {
       });
     });
 
+    it('adds transaction source `route` for root path HTTP_TARGET', async () => {
+      const tracer = provider.getTracer('default');
+
+      tracer.startActiveSpan('GET /', otelSpan => {
+        const sentrySpan = getSpanForOtelSpan(otelSpan);
+
+        otelSpan.setAttribute(SemanticAttributes.HTTP_METHOD, 'GET');
+        otelSpan.setAttribute(SemanticAttributes.HTTP_TARGET, '/');
+
+        otelSpan.end();
+
+        expect(sentrySpan?.transaction?.metadata.source).toBe('route');
+      });
+    });
+
     it('adds transaction source `url` for HTTP_ROUTE', async () => {
       const tracer = provider.getTracer('default');
 


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-javascript/issues/6301

If a low cardinality `http.route` is not defined, we fall back to `http.target` and set transaction source to be `url`. In that case, we should special case `http.target` === `/` since we know the `/` root transaction has no parameters. Therefore we categorize it as transaction source `route`.