### PR TITLE
fix(nextjs): Connect Edge API route errors to span

### DIFF
--- a/packages/nextjs/src/edge/utils/edgeWrapperUtils.ts
+++ b/packages/nextjs/src/edge/utils/edgeWrapperUtils.ts
@@ -80,6 +80,7 @@ export function withEdgeWrapping<H extends EdgeRouteHandler>(
       span?.setStatus('internal_error');
 
       captureException(objectifiedErr, scope => {
+        scope.setSpan(span);
         scope.addEventProcessor(event => {
           addExceptionMechanism(event, {
             type: 'instrument',


### PR DESCRIPTION
Seems like through some weird behavior passing a scope function to `captureException` disconnects the active span from the error. This PR fixes this for Edge API routes in the Next.js SDK.