### PR TITLE
feat(sveltekit): Add server-side `handleError` wrapper

### DIFF
--- a/packages/sveltekit/src/client/handleError.ts
+++ b/packages/sveltekit/src/client/handleError.ts
@@ -11,7 +11,7 @@ import type { HandleClientError, NavigationEvent } from '@sveltejs/kit';
  *
  * @param handleError The original SvelteKit error handler.
  */
-export function wrapHandleErrorWithSentry(handleError: HandleClientError): HandleClientError {
+export function handleErrorWithSentry(handleError?: HandleClientError): HandleClientError {
   return (input: { error: unknown; event: NavigationEvent }): ReturnType<HandleClientError> => {
     captureException(input.error, scope => {
       scope.addEventProcessor(event => {
@@ -23,6 +23,8 @@ export function wrapHandleErrorWithSentry(handleError: HandleClientError): Handl
       });
       return scope;
     });
-    return handleError(input);
+    if (handleError) {
+      return handleError(input);
+    }
   };
 }

--- a/packages/sveltekit/src/client/index.ts
+++ b/packages/sveltekit/src/client/index.ts
@@ -1,7 +1,7 @@
 export * from '@sentry/svelte';
 
 export { init } from './sdk';
-export { wrapHandleErrorWithSentry } from './handleError';
+export { handleErrorWithSentry } from './handleError';
 
 // Just here so that eslint is happy until we export more stuff here
 export const PLACEHOLDER_CLIENT = 'PLACEHOLDER';

--- a/packages/sveltekit/src/client/index.ts
+++ b/packages/sveltekit/src/client/index.ts
@@ -1,7 +1,7 @@
 export * from '@sentry/svelte';
 
 export { init } from './sdk';
-export { wrapHandleError } from './handleError';
+export { wrapHandleErrorWithSentry } from './handleError';
 
 // Just here so that eslint is happy until we export more stuff here
 export const PLACEHOLDER_CLIENT = 'PLACEHOLDER';

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -17,7 +17,7 @@ import type * as serverSdk from './server';
 /** Initializes Sentry SvelteKit SDK */
 export declare function init(options: Options | clientSdk.BrowserOptions | serverSdk.NodeOptions): void;
 
-export declare function wrapHandleErrorWithSentry<T extends HandleClientError | HandleServerError>(
+export declare function handleErrorWithSentry<T extends HandleClientError | HandleServerError>(
   handleError: T,
 ): ReturnType<T>;
 

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -8,12 +8,18 @@ export * from './config';
 export * from './server';
 
 import type { Integration, Options, StackParser } from '@sentry/types';
+// eslint-disable-next-line import/no-unresolved
+import type { HandleClientError, HandleServerError } from '@sveltejs/kit';
 
 import type * as clientSdk from './client';
 import type * as serverSdk from './server';
 
 /** Initializes Sentry SvelteKit SDK */
 export declare function init(options: Options | clientSdk.BrowserOptions | serverSdk.NodeOptions): void;
+
+export declare function wrapHandleErrorWithSentry<T extends HandleClientError | HandleServerError>(
+  handleError: T,
+): ReturnType<T>;
 
 // We export a merged Integrations object so that users can (at least typing-wise) use all integrations everywhere.
 export declare const Integrations: typeof clientSdk.Integrations & typeof serverSdk.Integrations;

--- a/packages/sveltekit/src/server/handleError.ts
+++ b/packages/sveltekit/src/server/handleError.ts
@@ -1,18 +1,18 @@
-import { captureException } from '@sentry/svelte';
+import { captureException } from '@sentry/node';
 import { addExceptionMechanism } from '@sentry/utils';
 // For now disable the import/no-unresolved rule, because we don't have a way to
 // tell eslint that we are only importing types from the @sveltejs/kit package without
 // adding a custom resolver, which will take too much time.
 // eslint-disable-next-line import/no-unresolved
-import type { HandleClientError, NavigationEvent } from '@sveltejs/kit';
+import type { HandleServerError, RequestEvent } from '@sveltejs/kit';
 
 /**
  * Wrapper for the SvelteKit error handler that sends the error to Sentry.
  *
  * @param handleError The original SvelteKit error handler.
  */
-export function wrapHandleErrorWithSentry(handleError: HandleClientError): HandleClientError {
-  return (input: { error: unknown; event: NavigationEvent }): ReturnType<HandleClientError> => {
+export function wrapHandleErrorWithSentry(handleError: HandleServerError): HandleServerError {
+  return (input: { error: unknown; event: RequestEvent }): ReturnType<HandleServerError> => {
     captureException(input.error, scope => {
       scope.addEventProcessor(event => {
         addExceptionMechanism(event, {

--- a/packages/sveltekit/src/server/handleError.ts
+++ b/packages/sveltekit/src/server/handleError.ts
@@ -11,7 +11,7 @@ import type { HandleServerError, RequestEvent } from '@sveltejs/kit';
  *
  * @param handleError The original SvelteKit error handler.
  */
-export function wrapHandleErrorWithSentry(handleError: HandleServerError): HandleServerError {
+export function handleErrorWithSentry(handleError?: HandleServerError): HandleServerError {
   return (input: { error: unknown; event: RequestEvent }): ReturnType<HandleServerError> => {
     captureException(input.error, scope => {
       scope.addEventProcessor(event => {
@@ -23,6 +23,8 @@ export function wrapHandleErrorWithSentry(handleError: HandleServerError): Handl
       });
       return scope;
     });
-    return handleError(input);
+    if (handleError) {
+      return handleError(input);
+    }
   };
 }

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -1,3 +1,4 @@
 export * from '@sentry/node';
 
 export { init } from './sdk';
+export { wrapHandleErrorWithSentry } from './handleError';

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -1,4 +1,4 @@
 export * from '@sentry/node';
 
 export { init } from './sdk';
-export { wrapHandleErrorWithSentry } from './handleError';
+export { handleErrorWithSentry } from './handleError';

--- a/packages/sveltekit/test/client/handleError.test.ts
+++ b/packages/sveltekit/test/client/handleError.test.ts
@@ -55,6 +55,16 @@ describe('handleError', () => {
     mockScope = new Scope();
   });
 
+  it('works when a handleError func is not provided', async () => {
+    const wrappedHandleError = wrapHandleErrorWithSentry();
+    const mockError = new Error('test');
+    const returnVal = await wrappedHandleError({ error: mockError, event: navigationEvent });
+
+    expect(returnVal).not.toBeDefined();
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException).toHaveBeenCalledWith(mockError, expect.any(Function));
+  });
+
   it('calls captureException', async () => {
     const wrappedHandleError = wrapHandleErrorWithSentry(handleError);
     const mockError = new Error('test');

--- a/packages/sveltekit/test/client/handleError.test.ts
+++ b/packages/sveltekit/test/client/handleError.test.ts
@@ -5,7 +5,7 @@ import { Scope } from '@sentry/svelte';
 // eslint-disable-next-line import/no-unresolved
 import type { HandleClientError, NavigationEvent } from '@sveltejs/kit';
 
-import { wrapHandleErrorWithSentry } from '../../src/client/handleError';
+import { handleErrorWithSentry } from '../../src/client/handleError';
 
 const mockCaptureException = jest.fn();
 let mockScope = new Scope();
@@ -56,7 +56,7 @@ describe('handleError', () => {
   });
 
   it('works when a handleError func is not provided', async () => {
-    const wrappedHandleError = wrapHandleErrorWithSentry();
+    const wrappedHandleError = handleErrorWithSentry();
     const mockError = new Error('test');
     const returnVal = await wrappedHandleError({ error: mockError, event: navigationEvent });
 
@@ -66,7 +66,7 @@ describe('handleError', () => {
   });
 
   it('calls captureException', async () => {
-    const wrappedHandleError = wrapHandleErrorWithSentry(handleError);
+    const wrappedHandleError = handleErrorWithSentry(handleError);
     const mockError = new Error('test');
     const returnVal = await wrappedHandleError({ error: mockError, event: navigationEvent });
 
@@ -81,7 +81,7 @@ describe('handleError', () => {
       return mockScope;
     });
 
-    const wrappedHandleError = wrapHandleErrorWithSentry(handleError);
+    const wrappedHandleError = handleErrorWithSentry(handleError);
     const mockError = new Error('test');
     await wrappedHandleError({ error: mockError, event: navigationEvent });
 

--- a/packages/sveltekit/test/server/handleError.test.ts
+++ b/packages/sveltekit/test/server/handleError.test.ts
@@ -1,16 +1,16 @@
-import { Scope } from '@sentry/svelte';
+import { Scope } from '@sentry/node';
 // For now disable the import/no-unresolved rule, because we don't have a way to
 // tell eslint that we are only importing types from the @sveltejs/kit package without
 // adding a custom resolver, which will take too much time.
 // eslint-disable-next-line import/no-unresolved
-import type { HandleClientError, NavigationEvent } from '@sveltejs/kit';
+import type { HandleServerError, RequestEvent } from '@sveltejs/kit';
 
-import { wrapHandleErrorWithSentry } from '../../src/client/handleError';
+import { wrapHandleErrorWithSentry } from '../../src/server/handleError';
 
 const mockCaptureException = jest.fn();
 let mockScope = new Scope();
 
-jest.mock('@sentry/svelte', () => {
+jest.mock('@sentry/node', () => {
   const original = jest.requireActual('@sentry/core');
   return {
     ...original,
@@ -32,21 +32,13 @@ jest.mock('@sentry/utils', () => {
   };
 });
 
-function handleError(_input: { error: unknown; event: NavigationEvent }): ReturnType<HandleClientError> {
+function handleError(_input: { error: unknown; event: RequestEvent }): ReturnType<HandleServerError> {
   return {
     message: 'Whoops!',
   };
 }
 
-const navigationEvent: NavigationEvent = {
-  params: {
-    id: '123',
-  },
-  route: {
-    id: 'users/[id]',
-  },
-  url: new URL('http://example.org/users/123'),
-};
+const requestEvent = {} as RequestEvent;
 
 describe('handleError', () => {
   beforeEach(() => {
@@ -58,7 +50,7 @@ describe('handleError', () => {
   it('calls captureException', async () => {
     const wrappedHandleError = wrapHandleErrorWithSentry(handleError);
     const mockError = new Error('test');
-    const returnVal = await wrappedHandleError({ error: mockError, event: navigationEvent });
+    const returnVal = await wrappedHandleError({ error: mockError, event: requestEvent });
 
     expect(returnVal!.message).toEqual('Whoops!');
     expect(mockCaptureException).toHaveBeenCalledTimes(1);
@@ -73,7 +65,7 @@ describe('handleError', () => {
 
     const wrappedHandleError = wrapHandleErrorWithSentry(handleError);
     const mockError = new Error('test');
-    await wrappedHandleError({ error: mockError, event: navigationEvent });
+    await wrappedHandleError({ error: mockError, event: requestEvent });
 
     expect(addEventProcessorSpy).toBeCalledTimes(1);
     expect(mockAddExceptionMechanism).toBeCalledTimes(1);

--- a/packages/sveltekit/test/server/handleError.test.ts
+++ b/packages/sveltekit/test/server/handleError.test.ts
@@ -47,6 +47,16 @@ describe('handleError', () => {
     mockScope = new Scope();
   });
 
+  it('works when a handleError func is not provided', async () => {
+    const wrappedHandleError = wrapHandleErrorWithSentry();
+    const mockError = new Error('test');
+    const returnVal = await wrappedHandleError({ error: mockError, event: requestEvent });
+
+    expect(returnVal).not.toBeDefined();
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException).toHaveBeenCalledWith(mockError, expect.any(Function));
+  });
+
   it('calls captureException', async () => {
     const wrappedHandleError = wrapHandleErrorWithSentry(handleError);
     const mockError = new Error('test');

--- a/packages/sveltekit/test/server/handleError.test.ts
+++ b/packages/sveltekit/test/server/handleError.test.ts
@@ -5,7 +5,7 @@ import { Scope } from '@sentry/node';
 // eslint-disable-next-line import/no-unresolved
 import type { HandleServerError, RequestEvent } from '@sveltejs/kit';
 
-import { wrapHandleErrorWithSentry } from '../../src/server/handleError';
+import { handleErrorWithSentry } from '../../src/server/handleError';
 
 const mockCaptureException = jest.fn();
 let mockScope = new Scope();
@@ -48,7 +48,7 @@ describe('handleError', () => {
   });
 
   it('works when a handleError func is not provided', async () => {
-    const wrappedHandleError = wrapHandleErrorWithSentry();
+    const wrappedHandleError = handleErrorWithSentry();
     const mockError = new Error('test');
     const returnVal = await wrappedHandleError({ error: mockError, event: requestEvent });
 
@@ -58,7 +58,7 @@ describe('handleError', () => {
   });
 
   it('calls captureException', async () => {
-    const wrappedHandleError = wrapHandleErrorWithSentry(handleError);
+    const wrappedHandleError = handleErrorWithSentry(handleError);
     const mockError = new Error('test');
     const returnVal = await wrappedHandleError({ error: mockError, event: requestEvent });
 
@@ -73,7 +73,7 @@ describe('handleError', () => {
       return mockScope;
     });
 
-    const wrappedHandleError = wrapHandleErrorWithSentry(handleError);
+    const wrappedHandleError = handleErrorWithSentry(handleError);
     const mockError = new Error('test');
     await wrappedHandleError({ error: mockError, event: requestEvent });
 


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/7403

Adds a wrapper for the server-side [`handleError` hook](https://kit.svelte.dev/docs/hooks#shared-hooks-handleerror).

Usage is like the following:

> src/hooks.server.js
```js
import { handleErrorWithSentry } from '@sentry/sveltekit';

/** @type {import('@sveltejs/kit').HandleServerError} */
function myCustomHandleError() {
 ...
}

// myCustomHandleError is optional
export const handleError = handleErrorWithSentry(myCustomHandleError);
```

In https://github.com/getsentry/sentry-javascript/pull/7406 I introduced this functionality on the client side.