### PR TITLE
fix(browser): Support `async` in stack frame urls

### DIFF
--- a/packages/browser/src/stack-parsers.ts
+++ b/packages/browser/src/stack-parsers.ts
@@ -31,7 +31,7 @@ function createFrame(filename: string, func: string, lineno?: number, colno?: nu
 
 // Chromium based browsers: Chrome, Brave, new Opera, new Edge
 const chromeRegex =
-  /^\s*at (?:(.*\).*?|.*?) ?\((?:address at )?)?((?:file|https?|blob|chrome-extension|address|native|eval|webpack|<anonymous>|[-a-z]+:|.*bundle|\/)?.*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i;
+  /^\s*at (?:(.*\).*?|.*?) ?\((?:address at )?)?(?:async )?((?:file|https?|blob|chrome-extension|address|native|eval|webpack|<anonymous>|[-a-z]+:|.*bundle|\/)?.*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i;
 const chromeEvalRegex = /\((\S*)(?::(\d+))(?::(\d+))\)/;
 
 const chrome: StackLineParserFn = line => {

--- a/packages/browser/test/unit/tracekit/chromium.test.ts
+++ b/packages/browser/test/unit/tracekit/chromium.test.ts
@@ -332,6 +332,35 @@ describe('Tracekit - Chrome Tests', () => {
     });
   });
 
+  it('should parse frames with async urls', () => {
+    const CHROME_109_ASYNC_URL = {
+      message: 'bad',
+      name: 'Error',
+      stack: `Error: bad
+          at Object.aha (http://localhost:5000/:19:13)
+          at callAnotherThing (http://localhost:5000/:20:16)
+          at Object.callback (async http://localhost:5000/:25:7)
+          at test (http://localhost:5000/:33:23)
+          at Foo.testMethod (http://localhost:5000/:44:7)`,
+    };
+
+    const ex = exceptionFromError(parser, CHROME_109_ASYNC_URL);
+
+    expect(ex).toEqual({
+      value: 'bad',
+      type: 'Error',
+      stacktrace: {
+        frames: [
+          { filename: 'http://localhost:5000/', function: 'Foo.testMethod', lineno: 44, colno: 7, in_app: true },
+          { filename: 'http://localhost:5000/', function: 'test', lineno: 33, colno: 23, in_app: true },
+          { filename: 'http://localhost:5000/', function: 'Object.callback', lineno: 25, colno: 7, in_app: true },
+          { filename: 'http://localhost:5000/', function: 'callAnotherThing', lineno: 20, colno: 16, in_app: true },
+          { filename: 'http://localhost:5000/', function: 'Object.aha', lineno: 19, colno: 13, in_app: true },
+        ],
+      },
+    });
+  });
+
   it('should parse exceptions with native code frames in Edge 44', () => {
     const EDGE44_NATIVE_CODE_EXCEPTION = {
       message: 'test',

--- a/packages/browser/test/unit/tracekit/chromium.test.ts
+++ b/packages/browser/test/unit/tracekit/chromium.test.ts
@@ -337,11 +337,9 @@ describe('Tracekit - Chrome Tests', () => {
       message: 'bad',
       name: 'Error',
       stack: `Error: bad
-          at Object.aha (http://localhost:5000/:19:13)
           at callAnotherThing (http://localhost:5000/:20:16)
           at Object.callback (async http://localhost:5000/:25:7)
-          at test (http://localhost:5000/:33:23)
-          at Foo.testMethod (http://localhost:5000/:44:7)`,
+          at test (http://localhost:5000/:33:23)`,
     };
 
     const ex = exceptionFromError(parser, CHROME_109_ASYNC_URL);
@@ -351,11 +349,9 @@ describe('Tracekit - Chrome Tests', () => {
       type: 'Error',
       stacktrace: {
         frames: [
-          { filename: 'http://localhost:5000/', function: 'Foo.testMethod', lineno: 44, colno: 7, in_app: true },
           { filename: 'http://localhost:5000/', function: 'test', lineno: 33, colno: 23, in_app: true },
           { filename: 'http://localhost:5000/', function: 'Object.callback', lineno: 25, colno: 7, in_app: true },
           { filename: 'http://localhost:5000/', function: 'callAnotherThing', lineno: 20, colno: 16, in_app: true },
-          { filename: 'http://localhost:5000/', function: 'Object.aha', lineno: 19, colno: 13, in_app: true },
         ],
       },
     });


### PR DESCRIPTION
Closes #7128

That regex is becoming a monster!