### PR TITLE
fix(replay): Handle compression worker errors more gracefully

### DIFF
--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -27,5 +27,8 @@ export const MASK_ALL_TEXT_SELECTOR = 'body *:not(style), body *:not(script)';
 export const DEFAULT_FLUSH_MIN_DELAY = 5_000;
 export const DEFAULT_FLUSH_MAX_DELAY = 5_000;
 
+/* How long to wait for error checkouts */
+export const ERROR_CHECKOUT_TIME = 60_000;
+
 export const RETRY_BASE_INTERVAL = 5000;
 export const RETRY_MAX_COUNT = 3;

--- a/packages/replay/src/eventBuffer/EventBufferArray.ts
+++ b/packages/replay/src/eventBuffer/EventBufferArray.ts
@@ -1,0 +1,54 @@
+import type { AddEventResult, EventBuffer, RecordingEvent } from '../types';
+
+/**
+ * A basic event buffer that does not do any compression.
+ * Used as fallback if the compression worker cannot be loaded or is disabled.
+ */
+export class EventBufferArray implements EventBuffer {
+  private _events: RecordingEvent[];
+
+  public constructor() {
+    this._events = [];
+  }
+
+  /** @inheritdoc */
+  public get pendingLength(): number {
+    return this._events.length;
+  }
+
+  /**
+   * Returns the raw events that are buffered. In `EventBufferArray`, this is the
+   * same as `this._events`.
+   */
+  public get pendingEvents(): RecordingEvent[] {
+    return this._events;
+  }
+
+  /** @inheritdoc */
+  public destroy(): void {
+    this._events = [];
+  }
+
+  /** @inheritdoc */
+  public async addEvent(event: RecordingEvent, isCheckout?: boolean): Promise<AddEventResult> {
+    if (isCheckout) {
+      this._events = [event];
+      return;
+    }
+
+    this._events.push(event);
+    return;
+  }
+
+  /** @inheritdoc */
+  public finish(): Promise<string> {
+    return new Promise<string>(resolve => {
+      // Make a copy of the events array reference and immediately clear the
+      // events member so that we do not lose new events while uploading
+      // attachment.
+      const eventsRet = this._events;
+      this._events = [];
+      resolve(JSON.stringify(eventsRet));
+    });
+  }
+}

--- a/packages/replay/src/eventBuffer/EventBufferProxy.ts
+++ b/packages/replay/src/eventBuffer/EventBufferProxy.ts
@@ -1,0 +1,81 @@
+import type { ReplayRecordingData } from '@sentry/types';
+import { logger } from '@sentry/utils';
+
+import type { AddEventResult, EventBuffer, RecordingEvent } from '../types';
+import { EventBufferArray } from './EventBufferArray';
+import { EventBufferCompressionWorker } from './EventBufferCompressionWorker';
+
+/**
+ * This proxy will try to use the compression worker, and fall back to use the simple buffer if an error occurs there.
+ * This can happen e.g. if the worker cannot be loaded.
+ * Exported only for testing.
+ */
+export class EventBufferProxy implements EventBuffer {
+  private _fallback: EventBufferArray;
+  private _compression: EventBufferCompressionWorker;
+  private _used: EventBuffer;
+
+  public constructor(worker: Worker) {
+    this._fallback = new EventBufferArray();
+    this._compression = new EventBufferCompressionWorker(worker);
+    this._used = this._fallback;
+
+    void this._ensureWorkerIsLoaded();
+  }
+
+  /** @inheritDoc */
+  public get pendingLength(): number {
+    return this._used.pendingLength;
+  }
+
+  /** @inheritDoc */
+  public get pendingEvents(): RecordingEvent[] {
+    return this._used.pendingEvents;
+  }
+
+  /** @inheritDoc */
+  public destroy(): void {
+    this._fallback.destroy();
+    this._compression.destroy();
+  }
+
+  /**
+   * Add an event to the event buffer.
+   *
+   * Returns true if event was successfully added.
+   */
+  public addEvent(event: RecordingEvent, isCheckout?: boolean): Promise<AddEventResult> {
+    return this._used.addEvent(event, isCheckout);
+  }
+
+  /** @inheritDoc */
+  public finish(): Promise<ReplayRecordingData> {
+    return this._used.finish();
+  }
+
+  /** Ensure the worker has loaded. */
+  private async _ensureWorkerIsLoaded(): Promise<void> {
+    try {
+      await this._compression.ensureReady();
+    } catch (error) {
+      // If the worker fails to load, we fall back to the simple buffer.
+      // Nothing more to do from our side here
+      __DEBUG_BUILD__ && logger.log('[Replay] Failed to load the compression worker, falling back to simple buffer');
+      return;
+    }
+
+    // Compression worker is ready, we can use it
+    // Now we need to switch over the array buffer to the compression worker
+    const addEventPromises: Promise<void>[] = [];
+    for (const event of this._fallback.pendingEvents) {
+      addEventPromises.push(this._compression.addEvent(event));
+    }
+
+    // We switch over to the compression buffer immediately - any further events will be added
+    // after the previously buffered ones
+    this._used = this._compression;
+
+    // Wait for original events to be re-added before resolving
+    await Promise.all(addEventPromises);
+  }
+}

--- a/packages/replay/src/eventBuffer/EventBufferProxy.ts
+++ b/packages/replay/src/eventBuffer/EventBufferProxy.ts
@@ -49,7 +49,14 @@ export class EventBufferProxy implements EventBuffer {
   }
 
   /** @inheritDoc */
-  public finish(): Promise<ReplayRecordingData> {
+  public async finish(): Promise<ReplayRecordingData> {
+    // Ensure the worker is loaded, so the sent event is compressed
+    try {
+      await this.ensureWorkerIsLoaded();
+    } catch (error) {
+      // If this fails, we'll just send uncompressed events
+    }
+
     return this._used.finish();
   }
 

--- a/packages/replay/src/eventBuffer/EventBufferProxy.ts
+++ b/packages/replay/src/eventBuffer/EventBufferProxy.ts
@@ -20,7 +20,7 @@ export class EventBufferProxy implements EventBuffer {
     this._compression = new EventBufferCompressionWorker(worker);
     this._used = this._fallback;
 
-    void this._ensureWorkerIsLoaded();
+    void this.ensureWorkerIsLoaded();
   }
 
   /** @inheritDoc */
@@ -54,7 +54,7 @@ export class EventBufferProxy implements EventBuffer {
   }
 
   /** Ensure the worker has loaded. */
-  private async _ensureWorkerIsLoaded(): Promise<void> {
+  public async ensureWorkerIsLoaded(): Promise<void> {
     try {
       await this._compression.ensureReady();
     } catch (error) {

--- a/packages/replay/src/eventBuffer/index.ts
+++ b/packages/replay/src/eventBuffer/index.ts
@@ -1,0 +1,28 @@
+import { logger } from '@sentry/utils';
+
+import type { EventBuffer } from '../types';
+import workerString from '../worker/worker.js';
+import { EventBufferArray } from './EventBufferArray';
+import { EventBufferProxy } from './EventBufferProxy';
+
+interface CreateEventBufferParams {
+  useCompression: boolean;
+}
+
+/**
+ * Create an event buffer for replays.
+ */
+export function createEventBuffer({ useCompression }: CreateEventBufferParams): EventBuffer {
+  // eslint-disable-next-line no-restricted-globals
+  if (useCompression && window.Worker) {
+    const workerBlob = new Blob([workerString]);
+    const workerUrl = URL.createObjectURL(workerBlob);
+
+    __DEBUG_BUILD__ && logger.log('[Replay] Using compression worker');
+    const worker = new Worker(workerUrl);
+    return new EventBufferProxy(worker);
+  }
+
+  __DEBUG_BUILD__ && logger.log('[Replay] Using simple buffer');
+  return new EventBufferArray();
+}

--- a/packages/replay/src/eventBuffer/index.ts
+++ b/packages/replay/src/eventBuffer/index.ts
@@ -15,12 +15,17 @@ interface CreateEventBufferParams {
 export function createEventBuffer({ useCompression }: CreateEventBufferParams): EventBuffer {
   // eslint-disable-next-line no-restricted-globals
   if (useCompression && window.Worker) {
-    const workerBlob = new Blob([workerString]);
-    const workerUrl = URL.createObjectURL(workerBlob);
+    try {
+      const workerBlob = new Blob([workerString]);
+      const workerUrl = URL.createObjectURL(workerBlob);
 
-    __DEBUG_BUILD__ && logger.log('[Replay] Using compression worker');
-    const worker = new Worker(workerUrl);
-    return new EventBufferProxy(worker);
+      __DEBUG_BUILD__ && logger.log('[Replay] Using compression worker');
+      const worker = new Worker(workerUrl);
+      return new EventBufferProxy(worker);
+    } catch (error) {
+      __DEBUG_BUILD__ && logger.log('[Replay] Failed to create compression worker');
+      // Fall back to use simple event buffer array
+    }
   }
 
   __DEBUG_BUILD__ && logger.log('[Replay] Using simple buffer');

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -5,9 +5,16 @@ import type { Breadcrumb, ReplayRecordingMode } from '@sentry/types';
 import type { RateLimits } from '@sentry/utils';
 import { disabledUntil, logger } from '@sentry/utils';
 
-import { MAX_SESSION_LIFE, SESSION_IDLE_DURATION, VISIBILITY_CHANGE_TIMEOUT, WINDOW } from './constants';
+import {
+  ERROR_CHECKOUT_TIME,
+  MAX_SESSION_LIFE,
+  SESSION_IDLE_DURATION,
+  VISIBILITY_CHANGE_TIMEOUT,
+  WINDOW,
+} from './constants';
 import { setupPerformanceObserver } from './coreHandlers/performanceObserver';
 import { createEventBuffer } from './eventBuffer';
+import { EventBufferProxy } from './eventBuffer/EventBufferProxy';
 import { getSession } from './session/getSession';
 import { saveSession } from './session/saveSession';
 import type {
@@ -196,7 +203,7 @@ export class ReplayContainer implements ReplayContainerInterface {
         // When running in error sampling mode, we need to overwrite `checkoutEveryNms`
         // Without this, it would record forever, until an error happens, which we don't want
         // instead, we'll always keep the last 60 seconds of replay before an error happened
-        ...(this.recordingMode === 'error' && { checkoutEveryNms: 60000 }),
+        ...(this.recordingMode === 'error' && { checkoutEveryNms: ERROR_CHECKOUT_TIME }),
         emit: this._handleRecordingEmit,
       });
     } catch (err) {
@@ -323,9 +330,18 @@ export class ReplayContainer implements ReplayContainerInterface {
    * from calling both `flush` and `_debouncedFlush`. Otherwise, there could be
    * cases of mulitple flushes happening closely together.
    */
-  public flushImmediate(): Promise<void> {
+  public async flushImmediate(waitForCompression?: boolean): Promise<void> {
     this._debouncedFlush();
     // `.flush` is provided by the debounced function, analogously to lodash.debounce
+
+    // Ensure the worker is loaded, so the sent event is compressed
+    if (waitForCompression && this.eventBuffer instanceof EventBufferProxy) {
+      try {
+        await this.eventBuffer.ensureWorkerIsLoaded();
+      } catch (error) {
+        // If this fails, we'll just send uncompressed events
+      }
+    }
     return this._debouncedFlush.flush() as Promise<void>;
   }
 
@@ -536,7 +552,8 @@ export class ReplayContainer implements ReplayContainerInterface {
       // replays (e.g. opening and closing a tab quickly), but these can be
       // filtered on the UI.
       if (this.recordingMode === 'session') {
-        void this.flushImmediate();
+        // We want to ensure the worker is ready, as otherwise we'd always send the first event uncompressed
+        void this.flushImmediate(true);
       }
 
       return true;

--- a/packages/replay/test/integration/errorSampleRate.test.ts
+++ b/packages/replay/test/integration/errorSampleRate.test.ts
@@ -1,6 +1,12 @@
 import { captureException } from '@sentry/core';
 
-import { DEFAULT_FLUSH_MIN_DELAY, REPLAY_SESSION_KEY, VISIBILITY_CHANGE_TIMEOUT, WINDOW } from '../../src/constants';
+import {
+  DEFAULT_FLUSH_MIN_DELAY,
+  ERROR_CHECKOUT_TIME,
+  REPLAY_SESSION_KEY,
+  VISIBILITY_CHANGE_TIMEOUT,
+  WINDOW,
+} from '../../src/constants';
 import type { ReplayContainer } from '../../src/replay';
 import { addEvent } from '../../src/util/addEvent';
 import { PerformanceEntryResource } from '../fixtures/performanceEntry/resource';
@@ -322,7 +328,7 @@ describe('Integration | errorSampleRate', () => {
   });
 
   it('has correct timestamps when error occurs much later than initial pageload/checkout', async () => {
-    const ELAPSED = 60000;
+    const ELAPSED = ERROR_CHECKOUT_TIME;
     const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
     mockRecord._emitter(TEST_EVENT);
 

--- a/packages/replay/test/unit/eventBuffer.test.ts
+++ b/packages/replay/test/unit/eventBuffer.test.ts
@@ -2,8 +2,9 @@ import 'jsdom-worker';
 
 import pako from 'pako';
 
-import { createEventBuffer, EventBufferProxy } from './../../src/eventBuffer';
+import { createEventBuffer } from './../../src/eventBuffer';
 import { BASE_TIMESTAMP } from './../index';
+import { EventBufferProxy } from '../../src/eventBuffer/EventBufferProxy';
 
 const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
 describe('Unit | eventBuffer', () => {

--- a/packages/replay/test/unit/eventBuffer.test.ts
+++ b/packages/replay/test/unit/eventBuffer.test.ts
@@ -132,6 +132,7 @@ describe('Unit | eventBuffer', () => {
       buffer.addEvent(TEST_EVENT);
 
       const promise1 = buffer.finish();
+      await new Promise(process.nextTick);
 
       buffer.addEvent({ ...TEST_EVENT, type: 5 });
       const promise2 = buffer.finish();
@@ -146,7 +147,7 @@ describe('Unit | eventBuffer', () => {
       expect(restored2).toEqual(JSON.stringify([{ ...TEST_EVENT, type: 5 }]));
     });
 
-    it('handles an error when compressing the payload xxx', async function () {
+    it('handles an error when compressing the payload', async function () {
       const buffer = createEventBuffer({
         useCompression: true,
       }) as EventBufferProxy;
@@ -184,7 +185,7 @@ describe('Unit | eventBuffer', () => {
       consoleErrorSpy.mockRestore();
     });
 
-    it('first uses simple buffer, and switches over once worker is loaded', async function () {
+    it('waits for the worker to be loaded when calling finish', async function () {
       const buffer = createEventBuffer({
         useCompression: true,
       }) as EventBufferProxy;
@@ -196,26 +197,10 @@ describe('Unit | eventBuffer', () => {
 
       expect(buffer.pendingEvents).toEqual([TEST_EVENT, TEST_EVENT]);
 
-      // Finish before the worker is loaded
       const result = await buffer.finish();
-      expect(typeof result).toBe('string');
-      expect(result).toEqual(JSON.stringify([TEST_EVENT, TEST_EVENT]));
-
-      // Now actually finish loading the worker
-      await buffer.ensureWorkerIsLoaded();
-
-      buffer.addEvent(TEST_EVENT);
-      buffer.addEvent(TEST_EVENT);
-      buffer.addEvent(TEST_EVENT);
-
-      expect(buffer.pendingEvents).toEqual([TEST_EVENT, TEST_EVENT, TEST_EVENT]);
-
-      const result2 = await buffer.finish();
-      expect(result2).toBeInstanceOf(Uint8Array);
-
-      const restored2 = pako.inflate(result2 as Uint8Array, { to: 'string' });
-
-      expect(restored2).toEqual(JSON.stringify([TEST_EVENT, TEST_EVENT, TEST_EVENT]));
+      expect(result).toBeInstanceOf(Uint8Array);
+      const restored = pako.inflate(result as Uint8Array, { to: 'string' });
+      expect(restored).toEqual(JSON.stringify([TEST_EVENT, TEST_EVENT]));
     });
 
     it('keeps using simple buffer if worker cannot be loaded', async function () {

--- a/packages/replay/test/unit/eventBuffer.test.ts
+++ b/packages/replay/test/unit/eventBuffer.test.ts
@@ -58,7 +58,7 @@ describe('Unit | eventBuffer', () => {
       expect(buffer).toBeInstanceOf(EventBufferProxy);
 
       // Ensure worker is ready
-      await buffer['_ensureWorkerIsLoaded']();
+      await buffer.ensureWorkerIsLoaded();
 
       buffer.addEvent(TEST_EVENT);
       buffer.addEvent(TEST_EVENT);
@@ -80,7 +80,7 @@ describe('Unit | eventBuffer', () => {
       expect(buffer).toBeInstanceOf(EventBufferProxy);
 
       // Ensure worker is ready
-      await buffer['_ensureWorkerIsLoaded']();
+      await buffer.ensureWorkerIsLoaded();
 
       await buffer.addEvent(TEST_EVENT);
       await buffer.addEvent(TEST_EVENT);
@@ -103,7 +103,7 @@ describe('Unit | eventBuffer', () => {
       expect(buffer).toBeInstanceOf(EventBufferProxy);
 
       // Ensure worker is ready
-      await buffer['_ensureWorkerIsLoaded']();
+      await buffer.ensureWorkerIsLoaded();
 
       buffer.addEvent(TEST_EVENT);
 
@@ -127,7 +127,7 @@ describe('Unit | eventBuffer', () => {
       expect(buffer).toBeInstanceOf(EventBufferProxy);
 
       // Ensure worker is ready
-      await buffer['_ensureWorkerIsLoaded']();
+      await buffer.ensureWorkerIsLoaded();
 
       buffer.addEvent(TEST_EVENT);
 
@@ -177,7 +177,7 @@ describe('Unit | eventBuffer', () => {
       expect(result).toEqual(JSON.stringify([TEST_EVENT, TEST_EVENT]));
 
       // Now actually finish loading the worker
-      await buffer['_ensureWorkerIsLoaded']();
+      await buffer.ensureWorkerIsLoaded();
 
       buffer.addEvent(TEST_EVENT);
       buffer.addEvent(TEST_EVENT);
@@ -211,7 +211,7 @@ describe('Unit | eventBuffer', () => {
       expect(result).toEqual(JSON.stringify([TEST_EVENT, TEST_EVENT]));
 
       // Now actually finish loading the worker - which triggers an error
-      await buffer['_ensureWorkerIsLoaded']();
+      await buffer.ensureWorkerIsLoaded();
 
       buffer.addEvent(TEST_EVENT);
       buffer.addEvent(TEST_EVENT);


### PR DESCRIPTION
partially extracted from https://github.com/getsentry/sentry-javascript/pull/6924

This PR improves the event buffer to handle compression worker errors more gracefully.

1. Split up the event buffers into separate files
2. Ensure the initial event is compressed
3. Fall back to using the uncompressed payload when worker compression fails