### PR TITLE
feat(replay): Send client_report when replay sending fails

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -812,8 +812,7 @@ export class ReplayContainer implements ReplayContainerInterface {
       // In this case, we want to completely stop the replay - otherwise, we may get inconsistent segments
       this.stop();
 
-      const hub = getCurrentHub();
-      const client = hub.getClient();
+      const client = getCurrentHub().getClient();
 
       if (client) {
         client.recordDroppedEvent('send_error', 'replay');

--- a/packages/replay/src/util/addEvent.ts
+++ b/packages/replay/src/util/addEvent.ts
@@ -1,8 +1,8 @@
+import { getCurrentHub } from '@sentry/core';
 import { logger } from '@sentry/utils';
 
 import { SESSION_IDLE_DURATION } from '../constants';
 import type { AddEventResult, RecordingEvent, ReplayContainer } from '../types';
-import { getCurrentHub } from '@sentry/core';
 
 /**
  * Add an event to the event buffer

--- a/packages/replay/src/util/addEvent.ts
+++ b/packages/replay/src/util/addEvent.ts
@@ -2,6 +2,7 @@ import { logger } from '@sentry/utils';
 
 import { SESSION_IDLE_DURATION } from '../constants';
 import type { AddEventResult, RecordingEvent, ReplayContainer } from '../types';
+import { getCurrentHub } from '@sentry/core';
 
 /**
  * Add an event to the event buffer
@@ -46,5 +47,12 @@ export async function addEvent(
   } catch (error) {
     __DEBUG_BUILD__ && logger.error(error);
     replay.stop();
+
+    const hub = getCurrentHub();
+    const client = hub.getClient();
+
+    if (client) {
+      client.recordDroppedEvent('internal_sdk_error', 'replay');
+    }
   }
 }

--- a/packages/replay/src/util/addEvent.ts
+++ b/packages/replay/src/util/addEvent.ts
@@ -48,8 +48,7 @@ export async function addEvent(
     __DEBUG_BUILD__ && logger.error(error);
     replay.stop();
 
-    const hub = getCurrentHub();
-    const client = hub.getClient();
+    const client = getCurrentHub().getClient();
 
     if (client) {
       client.recordDroppedEvent('internal_sdk_error', 'replay');

--- a/packages/types/src/clientreport.ts
+++ b/packages/types/src/clientreport.ts
@@ -6,7 +6,9 @@ export type EventDropReason =
   | 'network_error'
   | 'queue_overflow'
   | 'ratelimit_backoff'
-  | 'sample_rate';
+  | 'sample_rate'
+  | 'send_error'
+  | 'internal_sdk_error';
 
 export type Outcome = {
   reason: EventDropReason;


### PR DESCRIPTION
This leverages the new client_report categories.

See https://github.com/getsentry/develop/pull/830

Closes https://github.com/getsentry/sentry-javascript/issues/6774