### PR TITLE
build: Improve nx caching strategy

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -6,11 +6,23 @@
         "cacheableOperations": [
           "build:bundle",
           "build:transpile",
-          "build:tarball",
           "build:types"
         ]
       }
     }
+  },
+  "namedInputs": {
+    "sharedGlobals": [
+      "{workspaceRoot}/*.js",
+      "{workspaceRoot}/*.json",
+      "{workspaceRoot}/yarn.lock"
+    ],
+    "default": [
+      "{projectRoot}/**/*",
+      "sharedGlobals",
+      "!{projectRoot}/test/**/*",
+      "!{projectRoot}/**/*.md"
+    ]
   },
   "targetDefaults": {
     "build:bundle": {
@@ -58,7 +70,12 @@
   "targets": {
     "@sentry/serverless": {
       "build:bundle": {
-        "dependsOn": [],
+        "dependsOn": [
+          "^build:transpile",
+          "build:transpile",
+          "^build:types",
+          "build:types"
+        ],
         "outputs": [
           "{projectRoot}/build/aws"
         ]


### PR DESCRIPTION
1. `build:tarball` is actually not cacheable
2. Make sure that we do not mark a package as needing to rebuild when tests change
3. Add missing dependencies for serverless build

Note that we are still very defensive and will rebuild quite often. E.g. when you change a file in replay/src, it will not cache replay, browser, and anything that depends on browser. but IMHO it is better to be too defensive, so that's OK.

Reference: https://nx.dev/more-concepts/customizing-inputs
