### PR TITLE
fix(integration-tests): Skip non-replay bundles in replay test

### DIFF
--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -23,6 +23,8 @@
     "test:bundle:es5:min": "PW_BUNDLE=bundle_es5_min yarn test",
     "test:bundle:es6": "PW_BUNDLE=bundle_es6 yarn test",
     "test:bundle:es6:min": "PW_BUNDLE=bundle_es6_min yarn test",
+    "test:bundle:replay:es6": "PW_BUNDLE=bundle_replay_es6 yarn test",
+    "test:bundle:replay:es6:min": "PW_BUNDLE=bundle_replay_es6_min yarn test",
     "test:cjs": "PW_BUNDLE=cjs yarn test",
     "test:esm": "PW_BUNDLE=esm yarn test",
     "test:ci": "playwright test ./suites --browser='all' --reporter='line'"

--- a/packages/integration-tests/suites/replay/privacy/test.ts
+++ b/packages/integration-tests/suites/replay/privacy/test.ts
@@ -4,11 +4,10 @@ import type { RecordingEvent } from '@sentry/replay/build/npm/types/types';
 
 import { sentryTest } from '../../../utils/fixtures';
 import { envelopeRequestParser } from '../../../utils/helpers';
-import { waitForReplayRequest } from '../../../utils/replayHelpers';
+import { shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
 sentryTest('should have the correct default privacy settings', async ({ getLocalTestPath, page }) => {
-  // Replay bundles are es6 only
-  if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_es5')) {
+  if (shouldSkipReplayTest()) {
     sentryTest.skip();
   }
 


### PR DESCRIPTION
Forgot to rebase #7096 before merging, which causes PW tests to fail after #7055 was merged. This skips the test on non-replay bundles, just like the other replay tests. 
