### PR TITLE
feat(tracing): Track PerformanceObserver interactions as spans

### DIFF
--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/assets/script.js
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/assets/script.js
@@ -1,4 +1,4 @@
-(() => {
+const delay = e => {
   const startTime = Date.now();
 
   function getElasped() {
@@ -6,7 +6,11 @@
     return time - startTime;
   }
 
-  while (getElasped() < 105) {
+  while (getElasped() < 70) {
     //
   }
-})();
+
+  e.target.classList.add('clicked');
+};
+
+document.querySelector('[data-test-id=interaction-button]').addEventListener('click', delay);

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/assets/script.js
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/assets/script.js
@@ -1,4 +1,4 @@
-const delay = () => {
+(() => {
   const startTime = Date.now();
 
   function getElasped() {
@@ -9,8 +9,4 @@ const delay = () => {
   while (getElasped() < 105) {
     //
   }
-};
-
-document.getElementById('interaction-button').addEventListener('click', delay);
-
-delay();
+})();

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/assets/script.js
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/assets/script.js
@@ -1,4 +1,4 @@
-(() => {
+const delay = () => {
   const startTime = Date.now();
 
   function getElasped() {
@@ -9,4 +9,8 @@
   while (getElasped() < 105) {
     //
   }
-})();
+};
+
+document.getElementById('interaction-button').addEventListener('click', delay);
+
+delay();

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/init.js
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/init.js
@@ -10,6 +10,7 @@ Sentry.init({
       idleTimeout: 1000,
       _experiments: {
         enableInteractions: true,
+        enableLongTask: false,
       },
     }),
   ],

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/template.html
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/template.html
@@ -6,6 +6,6 @@
   <body>
     <div>Rendered Before Long Task</div>
     <script src="https://example.com/path/to/script.js"></script>
-    <button data-test-id="interaction-button">Click Me</button>
+    <button data-test-id="interaction-button" id="interaction-button">Click Me</button>
   </body>
 </html>

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/template.html
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/template.html
@@ -6,6 +6,6 @@
   <body>
     <div>Rendered Before Long Task</div>
     <script src="https://example.com/path/to/script.js"></script>
-    <button data-test-id="interaction-button" id="interaction-button">Click Me</button>
+    <button data-test-id="interaction-button">Click Me</button>
   </body>
 </html>

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/template.html
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/template.html
@@ -5,7 +5,7 @@
   </head>
   <body>
     <div>Rendered Before Long Task</div>
-    <script src="https://example.com/path/to/script.js"></script>
     <button data-test-id="interaction-button">Click Me</button>
+    <script src="https://example.com/path/to/script.js"></script>
   </body>
 </html>

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
@@ -32,3 +32,30 @@ sentryTest('should capture interaction transaction.', async ({ browserName, getL
   expect(interactionSpan.op).toBe('ui.action.click');
   expect(interactionSpan.description).toBe('body > button');
 });
+
+sentryTest('should create only one transaction per interaction', async ({ browserName, getLocalTestPath, page }) => {
+  const supportedBrowsers = ['chromium', 'firefox'];
+
+  if (!supportedBrowsers.includes(browserName)) {
+    sentryTest.skip();
+  }
+
+  await page.route('**/path/to/script.js', (route: Route) => route.fulfill({ path: `${__dirname}/assets/script.js` }));
+
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  await getFirstSentryEnvelopeRequest<Event>(page, url);
+
+  for (let i = 0; i < 4; i++) {
+    setTimeout(async () => {
+      await page.locator('[data-test-id=interaction-button]').click();
+    }, i * 100);
+  }
+
+  const envelopes = await getMultipleSentryEnvelopeRequests<Event>(page, 4);
+  expect(envelopes).toHaveLength(4);
+
+  envelopes.forEach(event => {
+    expect(event.spans).toHaveLength(1);
+  });
+});

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
@@ -66,7 +66,7 @@ sentryTest('should create only one transaction per interaction', async ({ browse
 
   for (let i = 0; i < 4; i++) {
     await wait(100);
-    page.locator('[data-test-id=interaction-button]').click();
+    await page.locator('[data-test-id=interaction-button]').click();
     const envelope = await getMultipleSentryEnvelopeRequests<Event>(page, 1);
     expect(envelope[0].spans).toHaveLength(1);
   }

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
@@ -6,7 +6,9 @@ import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
 
 sentryTest('should capture interaction transaction.', async ({ browserName, getLocalTestPath, page }) => {
-  if (browserName !== 'chromium') {
+  const supportedBrowsers = ['chromium', 'firefox'];
+
+  if (!supportedBrowsers.includes(browserName)) {
     sentryTest.skip();
   }
 
@@ -21,17 +23,12 @@ sentryTest('should capture interaction transaction.', async ({ browserName, getL
   const envelopes = await getMultipleSentryEnvelopeRequests<Event>(page, 1);
   const eventData = envelopes[0];
 
-  expect(eventData).toEqual(
-    expect.objectContaining({
-      contexts: expect.objectContaining({
-        trace: expect.objectContaining({
-          op: 'ui.action.click',
-        }),
-      }),
-      platform: 'javascript',
-      spans: [],
-      tags: {},
-      type: 'transaction',
-    }),
-  );
+  expect(eventData.contexts).toMatchObject({ trace: { op: 'ui.action.click' } });
+  expect(eventData.platform).toBe('javascript');
+  expect(eventData.type).toBe('transaction');
+
+  expect(eventData.spans).toBeDefined();
+  const interactionSpan = eventData.spans![0];
+  expect(interactionSpan.op).toBe('ui.action.click');
+  expect(interactionSpan.description).toBe('body > button');
 });

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
@@ -30,7 +30,7 @@ sentryTest('should capture interaction transaction.', async ({ browserName, getL
   expect(eventData.spans).toHaveLength(1);
   const interactionSpan = eventData.spans![0];
   expect(interactionSpan.op).toBe('ui.action.click');
-  expect(interactionSpan.description).toBe('body > button#interaction-button');
+  expect(interactionSpan.description).toBe('body > button');
 });
 
 sentryTest('should create only one transaction per interaction', async ({ browserName, getLocalTestPath, page }) => {

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
@@ -30,7 +30,7 @@ sentryTest('should capture interaction transaction.', async ({ browserName, getL
   expect(eventData.spans).toHaveLength(1);
   const interactionSpan = eventData.spans![0];
   expect(interactionSpan.op).toBe('ui.action.click');
-  expect(interactionSpan.description).toBe('body > button');
+  expect(interactionSpan.description).toBe('body > button#interaction-button');
 });
 
 sentryTest('should create only one transaction per interaction', async ({ browserName, getLocalTestPath, page }) => {

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
@@ -27,7 +27,7 @@ sentryTest('should capture interaction transaction.', async ({ browserName, getL
   expect(eventData.platform).toBe('javascript');
   expect(eventData.type).toBe('transaction');
 
-  expect(eventData.spans).toBeDefined();
+  expect(eventData.spans).toHaveLength(1);
   const interactionSpan = eventData.spans![0];
   expect(interactionSpan.op).toBe('ui.action.click');
   expect(interactionSpan.description).toBe('body > button');

--- a/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
+++ b/packages/integration-tests/suites/tracing/browsertracing/interactions/test.ts
@@ -1,9 +1,16 @@
 import type { Route } from '@playwright/test';
 import { expect } from '@playwright/test';
-import type { Event } from '@sentry/types';
+import type { Event, Span, SpanContext, Transaction } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
+
+type TransactionJSON = ReturnType<Transaction['toJSON']> & {
+  spans: ReturnType<Span['toJSON']>[];
+  contexts: SpanContext;
+  platform: string;
+  type: string;
+};
 
 sentryTest('should capture interaction transaction.', async ({ browserName, getLocalTestPath, page }) => {
   const supportedBrowsers = ['chromium', 'firefox'];
@@ -16,21 +23,31 @@ sentryTest('should capture interaction transaction.', async ({ browserName, getL
 
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  await getFirstSentryEnvelopeRequest<Event>(page, url);
+  await page.goto(url);
+
+  await getFirstSentryEnvelopeRequest<Event>(page);
 
   await page.locator('[data-test-id=interaction-button]').click();
+  await page.locator('.clicked[data-test-id=interaction-button]').isVisible();
 
-  const envelopes = await getMultipleSentryEnvelopeRequests<Event>(page, 1);
+  const envelopes = await getMultipleSentryEnvelopeRequests<TransactionJSON>(page, 1);
+  expect(envelopes).toHaveLength(1);
+
   const eventData = envelopes[0];
 
   expect(eventData.contexts).toMatchObject({ trace: { op: 'ui.action.click' } });
   expect(eventData.platform).toBe('javascript');
   expect(eventData.type).toBe('transaction');
-
   expect(eventData.spans).toHaveLength(1);
+
   const interactionSpan = eventData.spans![0];
-  expect(interactionSpan.op).toBe('ui.action.click');
-  expect(interactionSpan.description).toBe('body > button');
+  expect(interactionSpan.op).toBe('ui.interaction.click');
+  expect(interactionSpan.description).toBe('body > button.clicked');
+  expect(interactionSpan.timestamp).toBeDefined();
+
+  const interactionSpanDuration = (interactionSpan.timestamp! - interactionSpan.start_timestamp) * 1000;
+  expect(interactionSpanDuration).toBeGreaterThan(70);
+  expect(interactionSpanDuration).toBeLessThan(200);
 });
 
 sentryTest('should create only one transaction per interaction', async ({ browserName, getLocalTestPath, page }) => {

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -192,9 +192,11 @@ export class BrowserTracing implements Integration {
     }
 
     startTrackingWebVitals();
-    startTrackingInteractions();
     if (this.options.enableLongTask) {
       startTrackingLongTasks();
+    }
+    if (this.options._experiments.enableInteractions) {
+      startTrackingInteractions();
     }
   }
 

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -8,7 +8,12 @@ import type { IdleTransaction } from '../idletransaction';
 import { DEFAULT_FINAL_TIMEOUT, DEFAULT_HEARTBEAT_INTERVAL, DEFAULT_IDLE_TIMEOUT } from '../idletransaction';
 import { extractTraceparentData } from '../utils';
 import { registerBackgroundTabDetection } from './backgroundtab';
-import { addPerformanceEntries, startTrackingLongTasks, startTrackingWebVitals } from './metrics';
+import {
+  addPerformanceEntries,
+  startTrackingInteractions,
+  startTrackingLongTasks,
+  startTrackingWebVitals,
+} from './metrics';
 import type { RequestInstrumentationOptions } from './request';
 import { defaultRequestInstrumentationOptions, instrumentOutgoingRequests } from './request';
 import { instrumentRoutingWithDefaults } from './router';
@@ -187,6 +192,7 @@ export class BrowserTracing implements Integration {
     }
 
     startTrackingWebVitals();
+    startTrackingInteractions();
     if (this.options.enableLongTask) {
       startTrackingLongTasks();
     }

--- a/packages/tracing/src/browser/metrics/index.ts
+++ b/packages/tracing/src/browser/metrics/index.ts
@@ -81,7 +81,7 @@ export function startTrackingInteractions(): void {
 
         transaction.startChild({
           description: htmlTreeAsString(entry.target),
-          op: `ui.action.${entry.name}`,
+          op: `ui.interaction.${entry.name}`,
           startTimestamp: startTime,
           endTimestamp: startTime + duration,
         });

--- a/packages/tracing/src/browser/metrics/index.ts
+++ b/packages/tracing/src/browser/metrics/index.ts
@@ -89,7 +89,7 @@ export function startTrackingInteractions(): void {
     }
   };
 
-  observe('event', entryHandler, { durationThreshold: 10 });
+  observe('event', entryHandler, { durationThreshold: 0 });
 }
 
 /** Starts tracking the Cumulative Layout Shift on the current page. */

--- a/packages/tracing/src/browser/metrics/index.ts
+++ b/packages/tracing/src/browser/metrics/index.ts
@@ -64,6 +64,34 @@ export function startTrackingLongTasks(): void {
   observe('longtask', entryHandler);
 }
 
+/**
+ * Start tracking interaction events.
+ */
+export function startTrackingInteractions(): void {
+  const entryHandler = (entries: PerformanceEventTiming[]): void => {
+    for (const entry of entries) {
+      const transaction = getActiveTransaction() as IdleTransaction | undefined;
+      if (!transaction) {
+        return;
+      }
+
+      if (entry.name === 'click') {
+        const startTime = msToSec((browserPerformanceTimeOrigin as number) + entry.startTime);
+        const duration = msToSec(entry.duration);
+
+        transaction.startChild({
+          description: htmlTreeAsString(entry.target),
+          op: `ui.action.${entry.name}`,
+          startTimestamp: startTime,
+          endTimestamp: startTime + duration,
+        });
+      }
+    }
+  };
+
+  observe('event', entryHandler, { durationThreshold: 10 });
+}
+
 /** Starts tracking the Cumulative Layout Shift on the current page. */
 function _trackCLS(): void {
   // See:

--- a/packages/tracing/src/browser/web-vitals/types.ts
+++ b/packages/tracing/src/browser/web-vitals/types.ts
@@ -135,6 +135,7 @@ declare global {
   interface PerformanceEventTiming extends PerformanceEntry {
     duration: DOMHighResTimeStamp;
     interactionId?: number;
+    readonly target: Node | null;
   }
 
   // https://wicg.github.io/layout-instability/#sec-layout-shift-attribution


### PR DESCRIPTION
### Summary

We hypothesize that there is a 1:1 mapping of `PerformanceObserver` Interactions -> Interaction Transactions. This PR will allow us to confirm whether this hypothesis is true, so we can decide our next steps for refining interaction transactions. To elaborate, we're unsure whether interaction transactions that have no child spans are worth keeping or not, and there are a lot of transactions like this in prod.

Enhances the existing interaction transactions by adding the ability to track interaction events exposed by the `PerformanceObserver` API. Note that this is still hidden under an experimental flag along with interaction transactions.

For now, we are only tracking `click` interactions, but we can expand this functionality later as needed.

### TODO:

- [x] Add tests