### PR TITLE
ci: Fix auto-release regex

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -24,8 +24,8 @@ jobs:
         with:
           # Parse version from head branch
           text: ${{ github.head_ref }}
-          # match: refs/heads/preprare-release/xx.xx.xx
-          regex: '^refs\/heads\/preprare-release\/(\d+\.\d+\.\d+)$'
+          # match: preprare-release/xx.xx.xx
+          regex: '^preprare-release\/(\d+\.\d+\.\d+)$'
 
       - name: Prepare release
         uses: getsentry/action-prepare-release@v1


### PR DESCRIPTION
Based on e.g. https://github.com/getsentry/sentry-javascript/actions/runs/4135873735/jobs/7148935627 you can see that `head_ref` is actually just the branch name without `refs/heads`
