### PR TITLE
fix(otel): Always set baggage regardless of active transaction

### DIFF
--- a/packages/opentelemetry-node/src/spanprocessor.ts
+++ b/packages/opentelemetry-node/src/spanprocessor.ts
@@ -23,7 +23,7 @@ export const SENTRY_SPAN_PROCESSOR_MAP: Map<SentrySpan['spanId'], SentrySpan> = 
 export class SentrySpanProcessor implements OtelSpanProcessor {
   public constructor() {
     addGlobalEventProcessor(event => {
-      const otelSpan = trace.getActiveSpan() as OtelSpan;
+      const otelSpan = trace && trace.getActiveSpan && (trace.getActiveSpan() as OtelSpan | undefined);
       if (!otelSpan) {
         return event;
       }

--- a/packages/opentelemetry-node/test/propagator.test.ts
+++ b/packages/opentelemetry-node/test/propagator.test.ts
@@ -166,6 +166,18 @@ describe('SentryPropagator', () => {
           );
         });
 
+        it('should create baggage without active transaction', () => {
+          const spanContext = {
+            traceId: 'd4cda95b652f4a1592b449d5929fda1b',
+            spanId: '6e0c63257de34c92',
+            traceFlags: TraceFlags.SAMPLED,
+          };
+          const context = trace.setSpanContext(ROOT_CONTEXT, spanContext);
+          const baggage = propagation.createBaggage({ foo: { value: 'bar' } });
+          propagator.inject(propagation.setBaggage(context, baggage), carrier, defaultTextMapSetter);
+          expect(carrier[SENTRY_BAGGAGE_HEADER]).toBe('foo=bar');
+        });
+
         it('should NOT set baggage and sentry-trace header if instrumentation is supressed', () => {
           const spanContext = {
             traceId: 'd4cda95b652f4a1592b449d5929fda1b',


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-javascript/issues/6807

Set baggage even when there is no active transaction. We do this because we are responsible for propagating baggage via the `W3CBaggagePropagator` which the `SentryPropagator` inherits from.