### PR TITLE
fix(tracing): Instrument cursors returned from MongoDB operations.

### DIFF
--- a/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/scenario.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/scenario.ts
@@ -36,6 +36,8 @@ async function run(): Promise<void> {
     await collection.findOne({ title: 'Back to the Future' });
     await collection.updateOne({ title: 'Back to the Future' }, { $set: { title: 'South Park' } });
     await collection.findOne({ title: 'South Park' });
+
+    await collection.find({ title: 'South Park' }).toArray();
   } finally {
     if (transaction) transaction.finish();
     await client.close();

--- a/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/test.ts
@@ -53,16 +53,6 @@ conditionalTest({ min: 12 })('MongoDB Test', () => {
             collectionName: 'movies',
             dbName: 'admin',
             namespace: 'admin.movies',
-            query: '{"title":"Back to the Future"}',
-          },
-          description: 'find',
-          op: 'db',
-        },
-        {
-          data: {
-            collectionName: 'movies',
-            dbName: 'admin',
-            namespace: 'admin.movies',
             filter: '{"title":"Back to the Future"}',
             update: '{"$set":{"title":"South Park"}}',
           },

--- a/packages/tracing/src/integrations/node/mongo.ts
+++ b/packages/tracing/src/integrations/node/mongo.ts
@@ -1,6 +1,7 @@
 import { Hub } from '@sentry/core';
 import { EventProcessor, Integration, SpanContext } from '@sentry/types';
-import { fill, isThenable, loadModule, logger } from '@sentry/utils';
+import { fill, isInstanceOf, isThenable, loadModule, logger } from '@sentry/utils';
+import { EventEmitter } from 'events';
 
 import { shouldDisableAutoInstrumentation } from './utils/node-utils';
 
@@ -160,20 +161,38 @@ export class Mongo implements Integration {
         // its (non-callback) arguments can also be functions.)
         if (typeof lastArg !== 'function' || (operation === 'mapReduce' && args.length === 2)) {
           const span = parentSpan?.startChild(getSpanContext(this, operation, args));
-          const maybePromise = orig.call(this, ...args) as Promise<unknown>;
+          const maybePromiseOrCursor = orig.call(this, ...args);
 
-          if (isThenable(maybePromise)) {
-            return maybePromise.then((res: unknown) => {
+          if (isThenable(maybePromiseOrCursor)) {
+            return maybePromiseOrCursor.then((res: unknown) => {
               span?.finish();
               return res;
             });
+          }
+          // If the operation returns a cursor (which is an EventEmitter),
+          // we need to attach a listener to it to finish the span when the cursor is closed.
+          else if (isInstanceOf(maybePromiseOrCursor, EventEmitter)) {
+            const cursor = maybePromiseOrCursor as EventEmitter;
+
+            try {
+              cursor.once('close', () => {
+                span?.finish();
+              });
+            } catch (e) {
+              // If the cursor is already closed, `once` will throw an error. In that case, we can
+              // finish the span immediately.
+              span?.finish();
+            }
+
+            return cursor;
           } else {
             span?.finish();
-            return maybePromise;
+            return maybePromiseOrCursor;
           }
         }
 
         const span = parentSpan?.startChild(getSpanContext(this, operation, args.slice(0, -1)));
+
         return orig.call(this, ...args.slice(0, -1), function (err: Error, result: unknown) {
           span?.finish();
           lastArg(err, result);


### PR DESCRIPTION
Checking if the returned value is a `Cursor` using an internal utility instead of matching `EventEmitter` type as done in #6412 and #6337. 

Fixes https://github.com/getsentry/sentry-javascript/issues/4495

Instrumented [Cursor](https://mongodb.github.io/node-mongodb-native/4.12/classes/AbstractCursor.html)s returned from certain MongoDB operations, this also resolves the problem mentioned in https://github.com/getsentry/sentry-javascript/issues/5278.