### PR TITLE
fix(core): Avoid using `Object.values()`

### DIFF
--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -40,7 +40,7 @@ function filterDuplicates(integrations: Integration[]): Integration[] {
     integrationsByName[name] = currentInstance;
   });
 
-  return Object.values(integrationsByName);
+  return Object.keys(integrationsByName).map(k => integrationsByName[k]);
 }
 
 /** Gets integrations to install */


### PR DESCRIPTION
This is not downcompiled for ES5 (=it is still present this way in the bundle.es5.js files - see e.g. https://browser.sentry-cdn.com/7.41.0/bundle.es5.js and search for `Object.values()`). So instead we use `Object.keys()` ([which works in IE11](https://caniuse.com/?search=object.keys)) here.

Fixes https://github.com/getsentry/sentry-javascript/issues/7354
