### PR TITLE
ref(nextjs): Remove NFT build time exclusions

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -27,7 +27,6 @@ import type {
   WebpackConfigObjectWithModuleRules,
   WebpackEntryProperty,
   WebpackModuleRule,
-  WebpackPluginInstance,
 } from './types';
 
 export { SentryWebpackPlugin };
@@ -158,31 +157,6 @@ export function constructWebpackConfigFunction(
             },
           ],
         });
-      }
-
-      // Prevent `@vercel/nft` (which nextjs uses to determine which files are needed when packaging up a lambda) from
-      // including any of our build-time code or dependencies. (Otherwise it'll include files like this one and even the
-      // entirety of rollup and sucrase.) Since this file is the root of that dependency tree, it's enough to just
-      // exclude it and the rest will be excluded as well.
-      const nftPlugin = newConfig.plugins?.find((plugin: WebpackPluginInstance) => {
-        const proto = Object.getPrototypeOf(plugin) as WebpackPluginInstance;
-        return proto.constructor.name === 'TraceEntryPointsPlugin';
-      }) as WebpackPluginInstance & { excludeFiles: string[] };
-      if (nftPlugin) {
-        if (Array.isArray(nftPlugin.excludeFiles)) {
-          nftPlugin.excludeFiles.push(__filename);
-        } else {
-          __DEBUG_BUILD__ &&
-            logger.warn(
-              'Unable to exclude Sentry build-time helpers from nft files. `TraceEntryPointsPlugin.excludeFiles` is not ' +
-                'an array. This is a bug; please report this to Sentry:  https://github.com/getsentry/sentry-javascript/issues/.',
-            );
-        }
-      } else {
-        __DEBUG_BUILD__ &&
-          logger.warn(
-            'Unable to exclude Sentry build-time helpers from nft files. Could not find `TraceEntryPointsPlugin`.',
-          );
       }
     }
 

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -1,14 +1,7 @@
 /* eslint-disable complexity */
 /* eslint-disable max-lines */
 import { getSentryRelease } from '@sentry/node';
-import {
-  arrayify,
-  dropUndefinedKeys,
-  escapeStringForRegex,
-  GLOBAL_OBJ,
-  logger,
-  stringMatchesSomePattern,
-} from '@sentry/utils';
+import { arrayify, dropUndefinedKeys, escapeStringForRegex, logger, stringMatchesSomePattern } from '@sentry/utils';
 import { default as SentryWebpackPlugin } from '@sentry/webpack-plugin';
 import * as chalk from 'chalk';
 import * as fs from 'fs';
@@ -34,14 +27,6 @@ export { SentryWebpackPlugin };
 // TODO: merge default SentryWebpackPlugin ignore with their SentryWebpackPlugin ignore or ignoreFile
 // TODO: merge default SentryWebpackPlugin include with their SentryWebpackPlugin include
 // TODO: drop merged keys from override check? `includeDefaults` option?
-
-// In order to make sure that build-time code isn't getting bundled in runtime bundles (specifically, in the serverless
-// functions into which nextjs converts a user's routes), we exclude this module (and all of its dependencies) from the
-// nft file manifests nextjs generates. (See the code dealing with the `TraceEntryPointsPlugin` below.) So that we don't
-// crash people, we therefore need to make sure nothing tries to either require this file or import from it. Setting
-// this env variable allows us to test whether or not that's happened.
-const _global = GLOBAL_OBJ as typeof GLOBAL_OBJ & { _sentryWebpackModuleLoaded?: true };
-_global._sentryWebpackModuleLoaded = true;
 
 /**
  * Construct the function which will be used as the nextjs config's `webpack` value.

--- a/packages/nextjs/test/config/withSentryConfig.test.ts
+++ b/packages/nextjs/test/config/withSentryConfig.test.ts
@@ -59,46 +59,4 @@ describe('withSentryConfig', () => {
     // directly
     expect('sentry' in finalConfig).toBe(false);
   });
-
-  describe('conditional use of `constructWebpackConfigFunction`', () => {
-    // Note: In these tests, it would be nice to be able to spy on `constructWebpackConfigFunction` to see whether or
-    // not it's called, but that sets up a catch-22: If you import or require the module to spy on the function, it gets
-    // cached and the `require` call we care about (inside of `withSentryConfig`) doesn't actually run the module code.
-    // Alternatively, if we call `jest.resetModules()` after setting up the spy, then the module code *is* run a second
-    // time, but the spy belongs to the first instance of the module and therefore never registers a call. Thus we have
-    // to test whether or not the file is required instead.
-
-    it('imports from `webpack.ts` if build phase is "phase-production-build"', () => {
-      jest.isolateModules(() => {
-        // In case this is still set from elsewhere, reset it
-        delete (global as any)._sentryWebpackModuleLoaded;
-
-        materializeFinalNextConfig(exportedNextConfig, undefined, 'phase-production-build');
-
-        expect((global as any)._sentryWebpackModuleLoaded).toBe(true);
-      });
-    });
-
-    it('imports from `webpack.ts` if build phase is "phase-development-server"', () => {
-      jest.isolateModules(() => {
-        // In case this is still set from elsewhere, reset it
-        delete (global as any)._sentryWebpackModuleLoaded;
-
-        materializeFinalNextConfig(exportedNextConfig, undefined, 'phase-production-build');
-
-        expect((global as any)._sentryWebpackModuleLoaded).toBe(true);
-      });
-    });
-
-    it('Doesn\'t import from `webpack.ts` if build phase is "phase-production-server"', () => {
-      jest.isolateModules(() => {
-        // In case this is still set from elsewhere, reset it
-        delete (global as any)._sentryWebpackModuleLoaded;
-
-        materializeFinalNextConfig(exportedNextConfig, undefined, 'phase-production-server');
-
-        expect((global as any)._sentryWebpackModuleLoaded).toBeUndefined();
-      });
-    });
-  });
 });


### PR DESCRIPTION
First, a bit of history: A while back we decided to [exclude our build time dependencies](https://github.com/getsentry/sentry-javascript/pull/6058) from the files that are uploaded to AWS Lambdas through Vercel. This was done by modifying the NFT Plugin Next.js injects. This [caused us to break during runtime](https://github.com/getsentry/sentry-javascript/issues/6265) because the build files could be required when the server starts. The fix for that however [broke `next dev`](https://github.com/getsentry/sentry-javascript/issues/6284) and we had to [convert our `withSentryConfig` function to return a function](https://github.com/getsentry/sentry-javascript/pull/6291) so that we can make an exception for the `dev` phase.

The last change caused an avalanche of issues to appear which we mostly brushed off and told users to "fix" their Next.js configs to be able to deal with `withSentryConfig` to return a function.
The issues have now reached a critical mass so we should unship this feature, just so we don't ruin DX for a ton of people.

Here are the issues related to this I could find retroactively:

- https://github.com/getsentry/sentry-javascript/issues/6472
- https://github.com/getsentry/sentry-javascript/issues/6691
- https://github.com/getsentry/sentry-javascript/issues/6401
- https://github.com/getsentry/sentry-javascript/issues/6355
- https://github.com/getsentry/sentry-javascript/issues/6339
- https://github.com/getsentry/sentry-javascript/issues/6475
- https://github.com/getsentry/sentry-javascript/issues/6447
- https://github.com/getsentry/sentry-javascript/issues/6336
- https://github.com/getsentry/sentry-javascript/issues/6363

IMO the build time dependencies we have aren't that huge that it is worth adding a lot of complexity and DX degradation and I verified that Sentry CLI is still not included in the generated nft files.