### PR TITLE
fix(core): Ensure `ignoreErrors` only applies to error events

### DIFF
--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -103,7 +103,8 @@ export function _shouldDropEvent(event: Event, options: Partial<InboundFiltersOp
 }
 
 function _isIgnoredError(event: Event, ignoreErrors?: Array<string | RegExp>): boolean {
-  if (!ignoreErrors || !ignoreErrors.length) {
+  // If event.type, this is not an error
+  if (event.type || !ignoreErrors || !ignoreErrors.length) {
     return false;
   }
 

--- a/packages/core/test/lib/integrations/inboundfilters.test.ts
+++ b/packages/core/test/lib/integrations/inboundfilters.test.ts
@@ -177,6 +177,11 @@ const MALFORMED_EVENT: Event = {
   },
 };
 
+const TRANSACTION_EVENT: Event = {
+  message: 'transaction message',
+  type: 'transaction',
+};
+
 describe('InboundFilters', () => {
   describe('_isSentryError', () => {
     it('should work as expected', () => {
@@ -200,6 +205,13 @@ describe('InboundFilters', () => {
         ignoreErrors: ['capture'],
       });
       expect(eventProcessor(MESSAGE_EVENT, {})).toBe(null);
+    });
+
+    it('ignores transaction event for filtering', () => {
+      const eventProcessor = createInboundFiltersEventProcessor({
+        ignoreErrors: ['transaction'],
+      });
+      expect(eventProcessor(TRANSACTION_EVENT, {})).toBe(TRANSACTION_EVENT);
     });
 
     it('string filter with exact match', () => {


### PR DESCRIPTION
Noticed that actually currently we filter _any_ type of event here.

We should handle transactions separately (TBD).