### PR TITLE
fix(nextjs): Pass `this` through wrappers

### DIFF
--- a/packages/nextjs/test/integration/pages/_document.tsx
+++ b/packages/nextjs/test/integration/pages/_document.tsx
@@ -2,6 +2,7 @@ import Document, { DocumentContext } from 'next/document';
 
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
+    // Verify that wrapping correctly passes `this`
     this.testFunction();
 
     const initialProps = await Document.getInitialProps(ctx);
@@ -10,7 +11,7 @@ class MyDocument extends Document {
   }
 
   static testFunction() {
-    console.log('Calling me with this should not throw after wrapping');
+    // noop
   }
 }
 

--- a/packages/nextjs/test/integration/pages/_document.tsx
+++ b/packages/nextjs/test/integration/pages/_document.tsx
@@ -1,0 +1,17 @@
+import Document, { DocumentContext } from 'next/document';
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext) {
+    this.testFunction();
+
+    const initialProps = await Document.getInitialProps(ctx);
+
+    return initialProps;
+  }
+
+  static testFunction() {
+    console.log('Calling me with this should not throw after wrapping');
+  }
+}
+
+export default MyDocument;


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/6479

Our Next.js wrapping methods didn't take care of correctly passing `this` context. This PR fixes that.