### PR TITLE
ref(replay): Pause recording when replay requests are rate-limited

### DIFF
--- a/packages/integration-tests/suites/replay/captureReplay/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplay/test.ts
@@ -23,7 +23,7 @@ sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
   await page.goto(url);
 
   await page.click('button');
-  await page.waitForTimeout(200);
+  await page.waitForTimeout(300);
 
   const replayEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -1108,7 +1108,6 @@ export class ReplayContainer implements ReplayContainerInterface {
       setTimeout(() => {
         __DEBUG_BUILD__ && logger.info('[Replay]', 'Resuming replay after rate limit');
         this.resume();
-        this._debouncedFlush();
       }, rateLimitDuration);
     }
   }

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -275,6 +275,10 @@ export class ReplayContainer implements ReplayContainerInterface {
    * not as thorough of a shutdown as `stop()`.
    */
   public pause(): void {
+    console.log('I was called');
+
+    console.trace();
+
     this._isPaused = true;
     try {
       if (this._stopRecording) {
@@ -1093,6 +1097,12 @@ export class ReplayContainer implements ReplayContainerInterface {
    * Pauses the replay and resumes it after the rate-limit duration is over.
    */
   private _handleRateLimit(): void {
+    // in case recording is already paused, we don't need to do anything, as we might have already paused because of a
+    // rate limit
+    if (this.isPaused()) {
+      return;
+    }
+
     const rateLimitEnd = disabledUntil(this._rateLimits, 'replay');
     const rateLimitDuration = rateLimitEnd - Date.now();
 

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -1004,7 +1004,7 @@ export class ReplayContainer implements ReplayContainerInterface {
       // TODO (v8): we can remove this guard once transport.end's type signature doesn't include void anymore
       if (response) {
         this._rateLimits = updateRateLimits(this._rateLimits, response);
-        if (isRateLimited(this._rateLimits, 'replay_event') || isRateLimited(this._rateLimits, 'replay_recording')) {
+        if (isRateLimited(this._rateLimits, 'replay')) {
           this._handleRateLimit();
         }
       }
@@ -1093,11 +1093,7 @@ export class ReplayContainer implements ReplayContainerInterface {
    * Pauses the replay and resumes it after the rate-limit duration is over.
    */
   private _handleRateLimit(): void {
-    const rateLimitEnd = Math.max(
-      disabledUntil(this._rateLimits, 'replay_event'),
-      disabledUntil(this._rateLimits, 'replay_recording'),
-    );
-
+    const rateLimitEnd = disabledUntil(this._rateLimits, 'replay');
     const rateLimitDuration = rateLimitEnd - Date.now();
 
     if (rateLimitDuration > 0) {

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -1,14 +1,8 @@
 /* eslint-disable max-lines */ // TODO: We might want to split this file up
 import { addGlobalEventProcessor, captureException, getCurrentHub, setContext } from '@sentry/core';
 import type { Breadcrumb, ReplayEvent, ReplayRecordingMode, TransportMakeRequestResponse } from '@sentry/types';
-import {
-  addInstrumentationHandler,
-  disabledUntil,
-  isRateLimited,
-  logger,
-  RateLimits,
-  updateRateLimits,
-} from '@sentry/utils';
+import type { RateLimits } from '@sentry/utils';
+import { addInstrumentationHandler, disabledUntil, isRateLimited, logger, updateRateLimits } from '@sentry/utils';
 import { EventType, record } from 'rrweb';
 
 import {
@@ -275,10 +269,6 @@ export class ReplayContainer implements ReplayContainerInterface {
    * not as thorough of a shutdown as `stop()`.
    */
   public pause(): void {
-    console.log('I was called');
-
-    console.trace();
-
     this._isPaused = true;
     try {
       if (this._stopRecording) {

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -1001,7 +1001,7 @@ export class ReplayContainer implements ReplayContainerInterface {
 
     try {
       const response = await transport.send(envelope);
-      // TODO (v8): we can remove this guard once transport.end's type signature doesn't include void anymore
+      // TODO (v8): we can remove this guard once transport.send's type signature doesn't include void anymore
       if (response) {
         this._rateLimits = updateRateLimits(this._rateLimits, response);
         if (isRateLimited(this._rateLimits, 'replay')) {

--- a/packages/replay/test/integration/rateLimiting.test.ts
+++ b/packages/replay/test/integration/rateLimiting.test.ts
@@ -50,6 +50,8 @@ describe('Integration | rate-limiting behaviour', () => {
     replay.loadSession({ expiry: 0 });
 
     mockSendReplayRequest.mockClear();
+
+    replay['_rateLimits'] = {};
   });
 
   afterEach(async () => {
@@ -171,4 +173,87 @@ describe('Integration | rate-limiting behaviour', () => {
       expect(replay.eventBuffer?.length).toBe(0);
     },
   );
+
+  it('handles rate-limits from a plain 429 response without any retry time', async () => {
+    expect(replay.session?.segmentId).toBe(0);
+    jest.spyOn(replay, 'sendReplay');
+    jest.spyOn(replay, 'pause');
+    jest.spyOn(replay, 'resume');
+    // @ts-ignore private API
+    jest.spyOn(replay, '_handleRateLimit');
+
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 2 };
+
+    mockTransportSend.mockImplementationOnce(() => {
+      return Promise.resolve({ statusCode: 429 });
+    });
+
+    mockRecord._emitter(TEST_EVENT);
+
+    // T = base + 5
+    await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
+
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+    expect(mockTransportSend).toHaveBeenCalledTimes(1);
+    expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT]) });
+
+    expect(replay['_handleRateLimit']).toHaveBeenCalledTimes(1);
+    // resume() was called once before we even started
+    expect(replay.resume).not.toHaveBeenCalled();
+    expect(replay.pause).toHaveBeenCalledTimes(1);
+
+    // No user activity to trigger an update
+    expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP);
+    expect(replay.session?.segmentId).toBe(1);
+
+    // let's simulate the rate-limit time of inactivity (60secs) and check that we don't do anything in the meantime
+    // 60secs are the default we fall back to in the plain 429 case in updateRateLimits()
+    const TEST_EVENT2 = { data: {}, timestamp: BASE_TIMESTAMP + DEFAULT_FLUSH_MIN_DELAY, type: 3 };
+    for (let i = 0; i < 11; i++) {
+      const ev = {
+        ...TEST_EVENT2,
+        timestamp: BASE_TIMESTAMP + DEFAULT_FLUSH_MIN_DELAY * (i + 1),
+      };
+      mockRecord._emitter(ev);
+      await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
+      expect(replay.isPaused()).toBe(true);
+      expect(replay.sendReplay).toHaveBeenCalledTimes(1);
+      expect(mockTransportSend).toHaveBeenCalledTimes(1);
+    }
+
+    // T = base + 60
+    await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
+
+    // now, recording should resume and first, we expect a checkout event to be sent, as resume()
+    // should trigger a full snapshot
+    expect(replay.resume).toHaveBeenCalledTimes(1);
+    expect(replay.isPaused()).toBe(false);
+
+    expect(replay.sendReplay).toHaveBeenCalledTimes(2);
+    expect(replay).toHaveLastSentReplay({
+      events: '[{"data":{"isCheckout":true},"timestamp":1580598065000,"type":2}]',
+    });
+
+    // and let's also emit a new event and check that it is recorded
+    const TEST_EVENT3 = {
+      data: {},
+      timestamp: BASE_TIMESTAMP + 7 * DEFAULT_FLUSH_MIN_DELAY,
+      type: 3,
+    };
+    mockRecord._emitter(TEST_EVENT3);
+
+    // T = base + 65
+    await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
+    expect(replay.sendReplay).toHaveBeenCalledTimes(3);
+    expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT3]) });
+
+    // nothing should happen afterwards
+    // T = base + 85
+    await advanceTimers(20_000);
+    expect(replay.sendReplay).toHaveBeenCalledTimes(3);
+    expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT3]) });
+
+    // events array should be empty
+    expect(replay.eventBuffer?.length).toBe(0);
+  });
 });

--- a/packages/replay/test/integration/rateLimiting.test.ts
+++ b/packages/replay/test/integration/rateLimiting.test.ts
@@ -1,0 +1,154 @@
+import { Transport, TransportMakeRequestResponse } from '@sentry/types';
+import { ReplayContainer } from '../../src/replay';
+import { BASE_TIMESTAMP, mockSdk } from '../index';
+import { mockRrweb } from '../mocks/mockRrweb';
+import { useFakeTimers } from '../utils/use-fake-timers';
+import { getCurrentHub } from '@sentry/core';
+import { clearSession } from '../utils/clearSession';
+import { DEFAULT_FLUSH_MIN_DELAY, SESSION_IDLE_DURATION } from '../../src/constants';
+
+useFakeTimers();
+
+async function advanceTimers(time: number) {
+  jest.advanceTimersByTime(time);
+  await new Promise(process.nextTick);
+}
+
+type MockTransportSend = jest.MockedFunction<Transport['send']>;
+type MockSendReplayRequest = jest.MockedFunction<ReplayContainer['sendReplayRequest']>;
+
+describe('Integration | rate-limiting behaviour', () => {
+  let replay: ReplayContainer;
+  let mockTransportSend: MockTransportSend;
+  let mockSendReplayRequest: MockSendReplayRequest;
+  const { record: mockRecord } = mockRrweb();
+
+  beforeAll(async () => {
+    jest.setSystemTime(new Date(BASE_TIMESTAMP));
+
+    ({ replay } = await mockSdk({
+      replayOptions: {
+        stickySession: false,
+      },
+    }));
+
+    jest.spyOn(replay, 'sendReplayRequest');
+
+    jest.runAllTimers();
+    mockTransportSend = getCurrentHub()?.getClient()?.getTransport()?.send as MockTransportSend;
+    mockSendReplayRequest = replay.sendReplayRequest as MockSendReplayRequest;
+  });
+
+  beforeEach(() => {
+    jest.setSystemTime(new Date(BASE_TIMESTAMP));
+    mockRecord.takeFullSnapshot.mockClear();
+    mockTransportSend.mockClear();
+
+    // Create a new session and clear mocks because a segment (from initial
+    // checkout) will have already been uploaded by the time the tests run
+    clearSession(replay);
+    replay.loadSession({ expiry: 0 });
+
+    mockSendReplayRequest.mockClear();
+  });
+
+  afterEach(async () => {
+    jest.runAllTimers();
+    await new Promise(process.nextTick);
+    jest.setSystemTime(new Date(BASE_TIMESTAMP));
+    clearSession(replay);
+    replay.loadSession({ expiry: SESSION_IDLE_DURATION });
+  });
+
+  afterAll(() => {
+    replay && replay.stop();
+  });
+
+  it('pauses recording and flushing a rate limit is hit and resumes both after the rate limit duration is over', async () => {
+    expect(replay.session?.segmentId).toBe(0);
+    jest.spyOn(replay, 'sendReplay');
+    jest.spyOn(replay, 'pause');
+    jest.spyOn(replay, 'resume');
+    // @ts-ignore private API
+    jest.spyOn(replay, '_handleRateLimit');
+
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 2 };
+
+    mockTransportSend.mockImplementationOnce(() => {
+      return Promise.resolve({
+        statusCode: 429,
+        headers: {
+          'x-sentry-rate-limits': null,
+          'retry-after': `30`,
+        },
+      } as TransportMakeRequestResponse);
+    });
+
+    mockRecord._emitter(TEST_EVENT);
+
+    // T = base + 5
+    await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
+
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+    expect(mockTransportSend).toHaveBeenCalledTimes(1);
+    expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT]) });
+
+    expect(replay['_handleRateLimit']).toHaveBeenCalledTimes(1);
+    // resume() was called once before we even started
+    expect(replay.resume).not.toHaveBeenCalled();
+    expect(replay.pause).toHaveBeenCalledTimes(1);
+
+    // No user activity to trigger an update
+    expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP);
+    expect(replay.session?.segmentId).toBe(1);
+
+    // let's simulate the rate-limit time of inactivity (30secs) and check that we don't do anything in the meantime
+    const TEST_EVENT2 = { data: {}, timestamp: BASE_TIMESTAMP + DEFAULT_FLUSH_MIN_DELAY, type: 3 };
+    for (let i = 0; i < 5; i++) {
+      const ev = {
+        ...TEST_EVENT2,
+        timestamp: BASE_TIMESTAMP + DEFAULT_FLUSH_MIN_DELAY * (i + 1),
+      };
+      mockRecord._emitter(ev);
+      await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
+      expect(replay.isPaused()).toBe(true);
+      expect(replay.sendReplay).toHaveBeenCalledTimes(1);
+      expect(mockTransportSend).toHaveBeenCalledTimes(1);
+    }
+
+    // T = base + 35
+    await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
+
+    // now, recording should resume and first, we expect a checkout event to be sent, as resume()
+    // should trigger a full snapshot
+    expect(replay.resume).toHaveBeenCalledTimes(1);
+    expect(replay.isPaused()).toBe(false);
+
+    expect(replay.sendReplay).toHaveBeenCalledTimes(2);
+    expect(replay).toHaveLastSentReplay({
+      events: '[{"data":{"isCheckout":true},"timestamp":1580598035000,"type":2}]',
+    });
+
+    // and let's also emit a new event and check that it is recorded
+    const TEST_EVENT3 = {
+      data: {},
+      timestamp: BASE_TIMESTAMP + 7 * DEFAULT_FLUSH_MIN_DELAY,
+      type: 3,
+    };
+    mockRecord._emitter(TEST_EVENT3);
+
+    // T = base + 40
+    await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
+    expect(replay.sendReplay).toHaveBeenCalledTimes(3);
+    expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT3]) });
+
+    // nothing should happen afterwards
+    // T = base + 60
+    await advanceTimers(20_000);
+    expect(replay.sendReplay).toHaveBeenCalledTimes(3);
+    expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT3]) });
+
+    // events array should be empty
+    expect(replay.eventBuffer?.length).toBe(0);
+  });
+});

--- a/packages/replay/test/integration/rateLimiting.test.ts
+++ b/packages/replay/test/integration/rateLimiting.test.ts
@@ -150,7 +150,9 @@ describe('Integration | rate-limiting behaviour', () => {
 
       expect(replay['_sendReplay']).toHaveBeenCalledTimes(2);
       expect(replay).toHaveLastSentReplay({
-        events: '[{"data":{"isCheckout":true},"timestamp":1580598035000,"type":2}]',
+        events: JSON.stringify([
+          { data: { isCheckout: true }, timestamp: BASE_TIMESTAMP + DEFAULT_FLUSH_MIN_DELAY * 7, type: 2 },
+        ]),
       });
 
       // and let's also emit a new event and check that it is recorded
@@ -235,7 +237,9 @@ describe('Integration | rate-limiting behaviour', () => {
 
     expect(replay['_sendReplay']).toHaveBeenCalledTimes(2);
     expect(replay).toHaveLastSentReplay({
-      events: '[{"data":{"isCheckout":true},"timestamp":1580598065000,"type":2}]',
+      events: JSON.stringify([
+        { data: { isCheckout: true }, timestamp: BASE_TIMESTAMP + DEFAULT_FLUSH_MIN_DELAY * 13, type: 2 },
+      ]),
     });
 
     // and let's also emit a new event and check that it is recorded

--- a/packages/replay/test/integration/rateLimiting.test.ts
+++ b/packages/replay/test/integration/rateLimiting.test.ts
@@ -57,6 +57,7 @@ describe('Integration | rate-limiting behaviour', () => {
     await new Promise(process.nextTick);
     jest.setSystemTime(new Date(BASE_TIMESTAMP));
     clearSession(replay);
+    jest.clearAllMocks();
     replay.loadSession({ expiry: SESSION_IDLE_DURATION });
   });
 
@@ -64,91 +65,117 @@ describe('Integration | rate-limiting behaviour', () => {
     replay && replay.stop();
   });
 
-  it('pauses recording and flushing a rate limit is hit and resumes both after the rate limit duration is over', async () => {
-    expect(replay.session?.segmentId).toBe(0);
-    jest.spyOn(replay, 'sendReplay');
-    jest.spyOn(replay, 'pause');
-    jest.spyOn(replay, 'resume');
-    // @ts-ignore private API
-    jest.spyOn(replay, '_handleRateLimit');
+  it.each([
+    {
+      statusCode: 429,
+      headers: {
+        'x-sentry-rate-limits': '30',
+        'retry-after': null,
+      },
+    },
+    {
+      statusCode: 429,
+      headers: {
+        'x-sentry-rate-limits': '30:replay_event',
+        'retry-after': null,
+      },
+    },
+    {
+      statusCode: 429,
+      headers: {
+        'x-sentry-rate-limits': '30:replay_recording',
+        'retry-after': null,
+      },
+    },
+    {
+      statusCode: 429,
+      headers: {
+        'x-sentry-rate-limits': null,
+        'retry-after': '30',
+      },
+    },
+  ] as TransportMakeRequestResponse[])(
+    'pauses recording and flushing a rate limit is hit and resumes both after the rate limit duration is over',
+    async rateLimitResponse => {
+      expect(replay.session?.segmentId).toBe(0);
+      jest.spyOn(replay, 'sendReplay');
+      jest.spyOn(replay, 'pause');
+      jest.spyOn(replay, 'resume');
+      // @ts-ignore private API
+      jest.spyOn(replay, '_handleRateLimit');
 
-    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 2 };
+      const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 2 };
 
-    mockTransportSend.mockImplementationOnce(() => {
-      return Promise.resolve({
-        statusCode: 429,
-        headers: {
-          'x-sentry-rate-limits': null,
-          'retry-after': `30`,
-        },
-      } as TransportMakeRequestResponse);
-    });
+      mockTransportSend.mockImplementationOnce(() => {
+        return Promise.resolve(rateLimitResponse);
+      });
 
-    mockRecord._emitter(TEST_EVENT);
+      mockRecord._emitter(TEST_EVENT);
 
-    // T = base + 5
-    await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
-
-    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
-    expect(mockTransportSend).toHaveBeenCalledTimes(1);
-    expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT]) });
-
-    expect(replay['_handleRateLimit']).toHaveBeenCalledTimes(1);
-    // resume() was called once before we even started
-    expect(replay.resume).not.toHaveBeenCalled();
-    expect(replay.pause).toHaveBeenCalledTimes(1);
-
-    // No user activity to trigger an update
-    expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP);
-    expect(replay.session?.segmentId).toBe(1);
-
-    // let's simulate the rate-limit time of inactivity (30secs) and check that we don't do anything in the meantime
-    const TEST_EVENT2 = { data: {}, timestamp: BASE_TIMESTAMP + DEFAULT_FLUSH_MIN_DELAY, type: 3 };
-    for (let i = 0; i < 5; i++) {
-      const ev = {
-        ...TEST_EVENT2,
-        timestamp: BASE_TIMESTAMP + DEFAULT_FLUSH_MIN_DELAY * (i + 1),
-      };
-      mockRecord._emitter(ev);
+      // T = base + 5
       await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
-      expect(replay.isPaused()).toBe(true);
-      expect(replay.sendReplay).toHaveBeenCalledTimes(1);
+
+      expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
       expect(mockTransportSend).toHaveBeenCalledTimes(1);
-    }
+      expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT]) });
 
-    // T = base + 35
-    await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
+      expect(replay['_handleRateLimit']).toHaveBeenCalledTimes(1);
+      // resume() was called once before we even started
+      expect(replay.resume).not.toHaveBeenCalled();
+      expect(replay.pause).toHaveBeenCalledTimes(1);
 
-    // now, recording should resume and first, we expect a checkout event to be sent, as resume()
-    // should trigger a full snapshot
-    expect(replay.resume).toHaveBeenCalledTimes(1);
-    expect(replay.isPaused()).toBe(false);
+      // No user activity to trigger an update
+      expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP);
+      expect(replay.session?.segmentId).toBe(1);
 
-    expect(replay.sendReplay).toHaveBeenCalledTimes(2);
-    expect(replay).toHaveLastSentReplay({
-      events: '[{"data":{"isCheckout":true},"timestamp":1580598035000,"type":2}]',
-    });
+      // let's simulate the rate-limit time of inactivity (30secs) and check that we don't do anything in the meantime
+      const TEST_EVENT2 = { data: {}, timestamp: BASE_TIMESTAMP + DEFAULT_FLUSH_MIN_DELAY, type: 3 };
+      for (let i = 0; i < 5; i++) {
+        const ev = {
+          ...TEST_EVENT2,
+          timestamp: BASE_TIMESTAMP + DEFAULT_FLUSH_MIN_DELAY * (i + 1),
+        };
+        mockRecord._emitter(ev);
+        await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
+        expect(replay.isPaused()).toBe(true);
+        expect(replay.sendReplay).toHaveBeenCalledTimes(1);
+        expect(mockTransportSend).toHaveBeenCalledTimes(1);
+      }
 
-    // and let's also emit a new event and check that it is recorded
-    const TEST_EVENT3 = {
-      data: {},
-      timestamp: BASE_TIMESTAMP + 7 * DEFAULT_FLUSH_MIN_DELAY,
-      type: 3,
-    };
-    mockRecord._emitter(TEST_EVENT3);
+      // T = base + 35
+      await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
 
-    // T = base + 40
-    await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
-    expect(replay.sendReplay).toHaveBeenCalledTimes(3);
-    expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT3]) });
+      // now, recording should resume and first, we expect a checkout event to be sent, as resume()
+      // should trigger a full snapshot
+      expect(replay.resume).toHaveBeenCalledTimes(1);
+      expect(replay.isPaused()).toBe(false);
 
-    // nothing should happen afterwards
-    // T = base + 60
-    await advanceTimers(20_000);
-    expect(replay.sendReplay).toHaveBeenCalledTimes(3);
-    expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT3]) });
+      expect(replay.sendReplay).toHaveBeenCalledTimes(2);
+      expect(replay).toHaveLastSentReplay({
+        events: '[{"data":{"isCheckout":true},"timestamp":1580598035000,"type":2}]',
+      });
 
-    // events array should be empty
-    expect(replay.eventBuffer?.length).toBe(0);
-  });
+      // and let's also emit a new event and check that it is recorded
+      const TEST_EVENT3 = {
+        data: {},
+        timestamp: BASE_TIMESTAMP + 7 * DEFAULT_FLUSH_MIN_DELAY,
+        type: 3,
+      };
+      mockRecord._emitter(TEST_EVENT3);
+
+      // T = base + 40
+      await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
+      expect(replay.sendReplay).toHaveBeenCalledTimes(3);
+      expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT3]) });
+
+      // nothing should happen afterwards
+      // T = base + 60
+      await advanceTimers(20_000);
+      expect(replay.sendReplay).toHaveBeenCalledTimes(3);
+      expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT3]) });
+
+      // events array should be empty
+      expect(replay.eventBuffer?.length).toBe(0);
+    },
+  );
 });

--- a/packages/replay/test/integration/rateLimiting.test.ts
+++ b/packages/replay/test/integration/rateLimiting.test.ts
@@ -1,11 +1,12 @@
-import { Transport, TransportMakeRequestResponse } from '@sentry/types';
-import { ReplayContainer } from '../../src/replay';
+import { getCurrentHub } from '@sentry/core';
+import type { Transport, TransportMakeRequestResponse } from '@sentry/types';
+
+import { DEFAULT_FLUSH_MIN_DELAY, SESSION_IDLE_DURATION } from '../../src/constants';
+import type { ReplayContainer } from '../../src/replay';
 import { BASE_TIMESTAMP, mockSdk } from '../index';
 import { mockRrweb } from '../mocks/mockRrweb';
-import { useFakeTimers } from '../utils/use-fake-timers';
-import { getCurrentHub } from '@sentry/core';
 import { clearSession } from '../utils/clearSession';
-import { DEFAULT_FLUSH_MIN_DELAY, SESSION_IDLE_DURATION } from '../../src/constants';
+import { useFakeTimers } from '../utils/use-fake-timers';
 
 useFakeTimers();
 

--- a/packages/replay/test/integration/rateLimiting.test.ts
+++ b/packages/replay/test/integration/rateLimiting.test.ts
@@ -76,14 +76,7 @@ describe('Integration | rate-limiting behaviour', () => {
     {
       statusCode: 429,
       headers: {
-        'x-sentry-rate-limits': '30:replay_event',
-        'retry-after': null,
-      },
-    },
-    {
-      statusCode: 429,
-      headers: {
-        'x-sentry-rate-limits': '30:replay_recording',
+        'x-sentry-rate-limits': '30:replay',
         'retry-after': null,
       },
     },


### PR DESCRIPTION
Following up on #6710, this PR addresses option B and adds the following rate-limiting strategy to the Replay integration:

If we receive a rate limit response from the server after sending a replay event, we pause recording and flushing for the received rate limit period. After this period, we resume recording the same session, which triggers a full snapshot and hence should give us working replays. This should reduce segment-loss due to rate limiting, as we previously ignored handling rate limits specifically for replay (other than the transport's internal rate-limiting). 

I added a test to verify this behaviour but couldn't test it easily with a test app. Happy to take suggestions how to test this better. Otherwise, I think this should be good to go. 

ref #6710 
ref #6533   