### PR TITLE
fix(node): Use SENTRY_ENVIRONMENT even when environment is already set

### DIFF
--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -140,7 +140,7 @@ export function init(options: NodeOptions = {}): void {
     }
   }
 
-  if (options.environment === undefined && process.env.SENTRY_ENVIRONMENT) {
+  if (process.env.SENTRY_ENVIRONMENT) {
     options.environment = process.env.SENTRY_ENVIRONMENT;
   }
 


### PR DESCRIPTION
Mostly a suggestion now (no tests or anything yet), don't really know how much of a breaking change this is.

The problem is the following: init functions for NextJS and Remix (e.g. [here](https://github.com/getsentry/sentry-javascript/blob/master/packages/nextjs/src/index.server.ts#L67)) will use the value of NODE_ENV env variable as Sentry environment, and without the change in this PR, SENTRY_ENVIRONMENT will no longer be able to override the environment.

Came up here: https://github.com/getsentry/opentelemetry-demo/pull/34