### PR TITLE
feat(nextjs): Run source map upload in Vercel develop and preview environments

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -701,10 +701,6 @@ function shouldEnableWebpackPlugin(buildContext: BuildContext, userSentryOptions
     // return false
   }
 
-  if (process.env.VERCEL_ENV === 'preview' || process.env.VERCEL_ENV === 'development') {
-    return false;
-  }
-
   // We've passed all of the tests!
   return true;
 }

--- a/packages/nextjs/test/config/webpack/sentryWebpackPlugin.test.ts
+++ b/packages/nextjs/test/config/webpack/sentryWebpackPlugin.test.ts
@@ -240,40 +240,6 @@ describe('Sentry webpack plugin config', () => {
         false,
         true,
       ],
-      [
-        'disables the plugin in Vercel `preview` environment',
-        exportedNextConfig,
-        { VERCEL_ENV: 'preview' },
-        false,
-        false,
-      ],
-      [
-        'disables the plugin in Vercel `development` environment',
-        exportedNextConfig,
-        { VERCEL_ENV: 'development' },
-        false,
-        false,
-      ],
-      [
-        'allows `disableClientWebpackPlugin = false` to override env vars`',
-        {
-          ...exportedNextConfig,
-          sentry: { disableClientWebpackPlugin: false },
-        },
-        { VERCEL_ENV: 'preview' },
-        false,
-        true,
-      ],
-      [
-        'allows `disableServerWebpackPlugin = false` to override env vars`',
-        {
-          ...exportedNextConfig,
-          sentry: { disableServerWebpackPlugin: false },
-        },
-        { VERCEL_ENV: 'preview' },
-        true,
-        false,
-      ],
     ])(
       '%s',
       async (


### PR DESCRIPTION
Since with https://github.com/getsentry/sentry-javascript/pull/7427 we don't throw anymore on missing auth tokens it is pretty safe for us to upload source maps for Vercel develop and preview environments now.
