### PR TITLE
chore(repo): Add CDN bundle and loader entries to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -25,7 +25,9 @@ body:
   - type: dropdown
     id: package
     attributes:
-      label: Which package are you using?
+      label:
+        Which SDK are you using? If you use the CDN bundles, please specify the exact bundle (e.g.
+        `bundle.tracing.min.js`) in your SDK setup.
       options:
         - '@sentry/angular'
         - '@sentry/browser'
@@ -40,6 +42,8 @@ body:
         - '@sentry/svelte'
         - '@sentry/vue'
         - '@sentry/wasm'
+        - Sentry Browser CDN bundle
+        - Sentry Browser Loader
     validations:
       required: true
   - type: input


### PR DESCRIPTION
Right now, users can't specify that they're using the CDN bundles or the loader when opening a bug report (e.g. #7080) I suggest we add two entries for CDN and loader so that they can set their used SDK correctly. 