### PR TITLE
fix(utils): Don't attach context lines to stack frames without line number

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -147,9 +147,13 @@ export function parseSemver(input: string): SemVer {
  * @param linesOfContext number of context lines we want to add pre/post
  */
 export function addContextToFrame(lines: string[], frame: StackFrame, linesOfContext: number = 5): void {
-  const lineno = frame.lineno || 0;
+  // When there is no line number in the frame, attaching context is nonsensical and will even break grouping
+  if (frame.lineno === undefined) {
+    return;
+  }
+
   const maxLines = lines.length;
-  const sourceLine = Math.max(Math.min(maxLines, lineno - 1), 0);
+  const sourceLine = Math.max(Math.min(maxLines, frame.lineno - 1), 0);
 
   frame.pre_context = lines
     .slice(Math.max(0, sourceLine - linesOfContext), sourceLine)


### PR DESCRIPTION
This PR fixes a bug that breaks grouping in Sentry. Currently, when a stack frame doesn't have a line number we attach context lines based on line number 0. This is simply wrong and conflicts with grouping algorithms. We solve this by not attaching context lines at all for frames that do not have line numbers.

Some (ephemeral) context: https://sentry.slack.com/archives/GUCRT2B70/p1671103033977659