### PR TITLE
fix(tracing): Export `defaultStackParser` from tracing CDN bundles

### DIFF
--- a/packages/tracing/src/index.bundle.ts
+++ b/packages/tracing/src/index.bundle.ts
@@ -41,6 +41,7 @@ export {
 export { BrowserClient } from '@sentry/browser';
 export {
   defaultIntegrations,
+  defaultStackParser,
   forceLoad,
   init,
   lastEventId,


### PR DESCRIPTION
closes #7102 