### PR TITLE
test(replay): Fix flaky flush test

### DIFF
--- a/packages/integration-tests/suites/replay/flushing/init.js
+++ b/packages/integration-tests/suites/replay/flushing/init.js
@@ -4,6 +4,7 @@ window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
   flushMinDelay: 500,
   flushMaxDelay: 500,
+  useCompression: false,
 });
 
 Sentry.init({

--- a/packages/integration-tests/suites/replay/flushing/template.html
+++ b/packages/integration-tests/suites/replay/flushing/template.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8" />
   </head>
   <body>
-    <button id="go-background">New Tab</button>
     <button id="something">Do something</button>
   </body>
 </html>

--- a/packages/integration-tests/suites/replay/flushing/template.html
+++ b/packages/integration-tests/suites/replay/flushing/template.html
@@ -5,5 +5,6 @@
   </head>
   <body>
     <button id="go-background">New Tab</button>
+    <button id="something">Do something</button>
   </body>
 </html>

--- a/packages/integration-tests/suites/replay/flushing/test.ts
+++ b/packages/integration-tests/suites/replay/flushing/test.ts
@@ -47,7 +47,7 @@ for (let index = 0; index < 25; index++) {
         } catch {
           // ignore errors here, we don't care if the page is closed
         }
-      }, i * 50);
+      }, i * 200);
     }
 
     const replayEvent2 = getReplayEvent(await reqPromise2);

--- a/packages/integration-tests/suites/replay/flushing/test.ts
+++ b/packages/integration-tests/suites/replay/flushing/test.ts
@@ -39,16 +39,17 @@ for (let index = 0; index < 25; index++) {
       getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 1, urls: [] }),
     );
 
-    // trigger mouse click every 100ms, it should still flush after 0.5s even if clicks are ongoing
-    for (let i = 0; i < 70; i++) {
-      setTimeout(async () => {
-        try {
-          await page.click('#something');
-        } catch {
-          // ignore errors here, we don't care if the page is closed
-        }
-      }, i * 200);
-    }
+    // // trigger mouse click every 100ms, it should still flush after 0.5s even if clicks are ongoing
+    // for (let i = 0; i < 70; i++) {
+    //   setTimeout(async () => {
+    //     try {
+    //       await page.click('#something');
+    //     } catch {
+    //       // ignore errors here, we don't care if the page is closed
+    //     }
+    //   }, i * 100);
+    // }
+    await page.click('#something');
 
     const replayEvent2 = getReplayEvent(await reqPromise2);
     expect(replayEvent2).toEqual(

--- a/packages/integration-tests/suites/replay/flushing/test.ts
+++ b/packages/integration-tests/suites/replay/flushing/test.ts
@@ -8,7 +8,6 @@ import { getReplayEvent, shouldSkipReplayTest, waitForReplayRequest } from '../.
 const FLUSH_DELAY_SECONDS = 0.5;
 
 for (let index = 0; index < 25; index++) {
-  console.log('test', index);
   sentryTest(`replay recording flushes every FLUSH_DELAY_SECONDS (${index})}`, async ({ getLocalTestPath, page }) => {
     if (shouldSkipReplayTest()) {
       sentryTest.skip();
@@ -48,7 +47,7 @@ for (let index = 0; index < 25; index++) {
         } catch {
           // ignore errors here, we don't care if the page is closed
         }
-      }, i * 100);
+      }, i * 150);
     }
 
     const replayEvent2 = getReplayEvent(await reqPromise2);
@@ -60,10 +59,10 @@ for (let index = 0; index < 25; index++) {
     const diff1 = replayEvent1.timestamp! - replayEvent0.timestamp!;
     const diff2 = replayEvent2.timestamp! - replayEvent1.timestamp!;
 
-    // We want to check that the diff is between 0.1 and 0.9 seconds, to accomodate for some wiggle room
-    expect(diff1).toBeLessThan(FLUSH_DELAY_SECONDS + 0.4);
-    expect(diff1).toBeGreaterThanOrEqual(FLUSH_DELAY_SECONDS - 0.4);
-    expect(diff2).toBeLessThan(FLUSH_DELAY_SECONDS + 0.4);
-    expect(diff2).toBeGreaterThanOrEqual(FLUSH_DELAY_SECONDS - 0.4);
+    // We want to check that the diff is between 0.05 and 0.95 seconds, to accomodate for some wiggle room
+    expect(diff1).toBeLessThan(FLUSH_DELAY_SECONDS + 0.45);
+    expect(diff1).toBeGreaterThanOrEqual(FLUSH_DELAY_SECONDS - 0.45);
+    expect(diff2).toBeLessThan(FLUSH_DELAY_SECONDS + 0.45);
+    expect(diff2).toBeGreaterThanOrEqual(FLUSH_DELAY_SECONDS - 0.45);
   });
 }

--- a/packages/integration-tests/suites/replay/flushing/test.ts
+++ b/packages/integration-tests/suites/replay/flushing/test.ts
@@ -47,7 +47,7 @@ for (let index = 0; index < 25; index++) {
         } catch {
           // ignore errors here, we don't care if the page is closed
         }
-      }, i * 150);
+      }, i * 50);
     }
 
     const replayEvent2 = getReplayEvent(await reqPromise2);

--- a/packages/integration-tests/suites/replay/flushing/test.ts
+++ b/packages/integration-tests/suites/replay/flushing/test.ts
@@ -4,64 +4,55 @@ import { sentryTest } from '../../../utils/fixtures';
 import { getExpectedReplayEvent } from '../../../utils/replayEventTemplates';
 import { getReplayEvent, shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
-for (let index = 0; index < 50; index++) {
-  /*
-   * In this test we're explicitly not forcing a flush by triggering a visibility change.
-   * Instead, we want to verify that the `flushMaxDelay` works in the sense that eventually
-   * a flush is triggered if some events are in the buffer.
-   * Note: Due to timing problems and inconsistencies in Playwright/CI, we can't reliably
-   * assert on the flush timestamps. Therefore we only assert that events were eventually
-   * sent (i.e. flushed).
-   */
-  sentryTest(
-    `replay events are flushed after max flash delay was reached (${index})`,
-    async ({ getLocalTestPath, page }) => {
-      if (shouldSkipReplayTest()) {
-        sentryTest.skip();
+/*
+ * In this test we're explicitly not forcing a flush by triggering a visibility change.
+ * Instead, we want to verify that the `flushMaxDelay` works in the sense that eventually
+ * a flush is triggered if some events are in the buffer.
+ * Note: Due to timing problems and inconsistencies in Playwright/CI, we can't reliably
+ * assert on the flush timestamps. Therefore we only assert that events were eventually
+ * sent (i.e. flushed).
+ */
+sentryTest('replay events are flushed after max flush delay was reached', async ({ getLocalTestPath, page }) => {
+  if (shouldSkipReplayTest()) {
+    sentryTest.skip();
+  }
+
+  const reqPromise0 = waitForReplayRequest(page, 0);
+  const reqPromise1 = waitForReplayRequest(page, 1);
+  const reqPromise2 = waitForReplayRequest(page, 2);
+
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  await page.goto(url);
+  const replayEvent0 = getReplayEvent(await reqPromise0);
+  expect(replayEvent0).toEqual(getExpectedReplayEvent());
+
+  // trigger one mouse click
+  void page.click('#something');
+
+  // this must eventually lead to a flush after the max delay was reached
+  const replayEvent1 = getReplayEvent(await reqPromise1);
+  expect(replayEvent1).toEqual(getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 1, urls: [] }));
+
+  // trigger mouse click every 100ms, it should still flush after the max delay even if clicks are ongoing
+  for (let i = 0; i < 700; i++) {
+    setTimeout(async () => {
+      try {
+        await page.click('#something');
+      } catch {
+        // ignore errors here, we don't care if the page is closed
       }
+    }, i * 100);
+  }
 
-      const reqPromise0 = waitForReplayRequest(page, 0);
-      const reqPromise1 = waitForReplayRequest(page, 1);
-      const reqPromise2 = waitForReplayRequest(page, 2);
-
-      await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-        return route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({ id: 'test-id' }),
-        });
-      });
-
-      const url = await getLocalTestPath({ testDir: __dirname });
-
-      await page.goto(url);
-      const replayEvent0 = getReplayEvent(await reqPromise0);
-      expect(replayEvent0).toEqual(getExpectedReplayEvent());
-
-      // trigger one mouse click
-      void page.click('#something');
-
-      // this must eventually lead to a flush after the max delay was reached
-      const replayEvent1 = getReplayEvent(await reqPromise1);
-      expect(replayEvent1).toEqual(
-        getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 1, urls: [] }),
-      );
-
-      // trigger mouse click every 100ms, it should still flush after the max delay even if clicks are ongoing
-      for (let i = 0; i < 700; i++) {
-        setTimeout(async () => {
-          try {
-            await page.click('#something');
-          } catch {
-            // ignore errors here, we don't care if the page is closed
-          }
-        }, i * 100);
-      }
-
-      const replayEvent2 = getReplayEvent(await reqPromise2);
-      expect(replayEvent2).toEqual(
-        getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 2, urls: [] }),
-      );
-    },
-  );
-}
+  const replayEvent2 = getReplayEvent(await reqPromise2);
+  expect(replayEvent2).toEqual(getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 2, urls: [] }));
+});

--- a/packages/integration-tests/suites/replay/flushing/test.ts
+++ b/packages/integration-tests/suites/replay/flushing/test.ts
@@ -7,56 +7,63 @@ import { getReplayEvent, shouldSkipReplayTest, waitForReplayRequest } from '../.
 // Sync this with init.js - not we take seconds here instead of ms
 const FLUSH_DELAY_SECONDS = 0.5;
 
-sentryTest('replay recording flushes every 5s', async ({ getLocalTestPath, page }) => {
-  if (shouldSkipReplayTest()) {
-    sentryTest.skip();
-  }
+for (let index = 0; index < 25; index++) {
+  console.log('test', index);
+  sentryTest(`replay recording flushes every FLUSH_DELAY_SECONDS (${index})}`, async ({ getLocalTestPath, page }) => {
+    if (shouldSkipReplayTest()) {
+      sentryTest.skip();
+    }
 
-  const reqPromise0 = waitForReplayRequest(page, 0);
-  const reqPromise1 = waitForReplayRequest(page, 1);
-  const reqPromise2 = waitForReplayRequest(page, 2);
+    const reqPromise0 = waitForReplayRequest(page, 0);
+    const reqPromise1 = waitForReplayRequest(page, 1);
+    const reqPromise2 = waitForReplayRequest(page, 2);
 
-  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-    return route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ id: 'test-id' }),
+    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 'test-id' }),
+      });
     });
+
+    const url = await getLocalTestPath({ testDir: __dirname });
+
+    await page.goto(url);
+    const replayEvent0 = getReplayEvent(await reqPromise0);
+    expect(replayEvent0).toEqual(getExpectedReplayEvent());
+
+    // trigger mouse click
+    void page.click('#go-background');
+
+    const replayEvent1 = getReplayEvent(await reqPromise1);
+    expect(replayEvent1).toEqual(
+      getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 1, urls: [] }),
+    );
+
+    // trigger mouse click every 100ms, it should still flush after 0.5s even if clicks are ongoing
+    for (let i = 0; i < 70; i++) {
+      setTimeout(async () => {
+        try {
+          await page.click('#something');
+        } catch {
+          // ignore errors here, we don't care if the page is closed
+        }
+      }, i * 100);
+    }
+
+    const replayEvent2 = getReplayEvent(await reqPromise2);
+    expect(replayEvent2).toEqual(
+      getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 2, urls: [] }),
+    );
+
+    // Ensure time diff is about 500ms between each event
+    const diff1 = replayEvent1.timestamp! - replayEvent0.timestamp!;
+    const diff2 = replayEvent2.timestamp! - replayEvent1.timestamp!;
+
+    // We want to check that the diff is between 0.1 and 0.9 seconds, to accomodate for some wiggle room
+    expect(diff1).toBeLessThan(FLUSH_DELAY_SECONDS + 0.4);
+    expect(diff1).toBeGreaterThanOrEqual(FLUSH_DELAY_SECONDS - 0.4);
+    expect(diff2).toBeLessThan(FLUSH_DELAY_SECONDS + 0.4);
+    expect(diff2).toBeGreaterThanOrEqual(FLUSH_DELAY_SECONDS - 0.4);
   });
-
-  const url = await getLocalTestPath({ testDir: __dirname });
-
-  await page.goto(url);
-  const replayEvent0 = getReplayEvent(await reqPromise0);
-  expect(replayEvent0).toEqual(getExpectedReplayEvent());
-
-  // trigger mouse click
-  void page.click('#go-background');
-
-  const replayEvent1 = getReplayEvent(await reqPromise1);
-  expect(replayEvent1).toEqual(getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 1, urls: [] }));
-
-  // trigger mouse click every 100ms, it should still flush after 5s even if clicks are ongoing
-  for (let i = 0; i < 70; i++) {
-    setTimeout(async () => {
-      try {
-        await page.click('#go-background');
-      } catch {
-        // ignore errors here, we don't care if the page is closed
-      }
-    }, i * 100);
-  }
-
-  const replayEvent2 = getReplayEvent(await reqPromise2);
-  expect(replayEvent2).toEqual(getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 2, urls: [] }));
-
-  // Ensure time diff is about 500ms between each event
-  const diff1 = replayEvent1.timestamp! - replayEvent0.timestamp!;
-  const diff2 = replayEvent2.timestamp! - replayEvent1.timestamp!;
-
-  // We want to check that the diff is between 0.1 and 0.9 seconds, to accomodate for some wiggle room
-  expect(diff1).toBeLessThan(FLUSH_DELAY_SECONDS + 0.4);
-  expect(diff1).toBeGreaterThanOrEqual(FLUSH_DELAY_SECONDS - 0.4);
-  expect(diff2).toBeLessThan(FLUSH_DELAY_SECONDS + 0.4);
-  expect(diff2).toBeGreaterThanOrEqual(FLUSH_DELAY_SECONDS - 0.4);
-});
+}

--- a/packages/integration-tests/suites/replay/flushing/test.ts
+++ b/packages/integration-tests/suites/replay/flushing/test.ts
@@ -32,7 +32,7 @@ for (let index = 0; index < 25; index++) {
     expect(replayEvent0).toEqual(getExpectedReplayEvent());
 
     // trigger mouse click
-    void page.click('#go-background');
+    void page.click('#something');
 
     const replayEvent1 = getReplayEvent(await reqPromise1);
     expect(replayEvent1).toEqual(

--- a/packages/integration-tests/suites/replay/flushing/test.ts
+++ b/packages/integration-tests/suites/replay/flushing/test.ts
@@ -4,68 +4,56 @@ import { sentryTest } from '../../../utils/fixtures';
 import { getExpectedReplayEvent } from '../../../utils/replayEventTemplates';
 import { getReplayEvent, shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
-// Sync this with init.js - not we take seconds here instead of ms
-const FLUSH_DELAY_SECONDS = 0.5;
+for (let index = 0; index < 50; index++) {
+  sentryTest(
+    `replay events are flushed after max flash delay was reached (${index})`,
+    async ({ getLocalTestPath, page }) => {
+      if (shouldSkipReplayTest()) {
+        sentryTest.skip();
+      }
 
-for (let index = 0; index < 25; index++) {
-  sentryTest(`replay recording flushes every FLUSH_DELAY_SECONDS (${index})}`, async ({ getLocalTestPath, page }) => {
-    if (shouldSkipReplayTest()) {
-      sentryTest.skip();
-    }
+      const reqPromise0 = waitForReplayRequest(page, 0);
+      const reqPromise1 = waitForReplayRequest(page, 1);
+      const reqPromise2 = waitForReplayRequest(page, 2);
 
-    const reqPromise0 = waitForReplayRequest(page, 0);
-    const reqPromise1 = waitForReplayRequest(page, 1);
-    const reqPromise2 = waitForReplayRequest(page, 2);
-
-    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
-      return route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'test-id' }),
+      await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ id: 'test-id' }),
+        });
       });
-    });
 
-    const url = await getLocalTestPath({ testDir: __dirname });
+      const url = await getLocalTestPath({ testDir: __dirname });
 
-    await page.goto(url);
-    const replayEvent0 = getReplayEvent(await reqPromise0);
-    expect(replayEvent0).toEqual(getExpectedReplayEvent());
+      await page.goto(url);
+      const replayEvent0 = getReplayEvent(await reqPromise0);
+      expect(replayEvent0).toEqual(getExpectedReplayEvent());
 
-    // trigger mouse click
-    void page.click('#go-background');
+      // trigger one mouse click
+      void page.click('#something');
 
-    const replayEvent1 = getReplayEvent(await reqPromise1);
-    expect(replayEvent1).toEqual(
-      getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 1, urls: [] }),
-    );
+      // this must eventually lead to a flush after the max delay was reached
+      const replayEvent1 = getReplayEvent(await reqPromise1);
+      expect(replayEvent1).toEqual(
+        getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 1, urls: [] }),
+      );
 
-    // trigger mouse click every 100ms, it should still flush after 0.5s even if clicks are ongoing
-    for (let i = 0; i < 70; i++) {
-      setTimeout(async () => {
-        try {
-          await page.click('#go-background');
-        } catch {
-          // ignore errors here, we don't care if the page is closed
-        }
-      }, i * 100);
-    }
+      // trigger mouse click every 100ms, it should still flush after the max delay even if clicks are ongoing
+      for (let i = 0; i < 700; i++) {
+        setTimeout(async () => {
+          try {
+            await page.click('#something');
+          } catch {
+            // ignore errors here, we don't care if the page is closed
+          }
+        }, i * 100);
+      }
 
-    const replayEvent2 = getReplayEvent(await reqPromise2);
-    expect(replayEvent2).toEqual(
-      getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 2, urls: [] }),
-    );
-
-    // Ensure time diff is about 500ms between each event
-    const diff1 = replayEvent1.timestamp! - replayEvent0.timestamp!;
-    const diff2 = replayEvent2.timestamp! - replayEvent1.timestamp!;
-
-    // Playwright is very inconsistent with timing, so we have to ease up the expectations a lot here.
-    // Generally, we'd expect to see a diff of FLUSH_DELAY_SECONDS, but we've observed test flakes up to 2.5s.
-    // The beste we can do here is ensure that the flushes actually happen in a somewhat reasonable time frame within
-    // one order of magnitude of FLUSH_DELAY_SECONDS.
-    expect(diff1).toBeLessThan(FLUSH_DELAY_SECONDS * 10);
-    expect(diff1).toBeGreaterThanOrEqual(FLUSH_DELAY_SECONDS - 0.4);
-    expect(diff2).toBeLessThan(FLUSH_DELAY_SECONDS * 10);
-    expect(diff2).toBeGreaterThanOrEqual(FLUSH_DELAY_SECONDS - 0.4);
-  });
+      const replayEvent2 = getReplayEvent(await reqPromise2);
+      expect(replayEvent2).toEqual(
+        getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 2, urls: [] }),
+      );
+    },
+  );
 }

--- a/packages/integration-tests/suites/replay/flushing/test.ts
+++ b/packages/integration-tests/suites/replay/flushing/test.ts
@@ -5,6 +5,14 @@ import { getExpectedReplayEvent } from '../../../utils/replayEventTemplates';
 import { getReplayEvent, shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
 for (let index = 0; index < 50; index++) {
+  /*
+   * In this test we're explicitly not forcing a flush by triggering a visibility change.
+   * Instead, we want to verify that the `flushMaxDelay` works in the sense that eventually
+   * a flush is triggered if some events are in the buffer.
+   * Note: Due to timing problems and inconsistencies in Playwright/CI, we can't reliably
+   * assert on the flush timestamps. Therefore we only assert that events were eventually
+   * sent (i.e. flushed).
+   */
   sentryTest(
     `replay events are flushed after max flash delay was reached (${index})`,
     async ({ getLocalTestPath, page }) => {


### PR DESCRIPTION
This PR fixes the flakiness of our replay event flushing test by slightly changing the test requirements/expectations:

* Disabled compression to avoid potential timing problems
* Instead of asserting that a flush happens within a certain time frame from the last flush, we ease up this expectation so that we only expect _that_ another flush happens after the previous one, given that click events happened in between. 
* Instead of forcing a flush by triggering a visibility change (like we do a lot in other tests to avoid flakes), this test focuses on the max delay of flushing, thereby ensuring that our flushes are not debounced to eternity.

Note: I tested that flakes were gone by running this test 75x per CI job for multiple times and didn't see this test failing anymore. 

closes #7266