### PR TITLE
fix(nextjs): Fix SDK multiplexer loader on Windows

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -70,10 +70,10 @@ export function constructWebpackConfigFunction(
     addValueInjectionLoader(newConfig, userNextConfig, userSentryOptions);
 
     newConfig.module.rules.push({
-      test: /node_modules\/@sentry\/nextjs/,
+      test: /node_modules[/\\]@sentry[/\\]nextjs/,
       use: [
         {
-          loader: path.resolve(__dirname, 'loaders/sdkMultiplexerLoader.js'),
+          loader: path.resolve(__dirname, 'loaders', 'sdkMultiplexerLoader.js'),
           options: {
             importTarget: buildContext.nextRuntime === 'edge' ? './edge' : './client',
           },
@@ -133,7 +133,7 @@ export function constructWebpackConfigFunction(
           },
           use: [
             {
-              loader: path.resolve(__dirname, 'loaders/wrappingLoader.js'),
+              loader: path.resolve(__dirname, 'loaders', 'wrappingLoader.js'),
               options: {
                 pagesDir: pagesDirPath,
                 pageExtensionRegex,


### PR DESCRIPTION
The SDK multiplexer loader in the Next.js SDK responsible for routing imports to the correct runtime SDK wasn't matching files correctly on Windows. This PR adjusts the loader matching to be able to deal with Windows paths.

Fixes https://github.com/getsentry/sentry-javascript/issues/6858