### PR TITLE
fix(replay): Fix feature detection of PerformanceObserver

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -476,8 +476,8 @@ export class ReplayContainer implements ReplayContainerInterface {
       this._handleException(err);
     }
 
-    // _performanceObserver //
-    if (!('_performanceObserver' in WINDOW)) {
+    // PerformanceObserver //
+    if (!('PerformanceObserver' in WINDOW)) {
       return;
     }
 


### PR DESCRIPTION
This was unintentionally find/replaced. Our Network tab basically had no data (although some did, and Im not sure how thats possible).
