### PR TITLE
feat(replay): Move sample rate tags into event context

### DIFF
--- a/packages/integration-tests/suites/replay/captureReplay/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplay/test.ts
@@ -105,6 +105,6 @@ sentryTest('should capture replays', async ({ getLocalTestPath, page }) => {
       },
     },
     platform: 'javascript',
-    tags: { sessionSampleRate: 1, errorSampleRate: 0 },
+    contexts: { replay: { session_sample_rate: 1, error_sample_rate: 0 } },
   });
 });

--- a/packages/integration-tests/suites/replay/captureReplay/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplay/test.ts
@@ -67,7 +67,7 @@ sentryTest('should capture replays', async ({ getLocalTestPath, page }) => {
       },
     },
     platform: 'javascript',
-    tags: { sessionSampleRate: 1, errorSampleRate: 0 },
+    contexts: { replay: { session_sample_rate: 1, error_sample_rate: 0 } },
   });
 
   expect(replayEvent1).toBeDefined();

--- a/packages/integration-tests/suites/replay/captureReplayViaBrowser/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplayViaBrowser/test.ts
@@ -68,7 +68,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
       },
     },
     platform: 'javascript',
-    tags: { sessionSampleRate: 1, errorSampleRate: 0 },
+    contexts: { replay: { session_sample_rate: 1, error_sample_rate: 0 } },
   });
 
   expect(replayEvent1).toBeDefined();
@@ -106,6 +106,6 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
       },
     },
     platform: 'javascript',
-    tags: { sessionSampleRate: 1, errorSampleRate: 0 },
+    contexts: { replay: { session_sample_rate: 1, error_sample_rate: 0 } },
   });
 });

--- a/packages/replay/src/util/sendReplayRequest.ts
+++ b/packages/replay/src/util/sendReplayRequest.ts
@@ -52,8 +52,6 @@ export async function sendReplayRequest({
     replay_id: replayId,
     segment_id,
     replay_type: session.sampled,
-    session_sample_rate: options.sessionSampleRate,
-    error_sample_rate: options.errorSampleRate,
   };
 
   const replayEvent = await prepareReplayEvent({ scope, client, replayId, event: baseEvent });
@@ -64,6 +62,15 @@ export async function sendReplayRequest({
     __DEBUG_BUILD__ && logger.log('An event processor returned `null`, will not send event.');
     return;
   }
+
+  replayEvent.contexts = {
+    ...replayEvent.contexts,
+    replay: {
+      ...(replayEvent.contexts && replayEvent.contexts.replay),
+      session_sample_rate: options.sessionSampleRate,
+      error_sample_rate: options.errorSampleRate,
+    },
+  };
 
   /*
   For reference, the fully built event looks something like this:
@@ -82,8 +89,6 @@ export async function sendReplayRequest({
       "replay_id": "eventId",
       "segment_id": 3,
       "replay_type": "error",
-      "session_sample_rate": 1,
-      "error_sample_rate": 0,
       "platform": "javascript",
       "event_id": "eventId",
       "environment": "production",
@@ -96,6 +101,12 @@ export async function sendReplayRequest({
           "version": "7.25.0"
       },
       "sdkProcessingMetadata": {},
+      "contexts": {
+        "replay": {
+          "session_sample_rate": 1,
+          "error_sample_rate": 0,
+        },
+      },
   }
   */
 

--- a/packages/replay/src/util/sendReplayRequest.ts
+++ b/packages/replay/src/util/sendReplayRequest.ts
@@ -52,6 +52,8 @@ export async function sendReplayRequest({
     replay_id: replayId,
     segment_id,
     replay_type: session.sampled,
+    session_sample_rate: options.sessionSampleRate,
+    error_sample_rate: options.errorSampleRate,
   };
 
   const replayEvent = await prepareReplayEvent({ scope, client, replayId, event: baseEvent });
@@ -62,12 +64,6 @@ export async function sendReplayRequest({
     __DEBUG_BUILD__ && logger.log('An event processor returned `null`, will not send event.');
     return;
   }
-
-  replayEvent.tags = {
-    ...replayEvent.tags,
-    sessionSampleRate: options.sessionSampleRate,
-    errorSampleRate: options.errorSampleRate,
-  };
 
   /*
   For reference, the fully built event looks something like this:
@@ -86,6 +82,8 @@ export async function sendReplayRequest({
       "replay_id": "eventId",
       "segment_id": 3,
       "replay_type": "error",
+      "session_sample_rate": 1,
+      "error_sample_rate": 0,
       "platform": "javascript",
       "event_id": "eventId",
       "environment": "production",
@@ -98,10 +96,6 @@ export async function sendReplayRequest({
           "version": "7.25.0"
       },
       "sdkProcessingMetadata": {},
-      "tags": {
-          "sessionSampleRate": 1,
-          "errorSampleRate": 0,
-      }
   }
   */
 

--- a/packages/replay/test/integration/errorSampleRate.test.ts
+++ b/packages/replay/test/integration/errorSampleRate.test.ts
@@ -63,8 +63,12 @@ describe('Integration | errorSampleRate', () => {
       recordingPayloadHeader: { segment_id: 0 },
       replayEventPayload: expect.objectContaining({
         replay_type: 'error',
-        error_sample_rate: 1,
-        session_sample_rate: 0,
+        contexts: {
+          replay: {
+            error_sample_rate: 1,
+            session_sample_rate: 0,
+          },
+        },
       }),
       recordingData: JSON.stringify([
         { data: { isCheckout: true }, timestamp: BASE_TIMESTAMP, type: 2 },
@@ -91,8 +95,12 @@ describe('Integration | errorSampleRate', () => {
       recordingPayloadHeader: { segment_id: 1 },
       replayEventPayload: expect.objectContaining({
         replay_type: 'error',
-        error_sample_rate: 1,
-        session_sample_rate: 0,
+        contexts: {
+          replay: {
+            error_sample_rate: 1,
+            session_sample_rate: 0,
+          },
+        },
       }),
       recordingData: JSON.stringify([{ data: { isCheckout: true }, timestamp: BASE_TIMESTAMP + 5020, type: 2 }]),
     });

--- a/packages/replay/test/integration/errorSampleRate.test.ts
+++ b/packages/replay/test/integration/errorSampleRate.test.ts
@@ -63,10 +63,8 @@ describe('Integration | errorSampleRate', () => {
       recordingPayloadHeader: { segment_id: 0 },
       replayEventPayload: expect.objectContaining({
         replay_type: 'error',
-        tags: expect.objectContaining({
-          errorSampleRate: 1,
-          sessionSampleRate: 0,
-        }),
+        error_sample_rate: 1,
+        session_sample_rate: 0,
       }),
       recordingData: JSON.stringify([
         { data: { isCheckout: true }, timestamp: BASE_TIMESTAMP, type: 2 },
@@ -93,10 +91,8 @@ describe('Integration | errorSampleRate', () => {
       recordingPayloadHeader: { segment_id: 1 },
       replayEventPayload: expect.objectContaining({
         replay_type: 'error',
-        tags: expect.objectContaining({
-          errorSampleRate: 1,
-          sessionSampleRate: 0,
-        }),
+        error_sample_rate: 1,
+        session_sample_rate: 0,
       }),
       recordingData: JSON.stringify([{ data: { isCheckout: true }, timestamp: BASE_TIMESTAMP + 5020, type: 2 }]),
     });

--- a/packages/replay/test/integration/events.test.ts
+++ b/packages/replay/test/integration/events.test.ts
@@ -130,8 +130,12 @@ describe('Integration | events', () => {
     expect(replay).toHaveLastSentReplay({
       replayEventPayload: expect.objectContaining({
         replay_start_timestamp: (BASE_TIMESTAMP - 10000) / 1000,
-        error_sample_rate: 0,
-        session_sample_rate: 1,
+        contexts: {
+          replay: {
+            error_sample_rate: 0,
+            session_sample_rate: 1,
+          },
+        },
         urls: ['http://localhost/'], // this doesn't truly test if we are capturing the right URL as we don't change URLs, but good enough
       }),
     });

--- a/packages/replay/test/integration/events.test.ts
+++ b/packages/replay/test/integration/events.test.ts
@@ -130,11 +130,9 @@ describe('Integration | events', () => {
     expect(replay).toHaveLastSentReplay({
       replayEventPayload: expect.objectContaining({
         replay_start_timestamp: (BASE_TIMESTAMP - 10000) / 1000,
+        error_sample_rate: 0,
+        session_sample_rate: 1,
         urls: ['http://localhost/'], // this doesn't truly test if we are capturing the right URL as we don't change URLs, but good enough
-        tags: expect.objectContaining({
-          errorSampleRate: 0,
-          sessionSampleRate: 1,
-        }),
       }),
     });
   });

--- a/packages/replay/test/unit/util/createReplayEnvelope.test.ts
+++ b/packages/replay/test/unit/util/createReplayEnvelope.test.ts
@@ -24,10 +24,9 @@ describe('Unit | util | createReplayEnvelope', () => {
       version: '7.25.0',
     },
     replay_type: 'error',
-    tags: {
-      sessionSampleRate: 1,
-      errorSampleRate: 0,
-    },
+    error_sample_rate: 0,
+    session_sample_rate: 1,
+    tags: {},
   };
 
   const payloadWithSequence = 'payload';
@@ -56,13 +55,15 @@ describe('Unit | util | createReplayEnvelope', () => {
           {
             environment: 'production',
             error_ids: ['errorId'],
+            error_sample_rate: 0,
             event_id: REPLAY_ID,
             platform: 'javascript',
             replay_id: REPLAY_ID,
             replay_type: 'error',
             sdk: { integrations: ['BrowserTracing', 'Replay'], name: 'sentry.javascript.unknown', version: '7.25.0' },
             segment_id: 3,
-            tags: { errorSampleRate: 0, sessionSampleRate: 1 },
+            session_sample_rate: 1,
+            tags: {},
             timestamp: 1670837008.634,
             trace_ids: ['traceId'],
             type: 'replay_event',
@@ -90,13 +91,15 @@ describe('Unit | util | createReplayEnvelope', () => {
           {
             environment: 'production',
             error_ids: ['errorId'],
+            error_sample_rate: 0,
             event_id: REPLAY_ID,
             platform: 'javascript',
             replay_id: REPLAY_ID,
             sdk: { integrations: ['BrowserTracing', 'Replay'], name: 'sentry.javascript.unknown', version: '7.25.0' },
             segment_id: 3,
             replay_type: 'error',
-            tags: { errorSampleRate: 0, sessionSampleRate: 1 },
+            session_sample_rate: 1,
+            tags: {},
             timestamp: 1670837008.634,
             trace_ids: ['traceId'],
             type: 'replay_event',

--- a/packages/replay/test/unit/util/createReplayEnvelope.test.ts
+++ b/packages/replay/test/unit/util/createReplayEnvelope.test.ts
@@ -24,8 +24,12 @@ describe('Unit | util | createReplayEnvelope', () => {
       version: '7.25.0',
     },
     replay_type: 'error',
-    error_sample_rate: 0,
-    session_sample_rate: 1,
+    contexts: {
+      replay: {
+        error_sample_rate: 0,
+        session_sample_rate: 1,
+      },
+    },
     tags: {},
   };
 
@@ -53,16 +57,20 @@ describe('Unit | util | createReplayEnvelope', () => {
         [
           { type: 'replay_event' },
           {
+            contexts: {
+              replay: {
+                error_sample_rate: 0,
+                session_sample_rate: 1,
+              },
+            },
             environment: 'production',
             error_ids: ['errorId'],
-            error_sample_rate: 0,
             event_id: REPLAY_ID,
             platform: 'javascript',
             replay_id: REPLAY_ID,
             replay_type: 'error',
             sdk: { integrations: ['BrowserTracing', 'Replay'], name: 'sentry.javascript.unknown', version: '7.25.0' },
             segment_id: 3,
-            session_sample_rate: 1,
             tags: {},
             timestamp: 1670837008.634,
             trace_ids: ['traceId'],
@@ -89,16 +97,20 @@ describe('Unit | util | createReplayEnvelope', () => {
         [
           { type: 'replay_event' },
           {
+            contexts: {
+              replay: {
+                error_sample_rate: 0,
+                session_sample_rate: 1,
+              },
+            },
             environment: 'production',
             error_ids: ['errorId'],
-            error_sample_rate: 0,
             event_id: REPLAY_ID,
             platform: 'javascript',
             replay_id: REPLAY_ID,
             sdk: { integrations: ['BrowserTracing', 'Replay'], name: 'sentry.javascript.unknown', version: '7.25.0' },
             segment_id: 3,
             replay_type: 'error',
-            session_sample_rate: 1,
             tags: {},
             timestamp: 1670837008.634,
             trace_ids: ['traceId'],

--- a/packages/replay/test/unit/util/prepareReplayEvent.test.ts
+++ b/packages/replay/test/unit/util/prepareReplayEvent.test.ts
@@ -48,6 +48,8 @@ describe('Unit | util | prepareReplayEvent', () => {
       replay_id: replayId,
       replay_type: 'session',
       segment_id: 3,
+      error_sample_rate: 1.0,
+      session_sample_rate: 0.1,
     };
 
     const replayEvent = await prepareReplayEvent({ scope, client, replayId, event });
@@ -66,6 +68,8 @@ describe('Unit | util | prepareReplayEvent', () => {
       platform: 'javascript',
       event_id: 'replay-ID',
       environment: 'production',
+      error_sample_rate: 1.0,
+      session_sample_rate: 0.1,
       sdk: {
         name: 'sentry.javascript.testSdk',
         version: '1.0.0',

--- a/packages/replay/test/unit/util/prepareReplayEvent.test.ts
+++ b/packages/replay/test/unit/util/prepareReplayEvent.test.ts
@@ -48,8 +48,12 @@ describe('Unit | util | prepareReplayEvent', () => {
       replay_id: replayId,
       replay_type: 'session',
       segment_id: 3,
-      error_sample_rate: 1.0,
-      session_sample_rate: 0.1,
+      contexts: {
+        replay: {
+          error_sample_rate: 1.0,
+          session_sample_rate: 0.1,
+        },
+      },
     };
 
     const replayEvent = await prepareReplayEvent({ scope, client, replayId, event });
@@ -68,8 +72,12 @@ describe('Unit | util | prepareReplayEvent', () => {
       platform: 'javascript',
       event_id: 'replay-ID',
       environment: 'production',
-      error_sample_rate: 1.0,
-      session_sample_rate: 0.1,
+      contexts: {
+        replay: {
+          error_sample_rate: 1.0,
+          session_sample_rate: 0.1,
+        },
+      },
       sdk: {
         name: 'sentry.javascript.testSdk',
         version: '1.0.0',

--- a/packages/types/src/replay.ts
+++ b/packages/types/src/replay.ts
@@ -11,8 +11,6 @@ export interface ReplayEvent extends Event {
   replay_id: string;
   segment_id: number;
   replay_type: ReplayRecordingMode;
-  session_sample_rate: number;
-  error_sample_rate: number;
 }
 
 /**

--- a/packages/types/src/replay.ts
+++ b/packages/types/src/replay.ts
@@ -11,6 +11,8 @@ export interface ReplayEvent extends Event {
   replay_id: string;
   segment_id: number;
   replay_type: ReplayRecordingMode;
+  session_sample_rate: number;
+  error_sample_rate: number;
 }
 
 /**


### PR DESCRIPTION
Move sample rate from tags into context as that is the more appropriate location for this type of data. This data is more for us to collect to debug rather than having as a top level field on the replay event.