### PR TITLE
chore(replay): contributing.md outdated note

### DIFF
--- a/packages/replay/CONTRIBUTING.md
+++ b/packages/replay/CONTRIBUTING.md
@@ -1,5 +1,4 @@
 ## Updating the rrweb dependency
 
 When [updating the `rrweb` dependency](https://github.com/getsentry/sentry-javascript/blob/a493aa6a46555b944c8d896a2164bcd8b11caaf5/packages/replay/package.json?plain=1#LL55),
-please be aware that in [addition to `@sentry/replay`'s README.md](https://github.com/getsentry/sentry-javascript/blob/a493aa6a46555b944c8d896a2164bcd8b11caaf5/packages/replay/README.md?plain=1#LL204),
-Sentry docs also [point to a specific version of `rrweb`](https://github.com/getsentry/sentry-docs/blob/d6adadffc9e468ba777ccc733e69c373181237c9/src/platforms/javascript/common/session-replay/configuration.mdx?plain=1#LL49) that has configuration that needs to be updated.
+please be aware that [`@sentry/replay`'s README.md](https://github.com/getsentry/sentry-javascript/blob/a493aa6a46555b944c8d896a2164bcd8b11caaf5/packages/replay/README.md?plain=1#LL204) also needs to be updated.


### PR DESCRIPTION
No longer true after:

https://github.com/getsentry/sentry-docs/pull/6094/files