### PR TITLE
feat(replay): Improve ignoring of rrweb-internal errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,11 +164,9 @@ jobs:
         id: compute_lockfile_hash
         run: echo "hash=${{ hashFiles('yarn.lock') }}" >> "$GITHUB_OUTPUT"
 
-      # When the `ci-skip-cache` label is added to a PR, we always want to skip dependency cache
       - name: Check dependency cache
         uses: actions/cache@v3
         id: cache_dependencies
-        if: needs.job_get_metadata.outputs.force_skip_cache == 'false'
         with:
           path: ${{ env.CACHED_DEPENDENCY_PATHS }}
           key: ${{ steps.compute_lockfile_hash.outputs.hash }}

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -46,7 +46,7 @@
   "homepage": "https://docs.sentry.io/platforms/javascript/session-replay/",
   "devDependencies": {
     "@babel/core": "^7.17.5",
-    "@sentry-internal/rrweb": "1.100.2",
+    "@sentry-internal/rrweb": "1.101.2",
     "@types/pako": "^2.0.0",
     "jsdom-worker": "^0.2.1",
     "pako": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3139,17 +3139,17 @@
     semver "7.3.2"
     semver-intersect "1.4.0"
 
-"@sentry-internal/rrweb-snapshot@1.100.2":
-  version "1.100.2"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-1.100.2.tgz#982b239d67872da5eb31d7d466815d4a05680450"
-  integrity sha512-6EvrPBPTlSD21lhDX20gxN3hnU4xj5hMLO5K4F0B1kPNVKXs1Mtf1nbpHYoIyU/67fZKmRuw/qlCjZykecXXBQ==
+"@sentry-internal/rrweb-snapshot@1.101.2":
+  version "1.101.2"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-1.101.2.tgz#cf73629374812f110ab7271f9da65f1afc6c08c3"
+  integrity sha512-wbc/lQ4ta7zXZGFU3sFfTz8PVcfOTeI2H2l2bo4BehZiQEEDTrqhGSFe5Nzq6Noi38CZyPT0kweGI4fUk1u0KQ==
 
-"@sentry-internal/rrweb@1.100.2":
-  version "1.100.2"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-1.100.2.tgz#3403161925d0e4778d58033ba93766b6d261736a"
-  integrity sha512-MtB2fpmc7XHCwS6JdjAEJsKO/0C/VmFxI1I4o+qIjWHOEpOF1nBYZ/RSE1BadEwgGjWlU8Hp0eWUBvSBDTF8sg==
+"@sentry-internal/rrweb@1.101.2":
+  version "1.101.2"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-1.101.2.tgz#65e5d80745e1c01c2f66031fb807b36837283944"
+  integrity sha512-IaDgoo9kxnwC6xn25yLU0ymKLVBAWGEH90iMdweTC7Izhza6k4oTy01t4/wy7ORCnfCeHZYJ4gkNJJyi4J1XHQ==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "1.100.2"
+    "@sentry-internal/rrweb-snapshot" "1.101.2"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"


### PR DESCRIPTION
This updates rrweb to https://github.com/getsentry/rrweb/releases/tag/1.101.0, which mainly improves our wrapping of rrweb errors.
