### PR TITLE
feat(nextjs): Remove `@sentry/tracing` dependency from nextjs SDK

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -21,8 +21,8 @@ const INTEGRATIONS = {
 export { INTEGRATIONS as Integrations };
 
 export { Replay } from '@sentry/replay';
-export { BrowserTracing } from '@sentry-internal/tracing';
-export { addTracingExtensions } from '@sentry/core';
+export { BrowserTracing, defaultRequestInstrumentationOptions } from '@sentry-internal/tracing';
+export { addTracingExtensions, getActiveTransaction } from '@sentry/core';
 export { makeBrowserOfflineTransport } from './transports/offline';
 export { onProfilingStartRouteTransaction } from './profiling/hubextensions';
 export { BrowserProfilingIntegration } from './profiling/integration';

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -22,7 +22,6 @@
     "@sentry/integrations": "7.44.2",
     "@sentry/node": "7.44.2",
     "@sentry/react": "7.44.2",
-    "@sentry/tracing": "7.44.2",
     "@sentry/types": "7.44.2",
     "@sentry/utils": "7.44.2",
     "@sentry/webpack-plugin": "1.20.0",

--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -1,8 +1,13 @@
 import { hasTracingEnabled } from '@sentry/core';
 import { RewriteFrames } from '@sentry/integrations';
 import type { BrowserOptions } from '@sentry/react';
-import { configureScope, init as reactInit, Integrations } from '@sentry/react';
-import { BrowserTracing, defaultRequestInstrumentationOptions } from '@sentry/tracing';
+import {
+  BrowserTracing,
+  configureScope,
+  defaultRequestInstrumentationOptions,
+  init as reactInit,
+  Integrations,
+} from '@sentry/react';
 import type { EventProcessor } from '@sentry/types';
 import { addOrUpdateIntegration } from '@sentry/utils';
 

--- a/packages/nextjs/src/edge/edgeclient.ts
+++ b/packages/nextjs/src/edge/edgeclient.ts
@@ -1,5 +1,5 @@
 import type { Scope } from '@sentry/core';
-import { BaseClient, SDK_VERSION } from '@sentry/core';
+import { addTracingExtensions, BaseClient, SDK_VERSION } from '@sentry/core';
 import type { ClientOptions, Event, EventHint, Severity, SeverityLevel } from '@sentry/types';
 
 import { eventFromMessage, eventFromUnknownInput } from './eventbuilder';
@@ -27,6 +27,9 @@ export class EdgeClient extends BaseClient<EdgeClientOptions> {
       ],
       version: SDK_VERSION,
     };
+
+    // The Edge client always supports tracing
+    addTracingExtensions();
 
     super(options);
   }

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -1,5 +1,3 @@
-import '@sentry/tracing'; // Allow people to call tracing API methods without explicitly importing the tracing package.
-
 import { getCurrentHub, getIntegrationsToSetup, initAndBind, Integrations as CoreIntegrations } from '@sentry/core';
 import type { Options } from '@sentry/types';
 import {

--- a/packages/nextjs/src/server/utils/wrapperUtils.ts
+++ b/packages/nextjs/src/server/utils/wrapperUtils.ts
@@ -1,5 +1,4 @@
-import { captureException, getCurrentHub, startTransaction } from '@sentry/core';
-import { getActiveTransaction } from '@sentry/tracing';
+import { captureException, getActiveTransaction, getCurrentHub, startTransaction } from '@sentry/core';
 import type { Transaction } from '@sentry/types';
 import { baggageHeaderToDynamicSamplingContext, extractTraceparentData } from '@sentry/utils';
 import * as domain from 'domain';

--- a/packages/nextjs/test/config/wrappers.test.ts
+++ b/packages/nextjs/test/config/wrappers.test.ts
@@ -1,10 +1,15 @@
 import * as SentryCore from '@sentry/core';
+import { addTracingExtensions } from '@sentry/core';
 import * as SentryNode from '@sentry/node';
 import type { IncomingMessage, ServerResponse } from 'http';
 
 import { wrapGetInitialPropsWithSentry, wrapGetServerSidePropsWithSentry } from '../../src/server';
 
 const startTransactionSpy = jest.spyOn(SentryCore, 'startTransaction');
+
+// The wrap* functions require the hub to have tracing extensions. This is normally called by the NodeClient
+// constructor but the client isn't used in these tests.
+addTracingExtensions();
 
 describe('data-fetching function wrappers', () => {
   const route = '/tricks/[trickName]';

--- a/packages/nextjs/test/edge/withSentryAPI.test.ts
+++ b/packages/nextjs/test/edge/withSentryAPI.test.ts
@@ -2,6 +2,10 @@ import * as coreSdk from '@sentry/core';
 
 import { wrapApiHandlerWithSentry } from '../../src/edge';
 
+// The wrap* functions require the hub to have tracing extensions. This is normally called by the EdgeClient
+// constructor but the client isn't used in these tests.
+coreSdk.addTracingExtensions();
+
 // @ts-ignore Request does not exist on type Global
 const origRequest = global.Request;
 // @ts-ignore Response does not exist on type Global

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -30,6 +30,7 @@ export {
   captureMessage,
   configureScope,
   createTransport,
+  getActiveTransaction,
   getHubFromCarrier,
   getCurrentHub,
   Hub,


### PR DESCRIPTION
This PR removes the `@sentry/tracing` dependency from the nextjs SDK.

This involved:
- Moving some imports around 
- Ensuring `@sentry/browser` and `@sentry/node` were exporting the tracing types required
- Calling `addTracingExtensions` where this was previously taken care of by side-effects
