### PR TITLE
feat(replay): Add "start recording" breadcrumb to replays

### DIFF
--- a/packages/integration-tests/suites/replay/startRecordingBreadcrumb/init.js
+++ b/packages/integration-tests/suites/replay/startRecordingBreadcrumb/init.js
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/browser';
+import { Replay } from '@sentry/replay';
+
+window.Sentry = Sentry;
+window.Replay = new Replay({
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
+  useCompression: false,
+});
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  sampleRate: 0,
+  replaysSessionSampleRate: 1.0,
+  replaysOnErrorSampleRate: 0.0,
+
+  integrations: [window.Replay],
+});

--- a/packages/integration-tests/suites/replay/startRecordingBreadcrumb/template.html
+++ b/packages/integration-tests/suites/replay/startRecordingBreadcrumb/template.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <button onclick="console.log('Test log')">Click me</button>
+  </body>
+</html>

--- a/packages/integration-tests/suites/replay/startRecordingBreadcrumb/test.ts
+++ b/packages/integration-tests/suites/replay/startRecordingBreadcrumb/test.ts
@@ -1,0 +1,42 @@
+import { expect } from '@playwright/test';
+import { SDK_VERSION } from '@sentry/browser';
+import type { RecordingEvent } from '@sentry/replay/build/npm/types/types';
+import type { ReplayEvent } from '@sentry/types';
+
+import { sentryTest } from '../../../utils/fixtures';
+import { envelopeRequestParser } from '../../../utils/helpers';
+import { getReplayBreadcrumbs, waitForReplayRequest } from '../../../utils/replayHelpers';
+
+sentryTest('adds a start recording breadcrumb to the replay', async ({ getLocalTestPath, page }) => {
+  // Replay bundles are es6 only
+  if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_es5')) {
+    sentryTest.skip();
+  }
+
+  const reqPromise = waitForReplayRequest(page, 0);
+
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  await page.goto(url);
+
+  const replayRecording = envelopeRequestParser(await reqPromise, 5) as RecordingEvent[];
+  const breadCrumbs = getReplayBreadcrumbs(replayRecording, 'replay.recording.start');
+
+  expect(breadCrumbs.length).toBe(1);
+  expect(breadCrumbs[0]).toEqual({
+    category: 'replay.recording.start',
+    data: {
+      url: expect.stringContaining('replay/startRecordingBreadcrumb/dist/index.html'),
+    },
+    timestamp: expect.any(Number),
+    type: 'default',
+  });
+});

--- a/packages/integration-tests/suites/replay/startRecordingBreadcrumb/test.ts
+++ b/packages/integration-tests/suites/replay/startRecordingBreadcrumb/test.ts
@@ -1,7 +1,5 @@
 import { expect } from '@playwright/test';
-import { SDK_VERSION } from '@sentry/browser';
 import type { RecordingEvent } from '@sentry/replay/build/npm/types/types';
-import type { ReplayEvent } from '@sentry/types';
 
 import { sentryTest } from '../../../utils/fixtures';
 import { envelopeRequestParser } from '../../../utils/helpers';

--- a/packages/integration-tests/utils/helpers.ts
+++ b/packages/integration-tests/utils/helpers.ts
@@ -17,8 +17,8 @@ export const envelopeParser = (request: Request | null): unknown[] => {
   });
 };
 
-export const envelopeRequestParser = (request: Request | null): Event => {
-  return envelopeParser(request)[2] as Event;
+export const envelopeRequestParser = (request: Request | null, envelopeIndex = 2): Event => {
+  return envelopeParser(request)[envelopeIndex] as Event;
 };
 
 export const envelopeHeaderRequestParser = (request: Request | null): EventEnvelopeHeaders => {

--- a/packages/integration-tests/utils/replayHelpers.ts
+++ b/packages/integration-tests/utils/replayHelpers.ts
@@ -1,5 +1,5 @@
-import type { ReplayContainer } from '@sentry/replay/build/npm/types/types';
-import type { Event, ReplayEvent } from '@sentry/types';
+import type { RecordingEvent, ReplayContainer } from '@sentry/replay/build/npm/types/types';
+import type { Breadcrumb, Event, ReplayEvent } from '@sentry/types';
 import type { Page, Request } from 'playwright';
 
 import { envelopeRequestParser } from './helpers';
@@ -56,3 +56,12 @@ export async function getReplaySnapshot(page: Page): Promise<ReplayContainer> {
 }
 
 export const REPLAY_DEFAULT_FLUSH_MAX_DELAY = 5_000;
+
+export function getReplayBreadcrumbs(rrwebEvents: RecordingEvent[], category?: string): Breadcrumb[] {
+  return rrwebEvents
+    .filter(event => event.type === 5)
+    .map(event => event.data as { tag: string; payload: { category: string } })
+    .filter(data => data.tag === 'breadcrumb')
+    .map(data => data.payload)
+    .filter(payload => !category || payload.category === category);
+}

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -112,8 +112,6 @@ export class ReplayContainer implements ReplayContainerInterface {
     initialUrl: '',
   };
 
-  private _startRecordingbreadcrumb: Breadcrumb | undefined;
-
   public constructor({
     options,
     recordingOptions,
@@ -212,7 +210,6 @@ export class ReplayContainer implements ReplayContainerInterface {
       });
     } catch (err) {
       this._handleException(err);
-      return;
     }
   }
 
@@ -910,15 +907,13 @@ export class ReplayContainer implements ReplayContainerInterface {
 
   /**
    * Creates a breadcrumb indicating the start of a replay recording
+   * and adds the current, full URL to the breadcrumb data.
    */
   private _addStartRecordingBreadcrumb(): void {
-    // if (this._startRecordingbreadcrumb) {
-    //   return;
-    // }
-    this._startRecordingbreadcrumb = createBreadcrumb({
+    const breadcrumb = createBreadcrumb({
       category: 'replay.recording.start',
       data: { url: getFullURL() },
     });
-    this._createCustomBreadcrumb(this._startRecordingbreadcrumb);
+    this._createCustomBreadcrumb(breadcrumb);
   }
 }

--- a/packages/replay/src/util/addEvent.ts
+++ b/packages/replay/src/util/addEvent.ts
@@ -19,8 +19,6 @@ export async function addEvent(
     return null;
   }
 
-  console.log(event);
-
   // TODO: sadness -- we will want to normalize timestamps to be in ms -
   // requires coordination with frontend
   const isMs = event.timestamp > 9999999999;

--- a/packages/replay/src/util/addEvent.ts
+++ b/packages/replay/src/util/addEvent.ts
@@ -19,6 +19,8 @@ export async function addEvent(
     return null;
   }
 
+  console.log(event);
+
   // TODO: sadness -- we will want to normalize timestamps to be in ms -
   // requires coordination with frontend
   const isMs = event.timestamp > 9999999999;

--- a/packages/replay/src/util/getFullUrl.ts
+++ b/packages/replay/src/util/getFullUrl.ts
@@ -1,0 +1,10 @@
+import { WINDOW } from '../constants';
+
+/**
+ * Takes the full URL from `window.location` and returns it as a string.
+ */
+export function getFullURL(): string {
+  const urlPath = `${WINDOW.location.pathname}${WINDOW.location.hash}${WINDOW.location.search}`;
+  const url = `${WINDOW.location.origin}${urlPath}`;
+  return url;
+}

--- a/packages/replay/test/integration/errorSampleRate.test.ts
+++ b/packages/replay/test/integration/errorSampleRate.test.ts
@@ -109,19 +109,32 @@ describe('Integration | errorSampleRate', () => {
           },
         },
       }),
-      recordingData: JSON.stringify([{ data: { isCheckout: true }, timestamp: BASE_TIMESTAMP + 5020, type: 2 }]),
     });
 
     jest.advanceTimersByTime(DEFAULT_FLUSH_MIN_DELAY);
 
     // New checkout when we call `startRecording` again after uploading segment
     // after an error occurs
+    const timestamp = BASE_TIMESTAMP + DEFAULT_FLUSH_MIN_DELAY + 20;
     expect(replay).toHaveLastSentReplay({
       recordingData: JSON.stringify([
         {
           data: { isCheckout: true },
-          timestamp: BASE_TIMESTAMP + DEFAULT_FLUSH_MIN_DELAY + 20,
+          timestamp,
           type: 2,
+        },
+        {
+          type: 5,
+          timestamp: timestamp / 1000,
+          data: {
+            tag: 'breadcrumb',
+            payload: {
+              timestamp: timestamp / 1000,
+              type: 'default',
+              category: 'replay.recording.start',
+              data: { url: 'http://localhost/' },
+            },
+          },
         },
       ]),
     });
@@ -460,9 +473,25 @@ it('sends a replay after loading the session multiple times', async () => {
     recordingData: JSON.stringify([{ data: { isCheckout: true }, timestamp: BASE_TIMESTAMP, type: 2 }, TEST_EVENT]),
   });
 
+  const timestamp = BASE_TIMESTAMP + 5020;
   // Latest checkout when we call `startRecording` again after uploading segment
   // after an error occurs (e.g. when we switch to session replay recording)
   expect(replay).toHaveLastSentReplay({
-    recordingData: JSON.stringify([{ data: { isCheckout: true }, timestamp: BASE_TIMESTAMP + 5020, type: 2 }]),
+    recordingData: JSON.stringify([
+      { data: { isCheckout: true }, timestamp: timestamp, type: 2 },
+      {
+        type: 5,
+        timestamp: timestamp / 1000,
+        data: {
+          tag: 'breadcrumb',
+          payload: {
+            timestamp: timestamp / 1000,
+            type: 'default',
+            category: 'replay.recording.start',
+            data: { url: 'http://localhost/' },
+          },
+        },
+      },
+    ]),
   });
 });

--- a/packages/replay/test/integration/session.test.ts
+++ b/packages/replay/test/integration/session.test.ts
@@ -153,6 +153,19 @@ describe('Integration | session', () => {
         { data: { isCheckout: true }, timestamp: newTimestamp, type: 2 },
         {
           type: 5,
+          timestamp: newTimestamp / 1000,
+          data: {
+            tag: 'breadcrumb',
+            payload: {
+              timestamp: newTimestamp / 1000,
+              type: 'default',
+              category: 'replay.recording.start',
+              data: { url: 'http://localhost/' },
+            },
+          },
+        },
+        {
+          type: 5,
           timestamp: breadcrumbTimestamp,
           data: {
             tag: 'breadcrumb',
@@ -313,6 +326,19 @@ describe('Integration | session', () => {
         { data: { isCheckout: true }, timestamp: newTimestamp, type: 2 },
         {
           type: 5,
+          timestamp: newTimestamp / 1000,
+          data: {
+            tag: 'breadcrumb',
+            payload: {
+              timestamp: newTimestamp / 1000,
+              type: 'default',
+              category: 'replay.recording.start',
+              data: { url: 'http://dummy/' },
+            },
+          },
+        },
+        {
+          type: 5,
           timestamp: breadcrumbTimestamp,
           data: {
             tag: 'breadcrumb',
@@ -422,6 +448,19 @@ describe('Integration | session', () => {
       recordingPayloadHeader: { segment_id: 0 },
       recordingData: JSON.stringify([
         { data: { isCheckout: true }, timestamp: newTimestamp, type: 2 },
+        {
+          type: 5,
+          timestamp: newTimestamp / 1000,
+          data: {
+            tag: 'breadcrumb',
+            payload: {
+              timestamp: newTimestamp / 1000,
+              type: 'default',
+              category: 'replay.recording.start',
+              data: { url: 'http://dummy/' },
+            },
+          },
+        },
         {
           type: 5,
           timestamp: breadcrumbTimestamp,

--- a/packages/replay/test/integration/stop.test.ts
+++ b/packages/replay/test/integration/stop.test.ts
@@ -109,13 +109,27 @@ describe('Integration | stop', () => {
     WINDOW.dispatchEvent(new Event('blur'));
     jest.runAllTimers();
     await new Promise(process.nextTick);
+    const checkoutTimestamp = BASE_TIMESTAMP + ELAPSED + EXTRA_TICKS;
     expect(replay).toHaveLastSentReplay({
       recordingData: JSON.stringify([
         // This event happens when we call `replay.start`
         {
           data: { isCheckout: true },
-          timestamp: BASE_TIMESTAMP + ELAPSED + EXTRA_TICKS,
+          timestamp: checkoutTimestamp,
           type: 2,
+        },
+        {
+          type: 5,
+          timestamp: checkoutTimestamp / 1000,
+          data: {
+            tag: 'breadcrumb',
+            payload: {
+              timestamp: checkoutTimestamp / 1000,
+              type: 'default',
+              category: 'replay.recording.start',
+              data: { url: 'http://localhost/' },
+            },
+          },
         },
         TEST_EVENT,
         hiddenBreadcrumb,

--- a/packages/replay/test/unit/util/getFullUrl.test.ts
+++ b/packages/replay/test/unit/util/getFullUrl.test.ts
@@ -1,0 +1,20 @@
+import { getFullURL } from '../../../src/util/getFullUrl';
+
+jest.mock('../../../src/constants', () => {
+  return {
+    WINDOW: {
+      location: {
+        origin: 'https://myDomain.com',
+        pathname: '/users/123',
+        hash: '#edit',
+        search: '?mode=admin',
+      },
+    },
+  };
+});
+
+describe('Unit | util | getFullURL', () => {
+  it('returns the concatenated full URL form `window.location`', () => {
+    expect(getFullURL()).toBe('https://myDomain.com/users/123#edit?mode=admin');
+  });
+});


### PR DESCRIPTION
This PR adds a breadcrumb to replay, whenever a full checkout occurs and we're in session mode. The purpose of this breadcrumb (as explained in #6928) is that we need to be aware of page reloads and multi-page app navigations (i.e. page loads). Therefore, this new breadcrumb contains a `url` string in its `data` object, which contains the current full URL. 

Initially, I wanted to add it in `startRecording`, which however, caused weird behaviour in error mode, causing too early flushes of the initial segment (at least according to the weird test failures I got). So for now, this breadcrumb is always added for session-mode and for error-mode replays only when the actual error is caught and we switch to session mode. I'm not too happy about this, as we do not get this breadcrumb for the initial 30-60 seconds of the replay but not sure if we can actually do this, without rewriting how adding breadcrumbs actually works in the SDK. Open for suggestions if anyone has ideas.

I'm not sure if `category: 'replay.recording.start'` is set correctly but it seems like we already do some processing for it to transform the name in the UI (cc @ryan953). Happy to change if if necessary.

closes #6928 
