### PR TITLE
fix(otel): Make sure we handle when sentry-trace is an empty array

### DIFF
--- a/packages/opentelemetry-node/src/propagator.ts
+++ b/packages/opentelemetry-node/src/propagator.ts
@@ -59,7 +59,7 @@ export class SentryPropagator extends W3CBaggagePropagator {
     const maybeSentryTraceHeader: string | string[] | undefined = getter.get(carrier, SENTRY_TRACE_HEADER);
     if (maybeSentryTraceHeader) {
       const header = Array.isArray(maybeSentryTraceHeader) ? maybeSentryTraceHeader[0] : maybeSentryTraceHeader;
-      const traceparentData = extractTraceparentData(header);
+      const traceparentData = extractTraceparentData(header || '');
       newContext = newContext.setValue(SENTRY_TRACE_PARENT_CONTEXT_KEY, traceparentData);
       if (traceparentData) {
         const spanContext = {

--- a/packages/opentelemetry-node/test/propagator.test.ts
+++ b/packages/opentelemetry-node/test/propagator.test.ts
@@ -239,5 +239,11 @@ describe('SentryPropagator', () => {
       const context = propagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter);
       expect(context.getValue(SENTRY_DYNAMIC_SAMPLING_CONTEXT_KEY)).toEqual(undefined);
     });
+
+    it('handles when sentry-trace is an empty array', () => {
+      carrier[SENTRY_TRACE_HEADER] = [];
+      const context = propagator.extract(ROOT_CONTEXT, carrier, defaultTextMapGetter);
+      expect(context.getValue(SENTRY_TRACE_PARENT_CONTEXT_KEY)).toEqual(undefined);
+    });
   });
 });


### PR DESCRIPTION
When testing with a GRPC example I found that the carrier can return an empty array for some values. This checks for that, and adds a validation test.