### PR TITLE
feat(browser): add interactionClassName for tracing interaction

### DIFF
--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -105,6 +105,7 @@ export interface BrowserTracingOptions extends RequestInstrumentationOptions {
   _experiments: Partial<{
     enableLongTask: boolean;
     enableInteractions: boolean;
+    interactionClassName: string;
     onStartRouteTransaction: (t: Transaction | undefined, ctx: TransactionContext, getCurrentHub: () => Hub) => void;
   }>;
 
@@ -199,7 +200,7 @@ export class BrowserTracing implements Integration {
       startTrackingLongTasks();
     }
     if (this.options._experiments.enableInteractions) {
-      startTrackingInteractions();
+      startTrackingInteractions(this.options._experiments.interactionClassName);
     }
   }
 

--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -87,11 +87,14 @@ export function startTrackingLongTasks(): void {
 /**
  * Start tracking interaction events.
  */
-export function startTrackingInteractions(): void {
+export function startTrackingInteractions(interactionClassName: string | undefined): void {
   const entryHandler = (entries: PerformanceEventTiming[]): void => {
     for (const entry of entries) {
       const transaction = getActiveTransaction() as IdleTransaction | undefined;
-      if (!transaction) {
+      if (
+        !transaction ||
+        !(interactionClassName && entry.target?.parentElement?.classList.contains(interactionClassName))
+      ) {
         return;
       }
 


### PR DESCRIPTION
Hi Sentry team, As I mentioned in #7513 I wonder if this is a good idea if we have a class name to detect whether the click interaction should be traced or not.

interaction transaction will be recorded for the element has specific class name, Ex:

```tsx
Sentry.init({
  // ...
  integrations: [
    new BrowserTracing({
      _experiments: {
        enableInteractions: true,
        interactionClassName: 'trace-this'
      },
    }),
  ],
})

function App() {
  return (
    <button className="trace-this">Trace this button</button>
  )
}