### PR TITLE
ref(nextjs): Clean up client-side integrations code

### DIFF
--- a/packages/nextjs/test/index.client.test.ts
+++ b/packages/nextjs/test/index.client.test.ts
@@ -63,7 +63,7 @@ describe('Client init()', () => {
           },
         },
         environment: 'test',
-        integrations: undefined,
+        integrations: [],
       }),
     );
   });


### PR DESCRIPTION
This refactors the code in the nextjs SDK adding client-side integrations to:

- Consolidate the logic, which currently is split between `init` and a helper function, to all live in the helper. Not only is this better practice in general, it also sets up for a future PR which will add a new integration. (Adding more code to the current somewhat-messy setup would just make it worse, and it's easier to fix it before that happens.)
- Align the client-side code with the server-side code, for greater maintainability.