### PR TITLE
fix(otel): Set trace context via Otel Span instead of Sentry span

### DIFF
--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -744,7 +744,6 @@ describe('SentrySpanProcessor', () => {
     expect(sentryEvent).toBeDefined();
     expect(sentryEvent.exception).toBeDefined();
     expect(sentryEvent.contexts.trace).toEqual({
-      description: otelSpan.name,
       parent_span_id: otelSpan.parentSpanId,
       span_id: otelSpan.spanContext().spanId,
       trace_id: otelSpan.spanContext().traceId,


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry-javascript/issues/6713

Since the `SENTRY_SPAN_PROCESSOR_MAP` can be empty due to the transaction/span already finishing after the event processor was triggered (due to async event processors), we instead rely only on the OpenTelemetry context to determine the active span.

The product uses `trace_id` and `span_id` to associate errors to transactions, so that's what we've kept. 