### PR TITLE
build(replay): Stop preserving modules

### DIFF
--- a/packages/replay/rollup.npm.config.js
+++ b/packages/replay/rollup.npm.config.js
@@ -1,5 +1,3 @@
-import path from 'path';
-
 import replace from '@rollup/plugin-replace';
 
 import { makeBaseNPMConfig, makeNPMConfigVariants } from '../../rollup/index';
@@ -23,12 +21,7 @@ export default makeNPMConfigVariants(
         // set exports to 'named' or 'auto' so that rollup doesn't warn about
         // the default export in `worker/worker.js`
         exports: 'named',
-
-        // As we are inlining the rrweb dependency here, we need to ensure the nested folders are correct
-        // Without this config, you get:
-        // * build/npm/esm/node_modules/rrweb/...
-        // * build/npm/esm/packages/replay/...
-        preserveModulesRoot: path.join(process.cwd(), 'src'),
+        preserveModules: false,
       },
     },
   }),

--- a/rollup/npmHelpers.js
+++ b/rollup/npmHelpers.js
@@ -95,12 +95,6 @@ export function makeBaseNPMConfig(options = {}) {
       ...Object.keys(packageDotJSON.dependencies || {}),
       ...Object.keys(packageDotJSON.peerDependencies || {}),
     ],
-
-    // TODO `'smallest'` will get rid of `isDebugBuild()` by evaluating it and inlining the result and then treeshaking
-    // from there. The current setting (false) prevents this, in case we want to leave it there for users to use in
-    // their own bundling. That said, we don't yet know for sure that that works, so come back to this.
-    // treeshake: 'smallest',
-    treeshake: false,
   };
 
   return deepMerge(defaultBaseConfig, packageSpecificConfig, {


### PR DESCRIPTION
Previously, when transpiling Replay, we preserved modules, just like in every other SDK of ours. In the case of Replay, however, we don't just rely on external dependencies but we want to include a patched version of rrweb in our NPM package. This lead to problems with specific bundler/build tool setups as reported in (#6690). 

With this PR, we don't preserve modules any longer, meaning, everything is bundled into one `index.js` file (similarly to CDN bundles). 

Just so that we're all aware: This is a breaking change for anyone who imports from explicit paths (e.g. `import { something } from '@sentry/replay/utils/test'`). However, we considered this okay in the past (e.g. #6707) as it is not something we instruct people to do in our docs and it is kind of an edge case. Given that Replay isn't fully stable yet, I'd vote it's an okay change to make right now. 

Tested this change locally with a plain-js test app.  

fixes #6690 

