### PR TITLE
ci(ember): Only run pinned tests for ember on build, + add canary tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -492,50 +492,6 @@ jobs:
           cd packages/nextjs
           yarn test:integration
 
-  # Ember tests are separate from the rest because they are the slowest part of the test suite, and making them a
-  # separate job allows them to run in parallel with the other tests.
-  job_ember_tests:
-    name: Ember (${{ matrix.scenario }}) Tests
-    needs: [job_get_metadata, job_build]
-    if: needs.job_get_metadata.outputs.changed_ember == 'true' || github.event_name != 'pull_request'
-    timeout-minutes: 10
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        scenario: [ember-release, embroider-optimized, ember-4.0]
-    steps:
-      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ env.HEAD_COMMIT }}
-          # TODO: removing `fetch-depth` below seems to have no effect, and the commit which added it had no description,
-          # so it's not clear why it's necessary. That said, right now ember tests are xfail, so it's a little hard to
-          # tell if it's safe to remove. Once ember tests are fixed, let's try again with it turned off, and if all goes
-          # well, we can pull it out.
-          fetch-depth: 0
-      - name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-          # We support node 14+. If that works, we can safely assume that newer versions will also work.
-          node-version: '14'
-      - name: Check dependency cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
-          key: ${{ needs.job_build.outputs.dependency_cache_key }}
-      - name: Check build cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ env.CACHED_BUILD_PATHS }}
-          key: ${{ env.BUILD_CACHE_KEY }}
-      - name: Run Ember tests
-        run: |
-          cd packages/ember
-          yarn ember try:one ${{ matrix.scenario }} --skip-cleanup=true
-      - name: Compute test coverage
-        uses: codecov/codecov-action@v3
-
   job_browser_playwright_tests:
     name: Playwright (${{ matrix.bundle }})${{ (matrix.tracing_only && ' tracing only') || '' }} Tests
     needs: [job_get_metadata, job_build]
@@ -804,7 +760,6 @@ jobs:
         job_browser_playwright_tests,
         job_browser_integration_tests,
         job_remix_integration_tests,
-        job_ember_tests,
       ]
     # Always run this, even if a dependent job failed
     if: always()

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   job_canary_test:
-    name: Run Canary Tests
+    name: Canary Tests
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
@@ -47,6 +47,44 @@ jobs:
         run: |
           cd packages/e2e-tests
           yarn test:e2e
+      - name: Create Issue
+        if: failure()
+        uses: JasonEtco/create-an-issue@e27dddc79c92bc6e4562f268fffa5ed752639abd
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_LINK: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/CANARY_FAILURE_TEMPLATE.md
+
+  job_ember_canary_test:
+    name: Ember Canary Tests
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario: [ember-release, embroider-optimized, ember-4.0]
+    steps:
+      - name: 'Check out current commit'
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.HEAD_COMMIT }}
+      - name: Set up Node
+        uses: volta-cli/action@v4
+
+      - name: Install dependencies
+        run: yarn install --ignore-engines --frozen-lockfile
+
+      - name: Build dependencies
+        run: |
+          yarn lerna run build:types --scope=@sentry/ember --include-dependencies
+          yarn lerna run build:transpile --scope=@sentry/ember --include-dependencies
+
+      - name: Run Ember tests
+        run: |
+          cd packages/ember
+          yarn ember try:one ${{ matrix.scenario }} --skip-cleanup=true
+
       - name: Create Issue
         if: failure()
         uses: JasonEtco/create-an-issue@e27dddc79c92bc6e4562f268fffa5ed752639abd

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -17,15 +17,18 @@
     "test": "tests"
   },
   "scripts": {
-    "build:uncached": "ember build --environment=production",
+    "build": "ember build --environment=test --output-path=build",
+    "build:dev": "yarn build",
+    "build:dev:watch": "ember build --environment=test --output-path=build --watch",
     "build:tarball": "ember ts:precompile && npm pack && ember ts:clean",
-    "clean": "yarn rimraf sentry-ember-*.tgz",
+    "clean": "yarn rimraf sentry-ember-*.tgz dist tmp build .node_modules.ember-try package.json.ember-try",
     "lint": "run-p lint:js lint:hbs lint:ts",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint . --cache --cache-location '../../eslintcache/'",
     "lint:ts": "tsc",
     "start": "ember serve",
-    "test": "ember test",
+    "test": "ember test --path=build",
+    "test:uncached": "ember test",
     "test:all": "ember try:each"
   },
   "dependencies": {

--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -17,9 +17,6 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "ember build --environment=test --output-path=build",
-    "build:dev": "yarn build",
-    "build:dev:watch": "ember build --environment=test --output-path=build --watch",
     "build:tarball": "ember ts:precompile && npm pack && ember ts:clean",
     "clean": "yarn rimraf sentry-ember-*.tgz dist tmp build .node_modules.ember-try package.json.ember-try",
     "lint": "run-p lint:js lint:hbs lint:ts",
@@ -27,8 +24,7 @@
     "lint:js": "eslint . --cache --cache-location '../../eslintcache/'",
     "lint:ts": "tsc",
     "start": "ember serve",
-    "test": "ember test --path=build",
-    "test:uncached": "ember test",
+    "test": "ember test",
     "test:all": "ember try:each"
   },
   "dependencies": {


### PR DESCRIPTION
Now, the ember tests are run "normally" as part of the browser unit tests, plus with the canary tests we run it in all envs (which are the latest versions), potentially spotting breaking changes.