### PR TITLE
fix(tracing): Don't finish React Router 6 `pageload` transactions early

### DIFF
--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -170,7 +170,7 @@ export function withSentryReactRouterV6Routing<P extends Record<string, any>, R 
     return Routes;
   }
 
-  let previousLocation: Location | null = null;
+  let isMountRenderPass: boolean = true;
 
   const SentryRoutes: React.FC<P> = (props: P) => {
     const location = _useLocation();
@@ -180,13 +180,12 @@ export function withSentryReactRouterV6Routing<P extends Record<string, any>, R 
       () => {
         const routes = _createRoutesFromChildren(props.children) as RouteObject[];
 
-        if (previousLocation === null) {
+        if (isMountRenderPass) {
           updatePageloadTransaction(location, routes);
+          isMountRenderPass = false;
         } else {
           handleNavigation(location, routes, navigationType);
         }
-
-        previousLocation = location;
       },
       // `props.children` is purpusely not included in the dependency array, because we do not want to re-run this effect
       // when the children change. We only want to start transactions when the location or navigation type change.
@@ -215,7 +214,7 @@ export function wrapUseRoutes(origUseRoutes: UseRoutes): UseRoutes {
     return origUseRoutes;
   }
 
-  let previousLocation: Location | null = null;
+  let isMountRenderPass: boolean = true;
 
   // eslint-disable-next-line react/display-name
   return (routes: RouteObject[], locationArg?: Partial<Location> | string): React.ReactElement | null => {
@@ -235,13 +234,12 @@ export function wrapUseRoutes(origUseRoutes: UseRoutes): UseRoutes {
         const normalizedLocation =
           typeof stableLocationParam === 'string' ? { pathname: stableLocationParam } : stableLocationParam;
 
-        if (previousLocation === null) {
+        if (isMountRenderPass) {
           updatePageloadTransaction(normalizedLocation, routes);
+          isMountRenderPass = false;
         } else {
           handleNavigation(normalizedLocation, routes, navigationType);
         }
-
-        previousLocation = normalizedLocation;
       }, [navigationType, stableLocationParam]);
 
       return Routes;

--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -185,20 +185,20 @@ export function withSentryReactRouterV6Routing<P extends Record<string, any>, R 
     }, [props.children]);
 
     _useEffect(() => {
-      if (isFirstNavigationUseEffectCall) {
-        isFirstNavigationUseEffectCall = false;
-      } else {
-        handleNavigation(location, routes, navigationType);
-      }
-    }, [location, navigationType]);
-
-    _useEffect(() => {
       if (isFirstPageloadUpdateUseEffectCall) {
         isFirstPageloadUpdateUseEffectCall = false;
         routes = _createRoutesFromChildren(props.children) as RouteObject[];
         updatePageloadTransaction(location, routes);
       }
     }, [props.children, location]);
+
+    _useEffect(() => {
+      if (isFirstNavigationUseEffectCall) {
+        isFirstNavigationUseEffectCall = false;
+      } else {
+        handleNavigation(location, routes, navigationType);
+      }
+    }, [location, navigationType]);
 
     // @ts-ignore Setting more specific React Component typing for `R` generic above
     // will break advanced type inference done by react router params

--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -194,10 +194,9 @@ export function withSentryReactRouterV6Routing<P extends Record<string, any>, R 
 
     _useEffect(() => {
       if (isFirstPageloadUpdateUseEffectCall) {
+        isFirstPageloadUpdateUseEffectCall = false;
         routes = _createRoutesFromChildren(props.children) as RouteObject[];
         updatePageloadTransaction(location, routes);
-      } else {
-        isFirstPageloadUpdateUseEffectCall = false;
       }
     }, [props.children, location]);
 
@@ -240,17 +239,16 @@ export function wrapUseRoutes(origUseRoutes: UseRoutes): UseRoutes {
 
       _useEffect(() => {
         if (isFirstPageloadUpdateUseEffectCall) {
-          updatePageloadTransaction(locationObject, routes);
-        } else {
           isFirstPageloadUpdateUseEffectCall = false;
+          updatePageloadTransaction(locationObject, routes);
         }
       }, [locationObject, routes]);
 
       _useEffect(() => {
         if (isFirstNavigationUseEffectCall) {
-          handleNavigation(locationObject, routes, navigationType);
-        } else {
           isFirstNavigationUseEffectCall = false;
+        } else {
+          handleNavigation(locationObject, routes, navigationType);
         }
       }, [locationObject, routes, navigationType]);
 


### PR DESCRIPTION
Fixes #6470 

This PR fixes a bug where we prematurely finish pageload transactions in our React Router 6 implementation due to some funky logic.

h/t to @onurtemizkan for doing the foundational work on this in https://github.com/getsentry/sentry-javascript/pull/6599