### PR TITLE
docs: Add docs about internal event sending flow

### DIFF
--- a/docs/event-sending.md
+++ b/docs/event-sending.md
@@ -1,0 +1,99 @@
+# Event processing & sending
+
+This document gives an outline for how event sending works, and which which places it goes through.
+
+## Errors
+
+* `hub.captureException()`
+  * `client.captureException()` (see baseclient)
+    * `checkOrSetAlreadyCaught()`
+    * `baseclient._process()`
+    * `baseclient.eventFromException()`
+    * `baseclient._captureEvent()`
+      * `baseclient._processEvent()`
+        * `baseclient._prepareEvent()`
+          * `baseclient._applyClientOptions()`
+          * `baseclient._applyIntegrationsMetadata()`
+          * `scope.applyToEvent()`
+          * `baseclient._normalizeEvent()`
+        * `baseclient._updateSessionFromEvent()`
+        * `baseclient.sendEvent()`
+          * `createEventEnvelope()`
+            * `getSdkMetadataForEnvelopeHeader()`
+            * `enhanceEventWithSdkInfo()`
+            * `createEventEnvelopeHeaders()`
+            * `createEnvelope()`
+          * `addItemToEnvelope()`
+            * `createAttachmentEnvelopeItem()`
+          * `baseclient._sendEnvelope()`
+            * `transport.send()`
+
+## Transactions
+
+* `transaction.finish()`
+  * `transaction.getTraceContext()`
+  * `transaction.getDynamicSamplingContext()`
+  * `hub.captureEvent()`
+  * `client.captureEvent()` (see baseclient)
+    * `checkOrSetAlreadyCaught()`
+    * `baseclient._process()`
+    * `baseclient.eventFromException()`
+    * `baseclient._captureEvent()`
+      * `baseclient._processEvent()`
+        * `baseclient._prepareEvent()`
+          * `baseclient._applyClientOptions()`
+          * `baseclient._applyIntegrationsMetadata()`
+          * `scope.applyToEvent()`
+          * `baseclient._normalizeEvent()`
+        * `baseclient._updateSessionFromEvent()`
+        * `baseclient.sendEvent()`
+          * `createEventEnvelope()`
+            * `getSdkMetadataForEnvelopeHeader()`
+            * `enhanceEventWithSdkInfo()`
+            * `createEventEnvelopeHeaders()`
+            * `createEnvelope()`
+          * `addItemToEnvelope()`
+            * `createAttachmentEnvelopeItem()`
+          * `baseclient._sendEnvelope()`
+            * `transport.send()`
+
+## Sessions
+
+* `hub.captureSession()`
+  * `hub.endSession()`
+    * `closeSession()`
+    * `hub._sendSessionUpdate()`
+    * `scope.setSession()`
+  * `hub._sendSessionUpdate()`
+    * `client.captureSession()` (see baseclient)
+      * `baseclient.sendSession()`
+        * `createSessionEnvelope()`
+          * `getSdkMetadataForEnvelopeHeader()`
+          * `createEnvelope()`
+        * `baseclient._sendEnvelope()`
+          * `transport.send()`
+      * `updateSession()`
+
+## Replay (WIP)
+
+* `replay.sendReplayRequest()`
+  * `createPayload()`
+  * `getReplayEvent()`
+    * `client._prepareEvent()` (see baseclient)
+      * `baseclient._applyClientOptions()`
+      * `baseclient._applyIntegrationsMetadata()`
+      * `scope.applyToEvent()`
+      * `baseclient._normalizeEvent()`
+    * `baseclient._updateSessionFromEvent()`
+  * `createReplayEnvelope()`
+    * `createEnvelope()`
+  * `transport.send()`
+
+## Client Reports
+
+* `browser.client.constructor()`
+  * `browser.client._flushOutcomes()`
+    * `getEnvelopeEndpointWithUrlEncodedAuth()`
+    * `createClientReportEnvelope()`
+    * `baseclient._sendEnvelope()`
+      * `transport.send()`


### PR DESCRIPTION
This adds a docs page which outlines the flow that events go through when being processed.
I wrote this while trying to reason about the replay event sending - it can be quite hard to have an overview what is added/updated on an event where. This document hopefully helps a bit with that, for future reference.