### PR TITLE
feat(browser): Track if cdn or npm bundle

### DIFF
--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -9,13 +9,16 @@ import type {
   Severity,
   SeverityLevel,
 } from '@sentry/types';
-import { createClientReportEnvelope, dsnToString, logger, serializeEnvelope } from '@sentry/utils';
+import { createClientReportEnvelope, dsnToString, getSDKSource, logger, serializeEnvelope } from '@sentry/utils';
 
 import { eventFromException, eventFromMessage } from './eventbuilder';
 import { WINDOW } from './helpers';
 import type { Breadcrumbs } from './integrations';
 import { BREADCRUMB_INTEGRATION_ID } from './integrations/breadcrumbs';
 import type { BrowserTransportOptions } from './transports/types';
+
+const sdkSource = getSDKSource();
+
 /**
  * Configuration options for the Sentry Browser SDK.
  * @see @sentry/types Options for more information.
@@ -46,7 +49,7 @@ export class BrowserClient extends BaseClient<BrowserClientOptions> {
       name: 'sentry.javascript.browser',
       packages: [
         {
-          name: 'npm:@sentry/browser',
+          name: `${sdkSource}:@sentry/browser`,
           version: SDK_VERSION,
         },
       ],

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -17,8 +17,6 @@ import type { Breadcrumbs } from './integrations';
 import { BREADCRUMB_INTEGRATION_ID } from './integrations/breadcrumbs';
 import type { BrowserTransportOptions } from './transports/types';
 
-const sdkSource = getSDKSource();
-
 /**
  * Configuration options for the Sentry Browser SDK.
  * @see @sentry/types Options for more information.
@@ -44,6 +42,8 @@ export class BrowserClient extends BaseClient<BrowserClientOptions> {
    * @param options Configuration options for this SDK.
    */
   public constructor(options: BrowserClientOptions) {
+    const sdkSource = WINDOW.SENTRY_SDK_SOURCE || getSDKSource();
+
     options._metadata = options._metadata || {};
     options._metadata.sdk = options._metadata.sdk || {
       name: 'sentry.javascript.browser',

--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -277,6 +277,16 @@ describe('SentryBrowser initialization', () => {
       expect(sdkData?.version).toBe(SDK_VERSION);
     });
 
+    it('uses SDK source from window', () => {
+      global.SENTRY_SDK_SOURCE = 'loader';
+      init({ dsn });
+
+      const sdkData = (getCurrentHub().getClient() as any).getOptions()._metadata.sdk;
+
+      expect(sdkData?.packages[0].name).toBe('loader:@sentry/browser');
+      delete global.SENTRY_SDK_SOURCE;
+    });
+
     it('should set SDK data when instantiating a client directly', () => {
       const options = getDefaultBrowserClientOptions({ dsn });
       const client = new BrowserClient(options);

--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -1,4 +1,5 @@
 import { getReportDialogEndpoint, SDK_VERSION } from '@sentry/core';
+import * as utils from '@sentry/utils';
 
 import type { Event } from '../../src';
 import {
@@ -277,7 +278,7 @@ describe('SentryBrowser initialization', () => {
       expect(sdkData?.version).toBe(SDK_VERSION);
     });
 
-    it('uses SDK source from window', () => {
+    it('uses SDK source from window for package name', () => {
       global.SENTRY_SDK_SOURCE = 'loader';
       init({ dsn });
 
@@ -285,6 +286,17 @@ describe('SentryBrowser initialization', () => {
 
       expect(sdkData?.packages[0].name).toBe('loader:@sentry/browser');
       delete global.SENTRY_SDK_SOURCE;
+    });
+
+    it('uses SDK source from global for package name', () => {
+      const spy = jest.spyOn(utils, 'getSDKSource').mockReturnValue('cdn');
+      init({ dsn });
+
+      const sdkData = (getCurrentHub().getClient() as any).getOptions()._metadata.sdk;
+
+      expect(sdkData?.packages[0].name).toBe('cdn:@sentry/browser');
+      expect(utils.getSDKSource).toBeCalledTimes(1);
+      spy.mockRestore();
     });
 
     it('should set SDK data when instantiating a client directly', () => {

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -15,7 +15,7 @@
 
 declare const __SENTRY_BROWSER_BUNDLE__: boolean | undefined;
 
-type SdkSource = 'npm' | 'cdn' | 'loader';
+export type SdkSource = 'npm' | 'cdn' | 'loader';
 
 /**
  * Figures out if we're building a browser bundle.

--- a/packages/utils/src/worldwide.ts
+++ b/packages/utils/src/worldwide.ts
@@ -14,6 +14,8 @@
 
 import type { Integration } from '@sentry/types';
 
+import type { SdkSource } from './env';
+
 /** Internal global with common properties and Sentry extensions  */
 export interface InternalGlobal {
   navigator?: { userAgent?: string };
@@ -26,6 +28,7 @@ export interface InternalGlobal {
   SENTRY_RELEASE?: {
     id?: string;
   };
+  SENTRY_SDK_SOURCE?: SdkSource;
   __SENTRY__: {
     globalEventProcessors: any;
     hub: any;


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/6903

Based on work in https://github.com/getsentry/sentry-javascript/pull/6904

Adjust the package name source to see if from cdn or npm.

