### PR TITLE
test(replay): Add test for fetch and XHR performance spans

### DIFF
--- a/packages/integration-tests/suites/replay/requests/init.js
+++ b/packages/integration-tests/suites/replay/requests/init.js
@@ -1,0 +1,17 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+window.Replay = new Sentry.Replay({
+  flushMinDelay: 500,
+  flushMaxDelay: 500,
+  useCompression: true,
+});
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  sampleRate: 0,
+  replaysSessionSampleRate: 1.0,
+  replaysOnErrorSampleRate: 0.0,
+
+  integrations: [window.Replay],
+});

--- a/packages/integration-tests/suites/replay/requests/subject.js
+++ b/packages/integration-tests/suites/replay/requests/subject.js
@@ -1,0 +1,16 @@
+document.getElementById('go-background').addEventListener('click', () => {
+  Object.defineProperty(document, 'hidden', { value: true, writable: true });
+  const ev = document.createEvent('Event');
+  ev.initEvent('visibilitychange');
+  document.dispatchEvent(ev);
+});
+
+document.getElementById('fetch').addEventListener('click', () => {
+  fetch('https://example.com');
+});
+
+document.getElementById('xhr').addEventListener('click', () => {
+  const xhr = new XMLHttpRequest();
+  xhr.open('GET', 'https://example.com');
+  xhr.send();
+});

--- a/packages/integration-tests/suites/replay/requests/template.html
+++ b/packages/integration-tests/suites/replay/requests/template.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <button id="go-background">Go to background</button>
+    <button id="fetch">New Fetch Request</button>
+    <button id="xhr">New Fetch Request</button>
+  </body>
+</html>

--- a/packages/integration-tests/suites/replay/requests/test.ts
+++ b/packages/integration-tests/suites/replay/requests/test.ts
@@ -69,6 +69,7 @@ sentryTest('replay recording should contain XHR request span', async ({ getLocal
 
   await page.goto(url);
   await page.click('#xhr');
+  await page.click('#go-background');
 
   const { performanceSpans: spans0 } = getReplayRecordingContent(await reqPromise0);
   const { performanceSpans: spans1 } = getReplayRecordingContent(await reqPromise1);

--- a/packages/integration-tests/suites/replay/requests/test.ts
+++ b/packages/integration-tests/suites/replay/requests/test.ts
@@ -1,0 +1,73 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../utils/fixtures';
+import { expectedFetchPerformanceSpan, expectedXHRPerformanceSpan } from '../../../utils/replayEventTemplates';
+import { getReplayRecordingContent, shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
+
+sentryTest('replay recording should contain fetch request span', async ({ getLocalTestPath, page }) => {
+  if (shouldSkipReplayTest()) {
+    sentryTest.skip();
+  }
+
+  // we're only interested in segment 1 which should contain the fetch span
+  const reqPromise1 = waitForReplayRequest(page, 1);
+
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  await page.route('https://example.com', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: 'hello world',
+    });
+  });
+
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  await page.goto(url);
+  await page.click('#fetch');
+
+  const { performanceSpans } = getReplayRecordingContent(await reqPromise1);
+
+  expect(performanceSpans).toContainEqual(expectedFetchPerformanceSpan);
+});
+
+sentryTest('replay recording should contain XHR request span', async ({ getLocalTestPath, page }) => {
+  if (shouldSkipReplayTest()) {
+    sentryTest.skip();
+  }
+
+  // we're only interested in segment 1 which should contain the fetch span
+  const reqPromise1 = waitForReplayRequest(page, 1);
+
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  await page.route('https://example.com', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: 'hello world',
+    });
+  });
+
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  await page.goto(url);
+  await page.click('#xhr');
+
+  const { performanceSpans } = getReplayRecordingContent(await reqPromise1);
+
+  expect(performanceSpans).toContainEqual(expectedXHRPerformanceSpan);
+});

--- a/packages/integration-tests/suites/replay/requests/test.ts
+++ b/packages/integration-tests/suites/replay/requests/test.ts
@@ -9,7 +9,7 @@ sentryTest('replay recording should contain fetch request span', async ({ getLoc
     sentryTest.skip();
   }
 
-  // we're only interested in segment 1 which should contain the fetch span
+  const reqPromise0 = waitForReplayRequest(page, 0);
   const reqPromise1 = waitForReplayRequest(page, 1);
 
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
@@ -34,7 +34,9 @@ sentryTest('replay recording should contain fetch request span', async ({ getLoc
   await page.click('#fetch');
   await page.click('#go-background');
 
-  const { performanceSpans } = getReplayRecordingContent(await reqPromise1);
+  const { performanceSpans: spans0 } = getReplayRecordingContent(await reqPromise0);
+  const { performanceSpans: spans1 } = getReplayRecordingContent(await reqPromise1);
+  const performanceSpans = [...spans0, ...spans1];
 
   expect(performanceSpans).toContainEqual(expectedFetchPerformanceSpan);
 });
@@ -44,7 +46,7 @@ sentryTest('replay recording should contain XHR request span', async ({ getLocal
     sentryTest.skip();
   }
 
-  // we're only interested in segment 1 which should contain the fetch span
+  const reqPromise0 = waitForReplayRequest(page, 0);
   const reqPromise1 = waitForReplayRequest(page, 1);
 
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
@@ -68,7 +70,9 @@ sentryTest('replay recording should contain XHR request span', async ({ getLocal
   await page.goto(url);
   await page.click('#xhr');
 
-  const { performanceSpans } = getReplayRecordingContent(await reqPromise1);
+  const { performanceSpans: spans0 } = getReplayRecordingContent(await reqPromise0);
+  const { performanceSpans: spans1 } = getReplayRecordingContent(await reqPromise1);
+  const performanceSpans = [...spans0, ...spans1];
 
   expect(performanceSpans).toContainEqual(expectedXHRPerformanceSpan);
 });

--- a/packages/integration-tests/suites/replay/requests/test.ts
+++ b/packages/integration-tests/suites/replay/requests/test.ts
@@ -32,6 +32,7 @@ sentryTest('replay recording should contain fetch request span', async ({ getLoc
 
   await page.goto(url);
   await page.click('#fetch');
+  await page.click('#go-background');
 
   const { performanceSpans } = getReplayRecordingContent(await reqPromise1);
 

--- a/packages/integration-tests/utils/replayEventTemplates.ts
+++ b/packages/integration-tests/utils/replayEventTemplates.ts
@@ -130,6 +130,28 @@ export const expectedFPPerformanceSpan = {
   endTimestamp: expect.any(Number),
 };
 
+export const expectedFetchPerformanceSpan = {
+  op: 'resource.fetch',
+  description: expect.any(String),
+  startTimestamp: expect.any(Number),
+  endTimestamp: expect.any(Number),
+  data: {
+    method: expect.any(String),
+    statusCode: expect.any(Number),
+  },
+};
+
+export const expectedXHRPerformanceSpan = {
+  op: 'resource.xhr',
+  description: expect.any(String),
+  startTimestamp: expect.any(Number),
+  endTimestamp: expect.any(Number),
+  data: {
+    method: expect.any(String),
+    statusCode: expect.any(Number),
+  },
+};
+
 /* Breadcrumbs */
 
 export const expectedClickBreadcrumb = {


### PR DESCRIPTION
This PR adds two Playwright tests to test fetch/xhr requests being recorded as performance spans

ref #7044 
