### PR TITLE
fix: Account for object's prototype possibly being null

### DIFF
--- a/packages/utils/src/normalize.ts
+++ b/packages/utils/src/normalize.ts
@@ -233,10 +233,16 @@ function stringifyValue(
     // them to strings means that instances of classes which haven't defined their `toStringTag` will just come out as
     // `"[object Object]"`. If we instead look at the constructor's name (which is the same as the name of the class),
     // we can make sure that only plain objects come out that way.
-    return `[object ${(Object.getPrototypeOf(value) as Prototype).constructor.name}]`;
+    return `[object ${getConstructorName(value)}]`;
   } catch (err) {
     return `**non-serializable** (${err})`;
   }
+}
+
+function getConstructorName(value: unknown): string {
+  const prototype: Prototype | null = Object.getPrototypeOf(value);
+
+  return prototype ? prototype.constructor.name : 'null prototype';
 }
 
 /** Calculates bytes size of input string */

--- a/packages/utils/test/normalize.test.ts
+++ b/packages/utils/test/normalize.test.ts
@@ -286,6 +286,11 @@ describe('normalize()', () => {
       expect(normalize([{ a }, { b: new B() }, c])).toEqual([{ a: 1 }, { b: 2 }, 3]);
     });
 
+    test('should return a normalized object even if a property was created without a prototype', () => {
+      const subject = { a: 1, foo: Object.create(null), bar: Object.assign(Object.create(null), { baz: true }) } as any;
+      expect(normalize(subject)).toEqual({ a: 1, foo: {}, bar: { baz: true } });
+    });
+
     test('should return a normalized object even if toJSON throws', () => {
       const subject = { a: 1, foo: 'bar' } as any;
       subject.toJSON = () => {


### PR DESCRIPTION
It's possible for `Object.getPrototypeOf` to return `null` (when the object is created via `Object.create(null)`), in which case `null.constructor.name` will throw.

If there is no prototype, this falls back to `null prototype`.