### PR TITLE
test(replay): Ensure that unicode characters are handled correctly

### DIFF
--- a/packages/integration-tests/suites/replay/unicode/compressed/init.js
+++ b/packages/integration-tests/suites/replay/unicode/compressed/init.js
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+window.Replay = new Sentry.Replay({
+  flushMinDelay: 500,
+  flushMaxDelay: 500,
+  useCompression: true,
+  maskAllText: false,
+});
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  sampleRate: 0,
+  replaysSessionSampleRate: 1.0,
+  replaysOnErrorSampleRate: 0.0,
+
+  integrations: [window.Replay],
+});

--- a/packages/integration-tests/suites/replay/unicode/compressed/test.ts
+++ b/packages/integration-tests/suites/replay/unicode/compressed/test.ts
@@ -1,0 +1,33 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import {
+  getFullRecordingSnapshots,
+  normalize,
+  shouldSkipReplayTest,
+  waitForReplayRequest,
+} from '../../../../utils/replayHelpers';
+
+sentryTest('replay should handle unicode characters', async ({ getLocalTestPath, page }) => {
+  if (shouldSkipReplayTest()) {
+    sentryTest.skip();
+  }
+
+  const reqPromise0 = waitForReplayRequest(page, 0);
+
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  await page.goto(url);
+  const snapshots = getFullRecordingSnapshots(await reqPromise0);
+
+  expect(snapshots.length).toEqual(1);
+  expect(normalize(snapshots[0])).toMatchSnapshot('unicode-compressed.json');
+});

--- a/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-chromium.json
+++ b/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-chromium.json
@@ -1,0 +1,123 @@
+{
+  "node": {
+    "type": 0,
+    "childNodes": [
+      {
+        "type": 1,
+        "name": "html",
+        "publicId": "",
+        "systemId": "",
+        "id": 2
+      },
+      {
+        "type": 2,
+        "tagName": "html",
+        "attributes": {},
+        "childNodes": [
+          {
+            "type": 2,
+            "tagName": "head",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "meta",
+                "attributes": {
+                  "charset": "utf-8"
+                },
+                "childNodes": [],
+                "id": 5
+              }
+            ],
+            "id": 4
+          },
+          {
+            "type": 3,
+            "textContent": "\n  ",
+            "id": 6
+          },
+          {
+            "type": 2,
+            "tagName": "body",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 3,
+                "textContent": "\n    ",
+                "id": 8
+              },
+              {
+                "type": 2,
+                "tagName": "h1",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "Hi 👋👋👋",
+                    "id": 10
+                  }
+                ],
+                "id": 9
+              },
+              {
+                "type": 3,
+                "textContent": "\n    ",
+                "id": 11
+              },
+              {
+                "type": 2,
+                "tagName": "p",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
+                    "id": 13
+                  }
+                ],
+                "id": 12
+              },
+              {
+                "type": 3,
+                "textContent": "\n\n    ",
+                "id": 14
+              },
+              {
+                "type": 2,
+                "tagName": "button",
+                "attributes": {
+                  "id": "go-background"
+                },
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "✅ Acknowledge",
+                    "id": 16
+                  }
+                ],
+                "id": 15
+              },
+              {
+                "type": 3,
+                "textContent": "\n  ",
+                "id": 17
+              },
+              {
+                "type": 3,
+                "textContent": "\n\n🐈‍⬛\n",
+                "id": 18
+              }
+            ],
+            "id": 7
+          }
+        ],
+        "id": 3
+      }
+    ],
+    "id": 1
+  },
+  "initialOffset": {
+    "left": 0,
+    "top": 0
+  }
+}

--- a/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-chromium.json
+++ b/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-chromium.json
@@ -104,7 +104,7 @@
               },
               {
                 "type": 3,
-                "textContent": "\n\n🐈‍⬛\n",
+                "textContent": "\n\n",
                 "id": 18
               }
             ],

--- a/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-firefox.json
+++ b/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-firefox.json
@@ -1,0 +1,123 @@
+{
+  "node": {
+    "type": 0,
+    "childNodes": [
+      {
+        "type": 1,
+        "name": "html",
+        "publicId": "",
+        "systemId": "",
+        "id": 2
+      },
+      {
+        "type": 2,
+        "tagName": "html",
+        "attributes": {},
+        "childNodes": [
+          {
+            "type": 2,
+            "tagName": "head",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "meta",
+                "attributes": {
+                  "charset": "utf-8"
+                },
+                "childNodes": [],
+                "id": 5
+              }
+            ],
+            "id": 4
+          },
+          {
+            "type": 3,
+            "textContent": "\n  ",
+            "id": 6
+          },
+          {
+            "type": 2,
+            "tagName": "body",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 3,
+                "textContent": "\n    ",
+                "id": 8
+              },
+              {
+                "type": 2,
+                "tagName": "h1",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "Hi 👋👋👋",
+                    "id": 10
+                  }
+                ],
+                "id": 9
+              },
+              {
+                "type": 3,
+                "textContent": "\n    ",
+                "id": 11
+              },
+              {
+                "type": 2,
+                "tagName": "p",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
+                    "id": 13
+                  }
+                ],
+                "id": 12
+              },
+              {
+                "type": 3,
+                "textContent": "\n\n    ",
+                "id": 14
+              },
+              {
+                "type": 2,
+                "tagName": "button",
+                "attributes": {
+                  "id": "go-background"
+                },
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "✅ Acknowledge",
+                    "id": 16
+                  }
+                ],
+                "id": 15
+              },
+              {
+                "type": 3,
+                "textContent": "\n  ",
+                "id": 17
+              },
+              {
+                "type": 3,
+                "textContent": "\n\n🐈‍⬛\n",
+                "id": 18
+              }
+            ],
+            "id": 7
+          }
+        ],
+        "id": 3
+      }
+    ],
+    "id": 1
+  },
+  "initialOffset": {
+    "left": 0,
+    "top": 0
+  }
+}

--- a/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-firefox.json
+++ b/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-firefox.json
@@ -104,7 +104,7 @@
               },
               {
                 "type": 3,
-                "textContent": "\n\n🐈‍⬛\n",
+                "textContent": "\n\n",
                 "id": 18
               }
             ],

--- a/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-webkit.json
+++ b/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-webkit.json
@@ -1,0 +1,123 @@
+{
+  "node": {
+    "type": 0,
+    "childNodes": [
+      {
+        "type": 1,
+        "name": "html",
+        "publicId": "",
+        "systemId": "",
+        "id": 2
+      },
+      {
+        "type": 2,
+        "tagName": "html",
+        "attributes": {},
+        "childNodes": [
+          {
+            "type": 2,
+            "tagName": "head",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "meta",
+                "attributes": {
+                  "charset": "utf-8"
+                },
+                "childNodes": [],
+                "id": 5
+              }
+            ],
+            "id": 4
+          },
+          {
+            "type": 3,
+            "textContent": "\n  ",
+            "id": 6
+          },
+          {
+            "type": 2,
+            "tagName": "body",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 3,
+                "textContent": "\n    ",
+                "id": 8
+              },
+              {
+                "type": 2,
+                "tagName": "h1",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "Hi 👋👋👋",
+                    "id": 10
+                  }
+                ],
+                "id": 9
+              },
+              {
+                "type": 3,
+                "textContent": "\n    ",
+                "id": 11
+              },
+              {
+                "type": 2,
+                "tagName": "p",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
+                    "id": 13
+                  }
+                ],
+                "id": 12
+              },
+              {
+                "type": 3,
+                "textContent": "\n\n    ",
+                "id": 14
+              },
+              {
+                "type": 2,
+                "tagName": "button",
+                "attributes": {
+                  "id": "go-background"
+                },
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "✅ Acknowledge",
+                    "id": 16
+                  }
+                ],
+                "id": 15
+              },
+              {
+                "type": 3,
+                "textContent": "\n  ",
+                "id": 17
+              },
+              {
+                "type": 3,
+                "textContent": "\n\n🐈‍⬛\n",
+                "id": 18
+              }
+            ],
+            "id": 7
+          }
+        ],
+        "id": 3
+      }
+    ],
+    "id": 1
+  },
+  "initialOffset": {
+    "left": 0,
+    "top": 0
+  }
+}

--- a/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-webkit.json
+++ b/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-webkit.json
@@ -104,7 +104,7 @@
               },
               {
                 "type": 3,
-                "textContent": "\n\n🐈‍⬛\n",
+                "textContent": "\n\n",
                 "id": 18
               }
             ],

--- a/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed.json
+++ b/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed.json
@@ -1,0 +1,123 @@
+{
+  "node": {
+    "type": 0,
+    "childNodes": [
+      {
+        "type": 1,
+        "name": "html",
+        "publicId": "",
+        "systemId": "",
+        "id": 2
+      },
+      {
+        "type": 2,
+        "tagName": "html",
+        "attributes": {},
+        "childNodes": [
+          {
+            "type": 2,
+            "tagName": "head",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "meta",
+                "attributes": {
+                  "charset": "utf-8"
+                },
+                "childNodes": [],
+                "id": 5
+              }
+            ],
+            "id": 4
+          },
+          {
+            "type": 3,
+            "textContent": "\n  ",
+            "id": 6
+          },
+          {
+            "type": 2,
+            "tagName": "body",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 3,
+                "textContent": "\n    ",
+                "id": 8
+              },
+              {
+                "type": 2,
+                "tagName": "h1",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "Hi 👋👋👋",
+                    "id": 10
+                  }
+                ],
+                "id": 9
+              },
+              {
+                "type": 3,
+                "textContent": "\n    ",
+                "id": 11
+              },
+              {
+                "type": 2,
+                "tagName": "p",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
+                    "id": 13
+                  }
+                ],
+                "id": 12
+              },
+              {
+                "type": 3,
+                "textContent": "\n\n    ",
+                "id": 14
+              },
+              {
+                "type": 2,
+                "tagName": "button",
+                "attributes": {
+                  "id": "go-background"
+                },
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "✅ Acknowledge",
+                    "id": 16
+                  }
+                ],
+                "id": 15
+              },
+              {
+                "type": 3,
+                "textContent": "\n  ",
+                "id": 17
+              },
+              {
+                "type": 3,
+                "textContent": "\n\n🐈‍⬛\n",
+                "id": 18
+              }
+            ],
+            "id": 7
+          }
+        ],
+        "id": 3
+      }
+    ],
+    "id": 1
+  },
+  "initialOffset": {
+    "left": 0,
+    "top": 0
+  }
+}

--- a/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed.json
+++ b/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed.json
@@ -104,7 +104,7 @@
               },
               {
                 "type": 3,
-                "textContent": "\n\n🐈‍⬛\n",
+                "textContent": "\n\n",
                 "id": 18
               }
             ],

--- a/packages/integration-tests/suites/replay/unicode/subject.js
+++ b/packages/integration-tests/suites/replay/unicode/subject.js
@@ -1,0 +1,6 @@
+document.getElementById('go-background').addEventListener('click', () => {
+  Object.defineProperty(document, 'hidden', { value: true, writable: true });
+  const ev = document.createEvent('Event');
+  ev.initEvent('visibilitychange');
+  document.dispatchEvent(ev);
+});

--- a/packages/integration-tests/suites/replay/unicode/template.html
+++ b/packages/integration-tests/suites/replay/unicode/template.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <h1>Hi 👋👋👋</h1>
+    <p>
+      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We
+      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).
+    </p>
+
+    <button id="go-background">✅ Acknowledge</button>
+  </body>
+</html>
+🐈‍⬛

--- a/packages/integration-tests/suites/replay/unicode/template.html
+++ b/packages/integration-tests/suites/replay/unicode/template.html
@@ -13,4 +13,3 @@
     <button id="go-background">✅ Acknowledge</button>
   </body>
 </html>
-🐈‍⬛

--- a/packages/integration-tests/suites/replay/unicode/uncompressed/init.js
+++ b/packages/integration-tests/suites/replay/unicode/uncompressed/init.js
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+window.Replay = new Sentry.Replay({
+  flushMinDelay: 500,
+  flushMaxDelay: 500,
+  useCompression: false,
+  maskAllText: false,
+});
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  sampleRate: 0,
+  replaysSessionSampleRate: 1.0,
+  replaysOnErrorSampleRate: 0.0,
+
+  integrations: [window.Replay],
+});

--- a/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts
+++ b/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts
@@ -1,0 +1,34 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import {
+  getFullRecordingSnapshots,
+  normalize,
+  shouldSkipReplayTest,
+  waitForReplayRequest,
+} from '../../../../utils/replayHelpers';
+
+sentryTest('replay should handle unicode characters', async ({ getLocalTestPath, page }) => {
+  if (shouldSkipReplayTest()) {
+    sentryTest.skip();
+  }
+
+  const reqPromise0 = waitForReplayRequest(page, 0);
+
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  await page.goto(url);
+  const snapshots = getFullRecordingSnapshots(await reqPromise0);
+
+  expect(snapshots.length).toEqual(1);
+
+  expect(normalize(snapshots[0])).toMatchSnapshot('unicode-uncompressed.json');
+});

--- a/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-chromium.json
+++ b/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-chromium.json
@@ -1,0 +1,123 @@
+{
+  "node": {
+    "type": 0,
+    "childNodes": [
+      {
+        "type": 1,
+        "name": "html",
+        "publicId": "",
+        "systemId": "",
+        "id": 2
+      },
+      {
+        "type": 2,
+        "tagName": "html",
+        "attributes": {},
+        "childNodes": [
+          {
+            "type": 2,
+            "tagName": "head",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "meta",
+                "attributes": {
+                  "charset": "utf-8"
+                },
+                "childNodes": [],
+                "id": 5
+              }
+            ],
+            "id": 4
+          },
+          {
+            "type": 3,
+            "textContent": "\n  ",
+            "id": 6
+          },
+          {
+            "type": 2,
+            "tagName": "body",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 3,
+                "textContent": "\n    ",
+                "id": 8
+              },
+              {
+                "type": 2,
+                "tagName": "h1",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "Hi 👋👋👋",
+                    "id": 10
+                  }
+                ],
+                "id": 9
+              },
+              {
+                "type": 3,
+                "textContent": "\n    ",
+                "id": 11
+              },
+              {
+                "type": 2,
+                "tagName": "p",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
+                    "id": 13
+                  }
+                ],
+                "id": 12
+              },
+              {
+                "type": 3,
+                "textContent": "\n\n    ",
+                "id": 14
+              },
+              {
+                "type": 2,
+                "tagName": "button",
+                "attributes": {
+                  "id": "go-background"
+                },
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "✅ Acknowledge",
+                    "id": 16
+                  }
+                ],
+                "id": 15
+              },
+              {
+                "type": 3,
+                "textContent": "\n  ",
+                "id": 17
+              },
+              {
+                "type": 3,
+                "textContent": "\n\n🐈‍⬛\n",
+                "id": 18
+              }
+            ],
+            "id": 7
+          }
+        ],
+        "id": 3
+      }
+    ],
+    "id": 1
+  },
+  "initialOffset": {
+    "left": 0,
+    "top": 0
+  }
+}

--- a/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-chromium.json
+++ b/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-chromium.json
@@ -104,7 +104,7 @@
               },
               {
                 "type": 3,
-                "textContent": "\n\n🐈‍⬛\n",
+                "textContent": "\n\n",
                 "id": 18
               }
             ],

--- a/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-firefox.json
+++ b/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-firefox.json
@@ -1,0 +1,123 @@
+{
+  "node": {
+    "type": 0,
+    "childNodes": [
+      {
+        "type": 1,
+        "name": "html",
+        "publicId": "",
+        "systemId": "",
+        "id": 2
+      },
+      {
+        "type": 2,
+        "tagName": "html",
+        "attributes": {},
+        "childNodes": [
+          {
+            "type": 2,
+            "tagName": "head",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "meta",
+                "attributes": {
+                  "charset": "utf-8"
+                },
+                "childNodes": [],
+                "id": 5
+              }
+            ],
+            "id": 4
+          },
+          {
+            "type": 3,
+            "textContent": "\n  ",
+            "id": 6
+          },
+          {
+            "type": 2,
+            "tagName": "body",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 3,
+                "textContent": "\n    ",
+                "id": 8
+              },
+              {
+                "type": 2,
+                "tagName": "h1",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "Hi 👋👋👋",
+                    "id": 10
+                  }
+                ],
+                "id": 9
+              },
+              {
+                "type": 3,
+                "textContent": "\n    ",
+                "id": 11
+              },
+              {
+                "type": 2,
+                "tagName": "p",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
+                    "id": 13
+                  }
+                ],
+                "id": 12
+              },
+              {
+                "type": 3,
+                "textContent": "\n\n    ",
+                "id": 14
+              },
+              {
+                "type": 2,
+                "tagName": "button",
+                "attributes": {
+                  "id": "go-background"
+                },
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "✅ Acknowledge",
+                    "id": 16
+                  }
+                ],
+                "id": 15
+              },
+              {
+                "type": 3,
+                "textContent": "\n  ",
+                "id": 17
+              },
+              {
+                "type": 3,
+                "textContent": "\n\n🐈‍⬛\n",
+                "id": 18
+              }
+            ],
+            "id": 7
+          }
+        ],
+        "id": 3
+      }
+    ],
+    "id": 1
+  },
+  "initialOffset": {
+    "left": 0,
+    "top": 0
+  }
+}

--- a/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-firefox.json
+++ b/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-firefox.json
@@ -104,7 +104,7 @@
               },
               {
                 "type": 3,
-                "textContent": "\n\n🐈‍⬛\n",
+                "textContent": "\n\n",
                 "id": 18
               }
             ],

--- a/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-webkit.json
+++ b/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-webkit.json
@@ -1,0 +1,123 @@
+{
+  "node": {
+    "type": 0,
+    "childNodes": [
+      {
+        "type": 1,
+        "name": "html",
+        "publicId": "",
+        "systemId": "",
+        "id": 2
+      },
+      {
+        "type": 2,
+        "tagName": "html",
+        "attributes": {},
+        "childNodes": [
+          {
+            "type": 2,
+            "tagName": "head",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "meta",
+                "attributes": {
+                  "charset": "utf-8"
+                },
+                "childNodes": [],
+                "id": 5
+              }
+            ],
+            "id": 4
+          },
+          {
+            "type": 3,
+            "textContent": "\n  ",
+            "id": 6
+          },
+          {
+            "type": 2,
+            "tagName": "body",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 3,
+                "textContent": "\n    ",
+                "id": 8
+              },
+              {
+                "type": 2,
+                "tagName": "h1",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "Hi 👋👋👋",
+                    "id": 10
+                  }
+                ],
+                "id": 9
+              },
+              {
+                "type": 3,
+                "textContent": "\n    ",
+                "id": 11
+              },
+              {
+                "type": 2,
+                "tagName": "p",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
+                    "id": 13
+                  }
+                ],
+                "id": 12
+              },
+              {
+                "type": 3,
+                "textContent": "\n\n    ",
+                "id": 14
+              },
+              {
+                "type": 2,
+                "tagName": "button",
+                "attributes": {
+                  "id": "go-background"
+                },
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "✅ Acknowledge",
+                    "id": 16
+                  }
+                ],
+                "id": 15
+              },
+              {
+                "type": 3,
+                "textContent": "\n  ",
+                "id": 17
+              },
+              {
+                "type": 3,
+                "textContent": "\n\n🐈‍⬛\n",
+                "id": 18
+              }
+            ],
+            "id": 7
+          }
+        ],
+        "id": 3
+      }
+    ],
+    "id": 1
+  },
+  "initialOffset": {
+    "left": 0,
+    "top": 0
+  }
+}

--- a/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-webkit.json
+++ b/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-webkit.json
@@ -104,7 +104,7 @@
               },
               {
                 "type": 3,
-                "textContent": "\n\n🐈‍⬛\n",
+                "textContent": "\n\n",
                 "id": 18
               }
             ],

--- a/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed.json
+++ b/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed.json
@@ -1,0 +1,123 @@
+{
+  "node": {
+    "type": 0,
+    "childNodes": [
+      {
+        "type": 1,
+        "name": "html",
+        "publicId": "",
+        "systemId": "",
+        "id": 2
+      },
+      {
+        "type": 2,
+        "tagName": "html",
+        "attributes": {},
+        "childNodes": [
+          {
+            "type": 2,
+            "tagName": "head",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "meta",
+                "attributes": {
+                  "charset": "utf-8"
+                },
+                "childNodes": [],
+                "id": 5
+              }
+            ],
+            "id": 4
+          },
+          {
+            "type": 3,
+            "textContent": "\n  ",
+            "id": 6
+          },
+          {
+            "type": 2,
+            "tagName": "body",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 3,
+                "textContent": "\n    ",
+                "id": 8
+              },
+              {
+                "type": 2,
+                "tagName": "h1",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "Hi 👋👋👋",
+                    "id": 10
+                  }
+                ],
+                "id": 9
+              },
+              {
+                "type": 3,
+                "textContent": "\n    ",
+                "id": 11
+              },
+              {
+                "type": 2,
+                "tagName": "p",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
+                    "id": 13
+                  }
+                ],
+                "id": 12
+              },
+              {
+                "type": 3,
+                "textContent": "\n\n    ",
+                "id": 14
+              },
+              {
+                "type": 2,
+                "tagName": "button",
+                "attributes": {
+                  "id": "go-background"
+                },
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "✅ Acknowledge",
+                    "id": 16
+                  }
+                ],
+                "id": 15
+              },
+              {
+                "type": 3,
+                "textContent": "\n  ",
+                "id": 17
+              },
+              {
+                "type": 3,
+                "textContent": "\n\n🐈‍⬛\n",
+                "id": 18
+              }
+            ],
+            "id": 7
+          }
+        ],
+        "id": 3
+      }
+    ],
+    "id": 1
+  },
+  "initialOffset": {
+    "left": 0,
+    "top": 0
+  }
+}

--- a/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed.json
+++ b/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed.json
@@ -104,7 +104,7 @@
               },
               {
                 "type": 3,
-                "textContent": "\n\n🐈‍⬛\n",
+                "textContent": "\n\n",
                 "id": 18
               }
             ],


### PR DESCRIPTION
While working on #7082 we figured it'd be worthwhile to check that we handle unicode characters correctly. Especially when compressing payload we should check that nothing goes wrong.

Note: This test obviously only checks that the payloads _leave_ the SDK correctly. It cannot say anything about the replayer rendering them correctly in the Sentry UI. 

ref #7044
