### PR TITLE
fix(replay): Do not depend on `event.type` to infer `isCheckout`

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -534,7 +534,7 @@ export class ReplayContainer implements ReplayContainerInterface {
       // when an error occurs. Clear any state that happens before this current
       // checkout. This needs to happen before `addEvent()` which updates state
       // dependent on this reset.
-      if (this.recordingMode === 'error' && event.type === 2) {
+      if (this.recordingMode === 'error' && isCheckout) {
         this._setInitialState();
       }
 
@@ -542,9 +542,8 @@ export class ReplayContainer implements ReplayContainerInterface {
       // incremental event updates and should be appended
       void addEvent(this, event, isCheckout);
 
-      // Different behavior for full snapshots (type=2), ignore other event types
-      // See https://github.com/rrweb-io/rrweb/blob/d8f9290ca496712aa1e7d472549480c4e7876594/packages/rrweb/src/types.ts#L16
-      if (event.type !== 2) {
+      // Different behavior for checkouts, ignore other event types
+      if (!isCheckout) {
         return false;
       }
 


### PR DESCRIPTION
This relies on https://github.com/getsentry/rrweb/pull/56 to be merged & released first.

Currently, checking the `type` of the event is a bit brittle to infer if something is happening (e.g. the "checkout" event is often of type 4 and happens before the `type 2` full snapshot).

This is a requirement to get something like https://github.com/getsentry/rrweb/pull/55 landed, as that can trigger more full snapshots (without being a checkout), which in turn would lead to the error recording stuff not working as expected here.