### PR TITLE
ref(replay): Try to make flush on unload fully sync

### DIFF
--- a/packages/replay/src/eventBuffer.ts
+++ b/packages/replay/src/eventBuffer.ts
@@ -71,17 +71,11 @@ class EventBufferArray implements EventBuffer {
     return;
   }
 
-  public finish(): Promise<string> {
-    return new Promise<string>(resolve => {
-      resolve(this._finish());
-    });
+  public async finish(): Promise<string> {
+    return this.finishSync();
   }
 
-  public finishImmediate(): string {
-    return this._finish();
-  }
-
-  private _finish(): string {
+  public finishSync(): string {
     // Make a copy of the events array reference and immediately clear the
     // events member so that we do not lose new events while uploading
     // attachment.
@@ -169,7 +163,7 @@ export class EventBufferCompressionWorker implements EventBuffer {
   /**
    * Finish the event buffer and return the pending events.
    */
-  public finishImmediate(): string {
+  public finishSync(): string {
     const events = this._pendingEvents;
 
     // Ensure worker is still in a good state and disregard the result

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -13,7 +13,7 @@ export interface FlushOptions {
    * (e.g. worker calls). This is not directly related to `flushImmediate` which
    * skips the debounced flush.
    */
-  finishImmediate?: boolean;
+  sync?: boolean;
 }
 
 export interface SendReplayData {
@@ -254,7 +254,7 @@ export interface EventBuffer {
   /**
    * Clears and synchronously returns the pending contents of the buffer. This means no compression.
    */
-  finishImmediate(): string;
+  finishSync(): string;
 }
 
 export type AddUpdateCallback = () => boolean | void;

--- a/packages/replay/test/integration/flush.test.ts
+++ b/packages/replay/test/integration/flush.test.ts
@@ -108,23 +108,28 @@ describe('Integration | flush', () => {
   });
 
   it('flushes after each blur event', async () => {
+    // @ts-ignore privaye API
+    const mockFlushSync = jest.spyOn(replay, '_flushSync');
+
     // blur events cause an immediate flush that bypass the debounced flush
     // function and skip any async workers
-    expect(mockRunFlush).toHaveBeenCalledTimes(0);
+    expect(mockFlushSync).toHaveBeenCalledTimes(0);
     WINDOW.dispatchEvent(new Event('blur'));
-    expect(mockRunFlush).toHaveBeenCalledTimes(1);
+    expect(mockFlushSync).toHaveBeenCalledTimes(1);
     WINDOW.dispatchEvent(new Event('blur'));
-    expect(mockRunFlush).toHaveBeenCalledTimes(2);
+    expect(mockFlushSync).toHaveBeenCalledTimes(2);
     WINDOW.dispatchEvent(new Event('blur'));
-    expect(mockRunFlush).toHaveBeenCalledTimes(3);
+    expect(mockFlushSync).toHaveBeenCalledTimes(3);
     WINDOW.dispatchEvent(new Event('blur'));
-    expect(mockRunFlush).toHaveBeenCalledTimes(4);
+    expect(mockFlushSync).toHaveBeenCalledTimes(4);
 
+    expect(mockRunFlush).toHaveBeenCalledTimes(0);
     expect(mockFlush).toHaveBeenCalledTimes(0);
 
     jest.runAllTimers();
     await new Promise(process.nextTick);
-    expect(mockRunFlush).toHaveBeenCalledTimes(4);
+    expect(mockFlushSync).toHaveBeenCalledTimes(4);
+    expect(mockRunFlush).toHaveBeenCalledTimes(0);
   });
 
   it('long first flush enqueues following events', async () => {


### PR DESCRIPTION
This PR adjusts https://github.com/getsentry/sentry-javascript/pull/6854 to be fully sync.

I tried it in a test app, and it seemed to send the request out - I tried setting up a proxy to properly see logs, and it _appeared_ correct, although not 100% sure if that matches real-world usage.