### PR TITLE
feat(core): Add `getSdkMetadata` to `Client`

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -1,5 +1,4 @@
 /* eslint-disable max-lines */
-import { SdkInfo } from '@sentry/types';
 import {
   Client,
   ClientOptions,
@@ -13,6 +12,7 @@ import {
   Integration,
   IntegrationClass,
   Outcome,
+  SdkMetadata,
   Session,
   SessionAggregates,
   Severity,
@@ -225,7 +225,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    *
    * @return The metadata of the SDK
    */
-  public getSdkMetadata(): SdkInfo {
+  public getSdkMetadata(): SdkMetadata | undefined {
     return this._options._metadata;
   }
 

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+import { SdkInfo } from '@sentry/types';
 import {
   Client,
   ClientOptions,
@@ -224,7 +225,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    *
    * @return The metadata of the SDK
    */
-  public getSdkMetadata(): O['_metadata'] {
+  public getSdkMetadata(): SdkInfo {
     return this._options._metadata;
   }
 

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -220,6 +220,15 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   }
 
   /**
+   * @see SdkMetadata in @sentry/types
+   *
+   * @return The metadata of the SDK
+   */
+  public getSdkMetadata(): O['_metadata'] {
+    return this._options._metadata;
+  }
+
+  /**
    * @inheritDoc
    */
   public getTransport(): Transport | undefined {

--- a/packages/replay/src/util/getReplayEvent.ts
+++ b/packages/replay/src/util/getReplayEvent.ts
@@ -25,7 +25,7 @@ export async function getReplayEvent({
   preparedEvent.platform = preparedEvent.platform || 'javascript';
 
   // extract the SDK name because `client._prepareEvent` doesn't add it to the event
-  const metadata = client.getOptions() && client.getOptions()._metadata;
+  const metadata = client.getSdkMetadata && client.getSdkMetadata();
   const { name } = (metadata && metadata.sdk) || {};
 
   preparedEvent.sdk = {

--- a/packages/replay/src/util/getReplayEvent.ts
+++ b/packages/replay/src/util/getReplayEvent.ts
@@ -26,7 +26,7 @@ export async function getReplayEvent({
 
   // extract the SDK name because `client._prepareEvent` doesn't add it to the event
   const metadata = client.getSdkMetadata && client.getSdkMetadata();
-  const { name } = (metadata && metadata.sdk) || {};
+  const name = (metadata && metadata.sdk && metadata.sdk.name) || 'sentry.javascript.unknown';
 
   preparedEvent.sdk = {
     ...preparedEvent.sdk,

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -5,7 +5,7 @@ import { Event, EventHint } from './event';
 import { Integration, IntegrationClass } from './integration';
 import { ClientOptions } from './options';
 import { Scope } from './scope';
-import { SdkInfo } from './sdkinfo';
+import { SdkMetadata } from './sdkmetadata';
 import { Session, SessionAggregates } from './session';
 import { Severity, SeverityLevel } from './severity';
 import { Transport } from './transport';
@@ -75,7 +75,7 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    *
    * TODO (v8): Make this a required method.
    */
-  getSdkMetadata?(): SdkInfo;
+  getSdkMetadata?(): SdkMetadata | undefined;
 
   /**
    * Returns the transport that is used by the client.

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -70,6 +70,13 @@ export interface Client<O extends ClientOptions = ClientOptions> {
   getOptions(): O;
 
   /**
+   * @inheritdoc
+   *
+   * TODO (v8): Make this a required method.
+   */
+  getSdkMetadata?(): O['_metadata'];
+
+  /**
    * Returns the transport that is used by the client.
    * Please note that the transport gets lazy initialized so it will only be there once the first event has been sent.
    *

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -5,6 +5,7 @@ import { Event, EventHint } from './event';
 import { Integration, IntegrationClass } from './integration';
 import { ClientOptions } from './options';
 import { Scope } from './scope';
+import { SdkInfo } from './sdkinfo';
 import { Session, SessionAggregates } from './session';
 import { Severity, SeverityLevel } from './severity';
 import { Transport } from './transport';
@@ -74,7 +75,7 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    *
    * TODO (v8): Make this a required method.
    */
-  getSdkMetadata?(): O['_metadata'];
+  getSdkMetadata?(): SdkInfo;
 
   /**
    * Returns the transport that is used by the client.

--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -107,8 +107,6 @@ export function makeTerserPlugin() {
           '_driver',
           '_initStorage',
           '_support',
-          // TODO: Get rid of these once we use the SDK to send replay events
-          '_metadata', // replay uses client.getOptions()._metadata
         ],
       },
     },


### PR DESCRIPTION
This PR adds a new method to the `Client` interface: `getSdkMetadata`.
We can use this method in the Replay package to avoid accessing `client.getOptions()._metadata`, which previously caused broken CDN bundles which we hot-fixed with #6600. This PR now properly fixes this issue by simply not accessing this "private" field anymore.

Since adding a new method to the `Client` Interface is a breaking change, I made it an optional method, which should avoid breakage. We should consider making this method required in v8. 

I tested the Replay CDN bundles with this change to ensure that we still send events.

~Note: I'm curious about the bundle size impact here, for example, if the added cost is ammortized by mangling `_metadata` now again. Hence leaving this as a draft for now.~
So, turns out, there is a size increase but given that it seems to be <0.1% I'd vote to go forward with this change.