### PR TITLE
feat(browser): Re-export `addTracingExtensions` from `@sentry/core`

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -31,6 +31,7 @@ export { Replay } from '@sentry/replay';
 
 // __ROLLUP_EXCLUDE_BROWSER_TRACING_FROM_BUNDLES_BEGIN__
 export { BrowserTracing } from '@sentry-internal/tracing';
+export { addTracingExtensions } from '@sentry/core';
 // __ROLLUP_EXCLUDE_BROWSER_TRACING_FROM_BUNDLES_END__
 
 // __ROLLUP_EXCLUDE_OFFLINE_FROM_BUNDLES_BEGIN__


### PR DESCRIPTION
This was missed off of #7472.

We should re-export `addTracingExtensions` so that users can enable tracing features without needing to use `BrowserTracing`:

```ts
import * as Sentry from '@sentry/browser';

Sentry.addTracingExtensions();

Sentry.init({
  dsn: "__DSN__",
  tracesSampleRate: 1.0,
});
```

Perhaps we should have a warning if users supply `tracesSampleRate` without first calling `addTracingExtensions`?
