### PR TITLE
fix(ci): Update package lists before downloading playwright deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -546,7 +546,7 @@ jobs:
           PW_TRACING_ONLY: ${{ matrix.tracing_only }}
         run: |
           cd packages/integration-tests
-          apt-get update
+          sudo apt-get update
           yarn run playwright install-deps webkit
           yarn test:ci
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -546,6 +546,7 @@ jobs:
           PW_TRACING_ONLY: ${{ matrix.tracing_only }}
         run: |
           cd packages/integration-tests
+          apt-get update
           yarn run playwright install-deps webkit
           yarn test:ci
 


### PR DESCRIPTION
This is to fix CI that is currently failing because we can't download deps from the ubuntu registry.