### PR TITLE
ref(tracing): Remove `sentry_reportAllChanges` tag

### DIFF
--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -269,10 +269,6 @@ export class BrowserTracing implements Integration {
     );
     idleTransaction.registerBeforeFinishCallback(transaction => {
       addPerformanceEntries(transaction);
-      transaction.setTag(
-        'sentry_reportAllChanges',
-        Boolean(this.options._metricOptions && this.options._metricOptions._reportAllChanges),
-      );
     });
 
     return idleTransaction as Transaction;


### PR DESCRIPTION
The SDK should avoid setting tags when possible. This PR makes sure we remove this tag, which isn't really useful anymore. We were using this to track metadata when we were tracking improvements to `idleTimeout`: https://github.com/getsentry/sentry-javascript/pull/4251, but now that we've shipped that with v7, we can remove this tag.

Related: https://github.com/getsentry/team-mobile/issues/60#issuecomment-1333057921