### PR TITLE
ref(replay): Remove unused `initialFlushDelay` option

### DIFF
--- a/packages/integration-tests/suites/replay/captureReplayViaBrowser/init.js
+++ b/packages/integration-tests/suites/replay/captureReplayViaBrowser/init.js
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/browser';
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
   flushMinDelay: 200,
-  initialFlushDelay: 200,
+  flushMaxDelay: 200,
 });
 
 Sentry.init({

--- a/packages/integration-tests/suites/replay/init.js
+++ b/packages/integration-tests/suites/replay/init.js
@@ -4,7 +4,7 @@ import { Replay } from '@sentry/replay';
 window.Sentry = Sentry;
 window.Replay = new Replay({
   flushMinDelay: 200,
-  initialFlushDelay: 200,
+  flushMaxDelay: 200,
 });
 
 Sentry.init({

--- a/packages/integration-tests/suites/replay/sampling/init.js
+++ b/packages/integration-tests/suites/replay/sampling/init.js
@@ -4,7 +4,7 @@ import { Replay } from '@sentry/replay';
 window.Sentry = Sentry;
 window.Replay = new Replay({
   flushMinDelay: 200,
-  initialFlushDelay: 200,
+  flushMaxDelay: 200,
 });
 
 Sentry.init({

--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -32,7 +32,6 @@ export const MASK_ALL_TEXT_SELECTOR = 'body *:not(style), body *:not(script)';
 /** Default flush delays */
 export const DEFAULT_FLUSH_MIN_DELAY = 5_000;
 export const DEFAULT_FLUSH_MAX_DELAY = 5_000;
-export const INITIAL_FLUSH_DELAY = 5_000;
 
 export const RETRY_BASE_INTERVAL = 5000;
 export const RETRY_MAX_COUNT = 3;

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -6,7 +6,6 @@ import {
   DEFAULT_FLUSH_MAX_DELAY,
   DEFAULT_FLUSH_MIN_DELAY,
   DEFAULT_SESSION_SAMPLE_RATE,
-  INITIAL_FLUSH_DELAY,
   MASK_ALL_TEXT_SELECTOR,
 } from './constants';
 import { ReplayContainer } from './replay';
@@ -43,7 +42,6 @@ export class Replay implements Integration {
   public constructor({
     flushMinDelay = DEFAULT_FLUSH_MIN_DELAY,
     flushMaxDelay = DEFAULT_FLUSH_MAX_DELAY,
-    initialFlushDelay = INITIAL_FLUSH_DELAY,
     stickySession = true,
     useCompression = true,
     sessionSampleRate,
@@ -73,7 +71,6 @@ export class Replay implements Integration {
       flushMinDelay,
       flushMaxDelay,
       stickySession,
-      initialFlushDelay,
       sessionSampleRate: DEFAULT_SESSION_SAMPLE_RATE,
       errorSampleRate: DEFAULT_ERROR_SAMPLE_RATE,
       useCompression,

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -178,7 +178,7 @@ export class ReplayContainer implements ReplayContainerInterface {
     this._updateSessionActivity();
 
     this.eventBuffer = createEventBuffer({
-      useCompression: Boolean(this._options.useCompression),
+      useCompression: this._options.useCompression,
     });
 
     this._addListeners();

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -86,11 +86,6 @@ export interface ReplayPluginOptions extends SessionOptions {
   flushMaxDelay: number;
 
   /**
-   * The amount of time to buffer the initial snapshot
-   */
-  initialFlushDelay: number;
-
-  /**
    * Attempt to use compression when web workers are available
    *
    * (default is true)


### PR DESCRIPTION
This is not in use anymore - we always flush immediately on load. So we can remove this option.
