### PR TITLE
feat(remix): Remove `@sentry/tracing` dependency from Remix SDK

### DIFF
--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -25,7 +25,6 @@
     "@sentry/integrations": "7.44.2",
     "@sentry/node": "7.44.2",
     "@sentry/react": "7.44.2",
-    "@sentry/tracing": "7.44.2",
     "@sentry/types": "7.44.2",
     "@sentry/utils": "7.44.2",
     "@sentry/webpack-plugin": "1.19.0",

--- a/packages/remix/src/index.client.tsx
+++ b/packages/remix/src/index.client.tsx
@@ -1,12 +1,10 @@
 /* eslint-disable import/export */
-import { configureScope, init as reactInit, Integrations } from '@sentry/react';
+import { configureScope, init as reactInit } from '@sentry/react';
 
 import { buildMetadata } from './utils/metadata';
 import type { RemixOptions } from './utils/remixOptions';
 export { remixRouterInstrumentation, withSentry } from './performance/client';
 export * from '@sentry/react';
-
-export { Integrations };
 
 export function init(options: RemixOptions): void {
   buildMetadata(options, ['remix', 'react']);

--- a/packages/remix/src/index.client.tsx
+++ b/packages/remix/src/index.client.tsx
@@ -4,7 +4,6 @@ import { configureScope, init as reactInit, Integrations } from '@sentry/react';
 import { buildMetadata } from './utils/metadata';
 import type { RemixOptions } from './utils/remixOptions';
 export { remixRouterInstrumentation, withSentry } from './performance/client';
-export { BrowserTracing } from '@sentry/tracing';
 export * from '@sentry/react';
 
 export { Integrations };

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -8,7 +8,6 @@ import type { RemixOptions } from './utils/remixOptions';
 
 export { ErrorBoundary, withErrorBoundary } from '@sentry/react';
 export { remixRouterInstrumentation, withSentry } from './performance/client';
-export { BrowserTracing, Integrations } from '@sentry/tracing';
 export * from '@sentry/node';
 export { wrapExpressCreateRequestHandler } from './utils/serverAdapters/express';
 

--- a/packages/remix/test/index.server.test.ts
+++ b/packages/remix/test/index.server.test.ts
@@ -2,7 +2,7 @@ import * as SentryNode from '@sentry/node';
 import { getCurrentHub } from '@sentry/node';
 import { GLOBAL_OBJ } from '@sentry/utils';
 
-import { init } from '../src/index.server';
+import { init, Integrations } from '../src/index.server';
 
 const nodeInit = jest.spyOn(SentryNode, 'init');
 
@@ -56,5 +56,10 @@ describe('Server init()', () => {
 
     // @ts-ignore need access to protected _tags attribute
     expect(currentScope._tags).toEqual({ runtime: 'node' });
+  });
+
+  it('has both node and tracing integrations', () => {
+    expect(Integrations.Apollo).not.toBeUndefined();
+    expect(Integrations.Http).not.toBeUndefined();
   });
 });


### PR DESCRIPTION
- In `index.client.tsx`, `BrowserTracing` and `Integrations` are passed through from `@sentry/react`
- In `index.server.ts`:
  - `@sentry/node` already exports `Integrations` which includes both node and tracing integrations 
  - Previously, node Integrations were hidden due to the tracing Integrations export
  - ⚠️ `BrowserTracing` is no longer exported. This is technically a breaking change but I don't think it should have ever been exported from the server.