### PR TITLE
fix(nextjs): Correctly handle ts middleware files

### DIFF
--- a/packages/nextjs/src/config/loaders/wrappingLoader.ts
+++ b/packages/nextjs/src/config/loaders/wrappingLoader.ts
@@ -68,7 +68,7 @@ export default function wrappingLoader(
   }
 
   const middlewareJsPath = path.join(pagesDir, '..', 'middleware.js');
-  const middlewareTsPath = path.join(pagesDir, '..', 'middleware.js');
+  const middlewareTsPath = path.join(pagesDir, '..', 'middleware.ts');
 
   let templateCode: string;
   if (parameterizedRoute.startsWith('/api')) {


### PR DESCRIPTION
Potentially/hopefully relates to https://github.com/getsentry/sentry-javascript/issues/6815

s/js/ts/ in a place where js should be ts.