### PR TITLE
fix(serverless): Capture custom tags in error events of GCP functions

### DIFF
--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -1,5 +1,5 @@
 import type { AddRequestDataToEventOptions } from '@sentry/node';
-import { flush, getCurrentHub } from '@sentry/node';
+import { captureException, flush, getCurrentHub } from '@sentry/node';
 import { extractTraceparentData } from '@sentry/tracing';
 import {
   baggageHeaderToDynamicSamplingContext,
@@ -131,13 +131,13 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
     try {
       fnResult = fn(req, res);
     } catch (err) {
-      getCurrentHub().captureException(err);
+      captureException(err);
       throw err;
     }
 
     if (isThenable(fnResult)) {
       fnResult.then(null, err => {
-        getCurrentHub().captureException(err);
+        captureException(err);
         throw err;
       });
     }

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -1,5 +1,5 @@
 import type { AddRequestDataToEventOptions } from '@sentry/node';
-import { captureException, flush, getCurrentHub } from '@sentry/node';
+import { flush, getCurrentHub } from '@sentry/node';
 import { extractTraceparentData } from '@sentry/tracing';
 import {
   baggageHeaderToDynamicSamplingContext,
@@ -9,7 +9,7 @@ import {
   stripUrlQueryAndFragment,
 } from '@sentry/utils';
 
-import { domainify, getActiveDomain, proxyFunction } from './../utils';
+import { domainify, proxyFunction } from './../utils';
 import type { HttpFunction, WrapperOptions } from './general';
 
 // TODO (v8 / #5257): Remove this whole old/new business and just use the new stuff


### PR DESCRIPTION
As reported in #7222, our GCP function `wrapHttpFunction` handler didn't capture custom tags in error events. We suspect that this was caused by the SDK listening to errors on the wrong domain. This PR changes the way we listen to errors by directly try/catching the function instead of listening to the domain's error callback.  

h/t @lforst for debugging this

fixes #7222 