### PR TITLE
Revert "build(replay): Remove replay version string replacement (#6367)"

### DIFF
--- a/packages/replay/jest.setup.ts
+++ b/packages/replay/jest.setup.ts
@@ -5,6 +5,9 @@ import { Transport } from '@sentry/types';
 import { Replay } from './src';
 import { Session } from './src/session/Session';
 
+// @ts-ignore TS error, this is replaced in prod builds bc of rollup
+global.__SENTRY_REPLAY_VERSION__ = 'version:Test';
+
 type MockTransport = jest.MockedFunction<Transport['send']>;
 
 jest.mock('./src/util/isBrowser', () => {

--- a/packages/replay/rollup.npm.config.js
+++ b/packages/replay/rollup.npm.config.js
@@ -1,3 +1,5 @@
+import replace from '@rollup/plugin-replace';
+
 import { makeBaseNPMConfig, makeNPMConfigVariants } from '../../rollup/index';
 
 import pkg from './package.json';
@@ -7,6 +9,15 @@ export default makeNPMConfigVariants(
     hasBundles: true,
     packageSpecificConfig: {
       external: [...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})],
+      plugins: [
+        // TODO: Remove this - replay version will be in sync w/ SDK version
+        replace({
+          preventAssignment: true,
+          values: {
+            __SENTRY_REPLAY_VERSION__: JSON.stringify(pkg.version),
+          },
+        }),
+      ],
       output: {
         // set exports to 'named' or 'auto' so that rollup doesn't warn about
         // the default export in `worker/worker.js`

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */ // TODO: We might want to split this file up
 import { WINDOW } from '@sentry/browser';
-import { addGlobalEventProcessor, getCurrentHub, Scope, SDK_VERSION, setContext } from '@sentry/core';
+import { addGlobalEventProcessor, getCurrentHub, Scope, setContext } from '@sentry/core';
 import { Breadcrumb, Client, Event, Integration } from '@sentry/types';
 import { addInstrumentationHandler, createEnvelope, logger } from '@sentry/utils';
 import debounce from 'lodash.debounce';
@@ -1186,7 +1186,7 @@ export class Replay implements Integration {
 
     const sdkInfo = {
       name: 'sentry.javascript.integration.replay',
-      version: SDK_VERSION,
+      version: __SENTRY_REPLAY_VERSION__,
     };
 
     const replayEvent = await new Promise(resolve => {

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -33,6 +33,10 @@ export interface WorkerRequest {
   args: unknown[];
 }
 
+declare global {
+  const __SENTRY_REPLAY_VERSION__: string;
+}
+
 // PerformancePaintTiming and PerformanceNavigationTiming are only available with TS 4.4 and newer
 // Therefore, we're exporting them here to make them available in older TS versions
 export type PerformancePaintTiming = PerformanceEntry;


### PR DESCRIPTION
This PR reverts #6367 as the Replay team would like to continue injecting the version separately from the SDK to detect version package version mismatches more easily. 

Note: This will not avoid the 7.x bump in the next Replay release, it will just enable a scenario like users use the SDK on e.g. 7.25 and Replay on 7.24 and replay events will have the 7.24 version in their metadata.

Note 2: This makes a very good case for exporting Replay via the SDK to, as it avoids version mismatches all together. Same for Tracing later on...