### PR TITLE
feat(core): Add `addIntegration` method to client

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -37,7 +37,7 @@ import {
 
 import { getEnvelopeEndpointWithUrlEncodedAuth } from './api';
 import { createEventEnvelope, createSessionEnvelope } from './envelope';
-import { IntegrationIndex, setupIntegrations } from './integration';
+import { IntegrationIndex, setupIntegration, setupIntegrations } from './integration';
 import { Scope } from './scope';
 import { updateSession } from './session';
 import { prepareEvent } from './utils/prepareEvent';
@@ -289,6 +289,13 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
       __DEBUG_BUILD__ && logger.warn(`Cannot retrieve integration ${integration.id} from the current Client`);
       return null;
     }
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public addIntegration(integration: Integration): void {
+    setupIntegration(integration, this._integrations);
   }
 
   /**

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -88,14 +88,19 @@ export function setupIntegrations(integrations: Integration[]): IntegrationIndex
   const integrationIndex: IntegrationIndex = {};
 
   integrations.forEach(integration => {
-    integrationIndex[integration.name] = integration;
-
-    if (installedIntegrations.indexOf(integration.name) === -1) {
-      integration.setupOnce(addGlobalEventProcessor, getCurrentHub);
-      installedIntegrations.push(integration.name);
-      __DEBUG_BUILD__ && logger.log(`Integration installed: ${integration.name}`);
-    }
+    setupIntegration(integration, integrationIndex);
   });
 
   return integrationIndex;
+}
+
+/** Setup a single integration.  */
+export function setupIntegration(integration: Integration, integrationIndex: IntegrationIndex): void {
+  integrationIndex[integration.name] = integration;
+
+  if (installedIntegrations.indexOf(integration.name) === -1) {
+    integration.setupOnce(addGlobalEventProcessor, getCurrentHub);
+    installedIntegrations.push(integration.name);
+    __DEBUG_BUILD__ && logger.log(`Integration installed: ${integration.name}`);
+  }
 }

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -108,6 +108,14 @@ export interface Client<O extends ClientOptions = ClientOptions> {
   /** Returns the client's instance of the given integration class, it any. */
   getIntegration<T extends Integration>(integration: IntegrationClass<T>): T | null;
 
+  /**
+   * Add an integration to the client.
+   * This can be used to e.g. lazy load integrations.
+   * In most cases, this should not be necessary, and you're better off just passing the integrations via `integrations: []` at initialization time.
+   * However, if you find the need to conditionally load & add an integration, you can use `addIntegration` to do so.
+   * */
+  addIntegration?(integration: Integration): void;
+
   /** This is an internal function to setup all integrations that should run on the client */
   setupIntegrations(): void;
 

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -113,6 +113,8 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    * This can be used to e.g. lazy load integrations.
    * In most cases, this should not be necessary, and you're better off just passing the integrations via `integrations: []` at initialization time.
    * However, if you find the need to conditionally load & add an integration, you can use `addIntegration` to do so.
+   *
+   * TODO (v8): Make this a required method.
    * */
   addIntegration?(integration: Integration): void;
 

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -222,7 +222,7 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
    */
   tracesSampler?: (samplingContext: SamplingContext) => number | boolean;
 
-  // TODO v8: Narrow the response type to `ErrorEvent` - this is technically a breaking change.
+  // TODO (v8): Narrow the response type to `ErrorEvent` - this is technically a breaking change.
   /**
    * An event-processing callback for error and message events, guaranteed to be invoked after all other event
    * processors, which allows an event to be modified or dropped.
@@ -236,7 +236,7 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
    */
   beforeSend?: (event: ErrorEvent, hint: EventHint) => PromiseLike<Event | null> | Event | null;
 
-  // TODO v8: Narrow the response type to `TransactionEvent` - this is technically a breaking change.
+  // TODO (v8): Narrow the response type to `TransactionEvent` - this is technically a breaking change.
   /**
    * An event-processing callback for transaction events, guaranteed to be invoked after all other event
    * processors. This allows an event to be modified or dropped before it's sent.


### PR DESCRIPTION
This can be used to add an integration at runtime.

This is useful e.g. for replay, where we may want to lazy load this (as the payload is quite large).
