### PR TITLE
fix(integration): Ensure dedupe integration ignores non-errors

### DIFF
--- a/packages/browser/src/integrations/dedupe.ts
+++ b/packages/browser/src/integrations/dedupe.ts
@@ -23,6 +23,12 @@ export class Dedupe implements Integration {
    */
   public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
     const eventProcessor: EventProcessor = currentEvent => {
+      // We want to ignore any non-error type events, e.g. transactions or replays
+      // These should never be deduped, and also not be compared against as _previousEvent.
+      if (currentEvent.type) {
+        return currentEvent;
+      }
+
       const self = getCurrentHub().getIntegration(Dedupe);
       if (self) {
         // Juuust in case something goes wrong

--- a/packages/integrations/src/dedupe.ts
+++ b/packages/integrations/src/dedupe.ts
@@ -23,6 +23,12 @@ export class Dedupe implements Integration {
    */
   public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
     const eventProcessor: EventProcessor = currentEvent => {
+      // We want to ignore any non-error type events, e.g. transactions or replays
+      // These should never be deduped, and also not be compared against as _previousEvent.
+      if (currentEvent.type) {
+        return currentEvent;
+      }
+
       const self = getCurrentHub().getIntegration(Dedupe);
       if (self) {
         // Juuust in case something goes wrong


### PR DESCRIPTION
Currently, the dedupe integration will never _drop_ non-error events, but it will still consider them as `_previousEvent`. Thus, if we have e.g. a sequence of events like this:

* error 1
* transaction
* error 1

It _will_ capture `error 1` twice.

This PR fixes this so we only consider error events for deduping.

This _may_ be related to https://github.com/getsentry/sentry-javascript/issues/7147, although TBH I am not sure if this would really account for that many consecutive errors... 🤔 