### PR TITLE
ci: Fix invalid yaml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,10 +137,9 @@ jobs:
       # Note: These next three have to be checked as strings ('true'/'false')!
       is_develop: ${{ github.ref == 'refs/heads/develop' }}
       is_release: ${{ startsWith(github.ref, 'refs/heads/release/') }}
-      is_gitflow_sync: |
-        github.event_name == 'pull_request' &&
-        (github.head_ref == 'refs/heads/develop' || github.head_ref == 'refs/heads/master') &&
-        contains(steps.pr-labels.outputs.labels, ' Dev: Gitflow ')
+      is_gitflow_sync: ${{ github.head_ref == 'refs/heads/develop' || github.head_ref == 'refs/heads/master' }}
+      has_gitflow_label:
+        ${{ github.event_name == 'pull_request' && contains(steps.pr-labels.outputs.labels, ' Gitflow ') }}
       force_skip_cache:
         ${{ github.event_name == 'pull_request' && contains(steps.pr-labels.outputs.labels, ' ci-skip-cache ') }}
 
@@ -150,7 +149,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 15
     if: |
-      needs.job_get_metadata.outputs.is_gitflow_sync == 'false' &&
+      (needs.job_get_metadata.outputs.is_gitflow_sync == 'false' && needs.job_get_metadata.outputs.has_gitflow_label == 'false') &&
       (needs.job_get_metadata.outputs.changed_any_code == 'true' || github.event_name != 'pull_request')
     steps:
       - name: 'Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})'

--- a/.github/workflows/gitflow-sync-master.yml
+++ b/.github/workflows/gitflow-sync-master.yml
@@ -14,8 +14,8 @@ jobs:
     name: Create PR develop->master
     runs-on: ubuntu-20.04
     if: |
-      github.event.pull_request.merged == true
-      && startsWith(github.event.pull_request.title, "meta(changelog):")
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.title, 'meta(changelog):')
     permissions:
       pull-requests: write
       contents: write
@@ -55,8 +55,8 @@ jobs:
   skipped:
     runs-on: ubuntu-20.04
     if: |
-      github.event.pull_request.merged == false
-      || startsWith(github.event.pull_request.title, "meta(changelog):") == false
+      github.event.pull_request.merged == false ||
+      startsWith(github.event.pull_request.title, 'meta(changelog):') == false
     steps:
       - name: Sync skipped
         run: echo "OK"


### PR DESCRIPTION
It seems to not like double quotes.

See e.g. https://github.com/getsentry/sentry-javascript/actions/runs/4072470708

```
The workflow is not valid. .github/workflows/gitflow-sync-master.yml (Line: 16, Col: 9): Unexpected symbol: '"meta'. Located at position 89 within expression: github.event.pull_request.merged == true
&& startsWith(github.event.pull_request.title, "meta(changelog):")
 .github/workflows/gitflow-sync-master.yml (Line: 57, Col: 9): Unexpected symbol: '"meta'. Located at position 90 within expression: github.event.pull_request.merged == false
|| startsWith(github.event.pull_request.title, "meta(changelog):") == false
```

Note: This also fixes an incorrect check which meant we weren't running CI for all prs.