### PR TITLE
fix(replay): Debounced flushes not respecting `maxWait`

### DIFF
--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -22,7 +22,9 @@ export const MAX_SESSION_LIFE = 3_600_000; // 60 minutes
 
 /** Default flush delays */
 export const DEFAULT_FLUSH_MIN_DELAY = 5_000;
-export const DEFAULT_FLUSH_MAX_DELAY = 5_000;
+// XXX: Temp fix for our debounce logic where `maxWait` would never occur if it
+// was the same as `wait`
+export const DEFAULT_FLUSH_MAX_DELAY = 5_500;
 
 /* How long to wait for error checkouts */
 export const ERROR_CHECKOUT_TIME = 60_000;


### PR DESCRIPTION
This is happening due to a bug in the `debounce` function where it does not respect `maxWait` if its value is the same as `wait` (https://github.com/getsentry/sentry-javascript/blob/develop/packages/replay/src/util/debounce.ts#L60) . This is causing poor fidelity in Replays and possibly memory issues if it never flushes after the initial checkout.

This is just a quick fix until we fix `debounce`.
