### PR TITLE
fix(tracing): Check for otel before loading db module

### DIFF
--- a/packages/tracing/src/integrations/node/apollo.ts
+++ b/packages/tracing/src/integrations/node/apollo.ts
@@ -28,6 +28,11 @@ export class Apollo implements Integration {
    * @inheritDoc
    */
   public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
+    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
+      __DEBUG_BUILD__ && logger.log('Apollo Integration is skipped because of instrumenter configuration.');
+      return;
+    }
+
     const pkg = loadModule<{
       ApolloServerBase: {
         prototype: {
@@ -38,11 +43,6 @@ export class Apollo implements Integration {
 
     if (!pkg) {
       __DEBUG_BUILD__ && logger.error('Apollo Integration was unable to require apollo-server-core package.');
-      return;
-    }
-
-    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
-      __DEBUG_BUILD__ && logger.log('Apollo Integration is skipped because of instrumenter configuration.');
       return;
     }
 

--- a/packages/tracing/src/integrations/node/graphql.ts
+++ b/packages/tracing/src/integrations/node/graphql.ts
@@ -20,17 +20,17 @@ export class GraphQL implements Integration {
    * @inheritDoc
    */
   public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
+    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
+      __DEBUG_BUILD__ && logger.log('GraphQL Integration is skipped because of instrumenter configuration.');
+      return;
+    }
+
     const pkg = loadModule<{
       [method: string]: (...args: unknown[]) => unknown;
     }>('graphql/execution/execute.js');
 
     if (!pkg) {
       __DEBUG_BUILD__ && logger.error('GraphQL Integration was unable to require graphql/execution package.');
-      return;
-    }
-
-    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
-      __DEBUG_BUILD__ && logger.log('GraphQL Integration is skipped because of instrumenter configuration.');
       return;
     }
 

--- a/packages/tracing/src/integrations/node/mongo.ts
+++ b/packages/tracing/src/integrations/node/mongo.ts
@@ -127,16 +127,16 @@ export class Mongo implements Integration {
    * @inheritDoc
    */
   public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
+    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
+      __DEBUG_BUILD__ && logger.log('Mongo Integration is skipped because of instrumenter configuration.');
+      return;
+    }
+
     const moduleName = this._useMongoose ? 'mongoose' : 'mongodb';
     const pkg = loadModule<{ Collection: MongoCollection }>(moduleName);
 
     if (!pkg) {
       __DEBUG_BUILD__ && logger.error(`Mongo Integration was unable to require \`${moduleName}\` package.`);
-      return;
-    }
-
-    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
-      __DEBUG_BUILD__ && logger.log('Mongo Integration is skipped because of instrumenter configuration.');
       return;
     }
 

--- a/packages/tracing/src/integrations/node/mysql.ts
+++ b/packages/tracing/src/integrations/node/mysql.ts
@@ -24,15 +24,15 @@ export class Mysql implements Integration {
    * @inheritDoc
    */
   public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
+    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
+      __DEBUG_BUILD__ && logger.log('Mysql Integration is skipped because of instrumenter configuration.');
+      return;
+    }
+
     const pkg = loadModule<MysqlConnection>('mysql/lib/Connection.js');
 
     if (!pkg) {
       __DEBUG_BUILD__ && logger.error('Mysql Integration was unable to require `mysql` package.');
-      return;
-    }
-
-    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
-      __DEBUG_BUILD__ && logger.log('Mysql Integration is skipped because of instrumenter configuration.');
       return;
     }
 

--- a/packages/tracing/src/integrations/node/postgres.ts
+++ b/packages/tracing/src/integrations/node/postgres.ts
@@ -36,15 +36,15 @@ export class Postgres implements Integration {
    * @inheritDoc
    */
   public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
+    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
+      __DEBUG_BUILD__ && logger.log('Postgres Integration is skipped because of instrumenter configuration.');
+      return;
+    }
+
     const pkg = loadModule<{ Client: PgClient; native: { Client: PgClient } }>('pg');
 
     if (!pkg) {
       __DEBUG_BUILD__ && logger.error('Postgres Integration was unable to require `pg` package.');
-      return;
-    }
-
-    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
-      __DEBUG_BUILD__ && logger.log('Postgres Integration is skipped because of instrumenter configuration.');
       return;
     }
 


### PR DESCRIPTION
To make sure we don't override possible OpenTelemetry instrumentation, check for the instrumenter to be configured as `otel` before we dynamically load the database modules to instrument.