### PR TITLE
feat(react): Handle case where error.cause already defined

### DIFF
--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -66,6 +66,13 @@ const INITIAL_STATE = {
   eventId: null,
 };
 
+function setCause(error: Error & { cause?: Error }, cause: Error): void {
+  if (error.cause) {
+    return setCause(error.cause, cause);
+  }
+  error.cause = cause;
+}
+
 /**
  * A ErrorBoundary component that logs errors to Sentry. Requires React >= 16.
  * NOTE: If you are a Sentry user, and you are seeing this stack frame, it means the
@@ -93,7 +100,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
         errorBoundaryError.stack = componentStack;
 
         // Using the `LinkedErrors` integration to link the errors together.
-        error.cause = errorBoundaryError;
+        setCause(error, errorBoundaryError);
       }
 
       if (beforeCapture) {

--- a/packages/react/test/errorboundary.test.tsx
+++ b/packages/react/test/errorboundary.test.tsx
@@ -3,14 +3,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import * as React from 'react';
 import { useState } from 'react';
 
-import type {
-  ErrorBoundaryProps} from '../src/errorboundary';
-import {
-  ErrorBoundary,
-  isAtLeastReact17,
-  UNKNOWN_COMPONENT,
-  withErrorBoundary,
-} from '../src/errorboundary';
+import type { ErrorBoundaryProps } from '../src/errorboundary';
+import { ErrorBoundary, isAtLeastReact17, UNKNOWN_COMPONENT, withErrorBoundary } from '../src/errorboundary';
 
 const mockCaptureException = jest.fn();
 const mockShowReportDialog = jest.fn();
@@ -39,7 +33,13 @@ function Bam(): JSX.Element {
   return <Boo title={title} />;
 }
 
-const TestApp: React.FC<ErrorBoundaryProps> = ({ children, ...props }) => {
+interface TestAppProps extends ErrorBoundaryProps {
+  errorComp?: JSX.Element;
+}
+
+const TestApp: React.FC<TestAppProps> = ({ children, errorComp, ...props }) => {
+  // eslint-disable-next-line no-param-reassign
+  const customErrorComp = errorComp || <Bam />;
   const [isError, setError] = React.useState(false);
   return (
     <ErrorBoundary
@@ -51,7 +51,7 @@ const TestApp: React.FC<ErrorBoundaryProps> = ({ children, ...props }) => {
         }
       }}
     >
-      {isError ? <Bam /> : children}
+      {isError ? customErrorComp : children}
       <button
         data-testid="errorBtn"
         onClick={() => {
@@ -297,6 +297,48 @@ describe('ErrorBoundary', () => {
       // Check if error.cause -> react component stack
       const error = mockCaptureException.mock.calls[0][0];
       expect(error.cause).not.toBeDefined();
+    });
+
+    it('handles when `error.cause` is nested', () => {
+      const mockOnError = jest.fn();
+
+      function CustomBam(): JSX.Element {
+        const firstError = new Error('bam');
+        const secondError = new Error('bam2');
+        const thirdError = new Error('bam3');
+        // @ts-ignore Need to set cause on error
+        secondError.cause = firstError;
+        // @ts-ignore Need to set cause on error
+        thirdError.cause = secondError;
+        throw thirdError;
+      }
+
+      render(
+        <TestApp fallback={<p>You have hit an error</p>} onError={mockOnError} errorComp={<CustomBam />}>
+          <h1>children</h1>
+        </TestApp>,
+      );
+
+      expect(mockOnError).toHaveBeenCalledTimes(0);
+      expect(mockCaptureException).toHaveBeenCalledTimes(0);
+
+      const btn = screen.getByTestId('errorBtn');
+      fireEvent.click(btn);
+
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
+      expect(mockCaptureException).toHaveBeenLastCalledWith(expect.any(Error), {
+        contexts: { react: { componentStack: expect.any(String) } },
+      });
+
+      expect(mockOnError.mock.calls[0][0]).toEqual(mockCaptureException.mock.calls[0][0]);
+
+      const thirdError = mockCaptureException.mock.calls[0][0];
+      const secondError = thirdError.cause;
+      const firstError = secondError.cause;
+      const cause = firstError.cause;
+      expect(cause.stack).toEqual(mockCaptureException.mock.calls[0][1].contexts.react.componentStack);
+      expect(cause.name).toContain('React ErrorBoundary');
+      expect(cause.message).toEqual(thirdError.message);
     });
 
     it('calls `beforeCapture()` when an error occurs', () => {


### PR DESCRIPTION
ref: https://github.com/getsentry/sentry-javascript/issues/1401#issuecomment-1411095278

If `error.cause` is already defined, attempt to walk down the error chain to set the `ReactErrorBoundary` error.