### PR TITLE
feat(replay): Remove default sample rates for replay

### DIFF
--- a/packages/replay/MIGRATION.md
+++ b/packages/replay/MIGRATION.md
@@ -1,3 +1,13 @@
+# Upgrading Replay from 7.31.0 to 7.32.0
+
+In 7.32.0, we have removed the default values for the replay sample rates.
+Previously, they were:
+
+* `replaysSessionSampleRate: 0.1`
+* `replaysOnErrorSampleRate: 1.0`
+
+Now, you have to explicitly set the sample rates, otherwise they default to 0.
+
 # Upgrading Replay from 0.6.x to 7.24.0
 
 The Sentry Replay integration was moved to the Sentry JavaScript SDK monorepo. Hence we're jumping from version 0.x to the monorepo's 7.x version which is shared across all JS SDK packages.

--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -20,12 +20,6 @@ export const VISIBILITY_CHANGE_TIMEOUT = SESSION_IDLE_DURATION;
 // The maximum length of a session
 export const MAX_SESSION_LIFE = 3_600_000; // 60 minutes
 
-/**
- * Defaults for sampling rates
- */
-export const DEFAULT_SESSION_SAMPLE_RATE = 0.1;
-export const DEFAULT_ERROR_SAMPLE_RATE = 1.0;
-
 /** The select to use for the `maskAllText` option  */
 export const MASK_ALL_TEXT_SELECTOR = 'body *:not(style), body *:not(script)';
 

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -1,13 +1,7 @@
 import { getCurrentHub } from '@sentry/core';
 import type { BrowserClientReplayOptions, Integration } from '@sentry/types';
 
-import {
-  DEFAULT_ERROR_SAMPLE_RATE,
-  DEFAULT_FLUSH_MAX_DELAY,
-  DEFAULT_FLUSH_MIN_DELAY,
-  DEFAULT_SESSION_SAMPLE_RATE,
-  MASK_ALL_TEXT_SELECTOR,
-} from './constants';
+import { DEFAULT_FLUSH_MAX_DELAY, DEFAULT_FLUSH_MIN_DELAY, MASK_ALL_TEXT_SELECTOR } from './constants';
 import { ReplayContainer } from './replay';
 import type { RecordingOptions, ReplayConfiguration, ReplayPluginOptions } from './types';
 import { isBrowser } from './util/isBrowser';
@@ -71,8 +65,8 @@ export class Replay implements Integration {
       flushMinDelay,
       flushMaxDelay,
       stickySession,
-      sessionSampleRate: DEFAULT_SESSION_SAMPLE_RATE,
-      errorSampleRate: DEFAULT_ERROR_SAMPLE_RATE,
+      sessionSampleRate: 0,
+      errorSampleRate: 0,
       useCompression,
       maskAllText: typeof maskAllText === 'boolean' ? maskAllText : !maskTextSelector,
       blockAllMedia,


### PR DESCRIPTION
Previously, they were:

* `replaysSessionSampleRate: 0.1`
* `replaysOnErrorSampleRate: 1.0`

Now, you have to explicitly set the sample rates, otherwise they default to 0.

Closes https://github.com/getsentry/sentry-javascript/issues/6775
