### PR TITLE
ci: Improve gitflow process

### DIFF
--- a/.github/workflows/gitflow-sync-develop.yml
+++ b/.github/workflows/gitflow-sync-develop.yml
@@ -11,7 +11,8 @@ on:
   workflow_dispatch:
 
 env:
-  DEV_BRANCH: develop
+  SOURCE_BRANCH: master
+  TAGRET_BRANCH: develop
 
 jobs:
   main:
@@ -29,9 +30,10 @@ jobs:
         id: open-pr
         uses: repo-sync/pull-request@v2
         with:
-          destination_branch: ${{ env.DEV_BRANCH }}
-          pr_title: '[Gitflow] Merge ${{ github.ref_name }} into ${{ env.DEV_BRANCH }}'
-          pr_body: 'Merge ${{ github.ref_name }} branch into ${{ env.DEV_BRANCH }}'
+          source_branch: ${{ env.SOURCE_BRANCH }}
+          destination_branch: ${{ env.TARGET_BRANCH }}
+          pr_title: '[Gitflow] Merge ${{ env.SOURCE_BRANCH }} into ${{ env.TARGET_BRANCH }}'
+          pr_body: 'Merge ${{ env.SOURCE_BRANCH }} branch into ${{ env.TARGET_BRANCH }}'
           pr_label: 'Dev: Gitflow'
 
       # https://github.com/marketplace/actions/enable-pull-request-automerge
@@ -44,6 +46,8 @@ jobs:
 
       # https://github.com/marketplace/actions/auto-approve
       - name: Auto approve PR
+        # Always skip this for now, until we got a proper bot setup
+        if: steps.open-pr.outputs.pr_number != '' || 1 == 2
         uses: hmarr/auto-approve-action@v3
         with:
           pull-request-number: ${{ steps.open-pr.outputs.pr_number }}

--- a/.github/workflows/gitflow-sync-master.yml
+++ b/.github/workflows/gitflow-sync-master.yml
@@ -1,16 +1,10 @@
 name: Gitflow - Sync develop into master
 on:
   push:
-    branches:
-      - develop
-    paths:
-      # We want to trigger this when ONLY the changlog is changed on develop, but nothing else
-      - 'CHANGELOG.md'
-      - '!packages'
-      - '!**/*.js'
-      - '!**/*.json'
-      - '!**/*.ts'
-  workflow_dispatch:
+    pull_request:
+      - types: [closed]
+      - branches:
+          - 'develop'
 
 env:
   MAIN_BRANCH: master
@@ -19,6 +13,9 @@ jobs:
   main:
     name: Create PR develop->master
     runs-on: ubuntu-20.04
+    if: |
+      github.event.pull_request.merged == true
+      && startsWith(github.event.pull_request.title, "meta(changelog):")
     permissions:
       pull-requests: write
       contents: write
@@ -46,6 +43,8 @@ jobs:
 
       # https://github.com/marketplace/actions/auto-approve
       - name: Auto approve PR
+        # Always skip this for now, until we got a proper bot setup
+        if: steps.open-pr.outputs.pr_number != '' || 1 == 2
         uses: hmarr/auto-approve-action@v3
         with:
           pull-request-number: ${{ steps.open-pr.outputs.pr_number }}


### PR DESCRIPTION
This supersedes https://github.com/getsentry/sentry-javascript/pull/6999.

With this PR:

* We do not run auto-approval (until we figured this out)
* We only run develop->master sync when merging a PR with a title starting with `meta(changelog):`
* We merge this exact commit into master, not current develop (so if something was merged in the meanwhile, it should not go into this release).
* develop->master sync cannot be triggered via workflow_dispatch anymore (to simplify this. We can still always do this manually)