### PR TITLE
fix(nextjs): Make SDK multiplexer more resilient

### DIFF
--- a/packages/nextjs/src/config/loaders/sdkMultiplexerLoader.ts
+++ b/packages/nextjs/src/config/loaders/sdkMultiplexerLoader.ts
@@ -13,7 +13,7 @@ type LoaderOptions = {
  * or edge-runtime code.
  */
 export default function sdkMultiplexerLoader(this: LoaderThis<LoaderOptions>, userCode: string): string {
-  if (!userCode.includes('__SENTRY_SDK_MULTIPLEXER__')) {
+  if (!userCode.includes('_SENTRY_SDK_MULTIPLEXER')) {
     return userCode;
   }
 

--- a/packages/nextjs/src/index.client.ts
+++ b/packages/nextjs/src/index.client.ts
@@ -3,4 +3,4 @@ export * from './client';
 // This file is the main entrypoint for non-Next.js build pipelines that use
 // the package.json's "browser" field or the Edge runtime (Edge API routes and middleware)
 
-// __SENTRY_SDK_MULTIPLEXER__
+export const _SENTRY_SDK_MULTIPLEXER = true;

--- a/packages/nextjs/src/index.client.ts
+++ b/packages/nextjs/src/index.client.ts
@@ -3,4 +3,8 @@ export * from './client';
 // This file is the main entrypoint for non-Next.js build pipelines that use
 // the package.json's "browser" field or the Edge runtime (Edge API routes and middleware)
 
+/**
+ * This const serves no purpose besides being an identifier for this file that the SDK multiplexer loader can use to
+ * determine that this is in fact a file that wants to be multiplexed.
+ */
 export const _SENTRY_SDK_MULTIPLEXER = true;

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -3,4 +3,4 @@ export * from './server';
 
 // This file is the main entrypoint on the server and/or when the package is `require`d
 
-// __SENTRY_SDK_MULTIPLEXER__
+export const _SENTRY_SDK_MULTIPLEXER = true;

--- a/packages/nextjs/src/index.server.ts
+++ b/packages/nextjs/src/index.server.ts
@@ -3,4 +3,8 @@ export * from './server';
 
 // This file is the main entrypoint on the server and/or when the package is `require`d
 
+/**
+ * This const serves no purpose besides being an identifier for this file that the SDK multiplexer loader can use to
+ * determine that this is in fact a file that wants to be multiplexed.
+ */
 export const _SENTRY_SDK_MULTIPLEXER = true;


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/pull/6817/files#diff-5598248a0f2280565998f93876df482b2040cb761cc510b3bd2c4dfa5824dca8L103 seems to have broken the Next.js SDK multiplexer which is responsible for injecting the right SDK depending on whether the SDK is imported on browser/server/edge. It broke because it started stripping away the comment that told our loader to multiplex.

I suspected the comment was a little fragile from the beginning so let's make it a little bit more resilient by exporting a dummy const which is more or less guaranteed to be in the file to some extent. Maybe still not the optimal solution but better than the current one. The dummy export should not show up in types since the typing file we export doesn't actually point to the multiplexer files.

Oh, and we really need tests for middleware and edge routes. It was quite surprising that nothing caught this.