### PR TITLE
Lms/yalc scripts

### DIFF
--- a/docs/using-yalc.md
+++ b/docs/using-yalc.md
@@ -1,0 +1,51 @@
+# Using `yalc` for Local SDK Testing
+
+[Yalc](https://github.com/wclr/yalc) is a simple local dependency repository which we can use to work with local versions of our SDKs.
+This is a good alternative to `npm|yarn link` for packages where linking is problematic (e.g. SvelteKit or Angular).
+
+Here's how to set up and use yalc:
+
+## Installing `yalc`
+
+Either install yalc globally,
+
+```sh
+npm install -g yalc
+
+yarn global add yalc
+```
+
+or add it to your desired test projects (same command without the `-g|global` flags)
+
+## Registering/Updating packages
+
+Whenever you want to make your local changes available to your test projects (e.g. after a local code change), run:
+
+```sh
+yarn yalc:publish
+```
+
+If you run this command in the root of the repo, this will publish all SDK packages to the local yalc repo. If you run it in a specific SDK package, it will just publish this package. You **don't need to** call `yalc update` in your test project. Already linked test projects will be update automatically.
+
+## Using yalc packages
+
+In your test project, run
+
+```sh
+yalc add @sentry/browser #or any other SDK package
+```
+
+to add the local SDK package to your project.
+
+**Important:** You need to `yalc add` the dependencies of the SDK package as well (e.g. core, utils, types, etc.).
+
+## Troubleshooting:
+
+### My changes are not applied to the test project
+
+Did you run `yarn build && yarn publish:yalc` after making your changes?
+
+### My test project uses Vite and I still don't see changes
+
+Vite pre-bundles and caches dependencies for dev builds. It [doesn't recognize changes in yalc packages though](https://github.com/wclr/yalc/issues/189) :( To make these changes show up anyway, run `vite dev --force`.
+

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test:unit": "lerna run --ignore @sentry-internal/* test:unit",
     "test-ci-browser": "lerna run test --ignore \"@sentry/{node,opentelemetry-node,serverless,nextjs,remix,gatsby}\" --ignore @sentry-internal/*",
     "test-ci-node": "ts-node ./scripts/node-unit-tests.ts",
-    "test:update-snapshots": "lerna run test:update-snapshots"
+    "test:update-snapshots": "lerna run test:update-snapshots",
+    "yalc:publish": "lerna run yalc:publish"
   },
   "volta": {
     "node": "16.19.0",
@@ -117,7 +118,8 @@
     "tslib": "^2.3.1",
     "typedoc": "^0.18.0",
     "typescript": "3.8.3",
-    "vitest": "^0.29.2"
+    "vitest": "^0.29.2",
+    "yalc": "^1.0.0-pre.53"
   },
   "resolutions": {
     "**/agent-base": "5"

--- a/packages/angular-ivy/package.json
+++ b/packages/angular-ivy/package.json
@@ -56,7 +56,8 @@
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/**.ts\"",
     "lint": "run-s lint:prettier lint:eslint",
     "lint:eslint": "eslint . --format stylish",
-    "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\""
+    "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -59,7 +59,8 @@
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
     "test": "yarn test:unit",
     "test:unit": "jest",
-    "test:unit:watch": "jest --watch"
+    "test:unit:watch": "jest --watch",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -75,7 +75,8 @@
     "test:integration:checkbrowsers": "node scripts/checkbrowsers.js",
     "test:package": "node test/package/npm-build.js && rm test/package/tmp.js",
     "test:unit:watch": "jest --watch",
-    "test:integration:watch": "test/integration/run.js --watch"
+    "test:integration:watch": "test/integration/run.js --watch",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts --bundles && yalc publish ./build/npm --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,8 @@
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
     "test": "jest",
     "test:watch": "jest --watch",
-    "version": "node ../../scripts/versionbump.js src/version.ts"
+    "version": "node ../../scripts/versionbump.js src/version.ts",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -56,7 +56,8 @@
     "lint:eslint": "eslint . --format stylish",
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
     "test": "yarn ts-node scripts/pretest.ts && yarn jest",
-    "test:watch": "yarn ts-node scripts/pretest.ts && yarn jest --watch"
+    "test:watch": "yarn ts-node scripts/pretest.ts && yarn jest --watch",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -45,7 +45,8 @@
     "lint:eslint": "eslint . --format stylish",
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts --bundles && yalc publish ./build/npm --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -75,7 +75,8 @@
     "test:types": "cd test/types && yarn test",
     "test:watch": "jest --watch",
     "vercel:branch": "source vercel/set-up-branch-for-test-app-use.sh",
-    "vercel:project": "source vercel/make-project-use-current-branch.sh"
+    "vercel:project": "source vercel/make-project-use-current-branch.sh",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -56,7 +56,8 @@
     "test:jest": "jest",
     "test:release-health": "node test/manual/release-health/runner.js",
     "test:webpack": "cd test/manual/webpack-domain/ && yarn --silent && node npm-build.js",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -55,7 +55,8 @@
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
     "test": "yarn test:jest",
     "test:jest": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -69,7 +69,8 @@
     "lint:eslint": "eslint . --format stylish",
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -70,7 +70,8 @@
     "test:integration:client:ci": "yarn test:integration:client --browser='all' --reporter='line'",
     "test:integration:server": "export NODE_OPTIONS='--stack-trace-limit=25' && jest --config=test/integration/jest.config.js test/integration/test/server/",
     "test:unit": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -29,7 +29,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "bootstrap:demo": "cd demo && yarn",
-    "start:demo": "yarn build:dev && cd demo && yarn start"
+    "start:demo": "yarn build:dev && cd demo && yarn start",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts --bundles && yalc publish ./build/npm --push"
   },
   "repository": {
     "type": "git",

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -57,7 +57,8 @@
     "lint:eslint": "eslint . --format stylish",
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts --bundles && yalc publish ./build/npm --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -49,7 +49,8 @@
     "lint:eslint": "eslint . --format stylish",
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -52,7 +52,8 @@
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
     "test": "yarn test:unit",
     "test:unit": "vitest run",
-    "test:watch": "vitest --watch"
+    "test:watch": "vitest --watch",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/tracing-internal/package.json
+++ b/packages/tracing-internal/package.json
@@ -44,7 +44,8 @@
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
     "test:unit": "jest",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -48,7 +48,8 @@
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
     "test:unit": "jest",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts --bundles && yalc publish ./build/npm --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -31,7 +31,8 @@
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
-    "fix:prettier": "prettier --write \"{src,test,scripts}/**/**.ts\""
+    "fix:prettier": "prettier --write \"{src,test,scripts}/**/**.ts\"",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -45,7 +45,8 @@
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:package": "node test/types/index.js"
+    "test:package": "node test/types/index.js",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -49,7 +49,8 @@
     "lint:eslint": "eslint . --format stylish",
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -40,7 +40,8 @@
     "fix:prettier": "prettier --write \"{src,test,scripts}/**/**.ts\"",
     "lint": "run-s lint:prettier lint:eslint",
     "lint:eslint": "eslint . --format stylish",
-    "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\""
+    "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts --bundles && yalc publish ./build/npm --push"
   },
   "volta": {
     "extends": "../../package.json"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15070,7 +15070,7 @@ ini@1.3.6:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.6.tgz#f1c46a2a93a253e7b3905115e74d527cd23061a1"
   integrity sha512-IZUoxEjNjubzrmvzZU4lKP7OnYmX72XRl3sqkfJhBKweKi5rnGi5+IUdlj/H1M+Ip5JQ1WzaDMOBRY90Ajc5jg==
 
-ini@2.0.0:
+ini@2.0.0, ini@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
   integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
@@ -19450,6 +19450,16 @@ npm-packlist@^2.1.4:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-2.1.5.tgz#43ef5bbb9f59b7c0ef91e0905f1dd707b4cfb33c"
   integrity sha512-KCfK3Vi2F+PH1klYauoQzg81GQ8/GGjQRKYY6tRnpQUPKTs/1gBZSRWtTEd7jGdSn1LZL7gpAmJT+BcS55k2XQ==
+  dependencies:
+    glob "^7.1.6"
+    ignore-walk "^3.0.3"
+    npm-bundled "^1.1.1"
+    npm-normalize-package-bin "^1.0.1"
+
+npm-packlist@^2.1.5:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-2.2.2.tgz#076b97293fa620f632833186a7a8f65aaa6148c8"
+  integrity sha512-Jt01acDvJRhJGthnUJVF/w6gumWOZxO7IkpY/lsX9//zqQgnF7OJaxgQXcerd4uQOLu7W5bkb4mChL9mdfm+Zg==
   dependencies:
     glob "^7.1.6"
     ignore-walk "^3.0.3"
@@ -27797,6 +27807,20 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yalc@^1.0.0-pre.53:
+  version "1.0.0-pre.53"
+  resolved "https://registry.yarnpkg.com/yalc/-/yalc-1.0.0-pre.53.tgz#c51db2bb924a6908f4cb7e82af78f7e5606810bc"
+  integrity sha512-tpNqBCpTXplnduzw5XC+FF8zNJ9L/UXmvQyyQj7NKrDNavbJtHvzmZplL5ES/RCnjX7JR7W9wz5GVDXVP3dHUQ==
+  dependencies:
+    chalk "^4.1.0"
+    detect-indent "^6.0.0"
+    fs-extra "^8.0.1"
+    glob "^7.1.4"
+    ignore "^5.0.4"
+    ini "^2.0.0"
+    npm-packlist "^2.1.5"
+    yargs "^16.1.1"
 
 yallist@^3.0.0, yallist@^3.0.2, yallist@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
This PR adds a new yarn script to all SDK packages: `yalc:publish`. This script will publish locally built SDK packages to a local [yalc](https://github.com/wclr/yalc) repository which we can use as an alternative to `yarn link` for using our SDKs locally in test projects. 

To make use of this, [`yalc`](https://github.com/wclr/yalc) needs to be installed globally or in the respective test project

More specifically:

- Add a top-level `yalc:publish` script to publish all packages
- This will publish the packages from within the `build(/npm?)` directory of each package, meaning the structure is identical to our published tarballs. IMO this is good because we can test w/ the same structure that our users will get. 
- Add a brief usage doc how to get started
- The `yalc:publish` programm calls `yalc publish` with the `--push` flag, meaning that it automatically updates the published package in the test projects that added them with yalc. 

Reason for this PR: We noticed that `yarn link` doesn't work for the SvelteKit SDK, as linked dependencies apparently aren't processed identically as downloaded ones by Vite. The manual alternative is to build a tarball and install it locally. We also have other SDKs (e.g. Angular) where linking doesn't always work well, so IMO it's good to have another alternative. 
