### PR TITLE
fix(replay): Only set minimum browser SDK peer dependency version

### DIFF
--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -62,7 +62,7 @@
     "lodash.debounce": "^4.0.8"
   },
   "peerDependencies": {
-    "@sentry/browser": "7.23.0"
+    "@sentry/browser": ">=7.24.0"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
This unblocks our release so that the peer dependency isn't left hard-pinned on 7.23.0.