### PR TITLE
ref(replay): Improve logging for stopped replay

### DIFF
--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -293,7 +293,7 @@ export interface ReplayContainer {
   isPaused(): boolean;
   getContext(): InternalEventContext;
   start(): void;
-  stop(): void;
+  stop(reason?: string): void;
   pause(): void;
   resume(): void;
   startRecording(): void;

--- a/packages/replay/src/util/addEvent.ts
+++ b/packages/replay/src/util/addEvent.ts
@@ -46,7 +46,7 @@ export async function addEvent(
     return await replay.eventBuffer.addEvent(event, isCheckout);
   } catch (error) {
     __DEBUG_BUILD__ && logger.error(error);
-    replay.stop();
+    replay.stop('addEvent');
 
     const client = getCurrentHub().getClient();
 


### PR DESCRIPTION
This PR should help with debugging stopped replays.

* Add an (optional) reason for stopping replays, to know what triggered the stop
* Ensure that we log to the console when `_experiments.traceInternals === true`, so we get these logs for sentry.io.

Closes https://github.com/getsentry/sentry-javascript/issues/7149
Note that it doesn't actually _fix_ this issue, but will give us more info in the future to debug these things. As of now, it is pretty hard to reason about why this happend.