### PR TITLE
feat(core): Add `replay_event` type for events

### DIFF
--- a/packages/core/src/envelope.ts
+++ b/packages/core/src/envelope.ts
@@ -63,7 +63,15 @@ export function createEventEnvelope(
   tunnel?: string,
 ): EventEnvelope {
   const sdkInfo = getSdkMetadataForEnvelopeHeader(metadata);
-  const eventType = event.type || 'event';
+
+  /*
+    Note: Due to TS, event.type may be `replay_event`, theoretically.
+    In practice, we never call `createEventEnvelope` with `replay_event` type,
+    and we'd have to adjut a looot of types to make this work properly.
+    We want to avoid casting this around, as that could lead to bugs (e.g. when we add another type)
+    So the safe choice is to really guard against the replay_event type here.
+  */
+  const eventType = event.type && event.type !== 'replay_event' ? event.type : 'event';
 
   enhanceEventWithSdkInfo(event, metadata && metadata.sdk);
 

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -233,7 +233,7 @@ export class Hub implements HubInterface {
    */
   public captureEvent(event: Event, hint?: EventHint): string {
     const eventId = hint && hint.event_id ? hint.event_id : uuid4();
-    if (event.type !== 'transaction') {
+    if (!event.type) {
       this._lastEventId = eventId;
     }
 

--- a/packages/hub/test/hub.test.ts
+++ b/packages/hub/test/hub.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable deprecation/deprecation */
 
 import { Client, Event } from '@sentry/types';
+import { EventType } from '@sentry/types/build/types/event';
 
 import { getCurrentHub, Hub, Scope } from '../src';
 
@@ -358,10 +359,11 @@ describe('Hub', () => {
       expect(args[1].event_id).toEqual(hub.lastEventId());
     });
 
-    test('transactions do not set lastEventId', () => {
+    const eventTypesToIgnoreLastEventId: EventType[] = ['transaction', 'replay_event'];
+    it.each(eventTypesToIgnoreLastEventId)('eventType %s does not set lastEventId', eventType => {
       const event: Event = {
         extra: { b: 3 },
-        type: 'transaction',
+        type: eventType,
       };
       const testClient = makeClient();
       const hub = new Hub(testClient);

--- a/packages/hub/test/hub.test.ts
+++ b/packages/hub/test/hub.test.ts
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 /* eslint-disable deprecation/deprecation */
 
-import { Client, Event } from '@sentry/types';
-import { EventType } from '@sentry/types/build/types/event';
+import { Client, Event, EventType } from '@sentry/types';
 
 import { getCurrentHub, Hub, Scope } from '../src';
 

--- a/packages/replay/src/coreHandlers/handleGlobalEvent.ts
+++ b/packages/replay/src/coreHandlers/handleGlobalEvent.ts
@@ -12,10 +12,7 @@ import { isRrwebError } from '../util/isRrwebError';
 export function handleGlobalEventListener(replay: ReplayContainer): (event: Event) => Event | null {
   return (event: Event) => {
     // Do not apply replayId to the root event
-    if (
-      // @ts-ignore new event type
-      event.type === REPLAY_EVENT_NAME
-    ) {
+    if (event.type === REPLAY_EVENT_NAME) {
       // Replays have separate set of breadcrumbs, do not include breadcrumbs
       // from core SDK
       delete event.breadcrumbs;
@@ -31,7 +28,7 @@ export function handleGlobalEventListener(replay: ReplayContainer): (event: Even
 
     // Only tag transactions with replayId if not waiting for an error
     // @ts-ignore private
-    if (event.type !== 'transaction' || replay.recordingMode === 'session') {
+    if (!event.type || replay.recordingMode === 'session') {
       event.tags = { ...event.tags, replayId: replay.session?.id };
     }
 

--- a/packages/types/src/datacategory.ts
+++ b/packages/types/src/datacategory.ts
@@ -10,6 +10,8 @@ export type DataCategory =
   | 'error'
   // Transaction type event
   | 'transaction'
+  // Replay type event
+  | 'replay_event'
   // Events with `event_type` csp, hpkp, expectct, expectstaple
   | 'security'
   // Attachment bytes stored (unused for rate limiting

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -63,7 +63,7 @@ export interface Event {
  * Note that `ErrorEvent`s do not have a type (hence its undefined),
  * while all other events are required to have one.
  */
-export type EventType = 'transaction' | 'profile' | undefined;
+export type EventType = 'transaction' | 'profile' | 'replay_event' | undefined;
 
 export interface ErrorEvent extends Event {
   type: undefined;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -25,7 +25,7 @@ export type {
   UserFeedbackItem,
 } from './envelope';
 export type { ExtendedError } from './error';
-export type { Event, EventHint, ErrorEvent, TransactionEvent } from './event';
+export type { Event, EventHint, EventType, ErrorEvent, TransactionEvent } from './event';
 export type { EventProcessor } from './eventprocessor';
 export type { Exception } from './exception';
 export type { Extra, Extras } from './extra';


### PR DESCRIPTION
As a first step for https://github.com/getsentry/sentry-javascript/issues/6480, this adds the replay event type.

Note that replay is a bit special, in that it has two event types: `replay_event` and `replay_recording`. These are sent in one envelope, where `replay_event` contains the replay metadata etc, and `replay_recording` the actual recording as string. 

IMHO for the `event` type we have here it is sufficient to have `replay_event`, as the `replay_recording` is not really passed around but only need to be considered when we (eventually) build the envelope.