### PR TITLE
ref(core): Ensure we use `captureException()` from `@sentry/core` where possible

### DIFF
--- a/packages/angular/ng-package.json
+++ b/packages/angular/ng-package.json
@@ -5,9 +5,10 @@
     "entryFile": "src/index.ts",
     "umdModuleIds": {
       "@sentry/browser": "Sentry",
+      "@sentry/core": "Sentry.core",
       "@sentry/utils": "Sentry.util"
     }
   },
-  "whitelistedNonPeerDependencies": ["@sentry/browser", "@sentry/utils", "@sentry/types", "tslib"],
+  "whitelistedNonPeerDependencies": ["@sentry/browser", "@sentry/core", "@sentry/utils", "@sentry/types", "tslib"],
   "assets": ["README.md", "LICENSE"]
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@sentry/browser": "7.26.0",
+    "@sentry/core": "7.26.0",
     "@sentry/types": "7.26.0",
     "@sentry/utils": "7.26.0",
     "tslib": "^2.0.0"

--- a/packages/angular/src/errorhandler.ts
+++ b/packages/angular/src/errorhandler.ts
@@ -1,7 +1,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { ErrorHandler as AngularErrorHandler, Inject, Injectable } from '@angular/core';
 import * as Sentry from '@sentry/browser';
-import { captureException } from '@sentry/browser';
+import { captureException } from '@sentry/core';
 import { addExceptionMechanism } from '@sentry/utils';
 
 import { runOutsideAngular } from './zone';

--- a/packages/angular/test/errorhandler.test.ts
+++ b/packages/angular/test/errorhandler.test.ts
@@ -1,14 +1,14 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import * as SentryBrowser from '@sentry/browser';
-import { Scope } from '@sentry/browser';
+import * as SentryCore from '@sentry/core';
 import * as SentryUtils from '@sentry/utils';
 
 import { createErrorHandler, SentryErrorHandler } from '../src/errorhandler';
 
-const FakeScope = new Scope();
+const FakeScope = new SentryBrowser.Scope();
 
-jest.mock('@sentry/browser', () => {
-  const original = jest.requireActual('@sentry/browser');
+jest.mock('@sentry/core', () => {
+  const original = jest.requireActual('@sentry/core');
   return {
     ...original,
     captureException: (err: unknown, cb: (arg0?: unknown) => unknown) => {
@@ -18,7 +18,7 @@ jest.mock('@sentry/browser', () => {
   };
 });
 
-const captureExceptionSpy = jest.spyOn(SentryBrowser, 'captureException');
+const captureExceptionSpy = jest.spyOn(SentryCore, 'captureException');
 
 jest.spyOn(console, 'error').mockImplementation();
 

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -16,6 +16,7 @@
   "module": "build/npm/esm/index.js",
   "types": "build/npm/types/index.d.ts",
   "dependencies": {
+    "@sentry/core": "7.26.0",
     "@sentry/types": "7.26.0",
     "@sentry/utils": "7.26.0",
     "localforage": "^1.8.1",

--- a/packages/integrations/src/captureconsole.ts
+++ b/packages/integrations/src/captureconsole.ts
@@ -1,3 +1,4 @@
+import { captureException } from '@sentry/core';
 import { EventProcessor, Hub, Integration } from '@sentry/types';
 import { CONSOLE_LEVELS, fill, GLOBAL_OBJ, safeJoin, severityLevelFromString } from '@sentry/utils';
 
@@ -62,7 +63,7 @@ export class CaptureConsole implements Integration {
                 hub.captureMessage(message);
               }
             } else if (level === 'error' && args[0] instanceof Error) {
-              hub.captureException(args[0]);
+              captureException(args[0]);
             } else {
               hub.captureMessage(message);
             }

--- a/packages/integrations/test/captureconsole.test.ts
+++ b/packages/integrations/test/captureconsole.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/unbound-method */
+import * as SentryCore from '@sentry/core';
 import { Event, Hub, Integration } from '@sentry/types';
 
 import { CaptureConsole } from '../src/captureconsole';
@@ -31,6 +32,8 @@ const getMockHubWithIntegration = (integration: Integration) =>
     ...mockHub,
     getIntegration: jest.fn(() => integration),
   } as unknown as Hub);
+
+const mockCaptureException = jest.spyOn(SentryCore, 'captureException');
 
 // We're using this to un-monkey patch the console after each test.
 const originalConsole = Object.assign({}, global.console);
@@ -225,8 +228,8 @@ describe('CaptureConsole setup', () => {
     const someError = new Error('some error');
     global.console.error(someError);
 
-    expect(mockHub.captureException).toHaveBeenCalledTimes(1);
-    expect(mockHub.captureException).toHaveBeenCalledWith(someError);
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException).toHaveBeenCalledWith(someError);
   });
 
   it('should capture exception on `console.error` when no levels are provided in constructor', () => {
@@ -239,8 +242,8 @@ describe('CaptureConsole setup', () => {
     const someError = new Error('some error');
     global.console.error(someError);
 
-    expect(mockHub.captureException).toHaveBeenCalledTimes(1);
-    expect(mockHub.captureException).toHaveBeenCalledWith(someError);
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException).toHaveBeenCalledWith(someError);
   });
 
   it('should capture message on `console.log` when no levels are provided in constructor', () => {
@@ -267,7 +270,7 @@ describe('CaptureConsole setup', () => {
 
     expect(mockHub.captureMessage).toHaveBeenCalledTimes(1);
     expect(mockHub.captureMessage).toHaveBeenCalledWith('some non-error message');
-    expect(mockHub.captureException).not.toHaveBeenCalled();
+    expect(mockCaptureException).not.toHaveBeenCalled();
   });
 
   it('should capture a message for non-error log levels', () => {

--- a/packages/vue/src/errorhandler.ts
+++ b/packages/vue/src/errorhandler.ts
@@ -1,4 +1,5 @@
 import { getCurrentHub } from '@sentry/browser';
+import { captureException } from '@sentry/core';
 
 import { formatComponentName, generateComponentTrace } from './components';
 import { Options, ViewModel, Vue } from './types';
@@ -31,7 +32,7 @@ export const attachErrorHandler = (app: Vue, options: Options): void => {
     setTimeout(() => {
       getCurrentHub().withScope(scope => {
         scope.setContext('vue', metadata);
-        getCurrentHub().captureException(error);
+        captureException(error);
       });
     });
 

--- a/scenarios/browser/basic-capture-exception/index.js
+++ b/scenarios/browser/basic-capture-exception/index.js
@@ -1,7 +1,8 @@
-import { init, captureException } from "@sentry/browser";
+import { init } from '@sentry/browser';
+import { captureException } from '@sentry/core';
 
 init({
-  dsn: "https://00000000000000000000000000000000@o000000.ingest.sentry.io/0000000",
+  dsn: 'https://00000000000000000000000000000000@o000000.ingest.sentry.io/0000000',
 });
 
-captureException(new Error("error here!"));
+captureException(new Error('error here!'));


### PR DESCRIPTION
This is a reduced version of https://github.com/getsentry/sentry-javascript/pull/6488.

Basically, it makes sure we use the functional `captureException()` from core wherever possible internally.
There are two main places where we still use `hub.captureException` internally:

https://github.com/getsentry/sentry-javascript/blob/fn/import-captureException/packages/node/src/integrations/onuncaughtexception.ts#L127

and

https://github.com/getsentry/sentry-javascript/blob/fn/import-captureException/packages/node/src/integrations/onunhandledrejection.ts#L52

Which are both places that provide a `hint` with `handled: false`.

ref https://github.com/getsentry/sentry-javascript/issues/6073