### PR TITLE
feat(types): Add profilesSampler option to node client type

### DIFF
--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -1,4 +1,4 @@
-import type { ClientOptions, Options, TracePropagationTargets } from '@sentry/types';
+import type { ClientOptions, Options, SamplingContext, TracePropagationTargets } from '@sentry/types';
 
 import type { NodeTransportOptions } from './transports';
 
@@ -7,6 +7,20 @@ export interface BaseNodeOptions {
    * Sets profiling sample rate when @sentry/profiling-node is installed
    */
   profilesSampleRate?: number;
+
+  /**
+   * Function to compute profiling sample rate dynamically and filter unwanted profiles.
+   *
+   * Profiling is enabled if either this or `profilesSampleRate` is defined. If both are defined, `profilesSampleRate` is
+   * ignored.
+   *
+   * Will automatically be passed a context object of default and optional custom data. See
+   * {@link Transaction.samplingContext} and {@link Hub.startTransaction}.
+   *
+   * @returns A sample rate between 0 and 1 (0 drops the profile, 1 guarantees it will be sent). Returning `true` is
+   * equivalent to returning 1 and returning `false` is equivalent to returning 0.
+   */
+  profilesSampler?: (samplingContext: SamplingContext) => number | boolean;
 
   /** Sets an optional server name (device name) */
   serverName?: string;


### PR DESCRIPTION
We need to expose a similar option to tracesSampler but for profiling purposes. I kept the signature identical to tracing (maybe I should just reuse the same type?) as profiling just wraps that same startTransaction call.

We need to wait before merging to add the relevant changes to the profiling repository, I would just like to get some feedback on the type before proceeding