### PR TITLE
feat(replay): Add back deprecated `maskInputOptions`

### DIFF
--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -55,6 +55,7 @@ export class Replay implements Integration {
     errorSampleRate,
     maskAllText,
     maskAllInputs = true,
+    maskInputOptions,
     blockAllMedia = true,
 
     mask = [],
@@ -77,6 +78,7 @@ export class Replay implements Integration {
   }: ReplayConfiguration = {}) {
     this._recordingOptions = {
       maskAllInputs,
+      maskInputOptions,
       maskTextFn: maskFn,
       maskInputFn: maskFn,
 

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -79,7 +79,7 @@ export class Replay implements Integration {
   }: ReplayConfiguration = {}) {
     this._recordingOptions = {
       maskAllInputs,
-      maskInputOptions,
+     {...maskInputOptions, password: true},
       maskTextFn: maskFn,
       maskInputFn: maskFn,
 

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -79,7 +79,7 @@ export class Replay implements Integration {
   }: ReplayConfiguration = {}) {
     this._recordingOptions = {
       maskAllInputs,
-     {...maskInputOptions, password: true},
+      maskInputOptions: { ...maskInputOptions, password: true },
       maskTextFn: maskFn,
       maskInputFn: maskFn,
 

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -79,7 +79,7 @@ export class Replay implements Integration {
   }: ReplayConfiguration = {}) {
     this._recordingOptions = {
       maskAllInputs,
-      maskInputOptions: { ...maskInputOptions, password: true },
+      maskInputOptions: { ...(maskInputOptions || {}), password: true },
       maskTextFn: maskFn,
       maskInputFn: maskFn,
 

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -55,7 +55,6 @@ export class Replay implements Integration {
     errorSampleRate,
     maskAllText,
     maskAllInputs = true,
-    maskInputOptions,
     blockAllMedia = true,
 
     mask = [],
@@ -69,6 +68,8 @@ export class Replay implements Integration {
     blockClass,
     // eslint-disable-next-line deprecation/deprecation
     blockSelector,
+    // eslint-disable-next-line deprecation/deprecation
+    maskInputOptions,
     // eslint-disable-next-line deprecation/deprecation
     maskTextClass,
     // eslint-disable-next-line deprecation/deprecation

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -165,7 +165,7 @@ export interface DeprecatedPrivacyOptions {
   /**
    * @deprecated  Use `mask` which accepts an array of CSS selectors
    */
-  maskInputOptions: RecordingOptions['maskInputOptions'];
+  maskInputOptions?: RecordingOptions['maskInputOptions'];
   /**
    * @deprecated Use `mask` which accepts an array of CSS selectors
    */

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -159,6 +159,14 @@ export interface DeprecatedPrivacyOptions {
    */
   blockClass?: RecordingOptions['blockClass'];
   /**
+   * @deprecated Use `ignore` which accepts an array of CSS selectors
+   */
+  ignoreClass?: RecordingOptions['ignoreClass'];
+  /**
+   * @deprecated  Use `mask` which accepts an array of CSS selectors
+   */
+  maskInputOptions: RecordingOptions['maskInputOptions'];
+  /**
    * @deprecated Use `mask` which accepts an array of CSS selectors
    */
   maskTextClass?: RecordingOptions['maskTextClass'];
@@ -166,10 +174,6 @@ export interface DeprecatedPrivacyOptions {
    * @deprecated Use `mask` which accepts an array of CSS selectors
    */
   maskTextSelector?: RecordingOptions['maskTextSelector'];
-  /**
-   * @deprecated Use `ignore` which accepts an array of CSS selectors
-   */
-  ignoreClass?: RecordingOptions['ignoreClass'];
 }
 
 export interface ReplayConfiguration

--- a/packages/replay/src/types/rrweb.ts
+++ b/packages/replay/src/types/rrweb.ts
@@ -36,4 +36,5 @@ export type recordOptions = {
   maskTextClass?: maskTextClass;
   maskTextSelector?: string;
   blockSelector?: string;
+  maskInputOptions?: Record<string, boolean>;
 } & Record<string, unknown>;

--- a/packages/replay/src/util/getPrivacyOptions.ts
+++ b/packages/replay/src/util/getPrivacyOptions.ts
@@ -1,6 +1,6 @@
 import type { DeprecatedPrivacyOptions, ReplayIntegrationPrivacyOptions } from '../types';
 
-type GetPrivacyOptions = Required<Omit<ReplayIntegrationPrivacyOptions, 'maskFn'>> & DeprecatedPrivacyOptions;
+type GetPrivacyOptions = Required<Omit<ReplayIntegrationPrivacyOptions, 'maskFn'>> & Omit<DeprecatedPrivacyOptions, 'maskInputOptions'>;
 interface GetPrivacyReturn {
   maskTextSelector: string;
   unmaskTextSelector: string;

--- a/packages/replay/src/util/getPrivacyOptions.ts
+++ b/packages/replay/src/util/getPrivacyOptions.ts
@@ -1,6 +1,7 @@
 import type { DeprecatedPrivacyOptions, ReplayIntegrationPrivacyOptions } from '../types';
 
-type GetPrivacyOptions = Required<Omit<ReplayIntegrationPrivacyOptions, 'maskFn'>> & Omit<DeprecatedPrivacyOptions, 'maskInputOptions'>;
+type GetPrivacyOptions = Required<Omit<ReplayIntegrationPrivacyOptions, 'maskFn'>> &
+  Omit<DeprecatedPrivacyOptions, 'maskInputOptions'>;
 interface GetPrivacyReturn {
   maskTextSelector: string;
   unmaskTextSelector: string;

--- a/packages/replay/test/integration/rrweb.test.ts
+++ b/packages/replay/test/integration/rrweb.test.ts
@@ -25,7 +25,9 @@ describe('Integration | rrweb', () => {
         "inlineStylesheet": true,
         "maskAllInputs": true,
         "maskInputFn": undefined,
-        "maskInputOptions": undefined,
+        "maskInputOptions": Object {
+          "password": true,
+        },
         "maskInputSelector": ".sentry-mask,[data-sentry-mask]",
         "maskTextFn": undefined,
         "maskTextSelector": "body *:not(style), body *:not(script)",

--- a/packages/replay/test/integration/rrweb.test.ts
+++ b/packages/replay/test/integration/rrweb.test.ts
@@ -25,6 +25,7 @@ describe('Integration | rrweb', () => {
         "inlineStylesheet": true,
         "maskAllInputs": true,
         "maskInputFn": undefined,
+        "maskInputOptions": undefined,
         "maskInputSelector": ".sentry-mask,[data-sentry-mask]",
         "maskTextFn": undefined,
         "maskTextSelector": "body *:not(style), body *:not(script)",


### PR DESCRIPTION
This was unintentionally removed in #6645 - it is still deprecated and will be removed at a later date.
