### PR TITLE
feat(replay): Keep min. 30 seconds of data in error mode

### DIFF
--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -24,8 +24,8 @@ export const MAX_SESSION_LIFE = 3_600_000; // 60 minutes
 export const DEFAULT_FLUSH_MIN_DELAY = 5_000;
 export const DEFAULT_FLUSH_MAX_DELAY = 5_000;
 
-/* How long to wait for error checkouts */
-export const ERROR_CHECKOUT_TIME = 60_000;
+/* How often to capture a full checkout when in error mode */
+export const ERROR_CHECKOUT_TIME = 30_000;
 
 export const RETRY_BASE_INTERVAL = 5000;
 export const RETRY_MAX_COUNT = 3;

--- a/packages/replay/src/eventBuffer/EventBufferArray.ts
+++ b/packages/replay/src/eventBuffer/EventBufferArray.ts
@@ -1,4 +1,7 @@
+import type { ReplayRecordingData } from '@sentry/types';
+
 import type { AddEventResult, EventBuffer, RecordingEvent } from '../types';
+import { PartitionedQueue } from './PartitionedQueue';
 
 /**
  * A basic event buffer that does not do any compression.
@@ -6,42 +9,51 @@ import type { AddEventResult, EventBuffer, RecordingEvent } from '../types';
  */
 export class EventBufferArray implements EventBuffer {
   /** All the events that are buffered to be sent. */
-  public events: RecordingEvent[];
+  protected _events: PartitionedQueue<RecordingEvent>;
 
   public constructor() {
-    this.events = [];
+    this._events = new PartitionedQueue<RecordingEvent>();
+  }
+
+  /** @inheritdoc */
+  public get events(): RecordingEvent[] {
+    return this._events.getItems();
   }
 
   /** @inheritdoc */
   public get hasEvents(): boolean {
-    return this.events.length > 0;
+    return this._events.getLength() > 0;
   }
 
   /** @inheritdoc */
   public destroy(): void {
-    this.events = [];
+    this._events.clear();
+  }
+
+  /** @inheritdoc */
+  public async clear(keepLastCheckout?: boolean): Promise<void> {
+    this._events.clear(keepLastCheckout);
   }
 
   /** @inheritdoc */
   public async addEvent(event: RecordingEvent, isCheckout?: boolean): Promise<AddEventResult> {
-    if (isCheckout) {
-      this.events = [event];
-      return;
-    }
-
-    this.events.push(event);
-    return;
+    this._events.add(event, isCheckout);
   }
 
   /** @inheritdoc */
-  public finish(): Promise<string> {
+  public finish(): Promise<ReplayRecordingData> {
     return new Promise<string>(resolve => {
       // Make a copy of the events array reference and immediately clear the
       // events member so that we do not lose new events while uploading
       // attachment.
       const eventsRet = this.events;
-      this.events = [];
+      this._events.clear();
       resolve(JSON.stringify(eventsRet));
     });
+  }
+
+  /** @inheritdoc */
+  public getEarliestTimestamp(): number | null {
+    return this.events.map(event => event.timestamp).sort()[0] || null;
   }
 }

--- a/packages/replay/src/eventBuffer/EventBufferCompressionWorker.ts
+++ b/packages/replay/src/eventBuffer/EventBufferCompressionWorker.ts
@@ -57,6 +57,18 @@ export class EventBufferCompressionWorker implements EventBuffer {
     return this._finishRequest();
   }
 
+  /** @inheritdoc */
+  public clear(): Promise<void> {
+    // NOTE: We do not support keeping the last checkout in this implementation.
+    return this._clear();
+  }
+
+  /** @inheritdoc */
+  public getEarliestTimestamp(): number | null {
+    // Not supported in this mode
+    return null;
+  }
+
   /**
    * Send the event to the worker.
    */

--- a/packages/replay/src/eventBuffer/EventBufferPartitionedCompressionWorker.ts
+++ b/packages/replay/src/eventBuffer/EventBufferPartitionedCompressionWorker.ts
@@ -1,0 +1,46 @@
+import type { ReplayRecordingData } from '@sentry/types';
+
+import type { RecordingEvent } from '../types';
+import { EventBufferArray } from './EventBufferArray';
+import { WorkerHandler } from './WorkerHandler';
+
+/**
+ * Event buffer that uses a web worker to compress events.
+ * Exported only for testing.
+ */
+export class EventBufferPartitionedCompressionWorker extends EventBufferArray {
+  private _worker: WorkerHandler;
+
+  public constructor(worker: Worker) {
+    super();
+    this._worker = new WorkerHandler(worker);
+  }
+  /**
+   * Ensure the worker is ready (or not).
+   * This will either resolve when the worker is ready, or reject if an error occured.
+   */
+  public ensureReady(): Promise<void> {
+    return this._worker.ensureReady();
+  }
+
+  /** @inheritdoc */
+  public destroy(): void {
+    this._worker.destroy();
+    super.destroy();
+  }
+
+  /**
+   * Finish the event buffer and return the compressed data.
+   */
+  public finish(): Promise<ReplayRecordingData> {
+    const { events } = this;
+    this._events.clear();
+
+    return this._compressEvents(events);
+  }
+
+  /** Compress a given array of events at once. */
+  private _compressEvents(events: RecordingEvent[]): Promise<Uint8Array> {
+    return this._worker.postMessage<Uint8Array>('compress', JSON.stringify(events));
+  }
+}

--- a/packages/replay/src/eventBuffer/PartitionedQueue.ts
+++ b/packages/replay/src/eventBuffer/PartitionedQueue.ts
@@ -1,0 +1,49 @@
+/**
+ * A queue with partitions for each checkout.
+ */
+export class PartitionedQueue<T> {
+  private _items: T[];
+  private _lastCheckoutPos?: number;
+
+  public constructor() {
+    this._items = [];
+  }
+
+  /** Add an item to the queue. */
+  public add(record: T, isCheckout?: boolean): void {
+    this._items.push(record);
+
+    if (isCheckout) {
+      this._lastCheckoutPos = this._items.length - 1;
+    }
+  }
+
+  /**
+   * Clear items from the queue.
+   * If `keepLastCheckout` is given, all items after the last checkout will be kept.
+   */
+  public clear(keepLastCheckout?: boolean): void {
+    if (!keepLastCheckout) {
+      this._items = [];
+      this._lastCheckoutPos = undefined;
+      return;
+    }
+
+    if (this._lastCheckoutPos) {
+      this._items = this._items.splice(this._lastCheckoutPos);
+      this._lastCheckoutPos = undefined;
+    }
+
+    // Else, there is only a single checkout recorded yet, which we don't want to clear out
+  }
+
+  /** Get all items */
+  public getItems(): T[] {
+    return this._items;
+  }
+
+  /** Get the number of items that are queued. */
+  public getLength(): number {
+    return this._items.length;
+  }
+}

--- a/packages/replay/src/eventBuffer/index.ts
+++ b/packages/replay/src/eventBuffer/index.ts
@@ -7,12 +7,13 @@ import { EventBufferProxy } from './EventBufferProxy';
 
 interface CreateEventBufferParams {
   useCompression: boolean;
+  keepLastCheckout: boolean;
 }
 
 /**
  * Create an event buffer for replays.
  */
-export function createEventBuffer({ useCompression }: CreateEventBufferParams): EventBuffer {
+export function createEventBuffer({ useCompression, keepLastCheckout }: CreateEventBufferParams): EventBuffer {
   // eslint-disable-next-line no-restricted-globals
   if (useCompression && window.Worker) {
     try {
@@ -20,7 +21,7 @@ export function createEventBuffer({ useCompression }: CreateEventBufferParams): 
 
       __DEBUG_BUILD__ && logger.log('[Replay] Using compression worker');
       const worker = new Worker(workerUrl);
-      return new EventBufferProxy(worker);
+      return new EventBufferProxy(worker, keepLastCheckout);
     } catch (error) {
       __DEBUG_BUILD__ && logger.log('[Replay] Failed to create compression worker');
       // Fall back to use simple event buffer array

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -180,6 +180,7 @@ export class ReplayContainer implements ReplayContainerInterface {
 
     this.eventBuffer = createEventBuffer({
       useCompression: this._options.useCompression,
+      keepLastCheckout: this.recordingMode === 'error',
     });
 
     this._addListeners();

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -23,7 +23,7 @@ export interface SendReplayData {
  */
 export interface WorkerRequest {
   id: number;
-  method: 'clear' | 'addEvent' | 'finish';
+  method: 'clear' | 'addEvent' | 'finish' | 'compress';
   arg?: string;
 }
 
@@ -280,6 +280,12 @@ export interface EventBuffer {
    * Clears and returns the contents of the buffer.
    */
   finish(): Promise<ReplayRecordingData>;
+
+  /** Clear the buffer, and optional ensure we keep the last checkout. */
+  clear(keepLastCheckout?: boolean): Promise<void>;
+
+  /** Get the earliest timestamp of a pending event. */
+  getEarliestTimestamp(): number | null;
 }
 
 export type AddUpdateCallback = () => boolean | void;

--- a/packages/replay/test/unit/eventBuffer/EventBufferArray.test.ts
+++ b/packages/replay/test/unit/eventBuffer/EventBufferArray.test.ts
@@ -1,45 +1,53 @@
+import type { ReplayRecordingMode } from '@sentry/types';
+
 import { createEventBuffer } from './../../../src/eventBuffer';
 import { BASE_TIMESTAMP } from './../../index';
 
 const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
 
 describe('Unit | eventBuffer | EventBufferArray', () => {
-  it('adds events to normal event buffer', async function () {
-    const buffer = createEventBuffer({ useCompression: false });
+  for (const recordingMode of ['session', 'error'] as ReplayRecordingMode[]) {
+    it(`adds events to normal event buffer with recordingMode=${recordingMode}`, async function () {
+      const buffer = createEventBuffer({ useCompression: false, keepLastCheckout: recordingMode === 'error' });
 
-    buffer.addEvent(TEST_EVENT);
-    buffer.addEvent(TEST_EVENT);
+      buffer.addEvent(TEST_EVENT);
+      buffer.addEvent(TEST_EVENT);
 
-    const result = await buffer.finish();
+      const result = await buffer.finish();
 
-    expect(result).toEqual(JSON.stringify([TEST_EVENT, TEST_EVENT]));
-  });
+      expect(result).toEqual(JSON.stringify([TEST_EVENT, TEST_EVENT]));
+    });
 
-  it('adds checkout event to normal event buffer', async function () {
-    const buffer = createEventBuffer({ useCompression: false });
+    it(`adds checkout event to normal event buffer with recordingMode=${recordingMode}`, async function () {
+      const buffer = createEventBuffer({ useCompression: false, keepLastCheckout: recordingMode === 'error' });
 
-    buffer.addEvent(TEST_EVENT);
-    buffer.addEvent(TEST_EVENT);
-    buffer.addEvent(TEST_EVENT);
+      buffer.addEvent(TEST_EVENT);
+      buffer.addEvent(TEST_EVENT);
+      buffer.addEvent(TEST_EVENT);
 
-    buffer.addEvent(TEST_EVENT, true);
-    const result = await buffer.finish();
+      // Checkout triggers clear
+      buffer.clear();
+      buffer.addEvent(TEST_EVENT, true);
+      buffer.addEvent(TEST_EVENT);
+      const result = await buffer.finish();
+      buffer.addEvent(TEST_EVENT);
 
-    expect(result).toEqual(JSON.stringify([TEST_EVENT]));
-  });
+      expect(result).toEqual(JSON.stringify([TEST_EVENT, TEST_EVENT]));
+    });
 
-  it('calling `finish()` multiple times does not result in duplicated events', async function () {
-    const buffer = createEventBuffer({ useCompression: false });
+    it(`calling \`finish()\` multiple times does not result in duplicated events with recordingMode=${recordingMode}`, async function () {
+      const buffer = createEventBuffer({ useCompression: false, keepLastCheckout: recordingMode === 'error' });
 
-    buffer.addEvent(TEST_EVENT);
+      buffer.addEvent(TEST_EVENT);
 
-    const promise1 = buffer.finish();
-    const promise2 = buffer.finish();
+      const promise1 = buffer.finish();
+      const promise2 = buffer.finish();
 
-    const result1 = (await promise1) as Uint8Array;
-    const result2 = (await promise2) as Uint8Array;
+      const result1 = (await promise1) as Uint8Array;
+      const result2 = (await promise2) as Uint8Array;
 
-    expect(result1).toEqual(JSON.stringify([TEST_EVENT]));
-    expect(result2).toEqual(JSON.stringify([]));
-  });
+      expect(result1).toEqual(JSON.stringify([TEST_EVENT]));
+      expect(result2).toEqual(JSON.stringify([]));
+    });
+  }
 });

--- a/packages/replay/test/unit/eventBuffer/EventBufferProxy.test.ts
+++ b/packages/replay/test/unit/eventBuffer/EventBufferProxy.test.ts
@@ -23,6 +23,7 @@ describe('Unit | eventBuffer | EventBufferProxy', () => {
   it('waits for the worker to be loaded when calling finish', async function () {
     const buffer = createEventBuffer({
       useCompression: true,
+      keepLastCheckout: false,
     }) as EventBufferProxy;
 
     expect(buffer).toBeInstanceOf(EventBufferProxy);
@@ -41,7 +42,7 @@ describe('Unit | eventBuffer | EventBufferProxy', () => {
     const workerBlob = new Blob([workerString]);
     const workerUrl = URL.createObjectURL(workerBlob);
     const worker = new Worker(workerUrl);
-    const buffer = new EventBufferProxy(worker);
+    const buffer = new EventBufferProxy(worker, false);
 
     buffer.addEvent(TEST_EVENT);
     buffer.addEvent(TEST_EVENT);

--- a/packages/replay/test/unit/eventBuffer/PartitionedQueue.test.ts
+++ b/packages/replay/test/unit/eventBuffer/PartitionedQueue.test.ts
@@ -1,0 +1,58 @@
+import { PartitionedQueue } from '../../../src/eventBuffer/PartitionedQueue';
+
+describe('Unit | eventBuffer | PartitionedQueue', () => {
+  it('works with empty queue', () => {
+    const queue = new PartitionedQueue<string>();
+
+    expect(queue.getItems()).toEqual([]);
+    expect(queue.getLength()).toEqual(0);
+
+    queue.clear();
+
+    expect(queue.getItems()).toEqual([]);
+    expect(queue.getLength()).toEqual(0);
+
+    queue.clear(true);
+
+    expect(queue.getItems()).toEqual([]);
+    expect(queue.getLength()).toEqual(0);
+  });
+
+  it('allows to add records', () => {
+    const queue = new PartitionedQueue<string>();
+
+    queue.add('one');
+    queue.add('two');
+    queue.add('three');
+
+    expect(queue.getItems()).toEqual(['one', 'two', 'three']);
+    expect(queue.getLength()).toEqual(3);
+
+    queue.clear();
+
+    expect(queue.getItems()).toEqual([]);
+    expect(queue.getLength()).toEqual(0);
+  });
+
+  it('allows to add records with checkouts', () => {
+    const queue = new PartitionedQueue<string>();
+
+    queue.add('one');
+    queue.add('two');
+    queue.add('three', true);
+    queue.add('four');
+
+    expect(queue.getItems()).toEqual(['one', 'two', 'three', 'four']);
+    expect(queue.getLength()).toEqual(4);
+
+    queue.clear(true);
+
+    expect(queue.getItems()).toEqual(['three', 'four']);
+    expect(queue.getLength()).toEqual(2);
+
+    queue.clear(true);
+
+    expect(queue.getItems()).toEqual(['three', 'four']);
+    expect(queue.getLength()).toEqual(2);
+  });
+});

--- a/packages/replay/test/unit/util/addEvent.test.ts
+++ b/packages/replay/test/unit/util/addEvent.test.ts
@@ -1,7 +1,12 @@
 import 'jsdom-worker';
 
+import { inflate } from 'pako';
+
 import { BASE_TIMESTAMP } from '../..';
-import type { EventBufferProxy } from '../../../src/eventBuffer/EventBufferProxy';
+import type { EventBufferArray } from '../../../src/eventBuffer/EventBufferArray';
+import type { EventBufferCompressionWorker } from '../../../src/eventBuffer/EventBufferCompressionWorker';
+import type { EventBufferPartitionedCompressionWorker } from '../../../src/eventBuffer/EventBufferPartitionedCompressionWorker';
+import { EventBufferProxy } from '../../../src/eventBuffer/EventBufferProxy';
 import { addEvent } from '../../../src/util/addEvent';
 import { setupReplayContainer } from '../../utils/setupReplayContainer';
 import { useFakeTimers } from '../../utils/use-fake-timers';
@@ -28,5 +33,98 @@ describe('Unit | util | addEvent', () => {
     await addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP + 10, type: 2 });
 
     expect(replay.isEnabled()).toEqual(false);
+  });
+
+  it.each([
+    ['with compression ', true],
+    ['without compression', false],
+  ])('clears queue after two checkouts in error mode %s', async (_, useCompression) => {
+    jest.setSystemTime(BASE_TIMESTAMP);
+
+    const replay = setupReplayContainer({
+      options: { useCompression, sessionSampleRate: 0, errorSampleRate: 1 },
+    });
+
+    const _eventBuffer = replay.eventBuffer as EventBufferArray | EventBufferProxy;
+    let eventBuffer: EventBufferProxy | EventBufferArray = _eventBuffer;
+
+    if (eventBuffer instanceof EventBufferProxy) {
+      await eventBuffer.ensureWorkerIsLoaded();
+
+      // @ts-ignore access private
+      eventBuffer = eventBuffer._compression as EventBufferPartitionedCompressionWorker;
+    }
+
+    addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP + 10, type: 2 }, false);
+    addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP + 0, type: 3 });
+    await addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP + 100, type: 2 }, true);
+
+    expect(replay.getContext().earliestEvent).toEqual(BASE_TIMESTAMP);
+    expect(eventBuffer.events).toEqual([
+      { data: {}, timestamp: BASE_TIMESTAMP + 10, type: 2 },
+      { data: {}, timestamp: BASE_TIMESTAMP, type: 3 },
+      { data: {}, timestamp: BASE_TIMESTAMP + 100, type: 2 },
+    ]);
+
+    await addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP + 200, type: 2 }, true);
+
+    expect(replay.getContext().earliestEvent).toEqual(BASE_TIMESTAMP + 100);
+    expect(eventBuffer.events).toEqual([
+      { data: {}, timestamp: BASE_TIMESTAMP + 100, type: 2 },
+      { data: {}, timestamp: BASE_TIMESTAMP + 200, type: 2 },
+    ]);
+
+    addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP + 250, type: 3 }, false);
+    await addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP + 300, type: 2 }, true);
+
+    expect(replay.getContext().earliestEvent).toEqual(BASE_TIMESTAMP + 200);
+    expect(eventBuffer.events).toEqual([
+      { data: {}, timestamp: BASE_TIMESTAMP + 200, type: 2 },
+      { data: {}, timestamp: BASE_TIMESTAMP + 250, type: 3 },
+      { data: {}, timestamp: BASE_TIMESTAMP + 300, type: 2 },
+    ]);
+
+    const events = await _eventBuffer.finish();
+    const eventsString = typeof events === 'string' ? events : inflate(events, { to: 'string' });
+
+    expect(eventsString).toEqual(
+      JSON.stringify([
+        { data: {}, timestamp: BASE_TIMESTAMP + 200, type: 2 },
+        { data: {}, timestamp: BASE_TIMESTAMP + 250, type: 3 },
+        { data: {}, timestamp: BASE_TIMESTAMP + 300, type: 2 },
+      ]),
+    );
+  });
+
+  it.each([
+    ['with compression ', true],
+    ['without compression', false],
+  ])('clears queue after each checkout in session mode %s', async (_, useCompression) => {
+    jest.setSystemTime(BASE_TIMESTAMP);
+
+    const replay = setupReplayContainer({
+      options: { useCompression, sessionSampleRate: 1, errorSampleRate: 0 },
+    });
+
+    const _eventBuffer = replay.eventBuffer!;
+    let eventBuffer = _eventBuffer;
+
+    if (eventBuffer instanceof EventBufferProxy) {
+      await eventBuffer.ensureWorkerIsLoaded();
+
+      // @ts-ignore private api
+      eventBuffer = eventBuffer._compression as EventBufferCompressionWorker;
+    }
+
+    addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP + 10, type: 2 }, false);
+    addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP + 0, type: 3 });
+    await addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP + 100, type: 2 }, true);
+
+    expect(replay.getContext().earliestEvent).toEqual(BASE_TIMESTAMP);
+
+    const events = await _eventBuffer.finish();
+    const eventsString = typeof events === 'string' ? events : inflate(events, { to: 'string' });
+
+    expect(eventsString).toEqual(JSON.stringify([{ data: {}, timestamp: BASE_TIMESTAMP + 100, type: 2 }]));
   });
 });

--- a/packages/replay/test/utils/setupReplayContainer.ts
+++ b/packages/replay/test/utils/setupReplayContainer.ts
@@ -13,8 +13,8 @@ export function setupReplayContainer({
       flushMinDelay: 100,
       flushMaxDelay: 100,
       stickySession: false,
-      sessionSampleRate: 0,
-      errorSampleRate: 1,
+      sessionSampleRate: 1,
+      errorSampleRate: 0,
       useCompression: false,
       blockAllMedia: true,
       _experiments: {},
@@ -30,8 +30,10 @@ export function setupReplayContainer({
   replay['_setInitialState']();
   replay['_loadAndCheckSession'](SESSION_IDLE_DURATION);
   replay['_isEnabled'] = true;
+  replay.recordingMode = replay.session?.sampled === 'error' ? 'error' : 'session';
   replay.eventBuffer = createEventBuffer({
     useCompression: options?.useCompression || false,
+    keepLastCheckout: replay.recordingMode === 'error',
   });
 
   return replay;


### PR DESCRIPTION
Supersedes https://github.com/getsentry/sentry-javascript/pull/6924

This PR adjusts the event buffer to keep 30-60s of recording data (instead of 0-60s) in error mode.

This is accomplished by keeping the events in a queue that tracks when the last checkout happens, and allows to delete everything up until this event.

In compression mode, this means that we do not stream the events to the compressor, but compress them all at once. That's necessary because it is not really possible to remove parts of the compression stream.

In session mode, we continue to use the streaming compression as we do right now.