### PR TITLE
fix(nextjs): Use `basePath` for `assetPrefix` if needed

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -679,6 +679,8 @@ function addRewriteFramesLoader(
   target: 'server' | 'client',
   userNextConfig: NextConfigObject,
 ): void {
+  // Nextjs will use `basePath` in place of `assetPrefix` if it's defined but `assetPrefix` is not
+  const assetPrefix = userNextConfig.assetPrefix || userNextConfig.basePath || '';
   const replacements = {
     server: [
       [
@@ -693,9 +695,7 @@ function addRewriteFramesLoader(
         '__ASSET_PREFIX_PATH__',
         // Get the path part of `assetPrefix`, minus any trailing slash. (We use a placeholder for the origin if
         // `assetPreix` doesn't include one. Since we only care about the path, it doesn't matter what it is.)
-        userNextConfig.assetPrefix
-          ? new URL(userNextConfig.assetPrefix, 'http://dogs.are.great').pathname.replace(/\/$/, '')
-          : '',
+        assetPrefix ? new URL(assetPrefix, 'http://dogs.are.great').pathname.replace(/\/$/, '') : '',
       ],
     ],
   };


### PR DESCRIPTION
This fixes a bug in https://github.com/getsentry/sentry-javascript/pull/6388, wherein `basePath` was ignored when determining `assetPath`. Nextjs copies the former over to the latter if the former is provided and the latter is not. In my original implementation of https://github.com/getsentry/sentry-javascript/pull/6388, the SDK read the values after that had happened, so it was sufficient to look at `asssetPath`. When I moved the reading of the values earlier, I didn't account for the fact that `basePath` wouldn't have yet been copied over into `assetPath`, meaning we have to do it ourselves.
