### PR TITLE
test(replay): Test against full and errors+replay CDN bundles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -586,7 +586,6 @@ jobs:
         env:
           PW_BUNDLE: ${{ matrix.bundle }}
           PW_TRACING_ONLY: ${{ matrix.tracing_only }}
-          PW_REPLAY: ${{ matrix.replay }}
         run: |
           cd packages/integration-tests
           yarn test:ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -538,9 +538,6 @@ jobs:
         tracing_only:
           - true
           - false
-        replay:
-          - true
-          - false
         exclude:
           # `tracing_only` only makes a difference for bundles - tests of the esm and cjs builds always include the
           # tracing tests
@@ -548,16 +545,6 @@ jobs:
             tracing_only: false
           - bundle: cjs
             tracing_only: false
-          # `replay` only makes a difference for bundles - tests of the esm and cjs builds always include replay
-          - bundle: esm
-            replay: false
-          - bundle: cjs
-            replay: false
-          # Replay is es6-only, so we can't and don't need to test agains ES5 bundles.
-          - bundle: bundle_es5
-            replay: true
-          - bundle: bundle_es5_min
-            replay: true
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -533,7 +533,12 @@ jobs:
           - bundle_es5_min
           - bundle_es6
           - bundle_es6_min
+          - bundle_replay_es6
+          - bundle_replay_es6_min
         tracing_only:
+          - true
+          - false
+        replay:
           - true
           - false
         exclude:
@@ -543,6 +548,16 @@ jobs:
             tracing_only: false
           - bundle: cjs
             tracing_only: false
+          # `replay` only makes a difference for bundles - tests of the esm and cjs builds always include replay
+          - bundle: esm
+            replay: false
+          - bundle: cjs
+            replay: false
+          # Replay is es6-only, so we can't and don't need to test agains ES5 bundles.
+          - bundle: bundle_es5
+            replay: true
+          - bundle: bundle_es5_min
+            replay: true
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3
@@ -584,6 +599,7 @@ jobs:
         env:
           PW_BUNDLE: ${{ matrix.bundle }}
           PW_TRACING_ONLY: ${{ matrix.tracing_only }}
+          PW_REPLAY: ${{ matrix.replay }}
         run: |
           cd packages/integration-tests
           yarn test:ci

--- a/packages/integration-tests/suites/integrations/httpclient/init.js
+++ b/packages/integration-tests/suites/integrations/httpclient/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 import { HttpClient } from '@sentry/integrations';
 
-// window.Sentry = Sentry;
+window.Sentry = Sentry;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/packages/integration-tests/suites/integrations/httpclient/init.js
+++ b/packages/integration-tests/suites/integrations/httpclient/init.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 import { HttpClient } from '@sentry/integrations';
 
-window.Sentry = Sentry;
+// window.Sentry = Sentry;
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',

--- a/packages/integration-tests/suites/replay/captureReplay/test.ts
+++ b/packages/integration-tests/suites/replay/captureReplay/test.ts
@@ -4,11 +4,10 @@ import type { ReplayEvent } from '@sentry/types';
 
 import { sentryTest } from '../../../utils/fixtures';
 import { envelopeRequestParser } from '../../../utils/helpers';
-import { waitForReplayRequest } from '../../../utils/replayHelpers';
+import { shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
 sentryTest('should capture replays', async ({ getLocalTestPath, page }) => {
-  // Replay bundles are es6 only
-  if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_es5')) {
+  if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 

--- a/packages/integration-tests/suites/replay/compression/init.js
+++ b/packages/integration-tests/suites/replay/compression/init.js
@@ -1,8 +1,7 @@
 import * as Sentry from '@sentry/browser';
-import { Replay } from '@sentry/replay';
 
 window.Sentry = Sentry;
-window.Replay = new Replay({
+window.Replay = new Sentry.Replay({
   flushMinDelay: 500,
   flushMaxDelay: 500,
   useCompression: true,

--- a/packages/integration-tests/suites/replay/compression/test.ts
+++ b/packages/integration-tests/suites/replay/compression/test.ts
@@ -2,11 +2,15 @@ import { expect } from '@playwright/test';
 
 import { sentryTest } from '../../../utils/fixtures';
 import { getExpectedReplayEvent } from '../../../utils/replayEventTemplates';
-import { getFullRecordingSnapshots, getReplayEvent, waitForReplayRequest } from '../../../utils/replayHelpers';
+import {
+  getFullRecordingSnapshots,
+  getReplayEvent,
+  shouldSkipReplayTest,
+  waitForReplayRequest,
+} from '../../../utils/replayHelpers';
 
 sentryTest('replay recording should be compressed by default', async ({ getLocalTestPath, page }) => {
-  // Replay bundles are es6 only
-  if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_es5')) {
+  if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 

--- a/packages/integration-tests/suites/replay/customEvents/init.js
+++ b/packages/integration-tests/suites/replay/customEvents/init.js
@@ -1,8 +1,7 @@
 import * as Sentry from '@sentry/browser';
-import { Replay } from '@sentry/replay';
 
 window.Sentry = Sentry;
-window.Replay = new Replay({
+window.Replay = new Sentry.Replay({
   flushMinDelay: 500,
   flushMaxDelay: 500,
   useCompression: false,

--- a/packages/integration-tests/suites/replay/customEvents/test.ts
+++ b/packages/integration-tests/suites/replay/customEvents/test.ts
@@ -10,13 +10,19 @@ import {
   expectedNavigationPerformanceSpan,
   getExpectedReplayEvent,
 } from '../../../utils/replayEventTemplates';
-import { getCustomRecordingEvents, getReplayEvent, waitForReplayRequest } from '../../../utils/replayHelpers';
+import {
+  getCustomRecordingEvents,
+  getReplayEvent,
+  shouldSkipReplayTest,
+  waitForReplayRequest,
+} from '../../../utils/replayHelpers';
 
 sentryTest(
   'replay recording should contain default performance spans',
   async ({ getLocalTestPath, page, browserName }) => {
-    // Replay bundles are es6 only and most performance entries are only available in chromium
-    if ((process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_es5')) || browserName !== 'chromium') {
+    // We only test this against the NPM package and replay bundles
+    // and only on chromium as most performance entries are only available in chromium
+    if (shouldSkipReplayTest() || browserName !== 'chromium') {
       sentryTest.skip();
     }
 
@@ -68,8 +74,7 @@ sentryTest(
 sentryTest(
   'replay recording should contain a click breadcrumb when a button is clicked',
   async ({ getLocalTestPath, page }) => {
-    // Replay bundles are es6 only
-    if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_es5')) {
+    if (shouldSkipReplayTest()) {
       sentryTest.skip();
     }
 

--- a/packages/integration-tests/suites/replay/errorResponse/test.ts
+++ b/packages/integration-tests/suites/replay/errorResponse/test.ts
@@ -1,14 +1,17 @@
 import { expect } from '@playwright/test';
 
 import { sentryTest } from '../../../utils/fixtures';
-import { getReplaySnapshot, REPLAY_DEFAULT_FLUSH_MAX_DELAY, waitForReplayRequest } from '../../../utils/replayHelpers';
+import {
+  getReplaySnapshot,
+  REPLAY_DEFAULT_FLUSH_MAX_DELAY,
+  shouldSkipReplayTest,
+  waitForReplayRequest,
+} from '../../../utils/replayHelpers';
 
 sentryTest('should stop recording after receiving an error response', async ({ getLocalTestPath, page }) => {
-  // Currently bundle tests are not supported for replay
-  if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_es5')) {
+  if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
-
   let called = 0;
 
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {

--- a/packages/integration-tests/suites/replay/init.js
+++ b/packages/integration-tests/suites/replay/init.js
@@ -1,8 +1,7 @@
 import * as Sentry from '@sentry/browser';
-import { Replay } from '@sentry/replay';
 
 window.Sentry = Sentry;
-window.Replay = new Replay({
+window.Replay = new Sentry.Replay({
   flushMinDelay: 200,
   flushMaxDelay: 200,
 });

--- a/packages/integration-tests/suites/replay/sampling/init.js
+++ b/packages/integration-tests/suites/replay/sampling/init.js
@@ -1,8 +1,7 @@
 import * as Sentry from '@sentry/browser';
-import { Replay } from '@sentry/replay';
 
 window.Sentry = Sentry;
-window.Replay = new Replay({
+window.Replay = new Sentry.Replay({
   flushMinDelay: 200,
   flushMaxDelay: 200,
 });

--- a/packages/integration-tests/suites/replay/sampling/test.ts
+++ b/packages/integration-tests/suites/replay/sampling/test.ts
@@ -1,11 +1,10 @@
 import { expect } from '@playwright/test';
 
 import { sentryTest } from '../../../utils/fixtures';
-import { getReplaySnapshot } from '../../../utils/replayHelpers';
+import { getReplaySnapshot, shouldSkipReplayTest } from '../../../utils/replayHelpers';
 
 sentryTest('should not send replays if both sample rates are 0', async ({ getLocalTestPath, page }) => {
-  // Replay bundles are es6 only
-  if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_es5')) {
+  if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 

--- a/packages/integration-tests/utils/generatePlugin.ts
+++ b/packages/integration-tests/utils/generatePlugin.ts
@@ -7,7 +7,6 @@ import type { Compiler } from 'webpack';
 const PACKAGES_DIR = '../../packages';
 
 const tracingOnly = process.env.PW_TRACING_ONLY === 'true';
-const useReplay = process.env.PW_REPLAY === 'true';
 
 const bundleKey = process.env.PW_BUNDLE;
 
@@ -38,7 +37,6 @@ const BUNDLE_PATHS: Record<string, Record<string, string>> = {
     bundle_replay_es6: 'build/bundles/bundle.tracing.replay.js',
     bundle_replay_es6_min: 'build/bundles/bundle.tracing.replay.min.js',
   },
-  errorsAndReplay: {},
   integrations: {
     cjs: 'build/npm/cjs/index.js',
     esm: 'build/npm/esm/index.js',

--- a/packages/integration-tests/utils/generatePlugin.ts
+++ b/packages/integration-tests/utils/generatePlugin.ts
@@ -44,6 +44,8 @@ const BUNDLE_PATHS: Record<string, Record<string, string>> = {
     bundle_es5_min: 'build/bundles/[INTEGRATION_NAME].es5.min.js',
     bundle_es6: 'build/bundles/[INTEGRATION_NAME].js',
     bundle_es6_min: 'build/bundles/[INTEGRATION_NAME].min.js',
+    bundle_replay_es6: 'build/bundles/[INTEGRATION_NAME].js',
+    bundle_replay_es6_min: 'build/bundles/[INTEGRATION_NAME].min.js',
   },
 };
 

--- a/packages/integration-tests/utils/generatePlugin.ts
+++ b/packages/integration-tests/utils/generatePlugin.ts
@@ -15,9 +15,6 @@ const useCompiledModule = bundleKey === 'esm' || bundleKey === 'cjs';
 
 // Bundles need to be injected into HTML before Sentry initialization.
 const useBundle = bundleKey && !useCompiledModule;
-// `true` if we use an SDK bundle that supports Replay ootb,
-// without the need to add the additional addon replay integration bundle
-const useFullReplayBundle = useBundle && bundleKey.includes('replay');
 
 const BUNDLE_PATHS: Record<string, Record<string, string>> = {
   browser: {
@@ -47,12 +44,6 @@ const BUNDLE_PATHS: Record<string, Record<string, string>> = {
     bundle_es5_min: 'build/bundles/[INTEGRATION_NAME].es5.min.js',
     bundle_es6: 'build/bundles/[INTEGRATION_NAME].js',
     bundle_es6_min: 'build/bundles/[INTEGRATION_NAME].min.js',
-  },
-  replay: {
-    cjs: 'build/npm/cjs/index.js',
-    esm: 'build/npm/esm/index.js',
-    bundle_es6: 'build/bundles/replay.js',
-    bundle_es6_min: 'build/bundles/replay.min.js',
   },
 };
 
@@ -101,7 +92,6 @@ function generateSentryAlias(): Record<string, string> {
 class SentryScenarioGenerationPlugin {
   public requiresTracing: boolean = false;
   public requiredIntegrations: string[] = [];
-  public requiresReplay = false;
 
   private _name: string = 'SentryScenarioGenerationPlugin';
 
@@ -114,7 +104,7 @@ class SentryScenarioGenerationPlugin {
             '@sentry/browser': 'Sentry',
             '@sentry/tracing': 'Sentry',
             '@sentry/integrations': 'Sentry.Integrations',
-            '@sentry/replay': 'Sentry.Integrations',
+            '@sentry/replay': 'Sentry',
           }
         : {};
 
@@ -129,10 +119,6 @@ class SentryScenarioGenerationPlugin {
               this.requiresTracing = true;
             } else if (source === '@sentry/integrations') {
               this.requiredIntegrations.push(statement.specifiers[0].imported.name.toLowerCase());
-            } else if (!useFullReplayBundle && source === '@sentry/replay') {
-              console.log('injecting replay addon bundle');
-
-              this.requiresReplay = true;
             }
           },
         );
@@ -159,14 +145,6 @@ class SentryScenarioGenerationPlugin {
 
             data.assetTags.scripts.unshift(integrationObject);
           });
-
-          if (this.requiresReplay && BUNDLE_PATHS['replay'][bundleKey]) {
-            const replayObject = createHtmlTagObject('script', {
-              src: path.resolve(PACKAGES_DIR, 'replay', BUNDLE_PATHS['replay'][bundleKey]),
-            });
-
-            data.assetTags.scripts.unshift(replayObject);
-          }
 
           data.assetTags.scripts.unshift(bundleObject);
         }

--- a/packages/integration-tests/utils/generatePlugin.ts
+++ b/packages/integration-tests/utils/generatePlugin.ts
@@ -15,6 +15,9 @@ const useCompiledModule = bundleKey === 'esm' || bundleKey === 'cjs';
 
 // Bundles need to be injected into HTML before Sentry initialization.
 const useBundle = bundleKey && !useCompiledModule;
+// `true` if we use an SDK bundle that supports Replay ootb,
+// without the need to add the additional addon replay integration bundle
+const useFullReplayBundle = useBundle && bundleKey.includes('replay');
 
 const BUNDLE_PATHS: Record<string, Record<string, string>> = {
   browser: {
@@ -126,7 +129,9 @@ class SentryScenarioGenerationPlugin {
               this.requiresTracing = true;
             } else if (source === '@sentry/integrations') {
               this.requiredIntegrations.push(statement.specifiers[0].imported.name.toLowerCase());
-            } else if (source === '@sentry/replay') {
+            } else if (!useFullReplayBundle && source === '@sentry/replay') {
+              console.log('injecting replay addon bundle');
+
               this.requiresReplay = true;
             }
           },

--- a/packages/integration-tests/utils/generatePlugin.ts
+++ b/packages/integration-tests/utils/generatePlugin.ts
@@ -7,6 +7,8 @@ import type { Compiler } from 'webpack';
 const PACKAGES_DIR = '../../packages';
 
 const tracingOnly = process.env.PW_TRACING_ONLY === 'true';
+const useReplay = process.env.PW_REPLAY === 'true';
+
 const bundleKey = process.env.PW_BUNDLE;
 
 // `esm` and `cjs` builds are modules that can be imported / aliased by webpack
@@ -23,6 +25,8 @@ const BUNDLE_PATHS: Record<string, Record<string, string>> = {
     bundle_es5_min: 'build/bundles/bundle.es5.min.js',
     bundle_es6: 'build/bundles/bundle.js',
     bundle_es6_min: 'build/bundles/bundle.min.js',
+    bundle_replay_es6: 'build/bundles/bundle.replay.js',
+    bundle_replay_es6_min: 'build/bundles/bundle.replay.min.js',
   },
   tracing: {
     cjs: 'build/npm/cjs/index.js',
@@ -31,7 +35,10 @@ const BUNDLE_PATHS: Record<string, Record<string, string>> = {
     bundle_es5_min: 'build/bundles/bundle.tracing.es5.min.js',
     bundle_es6: 'build/bundles/bundle.tracing.js',
     bundle_es6_min: 'build/bundles/bundle.tracing.min.js',
+    bundle_replay_es6: 'build/bundles/bundle.tracing.replay.js',
+    bundle_replay_es6_min: 'build/bundles/bundle.tracing.replay.min.js',
   },
+  errorsAndReplay: {},
   integrations: {
     cjs: 'build/npm/cjs/index.js',
     esm: 'build/npm/esm/index.js',

--- a/packages/integration-tests/utils/replayHelpers.ts
+++ b/packages/integration-tests/utils/replayHelpers.ts
@@ -177,3 +177,15 @@ const replayEnvelopeParser = (request: Request | null): unknown[] => {
 
   return lines;
 };
+
+/**
+ * We can only test replay tests in certain bundles/packages:
+ * - NPM (ESM, CJS)
+ * - CDN bundles that contain the Replay integration
+ *
+ * @returns `true` if we should skip the replay test
+ */
+export function shouldSkipReplayTest(): boolean {
+  const bundle = process.env.PW_BUNDLE as string | undefined;
+  return bundle != null && !bundle.includes('replay') && !bundle.includes('esm') && !bundle.includes('cjs');
+}


### PR DESCRIPTION
This PR updates our Playwright test setup to test against four new SDK CDN bundles:

* SDK+Tracing+Replay
* SDK+Tracing+Replay minified
* SDK+Replay
* SDK+Replay minified

To make this work and simplify our test case inits, I decided to drop testing against the replay **addon** CDN bundle which we recently decided to deprecate in favour of the full bundles. This has the nice side effect that our PW setup is slightly simplified. 

Overall, this change adds four more PW test jobs to CI but I've checked runtime and the impact seems negligible.    

ref #7044 

Also, cc @billyvg - once this is merged, I think #7055 should work better. You might need to update your init.js file.