### PR TITLE
chore(docs): Add Replay link to main README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ development. If you're thinking about contributing to or creating a JavaScript-b
 below:
 
 - [`@sentry/tracing`](https://github.com/getsentry/sentry-javascript/tree/master/packages/tracing): Provides
-  Integrations and extensions for Performance Monitoring / Tracing
+  integrations and extensions for Performance Monitoring / Tracing.
+- [`@sentry/replay`](https://github.com/getsentry/sentry-javascript/tree/master/packages/replay): Provides
+  the integration for Session Replay.
 - [`@sentry/core`](https://github.com/getsentry/sentry-javascript/tree/master/packages/core): The base for all
   JavaScript SDKs with interfaces, type definitions and base classes.
 - [`@sentry/utils`](https://github.com/getsentry/sentry-javascript/tree/master/packages/utils): A set of helpers and


### PR DESCRIPTION
Just noticed that we're not yet linking to the replay package