### PR TITLE
ci: Add `fail-fast: false` to playwright tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -505,6 +505,7 @@ jobs:
     if: needs.job_get_metadata.outputs.changed_browser_integration == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         bundle:
           - esm


### PR DESCRIPTION
Only some of the playwright jobs seem to fail in the installation step and if one of them fails they cancel the other ones making it very unlikely that we will ever get CI to pass.

This is not a fix but a workaround until we understand why CI fails so often.