### PR TITLE
feat(gatsby): Support Gatsby v5

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -27,7 +27,7 @@
     "@sentry/webpack-plugin": "1.19.0"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0",
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
     "react": "15.x || 16.x || 17.x || 18.x"
   },
   "devDependencies": {


### PR DESCRIPTION
At least the [Gatsby v5 release notes](https://www.gatsbyjs.com/docs/reference/release-notes/v5.0/) mention no changes to the plugin interfaces used here (`gatsby-browser#onClientEntry` and `gatsby-node#onCreateWebpackConfig`).

The only instruction for plugin maintainers in the [v4 to v5 migration guide](https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v4-to-v5/#for-plugin-maintainers) is that ”In most cases, you won’t have to do anything to be v5 compatible.”

Resolves getsentry/sentry-javascript#6261.

----

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
