### PR TITLE
ref(nextjs): Don't initialize SDK during build

### DIFF
--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -33,6 +33,12 @@ const IS_VERCEL = !!process.env.VERCEL;
 
 /** Inits the Sentry NextJS SDK on node. */
 export function init(options: NextjsOptions): void {
+  if (IS_BUILD) {
+    // Next.js runs some of the user code (data fetching methods) during build and our init code is being run alongside
+    // the user code.Because it is a bit unnecessary to have the SDK running during the build we just noop.
+    return;
+  }
+
   if (__DEBUG_BUILD__ && options.debug) {
     logger.enable();
   }


### PR DESCRIPTION
Makes Next.js SDK init a no-op during build (`next build`). The reasoning behind that is that running the SDK is a bit unnecessary during the build.
