### PR TITLE
test: Adjust long task integration test ui span check

### DIFF
--- a/packages/integration-tests/suites/tracing/browsertracing/long-tasks-enabled/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/long-tasks-enabled/test.ts
@@ -18,7 +18,7 @@ sentryTest('should capture long task.', async ({ browserName, getLocalTestPath, 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const uiSpans = eventData.spans?.filter(({ op }) => op?.startsWith('ui'));
 
-  expect(uiSpans?.length).toBe(1);
+  expect(uiSpans?.length).toBeGreaterThan(0);
 
   const [firstUISpan] = uiSpans || [];
   expect(firstUISpan).toEqual(


### PR DESCRIPTION
Make the check in `should capture long task` integration test check for any number of ui spans instead of just one. In some situations in CI, there can be multiple long tasks instead of one (due to environmental conditions), so assert just to make sure they exist (and they are being recorded).

Should help fight against flakes like: https://github.com/getsentry/sentry-javascript/actions/runs/3901225358/jobs/6662950441
