### PR TITLE
test: Add Replay dependency resolution to Remix and NextJS integration tests

### DIFF
--- a/packages/nextjs/test/integration/package.json
+++ b/packages/nextjs/test/integration/package.json
@@ -29,6 +29,7 @@
     "@sentry/integrations": "file:../../../integrations",
     "@sentry/node": "file:../../../node",
     "@sentry/react": "file:../../../react",
+    "@sentry/replay": "file:../../../replay",
     "@sentry/tracing": "file:../../../tracing",
     "@sentry/types": "file:../../../types",
     "@sentry/utils": "file:../../../utils"

--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -28,6 +28,7 @@
     "@sentry/integrations": "file:../../../integrations",
     "@sentry/node": "file:../../../node",
     "@sentry/react": "file:../../../react",
+    "@sentry/replay": "file:../../../replay",
     "@sentry/tracing": "file:../../../tracing",
     "@sentry/types": "file:../../../types",
     "@sentry/utils": "file:../../../utils"


### PR DESCRIPTION
This PR fixes the broken NextJS and Remix integration tests which were unable to look up the local version of `@sentry/replay` before. Replay is now a dependency of these tests because they depend on `@sentry/browser` (which in turn depends on Replay after #6508).

Not sure why we didn't catch this earlier, as afaict, our [test job selection config](https://github.com/getsentry/sentry-javascript/blob/1f7328c27ed9628f88b662f7564b245e26ba4593/.github/workflows/build.yml#L65-L122) already covers this change.   


This should unblock our 7.27.0 release