### PR TITLE
ci: Ensure replay changes trigger tests in all browser related packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
             browser:
               - *shared
               - 'packages/browser/**'
+              - 'packages/replay/**'
             browser_integration:
               - *shared
               - 'packages/browser/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
               - 'packages/utils/**'
               - 'packages/types/**'
               - 'packages/integrations/**'
-            browser:
+            browser: &browser
               - *shared
               - 'packages/browser/**'
               - 'packages/replay/**'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,24 +87,24 @@ jobs:
               - 'packages/replay/**'
             browser_integration:
               - *shared
-              - 'packages/browser/**'
+              - *browser
               - 'packages/integration-tests/**'
             ember:
               - *shared
+              - *browser
               - 'packages/ember/**'
-              - 'packages/browser/**'
             nextjs:
               - *shared
+              - *browser
               - 'packages/nextjs/**'
               - 'packages/node/**'
               - 'packages/react/**'
-              - 'packages/browser/**'
             remix:
               - *shared
+              - *browser
               - 'packages/remix/**'
               - 'packages/node/**'
               - 'packages/react/**'
-              - 'packages/browser/**'
             node:
               - *shared
               - 'packages/node/**'


### PR DESCRIPTION
Since @sentry/browser now depends on @sentry/replay, we also need to make sure to run tests on CI accordingly.