### PR TITLE
fix(core): Permanent idle timeout cancel finishes the transaction with the last finished child

### DIFF
--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -239,10 +239,10 @@ export class IdleTransaction extends Transaction {
       restartOnChildSpanChange: true,
     },
   ): void {
+    this._idleTimeoutCanceledPermanently = restartOnChildSpanChange === false;
     if (this._idleTimeoutID) {
       clearTimeout(this._idleTimeoutID);
       this._idleTimeoutID = undefined;
-      this._idleTimeoutCanceledPermanently = restartOnChildSpanChange === false;
 
       if (Object.keys(this.activities).length === 0 && this._idleTimeoutCanceledPermanently) {
         this._finishReason = IDLE_TRANSACTION_FINISH_REASONS[5];
@@ -269,7 +269,7 @@ export class IdleTransaction extends Transaction {
    * @param spanId The span id that represents the activity
    */
   private _pushActivity(spanId: string): void {
-    this.cancelIdleTimeout();
+    this.cancelIdleTimeout(undefined, { restartOnChildSpanChange: !this._idleTimeoutCanceledPermanently });
     __DEBUG_BUILD__ && logger.log(`[Tracing] pushActivity: ${spanId}`);
     this.activities[spanId] = true;
     __DEBUG_BUILD__ && logger.log('[Tracing] new activities count', Object.keys(this.activities).length);


### PR DESCRIPTION
- fixes idle timeout cancel exposed in https://github.com/getsentry/sentry-javascript/pull/7236
- this cancellation only worked when no child was active