### PR TITLE
feat(serverless/awslambda/captureAllSettledReasons) : Build specific context for each captured promises

### DIFF
--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -133,9 +133,9 @@ function tryRequire<T>(taskRoot: string, subdir: string, mod: string): T {
   // Node-style path
   return require(require.resolve(mod, { paths: [taskRoot, subdir] }));
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type PromiseSettledResult<T, S extends 'rejected' | 'fulfilled' = 'rejected' | 'fulfilled'> = {
   status: S;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   reason?: any;
   value: T;
 };

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -3,7 +3,7 @@
 import { Callback, Handler } from 'aws-lambda';
 
 import * as Sentry from '../src';
-import {WrapperOptions} from '../src/awslambda';
+import { WrapperOptions } from '../src/awslambda';
 
 const { wrapHandler } = Sentry.AWSLambda;
 
@@ -166,7 +166,6 @@ describe('AWSLambda', () => {
           { status: 'rejected', reason: error2 },
         ]);
 
-
       test.each([
         ['undefined', undefined],
         ['no options', {}],
@@ -185,10 +184,10 @@ describe('AWSLambda', () => {
           'contextBuilderFn returning CaptureContext',
           {
             captureAllSettledReasons: {
-              contextBuilderFn: jest.fn().mockResolvedValue({ tags: {promise: false} }),
+              contextBuilderFn: jest.fn().mockResolvedValue({ tags: { promise: false } }),
             },
           },
-          { tags: {promise: false} },
+          { tags: { promise: false } },
         ],
         [
           'contextBuilderFn returning Promise<CaptureContext>',
@@ -202,7 +201,7 @@ describe('AWSLambda', () => {
       ])('captureAllSettledReasons is enable (%s)', async (_, config: Partial<WrapperOptions>, expectedContext) => {
         const wrappedHandler = wrapHandler(handler, config);
         await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
-        if(typeof config.captureAllSettledReasons !== 'boolean' && config.captureAllSettledReasons?.contextBuilderFn) {
+        if (typeof config.captureAllSettledReasons !== 'boolean' && config.captureAllSettledReasons?.contextBuilderFn) {
           expect(config.captureAllSettledReasons?.contextBuilderFn).toHaveBeenNthCalledWith(1, fakeEvent, error, 0);
           expect(config.captureAllSettledReasons?.contextBuilderFn).toHaveBeenNthCalledWith(2, fakeEvent, error2, 2);
           expect(config.captureAllSettledReasons?.contextBuilderFn).toBeCalledTimes(2);


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

--- 

- Following https://github.com/getsentry/sentry-javascript/pull/4130

# Description

It can be very interesting to build a specific context depending on the error. And especially in my case, the index. This allows to find the corresponding SQSRecord, and to design tags from the body. This increases greatly the debugging capacity, and filtering at the sentry interface level.


