### PR TITLE
feat(hub): Make scope always defined on the hub

### DIFF
--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -56,7 +56,7 @@ const DEFAULT_BREADCRUMBS = 100;
  */
 export interface Layer {
   client?: Client;
-  scope?: Scope;
+  scope: Scope;
 }
 
 /**
@@ -87,7 +87,7 @@ export interface Carrier {
  */
 export class Hub implements HubInterface {
   /** Is a {@link Layer}[] containing the client and scope */
-  private readonly _stack: Layer[] = [{}];
+  private readonly _stack: Layer[];
 
   /** Contains the last event id of a captured event.  */
   private _lastEventId?: string;
@@ -101,7 +101,7 @@ export class Hub implements HubInterface {
    * @param version number, higher number means higher priority.
    */
   public constructor(client?: Client, scope: Scope = new Scope(), private readonly _version: number = API_VERSION) {
-    this.getStackTop().scope = scope;
+    this._stack = [{ scope }];
     if (client) {
       this.bindClient(client);
     }
@@ -166,7 +166,7 @@ export class Hub implements HubInterface {
   }
 
   /** Returns the scope of the top stack. */
-  public getScope(): Scope | undefined {
+  public getScope(): Scope {
     return this.getStackTop().scope;
   }
 
@@ -256,7 +256,7 @@ export class Hub implements HubInterface {
   public addBreadcrumb(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): void {
     const { scope, client } = this.getStackTop();
 
-    if (!scope || !client) return;
+    if (!client) return;
 
     const { beforeBreadcrumb = null, maxBreadcrumbs = DEFAULT_BREADCRUMBS } =
       (client.getOptions && client.getOptions()) || {};
@@ -282,40 +282,35 @@ export class Hub implements HubInterface {
    * @inheritDoc
    */
   public setUser(user: User | null): void {
-    const scope = this.getScope();
-    if (scope) scope.setUser(user);
+    this.getScope().setUser(user);
   }
 
   /**
    * @inheritDoc
    */
   public setTags(tags: { [key: string]: Primitive }): void {
-    const scope = this.getScope();
-    if (scope) scope.setTags(tags);
+    this.getScope().setTags(tags);
   }
 
   /**
    * @inheritDoc
    */
   public setExtras(extras: Extras): void {
-    const scope = this.getScope();
-    if (scope) scope.setExtras(extras);
+    this.getScope().setExtras(extras);
   }
 
   /**
    * @inheritDoc
    */
   public setTag(key: string, value: Primitive): void {
-    const scope = this.getScope();
-    if (scope) scope.setTag(key, value);
+    this.getScope().setTag(key, value);
   }
 
   /**
    * @inheritDoc
    */
   public setExtra(key: string, extra: Extra): void {
-    const scope = this.getScope();
-    if (scope) scope.setExtra(key, extra);
+    this.getScope().setExtra(key, extra);
   }
 
   /**
@@ -323,8 +318,7 @@ export class Hub implements HubInterface {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public setContext(name: string, context: { [key: string]: any } | null): void {
-    const scope = this.getScope();
-    if (scope) scope.setContext(name, context);
+    this.getScope().setContext(name, context);
   }
 
   /**
@@ -395,17 +389,15 @@ export class Hub implements HubInterface {
    */
   public endSession(): void {
     const layer = this.getStackTop();
-    const scope = layer && layer.scope;
-    const session = scope && scope.getSession();
+    const scope = layer.scope;
+    const session = scope.getSession();
     if (session) {
       closeSession(session);
     }
     this._sendSessionUpdate();
 
     // the session is over; take it off of the scope
-    if (scope) {
-      scope.setSession();
-    }
+    scope.setSession();
   }
 
   /**
@@ -426,17 +418,15 @@ export class Hub implements HubInterface {
       ...context,
     });
 
-    if (scope) {
-      // End existing session if there's one
-      const currentSession = scope.getSession && scope.getSession();
-      if (currentSession && currentSession.status === 'ok') {
-        updateSession(currentSession, { status: 'exited' });
-      }
-      this.endSession();
-
-      // Afterwards we set the new session on the scope
-      scope.setSession(session);
+    // End existing session if there's one
+    const currentSession = scope.getSession && scope.getSession();
+    if (currentSession && currentSession.status === 'ok') {
+      updateSession(currentSession, { status: 'exited' });
     }
+    this.endSession();
+
+    // Afterwards we set the new session on the scope
+    scope.setSession(session);
 
     return session;
   }
@@ -472,7 +462,7 @@ export class Hub implements HubInterface {
    * @param method The method to call on the client.
    * @param args Arguments to pass to the client function.
    */
-  private _withClient(callback: (client: Client, scope: Scope | undefined) => void): void {
+  private _withClient(callback: (client: Client, scope: Scope) => void): void {
     const { scope, client } = this.getStackTop();
     if (client) {
       callback(client, scope);


### PR DESCRIPTION
While working on https://github.com/getsentry/sentry-javascript/pull/7536, and trying to abstract it into a generic `Sentry.trace` function I realized on unwieldy it is that `hub.getScope()` returns `Scope | undefined`.

In practice this should never happen, since in the hub constructor we default to always setting a scope.

```ts
public constructor(client?: Client, scope: Scope = new Scope(), private readonly _version: number = API_VERSION) {
```

In this PR I change the signature of `hub.getScope` to return only a `Scope`.

This should be a bundle size decrease, and allow us to do some nice refactors across the board.

In addition, we can now add a trace function that looks like so:

```ts
/**
 * Wraps a function with a transaction/span and finishes the span after the function is done.
 *
 */
export function trace<T>(context: TransactionContext, callback: (span: Span) => T): T {
  const ctx = { ...context };
  // If a name is set and a description is not, set the description to the name.
  if (ctx.name !== undefined && ctx.description === undefined) {
    ctx.description = ctx.name;
  }

  const hub = getCurrentHub();
  const scope = hub.getScope();

  const parentSpan = scope.getSpan();

  const activeSpan = parentSpan ? parentSpan.startChild(ctx) : hub.startTransaction(ctx);
  scope.setSpan(activeSpan);

  let maybePromiseResult: T;
  try {
    maybePromiseResult = callback(activeSpan);
  } catch (e) {
    activeSpan.setStatus('internal_error');
    activeSpan.finish();
    throw e;
  }

  if (isThenable(maybePromiseResult)) {
    Promise.resolve(maybePromiseResult).then(
      () => {
        activeSpan.finish();
      },
      _e => {
        activeSpan.setStatus('internal_error');
        activeSpan.finish();
      },
    );
  } else {
    activeSpan.finish();
  }

  return maybePromiseResult;
}
```