### PR TITLE
feat(tracing): Move `Integrations` from `tracing-internal` to `@sentry/tracing`

### DIFF
--- a/packages/tracing-internal/src/index.ts
+++ b/packages/tracing-internal/src/index.ts
@@ -1,29 +1,9 @@
 export * from './exports';
 
-import { addExtensionMethods } from './extensions';
-import * as Integrations from './node/integrations';
-
-export { Integrations };
-
-// BrowserTracing is already exported as part of `Integrations` above (and for the moment will remain so for
-// backwards compatibility), but that interferes with treeshaking, so we also export it separately
-// here.
-//
-// Previously we expected users to import tracing integrations like
-//
-// import { Integrations } from '@sentry/tracing';
-// const instance = new Integrations.BrowserTracing();
-//
-// This makes the integrations unable to be treeshaken though. To address this, we now have
-// this individual export. We now expect users to consume BrowserTracing like so:
-//
-// import { BrowserTracing } from '@sentry/tracing';
-// const instance = new BrowserTracing();
-//
-// For an example of of the new usage of BrowserTracing, see @sentry/nextjs index.client.ts
-export { BrowserTracing } from './browser';
+export { Apollo, Express, GraphQL, Mongo, Mysql, Postgres, Prisma } from './node/integrations';
 
 export {
+  BrowserTracing,
   BROWSER_TRACING_INTEGRATION_ID,
   instrumentOutgoingRequests,
   defaultRequestInstrumentationOptions,
@@ -31,4 +11,4 @@ export {
 
 export type { RequestInstrumentationOptions } from './browser';
 
-export { addExtensionMethods };
+export { addExtensionMethods } from './extensions';

--- a/packages/tracing-internal/src/node/integrations/index.ts
+++ b/packages/tracing-internal/src/node/integrations/index.ts
@@ -5,7 +5,3 @@ export { Mongo } from './mongo';
 export { Prisma } from './prisma';
 export { GraphQL } from './graphql';
 export { Apollo } from './apollo';
-
-// TODO(v8): Remove this export
-// Please see `src/index.ts` for more details.
-export { BrowserTracing } from '../../browser';

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -1,6 +1,49 @@
-export * from '@sentry-internal/tracing';
+export {
+  // BrowserTracing is already exported as part of `Integrations` below (and for the moment will remain so for
+  // backwards compatibility), but that interferes with treeshaking, so we also export it separately
+  // here.
+  BrowserTracing,
+  BROWSER_TRACING_INTEGRATION_ID,
+  IdleTransaction,
+  Span,
+  // eslint-disable-next-line deprecation/deprecation
+  SpanStatus,
+  TRACEPARENT_REGEXP,
+  Transaction,
+  addExtensionMethods,
+  defaultRequestInstrumentationOptions,
+  extractTraceparentData,
+  instrumentOutgoingRequests,
+  getActiveTransaction,
+  hasTracingEnabled,
+  spanStatusfromHttpCode,
+  startIdleTransaction,
+  stripUrlQueryAndFragment,
+} from '@sentry-internal/tracing';
+export type { RequestInstrumentationOptions, SpanStatusType } from '@sentry-internal/tracing';
 
-import { addExtensionMethods } from '@sentry-internal/tracing';
+import {
+  addExtensionMethods,
+  Apollo,
+  BrowserTracing,
+  Express,
+  GraphQL,
+  Mongo,
+  Mysql,
+  Postgres,
+  Prisma,
+} from '@sentry-internal/tracing';
+
+export const Integrations = {
+  BrowserTracing: BrowserTracing,
+  Apollo: Apollo,
+  Express: Express,
+  GraphQL: GraphQL,
+  Mongo: Mongo,
+  Mysql: Mysql,
+  Postgres: Postgres,
+  Prisma: Prisma,
+};
 
 // Treeshakable guard to remove all code related to tracing
 declare const __SENTRY_TRACING__: boolean;
@@ -10,5 +53,3 @@ if (typeof __SENTRY_TRACING__ === 'undefined' || __SENTRY_TRACING__) {
   // We are patching the global object with our hub extension methods
   addExtensionMethods();
 }
-
-export { addExtensionMethods };


### PR DESCRIPTION
This PR:
- Moves the legacy `Integrations` definition from `@sentry-internal/tracing` to `@sentry/tracing`
- Ensures all integrations are exported separately from `@sentry-internal/tracing`
