### PR TITLE
feat(tracing): Migrate some imports away from `@sentry/tracing`

### DIFF
--- a/packages/nextjs/src/server/utils/wrapperUtils.ts
+++ b/packages/nextjs/src/server/utils/wrapperUtils.ts
@@ -1,4 +1,5 @@
-import { captureException, getActiveTransaction, getCurrentHub, startTransaction } from '@sentry/core';
+import { captureException, getCurrentHub, startTransaction } from '@sentry/core';
+import { getActiveTransaction } from '@sentry/tracing';
 import type { Transaction } from '@sentry/types';
 import { baggageHeaderToDynamicSamplingContext, extractTraceparentData } from '@sentry/utils';
 import * as domain from 'domain';

--- a/packages/nextjs/src/server/utils/wrapperUtils.ts
+++ b/packages/nextjs/src/server/utils/wrapperUtils.ts
@@ -1,5 +1,4 @@
-import { captureException, getCurrentHub, startTransaction } from '@sentry/core';
-import { getActiveTransaction } from '@sentry/tracing';
+import { captureException, getActiveTransaction, getCurrentHub, startTransaction } from '@sentry/core';
 import type { Transaction } from '@sentry/types';
 import { baggageHeaderToDynamicSamplingContext, extractTraceparentData } from '@sentry/utils';
 import * as domain from 'domain';

--- a/packages/nextjs/src/server/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/server/wrapApiHandlerWithSentry.ts
@@ -1,10 +1,10 @@
 import { hasTracingEnabled } from '@sentry/core';
 import { captureException, getCurrentHub, startTransaction } from '@sentry/node';
-import { extractTraceparentData } from '@sentry/tracing';
 import type { Transaction } from '@sentry/types';
 import {
   addExceptionMechanism,
   baggageHeaderToDynamicSamplingContext,
+  extractTraceparentData,
   isString,
   logger,
   objectify,

--- a/packages/opentelemetry-node/src/spanprocessor.ts
+++ b/packages/opentelemetry-node/src/spanprocessor.ts
@@ -2,8 +2,7 @@ import type { Context } from '@opentelemetry/api';
 import { SpanKind, trace } from '@opentelemetry/api';
 import type { Span as OtelSpan, SpanProcessor as OtelSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import { addGlobalEventProcessor, getCurrentHub } from '@sentry/core';
-import { Transaction } from '@sentry/tracing';
+import { addGlobalEventProcessor, getCurrentHub, Transaction } from '@sentry/core';
 import type { DynamicSamplingContext, Span as SentrySpan, TraceparentData, TransactionContext } from '@sentry/types';
 import { isString, logger } from '@sentry/utils';
 

--- a/packages/opentelemetry-node/src/utils/map-otel-status.ts
+++ b/packages/opentelemetry-node/src/utils/map-otel-status.ts
@@ -1,6 +1,6 @@
 import type { Span as OtelSpan } from '@opentelemetry/sdk-trace-base';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import type { SpanStatusType as SentryStatus } from '@sentry/tracing';
+import type { SpanStatusType as SentryStatus } from '@sentry/core';
 
 // canonicalCodesHTTPMap maps some HTTP codes to Sentry's span statuses. See possible mapping in https://develop.sentry.dev/sdk/event-payloads/span/
 const canonicalCodesHTTPMap: Record<string, SentryStatus> = {

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -1,8 +1,7 @@
 /* eslint-disable max-lines */
-import { hasTracingEnabled } from '@sentry/core';
+import { getActiveTransaction, hasTracingEnabled } from '@sentry/core';
 import type { Hub } from '@sentry/node';
 import { captureException, getCurrentHub } from '@sentry/node';
-import { getActiveTransaction } from '@sentry/tracing';
 import type { Transaction, TransactionSource, WrappedFunction } from '@sentry/types';
 import {
   addExceptionMechanism,

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -2,9 +2,15 @@
 import type { Scope } from '@sentry/node';
 import * as Sentry from '@sentry/node';
 import { captureException, captureMessage, flush, getCurrentHub, withScope } from '@sentry/node';
-import { extractTraceparentData } from '@sentry/tracing';
 import type { Integration } from '@sentry/types';
-import { baggageHeaderToDynamicSamplingContext, dsnFromString, dsnToString, isString, logger } from '@sentry/utils';
+import {
+  baggageHeaderToDynamicSamplingContext,
+  dsnFromString,
+  dsnToString,
+  extractTraceparentData,
+  isString,
+  logger,
+} from '@sentry/utils';
 // NOTE: I have no idea how to fix this right now, and don't want to waste more time, as it builds just fine — Kamil
 // eslint-disable-next-line import/no-unresolved
 import type { Context, Handler } from 'aws-lambda';

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -1,8 +1,8 @@
 import type { AddRequestDataToEventOptions } from '@sentry/node';
 import { captureException, flush, getCurrentHub } from '@sentry/node';
-import { extractTraceparentData } from '@sentry/tracing';
 import {
   baggageHeaderToDynamicSamplingContext,
+  extractTraceparentData,
   isString,
   isThenable,
   logger,


### PR DESCRIPTION
To deprecate `@sentry/tracing` for v8, we need to remove all the internal imports of the package.

This PR migrates imports of types/functions that have already moved to `@sentry/core` and `@sentry/utils`.
