### PR TITLE
ci: Skip build (and consecutive steps) when only changing .md files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,8 @@ jobs:
               - *shared
               - 'packages/node/**'
               - 'packages/node-integration-tests/**'
+            any_code:
+              - '!**/*.md'
 
     outputs:
       commit_label: '${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}'
@@ -117,6 +119,7 @@ jobs:
       changed_node: ${{ steps.changed.outputs.node }}
       changed_browser: ${{ steps.changed.outputs.browser }}
       changed_browser_integration: ${{ steps.changed.outputs.browser_integration }}
+      changed_any_code: ${{ steps.changed.outputs.any_code }}
 
   job_install_deps:
     name: Install Dependencies
@@ -152,6 +155,7 @@ jobs:
     needs: [job_get_metadata, job_install_deps]
     runs-on: ubuntu-20.04
     timeout-minutes: 20
+    if: needs.job_get_metadata.outputs.changed_any_code == 'true' || github.event_name != 'pull_request'
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,7 @@ jobs:
     needs: job_get_metadata
     runs-on: ubuntu-20.04
     timeout-minutes: 15
+    if: needs.job_get_metadata.outputs.changed_any_code == 'true' || github.event_name != 'pull_request'
     steps:
       - name: 'Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})'
         uses: actions/checkout@v3
@@ -155,7 +156,6 @@ jobs:
     needs: [job_get_metadata, job_install_deps]
     runs-on: ubuntu-20.04
     timeout-minutes: 20
-    if: needs.job_get_metadata.outputs.changed_any_code == 'true' || github.event_name != 'pull_request'
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,9 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
+    paths:
+      # When _only_ changing .md files, no need to run CodeQL analysis
+      - '!**/*.md'
   schedule:
     - cron: '40 3 * * 0'
 


### PR DESCRIPTION
In order to cut down CI time when releasing, we can skip build & consecutive steps when we notice that _only_ `.md` files have been changed.