### PR TITLE
fix(vue): Do not depend on `window.location` for SSR environments

### DIFF
--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -65,7 +65,8 @@ export function vueRouterInstrumentation(
 
     // We have to start the pageload transaction as early as possible (before the router's `beforeEach` hook
     // is called) to not miss child spans of the pageload.
-    if (startTransactionOnPageLoad) {
+    // We check that window & window.location exists in order to not run this code in SSR environments.
+    if (startTransactionOnPageLoad && WINDOW && WINDOW.location) {
       startTransaction({
         name: WINDOW.location.pathname,
         op: 'pageload',


### PR DESCRIPTION
When rendering in an SSR environment, `window.location` may not be defined. In this case, we should not error but just not start a transaction.

There may be more graceful ways to handle this, but IMHO this should be fine (and def. better than breaking in SSR).

Closes https://github.com/getsentry/sentry-javascript/issues/7515