### PR TITLE
chore(sentry/nextjs): move rollup to dev-deps

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -17,7 +17,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@rollup/plugin-commonjs": "24.0.0",
     "@sentry/core": "7.34.0",
     "@sentry/integrations": "7.34.0",
     "@sentry/node": "7.34.0",
@@ -27,13 +26,14 @@
     "@sentry/utils": "7.34.0",
     "@sentry/webpack-plugin": "1.20.0",
     "chalk": "3.0.0",
-    "rollup": "2.78.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "24.0.0",
     "@types/webpack": "^4.41.31",
     "eslint-plugin-react": "^7.31.11",
-    "next": "10.1.3"
+    "next": "10.1.3",
+    "rollup": "2.78.0"
   },
   "peerDependencies": {
     "next": "^10.0.8 || ^11.0 || ^12.0 || ^13.0",


### PR DESCRIPTION
Not sure if rollup is used on a production build (?).

If not make sense to move it to dev dependencies. 

Shave off few Mb's when not using standalone builds.

![image](https://user-images.githubusercontent.com/259798/215579222-8106d543-17b8-43ee-b9e9-4cea043e1267.png)
