### PR TITLE
fix(replay): Send `dsn` in envelope header if tunneling is enabled

### DIFF
--- a/packages/core/src/envelope.ts
+++ b/packages/core/src/envelope.ts
@@ -2,7 +2,6 @@ import {
   DsnComponents,
   Event,
   EventEnvelope,
-  EventEnvelopeHeaders,
   EventItem,
   SdkInfo,
   SdkMetadata,
@@ -11,7 +10,12 @@ import {
   SessionEnvelope,
   SessionItem,
 } from '@sentry/types';
-import { createEnvelope, dropUndefinedKeys, dsnToString, getSdkMetadataForEnvelopeHeader } from '@sentry/utils';
+import {
+  createEnvelope,
+  createEventEnvelopeHeaders,
+  dsnToString,
+  getSdkMetadataForEnvelopeHeader,
+} from '@sentry/utils';
 
 /**
  * Apply SdkInfo (name, version, packages, integrations) to the corresponding event key.
@@ -73,24 +77,4 @@ export function createEventEnvelope(
 
   const eventItem: EventItem = [{ type: eventType }, event];
   return createEnvelope<EventEnvelope>(envelopeHeaders, [eventItem]);
-}
-
-function createEventEnvelopeHeaders(
-  event: Event,
-  sdkInfo: SdkInfo | undefined,
-  tunnel: string | undefined,
-  dsn: DsnComponents,
-): EventEnvelopeHeaders {
-  const dynamicSamplingContext = event.sdkProcessingMetadata && event.sdkProcessingMetadata.dynamicSamplingContext;
-
-  return {
-    event_id: event.event_id as string,
-    sent_at: new Date().toISOString(),
-    ...(sdkInfo && { sdk: sdkInfo }),
-    ...(!!tunnel && { dsn: dsnToString(dsn) }),
-    ...(event.type === 'transaction' &&
-      dynamicSamplingContext && {
-        trace: dropUndefinedKeys({ ...dynamicSamplingContext }),
-      }),
-  };
 }

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -921,8 +921,9 @@ export class ReplayContainer implements ReplayContainerInterface {
     const client = hub.getClient();
     const scope = hub.getScope();
     const transport = client && client.getTransport();
+    const dsn = client?.getDsn();
 
-    if (!client || !scope || !transport) {
+    if (!client || !scope || !transport || !dsn) {
       return;
     }
 
@@ -982,7 +983,7 @@ export class ReplayContainer implements ReplayContainerInterface {
     }
     */
 
-    const envelope = createReplayEnvelope(replayId, replayEvent, payloadWithSequence);
+    const envelope = createReplayEnvelope(replayEvent, payloadWithSequence, dsn, client.getOptions().tunnel);
 
     try {
       return transport.send(envelope);

--- a/packages/replay/src/util/createReplayEnvelope.ts
+++ b/packages/replay/src/util/createReplayEnvelope.ts
@@ -1,17 +1,14 @@
-import { Envelope, Event } from '@sentry/types';
-import { createEnvelope, getSdkMetadataForEnvelopeHeader } from '@sentry/utils';
+import { DsnComponents, Envelope, Event } from '@sentry/types';
+import { createEnvelope, createEventEnvelopeHeaders, getSdkMetadataForEnvelopeHeader } from '@sentry/utils';
 
 export function createReplayEnvelope(
-  replayId: string,
   replayEvent: Event,
   payloadWithSequence: string | Uint8Array,
+  dsn: DsnComponents,
+  tunnel?: string,
 ): Envelope {
   return createEnvelope(
-    {
-      event_id: replayId,
-      sent_at: new Date().toISOString(),
-      sdk: getSdkMetadataForEnvelopeHeader(replayEvent),
-    },
+    createEventEnvelopeHeaders(replayEvent, getSdkMetadataForEnvelopeHeader(replayEvent), tunnel, dsn),
     [
       // @ts-ignore New types
       [{ type: 'replay_event' }, replayEvent],


### PR DESCRIPTION
As outlined in #6539, we're right now not sending the `dsn` key in the replay event [envelope header](https://develop.sentry.dev/sdk/envelopes/#envelope-headers), thereby not including the necessary information to forward the event to Sentry. 

This PR fixes that by extracting the `createEventEnvelopeHeaders` function to utils so that we can use it in Replay (analogously to #6514), as well as using this function to create all headers. 

We tested this PR with NextJS' `tunnelRoute` as well as with the conventional `tunnel` option and everything seems to work now.

Note: While refactoring and adding tests, I discovered that right now, replay event envelopes always contain the identical `replayId` as `event_id` and `replay_id`. Not sure if this is intended but I'm not changing this in this PR (cc @billyvg). 
  
fixes #6539