### PR TITLE
fix(replay): Temporarily replace `__DEBUG_BUILD__` with `true`

### DIFF
--- a/packages/replay/config/rollup.config.core.ts
+++ b/packages/replay/config/rollup.config.core.ts
@@ -31,7 +31,8 @@ const config = defineConfig({
         __SENTRY_REPLAY_VERSION__: JSON.stringify(pkg.version),
         // @ts-ignore not gonna deal with types here
         __SENTRY_DEBUG__: !IS_PRODUCTION,
-        // @ts-ignore not gonna deal with types here
+        // @ts-ignore __DEBUG_BUILD__ variable isn't yet replaced correctly at build time so
+        // we need to set this as true.
         __DEBUG_BUILD__: true,
       },
     }),

--- a/packages/replay/config/rollup.config.core.ts
+++ b/packages/replay/config/rollup.config.core.ts
@@ -31,6 +31,8 @@ const config = defineConfig({
         __SENTRY_REPLAY_VERSION__: JSON.stringify(pkg.version),
         // @ts-ignore not gonna deal with types here
         __SENTRY_DEBUG__: !IS_PRODUCTION,
+        // @ts-ignore not gonna deal with types here
+        __DEBUG_BUILD__: true,
       },
     }),
   ],


### PR DESCRIPTION
This PR fixes a runtime bug with Replay which started happening after the monorepo migration because the `__DEBUG_BUILD__` variable isn't yet replaced correctly at build time. This temporary fix will be replaced once we use the monorepo's rollup configs for building Replay (WIP). 