### PR TITLE
chore(replay): Use Monorepo's toplevel `.npmignore`

### DIFF
--- a/packages/replay/.npmignore
+++ b/packages/replay/.npmignore
@@ -1,3 +1,0 @@
-# TODO after we migrated, we should revisit this file and check if we can use the monorepo's master
-# .npmigore file or if we should add custom entries here.
-# For the time being, this can stay empty.


### PR DESCRIPTION
This PR removes Replay's empty `.npmignore` file as we can use the monorepo's top-level `.npmignore` file. When running `build:npm`, this top-level ignore file is copied into the `build/npm` directory where it is used to control what's going into the NPM tarball. Because the Replay package now has the same contents and structure as all our other packages, we don't need a package-specific ignore file.

ref #6280