### PR TITLE
fix(react): Make fallback render types more accurate

### DIFF
--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -48,11 +48,17 @@ export type ErrorBoundaryProps = {
   beforeCapture?(scope: Scope, error: Error | null, componentStack: string | null): void;
 };
 
-type ErrorBoundaryState = {
-  componentStack: React.ErrorInfo['componentStack'] | null;
-  error: Error | null;
-  eventId: string | null;
-};
+type ErrorBoundaryState =
+  | {
+      componentStack: null;
+      error: null;
+      eventId: null;
+    }
+  | {
+      componentStack: React.ErrorInfo['componentStack'];
+      error: Error;
+      eventId: string;
+    };
 
 const INITIAL_STATE = {
   componentStack: null,
@@ -133,18 +139,16 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
 
   public render(): React.ReactNode {
     const { fallback, children } = this.props;
-    const { error, componentStack, eventId } = this.state;
+    const state = this.state;
 
-    if (error) {
+    if (state.error) {
       let element: React.ReactElement | undefined = undefined;
       if (typeof fallback === 'function') {
         element = fallback({
-          error,
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          componentStack: componentStack!,
+          error: state.error,
+          componentStack: state.componentStack,
           resetError: this.resetErrorBoundary,
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          eventId: eventId!,
+          eventId: state.eventId,
         });
       } else {
         element = fallback;

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -13,8 +13,8 @@ export const UNKNOWN_COMPONENT = 'unknown';
 
 export type FallbackRender = (errorData: {
   error: Error;
-  componentStack: string | null;
-  eventId: string | null;
+  componentStack: string;
+  eventId: string;
   resetError(): void;
 }) => React.ReactElement;
 
@@ -138,7 +138,14 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
     if (error) {
       let element: React.ReactElement | undefined = undefined;
       if (typeof fallback === 'function') {
-        element = fallback({ error, componentStack, resetError: this.resetErrorBoundary, eventId });
+        element = fallback({
+          error,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          componentStack: componentStack!,
+          resetError: this.resetErrorBoundary,
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          eventId: eventId!,
+        });
       } else {
         element = fallback;
       }


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-javascript/issues/4190

We set `error`, `componentStack`, and `eventId` at the same time https://github.com/getsentry/sentry-javascript/blob/2bdda8454ed89355fd9b727c09bb976a2eb88a90/packages/react/src/errorboundary.tsx#L106

This means that there is no way for `componentStack` and `eventId` to be `null` if `error` is defined. Making the TS types more accurate to reflect this.