### PR TITLE
feat(nextjs): Check for Vercel Edge Function GA

### DIFF
--- a/packages/nextjs/src/config/templates/apiProxyLoaderTemplate.ts
+++ b/packages/nextjs/src/config/templates/apiProxyLoaderTemplate.ts
@@ -53,13 +53,21 @@ export const config = {
   },
 };
 
-const isEdgeRuntime = origConfig.runtime === 'experimental-edge';
+// This is a variable that Next.js will string replace during build with a string if run in an edge runtime from Next.js
+// v12.2.1-canary.3 onwards:
+// https://github.com/vercel/next.js/blob/166e5fb9b92f64c4b5d1f6560a05e2b9778c16fb/packages/next/build/webpack-config.ts#L206
+// https://edge-runtime.vercel.sh/features/available-apis#addressing-the-runtime
+declare const EdgeRuntime: string | undefined;
 
-export default userProvidedHandler
-  ? isEdgeRuntime
-    ? userProvidedHandler
-    : Sentry.withSentryAPI(userProvidedHandler, '__ROUTE__')
-  : undefined;
+let exportedHandler;
+
+if (typeof EdgeRuntime === 'string') {
+  exportedHandler = userProvidedHandler;
+} else {
+  exportedHandler = userProvidedHandler ? Sentry.withSentryAPI(userProvidedHandler, '__ROUTE__') : undefined;
+}
+
+export default exportedHandler;
 
 // Re-export anything exported by the page module we're wrapping. When processing this code, Rollup is smart enough to
 // not include anything whose name matchs something we've explicitly exported above.

--- a/packages/nextjs/src/index.client.ts
+++ b/packages/nextjs/src/index.client.ts
@@ -34,6 +34,7 @@ declare const __SENTRY_TRACING__: boolean;
 // This is a variable that Next.js will string replace during build with a string if run in an edge runtime from Next.js
 // v12.2.1-canary.3 onwards:
 // https://github.com/vercel/next.js/blob/166e5fb9b92f64c4b5d1f6560a05e2b9778c16fb/packages/next/build/webpack-config.ts#L206
+// https://edge-runtime.vercel.sh/features/available-apis#addressing-the-runtime
 declare const EdgeRuntime: string | undefined;
 
 const globalWithInjectedValues = global as typeof global & {

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -28,6 +28,7 @@ const domain = domainModule as typeof domainModule & { active: (domainModule.Dom
 // This is a variable that Next.js will string replace during build with a string if run in an edge runtime from Next.js
 // v12.2.1-canary.3 onwards:
 // https://github.com/vercel/next.js/blob/166e5fb9b92f64c4b5d1f6560a05e2b9778c16fb/packages/next/build/webpack-config.ts#L206
+// https://edge-runtime.vercel.sh/features/available-apis#addressing-the-runtime
 declare const EdgeRuntime: string | undefined;
 
 // Exporting this constant means we can compute it without the linter complaining, even if we stop directly using it in


### PR DESCRIPTION
Vercel Edge Functions [GA'd](https://vercel.com/blog/edge-functions-generally-available) which means the check for "experimental-edge" doesn't always work anymore. Luckily Next.js provides us with a [magic string we can use instead](https://edge-runtime.vercel.sh/features/available-apis#addressing-the-runtime) (`EdgeRuntime`).