### PR TITLE
feat(replay): Add `replay_id` to transaction DSC

### DIFF
--- a/packages/browser-integration-tests/suites/replay/dsc/init.js
+++ b/packages/browser-integration-tests/suites/replay/dsc/init.js
@@ -1,0 +1,23 @@
+import * as Sentry from '@sentry/browser';
+import { Integrations } from '@sentry/tracing';
+
+window.Sentry = Sentry;
+window.Replay = new Sentry.Replay({
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
+});
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [new Integrations.BrowserTracing({ tracingOrigins: [/.*/] }), window.Replay],
+  environment: 'production',
+  tracesSampleRate: 1,
+  replaysSessionSampleRate: 0.0,
+  replaysOnErrorSampleRate: 1.0,
+  debug: true,
+});
+
+Sentry.configureScope(scope => {
+  scope.setUser({ id: 'user123', segment: 'segmentB' });
+  scope.setTransactionName('testTransactionDSC');
+});

--- a/packages/browser-integration-tests/suites/replay/dsc/init.js
+++ b/packages/browser-integration-tests/suites/replay/dsc/init.js
@@ -15,7 +15,6 @@ Sentry.init({
   tracesSampleRate: 1,
   replaysSessionSampleRate: 0.0,
   replaysOnErrorSampleRate: 1.0,
-  debug: true,
 });
 
 Sentry.configureScope(scope => {

--- a/packages/browser-integration-tests/suites/replay/dsc/init.js
+++ b/packages/browser-integration-tests/suites/replay/dsc/init.js
@@ -5,6 +5,7 @@ window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
   flushMinDelay: 200,
   flushMaxDelay: 200,
+  useCompression: false,
 });
 
 Sentry.init({

--- a/packages/browser-integration-tests/suites/replay/dsc/test.ts
+++ b/packages/browser-integration-tests/suites/replay/dsc/test.ts
@@ -3,9 +3,13 @@ import type { EventEnvelopeHeaders } from '@sentry/types';
 
 import { sentryTest } from '../../../utils/fixtures';
 import { envelopeHeaderRequestParser, getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
-import { getReplaySnapshot } from '../../../utils/replayHelpers';
+import { getReplaySnapshot, shouldSkipReplayTest } from '../../../utils/replayHelpers';
 
 sentryTest('should add replay_id to dsc of transactions', async ({ getLocalTestPath, page }) => {
+  if (shouldSkipReplayTest()) {
+    sentryTest.skip();
+  }
+
   const url = await getLocalTestPath({ testDir: __dirname });
   await page.goto(url);
 

--- a/packages/browser-integration-tests/suites/replay/dsc/test.ts
+++ b/packages/browser-integration-tests/suites/replay/dsc/test.ts
@@ -5,8 +5,9 @@ import { sentryTest } from '../../../utils/fixtures';
 import { envelopeHeaderRequestParser, getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
 import { getReplaySnapshot, shouldSkipReplayTest, waitForReplayRunning } from '../../../utils/replayHelpers';
 
-sentryTest('should add replay_id to dsc of transactions', async ({ getLocalTestPath, page }) => {
-  if (shouldSkipReplayTest()) {
+sentryTest('should add replay_id to dsc of transactions', async ({ getLocalTestPath, page, browserName }) => {
+  // This is flaky on webkit, so skipping there...
+  if (shouldSkipReplayTest() || browserName === 'webkit') {
     sentryTest.skip();
   }
 

--- a/packages/browser-integration-tests/suites/replay/dsc/test.ts
+++ b/packages/browser-integration-tests/suites/replay/dsc/test.ts
@@ -9,11 +9,11 @@ sentryTest('should add replay_id to dsc of transactions', async ({ getLocalTestP
   const url = await getLocalTestPath({ testDir: __dirname });
   await page.goto(url);
 
+  const envHeader = await getFirstSentryEnvelopeRequest<EventEnvelopeHeaders>(page, url, envelopeHeaderRequestParser);
+
   const replay = await getReplaySnapshot(page);
 
   expect(replay.session?.id).toBeDefined();
-
-  const envHeader = await getFirstSentryEnvelopeRequest<EventEnvelopeHeaders>(page, url, envelopeHeaderRequestParser);
 
   expect(envHeader.trace).toBeDefined();
   expect(envHeader.trace).toEqual({

--- a/packages/browser-integration-tests/suites/replay/dsc/test.ts
+++ b/packages/browser-integration-tests/suites/replay/dsc/test.ts
@@ -3,7 +3,7 @@ import type { EventEnvelopeHeaders } from '@sentry/types';
 
 import { sentryTest } from '../../../utils/fixtures';
 import { envelopeHeaderRequestParser, getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
-import { getReplaySnapshot, shouldSkipReplayTest } from '../../../utils/replayHelpers';
+import { getReplaySnapshot, shouldSkipReplayTest, waitForReplayRunning } from '../../../utils/replayHelpers';
 
 sentryTest('should add replay_id to dsc of transactions', async ({ getLocalTestPath, page }) => {
   if (shouldSkipReplayTest()) {
@@ -15,6 +15,7 @@ sentryTest('should add replay_id to dsc of transactions', async ({ getLocalTestP
 
   const envHeader = await getFirstSentryEnvelopeRequest<EventEnvelopeHeaders>(page, url, envelopeHeaderRequestParser);
 
+  await waitForReplayRunning(page);
   const replay = await getReplaySnapshot(page);
 
   expect(replay.session?.id).toBeDefined();

--- a/packages/browser-integration-tests/suites/replay/dsc/test.ts
+++ b/packages/browser-integration-tests/suites/replay/dsc/test.ts
@@ -1,0 +1,27 @@
+import { expect } from '@playwright/test';
+import type { EventEnvelopeHeaders } from '@sentry/types';
+
+import { sentryTest } from '../../../utils/fixtures';
+import { envelopeHeaderRequestParser, getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
+import { getReplaySnapshot } from '../../../utils/replayHelpers';
+
+sentryTest('should add replay_id to dsc of transactions', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+  await page.goto(url);
+
+  const replay = await getReplaySnapshot(page);
+
+  expect(replay.session?.id).toBeDefined();
+
+  const envHeader = await getFirstSentryEnvelopeRequest<EventEnvelopeHeaders>(page, url, envelopeHeaderRequestParser);
+
+  expect(envHeader.trace).toBeDefined();
+  expect(envHeader.trace).toEqual({
+    environment: 'production',
+    user_segment: 'segmentB',
+    sample_rate: '1',
+    trace_id: expect.any(String),
+    public_key: 'public',
+    replay_id: replay.session?.id,
+  });
+});

--- a/packages/browser-integration-tests/utils/replayHelpers.ts
+++ b/packages/browser-integration-tests/utils/replayHelpers.ts
@@ -99,6 +99,16 @@ function isCustomSnapshot(event: RecordingEvent): event is RecordingEvent & { da
   return event.type === EventType.Custom;
 }
 
+/** Wait for replay to be running & available. */
+export async function waitForReplayRunning(page: Page): Promise<void> {
+  await page.waitForFunction(() => {
+    const replayIntegration = (window as unknown as Window & { Replay: { _replay: ReplayContainer } }).Replay;
+    const replay = replayIntegration._replay;
+
+    return replay.isEnabled() && replay.session?.id !== undefined;
+  });
+}
+
 /**
  * This returns the replay container (assuming it exists).
  * Note that due to how this works with playwright, this is a POJO copy of replay.

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -6,6 +6,7 @@ import type {
   ClientOptions,
   DataCategory,
   DsnComponents,
+  DynamicSamplingContext,
   Envelope,
   ErrorEvent,
   Event,
@@ -379,6 +380,9 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   public on(hook: 'beforeAddBreadcrumb', callback: (breadcrumb: Breadcrumb, hint?: BreadcrumbHint) => void): void;
 
   /** @inheritdoc */
+  public on(hook: 'createDsc', callback: (dsc: DynamicSamplingContext) => void): void;
+
+  /** @inheritdoc */
   public on(hook: string, callback: unknown): void {
     if (!this._hooks[hook]) {
       this._hooks[hook] = [];
@@ -399,6 +403,9 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
 
   /** @inheritdoc */
   public emit(hook: 'beforeAddBreadcrumb', breadcrumb: Breadcrumb, hint?: BreadcrumbHint): void;
+
+  /** @inheritdoc */
+  public emit(hook: 'createDsc', dsc: DynamicSamplingContext): void;
 
   /** @inheritdoc */
   public emit(hook: string, ...rest: unknown[]): void {

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -276,6 +276,8 @@ export class Transaction extends SpanClass implements TransactionInterface {
     // Uncomment if we want to make DSC immutable
     // this._frozenDynamicSamplingContext = dsc;
 
+    client.emit && client.emit('createDsc', dsc);
+
     return dsc;
   }
 }

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -2,7 +2,7 @@ import type { Breadcrumb, BreadcrumbHint } from './breadcrumb';
 import type { EventDropReason } from './clientreport';
 import type { DataCategory } from './datacategory';
 import type { DsnComponents } from './dsn';
-import type { Envelope } from './envelope';
+import type { DynamicSamplingContext, Envelope } from './envelope';
 import type { Event, EventHint } from './event';
 import type { Integration, IntegrationClass } from './integration';
 import type { ClientOptions } from './options';
@@ -178,6 +178,11 @@ export interface Client<O extends ClientOptions = ClientOptions> {
   on?(hook: 'beforeAddBreadcrumb', callback: (breadcrumb: Breadcrumb, hint?: BreadcrumbHint) => void): void;
 
   /**
+   * Register a callback whena  DSC (Dynamic Sampling Context) is created.
+   */
+  on?(hook: 'createDsc', callback: (dsc: DynamicSamplingContext) => void): void;
+
+  /**
    * Fire a hook event for transaction start and finish. Expects to be given a transaction as the
    * second argument.
    */
@@ -196,7 +201,12 @@ export interface Client<O extends ClientOptions = ClientOptions> {
   emit?(hook: 'afterSendEvent', event: Event, sendResponse: TransportMakeRequestResponse | void): void;
 
   /**
-   * Fire a hook for when a bredacrumb is added. Expects the breadcrumb as second argument.
+   * Fire a hook for when a breadcrumb is added. Expects the breadcrumb as second argument.
    */
   emit?(hook: 'beforeAddBreadcrumb', breadcrumb: Breadcrumb, hint?: BreadcrumbHint): void;
+
+  /**
+   * Fire a hook for when a DSC (Dynamic Sampling Context) is created. Expects the DSC as second argument.
+   */
+  emit?(hook: 'createDsc', dsc: DynamicSamplingContext): void;
 }

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -18,6 +18,7 @@ export type DynamicSamplingContext = {
   environment?: string;
   transaction?: string;
   user_segment?: string;
+  replay_id?: string;
 };
 
 export type EnvelopeItemType =


### PR DESCRIPTION
This adds `replay_id` to the DSC of transactions.

Closes https://github.com/getsentry/sentry-javascript/issues/7555
Supersedes https://github.com/getsentry/sentry-javascript/pull/7493