### PR TITLE
feat(tracing): Remove some more `@sentry/tracing` references

### DIFF
--- a/packages/nextjs/test/clientSdk.test.ts
+++ b/packages/nextjs/test/clientSdk.test.ts
@@ -1,15 +1,12 @@
 import { BaseClient, getCurrentHub } from '@sentry/core';
 import * as SentryReact from '@sentry/react';
-import { WINDOW } from '@sentry/react';
-import { Integrations as TracingIntegrations } from '@sentry/tracing';
+import { BrowserTracing, WINDOW } from '@sentry/react';
 import type { Integration } from '@sentry/types';
 import type { UserIntegrationsFunction } from '@sentry/utils';
 import { logger } from '@sentry/utils';
 import { JSDOM } from 'jsdom';
 
 import { init, Integrations, nextRouterInstrumentation } from '../src/client';
-
-const { BrowserTracing } = TracingIntegrations;
 
 const reactInit = jest.spyOn(SentryReact, 'init');
 const captureEvent = jest.spyOn(BaseClient.prototype, 'captureEvent');

--- a/packages/nextjs/test/config/withSentry.test.ts
+++ b/packages/nextjs/test/config/withSentry.test.ts
@@ -1,10 +1,15 @@
 import * as hub from '@sentry/core';
+import { addTracingExtensions } from '@sentry/core';
 import * as Sentry from '@sentry/node';
 import type { Client, ClientOptions } from '@sentry/types';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { withSentry } from '../../src/server';
 import type { AugmentedNextApiResponse, NextApiHandler } from '../../src/server/types';
+
+// The wrap* functions require the hub to have tracing extensions. This is normally called by the NodeClient
+// constructor but the client isn't used in these tests.
+addTracingExtensions();
 
 const FLUSH_DURATION = 200;
 

--- a/packages/nextjs/test/edge/edgeWrapperUtils.test.ts
+++ b/packages/nextjs/test/edge/edgeWrapperUtils.test.ts
@@ -1,6 +1,11 @@
 import * as coreSdk from '@sentry/core';
+import { addTracingExtensions } from '@sentry/core';
 
 import { withEdgeWrapping } from '../../src/edge/utils/edgeWrapperUtils';
+
+// The wrap* functions require the hub to have tracing extensions. This is normally called by the EdgeClient
+// constructor but the client isn't used in these tests.
+addTracingExtensions();
 
 // @ts-ignore Request does not exist on type Global
 const origRequest = global.Request;

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -26,7 +26,6 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@sentry/tracing": "7.44.2",
     "@types/cookie": "0.3.2",
     "@types/express": "^4.17.14",
     "@types/lru-cache": "^5.1.0",

--- a/packages/node/src/integrations/onuncaughtexception.ts
+++ b/packages/node/src/integrations/onuncaughtexception.ts
@@ -105,7 +105,6 @@ export class OnUncaughtException implements Integration {
         if (
           // There are 3 listeners we ignore:
           listener.name === 'domainUncaughtExceptionClear' || // as soon as we're using domains this listener is attached by node itself
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           (listener.tag && listener.tag === 'sentry_tracingErrorCallback') || // the handler we register for tracing
           listener === this.handler // the handler we register in this integration
         ) {

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -1,9 +1,8 @@
+import type { Span, Transaction } from '@sentry/core';
 import * as sentryCore from '@sentry/core';
-import { Hub } from '@sentry/core';
-import type { Span, Transaction } from '@sentry/tracing';
-import { addExtensionMethods, TRACEPARENT_REGEXP } from '@sentry/tracing';
+import { addTracingExtensions, Hub } from '@sentry/core';
 import type { TransactionContext } from '@sentry/types';
-import { logger, parseSemver } from '@sentry/utils';
+import { logger, parseSemver, TRACEPARENT_REGEXP } from '@sentry/utils';
 import * as http from 'http';
 import * as https from 'https';
 import * as HttpsProxyAgent from 'https-proxy-agent';
@@ -34,7 +33,7 @@ describe('tracing', () => {
       ...customOptions,
     });
     const hub = new Hub(new NodeClient(options));
-    addExtensionMethods();
+    addTracingExtensions();
 
     hub.configureScope(scope =>
       scope.setUser({
@@ -227,7 +226,7 @@ describe('tracing', () => {
     }
 
     function createTransactionAndPutOnScope(hub: Hub) {
-      addExtensionMethods();
+      addTracingExtensions();
       const transaction = hub.startTransaction({ name: 'dogpark' });
       hub.getScope()?.setSpan(transaction);
       return transaction;


### PR DESCRIPTION
This PR cleans up some imports that were missed off the previous node and nextjs PRs.

It removes some more `@sentry/tracing` imports from tests and calls `addTracingExtensions` where tests were relying on the side-effects.