### PR TITLE
ref: Replace `string.substr` with `string.slice`

### DIFF
--- a/packages/node/src/module.ts
+++ b/packages/node/src/module.ts
@@ -27,14 +27,14 @@ export function getModule(filename: string | undefined): string | undefined {
   let n = path.lastIndexOf('/node_modules/');
   if (n > -1) {
     // /node_modules/ is 14 chars
-    return `${path.substr(n + 14).replace(/\//g, '.')}:${file}`;
+    return `${path.slice(n + 14).replace(/\//g, '.')}:${file}`;
   }
   // Let's see if it's a part of the main module
   // To be a part of main module, it has to share the same base
   n = `${path}/`.lastIndexOf(base, 0);
 
   if (n === 0) {
-    let moduleName = path.substr(base.length).replace(/\//g, '.');
+    let moduleName = path.slice(base.length).replace(/\//g, '.');
     if (moduleName) {
       moduleName += ':';
     }

--- a/packages/utils/src/path.ts
+++ b/packages/utils/src/path.ts
@@ -95,8 +95,8 @@ function trim(arr: string[]): string[] {
 /** JSDoc */
 export function relative(from: string, to: string): string {
   /* eslint-disable no-param-reassign */
-  from = resolve(from).substr(1);
-  to = resolve(to).substr(1);
+  from = resolve(from).slice(1);
+  to = resolve(to).slice(1);
   /* eslint-enable no-param-reassign */
 
   const fromParts = trim(from.split('/'));
@@ -126,7 +126,7 @@ export function relative(from: string, to: string): string {
 /** JSDoc */
 export function normalizePath(path: string): string {
   const isPathAbsolute = isAbsolute(path);
-  const trailingSlash = path.substr(-1) === '/';
+  const trailingSlash = path.slice(-1) === '/';
 
   // Normalize the path
   let normalizedPath = normalizeArray(
@@ -169,7 +169,7 @@ export function dirname(path: string): string {
 
   if (dir) {
     // It has a dirname, strip trailing slash
-    dir = dir.substr(0, dir.length - 1);
+    dir = dir.slice(0, dir.length - 1);
   }
 
   return root + dir;
@@ -178,8 +178,8 @@ export function dirname(path: string): string {
 /** JSDoc */
 export function basename(path: string, ext?: string): string {
   let f = splitPath(path)[2];
-  if (ext && f.substr(ext.length * -1) === ext) {
-    f = f.substr(0, f.length - ext.length);
+  if (ext && f.slice(ext.length * -1) === ext) {
+    f = f.slice(0, f.length - ext.length);
   }
   return f;
 }

--- a/packages/utils/src/stacktrace.ts
+++ b/packages/utils/src/stacktrace.ts
@@ -142,12 +142,12 @@ function node(getModule?: GetModuleFn): StackLineParserFn {
       }
 
       if (methodStart > 0) {
-        object = functionName.substr(0, methodStart);
-        method = functionName.substr(methodStart + 1);
+        object = functionName.slice(0, methodStart);
+        method = functionName.slice(methodStart + 1);
         const objectEnd = object.indexOf('.Module');
         if (objectEnd > 0) {
-          functionName = functionName.substr(objectEnd + 1);
-          object = object.substr(0, objectEnd);
+          functionName = functionName.slice(objectEnd + 1);
+          object = object.slice(0, objectEnd);
         }
       }
       typeName = undefined;
@@ -168,7 +168,7 @@ function node(getModule?: GetModuleFn): StackLineParserFn {
       functionName = typeName ? `${typeName}.${methodName}` : methodName;
     }
 
-    const filename = lineMatch[2]?.startsWith('file://') ? lineMatch[2].substr(7) : lineMatch[2];
+    const filename = lineMatch[2]?.startsWith('file://') ? lineMatch[2].slice(7) : lineMatch[2];
     const isNative = lineMatch[5] === 'native';
     const isInternal =
       isNative || (filename && !filename.startsWith('/') && !filename.startsWith('.') && filename.indexOf(':\\') !== 1);

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -11,7 +11,7 @@ export function truncate(str: string, max: number = 0): string {
   if (typeof str !== 'string' || max === 0) {
     return str;
   }
-  return str.length <= max ? str : `${str.substr(0, max)}...`;
+  return str.length <= max ? str : `${str.slice(0, max)}...`;
 }
 
 /**

--- a/packages/wasm/src/registry.ts
+++ b/packages/wasm/src/registry.ts
@@ -50,7 +50,7 @@ export function registerModule(module: WebAssembly.Module, url: string): void {
       code_id: buildId,
       code_file: url,
       debug_file: debugFile ? new URL(debugFile, url).href : null,
-      debug_id: `${buildId.padEnd(32, '0').substr(0, 32)}0`,
+      debug_id: `${buildId.padEnd(32, '0').slice(0, 32)}0`,
     });
   }
 }


### PR DESCRIPTION
`substr` is actually deprecated (see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr). 

For our cases, `slice()` should work just as well - see this very informative answer: https://stackoverflow.com/a/31910656

I noticed this while playing around with typescript update, which complains about this being deprecated.

As far as I see, `slice` and `substr` would only perform differently when `start !== 0`, which we don't have anywhere.