### PR TITLE
fix(nextjs): Mark multiplexer targets as entrypoints

### DIFF
--- a/packages/nextjs/rollup.npm.config.js
+++ b/packages/nextjs/rollup.npm.config.js
@@ -5,7 +5,14 @@ export default [
     makeBaseNPMConfig({
       // We need to include `instrumentServer.ts` separately because it's only conditionally required, and so rollup
       // doesn't automatically include it when calculating the module dependency tree.
-      entrypoints: ['src/index.server.ts', 'src/index.client.ts', 'src/edge/index.ts', 'src/config/webpack.ts'],
+      entrypoints: [
+        'src/index.server.ts',
+        'src/index.client.ts',
+        'src/client/index.ts',
+        'src/server/index.ts',
+        'src/edge/index.ts',
+        'src/config/webpack.ts',
+      ],
 
       // prevent this internal nextjs code from ending up in our built package (this doesn't happen automatially because
       // the name doesn't match an SDK dependency)


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry-javascript/pull/6905, https://github.com/getsentry/sentry-javascript/pull/6817/files#diff-5598248a0f2280565998f93876df482b2040cb761cc510b3bd2c4dfa5824dca8L103 started tree shaking away the exports from the files we were targeting with the multiplexer, causing some imports not to be available. This PR fixes this by marking the targets as entrypoints.

Fixes https://github.com/getsentry/sentry-javascript/issues/6915

(I am deeply questioning our test suite at this point)
