### PR TITLE
feat(core): Emit hooks for transaction start/finish

### DIFF
--- a/packages/core/src/tracing/hubextensions.ts
+++ b/packages/core/src/tracing/hubextensions.ts
@@ -186,6 +186,9 @@ The transaction will not be sampled. Please use the ${configInstrumenter} instru
   if (transaction.sampled) {
     transaction.initSpanRecorder(options._experiments && (options._experiments.maxSpans as number));
   }
+  if (client) {
+    client.emit('startTransaction', transaction);
+  }
   return transaction;
 }
 
@@ -212,6 +215,9 @@ export function startIdleTransaction(
   });
   if (transaction.sampled) {
     transaction.initSpanRecorder(options._experiments && (options._experiments.maxSpans as number));
+  }
+  if (client && client.emit) {
+    client.emit('startTransaction', transaction);
   }
   return transaction;
 }

--- a/packages/core/src/tracing/hubextensions.ts
+++ b/packages/core/src/tracing/hubextensions.ts
@@ -186,7 +186,7 @@ The transaction will not be sampled. Please use the ${configInstrumenter} instru
   if (transaction.sampled) {
     transaction.initSpanRecorder(options._experiments && (options._experiments.maxSpans as number));
   }
-  if (client) {
+  if (client && client.emit) {
     client.emit('startTransaction', transaction);
   }
   return transaction;

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -141,11 +141,15 @@ export class Transaction extends SpanClass implements TransactionInterface {
     // just sets the end timestamp
     super.finish(endTimestamp);
 
+    const client = this._hub.getClient();
+    if (client && client.emit) {
+      client.emit('finishTransaction', this);
+    }
+
     if (this.sampled !== true) {
       // At this point if `sampled !== true` we want to discard the transaction.
       __DEBUG_BUILD__ && logger.log('[Tracing] Discarding transaction because its trace was not chosen to be sampled.');
 
-      const client = this._hub.getClient();
       if (client) {
         client.recordDroppedEvent('sample_rate', 'transaction');
       }


### PR DESCRIPTION
Builds on top of https://github.com/getsentry/sentry-javascript/pull/7370

For now closes https://github.com/getsentry/sentry-javascript/issues/7262 (but we still need to add replay hooks).