### PR TITLE
ci: Fix CI failing on master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -503,7 +503,7 @@ jobs:
     name: Playwright (${{ matrix.bundle }})${{ (matrix.tracing_only && ' tracing only') || '' }} Tests
     needs: [job_get_metadata, job_build]
     if: needs.job_get_metadata.outputs.changed_browser_integration == 'true' || github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         bundle:
@@ -546,7 +546,6 @@ jobs:
           PW_TRACING_ONLY: ${{ matrix.tracing_only }}
         run: |
           cd packages/integration-tests
-          sudo apt-get update
           yarn run playwright install-deps webkit
           yarn test:ci
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -546,6 +546,7 @@ jobs:
           PW_TRACING_ONLY: ${{ matrix.tracing_only }}
         run: |
           cd packages/integration-tests
+          sudo apt-get update
           sudo apt-get install libicu70 libwebp6
           yarn run playwright install-deps webkit
           yarn test:ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -546,8 +546,6 @@ jobs:
           PW_TRACING_ONLY: ${{ matrix.tracing_only }}
         run: |
           cd packages/integration-tests
-          sudo apt-get update
-          sudo apt-get install libicu70 libwebp6
           yarn run playwright install-deps webkit
           yarn test:ci
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -503,7 +503,7 @@ jobs:
     name: Playwright (${{ matrix.bundle }})${{ (matrix.tracing_only && ' tracing only') || '' }} Tests
     needs: [job_get_metadata, job_build]
     if: needs.job_get_metadata.outputs.changed_browser_integration == 'true' || github.event_name != 'pull_request'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         bundle:
@@ -698,7 +698,7 @@ jobs:
     if:
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       github.actor != 'dependabot[bot]'
-    needs: [job_get_metadata, job_build]
+    needs: [job_get_metadata, job_bui^ld]
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -546,6 +546,7 @@ jobs:
           PW_TRACING_ONLY: ${{ matrix.tracing_only }}
         run: |
           cd packages/integration-tests
+          sudo apt-get install libicu70 libwebp6
           yarn run playwright install-deps webkit
           yarn test:ci
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -503,7 +503,7 @@ jobs:
     name: Playwright (${{ matrix.bundle }})${{ (matrix.tracing_only && ' tracing only') || '' }} Tests
     needs: [job_get_metadata, job_build]
     if: needs.job_get_metadata.outputs.changed_browser_integration == 'true' || github.event_name != 'pull_request'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         bundle:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -697,7 +697,7 @@ jobs:
     if:
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       github.actor != 'dependabot[bot]'
-    needs: [job_get_metadata, job_bui^ld]
+    needs: [job_get_metadata, job_build]
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -26,10 +26,10 @@
   },
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
-    "@playwright/test": "^1.27.1",
+    "@playwright/test": "^1.29.2",
     "babel-loader": "^8.2.2",
     "html-webpack-plugin": "^5.5.0",
-    "playwright": "^1.27.1",
+    "playwright": "^1.29.2",
     "typescript": "^4.5.2",
     "webpack": "^5.52.0"
   },

--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -7,16 +7,16 @@
     "start": "remix-serve build"
   },
   "dependencies": {
-    "@remix-run/express": "^1.6.5",
-    "@remix-run/node": "^1.6.5",
-    "@remix-run/react": "^1.6.5",
-    "@remix-run/serve": "^1.6.5",
+    "@remix-run/express": "1.9.0",
+    "@remix-run/node": "1.9.0",
+    "@remix-run/react": "1.9.0",
+    "@remix-run/serve": "1.9.0",
     "@sentry/remix": "file:../..",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@remix-run/dev": "^1.6.5",
+    "@remix-run/dev": "1.9.0",
     "@types/react": "^17.0.47",
     "@types/react-dom": "^17.0.17",
     "nock": "^13.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3225,13 +3225,13 @@
     "@opentelemetry/resources" "^0.12.0"
     "@opentelemetry/semantic-conventions" "^0.12.0"
 
-"@playwright/test@^1.27.1":
-  version "1.28.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.28.1.tgz#e5be297e024a3256610cac2baaa9347fd57c7860"
-  integrity sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==
+"@playwright/test@^1.29.2":
+  version "1.29.2"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.29.2.tgz#c48184721d0f0b7627a886e2ec42f1efb2be339d"
+  integrity sha512-+3/GPwOgcoF0xLz/opTnahel1/y42PdcgZ4hs+BZGIUjtmEFSXGg+nFoaH3NSmuc7a6GSFwXDJ5L7VXpqzigNg==
   dependencies:
     "@types/node" "*"
-    playwright-core "1.28.1"
+    playwright-core "1.29.2"
 
 "@polka/url@^1.0.0-next.9":
   version "1.0.0-next.12"
@@ -19107,12 +19107,24 @@ playwright-core@1.28.1:
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.28.1.tgz#8400be9f4a8d1c0489abdb9e75a4cc0ffc3c00cb"
   integrity sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==
 
+playwright-core@1.29.2:
+  version "1.29.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.29.2.tgz#2e8347e7e8522409f22b244e600e703b64022406"
+  integrity sha512-94QXm4PMgFoHAhlCuoWyaBYKb92yOcGVHdQLoxQ7Wjlc7Flg4aC/jbFW7xMR52OfXMVkWicue4WXE7QEegbIRA==
+
 playwright@^1.27.1:
   version "1.28.1"
   resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.28.1.tgz#f23247f1de466ff73d7230d94df96271e5da6583"
   integrity sha512-92Sz6XBlfHlb9tK5UCDzIFAuIkHHpemA9zwUaqvo+w7sFMSmVMGmvKcbptof/eJObq63PGnMhM75x7qxhTR78Q==
   dependencies:
     playwright-core "1.28.1"
+
+playwright@^1.29.2:
+  version "1.29.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.29.2.tgz#d6a0a3e8e44f023f7956ed19ffa8af915a042769"
+  integrity sha512-hKBYJUtdmYzcjdhYDkP9WGtORwwZBBKAW8+Lz7sr0ZMxtJr04ASXVzH5eBWtDkdb0c3LLFsehfPBTRfvlfKJOA==
+  dependencies:
+    playwright-core "1.29.2"
 
 plugin-error@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### 1. Remix failures

CI is failing on the newest remix version due to usage of the hammer operator: https://github.com/getsentry/sentry-javascript/actions/runs/3881841098/jobs/6621446961#step:6:1011

We assume this is a bug within the new remix release so we pin the version to a previous non-faulty one.

Issue in remix repo: https://github.com/remix-run/remix/issues/5043

### 2. Playwright failures

Updating playwright seems to fix things?