### PR TITLE
fix(nextjs): Don't share I/O resources in between requests

### DIFF
--- a/packages/nextjs/src/edge/transport.ts
+++ b/packages/nextjs/src/edge/transport.ts
@@ -15,6 +15,9 @@ const DEFAULT_TRANSPORT_BUFFER_SIZE = 30;
  * This is a modified promise buffer that collects tasks until drain is called.
  * We need this in the edge runtime because edge function invocations may not share I/O objects, like fetch requests
  * and responses, and the normal PromiseBuffer inherently buffers stuff inbetween incoming requests.
+ *
+ * A limitation we need to be aware of is that DEFAULT_TRANSPORT_BUFFER_SIZE is the maximum amount of payloads the
+ * SDK can send for a given edge function invocation.
  */
 export class IsolatedPromiseBuffer {
   // We just have this field because the promise buffer interface requires it.
@@ -29,7 +32,7 @@ export class IsolatedPromiseBuffer {
    * @inheritdoc
    */
   public add(taskProducer: () => PromiseLike<TransportMakeRequestResponse>): PromiseLike<void> {
-    if (this._taskProducers.length > this._bufferSize) {
+    if (this._taskProducers.length >= this._bufferSize) {
       return Promise.reject(new SentryError('Not adding Promise because buffer limit was reached.'));
     }
 

--- a/packages/nextjs/src/edge/transport.ts
+++ b/packages/nextjs/src/edge/transport.ts
@@ -16,7 +16,7 @@ const DEFAULT_TRANSPORT_BUFFER_SIZE = 30;
  * We need this in the edge runtime because edge function invocations may not share I/O objects, like fetch requests
  * and responses, and the normal PromiseBuffer inherently buffers stuff inbetween incoming requests.
  */
-class IsolatedPromiseBuffer {
+export class IsolatedPromiseBuffer {
   // We just have this field because the promise buffer interface requires it.
   // If we ever remove it from the interface we should also remove it here.
   public $: Array<PromiseLike<TransportMakeRequestResponse>> = [];
@@ -25,6 +25,9 @@ class IsolatedPromiseBuffer {
 
   public constructor(private readonly _bufferSize: number = DEFAULT_TRANSPORT_BUFFER_SIZE) {}
 
+  /**
+   * @inheritdoc
+   */
   public add(taskProducer: () => PromiseLike<TransportMakeRequestResponse>): PromiseLike<void> {
     if (this._taskProducers.length > this._bufferSize) {
       return Promise.reject(new SentryError('Not adding Promise because buffer limit was reached.'));
@@ -34,6 +37,9 @@ class IsolatedPromiseBuffer {
     return Promise.resolve();
   }
 
+  /**
+   * @inheritdoc
+   */
   public drain(timeout?: number): PromiseLike<boolean> {
     const oldTaskProducers = [...this._taskProducers];
     this._taskProducers = [];

--- a/packages/nextjs/src/edge/transport.ts
+++ b/packages/nextjs/src/edge/transport.ts
@@ -1,11 +1,63 @@
 import { createTransport } from '@sentry/core';
 import type { BaseTransportOptions, Transport, TransportMakeRequestResponse, TransportRequest } from '@sentry/types';
+import { SentryError } from '@sentry/utils';
 
 export interface EdgeTransportOptions extends BaseTransportOptions {
   /** Fetch API init parameters. Used by the FetchTransport */
   fetchOptions?: RequestInit;
   /** Custom headers for the transport. Used by the XHRTransport and FetchTransport */
   headers?: { [key: string]: string };
+}
+
+const DEFAULT_TRANSPORT_BUFFER_SIZE = 30;
+
+/**
+ * This is a modified promise buffer that collects tasks until drain is called.
+ * We need this in the edge runtime because edge function invocations may not share I/O objects, like fetch requests
+ * and responses, and the normal PromiseBuffer inherently buffers stuff inbetween incoming requests.
+ */
+class IsolatedPromiseBuffer {
+  // We just have this field because the promise buffer interface requires it.
+  // If we ever remove it from the interface we should also remove it here.
+  public $: Array<PromiseLike<TransportMakeRequestResponse>> = [];
+
+  private _taskProducers: (() => PromiseLike<TransportMakeRequestResponse>)[] = [];
+
+  public constructor(private readonly _bufferSize: number = DEFAULT_TRANSPORT_BUFFER_SIZE) {}
+
+  public add(taskProducer: () => PromiseLike<TransportMakeRequestResponse>): PromiseLike<void> {
+    if (this._taskProducers.length > this._bufferSize) {
+      return Promise.reject(new SentryError('Not adding Promise because buffer limit was reached.'));
+    }
+
+    this._taskProducers.push(taskProducer);
+    return Promise.resolve();
+  }
+
+  public drain(timeout?: number): PromiseLike<boolean> {
+    const oldTaskProducers = [...this._taskProducers];
+    this._taskProducers = [];
+
+    return new Promise(resolve => {
+      const timer = setTimeout(() => {
+        if (timeout && timeout > 0) {
+          resolve(false);
+        }
+      }, timeout);
+
+      void Promise.all(
+        oldTaskProducers.map(taskProducer =>
+          taskProducer().then(null, () => {
+            // catch all failed requests
+          }),
+        ),
+      ).then(() => {
+        // resolve to true if all fetch requests settled
+        clearTimeout(timer);
+        resolve(true);
+      });
+    });
+  }
 }
 
 /**
@@ -21,18 +73,16 @@ export function makeEdgeTransport(options: EdgeTransportOptions): Transport {
       ...options.fetchOptions,
     };
 
-    try {
-      return fetch(options.url, requestOptions).then(response => ({
+    return fetch(options.url, requestOptions).then(response => {
+      return {
         statusCode: response.status,
         headers: {
           'x-sentry-rate-limits': response.headers.get('X-Sentry-Rate-Limits'),
           'retry-after': response.headers.get('Retry-After'),
         },
-      }));
-    } catch (e) {
-      return Promise.reject(e);
-    }
+      };
+    });
   }
 
-  return createTransport(options, makeRequest);
+  return createTransport(options, makeRequest, new IsolatedPromiseBuffer(options.bufferSize));
 }

--- a/packages/nextjs/src/edge/utils/edgeWrapperUtils.ts
+++ b/packages/nextjs/src/edge/utils/edgeWrapperUtils.ts
@@ -44,19 +44,15 @@ export function withEdgeWrapping<H extends EdgeRouteHandler>(
 
         const dynamicSamplingContext = baggageHeaderToDynamicSamplingContext(req.headers.get('baggage'));
 
-        span = startTransaction(
-          {
-            name: options.spanDescription,
-            op: options.spanOp,
-            ...traceparentData,
-            metadata: {
-              dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,
-              source: 'route',
-            },
+        span = startTransaction({
+          name: options.spanDescription,
+          op: options.spanOp,
+          ...traceparentData,
+          metadata: {
+            dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,
+            source: 'route',
           },
-          // extra context passed to the `tracesSampler`
-          { request: req },
-        );
+        });
       }
 
       currentScope?.setSpan(span);

--- a/packages/nextjs/test/edge/edgeWrapperUtils.test.ts
+++ b/packages/nextjs/test/edge/edgeWrapperUtils.test.ts
@@ -84,7 +84,6 @@ describe('withEdgeWrapping', () => {
     expect(startTransactionSpy).toHaveBeenCalledTimes(1);
     expect(startTransactionSpy).toHaveBeenCalledWith(
       expect.objectContaining({ metadata: { source: 'route' }, name: 'some label', op: 'some op' }),
-      { request },
     );
   });
 

--- a/packages/nextjs/test/edge/transport.test.ts
+++ b/packages/nextjs/test/edge/transport.test.ts
@@ -51,6 +51,7 @@ describe('Edge Transport', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(0);
     await transport.send(ERROR_ENVELOPE);
+    await transport.flush();
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
     expect(mockFetch).toHaveBeenLastCalledWith(DEFAULT_EDGE_TRANSPORT_OPTIONS.url, {
@@ -77,6 +78,7 @@ describe('Edge Transport', () => {
 
     expect(headers.get).toHaveBeenCalledTimes(0);
     await transport.send(ERROR_ENVELOPE);
+    await transport.flush();
 
     expect(headers.get).toHaveBeenCalledTimes(2);
     expect(headers.get).toHaveBeenCalledWith('X-Sentry-Rate-Limits');
@@ -101,6 +103,7 @@ describe('Edge Transport', () => {
     const transport = makeEdgeTransport({ ...DEFAULT_EDGE_TRANSPORT_OPTIONS, fetchOptions: REQUEST_OPTIONS });
 
     await transport.send(ERROR_ENVELOPE);
+    await transport.flush();
     expect(mockFetch).toHaveBeenLastCalledWith(DEFAULT_EDGE_TRANSPORT_OPTIONS.url, {
       body: serializeEnvelope(ERROR_ENVELOPE, new TextEncoder()),
       method: 'POST',

--- a/packages/nextjs/test/edge/withSentryAPI.test.ts
+++ b/packages/nextjs/test/edge/withSentryAPI.test.ts
@@ -53,7 +53,6 @@ describe('wrapApiHandlerWithSentry', () => {
         name: 'POST /user/[userId]/post/[postId]',
         op: 'http.server',
       }),
-      { request },
     );
   });
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/6975

Vercel edge routes don't allow shared access to I/O resources (req, res objects etc.) between requests. Our flushing logic inside the default PromiseBuffer was inherently doing that by processing outgoing fetch requests, even after the Edge route terminated.

This PR aims to resolve this issue by making the flushing of Sentry events atomic to a particular request.