### PR TITLE
feat(utils): Improved envelope parser

### DIFF
--- a/packages/core/test/lib/attachments.test.ts
+++ b/packages/core/test/lib/attachments.test.ts
@@ -1,5 +1,5 @@
-import { parseEnvelope } from '@sentry/utils/test/testutils';
-import { TextEncoder } from 'util';
+import { parseEnvelope } from '@sentry/utils';
+import { TextDecoder, TextEncoder } from 'util';
 
 import { createTransport } from '../../src/transports/base';
 import { getDefaultTestClientOptions, TestClient } from '../mocks/client';
@@ -22,7 +22,7 @@ describe('Attachments', () => {
       enableSend: true,
       transport: () =>
         createTransport({ recordDroppedEvent: () => undefined, textEncoder: new TextEncoder() }, async req => {
-          const [, items] = parseEnvelope(req.body);
+          const [, items] = parseEnvelope(req.body, new TextEncoder(), new TextDecoder());
           expect(items.length).toEqual(2);
           // Second envelope item should be the attachment
           expect(items[1][0]).toEqual({ type: 'attachment', length: 50000, filename: 'empty.bin' });

--- a/packages/utils/src/envelope.ts
+++ b/packages/utils/src/envelope.ts
@@ -127,9 +127,9 @@ export function parseEnvelope(
   let buffer = typeof env === 'string' ? textEncoder.encode(env) : env;
 
   function readBinary(length: number): Uint8Array {
-    const bin = buffer.slice(0, length);
-    // Replace the buffer with the remaining data and newline
-    buffer = buffer.slice(length + 1);
+    const bin = buffer.subarray(0, length);
+    // Replace the buffer with the remaining data excluding trailing newline
+    buffer = buffer.subarray(length + 1);
     return bin;
   }
 
@@ -143,7 +143,7 @@ export function parseEnvelope(
     return JSON.parse(textDecoder.decode(readBinary(i))) as T;
   }
 
-  const header = readJson<BaseEnvelopeHeaders>();
+  const envelopeHeader = readJson<BaseEnvelopeHeaders>();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const items: [any, any][] = [];
 
@@ -154,7 +154,7 @@ export function parseEnvelope(
     items.push([itemHeader, binaryLength ? readBinary(binaryLength) : readJson()]);
   }
 
-  return [header, items];
+  return [envelopeHeader, items];
 }
 
 /**

--- a/packages/utils/test/clientreport.test.ts
+++ b/packages/utils/test/clientreport.test.ts
@@ -1,9 +1,11 @@
 import { ClientReport } from '@sentry/types';
-import { TextEncoder } from 'util';
+import { TextDecoder, TextEncoder } from 'util';
 
 import { createClientReportEnvelope } from '../src/clientreport';
-import { serializeEnvelope } from '../src/envelope';
-import { parseEnvelope } from './testutils';
+import { parseEnvelope, serializeEnvelope } from '../src/envelope';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
 
 const DEFAULT_DISCARDED_EVENTS: ClientReport['discarded_events'] = [
   {
@@ -44,7 +46,7 @@ describe('createClientReportEnvelope', () => {
   it('serializes an envelope', () => {
     const env = createClientReportEnvelope(DEFAULT_DISCARDED_EVENTS, MOCK_DSN, 123456);
 
-    const [headers, items] = parseEnvelope(serializeEnvelope(env, new TextEncoder()));
+    const [headers, items] = parseEnvelope(serializeEnvelope(env, encoder), encoder, decoder);
 
     expect(headers).toEqual({ dsn: 'https://public@example.com/1' });
     expect(items).toEqual([

--- a/packages/utils/test/testutils.ts
+++ b/packages/utils/test/testutils.ts
@@ -1,6 +1,3 @@
-import { BaseEnvelopeHeaders, BaseEnvelopeItemHeaders, Envelope } from '@sentry/types';
-import { TextDecoder, TextEncoder } from 'util';
-
 export const testOnlyIfNodeVersionAtLeast = (minVersion: number): jest.It => {
   const currentNodeVersion = process.env.NODE_VERSION;
 
@@ -14,56 +11,3 @@ export const testOnlyIfNodeVersionAtLeast = (minVersion: number): jest.It => {
 
   return it;
 };
-
-/**
- * A naive binary envelope parser
- */
-export function parseEnvelope(env: string | Uint8Array): Envelope {
-  let buf = typeof env === 'string' ? new TextEncoder().encode(env) : env;
-
-  let envelopeHeaders: BaseEnvelopeHeaders | undefined;
-  let lastItemHeader: BaseEnvelopeItemHeaders | undefined;
-  const items: [any, any][] = [];
-
-  let binaryLength = 0;
-  while (buf.length) {
-    // Next length is either the binary length from the previous header
-    // or the next newline character
-    let i = binaryLength || buf.indexOf(0xa);
-
-    // If no newline was found, assume this is the last block
-    if (i < 0) {
-      i = buf.length;
-    }
-
-    // If we read out a length in the previous header, assume binary
-    if (binaryLength > 0) {
-      const bin = buf.slice(0, binaryLength);
-      binaryLength = 0;
-      items.push([lastItemHeader, bin]);
-    } else {
-      const json = JSON.parse(new TextDecoder().decode(buf.slice(0, i + 1)));
-
-      if (typeof json.length === 'number') {
-        binaryLength = json.length;
-      }
-
-      // First json is always the envelope headers
-      if (!envelopeHeaders) {
-        envelopeHeaders = json;
-      } else {
-        // If there is a type property, assume this is an item header
-        if ('type' in json) {
-          lastItemHeader = json;
-        } else {
-          items.push([lastItemHeader, json]);
-        }
-      }
-    }
-
-    // Replace the buffer with the previous block and newline removed
-    buf = buf.slice(i + 1);
-  }
-
-  return [envelopeHeaders as BaseEnvelopeHeaders, items];
-}


### PR DESCRIPTION
An envelope parser has existed in `packages/utils/test/testutils.ts` for a while. It looks like this was originally copied from the Electron e2e test server. I wrote that code and it's pretty awful and was only ever intended to be used for testing. 

To offer the best support for Replay (https://github.com/getsentry/sentry-electron/issues/606), its looking like the Electron main process will need to parse, modify and relay envelopes from the renderer processes. Sending events from renderer to main via a transport rather than an integration also fixes issues with integration ordering and confusing messages logged about events being dropped due to event processors returns null.

The new `parseEnvelope` has moved to `@sentry/utils` where it can be used by downstream SDKs. 
  
`parseEnvelope` is tested as before by round-tripping with `serializeEnvelope`. 
