### PR TITLE
fix(replay): Cater for event processor returning null 

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -940,6 +940,12 @@ export class ReplayContainer implements ReplayContainerInterface {
     };
 
     const replayEvent = await getReplayEvent({ scope, client, replayId, event: baseEvent });
+
+    if (!replayEvent) {
+      __DEBUG_BUILD__ && logger.error('[Replay] An event processor returned null, will not send replay.');
+      return;
+    }
+
     replayEvent.tags = {
       ...replayEvent.tags,
       sessionSampleRate: this._options.sessionSampleRate,

--- a/packages/replay/src/util/getReplayEvent.ts
+++ b/packages/replay/src/util/getReplayEvent.ts
@@ -11,20 +11,22 @@ export async function getReplayEvent({
   scope: Scope;
   replayId: string;
   event: Event;
-}): Promise<Event> {
+}): Promise<Event | null> {
   // XXX: This event does not trigger `beforeSend` in SDK
   // @ts-ignore private api
-  const preparedEvent: Event = await client._prepareEvent(event, { event_id }, scope);
+  const preparedEvent: Event | null = await client._prepareEvent(event, { event_id }, scope);
 
-  // extract the SDK name because `client._prepareEvent` doesn't add it to the event
-  const metadata = client.getOptions() && client.getOptions()._metadata;
-  const { name } = (metadata && metadata.sdk) || {};
+  if (preparedEvent) {
+    // extract the SDK name because `client._prepareEvent` doesn't add it to the event
+    const metadata = client.getOptions() && client.getOptions()._metadata;
+    const { name } = (metadata && metadata.sdk) || {};
 
-  preparedEvent.sdk = {
-    ...preparedEvent.sdk,
-    version: __SENTRY_REPLAY_VERSION__,
-    name,
-  };
+    preparedEvent.sdk = {
+      ...preparedEvent.sdk,
+      version: __SENTRY_REPLAY_VERSION__,
+      name,
+    };
+  }
 
   return preparedEvent;
 }


### PR DESCRIPTION
This PR fixes an issue where an error is thrown if an event processor returns null.
