### PR TITLE
build(replay): Streamline tsconfig & jest config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,9 @@
   "search.exclude": {
     "**/node_modules/": true,
     "**/build/": true,
-    "**/dist/": true
+    "**/dist/": true,
+    "**/coverage/": true,
+    "**/yarn-error.log": true
   },
   "typescript.tsdk": "./node_modules/typescript/lib",
   "[json]": {

--- a/packages/replay/.eslintrc.js
+++ b/packages/replay/.eslintrc.js
@@ -60,8 +60,6 @@ module.exports = {
       files: ['test/**/*.ts'],
 
       rules: {
-        // TODO: decide if we want to keep our '@test' import paths
-        'import/no-unresolved': 'off',
         // most of these errors come from `new Promise(process.nextTick)`
         '@typescript-eslint/unbound-method': 'off',
         // TODO: decide if we want to enable this again after the migration

--- a/packages/replay/jest.config.ts
+++ b/packages/replay/jest.config.ts
@@ -1,8 +1,5 @@
 import type { Config } from '@jest/types';
-import { pathsToModuleNameMapper } from 'ts-jest';
 import { jsWithTs as jsWithTsPreset } from 'ts-jest/presets';
-
-import { compilerOptions } from './tsconfig.test.json';
 
 export default async (): Promise<Config.InitialOptions> => {
   return {
@@ -14,9 +11,6 @@ export default async (): Promise<Config.InitialOptions> => {
       },
       __DEBUG_BUILD__: true,
     },
-    moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
-      prefix: '<rootDir>/',
-    }),
     setupFilesAfterEnv: ['./jest.setup.ts'],
     testEnvironment: 'jsdom',
     testMatch: ['<rootDir>/test/**/*(*.)@(spec|test).ts'],

--- a/packages/replay/jest.config.ts
+++ b/packages/replay/jest.config.ts
@@ -4,7 +4,6 @@ import { jsWithTs as jsWithTsPreset } from 'ts-jest/presets';
 export default async (): Promise<Config.InitialOptions> => {
   return {
     ...jsWithTsPreset,
-    verbose: true,
     globals: {
       'ts-jest': {
         tsconfig: '<rootDir>/tsconfig.test.json',

--- a/packages/replay/test/mocks/index.ts
+++ b/packages/replay/test/mocks/index.ts
@@ -1,8 +1,8 @@
 import { getCurrentHub } from '@sentry/core';
 
 import { ReplayConfiguration } from '../../src/types';
-import { BASE_TIMESTAMP, RecordMock } from './..';
 import { Replay } from './../../src';
+import { BASE_TIMESTAMP, RecordMock } from './../index';
 import { DomHandler, MockTransportSend } from './../types';
 
 export async function resetSdkMock(options?: ReplayConfiguration): Promise<{

--- a/packages/replay/test/mocks/index.ts
+++ b/packages/replay/test/mocks/index.ts
@@ -1,9 +1,9 @@
 import { getCurrentHub } from '@sentry/core';
-import { BASE_TIMESTAMP, RecordMock } from '@test';
-import { DomHandler, MockTransportSend } from '@test/types';
-import { Replay } from 'src';
 
 import { ReplayConfiguration } from '../../src/types';
+import { BASE_TIMESTAMP, RecordMock } from './..';
+import { Replay } from './../../src';
+import { DomHandler, MockTransportSend } from './../types';
 
 export async function resetSdkMock(options?: ReplayConfiguration): Promise<{
   domHandler: DomHandler;

--- a/packages/replay/test/unit/coreHandlers/handleFetch.test.ts
+++ b/packages/replay/test/unit/coreHandlers/handleFetch.test.ts
@@ -1,5 +1,5 @@
 import { handleFetch } from '../../../src/coreHandlers/handleFetch';
-import { mockSdk } from './../..';
+import { mockSdk } from './../../index';
 
 jest.unmock('@sentry/browser');
 

--- a/packages/replay/test/unit/coreHandlers/handleFetch.test.ts
+++ b/packages/replay/test/unit/coreHandlers/handleFetch.test.ts
@@ -1,6 +1,5 @@
-import { mockSdk } from '@test';
-
 import { handleFetch } from '../../../src/coreHandlers/handleFetch';
+import { mockSdk } from './../..';
 
 jest.unmock('@sentry/browser');
 

--- a/packages/replay/test/unit/coreHandlers/handleScope-unit.test.ts
+++ b/packages/replay/test/unit/coreHandlers/handleScope-unit.test.ts
@@ -1,7 +1,7 @@
 import { getCurrentHub } from '@sentry/core';
-import { mockSdk } from '@test';
 
 import * as HandleScope from '../../../src/coreHandlers/handleScope';
+import { mockSdk } from './../..';
 
 let mockHandleScope: jest.MockedFunction<typeof HandleScope.handleScope>;
 

--- a/packages/replay/test/unit/coreHandlers/handleScope-unit.test.ts
+++ b/packages/replay/test/unit/coreHandlers/handleScope-unit.test.ts
@@ -1,7 +1,7 @@
 import { getCurrentHub } from '@sentry/core';
 
 import * as HandleScope from '../../../src/coreHandlers/handleScope';
-import { mockSdk } from './../..';
+import { mockSdk } from './../../index';
 
 let mockHandleScope: jest.MockedFunction<typeof HandleScope.handleScope>;
 

--- a/packages/replay/test/unit/createPerformanceEntry.test.ts
+++ b/packages/replay/test/unit/createPerformanceEntry.test.ts
@@ -1,5 +1,5 @@
 import { createPerformanceEntries } from '../../src/createPerformanceEntry';
-import { mockSdk } from './..';
+import { mockSdk } from './../index';
 
 jest.unmock('@sentry/browser');
 

--- a/packages/replay/test/unit/createPerformanceEntry.test.ts
+++ b/packages/replay/test/unit/createPerformanceEntry.test.ts
@@ -1,6 +1,5 @@
-import { mockSdk } from '@test';
-
 import { createPerformanceEntries } from '../../src/createPerformanceEntry';
+import { mockSdk } from './..';
 
 jest.unmock('@sentry/browser');
 

--- a/packages/replay/test/unit/eventBuffer.test.ts
+++ b/packages/replay/test/unit/eventBuffer.test.ts
@@ -1,8 +1,8 @@
 import 'jsdom-worker';
 
-import { BASE_TIMESTAMP } from '@test';
 import pako from 'pako';
 
+import { BASE_TIMESTAMP } from './..';
 import { createEventBuffer, EventBufferCompressionWorker } from './../../src/eventBuffer';
 
 const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };

--- a/packages/replay/test/unit/eventBuffer.test.ts
+++ b/packages/replay/test/unit/eventBuffer.test.ts
@@ -2,8 +2,8 @@ import 'jsdom-worker';
 
 import pako from 'pako';
 
-import { BASE_TIMESTAMP } from './..';
 import { createEventBuffer, EventBufferCompressionWorker } from './../../src/eventBuffer';
+import { BASE_TIMESTAMP } from './../index';
 
 const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
 

--- a/packages/replay/test/unit/flush.test.ts
+++ b/packages/replay/test/unit/flush.test.ts
@@ -1,10 +1,10 @@
 import * as SentryUtils from '@sentry/utils';
 
 import { SESSION_IDLE_DURATION, WINDOW } from '../../src/constants';
-import { BASE_TIMESTAMP, mockRrweb, mockSdk } from './..';
 import { Replay } from './../../src';
 import { createPerformanceEntries } from './../../src/createPerformanceEntry';
 import { useFakeTimers } from './../../test/utils/use-fake-timers';
+import { BASE_TIMESTAMP, mockRrweb, mockSdk } from './../index';
 
 useFakeTimers();
 

--- a/packages/replay/test/unit/flush.test.ts
+++ b/packages/replay/test/unit/flush.test.ts
@@ -1,7 +1,7 @@
 import * as SentryUtils from '@sentry/utils';
-import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
 import { SESSION_IDLE_DURATION, WINDOW } from '../../src/constants';
+import { BASE_TIMESTAMP, mockRrweb, mockSdk } from './..';
 import { Replay } from './../../src';
 import { createPerformanceEntries } from './../../src/createPerformanceEntry';
 import { useFakeTimers } from './../../test/utils/use-fake-timers';

--- a/packages/replay/test/unit/index-errorSampleRate.test.ts
+++ b/packages/replay/test/unit/index-errorSampleRate.test.ts
@@ -3,9 +3,9 @@ jest.unmock('@sentry/browser');
 import { captureException } from '@sentry/browser';
 
 import { REPLAY_SESSION_KEY, VISIBILITY_CHANGE_TIMEOUT, WINDOW } from '../../src/constants';
-import { BASE_TIMESTAMP, RecordMock } from './..';
 import { Replay } from './../../src';
 import { PerformanceEntryResource } from './../fixtures/performanceEntry/resource';
+import { BASE_TIMESTAMP, RecordMock } from './../index';
 import { resetSdkMock } from './../mocks';
 import { DomHandler, MockTransportSend } from './../types';
 import { useFakeTimers } from './../utils/use-fake-timers';

--- a/packages/replay/test/unit/index-errorSampleRate.test.ts
+++ b/packages/replay/test/unit/index-errorSampleRate.test.ts
@@ -1,13 +1,13 @@
 jest.unmock('@sentry/browser');
 
 import { captureException } from '@sentry/browser';
-import { BASE_TIMESTAMP, RecordMock } from '@test';
-import { PerformanceEntryResource } from '@test/fixtures/performanceEntry/resource';
-import { resetSdkMock } from '@test/mocks';
-import { DomHandler, MockTransportSend } from '@test/types';
 
 import { REPLAY_SESSION_KEY, VISIBILITY_CHANGE_TIMEOUT, WINDOW } from '../../src/constants';
+import { BASE_TIMESTAMP, RecordMock } from './..';
 import { Replay } from './../../src';
+import { PerformanceEntryResource } from './../fixtures/performanceEntry/resource';
+import { resetSdkMock } from './../mocks';
+import { DomHandler, MockTransportSend } from './../types';
 import { useFakeTimers } from './../utils/use-fake-timers';
 
 useFakeTimers();

--- a/packages/replay/test/unit/index-handleGlobalEvent.test.ts
+++ b/packages/replay/test/unit/index-handleGlobalEvent.test.ts
@@ -1,10 +1,10 @@
 import { getCurrentHub } from '@sentry/core';
-import { Error } from '@test/fixtures/error';
-import { Transaction } from '@test/fixtures/transaction';
-import { resetSdkMock } from '@test/mocks';
 
 import { REPLAY_EVENT_NAME } from '../../src/constants';
 import { Replay } from './../../src';
+import { Error } from './../fixtures/error';
+import { Transaction } from './../fixtures/transaction';
+import { resetSdkMock } from './../mocks';
 import { useFakeTimers } from './../utils/use-fake-timers';
 
 useFakeTimers();

--- a/packages/replay/test/unit/index-integrationSettings.test.ts
+++ b/packages/replay/test/unit/index-integrationSettings.test.ts
@@ -1,5 +1,5 @@
 import { Replay } from '../../src';
-import { mockSdk } from './..';
+import { mockSdk } from './../index';
 
 let replay: Replay;
 

--- a/packages/replay/test/unit/index-integrationSettings.test.ts
+++ b/packages/replay/test/unit/index-integrationSettings.test.ts
@@ -1,6 +1,5 @@
-import { mockSdk } from '@test';
-
 import { Replay } from '../../src';
+import { mockSdk } from './..';
 
 let replay: Replay;
 

--- a/packages/replay/test/unit/index-noSticky.test.ts
+++ b/packages/replay/test/unit/index-noSticky.test.ts
@@ -1,9 +1,9 @@
 import { getCurrentHub } from '@sentry/core';
 import { Transport } from '@sentry/types';
 import * as SentryUtils from '@sentry/utils';
-import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
 import { SESSION_IDLE_DURATION, VISIBILITY_CHANGE_TIMEOUT } from '../../src/constants';
+import { BASE_TIMESTAMP, mockRrweb, mockSdk } from './..';
 import { Replay } from './../../src';
 import { useFakeTimers } from './../utils/use-fake-timers';
 

--- a/packages/replay/test/unit/index-noSticky.test.ts
+++ b/packages/replay/test/unit/index-noSticky.test.ts
@@ -3,8 +3,8 @@ import { Transport } from '@sentry/types';
 import * as SentryUtils from '@sentry/utils';
 
 import { SESSION_IDLE_DURATION, VISIBILITY_CHANGE_TIMEOUT } from '../../src/constants';
-import { BASE_TIMESTAMP, mockRrweb, mockSdk } from './..';
 import { Replay } from './../../src';
+import { BASE_TIMESTAMP, mockRrweb, mockSdk } from './../index';
 import { useFakeTimers } from './../utils/use-fake-timers';
 
 useFakeTimers();

--- a/packages/replay/test/unit/index-sampling.test.ts
+++ b/packages/replay/test/unit/index-sampling.test.ts
@@ -1,7 +1,7 @@
 jest.unmock('@sentry/browser');
 
 // mock functions need to be imported first
-import { mockRrweb, mockSdk } from './..';
+import { mockRrweb, mockSdk } from './../index';
 import { useFakeTimers } from './../utils/use-fake-timers';
 
 useFakeTimers();

--- a/packages/replay/test/unit/index-sampling.test.ts
+++ b/packages/replay/test/unit/index-sampling.test.ts
@@ -1,8 +1,7 @@
 jest.unmock('@sentry/browser');
 
 // mock functions need to be imported first
-import { mockRrweb, mockSdk } from '@test';
-
+import { mockRrweb, mockSdk } from './..';
 import { useFakeTimers } from './../utils/use-fake-timers';
 
 useFakeTimers();

--- a/packages/replay/test/unit/index.test.ts
+++ b/packages/replay/test/unit/index.test.ts
@@ -1,16 +1,16 @@
 jest.mock('./../../src/util/isInternal', () => ({
   isInternal: jest.fn(() => true),
 }));
-import { BASE_TIMESTAMP, RecordMock } from '@test';
-import { PerformanceEntryResource } from '@test/fixtures/performanceEntry/resource';
-import { resetSdkMock } from '@test/mocks';
-import { DomHandler, MockTransportSend } from '@test/types';
 import { EventType } from 'rrweb';
 
 import { Replay } from '../../src';
 import { MAX_SESSION_LIFE, REPLAY_SESSION_KEY, VISIBILITY_CHANGE_TIMEOUT, WINDOW } from '../../src/constants';
 import { RecordingEvent } from '../../src/types';
 import { useFakeTimers } from '../utils/use-fake-timers';
+import { BASE_TIMESTAMP, RecordMock } from './..';
+import { PerformanceEntryResource } from './../fixtures/performanceEntry/resource';
+import { resetSdkMock } from './../mocks';
+import { DomHandler, MockTransportSend } from './../types';
 
 useFakeTimers();
 

--- a/packages/replay/test/unit/index.test.ts
+++ b/packages/replay/test/unit/index.test.ts
@@ -7,8 +7,8 @@ import { Replay } from '../../src';
 import { MAX_SESSION_LIFE, REPLAY_SESSION_KEY, VISIBILITY_CHANGE_TIMEOUT, WINDOW } from '../../src/constants';
 import { RecordingEvent } from '../../src/types';
 import { useFakeTimers } from '../utils/use-fake-timers';
-import { BASE_TIMESTAMP, RecordMock } from './..';
 import { PerformanceEntryResource } from './../fixtures/performanceEntry/resource';
+import { BASE_TIMESTAMP, RecordMock } from './../index';
 import { resetSdkMock } from './../mocks';
 import { DomHandler, MockTransportSend } from './../types';
 

--- a/packages/replay/test/unit/stop.test.ts
+++ b/packages/replay/test/unit/stop.test.ts
@@ -1,9 +1,9 @@
 import * as SentryUtils from '@sentry/utils';
 
 import { SESSION_IDLE_DURATION, WINDOW } from '../../src/constants';
-// mock functions need to be imported first
-import { BASE_TIMESTAMP, mockRrweb, mockSdk } from './..';
 import { Replay } from './../../src';
+// mock functions need to be imported first
+import { BASE_TIMESTAMP, mockRrweb, mockSdk } from './../index';
 import { useFakeTimers } from './../utils/use-fake-timers';
 
 useFakeTimers();

--- a/packages/replay/test/unit/stop.test.ts
+++ b/packages/replay/test/unit/stop.test.ts
@@ -1,8 +1,8 @@
 import * as SentryUtils from '@sentry/utils';
-// mock functions need to be imported first
-import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
 import { SESSION_IDLE_DURATION, WINDOW } from '../../src/constants';
+// mock functions need to be imported first
+import { BASE_TIMESTAMP, mockRrweb, mockSdk } from './..';
 import { Replay } from './../../src';
 import { useFakeTimers } from './../utils/use-fake-timers';
 

--- a/packages/replay/test/unit/util/dedupePerformanceEntries.test.ts
+++ b/packages/replay/test/unit/util/dedupePerformanceEntries.test.ts
@@ -1,9 +1,8 @@
 // eslint-disable-next-line import/no-unresolved
-import { PerformanceEntryLcp } from '@test/fixtures/performanceEntry/lcp';
-import { PerformanceEntryNavigation } from '@test/fixtures/performanceEntry/navigation';
-import { PerformanceEntryResource } from '@test/fixtures/performanceEntry/resource';
-
 import { dedupePerformanceEntries } from '../../../src/util/dedupePerformanceEntries';
+import { PerformanceEntryLcp } from './../../fixtures/performanceEntry/lcp';
+import { PerformanceEntryNavigation } from './../../fixtures/performanceEntry/navigation';
+import { PerformanceEntryResource } from './../../fixtures/performanceEntry/resource';
 
 it('does nothing with a single entry', function () {
   const entries = [PerformanceEntryNavigation()];

--- a/packages/replay/tsconfig.json
+++ b/packages/replay/tsconfig.json
@@ -1,16 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "module": "esnext",
-    "noImplicitAny": true,
-    "noEmitOnError": false,
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
-    "allowJs": true,
-    "declaration": true,
-    "declarationMap": true,
-    "strictNullChecks": true
+    "module": "esnext"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": ["src/**/*.ts"]
 }

--- a/packages/replay/tsconfig.test.json
+++ b/packages/replay/tsconfig.test.json
@@ -4,13 +4,12 @@
   "include": ["test/**/*.ts", "jest.config.ts", "jest.setup.ts"],
 
   "compilerOptions": {
-    "baseUrl": ".",
-    "rootDir": ".",
     "types": ["node", "jest"],
-    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "allowJs": true,
+    "noImplicitAny": true,
     "noImplicitThis": false,
-    "strictPropertyInitialization": false,
-    "resolveJsonModule": true,
-    "allowJs": true
+    "strictNullChecks": true,
+    "strictPropertyInitialization": false
   }
 }

--- a/packages/replay/tsconfig.test.json
+++ b/packages/replay/tsconfig.test.json
@@ -4,10 +4,6 @@
   "include": ["test/**/*.ts", "jest.config.ts", "jest.setup.ts"],
 
   "compilerOptions": {
-    "paths": {
-      "@test": ["./test"],
-      "@test/*": ["./test/*"]
-    },
     "baseUrl": ".",
     "rootDir": ".",
     "types": ["node", "jest"],


### PR DESCRIPTION
This PR goes some steps towards aligning tsconfig & jest config of replay with the rest of the packages.

* Move some tsconfig stuff we need for tests only to tsconfig.test.json
* Add some more common folders to vscode search.exclude
* Stop using `@test` imports in replay
* Make replay tests non-verbose

IMHO the goal should be to also re-export the jest config from `/jest/jest.config.js`, but I ran into a bunch of issues with that - I think related to typescript, and jest.setup.ts 😬 But this should be OK as a first step.