### PR TITLE
ci(gitflow): Use personal access token to create PR

### DIFF
--- a/.github/workflows/gitflow-sync-develop.yml
+++ b/.github/workflows/gitflow-sync-develop.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   SOURCE_BRANCH: master
-  TAGRET_BRANCH: develop
+  TARGET_BRANCH: develop
 
 jobs:
   main:
@@ -35,6 +35,8 @@ jobs:
           pr_title: '[Gitflow] Merge ${{ env.SOURCE_BRANCH }} into ${{ env.TARGET_BRANCH }}'
           pr_body: 'Merge ${{ env.SOURCE_BRANCH }} branch into ${{ env.TARGET_BRANCH }}'
           pr_label: 'Dev: Gitflow'
+          # This token is scoped to Daniel Griesser
+          github_token: ${{ secrets.REPO_SCOPED_TOKEN }}
 
       # https://github.com/marketplace/actions/enable-pull-request-automerge
       - name: Enable automerge for PR
@@ -47,10 +49,8 @@ jobs:
       # https://github.com/marketplace/actions/auto-approve
       - name: Auto approve PR
         # Always skip this for now, until we got a proper bot setup
-        if: steps.open-pr.outputs.pr_number != '' || 1 == 2
+        if: steps.open-pr.outputs.pr_number != ''
         uses: hmarr/auto-approve-action@v3
         with:
           pull-request-number: ${{ steps.open-pr.outputs.pr_number }}
           review-message: 'Auto approved automated PR'
-          # TODO: Use the token of some user here??
-          # github-token: ${{ secrets.SOME_USERS_PAT }}

--- a/.github/workflows/gitflow-sync-master.yml
+++ b/.github/workflows/gitflow-sync-master.yml
@@ -32,6 +32,8 @@ jobs:
           pr_title: '[Gitflow] Merge ${{ github.ref_name }} into ${{ env.MAIN_BRANCH }}'
           pr_body: 'Merge ${{ github.ref_name }} branch into ${{ env.MAIN_BRANCH }}'
           pr_label: 'Dev: Gitflow'
+          # This token is scoped to Daniel Griesser
+          github_token: ${{ secrets.REPO_SCOPED_TOKEN }}
 
       # https://github.com/marketplace/actions/enable-pull-request-automerge
       - name: Enable automerge for PR
@@ -44,10 +46,8 @@ jobs:
       # https://github.com/marketplace/actions/auto-approve
       - name: Auto approve PR
         # Always skip this for now, until we got a proper bot setup
-        if: steps.open-pr.outputs.pr_number != '' || 1 == 2
+        if: steps.open-pr.outputs.pr_number != ''
         uses: hmarr/auto-approve-action@v3
         with:
           pull-request-number: ${{ steps.open-pr.outputs.pr_number }}
           review-message: 'Auto approved automated PR'
-          # TODO: Use the token of some user here??
-          # github-token: ${{ secrets.SOME_USERS_PAT }}

--- a/.github/workflows/gitflow-sync-master.yml
+++ b/.github/workflows/gitflow-sync-master.yml
@@ -51,3 +51,12 @@ jobs:
         with:
           pull-request-number: ${{ steps.open-pr.outputs.pr_number }}
           review-message: 'Auto approved automated PR'
+
+  skipped:
+    runs-on: ubuntu-20.04
+    if: |
+      github.event.pull_request.merged == false
+      || startsWith(github.event.pull_request.title, "meta(changelog):") == false
+    steps:
+      - name: Sync skipped
+        run: echo "OK"


### PR DESCRIPTION
Otherwise, workflows will not be triggered due to security issues. See https://github.com/peter-evans/create-pull-request/issues/48 for details.

This should also fix the self-approval issue.

Also fixes a typo in the workflow.

Also fixes a problem where the master->develop workflow is triggered on each PR closed, but then fails because no job is run. Now it will run an empty dummy-job.