### PR TITLE
chore(deps): bump default node to latest v16 for e2e-tests

### DIFF
--- a/packages/e2e-tests/Dockerfile.publish-packages
+++ b/packages/e2e-tests/Dockerfile.publish-packages
@@ -1,5 +1,5 @@
 # This Dockerfile exists for the purpose of using a specific node/npm version (ie. the same we use in CI) to run npm publish with
-ARG NODE_VERSION=16.15.1
+ARG NODE_VERSION=16.19.0
 FROM node:${NODE_VERSION}
 
 WORKDIR /sentry-javascript/packages/e2e-tests


### PR DESCRIPTION
Bumps the default Node version for `Dockerfile.publish-packages` to the latest v16.19.0.
This resolves various vulnerabilities patched between 16.15.1 and 16.19.0.
