### PR TITLE
fix(remix): Make remix SDK type exports isomorphic

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -15,7 +15,7 @@
   "main": "build/cjs/index.server.js",
   "module": "build/esm/index.server.js",
   "browser": "build/esm/index.client.js",
-  "types": "build/types/index.server.d.ts",
+  "types": "build/types/index.types.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/export */
 
-// We export everything from both the client part of the SDK and from the server part. Some of the exports collide which
-// is not allowed, unless we redifine the colliding exports in this file - which we do below.
+// We export everything from both the client part of the SDK and from the server part. Some of the exports collide,
+// which is not allowed, unless we redifine the colliding exports in this file - which we do below.
 export * from './index.client';
 export * from './index.server';
 

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -1,0 +1,23 @@
+/* eslint-disable import/export */
+
+export * from './index.client';
+export * from './index.server';
+
+import type { Integration, StackParser } from '@sentry/types';
+
+import * as clientSdk from './index.client';
+import * as serverSdk from './index.server';
+import { RemixOptions } from './utils/remixOptions';
+
+export declare function init(options: RemixOptions): void;
+
+export const Integrations = { ...clientSdk.Integrations, ...serverSdk.Integrations };
+
+export declare const defaultIntegrations: Integration[];
+export declare const defaultStackParser: StackParser;
+
+declare const runtime: 'client' | 'server';
+
+export const close = runtime === 'client' ? clientSdk.close : serverSdk.close;
+export const flush = runtime === 'client' ? clientSdk.flush : serverSdk.flush;
+export const lastEventId = runtime === 'client' ? clientSdk.lastEventId : serverSdk.lastEventId;

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -11,6 +11,7 @@ import * as clientSdk from './index.client';
 import * as serverSdk from './index.server';
 import { RemixOptions } from './utils/remixOptions';
 
+/** Initializes Sentry Remix SDK */
 export declare function init(options: RemixOptions): void;
 
 // We export a merged Integrations object so that users can (at least typing-wise) use all integrations everywhere.

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -1,5 +1,7 @@
 /* eslint-disable import/export */
 
+// We export everything from both the client part of the SDK and from the server part. Some of the exports collide which
+// is not allowed, unless we redifine the colliding exports in this file - which we do below.
 export * from './index.client';
 export * from './index.server';
 
@@ -11,11 +13,15 @@ import { RemixOptions } from './utils/remixOptions';
 
 export declare function init(options: RemixOptions): void;
 
+// We export a merged Integrations object so that users can (at least typing-wise) use all integrations everywhere.
 export const Integrations = { ...clientSdk.Integrations, ...serverSdk.Integrations };
 
 export declare const defaultIntegrations: Integration[];
 export declare const defaultStackParser: StackParser;
 
+// This variable is not a runtime variable but just a type to tell typescript that the methods below can either come
+// from the client SDK or from the server SDK. TypeScript is smart enough to understand that these resolve to the same
+// methods from `@sentry/core`.
 declare const runtime: 'client' | 'server';
 
 export const close = runtime === 'client' ? clientSdk.close : serverSdk.close;


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/6705

This PR makes the Remix SDK typings isomorphic by creating a type-only entrypoint that exports everything from the client part of the SDK and everything from the server part of the SDK.