### PR TITLE
test(replay): Test against CDN bundles in Playwright integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,7 +191,6 @@ jobs:
       - name: Check build cache
         uses: actions/cache@v3
         id: cache_built_packages
-        if: needs.job_get_metadata.outputs.force_skip_cache == 'false'
         with:
           path: ${{ env.CACHED_BUILD_PATHS }}
           key: ${{ env.BUILD_CACHE_KEY }}

--- a/packages/integration-tests/suites/replay/captureReplay/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplay/test.ts
@@ -6,8 +6,8 @@ import { sentryTest } from '../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
 
 sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
-  // Currently bundle tests are not supported for replay
-  if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_')) {
+  // Replay bundles are es6 only
+  if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_es5')) {
     sentryTest.skip();
   }
 

--- a/packages/integration-tests/suites/replay/captureReplayViaBrowser/init.js
+++ b/packages/integration-tests/suites/replay/captureReplayViaBrowser/init.js
@@ -1,0 +1,16 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+window.Replay = new Sentry.Replay({
+  flushMinDelay: 200,
+  initialFlushDelay: 200,
+});
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  sampleRate: 0,
+  replaysSessionSampleRate: 1.0,
+  replaysOnErrorSampleRate: 0.0,
+
+  integrations: [window.Replay],
+});

--- a/packages/integration-tests/suites/replay/captureReplayViaBrowser/template.html
+++ b/packages/integration-tests/suites/replay/captureReplayViaBrowser/template.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <button onclick="console.log('Test log')">Click me</button>
+  </body>
+</html>

--- a/packages/integration-tests/suites/replay/captureReplayViaBrowser/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplayViaBrowser/test.ts
@@ -1,0 +1,68 @@
+import { expect } from '@playwright/test';
+import { SDK_VERSION } from '@sentry/browser';
+import type { Event } from '@sentry/types';
+
+import { sentryTest } from '../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
+
+sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
+  // For this test, we skip all bundle tests, as we're only interested in Replay being correctly
+  // exported from the `@sentry/browser` npm package.
+  if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_')) {
+    sentryTest.skip();
+  }
+
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const url = await getLocalTestPath({ testDir: __dirname });
+  await page.goto(url);
+
+  await page.click('button');
+  await page.waitForTimeout(300);
+
+  const replayEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
+
+  expect(replayEvent).toBeDefined();
+  expect(replayEvent).toEqual({
+    type: 'replay_event',
+    timestamp: expect.any(Number),
+    error_ids: [],
+    trace_ids: [],
+    urls: [expect.stringContaining('/dist/index.html')],
+    replay_id: expect.stringMatching(/\w{32}/),
+    segment_id: 2,
+    replay_type: 'session',
+    event_id: expect.stringMatching(/\w{32}/),
+    environment: 'production',
+    sdk: {
+      integrations: [
+        'InboundFilters',
+        'FunctionToString',
+        'TryCatch',
+        'Breadcrumbs',
+        'GlobalHandlers',
+        'LinkedErrors',
+        'Dedupe',
+        'HttpContext',
+        'Replay',
+      ],
+      version: SDK_VERSION,
+      name: 'sentry.javascript.browser',
+    },
+    sdkProcessingMetadata: {},
+    request: {
+      url: expect.stringContaining('/dist/index.html'),
+      headers: {
+        'User-Agent': expect.stringContaining(''),
+      },
+    },
+    platform: 'javascript',
+    tags: { sessionSampleRate: 1, errorSampleRate: 0 },
+  });
+});

--- a/packages/integration-tests/suites/replay/errorResponse/test.ts
+++ b/packages/integration-tests/suites/replay/errorResponse/test.ts
@@ -31,6 +31,12 @@ sentryTest('errorResponse', async ({ getLocalTestPath, page }) => {
   await page.waitForTimeout(5001);
 
   expect(called).toBe(1);
+
+  await page.waitForFunction(() => {
+    // @ts-ignore private API
+    return window.Replay._replay !== undefined;
+  });
+
   const replay = await getReplaySnapshot(page);
 
   // @ts-ignore private API

--- a/packages/integration-tests/suites/replay/errorResponse/test.ts
+++ b/packages/integration-tests/suites/replay/errorResponse/test.ts
@@ -32,11 +32,6 @@ sentryTest('errorResponse', async ({ getLocalTestPath, page }) => {
 
   expect(called).toBe(1);
 
-  await page.waitForFunction(() => {
-    // @ts-ignore private API
-    return window.Replay._replay !== undefined;
-  });
-
   const replay = await getReplaySnapshot(page);
 
   // @ts-ignore private API

--- a/packages/integration-tests/suites/replay/errorResponse/test.ts
+++ b/packages/integration-tests/suites/replay/errorResponse/test.ts
@@ -31,7 +31,10 @@ sentryTest('errorResponse', async ({ getLocalTestPath, page }) => {
   await page.waitForTimeout(5001);
 
   expect(called).toBe(1);
+  debugger;
   const replay = await getReplaySnapshot(page);
+  debugger;
 
-  expect(replay['_isEnabled']).toBe(false);
+  // @ts-ignore private API
+  expect(replay._isEnabled).toBe(false);
 });

--- a/packages/integration-tests/suites/replay/errorResponse/test.ts
+++ b/packages/integration-tests/suites/replay/errorResponse/test.ts
@@ -5,7 +5,7 @@ import { getReplaySnapshot } from '../../../utils/helpers';
 
 sentryTest('errorResponse', async ({ getLocalTestPath, page }) => {
   // Currently bundle tests are not supported for replay
-  if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_')) {
+  if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_es5')) {
     sentryTest.skip();
   }
 

--- a/packages/integration-tests/suites/replay/errorResponse/test.ts
+++ b/packages/integration-tests/suites/replay/errorResponse/test.ts
@@ -31,9 +31,7 @@ sentryTest('errorResponse', async ({ getLocalTestPath, page }) => {
   await page.waitForTimeout(5001);
 
   expect(called).toBe(1);
-  debugger;
   const replay = await getReplaySnapshot(page);
-  debugger;
 
   // @ts-ignore private API
   expect(replay._isEnabled).toBe(false);

--- a/packages/integration-tests/suites/replay/init.js
+++ b/packages/integration-tests/suites/replay/init.js
@@ -1,7 +1,8 @@
 import * as Sentry from '@sentry/browser';
+import { Replay } from '@sentry/replay';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = new Replay({
   flushMinDelay: 200,
   initialFlushDelay: 200,
 });

--- a/packages/integration-tests/suites/replay/sampling/init.js
+++ b/packages/integration-tests/suites/replay/sampling/init.js
@@ -1,7 +1,8 @@
 import * as Sentry from '@sentry/browser';
+import { Replay } from '@sentry/replay';
 
 window.Sentry = Sentry;
-window.Replay = new Sentry.Replay({
+window.Replay = new Replay({
   flushMinDelay: 200,
   initialFlushDelay: 200,
 });

--- a/packages/integration-tests/suites/replay/sampling/test.ts
+++ b/packages/integration-tests/suites/replay/sampling/test.ts
@@ -4,8 +4,8 @@ import { sentryTest } from '../../../utils/fixtures';
 import { getReplaySnapshot } from '../../../utils/helpers';
 
 sentryTest('sampling', async ({ getLocalTestPath, page }) => {
-  // Currently bundle tests are not supported for replay
-  if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_')) {
+  // Replay bundles are es6 only
+  if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_es5')) {
     sentryTest.skip();
   }
 

--- a/packages/integration-tests/utils/helpers.ts
+++ b/packages/integration-tests/utils/helpers.ts
@@ -1,5 +1,5 @@
 import type { Page, Request } from '@playwright/test';
-import { ReplayContainer } from '@sentry/replay/build/npm/types/types';
+import type { ReplayContainer } from '@sentry/replay/build/npm/types/types';
 import type { Event, EventEnvelopeHeaders } from '@sentry/types';
 
 const envelopeUrlRegex = /\.sentry\.io\/api\/\d+\/envelope\//;

--- a/packages/integration-tests/utils/helpers.ts
+++ b/packages/integration-tests/utils/helpers.ts
@@ -60,12 +60,6 @@ async function getSentryEvents(page: Page, url?: string): Promise<Array<Event>> 
  */
 export async function getReplaySnapshot(page: Page): Promise<ReplayContainer> {
   const replayIntegration = await page.evaluate<{ _replay: ReplayContainer }>('window.Replay');
-  debugger;
-  console.log(replayIntegration._replay);
-  console.log(typeof replayIntegration);
-  console.log(Object.getPrototypeOf(replayIntegration._replay));
-  console.log('isenabled', replayIntegration._replay.isEnabled);
-
   return replayIntegration._replay;
 }
 

--- a/packages/integration-tests/utils/helpers.ts
+++ b/packages/integration-tests/utils/helpers.ts
@@ -1,5 +1,5 @@
 import type { Page, Request } from '@playwright/test';
-import type { ReplayContainer } from '@sentry/replay/build/npm/types/types';
+import { ReplayContainer } from '@sentry/replay/build/npm/types/types';
 import type { Event, EventEnvelopeHeaders } from '@sentry/types';
 
 const envelopeUrlRegex = /\.sentry\.io\/api\/\d+\/envelope\//;
@@ -60,6 +60,12 @@ async function getSentryEvents(page: Page, url?: string): Promise<Array<Event>> 
  */
 export async function getReplaySnapshot(page: Page): Promise<ReplayContainer> {
   const replayIntegration = await page.evaluate<{ _replay: ReplayContainer }>('window.Replay');
+  debugger;
+  console.log(replayIntegration._replay);
+  console.log(typeof replayIntegration);
+  console.log(Object.getPrototypeOf(replayIntegration._replay));
+  console.log('isenabled', replayIntegration._replay.isEnabled);
+
   return replayIntegration._replay;
 }
 

--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -107,6 +107,8 @@ export function makeTerserPlugin() {
           '_driver',
           '_initStorage',
           '_support',
+          // We want to keept he _replay variable unmangled to enable integration tests to access it
+          '_replay',
         ],
       },
     },

--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -107,8 +107,9 @@ export function makeTerserPlugin() {
           '_driver',
           '_initStorage',
           '_support',
-          // We want to keept he _replay variable unmangled to enable integration tests to access it
+          // We want to keept he _replay and _isEnabled variable unmangled to enable integration tests to access it
           '_replay',
+          '_isEnabled',
         ],
       },
     },


### PR DESCRIPTION
Thanks to #6666 we now can inject integration CDN bundles into our Playwright tests. This PR builds on top of #6666 and #6735 to inject the Replay CDN bundle into our integration tests and test against them.

We still can't get rid of the skip condition at the beginning of Replay tests, as we don't have es5 bundles for replay but I think that's fine for the time being. 

Furthermore, for this to work properly, Replay has to be imported from `@sentry/replay`. As a result, tests that run against Replay bundles technically don't check that it is continued to be exported via `@sentry/browser`. Hence, I copied the basic `captureReplay` test and left it once untouched, so we still cover importing Replay via `@sentry/browser`.

In order to test against the minified CDN bundles (which is most important IMO), I had to exclude the `_replay` variable from being mangled from terser in our bundles, as we're trying to access `window.Replay._replay` from the test. I'm fine with this change as long as it doesn't significantly blow up our bundle size but happy to look at better suggestions if necessary.

closes #6613 
