### PR TITLE
fix(replay): Add CDN bundle path to release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -344,6 +344,7 @@ jobs:
             ${{ github.workspace }}/packages/browser/build/bundles/**
             ${{ github.workspace }}/packages/integrations/build/bundles/**
             ${{ github.workspace }}/packages/tracing/build/bundles/**
+            ${{ github.workspace }}/packages/replay/build/bundles/**
             ${{ github.workspace }}/packages/**/*.tgz
 
   job_unit_test:

--- a/docs/new-sdk-release-checklist.md
+++ b/docs/new-sdk-release-checklist.md
@@ -40,6 +40,10 @@ This page serves as a checklist of what to do when releasing a new SDK for the f
     - [ ]  Ensure dependent packages are correctly set for “Determine changed packages”
     - [ ]  Ensure unit tests run correctly
 
+- [ ]  Make sure the file paths in the ["Uplad Artifacts" job](https://github.com/getsentry/sentry-javascript/blob/e5c1486eed236b878f2c49d6a04be86093816ac9/.github/workflows/build.yml#L314-L349) in `build.yml` include your new artifacts.
+    - **This is especially important, if you're adding new CDN bundles!**
+    - Tarballs (*.tgz archives) should work OOTB
+
 ## Cutting the Release
 
 When you’re ready to make the first release, there are a couple of steps that need to be performed in the **correct order**. Note that you can prepare the PRs at any time but the **merging oder** is important:


### PR DESCRIPTION
So, turns out, CDN bundles are **not** released automatically (I should have known...)

Craft uses the release artifacts zip generated by our "Upload Artifacts" job to search for files to upload. Our bundle path (`packages/replay/build/bundles`) wasn't added to this job's config so it wasn't included in the release.

This PR fixes that and it also adds an entry to our release checklist. It furthermore bumps the minimum version for the CDN bundles in the Replay README. Docs should automatically pick up the newest version, so we don't need to bump anything in https://github.com/getsentry/sentry-docs/pull/5899 
