### PR TITLE
ref: Hoist definitions of `flush`, `close` and `lastEventId` into `@sentry/core`

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -43,6 +43,9 @@ export {
   withScope,
   FunctionToString,
   InboundFilters,
+  close,
+  flush,
+  lastEventId,
 } from '@sentry/core';
 
 export { WINDOW } from './helpers';
@@ -58,5 +61,5 @@ export {
   winjsStackLineParser,
 } from './stack-parsers';
 export { eventFromException, eventFromMessage } from './eventbuilder';
-export { defaultIntegrations, forceLoad, init, lastEventId, onLoad, showReportDialog, flush, close, wrap } from './sdk';
+export { defaultIntegrations, forceLoad, init, onLoad, showReportDialog, wrap } from './sdk';
 export { GlobalHandlers, TryCatch, Breadcrumbs, LinkedErrors, HttpContext, Dedupe } from './integrations';

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -6,13 +6,7 @@ import {
   initAndBind,
   Integrations as CoreIntegrations,
 } from '@sentry/core';
-import {
-  addInstrumentationHandler,
-  logger,
-  resolvedSyncPromise,
-  stackParserFromStackParserOptions,
-  supportsFetch,
-} from '@sentry/utils';
+import { addInstrumentationHandler, logger, stackParserFromStackParserOptions, supportsFetch } from '@sentry/utils';
 
 import type { BrowserClientOptions, BrowserOptions } from './client';
 import { BrowserClient } from './client';
@@ -178,15 +172,6 @@ export function showReportDialog(options: ReportDialogOptions = {}, hub: Hub = g
 }
 
 /**
- * This is the getter for lastEventId.
- *
- * @returns The last event id of a captured event.
- */
-export function lastEventId(): string | undefined {
-  return getCurrentHub().lastEventId();
-}
-
-/**
  * This function is here to be API compatible with the loader.
  * @hidden
  */
@@ -200,40 +185,6 @@ export function forceLoad(): void {
  */
 export function onLoad(callback: () => void): void {
   callback();
-}
-
-/**
- * Call `flush()` on the current client, if there is one. See {@link Client.flush}.
- *
- * @param timeout Maximum time in ms the client should wait to flush its event queue. Omitting this parameter will cause
- * the client to wait until all events are sent before resolving the promise.
- * @returns A promise which resolves to `true` if the queue successfully drains before the timeout, or `false` if it
- * doesn't (or if there's no client defined).
- */
-export function flush(timeout?: number): PromiseLike<boolean> {
-  const client = getCurrentHub().getClient<BrowserClient>();
-  if (client) {
-    return client.flush(timeout);
-  }
-  __DEBUG_BUILD__ && logger.warn('Cannot flush events. No client defined.');
-  return resolvedSyncPromise(false);
-}
-
-/**
- * Call `close()` on the current client, if there is one. See {@link Client.close}.
- *
- * @param timeout Maximum time in ms the client should wait to flush its event queue before shutting down. Omitting this
- * parameter will cause the client to wait until all events are sent before disabling itself.
- * @returns A promise which resolves to `true` if the queue successfully drains before the timeout, or `false` if it
- * doesn't (or if there's no client defined).
- */
-export function close(timeout?: number): PromiseLike<boolean> {
-  const client = getCurrentHub().getClient<BrowserClient>();
-  if (client) {
-    return client.close(timeout);
-  }
-  __DEBUG_BUILD__ && logger.warn('Cannot flush events and disable SDK. No client defined.');
-  return resolvedSyncPromise(false);
 }
 
 /**

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -30,9 +30,7 @@ import {
   logger,
   makeDsn,
   rejectedSyncPromise,
-  resolvedSyncPromise,
   SentryError,
-  SyncPromise,
 } from '@sentry/utils';
 
 import { getEnvelopeEndpointWithUrlEncodedAuth } from './api';
@@ -240,21 +238,21 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   /**
    * @inheritDoc
    */
-  public flush(timeout?: number): PromiseLike<boolean> {
+  public flush(timeout?: number): Promise<boolean> {
     const transport = this._transport;
     if (transport) {
       return this._isClientDoneProcessing(timeout).then(clientFinished => {
         return transport.flush(timeout).then(transportFlushed => clientFinished && transportFlushed);
       });
     } else {
-      return resolvedSyncPromise(true);
+      return Promise.resolve(true);
     }
   }
 
   /**
    * @inheritDoc
    */
-  public close(timeout?: number): PromiseLike<boolean> {
+  public close(timeout?: number): Promise<boolean> {
     return this.flush(timeout).then(result => {
       this.getOptions().enabled = false;
       return result;
@@ -394,8 +392,8 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    * @returns A promise which will resolve to `true` if processing is already done or finishes before the timeout, and
    * `false` otherwise
    */
-  protected _isClientDoneProcessing(timeout?: number): PromiseLike<boolean> {
-    return new SyncPromise(resolve => {
+  protected _isClientDoneProcessing(timeout?: number): Promise<boolean> {
+    return new Promise(resolve => {
       let ticked: number = 0;
       const tick: number = 1;
 

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -160,7 +160,7 @@ export class Hub implements HubInterface {
   /**
    * @inheritDoc
    */
-  public getClient<C extends Client>(): C | undefined {
+  public getClient<C extends Client = Client>(): C | undefined {
     return this.getStackTop().client as C;
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,7 +22,7 @@ export { SessionFlusher } from './sessionflusher';
 export { addGlobalEventProcessor, Scope } from './scope';
 export { getEnvelopeEndpointWithUrlEncodedAuth, getReportDialogEndpoint } from './api';
 export { BaseClient } from './baseclient';
-export { initAndBind } from './sdk';
+export { initAndBind, flush, close, lastEventId } from './sdk';
 export { createTransport } from './transports/base';
 export { SDK_VERSION } from './version';
 export { getIntegrationsToSetup } from './integration';

--- a/packages/core/src/sdk.ts
+++ b/packages/core/src/sdk.ts
@@ -35,3 +35,47 @@ export function initAndBind<F extends Client, O extends ClientOptions>(
   const client = new clientClass(options);
   hub.bindClient(client);
 }
+
+/**
+ * This is the getter for lastEventId.
+ *
+ * @returns The last event id of a captured event.
+ */
+export function lastEventId(): string | undefined {
+  return getCurrentHub().lastEventId();
+}
+
+/**
+ * Call `flush()` on the current client, if there is one. See {@link Client.flush}.
+ *
+ * @param timeout Maximum time in ms the client should wait to flush its event queue. Omitting this parameter will cause
+ * the client to wait until all events are sent before resolving the promise.
+ * @returns A promise which resolves to `true` if the queue successfully drains before the timeout, or `false` if it
+ * doesn't (or if there's no client defined).
+ */
+export function flush(timeout?: number): Promise<boolean> {
+  const client = getCurrentHub().getClient();
+  if (client) {
+    return client.flush(timeout);
+  }
+
+  __DEBUG_BUILD__ && logger.warn('Cannot flush events. No client defined.');
+  return Promise.resolve(false);
+}
+
+/**
+ * Call `close()` on the current client, if there is one. See {@link Client.close}.
+ *
+ * @param timeout Maximum time in ms the client should wait to flush its event queue before shutting down. Omitting this
+ * parameter will cause the client to wait until all events are sent before disabling itself.
+ * @returns A promise which resolves to `true` if the queue successfully drains before the timeout, or `false` if it
+ * doesn't (or if there's no client defined).
+ */
+export function close(timeout?: number): Promise<boolean> {
+  const client = getCurrentHub().getClient();
+  if (client) {
+    return client.close(timeout);
+  }
+  __DEBUG_BUILD__ && logger.warn('Cannot flush events and disable SDK. No client defined.');
+  return Promise.resolve(false);
+}

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -1,14 +1,8 @@
 import '@sentry/tracing'; // Allow people to call tracing API methods without explicitly importing the tracing package.
 
-import { getCurrentHub, getIntegrationsToSetup, initAndBind, Integrations as CoreIntegrations } from '@sentry/core';
+import { getIntegrationsToSetup, initAndBind, Integrations as CoreIntegrations } from '@sentry/core';
 import type { Options } from '@sentry/types';
-import {
-  createStackParser,
-  GLOBAL_OBJ,
-  logger,
-  nodeStackLineParser,
-  stackParserFromStackParserOptions,
-} from '@sentry/utils';
+import { createStackParser, GLOBAL_OBJ, nodeStackLineParser, stackParserFromStackParserOptions } from '@sentry/utils';
 
 import { EdgeClient } from './edgeclient';
 import { makeEdgeTransport } from './transport';
@@ -100,49 +94,6 @@ export function getSentryRelease(fallback?: string): string | undefined {
     process.env.ZEIT_BITBUCKET_COMMIT_SHA ||
     fallback
   );
-}
-
-/**
- * Call `close()` on the current client, if there is one. See {@link Client.close}.
- *
- * @param timeout Maximum time in ms the client should wait to flush its event queue before shutting down. Omitting this
- * parameter will cause the client to wait until all events are sent before disabling itself.
- * @returns A promise which resolves to `true` if the queue successfully drains before the timeout, or `false` if it
- * doesn't (or if there's no client defined).
- */
-export async function close(timeout?: number): Promise<boolean> {
-  const client = getCurrentHub().getClient<EdgeClient>();
-  if (client) {
-    return client.close(timeout);
-  }
-  __DEBUG_BUILD__ && logger.warn('Cannot flush events and disable SDK. No client defined.');
-  return Promise.resolve(false);
-}
-
-/**
- * Call `flush()` on the current client, if there is one. See {@link Client.flush}.
- *
- * @param timeout Maximum time in ms the client should wait to flush its event queue. Omitting this parameter will cause
- * the client to wait until all events are sent before resolving the promise.
- * @returns A promise which resolves to `true` if the queue successfully drains before the timeout, or `false` if it
- * doesn't (or if there's no client defined).
- */
-export async function flush(timeout?: number): Promise<boolean> {
-  const client = getCurrentHub().getClient<EdgeClient>();
-  if (client) {
-    return client.flush(timeout);
-  }
-  __DEBUG_BUILD__ && logger.warn('Cannot flush events. No client defined.');
-  return Promise.resolve(false);
-}
-
-/**
- * This is the getter for lastEventId.
- *
- * @returns The last event id of a captured event.
- */
-export function lastEventId(): string | undefined {
-  return getCurrentHub().lastEventId();
 }
 
 export * from '@sentry/core';

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -25,7 +25,4 @@ export const Integrations = { ...clientSdk.Integrations, ...serverSdk.Integratio
 export declare const defaultIntegrations: Integration[];
 export declare const defaultStackParser: StackParser;
 
-export declare function close(timeout?: number | undefined): PromiseLike<boolean>;
-export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
-export declare function lastEventId(): string | undefined;
 export declare function getSentryRelease(fallback?: string): string | undefined;

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -95,7 +95,7 @@ export class NodeClient extends BaseClient<NodeClientOptions> {
    *
    * @inheritdoc
    */
-  public close(timeout?: number): PromiseLike<boolean> {
+  public close(timeout?: number): Promise<boolean> {
     this._sessionFlusher?.close();
     return super.close(timeout);
   }

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { captureException, getCurrentHub, startTransaction, withScope } from '@sentry/core';
+import { captureException, flush, getCurrentHub, startTransaction, withScope } from '@sentry/core';
 import type { Span } from '@sentry/types';
 import type { AddRequestDataToEventOptions } from '@sentry/utils';
 import {
@@ -18,7 +18,7 @@ import type { NodeClient } from './client';
 import { extractRequestData } from './requestdata';
 // TODO (v8 / XXX) Remove this import
 import type { ParseRequestOptions } from './requestDataDeprecated';
-import { flush, isAutoSessionTrackingEnabled } from './sdk';
+import { isAutoSessionTrackingEnabled } from './sdk';
 
 /**
  * Express-compatible tracing handler.

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -44,11 +44,14 @@ export {
   setTags,
   setUser,
   withScope,
+  lastEventId,
+  flush,
+  close,
 } from '@sentry/core';
 
 export { NodeClient } from './client';
 export { makeNodeTransport } from './transports';
-export { defaultIntegrations, init, defaultStackParser, lastEventId, flush, close, getSentryRelease } from './sdk';
+export { defaultIntegrations, init, defaultStackParser, getSentryRelease } from './sdk';
 export { addRequestDataToEvent, DEFAULT_USER_INCLUDES, extractRequestData } from './requestdata';
 export { deepReadDirSync } from './utils';
 

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -8,13 +8,7 @@ import {
   setHubOnCarrier,
 } from '@sentry/core';
 import type { SessionStatus, StackParser } from '@sentry/types';
-import {
-  createStackParser,
-  GLOBAL_OBJ,
-  logger,
-  nodeStackLineParser,
-  stackParserFromStackParserOptions,
-} from '@sentry/utils';
+import { createStackParser, GLOBAL_OBJ, nodeStackLineParser, stackParserFromStackParserOptions } from '@sentry/utils';
 import * as domain from 'domain';
 
 import { NodeClient } from './client';
@@ -172,49 +166,6 @@ export function init(options: NodeOptions = {}): void {
   if (options.autoSessionTracking) {
     startSessionTracking();
   }
-}
-
-/**
- * This is the getter for lastEventId.
- *
- * @returns The last event id of a captured event.
- */
-export function lastEventId(): string | undefined {
-  return getCurrentHub().lastEventId();
-}
-
-/**
- * Call `flush()` on the current client, if there is one. See {@link Client.flush}.
- *
- * @param timeout Maximum time in ms the client should wait to flush its event queue. Omitting this parameter will cause
- * the client to wait until all events are sent before resolving the promise.
- * @returns A promise which resolves to `true` if the queue successfully drains before the timeout, or `false` if it
- * doesn't (or if there's no client defined).
- */
-export async function flush(timeout?: number): Promise<boolean> {
-  const client = getCurrentHub().getClient<NodeClient>();
-  if (client) {
-    return client.flush(timeout);
-  }
-  __DEBUG_BUILD__ && logger.warn('Cannot flush events. No client defined.');
-  return Promise.resolve(false);
-}
-
-/**
- * Call `close()` on the current client, if there is one. See {@link Client.close}.
- *
- * @param timeout Maximum time in ms the client should wait to flush its event queue before shutting down. Omitting this
- * parameter will cause the client to wait until all events are sent before disabling itself.
- * @returns A promise which resolves to `true` if the queue successfully drains before the timeout, or `false` if it
- * doesn't (or if there's no client defined).
- */
-export async function close(timeout?: number): Promise<boolean> {
-  const client = getCurrentHub().getClient<NodeClient>();
-  if (client) {
-    return client.close(timeout);
-  }
-  __DEBUG_BUILD__ && logger.warn('Cannot flush events and disable SDK. No client defined.');
-  return Promise.resolve(false);
 }
 
 /**

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -7,7 +7,6 @@ import * as http from 'http';
 
 import { NodeClient } from '../src/client';
 import { errorHandler, requestHandler, tracingHandler } from '../src/handlers';
-import * as SDK from '../src/index';
 import { getDefaultNodeClientOptions } from './helper/node-client-options';
 
 describe('requestHandler', () => {
@@ -111,7 +110,7 @@ describe('requestHandler', () => {
   });
 
   it('patches `res.end` when `flushTimeout` is specified', done => {
-    const flush = jest.spyOn(SDK, 'flush').mockResolvedValue(true);
+    const flush = jest.spyOn(sentryCore, 'flush').mockResolvedValue(true);
 
     const sentryRequestMiddleware = requestHandler({ flushTimeout: 1337 });
     sentryRequestMiddleware(req, res, next);
@@ -125,7 +124,7 @@ describe('requestHandler', () => {
   });
 
   it('prevents errors thrown during `flush` from breaking the response', done => {
-    jest.spyOn(SDK, 'flush').mockRejectedValue(new SentryError('HTTP Error (429)'));
+    jest.spyOn(sentryCore, 'flush').mockRejectedValue(new SentryError('HTTP Error (429)'));
 
     const sentryRequestMiddleware = requestHandler({ flushTimeout: 1337 });
     sentryRequestMiddleware(req, res, next);

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -7,7 +7,7 @@ import * as http from 'http';
 
 import { NodeClient } from '../src/client';
 import { errorHandler, requestHandler, tracingHandler } from '../src/handlers';
-import * as SDK from '../src/sdk';
+import * as SDK from '../src/index';
 import { getDefaultNodeClientOptions } from './helper/node-client-options';
 
 describe('requestHandler', () => {

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -19,12 +19,3 @@ export const Integrations = { ...clientSdk.Integrations, ...serverSdk.Integratio
 
 export declare const defaultIntegrations: Integration[];
 export declare const defaultStackParser: StackParser;
-
-// This variable is not a runtime variable but just a type to tell typescript that the methods below can either come
-// from the client SDK or from the server SDK. TypeScript is smart enough to understand that these resolve to the same
-// methods from `@sentry/core`.
-declare const runtime: 'client' | 'server';
-
-export const close = runtime === 'client' ? clientSdk.close : serverSdk.close;
-export const flush = runtime === 'client' ? clientSdk.flush : serverSdk.flush;
-export const lastEventId = runtime === 'client' ? clientSdk.lastEventId : serverSdk.lastEventId;

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -93,7 +93,7 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    * @returns A promise which resolves to `true` if the flush completes successfully before the timeout, or `false` if
    * it doesn't.
    */
-  close(timeout?: number): PromiseLike<boolean>;
+  close(timeout?: number): Promise<boolean>;
 
   /**
    * Wait for all events to be sent or the timeout to expire, whichever comes first.
@@ -103,7 +103,7 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    * @returns A promise that will resolve with `true` if all events are sent before the timeout, or `false` if there are
    * still events in the queue when the timeout is reached.
    */
-  flush(timeout?: number): PromiseLike<boolean>;
+  flush(timeout?: number): Promise<boolean>;
 
   /** Returns the client's instance of the given integration class, it any. */
   getIntegration<T extends Integration>(integration: IntegrationClass<T>): T | null;


### PR DESCRIPTION
Resolves: https://github.com/getsentry/sentry-javascript/issues/6756

This PR hoists the `flush`, `close`, and `lastEventId` functions from `@sentry/node` and `@sentry/browser` into `@sentry/core`. The functionality was identical.

To go through with this change we had to change some instances of `PromiseLike` to `Promise`, but since `Promise` implements `PromiseLike` this is not a breaking change.