### PR TITLE
Revert "fix(replay): Generate uuids for replay events (#6650)"

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -938,7 +938,7 @@ export class ReplayContainer implements ReplayContainerInterface {
       segment_id,
     };
 
-    const replayEvent = await getReplayEvent({ scope, client, event: baseEvent });
+    const replayEvent = await getReplayEvent({ scope, client, replayId, event: baseEvent });
 
     if (!replayEvent) {
       // Taken from baseclient's `_processEvent` method, where this is handled for errors/transactions
@@ -971,7 +971,7 @@ export class ReplayContainer implements ReplayContainerInterface {
         "replay_id": "eventId",
         "segment_id": 3,
         "platform": "javascript",
-        "event_id": "generated-uuid",
+        "event_id": "eventId",
         "environment": "production",
         "sdk": {
             "integrations": [

--- a/packages/replay/src/util/getReplayEvent.ts
+++ b/packages/replay/src/util/getReplayEvent.ts
@@ -4,13 +4,15 @@ import { Client, ReplayEvent } from '@sentry/types';
 export async function getReplayEvent({
   client,
   scope,
+  replayId: event_id,
   event,
 }: {
   client: Client;
   scope: Scope;
+  replayId: string;
   event: ReplayEvent;
 }): Promise<ReplayEvent | null> {
-  const preparedEvent = (await prepareEvent(client.getOptions(), event, {}, scope)) as ReplayEvent | null;
+  const preparedEvent = (await prepareEvent(client.getOptions(), event, { event_id }, scope)) as ReplayEvent | null;
 
   // If e.g. a global event processor returned null
   if (!preparedEvent) {

--- a/packages/replay/test/unit/util/getReplayEvent.test.ts
+++ b/packages/replay/test/unit/util/getReplayEvent.test.ts
@@ -33,10 +33,11 @@ describe('getReplayEvent', () => {
       trace_ids: ['trace-ID'],
       urls: ['https://sentry.io/'],
       replay_id: replayId,
+      event_id: replayId,
       segment_id: 3,
     };
 
-    const replayEvent = await getReplayEvent({ scope, client, event });
+    const replayEvent = await getReplayEvent({ scope, client, replayId, event });
 
     expect(replayEvent).toEqual({
       type: 'replay_event',
@@ -47,8 +48,7 @@ describe('getReplayEvent', () => {
       replay_id: 'replay-ID',
       segment_id: 3,
       platform: 'javascript',
-      // generated uuid with 32 chars
-      event_id: expect.stringMatching(/^\w{32}$/),
+      event_id: 'replay-ID',
       environment: 'production',
       sdk: {
         name: 'sentry.javascript.browser',


### PR DESCRIPTION
While testing Replay with my test app, I noticed that after we merged in #6650, the sent replays are still displayed in the replays list on sentry.io but if I click on one of them, I get a "Page not found" error page. So apparently, I was wrong in #6649 and we do in fact need the `event_id` to be the `replay_id`. 

Fixing this on the back-end will take some time, so let's merge this in for the time being.