### PR TITLE
fix(tests): Use the default Playwright timeouts.

### DIFF
--- a/packages/integration-tests/playwright.config.ts
+++ b/packages/integration-tests/playwright.config.ts
@@ -2,7 +2,6 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   retries: 2,
-  timeout: 12000,
   workers: 3,
 };
 export default config;

--- a/packages/nextjs/playwright.config.ts
+++ b/packages/nextjs/playwright.config.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 
 const config: PlaywrightTestConfig = {
   retries: 0, // We do not accept flakes.
-  timeout: 12000,
   use: {
     baseURL: 'http://localhost:3000',
   },

--- a/packages/remix/playwright.config.ts
+++ b/packages/remix/playwright.config.ts
@@ -2,7 +2,6 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   retries: 0,
-  timeout: 12000,
   use: {
     baseURL: 'http://localhost:3000',
   },


### PR DESCRIPTION
Resolves: #6848
Resolves: #6872 

Updating Playwright configurations to use the [default 30 seconds](https://playwright.dev/docs/test-timeouts), instead of 12 seconds configured. Not sure why we decreased the test timeout in the first place.

The case in #6848 happens randomly in any test in the same file, so I suspect this is just about the shortened timeout, rather than certain implementation / test that trigger flaking.

Testing here to check if there is a hanging test that hits the default 30 seconds.

---

Edit: No flakes for #6848 or #6872 after 9 CI trials on this PR.