### PR TITLE
ref(core): move beforeEnvelope to client

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -646,6 +646,8 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    * @inheritdoc
    */
   protected _sendEnvelope(envelope: Envelope): PromiseLike<void | TransportMakeRequestResponse> | void {
+    this.emit('beforeEnvelope', envelope);
+
     if (this._transport && this._dsn) {
       return this._transport.send(envelope).then(null, reason => {
         __DEBUG_BUILD__ && logger.error('Error while sending event:', reason);

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -646,9 +646,9 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    * @inheritdoc
    */
   protected _sendEnvelope(envelope: Envelope): PromiseLike<void | TransportMakeRequestResponse> | void {
-    this.emit('beforeEnvelope', envelope);
-
     if (this._transport && this._dsn) {
+      this.emit('beforeEnvelope', envelope);
+
       return this._transport.send(envelope).then(null, reason => {
         __DEBUG_BUILD__ && logger.error('Error while sending event:', reason);
       });

--- a/packages/core/src/transports/base.ts
+++ b/packages/core/src/transports/base.ts
@@ -24,8 +24,6 @@ import {
   updateRateLimits,
 } from '@sentry/utils';
 
-import { getCurrentHub } from '../hub';
-
 export const DEFAULT_TRANSPORT_BUFFER_SIZE = 30;
 
 /**
@@ -43,13 +41,9 @@ export function createTransport(
 ): Transport {
   let rateLimits: RateLimits = {};
   const flush = (timeout?: number): PromiseLike<boolean> => buffer.drain(timeout);
-  const client = getCurrentHub().getClient();
 
   function send(envelope: Envelope): PromiseLike<void | TransportMakeRequestResponse> {
     const filteredEnvelopeItems: EnvelopeItem[] = [];
-    if (client && client.emit) {
-      client.emit('beforeEnvelope', envelope);
-    }
 
     // Drop rate limited items from envelope
     forEachEnvelopeItem(envelope, (item, type) => {


### PR DESCRIPTION
I was wrong in moving beforeEnvelope to transport constructor as no client is bound when transport is created, hence client && client.emit will fail...