### PR TITLE
feat(loader): Sync loader with Sentry template

### DIFF
--- a/packages/browser/src/loader.js
+++ b/packages/browser/src/loader.js
@@ -61,7 +61,7 @@
     var _currentScriptTag = _document.scripts[0];
     var _newScriptTag = _document.createElement(_script);
     _newScriptTag.src = _sdkBundleUrl;
-    _newScriptTag.setAttribute('crossorigin', 'anonymous');
+    _newScriptTag.crossOrigin = 'anonymous';
 
     // Once our SDK is loaded
     _newScriptTag.addEventListener('load', function() {


### PR DESCRIPTION
As per https://github.com/getsentry/sentry-javascript/issues/6990 the loader in the JS monorepo and sentry template has drifted apart. This syncs them together (validated by the integration tests in the JS monorepo).

PR in Sentry repo: https://github.com/getsentry/sentry/pull/43880