### PR TITLE
fix(tracing): Update correct mongoose option for Autoload Database Integrations

### DIFF
--- a/packages/tracing/src/hubextensions.ts
+++ b/packages/tracing/src/hubextensions.ts
@@ -256,7 +256,7 @@ function _autoloadDatabaseIntegrations(): void {
       const integration = dynamicRequire(module, './integrations/node/mongo') as {
         Mongo: IntegrationClass<Integration>;
       };
-      return new integration.Mongo({ mongoose: true });
+      return new integration.Mongo({ useMongoose: true });
     },
     mysql() {
       const integration = dynamicRequire(module, './integrations/node/mysql') as {


### PR DESCRIPTION
Currently the mongoose is not being loaded due to incorrect flag being passed to Mongo (integrations class) for Autoload Database Integrations. This PR fixes that by passed the expected option to load mongoose.

The constructor param defintion, uses the `useMongoose` flag to load the mongoose module
https://github.com/getsentry/sentry-javascript/blob/2bdda8454ed89355fd9b727c09bb976a2eb88a90/packages/tracing/src/integrations/node/mongo.ts#L87-L91
