### PR TITLE
test(nextjs): Fix integration tests for Next.js 13.0.7

### DIFF
--- a/packages/nextjs/test/integration/pages/[id]/withInitialProps.tsx
+++ b/packages/nextjs/test/integration/pages/[id]/withInitialProps.tsx
@@ -3,7 +3,9 @@ import Link from 'next/link';
 const WithInitialPropsPage = ({ data }: { data: string }) => (
   <>
     <h1>WithInitialPropsPage {data}</h1>
-    <Link href="/1337/withServerSideProps">
+    {/*
+      // @ts-ignore https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
+    <Link href="/1337/withServerSideProps" passHref legacyBehavior>
       <a id="server-side-props-page">Go to withServerSideProps</a>
     </Link>
   </>

--- a/packages/nextjs/test/integration/pages/[id]/withServerSideProps.tsx
+++ b/packages/nextjs/test/integration/pages/[id]/withServerSideProps.tsx
@@ -3,7 +3,9 @@ import Link from 'next/link';
 const WithServerSidePropsPage = ({ data }: { data: string }) => (
   <>
     <h1>WithServerSidePropsPage {data}</h1>
-    <Link href="/3c2e87573d/withInitialProps">
+    {/*
+      // @ts-ignore https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
+    <Link href="/3c2e87573d/withInitialProps" passHref legacyBehavior>
       <a id="initial-props-page">Go to withInitialProps</a>
     </Link>
   </>

--- a/packages/nextjs/test/integration/pages/alsoHealthy.tsx
+++ b/packages/nextjs/test/integration/pages/alsoHealthy.tsx
@@ -1,7 +1,8 @@
 import Link from 'next/link';
 
 const HealthyPage = (): JSX.Element => (
-  <Link href="/healthy">
+  // @ts-ignore
+  <Link href="/healthy" passHref legacyBehavior>
     <a id="healthy">Healthy</a>
   </Link>
 );

--- a/packages/nextjs/test/integration/pages/alsoHealthy.tsx
+++ b/packages/nextjs/test/integration/pages/alsoHealthy.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 
 const HealthyPage = (): JSX.Element => (
-  // @ts-ignore
+  // @ts-ignore https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag
   <Link href="/healthy" passHref legacyBehavior>
     <a id="healthy">Healthy</a>
   </Link>

--- a/packages/nextjs/test/integration/pages/healthy.tsx
+++ b/packages/nextjs/test/integration/pages/healthy.tsx
@@ -1,7 +1,8 @@
 import Link from 'next/link';
 
 const HealthyPage = (): JSX.Element => (
-  <Link href="/alsoHealthy">
+  // @ts-ignore
+  <Link href="/alsoHealthy" passHref legacyBehavior>
     <a id="alsoHealthy">AlsoHealthy</a>
   </Link>
 );

--- a/packages/nextjs/test/integration/pages/healthy.tsx
+++ b/packages/nextjs/test/integration/pages/healthy.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 
 const HealthyPage = (): JSX.Element => (
-  // @ts-ignore
+  // @ts-ignore https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag
   <Link href="/alsoHealthy" passHref legacyBehavior>
     <a id="alsoHealthy">AlsoHealthy</a>
   </Link>

--- a/packages/nextjs/test/integration/pages/users/index.tsx
+++ b/packages/nextjs/test/integration/pages/users/index.tsx
@@ -19,7 +19,9 @@ const WithStaticProps = ({ items }: Props) => (
     <p>You are currently on: /users</p>
     <List items={items} />
     <p>
-      <Link href="/">
+      {/*
+      // @ts-ignore https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
+      <Link href="/" passHref legacyBehavior>
         <a>Go home</a>
       </Link>
     </p>


### PR DESCRIPTION
In Next.js v13.0.7 anchor tags inside Link elements started throwing hydration errors in the browser. This flagged our session integration tests.

We fix this by abiding by the rules Next.js gives us: https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag

I opened an issue to let Vercel folks know that this suddenly started happening: https://github.com/vercel/next.js/issues/44050