### PR TITLE
fix(otel): Prevent baggage from being overwritten

### DIFF
--- a/packages/opentelemetry-node/src/propagator.ts
+++ b/packages/opentelemetry-node/src/propagator.ts
@@ -1,17 +1,18 @@
 import {
+  Baggage,
   Context,
   isSpanContextValid,
+  propagation,
   TextMapGetter,
-  TextMapPropagator,
   TextMapSetter,
   trace,
   TraceFlags,
 } from '@opentelemetry/api';
-import { isTracingSuppressed } from '@opentelemetry/core';
+import { isTracingSuppressed, W3CBaggagePropagator } from '@opentelemetry/core';
 import {
   baggageHeaderToDynamicSamplingContext,
-  dynamicSamplingContextToSentryBaggageHeader,
   extractTraceparentData,
+  SENTRY_BAGGAGE_KEY_PREFIX,
 } from '@sentry/utils';
 
 import {
@@ -25,7 +26,7 @@ import { SENTRY_SPAN_PROCESSOR_MAP } from './spanprocessor';
 /**
  * Injects and extracts `sentry-trace` and `baggage` headers from carriers.
  */
-export class SentryPropagator implements TextMapPropagator {
+export class SentryPropagator extends W3CBaggagePropagator {
   /**
    * @inheritDoc
    */
@@ -41,10 +42,18 @@ export class SentryPropagator implements TextMapPropagator {
 
       if (span.transaction) {
         const dynamicSamplingContext = span.transaction.getDynamicSamplingContext();
-        const sentryBaggageHeader = dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
-        if (sentryBaggageHeader) {
-          setter.set(carrier, SENTRY_BAGGAGE_HEADER, sentryBaggageHeader);
-        }
+
+        const baggage = propagation.getBaggage(context) || propagation.createBaggage({});
+        const baggageWithSentryInfo = Object.entries(dynamicSamplingContext).reduce<Baggage>(
+          (b, [dscKey, dscValue]) => {
+            if (dscValue) {
+              return b.setEntry(`${SENTRY_BAGGAGE_KEY_PREFIX}${dscKey}`, { value: dscValue });
+            }
+            return b;
+          },
+          baggage,
+        );
+        super.inject(propagation.setBaggage(context, baggageWithSentryInfo), carrier, setter);
       }
     }
   }

--- a/packages/opentelemetry-node/test/propagator.test.ts
+++ b/packages/opentelemetry-node/test/propagator.test.ts
@@ -1,10 +1,10 @@
 import {
   defaultTextMapGetter,
   defaultTextMapSetter,
+  propagation,
   ROOT_CONTEXT,
   trace,
   TraceFlags,
-  propagation,
 } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
 import { Hub, makeMain } from '@sentry/core';


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry-javascript/issues/6713

We want to make sure that existing baggage is not overwritten when the Sentry Propagator sets the baggage header on the carrier. To do this, we defer to using the `W3CBaggagePropagator` to set the baggage header, and add the Sentry values by setting baggage via [OpenTelemetry's baggage API](https://opentelemetry.io/docs/reference/specification/baggage/api/).