### PR TITLE
docs: Update replay docs for end of beta

### DIFF
--- a/packages/replay/MIGRATION.md
+++ b/packages/replay/MIGRATION.md
@@ -1,3 +1,47 @@
+# End of Replay Beta
+
+Sentry Replay is now out of Beta. This means that the usual stability guarantees apply.
+
+Because of experimentation and rapid iteration, during the Beta period some bugs and problems came up which have since been fixed/improved.
+We **storngly** recommend anyone using Replay in a version before 7.39.0 to update to 7.39.0 or newer, in order to prevent running Replay with known problems that have since been fixed.
+
+Below you can find a list of relevant replay issues that have been resolved until 7.39.0:
+
+## New features / improvements
+
+- Remove `autoplay` attribute from audio/video tags ([#59](https://github.com/getsentry/rrweb/pull/59))
+- Exclude `modulepreload` as well ([#52](https://github.com/getsentry/rrweb/pull/52))
+- With maskAllText, mask the attributes: placeholder, title, `aria-label`
+- Lower the flush max delay from 15 seconds to 5 seconds (#6761)
+- Stop recording when retry fails (#6765)
+- Stop without retry when receiving bad API response (#6773)
+- Send client_report when replay sending fails (#7093)
+- Stop recording when hitting a rate limit (#7018)
+- Allow Replay to be used in Electron renderers with nodeIntegration enabled (#6644)
+- Do not renew session in error mode (#6948)
+- Remove default sample rates for replay (#6878)
+- Add `flush` method to integration (#6776)
+- Improve compression worker & fallback behavior (#6988, #6936, #6827)
+- Improve error handling (#7087, #7094, #7010, getsentry/rrweb#16, #6856)
+- Add more default block filters (#7233)
+
+## Fixes
+
+- Fix masking inputs on change when `maskAllInputs:false` ([#61](https://github.com/getsentry/rrweb/pull/61))
+- More robust `rootShadowHost` check ([#50](https://github.com/getsentry/rrweb/pull/50))
+- Fix duplicated textarea value ([#62](https://github.com/getsentry/rrweb/pull/62))
+- Handle removed attributes ([#65](https://github.com/getsentry/rrweb/pull/65))
+- Change LCP calculation (#7187, #7225)
+- Fix debounced flushes not respecting `maxWait` (#7207, #7208)
+- Fix svgs not getting unblocked  (#7132)
+- Fix missing fetch/xhr requests (#7134)
+- Fix feature detection of PerformanceObserver (#7029)
+- Fix `checkoutEveryNms` (#6722)
+- Fix incorrect uncompressed recording size due to encoding (#6740)
+- Ensure dropping replays works (#6522)
+- Envelope send should be awaited in try/catch (#6625)
+- Improve handling of `maskAllText` selector (#6637)
+
 # Upgrading Replay from 7.34.0 to 7.35.0 - #6645
 
 This release will remove the ability to change the default rrweb recording options (outside of privacy options). The following are the new configuration values all replays will use:

--- a/packages/replay/README.md
+++ b/packages/replay/README.md
@@ -10,8 +10,6 @@
 [![npm dm](https://img.shields.io/npm/dm/@sentry/replay.svg)](https://www.npmjs.com/package/@sentry/replay)
 [![npm dt](https://img.shields.io/npm/dt/@sentry/replay.svg)](https://www.npmjs.com/package/@sentry/replay)
 
-**Note: Session Replay is currently in beta.** Functionality may change outside of major version bumps - while we try our best to avoid any breaking changes, semver cannot be guaranteed before Replay is out of beta. You can find more information about upgrading in [MIGRATION.md](./MIGRATION.md).
-
 ## Pre-requisites
 
 `@sentry/replay` requires Node 12+, and browsers newer than IE11.
@@ -112,11 +110,11 @@ The `replay.(min.)js` bundle will be removed in v8 of the JS SDKs.
 
 ```html
 <script
-  src="https://browser.sentry-cdn.com/7.31.1/bundle.min.js"
+  src="https://browser.sentry-cdn.com/7.41.0/bundle.min.js"
   crossorigin="anonymous"
 ></script>
 <script
-  src="https://browser.sentry-cdn.com/7.31.1/replay.min.js"
+  src="https://browser.sentry-cdn.com/7.41.0/replay.min.js"
   crossorigin="anonymous"
 ></script>
 ```


### PR DESCRIPTION
This updates docs for the end of replay beta, including a list of (relevant) features/fixes we shipped in the beta period.