### PR TITLE
fix(nextjs): Disable NextJS perf monitoring when using otel

### DIFF
--- a/packages/nextjs/src/server/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/server/wrapApiHandlerWithSentry.ts
@@ -94,7 +94,7 @@ export function withSentry(origHandler: NextApiHandler, parameterizedRoute?: str
       if (currentScope) {
         currentScope.setSDKProcessingMetadata({ request: req });
 
-        if (hasTracingEnabled() && options?.instrumenter === 'sentry') {
+        if (hasTracingEnabled(options) && options?.instrumenter === 'sentry') {
           // If there is a trace header set, extract the data from it (parentSpanId, traceId, and sampling decision)
           let traceparentData;
           if (req.headers && isString(req.headers['sentry-trace'])) {

--- a/packages/nextjs/src/server/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/server/wrapApiHandlerWithSentry.ts
@@ -87,12 +87,14 @@ export function withSentry(origHandler: NextApiHandler, parameterizedRoute?: str
     // eslint-disable-next-line complexity
     const boundHandler = local.bind(async () => {
       let transaction: Transaction | undefined;
-      const currentScope = getCurrentHub().getScope();
+      const hub = getCurrentHub();
+      const currentScope = hub.getScope();
+      const options = hub.getClient()?.getOptions();
 
       if (currentScope) {
         currentScope.setSDKProcessingMetadata({ request: req });
 
-        if (hasTracingEnabled()) {
+        if (hasTracingEnabled() && options?.instrumenter === 'sentry') {
           // If there is a trace header set, extract the data from it (parentSpanId, traceId, and sampling decision)
           let traceparentData;
           if (req.headers && isString(req.headers['sentry-trace'])) {
@@ -137,7 +139,6 @@ export function withSentry(origHandler: NextApiHandler, parameterizedRoute?: str
             { request: req },
           );
           currentScope.setSpan(transaction);
-
           if (platformSupportsStreaming() && !origHandler.__sentry_test_doesnt_support_streaming__) {
             autoEndTransactionOnResponseEnd(transaction, res);
           } else {

--- a/packages/nextjs/src/server/wrapAppGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/server/wrapAppGetInitialPropsWithSentry.ts
@@ -1,3 +1,4 @@
+import { getCurrentHub } from '@sentry/node';
 import { hasTracingEnabled } from '@sentry/tracing';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type App from 'next/app';
@@ -29,12 +30,13 @@ export function wrapAppGetInitialPropsWithSentry(origAppGetInitialProps: AppGetI
     const { req, res } = context.ctx;
 
     const errorWrappedAppGetInitialProps = withErrorInstrumentation(origAppGetInitialProps);
+    const options = getCurrentHub().getClient()?.getOptions();
 
     // Generally we can assume that `req` and `res` are always defined on the server:
     // https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#context-object
     // This does not seem to be the case in dev mode. Because we have no clean way of associating the the data fetcher
     // span with each other when there are no req or res objects, we simply do not trace them at all here.
-    if (hasTracingEnabled() && req && res) {
+    if (hasTracingEnabled() && req && res && options?.instrumenter === 'sentry') {
       const tracedGetInitialProps = withTracedServerSideDataFetcher(errorWrappedAppGetInitialProps, req, res, {
         dataFetcherRouteName: '/_app',
         requestedRouteName: context.ctx.pathname,

--- a/packages/nextjs/src/server/wrapDocumentGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/server/wrapDocumentGetInitialPropsWithSentry.ts
@@ -1,3 +1,4 @@
+import { getCurrentHub } from '@sentry/node';
 import { hasTracingEnabled } from '@sentry/tracing';
 import type Document from 'next/document';
 
@@ -29,12 +30,13 @@ export function wrapDocumentGetInitialPropsWithSentry(
     const { req, res } = context;
 
     const errorWrappedGetInitialProps = withErrorInstrumentation(origDocumentGetInitialProps);
+    const options = getCurrentHub().getClient()?.getOptions();
 
     // Generally we can assume that `req` and `res` are always defined on the server:
     // https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#context-object
     // This does not seem to be the case in dev mode. Because we have no clean way of associating the the data fetcher
     // span with each other when there are no req or res objects, we simply do not trace them at all here.
-    if (hasTracingEnabled() && req && res) {
+    if (hasTracingEnabled() && req && res && options?.instrumenter === 'sentry') {
       const tracedGetInitialProps = withTracedServerSideDataFetcher(errorWrappedGetInitialProps, req, res, {
         dataFetcherRouteName: '/_document',
         requestedRouteName: context.pathname,

--- a/packages/nextjs/src/server/wrapGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/server/wrapGetInitialPropsWithSentry.ts
@@ -1,3 +1,4 @@
+import { getCurrentHub } from '@sentry/node';
 import { hasTracingEnabled } from '@sentry/tracing';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { NextPage } from 'next';
@@ -28,12 +29,13 @@ export function wrapGetInitialPropsWithSentry(origGetInitialProps: GetInitialPro
     const { req, res } = context;
 
     const errorWrappedGetInitialProps = withErrorInstrumentation(origGetInitialProps);
+    const options = getCurrentHub().getClient()?.getOptions();
 
     // Generally we can assume that `req` and `res` are always defined on the server:
     // https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#context-object
     // This does not seem to be the case in dev mode. Because we have no clean way of associating the the data fetcher
     // span with each other when there are no req or res objects, we simply do not trace them at all here.
-    if (hasTracingEnabled() && req && res) {
+    if (hasTracingEnabled() && req && res && options?.instrumenter === 'sentry') {
       const tracedGetInitialProps = withTracedServerSideDataFetcher(errorWrappedGetInitialProps, req, res, {
         dataFetcherRouteName: context.pathname,
         requestedRouteName: context.pathname,

--- a/packages/nextjs/src/server/wrapGetServerSidePropsWithSentry.ts
+++ b/packages/nextjs/src/server/wrapGetServerSidePropsWithSentry.ts
@@ -1,3 +1,4 @@
+import { getCurrentHub } from '@sentry/node';
 import { hasTracingEnabled } from '@sentry/tracing';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { GetServerSideProps } from 'next';
@@ -29,8 +30,9 @@ export function wrapGetServerSidePropsWithSentry(
     const { req, res } = context;
 
     const errorWrappedGetServerSideProps = withErrorInstrumentation(origGetServerSideProps);
+    const options = getCurrentHub().getClient()?.getOptions();
 
-    if (hasTracingEnabled()) {
+    if (hasTracingEnabled() && options?.instrumenter === 'sentry') {
       const tracedGetServerSideProps = withTracedServerSideDataFetcher(errorWrappedGetServerSideProps, req, res, {
         dataFetcherRouteName: parameterizedRoute,
         requestedRouteName: parameterizedRoute,

--- a/packages/nextjs/test/config/withSentry.test.ts
+++ b/packages/nextjs/test/config/withSentry.test.ts
@@ -66,9 +66,9 @@ describe('withSentry', () => {
 
   describe('tracing', () => {
     it('starts a transaction and sets metadata when tracing is enabled', async () => {
-      jest
-        .spyOn(hub.Hub.prototype, 'getClient')
-        .mockReturnValueOnce({ getOptions: () => ({ tracesSampleRate: 1 } as ClientOptions) } as Client);
+      jest.spyOn(hub.Hub.prototype, 'getClient').mockReturnValueOnce({
+        getOptions: () => ({ tracesSampleRate: 1, instrumenter: 'sentry' } as ClientOptions),
+      } as Client);
 
       await callWrappedHandler(wrappedHandlerNoError, req, res);
 

--- a/packages/nextjs/test/config/wrappers.test.ts
+++ b/packages/nextjs/test/config/wrappers.test.ts
@@ -1,4 +1,5 @@
 import * as SentryCore from '@sentry/core';
+import * as SentryNode from '@sentry/node';
 import * as SentryTracing from '@sentry/tracing';
 import type { IncomingMessage, ServerResponse } from 'http';
 
@@ -17,6 +18,12 @@ describe('data-fetching function wrappers', () => {
       res = { end: jest.fn() } as unknown as ServerResponse;
 
       jest.spyOn(SentryTracing, 'hasTracingEnabled').mockReturnValueOnce(true);
+      jest.spyOn(SentryNode, 'getCurrentHub').mockReturnValueOnce({
+        getClient: () =>
+          ({
+            getOptions: () => ({ instrumenter: 'sentry' }),
+          } as any),
+      } as any);
     });
 
     afterEach(() => {


### PR DESCRIPTION
Blocks release in https://github.com/getsentry/sentry-javascript/pull/6818 as well

Only instrument NextJS data fetchers for performance if the instrumenter is set to sentry (default).