### PR TITLE
ref(replay): Export `WINDOW` within Replay instead of importing it from Browser

### DIFF
--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -1,3 +1,10 @@
+import { GLOBAL_OBJ } from '@sentry/utils';
+
+// exporting WINDOW from within the @sentry/replay instead of importing it from @sentry/browser
+// this avoids the Browser package being bundled into the CDN bundle as well as a
+// circular dependency between the Browser and Replay packages in the future
+export const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
+
 export const REPLAY_SESSION_KEY = 'sentryReplaySession';
 export const REPLAY_EVENT_NAME = 'replay_event';
 export const RECORDING_EVENT_NAME = 'replay_recording';

--- a/packages/replay/src/createPerformanceEntry.ts
+++ b/packages/replay/src/createPerformanceEntry.ts
@@ -1,7 +1,8 @@
 import { browserPerformanceTimeOrigin } from '@sentry/utils';
 import { record } from 'rrweb';
 
-import { AllPerformanceEntry, PerformanceNavigationTiming, PerformancePaintTiming, WINDOW } from './types';
+import { WINDOW } from './constants';
+import { AllPerformanceEntry, PerformanceNavigationTiming, PerformancePaintTiming } from './types';
 import { isIngestHost } from './util/isIngestHost';
 
 export interface ReplayPerformanceEntry {

--- a/packages/replay/src/createPerformanceEntry.ts
+++ b/packages/replay/src/createPerformanceEntry.ts
@@ -1,8 +1,7 @@
-import { WINDOW } from '@sentry/browser';
 import { browserPerformanceTimeOrigin } from '@sentry/utils';
 import { record } from 'rrweb';
 
-import { AllPerformanceEntry, PerformanceNavigationTiming, PerformancePaintTiming } from './types';
+import { AllPerformanceEntry, PerformanceNavigationTiming, PerformancePaintTiming, WINDOW } from './types';
 import { isIngestHost } from './util/isIngestHost';
 
 export interface ReplayPerformanceEntry {

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable max-lines */ // TODO: We might want to split this file up
-import { WINDOW } from '@sentry/browser';
 import { addGlobalEventProcessor, getCurrentHub, Scope, setContext } from '@sentry/core';
 import { Breadcrumb, Client, Event, Integration } from '@sentry/types';
 import { addInstrumentationHandler, createEnvelope, logger } from '@sentry/utils';
@@ -23,7 +22,7 @@ import { deleteSession } from './session/deleteSession';
 import { getSession } from './session/getSession';
 import { saveSession } from './session/saveSession';
 import { Session } from './session/Session';
-import type {
+import {
   AllPerformanceEntry,
   InstrumentationTypeBreadcrumb,
   InstrumentationTypeSpan,
@@ -34,6 +33,7 @@ import type {
   ReplayConfiguration,
   ReplayPluginOptions,
   SendReplay,
+  WINDOW,
 } from './types';
 import { addInternalBreadcrumb } from './util/addInternalBreadcrumb';
 import { captureInternalException } from './util/captureInternalException';

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -6,10 +6,6 @@ import debounce from 'lodash.debounce';
 import { PerformanceObserverEntryList } from 'perf_hooks';
 import { EventType, record } from 'rrweb';
 
-import { breadcrumbHandler } from './coreHandlers/breadcrumbHandler';
-import { spanHandler } from './coreHandlers/spanHandler';
-import { createMemoryEntry, createPerformanceEntries, ReplayPerformanceEntry } from './createPerformanceEntry';
-import { createEventBuffer, IEventBuffer } from './eventBuffer';
 import {
   DEFAULT_ERROR_SAMPLE_RATE,
   DEFAULT_SESSION_SAMPLE_RATE,
@@ -17,7 +13,12 @@ import {
   REPLAY_EVENT_NAME,
   SESSION_IDLE_DURATION,
   VISIBILITY_CHANGE_TIMEOUT,
-} from './session/constants';
+  WINDOW,
+} from './constants';
+import { breadcrumbHandler } from './coreHandlers/breadcrumbHandler';
+import { spanHandler } from './coreHandlers/spanHandler';
+import { createMemoryEntry, createPerformanceEntries, ReplayPerformanceEntry } from './createPerformanceEntry';
+import { createEventBuffer, IEventBuffer } from './eventBuffer';
 import { deleteSession } from './session/deleteSession';
 import { getSession } from './session/getSession';
 import { saveSession } from './session/saveSession';
@@ -33,7 +34,6 @@ import {
   ReplayConfiguration,
   ReplayPluginOptions,
   SendReplay,
-  WINDOW,
 } from './types';
 import { addInternalBreadcrumb } from './util/addInternalBreadcrumb';
 import { captureInternalException } from './util/captureInternalException';

--- a/packages/replay/src/session/deleteSession.ts
+++ b/packages/replay/src/session/deleteSession.ts
@@ -1,5 +1,4 @@
-import { WINDOW } from '../types';
-import { REPLAY_SESSION_KEY } from './constants';
+import { REPLAY_SESSION_KEY, WINDOW } from '../constants';
 
 /**
  * Deletes a session from storage

--- a/packages/replay/src/session/deleteSession.ts
+++ b/packages/replay/src/session/deleteSession.ts
@@ -1,5 +1,4 @@
-import { WINDOW } from '@sentry/browser';
-
+import { WINDOW } from '../types';
 import { REPLAY_SESSION_KEY } from './constants';
 
 /**

--- a/packages/replay/src/session/fetchSession.ts
+++ b/packages/replay/src/session/fetchSession.ts
@@ -1,5 +1,5 @@
-import { SampleRates, WINDOW } from '../types';
-import { REPLAY_SESSION_KEY } from './constants';
+import { REPLAY_SESSION_KEY, WINDOW } from '../constants';
+import { SampleRates } from '../types';
 import { Session } from './Session';
 
 /**

--- a/packages/replay/src/session/fetchSession.ts
+++ b/packages/replay/src/session/fetchSession.ts
@@ -1,6 +1,4 @@
-import { WINDOW } from '@sentry/browser';
-
-import { SampleRates } from '../types';
+import { SampleRates, WINDOW } from '../types';
 import { REPLAY_SESSION_KEY } from './constants';
 import { Session } from './Session';
 

--- a/packages/replay/src/session/saveSession.ts
+++ b/packages/replay/src/session/saveSession.ts
@@ -1,5 +1,4 @@
-import { WINDOW } from '@sentry/browser';
-
+import { WINDOW } from '../types';
 import { REPLAY_SESSION_KEY } from './constants';
 import { Session } from './Session';
 

--- a/packages/replay/src/session/saveSession.ts
+++ b/packages/replay/src/session/saveSession.ts
@@ -1,5 +1,4 @@
-import { WINDOW } from '../types';
-import { REPLAY_SESSION_KEY } from './constants';
+import { REPLAY_SESSION_KEY, WINDOW } from '../constants';
 import { Session } from './Session';
 
 export function saveSession(session: Session): void {

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -1,4 +1,10 @@
+import { GLOBAL_OBJ } from '@sentry/utils';
 import type { eventWithTime, recordOptions } from 'rrweb/typings/types';
+
+// exporting WINDOW from within this package instead of importing it from @sentry/browser
+// this avoids the Browser package being bundled into the CDN bundle as well as a
+// circular dependency between the Browser and Replay packages in the future
+export const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
 
 export type RecordingEvent = eventWithTime;
 export type RecordingOptions = recordOptions<eventWithTime>;

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -1,10 +1,4 @@
-import { GLOBAL_OBJ } from '@sentry/utils';
 import type { eventWithTime, recordOptions } from 'rrweb/typings/types';
-
-// exporting WINDOW from within this package instead of importing it from @sentry/browser
-// this avoids the Browser package being bundled into the CDN bundle as well as a
-// circular dependency between the Browser and Replay packages in the future
-export const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
 
 export type RecordingEvent = eventWithTime;
 export type RecordingOptions = recordOptions<eventWithTime>;

--- a/packages/replay/src/util/isInternal.ts
+++ b/packages/replay/src/util/isInternal.ts
@@ -1,4 +1,4 @@
-import { WINDOW } from '../types';
+import { WINDOW } from '../constants';
 import { isBrowser } from './isBrowser';
 
 /**

--- a/packages/replay/src/util/isInternal.ts
+++ b/packages/replay/src/util/isInternal.ts
@@ -1,5 +1,4 @@
-import { WINDOW } from '@sentry/browser';
-
+import { WINDOW } from '../types';
 import { isBrowser } from './isBrowser';
 
 /**

--- a/packages/replay/src/util/isSessionExpired.ts
+++ b/packages/replay/src/util/isSessionExpired.ts
@@ -1,4 +1,4 @@
-import { MAX_SESSION_LIFE } from '../session/constants';
+import { MAX_SESSION_LIFE } from '../constants';
 import { Session } from '../session/Session';
 import { isExpired } from './isExpired';
 

--- a/packages/replay/test/unit/flush.test.ts
+++ b/packages/replay/test/unit/flush.test.ts
@@ -1,10 +1,9 @@
 import * as SentryUtils from '@sentry/utils';
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
-import { WINDOW } from '../../src/types';
+import { SESSION_IDLE_DURATION, WINDOW } from '../../src/constants';
 import { Replay } from './../../src';
 import { createPerformanceEntries } from './../../src/createPerformanceEntry';
-import { SESSION_IDLE_DURATION } from './../../src/session/constants';
 import { useFakeTimers } from './../../test/utils/use-fake-timers';
 
 useFakeTimers();

--- a/packages/replay/test/unit/flush.test.ts
+++ b/packages/replay/test/unit/flush.test.ts
@@ -1,7 +1,7 @@
-import { WINDOW } from '@sentry/browser';
 import * as SentryUtils from '@sentry/utils';
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
+import { WINDOW } from '../../src/types';
 import { Replay } from './../../src';
 import { createPerformanceEntries } from './../../src/createPerformanceEntry';
 import { SESSION_IDLE_DURATION } from './../../src/session/constants';

--- a/packages/replay/test/unit/index-errorSampleRate.test.ts
+++ b/packages/replay/test/unit/index-errorSampleRate.test.ts
@@ -6,9 +6,8 @@ import { PerformanceEntryResource } from '@test/fixtures/performanceEntry/resour
 import { resetSdkMock } from '@test/mocks';
 import { DomHandler, MockTransportSend } from '@test/types';
 
-import { WINDOW } from '../../src/types';
+import { REPLAY_SESSION_KEY, VISIBILITY_CHANGE_TIMEOUT, WINDOW } from '../../src/constants';
 import { Replay } from './../../src';
-import { REPLAY_SESSION_KEY, VISIBILITY_CHANGE_TIMEOUT } from './../../src/session/constants';
 import { useFakeTimers } from './../utils/use-fake-timers';
 
 useFakeTimers();

--- a/packages/replay/test/unit/index-errorSampleRate.test.ts
+++ b/packages/replay/test/unit/index-errorSampleRate.test.ts
@@ -1,11 +1,12 @@
 jest.unmock('@sentry/browser');
 
-import { captureException, WINDOW } from '@sentry/browser';
+import { captureException } from '@sentry/browser';
 import { BASE_TIMESTAMP, RecordMock } from '@test';
 import { PerformanceEntryResource } from '@test/fixtures/performanceEntry/resource';
 import { resetSdkMock } from '@test/mocks';
 import { DomHandler, MockTransportSend } from '@test/types';
 
+import { WINDOW } from '../../src/types';
 import { Replay } from './../../src';
 import { REPLAY_SESSION_KEY, VISIBILITY_CHANGE_TIMEOUT } from './../../src/session/constants';
 import { useFakeTimers } from './../utils/use-fake-timers';

--- a/packages/replay/test/unit/index-handleGlobalEvent.test.ts
+++ b/packages/replay/test/unit/index-handleGlobalEvent.test.ts
@@ -2,8 +2,8 @@ import { Error } from '@test/fixtures/error';
 import { Transaction } from '@test/fixtures/transaction';
 import { resetSdkMock } from '@test/mocks';
 
+import { REPLAY_EVENT_NAME } from '../../src/constants';
 import { Replay } from './../../src';
-import { REPLAY_EVENT_NAME } from './../../src/session/constants';
 import { useFakeTimers } from './../utils/use-fake-timers';
 
 useFakeTimers();

--- a/packages/replay/test/unit/index-noSticky.test.ts
+++ b/packages/replay/test/unit/index-noSticky.test.ts
@@ -3,8 +3,8 @@ import { Transport } from '@sentry/types';
 import * as SentryUtils from '@sentry/utils';
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
+import { SESSION_IDLE_DURATION, VISIBILITY_CHANGE_TIMEOUT } from '../../src/constants';
 import { Replay } from './../../src';
-import { SESSION_IDLE_DURATION, VISIBILITY_CHANGE_TIMEOUT } from './../../src/session/constants';
 import { useFakeTimers } from './../utils/use-fake-timers';
 
 useFakeTimers();

--- a/packages/replay/test/unit/index.test.ts
+++ b/packages/replay/test/unit/index.test.ts
@@ -1,7 +1,6 @@
 jest.mock('./../../src/util/isInternal', () => ({
   isInternal: jest.fn(() => true),
 }));
-import { WINDOW } from '@sentry/browser';
 import { BASE_TIMESTAMP, RecordMock } from '@test';
 import { PerformanceEntryResource } from '@test/fixtures/performanceEntry/resource';
 import { resetSdkMock } from '@test/mocks';
@@ -10,7 +9,7 @@ import { EventType } from 'rrweb';
 
 import { Replay } from '../../src';
 import { MAX_SESSION_LIFE, REPLAY_SESSION_KEY, VISIBILITY_CHANGE_TIMEOUT } from '../../src/session/constants';
-import { RecordingEvent } from '../../src/types';
+import { RecordingEvent, WINDOW } from '../../src/types';
 import { useFakeTimers } from '../utils/use-fake-timers';
 
 useFakeTimers();

--- a/packages/replay/test/unit/index.test.ts
+++ b/packages/replay/test/unit/index.test.ts
@@ -8,8 +8,8 @@ import { DomHandler, MockTransportSend } from '@test/types';
 import { EventType } from 'rrweb';
 
 import { Replay } from '../../src';
-import { MAX_SESSION_LIFE, REPLAY_SESSION_KEY, VISIBILITY_CHANGE_TIMEOUT } from '../../src/session/constants';
-import { RecordingEvent, WINDOW } from '../../src/types';
+import { MAX_SESSION_LIFE, REPLAY_SESSION_KEY, VISIBILITY_CHANGE_TIMEOUT, WINDOW } from '../../src/constants';
+import { RecordingEvent } from '../../src/types';
 import { useFakeTimers } from '../utils/use-fake-timers';
 
 useFakeTimers();

--- a/packages/replay/test/unit/session/Session.test.ts
+++ b/packages/replay/test/unit/session/Session.test.ts
@@ -24,9 +24,9 @@ jest.mock('@sentry/utils', () => {
 });
 
 import * as Sentry from '@sentry/browser';
-import { WINDOW } from '@sentry/browser';
 
 import { Session } from '../../../src/session/Session';
+import { WINDOW } from '../../../src/types';
 
 type CaptureEventMockType = jest.MockedFunction<typeof Sentry.captureEvent>;
 

--- a/packages/replay/test/unit/session/Session.test.ts
+++ b/packages/replay/test/unit/session/Session.test.ts
@@ -25,8 +25,8 @@ jest.mock('@sentry/utils', () => {
 
 import * as Sentry from '@sentry/browser';
 
+import { WINDOW } from '../../../src/constants';
 import { Session } from '../../../src/session/Session';
-import { WINDOW } from '../../../src/types';
 
 type CaptureEventMockType = jest.MockedFunction<typeof Sentry.captureEvent>;
 

--- a/packages/replay/test/unit/session/createSession.test.ts
+++ b/packages/replay/test/unit/session/createSession.test.ts
@@ -1,8 +1,8 @@
-import { WINDOW } from '@sentry/browser';
 import * as Sentry from '@sentry/core';
 
 import { createSession } from '../../../src/session/createSession';
 import { saveSession } from '../../../src/session/saveSession';
+import { WINDOW } from '../../../src/types';
 
 jest.mock('./../../../src/session/saveSession');
 

--- a/packages/replay/test/unit/session/createSession.test.ts
+++ b/packages/replay/test/unit/session/createSession.test.ts
@@ -1,8 +1,8 @@
 import * as Sentry from '@sentry/core';
 
+import { WINDOW } from '../../../src/constants';
 import { createSession } from '../../../src/session/createSession';
 import { saveSession } from '../../../src/session/saveSession';
-import { WINDOW } from '../../../src/types';
 
 jest.mock('./../../../src/session/saveSession');
 

--- a/packages/replay/test/unit/session/deleteSession.test.ts
+++ b/packages/replay/test/unit/session/deleteSession.test.ts
@@ -1,6 +1,5 @@
-import { REPLAY_SESSION_KEY } from '../../../src/session/constants';
+import { REPLAY_SESSION_KEY, WINDOW } from '../../../src/constants';
 import { deleteSession } from '../../../src/session/deleteSession';
-import { WINDOW } from '../../../src/types';
 
 const storageEngine = WINDOW.sessionStorage;
 

--- a/packages/replay/test/unit/session/deleteSession.test.ts
+++ b/packages/replay/test/unit/session/deleteSession.test.ts
@@ -1,7 +1,6 @@
-import { WINDOW } from '@sentry/browser';
-
 import { REPLAY_SESSION_KEY } from '../../../src/session/constants';
 import { deleteSession } from '../../../src/session/deleteSession';
+import { WINDOW } from '../../../src/types';
 
 const storageEngine = WINDOW.sessionStorage;
 

--- a/packages/replay/test/unit/session/fetchSession.test.ts
+++ b/packages/replay/test/unit/session/fetchSession.test.ts
@@ -1,7 +1,6 @@
-import { WINDOW } from '@sentry/browser';
-
 import { REPLAY_SESSION_KEY } from '../../../src/session/constants';
 import { fetchSession } from '../../../src/session/fetchSession';
+import { WINDOW } from '../../../src/types';
 
 const oldSessionStorage = WINDOW.sessionStorage;
 

--- a/packages/replay/test/unit/session/fetchSession.test.ts
+++ b/packages/replay/test/unit/session/fetchSession.test.ts
@@ -1,6 +1,5 @@
-import { REPLAY_SESSION_KEY } from '../../../src/session/constants';
+import { REPLAY_SESSION_KEY, WINDOW } from '../../../src/constants';
 import { fetchSession } from '../../../src/session/fetchSession';
-import { WINDOW } from '../../../src/types';
 
 const oldSessionStorage = WINDOW.sessionStorage;
 

--- a/packages/replay/test/unit/session/getSession.test.ts
+++ b/packages/replay/test/unit/session/getSession.test.ts
@@ -1,9 +1,9 @@
+import { WINDOW } from '../../../src/constants';
 import * as CreateSession from '../../../src/session/createSession';
 import * as FetchSession from '../../../src/session/fetchSession';
 import { getSession } from '../../../src/session/getSession';
 import { saveSession } from '../../../src/session/saveSession';
 import { Session } from '../../../src/session/Session';
-import { WINDOW } from '../../../src/types';
 
 jest.mock('@sentry/utils', () => {
   return {

--- a/packages/replay/test/unit/session/getSession.test.ts
+++ b/packages/replay/test/unit/session/getSession.test.ts
@@ -1,10 +1,9 @@
-import { WINDOW } from '@sentry/browser';
-
 import * as CreateSession from '../../../src/session/createSession';
 import * as FetchSession from '../../../src/session/fetchSession';
 import { getSession } from '../../../src/session/getSession';
 import { saveSession } from '../../../src/session/saveSession';
 import { Session } from '../../../src/session/Session';
+import { WINDOW } from '../../../src/types';
 
 jest.mock('@sentry/utils', () => {
   return {

--- a/packages/replay/test/unit/session/saveSession.test.ts
+++ b/packages/replay/test/unit/session/saveSession.test.ts
@@ -1,8 +1,7 @@
-import { WINDOW } from '@sentry/browser';
-
 import { REPLAY_SESSION_KEY } from '../../../src/session/constants';
 import { saveSession } from '../../../src/session/saveSession';
 import { Session } from '../../../src/session/Session';
+import { WINDOW } from '../../../src/types';
 
 beforeAll(() => {
   WINDOW.sessionStorage.clear();

--- a/packages/replay/test/unit/session/saveSession.test.ts
+++ b/packages/replay/test/unit/session/saveSession.test.ts
@@ -1,7 +1,6 @@
-import { REPLAY_SESSION_KEY } from '../../../src/session/constants';
+import { REPLAY_SESSION_KEY, WINDOW } from '../../../src/constants';
 import { saveSession } from '../../../src/session/saveSession';
 import { Session } from '../../../src/session/Session';
-import { WINDOW } from '../../../src/types';
 
 beforeAll(() => {
   WINDOW.sessionStorage.clear();

--- a/packages/replay/test/unit/stop.test.ts
+++ b/packages/replay/test/unit/stop.test.ts
@@ -1,8 +1,8 @@
-import { WINDOW } from '@sentry/browser';
 import * as SentryUtils from '@sentry/utils';
 // mock functions need to be imported first
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
+import { WINDOW } from '../../src/types';
 import { Replay } from './../../src';
 import { SESSION_IDLE_DURATION } from './../../src/session/constants';
 import { useFakeTimers } from './../utils/use-fake-timers';

--- a/packages/replay/test/unit/stop.test.ts
+++ b/packages/replay/test/unit/stop.test.ts
@@ -2,9 +2,8 @@ import * as SentryUtils from '@sentry/utils';
 // mock functions need to be imported first
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
-import { WINDOW } from '../../src/types';
+import { SESSION_IDLE_DURATION, WINDOW } from '../../src/constants';
 import { Replay } from './../../src';
-import { SESSION_IDLE_DURATION } from './../../src/session/constants';
 import { useFakeTimers } from './../utils/use-fake-timers';
 
 useFakeTimers();


### PR DESCRIPTION
In preparation of generating CDN bundles, this PR copies the `WINDOW` constant declaration from `@sentry/browser` to the Replay package and updates the imports to use the package-internal version of `WINDOW`. This has two advantages:

* When building CDN bundles, we don't bundle contents from `@sentry/browser` anymore. This previously caused the generated bundles to not work correctly and it unnecessarily increased bundle size
* By not importing anything from `@sentry/browser` we avoid a circular dependency one we export the Replay integration from the Browser SDK.

ref #6362 