### PR TITLE
fix(replay): fix path separator substitution to replace all `\\`

### DIFF
--- a/packages/replay/metrics/src/scenarios.ts
+++ b/packages/replay/metrics/src/scenarios.ts
@@ -39,7 +39,7 @@ export class JankTestScenario implements Scenario {
   public async run(_: playwright.Browser, page: playwright.Page): Promise<void> {
     let url = path.resolve(`./test-apps/jank/${this._indexFile}`);
     assert(fs.existsSync(url));
-    url = `file:///${url.replace('\\', '/')}`;
+    url = `file:///${url.replace(/\\/g, '/')}`;
     console.log('Navigating to ', url);
     await page.goto(url, { waitUntil: 'load', timeout: 60000 });
     await new Promise(resolve => setTimeout(resolve, 5000));


### PR DESCRIPTION
Fixes [CodeQL #81](https://github.com/getsentry/sentry-javascript/security/code-scanning/81). The `.replace()` originally here only replaced the first occurrence of double-backslashes. Using a regex with a global flag option ensures all of the `\\`'s are replaced with `/`.
