### PR TITLE
chore(repo): Adjust Craft config to publish SvelteKit SDK to NPM

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -24,7 +24,6 @@ targets:
   - name: github
     includeNames: /^sentry-.*$/
   - name: npm
-    excludeNames: /^sentry-sveltekit-.*$/
   - name: registry
     sdks:
       'npm:@sentry/browser':


### PR DESCRIPTION
With this change, the `@sentry/sveltekit` package will be published to npm with the next release.

(Not to the release registry yet)

ref #7489 
