### PR TITLE
test(react): Make react unit tests silent

### DIFF
--- a/packages/react/jest.config.js
+++ b/packages/react/jest.config.js
@@ -3,4 +3,6 @@ const baseConfig = require('../../jest/jest.config.js');
 module.exports = {
   ...baseConfig,
   testEnvironment: 'jsdom',
+  // We have some tests that trigger warnings, which mess up the test logs
+  silent: true,
 };


### PR DESCRIPTION
Currently, we have a bunch of `console.warn()` outputs there which mess up the test logs a bit.