### PR TITLE
fix(serverless): Capture custom tags in GCP Background and CloudEvent function error events

### DIFF
--- a/packages/serverless/src/gcpfunction/cloud_events.ts
+++ b/packages/serverless/src/gcpfunction/cloud_events.ts
@@ -1,5 +1,5 @@
 import { captureException, flush, getCurrentHub } from '@sentry/node';
-import { logger } from '@sentry/utils';
+import { isThenable, logger } from '@sentry/utils';
 
 import { domainify, getActiveDomain, proxyFunction } from '../utils';
 import type { CloudEventFunction, CloudEventFunctionWithCallback, WrapperOptions } from './general';
@@ -65,7 +65,22 @@ function _wrapCloudEventFunction(
     });
 
     if (fn.length > 1) {
-      return (fn as CloudEventFunctionWithCallback)(context, newCallback);
+      let fnResult;
+      try {
+        fnResult = (fn as CloudEventFunctionWithCallback)(context, newCallback);
+      } catch (err) {
+        captureException(err);
+        throw err;
+      }
+
+      if (isThenable(fnResult)) {
+        fnResult.then(null, err => {
+          captureException(err);
+          throw err;
+        });
+      }
+
+      return fnResult;
     }
 
     return Promise.resolve()

--- a/packages/serverless/src/gcpfunction/cloud_events.ts
+++ b/packages/serverless/src/gcpfunction/cloud_events.ts
@@ -49,8 +49,6 @@ function _wrapCloudEventFunction(
 
     const activeDomain = getActiveDomain()!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
 
-    activeDomain.on('error', captureException);
-
     const newCallback = activeDomain.bind((...args: unknown[]) => {
       if (args[0] !== null && args[0] !== undefined) {
         captureException(args[0]);


### PR DESCRIPTION
Following up on #7222 and #7298 this PR fixes adding custom tags for GCP Background and CloudEvent function error events. As for Http functions, we also previously captured errors just via `domain.on('error',...)` which used the wrong domain, leading to tags (+other data) not being captured correctly. With this fix, we now also directly capture exceptions during function invocation.

ref #7222