### PR TITLE
ref(utils): use test instead of indexof in stacktrace

### DIFF
--- a/packages/utils/src/stacktrace.ts
+++ b/packages/utils/src/stacktrace.ts
@@ -55,6 +55,9 @@ export function stackParserFromStackParserOptions(stackParser: StackParser | Sta
 }
 
 /**
+ * Removes Sentry frames from the top and bottom of the stack if present and enforces a limit of max number of frames.
+ * Assumes stack input is ordered from top to bottom and returns the reverse representation so call site of the
+ * function that caused the crash is the last frame in the array.
  * @hidden
  */
 export function stripSentryFramesAndReverse(stack: ReadonlyArray<StackFrame>): StackFrame[] {
@@ -79,7 +82,6 @@ export function stripSentryFramesAndReverse(stack: ReadonlyArray<StackFrame>): S
     localStack.pop();
   }
 
-  // The frame where the crash happened, should be the last entry in the array
   return localStack.map(frame => ({
     ...frame,
     filename: frame.filename || localStack[0].filename,

--- a/packages/utils/src/stacktrace.ts
+++ b/packages/utils/src/stacktrace.ts
@@ -65,26 +65,26 @@ export function stripSentryFramesAndReverse(stack: ReadonlyArray<StackFrame>): S
     return [];
   }
 
-  let localStack = stack.slice(0, STACKTRACE_LIMIT);
+  const localStack = stack.slice(0, STACKTRACE_LIMIT);
 
   const lastFrameFunction = localStack[localStack.length - 1].function;
-  // If stack ends with one of our internal API calls, remove it (ends, meaning it's the bottom of the stack - aka top-most call)
+  // If stack starts with one of our API calls, remove it (starts, meaning it's the top of the stack - aka last call)
   if (lastFrameFunction && /sentryWrapped/.test(lastFrameFunction)) {
     localStack.pop();
   }
 
   // Reversing in the middle of the procedure allows us to just pop the values off the stack
-  localStack = localStack.reverse();
+  localStack.reverse();
 
   const firstFrameFunction = localStack[localStack.length - 1].function;
-  // If stack starts with one of our API calls, remove it (starts, meaning it's the top of the stack - aka last call)
+  // If stack ends with one of our internal API calls, remove it (ends, meaning it's the bottom of the stack - aka top-most call)
   if (firstFrameFunction && /captureMessage|captureException/.test(firstFrameFunction)) {
     localStack.pop();
   }
 
   return localStack.map(frame => ({
     ...frame,
-    filename: frame.filename || localStack[0].filename,
+    filename: frame.filename || localStack[localStack.length - 1].filename,
     function: frame.function || '?',
   }));
 }

--- a/packages/utils/src/stacktrace.ts
+++ b/packages/utils/src/stacktrace.ts
@@ -57,16 +57,12 @@ export function stackParserFromStackParserOptions(stackParser: StackParser | Sta
 /**
  * @hidden
  */
-export function stripSentryFramesAndReverse(stack: StackFrame[]): StackFrame[] {
+export function stripSentryFramesAndReverse(stack: ReadonlyArray<StackFrame>): StackFrame[] {
   if (!stack.length) {
     return [];
   }
 
-  let localStack = stack;
-
-  if (stack.length >= STACKTRACE_LIMIT) {
-    localStack.slice(0, STACKTRACE_LIMIT);
-  }
+  let localStack = stack.slice(0, STACKTRACE_LIMIT);
 
   const lastFrameFunction = localStack[localStack.length - 1].function;
   // If stack ends with one of our internal API calls, remove it (ends, meaning it's the bottom of the stack - aka top-most call)


### PR DESCRIPTION
We dont require the actual index + we can match with a single fn call