### PR TITLE
ref(core): Remove guards around scope usage

### DIFF
--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -326,7 +326,7 @@ export class Hub implements HubInterface {
    */
   public configureScope(callback: (scope: Scope) => void): void {
     const { scope, client } = this.getStackTop();
-    if (scope && client) {
+    if (client) {
       callback(scope);
     }
   }
@@ -413,7 +413,7 @@ export class Hub implements HubInterface {
     const session = makeSession({
       release,
       environment,
-      ...(scope && { user: scope.getUser() }),
+      user: scope.getUser(),
       ...(userAgent && { userAgent }),
       ...context,
     });

--- a/packages/core/src/sdk.ts
+++ b/packages/core/src/sdk.ts
@@ -28,9 +28,7 @@ export function initAndBind<F extends Client, O extends ClientOptions>(
   }
   const hub = getCurrentHub();
   const scope = hub.getScope();
-  if (scope) {
-    scope.update(options.initialScope);
-  }
+  scope.update(options.initialScope);
 
   const client = new clientClass(options);
   hub.bindClient(client);

--- a/packages/core/src/sessionflusher.ts
+++ b/packages/core/src/sessionflusher.ts
@@ -72,15 +72,13 @@ export class SessionFlusher implements SessionFlusherLike {
       return;
     }
     const scope = getCurrentHub().getScope();
-    const requestSession = scope && scope.getRequestSession();
+    const requestSession = scope.getRequestSession();
 
     if (requestSession && requestSession.status) {
       this._incrementSessionStatusCount(requestSession.status, new Date());
       // This is not entirely necessarily but is added as a safe guard to indicate the bounds of a request and so in
       // case captureRequestSession is called more than once to prevent double count
-      if (scope) {
-        scope.setRequestSession(undefined);
-      }
+      scope.setRequestSession(undefined);
       /* eslint-enable @typescript-eslint/no-unsafe-member-access */
     }
   }

--- a/packages/core/src/tracing/hubextensions.ts
+++ b/packages/core/src/tracing/hubextensions.ts
@@ -11,15 +11,13 @@ import { Transaction } from './transaction';
 /** Returns all trace headers that are currently on the top scope. */
 function traceHeaders(this: Hub): { [key: string]: string } {
   const scope = this.getScope();
-  if (scope) {
-    const span = scope.getSpan();
-    if (span) {
-      return {
+  const span = scope.getSpan();
+
+  return span
+    ? {
         'sentry-trace': span.toTraceparent(),
-      };
-    }
-  }
-  return {};
+      }
+    : {};
 }
 
 /**

--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -346,10 +346,7 @@ export class IdleTransaction extends Transaction {
  */
 function clearActiveTransaction(hub: Hub): void {
   const scope = hub.getScope();
-  if (scope) {
-    const transaction = scope.getTransaction();
-    if (transaction) {
-      scope.setSpan(undefined);
-    }
+  if (scope.getTransaction()) {
+    scope.setSpan(undefined);
   }
 }

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -256,8 +256,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
     const maybeSampleRate = this.metadata.sampleRate;
     const sample_rate = maybeSampleRate !== undefined ? maybeSampleRate.toString() : undefined;
 
-    const scope = hub.getScope();
-    const { segment: user_segment } = (scope && scope.getUser()) || {};
+    const { segment: user_segment } = hub.getScope().getUser() || {};
 
     const source = this.metadata.source;
 

--- a/packages/core/src/tracing/utils.ts
+++ b/packages/core/src/tracing/utils.ts
@@ -21,7 +21,7 @@ export { TRACEPARENT_REGEXP, extractTraceparentData } from '@sentry/utils';
 export function getActiveTransaction<T extends Transaction>(maybeHub?: Hub): T | undefined {
   const hub = maybeHub || getCurrentHub();
   const scope = hub.getScope();
-  return scope && (scope.getTransaction() as T | undefined);
+  return scope.getTransaction() as T | undefined;
 }
 
 // so it can be used in manual instrumentation without necessitating a hard dependency on @sentry/utils


### PR DESCRIPTION
Let's reduce some bundle size!

Now that https://github.com/getsentry/sentry-javascript/pull/7551 merged in, we can remove guards around using the scope.

It's not a huge deal in node packages, so we don't have to go in and change anything there, but we can have some byte savings in our browser packages, so let's save!

Starting with core, then will do the rest of the packages in other PRs when I get time.