### PR TITLE
feat(tracing): Add `enableTracing` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+This release adds a new `enableTracing` option, which can be used instead of `tracesSampleRate` for an easier setup.
+Related to this, the `hasTracingEnabled` utility function was moved from `@sentry/tracing` to `@sentry/core`.
+The old export from `@sentry/tracing` has been deprecated and will be removed in v8.
+
 ## 7.37.2
 
 This release includes changes and fixes around text masking and blocking in Replay's `rrweb` dependency. See versions [1.102.0](https://github.com/getsentry/rrweb/releases/tag/1.102.0) and [1.103.0](https://github.com/getsentry/rrweb/releases/tag/1.103.0).

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint:eslint": "lerna run lint:eslint",
     "postpublish": "lerna run --stream --concurrency 1 postpublish",
     "test": "lerna run --ignore @sentry-internal/* test",
+    "test:unit": "lerna run --ignore @sentry-internal/* test:unit",
     "test-ci-browser": "lerna run test --ignore \"@sentry/{node,opentelemetry-node,serverless,nextjs,remix,gatsby}\" --ignore @sentry-internal/*",
     "test-ci-node": "ts-node ./scripts/node-unit-tests.ts",
     "test:update-snapshots": "lerna run test:update-snapshots"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export { SDK_VERSION } from './version';
 export { getIntegrationsToSetup } from './integration';
 export { FunctionToString, InboundFilters } from './integrations';
 export { prepareEvent } from './utils/prepareEvent';
+export { hasTracingEnabled } from './utils/hasTracingEnabled';
 
 import * as Integrations from './integrations';
 

--- a/packages/core/src/utils/hasTracingEnabled.ts
+++ b/packages/core/src/utils/hasTracingEnabled.ts
@@ -1,0 +1,23 @@
+import type { Options } from '@sentry/types';
+
+import { getCurrentHub } from '../hub';
+
+// Treeshakable guard to remove all code related to tracing
+declare const __SENTRY_TRACING__: boolean | undefined;
+
+/**
+ * Determines if tracing is currently enabled.
+ *
+ * Tracing is enabled when at least one of `tracesSampleRate` and `tracesSampler` is defined in the SDK config.
+ */
+export function hasTracingEnabled(
+  maybeOptions?: Pick<Options, 'tracesSampleRate' | 'tracesSampler' | 'enableTracing'> | undefined,
+): boolean {
+  if (typeof __SENTRY_TRACING__ === 'boolean' && !__SENTRY_TRACING__) {
+    return false;
+  }
+
+  const client = getCurrentHub().getClient();
+  const options = maybeOptions || (client && client.getOptions());
+  return !!options && (options.enableTracing || 'tracesSampleRate' in options || 'tracesSampler' in options);
+}

--- a/packages/core/test/lib/utils/hasTracingEnabled.test.ts
+++ b/packages/core/test/lib/utils/hasTracingEnabled.test.ts
@@ -1,0 +1,32 @@
+import { hasTracingEnabled } from '../../../src';
+
+describe('hasTracingEnabled', () => {
+  const tracesSampler = () => 1;
+  const tracesSampleRate = 1;
+  it.each([
+    ['No options', undefined, false],
+    ['No tracesSampler or tracesSampleRate or enableTracing', {}, false],
+    ['With tracesSampler', { tracesSampler }, true],
+    ['With tracesSampleRate', { tracesSampleRate }, true],
+    ['With enableTracing=true', { enableTracing: true }, true],
+    ['With enableTracing=false', { enableTracing: false }, false],
+    ['With tracesSampler && enableTracing=false', { tracesSampler, enableTracing: false }, true],
+    ['With tracesSampleRate && enableTracing=false', { tracesSampler, enableTracing: false }, true],
+    ['With tracesSampler and tracesSampleRate', { tracesSampler, tracesSampleRate }, true],
+    [
+      'With tracesSampler and tracesSampleRate and enableTracing=true',
+      { tracesSampler, tracesSampleRate, enableTracing: true },
+      true,
+    ],
+    [
+      'With tracesSampler and tracesSampleRate and enableTracing=false',
+      { tracesSampler, tracesSampleRate, enableTracing: false },
+      true,
+    ],
+  ])(
+    '%s',
+    (_: string, input: Parameters<typeof hasTracingEnabled>[0], output: ReturnType<typeof hasTracingEnabled>) => {
+      expect(hasTracingEnabled(input)).toBe(output);
+    },
+  );
+});

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -20,6 +20,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@sentry/core": "7.38.0",
     "@sentry/react": "7.38.0",
     "@sentry/tracing": "7.38.0",
     "@sentry/types": "7.38.0",

--- a/packages/gatsby/src/utils/integrations.ts
+++ b/packages/gatsby/src/utils/integrations.ts
@@ -1,3 +1,4 @@
+import { hasTracingEnabled } from '@sentry/core';
 import * as Tracing from '@sentry/tracing';
 import type { Integration } from '@sentry/types';
 
@@ -13,7 +14,7 @@ export type UserIntegrations = Integration[] | UserFnIntegrations;
  * @param options The options users have defined.
  */
 export function getIntegrationsFromOptions(options: GatsbyOptions): UserIntegrations {
-  const isTracingEnabled = Tracing.hasTracingEnabled(options);
+  const isTracingEnabled = hasTracingEnabled(options);
   if (options.integrations === undefined) {
     return getIntegrationsFromArray([], isTracingEnabled);
   } else if (Array.isArray(options.integrations)) {

--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -1,7 +1,8 @@
+import { hasTracingEnabled } from '@sentry/core';
 import { RewriteFrames } from '@sentry/integrations';
 import type { BrowserOptions } from '@sentry/react';
 import { configureScope, init as reactInit, Integrations } from '@sentry/react';
-import { BrowserTracing, defaultRequestInstrumentationOptions, hasTracingEnabled } from '@sentry/tracing';
+import { BrowserTracing, defaultRequestInstrumentationOptions } from '@sentry/tracing';
 import type { EventProcessor } from '@sentry/types';
 
 import { getVercelEnv } from '../common/getVercelEnv';

--- a/packages/nextjs/src/edge/utils/edgeWrapperUtils.ts
+++ b/packages/nextjs/src/edge/utils/edgeWrapperUtils.ts
@@ -1,5 +1,4 @@
-import { captureException, getCurrentHub, startTransaction } from '@sentry/core';
-import { hasTracingEnabled } from '@sentry/tracing';
+import { captureException, getCurrentHub, hasTracingEnabled, startTransaction } from '@sentry/core';
 import type { Span } from '@sentry/types';
 import {
   addExceptionMechanism,

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -1,9 +1,8 @@
 import type { Carrier } from '@sentry/core';
-import { getHubFromCarrier, getMainCarrier } from '@sentry/core';
+import { getHubFromCarrier, getMainCarrier, hasTracingEnabled } from '@sentry/core';
 import { RewriteFrames } from '@sentry/integrations';
 import type { NodeOptions } from '@sentry/node';
 import { configureScope, getCurrentHub, init as nodeInit, Integrations } from '@sentry/node';
-import { hasTracingEnabled } from '@sentry/tracing';
 import type { EventProcessor } from '@sentry/types';
 import { escapeStringForRegex, logger } from '@sentry/utils';
 import * as domainModule from 'domain';

--- a/packages/nextjs/src/server/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/server/wrapApiHandlerWithSentry.ts
@@ -1,5 +1,6 @@
+import { hasTracingEnabled } from '@sentry/core';
 import { captureException, getCurrentHub, startTransaction } from '@sentry/node';
-import { extractTraceparentData, hasTracingEnabled } from '@sentry/tracing';
+import { extractTraceparentData } from '@sentry/tracing';
 import type { Transaction } from '@sentry/types';
 import {
   addExceptionMechanism,

--- a/packages/nextjs/src/server/wrapAppGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/server/wrapAppGetInitialPropsWithSentry.ts
@@ -1,5 +1,5 @@
+import { hasTracingEnabled } from '@sentry/core';
 import { getCurrentHub } from '@sentry/node';
-import { hasTracingEnabled } from '@sentry/tracing';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type App from 'next/app';
 

--- a/packages/nextjs/src/server/wrapDocumentGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/server/wrapDocumentGetInitialPropsWithSentry.ts
@@ -1,5 +1,5 @@
+import { hasTracingEnabled } from '@sentry/core';
 import { getCurrentHub } from '@sentry/node';
-import { hasTracingEnabled } from '@sentry/tracing';
 import type Document from 'next/document';
 
 import { isBuild } from './utils/isBuild';

--- a/packages/nextjs/src/server/wrapErrorGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/server/wrapErrorGetInitialPropsWithSentry.ts
@@ -1,5 +1,5 @@
+import { hasTracingEnabled } from '@sentry/core';
 import { getCurrentHub } from '@sentry/node';
-import { hasTracingEnabled } from '@sentry/tracing';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { NextPageContext } from 'next';
 import type { ErrorProps } from 'next/error';

--- a/packages/nextjs/src/server/wrapGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/server/wrapGetInitialPropsWithSentry.ts
@@ -1,5 +1,5 @@
+import { hasTracingEnabled } from '@sentry/core';
 import { getCurrentHub } from '@sentry/node';
-import { hasTracingEnabled } from '@sentry/tracing';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { NextPage } from 'next';
 

--- a/packages/nextjs/src/server/wrapGetServerSidePropsWithSentry.ts
+++ b/packages/nextjs/src/server/wrapGetServerSidePropsWithSentry.ts
@@ -1,5 +1,5 @@
+import { hasTracingEnabled } from '@sentry/core';
 import { getCurrentHub } from '@sentry/node';
-import { hasTracingEnabled } from '@sentry/tracing';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { GetServerSideProps } from 'next';
 

--- a/packages/nextjs/src/server/wrapGetStaticPropsWithSentry.ts
+++ b/packages/nextjs/src/server/wrapGetStaticPropsWithSentry.ts
@@ -1,5 +1,5 @@
+import { hasTracingEnabled } from '@sentry/core';
 import { getCurrentHub } from '@sentry/node';
-import { hasTracingEnabled } from '@sentry/tracing';
 import type { GetStaticProps } from 'next';
 
 import { isBuild } from './utils/isBuild';

--- a/packages/nextjs/test/config/wrappers.test.ts
+++ b/packages/nextjs/test/config/wrappers.test.ts
@@ -1,6 +1,5 @@
 import * as SentryCore from '@sentry/core';
 import * as SentryNode from '@sentry/node';
-import * as SentryTracing from '@sentry/tracing';
 import type { IncomingMessage, ServerResponse } from 'http';
 
 import { wrapGetInitialPropsWithSentry, wrapGetServerSidePropsWithSentry } from '../../src/server';
@@ -17,7 +16,7 @@ describe('data-fetching function wrappers', () => {
       req = { headers: {}, url: 'http://dogs.are.great/tricks/kangaroo' } as IncomingMessage;
       res = { end: jest.fn() } as unknown as ServerResponse;
 
-      jest.spyOn(SentryTracing, 'hasTracingEnabled').mockReturnValueOnce(true);
+      jest.spyOn(SentryCore, 'hasTracingEnabled').mockReturnValueOnce(true);
       jest.spyOn(SentryNode, 'getCurrentHub').mockReturnValueOnce({
         getClient: () =>
           ({

--- a/packages/nextjs/test/edge/edgeWrapperUtils.test.ts
+++ b/packages/nextjs/test/edge/edgeWrapperUtils.test.ts
@@ -1,5 +1,4 @@
 import * as coreSdk from '@sentry/core';
-import * as sentryTracing from '@sentry/tracing';
 
 import { withEdgeWrapping } from '../../src/edge/utils/edgeWrapperUtils';
 
@@ -30,7 +29,7 @@ afterAll(() => {
 beforeEach(() => {
   jest.clearAllMocks();
   jest.resetAllMocks();
-  jest.spyOn(sentryTracing, 'hasTracingEnabled').mockImplementation(() => true);
+  jest.spyOn(coreSdk, 'hasTracingEnabled').mockImplementation(() => true);
 });
 
 describe('withEdgeWrapping', () => {

--- a/packages/nextjs/test/edge/withSentryAPI.test.ts
+++ b/packages/nextjs/test/edge/withSentryAPI.test.ts
@@ -1,5 +1,4 @@
 import * as coreSdk from '@sentry/core';
-import * as sentryTracing from '@sentry/tracing';
 
 import { wrapApiHandlerWithSentry } from '../../src/edge';
 
@@ -32,7 +31,7 @@ afterAll(() => {
 beforeEach(() => {
   jest.resetAllMocks();
   jest.restoreAllMocks();
-  jest.spyOn(sentryTracing, 'hasTracingEnabled').mockImplementation(() => true);
+  jest.spyOn(coreSdk, 'hasTracingEnabled').mockImplementation(() => true);
 });
 
 describe('wrapApiHandlerWithSentry', () => {

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { captureException, getCurrentHub, startTransaction, withScope } from '@sentry/core';
+import { captureException, getCurrentHub, hasTracingEnabled, startTransaction, withScope } from '@sentry/core';
 import type { Span } from '@sentry/types';
 import type { AddRequestDataToEventOptions } from '@sentry/utils';
 import {
@@ -46,9 +46,7 @@ export function tracingHandler(): (
       return next();
     }
 
-    // TODO: This is the `hasTracingEnabled` check, but we're doing it manually since `@sentry/tracing` isn't a
-    // dependency of `@sentry/node`. Long term, that function should probably move to `@sentry/hub.
-    if (!('tracesSampleRate' in options) && !('tracesSampler' in options)) {
+    if (!hasTracingEnabled(options)) {
       __DEBUG_BUILD__ &&
         logger.warn(
           'Sentry `tracingHandler` is being used, but tracing is disabled. Please enable tracing by setting ' +

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -1,5 +1,4 @@
 import * as sentryCore from '@sentry/core';
-import { Hub, makeMain, Scope } from '@sentry/core';
 import { Transaction } from '@sentry/tracing';
 import type { Event } from '@sentry/types';
 import { SentryError } from '@sentry/utils';
@@ -47,7 +46,7 @@ describe('requestHandler', () => {
   it('autoSessionTracking is enabled, sets requestSession status to ok, when handling a request', () => {
     const options = getDefaultNodeClientOptions({ autoSessionTracking: true, release: '1.2' });
     client = new NodeClient(options);
-    const hub = new Hub(client);
+    const hub = new sentryCore.Hub(client);
 
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
 
@@ -60,7 +59,7 @@ describe('requestHandler', () => {
   it('autoSessionTracking is disabled, does not set requestSession, when handling a request', () => {
     const options = getDefaultNodeClientOptions({ autoSessionTracking: false, release: '1.2' });
     client = new NodeClient(options);
-    const hub = new Hub(client);
+    const hub = new sentryCore.Hub(client);
 
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
 
@@ -73,7 +72,7 @@ describe('requestHandler', () => {
   it('autoSessionTracking is enabled, calls _captureRequestSession, on response finish', done => {
     const options = getDefaultNodeClientOptions({ autoSessionTracking: true, release: '1.2' });
     client = new NodeClient(options);
-    const hub = new Hub(client);
+    const hub = new sentryCore.Hub(client);
 
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
 
@@ -94,7 +93,7 @@ describe('requestHandler', () => {
   it('autoSessionTracking is disabled, does not call _captureRequestSession, on response finish', done => {
     const options = getDefaultNodeClientOptions({ autoSessionTracking: false, release: '1.2' });
     client = new NodeClient(options);
-    const hub = new Hub(client);
+    const hub = new sentryCore.Hub(client);
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
 
     const captureRequestSession = jest.spyOn<any, any>(client, '_captureRequestSession');
@@ -138,7 +137,7 @@ describe('requestHandler', () => {
   });
 
   it('stores request and request data options in `sdkProcessingMetadata`', () => {
-    const hub = new Hub(new NodeClient(getDefaultNodeClientOptions()));
+    const hub = new sentryCore.Hub(new NodeClient(getDefaultNodeClientOptions()));
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
 
     const requestHandlerOptions = { include: { ip: false } };
@@ -165,7 +164,7 @@ describe('tracingHandler', () => {
 
   const sentryTracingMiddleware = tracingHandler();
 
-  let hub: Hub, req: http.IncomingMessage, res: http.ServerResponse, next: () => undefined;
+  let hub: sentryCore.Hub, req: http.IncomingMessage, res: http.ServerResponse, next: () => undefined;
 
   function createNoOpSpy() {
     const noop = { noop: () => undefined }; // this is wrapped in an object so jest can spy on it
@@ -173,7 +172,7 @@ describe('tracingHandler', () => {
   }
 
   beforeEach(() => {
-    hub = new Hub(new NodeClient(getDefaultNodeClientOptions({ tracesSampleRate: 1.0 })));
+    hub = new sentryCore.Hub(new NodeClient(getDefaultNodeClientOptions({ tracesSampleRate: 1.0 })));
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
     req = {
       headers,
@@ -271,7 +270,7 @@ describe('tracingHandler', () => {
   it('extracts request data for sampling context', () => {
     const tracesSampler = jest.fn();
     const options = getDefaultNodeClientOptions({ tracesSampler });
-    const hub = new Hub(new NodeClient(options));
+    const hub = new sentryCore.Hub(new NodeClient(options));
     hub.run(() => {
       sentryTracingMiddleware(req, res, next);
 
@@ -291,7 +290,7 @@ describe('tracingHandler', () => {
 
   it('puts its transaction on the scope', () => {
     const options = getDefaultNodeClientOptions({ tracesSampleRate: 1.0 });
-    const hub = new Hub(new NodeClient(options));
+    const hub = new sentryCore.Hub(new NodeClient(options));
 
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
 
@@ -411,7 +410,7 @@ describe('tracingHandler', () => {
 
   it('stores request in transaction metadata', () => {
     const options = getDefaultNodeClientOptions({ tracesSampleRate: 1.0 });
-    const hub = new Hub(new NodeClient(options));
+    const hub = new sentryCore.Hub(new NodeClient(options));
 
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
 
@@ -465,7 +464,7 @@ describe('errorHandler()', () => {
     client.initSessionFlusher();
 
     const scope = sentryCore.getCurrentHub().getScope();
-    const hub = new Hub(client);
+    const hub = new sentryCore.Hub(client);
 
     jest.spyOn<any, any>(client, '_captureRequestSession');
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
@@ -481,7 +480,7 @@ describe('errorHandler()', () => {
     client = new NodeClient(options);
 
     const scope = sentryCore.getCurrentHub().getScope();
-    const hub = new Hub(client);
+    const hub = new sentryCore.Hub(client);
 
     jest.spyOn<any, any>(client, '_captureRequestSession');
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
@@ -498,8 +497,8 @@ describe('errorHandler()', () => {
     // It is required to initialise SessionFlusher to capture Session Aggregates (it is usually initialised
     // by the`requestHandler`)
     client.initSessionFlusher();
-    const scope = new Scope();
-    const hub = new Hub(client, scope);
+    const scope = new sentryCore.Scope();
+    const hub = new sentryCore.Hub(client, scope);
 
     jest.spyOn<any, any>(client, '_captureRequestSession');
 
@@ -517,8 +516,8 @@ describe('errorHandler()', () => {
     // It is required to initialise SessionFlusher to capture Session Aggregates (it is usually initialised
     // by the`requestHandler`)
     client.initSessionFlusher();
-    const scope = new Scope();
-    const hub = new Hub(client, scope);
+    const scope = new sentryCore.Scope();
+    const hub = new sentryCore.Hub(client, scope);
 
     jest.spyOn<any, any>(client, '_captureRequestSession');
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
@@ -532,12 +531,12 @@ describe('errorHandler()', () => {
     const options = getDefaultNodeClientOptions({});
     client = new NodeClient(options);
 
-    const hub = new Hub(client);
-    makeMain(hub);
+    const hub = new sentryCore.Hub(client);
+    sentryCore.makeMain(hub);
 
     // `sentryErrorMiddleware` uses `withScope`, and we need access to the temporary scope it creates, so monkeypatch
     // `captureException` in order to examine the scope as it exists inside the `withScope` callback
-    hub.captureException = function (this: Hub, _exception: any) {
+    hub.captureException = function (this: sentryCore.Hub, _exception: any) {
       const scope = this.getScope();
       expect((scope as any)._sdkProcessingMetadata.request).toEqual(req);
     } as any;

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -1,7 +1,8 @@
 /* eslint-disable max-lines */
+import { hasTracingEnabled } from '@sentry/core';
 import type { Hub } from '@sentry/node';
 import { captureException, getCurrentHub } from '@sentry/node';
-import { getActiveTransaction, hasTracingEnabled } from '@sentry/tracing';
+import { getActiveTransaction } from '@sentry/tracing';
 import type { Transaction, TransactionSource, WrappedFunction } from '@sentry/types';
 import {
   addExceptionMechanism,

--- a/packages/remix/src/utils/serverAdapters/express.ts
+++ b/packages/remix/src/utils/serverAdapters/express.ts
@@ -1,6 +1,5 @@
-import { getCurrentHub } from '@sentry/core';
+import { getCurrentHub, hasTracingEnabled } from '@sentry/core';
 import { flush } from '@sentry/node';
-import { hasTracingEnabled } from '@sentry/tracing';
 import type { Transaction } from '@sentry/types';
 import { extractRequestData, isString, logger } from '@sentry/utils';
 import { cwd } from 'process';

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -45,6 +45,7 @@
     "lint": "run-s lint:prettier lint:eslint",
     "lint:eslint": "eslint . --format stylish",
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
+    "test:unit": "jest",
     "test": "jest",
     "test:watch": "jest --watch"
   },

--- a/packages/tracing/src/browser/request.ts
+++ b/packages/tracing/src/browser/request.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { getCurrentHub } from '@sentry/core';
+import { getCurrentHub, hasTracingEnabled } from '@sentry/core';
 import type { DynamicSamplingContext, Span } from '@sentry/types';
 import {
   addInstrumentationHandler,
@@ -8,8 +8,6 @@ import {
   isInstanceOf,
   stringMatchesSomePattern,
 } from '@sentry/utils';
-
-import { hasTracingEnabled } from '../utils';
 
 export const DEFAULT_TRACE_PROPAGATION_TARGETS = ['localhost', /^\//];
 

--- a/packages/tracing/src/hubextensions.ts
+++ b/packages/tracing/src/hubextensions.ts
@@ -1,5 +1,5 @@
 import type { Hub } from '@sentry/core';
-import { getMainCarrier } from '@sentry/core';
+import { getMainCarrier, hasTracingEnabled } from '@sentry/core';
 import type {
   ClientOptions,
   CustomSamplingContext,
@@ -14,7 +14,6 @@ import { dynamicRequire, isNaN, isNodeEnv, loadModule, logger } from '@sentry/ut
 import { registerErrorInstrumentation } from './errors';
 import { IdleTransaction } from './idletransaction';
 import { Transaction } from './transaction';
-import { hasTracingEnabled } from './utils';
 
 /** Returns all trace headers that are currently on the top scope. */
 function traceHeaders(this: Hub): { [key: string]: string } {

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -46,6 +46,7 @@ export { addExtensionMethods };
 export {
   extractTraceparentData,
   getActiveTransaction,
+  // eslint-disable-next-line deprecation/deprecation
   hasTracingEnabled,
   stripUrlQueryAndFragment,
   TRACEPARENT_REGEXP,

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -22,11 +22,11 @@ export { TRACEPARENT_REGEXP, extractTraceparentData } from '@sentry/utils';
  * Tracing is enabled when at least one of `tracesSampleRate` and `tracesSampler` is defined in the SDK config.
  */
 export function hasTracingEnabled(
-  maybeOptions?: Pick<Options, 'tracesSampleRate' | 'tracesSampler'> | undefined,
+  maybeOptions?: Pick<Options, 'tracesSampleRate' | 'tracesSampler' | 'enableTracing'> | undefined,
 ): boolean {
   const client = getCurrentHub().getClient();
   const options = maybeOptions || (client && client.getOptions());
-  return !!options && ('tracesSampleRate' in options || 'tracesSampler' in options);
+  return !!options && (options.enableTracing || 'tracesSampleRate' in options || 'tracesSampler' in options);
 }
 
 /** Grabs active transaction off scope, if any */

--- a/packages/tracing/src/utils.ts
+++ b/packages/tracing/src/utils.ts
@@ -1,5 +1,5 @@
 import type { Hub } from '@sentry/core';
-import { getCurrentHub } from '@sentry/core';
+import { getCurrentHub, hasTracingEnabled as _hasTracingEnabled } from '@sentry/core';
 import type { Options, Transaction } from '@sentry/types';
 
 /**
@@ -20,13 +20,12 @@ export { TRACEPARENT_REGEXP, extractTraceparentData } from '@sentry/utils';
  * Determines if tracing is currently enabled.
  *
  * Tracing is enabled when at least one of `tracesSampleRate` and `tracesSampler` is defined in the SDK config.
+ * @deprecated This export has moved to `@sentry/core`. This export will be removed from `@sentry/tracing` in v8.
  */
 export function hasTracingEnabled(
   maybeOptions?: Pick<Options, 'tracesSampleRate' | 'tracesSampler' | 'enableTracing'> | undefined,
 ): boolean {
-  const client = getCurrentHub().getClient();
-  const options = maybeOptions || (client && client.getOptions());
-  return !!options && (options.enableTracing || 'tracesSampleRate' in options || 'tracesSampler' in options);
+  return _hasTracingEnabled(maybeOptions);
 }
 
 /** Grabs active transaction off scope, if any */

--- a/packages/tracing/test/browser/request.test.ts
+++ b/packages/tracing/test/browser/request.test.ts
@@ -1,5 +1,5 @@
 import { BrowserClient } from '@sentry/browser';
-import { Hub, makeMain } from '@sentry/core';
+import * as sentryCore from '@sentry/core';
 import * as utils from '@sentry/utils';
 
 import type { Transaction } from '../../src';
@@ -7,7 +7,6 @@ import { Span, spanStatusfromHttpCode } from '../../src';
 import type { FetchData, XHRData } from '../../src/browser/request';
 import { fetchCallback, instrumentOutgoingRequests, shouldAttachHeaders, xhrCallback } from '../../src/browser/request';
 import { addExtensionMethods } from '../../src/hubextensions';
-import * as tracingUtils from '../../src/utils';
 import { getDefaultBrowserClientOptions } from '../testutils';
 
 beforeAll(() => {
@@ -17,7 +16,7 @@ beforeAll(() => {
   global.Request = {};
 });
 
-const hasTracingEnabled = jest.spyOn(tracingUtils, 'hasTracingEnabled');
+const hasTracingEnabled = jest.spyOn(sentryCore, 'hasTracingEnabled');
 const addInstrumentationHandler = jest.spyOn(utils, 'addInstrumentationHandler');
 const setRequestHeader = jest.fn();
 
@@ -47,7 +46,7 @@ describe('instrumentOutgoingRequests', () => {
 });
 
 describe('callbacks', () => {
-  let hub: Hub;
+  let hub: sentryCore.Hub;
   let transaction: Transaction;
   const alwaysCreateSpan = () => true;
   const alwaysAttachHeaders = () => true;
@@ -56,8 +55,8 @@ describe('callbacks', () => {
 
   beforeAll(() => {
     const options = getDefaultBrowserClientOptions({ tracesSampleRate: 1 });
-    hub = new Hub(new BrowserClient(options));
-    makeMain(hub);
+    hub = new sentryCore.Hub(new BrowserClient(options));
+    sentryCore.makeMain(hub);
   });
 
   beforeEach(() => {

--- a/packages/tracing/test/hub.test.ts
+++ b/packages/tracing/test/hub.test.ts
@@ -189,6 +189,57 @@ describe('Hub', () => {
         expect(transaction.sampled).toBe(true);
       });
 
+      it('should set sampled = true if enableTracing is true', () => {
+        const options = getDefaultBrowserClientOptions({ enableTracing: true });
+        const hub = new Hub(new BrowserClient(options));
+        makeMain(hub);
+        const transaction = hub.startTransaction({ name: 'dogpark' });
+
+        expect(transaction.sampled).toBe(true);
+      });
+
+      it('should set sampled = false if enableTracing is true & tracesSampleRate is 0', () => {
+        const options = getDefaultBrowserClientOptions({ enableTracing: true, tracesSampleRate: 0 });
+        const hub = new Hub(new BrowserClient(options));
+        makeMain(hub);
+        const transaction = hub.startTransaction({ name: 'dogpark' });
+
+        expect(transaction.sampled).toBe(false);
+      });
+
+      it('should set sampled = false if enableTracing is false & tracesSampleRate is 0', () => {
+        const options = getDefaultBrowserClientOptions({ enableTracing: false, tracesSampleRate: 0 });
+        const hub = new Hub(new BrowserClient(options));
+        makeMain(hub);
+        const transaction = hub.startTransaction({ name: 'dogpark' });
+
+        expect(transaction.sampled).toBe(false);
+      });
+
+      it('should prefer tracesSampler returning false to enableTracing', () => {
+        // make the two options do opposite things to prove precedence
+        const tracesSampler = jest.fn().mockReturnValue(false);
+        const options = getDefaultBrowserClientOptions({ enableTracing: true, tracesSampler });
+        const hub = new Hub(new BrowserClient(options));
+        makeMain(hub);
+        const transaction = hub.startTransaction({ name: 'dogpark' });
+
+        expect(tracesSampler).toHaveBeenCalled();
+        expect(transaction.sampled).toBe(false);
+      });
+
+      it('should prefer tracesSampler returning true to enableTracing', () => {
+        // make the two options do opposite things to prove precedence
+        const tracesSampler = jest.fn().mockReturnValue(true);
+        const options = getDefaultBrowserClientOptions({ enableTracing: false, tracesSampler });
+        const hub = new Hub(new BrowserClient(options));
+        makeMain(hub);
+        const transaction = hub.startTransaction({ name: 'dogpark' });
+
+        expect(tracesSampler).toHaveBeenCalled();
+        expect(transaction.sampled).toBe(true);
+      });
+
       it('should not try to override explicitly set positive sampling decision', () => {
         // so that the decision otherwise would be false
         const tracesSampler = jest.fn().mockReturnValue(0);

--- a/packages/tracing/test/utils.test.ts
+++ b/packages/tracing/test/utils.test.ts
@@ -5,10 +5,24 @@ describe('hasTracingEnabled', () => {
   const tracesSampleRate = 1;
   it.each([
     ['No options', undefined, false],
-    ['No tracesSampler or tracesSampleRate', {}, false],
+    ['No tracesSampler or tracesSampleRate or enableTracing', {}, false],
     ['With tracesSampler', { tracesSampler }, true],
     ['With tracesSampleRate', { tracesSampleRate }, true],
+    ['With enableTracing=true', { enableTracing: true }, true],
+    ['With enableTracing=false', { enableTracing: false }, false],
+    ['With tracesSampler && enableTracing=false', { tracesSampler, enableTracing: false }, true],
+    ['With tracesSampleRate && enableTracing=false', { tracesSampler, enableTracing: false }, true],
     ['With tracesSampler and tracesSampleRate', { tracesSampler, tracesSampleRate }, true],
+    [
+      'With tracesSampler and tracesSampleRate and enableTracing=true',
+      { tracesSampler, tracesSampleRate, enableTracing: true },
+      true,
+    ],
+    [
+      'With tracesSampler and tracesSampleRate and enableTracing=false',
+      { tracesSampler, tracesSampleRate, enableTracing: false },
+      true,
+    ],
   ])(
     '%s',
     (_: string, input: Parameters<typeof hasTracingEnabled>[0], output: ReturnType<typeof hasTracingEnabled>) => {

--- a/packages/tracing/test/utils.test.ts
+++ b/packages/tracing/test/utils.test.ts
@@ -1,6 +1,6 @@
 import { extractTraceparentData, hasTracingEnabled } from '../src/utils';
 
-describe('hasTracingEnabled', () => {
+describe('hasTracingEnabled (deprecated)', () => {
   const tracesSampler = () => 1;
   const tracesSampleRate = 1;
   it.each([
@@ -25,7 +25,9 @@ describe('hasTracingEnabled', () => {
     ],
   ])(
     '%s',
+    // eslint-disable-next-line deprecation/deprecation
     (_: string, input: Parameters<typeof hasTracingEnabled>[0], output: ReturnType<typeof hasTracingEnabled>) => {
+      // eslint-disable-next-line deprecation/deprecation
       expect(hasTracingEnabled(input)).toBe(output);
     },
   );

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -97,6 +97,13 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
   tracesSampleRate?: number;
 
   /**
+   * If this is enabled, transactions and trace data will be generated and captured.
+   * This will set the `tracesSampleRate` to the recommended default of `1.0`.
+   * Note that `tracesSampleRate` and `tracesSampler` take precedence over this option.
+   */
+  enableTracing?: boolean;
+
+  /**
    * Initial data to populate scope.
    */
   initialScope?: CaptureContext;

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -98,7 +98,7 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
 
   /**
    * If this is enabled, transactions and trace data will be generated and captured.
-   * This will set the `tracesSampleRate` to the recommended default of `1.0`.
+   * This will set the `tracesSampleRate` to the recommended default of `1.0` if `tracesSampleRate` is undefined.
    * Note that `tracesSampleRate` and `tracesSampler` take precedence over this option.
    */
   enableTracing?: boolean;

--- a/packages/vue/src/sdk.ts
+++ b/packages/vue/src/sdk.ts
@@ -1,4 +1,5 @@
 import { init as browserInit, SDK_VERSION } from '@sentry/browser';
+import { hasTracingEnabled } from '@sentry/core';
 import { arrayify, GLOBAL_OBJ } from '@sentry/utils';
 
 import { DEFAULT_HOOKS } from './constants';
@@ -80,7 +81,7 @@ const vueInit = (app: Vue, options: Options): void => {
 
   attachErrorHandler(app, options);
 
-  if ('tracesSampleRate' in options || 'tracesSampler' in options) {
+  if (hasTracingEnabled(options)) {
     app.mixin(
       createTracingMixins({
         ...options,


### PR DESCRIPTION
This adds a new `enableTracing` option, which can be used to streamline performance collection.

* Setting this to `true` will default the `tracesSampleRate` basically to 1
* It is overwritten by `tracesSampleRate` and `tracesSampler`, if they are defined

This change also moves the `hasTracingEnabled` util to `@sentry/core`, so we can use it everywhere in a consistent way.

Closes https://github.com/getsentry/sentry-javascript/issues/7065
