### PR TITLE
fix(next): Guard against missing serverSideProps

### DIFF
--- a/packages/nextjs/src/server/wrapGetServerSidePropsWithSentry.ts
+++ b/packages/nextjs/src/server/wrapGetServerSidePropsWithSentry.ts
@@ -44,7 +44,7 @@ export function wrapGetServerSidePropsWithSentry(
           typeof tracedGetServerSideProps
         >);
 
-        if ('props' in serverSideProps) {
+        if (serverSideProps && 'props' in serverSideProps) {
           const requestTransaction = getTransactionFromRequest(req);
           if (requestTransaction) {
             serverSideProps.props._sentryTraceData = requestTransaction.toTraceparent();


### PR DESCRIPTION
I don't know enough about next to be able to tell when this would happen, but as we are type-casting this above it seems prudent enough to check for existence here as well, to be on the safe side.

Fixes https://github.com/getsentry/sentry-javascript/issues/7516