### PR TITLE
ref(replay): Streamline replay EventBuffer implementation

### DIFF
--- a/packages/replay/MIGRATION.md
+++ b/packages/replay/MIGRATION.md
@@ -52,3 +52,8 @@ import something from '@sentry/replay/submodule';
 ```
 
 If you only imported from `@sentry/replay`, this will not affect you.
+
+## Changed type name from `IEventBuffer` to `EventBuffer` (https://github.com/getsentry/sentry-javascript/pull/6416)
+
+It is highly unlikely to affect anybody, but the type `IEventBuffer` was renamed to `EventBuffer` for consistency.
+Unless you manually imported this and used it somewhere in your codebase, this will not affect you.

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -19,7 +19,7 @@ import {
 import { breadcrumbHandler } from './coreHandlers/breadcrumbHandler';
 import { spanHandler } from './coreHandlers/spanHandler';
 import { createMemoryEntry, createPerformanceEntries, ReplayPerformanceEntry } from './createPerformanceEntry';
-import { createEventBuffer, IEventBuffer } from './eventBuffer';
+import { createEventBuffer, EventBuffer } from './eventBuffer';
 import { deleteSession } from './session/deleteSession';
 import { getSession } from './session/getSession';
 import { saveSession } from './session/saveSession';
@@ -68,7 +68,7 @@ export class Replay implements Integration {
    */
   public name: string = Replay.id;
 
-  public eventBuffer: IEventBuffer | null = null;
+  public eventBuffer: EventBuffer | null = null;
 
   /**
    * List of PerformanceEntry from PerformanceObserver


### PR DESCRIPTION
This ensures public/private annotation is correct for the event buffer implementation. It also refactors a few (internal) things in minor ways, for clarity.

For example, we used a getter which as a side effect incremented itself. It is cleaner to do this explicitly, as getters should generally be side-effect free.

This is technically a breaking change, as the exported name of the interface `IEventBuffer` was changed to `EventBuffer`. It is unlikely that a user relied on that, though.

ref https://github.com/getsentry/sentry-javascript/issues/6323