### PR TITLE
feat(types): add profile envelope item type

### DIFF
--- a/packages/types/src/datacategory.ts
+++ b/packages/types/src/datacategory.ts
@@ -17,4 +17,6 @@ export type DataCategory =
   // Session update events
   | 'session'
   // SDK internal event, like client_reports
-  | 'internal';
+  | 'internal'
+  // Profile event type
+  | 'profile';

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -49,7 +49,7 @@ type BaseEnvelope<EnvelopeHeader, Item> = [
 ];
 
 type EventItemHeaders = {
-  type: 'event' | 'transaction';
+  type: 'event' | 'transaction' | 'profile';
 };
 type AttachmentItemHeaders = {
   type: 'attachment';

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -26,7 +26,8 @@ export type EnvelopeItemType =
   | 'sessions'
   | 'transaction'
   | 'attachment'
-  | 'event';
+  | 'event'
+  | 'profile';
 
 export type BaseEnvelopeHeaders = {
   [key: string]: unknown;

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -55,7 +55,7 @@ export interface Event {
 }
 
 /** JSDoc */
-export type EventType = 'transaction';
+export type EventType = 'transaction' | 'profile';
 
 /** JSDoc */
 export interface EventHint {

--- a/packages/utils/src/envelope.ts
+++ b/packages/utils/src/envelope.ts
@@ -133,6 +133,7 @@ const ITEM_TYPE_TO_DATA_CATEGORY_MAP: Record<EnvelopeItemType, DataCategory> = {
   event: 'error',
   client_report: 'internal',
   user_report: 'default',
+  profile: 'profile',
 };
 
 /**


### PR DESCRIPTION
Adds profile envelope type so we can skip the ts-expect error in the profiling sdk.