### PR TITLE
ci: Fix adding size info to release

### DIFF
--- a/.github/workflows/release-size-info.yml
+++ b/.github/workflows/release-size-info.yml
@@ -18,16 +18,17 @@ jobs:
 
     steps:
       # https://github.com/actions-ecosystem/action-regex-match
-      - uses: actions-ecosystem/action-regex-match@v2
+      - name: Extract version from ref
+        uses: actions-ecosystem/action-regex-match@v2
         id: head_version
         with:
           # Parse version from head ref, which is refs/tags/<tag_name>
-          text: ${{ github.head_ref }}
+          text: ${{ env.GITHUB_REF }}
           regex: '^refs\/tags\/([\d.]+)$'
 
       - name: Get version
         id: get_version
-        run: echo "version=${{ github.event.inputs.version || steps.head_version.outputs.match }}" >> $GITHUB_OUTPUT
+        run: echo "version=${{ github.event.inputs.version || steps.head_version.outputs.group1 }}" >> $GITHUB_OUTPUT
 
       - name: Update Github Release
         if: steps.get_version.outputs.version != ''


### PR DESCRIPTION
Must actually use the group1 instead of match here, also `github.head_ref` is sadly not available, but apparently `env.GITHUB_REF` is (see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release).