### PR TITLE
ci: Add timeout to integration tests job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -528,7 +528,7 @@ jobs:
     needs: [job_get_metadata, job_build]
     if: needs.job_get_metadata.outputs.changed_browser_integration == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -469,7 +469,7 @@ jobs:
     name: Nextjs (Node ${{ matrix.node }}) Tests
     needs: [job_get_metadata, job_build]
     if: needs.job_get_metadata.outputs.changed_nextjs == 'true' || github.event_name != 'pull_request'
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -431,7 +431,7 @@ jobs:
   job_node_unit_tests:
     name: Node (${{ matrix.node }}) Unit Tests
     needs: [job_get_metadata, job_build]
-    timeout-minutes: 30
+    timeout-minutes: 10
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -469,7 +469,7 @@ jobs:
     name: Nextjs (Node ${{ matrix.node }}) Tests
     needs: [job_get_metadata, job_build]
     if: needs.job_get_metadata.outputs.changed_nextjs == 'true' || github.event_name != 'pull_request'
-    timeout-minutes: 30
+    timeout-minutes: 10
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
@@ -528,6 +528,7 @@ jobs:
     needs: [job_get_metadata, job_build]
     if: needs.job_get_metadata.outputs.changed_browser_integration == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-20.04
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Just noticed that the playwright tests go on forever, so adding a 10min timeout there should help.
Also reducing this from 30m to 10m for some other jobs, which should be sufficient IMHO.