### PR TITLE
fix(browser): Ensure keepalive flag is correctly set for parallel requests

### DIFF
--- a/packages/browser/src/transports/fetch.ts
+++ b/packages/browser/src/transports/fetch.ts
@@ -30,10 +30,9 @@ export function makeFetchTransport(
       // frequently sending events right before the user is switching pages (eg. whenfinishing navigation transactions).
       // Gotchas:
       // - `keepalive` isn't supported by Firefox
-      // - As per spec (https://fetch.spec.whatwg.org/#http-network-or-cache-fetch), a request with `keepalive: true`
-      //   and a content length of > 64 kibibytes returns a network error. We will therefore only activate the flag when
-      //   we're below that limit.
-      // Note that the limit is for all pending requests, not per request, so we need to check this based on all current requests.
+      // - As per spec (https://fetch.spec.whatwg.org/#http-network-or-cache-fetch):
+      //   If the sum of contentLength and inflightKeepaliveBytes is greater than 64 kibibytes, then return a network error.
+      //   We will therefore only activate the flag when we're below that limit.
       keepalive: pendingBodySize <= 65536,
       ...options.fetchOptions,
     };

--- a/packages/browser/test/unit/transports/fetch.test.ts
+++ b/packages/browser/test/unit/transports/fetch.test.ts
@@ -18,7 +18,7 @@ const ERROR_ENVELOPE = createEnvelope<EventEnvelope>({ event_id: 'aa3ff046696b4b
 
 const LARGE_ERROR_ENVELOPE = createEnvelope<EventEnvelope>(
   { event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2', sent_at: '123' },
-  [[{ type: 'event' }, { event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2', message: 'x'.repeat(10 * 1024) }] as EventItem],
+  [[{ type: 'event' }, { event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2', message: 'x'.repeat(10 * 900) }] as EventItem],
 );
 
 class Headers {
@@ -146,16 +146,19 @@ describe('NewFetchTransport', () => {
       expect(mockFetch).toHaveBeenNthCalledWith(i, expect.any(String), expect.objectContaining({ keepalive }));
     }
 
+    (mockFetch as jest.Mock<unknown>).mockClear();
+
     // Limit resets when requests have resolved
+    // Now try based on # of pending requests
     const promises2 = [];
-    for (let i = 0; i < 10; i++) {
-      promises2.push(transport.send(LARGE_ERROR_ENVELOPE));
+    for (let i = 0; i < 20; i++) {
+      promises2.push(transport.send(ERROR_ENVELOPE));
     }
 
     await Promise.all(promises2);
 
-    for (let i = 1; i <= 10; i++) {
-      const keepalive = i < 7;
+    for (let i = 1; i <= 20; i++) {
+      const keepalive = i < 15;
       expect(mockFetch).toHaveBeenNthCalledWith(i, expect.any(String), expect.objectContaining({ keepalive }));
     }
   });


### PR DESCRIPTION
We noticed that sometimes request would remain in a seemingly pending state.
After some investigation, we found out that the limit of 64kb for keepalive-enabled fetch requests is not _per request_ but for _all parallel requests_ running at the same time.

This PR fixes this by keeping track of how large the pending body sizes are, and setting `keepalive` accordingly.

I tried this in my local reproduction app, where it now worked as expected!

## When do we use keepalive now

We use keepalive if:

* total currently pending body size < 60k
* total # of pending requests < 15

This should defensively work for relevant cases.

## Why do we want to have keepalive, when possible?

Especially for replays and transactions, having keepalive enabled means we can capture more data when a user leaves the page, which would otherwise be lost. This lead to problems with [Next.js transaction collection](https://github.com/getsentry/sentry-javascript/pull/5697), for example. In Replay, we want to be able to make sure to do a final flush before the user leaves the page.

## Spec reference

* [fetch spec](https://fetch.spec.whatwg.org/#http-network-or-cache-fetch)
* 

Fixes https://github.com/getsentry/sentry-javascript/issues/7546
Fixes https://github.com/getsentry/sentry-javascript/issues/6049