### PR TITLE
test(replay): Ensure LCP spans have equals start and end timestamps (Playwright)

### DIFF
--- a/packages/integration-tests/suites/replay/customEvents/test.ts
+++ b/packages/integration-tests/suites/replay/customEvents/test.ts
@@ -10,6 +10,7 @@ import {
   expectedNavigationPerformanceSpan,
   getExpectedReplayEvent,
 } from '../../../utils/replayEventTemplates';
+import type { PerformanceSpan } from '../../../utils/replayHelpers';
 import {
   getCustomRecordingEvents,
   getReplayEvent,
@@ -68,6 +69,13 @@ sentryTest(
         expectedMemoryPerformanceSpan,
       ]),
     );
+
+    const lcpSpan = collectedPerformanceSpans.find(
+      s => s.description === 'largest-contentful-paint',
+    ) as PerformanceSpan;
+
+    // LCP spans should be point-in-time spans
+    expect(lcpSpan?.startTimestamp).toBeCloseTo(lcpSpan?.endTimestamp);
   },
 );
 

--- a/packages/integration-tests/utils/replayHelpers.ts
+++ b/packages/integration-tests/utils/replayHelpers.ts
@@ -6,7 +6,7 @@ import type { Page, Request } from 'playwright';
 import { envelopeRequestParser } from './helpers';
 
 type CustomRecordingEvent = { tag: string; payload: Record<string, unknown> };
-type PerformanceSpan = {
+export type PerformanceSpan = {
   op: string;
   description: string;
   startTimestamp: number;


### PR DESCRIPTION
Based on #7225, draft until merged, otherwise ready

Just adds a check for timestamp equality of LCP perf span start and end times
