### PR TITLE
fix(replay): Export Replay from Sentry namespace in full CDN bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@
 - feat(nextjs): Add auto-wrapping for server components (#6953)
 - feat(replay): Improve rrweb error ignoring (#7087 & #7094)
 - feat(replay): Send client_report when replay sending fails (#7093)
-- fix(replay): Export Replay from Sentry namespace in full CDN bundle (#TODO)
 - fix(node): `LocalVariables`, Improve frame matching for ESM (#7049)
 - fix(node): Add lru cache to http integration span map (#7064)
+- fix(replay): Export Replay from Sentry namespace in full CDN bundle (#7119)
 
 Work in this release contributed by @JamesHenry. Thank you for your contribution!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - feat(nextjs): Add auto-wrapping for server components (#6953)
 - feat(replay): Improve rrweb error ignoring (#7087 & #7094)
 - feat(replay): Send client_report when replay sending fails (#7093)
+- fix(replay): Export Replay from Sentry namespace in full CDN bundle (#TODO)
 - fix(node): `LocalVariables`, Improve frame matching for ESM (#7049)
 - fix(node): Add lru cache to http integration span map (#7064)
 

--- a/packages/tracing/src/index.bundle.replay.ts
+++ b/packages/tracing/src/index.bundle.replay.ts
@@ -2,6 +2,11 @@ import { Replay } from '@sentry/browser';
 
 import * as Sentry from './index.bundle';
 
+// TODO (v8): Remove this as it was only needed for backwards compatibility
+// We want replay to be available under Sentry.Replay, to be consistent
+// with the NPM package version.
 Sentry.Integrations.Replay = Replay;
 
-export default Sentry;
+export { Replay };
+
+export * from './index.bundle';

--- a/packages/tracing/test/index.bundle.replay.test.ts
+++ b/packages/tracing/test/index.bundle.replay.test.ts
@@ -1,4 +1,4 @@
-import Sentry from '../src/index.bundle.replay';
+import * as Sentry from '../src/index.bundle.replay';
 
 // Because of the way how we re-export stuff for the replay bundle, we only have a single default export
 const { Integrations } = Sentry;
@@ -15,5 +15,6 @@ describe('Integrations export', () => {
     });
 
     expect(Integrations.Replay).toBeDefined();
+    expect(Sentry.Replay).toBeDefined();
   });
 });


### PR DESCRIPTION
To be consistent with export namespaces, we want the `Replay` integration to be accesible under `Sentry.Replay` in the full CDN bundles. This is backwards compatible as we still permit `Sentry.Integrations.Replay` as well. We can remove it in v8.

With this change, both CDN bundles containing replay (sdk+tracing+replay and sdk+replay) export from `Sentry.Replay`. Only the addon bundle, which we already deprecated and don't mention in the docs anymore will only be available i n`Sentry.Integrations.Replay`.