### PR TITLE
feat(browser): Export `Replay` integration from Browser SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "karma-firefox-launcher": "^1.1.0",
     "lerna": "3.13.4",
     "madge": "4.0.2",
+    "magic-string": "^0.27.0",
     "mocha": "^6.1.4",
     "nodemon": "^2.0.16",
     "npm-run-all": "^4.1.5",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@sentry/core": "7.26.0",
+    "@sentry/replay": "7.26.0",
     "@sentry/types": "7.26.0",
     "@sentry/utils": "7.26.0",
     "tslib": "^1.9.3"

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -1,5 +1,13 @@
 import { BaseClient, getEnvelopeEndpointWithUrlEncodedAuth, Scope, SDK_VERSION } from '@sentry/core';
-import { ClientOptions, Event, EventHint, Options, Severity, SeverityLevel } from '@sentry/types';
+import {
+  BrowserClientReplayOptions,
+  ClientOptions,
+  Event,
+  EventHint,
+  Options,
+  Severity,
+  SeverityLevel,
+} from '@sentry/types';
 import { createClientReportEnvelope, dsnToString, logger, serializeEnvelope } from '@sentry/utils';
 
 import { eventFromException, eventFromMessage } from './eventbuilder';
@@ -7,22 +15,6 @@ import { WINDOW } from './helpers';
 import { Breadcrumbs } from './integrations';
 import { BREADCRUMB_INTEGRATION_ID } from './integrations/breadcrumbs';
 import { BrowserTransportOptions } from './transports/types';
-
-type BrowserClientReplayOptions = {
-  /**
-   * The sample rate for session-long replays.
-   * 1.0 will record all sessions and 0 will record none.
-   */
-  replaysSessionSampleRate?: number;
-
-  /**
-   * The sample rate for sessions that has had an error occur.
-   * This is independent of `sessionSampleRate`.
-   * 1.0 will record all sessions and 0 will record none.
-   */
-  replaysOnErrorSampleRate?: number;
-};
-
 /**
  * Configuration options for the Sentry Browser SDK.
  * @see @sentry/types Options for more information.

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -19,3 +19,12 @@ const INTEGRATIONS = {
 };
 
 export { INTEGRATIONS as Integrations };
+
+// DO NOT DELETE THESE COMMENTS!
+// We want to exclude Replay from CDN bundles, so we remove the block below with our
+// excludeReplay Rollup plugin when generating bundles. Everything between
+// ROLLUP_EXCLUDE_FROM_BUNDLES_BEGIN and _END__ is removed for bundles.
+
+// __ROLLUP_EXCLUDE_FROM_BUNDLES_BEGIN__
+export { Replay } from '@sentry/replay';
+// __ROLLUP_EXCLUDE_FROM_BUNDLES_END__

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -46,7 +46,6 @@
   "homepage": "https://github.com/getsentry/sentry-replay#readme",
   "devDependencies": {
     "@babel/core": "^7.17.5",
-    "@sentry/browser": "7.26.0",
     "@types/lodash.debounce": "4.0.7",
     "@types/pako": "^2.0.0",
     "jsdom-worker": "^0.2.1",

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -1,6 +1,5 @@
-import type { BrowserClient, BrowserOptions } from '@sentry/browser';
 import { getCurrentHub } from '@sentry/core';
-import { Integration } from '@sentry/types';
+import { BrowserClientReplayOptions, Integration } from '@sentry/types';
 
 import { DEFAULT_ERROR_SAMPLE_RATE, DEFAULT_SESSION_SAMPLE_RATE } from './constants';
 import { ReplayContainer } from './replay';
@@ -184,8 +183,8 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
 
   /** Parse Replay-related options from SDK options */
   private _loadReplayOptionsFromClient(): void {
-    const client = getCurrentHub().getClient() as BrowserClient | undefined;
-    const opt = client && (client.getOptions() as BrowserOptions | undefined);
+    const client = getCurrentHub().getClient();
+    const opt = client && (client.getOptions() as BrowserClientReplayOptions | undefined);
 
     if (opt && typeof opt.replaysSessionSampleRate === 'number') {
       this.options.sessionSampleRate = opt.replaysSessionSampleRate;

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -1,5 +1,6 @@
 import { getCurrentHub } from '@sentry/core';
-import { BrowserClientReplayOptions, Integration } from '@sentry/types';
+import type { BrowserClientReplayOptions } from '@sentry/types';
+import { Integration } from '@sentry/types';
 
 import { DEFAULT_ERROR_SAMPLE_RATE, DEFAULT_SESSION_SAMPLE_RATE } from './constants';
 import { ReplayContainer } from './replay';

--- a/packages/types/src/browseroptions.ts
+++ b/packages/types/src/browseroptions.ts
@@ -1,0 +1,18 @@
+/**
+ * Options added to the Browser SDK's init options that are specific for Replay.
+ * Note: This type was moved to @sentry/types to avoid a circular dependency between Browser and Replay.
+ */
+export type BrowserClientReplayOptions = {
+  /**
+   * The sample rate for session-long replays.
+   * 1.0 will record all sessions and 0 will record none.
+   */
+  replaysSessionSampleRate?: number;
+
+  /**
+   * The sample rate for sessions that has had an error occur.
+   * This is independent of `sessionSampleRate`.
+   * 1.0 will record all sessions and 0 will record none.
+   */
+  replaysOnErrorSampleRate?: number;
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -93,3 +93,5 @@ export type {
 export type { User, UserFeedback } from './user';
 export type { WrappedFunction } from './wrappedfunction';
 export type { Instrumenter } from './instrumenter';
+
+export type { BrowserClientReplayOptions } from './browseroptions';

--- a/rollup/bundleHelpers.js
+++ b/rollup/bundleHelpers.js
@@ -16,6 +16,7 @@ import {
   makeSucrasePlugin,
   makeTerserPlugin,
   makeTSPlugin,
+  makeExcludeReplayPlugin,
 } from './plugins/index.js';
 import { mergePlugins } from './utils';
 
@@ -30,6 +31,7 @@ export function makeBaseBundleConfig(options) {
   const markAsBrowserBuildPlugin = makeBrowserBuildPlugin(true);
   const licensePlugin = makeLicensePlugin(licenseTitle);
   const tsPlugin = makeTSPlugin(jsVersion.toLowerCase());
+  const excludeReplayPlugin = makeExcludeReplayPlugin();
 
   // The `commonjs` plugin is the `esModuleInterop` of the bundling world. When used with `transformMixedEsModules`, it
   // will include all dependencies, imported or required, in the final bundle. (Without it, CJS modules aren't included
@@ -43,7 +45,7 @@ export function makeBaseBundleConfig(options) {
       name: 'Sentry',
     },
     context: 'window',
-    plugins: [markAsBrowserBuildPlugin],
+    plugins: [markAsBrowserBuildPlugin, excludeReplayPlugin],
   };
 
   // used by `@sentry/integrations` and `@sentry/wasm` (bundles which need to be combined with a stand-alone SDK bundle)

--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -174,7 +174,7 @@ export function makeTSPlugin(jsVersion) {
  * If we need to add more such guards in the future, we might want to refactor this into a more generic plugin.
  */
 export function makeExcludeReplayPlugin() {
-  const replacementRegex = /\/\/ __ROLLUP_EXCLUDE_FROM_BUNDLES_BEGIN__(.|\n)*__ROLLUP_EXCLUDE_FROM_BUNDLES_END__/gm;
+  const replacementRegex = /\/\/ __ROLLUP_EXCLUDE_FROM_BUNDLES_BEGIN__(.|\n)*__ROLLUP_EXCLUDE_FROM_BUNDLES_END__/m;
   const browserIndexFilePath = path.resolve(__dirname, '../../packages/browser/src/index.ts');
 
   const plugin = {
@@ -185,7 +185,7 @@ export function makeExcludeReplayPlugin() {
       }
 
       const ms = new MagicString(code);
-      const transformedCode = ms.replace(new RegExp(replacementRegex), '');
+      const transformedCode = ms.replace(replacementRegex, '');
       return {
         code: transformedCode.toString(),
         map: transformedCode.generateMap({ hires: true }),

--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -8,6 +8,8 @@
  * Typescript plugin docs: https://github.com/ezolenko/rollup-plugin-typescript2
  */
 
+import path from 'path';
+
 import commonjs from '@rollup/plugin-commonjs';
 import deepMerge from 'deepmerge';
 import license from 'rollup-plugin-license';
@@ -169,13 +171,16 @@ export function makeTSPlugin(jsVersion) {
  * Creates a Rollup plugin that removes all code between the `__ROLLUP_EXCLUDE_FROM_BUNDLES_BEGIN__`
  * and `__ROLLUP_EXCLUDE_FROM_BUNDLES_END__` comment guards. This is used to exclude the Replay integration
  * from the browser and browser+tracing bundles.
+ * If we need to add more such guards in the future, we might want to refactor this into a more generic plugin.
  */
 export function makeExcludeReplayPlugin() {
   const replacementRegex = /\/\/ __ROLLUP_EXCLUDE_FROM_BUNDLES_BEGIN__(.|\n)*__ROLLUP_EXCLUDE_FROM_BUNDLES_END__/gm;
+  const browserIndexFilePath = path.resolve(__dirname, '../../packages/browser/src/index.ts');
 
   const plugin = {
-    transform(code) {
-      if (!replacementRegex.test(code)) {
+    transform(code, id) {
+      const isBrowserIndexFile = path.resolve(id) === browserIndexFilePath;
+      if (!isBrowserIndexFile || !replacementRegex.test(code)) {
         return null;
       }
 

--- a/rollup/utils.js
+++ b/rollup/utils.js
@@ -16,9 +16,11 @@ export const insertAt = (arr, index, ...insertees) => {
 export function mergePlugins(pluginsA, pluginsB) {
   const plugins = [...pluginsA, ...pluginsB];
   plugins.sort((a, b) => {
-    // Hacky way to make sure the ones we care about end up where they belong in the order. (Really the TS and sucrase
+    // Hacky way to make sure the ones we care about end up where they belong in the order. Really the TS and sucrase
     // plugins are tied - both should come first - but they're mutually exclusive, so they can come in arbitrary order
-    // here.)
+    // here.
+    // Additionally, the excludeReplay plugin must run before TS/Sucrase so that we can eliminate the replay code
+    // before anything is type-checked (TS-only) and transpiled.
     const order = ['excludeReplay', 'typescript', 'sucrase', '...', 'terser', 'license'];
     const sortKeyA = order.includes(a.name) ? a.name : '...';
     const sortKeyB = order.includes(b.name) ? b.name : '...';

--- a/rollup/utils.js
+++ b/rollup/utils.js
@@ -19,7 +19,7 @@ export function mergePlugins(pluginsA, pluginsB) {
     // Hacky way to make sure the ones we care about end up where they belong in the order. (Really the TS and sucrase
     // plugins are tied - both should come first - but they're mutually exclusive, so they can come in arbitrary order
     // here.)
-    const order = ['excludeReplay', 'typescript', 'sucrase', '...', 'terser', 'license'];
+    const order = ['typescript', 'sucrase', '...', 'terser', 'license'];
     const sortKeyA = order.includes(a.name) ? a.name : '...';
     const sortKeyB = order.includes(b.name) ? b.name : '...';
 

--- a/rollup/utils.js
+++ b/rollup/utils.js
@@ -19,7 +19,7 @@ export function mergePlugins(pluginsA, pluginsB) {
     // Hacky way to make sure the ones we care about end up where they belong in the order. (Really the TS and sucrase
     // plugins are tied - both should come first - but they're mutually exclusive, so they can come in arbitrary order
     // here.)
-    const order = ['typescript', 'sucrase', '...', 'terser', 'license'];
+    const order = ['excludeReplay', 'typescript', 'sucrase', '...', 'terser', 'license'];
     const sortKeyA = order.includes(a.name) ? a.name : '...';
     const sortKeyB = order.includes(b.name) ? b.name : '...';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2232,7 +2232,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
 
-"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
+"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.13":
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
@@ -16501,6 +16501,13 @@ magic-string@^0.26.2:
   integrity sha512-u1Po0NDyFcwdg2nzHT88wSK0+Rih0N1M+Ph1Sp08k8yvFFU3KR72wryS7e1qMPJypt99WB7fIFVCA92mQrMjrg==
   dependencies:
     sourcemap-codec "^1.4.8"
+
+magic-string@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.27.0.tgz#e4a3413b4bab6d98d2becffd48b4a257effdbbf3"
+  integrity sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.13"
 
 make-dir@^1.0.0:
   version "1.3.0"


### PR DESCRIPTION
This PR exports the `Replay` integration from `@sentry/replay` in `@sentry/browser`.  This will eliminate the need for users to separately install the `@sentry/replay` package as they have to do right now. Instead, they can just use Replay like it's part of the core Browser SDK or any FE Framework SDK that builds on top of Browser:

```js
import * as Sentry from '@sentry/browser'; // or @sentry/react, ...

Sentry.init({
  // dsn, other options, etc
  replaysSessionSampleRate: 0.1,
  replaysOnErrorSampleRate: 1.0,
  integrations: [new Sentry.Replay()]
});
```
Alternatively, `import { Replay } from '@sentry/browser'` works, too. 

Note: This does not affect users who imported the integration from `@sentry/replay` so it should be fully backwards compatible.  

### Bundle Size Concerns

As far as I tested, for the NPM package, everything Replay-related is tree-shaken out by bundlers if `Replay` is not used. 

For standalone CDN bundles of browser and browser+tracing, we have to first remove the export from `index.ts` in the Browser package, before we transpile and bundle so that the integration isn't included in them. In the future, we can think about a complete bundle that contains Replay but this is out of scope for this PR and its issue. 

To remove the export from `index.ts`, this PR introduces a new rollup plugin that removes all code between specific comment guards. I chose this approach over creating a separate `index.bundle.ts` file because we'd anyhow need to apply some rollup intervention to select the correct index file for the browser+tracing bundles. Since we're already experienced by now with rollup plugins, I figured, it'd be a nicer way. 

ref: #6326 

