### PR TITLE
build: Do not exclude `devDependencies` from rollup build

### DIFF
--- a/rollup/npmHelpers.js
+++ b/rollup/npmHelpers.js
@@ -93,7 +93,6 @@ export function makeBaseNPMConfig(options = {}) {
     external: [
       ...builtinModules,
       ...Object.keys(packageDotJSON.dependencies || {}),
-      ...Object.keys(packageDotJSON.devDependencies || {}),
       ...Object.keys(packageDotJSON.peerDependencies || {}),
     ],
 


### PR DESCRIPTION
Currently, our rollup config adds all `dependencies`, `devDependencies` and `peerDependencies` to the `external` array, meaning they will not be inlined into the build.

However, that makes it impossible to _selectively_ inline files. For example, in replay we'd like to inline `rrweb` into the bundle.

What makes this even more tricky is that because of the nature of `deepmerge`, which we use to merge custom config into the default one, it is actually impossible to overwrite this, as a custom `external` array will not overwrite the default one, but be added to it.

This change removes `devDependencies` from the externals. IMHO that is otherwise bound to break anyhow - as if the dependency is neither `dependency` nor `peerDependency`, and you import it (but not bundle it), stuff might break anyhow. If there is a dependency that you are referencing in a bundle, but it is not added as `dependencies`, you have to add it as `peerDependencies`.

I tried to locally `yarn clean && yarn build` and checked all the `build/esm` outputs, and there was no unexpected `node_modules` stuff to be found there. We generally use few dependencies, so as far as I can tell this has no actual impact on current output.
