### PR TITLE
fix(nextjs): Fix faulty import in Next.js .d.ts

### DIFF
--- a/packages/e2e-tests/test-applications/create-next-app/sentry.server.config.ts
+++ b/packages/e2e-tests/test-applications/create-next-app/sentry.server.config.ts
@@ -17,7 +17,9 @@ Sentry.init({
   // ...
   // Note: if you want to override the automatic release value, do not set a
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
-  // that it will also get attached to your source maps
+  // that it will also get attached to your source maps,
+
+  integrations: [new Sentry.Integrations.LocalVariables()],
 });
 
 Sentry.addGlobalEventProcessor(event => {

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -9,18 +9,19 @@ export * from './edge';
 
 import type { Integration, Options, StackParser } from '@sentry/types';
 
-import type { BrowserOptions } from './client';
-import * as clientSdk from './client';
-import type { EdgeOptions } from './edge';
-import * as edgeSdk from './edge';
-import type { NodeOptions } from './server';
-import * as serverSdk from './server';
+import type * as clientSdk from './client';
+import type * as edgeSdk from './edge';
+import type * as serverSdk from './server';
 
 /** Initializes Sentry Next.js SDK */
-export declare function init(options: Options | BrowserOptions | NodeOptions | EdgeOptions): void;
+export declare function init(
+  options: Options | clientSdk.BrowserOptions | serverSdk.NodeOptions | edgeSdk.EdgeOptions,
+): void;
 
 // We export a merged Integrations object so that users can (at least typing-wise) use all integrations everywhere.
-export const Integrations = { ...clientSdk.Integrations, ...serverSdk.Integrations, ...edgeSdk.Integrations };
+export declare const Integrations: typeof clientSdk.Integrations &
+  typeof serverSdk.Integrations &
+  typeof edgeSdk.Integrations;
 
 export declare const defaultIntegrations: Integration[];
 export declare const defaultStackParser: StackParser;

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -15,6 +15,8 @@ import { addOrUpdateIntegration } from '../common/userIntegrations';
 import { isBuild } from './utils/isBuild';
 
 export * from '@sentry/node';
+export { Integrations };
+
 export { captureUnderscoreErrorException } from '../common/_error';
 
 /**


### PR DESCRIPTION
This came up in discord: https://discord.com/channels/621778831602221064/621786575591702529/1074841610753413261

![Screenshot 2023-02-14 at 13 41 34](https://user-images.githubusercontent.com/8118419/218741483-21af909f-25b1-4add-acdc-00c7a9800a5e.png)

Our Next.js types currently have references to the Node package but the paths in the reference contain our internal build structure which leads to mismatches when you use the package outside of our monorepo.

https://unpkg.com/browse/@sentry/nextjs@7.37.2/types/index.types.d.ts

I didn't know how to fix this properly via settings and stuff but slightly changing how we import things seemed to get rid of these `import()` statements.

Also added an import that would have failed to our E2E tests.
