### PR TITLE
ci: Skip CI when syncing develop<>master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+      - master
       - release/**
   pull_request:
   workflow_dispatch:
@@ -136,6 +137,10 @@ jobs:
       # Note: These next three have to be checked as strings ('true'/'false')!
       is_develop: ${{ github.ref == 'refs/heads/develop' }}
       is_release: ${{ startsWith(github.ref, 'refs/heads/release/') }}
+      is_gitflow_sync: |
+        github.event_name == 'pull_request' &&
+        (github.head_ref == 'refs/heads/develop' || github.head_ref == 'refs/heads/master') &&
+        contains(steps.pr-labels.outputs.labels, ' Dev: Gitflow ')
       force_skip_cache:
         ${{ github.event_name == 'pull_request' && contains(steps.pr-labels.outputs.labels, ' ci-skip-cache ') }}
 
@@ -144,7 +149,9 @@ jobs:
     needs: job_get_metadata
     runs-on: ubuntu-20.04
     timeout-minutes: 15
-    if: needs.job_get_metadata.outputs.changed_any_code == 'true' || github.event_name != 'pull_request'
+    if: |
+      needs.job_get_metadata.outputs.is_gitflow_sync == 'false' &&
+      (needs.job_get_metadata.outputs.changed_any_code == 'true' || github.event_name != 'pull_request')
     steps:
       - name: 'Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})'
         uses: actions/checkout@v3


### PR DESCRIPTION
With this change, CI should be skipped when merging from master/develop to develop/master (when the `Dev: Gitflow` label is applied to the PR).

I _think_ this should all work, but it's a bit hard to test this 😬 