### PR TITLE
fix(nextjs): Export Replay from `index.server.ts` to avoid TS error

### DIFF
--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -15,6 +15,11 @@ import { addOrUpdateIntegration, IntegrationWithExclusionOption } from './utils/
 export * from '@sentry/node';
 export { captureUnderscoreErrorException } from './utils/_error';
 
+// Exporting the Replay integration also from index.server.ts because TS only recognizes types from index.server.ts
+// If we didn't export this, TS would complain that it can't find `Sentry.Replay` in the package,
+// causing a build failure, when users initialize Replay in their sentry.client.config.js/ts file.
+export { Replay } from './index.client';
+
 // Here we want to make sure to only include what doesn't have browser specifics
 // because or SSR of next.js we can only use this.
 export { ErrorBoundary, showReportDialog, withErrorBoundary } from '@sentry/react';


### PR DESCRIPTION
This PR fixes a TypeScript error when using the `Replay` integration exported from the NextJS SDK (>= 7.27.0). Because our SDK tells TS that it should import types from `index.server.ts`, TS doesn't find the Replay integration class although it's correctly exported from `indext.client.ts`. 

Note: even without this change, Replay works in NextJS, it's just a TS error. 

@reviewers: I tested this with a basic NextJS app and for me it works. However, if you have a few minutes and would like to give it a try with more sophisticated test apps, I'd appreciate it. 

fixes #6574