### PR TITLE
fix(replay): Never record for bots

### DIFF
--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -7,6 +7,7 @@ import { ReplayContainer } from './replay';
 import type { RecordingOptions, ReplayConfiguration, ReplayPluginOptions } from './types';
 import { getPrivacyOptions } from './util/getPrivacyOptions';
 import { isBrowser } from './util/isBrowser';
+import { isBot } from './util/isBot';
 
 const MEDIA_SELECTORS = 'img,image,svg,video,object,picture,embed,map,audio';
 
@@ -268,6 +269,12 @@ function loadReplayOptionsFromClient(initialOptions: InitialReplayPluginOptions)
 
   if (typeof opt.replaysOnErrorSampleRate === 'number') {
     finalOptions.errorSampleRate = opt.replaysOnErrorSampleRate;
+  }
+
+  // For bots, never sample
+  if (isBot()) {
+    finalOptions.sessionSampleRate = 0;
+    finalOptions.errorSampleRate = 0;
   }
 
   return finalOptions;

--- a/packages/replay/src/util/isBot.ts
+++ b/packages/replay/src/util/isBot.ts
@@ -1,0 +1,38 @@
+// Based off https://www.npmjs.com/package/spider-detector
+
+import { WINDOW } from '../constants';
+
+const BOT_REGEXES = [
+  /bot/i,
+  /spider/i,
+  /facebookexternalhit/i,
+  /simplepie/i,
+  /yahooseeker/i,
+  /embedly/i,
+  /quora link preview/i,
+  /outbrain/i,
+  /vkshare/i,
+  /monit/i,
+  /Pingability/i,
+  /Monitoring/i,
+  /WinHttpRequest/i,
+  /Apache-HttpClient/i,
+  /getprismatic.com/i,
+  /python-requests/i,
+  /Twurly/i,
+  /yandex/i,
+  /browserproxy/i,
+  /crawler/i,
+  /Qwantify/i,
+  /Yahoo! Slurp/i,
+  /pinterest/i,
+  /Tumblr\/14.0.835.186/i,
+  /Tumblr Agent 14.0/i,
+  /WhatsApp/i,
+  /Google-Structured-Data-Testing-Tool/i,
+];
+
+/** Check if the current user agent is a bot. */
+export function isBot(userAgent = WINDOW.navigator.userAgent): boolean {
+  return BOT_REGEXES.some(regex => regex.test(userAgent));
+}

--- a/packages/replay/test/integration/integrationSettings.test.ts
+++ b/packages/replay/test/integration/integrationSettings.test.ts
@@ -1,4 +1,5 @@
 import { mockSdk } from '../index';
+import { WINDOW } from '../../src/constants';
 
 describe('Integration | integrationSettings', () => {
   beforeEach(() => {
@@ -231,6 +232,25 @@ describe('Integration | integrationSettings', () => {
       });
 
       expect(replay.getOptions()._experiments).toEqual({});
+    });
+  });
+
+  describe('bot detection', () => {
+    const userAgent = WINDOW.navigator.userAgent;
+
+    afterEach(() => {
+      Object.defineProperty(WINDOW.navigator, 'userAgent', { configurable: true, value: userAgent });
+    });
+
+    it('auto-detects bots and sets sample rates to 0', async () => {
+      Object.defineProperty(WINDOW.navigator, 'userAgent', { configurable: true, value: 'GoogleBot user agent' });
+
+      const { replay } = await mockSdk({
+        sentryOptions: { replaysSessionSampleRate: 1, replaysOnErrorSampleRate: 1 },
+      });
+
+      expect(replay.getOptions().sessionSampleRate).toBe(0);
+      expect(replay.getOptions().errorSampleRate).toBe(0);
     });
   });
 });

--- a/packages/replay/test/unit/util/isBot.test.ts
+++ b/packages/replay/test/unit/util/isBot.test.ts
@@ -1,0 +1,17 @@
+import { isBot } from '../../../src/util/isBot';
+
+describe('isBot', () => {
+  it('finds google bot user agent', () => {
+    expect(
+      isBot(
+        'Mozilla/5.0 (Linux; Android 5.0; SM-G920A) AppleWebKit (KHTML, like Gecko) Chrome Mobile Safari (compatible; AdsBot-Google-Mobile; +http://www.google.com/mobile/adsbot.html)',
+      ),
+    ).toBe(true);
+  });
+
+  it('allows other user agents', () => {
+    expect(
+      isBot('Mozilla/5.0 (Linux; Android 5.0; SM-G920A) AppleWebKit (KHTML, like Gecko) Chrome Mobile Safari'),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
This is not bullet proof, but may be at least a start. I built the bot list based on:
https://www.npmjs.com/package/spider-detector

Closes https://github.com/getsentry/replay-backend/issues/283