### PR TITLE
ref(replay): Remove `pause` and `resume` methods

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -102,13 +102,6 @@ export class ReplayContainer implements ReplayContainerInterface {
   private _isEnabled: boolean = false;
 
   /**
-   * Paused is a state where:
-   * - DOM Recording is not listening at all
-   * - Nothing will be added to event buffer (e.g. core SDK events)
-   */
-  private _isPaused: boolean = false;
-
-  /**
    * Have we attached listeners to the core SDK?
    * Note we have to track this as there is no way to remove instrumentation handlers.
    */
@@ -145,11 +138,6 @@ export class ReplayContainer implements ReplayContainerInterface {
   /** If recording is currently enabled. */
   public isEnabled(): boolean {
     return this._isEnabled;
-  }
-
-  /** If recording is currently paused. */
-  public isPaused(): boolean {
-    return this._isPaused;
   }
 
   /** Get the replay integration options. */
@@ -251,34 +239,6 @@ export class ReplayContainer implements ReplayContainerInterface {
     } catch (err) {
       this.handleException(err);
     }
-  }
-
-  /**
-   * Pause some replay functionality. See comments for `_isPaused`.
-   * This differs from stop as this only stops DOM recording, it is
-   * not as thorough of a shutdown as `stop()`.
-   */
-  pause(): void {
-    this._isPaused = true;
-    try {
-      if (this._stopRecording) {
-        this._stopRecording();
-        this._stopRecording = undefined;
-      }
-    } catch (err) {
-      this.handleException(err);
-    }
-  }
-
-  /**
-   * Resumes recording, see notes for `pause().
-   *
-   * Note that calling `startRecording()` here will cause a
-   * new DOM checkout.`
-   */
-  resume(): void {
-    this._isPaused = false;
-    this.startRecording();
   }
 
   /** A wrapper to conditionally capture exceptions. */

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -222,7 +222,6 @@ export interface ReplayContainer {
   session: Session | undefined;
   recordingMode: ReplayRecordingMode;
   isEnabled(): boolean;
-  isPaused(): boolean;
   getContext(): InternalEventContext;
   start(): void;
   stop(): void;

--- a/packages/replay/src/util/addEvent.ts
+++ b/packages/replay/src/util/addEvent.ts
@@ -10,11 +10,6 @@ export function addEvent(replay: ReplayContainer, event: RecordingEvent, isCheck
     return;
   }
 
-  if (replay.isPaused()) {
-    // Do not add to event buffer when recording is paused
-    return;
-  }
-
   // TODO: sadness -- we will want to normalize timestamps to be in ms -
   // requires coordination with frontend
   const isMs = event.timestamp > 9999999999;


### PR DESCRIPTION
This removes the `pause()` and `resume()` methods for replay. Instead, you can simply use `start()` and `stop()`.

The methods weren't documented and used internally.