### PR TITLE
fix(nextjs): Don't modify require calls in wrapping loader

### DIFF
--- a/packages/nextjs/src/config/loaders/wrappingLoader.ts
+++ b/packages/nextjs/src/config/loaders/wrappingLoader.ts
@@ -153,8 +153,14 @@ async function wrapUserCode(
       // People may use `module.exports` in their API routes or page files. Next.js allows that and we also need to
       // handle that correctly so we let a plugin to take care of bundling cjs exports for us.
       commonjs({
-        strictRequires: true,
         sourceMap: true,
+        strictRequires: true, // Don't hoist require statements that users may define
+        ignore() {
+          // We want basically only want to use this plugin for handling the case where users export their handlers with module.exports.
+          // This plugin would also be able to convert any `require` into something esm compatible but webpack does that anyways so we just skip that part of the plugin.
+          // (Also, modifying require may break user code)
+          return true;
+        },
       }),
     ],
 

--- a/packages/nextjs/src/config/loaders/wrappingLoader.ts
+++ b/packages/nextjs/src/config/loaders/wrappingLoader.ts
@@ -153,7 +153,7 @@ async function wrapUserCode(
       // People may use `module.exports` in their API routes or page files. Next.js allows that and we also need to
       // handle that correctly so we let a plugin to take care of bundling cjs exports for us.
       commonjs({
-        transformMixedEsModules: true,
+        strictRequires: true,
         sourceMap: true,
       }),
     ],

--- a/packages/nextjs/src/config/loaders/wrappingLoader.ts
+++ b/packages/nextjs/src/config/loaders/wrappingLoader.ts
@@ -155,6 +155,7 @@ async function wrapUserCode(
       commonjs({
         sourceMap: true,
         strictRequires: true, // Don't hoist require statements that users may define
+        ignoreDynamicRequires: true, // Don't break dynamic requires and things like Webpack's `require.context`
         ignore() {
           // We want basically only want to use this plugin for handling the case where users export their handlers with module.exports.
           // This plugin would also be able to convert any `require` into something esm compatible but webpack does that anyways so we just skip that part of the plugin.

--- a/packages/nextjs/test/integration/pages/api/requireTest.ts
+++ b/packages/nextjs/test/integration/pages/api/requireTest.ts
@@ -1,0 +1,14 @@
+import { NextApiResponse, NextApiRequest } from 'next';
+
+if (process.env.NEXT_PUBLIC_SOME_FALSE_ENV_VAR === 'enabled') {
+  require('../../test/server/utils/throw'); // Should not throw unless the hoisting in the wrapping loader is messed up!
+}
+
+const handler = async (_req: NextApiRequest, res: NextApiResponse): Promise<void> => {
+  require('@sentry/nextjs').captureException; // Should not throw unless the wrapping loader messes up cjs imports
+  // @ts-ignore
+  require.context('.'); // This is a webpack utility call. Should not throw unless the wrapping loader messes it up by mangling.
+  res.status(200).json({ success: true });
+};
+
+module.exports = handler;

--- a/packages/nextjs/test/integration/test/server/cjsApiEndpoints.test.ts
+++ b/packages/nextjs/test/integration/test/server/cjsApiEndpoints.test.ts
@@ -66,4 +66,37 @@ describe('CommonJS API Endpoints', () => {
       success: true,
     });
   });
+
+  it('should not mess up require statements', async () => {
+    const env = await NextTestEnv.init();
+    const route = '/api/requireTest';
+    const url = `${env.url}${route}`;
+
+    const wrappedEnvelope = await env.getEnvelopeRequest({
+      url,
+      envelopeType: 'transaction',
+      endServer: false,
+    });
+
+    expect(wrappedEnvelope[2]).toMatchObject({
+      contexts: {
+        trace: {
+          op: 'http.server',
+          status: 'ok',
+          tags: { 'http.status_code': '200' },
+        },
+      },
+      transaction: `GET ${route}`,
+      type: 'transaction',
+      request: {
+        url,
+      },
+    });
+
+    const response = await env.getAPIResponse(url);
+
+    expect(response).toMatchObject({
+      success: true,
+    });
+  });
 });

--- a/packages/nextjs/test/integration/test/server/utils/throw.js
+++ b/packages/nextjs/test/integration/test/server/utils/throw.js
@@ -1,0 +1,1 @@
+throw new Error('I am throwing');


### PR DESCRIPTION
The wrapping loader in the Next.js SDK seems to have problems with CJS.

Users reported the following issues:

- https://github.com/getsentry/sentry-javascript/issues/6970 reports that dynamic imports return undefined. This PR fixes that by setting the `ignore` option to ignore all CJS imports.
- https://github.com/getsentry/sentry-javascript/issues/6943 reports that require calls are incorrectly hoisted by our loader. This PR fixes that by setting `strictRequires` to true, which will disable the hoisting that is meant to simulate ESM.
- https://github.com/getsentry/sentry-javascript/issues/6961 reports that Webpack's `require.context` is broken with our SDK. This PR fixes that by setting the `ignoreDynamicRequires` option to `true` which will stop mangling these require calls.

Fixes https://github.com/getsentry/sentry-javascript/issues/6970
Fixes https://github.com/getsentry/sentry-javascript/issues/6943
Fixes https://github.com/getsentry/sentry-javascript/issues/6961