### PR TITLE
build(sveltekit): Remove `vite` types from build output

### DIFF
--- a/packages/sveltekit/.eslintrc.js
+++ b/packages/sveltekit/.eslintrc.js
@@ -11,6 +11,12 @@ module.exports = {
         'import/no-unresolved': 'off',
       },
     },
+    {
+      files: ['vite.config.ts'],
+      parserOptions: {
+        project: ['tsconfig.test.json'],
+      },
+    },
   ],
   extends: ['../../.eslintrc.js'],
 };

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -63,7 +63,7 @@
     "lint:eslint": "eslint . --format stylish",
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
     "test": "yarn test:unit",
-    "test:unit": "vitest",
+    "test:unit": "vitest run",
     "test:watch": "vitest --watch"
   },
   "volta": {

--- a/packages/sveltekit/tsconfig.json
+++ b/packages/sveltekit/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
 
-  "include": ["src/**/*", "vite.config.ts"],
+  "include": ["src/**/*"],
 
   "compilerOptions": {
     // package-specific options

--- a/packages/sveltekit/tsconfig.test.json
+++ b/packages/sveltekit/tsconfig.test.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
 
-  "include": ["test/**/*"],
+  "include": ["test/**/*", "vite.config.ts"],
 
   "compilerOptions": {
     // should include all types from `./tsconfig.json` plus types for all test frameworks used


### PR DESCRIPTION
In #7438, we added `vite.config.ts` to our SvelteKit pacakge. We also added it to our `sveltekit/tsconfig.json` instead of `sveltekit/tsconfig.test.json` which meant that some types from Vite ended up in our `sveltekt/build/types` directory.This messed up the directory structure and causing the types entry point to no longer be valid. This PR fixes that by adding the vite config to `tsconfig.test.json`.

Also, this PR fixes the `test:unit` yarn script as just executing `vitest` started vitest in watch mode on local machines (and single-run mode on CI). IMO we shouldn't start it in watch mode by default, as we have `test:unit:watch` to do that.
