### PR TITLE
ref(replay): Enable `@typescript-eslint/no-floating-promises` rule

### DIFF
--- a/packages/replay/.eslintrc.js
+++ b/packages/replay/.eslintrc.js
@@ -59,8 +59,6 @@ module.exports = {
         ],
         // TODO (high-prio): Re-enable this after migration
         '@sentry-internal/sdk/no-async-await': 'off',
-        // TODO (high-prio): Re-enable this after migration
-        '@typescript-eslint/no-floating-promises': 'off',
         // TODO (medium-prio): Re-enable this after migration
         'jsdoc/require-jsdoc': 'off',
       },

--- a/packages/replay/src/eventBuffer.ts
+++ b/packages/replay/src/eventBuffer.ts
@@ -142,7 +142,7 @@ export class EventBufferCompressionWorker implements IEventBuffer {
   }
 
   init(): void {
-    this.postMessage({ id: this.id, method: 'init', args: [] });
+    void this.postMessage({ id: this.id, method: 'init', args: [] });
     __DEBUG_BUILD__ && logger.log('[Replay] Initialized compression worker');
   }
 

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -724,7 +724,7 @@ export class Replay implements Integration {
       }
 
       this.addUpdate(() => {
-        this.createPerformanceSpans([result as ReplayPerformanceEntry]);
+        void this.createPerformanceSpans([result as ReplayPerformanceEntry]);
         // Returning true will cause `addUpdate` to not flush
         // We do not want network requests to cause a flush. This will prevent
         // recurring/polling requests from keeping the replay session alive.
@@ -901,7 +901,7 @@ export class Replay implements Integration {
    * called in an event handler for a user action that we consider as the user
    * being "active" (e.g. a mouse click).
    */
-  async triggerUserActivity(): Promise<void> {
+  triggerUserActivity(): void {
     this.updateUserActivity();
 
     // This case means that recording was once stopped due to inactivity.
@@ -1036,7 +1036,7 @@ export class Replay implements Integration {
       return;
     }
 
-    this.flushImmediate();
+    void this.flushImmediate();
   }
 
   /**


### PR DESCRIPTION
This one was rather straightforward, basically adding `void` before floating promises.