### PR TITLE
ref(replay): Avoid duplicate debounce timers

### DIFF
--- a/packages/replay/src/util/debounce.ts
+++ b/packages/replay/src/util/debounce.ts
@@ -57,7 +57,7 @@ export function debounce(func: CallbackFunction, wait: number, options?: Debounc
     }
     timerId = setTimeout(invokeFunc, wait);
 
-    if (maxWait && maxTimerId === undefined) {
+    if (maxWait && maxTimerId === undefined && maxWait !== wait) {
       maxTimerId = setTimeout(invokeFunc, maxWait);
     }
 

--- a/packages/replay/test/integration/sendReplayEvent.test.ts
+++ b/packages/replay/test/integration/sendReplayEvent.test.ts
@@ -249,25 +249,6 @@ describe('Integration | sendReplayEvent', () => {
     expect(replay.eventBuffer?.pendingLength).toBe(0);
   });
 
-  it('uploads a replay event if 5 seconds have elapsed since the last replay event occurred', async () => {
-    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
-    mockRecord._emitter(TEST_EVENT);
-    // Pretend 5 seconds have passed
-    const ELAPSED = 5000;
-    await advanceTimers(ELAPSED);
-
-    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
-    expect(mockTransportSend).toHaveBeenCalledTimes(1);
-    expect(replay).toHaveLastSentReplay({ recordingData: JSON.stringify([TEST_EVENT]) });
-
-    // No user activity to trigger an update
-    expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP);
-    expect(replay.session?.segmentId).toBe(1);
-
-    // events array should be empty
-    expect(replay.eventBuffer?.pendingLength).toBe(0);
-  });
-
   it('uploads a dom breadcrumb 5 seconds after listener receives an event', async () => {
     domHandler({
       name: 'click',


### PR DESCRIPTION
Since we now have a default flush time === max flush time in replay, we can skip the duplicate timer in that case.