### PR TITLE
fix(ci): Reduce flakiness of Replay integration tests

### DIFF
--- a/packages/integration-tests/suites/replay/captureReplay/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplay/test.ts
@@ -1,11 +1,12 @@
 import { expect } from '@playwright/test';
 import { SDK_VERSION } from '@sentry/browser';
+import type { ReplayEvent } from '@sentry/types';
 
 import { sentryTest } from '../../../utils/fixtures';
 import { envelopeRequestParser } from '../../../utils/helpers';
-import { waitForReplayRequest } from '../../../utils/replay';
+import { waitForReplayRequest } from '../../../utils/replayHelpers';
 
-sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
+sentryTest('should capture replays', async ({ getLocalTestPath, page }) => {
   // Replay bundles are es6 only
   if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_es5')) {
     sentryTest.skip();
@@ -25,10 +26,10 @@ sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);
-  const replayEvent0 = envelopeRequestParser(await reqPromise0);
+  const replayEvent0 = envelopeRequestParser(await reqPromise0) as ReplayEvent;
 
   await page.click('button');
-  const replayEvent1 = envelopeRequestParser(await reqPromise1);
+  const replayEvent1 = envelopeRequestParser(await reqPromise1) as ReplayEvent;
 
   expect(replayEvent0).toBeDefined();
   expect(replayEvent0).toEqual({

--- a/packages/integration-tests/suites/replay/captureReplay/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplay/test.ts
@@ -21,6 +21,7 @@ sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
 
   const url = await getLocalTestPath({ testDir: __dirname });
   await page.goto(url);
+  await page.waitForRequest('https://dsn.ingest.sentry.io/**/*');
 
   await page.click('button');
   await page.waitForRequest('https://dsn.ingest.sentry.io/**/*');

--- a/packages/integration-tests/suites/replay/captureReplay/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplay/test.ts
@@ -26,7 +26,7 @@ sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
     if (!postData) {
       return false;
     }
-    return postData.includes('replay_event');
+    return postData.includes('{"type":"replay_event"}');
   });
 
   await page.goto(url);
@@ -37,7 +37,7 @@ sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
     if (!postData) {
       return false;
     }
-    return postData.includes('replay_event');
+    return postData.includes('{"type":"replay_event"}');
   });
 
   await page.click('button');

--- a/packages/integration-tests/suites/replay/captureReplay/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplay/test.ts
@@ -21,11 +21,25 @@ sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
 
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  const reqPromise = page.waitForRequest('https://dsn.ingest.sentry.io/**/*');
+  const reqPromise = page.waitForRequest(req => {
+    const postData = req.postData();
+    if (!postData) {
+      return false;
+    }
+    return postData.includes('replay_event');
+  });
+
   await page.goto(url);
   await reqPromise;
 
-  const reqPromise2 = page.waitForRequest('https://dsn.ingest.sentry.io/**/*');
+  const reqPromise2 = page.waitForRequest(req => {
+    const postData = req.postData();
+    if (!postData) {
+      return false;
+    }
+    return postData.includes('replay_event');
+  });
+
   await page.click('button');
   await reqPromise2;
 

--- a/packages/integration-tests/suites/replay/captureReplay/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplay/test.ts
@@ -20,11 +20,14 @@ sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
   });
 
   const url = await getLocalTestPath({ testDir: __dirname });
-  await page.goto(url);
-  await page.waitForRequest('https://dsn.ingest.sentry.io/**/*');
 
+  const reqPromise = page.waitForRequest('https://dsn.ingest.sentry.io/**/*');
+  await page.goto(url);
+  await reqPromise;
+
+  const reqPromise2 = page.waitForRequest('https://dsn.ingest.sentry.io/**/*');
   await page.click('button');
-  await page.waitForRequest('https://dsn.ingest.sentry.io/**/*');
+  await reqPromise2;
 
   const replayEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/packages/integration-tests/suites/replay/captureReplay/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplay/test.ts
@@ -1,15 +1,19 @@
+import type { Page, Request } from '@playwright/test';
 import { expect } from '@playwright/test';
 import { SDK_VERSION } from '@sentry/browser';
-import type { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../utils/fixtures';
-import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
+import { envelopeRequestParser } from '../../../utils/helpers';
 
 sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
   // Replay bundles are es6 only
   if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_es5')) {
     sentryTest.skip();
   }
+
+  const reqPromise0 = waitForReplayRequest(page, 0);
+  const reqPromise1 = waitForReplayRequest(page, 1);
+  const reqPromise2 = waitForReplayRequest(page, 2);
 
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
     return route.fulfill({
@@ -21,37 +25,64 @@ sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
 
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  const reqPromise = page.waitForRequest(req => {
-    const postData = req.postData();
-    if (!postData) {
-      return false;
-    }
-    return postData.includes('{"type":"replay_event"}');
-  });
-
   await page.goto(url);
-  await reqPromise;
-
-  const reqPromise2 = page.waitForRequest(req => {
-    const postData = req.postData();
-    if (!postData) {
-      return false;
-    }
-    return postData.includes('{"type":"replay_event"}');
-  });
+  const req0 = await reqPromise0;
+  const replayEvent0 = envelopeRequestParser(req0);
 
   await page.click('button');
-  await reqPromise2;
+  await reqPromise1;
 
-  const replayEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
+  await page.click('button');
+  const req2 = await reqPromise2;
 
-  expect(replayEvent).toBeDefined();
-  expect(replayEvent).toEqual({
+  const replayEvent2 = envelopeRequestParser(req2);
+
+  expect(replayEvent0).toBeDefined();
+  expect(replayEvent0).toEqual({
     type: 'replay_event',
     timestamp: expect.any(Number),
     error_ids: [],
     trace_ids: [],
     urls: [expect.stringContaining('/dist/index.html')],
+    replay_id: expect.stringMatching(/\w{32}/),
+    replay_start_timestamp: expect.any(Number),
+    segment_id: 0,
+    replay_type: 'session',
+    event_id: expect.stringMatching(/\w{32}/),
+    environment: 'production',
+    sdk: {
+      integrations: [
+        'InboundFilters',
+        'FunctionToString',
+        'TryCatch',
+        'Breadcrumbs',
+        'GlobalHandlers',
+        'LinkedErrors',
+        'Dedupe',
+        'HttpContext',
+        'Replay',
+      ],
+      version: SDK_VERSION,
+      name: 'sentry.javascript.browser',
+    },
+    sdkProcessingMetadata: {},
+    request: {
+      url: expect.stringContaining('/dist/index.html'),
+      headers: {
+        'User-Agent': expect.stringContaining(''),
+      },
+    },
+    platform: 'javascript',
+    tags: { sessionSampleRate: 1, errorSampleRate: 0 },
+  });
+
+  expect(replayEvent2).toBeDefined();
+  expect(replayEvent2).toEqual({
+    type: 'replay_event',
+    timestamp: expect.any(Number),
+    error_ids: [],
+    trace_ids: [],
+    urls: [],
     replay_id: expect.stringMatching(/\w{32}/),
     segment_id: 2,
     replay_type: 'session',
@@ -83,3 +114,23 @@ sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
     tags: { sessionSampleRate: 1, errorSampleRate: 0 },
   });
 });
+
+function waitForReplayRequest(page: Page, segmentId?: number): Promise<Request> {
+  return page.waitForRequest(
+    req => {
+      const postData = req.postData();
+      if (!postData) {
+        return false;
+      }
+      console.log(postData);
+
+      const isReplayRequest = postData.includes('{"type":"replay_event"}');
+
+      if (isReplayRequest && segmentId !== undefined) {
+        return postData.includes(`{"segment_id":${segmentId}}`);
+      }
+      return isReplayRequest;
+    },
+    { timeout: 30_000 },
+  );
+}

--- a/packages/integration-tests/suites/replay/captureReplay/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplay/test.ts
@@ -23,7 +23,7 @@ sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
   await page.goto(url);
 
   await page.click('button');
-  await page.waitForTimeout(300);
+  await page.waitForRequest('https://dsn.ingest.sentry.io/**/*');
 
   const replayEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/packages/integration-tests/suites/replay/captureReplayViaBrowser/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplayViaBrowser/test.ts
@@ -1,11 +1,12 @@
 import { expect } from '@playwright/test';
 import { SDK_VERSION } from '@sentry/browser';
+import type { ReplayEvent } from '@sentry/types';
 
 import { sentryTest } from '../../../utils/fixtures';
 import { envelopeRequestParser } from '../../../utils/helpers';
-import { waitForReplayRequest } from '../../../utils/replay';
+import { waitForReplayRequest } from '../../../utils/replayHelpers';
 
-sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
+sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalTestPath, page }) => {
   // For this test, we skip all bundle tests, as we're only interested in Replay being correctly
   // exported from the `@sentry/browser` npm package.
   if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_')) {
@@ -26,10 +27,10 @@ sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);
-  const replayEvent0 = envelopeRequestParser(await reqPromise0);
+  const replayEvent0 = envelopeRequestParser(await reqPromise0) as ReplayEvent;
 
   await page.click('button');
-  const replayEvent1 = envelopeRequestParser(await reqPromise1);
+  const replayEvent1 = envelopeRequestParser(await reqPromise1) as ReplayEvent;
 
   expect(replayEvent0).toBeDefined();
   expect(replayEvent0).toEqual({

--- a/packages/integration-tests/suites/replay/captureReplayViaBrowser/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplayViaBrowser/test.ts
@@ -1,9 +1,9 @@
 import { expect } from '@playwright/test';
 import { SDK_VERSION } from '@sentry/browser';
-import type { Event } from '@sentry/types';
 
 import { sentryTest } from '../../../utils/fixtures';
-import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
+import { envelopeRequestParser } from '../../../utils/helpers';
+import { waitForReplayRequest } from '../../../utils/replay';
 
 sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
   // For this test, we skip all bundle tests, as we're only interested in Replay being correctly
@@ -11,6 +11,9 @@ sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
   if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_')) {
     sentryTest.skip();
   }
+
+  const reqPromise0 = waitForReplayRequest(page, 0);
+  const reqPromise1 = waitForReplayRequest(page, 1);
 
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
     return route.fulfill({
@@ -21,23 +24,61 @@ sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
   });
 
   const url = await getLocalTestPath({ testDir: __dirname });
+
   await page.goto(url);
-  await page.waitForRequest('https://dsn.ingest.sentry.io/**/*');
+  const replayEvent0 = envelopeRequestParser(await reqPromise0);
 
   await page.click('button');
-  await page.waitForRequest('https://dsn.ingest.sentry.io/**/*');
+  const replayEvent1 = envelopeRequestParser(await reqPromise1);
 
-  const replayEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
-
-  expect(replayEvent).toBeDefined();
-  expect(replayEvent).toEqual({
+  expect(replayEvent0).toBeDefined();
+  expect(replayEvent0).toEqual({
     type: 'replay_event',
     timestamp: expect.any(Number),
     error_ids: [],
     trace_ids: [],
     urls: [expect.stringContaining('/dist/index.html')],
     replay_id: expect.stringMatching(/\w{32}/),
-    segment_id: 2,
+    replay_start_timestamp: expect.any(Number),
+    segment_id: 0,
+    replay_type: 'session',
+    event_id: expect.stringMatching(/\w{32}/),
+    environment: 'production',
+    sdk: {
+      integrations: [
+        'InboundFilters',
+        'FunctionToString',
+        'TryCatch',
+        'Breadcrumbs',
+        'GlobalHandlers',
+        'LinkedErrors',
+        'Dedupe',
+        'HttpContext',
+        'Replay',
+      ],
+      version: SDK_VERSION,
+      name: 'sentry.javascript.browser',
+    },
+    sdkProcessingMetadata: {},
+    request: {
+      url: expect.stringContaining('/dist/index.html'),
+      headers: {
+        'User-Agent': expect.stringContaining(''),
+      },
+    },
+    platform: 'javascript',
+    tags: { sessionSampleRate: 1, errorSampleRate: 0 },
+  });
+
+  expect(replayEvent1).toBeDefined();
+  expect(replayEvent1).toEqual({
+    type: 'replay_event',
+    timestamp: expect.any(Number),
+    error_ids: [],
+    trace_ids: [],
+    urls: [],
+    replay_id: expect.stringMatching(/\w{32}/),
+    segment_id: 1,
     replay_type: 'session',
     event_id: expect.stringMatching(/\w{32}/),
     environment: 'production',

--- a/packages/integration-tests/suites/replay/captureReplayViaBrowser/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplayViaBrowser/test.ts
@@ -24,7 +24,7 @@ sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
   await page.goto(url);
 
   await page.click('button');
-  await page.waitForTimeout(300);
+  await page.waitForRequest('https://dsn.ingest.sentry.io/**/*');
 
   const replayEvent = await getFirstSentryEnvelopeRequest<Event>(page, url);
 

--- a/packages/integration-tests/suites/replay/captureReplayViaBrowser/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplayViaBrowser/test.ts
@@ -22,6 +22,7 @@ sentryTest('captureReplay', async ({ getLocalTestPath, page }) => {
 
   const url = await getLocalTestPath({ testDir: __dirname });
   await page.goto(url);
+  await page.waitForRequest('https://dsn.ingest.sentry.io/**/*');
 
   await page.click('button');
   await page.waitForRequest('https://dsn.ingest.sentry.io/**/*');

--- a/packages/integration-tests/suites/replay/errorResponse/test.ts
+++ b/packages/integration-tests/suites/replay/errorResponse/test.ts
@@ -22,8 +22,8 @@ sentryTest('errorResponse', async ({ getLocalTestPath, page }) => {
   const url = await getLocalTestPath({ testDir: __dirname });
   await page.goto(url);
 
+  await page.waitForRequest('https://dsn.ingest.sentry.io/**/*');
   await page.click('button');
-  await page.waitForTimeout(300);
 
   expect(called).toBe(1);
 

--- a/packages/integration-tests/suites/replay/errorResponse/test.ts
+++ b/packages/integration-tests/suites/replay/errorResponse/test.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 
 import { sentryTest } from '../../../utils/fixtures';
-import { getReplaySnapshot, waitForReplayRequest } from '../../../utils/replayHelpers';
+import { getReplaySnapshot, REPLAY_DEFAULT_FLUSH_MAX_DELAY, waitForReplayRequest } from '../../../utils/replayHelpers';
 
 sentryTest('should stop recording after receiving an error response', async ({ getLocalTestPath, page }) => {
   // Currently bundle tests are not supported for replay
@@ -30,7 +30,7 @@ sentryTest('should stop recording after receiving an error response', async ({ g
   // Should immediately skip retrying and just cancel, no backoff
   // This waitForTimeout call should be okay, as we're not checking for any
   // further network requests afterwards.
-  await page.waitForTimeout(5001);
+  await page.waitForTimeout(REPLAY_DEFAULT_FLUSH_MAX_DELAY + 1);
 
   expect(called).toBe(1);
 

--- a/packages/integration-tests/suites/replay/sampling/test.ts
+++ b/packages/integration-tests/suites/replay/sampling/test.ts
@@ -24,7 +24,7 @@ sentryTest('sampling', async ({ getLocalTestPath, page }) => {
   await page.goto(url);
 
   await page.click('button');
-  await page.waitForTimeout(200);
+  await page.waitForTimeout(500);
 
   const replay = await getReplaySnapshot(page);
 

--- a/packages/integration-tests/suites/replay/sampling/test.ts
+++ b/packages/integration-tests/suites/replay/sampling/test.ts
@@ -1,9 +1,9 @@
 import { expect } from '@playwright/test';
 
 import { sentryTest } from '../../../utils/fixtures';
-import { getReplaySnapshot } from '../../../utils/helpers';
+import { getReplaySnapshot } from '../../../utils/replayHelpers';
 
-sentryTest('sampling', async ({ getLocalTestPath, page }) => {
+sentryTest('should not send replays if both sample rates are 0', async ({ getLocalTestPath, page }) => {
   // Replay bundles are es6 only
   if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_es5')) {
     sentryTest.skip();
@@ -24,6 +24,8 @@ sentryTest('sampling', async ({ getLocalTestPath, page }) => {
   await page.goto(url);
 
   await page.click('button');
+
+  // This waitForTimeout call should be okay, as we're not checking for any requests after it
   await page.waitForTimeout(500);
 
   const replay = await getReplaySnapshot(page);

--- a/packages/integration-tests/suites/replay/sampling/test.ts
+++ b/packages/integration-tests/suites/replay/sampling/test.ts
@@ -25,9 +25,6 @@ sentryTest('should not send replays if both sample rates are 0', async ({ getLoc
 
   await page.click('button');
 
-  // This waitForTimeout call should be okay, as we're not checking for any requests after it
-  await page.waitForTimeout(500);
-
   const replay = await getReplaySnapshot(page);
 
   expect(replay.session?.sampled).toBe(false);

--- a/packages/integration-tests/utils/helpers.ts
+++ b/packages/integration-tests/utils/helpers.ts
@@ -1,5 +1,4 @@
 import type { Page, Request } from '@playwright/test';
-import type { ReplayContainer } from '@sentry/replay/build/npm/types/types';
 import type { EnvelopeItemType, Event, EventEnvelopeHeaders } from '@sentry/types';
 
 const envelopeUrlRegex = /\.sentry\.io\/api\/\d+\/envelope\//;
@@ -103,16 +102,6 @@ async function getSentryEvents(page: Page, url?: string): Promise<Array<Event>> 
   const eventsHandle = await page.evaluateHandle<Array<Event>>('window.events');
 
   return eventsHandle.jsonValue();
-}
-
-/**
- * This returns the replay container (assuming it exists).
- * Note that due to how this works with playwright, this is a POJO copy of replay.
- * This means that we cannot access any methods on it, and also not mutate it in any way.
- */
-export async function getReplaySnapshot(page: Page): Promise<ReplayContainer> {
-  const replayIntegration = await page.evaluate<{ _replay: ReplayContainer }>('window.Replay');
-  return replayIntegration._replay;
 }
 
 /**

--- a/packages/integration-tests/utils/helpers.ts
+++ b/packages/integration-tests/utils/helpers.ts
@@ -4,7 +4,7 @@ import type { EnvelopeItemType, Event, EventEnvelopeHeaders } from '@sentry/type
 
 const envelopeUrlRegex = /\.sentry\.io\/api\/\d+\/envelope\//;
 
-const envelopeRequestParser = (request: Request | null): Event => {
+export const envelopeRequestParser = (request: Request | null): Event => {
   // https://develop.sentry.dev/sdk/envelopes/
   const envelope = request?.postData() || '';
 

--- a/packages/integration-tests/utils/replayHelpers.ts
+++ b/packages/integration-tests/utils/replayHelpers.ts
@@ -1,0 +1,56 @@
+import type { ReplayContainer } from '@sentry/replay/build/npm/types/types';
+import type { Event, ReplayEvent } from '@sentry/types';
+import type { Page, Request } from 'playwright';
+
+import { envelopeRequestParser } from './helpers';
+
+/**
+ * Waits for a replay request to be sent by the page and returns it.
+ *
+ * Optionally, you can specify a segmentId to wait for a specific replay request, containing
+ * the segment_id in the replay envelope.
+ * This is useful for tests where you want to wait on multiple replay requests or check
+ * segment order.
+ *
+ * @param page the playwright page object
+ * @param segmentId the segment_id of the replay event
+ * @returns
+ */
+export function waitForReplayRequest(page: Page, segmentId?: number): Promise<Request> {
+  return page.waitForRequest(req => {
+    const postData = req.postData();
+    if (!postData) {
+      return false;
+    }
+
+    try {
+      const event = envelopeRequestParser(req);
+
+      if (!isReplayEvent(event)) {
+        return false;
+      }
+
+      if (segmentId !== undefined) {
+        return event.segment_id === segmentId;
+      }
+
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function isReplayEvent(event: Event): event is ReplayEvent {
+  return event.type === 'replay_event';
+}
+
+/**
+ * This returns the replay container (assuming it exists).
+ * Note that due to how this works with playwright, this is a POJO copy of replay.
+ * This means that we cannot access any methods on it, and also not mutate it in any way.
+ */
+export async function getReplaySnapshot(page: Page): Promise<ReplayContainer> {
+  const replayIntegration = await page.evaluate<{ _replay: ReplayContainer }>('window.Replay');
+  return replayIntegration._replay;
+}

--- a/packages/integration-tests/utils/replayHelpers.ts
+++ b/packages/integration-tests/utils/replayHelpers.ts
@@ -54,3 +54,5 @@ export async function getReplaySnapshot(page: Page): Promise<ReplayContainer> {
   const replayIntegration = await page.evaluate<{ _replay: ReplayContainer }>('window.Replay');
   return replayIntegration._replay;
 }
+
+export const REPLAY_DEFAULT_FLUSH_MAX_DELAY = 5_000;


### PR DESCRIPTION
This PR replaces a bunch of `page.waitForTimeout` calls with `page.waitForRequest` waits which should make Replay integration tests more stable. I couldn't remove all timeout calls, as we're not always actually waiting for a request but the ones that failed mostly in CI are now gone. 

When relying on outgoing http requests during a test, we should try to be as specific as possible in terms of _which_ request we're actually expecting when. Therefore, I added a `waitForReplayRequest`, which ensures we're actually waiting for a replay request. Optionally, this helper takes a `segmentId` to wait for a replay request of a specific replay segment. This might be useful for more involved testing scenarios.

closes #6800 