### PR TITLE
fix(replay): fix rrweb issue & vendor it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ env:
 
   CACHED_DEPENDENCY_PATHS: |
     ${{ github.workspace }}/node_modules
-    ${{ github.workspace }}/packages/**/node_modules
+    ${{ github.workspace }}/packages/*/node_modules
     ~/.cache/ms-playwright/
     ~/.cache/mongodb-binaries/
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lint:eslint": "lerna run --parallel lint:eslint",
     "postpublish": "lerna run --stream --concurrency 1 postpublish",
     "test": "lerna run --ignore @sentry-internal/browser-integration-tests --ignore @sentry-internal/node-integration-tests --stream --concurrency 1 --sort test",
-    "test-ci": "ts-node ./scripts/test.ts"
+    "test-ci": "ts-node ./scripts/test.ts",
+    "postinstall": "patch-package"
   },
   "volta": {
     "node": "16.18.1",
@@ -89,6 +90,7 @@
     "mocha": "^6.1.4",
     "nodemon": "^2.0.16",
     "npm-run-all": "^4.1.5",
+    "patch-package": "^6.5.0",
     "prettier": "2.7.1",
     "recast": "^0.20.5",
     "replace-in-file": "^4.0.0",

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -52,14 +52,14 @@
     "@types/pako": "^2.0.0",
     "jsdom-worker": "^0.2.1",
     "pako": "^2.0.4",
+    "rrweb": "1.1.3",
     "tslib": "^1.9.3"
   },
   "dependencies": {
     "@sentry/core": "7.23.0",
     "@sentry/types": "7.23.0",
     "@sentry/utils": "7.23.0",
-    "lodash.debounce": "^4.0.8",
-    "rrweb": "1.1.3"
+    "lodash.debounce": "^4.0.8"
   },
   "peerDependencies": {
     "@sentry/browser": "7.23.0"

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -59,7 +59,7 @@
     "@sentry/types": "7.23.0",
     "@sentry/utils": "7.23.0",
     "lodash.debounce": "^4.0.8",
-    "rrweb": "^1.1.3"
+    "rrweb": "1.1.3"
   },
   "peerDependencies": {
     "@sentry/browser": "7.23.0"

--- a/packages/replay/rollup.npm.config.js
+++ b/packages/replay/rollup.npm.config.js
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import replace from '@rollup/plugin-replace';
 
 import { makeBaseNPMConfig, makeNPMConfigVariants } from '../../rollup/index';
@@ -8,7 +10,6 @@ export default makeNPMConfigVariants(
   makeBaseNPMConfig({
     hasBundles: true,
     packageSpecificConfig: {
-      external: [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})],
       plugins: [
         // TODO: Remove this - replay version will be in sync w/ SDK version
         replace({
@@ -22,6 +23,12 @@ export default makeNPMConfigVariants(
         // set exports to 'named' or 'auto' so that rollup doesn't warn about
         // the default export in `worker/worker.js`
         exports: 'named',
+
+        // As we are inlining the rrweb dependency here, we need to ensure the nested folders are correct
+        // Without this config, you get:
+        // * build/npm/esm/node_modules/rrweb/...
+        // * build/npm/esm/packages/replay/...
+        preserveModulesRoot: path.join(process.cwd(), 'src'),
       },
     },
   }),

--- a/patches/rrweb+1.1.3.patch
+++ b/patches/rrweb+1.1.3.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/rrweb/es/rrweb/packages/rrweb/src/record/index.js b/node_modules/rrweb/es/rrweb/packages/rrweb/src/record/index.js
+index 8091399..48e8321 100644
+--- a/node_modules/rrweb/es/rrweb/packages/rrweb/src/record/index.js
++++ b/node_modules/rrweb/es/rrweb/packages/rrweb/src/record/index.js
+@@ -325,7 +325,11 @@ function record(options) {
+             }, hooks);
+         };
+         iframeManager.addLoadListener(function (iframeEl) {
+-            handlers_1.push(observe_1(iframeEl.contentDocument));
++            try {
++                handlers_1.push(observe_1(iframeEl.contentDocument));
++            } catch (error) {
++                console.warn('error in rrweb iframe observer', error);
++            }
+         });
+         var init_1 = function () {
+             takeFullSnapshot();

--- a/yarn.lock
+++ b/yarn.lock
@@ -6043,7 +6043,7 @@
     tslib "^2.3.1"
     upath2 "^3.1.12"
 
-"@yarnpkg/lockfile@1.1.0":
+"@yarnpkg/lockfile@1.1.0", "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
@@ -17127,6 +17127,13 @@ kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
@@ -19600,6 +19607,14 @@ open@7.2.0:
     is-docker "^2.0.0"
     is-wsl "^2.1.1"
 
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 open@^8.3.0:
   version "8.4.0"
   resolved "https://registry.yarnpkg.com/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8"
@@ -20147,6 +20162,26 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+patch-package@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.5.0.tgz#feb058db56f0005da59cfa316488321de585e88a"
+  integrity sha512-tC3EqJmo74yKqfsMzELaFwxOAu6FH6t+FzFOsnWAuARm7/n2xB5AOeOueE221eM9gtMuIKMKpF9tBy/X2mNP0Q==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^4.1.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.6"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+    yaml "^1.10.2"
 
 path-browserify@0.0.1:
   version "0.0.1"
@@ -22608,7 +22643,7 @@ rrweb-snapshot@^1.1.14:
   resolved "https://registry.yarnpkg.com/rrweb-snapshot/-/rrweb-snapshot-1.1.14.tgz#9d4d9be54a28a893373428ee4393ec7e5bd83fcc"
   integrity sha512-eP5pirNjP5+GewQfcOQY4uBiDnpqxNRc65yKPW0eSoU1XamDfc4M8oqpXGMyUyvLyxFDB0q0+DChuxxiU2FXBQ==
 
-rrweb@^1.1.3:
+rrweb@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/rrweb/-/rrweb-1.1.3.tgz#4fbb3d473d71c79b6c30a54e585e5a01c8ac08bb"
   integrity sha512-F2qp8LteJLyycsv+lCVJqtVpery63L3U+/ogqMA0da8R7Jx57o6gT+HpjrzdeeGMIBZR7kKNaKyJwDupTTu5KA==
@@ -26607,6 +26642,11 @@ yaml@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.1.1.tgz#1e06fb4ca46e60d9da07e4f786ea370ed3c3cfec"
   integrity sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==
+
+yaml@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
+  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yargs-parser@13.1.2, yargs-parser@^13.1.2:
   version "13.1.2"


### PR DESCRIPTION
While debugging the replay issue https://github.com/getsentry/sentry-replay/issues/297, we found that most likely the problem is upstream in rrweb. I created an issue there to fix it: https://github.com/rrweb-io/rrweb/issues/1057

Really, the change is minimal, but the PR is not yet merged & even when it is merged it is not clear when this will be released. Even _when_ it will be released, it will probably go into 2.0.0-alpha.X, which will need some time from us to actually update (as there are no upgrade docs yet etc.)

So, with that in mind, this PR does two things:

1. Introduce `patch-package` to fix the exact issue we care about in rrweb
2. Inline rrweb into the replay bundle

## Details

### 1. Using `patch-package` to fix rrweb

This approach has two main benefits:
a) We can fix this issue very quickly
b) We still maintain the ability to easily update rrweb in the future

patch-package works at build-time via `postinstall`, literally fixing the code in your node_modules folder. 

### 2. Inlining rrweb

The only downside of this, really, is that users cannot manually update/pin rrweb to any other version as the one we include. But I think that is acceptable for us. It will be on us to update rrweb whenever they ship fixes/new updates/improvements.

Without this, `patch-package` could not actually work for users that install `@sentry/replay` via `npm install`, as they would not get the patched version. So inlining this is basically a requirement for this to work.


Closes https://github.com/getsentry/sentry-replay/issues/297