### PR TITLE
feat: Ensure we use the same default `environment` everywhere

### DIFF
--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_ENVIRONMENT } from '@sentry/core';
 import type {
   DsnComponents,
   DynamicSamplingContext,
@@ -222,7 +223,7 @@ export function createProfilingEventEnvelope(
     platform: 'javascript',
     version: '1',
     release: event.release || '',
-    environment: event.environment || '',
+    environment: event.environment || DEFAULT_ENVIRONMENT,
     runtime: {
       name: 'javascript',
       version: WINDOW.navigator.userAgent,

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_ENVIRONMENT = 'production';

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -30,6 +30,7 @@ import {
   uuid4,
 } from '@sentry/utils';
 
+import { DEFAULT_ENVIRONMENT } from './constants';
 import { Scope } from './scope';
 import { closeSession, makeSession, updateSession } from './session';
 
@@ -409,7 +410,7 @@ export class Hub implements HubInterface {
    */
   public startSession(context?: SessionContext): Session {
     const { scope, client } = this.getStackTop();
-    const { release, environment } = (client && client.getOptions()) || {};
+    const { release, environment = DEFAULT_ENVIRONMENT } = (client && client.getOptions()) || {};
 
     // Will fetch userAgent if called from browser sdk
     const { userAgent } = GLOBAL_OBJ.navigator || {};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export { getIntegrationsToSetup } from './integration';
 export { FunctionToString, InboundFilters } from './integrations';
 export { prepareEvent } from './utils/prepareEvent';
 export { hasTracingEnabled } from './utils/hasTracingEnabled';
+export { DEFAULT_ENVIRONMENT } from './constants';
 
 import * as Integrations from './integrations';
 

--- a/packages/core/src/utils/prepareEvent.ts
+++ b/packages/core/src/utils/prepareEvent.ts
@@ -1,6 +1,7 @@
 import type { ClientOptions, Event, EventHint, StackParser } from '@sentry/types';
 import { dateTimestampInSeconds, GLOBAL_OBJ, normalize, resolvedSyncPromise, truncate, uuid4 } from '@sentry/utils';
 
+import { DEFAULT_ENVIRONMENT } from '../constants';
 import { Scope } from '../scope';
 
 /**
@@ -87,7 +88,7 @@ function applyClientOptions(event: Event, options: ClientOptions): void {
   const { environment, release, dist, maxValueLength = 250 } = options;
 
   if (!('environment' in event)) {
-    event.environment = 'environment' in options ? environment : 'production';
+    event.environment = 'environment' in options ? environment : DEFAULT_ENVIRONMENT;
   }
 
   if (event.release === undefined && release !== undefined) {

--- a/packages/tracing/src/transaction.ts
+++ b/packages/tracing/src/transaction.ts
@@ -1,5 +1,5 @@
 import type { Hub } from '@sentry/core';
-import { getCurrentHub } from '@sentry/core';
+import { DEFAULT_ENVIRONMENT, getCurrentHub } from '@sentry/core';
 import type {
   Context,
   Contexts,
@@ -260,7 +260,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
     const transaction = source && source !== 'url' ? this.name : undefined;
 
     const dsc = dropUndefinedKeys({
-      environment,
+      environment: environment || DEFAULT_ENVIRONMENT,
       release,
       transaction,
       user_segment,


### PR DESCRIPTION
This PR adjusts our code to use the same default environment everywhere in the codebase for consistency.
Currently, we use `production` some places and `''` in others.

I _may_ have missed something, but tried to find all places using this.

Closes https://github.com/getsentry/sentry-javascript/issues/6239
