### PR TITLE
fix(serverless): Explicitly export node package exports

### DIFF
--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -3,5 +3,47 @@ import * as AWSLambda from './awslambda';
 import * as GCPFunction from './gcpfunction';
 export { AWSLambda, GCPFunction };
 
-export * from './awsservices';
-export * from '@sentry/node';
+export { AWSServices } from './awsservices';
+
+// TODO(v8): We have to explicitly export these because of the namespace exports
+// above. This is because just doing `export * from '@sentry/node'` will not
+// work with Node native esm while we also have namespace exports in a package.
+// What we should do is get rid of the namespace exports.
+export {
+  Hub,
+  SDK_VERSION,
+  Scope,
+  addBreadcrumb,
+  addGlobalEventProcessor,
+  captureEvent,
+  captureException,
+  captureMessage,
+  configureScope,
+  createTransport,
+  getCurrentHub,
+  getHubFromCarrier,
+  makeMain,
+  setContext,
+  setExtra,
+  setExtras,
+  setTag,
+  setTags,
+  setUser,
+  startTransaction,
+  withScope,
+  NodeClient,
+  makeNodeTransport,
+  close,
+  defaultIntegrations,
+  defaultStackParser,
+  flush,
+  getSentryRelease,
+  init,
+  lastEventId,
+  DEFAULT_USER_INCLUDES,
+  addRequestDataToEvent,
+  extractRequestData,
+  deepReadDirSync,
+  Handlers,
+  Integrations,
+} from '@sentry/node';

--- a/packages/serverless/test/awsservices.test.ts
+++ b/packages/serverless/test/awsservices.test.ts
@@ -1,7 +1,7 @@
+import * as SentryNode from '@sentry/node';
 import * as AWS from 'aws-sdk';
 import * as nock from 'nock';
 
-import * as Sentry from '../src';
 import { AWSServices } from '../src/awsservices';
 
 /**
@@ -17,7 +17,7 @@ describe('AWSServices', () => {
   });
   afterEach(() => {
     // @ts-ignore see "Why @ts-ignore" note
-    Sentry.resetMocks();
+    SentryNode.resetMocks();
   });
   afterAll(() => {
     nock.restore();
@@ -31,12 +31,12 @@ describe('AWSServices', () => {
       const data = await s3.getObject({ Bucket: 'foo', Key: 'bar' }).promise();
       expect(data.Body?.toString('utf-8')).toEqual('contents');
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.startChild).toBeCalledWith({
+      expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'http.client',
         description: 'aws.s3.getObject foo',
       });
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeSpan.finish).toBeCalled();
+      expect(SentryNode.fakeSpan.finish).toBeCalled();
     });
 
     test('getObject with callback', done => {
@@ -48,7 +48,7 @@ describe('AWSServices', () => {
         done();
       });
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.startChild).toBeCalledWith({
+      expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'http.client',
         description: 'aws.s3.getObject foo',
       });
@@ -63,7 +63,7 @@ describe('AWSServices', () => {
       const data = await lambda.invoke({ FunctionName: 'foo' }).promise();
       expect(data.Payload?.toString('utf-8')).toEqual('reply');
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.startChild).toBeCalledWith({
+      expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'http.client',
         description: 'aws.lambda.invoke foo',
       });

--- a/packages/serverless/test/gcpfunction.test.ts
+++ b/packages/serverless/test/gcpfunction.test.ts
@@ -23,7 +23,7 @@ import type {
 describe('GCPFunction', () => {
   afterEach(() => {
     // @ts-ignore see "Why @ts-ignore" note
-    Sentry.resetMocks();
+    SentryNode.resetMocks();
   });
 
   async function handleHttp(fn: HttpFunction, trace_headers: { [key: string]: string } | null = null): Promise<void> {
@@ -96,7 +96,7 @@ describe('GCPFunction', () => {
       const wrappedHandler = wrapHttpFunction(handler, { flushTimeout: 1337 });
 
       await handleHttp(wrappedHandler);
-      expect(Sentry.flush).toBeCalledWith(1337);
+      expect(SentryNode.flush).toBeCalledWith(1337);
     });
   });
 
@@ -117,17 +117,17 @@ describe('GCPFunction', () => {
         metadata: { source: 'route' },
       };
       // @ts-ignore see "Why @ts-ignore" note
-      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+      const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
+      expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.setHttpStatus).toBeCalledWith(200);
+      expect(SentryNode.fakeTransaction.setHttpStatus).toBeCalledWith(200);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.finish).toBeCalled();
-      expect(Sentry.flush).toBeCalledWith(2000);
+      expect(SentryNode.fakeTransaction.finish).toBeCalled();
+      expect(SentryNode.flush).toBeCalledWith(2000);
     });
 
     test('incoming trace headers are correctly parsed and used', async () => {
@@ -159,10 +159,10 @@ describe('GCPFunction', () => {
       };
 
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
 
       // @ts-ignore see "Why @ts-ignore" note
-      // expect(Sentry.fakeHub.startTransaction).toBeCalledWith(expect.objectContaining(fakeTransactionContext));
+      // expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(expect.objectContaining(fakeTransactionContext));
     });
 
     test('capture error', async () => {
@@ -189,16 +189,16 @@ describe('GCPFunction', () => {
         metadata: { dynamicSamplingContext: {}, source: 'route' },
       };
       // @ts-ignore see "Why @ts-ignore" note
-      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+      const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      expect(Sentry.captureException).toBeCalledWith(error);
+      expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
+      expect(SentryNode.captureException).toBeCalledWith(error);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.finish).toBeCalled();
-      expect(Sentry.flush).toBeCalled();
+      expect(SentryNode.fakeTransaction.finish).toBeCalled();
+      expect(SentryNode.flush).toBeCalled();
     });
 
     test('should not throw when flush rejects', async () => {
@@ -252,7 +252,7 @@ describe('GCPFunction', () => {
     );
 
     // @ts-ignore see "Why @ts-ignore" note
-    expect(Sentry.fakeScope.setSDKProcessingMetadata).toHaveBeenCalledWith({
+    expect(SentryNode.fakeScope.setSDKProcessingMetadata).toHaveBeenCalledWith({
       request: {
         method: 'POST',
         url: '/path?q=query',
@@ -279,15 +279,15 @@ describe('GCPFunction', () => {
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
-      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+      const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
+      expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.finish).toBeCalled();
-      expect(Sentry.flush).toBeCalledWith(2000);
+      expect(SentryNode.fakeTransaction.finish).toBeCalled();
+      expect(SentryNode.flush).toBeCalledWith(2000);
     });
 
     test('capture error', async () => {
@@ -306,16 +306,16 @@ describe('GCPFunction', () => {
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
-      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+      const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      expect(Sentry.captureException).toBeCalledWith(error);
+      expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
+      expect(SentryNode.captureException).toBeCalledWith(error);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.finish).toBeCalled();
-      expect(Sentry.flush).toBeCalled();
+      expect(SentryNode.fakeTransaction.finish).toBeCalled();
+      expect(SentryNode.flush).toBeCalled();
     });
   });
 
@@ -338,15 +338,15 @@ describe('GCPFunction', () => {
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
-      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+      const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
+      expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.finish).toBeCalled();
-      expect(Sentry.flush).toBeCalledWith(2000);
+      expect(SentryNode.fakeTransaction.finish).toBeCalled();
+      expect(SentryNode.flush).toBeCalledWith(2000);
     });
 
     test('capture error', async () => {
@@ -369,16 +369,16 @@ describe('GCPFunction', () => {
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
-      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+      const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      expect(Sentry.captureException).toBeCalledWith(error);
+      expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
+      expect(SentryNode.captureException).toBeCalledWith(error);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.finish).toBeCalled();
-      expect(Sentry.flush).toBeCalled();
+      expect(SentryNode.fakeTransaction.finish).toBeCalled();
+      expect(SentryNode.flush).toBeCalled();
     });
   });
 
@@ -398,15 +398,15 @@ describe('GCPFunction', () => {
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
-      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+      const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
+      expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.finish).toBeCalled();
-      expect(Sentry.flush).toBeCalledWith(2000);
+      expect(SentryNode.fakeTransaction.finish).toBeCalled();
+      expect(SentryNode.flush).toBeCalledWith(2000);
     });
 
     test('capture error', async () => {
@@ -425,16 +425,16 @@ describe('GCPFunction', () => {
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
-      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+      const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      expect(Sentry.captureException).toBeCalledWith(error);
+      expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
+      expect(SentryNode.captureException).toBeCalledWith(error);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.finish).toBeCalled();
-      expect(Sentry.flush).toBeCalled();
+      expect(SentryNode.fakeTransaction.finish).toBeCalled();
+      expect(SentryNode.flush).toBeCalled();
     });
 
     test('capture exception', async () => {
@@ -453,13 +453,13 @@ describe('GCPFunction', () => {
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
-      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+      const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      expect(Sentry.captureException).toBeCalledWith(error);
+      expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
+      expect(SentryNode.captureException).toBeCalledWith(error);
     });
   });
 
@@ -470,7 +470,7 @@ describe('GCPFunction', () => {
     const wrappedHandler = wrapEventFunction(handler);
     await handleEvent(wrappedHandler);
     // @ts-ignore see "Why @ts-ignore" note
-    expect(Sentry.fakeScope.setContext).toBeCalledWith('gcp.function.context', {
+    expect(SentryNode.fakeScope.setContext).toBeCalledWith('gcp.function.context', {
       eventType: 'event.type',
       resource: 'some.resource',
     });
@@ -492,15 +492,15 @@ describe('GCPFunction', () => {
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
-      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+      const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
+      expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.finish).toBeCalled();
-      expect(Sentry.flush).toBeCalledWith(2000);
+      expect(SentryNode.fakeTransaction.finish).toBeCalled();
+      expect(SentryNode.flush).toBeCalledWith(2000);
     });
 
     test('capture error', async () => {
@@ -519,16 +519,16 @@ describe('GCPFunction', () => {
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
-      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+      const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      expect(Sentry.captureException).toBeCalledWith(error);
+      expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
+      expect(SentryNode.captureException).toBeCalledWith(error);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.finish).toBeCalled();
-      expect(Sentry.flush).toBeCalled();
+      expect(SentryNode.fakeTransaction.finish).toBeCalled();
+      expect(SentryNode.flush).toBeCalled();
     });
   });
 
@@ -548,15 +548,15 @@ describe('GCPFunction', () => {
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
-      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+      const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
+      expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.finish).toBeCalled();
-      expect(Sentry.flush).toBeCalledWith(2000);
+      expect(SentryNode.fakeTransaction.finish).toBeCalled();
+      expect(SentryNode.flush).toBeCalledWith(2000);
     });
 
     test('capture error', async () => {
@@ -575,16 +575,16 @@ describe('GCPFunction', () => {
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
-      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+      const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      expect(Sentry.captureException).toBeCalledWith(error);
+      expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
+      expect(SentryNode.captureException).toBeCalledWith(error);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.finish).toBeCalled();
-      expect(Sentry.flush).toBeCalled();
+      expect(SentryNode.fakeTransaction.finish).toBeCalled();
+      expect(SentryNode.flush).toBeCalled();
     });
 
     test('capture exception', async () => {
@@ -603,14 +603,14 @@ describe('GCPFunction', () => {
         metadata: { source: 'component' },
       };
       // @ts-ignore see "Why @ts-ignore" note
-      const fakeTransaction = { ...Sentry.fakeTransaction, ...fakeTransactionContext };
+      const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
+      expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
+      expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
 
-      expect(Sentry.captureException).toBeCalledWith(error);
+      expect(SentryNode.captureException).toBeCalledWith(error);
     });
   });
 
@@ -621,7 +621,7 @@ describe('GCPFunction', () => {
     const wrappedHandler = wrapCloudEventFunction(handler);
     await handleCloudEvent(wrappedHandler);
     // @ts-ignore see "Why @ts-ignore" note
-    expect(Sentry.fakeScope.setContext).toBeCalledWith('gcp.function.context', { type: 'event.type' });
+    expect(SentryNode.fakeScope.setContext).toBeCalledWith('gcp.function.context', { type: 'event.type' });
   });
 
   describe('init()', () => {

--- a/packages/serverless/test/google-cloud-grpc.test.ts
+++ b/packages/serverless/test/google-cloud-grpc.test.ts
@@ -1,6 +1,7 @@
 jest.mock('dns');
 
 import { PubSub } from '@google-cloud/pubsub';
+import * as SentryNode from '@sentry/node';
 import * as dns from 'dns';
 import { EventEmitter } from 'events';
 import * as fs from 'fs';
@@ -8,7 +9,6 @@ import * as http2 from 'http2';
 import * as nock from 'nock';
 import * as path from 'path';
 
-import * as Sentry from '../src';
 import { GoogleCloudGrpc } from '../src/google-cloud-grpc';
 
 /**
@@ -86,7 +86,7 @@ describe('GoogleCloudGrpc tracing', () => {
   });
   afterEach(() => {
     // @ts-ignore see "Why @ts-ignore" note
-    Sentry.resetMocks();
+    SentryNode.resetMocks();
     spyConnect.mockClear();
   });
   afterAll(() => {
@@ -127,7 +127,7 @@ describe('GoogleCloudGrpc tracing', () => {
       const resp = await pubsub.topic('nicetopic').publish(Buffer.from('data'));
       expect(resp).toEqual('1637084156623860');
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.startChild).toBeCalledWith({
+      expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'grpc.pubsub',
         description: 'unary call publish',
       });

--- a/packages/serverless/test/google-cloud-http.test.ts
+++ b/packages/serverless/test/google-cloud-http.test.ts
@@ -1,9 +1,9 @@
 import { BigQuery } from '@google-cloud/bigquery';
+import * as SentryNode from '@sentry/node';
 import * as fs from 'fs';
 import * as nock from 'nock';
 import * as path from 'path';
 
-import * as Sentry from '../src';
 import { GoogleCloudHttp } from '../src/google-cloud-http';
 
 /**
@@ -24,7 +24,7 @@ describe('GoogleCloudHttp tracing', () => {
   });
   afterEach(() => {
     // @ts-ignore see "Why @ts-ignore" note
-    Sentry.resetMocks();
+    SentryNode.resetMocks();
   });
   afterAll(() => {
     nock.restore();
@@ -58,12 +58,12 @@ describe('GoogleCloudHttp tracing', () => {
       const resp = await bigquery.query('SELECT true AS foo');
       expect(resp).toEqual([[{ foo: true }]]);
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.startChild).toBeCalledWith({
+      expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'http.client.bigquery',
         description: 'POST /jobs',
       });
       // @ts-ignore see "Why @ts-ignore" note
-      expect(Sentry.fakeTransaction.startChild).toBeCalledWith({
+      expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'http.client.bigquery',
         description: expect.stringMatching(new RegExp('^GET /queries/.+')),
       });


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-javascript/issues/7441

A serverless package that is esm only breaks when trying to import our serverless package. This is because in our serverless we combine both wildcard and namespace exports. This confuses our rollup bundler, which causes it to put all of the wildcard exports (from `@sentry/node`) into `default`, which means it is not exposed as a top level export.

When users try to use the esm serverless package, they are unable to access exports like `captureException` or `init`.

The solution here is to just explicitly export everything from the `@sentry/node` package. In v8 we have to re-visit this and get rid of the namespace exports, since they don't serve much use, and mean that tree-shaking does not work.