### PR TITLE
ci: Avoid `continue-on-error` for nextjs tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -474,7 +474,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12, 14, 16, '18.13.0']
+        node: [10, 12, 14, 16, 18]
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3
@@ -507,14 +507,12 @@ jobs:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-Playwright-${{steps.playwright-version.outputs.version}}
       - name: Install Playwright browser if not cached
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        continue-on-error: true # playwright needs node >= 14
+        if: steps.playwright-cache.outputs.cache-hit != 'true' && matrix.node >= 14
         run: npx playwright install --with-deps
         env:
           PLAYWRIGHT_BROWSERS_PATH: ${{steps.npm-cache-dir.outputs.dir}}
       - name: Install OS dependencies of Playwright if cache hit
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        continue-on-error: true # playwright needs node >= 14
+        if: steps.playwright-cache.outputs.cache-hit == 'true' && matrix.node >= 14
         run: npx playwright install-deps
       - name: Run tests
         env:


### PR DESCRIPTION
Not 100% sure if this will work, but it would be nice to avoid having the error logs in all CI runs:

![image](https://user-images.githubusercontent.com/2411343/222125622-eba0fa52-6080-4277-87a7-1bfe368cc8d6.png)

Let's also see if stuff works with Node 18.14.2 again...!