### PR TITLE
codeql(config): fix workflow on ignored .md files

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,9 +17,9 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
-    paths:
+    paths-ignore:
       # When _only_ changing .md files, no need to run CodeQL analysis
-      - '!**/*.md'
+      - '**/*.md'
   schedule:
     - cron: '40 3 * * 0'
 


### PR DESCRIPTION
CodeQL was not running on pull requests targeting the master branch. 🙂 

Using a `!` in the `paths` directive requires us to list another path without it to work properly in this case.(docs [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths:~:text=If%20you%20define%20a%20path%20with%20the%20!%20character%2C%20you%20must%20also%20define%20at%20least%20one%20path%20without%20the%20!%20character.%20If%20you%20only%20want%20to%20exclude%20paths%2C%20use%20paths%2Dignore%20instead.)). Since we are only looking to exclude the path, I've opted to switch us to use `paths-ignore`.
