### PR TITLE
build(core): Do not mangle private methods used by Replay

### DIFF
--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -104,6 +104,11 @@ export function makeTerserPlugin() {
           '_driver',
           '_initStorage',
           '_support',
+          // TODO: Get rid of these once we use the SDK to send replay events
+          '_breadcrumbs', // replay uses scope._breadcrumbs
+          '_withClient', // replay uses hub._withClient
+          '_prepareEvent', // replay uses client._prepareEvent
+          '_updateSessionFromEvent', // replay client._updateSessionFromEvent
         ],
       },
     },

--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -105,8 +105,6 @@ export function makeTerserPlugin() {
           '_initStorage',
           '_support',
           // TODO: Get rid of these once we use the SDK to send replay events
-          '_breadcrumbs', // replay uses scope._breadcrumbs
-          '_withClient', // replay uses hub._withClient
           '_prepareEvent', // replay uses client._prepareEvent
           '_updateSessionFromEvent', // replay client._updateSessionFromEvent
         ],


### PR DESCRIPTION
In Replay, we access some private methods from the core SDK package from the `Client` class. Because we mangle private fields by default, our SDK CDN bundles wouldn't expose these methods and fields anymore in their clear name to external callers, such as our Replay CDN bundle, producing runtime errors because the methods were not found. 

This PR fixes these errors by explicitly excluding the called private methods from mangling so that they can be accessed externally. This is admittedly not a clean solution but it unblocks minified CDN bundle users. In the long run we can revert this PR once we streamlined Replay event sending into the SDK (#6480) (as well as breadcrumbs via hooks?). 

Note: This unfortunately increases bundle size, not just for the Replay CDN bundle, but also for the Browser SDK CDN bundle. 

fixes https://github.com/getsentry/sentry-javascript/issues/6466