### PR TITLE
feat(nextjs): Add optional options argument to `withSentryConfig` as an alternative to the `sentry` property

### DIFF
--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -29,9 +29,7 @@ export function withSentryConfig(
       userNextConfigObject = exportedUserNextConfig;
     }
     // If there are addons from the Wizard, add them to existing config
-    if (sentryWizardAddon) {
-      userNextConfigObject.sentry = { ...userNextConfigObject.sentry, ...sentryWizardAddon };
-    }
+    userNextConfigObject.sentry = { ...userNextConfigObject.sentry, ...sentryWizardAddon };
     return getFinalConfigObject(phase, userNextConfigObject, userSentryWebpackPluginOptions);
   };
 }

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -22,13 +22,13 @@ export function withSentryConfig(
   sentryWizardAddon?: UserSentryOptions,
 ): NextConfigFunction | NextConfigObject {
   return function (phase: string, defaults: { defaultConfig: NextConfigObject }): NextConfigObject {
-    // If there are addons from the Wizard, add them to existing config
     let userNextConfigObject;
     if (typeof exportedUserNextConfig === 'function') {
       userNextConfigObject = exportedUserNextConfig(phase, defaults);
     } else {
       userNextConfigObject = exportedUserNextConfig;
     }
+    // If there are addons from the Wizard, add them to existing config
     if (sentryWizardAddon) {
       userNextConfigObject.sentry = { ...userNextConfigObject.sentry, ...sentryWizardAddon };
     }

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -13,19 +13,20 @@ import type {
  *
  * @param exportedUserNextConfig The existing config to be exported prior to adding Sentry
  * @param userSentryWebpackPluginOptions Configuration for SentryWebpackPlugin
- * @param sentryWizardAddon Addons from automatic config.next.js merging from Sentry Wizard
+ * @param sentryOptions Optional additional options to add as alternative to `sentry` property of config
  * @returns The modified config to be exported
  */
 export function withSentryConfig(
   exportedUserNextConfig: ExportedNextConfig = {},
   userSentryWebpackPluginOptions: Partial<SentryWebpackPluginOptions> = {},
-  sentryWizardAddon?: UserSentryOptions,
+  sentryOptions?: UserSentryOptions,
 ): NextConfigFunction | NextConfigObject {
   return function (phase: string, defaults: { defaultConfig: NextConfigObject }): NextConfigObject {
     const userNextConfigObject =
       typeof exportedUserNextConfig === 'function' ? exportedUserNextConfig(phase, defaults) : exportedUserNextConfig;
-    // If there are addons from the Wizard, add them to existing config
-    userNextConfigObject.sentry = { ...userNextConfigObject.sentry, ...sentryWizardAddon };
+    // Inserts additional `sentry` options into the existing config, allows for backwards compatability
+    // in case nothing is passed into the optional `sentryOptions` argument
+    userNextConfigObject.sentry = { ...userNextConfigObject.sentry, ...sentryOptions };
     return getFinalConfigObject(phase, userNextConfigObject, userSentryWebpackPluginOptions);
   };
 }

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -23,27 +23,16 @@ export function withSentryConfig(
 ): NextConfigFunction | NextConfigObject {
   return function (phase: string, defaults: { defaultConfig: NextConfigObject }): NextConfigObject {
     // If there are addons from the Wizard, add them to existing config
-    if (sentryWizardAddon) {
-      let userNextConfigObject;
-      if (typeof exportedUserNextConfig === 'function') {
-        userNextConfigObject = exportedUserNextConfig(phase, defaults);
-      } else {
-        userNextConfigObject = exportedUserNextConfig;
-      }
-      if (userNextConfigObject.sentry) {
-        userNextConfigObject.sentry = { ...userNextConfigObject.sentry, ...sentryWizardAddon };
-      } else {
-        userNextConfigObject.sentry = sentryWizardAddon;
-      }
-      return getFinalConfigObject(phase, userNextConfigObject, userSentryWebpackPluginOptions);
+    let userNextConfigObject;
+    if (typeof exportedUserNextConfig === 'function') {
+      userNextConfigObject = exportedUserNextConfig(phase, defaults);
     } else {
-      if (typeof exportedUserNextConfig === 'function') {
-        const userNextConfigObject = exportedUserNextConfig(phase, defaults);
-        return getFinalConfigObject(phase, userNextConfigObject, userSentryWebpackPluginOptions);
-      } else {
-        return getFinalConfigObject(phase, exportedUserNextConfig, userSentryWebpackPluginOptions);
-      }
+      userNextConfigObject = exportedUserNextConfig;
     }
+    if (sentryWizardAddon) {
+      userNextConfigObject.sentry = { ...userNextConfigObject.sentry, ...sentryWizardAddon };
+    }
+    return getFinalConfigObject(phase, userNextConfigObject, userSentryWebpackPluginOptions);
   };
 }
 

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -22,12 +22,8 @@ export function withSentryConfig(
   sentryWizardAddon?: UserSentryOptions,
 ): NextConfigFunction | NextConfigObject {
   return function (phase: string, defaults: { defaultConfig: NextConfigObject }): NextConfigObject {
-    let userNextConfigObject;
-    if (typeof exportedUserNextConfig === 'function') {
-      userNextConfigObject = exportedUserNextConfig(phase, defaults);
-    } else {
-      userNextConfigObject = exportedUserNextConfig;
-    }
+    const userNextConfigObject =
+      typeof exportedUserNextConfig === 'function' ? exportedUserNextConfig(phase, defaults) : exportedUserNextConfig;
     // If there are addons from the Wizard, add them to existing config
     userNextConfigObject.sentry = { ...userNextConfigObject.sentry, ...sentryWizardAddon };
     return getFinalConfigObject(phase, userNextConfigObject, userSentryWebpackPluginOptions);


### PR DESCRIPTION
This pr adds a new optional argument for withSentryConfig that allows for easier merging of the next.config.js files in the Sentry Wizard. Now, the Wizard will call withSentryConfig with the 3rd argument which adds in the Sentry options we want to add to the config. This allows for easier merging of the config files, as 2 lines can be added to the existing next.config.js for it to work (https://github.com/getsentry/sentry-wizard/pull/222) 
