### PR TITLE
fix(core): Exclude client reports from offline queuing

### DIFF
--- a/packages/core/src/transports/offline.ts
+++ b/packages/core/src/transports/offline.ts
@@ -1,21 +1,9 @@
 import type { Envelope, InternalBaseTransportOptions, Transport, TransportMakeRequestResponse } from '@sentry/types';
-import { forEachEnvelopeItem, logger, parseRetryAfterHeader } from '@sentry/utils';
+import { envelopeContainsItemType, logger, parseRetryAfterHeader } from '@sentry/utils';
 
 export const MIN_DELAY = 100; // 100 ms
 export const START_DELAY = 5_000; // 5 seconds
 const MAX_DELAY = 3.6e6; // 1 hour
-
-function isReplayEnvelope(envelope: Envelope): boolean {
-  let isReplay = false;
-
-  forEachEnvelopeItem(envelope, (_, type) => {
-    if (type === 'replay_event') {
-      isReplay = true;
-    }
-  });
-
-  return isReplay;
-}
 
 function log(msg: string, error?: Error): void {
   __DEBUG_BUILD__ && logger.info(`[Offline]: ${msg}`, error);
@@ -74,7 +62,8 @@ export function makeOfflineTransport<TO>(
       // We don't queue Session Replay envelopes because they are:
       // - Ordered and Replay relies on the response status to know when they're successfully sent.
       // - Likely to fill the queue quickly and block other events from being sent.
-      if (isReplayEnvelope(env)) {
+      // We also want to drop client reports because they can be generated when we retry sending events while offline.
+      if (envelopeContainsItemType(env, 'replay_event', 'replay_recording', 'client_report')) {
         return false;
       }
 

--- a/packages/core/src/transports/offline.ts
+++ b/packages/core/src/transports/offline.ts
@@ -63,7 +63,7 @@ export function makeOfflineTransport<TO>(
       // - Ordered and Replay relies on the response status to know when they're successfully sent.
       // - Likely to fill the queue quickly and block other events from being sent.
       // We also want to drop client reports because they can be generated when we retry sending events while offline.
-      if (envelopeContainsItemType(env, 'replay_event', 'replay_recording', 'client_report')) {
+      if (envelopeContainsItemType(env, ['replay_event', 'replay_recording', 'client_report'])) {
         return false;
       }
 

--- a/packages/utils/src/envelope.ts
+++ b/packages/utils/src/envelope.ts
@@ -6,7 +6,6 @@ import type {
   DataCategory,
   DsnComponents,
   Envelope,
-  EnvelopeItem,
   EnvelopeItemType,
   Event,
   EventEnvelopeHeaders,
@@ -41,16 +40,32 @@ export function addItemToEnvelope<E extends Envelope>(envelope: E, newItem: E[1]
 /**
  * Convenience function to loop through the items and item types of an envelope.
  * (This function was mostly created because working with envelope types is painful at the moment)
+ *
+ * If the callback returns true, the rest of the items will be skipped.
  */
 export function forEachEnvelopeItem<E extends Envelope>(
   envelope: Envelope,
-  callback: (envelopeItem: E[1][number], envelopeItemType: E[1][number][0]['type']) => void,
-): void {
+  callback: (envelopeItem: E[1][number], envelopeItemType: E[1][number][0]['type']) => boolean | void,
+): boolean {
   const envelopeItems = envelope[1];
-  envelopeItems.forEach((envelopeItem: EnvelopeItem) => {
+
+  for (const envelopeItem of envelopeItems) {
     const envelopeItemType = envelopeItem[0].type;
-    callback(envelopeItem, envelopeItemType);
-  });
+    const result = callback(envelopeItem, envelopeItemType);
+
+    if (result) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Returns true if the envelope contains any of the given envelope item types
+ */
+export function envelopeContainsItemType(envelope: Envelope, ...types: EnvelopeItemType[]): boolean {
+  return forEachEnvelopeItem(envelope, (_, type) => types.includes(type));
 }
 
 /**

--- a/packages/utils/src/envelope.ts
+++ b/packages/utils/src/envelope.ts
@@ -64,7 +64,7 @@ export function forEachEnvelopeItem<E extends Envelope>(
 /**
  * Returns true if the envelope contains any of the given envelope item types
  */
-export function envelopeContainsItemType(envelope: Envelope, ...types: EnvelopeItemType[]): boolean {
+export function envelopeContainsItemType(envelope: Envelope, types: EnvelopeItemType[]): boolean {
   return forEachEnvelopeItem(envelope, (_, type) => types.includes(type));
 }
 


### PR DESCRIPTION
If a user sets any `transportOptions`, the transport is used directly to send client reports rather than beacon which means they can get queued by the offline transport wrapper.

Client reports can be generated every time an event fails to send and these could fill the queue when offline and mean error events get dropped.

This PR modifies `forEachEnvelopeItem` to allow short-cut out of the for loop if the callback returns `true`.