### PR TITLE
Revert "fix(core): Only generate eventIds in client"

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -127,7 +127,8 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
       return;
     }
 
-    let eventId: string | undefined;
+    let eventId: string | undefined = hint && hint.event_id;
+
     this._process(
       this.eventFromException(exception, hint)
         .then(event => this._captureEvent(event, hint, scope))
@@ -149,7 +150,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
     hint?: EventHint,
     scope?: Scope,
   ): string | undefined {
-    let eventId: string | undefined;
+    let eventId: string | undefined = hint && hint.event_id;
 
     const promisedEvent = isPrimitive(message)
       ? this.eventFromMessage(String(message), level, hint)
@@ -176,7 +177,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
       return;
     }
 
-    let eventId: string | undefined;
+    let eventId: string | undefined = hint && hint.event_id;
 
     this._process(
       this._captureEvent(event, hint, scope).then(result => {

--- a/packages/hub/test/hub.test.ts
+++ b/packages/hub/test/hub.test.ts
@@ -7,13 +7,11 @@ import { getCurrentHub, Hub, Scope } from '../src';
 
 const clientFn: any = jest.fn();
 
-const MOCK_EVENT_ID = '7bab5137428b4de29891fb8bd34a31cb';
-
 function makeClient() {
   return {
     getOptions: jest.fn(),
     captureEvent: jest.fn(),
-    captureException: jest.fn().mockReturnValue(MOCK_EVENT_ID),
+    captureException: jest.fn(),
     close: jest.fn(),
     flush: jest.fn(),
     getDsn: jest.fn(),
@@ -226,12 +224,14 @@ describe('Hub', () => {
       expect(args[0]).toBe('a');
     });
 
-    test('should get event_id from client', () => {
+    test('should set event_id in hint', () => {
       const testClient = makeClient();
       const hub = new Hub(testClient);
 
-      const id = hub.captureException('a');
-      expect(id).toBeDefined();
+      hub.captureException('a');
+      const args = getPassedArgs(testClient.captureException);
+
+      expect(args[1].event_id).toBeTruthy();
     });
 
     test('should keep event_id from hint', () => {
@@ -270,12 +270,14 @@ describe('Hub', () => {
       expect(args[0]).toBe('a');
     });
 
-    test('should get event_id from client', () => {
+    test('should set event_id in hint', () => {
       const testClient = makeClient();
       const hub = new Hub(testClient);
 
-      const id = hub.captureMessage('a');
-      expect(id).toBeDefined();
+      hub.captureMessage('a');
+      const args = getPassedArgs(testClient.captureMessage);
+
+      expect(args[2].event_id).toBeTruthy();
     });
 
     test('should keep event_id from hint', () => {
@@ -316,15 +318,17 @@ describe('Hub', () => {
       expect(args[0]).toBe(event);
     });
 
-    test('should get event_id from client', () => {
+    test('should set event_id in hint', () => {
       const event: Event = {
         extra: { b: 3 },
       };
       const testClient = makeClient();
       const hub = new Hub(testClient);
 
-      const id = hub.captureEvent(event);
-      expect(id).toBeDefined();
+      hub.captureEvent(event);
+      const args = getPassedArgs(testClient.captureEvent);
+
+      expect(args[1].event_id).toBeTruthy();
     });
 
     test('should keep event_id from hint', () => {
@@ -348,8 +352,10 @@ describe('Hub', () => {
       const testClient = makeClient();
       const hub = new Hub(testClient);
 
-      const id = hub.captureEvent(event);
-      expect(id).toEqual(hub.lastEventId());
+      hub.captureEvent(event);
+      const args = getPassedArgs(testClient.captureEvent);
+
+      expect(args[1].event_id).toEqual(hub.lastEventId());
     });
 
     test('transactions do not set lastEventId', () => {
@@ -360,8 +366,10 @@ describe('Hub', () => {
       const testClient = makeClient();
       const hub = new Hub(testClient);
 
-      const id = hub.captureEvent(event);
-      expect(id).not.toEqual(hub.lastEventId());
+      hub.captureEvent(event);
+      const args = getPassedArgs(testClient.captureEvent);
+
+      expect(args[1].event_id).not.toEqual(hub.lastEventId());
     });
   });
 


### PR DESCRIPTION
Reverts getsentry/sentry-javascript#6247

Fixes https://github.com/getsentry/sentry-javascript/issues/6380

Reverting the PR that moved the event_id generation into the client because this is causing issues if you have async event processors. Although our processing pipeline uses `SyncPromise`, async code can sneak in there, and this means that our event id's can be undefined.

Since there is a workaround for the initial perf problem we are electing to just revert. 