### PR TITLE
test(browser-integration): Skip "browsertracing/backgroundtab-pageload" test for firefox

### DIFF
--- a/packages/browser-integration-tests/suites/tracing/browsertracing/backgroundtab-pageload/test.ts
+++ b/packages/browser-integration-tests/suites/tracing/browsertracing/backgroundtab-pageload/test.ts
@@ -4,7 +4,11 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should finish pageload transaction when the page goes background', async ({ getLocalTestPath, page }) => {
+sentryTest('should finish pageload transaction when the page goes background', async ({ browserName, getLocalTestPath, page }) => {
+  // TODO: This is flakey on firefox... trace.status is sometimes undefined
+  if (['firefox'].includes(browserName)) {
+    sentryTest.skip();
+  }
   const url = await getLocalTestPath({ testDir: __dirname });
 
   await page.goto(url);

--- a/packages/browser-integration-tests/suites/tracing/browsertracing/backgroundtab-pageload/test.ts
+++ b/packages/browser-integration-tests/suites/tracing/browsertracing/backgroundtab-pageload/test.ts
@@ -4,21 +4,24 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
 
-sentryTest('should finish pageload transaction when the page goes background', async ({ browserName, getLocalTestPath, page }) => {
-  // TODO: This is flakey on firefox... trace.status is sometimes undefined
-  if (['firefox'].includes(browserName)) {
-    sentryTest.skip();
-  }
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest(
+  'should finish pageload transaction when the page goes background',
+  async ({ browserName, getLocalTestPath, page }) => {
+    // TODO: This is flakey on firefox... trace.status is sometimes undefined
+    if (['firefox'].includes(browserName)) {
+      sentryTest.skip();
+    }
+    const url = await getLocalTestPath({ testDir: __dirname });
 
-  await page.goto(url);
-  await page.click('#go-background');
+    await page.goto(url);
+    await page.click('#go-background');
 
-  const pageloadTransaction = await getFirstSentryEnvelopeRequest<Event>(page);
+    const pageloadTransaction = await getFirstSentryEnvelopeRequest<Event>(page);
 
-  expect(pageloadTransaction.contexts?.trace?.op).toBe('pageload');
-  expect(pageloadTransaction.contexts?.trace?.status).toBe('cancelled');
-  expect(pageloadTransaction.contexts?.trace?.tags).toMatchObject({
-    visibilitychange: 'document.hidden',
-  });
-});
+    expect(pageloadTransaction.contexts?.trace?.op).toBe('pageload');
+    expect(pageloadTransaction.contexts?.trace?.status).toBe('cancelled');
+    expect(pageloadTransaction.contexts?.trace?.tags).toMatchObject({
+      visibilitychange: 'document.hidden',
+    });
+  },
+);


### PR DESCRIPTION
This has been flakey... trace.status is sometimes undefined, lets skip for firefox
