### PR TITLE
chore(angular-ivy): Update Angular `README`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ package. Please refer to the README and instructions of those SDKs for more deta
   integrations for Express
 - [`@sentry/angular`](https://github.com/getsentry/sentry-javascript/tree/master/packages/angular): Browser SDK with
   Angular integration enabled
+- [`@sentry/angular-ivy`](https://github.com/getsentry/sentry-javascript/tree/master/packages/angular-ivy): Browser SDK with
+  Angular integration enabled including native support for Angular's Ivy rendering engine.
 - [`@sentry/ember`](https://github.com/getsentry/sentry-javascript/tree/master/packages/ember): Browser SDK with Ember
   integration enabled
 - [`@sentry/react`](https://github.com/getsentry/sentry-javascript/tree/master/packages/react): Browser SDK with React

--- a/packages/angular-ivy/README.md
+++ b/packages/angular-ivy/README.md
@@ -6,15 +6,15 @@
 
 # Official Sentry SDK for Angular with Ivy Compatibility
 
+[![npm version](https://img.shields.io/npm/v/@sentry/angular-ivy.svg)](https://www.npmjs.com/package/@sentry/angular-ivy)
+[![npm dm](https://img.shields.io/npm/dm/@sentry/angular-ivy.svg)](https://www.npmjs.com/package/@sentry/angular-ivy)
+[![npm dt](https://img.shields.io/npm/dt/@sentry/angular-ivy.svg)](https://www.npmjs.com/package/@sentry/angular-ivy)
+
 ## Links
 
 - [Official SDK Docs](https://docs.sentry.io/platforms/javascript/angular/)
 
 ## Angular Version Compatibility
-
-**Note**: This SDK is still experimental and not yet stable.
-We do not yet make guarantees in terms of breaking changes, version compatibilities or semver.
-Please open a Github issue if you experience bugs or would like to share feedback.
 
 This SDK officially supports Angular 12-15 with Angular's new rendering engine, Ivy.
 

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -6,6 +6,10 @@
 
 # Official Sentry SDK for Angular
 
+[![npm version](https://img.shields.io/npm/v/@sentry/angular.svg)](https://www.npmjs.com/package/@sentry/angular)
+[![npm dm](https://img.shields.io/npm/dm/@sentry/angular.svg)](https://www.npmjs.com/package/@sentry/angular)
+[![npm dt](https://img.shields.io/npm/dt/@sentry/angular.svg)](https://www.npmjs.com/package/@sentry/angular)
+
 ## Links
 
 - [Official SDK Docs](https://docs.sentry.io/platforms/javascript/angular/)


### PR DESCRIPTION
This PR just makes a few changes to 3 readmes:
* angular-ivy: 
  * remove experimental note
  * add badges
* angular:
  * add badges
* main readme:
  * add entry for` @sentry/angular-ivy  `

still sort of ref #7265 