### PR TITLE
fix(replay): Envelope send should be awaited in try/catch

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -992,7 +992,7 @@ export class ReplayContainer implements ReplayContainerInterface {
     const envelope = createReplayEnvelope(replayEvent, payloadWithSequence, dsn, client.getOptions().tunnel);
 
     try {
-      return transport.send(envelope);
+      return await transport.send(envelope);
     } catch {
       throw new Error(UNABLE_TO_SEND_REPLAY);
     }


### PR DESCRIPTION
I was just checking all the places where the Transport `send` is called and noticed this.

If the promise is not awaited within the try, the catch will never be called.


