### PR TITLE
fix(nextjs/remix): Prioritize SENTRY_ENVIRONMENT when overriding environment

### DIFF
--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -38,7 +38,7 @@ const globalWithInjectedValues = global as typeof global & {
 export function init(options: BrowserOptions): void {
   applyTunnelRouteOption(options);
   buildMetadata(options, ['nextjs', 'react']);
-  options.environment = options.environment || process.env.NODE_ENV;
+  options.environment = options.environment || process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV;
   addClientIntegrations(options);
 
   reactInit(options);

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -79,7 +79,7 @@ export function init(options: NodeOptions): void {
   }
 
   buildMetadata(options, ['nextjs', 'node']);
-  options.environment = options.environment || process.env.NODE_ENV;
+  options.environment = options.environment || process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV;
   addServerIntegrations(options);
   // Right now we only capture frontend sessions for Next.js
   options.autoSessionTracking = false;

--- a/packages/remix/src/index.client.tsx
+++ b/packages/remix/src/index.client.tsx
@@ -11,7 +11,7 @@ export { Integrations };
 
 export function init(options: RemixOptions): void {
   buildMetadata(options, ['remix', 'react']);
-  options.environment = options.environment || process.env.NODE_ENV;
+  options.environment = options.environment || process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV;
 
   reactInit(options);
 


### PR DESCRIPTION
A follow-up from #6588.

The problem is the following: when `options.environment` is empty, init functions for NextJS and Remix will use the value of NODE_ENV env variable as Sentry environment, and without the changes in this PR, SENTRY_ENVIRONMENT will no longer be able to override the environment.

Came up here first: https://github.com/getsentry/opentelemetry-demo/pull/34