### PR TITLE
fix(replay): Only call `scope.getLastBreadcrumb` if available

### DIFF
--- a/packages/replay/src/coreHandlers/handleScope.ts
+++ b/packages/replay/src/coreHandlers/handleScope.ts
@@ -26,11 +26,11 @@ export const handleScopeListener: (replay: ReplayContainer) => (scope: Scope) =>
  * An event handler to handle scope changes.
  */
 export function handleScope(scope: Scope): Breadcrumb | null {
-  if (typeof scope.getLastBreadcrumb !== 'function') {
-    return null;
-  }
-
-  const newBreadcrumb = scope.getLastBreadcrumb();
+  // TODO (v8): Remove this guard. This was put in place because we introduced
+  // Scope.getLastBreadcrumb mid-v7 which caused incompatibilities with older SDKs.
+  // For now, we'll just return null if the method doesn't exist but we should eventually
+  // get rid of this guard.
+  const newBreadcrumb = scope.getLastBreadcrumb && scope.getLastBreadcrumb();
 
   // Listener can be called when breadcrumbs have not changed, so we store the
   // reference to the last crumb and only return a crumb if it has changed

--- a/packages/replay/src/coreHandlers/handleScope.ts
+++ b/packages/replay/src/coreHandlers/handleScope.ts
@@ -26,6 +26,10 @@ export const handleScopeListener: (replay: ReplayContainer) => (scope: Scope) =>
  * An event handler to handle scope changes.
  */
 export function handleScope(scope: Scope): Breadcrumb | null {
+  if (typeof scope.getLastBreadcrumb !== 'function') {
+    return null;
+  }
+
   const newBreadcrumb = scope.getLastBreadcrumb();
 
   // Listener can be called when breadcrumbs have not changed, so we store the

--- a/packages/replay/test/unit/coreHandlers/handleScope.test.ts
+++ b/packages/replay/test/unit/coreHandlers/handleScope.test.ts
@@ -3,7 +3,12 @@ import type { Breadcrumb, Scope } from '@sentry/types';
 import * as HandleScope from '../../../src/coreHandlers/handleScope';
 
 describe('Unit | coreHandlers | handleScope', () => {
-  const mockHandleScope = jest.spyOn(HandleScope, 'handleScope');
+  let mockHandleScope: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockHandleScope = jest.spyOn(HandleScope, 'handleScope');
+    mockHandleScope.mockClear();
+  });
 
   it('returns a breadcrumb only if last breadcrumb has changed', function () {
     const scope = {
@@ -46,5 +51,12 @@ describe('Unit | coreHandlers | handleScope', () => {
     HandleScope.handleScope(scope);
     expect(mockHandleScope).toHaveBeenCalledTimes(1);
     expect(mockHandleScope).toHaveReturnedWith(expect.objectContaining({ message: 'f00', category: 'console' }));
+  });
+
+  it('returns null if the method does not exist on the scope', () => {
+    const scope = {} as unknown as Scope;
+    HandleScope.handleScope(scope);
+    expect(mockHandleScope).toHaveBeenCalledTimes(1);
+    expect(mockHandleScope).toHaveReturnedWith(null);
   });
 });


### PR DESCRIPTION
`Scope.getLastBreadcrumb` was introduced quite recently for replay and it generally works fine. Just in the few edge cases, where the base SDK version can't be changed or multiple hubs cause conflicts, Replay will crash when the method is not available on the passed scope. This PR lets `handleScope` early-return `null` in case the `getLastBreadcrumb` method does not exist. This will lead to missing breadcrumbs in the replay but at least it will avoid a crash.

closes https://github.com/getsentry/sentry-javascript/issues/6542 