### PR TITLE
build(replay): Adjust type declaration output directory

### DIFF
--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -4,7 +4,7 @@
   "description": "User replays for Sentry",
   "main": "build/npm/cjs/index.js",
   "module": "build/npm/esm/index.js",
-  "types": "build/npm/types/src/index.d.ts",
+  "types": "build/npm/types/index.d.ts",
   "sideEffects": false,
   "scripts": {
     "bootstrap": "yarn && cd demo && yarn #TODO: change after migration",

--- a/packages/replay/tsconfig.json
+++ b/packages/replay/tsconfig.json
@@ -1,13 +1,6 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "paths": {
-      "@test": ["./test"],
-      "@test/*": ["./test/*"]
-    },
-    "baseUrl": ".",
-    "rootDir": ".",
-    "types": ["node", "jest"],
     "module": "esnext",
     "noImplicitAny": true,
     "noEmitOnError": false,


### PR DESCRIPTION
This PR follows up with a small change on top of #6343 to further align the `build` directory. Previously, types were built into `build/npm/types/src/index.d.ts`. The `src` sub-directory shouldn't be in there, so this PR fixes that by removing some leftover properties in the main `tsconfig.json` which caused this sub-directory to appear. 

This PR also removes a few additional unnecessary properties, such as `types` which we only need in `tsconfig.test.json`.

ref: #6280