### PR TITLE
fix(ember): Disable performance in FastBoot

### DIFF
--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -25,6 +25,12 @@ function getSentryConfig() {
 }
 
 export function initialize(appInstance: ApplicationInstance): void {
+  // Disable in fastboot - we only want to run Sentry client-side
+  const fastboot = appInstance.lookup('service:fastboot') as { isFastBoot: boolean } | undefined;
+  if (fastboot?.isFastBoot) {
+    return;
+  }
+
   const config = getSentryConfig();
   if (config['disablePerformance']) {
     return;


### PR DESCRIPTION
We do not want to run the instance initializer in fastboot env, as that relies on Browser stuff.

Note that it would prob. make sense to skip all of sentry in fastboot (SSR), but that probably has to happen in user code. 
This fix at least should lead to the app not failing to be served when fastboot & sentry are installed.

ref https://github.com/getsentry/sentry-javascript/issues/7258
