### PR TITLE
test(e2e): Publish otel-node package tarballs

### DIFF
--- a/packages/e2e-tests/publish-packages.ts
+++ b/packages/e2e-tests/publish-packages.ts
@@ -16,11 +16,6 @@ const packageTarballPaths = glob.sync('packages/*/sentry-*.tgz', {
 
 // Publish built packages to the fake registry
 packageTarballPaths.forEach(tarballPath => {
-  // Don't run publish opentelemetry-node package because it is private.
-  if (tarballPath.includes('sentry-opentelemetry-node')) {
-    return;
-  }
-
   // `--userconfig` flag needs to be before `publish`
   childProcess.execSync(`npm --userconfig ${__dirname}/test-registry.npmrc publish ${tarballPath}`, {
     cwd: repositoryRoot, // Can't use __dirname here because npm would try to publish `@sentry-internal/e2e-tests`


### PR DESCRIPTION
the opentelemetry node package is no longer private, let's remove this note then.