### PR TITLE
fix(replay): Fix missing fetch/xhr requests

### DIFF
--- a/packages/replay/src/util/shouldFilterRequest.ts
+++ b/packages/replay/src/util/shouldFilterRequest.ts
@@ -3,7 +3,8 @@ import { getCurrentHub } from '@sentry/core';
 import type { ReplayContainer } from '../types';
 
 /**
- * Check whether a given request URL should be filtered out.
+ * Check whether a given request URL should be filtered out. This is so we
+ * don't log Sentry ingest requests.
  */
 export function shouldFilterRequest(replay: ReplayContainer, url: string): boolean {
   // If we enabled the `traceInternals` experiment, we want to trace everything
@@ -11,7 +12,7 @@ export function shouldFilterRequest(replay: ReplayContainer, url: string): boole
     return false;
   }
 
-  return !_isSentryRequest(url);
+  return _isSentryRequest(url);
 }
 
 /**

--- a/packages/replay/test/integration/shouldFilterRequest.test.ts
+++ b/packages/replay/test/integration/shouldFilterRequest.test.ts
@@ -1,0 +1,20 @@
+import { shouldFilterRequest } from '../../src/util/shouldFilterRequest';
+import { mockSdk } from '../index';
+
+describe('Integration | shouldFilterRequest', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('should not filter requests from non-Sentry ingest URLs', async () => {
+    const { replay } = await mockSdk();
+
+    expect(shouldFilterRequest(replay, 'https://example.com/foo')).toBe(false);
+  });
+
+  it('should filter requests for Sentry ingest URLs', async () => {
+    const { replay } = await mockSdk();
+
+    expect(shouldFilterRequest(replay, 'https://03031aa.ingest.f00.f00/api/129312/')).toBe(true);
+  });
+});


### PR DESCRIPTION
Logic was flipped for the filter function so fetch and xhr requests were not being recorded at all.

Closes https://github.com/getsentry/team-replay/issues/9
Closes https://github.com/getsentry/sentry-javascript/issues/7078