### PR TITLE
test: Run playwright tests in parallel

### DIFF
--- a/packages/integration-tests/playwright.config.ts
+++ b/packages/integration-tests/playwright.config.ts
@@ -2,6 +2,6 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   retries: 0,
-  workers: 3,
+  fullyParallel: true,
 };
 export default config;

--- a/packages/integration-tests/playwright.config.ts
+++ b/packages/integration-tests/playwright.config.ts
@@ -5,6 +5,7 @@ const config: PlaywrightTestConfig = {
   // Run tests inside of a single file in parallel
   fullyParallel: true,
   // Use 5 workers on CI, else use defaults (based on available CPU cores)
+  // Note that 5 is a random number selected to work well with our CI setup
   workers: process.env.CI ? 5 : undefined,
 };
 export default config;

--- a/packages/integration-tests/playwright.config.ts
+++ b/packages/integration-tests/playwright.config.ts
@@ -2,6 +2,9 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   retries: 0,
+  // Run tests inside of a single file in parallel
   fullyParallel: true,
+  // Use 5 workers on CI, else use defaults (based on available CPU cores)
+  workers: process.env.CI ? 5 : undefined,
 };
 export default config;

--- a/packages/integration-tests/suites/replay/privacyDefault/test.ts-snapshots/privacy.json
+++ b/packages/integration-tests/suites/replay/privacyDefault/test.ts-snapshots/privacy.json
@@ -32,9 +32,8 @@
                 "type": 2,
                 "tagName": "link",
                 "attributes": {
-                  "rel": "icon",
-                  "type": "image/png",
-                  "href": "file://assets/icon/favicon.png"
+                  "rr_width": "[0-50]px",
+                  "rr_height": "[0-50]px"
                 },
                 "childNodes": [],
                 "id": 6

--- a/packages/nextjs/playwright.config.ts
+++ b/packages/nextjs/playwright.config.ts
@@ -6,7 +6,7 @@ const config: PlaywrightTestConfig = {
   use: {
     baseURL: 'http://localhost:3000',
   },
-  workers: 3,
+  fullyParallel: true,
   webServer: {
     cwd: path.join(__dirname, 'test', 'integration'),
     command: 'yarn start',

--- a/packages/nextjs/playwright.config.ts
+++ b/packages/nextjs/playwright.config.ts
@@ -6,7 +6,10 @@ const config: PlaywrightTestConfig = {
   use: {
     baseURL: 'http://localhost:3000',
   },
+  // Run tests inside of a single file in parallel
   fullyParallel: true,
+  // Use 5 workers on CI, else use defaults (based on available CPU cores)
+  workers: process.env.CI ? 5 : undefined,
   webServer: {
     cwd: path.join(__dirname, 'test', 'integration'),
     command: 'yarn start',

--- a/packages/nextjs/playwright.config.ts
+++ b/packages/nextjs/playwright.config.ts
@@ -9,6 +9,7 @@ const config: PlaywrightTestConfig = {
   // Run tests inside of a single file in parallel
   fullyParallel: true,
   // Use 5 workers on CI, else use defaults (based on available CPU cores)
+  // Note that 5 is a random number selected to work well with our CI setup
   workers: process.env.CI ? 5 : undefined,
   webServer: {
     cwd: path.join(__dirname, 'test', 'integration'),

--- a/packages/remix/playwright.config.ts
+++ b/packages/remix/playwright.config.ts
@@ -5,7 +5,7 @@ const config: PlaywrightTestConfig = {
   use: {
     baseURL: 'http://localhost:3000',
   },
-  workers: 3,
+  fullyParallel: true,
   webServer: {
     command: '(cd test/integration/ && yarn build && yarn start)',
     port: 3000,

--- a/packages/remix/playwright.config.ts
+++ b/packages/remix/playwright.config.ts
@@ -8,6 +8,7 @@ const config: PlaywrightTestConfig = {
   // Run tests inside of a single file in parallel
   fullyParallel: true,
   // Use 5 workers on CI, else use defaults (based on available CPU cores)
+  // Note that 5 is a random number selected to work well with our CI setup
   workers: process.env.CI ? 5 : undefined,
   webServer: {
     command: '(cd test/integration/ && yarn build && yarn start)',

--- a/packages/remix/playwright.config.ts
+++ b/packages/remix/playwright.config.ts
@@ -5,7 +5,10 @@ const config: PlaywrightTestConfig = {
   use: {
     baseURL: 'http://localhost:3000',
   },
+  // Run tests inside of a single file in parallel
   fullyParallel: true,
+  // Use 5 workers on CI, else use defaults (based on available CPU cores)
+  workers: process.env.CI ? 5 : undefined,
   webServer: {
     command: '(cd test/integration/ && yarn build && yarn start)',
     port: 3000,


### PR DESCRIPTION
This:

* updates the `workers` config for playwright, making sure we use the default on local machines (which depends on available CPU cores), and bump it to 5 on CI to speed this up slightly
* enabled [fullyParallel](https://playwright.dev/docs/api/class-testconfig#test-config-fully-parallel) config to ensure tests inside of a file are also parallelised - IMHO failures due to this show bad test design anyhow, so this should be fine.