### PR TITLE
ref(stacktrace): parser logic

### DIFF
--- a/packages/node/src/module.ts
+++ b/packages/node/src/module.ts
@@ -1,45 +1,63 @@
-import { basename, dirname } from '@sentry/utils';
+import { posix, sep } from 'path';
+
+const isWindowsPlatform = sep === '\\';
 
 /** normalizes Windows paths */
-function normalizePath(path: string): string {
+function normalizeWindowsPath(path: string): string {
   return path
     .replace(/^[A-Z]:/, '') // remove Windows-style prefix
     .replace(/\\/g, '/'); // replace all `\` instances with `/`
 }
 
 /** Gets the module from a filename */
-export function getModule(filename: string | undefined): string | undefined {
+export function getModule(
+  filename: string | undefined,
+  normalizeWindowsPathSeparator: boolean = isWindowsPlatform,
+): string | undefined {
   if (!filename) {
     return;
   }
 
-  const normalizedFilename = normalizePath(filename);
+  // Convert to and assume posix going forward
+  const normalizedFilename = normalizeWindowsPathSeparator ? normalizeWindowsPath(filename) : filename;
+
+  // eslint-disable-next-line prefer-const
+  let { root, dir, base: basename, ext } = posix.parse(normalizedFilename);
+
+  const base = (require && require.main && require.main.filename && dir) || global.process.cwd();
 
   // We could use optional chaining here but webpack does like that mixed with require
-  const base = normalizePath(
-    `${(require && require.main && require.main.filename && dirname(require.main.filename)) || global.process.cwd()}/`,
-  );
+  const normalizedBase = normalizeWindowsPathSeparator ? normalizeWindowsPath(`${base}/`) : base;
 
   // It's specifically a module
-  const file = basename(normalizedFilename, '.js');
+  let file = basename;
+  if (ext === '.js') {
+    file = file.slice(0, file.length - '.js'.length);
+  }
 
-  const path = dirname(normalizedFilename);
-  let n = path.lastIndexOf('/node_modules/');
+  if (!root && !dir) {
+    // No dirname whatsoever
+    dir = '.';
+  }
+
+  let n = dir.lastIndexOf('/node_modules/');
   if (n > -1) {
     // /node_modules/ is 14 chars
-    return `${path.slice(n + 14).replace(/\//g, '.')}:${file}`;
+    return `${dir.slice(n + 14).replace(/\//g, '.')}:${file}`;
   }
   // Let's see if it's a part of the main module
   // To be a part of main module, it has to share the same base
-  n = `${path}/`.lastIndexOf(base, 0);
+  n = `${dir}/`.indexOf(normalizedBase);
 
   if (n === 0) {
-    let moduleName = path.slice(base.length).replace(/\//g, '.');
+    let moduleName = dir.slice(normalizedBase.length).replace(/\//g, '.');
+
     if (moduleName) {
       moduleName += ':';
     }
     moduleName += file;
     return moduleName;
   }
+
   return file;
 }


### PR DESCRIPTION
Opening this PR for informational purposes (do what you like with it), but I noticed a nodejs profile where parsing an error was slow and wanted to see if I can quickly get some wins - I will add some comments into the code

before
Error: Error: write ECONNRESET... x 54,273 ops/sec ±0.38% (93 runs sampled)
Error: Error: Error to find... x 149,314 ops/sec ±0.33% (101 runs sampled)
Error: Client request error... x 150,630 ops/sec ±0.28% (97 runs sampled)

after
Error: Error: write ECONNRESET... x 203,645 ops/sec ±0.42% (97 runs sampled)
Error: Error: Error to find... x 464,063 ops/sec ±0.66% (98 runs sampled)
Error: Client request error... x 463,601 ops/sec ±0.24% (100 runs sampled)

