### PR TITLE
fix(replay): Use correct replay category in client reports

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -2,7 +2,7 @@
 import type {
   Client,
   ClientOptions,
-  ClientReportDataCategory,
+  ClientReportCategory,
   DataCategory,
   DsnComponents,
   Envelope,
@@ -692,7 +692,7 @@ function isTransactionEvent(event: Event): event is TransactionEvent {
   return event.type === 'transaction';
 }
 
-function dataCategoryToClientReportCategory(category: DataCategory): ClientReportDataCategory {
+function dataCategoryToClientReportCategory(category: DataCategory): ClientReportCategory {
   if (category === 'replay_event' || category === 'replay_recording') {
     return 'replay';
   }

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -1728,7 +1728,7 @@ describe('BaseClient', () => {
           {
             reason: 'ratelimit_backoff',
             category: 'replay',
-            quantity: 2,
+            quantity: 1,
           },
         ]);
       },

--- a/packages/types/src/datacategory.ts
+++ b/packages/types/src/datacategory.ts
@@ -10,8 +10,6 @@ export type DataCategory =
   | 'error'
   // Transaction type event
   | 'transaction'
-  // Replay type event
-  | 'replay_event'
   // Events with `event_type` csp, hpkp, expectct, expectstaple
   | 'security'
   // Attachment bytes stored (unused for rate limiting
@@ -22,6 +20,11 @@ export type DataCategory =
   | 'internal'
   // Profile event type
   | 'profile'
-  // Replay event types
+  // Replay event types (see note below)
   | 'replay_event'
   | 'replay_recording';
+
+// Replay event types and categories are a little different in envelopes, client reports and rate limits
+// Hence, we're using a type alias to make it easier to use the correct category in the right place
+export type RateLimitDataCategory = Omit<DataCategory, 'replay_event' | 'replay_recording'> | 'replay';
+export type ClientReportDataCategory = RateLimitDataCategory;

--- a/packages/types/src/datacategory.ts
+++ b/packages/types/src/datacategory.ts
@@ -26,5 +26,5 @@ export type DataCategory =
 
 // Replay event types and categories are a little different in envelopes, client reports and rate limits
 // Hence, we're using a type alias to make it easier to use the correct category in the right place
-export type RateLimitDataCategory = Omit<DataCategory, 'replay_event' | 'replay_recording'> | 'replay';
-export type ClientReportDataCategory = RateLimitDataCategory;
+export type RateLimitCategory = Omit<DataCategory, 'replay_event' | 'replay_recording'> | 'replay';
+export type ClientReportCategory = RateLimitCategory;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,7 +3,7 @@ export type { Breadcrumb, BreadcrumbHint } from './breadcrumb';
 export type { Client } from './client';
 export type { ClientReport, Outcome, EventDropReason } from './clientreport';
 export type { Context, Contexts, DeviceContext, OsContext, AppContext, CultureContext, TraceContext } from './context';
-export type { DataCategory, ClientReportDataCategory, RateLimitDataCategory } from './datacategory';
+export type { DataCategory, ClientReportCategory, RateLimitCategory } from './datacategory';
 export type { DsnComponents, DsnLike, DsnProtocol } from './dsn';
 export type { DebugImage, DebugImageType, DebugMeta } from './debugMeta';
 export type {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -3,7 +3,7 @@ export type { Breadcrumb, BreadcrumbHint } from './breadcrumb';
 export type { Client } from './client';
 export type { ClientReport, Outcome, EventDropReason } from './clientreport';
 export type { Context, Contexts, DeviceContext, OsContext, AppContext, CultureContext, TraceContext } from './context';
-export type { DataCategory } from './datacategory';
+export type { DataCategory, ClientReportDataCategory, RateLimitDataCategory } from './datacategory';
 export type { DsnComponents, DsnLike, DsnProtocol } from './dsn';
 export type { DebugImage, DebugImageType, DebugMeta } from './debugMeta';
 export type {

--- a/packages/utils/src/ratelimit.ts
+++ b/packages/utils/src/ratelimit.ts
@@ -1,4 +1,4 @@
-import type { RateLimitDataCategory, TransportMakeRequestResponse } from '@sentry/types';
+import type { RateLimitCategory, TransportMakeRequestResponse } from '@sentry/types';
 
 // Intentionally keeping the key broad, as we don't know for sure what rate limit headers get returned from backend
 export type RateLimits = Record<string, number>;
@@ -32,7 +32,7 @@ export function parseRetryAfterHeader(header: string, now: number = Date.now()):
  *
  * @return the time in ms that the category is disabled until or 0 if there's no active rate limit.
  */
-export function disabledUntil(limits: RateLimits, category: RateLimitDataCategory | string): number {
+export function disabledUntil(limits: RateLimits, category: RateLimitCategory | string): number {
   // type casting here because TS doesn't relaize that RateLimitDataCategory is a string literal type
   return limits[category as string] || limits.all || 0;
 }
@@ -42,7 +42,7 @@ export function disabledUntil(limits: RateLimits, category: RateLimitDataCategor
  */
 export function isRateLimited(
   limits: RateLimits,
-  category: RateLimitDataCategory | string,
+  category: RateLimitCategory | string,
   now: number = Date.now(),
 ): boolean {
   return disabledUntil(limits, category) > now;

--- a/packages/utils/src/ratelimit.ts
+++ b/packages/utils/src/ratelimit.ts
@@ -1,4 +1,4 @@
-import type { TransportMakeRequestResponse } from '@sentry/types';
+import type { RateLimitDataCategory, TransportMakeRequestResponse } from '@sentry/types';
 
 // Intentionally keeping the key broad, as we don't know for sure what rate limit headers get returned from backend
 export type RateLimits = Record<string, number>;
@@ -32,14 +32,19 @@ export function parseRetryAfterHeader(header: string, now: number = Date.now()):
  *
  * @return the time in ms that the category is disabled until or 0 if there's no active rate limit.
  */
-export function disabledUntil(limits: RateLimits, category: string): number {
-  return limits[category] || limits.all || 0;
+export function disabledUntil(limits: RateLimits, category: RateLimitDataCategory | string): number {
+  // type casting here because TS doesn't relaize that RateLimitDataCategory is a string literal type
+  return limits[category as string] || limits.all || 0;
 }
 
 /**
  * Checks if a category is rate limited
  */
-export function isRateLimited(limits: RateLimits, category: string, now: number = Date.now()): boolean {
+export function isRateLimited(
+  limits: RateLimits,
+  category: RateLimitDataCategory | string,
+  now: number = Date.now(),
+): boolean {
   return disabledUntil(limits, category) > now;
 }
 

--- a/packages/utils/src/ratelimit.ts
+++ b/packages/utils/src/ratelimit.ts
@@ -33,7 +33,7 @@ export function parseRetryAfterHeader(header: string, now: number = Date.now()):
  * @return the time in ms that the category is disabled until or 0 if there's no active rate limit.
  */
 export function disabledUntil(limits: RateLimits, category: RateLimitCategory | string): number {
-  // type casting here because TS doesn't relaize that RateLimitDataCategory is a string literal type
+  // type casting here because TS doesn't realize that RateLimitDataCategory is a string literal type
   return limits[category as string] || limits.all || 0;
 }
 


### PR DESCRIPTION
After adjusting the _admin UI to display outcomes of replay events (https://github.com/getsentry/getsentry/pull/9301), we noticed that only server-side outcomes are shown. After some investigation, I found out that the client reports our SDKs send to Sentry contain the wrong category for replay events:

Instead of `replay_event` (or `replay_recording`) the valid category for client reports should simply be `replay`. 

To fix this, this PR first adds a conversion function to the `recordDroppedEvent` function (which collects the client outcomes) and secondly, it adds two new `DataCategory` types for rate limits and client reports. This is necessary because replay event types and rate-limit/client-report categories aren't identical anymore. While it'd arguably be better that they are in fact identical, I think this is the quickest fix and the types should help us distinguishing the applicable categories going forward.

ref #6502     