### PR TITLE
fix(cdn): Fix es5 CDN bundles

### DIFF
--- a/docs/new-sdk-release-checklist.md
+++ b/docs/new-sdk-release-checklist.md
@@ -44,6 +44,9 @@ This page serves as a checklist of what to do when releasing a new SDK for the f
     - **This is especially important, if you're adding new CDN bundles!**
     - Tarballs (*.tgz archives) should work OOTB
 
+
+- [ ] Make sure it is added to `bundlePlugins.ts:makeTSPlugin` as `paths`, otherwise it will not be ES5 transpiled correctly for CDN builds.
+
 ## Cutting the Release
 
 When you’re ready to make the first release, there are a couple of steps that need to be performed in the **correct order**. Note that you can prepare the PRs at any time but the **merging oder** is important:

--- a/packages/integration-shims/tsconfig.json
+++ b/packages/integration-shims/tsconfig.json
@@ -1,11 +1,9 @@
 {
   "extends": "../../tsconfig.json",
+
+  "include": ["src/**/*"],
+
   "compilerOptions": {
-    "module": "esnext",
-    "lib": ["ES6"],
-    "esModuleInterop": true,
-    "target": "es6",
-    "strictPropertyInitialization": false
-  },
-  "include": ["src/**/*.ts"]
+    // package-specific options
+  }
 }

--- a/rollup/bundleHelpers.js
+++ b/rollup/bundleHelpers.js
@@ -30,7 +30,7 @@ export function makeBaseBundleConfig(options) {
   const cleanupPlugin = makeCleanupPlugin();
   const markAsBrowserBuildPlugin = makeBrowserBuildPlugin(true);
   const licensePlugin = makeLicensePlugin(licenseTitle);
-  const tsPlugin = makeTSPlugin(jsVersion.toLowerCase());
+  const tsPlugin = makeTSPlugin('es5');
 
   // The `commonjs` plugin is the `esModuleInterop` of the bundling world. When used with `transformMixedEsModules`, it
   // will include all dependencies, imported or required, in the final bundle. (Without it, CJS modules aren't included

--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -147,6 +147,8 @@ export function makeTSPlugin(jsVersion) {
           '@sentry/hub': ['../hub/src'],
           '@sentry/types': ['../types/src'],
           '@sentry/utils': ['../utils/src'],
+          '@sentry-internal/integration-shims': ['../integration-shims/src'],
+          '@sentry-internal/tracing': ['../tracing-internal/src'],
         },
         baseUrl: '.',
       },


### PR DESCRIPTION
We need to add packages to the ts plugin config, otherwise they are not correctly ES5 transpiled. I also added this to the checklist.

I will merge this PR into master and cut a release so we can do a bugfix release (there is already a feature on develop). 

Closes https://github.com/getsentry/sentry-javascript/issues/7541