### PR TITLE
fix(tests): Increase flush interval of session tests.

### DIFF
--- a/packages/node-integration-tests/suites/sessions/server.ts
+++ b/packages/node-integration-tests/suites/sessions/server.ts
@@ -22,9 +22,9 @@ let flusherIntervalId = flusher?._intervalId;
 clearInterval(flusherIntervalId);
 
 // @ts-ignore: need access to `_intervalId`
-flusherIntervalId = flusher?._intervalId = setInterval(() => flusher?.flush(), 1000);
+flusherIntervalId = flusher?._intervalId = setInterval(() => flusher?.flush(), 2000);
 
-setTimeout(() => clearInterval(flusherIntervalId), 2000);
+setTimeout(() => clearInterval(flusherIntervalId), 4000);
 
 app.get('/test/success', (_req, res) => {
   res.send('Success!');
@@ -36,7 +36,7 @@ app.get('/test/success_next', (_req, res, next) => {
 });
 
 app.get('/test/success_slow', async (_req, res) => {
-  await new Promise(res => setTimeout(res, 500));
+  await new Promise(res => setTimeout(res, 50));
 
   res.send('Success!');
 });

--- a/packages/remix/test/integration/test/client/manualtracing.test.ts
+++ b/packages/remix/test/integration/test/client/manualtracing.test.ts
@@ -14,7 +14,7 @@ test('should report a manually created / finished transaction.', async ({ page }
   expect(manualTransactionEnvelope.start_timestamp).toBeDefined();
   expect(manualTransactionEnvelope.timestamp).toBeDefined();
 
-  expect(pageloadEnvelope.contexts?.trace.op).toBe('pageload');
+  expect(pageloadEnvelope.contexts?.trace?.op).toBe('pageload');
   expect(pageloadEnvelope.tags?.['routing.instrumentation']).toBe('remix-router');
   expect(pageloadEnvelope.type).toBe('transaction');
   expect(pageloadEnvelope.transaction).toBe('routes/manual-tracing/$id');


### PR DESCRIPTION
Resolves: #6868 

Increasing flush interval to 1000ms to 2000ms, with overall timeout from 2000ms to 4000ms.

Looks like the test flakes because of early-flushing (before 'slow' endpoint finishes), so also decreased the slowness of the 'slow' endpoint. 

This branch consistently succeeded on local, will test on CI here.

---

**Update**: None of the 11 CI runs here have failed session tests.