### PR TITLE
build: `build:bundle` does not depend on `build:types`

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -28,9 +28,7 @@
     "build:bundle": {
       "dependsOn": [
         "^build:transpile",
-        "build:transpile",
-        "^build:types",
-        "build:types"
+        "build:transpile"
       ],
       "outputs": [
         "{projectRoot}/build/bundles"


### PR DESCRIPTION
This sneaked through, and is actually not necessary from a dependency perspecitve.