### PR TITLE
ref(utils): test for webpack error before running replace

### DIFF
--- a/packages/utils/src/stacktrace.ts
+++ b/packages/utils/src/stacktrace.ts
@@ -1,6 +1,8 @@
 import type { StackFrame, StackLineParser, StackLineParserFn, StackParser } from '@sentry/types';
 
 const STACKTRACE_LIMIT = 50;
+// Used to sanitize webpack (error: *) wrapped stack errors
+const WEBPACK_ERROR_REGEXP = /\(error: (.*)\)/;
 
 /**
  * Creates a stack parser with the supplied line parsers
@@ -25,7 +27,7 @@ export function createStackParser(...parsers: StackLineParser[]): StackParser {
 
       // https://github.com/getsentry/sentry-javascript/issues/5459
       // Remove webpack (error: *) wrappers
-      const cleanedLine = line.replace(/\(error: (.*)\)/, '$1');
+      const cleanedLine = WEBPACK_ERROR_REGEXP.test(line) ? line.replace(WEBPACK_ERROR_REGEXP, '$1') : line;
 
       for (const parser of sortedParsers) {
         const frame = parser(cleanedLine);


### PR DESCRIPTION
If we do not match a webpack error, then dont run replace as it will allocate a new string. This optimizes for non-webpack style errors. For cases where we would actually sanitize the string, calling test + replace makes it slightly slower.

[Browser benchmarks](https://jsbench.me/rolf1s91ki/1) (node benchmarks seem to confirm this)
