### PR TITLE
fix(utils): Don't run stack trace regexes over huge strings

### DIFF
--- a/packages/browser/test/unit/tracekit/chromium.test.ts
+++ b/packages/browser/test/unit/tracekit/chromium.test.ts
@@ -547,4 +547,30 @@ describe('Tracekit - Chrome Tests', () => {
       },
     });
   });
+
+  it('should drop frames that are over 1kb', () => {
+    const LONG_STR = 'A'.repeat(1040);
+
+    const LONG_FRAME = {
+      message: 'bad',
+      name: 'Error',
+      stack: `Error: bad
+          at aha (http://localhost:5000/:39:5)
+          at Foo.testMethod (http://localhost:5000/${LONG_STR}:44:7)
+          at http://localhost:5000/:50:19`,
+    };
+
+    const ex = exceptionFromError(parser, LONG_FRAME);
+
+    expect(ex).toEqual({
+      value: 'bad',
+      type: 'Error',
+      stacktrace: {
+        frames: [
+          { filename: 'http://localhost:5000/', function: '?', lineno: 50, colno: 19, in_app: true },
+          { filename: 'http://localhost:5000/', function: 'aha', lineno: 39, colno: 5, in_app: true },
+        ],
+      },
+    });
+  });
 });

--- a/packages/utils/src/stacktrace.ts
+++ b/packages/utils/src/stacktrace.ts
@@ -16,6 +16,14 @@ export function createStackParser(...parsers: StackLineParser[]): StackParser {
     const frames: StackFrame[] = [];
 
     for (const line of stack.split('\n').slice(skipFirst)) {
+      // Ignore lines over 1kb as they are unlikely to be stack frames.
+      // Many of the regular expressions use backtracking which results in run time that increases exponentially with
+      // input size. Huge strings can result in hangs/Denial of Service:
+      // https://github.com/getsentry/sentry-javascript/issues/2286
+      if (line.length > 1024) {
+        continue;
+      }
+
       // https://github.com/getsentry/sentry-javascript/issues/5459
       // Remove webpack (error: *) wrappers
       const cleanedLine = line.replace(/\(error: (.*)\)/, '$1');


### PR DESCRIPTION
Closes #2286

The CI code scanning previously warned about our stack trace regexes having the potential for DoS due to backtracking and exponential time required for large input strings. We ignored these CI warnings since the JavaScript SDKs have always contained these regexes but since a customer has reported a 90 second hang caused by this it makes sense to add some sensible limits.
