### PR TITLE
fix(replay): Do not renew session in error mode

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -264,6 +264,11 @@ export class ReplayContainer implements ReplayContainerInterface {
    * new DOM checkout.`
    */
   public resume(): void {
+    if (!this.session || !this.session.sampled) {
+      this.stop();
+      return;
+    }
+
     this._isPaused = false;
     this.startRecording();
   }
@@ -311,6 +316,13 @@ export class ReplayContainer implements ReplayContainerInterface {
       // Create a new session, otherwise when the user action is flushed, it
       // will get rejected due to an expired session.
       this._loadSession({ expiry: SESSION_IDLE_DURATION });
+
+      // We know this is set, because it is always set in _loadSession
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      if (!this.session!.sampled) {
+        this.stop();
+        return;
+      }
 
       // Note: This will cause a new DOM checkout
       this.resume();
@@ -364,6 +376,13 @@ export class ReplayContainer implements ReplayContainerInterface {
     // --- There is recent user activity --- //
     // This will create a new session if expired, based on expiry length
     this._loadSession({ expiry });
+
+    // We know this is set, because it is always set in _loadSession
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    if (!this.session!.sampled) {
+      this.stop();
+      return;
+    }
 
     // Session was expired if session ids do not match
     const expired = oldSessionId !== this.getSessionId();

--- a/packages/replay/src/session/getSession.ts
+++ b/packages/replay/src/session/getSession.ts
@@ -4,6 +4,7 @@ import type { Session, SessionOptions } from '../types';
 import { isSessionExpired } from '../util/isSessionExpired';
 import { createSession } from './createSession';
 import { fetchSession } from './fetchSession';
+import { makeSession } from './Session';
 
 interface GetSessionParams extends SessionOptions {
   /**
@@ -38,6 +39,10 @@ export function getSession({
 
     if (!isExpired) {
       return { type: 'saved', session };
+    } else if (session.sampled === 'error') {
+      // Error samples should not be re-created when expired, but instead we stop when the replay is done
+      const discardedSession = makeSession({ sampled: false });
+      return { type: 'new', session: discardedSession };
     } else {
       __DEBUG_BUILD__ && logger.log('[Replay] Session has expired');
     }

--- a/packages/replay/test/integration/errorSampleRate.test.ts
+++ b/packages/replay/test/integration/errorSampleRate.test.ts
@@ -1,8 +1,9 @@
-import { captureException } from '@sentry/core';
+import { captureException, getCurrentHub } from '@sentry/core';
 
 import {
   DEFAULT_FLUSH_MIN_DELAY,
   ERROR_CHECKOUT_TIME,
+  MAX_SESSION_LIFE,
   REPLAY_SESSION_KEY,
   VISIBILITY_CHANGE_TIMEOUT,
   WINDOW,
@@ -264,12 +265,10 @@ describe('Integration | errorSampleRate', () => {
     expect(replay).not.toHaveLastSentReplay();
   });
 
-  it('does not upload if user has been idle for more than 15 minutes and comes back to move their mouse', async () => {
+  it('stops replay if user has been idle for more than 15 minutes and comes back to move their mouse', async () => {
     // Idle for 15 minutes
     jest.advanceTimersByTime(15 * 60000);
 
-    // TBD: We are currently deciding that this event will get dropped, but
-    // this could/should change in the future.
     const TEST_EVENT = {
       data: { name: 'lost event' },
       timestamp: BASE_TIMESTAMP,
@@ -281,15 +280,11 @@ describe('Integration | errorSampleRate', () => {
     jest.runAllTimers();
     await new Promise(process.nextTick);
 
-    // Instead of recording the above event, a full snapshot will occur.
-    //
-    // TODO: We could potentially figure out a way to save the last session,
-    // and produce a checkout based on a previous checkout + updates, and then
-    // replay the event on top. Or maybe replay the event on top of a refresh
-    // snapshot.
+    // We stop recording after 15 minutes of inactivity in error mode
 
     expect(replay).not.toHaveLastSentReplay();
-    expect(mockRecord.takeFullSnapshot).toHaveBeenCalledWith(true);
+    expect(replay.isEnabled()).toBe(false);
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
   });
 
   it('has the correct timestamps with deferred root event and last replay update', async () => {
@@ -374,6 +369,52 @@ describe('Integration | errorSampleRate', () => {
         },
       ]),
     });
+  });
+
+  it('stops replay when session expires', async () => {
+    jest.setSystemTime(BASE_TIMESTAMP);
+
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
+    mockRecord._emitter(TEST_EVENT);
+
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+    expect(replay).not.toHaveLastSentReplay();
+
+    jest.runAllTimers();
+    await new Promise(process.nextTick);
+
+    captureException(new Error('testing'));
+
+    jest.advanceTimersByTime(DEFAULT_FLUSH_MIN_DELAY);
+    await new Promise(process.nextTick);
+
+    expect(replay).toHaveLastSentReplay();
+
+    // Wait a bit, shortly before session expires
+    jest.advanceTimersByTime(MAX_SESSION_LIFE - 1000);
+    await new Promise(process.nextTick);
+
+    mockRecord._emitter(TEST_EVENT);
+    replay.triggerUserActivity();
+
+    expect(replay).toHaveLastSentReplay();
+
+    // Now wait after session expires - should stop recording
+    mockRecord.takeFullSnapshot.mockClear();
+    (getCurrentHub().getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>).mockClear();
+
+    jest.advanceTimersByTime(10_000);
+    await new Promise(process.nextTick);
+
+    mockRecord._emitter(TEST_EVENT);
+    replay.triggerUserActivity();
+
+    jest.advanceTimersByTime(DEFAULT_FLUSH_MIN_DELAY);
+    await new Promise(process.nextTick);
+
+    expect(replay).not.toHaveLastSentReplay();
+    expect(mockRecord.takeFullSnapshot).toHaveBeenCalledTimes(0);
+    expect(replay.isEnabled()).toBe(false);
   });
 });
 

--- a/packages/replay/test/integration/events.test.ts
+++ b/packages/replay/test/integration/events.test.ts
@@ -40,7 +40,7 @@ describe('Integration | events', () => {
     // Create a new session and clear mocks because a segment (from initial
     // checkout) will have already been uploaded by the time the tests run
     clearSession(replay);
-    replay['_loadSession']({ expiry: 0 });
+    replay['_loadAndCheckSession'](0);
     mockTransportSend.mockClear();
   });
 
@@ -93,7 +93,7 @@ describe('Integration | events', () => {
 
   it('has correct timestamps when there are events earlier than initial timestamp', async function () {
     clearSession(replay);
-    replay['_loadSession']({ expiry: 0 });
+    replay['_loadAndCheckSession'](0);
     mockTransportSend.mockClear();
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,

--- a/packages/replay/test/integration/flush.test.ts
+++ b/packages/replay/test/integration/flush.test.ts
@@ -95,7 +95,7 @@ describe('Integration | flush', () => {
     jest.setSystemTime(new Date(BASE_TIMESTAMP));
     sessionStorage.clear();
     clearSession(replay);
-    replay['_loadSession']({ expiry: SESSION_IDLE_DURATION });
+    replay['_loadAndCheckSession'](SESSION_IDLE_DURATION);
     mockRecord.takeFullSnapshot.mockClear();
     Object.defineProperty(WINDOW, 'location', {
       value: prevLocation,

--- a/packages/replay/test/integration/rateLimiting.test.ts
+++ b/packages/replay/test/integration/rateLimiting.test.ts
@@ -46,7 +46,7 @@ describe('Integration | rate-limiting behaviour', () => {
     // Create a new session and clear mocks because a segment (from initial
     // checkout) will have already been uploaded by the time the tests run
     clearSession(replay);
-    replay['_loadSession']({ expiry: 0 });
+    replay['_loadAndCheckSession'](0);
 
     mockSendReplayRequest.mockClear();
   });
@@ -57,7 +57,7 @@ describe('Integration | rate-limiting behaviour', () => {
     jest.setSystemTime(new Date(BASE_TIMESTAMP));
     clearSession(replay);
     jest.clearAllMocks();
-    replay['_loadSession']({ expiry: SESSION_IDLE_DURATION });
+    replay['_loadAndCheckSession'](SESSION_IDLE_DURATION);
   });
 
   afterAll(() => {

--- a/packages/replay/test/integration/sendReplayEvent.test.ts
+++ b/packages/replay/test/integration/sendReplayEvent.test.ts
@@ -59,7 +59,7 @@ describe('Integration | sendReplayEvent', () => {
     // Create a new session and clear mocks because a segment (from initial
     // checkout) will have already been uploaded by the time the tests run
     clearSession(replay);
-    replay['_loadSession']({ expiry: 0 });
+    replay['_loadAndCheckSession'](0);
 
     mockSendReplayRequest.mockClear();
   });
@@ -69,7 +69,7 @@ describe('Integration | sendReplayEvent', () => {
     await new Promise(process.nextTick);
     jest.setSystemTime(new Date(BASE_TIMESTAMP));
     clearSession(replay);
-    replay['_loadSession']({ expiry: SESSION_IDLE_DURATION });
+    replay['_loadAndCheckSession'](SESSION_IDLE_DURATION);
   });
 
   afterAll(() => {

--- a/packages/replay/test/integration/session.test.ts
+++ b/packages/replay/test/integration/session.test.ts
@@ -451,7 +451,7 @@ describe('Integration | session', () => {
 
   it('increases segment id after each event', async () => {
     clearSession(replay);
-    replay['_loadSession']({ expiry: 0 });
+    replay['_loadAndCheckSession'](0);
 
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,

--- a/packages/replay/test/integration/stop.test.ts
+++ b/packages/replay/test/integration/stop.test.ts
@@ -44,7 +44,7 @@ describe('Integration | stop', () => {
     jest.setSystemTime(new Date(BASE_TIMESTAMP));
     sessionStorage.clear();
     clearSession(replay);
-    replay['_loadSession']({ expiry: SESSION_IDLE_DURATION });
+    replay['_loadAndCheckSession'](SESSION_IDLE_DURATION);
     mockRecord.takeFullSnapshot.mockClear();
     mockAddInstrumentationHandler.mockClear();
     Object.defineProperty(WINDOW, 'location', {


### PR DESCRIPTION
Currently, when you have a replay session running because of an error, and the session expires (after 15min of inactivity or 60min of activity), we just create a new session (again in error mode) and continue recording.

This is confusing because from a users perspective, they see replays in error mode but with (potentially) no error connected to it.

This PR changes this behavior - when in error mode, and the session expires, we stop the replay.