### PR TITLE
fix(replay): Fix ts errors with `replay_type`

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */ // TODO: We might want to split this file up
 import { addGlobalEventProcessor, captureException, getCurrentHub, setContext } from '@sentry/core';
-import { Breadcrumb, ReplayEvent, TransportMakeRequestResponse } from '@sentry/types';
+import type { Breadcrumb, ReplayEvent, ReplayRecordingMode, TransportMakeRequestResponse } from '@sentry/types';
 import { addInstrumentationHandler, logger } from '@sentry/utils';
 import { EventType, record } from 'rrweb';
 
@@ -34,7 +34,6 @@ import type {
   RecordingOptions,
   ReplayContainer as ReplayContainerInterface,
   ReplayPluginOptions,
-  ReplayRecordingMode,
   SendReplay,
   Session,
 } from './types';

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -922,7 +922,7 @@ export class ReplayContainer implements ReplayContainerInterface {
     const transport = client && client.getTransport();
     const dsn = client?.getDsn();
 
-    if (!client || !scope || !transport || !dsn) {
+    if (!client || !scope || !transport || !dsn || !this.session || !this.session.sampled) {
       return;
     }
 
@@ -936,7 +936,7 @@ export class ReplayContainer implements ReplayContainerInterface {
       urls,
       replay_id: replayId,
       segment_id,
-      replay_type: this.session?.sampled,
+      replay_type: this.session.sampled,
     };
 
     const replayEvent = await getReplayEvent({ scope, client, replayId, event: baseEvent });

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -1,4 +1,4 @@
-import { ReplayRecordingData } from '@sentry/types';
+import type { ReplayRecordingData, ReplayRecordingMode } from '@sentry/types';
 
 import type { eventWithTime, recordOptions } from './types/rrweb';
 
@@ -8,8 +8,6 @@ export type RecordingOptions = recordOptions;
 export type RecordedEvents = Uint8Array | string;
 
 export type AllPerformanceEntry = PerformancePaintTiming | PerformanceResourceTiming | PerformanceNavigationTiming;
-
-export type ReplayRecordingMode = 'session' | 'error';
 
 export interface SendReplay {
   events: RecordedEvents;

--- a/packages/replay/test/unit/util/getReplayEvent.test.ts
+++ b/packages/replay/test/unit/util/getReplayEvent.test.ts
@@ -34,6 +34,7 @@ describe('getReplayEvent', () => {
       urls: ['https://sentry.io/'],
       replay_id: replayId,
       event_id: replayId,
+      replay_type: 'session',
       segment_id: 3,
     };
 
@@ -46,6 +47,7 @@ describe('getReplayEvent', () => {
       trace_ids: ['trace-ID'],
       urls: ['https://sentry.io/'],
       replay_id: 'replay-ID',
+      replay_type: 'session',
       segment_id: 3,
       platform: 'javascript',
       event_id: 'replay-ID',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -40,7 +40,7 @@ export type { ExtractedNodeRequestData, HttpHeaderValue, Primitive, WorkerLocati
 export type { ClientOptions, Options } from './options';
 export type { Package } from './package';
 export type { PolymorphicEvent, PolymorphicRequest } from './polymorphics';
-export type { ReplayEvent, ReplayRecordingData } from './replay';
+export type { ReplayEvent, ReplayRecordingData, ReplayRecordingMode } from './replay';
 export type { QueryParams, Request } from './request';
 export type { Runtime } from './runtime';
 export type { CaptureContext, Scope, ScopeContext } from './scope';

--- a/packages/types/src/replay.ts
+++ b/packages/types/src/replay.ts
@@ -10,7 +10,7 @@ export interface ReplayEvent extends Event {
   trace_ids: string[];
   replay_id: string;
   segment_id: number;
-  replay_type: 'session' | 'error';
+  replay_type: ReplayRecordingMode;
 }
 
 /**
@@ -18,3 +18,9 @@ export interface ReplayEvent extends Event {
  * @hidden
  */
 export type ReplayRecordingData = string | Uint8Array;
+
+/**
+ * NOTE: These types are still considered Beta and subject to change.
+ * @hidden
+ */
+export type ReplayRecordingMode = 'session' | 'error';

--- a/packages/types/src/replay.ts
+++ b/packages/types/src/replay.ts
@@ -10,6 +10,7 @@ export interface ReplayEvent extends Event {
   trace_ids: string[];
   replay_id: string;
   segment_id: number;
+  replay_type: 'session' | 'error';
 }
 
 /**


### PR DESCRIPTION
Fixes type error from https://github.com/getsentry/sentry-javascript/pull/6658 (semantic merge issue).
