### PR TITLE
fix(otel): Account for number status code

### DIFF
--- a/packages/opentelemetry-node/src/utils/map-otel-status.ts
+++ b/packages/opentelemetry-node/src/utils/map-otel-status.ts
@@ -59,8 +59,9 @@ export function mapOtelStatus(otelSpan: OtelSpan): SentryStatus {
   const httpCode = attributes[SemanticAttributes.HTTP_STATUS_CODE];
   const grpcCode = attributes[SemanticAttributes.RPC_GRPC_STATUS_CODE];
 
-  if (typeof httpCode === 'string') {
-    const sentryStatus = canonicalCodesHTTPMap[httpCode];
+  const code = typeof httpCode === 'string' ? httpCode : typeof httpCode === 'number' ? httpCode.toString() : undefined;
+  if (code) {
+    const sentryStatus = canonicalCodesHTTPMap[code];
     if (sentryStatus) {
       return sentryStatus;
     }

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -260,7 +260,7 @@ describe('SentrySpanProcessor', () => {
     });
   });
 
-  const statusTestTable: [number, undefined | string, undefined | string, SpanStatusType][] = [
+  const statusTestTable: [number, undefined | number | string, undefined | string, SpanStatusType][] = [
     [-1, undefined, undefined, 'unknown_error'],
     [3, undefined, undefined, 'unknown_error'],
     [0, undefined, undefined, 'ok'],
@@ -268,6 +268,19 @@ describe('SentrySpanProcessor', () => {
     [2, undefined, undefined, 'unknown_error'],
 
     // http codes
+    [2, 400, undefined, 'failed_precondition'],
+    [2, 401, undefined, 'unauthenticated'],
+    [2, 403, undefined, 'permission_denied'],
+    [2, 404, undefined, 'not_found'],
+    [2, 409, undefined, 'aborted'],
+    [2, 429, undefined, 'resource_exhausted'],
+    [2, 499, undefined, 'cancelled'],
+    [2, 500, undefined, 'internal_error'],
+    [2, 501, undefined, 'unimplemented'],
+    [2, 503, undefined, 'unavailable'],
+    [2, 504, undefined, 'deadline_exceeded'],
+    [2, 999, undefined, 'unknown_error'],
+
     [2, '400', undefined, 'failed_precondition'],
     [2, '401', undefined, 'unauthenticated'],
     [2, '403', undefined, 'permission_denied'],


### PR DESCRIPTION
http status code is defined in the spec as a number: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes

Let's add special casing for both possibilities (status code is either a string or a number).