### PR TITLE
fix(nextjs): Don't crash build when auth token is missing

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -633,19 +633,26 @@ export function getWebpackPluginOptions(
       // Hardcoded way to check for missing auth token until we have a better way of doing this.
       if (err && err.message.includes('Authentication credentials were not provided.')) {
         const warningPrefix = `${chalk.yellow('warn')}  -`;
-        // eslint-disable-next-line no-console
-        console.warn(
-          `${warningPrefix} ${
-            `${chalk.bold('No Sentry auth token configured.')} Source maps will not be uploaded.\n` +
+
+        let msg;
+
+        if (process.env.VERCEL) {
+          msg = `To fix this, use Sentry's Vercel integration to automatically set the ${chalk.bold.cyan(
+            'SENTRY_AUTH_TOKEN',
+          )} environment variable: https://vercel.com/integrations/sentry`;
+        } else {
+          msg =
             'You can find information on how to generate a Sentry auth token here: https://docs.sentry.io/api/auth/\n' +
             `After generating a Sentry auth token, set it via the ${chalk.bold.cyan(
               'SENTRY_AUTH_TOKEN',
-            )} environment variable during the build.\n`
-          }${
-            process.env.VERCEL
-              ? "If you're deploying to Vercel, use the Vercel integration: https://vercel.com/integrations/sentry\n"
-              : ''
-          }`,
+            )} environment variable during the build.`;
+        }
+
+        // eslint-disable-next-line no-console
+        console.warn(
+          `${warningPrefix} ${chalk.bold(
+            'No Sentry auth token configured.',
+          )} Source maps will not be uploaded.\n${msg}\n`,
         );
 
         return;

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -649,7 +649,7 @@ export function getWebpackPluginOptions(
         }
 
         // eslint-disable-next-line no-console
-        console.warn(
+        console.error(
           `${warningPrefix} ${chalk.bold(
             'No Sentry auth token configured.',
           )} Source maps will not be uploaded.\n${msg}\n`,


### PR DESCRIPTION
Prevents Next.js builds from crashing during source maps upload when building and instead prints an error message that gives instructions on how to configure the auth token.

Because the webpack config is invoked 3 times, the message will show up 3 times. I will leave this up for a future fix.