### PR TITLE
ref(replay): Allow `timestamp` to be passed as an argument to `sendReplayRequest`

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -895,6 +895,7 @@ export class ReplayContainer implements ReplayContainerInterface {
     segmentId: segment_id,
     includeReplayStartTimestamp,
     eventContext,
+    timestamp = new Date().getTime(),
   }: SendReplay): Promise<void | TransportMakeRequestResponse> {
     const recordingData = createRecordingData({
       events,
@@ -904,8 +905,6 @@ export class ReplayContainer implements ReplayContainerInterface {
     });
 
     const { urls, errorIds, traceIds, initialTimestamp } = eventContext;
-
-    const currentTimestamp = new Date().getTime();
 
     const hub = getCurrentHub();
     const client = hub.getClient();
@@ -921,7 +920,7 @@ export class ReplayContainer implements ReplayContainerInterface {
       // @ts-ignore private api
       type: REPLAY_EVENT_NAME,
       ...(includeReplayStartTimestamp ? { replay_start_timestamp: initialTimestamp / 1000 } : {}),
-      timestamp: currentTimestamp / 1000,
+      timestamp,
       error_ids: errorIds,
       trace_ids: traceIds,
       urls,

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -920,7 +920,7 @@ export class ReplayContainer implements ReplayContainerInterface {
       // @ts-ignore private api
       type: REPLAY_EVENT_NAME,
       ...(includeReplayStartTimestamp ? { replay_start_timestamp: initialTimestamp / 1000 } : {}),
-      timestamp,
+      timestamp: timestamp / 1000,
       error_ids: errorIds,
       trace_ids: traceIds,
       urls,

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -15,6 +15,7 @@ export interface SendReplay {
   segmentId: number;
   includeReplayStartTimestamp: boolean;
   eventContext: PopEventContext;
+  timestamp?: number;
 }
 
 export type InstrumentationTypeBreadcrumb = 'dom' | 'scope';


### PR DESCRIPTION
This will be needed when attempting to send a replay request at a different time (e.g. after a reload).
