### PR TITLE
ref(tracing): Revert conditional exports usage

### DIFF
--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -12,36 +12,6 @@
   "main": "build/npm/cjs/index.js",
   "module": "build/npm/esm/index.js",
   "types": "build/npm/types/index.d.ts",
-  "exports": {
-    ".": {
-      "import": "./build/npm/esm/index.js",
-      "require": "./build/npm/cjs/index.js",
-      "types": "./build/npm/types/index.d.ts"
-    },
-    "./node": {
-      "import": "./build/npm/esm/node/index.js",
-      "require": "./build/npm/cjs/node/index.js",
-      "types": "./build/npm/types/node/index.d.ts"
-    },
-    "./browser": {
-      "import": "./build/npm/esm/browser/index.js",
-      "require": "./build/npm/cjs/browser/index.js",
-      "types": "./build/npm/types/browser/index.d.ts"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./build/npm/types/index.d.ts"
-      ],
-      "node": [
-        "./build/npm/types/node/index.d.ts"
-      ],
-      "browser": [
-        "./build/npm/types/browser/index.d.ts"
-      ]
-    }
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/tracing/rollup.npm.config.js
+++ b/packages/tracing/rollup.npm.config.js
@@ -2,7 +2,6 @@ import { makeBaseNPMConfig, makeNPMConfigVariants } from '../../rollup/index.js'
 
 export default makeNPMConfigVariants(
   makeBaseNPMConfig({
-    entrypoints: ['src/browser/index.ts', 'src/node/index.ts', 'src/index.ts'],
     // packages with bundles have a different build directory structure
     hasBundles: true,
   }),


### PR DESCRIPTION
This partially reverts the work done in https://github.com/getsentry/sentry-javascript/pull/7345

We cannot use this conditional exports approach since this will break users who use older bundlers (think Webpack 4).

Thus the only way to make the splitting of `@sentry/tracing` into multiple packages work in https://github.com/getsentry/sentry-javascript/issues/5815 is to make it a part of the next major version.