### PR TITLE
fix(sveltekit): Make `handleErrorWithSentry` parameter optional in function declaration

### DIFF
--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -18,7 +18,7 @@ import type * as serverSdk from './server';
 export declare function init(options: Options | clientSdk.BrowserOptions | serverSdk.NodeOptions): void;
 
 export declare function handleErrorWithSentry<T extends HandleClientError | HandleServerError>(
-  handleError: T,
+  handleError?: T,
 ): ReturnType<T>;
 
 export declare function wrapLoadWithSentry<S extends ServerLoad>(origLoad: S): S;


### PR DESCRIPTION
Noticed while testing that the parameter is optional in the implementation but not in the isomorphic declaration.

ref #7402 #7403
