### PR TITLE
fix(nextjs): Exclude SDK from Edge runtime bundles

### DIFF
--- a/packages/nextjs/src/config/loaders/proxyLoader.ts
+++ b/packages/nextjs/src/config/loaders/proxyLoader.ts
@@ -9,6 +9,7 @@ type LoaderOptions = {
   pagesDir: string;
   pageExtensionRegex: string;
   excludeServerRoutes: Array<RegExp | string>;
+  isEdgeRuntime: boolean;
 };
 
 /**
@@ -22,7 +23,13 @@ export default async function proxyLoader(this: LoaderThis<LoaderOptions>, userC
     pagesDir,
     pageExtensionRegex,
     excludeServerRoutes = [],
+    isEdgeRuntime,
   } = 'getOptions' in this ? this.getOptions() : this.query;
+
+  // We currently don't support the edge runtime
+  if (isEdgeRuntime) {
+    return userCode;
+  }
 
   // Get the parameterized route name from this page's filepath
   const parameterizedRoute = path

--- a/packages/nextjs/src/config/templates/apiProxyLoaderTemplate.ts
+++ b/packages/nextjs/src/config/templates/apiProxyLoaderTemplate.ts
@@ -23,7 +23,7 @@ type NextApiModule = (
     }
   // CJS export
   | NextApiHandler
-) & { config?: PageConfig & { runtime?: string } };
+) & { config?: PageConfig };
 
 const userApiModule = origModule as NextApiModule;
 
@@ -53,21 +53,7 @@ export const config = {
   },
 };
 
-// This is a variable that Next.js will string replace during build with a string if run in an edge runtime from Next.js
-// v12.2.1-canary.3 onwards:
-// https://github.com/vercel/next.js/blob/166e5fb9b92f64c4b5d1f6560a05e2b9778c16fb/packages/next/build/webpack-config.ts#L206
-// https://edge-runtime.vercel.sh/features/available-apis#addressing-the-runtime
-declare const EdgeRuntime: string | undefined;
-
-let exportedHandler;
-
-if (typeof EdgeRuntime === 'string') {
-  exportedHandler = userProvidedHandler;
-} else {
-  exportedHandler = userProvidedHandler ? Sentry.withSentryAPI(userProvidedHandler, '__ROUTE__') : undefined;
-}
-
-export default exportedHandler;
+export default userProvidedHandler ? Sentry.withSentryAPI(userProvidedHandler, '__ROUTE__') : undefined;
 
 // Re-export anything exported by the page module we're wrapping. When processing this code, Rollup is smart enough to
 // not include anything whose name matchs something we've explicitly exported above.

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -137,7 +137,7 @@ export type BuildContext = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   defaultLoaders: any;
   totalPages: number;
-  nextRuntime?: 'nodejs' | 'edge';
+  nextRuntime?: 'nodejs' | 'edge'; // Added in Next.js 12+
 };
 
 /**

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -85,6 +85,13 @@ export function constructWebpackConfigFunction(
     // Add a loader which will inject code that sets global values
     addValueInjectionLoader(newConfig, userNextConfig, userSentryOptions);
 
+    if (buildContext.nextRuntime === 'edge') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[@sentry/nextjs] You are using edge functions or middleware. Please note that Sentry does not yet support error monitoring for these features.',
+      );
+    }
+
     if (isServer) {
       if (userSentryOptions.autoInstrumentServerFunctions !== false) {
         const pagesDir = newConfig.resolve?.alias?.['private-next-pages'] as string;
@@ -102,6 +109,7 @@ export function constructWebpackConfigFunction(
                 pagesDir,
                 pageExtensionRegex,
                 excludeServerRoutes: userSentryOptions.excludeServerRoutes,
+                isEdgeRuntime: buildContext.nextRuntime === 'edge',
               },
             },
           ],
@@ -305,7 +313,15 @@ async function addSentryToEntryProperty(
 
   // inject into all entry points which might contain user's code
   for (const entryPointName in newEntryProperty) {
-    if (shouldAddSentryToEntryPoint(entryPointName, isServer, userSentryOptions.excludeServerRoutes, isDev)) {
+    if (
+      shouldAddSentryToEntryPoint(
+        entryPointName,
+        isServer,
+        userSentryOptions.excludeServerRoutes,
+        isDev,
+        buildContext.nextRuntime === 'edge',
+      )
+    ) {
       addFilesToExistingEntryPoint(newEntryProperty, entryPointName, filesToInject);
     } else {
       if (
@@ -432,7 +448,13 @@ function shouldAddSentryToEntryPoint(
   isServer: boolean,
   excludeServerRoutes: Array<string | RegExp> = [],
   isDev: boolean,
+  isEdgeRuntime: boolean,
 ): boolean {
+  // We don't support the Edge runtime yet
+  if (isEdgeRuntime) {
+    return false;
+  }
+
   // On the server side, by default we inject the `Sentry.init()` code into every page (with a few exceptions).
   if (isServer) {
     const entryPointRoute = entryPointName.replace(/^pages/, '');
@@ -529,7 +551,13 @@ export function getWebpackPluginOptions(
     stripPrefix: ['webpack://_N_E/'],
     urlPrefix,
     entries: (entryPointName: string) =>
-      shouldAddSentryToEntryPoint(entryPointName, isServer, userSentryOptions.excludeServerRoutes, isDev),
+      shouldAddSentryToEntryPoint(
+        entryPointName,
+        isServer,
+        userSentryOptions.excludeServerRoutes,
+        isDev,
+        buildContext.nextRuntime === 'edge',
+      ),
     release: getSentryRelease(buildId),
     dryRun: isDev,
   });

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -30,12 +30,6 @@ const globalWithInjectedValues = global as typeof global & {
 
 const domain = domainModule as typeof domainModule & { active: (domainModule.Domain & Carrier) | null };
 
-// This is a variable that Next.js will string replace during build with a string if run in an edge runtime from Next.js
-// v12.2.1-canary.3 onwards:
-// https://github.com/vercel/next.js/blob/166e5fb9b92f64c4b5d1f6560a05e2b9778c16fb/packages/next/build/webpack-config.ts#L206
-// https://edge-runtime.vercel.sh/features/available-apis#addressing-the-runtime
-declare const EdgeRuntime: string | undefined;
-
 // Exporting this constant means we can compute it without the linter complaining, even if we stop directly using it in
 // this file. It's important that it be computed as early as possible, because one of its indicators is seeing 'build'
 // (as in the CLI command `next build`) in `process.argv`. Later on in the build process, everything's been spun out
@@ -49,11 +43,6 @@ const IS_VERCEL = !!process.env.VERCEL;
 export function init(options: NextjsOptions): void {
   if (__DEBUG_BUILD__ && options.debug) {
     logger.enable();
-  }
-
-  if (typeof EdgeRuntime === 'string') {
-    __DEBUG_BUILD__ && logger.log('Vercel Edge Runtime detected. Will not initialize SDK.');
-    return;
   }
 
   __DEBUG_BUILD__ && logger.log('Initializing SDK...');


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry-javascript/issues/6120

Builds currently emit warnings when there is a route using the Vercel edge runtime because we are injecting code into the serverless bundles that is using APIs that are not WinterCG compatible or we are wrapping with code that uses server SDK functions even though we are injecting the client SDK.

Also resolves https://github.com/getsentry/sentry-javascript/issues/5974