### PR TITLE
feat(serverless): Publish lambda layer for Node 16/18

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -11,6 +11,8 @@ targets:
           - nodejs10.x
           - nodejs12.x
           - nodejs14.x
+          - nodejs16.x
+          - nodejs18.x
     license: MIT
   - name: gcs
     includeNames: /.*\.js.*$/


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/5752

https://aws.amazon.com/about-aws/whats-new/2022/05/aws-lambda-adds-support-node-js-16/

https://aws.amazon.com/about-aws/whats-new/2022/11/aws-lambda-support-node-js-18/