### PR TITLE
feat(core): Add universal `buildMetadata` function

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export { getIntegrationsToSetup } from './integration';
 export { FunctionToString, InboundFilters } from './integrations';
 export { prepareEvent } from './utils/prepareEvent';
 export { hasTracingEnabled } from './utils/hasTracingEnabled';
+export { buildMetadata } from './utils/buildMetadata';
 export { DEFAULT_ENVIRONMENT } from './constants';
 
 import * as Integrations from './integrations';

--- a/packages/core/src/utils/buildMetadata.ts
+++ b/packages/core/src/utils/buildMetadata.ts
@@ -1,0 +1,26 @@
+import type { Options, SdkInfo } from '@sentry/types';
+
+import { SDK_VERSION } from '../version';
+
+const PACKAGE_NAME_PREFIX = 'npm:@sentry/';
+
+/**
+ * A builder for the SDK metadata in the options for the SDK initialization.
+ *
+ * @param options sdk options object that gets mutated
+ * @param sdkName name of the SDK (e.g. 'nextjs')
+ * @param packageNames list of package names (e.g. ['nextjs', 'react'])
+ */
+export function buildMetadata(options: Options, sdkName: string, packageNames: string[]): void {
+  options._metadata = options._metadata || {};
+  options._metadata.sdk =
+    options._metadata.sdk ||
+    ({
+      name: `sentry.javascript.${sdkName}`,
+      packages: packageNames.map(name => ({
+        name: `${PACKAGE_NAME_PREFIX}${name}`,
+        version: SDK_VERSION,
+      })),
+      version: SDK_VERSION,
+    } as SdkInfo);
+}

--- a/packages/core/test/lib/utils/buildMetadata.test.ts
+++ b/packages/core/test/lib/utils/buildMetadata.test.ts
@@ -1,0 +1,45 @@
+import { buildMetadata } from '../../../src/utils/buildMetadata';
+import { SDK_VERSION } from '../../../src/version';
+
+describe('buildMetadata', () => {
+  it('adds SDK name and packages to the passed options object', () => {
+    const options = {};
+    const sdkName = 'jQuery';
+
+    buildMetadata(options, sdkName, ['jQuery', 'browser']);
+
+    expect(options).toEqual({
+      _metadata: {
+        sdk: {
+          name: `sentry.javascript.${sdkName}`,
+          packages: [
+            {
+              name: 'npm:@sentry/jQuery',
+              version: SDK_VERSION,
+            },
+            {
+              name: 'npm:@sentry/browser',
+              version: SDK_VERSION,
+            },
+          ],
+          version: SDK_VERSION,
+        },
+      },
+    });
+  });
+
+  it('does not overwrite existing SDK metadata', () => {
+    const options = {
+      _metadata: {
+        sdk: {
+          name: 'sentry.javascript.SomeSDK',
+          version: '7.40.0',
+        },
+      },
+    };
+
+    buildMetadata(options, 'jQuery', ['jQuery', 'browser']);
+
+    expect(options).toStrictEqual(options);
+  });
+});


### PR DESCRIPTION
While working on adding client and server `init` functions for the SvelteKit SDK, I noticed that we use utility functions both in Remix and NextJS to add SDK metadata to the init options. These functions are identical and we need the same functionality in SvelteKit as well. Therefore, this PR introduces a universal `buildMetadata` function in the core package which we can use in all three SDKs (follow-up PR for NextJS and Remix coming soon).

Why core? Because we need the `SDK_VERSION` constant. The alternative would be to move this function to the utils package and pass the version as a parameter. Happy to do this if reviewers prefer it. Otherwise, I think it's fine to leave it in core.

ref #7348 
