### PR TITLE
fix(nextjs): correct withSentryConfig return type

### DIFF
--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -17,7 +17,7 @@ import type {
 export function withSentryConfig(
   exportedUserNextConfig: ExportedNextConfig = {},
   userSentryWebpackPluginOptions: Partial<SentryWebpackPluginOptions> = {},
-): NextConfigFunction | NextConfigObject {
+): NextConfigFunction {
   return function (phase: string, defaults: { defaultConfig: NextConfigObject }): NextConfigObject {
     if (typeof exportedUserNextConfig === 'function') {
       const userNextConfigObject = exportedUserNextConfig(phase, defaults);


### PR DESCRIPTION
In #6291, `withSentryConfig` was updated to always return a function so this PR updates the return value type to no longer include `NextConfigObject`.
