### PR TITLE
feat(replay): Add non-async flush for page unloads

### DIFF
--- a/packages/replay/src/eventBuffer.ts
+++ b/packages/replay/src/eventBuffer.ts
@@ -73,13 +73,22 @@ class EventBufferArray implements EventBuffer {
 
   public finish(): Promise<string> {
     return new Promise<string>(resolve => {
-      // Make a copy of the events array reference and immediately clear the
-      // events member so that we do not lose new events while uploading
-      // attachment.
-      const eventsRet = this._events;
-      this._events = [];
-      resolve(JSON.stringify(eventsRet));
+      resolve(
+        this._finish());
     });
+  }
+
+  public finishImmediate(): string {
+    return this._finish();
+  }
+
+  private _finish(): string {
+    // Make a copy of the events array reference and immediately clear the
+    // events member so that we do not lose new events while uploading
+    // attachment.
+    const events = this._events;
+    this._events = [];
+    return JSON.stringify(events);
   }
 }
 
@@ -156,6 +165,18 @@ export class EventBufferCompressionWorker implements EventBuffer {
    */
   public finish(): Promise<Uint8Array> {
     return this._finishRequest(this._getAndIncrementId());
+  }
+
+  /**
+   * Finish the event buffer and return the pending events.
+   */
+  public finishImmediate(): string {
+    const events = this._pendingEvents;
+
+    // Ensure worker is still in a good state and disregard the result
+    void this._finishRequest(this._getAndIncrementId());
+
+    return JSON.stringify(events);
   }
 
   /**

--- a/packages/replay/src/eventBuffer.ts
+++ b/packages/replay/src/eventBuffer.ts
@@ -73,8 +73,7 @@ class EventBufferArray implements EventBuffer {
 
   public finish(): Promise<string> {
     return new Promise<string>(resolve => {
-      resolve(
-        this._finish());
+      resolve(this._finish());
     });
   }
 

--- a/packages/replay/src/eventBuffer.ts
+++ b/packages/replay/src/eventBuffer.ts
@@ -71,17 +71,11 @@ class EventBufferArray implements EventBuffer {
     return;
   }
 
-  public finish(): Promise<string> {
-    return new Promise<string>(resolve => {
-      resolve(this._finish());
-    });
+  public async finish(): Promise<string> {
+    return this.finishSync();
   }
 
-  public finishImmediate(): string {
-    return this._finish();
-  }
-
-  private _finish(): string {
+  public finishSync(): string {
     // Make a copy of the events array reference and immediately clear the
     // events member so that we do not lose new events while uploading
     // attachment.
@@ -169,7 +163,7 @@ export class EventBufferCompressionWorker implements EventBuffer {
   /**
    * Finish the event buffer and return the pending events.
    */
-  public finishImmediate(): string {
+  public finishSync(): string {
     const events = this._pendingEvents;
 
     // Ensure worker is still in a good state and disregard the result

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -170,7 +170,7 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
       return;
     }
 
-    void this._replay.start();
+    this._replay.start();
   }
 
   /**

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -170,7 +170,7 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
       return;
     }
 
-    this._replay.start();
+    void this._replay.start();
   }
 
   /**

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -13,7 +13,7 @@ export interface FlushOptions {
    * (e.g. worker calls). This is not directly related to `flushImmediate` which
    * skips the debounced flush.
    */
-  finishImmediate?: boolean;
+  sync?: boolean;
 }
 
 export interface SendReplayData {
@@ -254,7 +254,7 @@ export interface EventBuffer {
   /**
    * Clears and synchronously returns the pending contents of the buffer. This means no compression.
    */
-  finishImmediate(): string;
+  finishSync(): string;
 }
 
 export type AddUpdateCallback = () => boolean | void;

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -7,6 +7,15 @@ export type RecordingOptions = recordOptions;
 
 export type AllPerformanceEntry = PerformancePaintTiming | PerformanceResourceTiming | PerformanceNavigationTiming;
 
+export interface FlushOptions {
+  /**
+   * Attempt to finish the flush immediately without any asynchronous operations
+   * (e.g. worker calls). This is not directly related to `flushImmediate` which
+   * skips the debounced flush.
+   */
+  finishImmediate?: boolean;
+}
+
 export interface SendReplayData {
   recordingData: ReplayRecordingData;
   replayId: string;
@@ -17,6 +26,10 @@ export interface SendReplayData {
   session: Session;
   options: ReplayPluginOptions;
 }
+
+export type PendingReplayData = Omit<SendReplayData, 'recordingData'|'session'|'options'> & {
+  recordingData: RecordingEvent[];
+};
 
 export type InstrumentationTypeBreadcrumb = 'dom' | 'scope';
 
@@ -237,6 +250,11 @@ export interface EventBuffer {
    * Clears and returns the contents of the buffer.
    */
   finish(): Promise<ReplayRecordingData>;
+
+  /**
+* Clears and synchronously returns the pending contents of the buffer. This means no compression.
+*/
+  finishImmediate(): string;
 }
 
 export type AddUpdateCallback = () => boolean | void;

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -27,7 +27,7 @@ export interface SendReplayData {
   options: ReplayPluginOptions;
 }
 
-export type PendingReplayData = Omit<SendReplayData, 'recordingData'|'session'|'options'> & {
+export type PendingReplayData = Omit<SendReplayData, 'recordingData' | 'session' | 'options'> & {
   recordingData: RecordingEvent[];
 };
 
@@ -252,8 +252,8 @@ export interface EventBuffer {
   finish(): Promise<ReplayRecordingData>;
 
   /**
-* Clears and synchronously returns the pending contents of the buffer. This means no compression.
-*/
+   * Clears and synchronously returns the pending contents of the buffer. This means no compression.
+   */
   finishImmediate(): string;
 }
 

--- a/packages/replay/test/integration/flush.test.ts
+++ b/packages/replay/test/integration/flush.test.ts
@@ -108,23 +108,28 @@ describe('Integration | flush', () => {
   });
 
   it('flushes after each blur event', async () => {
+    // @ts-ignore privaye API
+    const mockFlushSync = jest.spyOn(replay, '_flushSync');
+
     // blur events cause an immediate flush that bypass the debounced flush
     // function and skip any async workers
-    expect(mockRunFlush).toHaveBeenCalledTimes(0);
+    expect(mockFlushSync).toHaveBeenCalledTimes(0);
     WINDOW.dispatchEvent(new Event('blur'));
-    expect(mockRunFlush).toHaveBeenCalledTimes(1);
+    expect(mockFlushSync).toHaveBeenCalledTimes(1);
     WINDOW.dispatchEvent(new Event('blur'));
-    expect(mockRunFlush).toHaveBeenCalledTimes(2);
+    expect(mockFlushSync).toHaveBeenCalledTimes(2);
     WINDOW.dispatchEvent(new Event('blur'));
-    expect(mockRunFlush).toHaveBeenCalledTimes(3);
+    expect(mockFlushSync).toHaveBeenCalledTimes(3);
     WINDOW.dispatchEvent(new Event('blur'));
-    expect(mockRunFlush).toHaveBeenCalledTimes(4);
+    expect(mockFlushSync).toHaveBeenCalledTimes(4);
 
+    expect(mockRunFlush).toHaveBeenCalledTimes(0);
     expect(mockFlush).toHaveBeenCalledTimes(0);
 
     jest.runAllTimers();
     await new Promise(process.nextTick);
-    expect(mockRunFlush).toHaveBeenCalledTimes(4);
+    expect(mockFlushSync).toHaveBeenCalledTimes(4);
+    expect(mockRunFlush).toHaveBeenCalledTimes(0);
   });
 
   it('long first flush enqueues following events', async () => {

--- a/packages/replay/test/integration/stop.test.ts
+++ b/packages/replay/test/integration/stop.test.ts
@@ -106,6 +106,9 @@ describe('Integration | stop', () => {
     };
 
     addEvent(replay, TEST_EVENT);
+    // This is an interesting test case because `start()` causes a checkout and a `flushImmediate`, and
+    // blur causes a direct `runFlush` call to ensure if window unloads, it is able to send out an uncompressed segment.
+    // This means that the non-async blur call can empty out the buffer before `flushImmediate` finishes.
     WINDOW.dispatchEvent(new Event('blur'));
     jest.runAllTimers();
     await new Promise(process.nextTick);
@@ -127,7 +130,7 @@ describe('Integration | stop', () => {
   });
 
   it('does not buffer events when stopped', async function () {
-    WINDOW.dispatchEvent(new Event('blur'));
+    WINDOW.dispatchEvent(new Event('focus'));
     expect(replay.eventBuffer?.pendingLength).toBe(1);
 
     // stop replays
@@ -135,7 +138,7 @@ describe('Integration | stop', () => {
 
     expect(replay.eventBuffer?.pendingLength).toBe(undefined);
 
-    WINDOW.dispatchEvent(new Event('blur'));
+    WINDOW.dispatchEvent(new Event('focus'));
     await new Promise(process.nextTick);
 
     expect(replay.eventBuffer?.pendingLength).toBe(undefined);


### PR DESCRIPTION
Add a method of using a non-async flush so that we are able to send a segment when the user unloads the page. This means the segment for blurs/unloads will be uncompressed if default settings are used.


Closes #6698 as we can avoid constant writes to sessionStorage and having to maintain additional state.