### PR TITLE
feat(core): Add `scope.getLastBreadcrumb()`

### DIFF
--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -414,6 +414,13 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
+  public getLastBreadcrumb(): Breadcrumb | undefined {
+    return this._breadcrumbs[this._breadcrumbs.length - 1];
+  }
+
+  /**
+   * @inheritDoc
+   */
   public clearBreadcrumbs(): this {
     this._breadcrumbs = [];
     this._notifyScopeListeners();

--- a/packages/replay/src/coreHandlers/handleScope.ts
+++ b/packages/replay/src/coreHandlers/handleScope.ts
@@ -5,10 +5,7 @@ import { createBreadcrumb } from '../util/createBreadcrumb';
 let _LAST_BREADCRUMB: null | Breadcrumb = null;
 
 export function handleScope(scope: Scope): Breadcrumb | null {
-  // TODO: remove ignores here
-  // @ts-ignore using private val
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  const newBreadcrumb = scope._breadcrumbs[scope._breadcrumbs.length - 1];
+  const newBreadcrumb = scope.getLastBreadcrumb();
 
   // Listener can be called when breadcrumbs have not changed, so we store the
   // reference to the last crumb and only return a crumb if it has changed
@@ -19,10 +16,9 @@ export function handleScope(scope: Scope): Breadcrumb | null {
   _LAST_BREADCRUMB = newBreadcrumb;
 
   if (
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    ['fetch', 'xhr', 'sentry.event', 'sentry.transaction'].includes(newBreadcrumb.category) ||
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    newBreadcrumb.category?.startsWith('ui.')
+    newBreadcrumb.category &&
+    (['fetch', 'xhr', 'sentry.event', 'sentry.transaction'].includes(newBreadcrumb.category) ||
+      newBreadcrumb.category.startsWith('ui.'))
   ) {
     return null;
   }

--- a/packages/replay/test/unit/coreHandlers/handleScope.test.ts
+++ b/packages/replay/test/unit/coreHandlers/handleScope.test.ts
@@ -8,6 +8,9 @@ const mockHandleScope = HandleScope.handleScope as jest.MockedFunction<typeof Ha
 it('returns a breadcrumb only if last breadcrumb has changed (unit)', function () {
   const scope = {
     _breadcrumbs: [],
+    getLastBreadcrumb() {
+      return this._breadcrumbs[this._breadcrumbs.length - 1];
+    },
   } as unknown as Scope;
 
   function addBreadcrumb(breadcrumb: Breadcrumb) {

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -156,6 +156,11 @@ export interface Scope {
   addBreadcrumb(breadcrumb: Breadcrumb, maxBreadcrumbs?: number): this;
 
   /**
+   * Get the last breadcrumb.
+   */
+  getLastBreadcrumb(): Breadcrumb | undefined;
+
+  /**
    * Clears all currently set Breadcrumbs.
    */
   clearBreadcrumbs(): this;


### PR DESCRIPTION
This is needed by replay, which can then stop using the private API `_breadcrumbs`.
