### PR TITLE
ci: Fix size-limit check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,6 +120,10 @@ jobs:
             any_code:
               - '!**/*.md'
 
+      - name: Get PR labels
+        id: pr-labels
+        uses: mydea/pr-labels-action@update-core
+
     outputs:
       commit_label: '${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}'
       changed_nextjs: ${{ steps.changed.outputs.nextjs }}
@@ -133,7 +137,7 @@ jobs:
       is_master: ${{ github.ref == 'refs/heads/master' }}
       is_release: ${{ startsWith(github.ref, 'refs/heads/release/') }}
       force_skip_cache:
-        ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci-skip-cache') }}
+        ${{ github.event_name == 'pull_request' && contains(steps.pr-labels.outputs.labels, ' ci-skip-cache ') }}
 
   job_install_deps:
     name: Install Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,7 +272,7 @@ jobs:
     needs: [job_get_metadata, job_build]
     timeout-minutes: 15
     runs-on: ubuntu-20.04
-    # Size Check will error out outside of the context of a PR
+    # Size Check will error out outside of the context of a PR or master branch
     if: github.event_name == 'pull_request' || needs.job_get_metadata.outputs.is_master == 'true'
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
@@ -297,9 +297,7 @@ jobs:
           path: ${{ env.CACHED_BUILD_PATHS }}
           key: ${{ env.BUILD_CACHE_KEY }}
       - name: Check bundle sizes
-        uses: getsentry/size-limit-action@v5
-        # Don't run size check on release branches - at that point, we're already committed
-        if: needs.job_get_metadata.outputs.is_release == 'false'
+        uses: getsentry/size-limit-action@main-skip-step
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           skip_step: build


### PR DESCRIPTION
This PR fixes (hopefully) the size-limit CI check.

After a lot of digging, I figured out that when the size-limit action runs on CI, it basically doesn't do the same as on the PR. On master, we do not skip the install & build step, but re-run them. Especially, we also just run `yarn install` & `yarn build`, which may have a slightly different outcome. Additionally, this also means that the size check on master takes > 8min, because we re-run all the build stuff etc.

I made a PR to fix our size-limit action: https://github.com/getsentry/size-limit-action/pull/7
For now, we can simply use this branch, until this has been merged.

Note that while debugging this, I also noticed a necessary improvement with the label check. basically, it appeares that the labels that we can fetch from the github context are always the ones that existed when the action run was initially made. So if you added a label later and re-run a workflow, it will not be updated. Instead, we need to fetch the labels from the github API, which the provided action does.

With these changes, hopefully the size limit output will be stable between master & PR branches again.

Note: Using custom branch of pr-labels-action until https://github.com/joerick/pr-labels-action/pull/10 is merged & released