### PR TITLE
chore(nextjs): Pin node 18.13.0 in nextjs integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -468,7 +468,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12, 14, 16, 18]
+        node: [10, 12, 14, 16, '18.13.0']
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3


### PR DESCRIPTION
Something in 18.14.0 causes npm's module resolution to local file paths to fail. Let's pin to 18.13.0 for the time being. 