### PR TITLE
feat(vue): Log errors to the console by default

### DIFF
--- a/packages/vue/src/sdk.ts
+++ b/packages/vue/src/sdk.ts
@@ -12,7 +12,7 @@ const globalWithVue = GLOBAL_OBJ as typeof GLOBAL_OBJ & { Vue: Vue };
 const DEFAULT_CONFIG: Options = {
   Vue: globalWithVue.Vue,
   attachProps: true,
-  logErrors: false,
+  logErrors: true,
   hooks: DEFAULT_HOOKS,
   timeout: 2000,
   trackComponents: false,


### PR DESCRIPTION
As brought up by @cleptric, right now our Vue SDK doesn't log errors occurring in the Vue renderer to the console by default. Users need to manually set [`logErrors: true`](https://docs.sentry.io/platforms/javascript/guides/vue/#vue-3---manual-initialization) to enable logging of errors. 

After an internal discussion, we decided to log errors by default. Users can continue to use `logErrors` to opt out of that. 

ref: https://github.com/getsentry/sentry-javascript/issues/1416

Docs PR: https://github.com/getsentry/sentry-docs/pull/6392