### PR TITLE
fix: Make redux integration be configurable via `normalizeDepth`

### DIFF
--- a/packages/utils/src/normalize.ts
+++ b/packages/utils/src/normalize.ts
@@ -105,7 +105,7 @@ function visit(
   // have already been normalized.
   let overriddenDepth = depth;
 
-  if ((value as ObjOrArray<unknown>)['__sentry_override_normalization_depth__']) {
+  if (typeof (value as ObjOrArray<unknown>)['__sentry_override_normalization_depth__'] === 'number') {
     overriddenDepth = (value as ObjOrArray<unknown>)['__sentry_override_normalization_depth__'] as number;
   }
 

--- a/packages/utils/test/normalize.test.ts
+++ b/packages/utils/test/normalize.test.ts
@@ -582,4 +582,58 @@ describe('normalize()', () => {
       expect(result?.foo?.bar?.boo?.bam?.pow).not.toBe('poof');
     });
   });
+
+  describe('overrides normalization depth with a non-enumerable property __sentry_override_normalization_depth__', () => {
+    test('by increasing depth if it is higher', () => {
+      const normalizationTarget = {
+        foo: 'bar',
+        baz: 42,
+        obj: {
+          obj: {
+            obj: {
+              bestSmashCharacter: 'Cpt. Falcon',
+            },
+          },
+        },
+      };
+
+      addNonEnumerableProperty(normalizationTarget, '__sentry_override_normalization_depth__', 3);
+
+      const result = normalize(normalizationTarget, 1);
+
+      expect(result).toEqual({
+        baz: 42,
+        foo: 'bar',
+        obj: {
+          obj: {
+            obj: '[Object]',
+          },
+        },
+      });
+    });
+
+    test('by decreasing depth if it is lower', () => {
+      const normalizationTarget = {
+        foo: 'bar',
+        baz: 42,
+        obj: {
+          obj: {
+            obj: {
+              bestSmashCharacter: 'Cpt. Falcon',
+            },
+          },
+        },
+      };
+
+      addNonEnumerableProperty(normalizationTarget, '__sentry_override_normalization_depth__', 1);
+
+      const result = normalize(normalizationTarget, 3);
+
+      expect(result).toEqual({
+        baz: 42,
+        foo: 'bar',
+        obj: '[Object]',
+      });
+    });
+  });
 });


### PR DESCRIPTION
Attempts to fix https://github.com/getsentry/sentry-javascript/issues/7376

Makes the `normalize` function overridable via a non-enumerable property on the normalization target.