### PR TITLE
fix(react): Add type for React Router's `encodeLocation` method

### DIFF
--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -236,6 +236,7 @@ export interface Router {
   getFetcher(key?: string): any;
   deleteFetcher(key?: string): void;
   dispose(): void;
+  encodeLocation(to: To): Path;
 }
 
 export type CreateRouterFunction = (routes: RouteObject[], opts?: any) => Router;


### PR DESCRIPTION
Fixes: #6421 

`encodeLocation` method is added to `Router` class by: https://github.com/remix-run/react-router/pull/9589

--- 

Note: https://github.com/remix-run/react-router/pull/9589 may also potentially help us with #5997 
I'll investigate it further.