### PR TITLE
ref(types): Add `undefined` as possible value to  `EventType`

### DIFF
--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -58,8 +58,12 @@ export interface Event {
   };
 }
 
-/** JSDoc */
-export type EventType = 'transaction' | 'profile';
+/**
+ * The type of an `Event`.
+ * Note that `ErrorEvent`s do not have a type (hence its undefined),
+ * while all other events are required to have one.
+ */
+export type EventType = 'transaction' | 'profile' | undefined;
 
 export interface ErrorEvent extends Event {
   type: undefined;


### PR DESCRIPTION
Fixes #6575 

As described in the issue, setting an `Event`'s property `type: undefined`, like we do in the SDK for `ErrorEvent`s
 
https://github.com/getsentry/sentry-javascript/blob/aad38ab819de0b7f83f6b188652f9ee8337704b0/packages/types/src/event.ts#L68-L70

causes a TS error, whenever the recommended `exactOptionalPropertyTypes` TS option is enabled. This option was introduced in TS 4.4. Since we're on TS 3.8, we couldn't catch this error. 

This PR changes to `EventType` type declaration to also accept `undefined` as a value, thereby resolving the TS error.

Note:
The initially suggested fix to change the `Event`'s  `type` type to `type: EventType | undefined` causes TS errors all over the place as it would require us to set `type` explicitly to `undefined` whenever we create error events. I'd vote not to do this as it is a breaking change because it makes an optional parameter non-optional. Furthermore, it requires a lot of changes and also increases bundle size
