### PR TITLE
ci: Skip gitflow steps if no PR was created

### DIFF
--- a/.github/workflows/gitflow-sync-develop.yml
+++ b/.github/workflows/gitflow-sync-develop.yml
@@ -11,7 +11,8 @@ on:
   workflow_dispatch:
 
 env:
-  DEV_BRANCH: develop
+  SOURCE_BRANCH: master
+  TARGET_BRANCH: develop
 
 jobs:
   main:
@@ -29,9 +30,10 @@ jobs:
         id: open-pr
         uses: repo-sync/pull-request@v2
         with:
-          destination_branch: ${{ env.DEV_BRANCH }}
-          pr_title: '[Gitflow] Merge ${{ github.ref_name }} into ${{ env.DEV_BRANCH }}'
-          pr_body: 'Merge ${{ github.ref_name }} branch into ${{ env.DEV_BRANCH }}'
+          source_branch: ${{ env.SOURCE_BRANCH }}
+          destination_branch: ${{ env.TARGET_BRANCH }}
+          pr_title: '[Gitflow] Merge ${{ env.SOURCE_BRANCH }} into ${{ env.TARGET_BRANCH }}'
+          pr_body: 'Merge ${{ env.SOURCE_BRANCH }} branch into ${{ env.TARGET_BRANCH }}'
           pr_label: 'Dev: Gitflow'
 
       # https://github.com/marketplace/actions/enable-pull-request-automerge

--- a/.github/workflows/gitflow-sync-develop.yml
+++ b/.github/workflows/gitflow-sync-develop.yml
@@ -45,6 +45,7 @@ jobs:
       # https://github.com/marketplace/actions/auto-approve
       - name: Auto approve PR
         uses: hmarr/auto-approve-action@v3
+        if: steps.open-pr.outputs.pr_number != ''
         with:
           pull-request-number: ${{ steps.open-pr.outputs.pr_number }}
           review-message: 'Auto approved automated PR'

--- a/.github/workflows/gitflow-sync-master.yml
+++ b/.github/workflows/gitflow-sync-master.yml
@@ -47,6 +47,7 @@ jobs:
       # https://github.com/marketplace/actions/auto-approve
       - name: Auto approve PR
         uses: hmarr/auto-approve-action@v3
+        if: steps.open-pr.outputs.pr_number != ''
         with:
           pull-request-number: ${{ steps.open-pr.outputs.pr_number }}
           review-message: 'Auto approved automated PR'

--- a/.github/workflows/gitflow-sync-master.yml
+++ b/.github/workflows/gitflow-sync-master.yml
@@ -13,7 +13,8 @@ on:
   workflow_dispatch:
 
 env:
-  MAIN_BRANCH: master
+  SOURCE_BRANCH: develop
+  TARGET_BRANCH: master
 
 jobs:
   main:
@@ -31,9 +32,10 @@ jobs:
         id: open-pr
         uses: repo-sync/pull-request@v2
         with:
-          destination_branch: ${{ env.MAIN_BRANCH }}
-          pr_title: '[Gitflow] Merge ${{ github.ref_name }} into ${{ env.MAIN_BRANCH }}'
-          pr_body: 'Merge ${{ github.ref_name }} branch into ${{ env.MAIN_BRANCH }}'
+          source_branch: ${{ env.SOURCE_BRANCH }}
+          destination_branch: ${{ env.TARGET_BRANCH }}
+          pr_title: '[Gitflow] Merge ${{ env.SOURCE_BRANCH }} into ${{ env.TARGET_BRANCH }}'
+          pr_body: 'Merge ${{ env.SOURCE_BRANCH }} branch into ${{ env.TARGET_BRANCH }}'
           pr_label: 'Dev: Gitflow'
 
       # https://github.com/marketplace/actions/enable-pull-request-automerge


### PR DESCRIPTION
If you run the workflow manually, it will not create a PR if the branches are in sync, we should not error out in that case.

Also, we hard-code the source/target branches for the workflow instead of using "current branch" - as that would allow you to accidentally merge a different branch when triggering it as a workflow.