### PR TITLE
ref(core): Move `getSdkMetadataForEnvelopeHeader` to utils

### DIFF
--- a/packages/core/src/envelope.ts
+++ b/packages/core/src/envelope.ts
@@ -11,16 +11,7 @@ import {
   SessionEnvelope,
   SessionItem,
 } from '@sentry/types';
-import { createEnvelope, dropUndefinedKeys, dsnToString } from '@sentry/utils';
-
-/** Extract sdk info from from the API metadata */
-function getSdkMetadataForEnvelopeHeader(metadata?: SdkMetadata): SdkInfo | undefined {
-  if (!metadata || !metadata.sdk) {
-    return;
-  }
-  const { name, version } = metadata.sdk;
-  return { name, version };
-}
+import { createEnvelope, dropUndefinedKeys, dsnToString, getSdkMetadataForEnvelopeHeader } from '@sentry/utils';
 
 /**
  * Apply SdkInfo (name, version, packages, integrations) to the corresponding event key.

--- a/packages/replay/src/util/createReplayEnvelope.ts
+++ b/packages/replay/src/util/createReplayEnvelope.ts
@@ -1,17 +1,16 @@
 import { Envelope, Event } from '@sentry/types';
-import { createEnvelope } from '@sentry/utils';
+import { createEnvelope, getSdkMetadataForEnvelopeHeader } from '@sentry/utils';
 
 export function createReplayEnvelope(
   replayId: string,
   replayEvent: Event,
   payloadWithSequence: string | Uint8Array,
 ): Envelope {
-  const { name, version } = replayEvent.sdk || {};
   return createEnvelope(
     {
       event_id: replayId,
       sent_at: new Date().toISOString(),
-      sdk: { name, version },
+      sdk: getSdkMetadataForEnvelopeHeader(replayEvent),
     },
     [
       // @ts-ignore New types

--- a/packages/utils/src/envelope.ts
+++ b/packages/utils/src/envelope.ts
@@ -5,6 +5,9 @@ import {
   Envelope,
   EnvelopeItem,
   EnvelopeItemType,
+  Event,
+  SdkInfo,
+  SdkMetadata,
   TextEncoderInternal,
 } from '@sentry/types';
 
@@ -141,4 +144,13 @@ const ITEM_TYPE_TO_DATA_CATEGORY_MAP: Record<EnvelopeItemType, DataCategory> = {
  */
 export function envelopeItemTypeToDataCategory(type: EnvelopeItemType): DataCategory {
   return ITEM_TYPE_TO_DATA_CATEGORY_MAP[type];
+}
+
+/** Extracts the minimal SDK info from from the metadata or an events */
+export function getSdkMetadataForEnvelopeHeader(metadataOrEvent?: SdkMetadata | Event): SdkInfo | undefined {
+  if (!metadataOrEvent || !metadataOrEvent.sdk) {
+    return;
+  }
+  const { name, version } = metadataOrEvent.sdk;
+  return { name, version };
 }


### PR DESCRIPTION
We want to use `getSdkMetadataForEnvelopeHeader` in Replay to not have duplicated minimal SDKInfo extraction logic. I checked that envelope helper functions are usually publicly exposed from the utils package only (which makes sense to me). So, this PR moves the function from core to utils and calls it in the replay envelope creation function.

Note that I changed the input type to accept both, an `Event` as well as `SdkMetadata`, as both have the `sdk: SdkInfo` property. 

Since `getSdkMetadataForEnvelopeHeader` wasn't exported before, I think we don't have to worry about a breaking change here.

ref: #6366 
