### PR TITLE
test(replay): Normalize time offset in DOM snapshots

### DIFF
--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-1-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-1-snap-incremental
@@ -6,7 +6,7 @@
         "x": 41,
         "y": 18,
         "id": 9,
-        "timeOffset": 0
+        "timeOffset": [timeOffset]
       }
     ]
   },

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-1-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-1-snap-incremental-chromium
@@ -6,7 +6,7 @@
         "x": 41,
         "y": 18,
         "id": 9,
-        "timeOffset": 0
+        "timeOffset": [timeOffset]
       }
     ]
   },

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-3-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-3-snap-incremental
@@ -6,7 +6,7 @@
         "x": 41,
         "y": 18,
         "id": 9,
-        "timeOffset": 0
+        "timeOffset": [timeOffset]
       }
     ]
   },

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-3-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-3-snap-incremental-chromium
@@ -6,7 +6,7 @@
         "x": 41,
         "y": 18,
         "id": 9,
-        "timeOffset": 0
+        "timeOffset": [timeOffset]
       }
     ]
   },

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-5-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-5-snap-incremental
@@ -6,7 +6,7 @@
         "x": 41,
         "y": 90,
         "id": 12,
-        "timeOffset": 0
+        "timeOffset": [timeOffset]
       }
     ]
   },

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-5-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-5-snap-incremental-chromium
@@ -6,7 +6,7 @@
         "x": 41,
         "y": 90,
         "id": 12,
-        "timeOffset": 0
+        "timeOffset": [timeOffset]
       }
     ]
   },

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-6-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-6-snap-incremental
@@ -6,7 +6,7 @@
         "x": 157,
         "y": 90,
         "id": 15,
-        "timeOffset": 0
+        "timeOffset": [timeOffset]
       }
     ]
   },

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-6-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-6-snap-incremental-chromium
@@ -6,7 +6,7 @@
         "x": 157,
         "y": 90,
         "id": 15,
-        "timeOffset": 0
+        "timeOffset": [timeOffset]
       }
     ]
   },

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-7-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-7-snap-incremental
@@ -6,7 +6,7 @@
         "x": 41,
         "y": 90,
         "id": 12,
-        "timeOffset": 0
+        "timeOffset": [timeOffset]
       }
     ]
   },

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-7-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-7-snap-incremental-chromium
@@ -6,7 +6,7 @@
         "x": 41,
         "y": 90,
         "id": 12,
-        "timeOffset": 0
+        "timeOffset": [timeOffset]
       }
     ]
   },

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-9-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-9-snap-incremental
@@ -6,7 +6,7 @@
         "x": 41,
         "y": 18,
         "id": 9,
-        "timeOffset": 0
+        "timeOffset": [timeOffset]
       }
     ]
   },

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-9-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-9-snap-incremental-chromium
@@ -6,7 +6,7 @@
         "x": 41,
         "y": 18,
         "id": 9,
-        "timeOffset": 0
+        "timeOffset": [timeOffset]
       }
     ]
   },

--- a/packages/integration-tests/utils/replayHelpers.ts
+++ b/packages/integration-tests/utils/replayHelpers.ts
@@ -219,7 +219,7 @@ export function shouldSkipReplayTest(): boolean {
 export function normalize(obj: unknown): string {
   const rawString = JSON.stringify(obj, null, 2);
   const normalizedString = rawString
-    .replace(/"file:\/\/.+(\/.*\.html)"/, '"$1"')
-    .replace(/"timeOffset":\s*\d+/, '"timeOffset": 0');
+    .replace(/"file:\/\/.+(\/.*\.html)"/gm, '"$1"')
+    .replace(/"timeOffset":\s*-?\d+/gm, '"timeOffset": [timeOffset]');
   return normalizedString;
 }

--- a/packages/integration-tests/utils/replayHelpers.ts
+++ b/packages/integration-tests/utils/replayHelpers.ts
@@ -214,9 +214,12 @@ export function shouldSkipReplayTest(): boolean {
  * Takes a replay recording payload and returns a normalized string representation.
  * This is necessary because the DOM snapshots contain absolute paths to other HTML
  * files which break the tests on different machines.
+ * Also, we need to reset any time offsets to 0 as they can differ and cause flakes.
  */
 export function normalize(obj: unknown): string {
   const rawString = JSON.stringify(obj, null, 2);
-  const normalizedString = rawString.replace(/"file:\/\/.+(\/.*\.html)"/g, '"$1"');
+  const normalizedString = rawString
+    .replace(/"file:\/\/.+(\/.*\.html)"/, '"$1"')
+    .replace(/"timeOffset":\s*\d+/, '"timeOffset": 0');
   return normalizedString;
 }

--- a/packages/integration-tests/utils/replayHelpers.ts
+++ b/packages/integration-tests/utils/replayHelpers.ts
@@ -214,7 +214,7 @@ export function shouldSkipReplayTest(): boolean {
  * Takes a replay recording payload and returns a normalized string representation.
  * This is necessary because the DOM snapshots contain absolute paths to other HTML
  * files which break the tests on different machines.
- * Also, we need to reset any time offsets to 0 as they can differ and cause flakes.
+ * Also, we need to normalize any time offsets as they can vary and cause flakes.
  */
 export function normalize(obj: unknown): string {
   const rawString = JSON.stringify(obj, null, 2);


### PR DESCRIPTION
I just noticed that the last integration test I added in #7212 is flaky because of time offsets which can change in some CI runs. This PR normalizes the time offset to `[timeOffset]` in DOM snapshots to make sure this doesn't happen.
