### PR TITLE
test(replay): Skip flaky test in firefox

### DIFF
--- a/packages/browser-integration-tests/suites/replay/errors/errorMode/test.ts
+++ b/packages/browser-integration-tests/suites/replay/errors/errorMode/test.ts
@@ -17,8 +17,9 @@ import {
 
 sentryTest(
   '[error-mode] should start recording and switch to session mode once an error is thrown',
-  async ({ getLocalTestPath, page }) => {
-    if (shouldSkipReplayTest()) {
+  async ({ getLocalTestPath, page, browserName }) => {
+    // This was sometimes flaky on firefox/webkit, so skipping for now
+    if (shouldSkipReplayTest() || ['firefox', 'webkit'].includes(browserName)) {
       sentryTest.skip();
     }
 

--- a/packages/browser-integration-tests/suites/replay/errors/errorsInSession/test.ts
+++ b/packages/browser-integration-tests/suites/replay/errors/errorsInSession/test.ts
@@ -13,8 +13,8 @@ import {
 sentryTest(
   '[session-mode] replay event should contain an error id of an error that occurred during session recording',
   async ({ getLocalTestPath, page, browserName, forceFlushReplay }) => {
-    // TODO(replay): This is flakey on firefox where clicks are flakey
-    if (shouldSkipReplayTest() || ['firefox'].includes(browserName)) {
+    // Skipping this in firefox/webkit because it is flakey there
+    if (shouldSkipReplayTest() || ['firefox', 'webkit'].includes(browserName)) {
       sentryTest.skip();
     }
 
@@ -86,8 +86,9 @@ sentryTest(
 
 sentryTest(
   '[session-mode] replay event should not contain an error id of a dropped error while recording',
-  async ({ getLocalTestPath, page, forceFlushReplay }) => {
-    if (shouldSkipReplayTest()) {
+  async ({ getLocalTestPath, page, forceFlushReplay, browserName }) => {
+    // Skipping this in firefox/webkit because it is flakey there
+    if (shouldSkipReplayTest() || ['firefox', 'webkit'].includes(browserName)) {
       sentryTest.skip();
     }
 

--- a/packages/browser-integration-tests/suites/replay/requests/test.ts
+++ b/packages/browser-integration-tests/suites/replay/requests/test.ts
@@ -5,10 +5,10 @@ import { expectedFetchPerformanceSpan, expectedXHRPerformanceSpan } from '../../
 import { getReplayRecordingContent, shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
 sentryTest('replay recording should contain fetch request span', async ({ getLocalTestPath, page, browserName }) => {
-  // For some reason, observing and waiting for requests in firefox is extremely flaky.
-  // We therefore skip this test for firefox and only test on chromium/webkit.
+  // For some reason, observing and waiting for requests in firefox/webkit is extremely flaky.
+  // We therefore skip this test for firefox and only test on chromium.
   // Possibly related: https://github.com/microsoft/playwright/issues/11390
-  if (shouldSkipReplayTest() || browserName === 'firefox') {
+  if (shouldSkipReplayTest() || ['firefox', 'webkit'].includes(browserName)) {
     sentryTest.skip();
   }
 
@@ -48,9 +48,9 @@ sentryTest('replay recording should contain fetch request span', async ({ getLoc
 });
 
 sentryTest('replay recording should contain XHR request span', async ({ getLocalTestPath, page, browserName }) => {
-  // For some reason, observing and waiting for requests in firefox is extremely flaky.
-  // We therefore skip this test for firefox and only test on chromium/webkit.
-  if (shouldSkipReplayTest() || browserName === 'firefox') {
+  // For some reason, observing and waiting for requests in firefox/webkit is extremely flaky.
+  // We therefore skip this test for firefox and only test on chromium.
+  if (shouldSkipReplayTest() || ['firefox', 'webkit'].includes(browserName)) {
     sentryTest.skip();
   }
 


### PR DESCRIPTION
Skip some more tests for webkit & firefox, as they have been flaky sometimes.

Ran these 100x successfully!