### PR TITLE
fix(replay): Ensure lodash.debounce does not trigger next.js warning

### DIFF
--- a/patches/lodash.debounce+4.0.8.patch
+++ b/patches/lodash.debounce+4.0.8.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/lodash.debounce/index.js b/node_modules/lodash.debounce/index.js
+index ac5707d..7447acd 100644
+--- a/node_modules/lodash.debounce/index.js
++++ b/node_modules/lodash.debounce/index.js
+@@ -38,7 +38,7 @@ var freeGlobal = typeof global == 'object' && global && global.Object === Object
+ var freeSelf = typeof self == 'object' && self && self.Object === Object && self;
+ 
+ /** Used as a reference to the global object. */
+-var root = freeGlobal || freeSelf || Function('return this')();
++var root = freeGlobal || freeSelf;
+ 
+ /** Used for built-in method references. */
+ var objectProto = Object.prototype;


### PR DESCRIPTION
lodash.debounce uses `Function('')`, which nextjs interprets as unsafe, and does not work there.  See: https://github.com/lodash/lodash/issues/5394

We don't really need that fallback anyhow, `global || self` should be fine for us.

Eventually, we should get rid of lodash...!