### PR TITLE
feat(replay): Add `flush` method to integration

### DIFF
--- a/packages/replay/README.md
+++ b/packages/replay/README.md
@@ -233,3 +233,9 @@ However, please note that it is _possible_ that the error count reported on the 
 does not match the actual errors that have been captured.
 The reason for that is that errors _can_ be lost, e.g. a network request fails, or similar.
 This should not happen to often, but be aware that it is theoretically possible.
+
+## Manually sending replay data
+
+You can use `replay.flush()` to immediately send all currently captured replay data.
+This can be combined with `replaysOnErrorSampleRate: 1`
+in order to be able to send the last 60 seconds of replay data on-demand.

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -185,6 +185,17 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
     this._replay.stop();
   }
 
+  /**
+   * Immediately send all pending events.
+   */
+  public flush(): Promise<void> | void {
+    if (!this._replay || !this._replay.isEnabled()) {
+      return;
+    }
+
+    return this._replay.flushImmediate();
+  }
+
   /** Setup the integration. */
   private _setup(): void {
     // Client is not available in constructor, so we need to wait until setupOnce


### PR DESCRIPTION
This exposes a `flush` method on the integration class, which can be used to flush any pending replay recording data immediately.

This has been requested a few times, and while this PR does not really add a first-class solution for this problem, it at least makes it possible to solve it manually. In combination with `replaysOnErrorSampleRate: 1` we can ensure that we _always_ capture up to 60s of replay data. Then, clients may trigger `replay.flush()` at any time (e.g. when the user clicks a "submit error" button or similar), sending the buffered replay data.

note: I went with `flush` vs. `flushImmediate`, as I'd say that is an internal concern of the replay container class - from a users perspective, `flush` makes sense here IMHO?

ref https://github.com/getsentry/sentry-javascript/issues/6537
ref https://github.com/getsentry/sentry-javascript/issues/6420