### PR TITLE
feat(tracing): Promote `enableLongTask` to option of `BrowserTracing`

### DIFF
--- a/packages/integration-tests/suites/tracing/browsertracing/long-tasks-disabled/init.js
+++ b/packages/integration-tests/suites/tracing/browsertracing/long-tasks-disabled/init.js
@@ -5,6 +5,6 @@ window.Sentry = Sentry;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  integrations: [new Integrations.BrowserTracing({ _experiments: { enableLongTasks: false }, idleTimeout: 9000 })],
+  integrations: [new Integrations.BrowserTracing({ enableLongTask: false, idleTimeout: 9000 })],
   tracesSampleRate: 1,
 });

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -72,6 +72,13 @@ export interface BrowserTracingOptions extends RequestInstrumentationOptions {
   markBackgroundTransactions: boolean;
 
   /**
+   * If true, Sentry will capture long tasks and add them to the corresponding transaction.
+   *
+   * Default: true
+   */
+  enableLongTask: boolean;
+
+  /**
    * _metricOptions allows the user to send options to change how metrics are collected.
    *
    * _metricOptions is currently experimental.
@@ -87,6 +94,9 @@ export interface BrowserTracingOptions extends RequestInstrumentationOptions {
 
   /**
    * _experiments allows the user to send options to define how this integration works.
+   * Note that the `enableLongTask` options is deprecated in favor of the option at the top level, and will be removed in v8.
+   *
+   * TODO (v8): Remove enableLongTask
    *
    * Default: undefined
    */
@@ -124,7 +134,8 @@ const DEFAULT_BROWSER_TRACING_OPTIONS: BrowserTracingOptions = {
   routingInstrumentation: instrumentRoutingWithDefaults,
   startTransactionOnLocationChange: true,
   startTransactionOnPageLoad: true,
-  _experiments: { enableLongTask: true, enableInteractions: false },
+  enableLongTask: true,
+  _experiments: {},
   ...defaultRequestInstrumentationOptions,
 };
 
@@ -160,6 +171,12 @@ export class BrowserTracing implements Integration {
       ..._options,
     };
 
+    // Special case: enableLongTask can be set in _experiments
+    // TODO (v8): Remove this in v8
+    if (this.options._experiments.enableLongTask !== undefined) {
+      this.options.enableLongTask = this.options._experiments.enableLongTask;
+    }
+
     // TODO (v8): remove this block after tracingOrigins is removed
     // Set tracePropagationTargets to tracingOrigins if specified by the user
     // In case both are specified, tracePropagationTargets takes precedence
@@ -170,7 +187,7 @@ export class BrowserTracing implements Integration {
     }
 
     startTrackingWebVitals();
-    if (this.options._experiments.enableLongTask) {
+    if (this.options.enableLongTask) {
       startTrackingLongTasks();
     }
   }

--- a/packages/tracing/test/browser/browsertracing.test.ts
+++ b/packages/tracing/test/browser/browsertracing.test.ts
@@ -84,10 +84,50 @@ describe('BrowserTracing', () => {
     const browserTracing = createBrowserTracing();
 
     expect(browserTracing.options).toEqual({
+      _experiments: {},
+      enableLongTask: true,
+      idleTimeout: DEFAULT_IDLE_TIMEOUT,
+      finalTimeout: DEFAULT_FINAL_TIMEOUT,
+      heartbeatInterval: DEFAULT_HEARTBEAT_INTERVAL,
+      markBackgroundTransactions: true,
+      routingInstrumentation: instrumentRoutingWithDefaults,
+      startTransactionOnLocationChange: true,
+      startTransactionOnPageLoad: true,
+      ...defaultRequestInstrumentationOptions,
+    });
+  });
+
+  it('is allows to disable enableLongTask via _experiments', () => {
+    const browserTracing = createBrowserTracing(false, {
       _experiments: {
-        enableLongTask: true,
-        enableInteractions: false,
+        enableLongTask: false,
       },
+    });
+
+    expect(browserTracing.options).toEqual({
+      _experiments: {
+        enableLongTask: false,
+      },
+      enableLongTask: false,
+      idleTimeout: DEFAULT_IDLE_TIMEOUT,
+      finalTimeout: DEFAULT_FINAL_TIMEOUT,
+      heartbeatInterval: DEFAULT_HEARTBEAT_INTERVAL,
+      markBackgroundTransactions: true,
+      routingInstrumentation: instrumentRoutingWithDefaults,
+      startTransactionOnLocationChange: true,
+      startTransactionOnPageLoad: true,
+      ...defaultRequestInstrumentationOptions,
+    });
+  });
+
+  it('is allows to disable enableLongTask', () => {
+    const browserTracing = createBrowserTracing(false, {
+      enableLongTask: false,
+    });
+
+    expect(browserTracing.options).toEqual({
+      _experiments: {},
+      enableLongTask: false,
       idleTimeout: DEFAULT_IDLE_TIMEOUT,
       finalTimeout: DEFAULT_FINAL_TIMEOUT,
       heartbeatInterval: DEFAULT_HEARTBEAT_INTERVAL,


### PR DESCRIPTION
This experiment was on by default, which showed that this is not actually an experiment anymore, and thus should be promoted to a regular option.