### PR TITLE
ref(replay): Extract `sendReplay` functionality into functions

### DIFF
--- a/packages/replay/jest.setup.ts
+++ b/packages/replay/jest.setup.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { getCurrentHub } from '@sentry/core';
-import type { ReplayRecordingData,Transport } from '@sentry/types';
+import type { ReplayRecordingData, Transport } from '@sentry/types';
 
 import type { ReplayContainer, Session } from './src/types';
 
@@ -34,7 +34,7 @@ type SentReplayExpected = {
   replayEventPayload?: ReplayEventPayload;
   recordingHeader?: RecordingHeader;
   recordingPayloadHeader?: RecordingPayloadHeader;
-  events?: ReplayRecordingData;
+  recordingData?: ReplayRecordingData;
 };
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -79,7 +79,7 @@ function checkCallForSentReplay(
   const [[replayEventHeader, replayEventPayload], [recordingHeader, recordingPayload] = []] = envelopeItems;
 
   // @ts-ignore recordingPayload is always a string in our tests
-  const [recordingPayloadHeader, events] = recordingPayload?.split('\n') || [];
+  const [recordingPayloadHeader, recordingData] = recordingPayload?.split('\n') || [];
 
   const actualObj: Required<SentReplayExpected> = {
     // @ts-ignore Custom envelope
@@ -91,7 +91,7 @@ function checkCallForSentReplay(
     // @ts-ignore Custom envelope
     recordingHeader: recordingHeader,
     recordingPayloadHeader: recordingPayloadHeader && JSON.parse(recordingPayloadHeader),
-    events,
+    recordingData,
   };
 
   const isObjectContaining = expected && 'sample' in expected && 'inverse' in expected;

--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -33,3 +33,6 @@ export const MASK_ALL_TEXT_SELECTOR = 'body *:not(style), body *:not(script)';
 export const DEFAULT_FLUSH_MIN_DELAY = 5_000;
 export const DEFAULT_FLUSH_MAX_DELAY = 15_000;
 export const INITIAL_FLUSH_DELAY = 5_000;
+
+export const RETRY_BASE_INTERVAL = 5000;
+export const RETRY_MAX_COUNT = 3;

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -818,7 +818,7 @@ export class ReplayContainer implements ReplayContainerInterface {
 
       await sendReplay({
         replayId,
-        events: recordingData,
+        recordingData,
         segmentId,
         includeReplayStartTimestamp: segmentId === 0,
         eventContext,

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -824,6 +824,7 @@ export class ReplayContainer implements ReplayContainerInterface {
         eventContext,
         session: this.session,
         options: this.getOptions(),
+        timestamp: new Date().getTime(),
       });
     } catch (err) {
       this._handleException(err);

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -16,6 +16,8 @@ export interface SendReplay {
   includeReplayStartTimestamp: boolean;
   eventContext: PopEventContext;
   timestamp?: number;
+  session: Session;
+  options: ReplayPluginOptions;
 }
 
 export type InstrumentationTypeBreadcrumb = 'dom' | 'scope';

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -15,7 +15,7 @@ export interface SendReplay {
   segmentId: number;
   includeReplayStartTimestamp: boolean;
   eventContext: PopEventContext;
-  timestamp?: number;
+  timestamp: number;
   session: Session;
   options: ReplayPluginOptions;
 }

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -9,7 +9,7 @@ export type RecordedEvents = Uint8Array | string;
 
 export type AllPerformanceEntry = PerformancePaintTiming | PerformanceResourceTiming | PerformanceNavigationTiming;
 
-export interface SendReplay {
+export interface SendReplayData {
   events: RecordedEvents;
   replayId: string;
   segmentId: number;

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -5,12 +5,10 @@ import type { eventWithTime, recordOptions } from './types/rrweb';
 export type RecordingEvent = eventWithTime;
 export type RecordingOptions = recordOptions;
 
-export type RecordedEvents = Uint8Array | string;
-
 export type AllPerformanceEntry = PerformancePaintTiming | PerformanceResourceTiming | PerformanceNavigationTiming;
 
 export interface SendReplayData {
-  events: RecordedEvents;
+  recordingData: ReplayRecordingData;
   replayId: string;
   segmentId: number;
   includeReplayStartTimestamp: boolean;

--- a/packages/replay/src/util/prepareRecordingData.ts
+++ b/packages/replay/src/util/prepareRecordingData.ts
@@ -1,15 +1,13 @@
 import type { ReplayRecordingData } from '@sentry/types';
 
-import type { RecordedEvents } from '../types';
-
 /**
- * Create the recording data ready to be sent.
+ * Prepare the recording data ready to be sent.
  */
-export function createRecordingData({
-  events,
+export function prepareRecordingData({
+  recordingData,
   headers,
 }: {
-  events: RecordedEvents;
+  recordingData: ReplayRecordingData;
   headers: Record<string, unknown>;
 }): ReplayRecordingData {
   let payloadWithSequence;
@@ -18,16 +16,16 @@ export function createRecordingData({
   const replayHeaders = `${JSON.stringify(headers)}
 `;
 
-  if (typeof events === 'string') {
-    payloadWithSequence = `${replayHeaders}${events}`;
+  if (typeof recordingData === 'string') {
+    payloadWithSequence = `${replayHeaders}${recordingData}`;
   } else {
     const enc = new TextEncoder();
     // XXX: newline is needed to separate sequence id from events
     const sequence = enc.encode(replayHeaders);
     // Merge the two Uint8Arrays
-    payloadWithSequence = new Uint8Array(sequence.length + events.length);
+    payloadWithSequence = new Uint8Array(sequence.length + recordingData.length);
     payloadWithSequence.set(sequence);
-    payloadWithSequence.set(events, sequence.length);
+    payloadWithSequence.set(recordingData, sequence.length);
   }
 
   return payloadWithSequence;

--- a/packages/replay/src/util/sendReplay.ts
+++ b/packages/replay/src/util/sendReplay.ts
@@ -1,0 +1,74 @@
+import { captureException, setContext } from '@sentry/core';
+
+import { RETRY_BASE_INTERVAL, RETRY_MAX_COUNT, UNABLE_TO_SEND_REPLAY } from '../constants';
+import type { SendReplay } from '../types';
+import { sendReplayRequest } from './sendReplayRequest';
+
+/**
+ * Finalize and send the current replay event to Sentry
+ */
+export async function sendReplay(
+  { replayId, events, segmentId, includeReplayStartTimestamp, eventContext, session, options }: SendReplay,
+  retryConfig = {
+    count: 0,
+    interval: RETRY_BASE_INTERVAL,
+  },
+): Promise<unknown> {
+  // short circuit if there's no events to upload (this shouldn't happen as _runFlush makes this check)
+  if (!events.length) {
+    return;
+  }
+
+  try {
+    await sendReplayRequest({
+      events,
+      replayId,
+      segmentId,
+      includeReplayStartTimestamp,
+      eventContext,
+      session,
+      options,
+    });
+    return true;
+  } catch (err) {
+    // Capture error for every failed replay
+    setContext('Replays', {
+      _retryCount: retryConfig.count,
+    });
+
+    if (__DEBUG_BUILD__ && options._experiments && options._experiments.captureExceptions) {
+      captureException(err);
+    }
+
+    // If an error happened here, it's likely that uploading the attachment
+    // failed, we'll can retry with the same events payload
+    if (retryConfig.count >= RETRY_MAX_COUNT) {
+      throw new Error(`${UNABLE_TO_SEND_REPLAY} - max retries exceeded`);
+    }
+
+    // will retry in intervals of 5, 10, 30
+    retryConfig.interval *= ++retryConfig.count;
+
+    return await new Promise((resolve, reject) => {
+      setTimeout(async () => {
+        try {
+          await sendReplay(
+            {
+              replayId,
+              events,
+              segmentId,
+              includeReplayStartTimestamp,
+              eventContext,
+              session,
+              options,
+            },
+            retryConfig,
+          );
+          resolve(true);
+        } catch (err) {
+          reject(err);
+        }
+      }, retryConfig.interval);
+    });
+  }
+}

--- a/packages/replay/src/util/sendReplay.ts
+++ b/packages/replay/src/util/sendReplay.ts
@@ -2,7 +2,7 @@ import { captureException, setContext } from '@sentry/core';
 
 import { RETRY_BASE_INTERVAL, RETRY_MAX_COUNT, UNABLE_TO_SEND_REPLAY } from '../constants';
 import type { SendReplayData } from '../types';
-import { sendReplayRequest } from './sendReplayRequest';
+import { RateLimitError, sendReplayRequest } from './sendReplayRequest';
 
 /**
  * Finalize and send the current replay event to Sentry
@@ -25,6 +25,10 @@ export async function sendReplay(
     await sendReplayRequest(replayData);
     return true;
   } catch (err) {
+    if (err instanceof RateLimitError) {
+      throw err;
+    }
+
     // Capture error for every failed replay
     setContext('Replays', {
       _retryCount: retryConfig.count,

--- a/packages/replay/src/util/sendReplay.ts
+++ b/packages/replay/src/util/sendReplay.ts
@@ -14,10 +14,10 @@ export async function sendReplay(
     interval: RETRY_BASE_INTERVAL,
   },
 ): Promise<unknown> {
-  const { events, options } = replayData;
+  const { recordingData, options } = replayData;
 
   // short circuit if there's no events to upload (this shouldn't happen as _runFlush makes this check)
-  if (!events.length) {
+  if (!recordingData.length) {
     return;
   }
 

--- a/packages/replay/src/util/sendReplay.ts
+++ b/packages/replay/src/util/sendReplay.ts
@@ -1,14 +1,14 @@
 import { captureException, setContext } from '@sentry/core';
 
 import { RETRY_BASE_INTERVAL, RETRY_MAX_COUNT, UNABLE_TO_SEND_REPLAY } from '../constants';
-import type { SendReplay } from '../types';
+import type { SendReplayData } from '../types';
 import { sendReplayRequest } from './sendReplayRequest';
 
 /**
  * Finalize and send the current replay event to Sentry
  */
 export async function sendReplay(
-  replayData: SendReplay,
+  replayData: SendReplayData,
   retryConfig = {
     count: 0,
     interval: RETRY_BASE_INTERVAL,

--- a/packages/replay/src/util/sendReplayRequest.ts
+++ b/packages/replay/src/util/sendReplayRequest.ts
@@ -3,7 +3,7 @@ import type { ReplayEvent, TransportMakeRequestResponse } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import { REPLAY_EVENT_NAME, UNABLE_TO_SEND_REPLAY } from '../constants';
-import type { SendReplay } from '../types';
+import type { SendReplayData } from '../types';
 import { createRecordingData } from './createRecordingData';
 import { createReplayEnvelope } from './createReplayEnvelope';
 import { prepareReplayEvent } from './prepareReplayEvent';
@@ -20,7 +20,7 @@ export async function sendReplayRequest({
   timestamp,
   session,
   options,
-}: SendReplay): Promise<void | TransportMakeRequestResponse> {
+}: SendReplayData): Promise<void | TransportMakeRequestResponse> {
   const recordingData = createRecordingData({
     events,
     headers: {

--- a/packages/replay/src/util/sendReplayRequest.ts
+++ b/packages/replay/src/util/sendReplayRequest.ts
@@ -4,15 +4,15 @@ import { logger } from '@sentry/utils';
 
 import { REPLAY_EVENT_NAME, UNABLE_TO_SEND_REPLAY } from '../constants';
 import type { SendReplayData } from '../types';
-import { createRecordingData } from './createRecordingData';
 import { createReplayEnvelope } from './createReplayEnvelope';
+import { prepareRecordingData } from './prepareRecordingData';
 import { prepareReplayEvent } from './prepareReplayEvent';
 
 /**
  * Send replay attachment using `fetch()`
  */
 export async function sendReplayRequest({
-  events,
+  recordingData,
   replayId,
   segmentId: segment_id,
   includeReplayStartTimestamp,
@@ -21,8 +21,8 @@ export async function sendReplayRequest({
   session,
   options,
 }: SendReplayData): Promise<void | TransportMakeRequestResponse> {
-  const recordingData = createRecordingData({
-    events,
+  const preparedRecordingData = prepareRecordingData({
+    recordingData,
     headers: {
       segment_id,
     },
@@ -104,7 +104,7 @@ export async function sendReplayRequest({
   }
   */
 
-  const envelope = createReplayEnvelope(replayEvent, recordingData, dsn, client.getOptions().tunnel);
+  const envelope = createReplayEnvelope(replayEvent, preparedRecordingData, dsn, client.getOptions().tunnel);
 
   try {
     return await transport.send(envelope);

--- a/packages/replay/src/util/sendReplayRequest.ts
+++ b/packages/replay/src/util/sendReplayRequest.ts
@@ -1,0 +1,114 @@
+import { getCurrentHub } from '@sentry/core';
+import type { ReplayEvent, TransportMakeRequestResponse } from '@sentry/types';
+import { logger } from '@sentry/utils';
+
+import { REPLAY_EVENT_NAME, UNABLE_TO_SEND_REPLAY } from '../constants';
+import type { SendReplay } from '../types';
+import { createRecordingData } from './createRecordingData';
+import { createReplayEnvelope } from './createReplayEnvelope';
+import { prepareReplayEvent } from './prepareReplayEvent';
+
+/**
+ * Send replay attachment using `fetch()`
+ */
+export async function sendReplayRequest({
+  events,
+  replayId,
+  segmentId: segment_id,
+  includeReplayStartTimestamp,
+  eventContext,
+  timestamp = new Date().getTime(),
+  session,
+  options,
+}: SendReplay): Promise<void | TransportMakeRequestResponse> {
+  const recordingData = createRecordingData({
+    events,
+    headers: {
+      segment_id,
+    },
+  });
+
+  const { urls, errorIds, traceIds, initialTimestamp } = eventContext;
+
+  const hub = getCurrentHub();
+  const client = hub.getClient();
+  const scope = hub.getScope();
+  const transport = client && client.getTransport();
+  const dsn = client?.getDsn();
+
+  if (!client || !scope || !transport || !dsn || !session.sampled) {
+    return;
+  }
+
+  const baseEvent: ReplayEvent = {
+    // @ts-ignore private api
+    type: REPLAY_EVENT_NAME,
+    ...(includeReplayStartTimestamp ? { replay_start_timestamp: initialTimestamp / 1000 } : {}),
+    timestamp: timestamp / 1000,
+    error_ids: errorIds,
+    trace_ids: traceIds,
+    urls,
+    replay_id: replayId,
+    segment_id,
+    replay_type: session.sampled,
+  };
+
+  const replayEvent = await prepareReplayEvent({ scope, client, replayId, event: baseEvent });
+
+  if (!replayEvent) {
+    // Taken from baseclient's `_processEvent` method, where this is handled for errors/transactions
+    client.recordDroppedEvent('event_processor', 'replay_event', baseEvent);
+    __DEBUG_BUILD__ && logger.log('An event processor returned `null`, will not send event.');
+    return;
+  }
+
+  replayEvent.tags = {
+    ...replayEvent.tags,
+    sessionSampleRate: options.sessionSampleRate,
+    errorSampleRate: options.errorSampleRate,
+  };
+
+  /*
+  For reference, the fully built event looks something like this:
+  {
+      "type": "replay_event",
+      "timestamp": 1670837008.634,
+      "error_ids": [
+          "errorId"
+      ],
+      "trace_ids": [
+          "traceId"
+      ],
+      "urls": [
+          "https://example.com"
+      ],
+      "replay_id": "eventId",
+      "segment_id": 3,
+      "replay_type": "error",
+      "platform": "javascript",
+      "event_id": "eventId",
+      "environment": "production",
+      "sdk": {
+          "integrations": [
+              "BrowserTracing",
+              "Replay"
+          ],
+          "name": "sentry.javascript.browser",
+          "version": "7.25.0"
+      },
+      "sdkProcessingMetadata": {},
+      "tags": {
+          "sessionSampleRate": 1,
+          "errorSampleRate": 0,
+      }
+  }
+  */
+
+  const envelope = createReplayEnvelope(replayEvent, recordingData, dsn, client.getOptions().tunnel);
+
+  try {
+    return await transport.send(envelope);
+  } catch {
+    throw new Error(UNABLE_TO_SEND_REPLAY);
+  }
+}

--- a/packages/replay/src/util/sendReplayRequest.ts
+++ b/packages/replay/src/util/sendReplayRequest.ts
@@ -17,7 +17,7 @@ export async function sendReplayRequest({
   segmentId: segment_id,
   includeReplayStartTimestamp,
   eventContext,
-  timestamp = new Date().getTime(),
+  timestamp,
   session,
   options,
 }: SendReplay): Promise<void | TransportMakeRequestResponse> {

--- a/packages/replay/test/integration/errorSampleRate.test.ts
+++ b/packages/replay/test/integration/errorSampleRate.test.ts
@@ -68,7 +68,7 @@ describe('Integration | errorSampleRate', () => {
           sessionSampleRate: 0,
         }),
       }),
-      events: JSON.stringify([
+      recordingData: JSON.stringify([
         { data: { isCheckout: true }, timestamp: BASE_TIMESTAMP, type: 2 },
         TEST_EVENT,
         {
@@ -98,7 +98,7 @@ describe('Integration | errorSampleRate', () => {
           sessionSampleRate: 0,
         }),
       }),
-      events: JSON.stringify([{ data: { isCheckout: true }, timestamp: BASE_TIMESTAMP + 5020, type: 2 }]),
+      recordingData: JSON.stringify([{ data: { isCheckout: true }, timestamp: BASE_TIMESTAMP + 5020, type: 2 }]),
     });
 
     jest.advanceTimersByTime(DEFAULT_FLUSH_MIN_DELAY);
@@ -106,7 +106,7 @@ describe('Integration | errorSampleRate', () => {
     // New checkout when we call `startRecording` again after uploading segment
     // after an error occurs
     expect(replay).toHaveLastSentReplay({
-      events: JSON.stringify([
+      recordingData: JSON.stringify([
         {
           data: { isCheckout: true },
           timestamp: BASE_TIMESTAMP + DEFAULT_FLUSH_MIN_DELAY + 20,
@@ -124,7 +124,7 @@ describe('Integration | errorSampleRate', () => {
     await new Promise(process.nextTick);
 
     expect(replay).toHaveLastSentReplay({
-      events: JSON.stringify([
+      recordingData: JSON.stringify([
         {
           type: 5,
           timestamp: BASE_TIMESTAMP + 10000 + 40,
@@ -304,7 +304,7 @@ describe('Integration | errorSampleRate', () => {
     await new Promise(process.nextTick);
 
     expect(replay).toHaveSentReplay({
-      events: JSON.stringify([{ data: { isCheckout: true }, timestamp: BASE_TIMESTAMP, type: 2 }, TEST_EVENT]),
+      recordingData: JSON.stringify([{ data: { isCheckout: true }, timestamp: BASE_TIMESTAMP, type: 2 }, TEST_EVENT]),
       replayEventPayload: expect.objectContaining({
         replay_start_timestamp: BASE_TIMESTAMP / 1000,
         // the exception happens roughly 10 seconds after BASE_TIMESTAMP
@@ -360,7 +360,7 @@ describe('Integration | errorSampleRate', () => {
         // Make sure the old performance event is thrown out
         replay_start_timestamp: (BASE_TIMESTAMP + ELAPSED + 20) / 1000,
       }),
-      events: JSON.stringify([
+      recordingData: JSON.stringify([
         {
           data: { isCheckout: true },
           timestamp: BASE_TIMESTAMP + ELAPSED + 20,
@@ -406,12 +406,12 @@ it('sends a replay after loading the session multiple times', async () => {
   await new Promise(process.nextTick);
 
   expect(replay).toHaveSentReplay({
-    events: JSON.stringify([{ data: { isCheckout: true }, timestamp: BASE_TIMESTAMP, type: 2 }, TEST_EVENT]),
+    recordingData: JSON.stringify([{ data: { isCheckout: true }, timestamp: BASE_TIMESTAMP, type: 2 }, TEST_EVENT]),
   });
 
   // Latest checkout when we call `startRecording` again after uploading segment
   // after an error occurs (e.g. when we switch to session replay recording)
   expect(replay).toHaveLastSentReplay({
-    events: JSON.stringify([{ data: { isCheckout: true }, timestamp: BASE_TIMESTAMP + 5020, type: 2 }]),
+    recordingData: JSON.stringify([{ data: { isCheckout: true }, timestamp: BASE_TIMESTAMP + 5020, type: 2 }]),
   });
 });

--- a/packages/replay/test/integration/events.test.ts
+++ b/packages/replay/test/integration/events.test.ts
@@ -176,7 +176,7 @@ describe('Integration | events', () => {
         // Make sure the old performance event is thrown out
         replay_start_timestamp: BASE_TIMESTAMP / 1000,
       }),
-      events: JSON.stringify([
+      recordingData: JSON.stringify([
         TEST_EVENT,
         {
           type: 5,

--- a/packages/replay/test/integration/events.test.ts
+++ b/packages/replay/test/integration/events.test.ts
@@ -23,9 +23,6 @@ describe('Integration | events', () => {
   let mockTransportSend: jest.SpyInstance<any>;
   const prevLocation = WINDOW.location;
 
-  type MockSendReplayRequest = jest.MockedFunction<ReplayContainer['_sendReplayRequest']>;
-  let mockSendReplayRequest: MockSendReplayRequest;
-
   beforeAll(async () => {
     jest.setSystemTime(new Date(BASE_TIMESTAMP));
     jest.runAllTimers();
@@ -40,15 +37,11 @@ describe('Integration | events', () => {
 
     mockTransportSend = jest.spyOn(getCurrentHub().getClient()!.getTransport()!, 'send');
 
-    // @ts-ignore private API
-    mockSendReplayRequest = jest.spyOn(replay, '_sendReplayRequest');
-
     // Create a new session and clear mocks because a segment (from initial
     // checkout) will have already been uploaded by the time the tests run
     clearSession(replay);
     replay['_loadSession']({ expiry: 0 });
     mockTransportSend.mockClear();
-    mockSendReplayRequest.mockClear();
   });
 
   afterEach(async () => {
@@ -60,7 +53,6 @@ describe('Integration | events', () => {
     });
     clearSession(replay);
     jest.clearAllMocks();
-    mockSendReplayRequest.mockRestore();
     mockRecord.takeFullSnapshot.mockClear();
     replay.stop();
   });

--- a/packages/replay/test/integration/flush.test.ts
+++ b/packages/replay/test/integration/flush.test.ts
@@ -177,7 +177,7 @@ describe('Integration | flush', () => {
     // sendReplay is called with replayId, events, segment
 
     expect(mockSendReplay).toHaveBeenLastCalledWith({
-      events: expect.any(String),
+      recordingData: expect.any(String),
       replayId: expect.any(String),
       includeReplayStartTimestamp: true,
       segmentId: 0,
@@ -227,7 +227,7 @@ describe('Integration | flush', () => {
     expect(mockFlush).toHaveBeenCalledTimes(5);
     expect(mockRunFlush).toHaveBeenCalledTimes(2);
     expect(mockSendReplay).toHaveBeenLastCalledWith({
-      events: expect.any(String),
+      recordingData: expect.any(String),
       replayId: expect.any(String),
       includeReplayStartTimestamp: false,
       segmentId: 1,

--- a/packages/replay/test/integration/flush.test.ts
+++ b/packages/replay/test/integration/flush.test.ts
@@ -184,6 +184,7 @@ describe('Integration | flush', () => {
       eventContext: expect.anything(),
       session: expect.any(Object),
       options: expect.any(Object),
+      timestamp: expect.any(Number),
     });
 
     // Add this to test that segment ID increases
@@ -233,6 +234,7 @@ describe('Integration | flush', () => {
       eventContext: expect.anything(),
       session: expect.any(Object),
       options: expect.any(Object),
+      timestamp: expect.any(Number),
     });
 
     // Make sure there's no other calls

--- a/packages/replay/test/integration/flush.test.ts
+++ b/packages/replay/test/integration/flush.test.ts
@@ -6,6 +6,7 @@ import type { EventBuffer } from '../../src/types';
 import * as AddMemoryEntry from '../../src/util/addMemoryEntry';
 import { createPerformanceEntries } from '../../src/util/createPerformanceEntries';
 import { createPerformanceSpans } from '../../src/util/createPerformanceSpans';
+import * as SendReplay from '../../src/util/sendReplay';
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '../index';
 import { clearSession } from '../utils/clearSession';
 import { useFakeTimers } from '../utils/use-fake-timers';
@@ -17,7 +18,7 @@ async function advanceTimers(time: number) {
   await new Promise(process.nextTick);
 }
 
-type MockSendReplay = jest.MockedFunction<ReplayContainer['_sendReplay']>;
+type MockSendReplay = jest.MockedFunction<any>;
 type MockAddPerformanceEntries = jest.MockedFunction<ReplayContainer['_addPerformanceEntries']>;
 type MockAddMemoryEntry = jest.SpyInstance;
 type MockEventBufferFinish = jest.MockedFunction<EventBuffer['finish']>;
@@ -48,8 +49,7 @@ describe('Integration | flush', () => {
 
     ({ replay } = await mockSdk());
 
-    // @ts-ignore private API
-    mockSendReplay = jest.spyOn(replay, '_sendReplay');
+    mockSendReplay = jest.spyOn(SendReplay, 'sendReplay');
     mockSendReplay.mockImplementation(
       jest.fn(async () => {
         return;
@@ -175,12 +175,15 @@ describe('Integration | flush', () => {
     // debouncedFlush, which will call `flush` in 1 second
     expect(mockFlush).toHaveBeenCalledTimes(4);
     // sendReplay is called with replayId, events, segment
+
     expect(mockSendReplay).toHaveBeenLastCalledWith({
       events: expect.any(String),
       replayId: expect.any(String),
       includeReplayStartTimestamp: true,
       segmentId: 0,
       eventContext: expect.anything(),
+      session: expect.any(Object),
+      options: expect.any(Object),
     });
 
     // Add this to test that segment ID increases
@@ -228,6 +231,8 @@ describe('Integration | flush', () => {
       includeReplayStartTimestamp: false,
       segmentId: 1,
       eventContext: expect.anything(),
+      session: expect.any(Object),
+      options: expect.any(Object),
     });
 
     // Make sure there's no other calls

--- a/packages/replay/test/integration/sendReplayEvent.test.ts
+++ b/packages/replay/test/integration/sendReplayEvent.test.ts
@@ -96,7 +96,7 @@ describe('Integration | sendReplayEvent', () => {
 
     expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
 
-    expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT]) });
+    expect(replay).toHaveLastSentReplay({ recordingData: JSON.stringify([TEST_EVENT]) });
 
     // Session's last activity is not updated because we do not consider
     // visibilitystate as user being active
@@ -136,7 +136,7 @@ describe('Integration | sendReplayEvent', () => {
 
     expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
 
-    expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT]) });
+    expect(replay).toHaveLastSentReplay({ recordingData: JSON.stringify([TEST_EVENT]) });
 
     // No user activity to trigger an update
     expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP);
@@ -160,7 +160,7 @@ describe('Integration | sendReplayEvent', () => {
     await new Promise(process.nextTick);
 
     expect(replay).toHaveLastSentReplay({
-      events: JSON.stringify([...Array(5)].map(() => TEST_EVENT)),
+      recordingData: JSON.stringify([...Array(5)].map(() => TEST_EVENT)),
     });
 
     // There should also not be another attempt at an upload 5 seconds after the last replay event
@@ -177,7 +177,7 @@ describe('Integration | sendReplayEvent', () => {
     mockTransportSend.mockClear();
     mockRecord._emitter(TEST_EVENT);
     await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
-    expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT]) });
+    expect(replay).toHaveLastSentReplay({ recordingData: JSON.stringify([TEST_EVENT]) });
   });
 
   it('uploads a replay event when WINDOW is blurred', async () => {
@@ -211,7 +211,7 @@ describe('Integration | sendReplayEvent', () => {
     await new Promise(process.nextTick);
     expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
     expect(replay).toHaveLastSentReplay({
-      events: JSON.stringify([TEST_EVENT, hiddenBreadcrumb]),
+      recordingData: JSON.stringify([TEST_EVENT, hiddenBreadcrumb]),
     });
     // Session's last activity should not be updated
     expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP);
@@ -238,7 +238,7 @@ describe('Integration | sendReplayEvent', () => {
     await new Promise(process.nextTick);
 
     expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
-    expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT]) });
+    expect(replay).toHaveLastSentReplay({ recordingData: JSON.stringify([TEST_EVENT]) });
 
     // Session's last activity is not updated because we do not consider
     // visibilitystate as user being active
@@ -256,7 +256,7 @@ describe('Integration | sendReplayEvent', () => {
 
     expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
     expect(mockTransportSend).toHaveBeenCalledTimes(1);
-    expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT]) });
+    expect(replay).toHaveLastSentReplay({ recordingData: JSON.stringify([TEST_EVENT]) });
 
     // No user activity to trigger an update
     expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP);
@@ -280,7 +280,7 @@ describe('Integration | sendReplayEvent', () => {
     await new Promise(process.nextTick);
 
     expect(replay).toHaveLastSentReplay({
-      events: JSON.stringify([...Array(5)].map(() => TEST_EVENT)),
+      recordingData: JSON.stringify([...Array(5)].map(() => TEST_EVENT)),
     });
 
     // There should also not be another attempt at an upload 5 seconds after the last replay event
@@ -298,7 +298,7 @@ describe('Integration | sendReplayEvent', () => {
     mockTransportSend.mockClear();
     mockRecord._emitter(TEST_EVENT);
     await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
-    expect(replay).toHaveLastSentReplay({ events: JSON.stringify([TEST_EVENT]) });
+    expect(replay).toHaveLastSentReplay({ recordingData: JSON.stringify([TEST_EVENT]) });
   });
 
   it('uploads a dom breadcrumb 5 seconds after listener receives an event', async () => {
@@ -311,7 +311,7 @@ describe('Integration | sendReplayEvent', () => {
     await advanceTimers(ELAPSED);
 
     expect(replay).toHaveLastSentReplay({
-      events: JSON.stringify([
+      recordingData: JSON.stringify([
         {
           type: 5,
           timestamp: BASE_TIMESTAMP,
@@ -369,7 +369,7 @@ describe('Integration | sendReplayEvent', () => {
         urls: ['http://localhost/'],
       }),
       recordingPayloadHeader: { segment_id: 0 },
-      events: JSON.stringify([TEST_EVENT]),
+      recordingData: JSON.stringify([TEST_EVENT]),
     });
 
     mockTransportSend.mockClear();

--- a/packages/replay/test/integration/sendReplayEvent.test.ts
+++ b/packages/replay/test/integration/sendReplayEvent.test.ts
@@ -332,7 +332,7 @@ describe('Integration | sendReplayEvent', () => {
     expect(replay.session?.segmentId).toBe(1);
   });
 
-  it('fails to upload data on first two calls and succeeds on the third xxx', async () => {
+  it('fails to upload data on first two calls and succeeds on the third', async () => {
     expect(replay.session?.segmentId).toBe(0);
     const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
 
@@ -363,8 +363,8 @@ describe('Integration | sendReplayEvent', () => {
         error_ids: [],
         replay_id: expect.any(String),
         replay_start_timestamp: BASE_TIMESTAMP / 1000,
-        // 20seconds = Add up all of the previous `advanceTimers()`
-        timestamp: (BASE_TIMESTAMP + 20000) / 1000 + 0.02,
+        // timestamp is set on first try, after 5s flush
+        timestamp: (BASE_TIMESTAMP + 5000) / 1000,
         trace_ids: [],
         urls: ['http://localhost/'],
       }),

--- a/packages/replay/test/integration/session.test.ts
+++ b/packages/replay/test/integration/session.test.ts
@@ -149,7 +149,7 @@ describe('Integration | session', () => {
     const breadcrumbTimestamp = newTimestamp + 20; // I don't know where this 20ms comes from
 
     expect(replay).toHaveLastSentReplay({
-      events: JSON.stringify([
+      recordingData: JSON.stringify([
         { data: { isCheckout: true }, timestamp: newTimestamp, type: 2 },
         {
           type: 5,
@@ -309,7 +309,7 @@ describe('Integration | session', () => {
 
     expect(replay).toHaveLastSentReplay({
       recordingPayloadHeader: { segment_id: 0 },
-      events: JSON.stringify([
+      recordingData: JSON.stringify([
         { data: { isCheckout: true }, timestamp: newTimestamp, type: 2 },
         {
           type: 5,
@@ -420,7 +420,7 @@ describe('Integration | session', () => {
 
     expect(replay).toHaveLastSentReplay({
       recordingPayloadHeader: { segment_id: 0 },
-      events: JSON.stringify([
+      recordingData: JSON.stringify([
         { data: { isCheckout: true }, timestamp: newTimestamp, type: 2 },
         {
           type: 5,

--- a/packages/replay/test/integration/stop.test.ts
+++ b/packages/replay/test/integration/stop.test.ts
@@ -110,7 +110,7 @@ describe('Integration | stop', () => {
     jest.runAllTimers();
     await new Promise(process.nextTick);
     expect(replay).toHaveLastSentReplay({
-      events: JSON.stringify([
+      recordingData: JSON.stringify([
         // This event happens when we call `replay.start`
         {
           data: { isCheckout: true },


### PR DESCRIPTION
This extracts this out into a more functional style.
In addition, it also changes the `timestamp` we put on the replay to always reflect the time we've added it, no matter if it was retried.

This also renames a few things for clarity (e.g. `events` that was often passed around is actually `recordingData`, so we may as well reflect that in order to be clear about recordingData vs. events).

Note: This depends on https://github.com/getsentry/sentry-javascript/pull/6733, where I'll need to merge the changes once that is merged.