### PR TITLE
feat(replay): Change LCP calculation

### DIFF
--- a/packages/integration-tests/utils/replayEventTemplates.ts
+++ b/packages/integration-tests/utils/replayEventTemplates.ts
@@ -91,7 +91,7 @@ export const expectedLCPPerformanceSpan = {
   startTimestamp: expect.any(Number),
   endTimestamp: expect.any(Number),
   data: {
-    duration: expect.any(Number),
+    value: expect.any(Number),
     nodeId: expect.any(Number),
     size: expect.any(Number),
   },

--- a/packages/replay/src/util/createPerformanceEntries.ts
+++ b/packages/replay/src/util/createPerformanceEntries.ts
@@ -109,10 +109,12 @@ function createLargestContentfulPaint(entry: PerformanceEntry & { size: number; 
   let startTimeOrNavigationActivation = 0;
 
   if (WINDOW.performance) {
-    const navEntry = WINDOW.performance.getEntriesByType('navigation')[0] as (PerformanceNavigationTiming & {activationStart: number});
+    const navEntry = WINDOW.performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming & {
+      activationStart: number;
+    };
 
     // See https://github.com/GoogleChrome/web-vitals/blob/9f11c4c6578fb4c5ee6fa4e32b9d1d756475f135/src/lib/getActivationStart.ts#L21
-    startTimeOrNavigationActivation = navEntry && navEntry.activationStart || 0;
+    startTimeOrNavigationActivation = (navEntry && navEntry.activationStart) || 0;
   }
 
   const start = getAbsoluteTime(startTimeOrNavigationActivation);


### PR DESCRIPTION
Fixes up calculating LCP timing based on `web-vitals`. Previously we were using the `duration` field on the PerformanceEntry, but it was always 0.

Decided to change the `data.duration` field to `data.value` so that we do not break the frontend when trying to display this new field.
