### PR TITLE
feat(replay): Use `requestIdleCallback` for events

### DIFF
--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -1,10 +1,13 @@
 import { GLOBAL_OBJ } from '@sentry/utils';
 
+// This is a new API that is not available everywhere yet
+type RequestIdleCallback = (cb: () => void, options?: { timeout: number }) => void;
+
 // exporting a separate copy of `WINDOW` rather than exporting the one from `@sentry/browser`
 // prevents the browser package from being bundled in the CDN bundle, and avoids a
 // circular dependency between the browser and replay packages should `@sentry/browser` import
 // from `@sentry/replay` in the future
-export const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
+export const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window & { requestIdleCallback?: RequestIdleCallback };
 
 export const REPLAY_SESSION_KEY = 'sentryReplaySession';
 export const REPLAY_EVENT_NAME = 'replay_event';

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -282,7 +282,7 @@ export interface EventBuffer {
   finish(): Promise<ReplayRecordingData>;
 }
 
-export type AddUpdateCallback = () => boolean | void;
+export type AddUpdateCallback = () => void;
 
 export interface ReplayContainer {
   eventBuffer: EventBuffer | null;

--- a/packages/replay/src/util/requestIdleCallback.ts
+++ b/packages/replay/src/util/requestIdleCallback.ts
@@ -1,0 +1,15 @@
+import { WINDOW } from '../constants';
+
+/**
+ * Enqueue a callback to be executed during the next idle period.
+ * After a max. of 50ms, it will be executed anyhow.
+ *
+ * Note that if `window.requestIdleCallback` is not supported (e.g. in Safari), we'll just execute the callback immediately.
+ */
+export function requestIdleCallback(cb: () => void): void {
+  if (WINDOW.requestIdleCallback) {
+    WINDOW.requestIdleCallback(cb, { timeout: 50 });
+  } else {
+    cb();
+  }
+}


### PR DESCRIPTION
This PR updates the event handling of replay to use `window.requestIdleCallback`, if available.
This API is supported everywhere except for Safari, and should schedule a callback to be run when the browser has "resources" for it.

Hopefully, this should improve performance in scenarios where a lot of events are emitted.

I defined a max. timeout of `50ms`, meaning that after max. 50ms each callback will be executed anyhow. This could be tweaked, but feels like a reasonably defensive value here. If the API is not available, we just run the callbacks immediately (like now), so it should degrade gracefully.

Note that there would also be an approach to only have a single callback that keeps an internal queue, but that would require more work to ensure that events cannot be postponed for too long, so IMHO this is the easier solution.

I tried this in my super simple test app, where it works as expected. it would be nice though to test this in a more complex app...

Note: I also refactored the `addUpdate` method to split this into dedicated methods, as this was a bit mixed up right now. Now, we have a dedicated (private) method for the event emitting, and one for adding a "generic" event from other handlers etc.

See https://w3c.github.io/requestidlecallback/ for some more info.

ref https://github.com/getsentry/sentry-javascript/issues/6946
ref https://github.com/getsentry/sentry-javascript/issues/7085