### PR TITLE
fix(nextjs): Make api route identifier stricter

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -96,7 +96,7 @@ export function constructWebpackConfigFunction(
       appDirPath = path.join(projectDir, 'src', 'app');
     }
 
-    const apiRoutesPath = path.join(pagesDirPath, 'api');
+    const apiRoutesPath = path.join(pagesDirPath, 'api', '/');
 
     const middlewareJsPath = path.join(pagesDirPath, '..', 'middleware.js');
     const middlewareTsPath = path.join(pagesDirPath, '..', 'middleware.ts');

--- a/packages/nextjs/test/config/loaders.test.ts
+++ b/packages/nextjs/test/config/loaders.test.ts
@@ -118,6 +118,11 @@ describe('webpack loaders', () => {
         resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/pages/[...testPage].js',
         expectedWrappingTargetKind: 'page',
       },
+      // Regression test for https://github.com/getsentry/sentry-javascript/issues/7122
+      {
+        resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/pages/apidoc/[version].tsx',
+        expectedWrappingTargetKind: 'page',
+      },
       {
         resourcePath: '/Users/Maisey/projects/squirrelChasingSimulator/src/middleware.js',
         expectedWrappingTargetKind: 'middleware',


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-javascript/issues/7122