### PR TITLE
feat(core): Ensure `originalException` has type `unknown`

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -560,7 +560,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
           data: {
             __sentry__: true,
           },
-          originalException: reason as Error,
+          originalException: reason,
         });
         throw new SentryError(
           `Event processing pipeline threw an error, original event will not be sent. Details have been sent as a new event.\nReason: ${reason}`,

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -183,8 +183,7 @@ export class Hub implements HubInterface {
   /**
    * @inheritDoc
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
-  public captureException(exception: any, hint?: EventHint): string {
+  public captureException(exception: unknown, hint?: EventHint): string {
     const eventId = (this._lastEventId = hint && hint.event_id ? hint.event_id : uuid4());
     const syntheticException = new Error('Sentry syntheticException');
     this._withClient((client, scope) => {

--- a/packages/node/src/integrations/onunhandledrejection.ts
+++ b/packages/node/src/integrations/onunhandledrejection.ts
@@ -44,8 +44,7 @@ export class OnUnhandledRejection implements Integration {
    * @param reason string
    * @param promise promise
    */
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
-  public sendUnhandledPromise(reason: any, promise: any): void {
+  public sendUnhandledPromise(reason: unknown, promise: unknown): void {
     const hub = getCurrentHub();
     if (hub.getIntegration(OnUnhandledRejection)) {
       hub.withScope((scope: Scope) => {

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -75,7 +75,7 @@ export interface EventHint {
   event_id?: string;
   captureContext?: CaptureContext;
   syntheticException?: Error | null;
-  originalException?: Error | string | null;
+  originalException?: unknown;
   attachments?: Attachment[];
   data?: any;
   integrations?: string[];


### PR DESCRIPTION
This used to be typed as `Error | string | null` which is not correct, as technically _anything_ can be thrown. To reflect this existing reality, we have to broaden this type. Note that this _could_ lead to problems for users that currently depend on this type, but any potential issues arising because of this would actually be valid problems that should actually be fixed in the user code (e.g. relying on `error.message` to be present, for example).

This also allows us to update some other types from `any` to `unknown`, which is IMHO more correct as we really just pass this through, whatever it is.

Closes https://github.com/getsentry/sentry-javascript/issues/7344