### PR TITLE
Update Replay README.md wrong default value

### DIFF
--- a/packages/replay/README.md
+++ b/packages/replay/README.md
@@ -152,7 +152,7 @@ The following options can be configured on the root level of your browser-based 
 | key                 | type    | default | description                                                                                                                                                                                                                     |
 | ------------------- | ------- | ------- | -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------   |
 | replaysSessionSampleRate   | number  | `0.1`   | The sample rate for replays that begin recording immediately and last the entirety of the user's session. 1.0 will collect all replays, 0 will collect no replays.                                           |
-| replaysOnErrorSampleRate     | number  | `1.0`   |The sample rate for replays that are recorded when an error happens. This type of replay will record up to a minute of events prior to the error and continue recording until the session ends. 1.0 capturing all sessions with an error, and 0 capturing none.
+| replaysOnErrorSampleRate     | number  | `0`   |The sample rate for replays that are recorded when an error happens. This type of replay will record up to a minute of events prior to the error and continue recording until the session ends. 1.0 capturing all sessions with an error, and 0 capturing none.
 
 ### General Integration Configuration
 


### PR DESCRIPTION
https://github.com/getsentry/sentry-javascript/pull/6878 altered on version 7.33.0 the default to 0 but the docs still point as if the default was 1.0

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
