### PR TITLE
fix(otel): Add trace info to error events

### DIFF
--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -715,7 +715,7 @@ describe('SentrySpanProcessor', () => {
     });
   });
 
-  it.only('associates an error to a transaction', () => {
+  it('associates an error to a transaction', () => {
     let sentryEvent: any;
     let otelSpan: any;
 


### PR DESCRIPTION
Follows spec as is outlined here: https://develop.sentry.dev/sdk/performance/opentelemetry/#step-1-implement-the-sentryspanprocessor-on-your-sdk

Uses the logic from the baseclient here: https://github.com/getsentry/sentry-javascript/blob/8139853e416d04772b31e9920bca889ecbee1516/packages/core/src/scope.ts#L473-L482

Attach trace context info from active transaction to errors in an event processor. Couple things to note.

1. This attaches the trace context to all events. Transactions should be setting their own trace context, and that will override this via the spread operator
2. We don't use scope at all here - we are relying on identifying the active span via opentelemetry.

Supercedes approach from https://github.com/getsentry/sentry-javascript/pull/6349 since we don't want to rely on scope.