### PR TITLE
fix(core): Skip empty integrations

### DIFF
--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -88,7 +88,10 @@ export function setupIntegrations(integrations: Integration[]): IntegrationIndex
   const integrationIndex: IntegrationIndex = {};
 
   integrations.forEach(integration => {
-    setupIntegration(integration, integrationIndex);
+    // guard against empty provided integrations
+    if (integration) {
+      setupIntegration(integration, integrationIndex);
+    }
   });
 
   return integrationIndex;

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -697,6 +697,22 @@ describe('BaseClient', () => {
       );
     });
 
+    test('skips empty integrations', () => {
+      const options = getDefaultTestClientOptions({
+        dsn: PUBLIC_DSN,
+        // @ts-ignore we want to force invalid integrations here
+        integrations: [new TestIntegration(), null, undefined],
+      });
+      const client = new TestClient(options);
+      client.setupIntegrations();
+
+      client.captureEvent({ message: 'message' });
+
+      expect(TestClient.instance!.event!.sdk).toEqual({
+        integrations: ['TestIntegration'],
+      });
+    });
+
     test('normalizes event with default depth of 3', () => {
       expect.assertions(1);
 


### PR DESCRIPTION
In the case when a user adds an empty integration, we want to handle this more gracefully instead of erroring out.

Closes https://github.com/getsentry/sentry-javascript/issues/7200
