### PR TITLE
fix(replay): Do not mangle `_metadata` in client options

### DIFF
--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -109,6 +109,7 @@ export function makeTerserPlugin() {
           '_support',
           // TODO: Get rid of these once we use the SDK to send replay events
           '_prepareEvent', // replay uses client._prepareEvent
+          '_metadata', // replay uses client.getOptions()._metadata
         ],
       },
     },


### PR DESCRIPTION
When working on #6514 I missed that we access a "private" field in `client.getOptions()._metadata` to retrieve the SDK name. This had the consequence that - once again - we mangled a cross-package field we shouldn't (`_metadata`) in our CDN bundles which caused the SDK name to not be included in the replay event and envelope. 

This caused minified CDN bundles to send incomplete replay event envelopes to Sentry and as a consequence, they were not processed (correctly) and hence users didn't get incoming replays. 

This PR excludes the `_metadata` field from being mangled. Before merging this, I wanna see how much bundle size increase this causes. If it's too much, we can also revert #6514.

h/t @souredoutlook for raising this issue.  
