### PR TITLE
fix(node): Handle node build without `inspector` in `LocalVariables` integration

### DIFF
--- a/packages/node/test/integrations/localvariables.test.ts
+++ b/packages/node/test/integrations/localvariables.test.ts
@@ -244,7 +244,25 @@ describe('LocalVariables', () => {
     expect(eventProcessor).toBeUndefined();
   });
 
-  it.only('Should cache identical uncaught exception events', async () => {
+  it('Should not initialize when inspector not loaded', async () => {
+    expect.assertions(1);
+
+    const localVariables = new LocalVariables({}, undefined);
+    const options = getDefaultNodeClientOptions({
+      stackParser: defaultStackParser,
+      _experiments: { includeStackLocals: false },
+    });
+
+    let eventProcessor: EventProcessor | undefined;
+
+    (localVariables as unknown as LocalVariablesPrivate)._setup(callback => {
+      eventProcessor = callback;
+    }, options);
+
+    expect(eventProcessor).toBeUndefined();
+  });
+
+  it('Should cache identical uncaught exception events', async () => {
     expect.assertions(1);
 
     const session = new MockDebugSession({


### PR DESCRIPTION
Closes #6769

I didn't use `process.config.variables.v8_enable_inspector` since it appears undocumented and wrapping the loading in try/catch feels more future proof.