### PR TITLE
ref(replay): Send SDK version in Replay events

### DIFF
--- a/packages/replay/jest.setup.ts
+++ b/packages/replay/jest.setup.ts
@@ -1,12 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { getCurrentHub } from '@sentry/core';
 import type { ReplayRecordingData, Transport } from '@sentry/types';
-import {TextEncoder} from 'util';
+import { TextEncoder } from 'util';
 
 import type { ReplayContainer, Session } from './src/types';
-
-// @ts-ignore TS error, this is replaced in prod builds bc of rollup
-global.__SENTRY_REPLAY_VERSION__ = 'version:Test';
 
 (global as any).TextEncoder = TextEncoder;
 

--- a/packages/replay/rollup.bundle.config.js
+++ b/packages/replay/rollup.bundle.config.js
@@ -1,8 +1,4 @@
-import replace from '@rollup/plugin-replace';
-
 import { makeBaseBundleConfig, makeBundleConfigVariants } from '../../rollup/index.js';
-
-import pkg from './package.json';
 
 const baseBundleConfig = makeBaseBundleConfig({
   bundleType: 'addon',
@@ -10,16 +6,6 @@ const baseBundleConfig = makeBaseBundleConfig({
   jsVersion: 'es6',
   licenseTitle: '@sentry/replay',
   outputFileBase: () => 'bundles/replay',
-  packageSpecificConfig: {
-    plugins: [
-      replace({
-        preventAssignment: true,
-        values: {
-          __SENTRY_REPLAY_VERSION__: JSON.stringify(pkg.version),
-        },
-      }),
-    ],
-  },
 });
 
 const builds = makeBundleConfigVariants(baseBundleConfig);

--- a/packages/replay/rollup.npm.config.js
+++ b/packages/replay/rollup.npm.config.js
@@ -1,22 +1,9 @@
-import replace from '@rollup/plugin-replace';
-
 import { makeBaseNPMConfig, makeNPMConfigVariants } from '../../rollup/index';
-
-import pkg from './package.json';
 
 export default makeNPMConfigVariants(
   makeBaseNPMConfig({
     hasBundles: true,
     packageSpecificConfig: {
-      plugins: [
-        // TODO: Remove this - replay version will be in sync w/ SDK version
-        replace({
-          preventAssignment: true,
-          values: {
-            __SENTRY_REPLAY_VERSION__: JSON.stringify(pkg.version),
-          },
-        }),
-      ],
       output: {
         // set exports to 'named' or 'auto' so that rollup doesn't warn about
         // the default export in `worker/worker.js`

--- a/packages/replay/rollup.npm.config.js
+++ b/packages/replay/rollup.npm.config.js
@@ -8,6 +8,8 @@ export default makeNPMConfigVariants(
         // set exports to 'named' or 'auto' so that rollup doesn't warn about
         // the default export in `worker/worker.js`
         exports: 'named',
+        // set preserveModules to false because for Replay we actually want
+        // to bundle everything into one file.
         preserveModules: false,
       },
     },

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -29,10 +29,6 @@ export interface WorkerRequest {
   args: unknown[];
 }
 
-declare global {
-  const __SENTRY_REPLAY_VERSION__: string;
-}
-
 // PerformancePaintTiming and PerformanceNavigationTiming are only available with TS 4.4 and newer
 // Therefore, we're exporting them here to make them available in older TS versions
 export type PerformancePaintTiming = PerformanceEntry;

--- a/packages/replay/src/util/prepareReplayEvent.ts
+++ b/packages/replay/src/util/prepareReplayEvent.ts
@@ -30,12 +30,12 @@ export async function prepareReplayEvent({
 
   // extract the SDK name because `client._prepareEvent` doesn't add it to the event
   const metadata = client.getSdkMetadata && client.getSdkMetadata();
-  const name = (metadata && metadata.sdk && metadata.sdk.name) || 'sentry.javascript.unknown';
+  const { name, version } = (metadata && metadata.sdk) || {};
 
   preparedEvent.sdk = {
     ...preparedEvent.sdk,
-    version: __SENTRY_REPLAY_VERSION__,
-    name,
+    name: name || 'sentry.javascript.unknown',
+    version: version || '0.0.0',
   };
 
   return preparedEvent;

--- a/packages/replay/test/unit/util/prepareReplayEvent.test.ts
+++ b/packages/replay/test/unit/util/prepareReplayEvent.test.ts
@@ -18,6 +18,19 @@ describe('Unit | util | prepareReplayEvent', () => {
 
     client = hub.getClient()!;
     scope = hub.getScope()!;
+
+    jest.spyOn(client, 'getSdkMetadata').mockImplementation(() => {
+      return {
+        sdk: {
+          name: 'sentry.javascript.testSdk',
+          version: '1.0.0',
+        },
+      };
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('works', async () => {
@@ -39,6 +52,8 @@ describe('Unit | util | prepareReplayEvent', () => {
 
     const replayEvent = await prepareReplayEvent({ scope, client, replayId, event });
 
+    expect(client.getSdkMetadata).toHaveBeenCalledTimes(1);
+
     expect(replayEvent).toEqual({
       type: 'replay_event',
       timestamp: 1670837008.634,
@@ -52,8 +67,8 @@ describe('Unit | util | prepareReplayEvent', () => {
       event_id: 'replay-ID',
       environment: 'production',
       sdk: {
-        name: 'sentry.javascript.unknown',
-        version: 'version:Test',
+        name: 'sentry.javascript.testSdk',
+        version: '1.0.0',
       },
       sdkProcessingMetadata: {},
       breadcrumbs: undefined,

--- a/packages/tracing/rollup.bundle.config.js
+++ b/packages/tracing/rollup.bundle.config.js
@@ -1,8 +1,4 @@
-import replace from '@rollup/plugin-replace';
-
 import { makeBaseBundleConfig, makeBundleConfigVariants } from '../../rollup/index.js';
-
-import pkg from './package.json';
 
 const builds = [];
 
@@ -26,16 +22,6 @@ const replayBaseBundleConfig = makeBaseBundleConfig({
   licenseTitle: '@sentry/tracing & @sentry/browser & @sentry/replay',
   outputFileBase: () => 'bundles/bundle.tracing.replay',
   includeReplay: true,
-  packageSpecificConfig: {
-    plugins: [
-      replace({
-        preventAssignment: true,
-        values: {
-          __SENTRY_REPLAY_VERSION__: JSON.stringify(pkg.version),
-        },
-      }),
-    ],
-  },
 });
 
 builds.push(...makeBundleConfigVariants(replayBaseBundleConfig));


### PR DESCRIPTION
Since we now export Replay via the Browser SDK we can now send the SDK version instead of the Replay package.json version, allowing us to get rid of the custom rollup config to inject said version. 

closes #6366 