### PR TITLE
ref(replay): Add jsdoc to all replay modules

### DIFF
--- a/docs/event-sending.md
+++ b/docs/event-sending.md
@@ -77,8 +77,8 @@ This document gives an outline for how event sending works, and which which plac
 ## Replay (WIP)
 
 * `replay.sendReplayRequest()`
-  * `createPayload()`
-  * `getReplayEvent()`
+  * `createRecordingData()`
+  * `prepareReplayEvent()`
     * `client._prepareEvent()` (see baseclient)
       * `baseclient._applyClientOptions()`
       * `baseclient._applyIntegrationsMetadata()`

--- a/packages/replay/.eslintrc.js
+++ b/packages/replay/.eslintrc.js
@@ -25,10 +25,8 @@ module.exports = {
       rules: {
         // TODO (high-prio): Re-enable this after migration
         '@typescript-eslint/explicit-member-accessibility': 'off',
-        // TODO (high-prio): Re-enable this after migration
+        // Since we target only es6 here, we can leave this off
         '@sentry-internal/sdk/no-async-await': 'off',
-        // TODO (medium-prio): Re-enable this after migration
-        'jsdoc/require-jsdoc': 'off',
       },
     },
     {

--- a/packages/replay/src/coreHandlers/breadcrumbHandler.ts
+++ b/packages/replay/src/coreHandlers/breadcrumbHandler.ts
@@ -4,6 +4,9 @@ import type { InstrumentationTypeBreadcrumb } from '../types';
 import { DomHandlerData, handleDom } from './handleDom';
 import { handleScope } from './handleScope';
 
+/**
+ * An event handler to react to breadcrumbs.
+ */
 export function breadcrumbHandler(type: InstrumentationTypeBreadcrumb, handlerData: unknown): Breadcrumb | null {
   if (type === 'scope') {
     return handleScope(handlerData as Scope);

--- a/packages/replay/src/coreHandlers/handleDom.ts
+++ b/packages/replay/src/coreHandlers/handleDom.ts
@@ -9,6 +9,9 @@ export interface DomHandlerData {
   event: Node | { target: Node };
 }
 
+/**
+ * An event handler to react to DOM events.
+ */
 export function handleDom(handlerData: DomHandlerData): Breadcrumb | null {
   // Taken from https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/integrations/breadcrumbs.ts#L112
   let target;

--- a/packages/replay/src/coreHandlers/handleFetch.ts
+++ b/packages/replay/src/coreHandlers/handleFetch.ts
@@ -1,5 +1,4 @@
-import type { ReplayPerformanceEntry } from '../createPerformanceEntry';
-import type { ReplayContainer } from '../types';
+import type { ReplayContainer, ReplayPerformanceEntry } from '../types';
 import { createPerformanceSpans } from '../util/createPerformanceSpans';
 import { shouldFilterRequest } from '../util/shouldFilterRequest';
 

--- a/packages/replay/src/coreHandlers/handleHistory.ts
+++ b/packages/replay/src/coreHandlers/handleHistory.ts
@@ -1,5 +1,4 @@
-import { ReplayPerformanceEntry } from '../createPerformanceEntry';
-import type { ReplayContainer } from '../types';
+import type { ReplayContainer, ReplayPerformanceEntry } from '../types';
 import { createPerformanceSpans } from '../util/createPerformanceSpans';
 
 interface HistoryHandlerData {

--- a/packages/replay/src/coreHandlers/handleScope.ts
+++ b/packages/replay/src/coreHandlers/handleScope.ts
@@ -4,6 +4,9 @@ import { createBreadcrumb } from '../util/createBreadcrumb';
 
 let _LAST_BREADCRUMB: null | Breadcrumb = null;
 
+/**
+ * An event handler to handle scope changes.
+ */
 export function handleScope(scope: Scope): Breadcrumb | null {
   const newBreadcrumb = scope.getLastBreadcrumb();
 

--- a/packages/replay/src/coreHandlers/handleXhr.ts
+++ b/packages/replay/src/coreHandlers/handleXhr.ts
@@ -1,5 +1,4 @@
-import { ReplayPerformanceEntry } from '../createPerformanceEntry';
-import type { ReplayContainer } from '../types';
+import type { ReplayContainer, ReplayPerformanceEntry } from '../types';
 import { createPerformanceSpans } from '../util/createPerformanceSpans';
 import { shouldFilterRequest } from '../util/shouldFilterRequest';
 

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -18,6 +18,9 @@ const MEDIA_SELECTORS = 'img,image,svg,path,rect,area,video,object,picture,embed
 
 let _initialized = false;
 
+/**
+ * The main replay integration class, to be passed to `init({  integrations: [] })`.
+ */
 export class Replay implements Integration {
   /**
    * @inheritDoc
@@ -126,10 +129,12 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
     this._isInitialized = true;
   }
 
+  /** If replay has already been initialized */
   protected get _isInitialized(): boolean {
     return _initialized;
   }
 
+  /** Update _isInitialized */
   protected set _isInitialized(value: boolean) {
     _initialized = value;
   }
@@ -181,6 +186,7 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
     this._replay.stop();
   }
 
+  /** Setup the integration. */
   private _setup(): void {
     // Client is not available in constructor, so we need to wait until setupOnce
     this._loadReplayOptionsFromClient();

--- a/packages/replay/src/session/saveSession.ts
+++ b/packages/replay/src/session/saveSession.ts
@@ -1,6 +1,9 @@
 import { REPLAY_SESSION_KEY, WINDOW } from '../constants';
 import type { Session } from '../types';
 
+/**
+ * Save a session to session storage.
+ */
 export function saveSession(session: Session): void {
   const hasSessionStorage = 'sessionStorage' in WINDOW;
   if (!hasSessionStorage) {

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -235,3 +235,30 @@ export interface ReplayContainer {
   addUpdate(cb: AddUpdateCallback): void;
   getOptions(): ReplayPluginOptions;
 }
+
+export interface ReplayPerformanceEntry {
+  /**
+   * One of these types https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry/entryType
+   */
+  type: string;
+
+  /**
+   * A more specific description of the performance entry
+   */
+  name: string;
+
+  /**
+   * The start timestamp in seconds
+   */
+  start: number;
+
+  /**
+   * The end timestamp in seconds
+   */
+  end: number;
+
+  /**
+   * Additional unstructured data to be included
+   */
+  data?: Record<string, unknown>;
+}

--- a/packages/replay/src/util/addMemoryEntry.ts
+++ b/packages/replay/src/util/addMemoryEntry.ts
@@ -1,6 +1,14 @@
 import { WINDOW } from '../constants';
-import type { ReplayContainer } from '../types';
+import type { ReplayContainer, ReplayPerformanceEntry } from '../types';
 import { createPerformanceSpans } from './createPerformanceSpans';
+
+type ReplayMemoryEntry = ReplayPerformanceEntry & { data: { memory: MemoryInfo } };
+
+interface MemoryInfo {
+  jsHeapSizeLimit: number;
+  totalJSHeapSize: number;
+  usedJSHeapSize: number;
+}
 
 /**
  * Create a "span" for the total amount of memory being used by JS objects
@@ -16,4 +24,24 @@ export function addMemoryEntry(replay: ReplayContainer): void {
   } catch (error) {
     // Do nothing
   }
+}
+
+function createMemoryEntry(memoryEntry: MemoryInfo): ReplayMemoryEntry {
+  const { jsHeapSizeLimit, totalJSHeapSize, usedJSHeapSize } = memoryEntry;
+  // we don't want to use `getAbsoluteTime` because it adds the event time to the
+  // time origin, so we get the current timestamp instead
+  const time = new Date().getTime() / 1000;
+  return {
+    type: 'memory',
+    name: 'memory',
+    start: time,
+    end: time,
+    data: {
+      memory: {
+        jsHeapSizeLimit,
+        totalJSHeapSize,
+        usedJSHeapSize,
+      },
+    },
+  };
 }

--- a/packages/replay/src/util/createBreadcrumb.ts
+++ b/packages/replay/src/util/createBreadcrumb.ts
@@ -2,6 +2,9 @@ import type { Breadcrumb } from '@sentry/types';
 
 type RequiredProperties = 'category' | 'message';
 
+/**
+ * Create a breadcrumb for a replay.
+ */
 export function createBreadcrumb(
   breadcrumb: Pick<Breadcrumb, RequiredProperties> & Partial<Omit<Breadcrumb, RequiredProperties>>,
 ): Breadcrumb {

--- a/packages/replay/src/util/createPerformanceSpans.ts
+++ b/packages/replay/src/util/createPerformanceSpans.ts
@@ -1,7 +1,6 @@
 import { EventType } from 'rrweb';
 
-import { ReplayPerformanceEntry } from '../createPerformanceEntry';
-import type { ReplayContainer } from '../types';
+import type { ReplayContainer, ReplayPerformanceEntry } from '../types';
 import { addEvent } from './addEvent';
 
 /**

--- a/packages/replay/src/util/createRecordingData.ts
+++ b/packages/replay/src/util/createRecordingData.ts
@@ -2,7 +2,10 @@ import { ReplayRecordingData } from '@sentry/types';
 
 import type { RecordedEvents } from '../types';
 
-export function createPayload({
+/**
+ * Create the recording data ready to be sent.
+ */
+export function createRecordingData({
   events,
   headers,
 }: {

--- a/packages/replay/src/util/createReplayEnvelope.ts
+++ b/packages/replay/src/util/createReplayEnvelope.ts
@@ -1,6 +1,10 @@
 import { DsnComponents, ReplayEnvelope, ReplayEvent, ReplayRecordingData } from '@sentry/types';
 import { createEnvelope, createEventEnvelopeHeaders, getSdkMetadataForEnvelopeHeader } from '@sentry/utils';
 
+/**
+ * Create a replay envelope ready to be sent.
+ * This includes both the replay event, as well as the recording data.
+ */
 export function createReplayEnvelope(
   replayEvent: ReplayEvent,
   recordingData: ReplayRecordingData,

--- a/packages/replay/src/util/isBrowser.ts
+++ b/packages/replay/src/util/isBrowser.ts
@@ -1,5 +1,8 @@
 import { isNodeEnv } from '@sentry/utils';
 
+/**
+ * Returns true if we are in the browser.
+ */
 export function isBrowser(): boolean {
   // eslint-disable-next-line no-restricted-globals
   return typeof window !== 'undefined' && (!isNodeEnv() || isElectronNodeRenderer());

--- a/packages/replay/src/util/isRrwebError.ts
+++ b/packages/replay/src/util/isRrwebError.ts
@@ -1,5 +1,8 @@
 import { Event } from '@sentry/types';
 
+/**
+ * Returns true if we think the given event is an error originating inside of rrweb.
+ */
 export function isRrwebError(event: Event): boolean {
   if (event.type || !event.exception?.values?.length) {
     return false;

--- a/packages/replay/src/util/monkeyPatchRecordDroppedEvent.ts
+++ b/packages/replay/src/util/monkeyPatchRecordDroppedEvent.ts
@@ -3,6 +3,9 @@ import { Client, DataCategory, Event, EventDropReason } from '@sentry/types';
 
 let _originalRecordDroppedEvent: Client['recordDroppedEvent'] | undefined;
 
+/**
+ * Overwrite the `recordDroppedEvent` method on the client, so we can find out which events were dropped.
+ * */
 export function overwriteRecordDroppedEvent(errorIds: Set<string>): void {
   const client = getCurrentHub().getClient();
 
@@ -28,6 +31,9 @@ export function overwriteRecordDroppedEvent(errorIds: Set<string>): void {
   _originalRecordDroppedEvent = _originalCallback;
 }
 
+/**
+ * Restore the original method.
+ * */
 export function restoreRecordDroppedEvent(): void {
   const client = getCurrentHub().getClient();
 

--- a/packages/replay/src/util/prepareReplayEvent.ts
+++ b/packages/replay/src/util/prepareReplayEvent.ts
@@ -1,7 +1,10 @@
 import { prepareEvent, Scope } from '@sentry/core';
 import { Client, ReplayEvent } from '@sentry/types';
 
-export async function getReplayEvent({
+/**
+ * Prepare a replay event & enrich it with the SDK metadata.
+ */
+export async function prepareReplayEvent({
   client,
   scope,
   replayId: event_id,

--- a/packages/replay/test/unit/util/prepareReplayEvent.test.ts
+++ b/packages/replay/test/unit/util/prepareReplayEvent.test.ts
@@ -3,10 +3,10 @@ import { getCurrentHub, Hub, Scope } from '@sentry/core';
 import { Client, ReplayEvent } from '@sentry/types';
 
 import { REPLAY_EVENT_NAME } from '../../../src/constants';
-import { getReplayEvent } from '../../../src/util/getReplayEvent';
+import { prepareReplayEvent } from '../../../src/util/prepareReplayEvent';
 import { getDefaultBrowserClientOptions } from '../../utils/getDefaultBrowserClientOptions';
 
-describe('getReplayEvent', () => {
+describe('prepareReplayEvent', () => {
   let hub: Hub;
   let client: Client;
   let scope: Scope;
@@ -33,12 +33,11 @@ describe('getReplayEvent', () => {
       trace_ids: ['trace-ID'],
       urls: ['https://sentry.io/'],
       replay_id: replayId,
-      event_id: replayId,
       replay_type: 'session',
       segment_id: 3,
     };
 
-    const replayEvent = await getReplayEvent({ scope, client, replayId, event });
+    const replayEvent = await prepareReplayEvent({ scope, client, replayId, event });
 
     expect(replayEvent).toEqual({
       type: 'replay_event',


### PR DESCRIPTION
This is one more step of https://github.com/getsentry/sentry-javascript/issues/6323.

Note that this also renames/moves a few things to make more sense:

* rename `createPayload()` to `createRecordingData()`
* rename `getReplayEvent()` to `prepareReplayEvent()`
* move `ReplayPerformanceEntry` type to `types.ts`
* move `createMemoryEntry` to `addMemoryEntry.ts`, as that was actually the only place where this was used