### PR TITLE
test(core): Skip flaky offline transport test

### DIFF
--- a/packages/browser/test/unit/transports/offline.test.ts
+++ b/packages/browser/test/unit/transports/offline.test.ts
@@ -58,8 +58,7 @@ function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-// TODO: Temp. skipping this because it is very flaky - we should revisit this and make this non-flaky
-describe.skip('makeOfflineTransport', () => {
+describe('makeOfflineTransport', () => {
   beforeAll(async () => {
     await deleteDatabase('sentry');
   });

--- a/packages/core/test/lib/transports/offline.test.ts
+++ b/packages/core/test/lib/transports/offline.test.ts
@@ -326,7 +326,7 @@ describe('makeOfflineTransport', () => {
     expect(getCalls()).toEqual([]);
   });
 
-  it(
+  it.skip(
     'Follows the Retry-After header',
     async () => {
       const { getCalls, store } = createTestStore(ERROR_ENVELOPE);


### PR DESCRIPTION
This PR
1. reverts #7305 as it seems these tests were in fact not flaky 🙈 
2. skips the actually flaky offline test from core, mentioned in #7079 until we properly fix the flake