### PR TITLE
build(replay): Fix peer dependency version

### DIFF
--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -58,7 +58,7 @@
     "rrweb": "^1.1.3"
   },
   "peerDependencies": {
-    "@sentry/browser": "7.22.0"
+    "@sentry/browser": "7.23.0"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
This was merged after a release, so the version wasn't bumped 🙈 