### PR TITLE
fix(sveltekit): Remove package.json exports

### DIFF
--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -13,18 +13,6 @@
   "module": "build/esm/index.server.js",
   "browser": "build/esm/index.client.js",
   "types": "build/types/index.types.d.ts",
-  "exports": {
-    "browser": {
-      "import": "./build/esm/index.client.js",
-      "require": "./build/cjs/index.client.js",
-      "default": "./build/esm/index.client.js"
-    },
-    "node": {
-      "import": "./build/esm/index.server.js",
-      "require": "./build/cjs/index.server.js",
-      "default": "./build/esm/index.server.js"
-    }
-  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Context:

This was initially added in https://github.com/getsentry/sentry-javascript/pull/7406 to make sure that vite could resolve the server/client entries properly, but this ended up breaking esm resolution for the server-side.

Instead of the exports approach, we are going to try to multiplex the same way the next.js sdk does.