### PR TITLE
test(nextjs): Disable `doubleEndMethodOnVercel` on Node 10

### DIFF
--- a/packages/nextjs/test/integration/test/server/doubleEndMethodOnVercel.js
+++ b/packages/nextjs/test/integration/test/server/doubleEndMethodOnVercel.js
@@ -1,8 +1,8 @@
-const { parseSemvar } = require('@sentry/utils');
+import { parseSemver } from '@sentry/utils';
 const assert = require('assert');
 const { getAsync } = require('../utils/server');
 
-const NODE_VERSION = parseSemvar(process.versions.node);
+const NODE_VERSION = parseSemver(process.versions.node);
 
 // This test asserts that our wrapping of `res.end` doesn't break API routes on Vercel if people call `res.json` or
 // `res.send` multiple times in one request handler.

--- a/packages/nextjs/test/integration/test/server/doubleEndMethodOnVercel.js
+++ b/packages/nextjs/test/integration/test/server/doubleEndMethodOnVercel.js
@@ -1,10 +1,17 @@
+const { parseSemvar } = require('@sentry/utils');
 const assert = require('assert');
 const { getAsync } = require('../utils/server');
+
+const NODE_VERSION = parseSemvar(process.versions.node);
 
 // This test asserts that our wrapping of `res.end` doesn't break API routes on Vercel if people call `res.json` or
 // `res.send` multiple times in one request handler.
 //  https://github.com/getsentry/sentry-javascript/issues/6670
 module.exports = async ({ url: urlBase }) => {
+  if (NODE_VERSION.major && NODE_VERSION.major <= 10) {
+    console.log('not running doubleEndMethodOnVercel test on Node 10');
+    return;
+  }
   const response = await getAsync(`${urlBase}/api/doubleEndMethodOnVercel`);
   assert.equal(response, '{"success":true}');
 };

--- a/packages/nextjs/test/integration/test/server/doubleEndMethodOnVercel.js
+++ b/packages/nextjs/test/integration/test/server/doubleEndMethodOnVercel.js
@@ -1,14 +1,11 @@
-import { parseSemver } from '@sentry/utils';
 const assert = require('assert');
 const { getAsync } = require('../utils/server');
-
-const NODE_VERSION = parseInt(process.env.NODE_VERSION, 10);
 
 // This test asserts that our wrapping of `res.end` doesn't break API routes on Vercel if people call `res.json` or
 // `res.send` multiple times in one request handler.
 //  https://github.com/getsentry/sentry-javascript/issues/6670
 module.exports = async ({ url: urlBase }) => {
-  if (NODE_VERSION <= 10) {
+  if (process.env.NODE_MAJOR === '10') {
     console.log('not running doubleEndMethodOnVercel test on Node 10');
     return;
   }

--- a/packages/nextjs/test/integration/test/server/doubleEndMethodOnVercel.js
+++ b/packages/nextjs/test/integration/test/server/doubleEndMethodOnVercel.js
@@ -2,13 +2,13 @@ import { parseSemver } from '@sentry/utils';
 const assert = require('assert');
 const { getAsync } = require('../utils/server');
 
-const NODE_VERSION = parseSemver(process.versions.node);
+const NODE_VERSION = parseInt(process.env.NODE_VERSION, 10);
 
 // This test asserts that our wrapping of `res.end` doesn't break API routes on Vercel if people call `res.json` or
 // `res.send` multiple times in one request handler.
 //  https://github.com/getsentry/sentry-javascript/issues/6670
 module.exports = async ({ url: urlBase }) => {
-  if (NODE_VERSION.major && NODE_VERSION.major <= 10) {
+  if (NODE_VERSION <= 10) {
     console.log('not running doubleEndMethodOnVercel test on Node 10');
     return;
   }

--- a/packages/nextjs/test/run-integration-tests.sh
+++ b/packages/nextjs/test/run-integration-tests.sh
@@ -36,6 +36,7 @@ for NEXTJS_VERSION in 10 11 12 13; do
   # having to pass this value from function to function to function to the one spot, deep in some callstack, where we
   # actually need it
   export NEXTJS_VERSION=$NEXTJS_VERSION
+  export NODE_VERSION=$NODE_VERSION
 
   # Next 10 requires at least Node v10
   if [ "$NODE_MAJOR" -lt "10" ]; then

--- a/packages/nextjs/test/run-integration-tests.sh
+++ b/packages/nextjs/test/run-integration-tests.sh
@@ -36,7 +36,7 @@ for NEXTJS_VERSION in 10 11 12 13; do
   # having to pass this value from function to function to function to the one spot, deep in some callstack, where we
   # actually need it
   export NEXTJS_VERSION=$NEXTJS_VERSION
-  export NODE_VERSION=$NODE_VERSION
+  export NODE_MAJOR=$NODE_MAJOR
 
   # Next 10 requires at least Node v10
   if [ "$NODE_MAJOR" -lt "10" ]; then


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/6784

Since `doubleEndMethodOnVercel` seems only to be flaky on Node 10, and it's very rare that NextJS apps are running on Node 10 (and impossible on Vercel), prevent this test from running in Node 10.