### PR TITLE
fix(nextjs): Add back browser field in package.json

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -9,8 +9,9 @@
   "engines": {
     "node": ">=8"
   },
-  "main": "build/cjs/index.js",
-  "module": "build/esm/index.js",
+  "main": "build/cjs/index.server.js",
+  "module": "build/esm/index.server.js",
+  "browser": "build/esm/index.client.js",
   "types": "build/types/index.types.d.ts",
   "publishConfig": {
     "access": "public"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -55,7 +55,7 @@
     "build:transpile:watch": "nodemon --ext ts --watch src scripts/buildRollup.ts",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:tarball": "ts-node ../../scripts/prepack.ts && npm pack ./build",
-    "circularDepCheck": "madge --circular src/index.ts && madge --circular src/client/index.ts && madge --circular src/index.types.ts",
+    "circularDepCheck": "madge --circular src/index.client.ts && madge --circular src/edge/index.ts && madge --circular src/index.server.ts && madge --circular src/index.types.ts",
     "clean": "rimraf build coverage sentry-nextjs-*.tgz",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",

--- a/packages/nextjs/rollup.npm.config.js
+++ b/packages/nextjs/rollup.npm.config.js
@@ -5,7 +5,13 @@ export default [
     makeBaseNPMConfig({
       // We need to include `instrumentServer.ts` separately because it's only conditionally required, and so rollup
       // doesn't automatically include it when calculating the module dependency tree.
-      entrypoints: ['src/index.ts', 'src/client/index.ts', 'src/edge/index.ts', 'src/config/webpack.ts'],
+      entrypoints: [
+        'src/index.server.ts',
+        'src/index.client.ts',
+        'src/client/index.ts',
+        'src/edge/index.ts',
+        'src/config/webpack.ts',
+      ],
 
       // prevent this internal nextjs code from ending up in our built package (this doesn't happen automatially because
       // the name doesn't match an SDK dependency)

--- a/packages/nextjs/rollup.npm.config.js
+++ b/packages/nextjs/rollup.npm.config.js
@@ -5,13 +5,7 @@ export default [
     makeBaseNPMConfig({
       // We need to include `instrumentServer.ts` separately because it's only conditionally required, and so rollup
       // doesn't automatically include it when calculating the module dependency tree.
-      entrypoints: [
-        'src/index.server.ts',
-        'src/index.client.ts',
-        'src/client/index.ts',
-        'src/edge/index.ts',
-        'src/config/webpack.ts',
-      ],
+      entrypoints: ['src/index.server.ts', 'src/index.client.ts', 'src/edge/index.ts', 'src/config/webpack.ts'],
 
       // prevent this internal nextjs code from ending up in our built package (this doesn't happen automatially because
       // the name doesn't match an SDK dependency)

--- a/packages/nextjs/src/index.client.ts
+++ b/packages/nextjs/src/index.client.ts
@@ -1,0 +1,6 @@
+export * from './client';
+
+// This file is the main entrypoint for non-Next.js build pipelines that use
+// the package.json's "browser" field or the Edge runtime (Edge API routes and middleware)
+
+// __SENTRY_SDK_MULTIPLEXER__

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -1,0 +1,6 @@
+export * from './config';
+export * from './server';
+
+// This file is the main entrypoint on the server and/or when the package is `require`d
+
+// __SENTRY_SDK_MULTIPLEXER__

--- a/packages/nextjs/src/index.ts
+++ b/packages/nextjs/src/index.ts
@@ -1,4 +1,0 @@
-export * from './config';
-export * from './server';
-
-// __SENTRY_SDK_MULTIPLEXER__

--- a/packages/nextjs/test/serverSdk.test.ts
+++ b/packages/nextjs/test/serverSdk.test.ts
@@ -4,7 +4,7 @@ import type { Integration } from '@sentry/types';
 import { GLOBAL_OBJ, logger } from '@sentry/utils';
 import * as domain from 'domain';
 
-import { init } from '../src/index';
+import { init } from '../src/server';
 
 const { Integrations } = SentryNode;
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/6808

Some build pipelines that run outside of Next.js look at the `browser` field in the package.json to import package code that is intended for the browser.

With https://github.com/getsentry/sentry-javascript/pull/6753 we removed the browser field, thinking it wasn't necessary, breaking tooling like Storybook which now imported Node code.

This PR adds back the browser field, but we need to add another multiplexer entry point because Next.js will also look at the `browser` field to import SDK code for the Edge runtime.
