### PR TITLE
ref(replay): Rename `replaysSampleRate` to `replaysSessionSampleRate`

### DIFF
--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -13,7 +13,7 @@ type BrowserClientReplayOptions = {
    * The sample rate for session-long replays.
    * 1.0 will record all sessions and 0 will record none.
    */
-  replaysSampleRate?: number;
+  replaysSessionSampleRate?: number;
 
   /**
    * The sample rate for sessions that has had an error occur.

--- a/packages/replay/MIGRATION.md
+++ b/packages/replay/MIGRATION.md
@@ -24,7 +24,7 @@ They are now defined on the top level of the SDK:
 ```js
 Sentry.init({
   dsn: '__DSN__',
-  replaysSampleRate: 0.1,
+  replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
   integrations: [
     new Replay({

--- a/packages/replay/README.md
+++ b/packages/replay/README.md
@@ -48,7 +48,7 @@ Sentry.init({
 
   // This sets the sample rate to be 10%. You may want this to be 100% while
   // in development and sample at a lower rate in production
-  replaysSampleRate: 0.1,
+  replaysSessionSampleRate: 0.1,
 
   // If the entire session is not sampled, use the below sample rate to sample
   // sessions when an error occurs.
@@ -101,10 +101,10 @@ Alternatively, rather than recording an entire session, you can capture a replay
 
 Sampling allows you to control how much of your website's traffic will result in a Session Replay. There are two sample rates you can adjust to get the replays more relevant to your interests:
 
-- `replaysSampleRate` - The sample rate for replays that begin recording immediately and last the entirety of the user's session.
+- `replaysSessionSampleRate` - The sample rate for replays that begin recording immediately and last the entirety of the user's session.
 - `replaysOnErrorSampleRate` - The sample rate for replays that are recorded when an error happens. This type of replay will record up to a minute of events prior to the error and continue recording until the session ends.
 
-Sampling occurs when the session is first started. `replaysSampleRate` is evaluated first. If it is sampled, then the replay recording begins. Otherwise, `replaysOnErrorSampleRate` is evaluated and if it is sampled, the integration will begin buffering the replay and will only upload a replay to Sentry when an error occurs. The remainder of the replay will behave similarly to a whole-session replay.
+Sampling occurs when the session is first started. `replaysSessionSampleRate` is evaluated first. If it is sampled, then the replay recording begins. Otherwise, `replaysOnErrorSampleRate` is evaluated and if it is sampled, the integration will begin buffering the replay and will only upload a replay to Sentry when an error occurs. The remainder of the replay will behave similarly to a whole-session replay.
 
 
 ## Configuration
@@ -116,7 +116,7 @@ The following options can be configured on the root level of your browser-based 
 
 | key                 | type    | default | description                                                                                                                                                                                                                     |
 | ------------------- | ------- | ------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------   |
-| replaysSampleRate   | number  | `0.1`   | The sample rate for replays that begin recording immediately and last the entirety of the user's session. 1.0 will collect all replays, 0 will collect no replays.                                           |
+| replaysSessionSampleRate   | number  | `0.1`   | The sample rate for replays that begin recording immediately and last the entirety of the user's session. 1.0 will collect all replays, 0 will collect no replays.                                           |
 | replaysOnErrorSampleRate     | number  | `1.0`   |The sample rate for replays that are recorded when an error happens. This type of replay will record up to a minute of events prior to the error and continue recording until the session ends. 1.0 capturing all sessions with an error, and 0 capturing none.
 
 ### General Integration Configuration

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -1354,8 +1354,8 @@ export class Replay implements Integration {
     const client = getCurrentHub().getClient() as BrowserClient | undefined;
     const opt = client && (client.getOptions() as BrowserOptions | undefined);
 
-    if (opt && opt.replaysSampleRate) {
-      this.options.sessionSampleRate = opt.replaysSampleRate;
+    if (opt && opt.replaysSessionSampleRate) {
+      this.options.sessionSampleRate = opt.replaysSessionSampleRate;
     }
 
     if (opt && opt.replaysOnErrorSampleRate) {

--- a/packages/replay/test/unit/index-integrationSettings.test.ts
+++ b/packages/replay/test/unit/index-integrationSettings.test.ts
@@ -33,7 +33,7 @@ describe('blockAllMedia', () => {
   });
 });
 
-describe('replaysSampleRate', () => {
+describe('replaysSessionSampleRate', () => {
   it('works with defining settings in integration', async () => {
     ({ replay } = await mockSdk({ replayOptions: { sessionSampleRate: 0.5 } }));
 
@@ -41,14 +41,14 @@ describe('replaysSampleRate', () => {
   });
 
   it('works with defining settings in SDK', async () => {
-    ({ replay } = await mockSdk({ sentryOptions: { replaysSampleRate: 0.5 } }));
+    ({ replay } = await mockSdk({ sentryOptions: { replaysSessionSampleRate: 0.5 } }));
 
     expect(replay.options.sessionSampleRate).toBe(0.5);
   });
 
   it('SDK option takes precedence', async () => {
     ({ replay } = await mockSdk({
-      sentryOptions: { replaysSampleRate: 0.5 },
+      sentryOptions: { replaysSessionSampleRate: 0.5 },
       replayOptions: { sessionSampleRate: 0.1 },
     }));
 


### PR DESCRIPTION
We wanted this config option to be a bit more specific in that it should be the sample rate for "session" replays (vs. on error samples). The previous name could be mistaken as a sample rate that affects both types of replays.
