### PR TITLE
fix(replay): Generate uuids for replay events

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -938,7 +938,7 @@ export class ReplayContainer implements ReplayContainerInterface {
       segment_id,
     };
 
-    const replayEvent = await getReplayEvent({ scope, client, replayId, event: baseEvent });
+    const replayEvent = await getReplayEvent({ scope, client, event: baseEvent });
 
     if (!replayEvent) {
       // Taken from baseclient's `_processEvent` method, where this is handled for errors/transactions
@@ -971,7 +971,7 @@ export class ReplayContainer implements ReplayContainerInterface {
         "replay_id": "eventId",
         "segment_id": 3,
         "platform": "javascript",
-        "event_id": "eventId",
+        "event_id": "generated-uuid",
         "environment": "production",
         "sdk": {
             "integrations": [

--- a/packages/replay/src/util/getReplayEvent.ts
+++ b/packages/replay/src/util/getReplayEvent.ts
@@ -4,15 +4,13 @@ import { Client, ReplayEvent } from '@sentry/types';
 export async function getReplayEvent({
   client,
   scope,
-  replayId: event_id,
   event,
 }: {
   client: Client;
   scope: Scope;
-  replayId: string;
   event: ReplayEvent;
 }): Promise<ReplayEvent | null> {
-  const preparedEvent = (await prepareEvent(client.getOptions(), event, { event_id }, scope)) as ReplayEvent | null;
+  const preparedEvent = (await prepareEvent(client.getOptions(), event, {}, scope)) as ReplayEvent | null;
 
   // If e.g. a global event processor returned null
   if (!preparedEvent) {

--- a/packages/replay/test/unit/util/getReplayEvent.test.ts
+++ b/packages/replay/test/unit/util/getReplayEvent.test.ts
@@ -33,11 +33,10 @@ describe('getReplayEvent', () => {
       trace_ids: ['trace-ID'],
       urls: ['https://sentry.io/'],
       replay_id: replayId,
-      event_id: replayId,
       segment_id: 3,
     };
 
-    const replayEvent = await getReplayEvent({ scope, client, replayId, event });
+    const replayEvent = await getReplayEvent({ scope, client, event });
 
     expect(replayEvent).toEqual({
       type: 'replay_event',
@@ -48,7 +47,8 @@ describe('getReplayEvent', () => {
       replay_id: 'replay-ID',
       segment_id: 3,
       platform: 'javascript',
-      event_id: 'replay-ID',
+      // generated uuid with 32 chars
+      event_id: expect.stringMatching(/^\w{32}$/),
       environment: 'production',
       sdk: {
         name: 'sentry.javascript.browser',


### PR DESCRIPTION
Instead of using the `replay_id`, we let sentry generate uuids for the `event_id` instead. Otherwise, multiple events will have the same `event_id`, which is not ideal. This still works because right now we do not actually use the `event_id` there, but for consistency it is better to have this be unique.

Closes https://github.com/getsentry/sentry-javascript/issues/6649
