### PR TITLE
chore(otel): Update docs for using propagator

### DIFF
--- a/packages/opentelemetry-node/README.md
+++ b/packages/opentelemetry-node/README.md
@@ -66,9 +66,8 @@ const sdk = new opentelemetry.NodeSDK({
 
   // Sentry config
   spanProcessor: new SentrySpanProcessor(),
+  textMapPropagator: new SentryPropagator(),
 });
-
-otelApi.propagation.setGlobalPropagator(new SentryPropagator());
 
 sdk.start();
 ```


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/7538

Dependency injecting the propagator is more correct than using the `setGlobalPropagator` API, so let's do that instead.