### PR TITLE
test(browser): Temporarily skip offline transport tests

### DIFF
--- a/packages/browser/test/unit/transports/offline.test.ts
+++ b/packages/browser/test/unit/transports/offline.test.ts
@@ -58,6 +58,7 @@ function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+// TODO: Temp. skipping this because it is very flaky - we should revisit this and make this non-flaky
 describe.skip('makeOfflineTransport', () => {
   beforeAll(async () => {
     await deleteDatabase('sentry');

--- a/packages/browser/test/unit/transports/offline.test.ts
+++ b/packages/browser/test/unit/transports/offline.test.ts
@@ -58,7 +58,7 @@ function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-describe('makeOfflineTransport', () => {
+describe.skip('makeOfflineTransport', () => {
   beforeAll(async () => {
     await deleteDatabase('sentry');
   });


### PR DESCRIPTION
Unfortunately, these tests are continuously flaky so we're disabling them temporarily until the flakes are resolved.

cc @timfish when you get back :) 

ref #7079 