### PR TITLE
test(replay): Make tests less flaky

### DIFF
--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-0-snap-full
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-0-snap-full
@@ -1,109 +1,113 @@
 [
   {
-    "node": {
-      "type": 0,
-      "childNodes": [
-        {
-          "type": 1,
-          "name": "html",
-          "publicId": "",
-          "systemId": "",
-          "id": 2
-        },
-        {
-          "type": 2,
-          "tagName": "html",
-          "attributes": {},
-          "childNodes": [
-            {
-              "type": 2,
-              "tagName": "head",
-              "attributes": {},
-              "childNodes": [
-                {
-                  "type": 2,
-                  "tagName": "meta",
-                  "attributes": {
-                    "charset": "utf-8"
+    "type": 2,
+    "data": {
+      "node": {
+        "type": 0,
+        "childNodes": [
+          {
+            "type": 1,
+            "name": "html",
+            "publicId": "",
+            "systemId": "",
+            "id": 2
+          },
+          {
+            "type": 2,
+            "tagName": "html",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "head",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 2,
+                    "tagName": "meta",
+                    "attributes": {
+                      "charset": "utf-8"
+                    },
+                    "childNodes": [],
+                    "id": 5
+                  }
+                ],
+                "id": 4
+              },
+              {
+                "type": 3,
+                "textContent": "\n  ",
+                "id": 6
+              },
+              {
+                "type": 2,
+                "tagName": "body",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 8
                   },
-                  "childNodes": [],
-                  "id": 5
-                }
-              ],
-              "id": 4
-            },
-            {
-              "type": 3,
-              "textContent": "\n  ",
-              "id": 6
-            },
-            {
-              "type": 2,
-              "tagName": "body",
-              "attributes": {},
-              "childNodes": [
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 8
-                },
-                {
-                  "type": 2,
-                  "tagName": "button",
-                  "attributes": {
-                    "id": "go-background"
+                  {
+                    "type": 2,
+                    "tagName": "button",
+                    "attributes": {
+                      "id": "go-background"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "*** ***",
+                        "id": 10
+                      }
+                    ],
+                    "id": 9
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "*** ***",
-                      "id": 10
-                    }
-                  ],
-                  "id": 9
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 11
-                },
-                {
-                  "type": 2,
-                  "tagName": "a",
-                  "attributes": {
-                    "href": "/page-0.html"
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 11
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "** ** *** ****",
-                      "id": 13
-                    }
-                  ],
-                  "id": 12
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n  ",
-                  "id": 14
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n\n",
-                  "id": 15
-                }
-              ],
-              "id": 7
-            }
-          ],
-          "id": 3
-        }
-      ],
-      "id": 1
+                  {
+                    "type": 2,
+                    "tagName": "a",
+                    "attributes": {
+                      "href": "/page-0.html"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "** ** *** ****",
+                        "id": 13
+                      }
+                    ],
+                    "id": 12
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n  ",
+                    "id": 14
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n\n",
+                    "id": 15
+                  }
+                ],
+                "id": 7
+              }
+            ],
+            "id": 3
+          }
+        ],
+        "id": 1
+      },
+      "initialOffset": {
+        "left": 0,
+        "top": 0
+      }
     },
-    "initialOffset": {
-      "left": 0,
-      "top": 0
-    }
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-0-snap-full-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-0-snap-full-chromium
@@ -1,109 +1,113 @@
 [
   {
-    "node": {
-      "type": 0,
-      "childNodes": [
-        {
-          "type": 1,
-          "name": "html",
-          "publicId": "",
-          "systemId": "",
-          "id": 2
-        },
-        {
-          "type": 2,
-          "tagName": "html",
-          "attributes": {},
-          "childNodes": [
-            {
-              "type": 2,
-              "tagName": "head",
-              "attributes": {},
-              "childNodes": [
-                {
-                  "type": 2,
-                  "tagName": "meta",
-                  "attributes": {
-                    "charset": "utf-8"
+    "type": 2,
+    "data": {
+      "node": {
+        "type": 0,
+        "childNodes": [
+          {
+            "type": 1,
+            "name": "html",
+            "publicId": "",
+            "systemId": "",
+            "id": 2
+          },
+          {
+            "type": 2,
+            "tagName": "html",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "head",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 2,
+                    "tagName": "meta",
+                    "attributes": {
+                      "charset": "utf-8"
+                    },
+                    "childNodes": [],
+                    "id": 5
+                  }
+                ],
+                "id": 4
+              },
+              {
+                "type": 3,
+                "textContent": "\n  ",
+                "id": 6
+              },
+              {
+                "type": 2,
+                "tagName": "body",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 8
                   },
-                  "childNodes": [],
-                  "id": 5
-                }
-              ],
-              "id": 4
-            },
-            {
-              "type": 3,
-              "textContent": "\n  ",
-              "id": 6
-            },
-            {
-              "type": 2,
-              "tagName": "body",
-              "attributes": {},
-              "childNodes": [
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 8
-                },
-                {
-                  "type": 2,
-                  "tagName": "button",
-                  "attributes": {
-                    "id": "go-background"
+                  {
+                    "type": 2,
+                    "tagName": "button",
+                    "attributes": {
+                      "id": "go-background"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "*** ***",
+                        "id": 10
+                      }
+                    ],
+                    "id": 9
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "*** ***",
-                      "id": 10
-                    }
-                  ],
-                  "id": 9
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 11
-                },
-                {
-                  "type": 2,
-                  "tagName": "a",
-                  "attributes": {
-                    "href": "/page-0.html"
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 11
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "** ** *** ****",
-                      "id": 13
-                    }
-                  ],
-                  "id": 12
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n  ",
-                  "id": 14
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n\n",
-                  "id": 15
-                }
-              ],
-              "id": 7
-            }
-          ],
-          "id": 3
-        }
-      ],
-      "id": 1
+                  {
+                    "type": 2,
+                    "tagName": "a",
+                    "attributes": {
+                      "href": "/page-0.html"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "** ** *** ****",
+                        "id": 13
+                      }
+                    ],
+                    "id": 12
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n  ",
+                    "id": 14
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n\n",
+                    "id": 15
+                  }
+                ],
+                "id": 7
+              }
+            ],
+            "id": 3
+          }
+        ],
+        "id": 1
+      },
+      "initialOffset": {
+        "left": 0,
+        "top": 0
+      }
     },
-    "initialOffset": {
-      "left": 0,
-      "top": 0
-    }
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-1-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-1-snap-incremental
@@ -1,39 +1,59 @@
 [
   {
-    "source": 1,
-    "positions": [
-      {
-        "x": 41,
-        "y": 18,
-        "id": 9,
-        "timeOffset": [timeOffset]
-      }
-    ]
+    "type": 3,
+    "data": {
+      "source": 1,
+      "positions": [
+        {
+          "x": 41,
+          "y": 18,
+          "id": 9,
+          "timeOffset": [timeOffset]
+        }
+      ]
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 1,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 1,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 5,
-    "id": 9
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 5,
+      "id": 9
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 0,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 0,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 2,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 2,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-1-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-1-snap-incremental
@@ -2,21 +2,6 @@
   {
     "type": 3,
     "data": {
-      "source": 1,
-      "positions": [
-        {
-          "x": 41,
-          "y": 18,
-          "id": 9,
-          "timeOffset": [timeOffset]
-        }
-      ]
-    },
-    "timestamp": [timestamp]
-  },
-  {
-    "type": 3,
-    "data": {
       "source": 2,
       "type": 1,
       "id": 9,

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-1-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-1-snap-incremental-chromium
@@ -1,39 +1,59 @@
 [
   {
-    "source": 1,
-    "positions": [
-      {
-        "x": 41,
-        "y": 18,
-        "id": 9,
-        "timeOffset": [timeOffset]
-      }
-    ]
+    "type": 3,
+    "data": {
+      "source": 1,
+      "positions": [
+        {
+          "x": 41,
+          "y": 18,
+          "id": 9,
+          "timeOffset": [timeOffset]
+        }
+      ]
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 1,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 1,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 5,
-    "id": 9
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 5,
+      "id": 9
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 0,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 0,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 2,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 2,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-1-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-1-snap-incremental-chromium
@@ -2,21 +2,6 @@
   {
     "type": 3,
     "data": {
-      "source": 1,
-      "positions": [
-        {
-          "x": 41,
-          "y": 18,
-          "id": 9,
-          "timeOffset": [timeOffset]
-        }
-      ]
-    },
-    "timestamp": [timestamp]
-  },
-  {
-    "type": 3,
-    "data": {
       "source": 2,
       "type": 1,
       "id": 9,

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-2-snap-full
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-2-snap-full
@@ -1,109 +1,113 @@
 [
   {
-    "node": {
-      "type": 0,
-      "childNodes": [
-        {
-          "type": 1,
-          "name": "html",
-          "publicId": "",
-          "systemId": "",
-          "id": 2
-        },
-        {
-          "type": 2,
-          "tagName": "html",
-          "attributes": {},
-          "childNodes": [
-            {
-              "type": 2,
-              "tagName": "head",
-              "attributes": {},
-              "childNodes": [
-                {
-                  "type": 2,
-                  "tagName": "meta",
-                  "attributes": {
-                    "charset": "utf-8"
+    "type": 2,
+    "data": {
+      "node": {
+        "type": 0,
+        "childNodes": [
+          {
+            "type": 1,
+            "name": "html",
+            "publicId": "",
+            "systemId": "",
+            "id": 2
+          },
+          {
+            "type": 2,
+            "tagName": "html",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "head",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 2,
+                    "tagName": "meta",
+                    "attributes": {
+                      "charset": "utf-8"
+                    },
+                    "childNodes": [],
+                    "id": 5
+                  }
+                ],
+                "id": 4
+              },
+              {
+                "type": 3,
+                "textContent": "\n  ",
+                "id": 6
+              },
+              {
+                "type": 2,
+                "tagName": "body",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 8
                   },
-                  "childNodes": [],
-                  "id": 5
-                }
-              ],
-              "id": 4
-            },
-            {
-              "type": 3,
-              "textContent": "\n  ",
-              "id": 6
-            },
-            {
-              "type": 2,
-              "tagName": "body",
-              "attributes": {},
-              "childNodes": [
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 8
-                },
-                {
-                  "type": 2,
-                  "tagName": "button",
-                  "attributes": {
-                    "id": "go-background"
+                  {
+                    "type": 2,
+                    "tagName": "button",
+                    "attributes": {
+                      "id": "go-background"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "*** ***",
+                        "id": 10
+                      }
+                    ],
+                    "id": 9
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "*** ***",
-                      "id": 10
-                    }
-                  ],
-                  "id": 9
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 11
-                },
-                {
-                  "type": 2,
-                  "tagName": "a",
-                  "attributes": {
-                    "href": "/page-0.html"
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 11
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "** ** *** ****",
-                      "id": 13
-                    }
-                  ],
-                  "id": 12
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n  ",
-                  "id": 14
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n\n",
-                  "id": 15
-                }
-              ],
-              "id": 7
-            }
-          ],
-          "id": 3
-        }
-      ],
-      "id": 1
+                  {
+                    "type": 2,
+                    "tagName": "a",
+                    "attributes": {
+                      "href": "/page-0.html"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "** ** *** ****",
+                        "id": 13
+                      }
+                    ],
+                    "id": 12
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n  ",
+                    "id": 14
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n\n",
+                    "id": 15
+                  }
+                ],
+                "id": 7
+              }
+            ],
+            "id": 3
+          }
+        ],
+        "id": 1
+      },
+      "initialOffset": {
+        "left": 0,
+        "top": 0
+      }
     },
-    "initialOffset": {
-      "left": 0,
-      "top": 0
-    }
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-2-snap-full-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-2-snap-full-chromium
@@ -1,109 +1,113 @@
 [
   {
-    "node": {
-      "type": 0,
-      "childNodes": [
-        {
-          "type": 1,
-          "name": "html",
-          "publicId": "",
-          "systemId": "",
-          "id": 2
-        },
-        {
-          "type": 2,
-          "tagName": "html",
-          "attributes": {},
-          "childNodes": [
-            {
-              "type": 2,
-              "tagName": "head",
-              "attributes": {},
-              "childNodes": [
-                {
-                  "type": 2,
-                  "tagName": "meta",
-                  "attributes": {
-                    "charset": "utf-8"
+    "type": 2,
+    "data": {
+      "node": {
+        "type": 0,
+        "childNodes": [
+          {
+            "type": 1,
+            "name": "html",
+            "publicId": "",
+            "systemId": "",
+            "id": 2
+          },
+          {
+            "type": 2,
+            "tagName": "html",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "head",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 2,
+                    "tagName": "meta",
+                    "attributes": {
+                      "charset": "utf-8"
+                    },
+                    "childNodes": [],
+                    "id": 5
+                  }
+                ],
+                "id": 4
+              },
+              {
+                "type": 3,
+                "textContent": "\n  ",
+                "id": 6
+              },
+              {
+                "type": 2,
+                "tagName": "body",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 8
                   },
-                  "childNodes": [],
-                  "id": 5
-                }
-              ],
-              "id": 4
-            },
-            {
-              "type": 3,
-              "textContent": "\n  ",
-              "id": 6
-            },
-            {
-              "type": 2,
-              "tagName": "body",
-              "attributes": {},
-              "childNodes": [
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 8
-                },
-                {
-                  "type": 2,
-                  "tagName": "button",
-                  "attributes": {
-                    "id": "go-background"
+                  {
+                    "type": 2,
+                    "tagName": "button",
+                    "attributes": {
+                      "id": "go-background"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "*** ***",
+                        "id": 10
+                      }
+                    ],
+                    "id": 9
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "*** ***",
-                      "id": 10
-                    }
-                  ],
-                  "id": 9
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 11
-                },
-                {
-                  "type": 2,
-                  "tagName": "a",
-                  "attributes": {
-                    "href": "/page-0.html"
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 11
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "** ** *** ****",
-                      "id": 13
-                    }
-                  ],
-                  "id": 12
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n  ",
-                  "id": 14
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n\n",
-                  "id": 15
-                }
-              ],
-              "id": 7
-            }
-          ],
-          "id": 3
-        }
-      ],
-      "id": 1
+                  {
+                    "type": 2,
+                    "tagName": "a",
+                    "attributes": {
+                      "href": "/page-0.html"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "** ** *** ****",
+                        "id": 13
+                      }
+                    ],
+                    "id": 12
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n  ",
+                    "id": 14
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n\n",
+                    "id": 15
+                  }
+                ],
+                "id": 7
+              }
+            ],
+            "id": 3
+          }
+        ],
+        "id": 1
+      },
+      "initialOffset": {
+        "left": 0,
+        "top": 0
+      }
     },
-    "initialOffset": {
-      "left": 0,
-      "top": 0
-    }
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-3-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-3-snap-incremental
@@ -1,39 +1,59 @@
 [
   {
-    "source": 1,
-    "positions": [
-      {
-        "x": 41,
-        "y": 18,
-        "id": 9,
-        "timeOffset": [timeOffset]
-      }
-    ]
+    "type": 3,
+    "data": {
+      "source": 1,
+      "positions": [
+        {
+          "x": 41,
+          "y": 18,
+          "id": 9,
+          "timeOffset": [timeOffset]
+        }
+      ]
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 1,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 1,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 5,
-    "id": 9
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 5,
+      "id": 9
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 0,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 0,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 2,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 2,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-3-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-3-snap-incremental
@@ -2,21 +2,6 @@
   {
     "type": 3,
     "data": {
-      "source": 1,
-      "positions": [
-        {
-          "x": 41,
-          "y": 18,
-          "id": 9,
-          "timeOffset": [timeOffset]
-        }
-      ]
-    },
-    "timestamp": [timestamp]
-  },
-  {
-    "type": 3,
-    "data": {
       "source": 2,
       "type": 1,
       "id": 9,

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-3-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-3-snap-incremental-chromium
@@ -1,39 +1,59 @@
 [
   {
-    "source": 1,
-    "positions": [
-      {
-        "x": 41,
-        "y": 18,
-        "id": 9,
-        "timeOffset": [timeOffset]
-      }
-    ]
+    "type": 3,
+    "data": {
+      "source": 1,
+      "positions": [
+        {
+          "x": 41,
+          "y": 18,
+          "id": 9,
+          "timeOffset": [timeOffset]
+        }
+      ]
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 1,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 1,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 5,
-    "id": 9
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 5,
+      "id": 9
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 0,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 0,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 2,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 2,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-3-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-3-snap-incremental-chromium
@@ -2,21 +2,6 @@
   {
     "type": 3,
     "data": {
-      "source": 1,
-      "positions": [
-        {
-          "x": 41,
-          "y": 18,
-          "id": 9,
-          "timeOffset": [timeOffset]
-        }
-      ]
-    },
-    "timestamp": [timestamp]
-  },
-  {
-    "type": 3,
-    "data": {
       "source": 2,
       "type": 1,
       "id": 9,

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-4-snap-full
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-4-snap-full
@@ -1,152 +1,156 @@
 [
   {
-    "node": {
-      "type": 0,
-      "childNodes": [
-        {
-          "type": 1,
-          "name": "html",
-          "publicId": "",
-          "systemId": "",
-          "id": 2
-        },
-        {
-          "type": 2,
-          "tagName": "html",
-          "attributes": {},
-          "childNodes": [
-            {
-              "type": 2,
-              "tagName": "head",
-              "attributes": {},
-              "childNodes": [
-                {
-                  "type": 2,
-                  "tagName": "meta",
-                  "attributes": {
-                    "charset": "utf-8"
+    "type": 2,
+    "data": {
+      "node": {
+        "type": 0,
+        "childNodes": [
+          {
+            "type": 1,
+            "name": "html",
+            "publicId": "",
+            "systemId": "",
+            "id": 2
+          },
+          {
+            "type": 2,
+            "tagName": "html",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "head",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 2,
+                    "tagName": "meta",
+                    "attributes": {
+                      "charset": "utf-8"
+                    },
+                    "childNodes": [],
+                    "id": 5
+                  }
+                ],
+                "id": 4
+              },
+              {
+                "type": 3,
+                "textContent": "\n  ",
+                "id": 6
+              },
+              {
+                "type": 2,
+                "tagName": "body",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 8
                   },
-                  "childNodes": [],
-                  "id": 5
-                }
-              ],
-              "id": 4
-            },
-            {
-              "type": 3,
-              "textContent": "\n  ",
-              "id": 6
-            },
-            {
-              "type": 2,
-              "tagName": "body",
-              "attributes": {},
-              "childNodes": [
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 8
-                },
-                {
-                  "type": 2,
-                  "tagName": "h1",
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "********* ****",
-                      "id": 10
-                    }
-                  ],
-                  "id": 9
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 11
-                },
-                {
-                  "type": 2,
-                  "tagName": "button",
-                  "attributes": {
-                    "id": "go-background"
+                  {
+                    "type": 2,
+                    "tagName": "h1",
+                    "attributes": {},
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "********* ****",
+                        "id": 10
+                      }
+                    ],
+                    "id": 9
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "*** ***",
-                      "id": 13
-                    }
-                  ],
-                  "id": 12
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 14
-                },
-                {
-                  "type": 2,
-                  "tagName": "button",
-                  "attributes": {
-                    "id": "spa-navigation"
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 11
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "***** * *** **********",
-                      "id": 16
-                    }
-                  ],
-                  "id": 15
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 17
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 18
-                },
-                {
-                  "type": 2,
-                  "tagName": "a",
-                  "attributes": {
-                    "href": "/index.html"
+                  {
+                    "type": 2,
+                    "tagName": "button",
+                    "attributes": {
+                      "id": "go-background"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "*** ***",
+                        "id": 13
+                      }
+                    ],
+                    "id": 12
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "** **** ** ***** ****",
-                      "id": 20
-                    }
-                  ],
-                  "id": 19
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n  ",
-                  "id": 21
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n\n",
-                  "id": 22
-                }
-              ],
-              "id": 7
-            }
-          ],
-          "id": 3
-        }
-      ],
-      "id": 1
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 14
+                  },
+                  {
+                    "type": 2,
+                    "tagName": "button",
+                    "attributes": {
+                      "id": "spa-navigation"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "***** * *** **********",
+                        "id": 16
+                      }
+                    ],
+                    "id": 15
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 17
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 18
+                  },
+                  {
+                    "type": 2,
+                    "tagName": "a",
+                    "attributes": {
+                      "href": "/index.html"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "** **** ** ***** ****",
+                        "id": 20
+                      }
+                    ],
+                    "id": 19
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n  ",
+                    "id": 21
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n\n",
+                    "id": 22
+                  }
+                ],
+                "id": 7
+              }
+            ],
+            "id": 3
+          }
+        ],
+        "id": 1
+      },
+      "initialOffset": {
+        "left": 0,
+        "top": 0
+      }
     },
-    "initialOffset": {
-      "left": 0,
-      "top": 0
-    }
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-4-snap-full-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-4-snap-full-chromium
@@ -1,152 +1,156 @@
 [
   {
-    "node": {
-      "type": 0,
-      "childNodes": [
-        {
-          "type": 1,
-          "name": "html",
-          "publicId": "",
-          "systemId": "",
-          "id": 2
-        },
-        {
-          "type": 2,
-          "tagName": "html",
-          "attributes": {},
-          "childNodes": [
-            {
-              "type": 2,
-              "tagName": "head",
-              "attributes": {},
-              "childNodes": [
-                {
-                  "type": 2,
-                  "tagName": "meta",
-                  "attributes": {
-                    "charset": "utf-8"
+    "type": 2,
+    "data": {
+      "node": {
+        "type": 0,
+        "childNodes": [
+          {
+            "type": 1,
+            "name": "html",
+            "publicId": "",
+            "systemId": "",
+            "id": 2
+          },
+          {
+            "type": 2,
+            "tagName": "html",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "head",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 2,
+                    "tagName": "meta",
+                    "attributes": {
+                      "charset": "utf-8"
+                    },
+                    "childNodes": [],
+                    "id": 5
+                  }
+                ],
+                "id": 4
+              },
+              {
+                "type": 3,
+                "textContent": "\n  ",
+                "id": 6
+              },
+              {
+                "type": 2,
+                "tagName": "body",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 8
                   },
-                  "childNodes": [],
-                  "id": 5
-                }
-              ],
-              "id": 4
-            },
-            {
-              "type": 3,
-              "textContent": "\n  ",
-              "id": 6
-            },
-            {
-              "type": 2,
-              "tagName": "body",
-              "attributes": {},
-              "childNodes": [
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 8
-                },
-                {
-                  "type": 2,
-                  "tagName": "h1",
-                  "attributes": {},
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "********* ****",
-                      "id": 10
-                    }
-                  ],
-                  "id": 9
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 11
-                },
-                {
-                  "type": 2,
-                  "tagName": "button",
-                  "attributes": {
-                    "id": "go-background"
+                  {
+                    "type": 2,
+                    "tagName": "h1",
+                    "attributes": {},
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "********* ****",
+                        "id": 10
+                      }
+                    ],
+                    "id": 9
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "*** ***",
-                      "id": 13
-                    }
-                  ],
-                  "id": 12
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 14
-                },
-                {
-                  "type": 2,
-                  "tagName": "button",
-                  "attributes": {
-                    "id": "spa-navigation"
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 11
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "***** * *** **********",
-                      "id": 16
-                    }
-                  ],
-                  "id": 15
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 17
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 18
-                },
-                {
-                  "type": 2,
-                  "tagName": "a",
-                  "attributes": {
-                    "href": "/index.html"
+                  {
+                    "type": 2,
+                    "tagName": "button",
+                    "attributes": {
+                      "id": "go-background"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "*** ***",
+                        "id": 13
+                      }
+                    ],
+                    "id": 12
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "** **** ** ***** ****",
-                      "id": 20
-                    }
-                  ],
-                  "id": 19
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n  ",
-                  "id": 21
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n\n",
-                  "id": 22
-                }
-              ],
-              "id": 7
-            }
-          ],
-          "id": 3
-        }
-      ],
-      "id": 1
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 14
+                  },
+                  {
+                    "type": 2,
+                    "tagName": "button",
+                    "attributes": {
+                      "id": "spa-navigation"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "***** * *** **********",
+                        "id": 16
+                      }
+                    ],
+                    "id": 15
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 17
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 18
+                  },
+                  {
+                    "type": 2,
+                    "tagName": "a",
+                    "attributes": {
+                      "href": "/index.html"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "** **** ** ***** ****",
+                        "id": 20
+                      }
+                    ],
+                    "id": 19
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n  ",
+                    "id": 21
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n\n",
+                    "id": 22
+                  }
+                ],
+                "id": 7
+              }
+            ],
+            "id": 3
+          }
+        ],
+        "id": 1
+      },
+      "initialOffset": {
+        "left": 0,
+        "top": 0
+      }
     },
-    "initialOffset": {
-      "left": 0,
-      "top": 0
-    }
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-5-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-5-snap-incremental
@@ -2,21 +2,6 @@
   {
     "type": 3,
     "data": {
-      "source": 1,
-      "positions": [
-        {
-          "x": 41,
-          "y": 90,
-          "id": 12,
-          "timeOffset": [timeOffset]
-        }
-      ]
-    },
-    "timestamp": [timestamp]
-  },
-  {
-    "type": 3,
-    "data": {
       "source": 2,
       "type": 1,
       "id": 12,

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-5-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-5-snap-incremental
@@ -1,39 +1,59 @@
 [
   {
-    "source": 1,
-    "positions": [
-      {
-        "x": 41,
-        "y": 90,
-        "id": 12,
-        "timeOffset": [timeOffset]
-      }
-    ]
+    "type": 3,
+    "data": {
+      "source": 1,
+      "positions": [
+        {
+          "x": 41,
+          "y": 90,
+          "id": 12,
+          "timeOffset": [timeOffset]
+        }
+      ]
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 1,
-    "id": 12,
-    "x": 41,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 1,
+      "id": 12,
+      "x": 41,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 5,
-    "id": 12
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 5,
+      "id": 12
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 0,
-    "id": 12,
-    "x": 41,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 0,
+      "id": 12,
+      "x": 41,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 2,
-    "id": 12,
-    "x": 41,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 2,
+      "id": 12,
+      "x": 41,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-5-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-5-snap-incremental-chromium
@@ -2,21 +2,6 @@
   {
     "type": 3,
     "data": {
-      "source": 1,
-      "positions": [
-        {
-          "x": 41,
-          "y": 90,
-          "id": 12,
-          "timeOffset": [timeOffset]
-        }
-      ]
-    },
-    "timestamp": [timestamp]
-  },
-  {
-    "type": 3,
-    "data": {
       "source": 2,
       "type": 1,
       "id": 12,

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-5-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-5-snap-incremental-chromium
@@ -1,39 +1,59 @@
 [
   {
-    "source": 1,
-    "positions": [
-      {
-        "x": 41,
-        "y": 90,
-        "id": 12,
-        "timeOffset": [timeOffset]
-      }
-    ]
+    "type": 3,
+    "data": {
+      "source": 1,
+      "positions": [
+        {
+          "x": 41,
+          "y": 90,
+          "id": 12,
+          "timeOffset": [timeOffset]
+        }
+      ]
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 1,
-    "id": 12,
-    "x": 41,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 1,
+      "id": 12,
+      "x": 41,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 5,
-    "id": 12
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 5,
+      "id": 12
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 0,
-    "id": 12,
-    "x": 41,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 0,
+      "id": 12,
+      "x": 41,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 2,
-    "id": 12,
-    "x": 41,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 2,
+      "id": 12,
+      "x": 41,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-6-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-6-snap-incremental
@@ -1,44 +1,68 @@
 [
   {
-    "source": 1,
-    "positions": [
-      {
-        "x": 157,
-        "y": 90,
-        "id": 15,
-        "timeOffset": [timeOffset]
-      }
-    ]
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 1,
+      "id": 15,
+      "x": 157,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 1,
-    "id": 15,
-    "x": 157,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 6,
+      "id": 12
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 6,
-    "id": 12
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 5,
+      "id": 15
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 5,
-    "id": 15
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 0,
+      "id": 15,
+      "x": 157,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 0,
-    "id": 15,
-    "x": 157,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 2,
+      "id": 15,
+      "x": 157,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 2,
-    "id": 15,
-    "x": 157,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 1,
+      "positions": [
+        {
+          "x": 157,
+          "y": 90,
+          "id": 15,
+          "timeOffset": [timeOffset]
+        }
+      ]
+    },
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-6-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-6-snap-incremental
@@ -49,20 +49,5 @@
       "y": 90
     },
     "timestamp": [timestamp]
-  },
-  {
-    "type": 3,
-    "data": {
-      "source": 1,
-      "positions": [
-        {
-          "x": 157,
-          "y": 90,
-          "id": 15,
-          "timeOffset": [timeOffset]
-        }
-      ]
-    },
-    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-6-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-6-snap-incremental-chromium
@@ -1,44 +1,68 @@
 [
   {
-    "source": 1,
-    "positions": [
-      {
-        "x": 157,
-        "y": 90,
-        "id": 15,
-        "timeOffset": [timeOffset]
-      }
-    ]
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 1,
+      "id": 15,
+      "x": 157,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 1,
-    "id": 15,
-    "x": 157,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 6,
+      "id": 12
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 6,
-    "id": 12
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 5,
+      "id": 15
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 5,
-    "id": 15
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 0,
+      "id": 15,
+      "x": 157,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 0,
-    "id": 15,
-    "x": 157,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 2,
+      "id": 15,
+      "x": 157,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 2,
-    "id": 15,
-    "x": 157,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 1,
+      "positions": [
+        {
+          "x": 157,
+          "y": 90,
+          "id": 15,
+          "timeOffset": [timeOffset]
+        }
+      ]
+    },
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-6-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-6-snap-incremental-chromium
@@ -49,20 +49,5 @@
       "y": 90
     },
     "timestamp": [timestamp]
-  },
-  {
-    "type": 3,
-    "data": {
-      "source": 1,
-      "positions": [
-        {
-          "x": 157,
-          "y": 90,
-          "id": 15,
-          "timeOffset": [timeOffset]
-        }
-      ]
-    },
-    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-7-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-7-snap-incremental
@@ -1,44 +1,68 @@
 [
   {
-    "source": 1,
-    "positions": [
-      {
-        "x": 41,
-        "y": 90,
-        "id": 12,
-        "timeOffset": [timeOffset]
-      }
-    ]
+    "type": 3,
+    "data": {
+      "source": 1,
+      "positions": [
+        {
+          "x": 41,
+          "y": 90,
+          "id": 12,
+          "timeOffset": [timeOffset]
+        }
+      ]
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 1,
-    "id": 12,
-    "x": 41,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 1,
+      "id": 12,
+      "x": 41,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 6,
-    "id": 15
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 6,
+      "id": 15
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 5,
-    "id": 12
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 5,
+      "id": 12
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 0,
-    "id": 12,
-    "x": 41,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 0,
+      "id": 12,
+      "x": 41,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 2,
-    "id": 12,
-    "x": 41,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 2,
+      "id": 12,
+      "x": 41,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-7-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-7-snap-incremental
@@ -2,21 +2,6 @@
   {
     "type": 3,
     "data": {
-      "source": 1,
-      "positions": [
-        {
-          "x": 41,
-          "y": 90,
-          "id": 12,
-          "timeOffset": [timeOffset]
-        }
-      ]
-    },
-    "timestamp": [timestamp]
-  },
-  {
-    "type": 3,
-    "data": {
       "source": 2,
       "type": 1,
       "id": 12,

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-7-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-7-snap-incremental-chromium
@@ -1,44 +1,68 @@
 [
   {
-    "source": 1,
-    "positions": [
-      {
-        "x": 41,
-        "y": 90,
-        "id": 12,
-        "timeOffset": [timeOffset]
-      }
-    ]
+    "type": 3,
+    "data": {
+      "source": 1,
+      "positions": [
+        {
+          "x": 41,
+          "y": 90,
+          "id": 12,
+          "timeOffset": [timeOffset]
+        }
+      ]
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 1,
-    "id": 12,
-    "x": 41,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 1,
+      "id": 12,
+      "x": 41,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 6,
-    "id": 15
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 6,
+      "id": 15
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 5,
-    "id": 12
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 5,
+      "id": 12
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 0,
-    "id": 12,
-    "x": 41,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 0,
+      "id": 12,
+      "x": 41,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 2,
-    "id": 12,
-    "x": 41,
-    "y": 90
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 2,
+      "id": 12,
+      "x": 41,
+      "y": 90
+    },
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-7-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-7-snap-incremental-chromium
@@ -2,21 +2,6 @@
   {
     "type": 3,
     "data": {
-      "source": 1,
-      "positions": [
-        {
-          "x": 41,
-          "y": 90,
-          "id": 12,
-          "timeOffset": [timeOffset]
-        }
-      ]
-    },
-    "timestamp": [timestamp]
-  },
-  {
-    "type": 3,
-    "data": {
       "source": 2,
       "type": 1,
       "id": 12,

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-8-snap-full
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-8-snap-full
@@ -1,109 +1,113 @@
 [
   {
-    "node": {
-      "type": 0,
-      "childNodes": [
-        {
-          "type": 1,
-          "name": "html",
-          "publicId": "",
-          "systemId": "",
-          "id": 2
-        },
-        {
-          "type": 2,
-          "tagName": "html",
-          "attributes": {},
-          "childNodes": [
-            {
-              "type": 2,
-              "tagName": "head",
-              "attributes": {},
-              "childNodes": [
-                {
-                  "type": 2,
-                  "tagName": "meta",
-                  "attributes": {
-                    "charset": "utf-8"
+    "type": 2,
+    "data": {
+      "node": {
+        "type": 0,
+        "childNodes": [
+          {
+            "type": 1,
+            "name": "html",
+            "publicId": "",
+            "systemId": "",
+            "id": 2
+          },
+          {
+            "type": 2,
+            "tagName": "html",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "head",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 2,
+                    "tagName": "meta",
+                    "attributes": {
+                      "charset": "utf-8"
+                    },
+                    "childNodes": [],
+                    "id": 5
+                  }
+                ],
+                "id": 4
+              },
+              {
+                "type": 3,
+                "textContent": "\n  ",
+                "id": 6
+              },
+              {
+                "type": 2,
+                "tagName": "body",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 8
                   },
-                  "childNodes": [],
-                  "id": 5
-                }
-              ],
-              "id": 4
-            },
-            {
-              "type": 3,
-              "textContent": "\n  ",
-              "id": 6
-            },
-            {
-              "type": 2,
-              "tagName": "body",
-              "attributes": {},
-              "childNodes": [
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 8
-                },
-                {
-                  "type": 2,
-                  "tagName": "button",
-                  "attributes": {
-                    "id": "go-background"
+                  {
+                    "type": 2,
+                    "tagName": "button",
+                    "attributes": {
+                      "id": "go-background"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "*** ***",
+                        "id": 10
+                      }
+                    ],
+                    "id": 9
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "*** ***",
-                      "id": 10
-                    }
-                  ],
-                  "id": 9
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 11
-                },
-                {
-                  "type": 2,
-                  "tagName": "a",
-                  "attributes": {
-                    "href": "/page-0.html"
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 11
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "** ** *** ****",
-                      "id": 13
-                    }
-                  ],
-                  "id": 12
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n  ",
-                  "id": 14
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n\n",
-                  "id": 15
-                }
-              ],
-              "id": 7
-            }
-          ],
-          "id": 3
-        }
-      ],
-      "id": 1
+                  {
+                    "type": 2,
+                    "tagName": "a",
+                    "attributes": {
+                      "href": "/page-0.html"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "** ** *** ****",
+                        "id": 13
+                      }
+                    ],
+                    "id": 12
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n  ",
+                    "id": 14
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n\n",
+                    "id": 15
+                  }
+                ],
+                "id": 7
+              }
+            ],
+            "id": 3
+          }
+        ],
+        "id": 1
+      },
+      "initialOffset": {
+        "left": 0,
+        "top": 0
+      }
     },
-    "initialOffset": {
-      "left": 0,
-      "top": 0
-    }
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-8-snap-full-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-8-snap-full-chromium
@@ -1,109 +1,113 @@
 [
   {
-    "node": {
-      "type": 0,
-      "childNodes": [
-        {
-          "type": 1,
-          "name": "html",
-          "publicId": "",
-          "systemId": "",
-          "id": 2
-        },
-        {
-          "type": 2,
-          "tagName": "html",
-          "attributes": {},
-          "childNodes": [
-            {
-              "type": 2,
-              "tagName": "head",
-              "attributes": {},
-              "childNodes": [
-                {
-                  "type": 2,
-                  "tagName": "meta",
-                  "attributes": {
-                    "charset": "utf-8"
+    "type": 2,
+    "data": {
+      "node": {
+        "type": 0,
+        "childNodes": [
+          {
+            "type": 1,
+            "name": "html",
+            "publicId": "",
+            "systemId": "",
+            "id": 2
+          },
+          {
+            "type": 2,
+            "tagName": "html",
+            "attributes": {},
+            "childNodes": [
+              {
+                "type": 2,
+                "tagName": "head",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 2,
+                    "tagName": "meta",
+                    "attributes": {
+                      "charset": "utf-8"
+                    },
+                    "childNodes": [],
+                    "id": 5
+                  }
+                ],
+                "id": 4
+              },
+              {
+                "type": 3,
+                "textContent": "\n  ",
+                "id": 6
+              },
+              {
+                "type": 2,
+                "tagName": "body",
+                "attributes": {},
+                "childNodes": [
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 8
                   },
-                  "childNodes": [],
-                  "id": 5
-                }
-              ],
-              "id": 4
-            },
-            {
-              "type": 3,
-              "textContent": "\n  ",
-              "id": 6
-            },
-            {
-              "type": 2,
-              "tagName": "body",
-              "attributes": {},
-              "childNodes": [
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 8
-                },
-                {
-                  "type": 2,
-                  "tagName": "button",
-                  "attributes": {
-                    "id": "go-background"
+                  {
+                    "type": 2,
+                    "tagName": "button",
+                    "attributes": {
+                      "id": "go-background"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "*** ***",
+                        "id": 10
+                      }
+                    ],
+                    "id": 9
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "*** ***",
-                      "id": 10
-                    }
-                  ],
-                  "id": 9
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n    ",
-                  "id": 11
-                },
-                {
-                  "type": 2,
-                  "tagName": "a",
-                  "attributes": {
-                    "href": "/page-0.html"
+                  {
+                    "type": 3,
+                    "textContent": "\n    ",
+                    "id": 11
                   },
-                  "childNodes": [
-                    {
-                      "type": 3,
-                      "textContent": "** ** *** ****",
-                      "id": 13
-                    }
-                  ],
-                  "id": 12
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n  ",
-                  "id": 14
-                },
-                {
-                  "type": 3,
-                  "textContent": "\n\n",
-                  "id": 15
-                }
-              ],
-              "id": 7
-            }
-          ],
-          "id": 3
-        }
-      ],
-      "id": 1
+                  {
+                    "type": 2,
+                    "tagName": "a",
+                    "attributes": {
+                      "href": "/page-0.html"
+                    },
+                    "childNodes": [
+                      {
+                        "type": 3,
+                        "textContent": "** ** *** ****",
+                        "id": 13
+                      }
+                    ],
+                    "id": 12
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n  ",
+                    "id": 14
+                  },
+                  {
+                    "type": 3,
+                    "textContent": "\n\n",
+                    "id": 15
+                  }
+                ],
+                "id": 7
+              }
+            ],
+            "id": 3
+          }
+        ],
+        "id": 1
+      },
+      "initialOffset": {
+        "left": 0,
+        "top": 0
+      }
     },
-    "initialOffset": {
-      "left": 0,
-      "top": 0
-    }
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-9-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-9-snap-incremental
@@ -1,39 +1,59 @@
 [
   {
-    "source": 1,
-    "positions": [
-      {
-        "x": 41,
-        "y": 18,
-        "id": 9,
-        "timeOffset": [timeOffset]
-      }
-    ]
+    "type": 3,
+    "data": {
+      "source": 1,
+      "positions": [
+        {
+          "x": 41,
+          "y": 18,
+          "id": 9,
+          "timeOffset": [timeOffset]
+        }
+      ]
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 1,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 1,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 5,
-    "id": 9
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 5,
+      "id": 9
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 0,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 0,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 2,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 2,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-9-snap-incremental
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-9-snap-incremental
@@ -2,21 +2,6 @@
   {
     "type": 3,
     "data": {
-      "source": 1,
-      "positions": [
-        {
-          "x": 41,
-          "y": 18,
-          "id": 9,
-          "timeOffset": [timeOffset]
-        }
-      ]
-    },
-    "timestamp": [timestamp]
-  },
-  {
-    "type": 3,
-    "data": {
       "source": 2,
       "type": 1,
       "id": 9,

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-9-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-9-snap-incremental-chromium
@@ -1,39 +1,59 @@
 [
   {
-    "source": 1,
-    "positions": [
-      {
-        "x": 41,
-        "y": 18,
-        "id": 9,
-        "timeOffset": [timeOffset]
-      }
-    ]
+    "type": 3,
+    "data": {
+      "source": 1,
+      "positions": [
+        {
+          "x": 41,
+          "y": 18,
+          "id": 9,
+          "timeOffset": [timeOffset]
+        }
+      ]
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 1,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 1,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 5,
-    "id": 9
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 5,
+      "id": 9
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 0,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 0,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   },
   {
-    "source": 2,
-    "type": 2,
-    "id": 9,
-    "x": 41,
-    "y": 18
+    "type": 3,
+    "data": {
+      "source": 2,
+      "type": 2,
+      "id": 9,
+      "x": 41,
+      "y": 18
+    },
+    "timestamp": [timestamp]
   }
 ]

--- a/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-9-snap-incremental-chromium
+++ b/packages/integration-tests/suites/replay/multiple-pages/test.ts-snapshots/seg-9-snap-incremental-chromium
@@ -2,21 +2,6 @@
   {
     "type": 3,
     "data": {
-      "source": 1,
-      "positions": [
-        {
-          "x": 41,
-          "y": 18,
-          "id": 9,
-          "timeOffset": [timeOffset]
-        }
-      ]
-    },
-    "timestamp": [timestamp]
-  },
-  {
-    "type": 3,
-    "data": {
       "source": 2,
       "type": 1,
       "id": 9,

--- a/packages/integration-tests/suites/replay/privacyBlock/test.ts-snapshots/privacy-chromium.json
+++ b/packages/integration-tests/suites/replay/privacyBlock/test.ts-snapshots/privacy-chromium.json
@@ -1,319 +1,323 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
                 },
-                "childNodes": [],
-                "id": 5
-              },
-              {
-                "type": 2,
-                "tagName": "link",
-                "attributes": {
-                  "rr_width": "[0-50]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 2,
+                  "tagName": "link",
+                  "attributes": {
+                    "rr_width": "[0-50]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 6
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 7
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 9
                 },
-                "childNodes": [],
-                "id": 6
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 7
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 9
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "aria-label": "***** **",
-                  "onclick": "console.log('Test log')"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "aria-label": "***** **",
+                    "onclick": "console.log('Test log')"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 11
+                    }
+                  ],
+                  "id": 10
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 11
-                  }
-                ],
-                "id": 10
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 12
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "**** ****** ** ****** ** *******",
-                    "id": 14
-                  }
-                ],
-                "id": 13
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 15
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "data-sentry-unmask": ""
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 12
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "This should be unmasked due to data attribute",
-                    "id": 17
-                  }
-                ],
-                "id": 16
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 18
-              },
-              {
-                "type": 2,
-                "tagName": "input",
-                "attributes": {
-                  "placeholder": "*********** ****** ** ******"
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "**** ****** ** ****** ** *******",
+                      "id": 14
+                    }
+                  ],
+                  "id": 13
                 },
-                "childNodes": [],
-                "id": 19
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 20
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "title": "***** ****** ** ******"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 15
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** ****** ** ******",
-                    "id": 22
-                  }
-                ],
-                "id": 21
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 23
-              },
-              {
-                "type": 2,
-                "tagName": "svg",
-                "attributes": {
-                  "style": "width:200px;height:200px",
-                  "viewBox": "0 0 80 80"
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "data-sentry-unmask": ""
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "This should be unmasked due to data attribute",
+                      "id": 17
+                    }
+                  ],
+                  "id": 16
                 },
-                "childNodes": [
-                  {
-                    "type": 2,
-                    "tagName": "path",
-                    "attributes": {
-                      "d": ""
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 18
+                },
+                {
+                  "type": 2,
+                  "tagName": "input",
+                  "attributes": {
+                    "placeholder": "*********** ****** ** ******"
+                  },
+                  "childNodes": [],
+                  "id": 19
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 20
+                },
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "title": "***** ****** ** ******"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** ****** ** ******",
+                      "id": 22
+                    }
+                  ],
+                  "id": 21
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 23
+                },
+                {
+                  "type": 2,
+                  "tagName": "svg",
+                  "attributes": {
+                    "style": "width:200px;height:200px",
+                    "viewBox": "0 0 80 80"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 2,
+                      "tagName": "path",
+                      "attributes": {
+                        "d": ""
+                      },
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 25
                     },
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 25
-                  },
-                  {
-                    "type": 2,
-                    "tagName": "area",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 26
-                  },
-                  {
-                    "type": 2,
-                    "tagName": "rect",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 27
-                  }
-                ],
-                "isSVG": true,
-                "id": 24
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 28
-              },
-              {
-                "type": 2,
-                "tagName": "svg",
-                "attributes": {
-                  "style": "width:200px;height:200px",
-                  "viewBox": "0 0 80 80",
-                  "data-sentry-unblock": ""
-                },
-                "childNodes": [
-                  {
-                    "type": 2,
-                    "tagName": "path",
-                    "attributes": {
-                      "d": ""
+                    {
+                      "type": 2,
+                      "tagName": "area",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 26
                     },
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 30
+                    {
+                      "type": 2,
+                      "tagName": "rect",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 27
+                    }
+                  ],
+                  "isSVG": true,
+                  "id": 24
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 28
+                },
+                {
+                  "type": 2,
+                  "tagName": "svg",
+                  "attributes": {
+                    "style": "width:200px;height:200px",
+                    "viewBox": "0 0 80 80",
+                    "data-sentry-unblock": ""
                   },
-                  {
-                    "type": 2,
-                    "tagName": "area",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 31
+                  "childNodes": [
+                    {
+                      "type": 2,
+                      "tagName": "path",
+                      "attributes": {
+                        "d": ""
+                      },
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 30
+                    },
+                    {
+                      "type": 2,
+                      "tagName": "area",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 31
+                    },
+                    {
+                      "type": 2,
+                      "tagName": "rect",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 32
+                    }
+                  ],
+                  "isSVG": true,
+                  "id": 29
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 33
+                },
+                {
+                  "type": 2,
+                  "tagName": "img",
+                  "attributes": {
+                    "style": "width:100px;height:100px",
+                    "src": "file:///none.png"
                   },
-                  {
-                    "type": 2,
-                    "tagName": "rect",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 32
-                  }
-                ],
-                "isSVG": true,
-                "id": 29
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 33
-              },
-              {
-                "type": 2,
-                "tagName": "img",
-                "attributes": {
-                  "style": "width:100px;height:100px",
-                  "src": "file:///none.png"
+                  "childNodes": [],
+                  "id": 34
                 },
-                "childNodes": [],
-                "id": 34
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 35
-              },
-              {
-                "type": 2,
-                "tagName": "img",
-                "attributes": {
-                  "data-sentry-unblock": "",
-                  "style": "width:100px;height:100px",
-                  "src": "file:///none.png"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 35
                 },
-                "childNodes": [],
-                "id": 36
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 37
-              },
-              {
-                "type": 2,
-                "tagName": "video",
-                "attributes": {
-                  "rr_width": "[0-50]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 2,
+                  "tagName": "img",
+                  "attributes": {
+                    "data-sentry-unblock": "",
+                    "style": "width:100px;height:100px",
+                    "src": "file:///none.png"
+                  },
+                  "childNodes": [],
+                  "id": 36
                 },
-                "childNodes": [],
-                "id": 38
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 39
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "class": "nested-hide",
-                  "rr_width": "[1250-1300]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 37
                 },
-                "childNodes": [],
-                "id": 40
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 41
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 42
-              }
-            ],
-            "id": 8
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "video",
+                  "attributes": {
+                    "rr_width": "[0-50]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 38
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 39
+                },
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "class": "nested-hide",
+                    "rr_width": "[1250-1300]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 40
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 41
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 42
+                }
+              ],
+              "id": 8
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/privacyBlock/test.ts-snapshots/privacy-firefox.json
+++ b/packages/integration-tests/suites/replay/privacyBlock/test.ts-snapshots/privacy-firefox.json
@@ -1,319 +1,323 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
                 },
-                "childNodes": [],
-                "id": 5
-              },
-              {
-                "type": 2,
-                "tagName": "link",
-                "attributes": {
-                  "rr_width": "[0-50]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 2,
+                  "tagName": "link",
+                  "attributes": {
+                    "rr_width": "[0-50]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 6
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 7
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 9
                 },
-                "childNodes": [],
-                "id": 6
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 7
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 9
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "aria-label": "***** **",
-                  "onclick": "console.log('Test log')"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "aria-label": "***** **",
+                    "onclick": "console.log('Test log')"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 11
+                    }
+                  ],
+                  "id": 10
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 11
-                  }
-                ],
-                "id": 10
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 12
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "**** ****** ** ****** ** *******",
-                    "id": 14
-                  }
-                ],
-                "id": 13
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 15
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "data-sentry-unmask": ""
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 12
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "This should be unmasked due to data attribute",
-                    "id": 17
-                  }
-                ],
-                "id": 16
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 18
-              },
-              {
-                "type": 2,
-                "tagName": "input",
-                "attributes": {
-                  "placeholder": "*********** ****** ** ******"
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "**** ****** ** ****** ** *******",
+                      "id": 14
+                    }
+                  ],
+                  "id": 13
                 },
-                "childNodes": [],
-                "id": 19
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 20
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "title": "***** ****** ** ******"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 15
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** ****** ** ******",
-                    "id": 22
-                  }
-                ],
-                "id": 21
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 23
-              },
-              {
-                "type": 2,
-                "tagName": "svg",
-                "attributes": {
-                  "style": "width:200px;height:200px",
-                  "viewBox": "0 0 80 80"
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "data-sentry-unmask": ""
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "This should be unmasked due to data attribute",
+                      "id": 17
+                    }
+                  ],
+                  "id": 16
                 },
-                "childNodes": [
-                  {
-                    "type": 2,
-                    "tagName": "path",
-                    "attributes": {
-                      "d": ""
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 18
+                },
+                {
+                  "type": 2,
+                  "tagName": "input",
+                  "attributes": {
+                    "placeholder": "*********** ****** ** ******"
+                  },
+                  "childNodes": [],
+                  "id": 19
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 20
+                },
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "title": "***** ****** ** ******"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** ****** ** ******",
+                      "id": 22
+                    }
+                  ],
+                  "id": 21
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 23
+                },
+                {
+                  "type": 2,
+                  "tagName": "svg",
+                  "attributes": {
+                    "style": "width:200px;height:200px",
+                    "viewBox": "0 0 80 80"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 2,
+                      "tagName": "path",
+                      "attributes": {
+                        "d": ""
+                      },
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 25
                     },
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 25
-                  },
-                  {
-                    "type": 2,
-                    "tagName": "area",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 26
-                  },
-                  {
-                    "type": 2,
-                    "tagName": "rect",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 27
-                  }
-                ],
-                "isSVG": true,
-                "id": 24
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 28
-              },
-              {
-                "type": 2,
-                "tagName": "svg",
-                "attributes": {
-                  "style": "width:200px;height:200px",
-                  "viewBox": "0 0 80 80",
-                  "data-sentry-unblock": ""
-                },
-                "childNodes": [
-                  {
-                    "type": 2,
-                    "tagName": "path",
-                    "attributes": {
-                      "d": ""
+                    {
+                      "type": 2,
+                      "tagName": "area",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 26
                     },
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 30
+                    {
+                      "type": 2,
+                      "tagName": "rect",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 27
+                    }
+                  ],
+                  "isSVG": true,
+                  "id": 24
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 28
+                },
+                {
+                  "type": 2,
+                  "tagName": "svg",
+                  "attributes": {
+                    "style": "width:200px;height:200px",
+                    "viewBox": "0 0 80 80",
+                    "data-sentry-unblock": ""
                   },
-                  {
-                    "type": 2,
-                    "tagName": "area",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 31
+                  "childNodes": [
+                    {
+                      "type": 2,
+                      "tagName": "path",
+                      "attributes": {
+                        "d": ""
+                      },
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 30
+                    },
+                    {
+                      "type": 2,
+                      "tagName": "area",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 31
+                    },
+                    {
+                      "type": 2,
+                      "tagName": "rect",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 32
+                    }
+                  ],
+                  "isSVG": true,
+                  "id": 29
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 33
+                },
+                {
+                  "type": 2,
+                  "tagName": "img",
+                  "attributes": {
+                    "style": "width:100px;height:100px",
+                    "src": "file:///none.png"
                   },
-                  {
-                    "type": 2,
-                    "tagName": "rect",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 32
-                  }
-                ],
-                "isSVG": true,
-                "id": 29
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 33
-              },
-              {
-                "type": 2,
-                "tagName": "img",
-                "attributes": {
-                  "style": "width:100px;height:100px",
-                  "src": "file:///none.png"
+                  "childNodes": [],
+                  "id": 34
                 },
-                "childNodes": [],
-                "id": 34
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 35
-              },
-              {
-                "type": 2,
-                "tagName": "img",
-                "attributes": {
-                  "data-sentry-unblock": "",
-                  "style": "width:100px;height:100px",
-                  "src": "file:///none.png"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 35
                 },
-                "childNodes": [],
-                "id": 36
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 37
-              },
-              {
-                "type": 2,
-                "tagName": "video",
-                "attributes": {
-                  "rr_width": "[0-50]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 2,
+                  "tagName": "img",
+                  "attributes": {
+                    "data-sentry-unblock": "",
+                    "style": "width:100px;height:100px",
+                    "src": "file:///none.png"
+                  },
+                  "childNodes": [],
+                  "id": 36
                 },
-                "childNodes": [],
-                "id": 38
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 39
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "class": "nested-hide",
-                  "rr_width": "[1250-1300]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 37
                 },
-                "childNodes": [],
-                "id": 40
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 41
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 42
-              }
-            ],
-            "id": 8
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "video",
+                  "attributes": {
+                    "rr_width": "[0-50]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 38
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 39
+                },
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "class": "nested-hide",
+                    "rr_width": "[1250-1300]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 40
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 41
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 42
+                }
+              ],
+              "id": 8
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/privacyBlock/test.ts-snapshots/privacy-webkit.json
+++ b/packages/integration-tests/suites/replay/privacyBlock/test.ts-snapshots/privacy-webkit.json
@@ -1,319 +1,323 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
                 },
-                "childNodes": [],
-                "id": 5
-              },
-              {
-                "type": 2,
-                "tagName": "link",
-                "attributes": {
-                  "rr_width": "[0-50]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 2,
+                  "tagName": "link",
+                  "attributes": {
+                    "rr_width": "[0-50]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 6
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 7
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 9
                 },
-                "childNodes": [],
-                "id": 6
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 7
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 9
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "aria-label": "***** **",
-                  "onclick": "console.log('Test log')"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "aria-label": "***** **",
+                    "onclick": "console.log('Test log')"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 11
+                    }
+                  ],
+                  "id": 10
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 11
-                  }
-                ],
-                "id": 10
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 12
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "**** ****** ** ****** ** *******",
-                    "id": 14
-                  }
-                ],
-                "id": 13
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 15
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "data-sentry-unmask": ""
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 12
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "This should be unmasked due to data attribute",
-                    "id": 17
-                  }
-                ],
-                "id": 16
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 18
-              },
-              {
-                "type": 2,
-                "tagName": "input",
-                "attributes": {
-                  "placeholder": "*********** ****** ** ******"
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "**** ****** ** ****** ** *******",
+                      "id": 14
+                    }
+                  ],
+                  "id": 13
                 },
-                "childNodes": [],
-                "id": 19
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 20
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "title": "***** ****** ** ******"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 15
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** ****** ** ******",
-                    "id": 22
-                  }
-                ],
-                "id": 21
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 23
-              },
-              {
-                "type": 2,
-                "tagName": "svg",
-                "attributes": {
-                  "style": "width:200px;height:200px",
-                  "viewBox": "0 0 80 80"
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "data-sentry-unmask": ""
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "This should be unmasked due to data attribute",
+                      "id": 17
+                    }
+                  ],
+                  "id": 16
                 },
-                "childNodes": [
-                  {
-                    "type": 2,
-                    "tagName": "path",
-                    "attributes": {
-                      "d": ""
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 18
+                },
+                {
+                  "type": 2,
+                  "tagName": "input",
+                  "attributes": {
+                    "placeholder": "*********** ****** ** ******"
+                  },
+                  "childNodes": [],
+                  "id": 19
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 20
+                },
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "title": "***** ****** ** ******"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** ****** ** ******",
+                      "id": 22
+                    }
+                  ],
+                  "id": 21
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 23
+                },
+                {
+                  "type": 2,
+                  "tagName": "svg",
+                  "attributes": {
+                    "style": "width:200px;height:200px",
+                    "viewBox": "0 0 80 80"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 2,
+                      "tagName": "path",
+                      "attributes": {
+                        "d": ""
+                      },
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 25
                     },
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 25
-                  },
-                  {
-                    "type": 2,
-                    "tagName": "area",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 26
-                  },
-                  {
-                    "type": 2,
-                    "tagName": "rect",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 27
-                  }
-                ],
-                "isSVG": true,
-                "id": 24
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 28
-              },
-              {
-                "type": 2,
-                "tagName": "svg",
-                "attributes": {
-                  "style": "width:200px;height:200px",
-                  "viewBox": "0 0 80 80",
-                  "data-sentry-unblock": ""
-                },
-                "childNodes": [
-                  {
-                    "type": 2,
-                    "tagName": "path",
-                    "attributes": {
-                      "d": ""
+                    {
+                      "type": 2,
+                      "tagName": "area",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 26
                     },
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 30
+                    {
+                      "type": 2,
+                      "tagName": "rect",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 27
+                    }
+                  ],
+                  "isSVG": true,
+                  "id": 24
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 28
+                },
+                {
+                  "type": 2,
+                  "tagName": "svg",
+                  "attributes": {
+                    "style": "width:200px;height:200px",
+                    "viewBox": "0 0 80 80",
+                    "data-sentry-unblock": ""
                   },
-                  {
-                    "type": 2,
-                    "tagName": "area",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 31
+                  "childNodes": [
+                    {
+                      "type": 2,
+                      "tagName": "path",
+                      "attributes": {
+                        "d": ""
+                      },
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 30
+                    },
+                    {
+                      "type": 2,
+                      "tagName": "area",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 31
+                    },
+                    {
+                      "type": 2,
+                      "tagName": "rect",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 32
+                    }
+                  ],
+                  "isSVG": true,
+                  "id": 29
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 33
+                },
+                {
+                  "type": 2,
+                  "tagName": "img",
+                  "attributes": {
+                    "style": "width:100px;height:100px",
+                    "src": "file:///none.png"
                   },
-                  {
-                    "type": 2,
-                    "tagName": "rect",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 32
-                  }
-                ],
-                "isSVG": true,
-                "id": 29
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 33
-              },
-              {
-                "type": 2,
-                "tagName": "img",
-                "attributes": {
-                  "style": "width:100px;height:100px",
-                  "src": "file:///none.png"
+                  "childNodes": [],
+                  "id": 34
                 },
-                "childNodes": [],
-                "id": 34
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 35
-              },
-              {
-                "type": 2,
-                "tagName": "img",
-                "attributes": {
-                  "data-sentry-unblock": "",
-                  "style": "width:100px;height:100px",
-                  "src": "file:///none.png"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 35
                 },
-                "childNodes": [],
-                "id": 36
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 37
-              },
-              {
-                "type": 2,
-                "tagName": "video",
-                "attributes": {
-                  "rr_width": "[0-50]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 2,
+                  "tagName": "img",
+                  "attributes": {
+                    "data-sentry-unblock": "",
+                    "style": "width:100px;height:100px",
+                    "src": "file:///none.png"
+                  },
+                  "childNodes": [],
+                  "id": 36
                 },
-                "childNodes": [],
-                "id": 38
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 39
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "class": "nested-hide",
-                  "rr_width": "[1250-1300]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 37
                 },
-                "childNodes": [],
-                "id": 40
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 41
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 42
-              }
-            ],
-            "id": 8
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "video",
+                  "attributes": {
+                    "rr_width": "[0-50]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 38
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 39
+                },
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "class": "nested-hide",
+                    "rr_width": "[1250-1300]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 40
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 41
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 42
+                }
+              ],
+              "id": 8
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/privacyBlock/test.ts-snapshots/privacy.json
+++ b/packages/integration-tests/suites/replay/privacyBlock/test.ts-snapshots/privacy.json
@@ -1,319 +1,323 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
                 },
-                "childNodes": [],
-                "id": 5
-              },
-              {
-                "type": 2,
-                "tagName": "link",
-                "attributes": {
-                  "rr_width": "[0-50]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 2,
+                  "tagName": "link",
+                  "attributes": {
+                    "rr_width": "[0-50]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 6
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 7
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 9
                 },
-                "childNodes": [],
-                "id": 6
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 7
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 9
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "aria-label": "***** **",
-                  "onclick": "console.log('Test log')"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "aria-label": "***** **",
+                    "onclick": "console.log('Test log')"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 11
+                    }
+                  ],
+                  "id": 10
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 11
-                  }
-                ],
-                "id": 10
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 12
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "**** ****** ** ****** ** *******",
-                    "id": 14
-                  }
-                ],
-                "id": 13
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 15
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "data-sentry-unmask": ""
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 12
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "This should be unmasked due to data attribute",
-                    "id": 17
-                  }
-                ],
-                "id": 16
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 18
-              },
-              {
-                "type": 2,
-                "tagName": "input",
-                "attributes": {
-                  "placeholder": "*********** ****** ** ******"
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "**** ****** ** ****** ** *******",
+                      "id": 14
+                    }
+                  ],
+                  "id": 13
                 },
-                "childNodes": [],
-                "id": 19
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 20
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "title": "***** ****** ** ******"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 15
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** ****** ** ******",
-                    "id": 22
-                  }
-                ],
-                "id": 21
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 23
-              },
-              {
-                "type": 2,
-                "tagName": "svg",
-                "attributes": {
-                  "style": "width:200px;height:200px",
-                  "viewBox": "0 0 80 80"
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "data-sentry-unmask": ""
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "This should be unmasked due to data attribute",
+                      "id": 17
+                    }
+                  ],
+                  "id": 16
                 },
-                "childNodes": [
-                  {
-                    "type": 2,
-                    "tagName": "path",
-                    "attributes": {
-                      "d": ""
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 18
+                },
+                {
+                  "type": 2,
+                  "tagName": "input",
+                  "attributes": {
+                    "placeholder": "*********** ****** ** ******"
+                  },
+                  "childNodes": [],
+                  "id": 19
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 20
+                },
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "title": "***** ****** ** ******"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** ****** ** ******",
+                      "id": 22
+                    }
+                  ],
+                  "id": 21
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 23
+                },
+                {
+                  "type": 2,
+                  "tagName": "svg",
+                  "attributes": {
+                    "style": "width:200px;height:200px",
+                    "viewBox": "0 0 80 80"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 2,
+                      "tagName": "path",
+                      "attributes": {
+                        "d": ""
+                      },
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 25
                     },
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 25
-                  },
-                  {
-                    "type": 2,
-                    "tagName": "area",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 26
-                  },
-                  {
-                    "type": 2,
-                    "tagName": "rect",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 27
-                  }
-                ],
-                "isSVG": true,
-                "id": 24
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 28
-              },
-              {
-                "type": 2,
-                "tagName": "svg",
-                "attributes": {
-                  "style": "width:200px;height:200px",
-                  "viewBox": "0 0 80 80",
-                  "data-sentry-unblock": ""
-                },
-                "childNodes": [
-                  {
-                    "type": 2,
-                    "tagName": "path",
-                    "attributes": {
-                      "d": ""
+                    {
+                      "type": 2,
+                      "tagName": "area",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 26
                     },
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 30
+                    {
+                      "type": 2,
+                      "tagName": "rect",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 27
+                    }
+                  ],
+                  "isSVG": true,
+                  "id": 24
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 28
+                },
+                {
+                  "type": 2,
+                  "tagName": "svg",
+                  "attributes": {
+                    "style": "width:200px;height:200px",
+                    "viewBox": "0 0 80 80",
+                    "data-sentry-unblock": ""
                   },
-                  {
-                    "type": 2,
-                    "tagName": "area",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 31
+                  "childNodes": [
+                    {
+                      "type": 2,
+                      "tagName": "path",
+                      "attributes": {
+                        "d": ""
+                      },
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 30
+                    },
+                    {
+                      "type": 2,
+                      "tagName": "area",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 31
+                    },
+                    {
+                      "type": 2,
+                      "tagName": "rect",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 32
+                    }
+                  ],
+                  "isSVG": true,
+                  "id": 29
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 33
+                },
+                {
+                  "type": 2,
+                  "tagName": "img",
+                  "attributes": {
+                    "style": "width:100px;height:100px",
+                    "src": "file:///none.png"
                   },
-                  {
-                    "type": 2,
-                    "tagName": "rect",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 32
-                  }
-                ],
-                "isSVG": true,
-                "id": 29
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 33
-              },
-              {
-                "type": 2,
-                "tagName": "img",
-                "attributes": {
-                  "style": "width:100px;height:100px",
-                  "src": "file:///none.png"
+                  "childNodes": [],
+                  "id": 34
                 },
-                "childNodes": [],
-                "id": 34
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 35
-              },
-              {
-                "type": 2,
-                "tagName": "img",
-                "attributes": {
-                  "data-sentry-unblock": "",
-                  "style": "width:100px;height:100px",
-                  "src": "file:///none.png"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 35
                 },
-                "childNodes": [],
-                "id": 36
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 37
-              },
-              {
-                "type": 2,
-                "tagName": "video",
-                "attributes": {
-                  "rr_width": "[0-50]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 2,
+                  "tagName": "img",
+                  "attributes": {
+                    "data-sentry-unblock": "",
+                    "style": "width:100px;height:100px",
+                    "src": "file:///none.png"
+                  },
+                  "childNodes": [],
+                  "id": 36
                 },
-                "childNodes": [],
-                "id": 38
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 39
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "class": "nested-hide",
-                  "rr_width": "[1250-1300]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 37
                 },
-                "childNodes": [],
-                "id": 40
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 41
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 42
-              }
-            ],
-            "id": 8
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "video",
+                  "attributes": {
+                    "rr_width": "[0-50]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 38
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 39
+                },
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "class": "nested-hide",
+                    "rr_width": "[1250-1300]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 40
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 41
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 42
+                }
+              ],
+              "id": 8
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/privacyDefault/test.ts-snapshots/privacy-chromium.json
+++ b/packages/integration-tests/suites/replay/privacyDefault/test.ts-snapshots/privacy-chromium.json
@@ -1,276 +1,280 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
                 },
-                "childNodes": [],
-                "id": 5
-              },
-              {
-                "type": 2,
-                "tagName": "link",
-                "attributes": {
-                  "rr_width": "[0-50]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 2,
+                  "tagName": "link",
+                  "attributes": {
+                    "rr_width": "[0-50]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 6
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 7
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 9
                 },
-                "childNodes": [],
-                "id": 6
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 7
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 9
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "aria-label": "***** **",
-                  "onclick": "console.log('Test log')"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "aria-label": "***** **",
+                    "onclick": "console.log('Test log')"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 11
+                    }
+                  ],
+                  "id": 10
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 11
-                  }
-                ],
-                "id": 10
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 12
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "**** ****** ** ****** ** *******",
-                    "id": 14
-                  }
-                ],
-                "id": 13
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 15
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "data-sentry-unmask": ""
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 12
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "This should be unmasked due to data attribute",
-                    "id": 17
-                  }
-                ],
-                "id": 16
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 18
-              },
-              {
-                "type": 2,
-                "tagName": "input",
-                "attributes": {
-                  "placeholder": "*********** ****** ** ******"
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "**** ****** ** ****** ** *******",
+                      "id": 14
+                    }
+                  ],
+                  "id": 13
                 },
-                "childNodes": [],
-                "id": 19
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 20
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "title": "***** ****** ** ******"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 15
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** ****** ** ******",
-                    "id": 22
-                  }
-                ],
-                "id": 21
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 23
-              },
-              {
-                "type": 2,
-                "tagName": "svg",
-                "attributes": {
-                  "rr_width": "[200-250]px",
-                  "rr_height": "[200-250]px"
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "data-sentry-unmask": ""
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "This should be unmasked due to data attribute",
+                      "id": 17
+                    }
+                  ],
+                  "id": 16
                 },
-                "childNodes": [],
-                "isSVG": true,
-                "id": 24
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 25
-              },
-              {
-                "type": 2,
-                "tagName": "svg",
-                "attributes": {
-                  "style": "width:200px;height:200px",
-                  "viewBox": "0 0 80 80",
-                  "data-sentry-unblock": ""
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 18
                 },
-                "childNodes": [
-                  {
-                    "type": 2,
-                    "tagName": "path",
-                    "attributes": {
-                      "d": ""
+                {
+                  "type": 2,
+                  "tagName": "input",
+                  "attributes": {
+                    "placeholder": "*********** ****** ** ******"
+                  },
+                  "childNodes": [],
+                  "id": 19
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 20
+                },
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "title": "***** ****** ** ******"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** ****** ** ******",
+                      "id": 22
+                    }
+                  ],
+                  "id": 21
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 23
+                },
+                {
+                  "type": 2,
+                  "tagName": "svg",
+                  "attributes": {
+                    "rr_width": "[200-250]px",
+                    "rr_height": "[200-250]px"
+                  },
+                  "childNodes": [],
+                  "isSVG": true,
+                  "id": 24
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 25
+                },
+                {
+                  "type": 2,
+                  "tagName": "svg",
+                  "attributes": {
+                    "style": "width:200px;height:200px",
+                    "viewBox": "0 0 80 80",
+                    "data-sentry-unblock": ""
+                  },
+                  "childNodes": [
+                    {
+                      "type": 2,
+                      "tagName": "path",
+                      "attributes": {
+                        "d": ""
+                      },
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 27
                     },
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 27
+                    {
+                      "type": 2,
+                      "tagName": "area",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 28
+                    },
+                    {
+                      "type": 2,
+                      "tagName": "rect",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 29
+                    }
+                  ],
+                  "isSVG": true,
+                  "id": 26
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 30
+                },
+                {
+                  "type": 2,
+                  "tagName": "img",
+                  "attributes": {
+                    "rr_width": "[100-150]px",
+                    "rr_height": "[100-150]px"
                   },
-                  {
-                    "type": 2,
-                    "tagName": "area",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 28
+                  "childNodes": [],
+                  "id": 31
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 32
+                },
+                {
+                  "type": 2,
+                  "tagName": "img",
+                  "attributes": {
+                    "data-sentry-unblock": "",
+                    "style": "width:100px;height:100px",
+                    "src": "file:///none.png"
                   },
-                  {
-                    "type": 2,
-                    "tagName": "rect",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 29
-                  }
-                ],
-                "isSVG": true,
-                "id": 26
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 30
-              },
-              {
-                "type": 2,
-                "tagName": "img",
-                "attributes": {
-                  "rr_width": "[100-150]px",
-                  "rr_height": "[100-150]px"
+                  "childNodes": [],
+                  "id": 33
                 },
-                "childNodes": [],
-                "id": 31
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 32
-              },
-              {
-                "type": 2,
-                "tagName": "img",
-                "attributes": {
-                  "data-sentry-unblock": "",
-                  "style": "width:100px;height:100px",
-                  "src": "file:///none.png"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 34
                 },
-                "childNodes": [],
-                "id": 33
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 34
-              },
-              {
-                "type": 2,
-                "tagName": "video",
-                "attributes": {
-                  "rr_width": "[0-50]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 2,
+                  "tagName": "video",
+                  "attributes": {
+                    "rr_width": "[0-50]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 35
                 },
-                "childNodes": [],
-                "id": 35
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 36
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 37
-              }
-            ],
-            "id": 8
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 36
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 37
+                }
+              ],
+              "id": 8
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/privacyDefault/test.ts-snapshots/privacy-firefox.json
+++ b/packages/integration-tests/suites/replay/privacyDefault/test.ts-snapshots/privacy-firefox.json
@@ -1,276 +1,280 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
                 },
-                "childNodes": [],
-                "id": 5
-              },
-              {
-                "type": 2,
-                "tagName": "link",
-                "attributes": {
-                  "rr_width": "[0-50]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 2,
+                  "tagName": "link",
+                  "attributes": {
+                    "rr_width": "[0-50]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 6
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 7
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 9
                 },
-                "childNodes": [],
-                "id": 6
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 7
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 9
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "aria-label": "***** **",
-                  "onclick": "console.log('Test log')"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "aria-label": "***** **",
+                    "onclick": "console.log('Test log')"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 11
+                    }
+                  ],
+                  "id": 10
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 11
-                  }
-                ],
-                "id": 10
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 12
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "**** ****** ** ****** ** *******",
-                    "id": 14
-                  }
-                ],
-                "id": 13
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 15
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "data-sentry-unmask": ""
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 12
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "This should be unmasked due to data attribute",
-                    "id": 17
-                  }
-                ],
-                "id": 16
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 18
-              },
-              {
-                "type": 2,
-                "tagName": "input",
-                "attributes": {
-                  "placeholder": "*********** ****** ** ******"
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "**** ****** ** ****** ** *******",
+                      "id": 14
+                    }
+                  ],
+                  "id": 13
                 },
-                "childNodes": [],
-                "id": 19
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 20
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "title": "***** ****** ** ******"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 15
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** ****** ** ******",
-                    "id": 22
-                  }
-                ],
-                "id": 21
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 23
-              },
-              {
-                "type": 2,
-                "tagName": "svg",
-                "attributes": {
-                  "rr_width": "[200-250]px",
-                  "rr_height": "[200-250]px"
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "data-sentry-unmask": ""
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "This should be unmasked due to data attribute",
+                      "id": 17
+                    }
+                  ],
+                  "id": 16
                 },
-                "childNodes": [],
-                "isSVG": true,
-                "id": 24
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 25
-              },
-              {
-                "type": 2,
-                "tagName": "svg",
-                "attributes": {
-                  "style": "width:200px;height:200px",
-                  "viewBox": "0 0 80 80",
-                  "data-sentry-unblock": ""
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 18
                 },
-                "childNodes": [
-                  {
-                    "type": 2,
-                    "tagName": "path",
-                    "attributes": {
-                      "d": ""
+                {
+                  "type": 2,
+                  "tagName": "input",
+                  "attributes": {
+                    "placeholder": "*********** ****** ** ******"
+                  },
+                  "childNodes": [],
+                  "id": 19
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 20
+                },
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "title": "***** ****** ** ******"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** ****** ** ******",
+                      "id": 22
+                    }
+                  ],
+                  "id": 21
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 23
+                },
+                {
+                  "type": 2,
+                  "tagName": "svg",
+                  "attributes": {
+                    "rr_width": "[200-250]px",
+                    "rr_height": "[200-250]px"
+                  },
+                  "childNodes": [],
+                  "isSVG": true,
+                  "id": 24
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 25
+                },
+                {
+                  "type": 2,
+                  "tagName": "svg",
+                  "attributes": {
+                    "style": "width:200px;height:200px",
+                    "viewBox": "0 0 80 80",
+                    "data-sentry-unblock": ""
+                  },
+                  "childNodes": [
+                    {
+                      "type": 2,
+                      "tagName": "path",
+                      "attributes": {
+                        "d": ""
+                      },
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 27
                     },
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 27
+                    {
+                      "type": 2,
+                      "tagName": "area",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 28
+                    },
+                    {
+                      "type": 2,
+                      "tagName": "rect",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 29
+                    }
+                  ],
+                  "isSVG": true,
+                  "id": 26
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 30
+                },
+                {
+                  "type": 2,
+                  "tagName": "img",
+                  "attributes": {
+                    "rr_width": "[100-150]px",
+                    "rr_height": "[100-150]px"
                   },
-                  {
-                    "type": 2,
-                    "tagName": "area",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 28
+                  "childNodes": [],
+                  "id": 31
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 32
+                },
+                {
+                  "type": 2,
+                  "tagName": "img",
+                  "attributes": {
+                    "data-sentry-unblock": "",
+                    "style": "width:100px;height:100px",
+                    "src": "file:///none.png"
                   },
-                  {
-                    "type": 2,
-                    "tagName": "rect",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 29
-                  }
-                ],
-                "isSVG": true,
-                "id": 26
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 30
-              },
-              {
-                "type": 2,
-                "tagName": "img",
-                "attributes": {
-                  "rr_width": "[100-150]px",
-                  "rr_height": "[100-150]px"
+                  "childNodes": [],
+                  "id": 33
                 },
-                "childNodes": [],
-                "id": 31
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 32
-              },
-              {
-                "type": 2,
-                "tagName": "img",
-                "attributes": {
-                  "data-sentry-unblock": "",
-                  "style": "width:100px;height:100px",
-                  "src": "file:///none.png"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 34
                 },
-                "childNodes": [],
-                "id": 33
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 34
-              },
-              {
-                "type": 2,
-                "tagName": "video",
-                "attributes": {
-                  "rr_width": "[0-50]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 2,
+                  "tagName": "video",
+                  "attributes": {
+                    "rr_width": "[0-50]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 35
                 },
-                "childNodes": [],
-                "id": 35
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 36
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 37
-              }
-            ],
-            "id": 8
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 36
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 37
+                }
+              ],
+              "id": 8
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/privacyDefault/test.ts-snapshots/privacy-webkit.json
+++ b/packages/integration-tests/suites/replay/privacyDefault/test.ts-snapshots/privacy-webkit.json
@@ -1,276 +1,280 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
                 },
-                "childNodes": [],
-                "id": 5
-              },
-              {
-                "type": 2,
-                "tagName": "link",
-                "attributes": {
-                  "rr_width": "[0-50]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 2,
+                  "tagName": "link",
+                  "attributes": {
+                    "rr_width": "[0-50]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 6
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 7
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 9
                 },
-                "childNodes": [],
-                "id": 6
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 7
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 9
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "aria-label": "***** **",
-                  "onclick": "console.log('Test log')"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "aria-label": "***** **",
+                    "onclick": "console.log('Test log')"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 11
+                    }
+                  ],
+                  "id": 10
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 11
-                  }
-                ],
-                "id": 10
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 12
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "**** ****** ** ****** ** *******",
-                    "id": 14
-                  }
-                ],
-                "id": 13
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 15
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "data-sentry-unmask": ""
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 12
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "This should be unmasked due to data attribute",
-                    "id": 17
-                  }
-                ],
-                "id": 16
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 18
-              },
-              {
-                "type": 2,
-                "tagName": "input",
-                "attributes": {
-                  "placeholder": "*********** ****** ** ******"
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "**** ****** ** ****** ** *******",
+                      "id": 14
+                    }
+                  ],
+                  "id": 13
                 },
-                "childNodes": [],
-                "id": 19
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 20
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "title": "***** ****** ** ******"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 15
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** ****** ** ******",
-                    "id": 22
-                  }
-                ],
-                "id": 21
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 23
-              },
-              {
-                "type": 2,
-                "tagName": "svg",
-                "attributes": {
-                  "rr_width": "[200-250]px",
-                  "rr_height": "[200-250]px"
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "data-sentry-unmask": ""
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "This should be unmasked due to data attribute",
+                      "id": 17
+                    }
+                  ],
+                  "id": 16
                 },
-                "childNodes": [],
-                "isSVG": true,
-                "id": 24
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 25
-              },
-              {
-                "type": 2,
-                "tagName": "svg",
-                "attributes": {
-                  "style": "width:200px;height:200px",
-                  "viewBox": "0 0 80 80",
-                  "data-sentry-unblock": ""
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 18
                 },
-                "childNodes": [
-                  {
-                    "type": 2,
-                    "tagName": "path",
-                    "attributes": {
-                      "d": ""
+                {
+                  "type": 2,
+                  "tagName": "input",
+                  "attributes": {
+                    "placeholder": "*********** ****** ** ******"
+                  },
+                  "childNodes": [],
+                  "id": 19
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 20
+                },
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "title": "***** ****** ** ******"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** ****** ** ******",
+                      "id": 22
+                    }
+                  ],
+                  "id": 21
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 23
+                },
+                {
+                  "type": 2,
+                  "tagName": "svg",
+                  "attributes": {
+                    "rr_width": "[200-250]px",
+                    "rr_height": "[200-250]px"
+                  },
+                  "childNodes": [],
+                  "isSVG": true,
+                  "id": 24
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 25
+                },
+                {
+                  "type": 2,
+                  "tagName": "svg",
+                  "attributes": {
+                    "style": "width:200px;height:200px",
+                    "viewBox": "0 0 80 80",
+                    "data-sentry-unblock": ""
+                  },
+                  "childNodes": [
+                    {
+                      "type": 2,
+                      "tagName": "path",
+                      "attributes": {
+                        "d": ""
+                      },
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 27
                     },
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 27
+                    {
+                      "type": 2,
+                      "tagName": "area",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 28
+                    },
+                    {
+                      "type": 2,
+                      "tagName": "rect",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 29
+                    }
+                  ],
+                  "isSVG": true,
+                  "id": 26
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 30
+                },
+                {
+                  "type": 2,
+                  "tagName": "img",
+                  "attributes": {
+                    "rr_width": "[100-150]px",
+                    "rr_height": "[100-150]px"
                   },
-                  {
-                    "type": 2,
-                    "tagName": "area",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 28
+                  "childNodes": [],
+                  "id": 31
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 32
+                },
+                {
+                  "type": 2,
+                  "tagName": "img",
+                  "attributes": {
+                    "data-sentry-unblock": "",
+                    "style": "width:100px;height:100px",
+                    "src": "file:///none.png"
                   },
-                  {
-                    "type": 2,
-                    "tagName": "rect",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 29
-                  }
-                ],
-                "isSVG": true,
-                "id": 26
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 30
-              },
-              {
-                "type": 2,
-                "tagName": "img",
-                "attributes": {
-                  "rr_width": "[100-150]px",
-                  "rr_height": "[100-150]px"
+                  "childNodes": [],
+                  "id": 33
                 },
-                "childNodes": [],
-                "id": 31
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 32
-              },
-              {
-                "type": 2,
-                "tagName": "img",
-                "attributes": {
-                  "data-sentry-unblock": "",
-                  "style": "width:100px;height:100px",
-                  "src": "file:///none.png"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 34
                 },
-                "childNodes": [],
-                "id": 33
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 34
-              },
-              {
-                "type": 2,
-                "tagName": "video",
-                "attributes": {
-                  "rr_width": "[0-50]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 2,
+                  "tagName": "video",
+                  "attributes": {
+                    "rr_width": "[0-50]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 35
                 },
-                "childNodes": [],
-                "id": 35
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 36
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 37
-              }
-            ],
-            "id": 8
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 36
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 37
+                }
+              ],
+              "id": 8
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/privacyDefault/test.ts-snapshots/privacy.json
+++ b/packages/integration-tests/suites/replay/privacyDefault/test.ts-snapshots/privacy.json
@@ -1,276 +1,280 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
                 },
-                "childNodes": [],
-                "id": 5
-              },
-              {
-                "type": 2,
-                "tagName": "link",
-                "attributes": {
-                  "rr_width": "[0-50]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 2,
+                  "tagName": "link",
+                  "attributes": {
+                    "rr_width": "[0-50]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 6
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 7
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 9
                 },
-                "childNodes": [],
-                "id": 6
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 7
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 9
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "aria-label": "***** **",
-                  "onclick": "console.log('Test log')"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "aria-label": "***** **",
+                    "onclick": "console.log('Test log')"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 11
+                    }
+                  ],
+                  "id": 10
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 11
-                  }
-                ],
-                "id": 10
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 12
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "**** ****** ** ****** ** *******",
-                    "id": 14
-                  }
-                ],
-                "id": 13
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 15
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "data-sentry-unmask": ""
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 12
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "This should be unmasked due to data attribute",
-                    "id": 17
-                  }
-                ],
-                "id": 16
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 18
-              },
-              {
-                "type": 2,
-                "tagName": "input",
-                "attributes": {
-                  "placeholder": "*********** ****** ** ******"
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "**** ****** ** ****** ** *******",
+                      "id": 14
+                    }
+                  ],
+                  "id": 13
                 },
-                "childNodes": [],
-                "id": 19
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 20
-              },
-              {
-                "type": 2,
-                "tagName": "div",
-                "attributes": {
-                  "title": "***** ****** ** ******"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 15
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** ****** ** ******",
-                    "id": 22
-                  }
-                ],
-                "id": 21
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 23
-              },
-              {
-                "type": 2,
-                "tagName": "svg",
-                "attributes": {
-                  "rr_width": "[200-250]px",
-                  "rr_height": "[200-250]px"
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "data-sentry-unmask": ""
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "This should be unmasked due to data attribute",
+                      "id": 17
+                    }
+                  ],
+                  "id": 16
                 },
-                "childNodes": [],
-                "isSVG": true,
-                "id": 24
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 25
-              },
-              {
-                "type": 2,
-                "tagName": "svg",
-                "attributes": {
-                  "style": "width:200px;height:200px",
-                  "viewBox": "0 0 80 80",
-                  "data-sentry-unblock": ""
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 18
                 },
-                "childNodes": [
-                  {
-                    "type": 2,
-                    "tagName": "path",
-                    "attributes": {
-                      "d": ""
+                {
+                  "type": 2,
+                  "tagName": "input",
+                  "attributes": {
+                    "placeholder": "*********** ****** ** ******"
+                  },
+                  "childNodes": [],
+                  "id": 19
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 20
+                },
+                {
+                  "type": 2,
+                  "tagName": "div",
+                  "attributes": {
+                    "title": "***** ****** ** ******"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** ****** ** ******",
+                      "id": 22
+                    }
+                  ],
+                  "id": 21
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 23
+                },
+                {
+                  "type": 2,
+                  "tagName": "svg",
+                  "attributes": {
+                    "rr_width": "[200-250]px",
+                    "rr_height": "[200-250]px"
+                  },
+                  "childNodes": [],
+                  "isSVG": true,
+                  "id": 24
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 25
+                },
+                {
+                  "type": 2,
+                  "tagName": "svg",
+                  "attributes": {
+                    "style": "width:200px;height:200px",
+                    "viewBox": "0 0 80 80",
+                    "data-sentry-unblock": ""
+                  },
+                  "childNodes": [
+                    {
+                      "type": 2,
+                      "tagName": "path",
+                      "attributes": {
+                        "d": ""
+                      },
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 27
                     },
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 27
+                    {
+                      "type": 2,
+                      "tagName": "area",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 28
+                    },
+                    {
+                      "type": 2,
+                      "tagName": "rect",
+                      "attributes": {},
+                      "childNodes": [],
+                      "isSVG": true,
+                      "id": 29
+                    }
+                  ],
+                  "isSVG": true,
+                  "id": 26
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 30
+                },
+                {
+                  "type": 2,
+                  "tagName": "img",
+                  "attributes": {
+                    "rr_width": "[100-150]px",
+                    "rr_height": "[100-150]px"
                   },
-                  {
-                    "type": 2,
-                    "tagName": "area",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 28
+                  "childNodes": [],
+                  "id": 31
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 32
+                },
+                {
+                  "type": 2,
+                  "tagName": "img",
+                  "attributes": {
+                    "data-sentry-unblock": "",
+                    "style": "width:100px;height:100px",
+                    "src": "file:///none.png"
                   },
-                  {
-                    "type": 2,
-                    "tagName": "rect",
-                    "attributes": {},
-                    "childNodes": [],
-                    "isSVG": true,
-                    "id": 29
-                  }
-                ],
-                "isSVG": true,
-                "id": 26
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 30
-              },
-              {
-                "type": 2,
-                "tagName": "img",
-                "attributes": {
-                  "rr_width": "[100-150]px",
-                  "rr_height": "[100-150]px"
+                  "childNodes": [],
+                  "id": 33
                 },
-                "childNodes": [],
-                "id": 31
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 32
-              },
-              {
-                "type": 2,
-                "tagName": "img",
-                "attributes": {
-                  "data-sentry-unblock": "",
-                  "style": "width:100px;height:100px",
-                  "src": "file:///none.png"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 34
                 },
-                "childNodes": [],
-                "id": 33
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 34
-              },
-              {
-                "type": 2,
-                "tagName": "video",
-                "attributes": {
-                  "rr_width": "[0-50]px",
-                  "rr_height": "[0-50]px"
+                {
+                  "type": 2,
+                  "tagName": "video",
+                  "attributes": {
+                    "rr_width": "[0-50]px",
+                    "rr_height": "[0-50]px"
+                  },
+                  "childNodes": [],
+                  "id": 35
                 },
-                "childNodes": [],
-                "id": 35
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 36
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 37
-              }
-            ],
-            "id": 8
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 36
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 37
+                }
+              ],
+              "id": 8
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/sessionExpiry/test.ts
+++ b/packages/integration-tests/suites/replay/sessionExpiry/test.ts
@@ -4,7 +4,6 @@ import { sentryTest } from '../../../utils/fixtures';
 import { getExpectedReplayEvent } from '../../../utils/replayEventTemplates';
 import {
   getFullRecordingSnapshots,
-  getIncrementalRecordingSnapshots,
   getReplayEvent,
   getReplaySnapshot,
   normalize,
@@ -52,29 +51,6 @@ sentryTest('handles an expired session RUN', async ({ getLocalTestPath, page }) 
 
   const replayEvent1 = getReplayEvent(req1);
   expect(replayEvent1).toEqual(getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 1, urls: [] }));
-
-  const fullSnapshots1 = getFullRecordingSnapshots(req1);
-  expect(fullSnapshots1.length).toEqual(0);
-
-  const incrementalSnapshots1 = getIncrementalRecordingSnapshots(req1);
-  // The number of incremental snapshots depends on the browser
-  expect(incrementalSnapshots1.length).toBeGreaterThanOrEqual(4);
-
-  expect(incrementalSnapshots1).toEqual(
-    expect.arrayContaining([
-      {
-        source: 1,
-        positions: [
-          {
-            id: 9,
-            timeOffset: expect.any(Number),
-            x: expect.any(Number),
-            y: expect.any(Number),
-          },
-        ],
-      },
-    ]),
-  );
 
   const replay = await getReplaySnapshot(page);
   const oldSessionId = replay.session?.id;

--- a/packages/integration-tests/suites/replay/sessionExpiry/test.ts-snapshots/snapshot-0-chromium.json
+++ b/packages/integration-tests/suites/replay/sessionExpiry/test.ts-snapshots/snapshot-0-chromium.json
@@ -1,109 +1,113 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 1')",
-                  "id": "button1"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 1')",
+                    "id": "button1"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 2')",
-                  "id": "button2"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 14
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 15
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 2')",
+                    "id": "button2"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 14
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 15
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/sessionExpiry/test.ts-snapshots/snapshot-0-firefox.json
+++ b/packages/integration-tests/suites/replay/sessionExpiry/test.ts-snapshots/snapshot-0-firefox.json
@@ -1,109 +1,113 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 1')",
-                  "id": "button1"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 1')",
+                    "id": "button1"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 2')",
-                  "id": "button2"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 14
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 15
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 2')",
+                    "id": "button2"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 14
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 15
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/sessionExpiry/test.ts-snapshots/snapshot-0-webkit.json
+++ b/packages/integration-tests/suites/replay/sessionExpiry/test.ts-snapshots/snapshot-0-webkit.json
@@ -1,109 +1,113 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 1')",
-                  "id": "button1"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 1')",
+                    "id": "button1"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 2')",
-                  "id": "button2"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 14
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 15
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 2')",
+                    "id": "button2"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 14
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 15
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/sessionExpiry/test.ts-snapshots/snapshot-0.json
+++ b/packages/integration-tests/suites/replay/sessionExpiry/test.ts-snapshots/snapshot-0.json
@@ -1,109 +1,113 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 1')",
-                  "id": "button1"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 1')",
+                    "id": "button1"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 2')",
-                  "id": "button2"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 14
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 15
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 2')",
+                    "id": "button2"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 14
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 15
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/sessionExpiry/test.ts-snapshots/snapshot-2-chromium.json
+++ b/packages/integration-tests/suites/replay/sessionExpiry/test.ts-snapshots/snapshot-2-chromium.json
@@ -1,109 +1,113 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 1')",
-                  "id": "button1"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 1')",
+                    "id": "button1"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 2')",
-                  "id": "button2"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 14
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 15
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 2')",
+                    "id": "button2"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 14
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 15
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/sessionExpiry/test.ts-snapshots/snapshot-2-firefox.json
+++ b/packages/integration-tests/suites/replay/sessionExpiry/test.ts-snapshots/snapshot-2-firefox.json
@@ -1,109 +1,113 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 1')",
-                  "id": "button1"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 1')",
+                    "id": "button1"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 2')",
-                  "id": "button2"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 14
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 15
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 2')",
+                    "id": "button2"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 14
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 15
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/sessionExpiry/test.ts-snapshots/snapshot-2-webkit.json
+++ b/packages/integration-tests/suites/replay/sessionExpiry/test.ts-snapshots/snapshot-2-webkit.json
@@ -1,109 +1,113 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 1')",
-                  "id": "button1"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 1')",
+                    "id": "button1"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 2')",
-                  "id": "button2"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 14
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 15
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 2')",
+                    "id": "button2"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 14
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 15
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/sessionExpiry/test.ts-snapshots/snapshot-2.json
+++ b/packages/integration-tests/suites/replay/sessionExpiry/test.ts-snapshots/snapshot-2.json
@@ -1,109 +1,113 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 1')",
-                  "id": "button1"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 1')",
+                    "id": "button1"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 2')",
-                  "id": "button2"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 14
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 15
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 2')",
+                    "id": "button2"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 14
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 15
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/sessionInactive/test.ts-snapshots/snapshot-0-chromium.json
+++ b/packages/integration-tests/suites/replay/sessionInactive/test.ts-snapshots/snapshot-0-chromium.json
@@ -1,109 +1,113 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 1')",
-                  "id": "button1"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 1')",
+                    "id": "button1"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 2')",
-                  "id": "button2"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 14
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 15
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 2')",
+                    "id": "button2"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 14
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 15
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/sessionInactive/test.ts-snapshots/snapshot-0-firefox.json
+++ b/packages/integration-tests/suites/replay/sessionInactive/test.ts-snapshots/snapshot-0-firefox.json
@@ -1,109 +1,113 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 1')",
-                  "id": "button1"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 1')",
+                    "id": "button1"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 2')",
-                  "id": "button2"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 14
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 15
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 2')",
+                    "id": "button2"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 14
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 15
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/sessionInactive/test.ts-snapshots/snapshot-0-webkit.json
+++ b/packages/integration-tests/suites/replay/sessionInactive/test.ts-snapshots/snapshot-0-webkit.json
@@ -1,109 +1,113 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 1')",
-                  "id": "button1"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 1')",
+                    "id": "button1"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 2')",
-                  "id": "button2"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 14
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 15
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 2')",
+                    "id": "button2"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 14
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 15
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/sessionInactive/test.ts-snapshots/snapshot-0.json
+++ b/packages/integration-tests/suites/replay/sessionInactive/test.ts-snapshots/snapshot-0.json
@@ -1,109 +1,113 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 1')",
-                  "id": "button1"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 1')",
+                    "id": "button1"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 2')",
-                  "id": "button2"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 14
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 15
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 2')",
+                    "id": "button2"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 14
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 15
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/sessionInactive/test.ts-snapshots/snapshot-1-chromium.json
+++ b/packages/integration-tests/suites/replay/sessionInactive/test.ts-snapshots/snapshot-1-chromium.json
@@ -1,109 +1,113 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 1')",
-                  "id": "button1"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 1')",
+                    "id": "button1"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 2')",
-                  "id": "button2"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 14
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 15
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 2')",
+                    "id": "button2"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 14
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 15
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/sessionInactive/test.ts-snapshots/snapshot-1-firefox.json
+++ b/packages/integration-tests/suites/replay/sessionInactive/test.ts-snapshots/snapshot-1-firefox.json
@@ -1,109 +1,113 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 1')",
-                  "id": "button1"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 1')",
+                    "id": "button1"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 2')",
-                  "id": "button2"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 14
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 15
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 2')",
+                    "id": "button2"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 14
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 15
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/sessionInactive/test.ts-snapshots/snapshot-1-webkit.json
+++ b/packages/integration-tests/suites/replay/sessionInactive/test.ts-snapshots/snapshot-1-webkit.json
@@ -1,109 +1,113 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 1')",
-                  "id": "button1"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 1')",
+                    "id": "button1"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 2')",
-                  "id": "button2"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 14
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 15
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 2')",
+                    "id": "button2"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 14
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 15
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/sessionInactive/test.ts-snapshots/snapshot-1.json
+++ b/packages/integration-tests/suites/replay/sessionInactive/test.ts-snapshots/snapshot-1.json
@@ -1,109 +1,113 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 1')",
-                  "id": "button1"
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 1')",
+                    "id": "button1"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "onclick": "console.log('Test log 2')",
-                  "id": "button2"
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "***** **",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 14
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 15
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "onclick": "console.log('Test log 2')",
+                    "id": "button2"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "***** **",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 14
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 15
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-chromium.json
+++ b/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-chromium.json
@@ -1,123 +1,127 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "h1",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "Hi 👋👋👋",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "p",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n    ",
-                "id": 14
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "id": "go-background"
+                {
+                  "type": 2,
+                  "tagName": "h1",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "Hi 👋👋👋",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "✅ Acknowledge",
-                    "id": 16
-                  }
-                ],
-                "id": 15
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 17
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 18
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
+                },
+                {
+                  "type": 2,
+                  "tagName": "p",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n    ",
+                  "id": 14
+                },
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "id": "go-background"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "✅ Acknowledge",
+                      "id": 16
+                    }
+                  ],
+                  "id": 15
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 17
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 18
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-firefox.json
+++ b/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-firefox.json
@@ -1,123 +1,127 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "h1",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "Hi 👋👋👋",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "p",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n    ",
-                "id": 14
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "id": "go-background"
+                {
+                  "type": 2,
+                  "tagName": "h1",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "Hi 👋👋👋",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "✅ Acknowledge",
-                    "id": 16
-                  }
-                ],
-                "id": 15
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 17
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 18
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
+                },
+                {
+                  "type": 2,
+                  "tagName": "p",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n    ",
+                  "id": 14
+                },
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "id": "go-background"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "✅ Acknowledge",
+                      "id": 16
+                    }
+                  ],
+                  "id": 15
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 17
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 18
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-webkit.json
+++ b/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed-webkit.json
@@ -1,123 +1,127 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "h1",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "Hi 👋👋👋",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "p",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n    ",
-                "id": 14
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "id": "go-background"
+                {
+                  "type": 2,
+                  "tagName": "h1",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "Hi 👋👋👋",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "✅ Acknowledge",
-                    "id": 16
-                  }
-                ],
-                "id": 15
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 17
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 18
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
+                },
+                {
+                  "type": 2,
+                  "tagName": "p",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n    ",
+                  "id": 14
+                },
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "id": "go-background"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "✅ Acknowledge",
+                      "id": 16
+                    }
+                  ],
+                  "id": 15
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 17
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 18
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed.json
+++ b/packages/integration-tests/suites/replay/unicode/compressed/test.ts-snapshots/unicode-compressed.json
@@ -1,123 +1,127 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "h1",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "Hi 👋👋👋",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "p",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n    ",
-                "id": 14
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "id": "go-background"
+                {
+                  "type": 2,
+                  "tagName": "h1",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "Hi 👋👋👋",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "✅ Acknowledge",
-                    "id": 16
-                  }
-                ],
-                "id": 15
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 17
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 18
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
+                },
+                {
+                  "type": 2,
+                  "tagName": "p",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n    ",
+                  "id": 14
+                },
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "id": "go-background"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "✅ Acknowledge",
+                      "id": 16
+                    }
+                  ],
+                  "id": 15
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 17
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 18
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-chromium.json
+++ b/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-chromium.json
@@ -1,123 +1,127 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "h1",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "Hi 👋👋👋",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "p",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n    ",
-                "id": 14
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "id": "go-background"
+                {
+                  "type": 2,
+                  "tagName": "h1",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "Hi 👋👋👋",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "✅ Acknowledge",
-                    "id": 16
-                  }
-                ],
-                "id": 15
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 17
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 18
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
+                },
+                {
+                  "type": 2,
+                  "tagName": "p",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n    ",
+                  "id": 14
+                },
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "id": "go-background"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "✅ Acknowledge",
+                      "id": 16
+                    }
+                  ],
+                  "id": 15
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 17
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 18
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-firefox.json
+++ b/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-firefox.json
@@ -1,123 +1,127 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "h1",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "Hi 👋👋👋",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "p",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n    ",
-                "id": 14
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "id": "go-background"
+                {
+                  "type": 2,
+                  "tagName": "h1",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "Hi 👋👋👋",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "✅ Acknowledge",
-                    "id": 16
-                  }
-                ],
-                "id": 15
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 17
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 18
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
+                },
+                {
+                  "type": 2,
+                  "tagName": "p",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n    ",
+                  "id": 14
+                },
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "id": "go-background"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "✅ Acknowledge",
+                      "id": 16
+                    }
+                  ],
+                  "id": 15
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 17
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 18
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-webkit.json
+++ b/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed-webkit.json
@@ -1,123 +1,127 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "h1",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "Hi 👋👋👋",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "p",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n    ",
-                "id": 14
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "id": "go-background"
+                {
+                  "type": 2,
+                  "tagName": "h1",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "Hi 👋👋👋",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "✅ Acknowledge",
-                    "id": 16
-                  }
-                ],
-                "id": 15
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 17
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 18
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
+                },
+                {
+                  "type": 2,
+                  "tagName": "p",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n    ",
+                  "id": 14
+                },
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "id": "go-background"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "✅ Acknowledge",
+                      "id": 16
+                    }
+                  ],
+                  "id": 15
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 17
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 18
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed.json
+++ b/packages/integration-tests/suites/replay/unicode/uncompressed/test.ts-snapshots/unicode-uncompressed.json
@@ -1,123 +1,127 @@
 {
-  "node": {
-    "type": 0,
-    "childNodes": [
-      {
-        "type": 1,
-        "name": "html",
-        "publicId": "",
-        "systemId": "",
-        "id": 2
-      },
-      {
-        "type": 2,
-        "tagName": "html",
-        "attributes": {},
-        "childNodes": [
-          {
-            "type": 2,
-            "tagName": "head",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 2,
-                "tagName": "meta",
-                "attributes": {
-                  "charset": "utf-8"
+  "type": 2,
+  "data": {
+    "node": {
+      "type": 0,
+      "childNodes": [
+        {
+          "type": 1,
+          "name": "html",
+          "publicId": "",
+          "systemId": "",
+          "id": 2
+        },
+        {
+          "type": 2,
+          "tagName": "html",
+          "attributes": {},
+          "childNodes": [
+            {
+              "type": 2,
+              "tagName": "head",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 2,
+                  "tagName": "meta",
+                  "attributes": {
+                    "charset": "utf-8"
+                  },
+                  "childNodes": [],
+                  "id": 5
+                }
+              ],
+              "id": 4
+            },
+            {
+              "type": 3,
+              "textContent": "\n  ",
+              "id": 6
+            },
+            {
+              "type": 2,
+              "tagName": "body",
+              "attributes": {},
+              "childNodes": [
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 8
                 },
-                "childNodes": [],
-                "id": 5
-              }
-            ],
-            "id": 4
-          },
-          {
-            "type": 3,
-            "textContent": "\n  ",
-            "id": 6
-          },
-          {
-            "type": 2,
-            "tagName": "body",
-            "attributes": {},
-            "childNodes": [
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 8
-              },
-              {
-                "type": 2,
-                "tagName": "h1",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "Hi 👋👋👋",
-                    "id": 10
-                  }
-                ],
-                "id": 9
-              },
-              {
-                "type": 3,
-                "textContent": "\n    ",
-                "id": 11
-              },
-              {
-                "type": 2,
-                "tagName": "p",
-                "attributes": {},
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
-                    "id": 13
-                  }
-                ],
-                "id": 12
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n    ",
-                "id": 14
-              },
-              {
-                "type": 2,
-                "tagName": "button",
-                "attributes": {
-                  "id": "go-background"
+                {
+                  "type": 2,
+                  "tagName": "h1",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "Hi 👋👋👋",
+                      "id": 10
+                    }
+                  ],
+                  "id": 9
                 },
-                "childNodes": [
-                  {
-                    "type": 3,
-                    "textContent": "✅ Acknowledge",
-                    "id": 16
-                  }
-                ],
-                "id": 15
-              },
-              {
-                "type": 3,
-                "textContent": "\n  ",
-                "id": 17
-              },
-              {
-                "type": 3,
-                "textContent": "\n\n",
-                "id": 18
-              }
-            ],
-            "id": 7
-          }
-        ],
-        "id": 3
-      }
-    ],
-    "id": 1
+                {
+                  "type": 3,
+                  "textContent": "\n    ",
+                  "id": 11
+                },
+                {
+                  "type": 2,
+                  "tagName": "p",
+                  "attributes": {},
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "\n      Adding some unicode characters to the page to make sure they are properly handled. At sentry, we like 🚢🚢🚢. We\n      also like 🍕, 🍺 and 🐕. (Some people might actually prefer 🐈‍⬛ but the test author is a dog person, so 🤷‍♂️).\n    ",
+                      "id": 13
+                    }
+                  ],
+                  "id": 12
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n    ",
+                  "id": 14
+                },
+                {
+                  "type": 2,
+                  "tagName": "button",
+                  "attributes": {
+                    "id": "go-background"
+                  },
+                  "childNodes": [
+                    {
+                      "type": 3,
+                      "textContent": "✅ Acknowledge",
+                      "id": 16
+                    }
+                  ],
+                  "id": 15
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n  ",
+                  "id": 17
+                },
+                {
+                  "type": 3,
+                  "textContent": "\n\n",
+                  "id": 18
+                }
+              ],
+              "id": 7
+            }
+          ],
+          "id": 3
+        }
+      ],
+      "id": 1
+    },
+    "initialOffset": {
+      "left": 0,
+      "top": 0
+    }
   },
-  "initialOffset": {
-    "left": 0,
-    "top": 0
-  }
+  "timestamp": [timestamp]
 }

--- a/packages/integration-tests/utils/replayHelpers.ts
+++ b/packages/integration-tests/utils/replayHelpers.ts
@@ -140,11 +140,17 @@ export function getIncrementalRecordingSnapshots(resOrReq: Request | Response): 
 
 function getDecompressedRecordingEvents(resOrReq: Request | Response): RecordingSnapshot[] {
   const replayRequest = getRequest(resOrReq);
-  return (replayEnvelopeRequestParser(replayRequest, 5) as eventWithTime[])
-    .sort((a, b) => a.timestamp - b.timestamp)
-    .map(event => {
-      return { ...event, timestamp: 0 };
-    });
+  return (
+    (replayEnvelopeRequestParser(replayRequest, 5) as eventWithTime[])
+      .sort((a, b) => a.timestamp - b.timestamp)
+      // source 1 is MouseMove, which is a bit flaky and we don't care about
+      .filter(
+        event => typeof event.data === 'object' && event.data && (event.data as Record<string, unknown>).source !== 1,
+      )
+      .map(event => {
+        return { ...event, timestamp: 0 };
+      })
+  );
 }
 
 export function getReplayRecordingContent(resOrReq: Request | Response): RecordingContent {


### PR DESCRIPTION
I've seen a few places where snapshot order got changed, which was a bit hard to understand.

This PR updates the snapshots to:

1. Ensure entries are always ordered by `timestamp`
2. Simply use the whole snapshot (instead of just data) for better clarity. We just replace `timestamp` with `[timestamp]`.