### PR TITLE
ci: Fix overhead measurements runs on default branch

### DIFF
--- a/packages/overhead-metrics/configs/ci/process.ts
+++ b/packages/overhead-metrics/configs/ci/process.ts
@@ -1,3 +1,4 @@
+import fs from 'fs-extra';
 import path from 'path';
 
 import { ResultsAnalyzer } from '../../src/results/analyzer.js';
@@ -11,9 +12,16 @@ import { artifactName, baselineResultsDir, latestResultFile, previousResultsDir 
 const latestResult = Result.readFromFile(latestResultFile);
 const branch = await Git.branch;
 const baseBranch = await Git.baseBranch;
+const branchIsBase = await Git.branchIsBase;
 
 await GitHub.downloadPreviousArtifact(baseBranch, baselineResultsDir, artifactName);
-await GitHub.downloadPreviousArtifact(branch, previousResultsDir, artifactName);
+
+if (branchIsBase) {
+  await GitHub.downloadPreviousArtifact(branch, previousResultsDir, artifactName);
+} else {
+  // Copy over same results
+  await fs.copy(baselineResultsDir, previousResultsDir);
+}
 
 GitHub.writeOutput('artifactName', artifactName);
 GitHub.writeOutput('artifactPath', path.resolve(previousResultsDir));

--- a/packages/overhead-metrics/package.json
+++ b/packages/overhead-metrics/package.json
@@ -26,6 +26,7 @@
     "axios": "^1.2.2",
     "extract-zip": "^2.0.1",
     "filesize": "^10.0.6",
+    "fs-extra": "^11.1.0",
     "p-timeout": "^6.0.0",
     "playwright": "^1.31.1",
     "playwright-core": "^1.29.1",

--- a/packages/overhead-metrics/src/util/git.ts
+++ b/packages/overhead-metrics/src/util/git.ts
@@ -53,6 +53,15 @@ export const Git = {
     }
   },
 
+  get branchIsBase(): Promise<boolean> {
+    return (async () => {
+      const branch = await this.branch;
+      const baseBranch = await this.baseBranch;
+
+      return branch === baseBranch;
+    })();
+  },
+
   get hash(): Promise<GitHash> {
     return (async () => {
       let gitHash = await git.revparse('HEAD');

--- a/packages/overhead-metrics/src/util/github.ts
+++ b/packages/overhead-metrics/src/util/github.ts
@@ -60,7 +60,7 @@ async function tryAddOrUpdateComment(commentBuilder: PrCommentBuilder): Promise<
     console.log(
       `Determined PR number ${prNumber} based on GITHUB_REF environment variable: '${process.env.GITHUB_REF}'`,
     );
-  } else {
+  } else if (!(await Git.branchIsBase)) {
     prNumber = (
       await octokit.rest.pulls.list({
         ...defaultArgs,


### PR DESCRIPTION
Currently, it doesn't handle the fact that it runs the measurements on develop very well, and picks random PRs to add comments to 😬 
