### PR TITLE
feat(replay): Stop replays when a segment could not be sent

### DIFF
--- a/packages/replay/test/integration/sendReplayEvent.test.ts
+++ b/packages/replay/test/integration/sendReplayEvent.test.ts
@@ -428,5 +428,17 @@ describe('Integration | sendReplayEvent', () => {
 
     // segmentId increases despite error
     expect(replay.session?.segmentId).toBe(1);
+
+    // Replay should be completely stopped now
+    expect(replay.isEnabled()).toBe(false);
+
+    // Events are ignored now, because we stopped
+    mockRecord._emitter(TEST_EVENT);
+    await advanceTimers(DEFAULT_FLUSH_MIN_DELAY);
+    expect(mockSendReplayRequest).toHaveBeenCalledTimes(4);
   });
+
+  // NOTE: If you add a test after the last one, make sure to adjust the test setup
+  // As this ends with a `stopped()` replay, which may prevent future tests from working
+  // Sadly, fixing this turned out to be much more annoying than expected, so leaving this warning here for now
 });


### PR DESCRIPTION
After some investigation, we decided that we actually don't really need a queue for handling replay events, because this is already basically handled by flushing.

For context, the flow in replay is as follows:

* When we try to flush (=send events), we wait debounced 5s
* When the debounce is done, we start flushing the currently recorded events. For this we take the events from the EventBuffer (removing them from there), and create a new flushlock.
* The flushlock resolves when the data has been successfully sent.
* While a flushlock exists, no new flush will happen. Any existing data remains in the eventBuffer.

Because of this, no segment can be sent before the previous segment has finished being sent.

So instead of adding a new queue, the only change of this PR is to ensure we actually `stop()` the replay when we exceed the retry limit. This will ensure that no following segment will be sent, and we don't get any inconsistent replays. Instead, the replay will just end with the last successful segment.

~~Additionally, this adds a new client report category, `retry_failed`. I am not 100% sure if we can just add this like this or if this needs any changes on the backend?~~

closes https://github.com/getsentry/sentry-javascript/issues/6639
closes https://github.com/getsentry/sentry-javascript/issues/6671