### PR TITLE
fix(tracing): Record LCP and CLS on transaction finish

### DIFF
--- a/packages/integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
+++ b/packages/integration-tests/suites/tracing/metrics/web-vitals-lcp/test.ts
@@ -17,8 +17,6 @@ sentryTest('should capture a LCP vital with element details.', async ({ browserN
   const url = await getLocalTestPath({ testDir: __dirname });
   await page.goto(url);
 
-  // Force closure of LCP listener.
-  await page.click('body');
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page);
 
   expect(eventData.measurements).toBeDefined();

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -164,6 +164,8 @@ export class BrowserTracing implements Integration {
   private _latestRouteName?: string;
   private _latestRouteSource?: TransactionSource;
 
+  private _stopListeningForLCP?: () => void;
+
   public constructor(_options?: Partial<BrowserTracingOptions>) {
     this.options = {
       ...DEFAULT_BROWSER_TRACING_OPTIONS,
@@ -185,7 +187,7 @@ export class BrowserTracing implements Integration {
       this.options.tracePropagationTargets = _options.tracingOrigins;
     }
 
-    startTrackingWebVitals();
+    this._stopListeningForLCP = startTrackingWebVitals();
     if (this.options.enableLongTask) {
       startTrackingLongTasks();
     }
@@ -303,6 +305,9 @@ export class BrowserTracing implements Integration {
       heartbeatInterval,
     );
     idleTransaction.registerBeforeFinishCallback(transaction => {
+      if (this._stopListeningForLCP) {
+        this._stopListeningForLCP();
+      }
       addPerformanceEntries(transaction);
     });
 

--- a/packages/tracing/src/browser/browsertracing.ts
+++ b/packages/tracing/src/browser/browsertracing.ts
@@ -169,7 +169,7 @@ export class BrowserTracing implements Integration {
   private _latestRouteName?: string;
   private _latestRouteSource?: TransactionSource;
 
-  private _stopListeningForLCP?: () => void;
+  private _collectWebVitals: () => void;
 
   public constructor(_options?: Partial<BrowserTracingOptions>) {
     this.options = {
@@ -192,7 +192,7 @@ export class BrowserTracing implements Integration {
       this.options.tracePropagationTargets = _options.tracingOrigins;
     }
 
-    this._stopListeningForLCP = startTrackingWebVitals();
+    this._collectWebVitals = startTrackingWebVitals();
     if (this.options.enableLongTask) {
       startTrackingLongTasks();
     }
@@ -313,9 +313,7 @@ export class BrowserTracing implements Integration {
       heartbeatInterval,
     );
     idleTransaction.registerBeforeFinishCallback(transaction => {
-      if (this._stopListeningForLCP) {
-        this._stopListeningForLCP();
-      }
+      this._collectWebVitals();
       addPerformanceEntries(transaction);
     });
 

--- a/packages/tracing/src/browser/metrics/index.ts
+++ b/packages/tracing/src/browser/metrics/index.ts
@@ -34,16 +34,18 @@ let _clsEntry: LayoutShift | undefined;
 /**
  * Start tracking web vitals
  */
-export function startTrackingWebVitals(): void {
+export function startTrackingWebVitals(): ReturnType<typeof _trackLCP> {
   const performance = getBrowserPerformanceAPI();
   if (performance && browserPerformanceTimeOrigin) {
     if (performance.mark) {
       WINDOW.performance.mark('sentry-tracing-init');
     }
     _trackCLS();
-    _trackLCP();
     _trackFID();
+    return _trackLCP();
   }
+
+  return;
 }
 
 /**
@@ -89,8 +91,8 @@ function _trackCLS(): void {
 }
 
 /** Starts tracking the Largest Contentful Paint on the current page. */
-function _trackLCP(): void {
-  onLCP(metric => {
+function _trackLCP(): ReturnType<typeof onLCP> {
+  return onLCP(metric => {
     const entry = metric.entries.pop();
     if (!entry) {
       return;

--- a/packages/tracing/src/browser/web-vitals/getLCP.ts
+++ b/packages/tracing/src/browser/web-vitals/getLCP.ts
@@ -24,13 +24,15 @@ import type { LCPMetric, ReportCallback } from './types';
 
 const reportedMetricIDs: Record<string, boolean> = {};
 
+type StopListening = () => void;
+
 /**
  * Calculates the [LCP](https://web.dev/lcp/) value for the current page and
  * calls the `callback` function once the value is ready (along with the
  * relevant `largest-contentful-paint` performance entry used to determine the
  * value). The reported value is a `DOMHighResTimeStamp`.
  */
-export const onLCP = (onReport: ReportCallback): void => {
+export const onLCP = (onReport: ReportCallback): StopListening | undefined => {
   const visibilityWatcher = getVisibilityWatcher();
   const metric = initMetric('LCP');
   let report: ReturnType<typeof bindReporter>;
@@ -75,5 +77,9 @@ export const onLCP = (onReport: ReportCallback): void => {
     });
 
     onHidden(stopListening, true);
+
+    return stopListening;
   }
+
+  return undefined;
 };

--- a/packages/tracing/src/browser/web-vitals/getLCP.ts
+++ b/packages/tracing/src/browser/web-vitals/getLCP.ts
@@ -20,11 +20,9 @@ import { getVisibilityWatcher } from './lib/getVisibilityWatcher';
 import { initMetric } from './lib/initMetric';
 import { observe } from './lib/observe';
 import { onHidden } from './lib/onHidden';
-import type { LCPMetric, ReportCallback } from './types';
+import type { LCPMetric, ReportCallback, StopListening } from './types';
 
 const reportedMetricIDs: Record<string, boolean> = {};
-
-type StopListening = () => void;
 
 /**
  * Calculates the [LCP](https://web.dev/lcp/) value for the current page and
@@ -81,5 +79,5 @@ export const onLCP = (onReport: ReportCallback): StopListening | undefined => {
     return stopListening;
   }
 
-  return undefined;
+  return;
 };

--- a/packages/tracing/src/browser/web-vitals/types/base.ts
+++ b/packages/tracing/src/browser/web-vitals/types/base.ts
@@ -104,3 +104,5 @@ export interface ReportOpts {
  *   loading. This is equivalent to the corresponding `readyState` value.
  */
 export type LoadState = 'loading' | 'dom-interactive' | 'dom-content-loaded' | 'complete';
+
+export type StopListening = () => void;


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-javascript/issues/7341

To get better LCP and CLS accuracy, let's fire the `stopListening` func on transaction finish.