### PR TITLE
ref(node): use native path module to infer path

### DIFF
--- a/packages/node/test/module.test.ts
+++ b/packages/node/test/module.test.ts
@@ -18,7 +18,7 @@ function withFilename(fn: () => void, filename: string) {
 describe('getModule', () => {
   test('Windows', () => {
     withFilename(() => {
-      expect(getModule('C:\\Users\\users\\Tim\\Desktop\\node_modules\\module.js')).toEqual('module');
+      expect(getModule('C:\\Users\\users\\Tim\\Desktop\\node_modules\\module.js', true)).toEqual('module');
     }, 'C:\\Users\\Tim\\app.js');
   });
 


### PR DESCRIPTION
When I initially profiled the code I noticed that the regexp used in splitPath function was dominating the profiles. Both basename and dirname from @sentry/utils were actually calling splitPath which executed the regexp - there were 3 call sites to basename and dirname, 1/3 was conditional. The "optimization" is to call path.parse once and extract each path component - this seems to have contributed to the largest win in terms of performance