### PR TITLE
fix(replay): Improve handling of `maskAllText` selector

### DIFF
--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -27,4 +27,4 @@ export const DEFAULT_SESSION_SAMPLE_RATE = 0.1;
 export const DEFAULT_ERROR_SAMPLE_RATE = 1.0;
 
 /** The select to use for the `maskAllText` option  */
-export const MASK_ALL_TEXT_SELECTOR = 'body *:not(style,script)';
+export const MASK_ALL_TEXT_SELECTOR = 'body *:not(style), body *:not(script)';

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -47,7 +47,8 @@ export class Replay implements Integration {
     useCompression = true,
     sessionSampleRate,
     errorSampleRate,
-    maskAllText = true,
+    maskAllText,
+    maskTextSelector,
     maskAllInputs = true,
     blockAllMedia = true,
     _experiments = {},
@@ -62,6 +63,7 @@ export class Replay implements Integration {
       blockClass,
       ignoreClass,
       maskTextClass,
+      maskTextSelector,
       blockSelector,
       ...recordingOptions,
     };
@@ -74,7 +76,7 @@ export class Replay implements Integration {
       sessionSampleRate: DEFAULT_SESSION_SAMPLE_RATE,
       errorSampleRate: DEFAULT_ERROR_SAMPLE_RATE,
       useCompression,
-      maskAllText,
+      maskAllText: typeof maskAllText === 'boolean' ? maskAllText : !maskTextSelector,
       blockAllMedia,
       _experiments,
     };

--- a/packages/replay/test/unit/index-integrationSettings.test.ts
+++ b/packages/replay/test/unit/index-integrationSettings.test.ts
@@ -184,7 +184,13 @@ describe('integration settings', () => {
       expect(replay['_recordingOptions'].maskTextSelector).toBe(undefined);
     });
 
-    it('overwrites custom maskTextSelector option', async () => {
+    it('maskTextSelector takes precedence over maskAllText when not specifiying maskAllText:true', async () => {
+      const { replay } = await mockSdk({ replayOptions: { maskTextSelector: '[custom]' } });
+
+      expect(replay['_recordingOptions'].maskTextSelector).toBe('[custom]');
+    });
+
+    it('maskAllText takes precedence over maskTextSelector when specifiying maskAllText:true', async () => {
       const { replay } = await mockSdk({ replayOptions: { maskAllText: true, maskTextSelector: '[custom]' } });
 
       expect(replay['_recordingOptions'].maskTextSelector).toBe(MASK_ALL_TEXT_SELECTOR);


### PR DESCRIPTION
This PR improves the handling of the replay `maskAllText` option in two ways:

1. Currently, when `maskAllText === true` we overwrite the `maskTextSelector`. However, since we set `maskAllText = true` by default, this means that if you configure replay like this:

```js
new Replay({
  maskTextSelector: '[custom]'
})
```

This will actually be overwritten by the maskAllText selector, because internally `maskAllText` is true.

This PR changes this behavior so that we only overwrite it if either we explicitly state `maskAllText: true`, or if we do not set it at all _and_ no `maskTextSelector` is specified.

So the new behavior is:

```js
// Result: all text selector
new Replay({})

// Result: [custom]
new Replay({ maskTextSelector: '[custom]' })

// Result: all text selector
new Replay({ maskTextSelector: '[custom]', maskAllText: true })
```

2. Apparently, some browsers have issues with the current all text selector. I suspect the problem is the selector list in `:not()`, see: https://developer.mozilla.org/en-US/docs/Web/CSS/:not#browser_compatibility
So I changed this to avoid using this selector type.

Closes https://github.com/getsentry/sentry-javascript/issues/6618