### PR TITLE
fix(remix): Correctly parse `X-Forwarded-For` Http header

### DIFF
--- a/packages/remix/src/utils/getIpAddress.ts
+++ b/packages/remix/src/utils/getIpAddress.ts
@@ -52,7 +52,7 @@ export function getClientIPAddress(headers: Headers): string | null {
       return parseForwardedHeader(value);
     }
 
-    return value?.split(', ');
+    return value?.split(',').map((v: string) => v.trim());
   });
 
   // Flatten the array and filter out any falsy entries

--- a/packages/remix/test/utils/getIpAddress.test.ts
+++ b/packages/remix/test/utils/getIpAddress.test.ts
@@ -1,0 +1,37 @@
+import { getClientIPAddress } from '../../src/utils/getIpAddress';
+
+class Headers {
+  private headers: Record<string, string> = {};
+
+  get(key: string): string | null {
+    return this.headers[key] ?? null;
+  }
+
+  set(key: string, value: string): void {
+    this.headers[key] = value;
+  }
+}
+
+describe('getClientIPAddress', () => {
+  it.each([
+    [
+      '2b01:cb19:8350:ed00:d0dd:fa5b:de31:8be5,2b01:cb19:8350:ed00:d0dd:fa5b:de31:8be5, 141.101.69.35',
+      '2b01:cb19:8350:ed00:d0dd:fa5b:de31:8be5',
+    ],
+    [
+      '2b01:cb19:8350:ed00:d0dd:fa5b:de31:8be5,   2b01:cb19:8350:ed00:d0dd:fa5b:de31:8be5, 141.101.69.35',
+      '2b01:cb19:8350:ed00:d0dd:fa5b:de31:8be5',
+    ],
+    [
+      '2a01:cb19:8350:ed00:d0dd:INVALID_IP_ADDR:8be5,141.101.69.35,2a01:cb19:8350:ed00:d0dd:fa5b:de31:8be5',
+      '141.101.69.35',
+    ],
+  ])('should parse the IP from the X-Forwarded-For header %s', (headerValue, expectedIP) => {
+    const headers = new Headers();
+    headers.set('X-Forwarded-For', headerValue);
+
+    const ip = getClientIPAddress(headers as any);
+
+    expect(ip).toEqual(expectedIP);
+  });
+});

--- a/packages/remix/test/utils/getIpAddress.test.ts
+++ b/packages/remix/test/utils/getIpAddress.test.ts
@@ -26,6 +26,11 @@ describe('getClientIPAddress', () => {
       '2a01:cb19:8350:ed00:d0dd:INVALID_IP_ADDR:8be5,141.101.69.35,2a01:cb19:8350:ed00:d0dd:fa5b:de31:8be5',
       '141.101.69.35',
     ],
+    [
+      '2b01:cb19:8350:ed00:d0dd:fa5b:nope:8be5,   2b01:cb19:NOPE:ed00:d0dd:fa5b:de31:8be5,   141.101.69.35  ',
+      '141.101.69.35',
+    ],
+    ['2b01:cb19:8350:ed00:d0 dd:fa5b:de31:8be5, 141.101.69.35', '141.101.69.35'],
   ])('should parse the IP from the X-Forwarded-For header %s', (headerValue, expectedIP) => {
     const headers = new Headers();
     headers.set('X-Forwarded-For', headerValue);

--- a/packages/remix/test/utils/getIpAddress.test.ts
+++ b/packages/remix/test/utils/getIpAddress.test.ts
@@ -1,14 +1,14 @@
 import { getClientIPAddress } from '../../src/utils/getIpAddress';
 
 class Headers {
-  private headers: Record<string, string> = {};
+  private _headers: Record<string, string> = {};
 
   get(key: string): string | null {
-    return this.headers[key] ?? null;
+    return this._headers[key] ?? null;
   }
 
   set(key: string, value: string): void {
-    this.headers[key] = value;
+    this._headers[key] = value;
   }
 }
 


### PR DESCRIPTION
Seems like we had a bug in the Remix Server SDK when parsing the `X-Forwarded-For` Http header to obtain the user IP address. This PR attempts to fix this and adds a few unit tests tests.

Fixes #7323 (hopefully)