### PR TITLE
build(replay): Rename `node_modules` directory inside build output directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "rollup": "^2.67.1",
     "rollup-plugin-cleanup": "3.2.1",
     "rollup-plugin-license": "^2.6.1",
+    "rollup-plugin-rename-node-modules": "^1.3.1",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.31.2",
     "sinon": "^7.3.2",

--- a/packages/replay/rollup.npm.config.js
+++ b/packages/replay/rollup.npm.config.js
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import replace from '@rollup/plugin-replace';
+import renameNodeModules from 'rollup-plugin-rename-node-modules';
 
 import { makeBaseNPMConfig, makeNPMConfigVariants } from '../../rollup/index';
 
@@ -18,6 +19,7 @@ export default makeNPMConfigVariants(
             __SENTRY_REPLAY_VERSION__: JSON.stringify(pkg.version),
           },
         }),
+        renameNodeModules('ext'),
       ],
       output: {
         // set exports to 'named' or 'auto' so that rollup doesn't warn about

--- a/packages/replay/rollup.npm.config.js
+++ b/packages/replay/rollup.npm.config.js
@@ -19,6 +19,9 @@ export default makeNPMConfigVariants(
             __SENTRY_REPLAY_VERSION__: JSON.stringify(pkg.version),
           },
         }),
+        // this renames the path under which rrweb is pulled into the build output directory
+        // from `node_modules/rrweb/...` to `ext/rrweb/...`
+        // see https://github.com/getsentry/sentry-javascript/issues/6690
         renameNodeModules('ext'),
       ],
       output: {

--- a/packages/replay/rollup.npm.config.js
+++ b/packages/replay/rollup.npm.config.js
@@ -22,7 +22,7 @@ export default makeNPMConfigVariants(
         // this renames the path under which rrweb is pulled into the build output directory
         // from `node_modules/rrweb/...` to `ext/rrweb/...`
         // see https://github.com/getsentry/sentry-javascript/issues/6690
-        renameNodeModules('ext'),
+        renameNodeModules('ext', false),
       ],
       output: {
         // set exports to 'named' or 'auto' so that rollup doesn't warn about

--- a/yarn.lock
+++ b/yarn.lock
@@ -21523,6 +21523,14 @@ rollup-plugin-license@^2.6.1:
     spdx-expression-validate "2.0.0"
     spdx-satisfies "5.0.1"
 
+rollup-plugin-rename-node-modules@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-rename-node-modules/-/rollup-plugin-rename-node-modules-1.3.1.tgz#d80091fc817ce726e7cdfc388ec2f4da286e280f"
+  integrity sha512-46TUPqO94GXuACYqVZjdbzNXTQAp+wTdZg/vUx2gaINb0da/ZPdaOtno2RGUOKBF4sbVM9v2ZqV98r4TQbp1UA==
+  dependencies:
+    estree-walker "^2.0.1"
+    magic-string "^0.25.7"
+
 rollup-plugin-sourcemaps@^0.6.0:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/rollup-plugin-sourcemaps/-/rollup-plugin-sourcemaps-0.6.3.tgz#bf93913ffe056e414419607f1d02780d7ece84ed"


### PR DESCRIPTION
As reported in #6690, apparently some bundlers and plugins seem to have problems when JS modules import from other modules under a `node_modules` directory. After we decided to vendor rrweb to patch it, we have such a directory inside our `build/npm/(esm|cjs)/node_modules/rrweb/...`. This PR adds the [rollup-plugin-rename-node-modules](https://github.com/Lazyuki/rollup-plugin-rename-node-modules) plugin which takes care of renaming such paths during the rollup build. 

With this change, rrweb can now be found under  `build/npm/(esm|cjs)/ext/rrweb/...`. Let's see if this fixes the bug reports.

Tested this change locally with a plain-js test app (npm package as well as minified cdn bundles).

Possibly fixes #6690 
