### PR TITLE
feat(tests): Inject `@sentry/integrations` bundles to Playwright templates

### DIFF
--- a/packages/integration-tests/suites/integrations/httpclient/fetch/test.ts
+++ b/packages/integration-tests/suites/integrations/httpclient/fetch/test.ts
@@ -7,12 +7,6 @@ import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 sentryTest(
   'should assign request and response context from a failed 500 fetch request',
   async ({ getLocalTestPath, page }) => {
-    // Skipping this test when running in bundle mode, because `@sentry/integrations` bundle
-    // is not injected to the page with the current test setup.
-    if (process.env.PW_BUNDLE?.includes('bundle')) {
-      sentryTest.skip();
-    }
-
     const url = await getLocalTestPath({ testDir: __dirname });
 
     await page.route('**/foo', route => {

--- a/packages/integration-tests/suites/integrations/httpclient/xhr/test.ts
+++ b/packages/integration-tests/suites/integrations/httpclient/xhr/test.ts
@@ -7,12 +7,6 @@ import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 sentryTest(
   'should assign request and response context from a failed 500 XHR request',
   async ({ getLocalTestPath, page }) => {
-    // Skipping this test when running in bundle mode, because `@sentry/integrations` bundle
-    // is not injected to the page with the current test setup.
-    if (process.env.PW_BUNDLE?.includes('bundle')) {
-      sentryTest.skip();
-    }
-
     const url = await getLocalTestPath({ testDir: __dirname });
 
     await page.route('**/foo', route => {

--- a/packages/integration-tests/utils/generatePlugin.ts
+++ b/packages/integration-tests/utils/generatePlugin.ts
@@ -33,8 +33,8 @@ const BUNDLE_PATHS: Record<string, Record<string, string>> = {
     bundle_es6_min: 'build/bundles/bundle.tracing.min.js',
   },
   integrations: {
-    cjs: 'build/npm/cjs/[INTEGRATION_NAME].js',
-    esm: 'build/npm/esm/[INTEGRATION_NAME].js',
+    cjs: 'build/npm/cjs/index.js',
+    esm: 'build/npm/esm/index.js',
     bundle_es5: 'build/bundles/[INTEGRATION_NAME].es5.js',
     bundle_es5_min: 'build/bundles/[INTEGRATION_NAME].es5.min.js',
     bundle_es6: 'build/bundles/[INTEGRATION_NAME].js',

--- a/packages/integration-tests/utils/generatePlugin.ts
+++ b/packages/integration-tests/utils/generatePlugin.ts
@@ -32,6 +32,14 @@ const BUNDLE_PATHS: Record<string, Record<string, string>> = {
     bundle_es6: 'build/bundles/bundle.tracing.js',
     bundle_es6_min: 'build/bundles/bundle.tracing.min.js',
   },
+  integrations: {
+    cjs: 'build/npm/cjs/[INTEGRATION_NAME].js',
+    esm: 'build/npm/esm/[INTEGRATION_NAME].js',
+    bundle_es5: 'build/bundles/[INTEGRATION_NAME].es5.js',
+    bundle_es5_min: 'build/bundles/[INTEGRATION_NAME].es5.min.js',
+    bundle_es6: 'build/bundles/[INTEGRATION_NAME].js',
+    bundle_es6_min: 'build/bundles/[INTEGRATION_NAME].min.js',
+  },
 };
 
 /*
@@ -78,6 +86,7 @@ function generateSentryAlias(): Record<string, string> {
 
 class SentryScenarioGenerationPlugin {
   public requiresTracing: boolean = false;
+  public requiredIntegrations: string[] = [];
 
   private _name: string = 'SentryScenarioGenerationPlugin';
 
@@ -89,18 +98,24 @@ class SentryScenarioGenerationPlugin {
             // To help Webpack resolve Sentry modules in `import` statements in cases where they're provided in bundles rather than in `node_modules`
             '@sentry/browser': 'Sentry',
             '@sentry/tracing': 'Sentry',
+            '@sentry/integrations': 'Sentry.Integrations',
           }
         : {};
 
-    // Checking if the current scenario has imported `@sentry/tracing`.
+    // Checking if the current scenario has imported `@sentry/tracing` or `@sentry/integrations`.
     compiler.hooks.normalModuleFactory.tap(this._name, factory => {
       factory.hooks.parser.for('javascript/auto').tap(this._name, parser => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        parser.hooks.import.tap(this._name, (_statement: unknown, source: string) => {
-          if (source === '@sentry/tracing') {
-            this.requiresTracing = true;
-          }
-        });
+        parser.hooks.import.tap(
+          this._name,
+          (statement: { specifiers: [{ imported: { name: string } }] }, source: string) => {
+            if (source === '@sentry/tracing') {
+              this.requiresTracing = true;
+            } else if (source === '@sentry/integrations') {
+              this.requiredIntegrations.push(statement.specifiers[0].imported.name.toLowerCase());
+            }
+          },
+        );
       });
     });
 
@@ -111,6 +126,18 @@ class SentryScenarioGenerationPlugin {
           const bundleName = useTracingBundle ? 'tracing' : 'browser';
           const bundleObject = createHtmlTagObject('script', {
             src: path.resolve(PACKAGES_DIR, bundleName, BUNDLE_PATHS[bundleName][bundleKey]),
+          });
+
+          this.requiredIntegrations.forEach(integration => {
+            const integrationObject = createHtmlTagObject('script', {
+              src: path.resolve(
+                PACKAGES_DIR,
+                'integrations',
+                BUNDLE_PATHS['integrations'][bundleKey].replace('[INTEGRATION_NAME]', integration),
+              ),
+            });
+
+            data.assetTags.scripts.unshift(integrationObject);
           });
 
           data.assetTags.scripts.unshift(bundleObject);


### PR DESCRIPTION
This PR adds a configuration to be able to use `@sentry/integrations` package in our browser integration test scenarios.)
Currently, it only supports `@sentry/browser` and `@sentry/tracing` packages / bundles.

This is required to properly integration test #6500 (which is a browser integration from `@sentry/integrations` package)