### PR TITLE
fix(replay): Allow Replay to be used in Electron renderers with nodeIntegration enabled

### DIFF
--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -5,7 +5,7 @@ import { Integration } from '@sentry/types';
 import { DEFAULT_ERROR_SAMPLE_RATE, DEFAULT_SESSION_SAMPLE_RATE, MASK_ALL_TEXT_SELECTOR } from './constants';
 import { ReplayContainer } from './replay';
 import type { RecordingOptions, ReplayConfiguration, ReplayPluginOptions } from './types';
-import { isBrowser, isElectronNodeRenderer } from './util/isBrowser';
+import { isBrowser } from './util/isBrowser';
 
 const MEDIA_SELECTORS = 'img,image,svg,path,rect,area,video,object,picture,embed,map,audio';
 
@@ -120,7 +120,7 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
         : `${this.recordingOptions.blockSelector},${MEDIA_SELECTORS}`;
     }
 
-    if (this._isInitialized && (isBrowser() || isElectronNodeRenderer())) {
+    if (this._isInitialized && isBrowser()) {
       throw new Error('Multiple Sentry Session Replay instances are not supported');
     }
 
@@ -138,7 +138,7 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
    * here to avoid any future issues.
    */
   setupOnce(): void {
-    if (!isBrowser() && !isElectronNodeRenderer()) {
+    if (!isBrowser()) {
       return;
     }
 

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -5,7 +5,7 @@ import { Integration } from '@sentry/types';
 import { DEFAULT_ERROR_SAMPLE_RATE, DEFAULT_SESSION_SAMPLE_RATE, MASK_ALL_TEXT_SELECTOR } from './constants';
 import { ReplayContainer } from './replay';
 import type { RecordingOptions, ReplayConfiguration, ReplayPluginOptions } from './types';
-import { isBrowser } from './util/isBrowser';
+import { isBrowser, isElectronNodeRenderer } from './util/isBrowser';
 
 const MEDIA_SELECTORS = 'img,image,svg,path,rect,area,video,object,picture,embed,map,audio';
 
@@ -120,7 +120,7 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
         : `${this.recordingOptions.blockSelector},${MEDIA_SELECTORS}`;
     }
 
-    if (isBrowser() && this._isInitialized) {
+    if (this._isInitialized && (isBrowser() || isElectronNodeRenderer())) {
       throw new Error('Multiple Sentry Session Replay instances are not supported');
     }
 
@@ -138,7 +138,7 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
    * here to avoid any future issues.
    */
   setupOnce(): void {
-    if (!isBrowser()) {
+    if (!isBrowser() && !isElectronNodeRenderer()) {
       return;
     }
 

--- a/packages/replay/src/util/isBrowser.ts
+++ b/packages/replay/src/util/isBrowser.ts
@@ -4,3 +4,9 @@ export function isBrowser(): boolean {
   // eslint-disable-next-line no-restricted-globals
   return typeof window !== 'undefined' && !isNodeEnv();
 }
+
+type ElectronProcess = { type?: string };
+
+export function isElectronNodeRenderer(): boolean {
+  return typeof process !== 'undefined' && (process as ElectronProcess).type === 'renderer';
+}

--- a/packages/replay/src/util/isBrowser.ts
+++ b/packages/replay/src/util/isBrowser.ts
@@ -2,11 +2,12 @@ import { isNodeEnv } from '@sentry/utils';
 
 export function isBrowser(): boolean {
   // eslint-disable-next-line no-restricted-globals
-  return typeof window !== 'undefined' && !isNodeEnv();
+  return typeof window !== 'undefined' && (!isNodeEnv() || isElectronNodeRenderer());
 }
 
 type ElectronProcess = { type?: string };
 
-export function isElectronNodeRenderer(): boolean {
+// Electron renderers with nodeIntegration enabled are detected as Node.js so we specifically test for them
+function isElectronNodeRenderer(): boolean {
   return typeof process !== 'undefined' && (process as ElectronProcess).type === 'renderer';
 }


### PR DESCRIPTION
Closes #6630

In Electron renderers with `nodeIntegration` enabled, `process.type === 'renderer'`.

I think this should be ok with bundlers. I think the check below for `isNodeEnv` uses `Object.prototype.toString` because bundlers can shim process with an object:

https://github.com/getsentry/sentry-javascript/blob/371d42d6eb8320ec7d1781e847649fcf06badf30/packages/utils/src/node.ts#L13-L20