### PR TITLE
feat(replay): Lower the flush max delay from 15 seconds to 5 seconds

### DIFF
--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -31,7 +31,7 @@ export const MASK_ALL_TEXT_SELECTOR = 'body *:not(style), body *:not(script)';
 
 /** Default flush delays */
 export const DEFAULT_FLUSH_MIN_DELAY = 5_000;
-export const DEFAULT_FLUSH_MAX_DELAY = 15_000;
+export const DEFAULT_FLUSH_MAX_DELAY = 5_000;
 export const INITIAL_FLUSH_DELAY = 5_000;
 
 export const RETRY_BASE_INTERVAL = 5000;


### PR DESCRIPTION
This means that we will only wait 5 seconds before flushing. This should help reduce potential lost segments due to page reloads/closed tabs.
