### PR TITLE
feat(tracing): Move `registerErrorInstrumentation` to `@sentry/core`

### DIFF
--- a/packages/core/src/tracing/errors.ts
+++ b/packages/core/src/tracing/errors.ts
@@ -1,11 +1,19 @@
-import type { SpanStatusType } from '@sentry/core';
-import { getActiveTransaction } from '@sentry/core';
 import { addInstrumentationHandler, logger } from '@sentry/utils';
+
+import type { SpanStatusType } from './span';
+import { getActiveTransaction } from './utils';
+
+let errorsInstrumented = false;
 
 /**
  * Configures global error listeners
  */
 export function registerErrorInstrumentation(): void {
+  if (errorsInstrumented) {
+    return;
+  }
+
+  errorsInstrumented = true;
   addInstrumentationHandler('error', errorCallback);
   addInstrumentationHandler('unhandledrejection', errorCallback);
 }

--- a/packages/core/src/tracing/hubextensions.ts
+++ b/packages/core/src/tracing/hubextensions.ts
@@ -4,9 +4,9 @@ import { isNaN, logger } from '@sentry/utils';
 import type { Hub } from '../hub';
 import { getMainCarrier } from '../hub';
 import { hasTracingEnabled } from '../utils/hasTracingEnabled';
+import { registerErrorInstrumentation } from './errors';
 import { IdleTransaction } from './idletransaction';
 import { Transaction } from './transaction';
-import { registerErrorInstrumentation } from './errors';
 
 /** Returns all trace headers that are currently on the top scope. */
 function traceHeaders(this: Hub): { [key: string]: string } {

--- a/packages/core/src/tracing/hubextensions.ts
+++ b/packages/core/src/tracing/hubextensions.ts
@@ -6,6 +6,7 @@ import { getMainCarrier } from '../hub';
 import { hasTracingEnabled } from '../utils/hasTracingEnabled';
 import { IdleTransaction } from './idletransaction';
 import { Transaction } from './transaction';
+import { registerErrorInstrumentation } from './errors';
 
 /** Returns all trace headers that are currently on the top scope. */
 function traceHeaders(this: Hub): { [key: string]: string } {
@@ -237,4 +238,6 @@ export function addTracingExtensions(): void {
   if (!carrier.__SENTRY__.extensions.traceHeaders) {
     carrier.__SENTRY__.extensions.traceHeaders = traceHeaders;
   }
+
+  registerErrorInstrumentation();
 }

--- a/packages/core/test/lib/tracing/errors.test.ts
+++ b/packages/core/test/lib/tracing/errors.test.ts
@@ -2,8 +2,8 @@ import { BrowserClient } from '@sentry/browser';
 import { addTracingExtensions, Hub, makeMain } from '@sentry/core';
 import type { InstrumentHandlerCallback, InstrumentHandlerType } from '@sentry/utils';
 
-import { getDefaultBrowserClientOptions } from '../../tracing/test/testutils';
-import { registerErrorInstrumentation } from '../src/errors';
+import { getDefaultBrowserClientOptions } from '../../../../tracing/test/testutils';
+import { registerErrorInstrumentation } from '../../../src/tracing/errors';
 
 const mockAddInstrumentationHandler = jest.fn();
 let mockErrorCallback: InstrumentHandlerCallback = () => undefined;

--- a/packages/tracing-internal/src/extensions.ts
+++ b/packages/tracing-internal/src/extensions.ts
@@ -2,8 +2,6 @@ import { addTracingExtensions, getMainCarrier } from '@sentry/core';
 import type { Integration, IntegrationClass } from '@sentry/types';
 import { dynamicRequire, isNodeEnv, loadModule } from '@sentry/utils';
 
-import { registerErrorInstrumentation } from './errors';
-
 /**
  * @private
  */
@@ -66,7 +64,4 @@ export function addExtensionMethods(): void {
   if (isNodeEnv()) {
     _autoloadDatabaseIntegrations();
   }
-
-  // If an error happens globally, we should make sure transaction status is set to error.
-  registerErrorInstrumentation();
 }


### PR DESCRIPTION
`addTracingExtensions` in `@sentry/core` feels like our better named replacement for `addExtensionMethods` however it didn't end up with the same functionality. 

While working on other tracing PRs I realised that we'd not moved `registerErrorInstrumentation` to core and it makes more sense for it to be there.

This PR moves `registerErrorInstrumentation` to `@sentry/core` and calls it from `addTracingExtensions` since they are called together in `addExtensionMethods`. It also adds a flag so errors are only instrumented once. This means we can safely call `addTracingExtensions` as many times as we like (ie. from integration constructors, etc).