### PR TITLE
fix(nextjs): Proxy public key with `tunnelRoute` option

### DIFF
--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -90,8 +90,13 @@ function setUpTunnelRewriteRules(userNextConfig: NextConfigObject, tunnelPath: s
           key: 'p', // short for projectId - we keep it short so matching is harder for ad-blockers
           value: '(?<projectid>.*)',
         },
+        {
+          type: 'query',
+          key: 'k', // short for sentryKey - we keep it short so matching is harder for ad-blockers
+          value: '(?<sentrykey>.*)',
+        },
       ],
-      destination: 'https://o:orgid.ingest.sentry.io/api/:projectid/envelope/',
+      destination: 'https://o:orgid.ingest.sentry.io/api/:projectid/envelope/?sentry_key=:sentrykey',
     };
 
     if (typeof originalRewrites !== 'function') {

--- a/packages/nextjs/src/utils/tunnelRoute.ts
+++ b/packages/nextjs/src/utils/tunnelRoute.ts
@@ -14,13 +14,15 @@ export function applyTunnelRouteOption(options: NextjsOptions): void {
   if (tunnelRouteOption && options.dsn) {
     const dsnComponents = dsnFromString(options.dsn);
     const sentrySaasDsnMatch = dsnComponents.host.match(/^o(\d+)\.ingest\.sentry\.io$/);
-    if (sentrySaasDsnMatch) {
+    if (!sentrySaasDsnMatch) {
+      __DEBUG_BUILD__ && logger.warn('Provided DSN is not a Sentry SaaS DSN. Will not tunnel events.');
+    } else if (!dsnComponents.publicKey) {
+      __DEBUG_BUILD__ && logger.warn('DSN is missing public key. Will not tunnel events.');
+    } else {
       const orgId = sentrySaasDsnMatch[1];
-      const tunnelPath = `${tunnelRouteOption}?o=${orgId}&p=${dsnComponents.projectId}`;
+      const tunnelPath = `${tunnelRouteOption}?o=${orgId}&p=${dsnComponents.projectId}&k=${dsnComponents.publicKey}`;
       options.tunnel = tunnelPath;
       __DEBUG_BUILD__ && logger.info(`Tunneling events to "${tunnelPath}"`);
-    } else {
-      __DEBUG_BUILD__ && logger.warn('Provided DSN is not a Sentry SaaS DSN. Will not tunnel events.');
     }
   }
 }

--- a/packages/nextjs/test/utils/tunnelRoute.test.ts
+++ b/packages/nextjs/test/utils/tunnelRoute.test.ts
@@ -18,7 +18,7 @@ describe('applyTunnelRouteOption()', () => {
 
     applyTunnelRouteOption(options);
 
-    expect(options.tunnel).toBe('/my-error-monitoring-route?o=2222222&p=3333333');
+    expect(options.tunnel).toBe('/my-error-monitoring-route?o=2222222&p=3333333&k=11111111111111111111111111111111');
   });
 
   it('should not apply `tunnelRoute` when DSN is missing', () => {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/6539

Replay events need a `sentry_key` query parameter. The current implementation of `tunnelRoute` doesn't proxy that query parameter leading to a 401 response from Sentry.

This PR fixes this issue by also proxying the `sentry_key` parameter. It is now a bit easier for adblockers to fingerprint for these proxy requests with the additional query parameter but we have to deal with that.