### PR TITLE
fix(replay): Don't mangle private `_cssText` rrweb property

### DIFF
--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -119,6 +119,8 @@ export function makeTerserPlugin() {
           // We want to keept he _replay and _isEnabled variable unmangled to enable integration tests to access it
           '_replay',
           '_isEnabled',
+          // We also can't mangle rrweb private fields when bundling rrweb in the replay CDN bundles
+          '_cssText',
           // We want to keep the _integrations variable unmangled to send all installed integrations from replay
           '_integrations',
         ],


### PR DESCRIPTION
Our mangler strikes again! This time in `rrweb` where `attributes._cssText` is accessed ([example](https://github.com/getsentry/rrweb/blob/69205deb8cc1f025af125c1fd6a1ecd623e83d59/packages/rrweb-snapshot/src/snapshot.ts#L502)). This PR adds this property to the list of reserved properties excluded from mangling. 

Note: I went through the rrweb source code and didn't find other private properties, leading me to believe that for now we should be good in terms of bundling. rrweb accesses a bunch of double `__` variables (e.g. `__sn` [here](https://github.com/getsentry/rrweb/blob/69205deb8cc1f025af125c1fd6a1ecd623e83d59/packages/rrweb/src/record/iframe-manager.ts#L25)) but these are not touched by terser and hence fine (+ I double checked that they actually end up in our bundles).  

h/t @billyvg for raising this issue