### PR TITLE
feat(replay): Remove `replayType` from tags and into `replay_event`

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -936,6 +936,7 @@ export class ReplayContainer implements ReplayContainerInterface {
       urls,
       replay_id: replayId,
       segment_id,
+      replay_type: this.session?.sampled,
     };
 
     const replayEvent = await getReplayEvent({ scope, client, event: baseEvent });
@@ -951,7 +952,6 @@ export class ReplayContainer implements ReplayContainerInterface {
       ...replayEvent.tags,
       sessionSampleRate: this._options.sessionSampleRate,
       errorSampleRate: this._options.errorSampleRate,
-      replayType: this.session?.sampled,
     };
 
     /*
@@ -970,6 +970,7 @@ export class ReplayContainer implements ReplayContainerInterface {
         ],
         "replay_id": "eventId",
         "segment_id": 3,
+        "replay_type": "error",
         "platform": "javascript",
         "event_id": "generated-uuid",
         "environment": "production",
@@ -985,7 +986,6 @@ export class ReplayContainer implements ReplayContainerInterface {
         "tags": {
             "sessionSampleRate": 1,
             "errorSampleRate": 0,
-            "replayType": "error"
         }
     }
     */

--- a/packages/replay/test/unit/index-errorSampleRate.test.ts
+++ b/packages/replay/test/unit/index-errorSampleRate.test.ts
@@ -60,9 +60,9 @@ describe('Replay (errorSampleRate)', () => {
     expect(replay).toHaveSentReplay({
       recordingPayloadHeader: { segment_id: 0 },
       replayEventPayload: expect.objectContaining({
+        replay_type: 'error',
         tags: expect.objectContaining({
           errorSampleRate: 1,
-          replayType: 'error',
           sessionSampleRate: 0,
         }),
       }),
@@ -90,9 +90,9 @@ describe('Replay (errorSampleRate)', () => {
     expect(replay).toHaveLastSentReplay({
       recordingPayloadHeader: { segment_id: 1 },
       replayEventPayload: expect.objectContaining({
+        replay_type: 'error',
         tags: expect.objectContaining({
           errorSampleRate: 1,
-          replayType: 'error',
           sessionSampleRate: 0,
         }),
       }),

--- a/packages/replay/test/unit/index.test.ts
+++ b/packages/replay/test/unit/index.test.ts
@@ -789,9 +789,9 @@ describe('Replay', () => {
       replayEventPayload: expect.objectContaining({
         replay_start_timestamp: (BASE_TIMESTAMP - 10000) / 1000,
         urls: ['http://localhost/'], // this doesn't truly test if we are capturing the right URL as we don't change URLs, but good enough
+        replay_type: 'session',
         tags: expect.objectContaining({
           errorSampleRate: 0,
-          replayType: 'session',
           sessionSampleRate: 1,
         }),
       }),

--- a/packages/replay/test/unit/util/createReplayEnvelope.test.ts
+++ b/packages/replay/test/unit/util/createReplayEnvelope.test.ts
@@ -23,10 +23,10 @@ describe('createReplayEnvelope', () => {
       name: 'sentry.javascript.browser',
       version: '7.25.0',
     },
+    replay_type: 'error',
     tags: {
       sessionSampleRate: 1,
       errorSampleRate: 0,
-      replayType: 'error',
     },
   };
 
@@ -59,9 +59,10 @@ describe('createReplayEnvelope', () => {
             event_id: REPLAY_ID,
             platform: 'javascript',
             replay_id: REPLAY_ID,
+            replay_type: 'error',
             sdk: { integrations: ['BrowserTracing', 'Replay'], name: 'sentry.javascript.browser', version: '7.25.0' },
             segment_id: 3,
-            tags: { errorSampleRate: 0, replayType: 'error', sessionSampleRate: 1 },
+            tags: { errorSampleRate: 0, sessionSampleRate: 1 },
             timestamp: 1670837008.634,
             trace_ids: ['traceId'],
             type: 'replay_event',
@@ -94,7 +95,8 @@ describe('createReplayEnvelope', () => {
             replay_id: REPLAY_ID,
             sdk: { integrations: ['BrowserTracing', 'Replay'], name: 'sentry.javascript.browser', version: '7.25.0' },
             segment_id: 3,
-            tags: { errorSampleRate: 0, replayType: 'error', sessionSampleRate: 1 },
+            replay_type: 'error',
+            tags: { errorSampleRate: 0, sessionSampleRate: 1 },
             timestamp: 1670837008.634,
             trace_ids: ['traceId'],
             type: 'replay_event',


### PR DESCRIPTION
Moves `replayType` from tags to part of `replay_event`.

Added in backend in https://github.com/getsentry/replay-backend/issues/210
