### PR TITLE
build: Generate errors + replay only CDN bundle

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -84,4 +84,10 @@ module.exports = [
     gzip: true,
     limit: '80 KB',
   },
+  {
+    name: '@sentry/browser + @sentry/replay - ES6 CDN Bundle (gzipped + minified)',
+    path: 'packages/browser/build/bundles/bundle.replay.min.js',
+    gzip: true,
+    limit: '80 KB',
+  },
 ];

--- a/packages/browser/rollup.bundle.config.js
+++ b/packages/browser/rollup.bundle.config.js
@@ -14,4 +14,16 @@ const builds = [];
   builds.push(...makeBundleConfigVariants(baseBundleConfig));
 });
 
+// Full bundle incl. replay only available for es6
+const replayBaseBundleConfig = makeBaseBundleConfig({
+  bundleType: 'standalone',
+  entrypoints: ['src/index.ts'],
+  jsVersion: 'es6',
+  licenseTitle: '@sentry/browser & @sentry/replay',
+  outputFileBase: () => 'bundles/bundle.replay',
+  includeReplay: true,
+});
+
+builds.push(...makeBundleConfigVariants(replayBaseBundleConfig));
+
 export default builds;

--- a/packages/tracing/rollup.bundle.config.js
+++ b/packages/tracing/rollup.bundle.config.js
@@ -14,7 +14,7 @@ const builds = [];
   builds.push(...makeBundleConfigVariants(baseBundleConfig));
 });
 
-// Full bundle incl. replay only avaialable for es6
+// Full bundle incl. replay only available for es6
 const replayBaseBundleConfig = makeBaseBundleConfig({
   bundleType: 'standalone',
   entrypoints: ['src/index.bundle.replay.ts'],


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/7066

Generate CDN bundle (es6 only) for Replay + errors. This gives us all the possible permutations between errors, replays and performance to dynamically load CDN bundle as appropriate for the new loader work.
