### PR TITLE
Update replay  README.md CDN version to 7.24.1

### DIFF
--- a/packages/replay/README.md
+++ b/packages/replay/README.md
@@ -98,13 +98,13 @@ You have to add it in addition to the Sentry Browser SDK bundle:
 ```js
 // Browser SDK bundle
 <script
-  src="https://browser.sentry-cdn.com/7.24.0/bundle.tracing.min.js"
+  src="https://browser.sentry-cdn.com/7.24.1/bundle.tracing.min.js"
   crossorigin="anonymous"
 ></script>
 
 // Replay integration bundle
 <script
-  src="https://browser.sentry-cdn.com/7.24.0/replay.min.js"
+  src="https://browser.sentry-cdn.com/7.24.1/replay.min.js"
   crossorigin="anonymous"
 ></script>
 


### PR DESCRIPTION
7.24.0 was giving me a 403

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ x] If you've added code that should be tested, please add tests.
- [x ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
