### PR TITLE
build: Add `yarn changelog` command

### DIFF
--- a/docs/publishing-a-release.md
+++ b/docs/publishing-a-release.md
@@ -17,10 +17,9 @@ _These steps are only relevant to Sentry employees when preparing and publishing
 ## Updating the Changelog
 
 1. Create a new branch.
-2. Run `git log --format="- %s"` and copy everything since the last release.
+2. Run `yarn changelog` and copy everything
 3. Create a new section in the changelog, deciding based on the changes whether it should be a minor bump or a patch release.
 4. Paste in the logs you copied earlier.
 5. Delete any which aren't user-facing changes.
-6. Alphabetize the rest.
 7. If any of the PRs are from external contributors, include underneath the commits `Work in this release contributed by <list of external contributors' GitHub usernames>. Thank you for your contributions!`. If there's only one external PR, don't forget to remove the final `s`. If there are three or more, use an Oxford comma. (It's in the Sentry styleguide!)
 8. Commit, push, and open a PR with the title `meta: Update changelog for <fill in relevant version here>` against `develop` branch.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "clean:all": "run-p clean:build clean:caches clean:deps",
     "codecov": "codecov",
     "fix": "lerna run fix",
+    "changelog": "ts-node ./scripts/get-commit-list.ts",
     "link:yarn": "lerna exec yarn link",
     "lint": "lerna run lint",
     "lint:eslint": "lerna run lint:eslint",

--- a/scripts/get-commit-list.ts
+++ b/scripts/get-commit-list.ts
@@ -1,0 +1,23 @@
+import { execSync } from 'child_process';
+
+function run(): void {
+  const commits = execSync('git log --format="- %s"').toString().split('\n');
+
+  const lastReleasePos = commits.findIndex(commit => commit.includes("Merge branch 'release"));
+
+  const newCommits = commits.splice(0, lastReleasePos).filter(commit => {
+    // Filter out master/develop merges
+    if (/Merge pull request #(\d+) from getsentry\/(master|develop)/.test(commit)) {
+      return false;
+    }
+
+    return true;
+  });
+
+  newCommits.sort((a, b) => a.localeCompare(b));
+
+  // eslint-disable-next-line no-console
+  console.log(newCommits.join('\n'));
+}
+
+run();


### PR DESCRIPTION
Since I got slightly annoyed about manually sorting the commits, I wrote a small script to automate that for us.

Now, you can just run `yarn changelog` to get all commits since the last release, alphabetized.

E.g. for the current release it output this:

```
- build(deps): bump simple-git in /packages/replay/metrics
- build(utils): Add build constant for cdn vs. npm bundles (#6904)
- chore: Upgrade Node to 16.9.0 (#6971)
- chore(deps): bump default node to latest v16 for e2e-tests (#6962)
- ci: Add labels to gitflow PRs (#6997)
- ci: Fix gitflow workflows (#6995)
- ci: Setup gitflow process (#6890)
- ci(deps): bump actions/upload-artifact from 3.1.1 to 3.1.2 (#6994)
- docs(replay): Add changelog entry and migration log for privacy API (#7008)
- feat: Add aria label to breadcrumb attributes (#6955)
- feat(browser): Track if cdn or npm bundle (#6976)
- feat(core): Add Offline Transport wrapper (#6884)
- feat(loader): Add SENTRY_SDK_SOURCE to track loader stats (#6985)
- feat(replay): Deprecate privacy options in favor of a new API, remove some recording options (#6645)
- feat(replay): Move sample rate tags into event context (#6659)
- fix(nextjs): Add isomorphic versions of `ErrorBoundary`, `withErrorBoundary` and `showReportDialog` (#6987)
- fix(nextjs): Don't modify require calls in wrapping loader (#6979)
- fix(nextjs): Don't share I/O resources in between requests (#6980)
- fix(nextjs): Inject client config into `_app` instead of `main` (#7009)
- fix(nextjs): Use Proxies to wrap to preserve static methods (#7002)
- fix(replay): Catch style mutation handling & null events in rrweb (#7010)
- fix(replay): Handle compression failures more robustly (#6988)
- fix(replay): Only call `scope.getLastBreadcrumb` if available (#6969)
- fix(utils): Account for null prototype during normalization (#6925)
- ref(replay): Log warning if sample rates are all undefined (#6959)
```

You still need to manually remove stuff etc., but it should help a bit.