### PR TITLE
feat(otel): Remove `@sentry/tracing` dependency from `opentelemetry-node`

### DIFF
--- a/packages/opentelemetry-node/package.json
+++ b/packages/opentelemetry-node/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@sentry/core": "7.44.2",
-    "@sentry/tracing": "7.44.2",
     "@sentry/types": "7.44.2",
     "@sentry/utils": "7.44.2"
   },

--- a/packages/opentelemetry-node/src/index.ts
+++ b/packages/opentelemetry-node/src/index.ts
@@ -1,4 +1,2 @@
-import '@sentry/tracing';
-
 export { SentrySpanProcessor } from './spanprocessor';
 export { SentryPropagator } from './propagator';

--- a/packages/opentelemetry-node/src/spanprocessor.ts
+++ b/packages/opentelemetry-node/src/spanprocessor.ts
@@ -2,7 +2,7 @@ import type { Context } from '@opentelemetry/api';
 import { SpanKind, trace } from '@opentelemetry/api';
 import type { Span as OtelSpan, SpanProcessor as OtelSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import { addGlobalEventProcessor, getCurrentHub, Transaction } from '@sentry/core';
+import { addGlobalEventProcessor, addTracingExtensions, getCurrentHub, Transaction } from '@sentry/core';
 import type { DynamicSamplingContext, Span as SentrySpan, TraceparentData, TransactionContext } from '@sentry/types';
 import { isString, logger } from '@sentry/utils';
 
@@ -22,6 +22,8 @@ export const SENTRY_SPAN_PROCESSOR_MAP: Map<SentrySpan['spanId'], SentrySpan> = 
  */
 export class SentrySpanProcessor implements OtelSpanProcessor {
   public constructor() {
+    addTracingExtensions();
+
     addGlobalEventProcessor(event => {
       const otelSpan = trace && trace.getActiveSpan && (trace.getActiveSpan() as OtelSpan | undefined);
       if (!otelSpan) {

--- a/packages/opentelemetry-node/test/propagator.test.ts
+++ b/packages/opentelemetry-node/test/propagator.test.ts
@@ -7,8 +7,7 @@ import {
   TraceFlags,
 } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
-import { Hub, makeMain } from '@sentry/core';
-import { addExtensionMethods, Transaction } from '@sentry/tracing';
+import { addTracingExtensions, Hub, makeMain, Transaction } from '@sentry/core';
 import type { TransactionContext } from '@sentry/types';
 
 import {
@@ -21,7 +20,7 @@ import { SentryPropagator } from '../src/propagator';
 import { SENTRY_SPAN_PROCESSOR_MAP } from '../src/spanprocessor';
 
 beforeAll(() => {
-  addExtensionMethods();
+  addTracingExtensions();
 });
 
 describe('SentryPropagator', () => {

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -4,10 +4,9 @@ import { Resource } from '@opentelemetry/resources';
 import type { Span as OtelSpan } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { SemanticAttributes, SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
-import { createTransport, Hub, makeMain } from '@sentry/core';
+import type { SpanStatusType } from '@sentry/core';
+import { addTracingExtensions, createTransport, Hub, makeMain, Span as SentrySpan, Transaction } from '@sentry/core';
 import { NodeClient } from '@sentry/node';
-import type { SpanStatusType } from '@sentry/tracing';
-import { addExtensionMethods, Span as SentrySpan, Transaction } from '@sentry/tracing';
 import { resolvedSyncPromise } from '@sentry/utils';
 
 import { SENTRY_SPAN_PROCESSOR_MAP, SentrySpanProcessor } from '../src/spanprocessor';
@@ -24,7 +23,7 @@ const DEFAULT_NODE_CLIENT_OPTIONS = {
 // Integration Test of SentrySpanProcessor
 
 beforeAll(() => {
-  addExtensionMethods();
+  addTracingExtensions();
 });
 
 describe('SentrySpanProcessor', () => {


### PR DESCRIPTION
This PR removes `@sentry/tracing` as dependency from `opentelemetry-node`
