### PR TITLE
ref(replay): Enable `no-console` rule

### DIFF
--- a/packages/replay/.eslintrc.js
+++ b/packages/replay/.eslintrc.js
@@ -37,8 +37,6 @@ module.exports = {
     {
       files: ['*.ts', '*.tsx', '*.d.ts'],
       rules: {
-        // TODO (high-prio): Go through console logs and figure out which ones should be replaced with the SDK logger
-        'no-console': 'off',
         // TODO (high-prio): Re-enable this after migration
         '@typescript-eslint/explicit-member-accessibility': 'off',
         // TODO (high-prio): Remove this exception from naming convention after migration

--- a/packages/replay/src/eventBuffer.ts
+++ b/packages/replay/src/eventBuffer.ts
@@ -130,7 +130,7 @@ export class EventBufferCompressionWorker implements IEventBuffer {
       try {
         stringifiedArgs = JSON.stringify(args);
       } catch (err) {
-        console.error(err);
+        __DEBUG_BUILD__ && logger.error('[Replay] Error when trying to stringify args', err);
         stringifiedArgs = '[]';
       }
 

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -180,12 +180,14 @@ export class Replay implements Integration {
 
     // TODO(deprecated): Maintain backwards compatibility for alpha users
     if (usingDeprecatedCaptureOnlyOnError) {
+      // eslint-disable-next-line no-console
       console.warn(
         '[@sentry/replay]: The `captureOnlyOnError` option is deprecated! Please configure `errorSampleRate` instead.',
       );
     }
 
     if (usingDeprecatedReplaysSamplingRate) {
+      // eslint-disable-next-line no-console
       console.warn(
         '[@sentry/replay]: The `replaysSamplingRate` option is deprecated! Please configure `sessionSampleRate` instead.',
       );
@@ -1081,7 +1083,7 @@ export class Replay implements Integration {
    */
   async runFlush(): Promise<void> {
     if (!this.session) {
-      console.error(new Error('[Sentry]: No transaction, no replay'));
+      __DEBUG_BUILD__ && logger.error('[Replay] No session found to flush.');
       return;
     }
 
@@ -1113,8 +1115,8 @@ export class Replay implements Integration {
         eventContext,
       });
     } catch (err) {
+      __DEBUG_BUILD__ && logger.error(err);
       captureInternalException(err);
-      console.error(err);
     }
   }
 
@@ -1135,7 +1137,7 @@ export class Replay implements Integration {
     }
 
     if (!this.session?.id) {
-      console.error('[Replay]: No transaction, no replay');
+      __DEBUG_BUILD__ && logger.error('[Replay] No session found to flush.');
       return;
     }
 
@@ -1161,7 +1163,7 @@ export class Replay implements Integration {
     try {
       await this.flushLock;
     } catch (err) {
-      console.error(err);
+      __DEBUG_BUILD__ && logger.error(err);
     } finally {
       this.debouncedFlush();
     }
@@ -1306,13 +1308,13 @@ export class Replay implements Integration {
       });
       this.resetRetries();
       return true;
-    } catch (ex) {
-      console.error(ex);
+    } catch (err) {
+      __DEBUG_BUILD__ && logger.error(err);
       // Capture error for every failed replay
       setContext('Replays', {
         retryCount: this.retryCount,
       });
-      captureInternalException(ex);
+      captureInternalException(err);
 
       // If an error happened here, it's likely that uploading the attachment
       // failed, we'll can retry with the same events payload

--- a/packages/replay/test/unit/index.test.ts
+++ b/packages/replay/test/unit/index.test.ts
@@ -525,8 +525,7 @@ describe('Replay', () => {
     const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
 
     // Suppress console.errors
-    jest.spyOn(console, 'error').mockImplementation(jest.fn());
-    const mockConsole = console.error as jest.MockedFunction<typeof console.error>;
+    const mockConsole = jest.spyOn(console, 'error').mockImplementation(jest.fn());
 
     // fail the first and second requests and pass the third one
     mockTransportSend.mockImplementationOnce(() => {
@@ -576,8 +575,7 @@ describe('Replay', () => {
     jest.spyOn(replay, 'sendReplay');
 
     // Suppress console.errors
-    jest.spyOn(console, 'error').mockImplementation(jest.fn());
-    const mockConsole = console.error as jest.MockedFunction<typeof console.error>;
+    const mockConsole = jest.spyOn(console, 'error').mockImplementation(jest.fn());
 
     expect(replay.session?.segmentId).toBe(0);
 
@@ -693,8 +691,7 @@ describe('Replay', () => {
   it('does not create replay event if recording upload completely fails', async () => {
     const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
     // Suppress console.errors
-    jest.spyOn(console, 'error').mockImplementation(jest.fn());
-    const mockConsole = console.error as jest.MockedFunction<typeof console.error>;
+    const mockConsole = jest.spyOn(console, 'error').mockImplementation(jest.fn());
     // fail the first and second requests and pass the third one
     mockSendReplayRequest.mockImplementationOnce(() => {
       throw new Error('Something bad happened');

--- a/packages/replay/worker/src/handleMessage.ts
+++ b/packages/replay/worker/src/handleMessage.ts
@@ -50,6 +50,8 @@ export function handleMessage(e: MessageEvent): void {
         success: false,
         response: err,
       });
+
+      // eslint-disable-next-line no-console
       console.error(err);
     }
   }


### PR DESCRIPTION
This enabled `no-console` eslint rule.

I left two cases of actual `console.warn` in, where it is basically a deprecation for old settings (which we can probably eventually delete).