### PR TITLE
chore: Add flaky test template

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky.yml
+++ b/.github/ISSUE_TEMPLATE/flaky.yml
@@ -1,0 +1,45 @@
+name: ❅ Flaky Test
+description: Report a flaky test in CI
+title: '[Flaky CI]: '
+labels: ['Type: CI Flakiness']
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Flakiness Type
+      description: What are you observing
+      options:
+        - Timeout
+        - Assertion failure
+        - Other / Unknown
+    validations:
+      required: true
+  - type: input
+    id: job-name
+    attributes:
+      label: Name of Job
+      placeholder: Build & Test / Nextjs (Node 10) Tests
+      description: name of job as reported in the status report
+    validations:
+      required: true
+  - type: input
+    id: test-name
+    attributes:
+      label: Name of Test
+      placeholder: tests/js/spec/views/settings/projectDebugFiles/customRepositories.spec.tsx
+      description: file name or function name of failing test
+    validations:
+      required: false
+  - type: input
+    id: test-run-link
+    attributes:
+      label: Link to Test Run
+      placeholder: https://github.com/getsentry/sentry/runs/5582673807
+      description: paste the URL to a test run showing the issue
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: If you know anything else, please add it here

--- a/.github/ISSUE_TEMPLATE/flaky.yml
+++ b/.github/ISSUE_TEMPLATE/flaky.yml
@@ -1,7 +1,7 @@
 name: ❅ Flaky Test
 description: Report a flaky test in CI
 title: '[Flaky CI]: '
-labels: ['Type: CI Flakiness']
+labels: ['Type: Tests']
 body:
   - type: dropdown
     id: type
@@ -26,7 +26,7 @@ body:
     id: test-name
     attributes:
       label: Name of Test
-      placeholder: tests/js/spec/views/settings/projectDebugFiles/customRepositories.spec.tsx
+      placeholder: suites/replay/captureReplay/test.ts
       description: file name or function name of failing test
     validations:
       required: false


### PR DESCRIPTION
Flaky tests are cancelled.

Add a issue template (mostly copied from https://github.com/getsentry/sentry/blame/master/.github/ISSUE_TEMPLATE/flaky.yml) that allows us to easily create issues when we identify flaky tests. 