### PR TITLE
fix(remix): Make sure the domain is created before running.

### DIFF
--- a/packages/remix/playwright.config.ts
+++ b/packages/remix/playwright.config.ts
@@ -1,7 +1,7 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
-  retries: 2,
+  retries: 0,
   timeout: 12000,
   use: {
     baseURL: 'http://localhost:3000',

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -391,6 +391,11 @@ function wrapRequestHandler(origRequestHandler: RequestHandler, build: ServerBui
 
   return async function (this: unknown, request: RemixRequest, loadContext?: unknown): Promise<Response> {
     const local = domain.create();
+
+    // Waiting for the next tick to make sure that the domain is active
+    // https://github.com/nodejs/node/issues/40999#issuecomment-1002719169
+    await new Promise(resolve => setImmediate(resolve));
+
     return local.bind(async () => {
       const hub = getCurrentHub();
       const options = hub.getClient()?.getOptions();


### PR DESCRIPTION
Resolves: #6821 

This problem appears not to be a flaky test, it's a node bug recurring on certain versions, which apparently happens rarely, and our testing environment (high concurrency in a small container maybe) seems to amplify its frequency.

Looks like this can happen when the domain is used right after the creation, which is the case in our Remix implementation. And the [proposed workaround](https://github.com/nodejs/node/issues/40999#issuecomment-1002719169) seems to resolve it with this PR. (8 CI runs without errors here, only failed case is https://github.com/getsentry/sentry-javascript/issues/6848, will be addressed with another PR).

For reference:
https://github.com/getsentry/sentry-javascript/issues/2089
https://github.com/nodejs/node/issues/30122
https://github.com/nodejs/node/issues/40999


