### PR TITLE
feat(replay): Handle large amounts of consecutive events

### DIFF
--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -31,3 +31,7 @@ export const ERROR_CHECKOUT_TIME = 60_000;
 
 export const RETRY_BASE_INTERVAL = 5000;
 export const RETRY_MAX_COUNT = 3;
+
+// How many events can occur in the given rolling time window before we want to pause & full checkout the replay?
+export const EVENT_ROLLING_WINDOW_TIME = 100;
+export const EVENT_ROLLING_WINDOW_MAX = 2_000;

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -35,6 +35,7 @@ import { createBreadcrumb } from './util/createBreadcrumb';
 import { createPerformanceEntries } from './util/createPerformanceEntries';
 import { createPerformanceSpans } from './util/createPerformanceSpans';
 import { debounce } from './util/debounce';
+import { EventCounter } from './util/EventCounter';
 import { isExpired } from './util/isExpired';
 import { isSessionExpired } from './util/isSessionExpired';
 import { overwriteRecordDroppedEvent, restoreRecordDroppedEvent } from './util/monkeyPatchRecordDroppedEvent';
@@ -59,6 +60,8 @@ export class ReplayContainer implements ReplayContainerInterface {
    * * error: Always keep the last 60s of recording, and when an error occurs, send it immediately
    */
   public recordingMode: ReplayRecordingMode = 'session';
+
+  public eventCounter: EventCounter;
 
   /**
    * Options to pass to `rrweb.record()`
@@ -122,6 +125,8 @@ export class ReplayContainer implements ReplayContainerInterface {
     this._debouncedFlush = debounce(() => this._flush(), this._options.flushMinDelay, {
       maxWait: this._options.flushMaxDelay,
     });
+
+    this.eventCounter = new EventCounter();
   }
 
   /** Get the event context. */

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -1,6 +1,7 @@
 import type { ReplayRecordingData, ReplayRecordingMode } from '@sentry/types';
 
 import type { eventWithTime, recordOptions } from './types/rrweb';
+import type { EventCounter } from './util/EventCounter';
 
 export type RecordingEvent = eventWithTime;
 export type RecordingOptions = recordOptions;
@@ -289,6 +290,7 @@ export interface ReplayContainer {
   performanceEvents: AllPerformanceEntry[];
   session: Session | undefined;
   recordingMode: ReplayRecordingMode;
+  eventCounter: EventCounter;
   isEnabled(): boolean;
   isPaused(): boolean;
   getContext(): InternalEventContext;

--- a/packages/replay/src/util/EventCounter.ts
+++ b/packages/replay/src/util/EventCounter.ts
@@ -1,0 +1,29 @@
+import { EVENT_ROLLING_WINDOW_MAX, EVENT_ROLLING_WINDOW_TIME } from '../constants';
+
+/** A simple rolling window event counter. */
+export class EventCounter {
+  // How many events happed in a rolling window of 100ms
+  private _count: number;
+  // How long the rolling window is
+  private _time: number;
+  // How many events can happen in the rolling window
+  private _max: number;
+
+  public constructor(time = EVENT_ROLLING_WINDOW_TIME, max = EVENT_ROLLING_WINDOW_MAX) {
+    this._count = 0;
+    this._time = time;
+    this._max = max;
+  }
+
+  /** An event is added. */
+  public add(): void {
+    this._count++;
+
+    setTimeout(() => this._count--, this._time);
+  }
+
+  /** If there are too many events in the rolling window. */
+  public hasExceededLimit(): boolean {
+    return this._count > this._max;
+  }
+}

--- a/packages/replay/test/mocks/mockSdk.ts
+++ b/packages/replay/test/mocks/mockSdk.ts
@@ -5,6 +5,7 @@ import type { ReplayContainer } from '../../src/replay';
 import type { ReplayConfiguration } from '../../src/types';
 import type { TestClientOptions } from '../utils/TestClient';
 import { getDefaultClientOptions, init } from '../utils/TestClient';
+import { EventCounter } from '../../src/util/EventCounter';
 
 export interface MockSdkParams {
   replayOptions?: ReplayConfiguration;
@@ -83,6 +84,10 @@ export async function mockSdk({ replayOptions, sentryOptions, autoStart = true }
   }
 
   const replay = replayIntegration['_replay']!;
+
+  // In tests, we want to ignore the event counter by default
+  // As it adds timeouts that can interfere with other things
+  replay.eventCounter = new EventCounter(0);
 
   return { replay, integration: replayIntegration };
 }

--- a/packages/replay/test/unit/util/addEvent.test.ts
+++ b/packages/replay/test/unit/util/addEvent.test.ts
@@ -5,13 +5,17 @@ import type { EventBufferProxy } from '../../../src/eventBuffer/EventBufferProxy
 import { addEvent } from '../../../src/util/addEvent';
 import { setupReplayContainer } from '../../utils/setupReplayContainer';
 import { useFakeTimers } from '../../utils/use-fake-timers';
+import { EventCounter } from '../../../src/util/EventCounter';
+import { EVENT_ROLLING_WINDOW_TIME, EVENT_ROLLING_WINDOW_MAX } from '../../../src/constants';
 
 useFakeTimers();
 
 describe('Unit | util | addEvent', () => {
-  it('stops when encountering a compression error', async function () {
+  beforeEach(function () {
     jest.setSystemTime(BASE_TIMESTAMP);
+  });
 
+  it('stops when encountering a compression error', async function () {
     const replay = setupReplayContainer({
       options: {
         useCompression: true,
@@ -28,5 +32,60 @@ describe('Unit | util | addEvent', () => {
     await addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP + 10, type: 2 });
 
     expect(replay.isEnabled()).toEqual(false);
+  });
+
+  describe('event count rolling window', () => {
+    it('pauses when triggering too many events', async function () {
+      const replay = setupReplayContainer({});
+      // This is overwritten by defaults for tests, we want to try it with the proper values
+      replay.eventCounter = new EventCounter(EVENT_ROLLING_WINDOW_TIME, EVENT_ROLLING_WINDOW_MAX);
+
+      // Now trigger A LOT of events
+      for (let i = 0; i < EVENT_ROLLING_WINDOW_MAX - 10; i++) {
+        addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP, type: 2 });
+      }
+      await new Promise(process.nextTick);
+
+      // Nothing should have happend, all still live
+      expect(replay.isPaused()).toEqual(false);
+
+      // now add a few more with a short delay, should still be running
+      for (let i = 0; i < 10; i++) {
+        jest.advanceTimersByTime(5);
+        addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP + i * 5, type: 2 });
+      }
+      await new Promise(process.nextTick);
+
+      expect(replay.isPaused()).toEqual(false);
+
+      // Now add one more, should trigger the pause
+      addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP + 90, type: 2 });
+      await new Promise(process.nextTick);
+
+      expect(replay.isPaused()).toEqual(true);
+
+      // Wait for the rolling window to pass, should trigger a resume
+      jest.advanceTimersByTime(EVENT_ROLLING_WINDOW_TIME);
+      await new Promise(process.nextTick);
+
+      expect(replay.isPaused()).toEqual(false);
+    });
+
+    it('throws out event count after rolling window timeout', async function () {
+      const replay = setupReplayContainer({});
+      // This is overwritten by defaults for tests, we want to try it with the proper values
+      replay.eventCounter = new EventCounter(EVENT_ROLLING_WINDOW_TIME, EVENT_ROLLING_WINDOW_MAX);
+
+      // Now trigger A LOT of events
+      for (let i = 0; i < EVENT_ROLLING_WINDOW_MAX * 2; i++) {
+        jest.advanceTimersByTime(1);
+        addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP + i * 1, type: 2 });
+      }
+      await new Promise(process.nextTick);
+
+      // Nothing should have happend, all still live,
+      // because the events continuously move out of the window
+      expect(replay.isPaused()).toEqual(false);
+    });
   });
 });


### PR DESCRIPTION
We've seen problems when a lot of events are happening at the same time. E.g. when thousands of mutation observer events are triggered at the same time, this can lead to very poor performance.

With this change, we detect if more than 2000 events happen in a rolling time window of 100ms. If so, we pause the replay, wait for 100ms, and resume it (which will trigger a full snapshot).

Note: I've selected the values 2000 & 100ms completely random. We can think about what reasonable amounts are here.
This is not a perfect fix, but IMHO it is a better experience to have a 100ms gap in your replay (and afterwards it should continue normally), than to freeze your page.

@billyvg can you try this with the repro app you've got?