### PR TITLE
build: Add size limit info to releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,7 +275,7 @@ jobs:
     needs: [job_get_metadata, job_build]
     timeout-minutes: 15
     runs-on: ubuntu-20.04
-    if: github.event_name == 'pull_request' || needs.job_get_metadata.outputs.is_develop == 'true'
+    if: github.event_name == 'pull_request' || needs.job_get_metadata.outputs.is_develop == 'true' || needs.job_get_metadata.outputs.is_release == 'true'
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3

--- a/.github/workflows/release-size-info.yml
+++ b/.github/workflows/release-size-info.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Update Github Release
         if: steps.get_version.outputs.version != ''
-        uses: getsentry/size-limit-release@main
+        uses: getsentry/size-limit-release@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/release-size-info.yml
+++ b/.github/workflows/release-size-info.yml
@@ -1,0 +1,38 @@
+name: Add size info to release
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Which version to add size info for
+        required: false
+
+# This workflow is triggered when a release is published
+# It fetches the size-limit info from the release branch and adds it to the release
+jobs:
+  release-size-info:
+    runs-on: ubuntu-20.04
+    name: 'Add size-limit info to release'
+
+    steps:
+      # https://github.com/actions-ecosystem/action-regex-match
+      - uses: actions-ecosystem/action-regex-match@v2
+        id: head_version
+        with:
+          # Parse version from head ref, which is refs/tags/<tag_name>
+          text: ${{ github.head_ref }}
+          regex: '^refs\/tags\/([\d.]+)$'
+
+      - name: Get version
+        id: get_version
+        run: echo "version=${{ github.event.inputs.version || steps.head_version.outputs.match }}" >> $GITHUB_OUTPUT
+
+      - name: Update Github Release
+        if: steps.get_version.outputs.version != ''
+        uses: getsentry/size-limit-release@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ steps.get_version.outputs.version }}
+          workflow_name: 'Build & Test'


### PR DESCRIPTION
This adds a Github action workflow that runs when a release is published, and updates the release body with the size limit table.

This uses the new action https://github.com/getsentry/size-limit-release, which uses our size-limit-action fork under the hood and re-uses the same markdown table building functionality.