### PR TITLE
feat(tracing): Bring back `finishReason` for interaction transactions

### DIFF
--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -13,6 +13,17 @@ export const TRACING_DEFAULTS = {
   heartbeatInterval: 5000,
 };
 
+const FINISH_REASON_TAG = 'finishReason';
+
+const IDLE_TRANSACTION_FINISH_REASONS = [
+  'heartbeatFailed',
+  'idleTimeout',
+  'documentHidden',
+  'finalTimeout',
+  'externalFinish',
+  'cancelled',
+];
+
 /**
  * @inheritDoc
  */
@@ -79,6 +90,8 @@ export class IdleTransaction extends Transaction {
    */
   private _idleTimeoutID: ReturnType<typeof setTimeout> | undefined;
 
+  private _finishReason: typeof IDLE_TRANSACTION_FINISH_REASONS[number] = IDLE_TRANSACTION_FINISH_REASONS[4];
+
   public constructor(
     transactionContext: TransactionContext,
     private readonly _idleHub: Hub,
@@ -111,6 +124,7 @@ export class IdleTransaction extends Transaction {
     setTimeout(() => {
       if (!this._finished) {
         this.setStatus('deadline_exceeded');
+        this._finishReason = IDLE_TRANSACTION_FINISH_REASONS[3];
         this.finish();
       }
     }, this._finalTimeout);
@@ -120,6 +134,10 @@ export class IdleTransaction extends Transaction {
   public finish(endTimestamp: number = timestampWithMs()): string | undefined {
     this._finished = true;
     this.activities = {};
+
+    if (this.op === 'ui.action.click') {
+      this.setTag(FINISH_REASON_TAG, this._finishReason);
+    }
 
     if (this.spanRecorder) {
       __DEBUG_BUILD__ &&
@@ -227,6 +245,7 @@ export class IdleTransaction extends Transaction {
       this._idleTimeoutCanceledPermanently = restartOnChildSpanChange === false;
 
       if (Object.keys(this.activities).length === 0 && this._idleTimeoutCanceledPermanently) {
+        this._finishReason = IDLE_TRANSACTION_FINISH_REASONS[5];
         this.finish(endTimestamp);
       }
     }
@@ -239,6 +258,7 @@ export class IdleTransaction extends Transaction {
     this.cancelIdleTimeout();
     this._idleTimeoutID = setTimeout(() => {
       if (!this._finished && Object.keys(this.activities).length === 0) {
+        this._finishReason = IDLE_TRANSACTION_FINISH_REASONS[1];
         this.finish(endTimestamp);
       }
     }, this._idleTimeout);
@@ -270,6 +290,7 @@ export class IdleTransaction extends Transaction {
     if (Object.keys(this.activities).length === 0) {
       const endTimestamp = timestampWithMs();
       if (this._idleTimeoutCanceledPermanently) {
+        this._finishReason = IDLE_TRANSACTION_FINISH_REASONS[5];
         this.finish(endTimestamp);
       } else {
         // We need to add the timeout here to have the real endtimestamp of the transaction
@@ -302,6 +323,7 @@ export class IdleTransaction extends Transaction {
     if (this._heartbeatCounter >= 3) {
       __DEBUG_BUILD__ && logger.log('[Tracing] Transaction finished because of no change for 3 heart beats');
       this.setStatus('deadline_exceeded');
+      this._finishReason = IDLE_TRANSACTION_FINISH_REASONS[0];
       this.finish();
     } else {
       this._pingHeartbeat();


### PR DESCRIPTION
There are several interaction transactions in production that have no spans at all, and we want to find out why this is the case. 

This PR reintroduces `finishReason` from https://github.com/getsentry/sentry-javascript/commit/e0f9ca0c1b59b99314502052d39d9c99c455cc99 but only sets it as a tag for interaction transactions.

This is only temporary, this tag will allow us to diagnose the reason for why interaction transactions appear to be ending early, or without any data. We can remove it from the SDK once we've finished investigating.

[Here's an example of one of these strange transactions](https://sentry.sentry.io/discover/javascript:03b1715e96de4e21995b12e70082c09f/?field=span_ops_breakdown.relative&field=transaction&field=spans.ui&field=transaction.duration&field=spans.http&field=replayId&field=timestamp&id=19735&name=JS+UI+Transactions&project=11276&query=event.type%3Atransaction+transaction.op%3Aui.action.click+%21has%3Aspans.ui+%21has%3Aspans.http&sort=-timestamp&statsPeriod=14d&topEvents=5&yAxis=count%28%29#span-87783753e7e772dc):
![image](https://user-images.githubusercontent.com/16740047/224824781-015d1cb2-a42e-4607-9c43-129446b18e43.png)

