### PR TITLE
feat(nextjs): Default to `VERCEL_ENV` as environment

### DIFF
--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -4,6 +4,7 @@ import { configureScope, init as reactInit, Integrations } from '@sentry/react';
 import { BrowserTracing, defaultRequestInstrumentationOptions, hasTracingEnabled } from '@sentry/tracing';
 import type { EventProcessor } from '@sentry/types';
 
+import { getVercelEnv } from '../common/getVercelEnv';
 import { buildMetadata } from '../common/metadata';
 import { addOrUpdateIntegration } from '../common/userIntegrations';
 import { nextRouterInstrumentation } from './performance';
@@ -39,10 +40,7 @@ export function init(options: BrowserOptions): void {
   applyTunnelRouteOption(options);
   buildMetadata(options, ['nextjs', 'react']);
 
-  options.environment =
-    options.environment ||
-    (process.env.NEXT_PUBLIC_VERCEL_ENV ? `vercel-${process.env.NEXT_PUBLIC_VERCEL_ENV}` : undefined) ||
-    process.env.NODE_ENV;
+  options.environment = options.environment || getVercelEnv(true) || process.env.NODE_ENV;
 
   addClientIntegrations(options);
 

--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -39,7 +39,10 @@ export function init(options: BrowserOptions): void {
   applyTunnelRouteOption(options);
   buildMetadata(options, ['nextjs', 'react']);
 
-  options.environment = options.environment || process.env.NEXT_PUBLIC_VERCEL_ENV || process.env.NODE_ENV;
+  options.environment =
+    options.environment ||
+    (process.env.NEXT_PUBLIC_VERCEL_ENV ? `vercel-${process.env.NEXT_PUBLIC_VERCEL_ENV}` : undefined) ||
+    process.env.NODE_ENV;
 
   addClientIntegrations(options);
 

--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -38,7 +38,9 @@ const globalWithInjectedValues = global as typeof global & {
 export function init(options: BrowserOptions): void {
   applyTunnelRouteOption(options);
   buildMetadata(options, ['nextjs', 'react']);
-  options.environment = options.environment || process.env.NODE_ENV;
+
+  options.environment = options.environment || process.env.NEXT_PUBLIC_VERCEL_ENV || process.env.NODE_ENV;
+
   addClientIntegrations(options);
 
   reactInit(options);

--- a/packages/nextjs/src/common/getVercelEnv.ts
+++ b/packages/nextjs/src/common/getVercelEnv.ts
@@ -1,0 +1,9 @@
+/**
+ * Returns an environment setting value determined by Vercel's `VERCEL_ENV` environment variable.
+ *
+ * @param isClient Flag to indicate whether to use the `NEXT_PUBLIC_` prefixed version of the environment variable.
+ */
+export function getVercelEnv(isClient: boolean): string | undefined {
+  const vercelEnvVar = isClient ? process.env.NEXT_PUBLIC_VERCEL_ENV : process.env.VERCEL_ENV;
+  return vercelEnvVar ? `vercel-${vercelEnvVar}` : undefined;
+}

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -46,9 +46,8 @@ export function init(options: EdgeOptions = {}): void {
     }
   }
 
-  if (options.environment === undefined && process.env.SENTRY_ENVIRONMENT) {
-    options.environment = process.env.SENTRY_ENVIRONMENT;
-  }
+  options.environment =
+    options.environment || process.env.SENTRY_ENVIRONMENT || process.env.VERCEL_ENV || process.env.NODE_ENV;
 
   if (options.autoSessionTracking === undefined && options.dsn !== undefined) {
     options.autoSessionTracking = true;

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -10,6 +10,7 @@ import {
   stackParserFromStackParserOptions,
 } from '@sentry/utils';
 
+import { getVercelEnv } from '../common/getVercelEnv';
 import { EdgeClient } from './edgeclient';
 import { makeEdgeTransport } from './transport';
 
@@ -47,10 +48,7 @@ export function init(options: EdgeOptions = {}): void {
   }
 
   options.environment =
-    options.environment ||
-    process.env.SENTRY_ENVIRONMENT ||
-    (process.env.VERCEL_ENV ? `vercel-${process.env.VERCEL_ENV}` : undefined) ||
-    process.env.NODE_ENV;
+    options.environment || process.env.SENTRY_ENVIRONMENT || getVercelEnv(false) || process.env.NODE_ENV;
 
   if (options.autoSessionTracking === undefined && options.dsn !== undefined) {
     options.autoSessionTracking = true;

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -47,7 +47,10 @@ export function init(options: EdgeOptions = {}): void {
   }
 
   options.environment =
-    options.environment || process.env.SENTRY_ENVIRONMENT || process.env.VERCEL_ENV || process.env.NODE_ENV;
+    options.environment ||
+    process.env.SENTRY_ENVIRONMENT ||
+    (process.env.VERCEL_ENV ? `vercel-${process.env.VERCEL_ENV}` : undefined) ||
+    process.env.NODE_ENV;
 
   if (options.autoSessionTracking === undefined && options.dsn !== undefined) {
     options.autoSessionTracking = true;

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -79,7 +79,10 @@ export function init(options: NodeOptions): void {
   }
 
   buildMetadata(options, ['nextjs', 'node']);
-  options.environment = options.environment || process.env.NODE_ENV;
+
+  options.environment =
+    options.environment || process.env.SENTRY_ENVIRONMENT || process.env.VERCEL_ENV || process.env.NODE_ENV;
+
   addServerIntegrations(options);
   // Right now we only capture frontend sessions for Next.js
   options.autoSessionTracking = false;

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -9,6 +9,7 @@ import { escapeStringForRegex, logger } from '@sentry/utils';
 import * as domainModule from 'domain';
 import * as path from 'path';
 
+import { getVercelEnv } from '../common/getVercelEnv';
 import { buildMetadata } from '../common/metadata';
 import type { IntegrationWithExclusionOption } from '../common/userIntegrations';
 import { addOrUpdateIntegration } from '../common/userIntegrations';
@@ -81,10 +82,7 @@ export function init(options: NodeOptions): void {
   buildMetadata(options, ['nextjs', 'node']);
 
   options.environment =
-    options.environment ||
-    process.env.SENTRY_ENVIRONMENT ||
-    (process.env.VERCEL_ENV ? `vercel-${process.env.VERCEL_ENV}` : undefined) ||
-    process.env.NODE_ENV;
+    options.environment || process.env.SENTRY_ENVIRONMENT || getVercelEnv(false) || process.env.NODE_ENV;
 
   addServerIntegrations(options);
   // Right now we only capture frontend sessions for Next.js

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -81,7 +81,10 @@ export function init(options: NodeOptions): void {
   buildMetadata(options, ['nextjs', 'node']);
 
   options.environment =
-    options.environment || process.env.SENTRY_ENVIRONMENT || process.env.VERCEL_ENV || process.env.NODE_ENV;
+    options.environment ||
+    process.env.SENTRY_ENVIRONMENT ||
+    (process.env.VERCEL_ENV ? `vercel-${process.env.VERCEL_ENV}` : undefined) ||
+    process.env.NODE_ENV;
 
   addServerIntegrations(options);
   // Right now we only capture frontend sessions for Next.js


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/6993

This PR is just a quick win that should improve the ootb experience for Vercel on Next.js by setting the environment option to a sensible default provided by the hosting provider.

The `vercel-` prefix is so you can discern the vercel `development` environment from local development because there the `NODE_ENV` var with `development` is likely gonna be picked up.