### PR TITLE
fix(tracing): Instrument cursors returned from MongoDB operations.

### DIFF
--- a/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/scenario.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/scenario.ts
@@ -36,6 +36,8 @@ async function run(): Promise<void> {
     await collection.findOne({ title: 'Back to the Future' });
     await collection.updateOne({ title: 'Back to the Future' }, { $set: { title: 'South Park' } });
     await collection.findOne({ title: 'South Park' });
+
+    await collection.find({ title: 'South Park' }).toArray();
   } finally {
     if (transaction) transaction.finish();
     await client.close();

--- a/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
@@ -53,16 +53,6 @@ conditionalTest({ min: 12 })('MongoDB Test', () => {
             collectionName: 'movies',
             dbName: 'admin',
             namespace: 'admin.movies',
-            query: '{"title":"Back to the Future"}',
-          },
-          description: 'find',
-          op: 'db',
-        },
-        {
-          data: {
-            collectionName: 'movies',
-            dbName: 'admin',
-            namespace: 'admin.movies',
             filter: '{"title":"Back to the Future"}',
             update: '{"$set":{"title":"South Park"}}',
           },

--- a/packages/tracing/src/integrations/node/mongo.ts
+++ b/packages/tracing/src/integrations/node/mongo.ts
@@ -1,7 +1,7 @@
 import { Hub } from '@sentry/core';
 import { EventProcessor, Integration, SpanContext } from '@sentry/types';
 import { fill, isInstanceOf, isThenable, loadModule, logger } from '@sentry/utils';
-import { EventEmitter } from 'stream';
+import { EventEmitter } from 'events';
 
 import { shouldDisableAutoInstrumentation } from './utils/node-utils';
 


### PR DESCRIPTION
Fixes #4495 

Instrumented [`Cursor`](https://mongodb.github.io/node-mongodb-native/4.12/classes/AbstractCursor.html)s returned from certain MongoDB operations, this also resolves the problem mentioned in #5278.