### PR TITLE
chore: Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Since version 2.23 (released in August 2019), git-blame has a feature
+# to ignore or bypass certain commits.
+#
+# This file contains a list of commits that are not likely what you
+# are looking for in a blame, such as mass reformatting or renaming.
+
+#  build: Add `@typescript-eslint/consistent-type-imports` rule (#6662)
+2aa4e94b036675245290596884959e06dcced044


### PR DESCRIPTION
Inspired by https://github.com/getsentry/sentry/blob/master/.git-blame-ignore-revs, this patch adds a .git-blame-ignore-revs file to the JS monorepo.

It was mainly motivated by getting rid of #6662 from git blame, and hopefully in the future this will help with bigger refactors.