### PR TITLE
Fixed withSentryConfig to work with Object again in next.config.js

### DIFF
--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -18,20 +18,22 @@ export function withSentryConfig(
   exportedUserNextConfig: ExportedNextConfig = {},
   userSentryWebpackPluginOptions: Partial<SentryWebpackPluginOptions> = {},
 ): NextConfigFunction | NextConfigObject {
-  return function (phase: string, defaults: { defaultConfig: NextConfigObject }): NextConfigObject {
-    if (typeof exportedUserNextConfig === 'function') {
+
+  if (typeof exportedUserNextConfig === 'function') {
+    return function (phase: string, defaults: { defaultConfig: NextConfigObject }): NextConfigObject {
       const userNextConfigObject = exportedUserNextConfig(phase, defaults);
       return getFinalConfigObject(phase, userNextConfigObject, userSentryWebpackPluginOptions);
-    } else {
-      return getFinalConfigObject(phase, exportedUserNextConfig, userSentryWebpackPluginOptions);
-    }
-  };
+    };
+  } else {
+    return getFinalConfigObject(undefined, exportedUserNextConfig, userSentryWebpackPluginOptions);
+  }
+
 }
 
 // Modify the materialized object form of the user's next config by deleting the `sentry` property and wrapping the
 // `webpack` property
 function getFinalConfigObject(
-  phase: string,
+  phase: string | undefined,
   incomingUserNextConfigObject: NextConfigObjectWithSentry,
   userSentryWebpackPluginOptions: Partial<SentryWebpackPluginOptions>,
 ): NextConfigObject {


### PR DESCRIPTION
A change was made in withSentryConfig.ts in f1e59f9973a092724615b7fbc421a893eb6438c3 where withSentryConfig always returns a function, regardless if next.config.js exports a function or object. This means that settings in next.config.js are wiped with withSentryConfig if they are defined as an Object. This PR reverses this issue.

Phase is not passed when next.config.js is an Object, so getFinalConfigObject was modified to allow undefined for the phase.