### PR TITLE
build(utils): Add build constant for cdn vs. npm bundles

### DIFF
--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -7,13 +7,15 @@
  *
  * Attention:
  * This file should not be used to define constants/flags that are intended to be used for tree-shaking conducted by
- * users. These fags should live in their respective packages, as we identified user tooling (specifically webpack)
+ * users. These flags should live in their respective packages, as we identified user tooling (specifically webpack)
  * having issues tree-shaking these constants across package boundaries.
  * An example for this is the __SENTRY_DEBUG__ constant. It is declared in each package individually because we want
  * users to be able to shake away expressions that it guards.
  */
 
 declare const __SENTRY_BROWSER_BUNDLE__: boolean | undefined;
+
+declare const __SENTRY_CDN_BUNDLE__: boolean | undefined;
 
 /**
  * Figures out if we're building a browser bundle.
@@ -22,4 +24,11 @@ declare const __SENTRY_BROWSER_BUNDLE__: boolean | undefined;
  */
 export function isBrowserBundle(): boolean {
   return typeof __SENTRY_BROWSER_BUNDLE__ !== 'undefined' && !!__SENTRY_BROWSER_BUNDLE__;
+}
+
+/**
+ * Figures out if we're a CDN or npm bundle.
+ */
+export function isCDNBundle(): 'cdn' | 'npm' {
+  return typeof __SENTRY_CDN_BUNDLE__ !== 'undefined' && !!__SENTRY_CDN_BUNDLE__ ? 'npm' : 'cdn';
 }

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -15,7 +15,9 @@
 
 declare const __SENTRY_BROWSER_BUNDLE__: boolean | undefined;
 
-declare const __SENTRY_CDN_BUNDLE__: boolean | undefined;
+type SdkSource = 'npm' | 'cdn' | 'loader';
+
+declare const __SENTRY_SDK_SOURCE__: SdkSource | undefined;
 
 /**
  * Figures out if we're building a browser bundle.
@@ -27,8 +29,8 @@ export function isBrowserBundle(): boolean {
 }
 
 /**
- * Figures out if we're a CDN or npm bundle.
+ * Get source of SDK.
  */
-export function isCDNBundle(): 'cdn' | 'npm' {
-  return typeof __SENTRY_CDN_BUNDLE__ !== 'undefined' && !!__SENTRY_CDN_BUNDLE__ ? 'npm' : 'cdn';
+export function getSDKSource(): SdkSource {
+  return typeof __SENTRY_SDK_SOURCE__ !== 'undefined' ? __SENTRY_SDK_SOURCE__ : 'npm';
 }

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -17,8 +17,6 @@ declare const __SENTRY_BROWSER_BUNDLE__: boolean | undefined;
 
 type SdkSource = 'npm' | 'cdn' | 'loader';
 
-declare const __SENTRY_SDK_SOURCE__: SdkSource | undefined;
-
 /**
  * Figures out if we're building a browser bundle.
  *
@@ -32,5 +30,6 @@ export function isBrowserBundle(): boolean {
  * Get source of SDK.
  */
 export function getSDKSource(): SdkSource {
-  return typeof __SENTRY_SDK_SOURCE__ !== 'undefined' ? __SENTRY_SDK_SOURCE__ : 'npm';
+  // @ts-ignore __SENTRY_SDK_SOURCE__ is injected by rollup during build process
+  return __SENTRY_SDK_SOURCE__;
 }

--- a/rollup/bundleHelpers.js
+++ b/rollup/bundleHelpers.js
@@ -17,6 +17,7 @@ import {
   makeTerserPlugin,
   makeTSPlugin,
   makeExcludeReplayPlugin,
+  makeIsCDNBundlePlugin,
 } from './plugins/index.js';
 import { mergePlugins } from './utils';
 
@@ -141,6 +142,7 @@ export function makeBundleConfigVariants(baseConfig, options = {}) {
   const includeDebuggingPlugin = makeIsDebugBuildPlugin(true);
   const stripDebuggingPlugin = makeIsDebugBuildPlugin(false);
   const terserPlugin = makeTerserPlugin();
+  const isCDNBundlePlugin = makeIsCDNBundlePlugin(true);
 
   // The additional options to use for each variant we're going to create.
   const variantSpecificConfigMap = {
@@ -148,21 +150,21 @@ export function makeBundleConfigVariants(baseConfig, options = {}) {
       output: {
         entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.js`,
       },
-      plugins: [includeDebuggingPlugin],
+      plugins: [includeDebuggingPlugin, isCDNBundlePlugin],
     },
 
     '.min.js': {
       output: {
         entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.min.js`,
       },
-      plugins: [stripDebuggingPlugin, terserPlugin],
+      plugins: [stripDebuggingPlugin, terserPlugin, isCDNBundlePlugin],
     },
 
     '.debug.min.js': {
       output: {
         entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.debug.min.js`,
       },
-      plugins: [includeDebuggingPlugin, terserPlugin],
+      plugins: [includeDebuggingPlugin, terserPlugin, isCDNBundlePlugin],
     },
   };
 

--- a/rollup/bundleHelpers.js
+++ b/rollup/bundleHelpers.js
@@ -17,7 +17,7 @@ import {
   makeTerserPlugin,
   makeTSPlugin,
   makeExcludeReplayPlugin,
-  makeIsCDNBundlePlugin,
+  makeSetSDKSourcePlugin,
 } from './plugins/index.js';
 import { mergePlugins } from './utils';
 
@@ -142,7 +142,7 @@ export function makeBundleConfigVariants(baseConfig, options = {}) {
   const includeDebuggingPlugin = makeIsDebugBuildPlugin(true);
   const stripDebuggingPlugin = makeIsDebugBuildPlugin(false);
   const terserPlugin = makeTerserPlugin();
-  const isCDNBundlePlugin = makeIsCDNBundlePlugin(true);
+  const setSdkSourcePlugin = makeSetSDKSourcePlugin('cdn');
 
   // The additional options to use for each variant we're going to create.
   const variantSpecificConfigMap = {
@@ -150,21 +150,21 @@ export function makeBundleConfigVariants(baseConfig, options = {}) {
       output: {
         entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.js`,
       },
-      plugins: [includeDebuggingPlugin, isCDNBundlePlugin],
+      plugins: [includeDebuggingPlugin, setSdkSourcePlugin],
     },
 
     '.min.js': {
       output: {
         entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.min.js`,
       },
-      plugins: [stripDebuggingPlugin, terserPlugin, isCDNBundlePlugin],
+      plugins: [stripDebuggingPlugin, setSdkSourcePlugin, terserPlugin],
     },
 
     '.debug.min.js': {
       output: {
         entryFileNames: chunkInfo => `${baseConfig.output.entryFileNames(chunkInfo)}.debug.min.js`,
       },
-      plugins: [includeDebuggingPlugin, terserPlugin, isCDNBundlePlugin],
+      plugins: [includeDebuggingPlugin, setSdkSourcePlugin, terserPlugin],
     },
   };
 

--- a/rollup/npmHelpers.js
+++ b/rollup/npmHelpers.js
@@ -13,6 +13,7 @@ import {
   makeCleanupPlugin,
   makeSucrasePlugin,
   makeDebugBuildStatementReplacePlugin,
+  makeIsCDNBundlePlugin,
 } from './plugins/index.js';
 import { mergePlugins } from './utils';
 
@@ -31,6 +32,7 @@ export function makeBaseNPMConfig(options = {}) {
   const debugBuildStatementReplacePlugin = makeDebugBuildStatementReplacePlugin();
   const cleanupPlugin = makeCleanupPlugin();
   const extractPolyfillsPlugin = makeExtractPolyfillsPlugin();
+  const isNPMBundlePlugin = makeIsCDNBundlePlugin(false);
 
   const defaultBaseConfig = {
     input: entrypoints,
@@ -87,6 +89,7 @@ export function makeBaseNPMConfig(options = {}) {
       debugBuildStatementReplacePlugin,
       cleanupPlugin,
       extractPolyfillsPlugin,
+      isNPMBundlePlugin,
     ],
 
     // don't include imported modules from outside the package in the final output

--- a/rollup/npmHelpers.js
+++ b/rollup/npmHelpers.js
@@ -13,7 +13,7 @@ import {
   makeCleanupPlugin,
   makeSucrasePlugin,
   makeDebugBuildStatementReplacePlugin,
-  makeIsCDNBundlePlugin,
+  makeSetSDKSourcePlugin,
 } from './plugins/index.js';
 import { mergePlugins } from './utils';
 
@@ -32,7 +32,7 @@ export function makeBaseNPMConfig(options = {}) {
   const debugBuildStatementReplacePlugin = makeDebugBuildStatementReplacePlugin();
   const cleanupPlugin = makeCleanupPlugin();
   const extractPolyfillsPlugin = makeExtractPolyfillsPlugin();
-  const isNPMBundlePlugin = makeIsCDNBundlePlugin(false);
+  const setSdkSourcePlugin = makeSetSDKSourcePlugin('npm');
 
   const defaultBaseConfig = {
     input: entrypoints,
@@ -85,11 +85,11 @@ export function makeBaseNPMConfig(options = {}) {
 
     plugins: [
       nodeResolvePlugin,
+      setSdkSourcePlugin,
       sucrasePlugin,
       debugBuildStatementReplacePlugin,
       cleanupPlugin,
       extractPolyfillsPlugin,
-      isNPMBundlePlugin,
     ],
 
     // don't include imported modules from outside the package in the final output

--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -63,6 +63,14 @@ export function makeIsDebugBuildPlugin(includeDebugging) {
   });
 }
 
+export function makeIsCDNBundlePlugin(isCDNBundle) {
+  return replace({
+    values: {
+      __SENTRY_CDN_BUNDLE__: isCDNBundle,
+    },
+  });
+}
+
 /**
  * Create a plugin to set the value of the `__SENTRY_BROWSER_BUNDLE__` magic string.
  *

--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -65,6 +65,7 @@ export function makeIsDebugBuildPlugin(includeDebugging) {
 
 export function makeSetSDKSourcePlugin(sdkSource) {
   return replace({
+    preventAssignment: true,
     values: {
       __SENTRY_SDK_SOURCE__: sdkSource,
     },

--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -63,10 +63,10 @@ export function makeIsDebugBuildPlugin(includeDebugging) {
   });
 }
 
-export function makeIsCDNBundlePlugin(isCDNBundle) {
+export function makeSetSDKSourcePlugin(sdkSource) {
   return replace({
     values: {
-      __SENTRY_CDN_BUNDLE__: isCDNBundle,
+      __SENTRY_SDK_SOURCE__: sdkSource,
     },
   });
 }

--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -65,9 +65,9 @@ export function makeIsDebugBuildPlugin(includeDebugging) {
 
 export function makeSetSDKSourcePlugin(sdkSource) {
   return replace({
-    preventAssignment: true,
+    preventAssignment: false,
     values: {
-      __SENTRY_SDK_SOURCE__: sdkSource,
+      __SENTRY_SDK_SOURCE__: JSON.stringify(sdkSource),
     },
   });
 }


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry-javascript/issues/6903

Add `__SENTRY_SDK_SOURCE__` that tracks the source of the sdk. Right now there are 3 specific values for this: `'npm' | 'cdn' | 'loader'`.

`npm` and `cdn` are filled in at build time, and `loader` will be added via a global flag that the loader itself will set. More details on this soon.