### PR TITLE
fix(replay): Fix debounce when `maxWait` == `wait`

### DIFF
--- a/packages/replay/src/util/debounce.ts
+++ b/packages/replay/src/util/debounce.ts
@@ -58,12 +58,7 @@ export function debounce(func: CallbackFunction, wait: number, options?: Debounc
     timerId = setTimeout(invokeFunc, wait);
 
     if (maxWait && maxTimerId === undefined) {
-      maxTimerId = setTimeout(() => {
-        invokeFunc();
-        if (timerId) {
-          clearTimeout(timerId);
-        }
-      }, maxWait);
+      maxTimerId = setTimeout(invokeFunc, maxWait);
     }
 
     return callbackReturnValue;

--- a/packages/replay/src/util/debounce.ts
+++ b/packages/replay/src/util/debounce.ts
@@ -60,7 +60,9 @@ export function debounce(func: CallbackFunction, wait: number, options?: Debounc
     if (maxWait && maxTimerId === undefined) {
       maxTimerId = setTimeout(() => {
         invokeFunc();
-        if (timerId) { clearTimeout(timerId)}
+        if (timerId) {
+          clearTimeout(timerId);
+        }
       }, maxWait);
     }
 

--- a/packages/replay/src/util/debounce.ts
+++ b/packages/replay/src/util/debounce.ts
@@ -57,8 +57,11 @@ export function debounce(func: CallbackFunction, wait: number, options?: Debounc
     }
     timerId = setTimeout(invokeFunc, wait);
 
-    if (maxWait && maxTimerId === undefined && maxWait !== wait) {
-      maxTimerId = setTimeout(invokeFunc, maxWait);
+    if (maxWait && maxTimerId === undefined) {
+      maxTimerId = setTimeout(() => {
+        invokeFunc();
+        if (timerId) { clearTimeout(timerId)}
+      }, maxWait);
     }
 
     return callbackReturnValue;

--- a/packages/replay/test/unit/util/debounce.test.ts
+++ b/packages/replay/test/unit/util/debounce.test.ts
@@ -246,14 +246,27 @@ describe('Unit | util | debounce', () => {
     const debouncedCallback = debounce(callback, 100, { maxWait: 100 });
 
     debouncedCallback();
-    jest.advanceTimersByTime(100);
+    jest.advanceTimersByTime(25);
+    debouncedCallback();
+    jest.advanceTimersByTime(25);
+    debouncedCallback();
+    jest.advanceTimersByTime(25);
+    debouncedCallback();
+    jest.advanceTimersByTime(25);
 
     expect(callback).toHaveBeenCalledTimes(1);
 
     const retval = debouncedCallback();
     expect(retval).toBe('foo');
 
-    jest.advanceTimersByTime(100);
+    jest.advanceTimersByTime(25);
+    debouncedCallback();
+    jest.advanceTimersByTime(25);
+    debouncedCallback();
+    jest.advanceTimersByTime(25);
+    debouncedCallback();
+    jest.advanceTimersByTime(25);
+
     expect(callback).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
Update and fix tests for debounce when `maxWait` == `wait`.
