### PR TITLE
feat(gatsby): Remove `@sentry/tracing` dependency from Gatsby SDK

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@sentry/core": "7.44.2",
     "@sentry/react": "7.44.2",
-    "@sentry/tracing": "7.44.2",
     "@sentry/types": "7.44.2",
     "@sentry/utils": "7.44.2",
     "@sentry/webpack-plugin": "1.19.0"

--- a/packages/gatsby/src/index.ts
+++ b/packages/gatsby/src/index.ts
@@ -1,4 +1,3 @@
 export * from '@sentry/react';
-export { Integrations } from '@sentry/tracing';
 
 export { init } from './sdk';

--- a/packages/gatsby/src/utils/integrations.ts
+++ b/packages/gatsby/src/utils/integrations.ts
@@ -1,5 +1,5 @@
 import { hasTracingEnabled } from '@sentry/core';
-import * as Tracing from '@sentry/tracing';
+import { BrowserTracing } from '@sentry/react';
 import type { Integration } from '@sentry/types';
 
 import type { GatsbyOptions } from './types';
@@ -31,11 +31,8 @@ export function getIntegrationsFromOptions(options: GatsbyOptions): UserIntegrat
  * @param isTracingEnabled Whether the user has enabled tracing.
  */
 function getIntegrationsFromArray(userIntegrations: Integration[], isTracingEnabled: boolean): Integration[] {
-  if (
-    isTracingEnabled &&
-    !userIntegrations.some(integration => integration.name === Tracing.Integrations.BrowserTracing.name)
-  ) {
-    userIntegrations.push(new Tracing.Integrations.BrowserTracing());
+  if (isTracingEnabled && !userIntegrations.some(integration => integration.name === BrowserTracing.name)) {
+    userIntegrations.push(new BrowserTracing());
   }
   return userIntegrations;
 }

--- a/packages/gatsby/test/gatsby-browser.test.ts
+++ b/packages/gatsby/test/gatsby-browser.test.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { onClientEntry } from '../gatsby-browser';
+import { BrowserTracing } from '../src/index';
 
 (global as any).__SENTRY_RELEASE__ = '683f3a6ab819d47d23abfca9a914c81f0524d35b';
 (global as any).__SENTRY_DSN__ = 'https://examplePublicKey@o0.ingest.sentry.io/0';
@@ -20,11 +21,11 @@ global.console.warn = jest.fn();
 global.console.error = jest.fn();
 
 let tracingAddExtensionMethods = jest.fn();
-jest.mock('@sentry/tracing', () => {
-  const original = jest.requireActual('@sentry/tracing');
+jest.mock('@sentry/core', () => {
+  const original = jest.requireActual('@sentry/core');
   return {
     ...original,
-    addExtensionMethods: (...args: any[]) => {
+    addTracingExtensions: (...args: any[]) => {
       tracingAddExtensionMethods(...args);
     },
   };
@@ -140,8 +141,7 @@ describe('onClientEntry', () => {
   });
 
   it('only defines a single `BrowserTracing` integration', () => {
-    const Tracing = jest.requireActual('@sentry/tracing');
-    const integrations = [new Tracing.Integrations.BrowserTracing()];
+    const integrations = [new BrowserTracing()];
     onClientEntry(undefined, { tracesSampleRate: 0.5, integrations });
 
     expect(sentryInit).toHaveBeenLastCalledWith(

--- a/packages/gatsby/test/sdk.test.ts
+++ b/packages/gatsby/test/sdk.test.ts
@@ -1,5 +1,4 @@
-import { init, SDK_VERSION } from '@sentry/react';
-import { Integrations } from '@sentry/tracing';
+import { BrowserTracing, init, SDK_VERSION } from '@sentry/react';
 import type { Integration } from '@sentry/types';
 
 import { init as gatsbyInit } from '../src/sdk';
@@ -58,6 +57,8 @@ describe('Initialize React SDK', () => {
   });
 });
 
+type TestArgs = [string, Integration[], GatsbyOptions, string[]];
+
 describe('Integrations from options', () => {
   afterEach(() => reactInit.mockClear());
 
@@ -65,72 +66,39 @@ describe('Integrations from options', () => {
     ['tracing disabled, no integrations', [], {}, []],
     ['tracing enabled, no integrations', [], { tracesSampleRate: 1 }, ['BrowserTracing']],
     [
-      'tracing disabled, with Integrations.BrowserTracing as an array',
+      'tracing disabled, with BrowserTracing as an array',
       [],
-      { integrations: [new Integrations.BrowserTracing()] },
+      { integrations: [new BrowserTracing()] },
       ['BrowserTracing'],
     ],
     [
-      'tracing disabled, with Integrations.BrowserTracing as a function',
+      'tracing disabled, with BrowserTracing as a function',
       [],
       {
-        integrations: () => [new Integrations.BrowserTracing()],
+        integrations: () => [new BrowserTracing()],
       },
       ['BrowserTracing'],
     ],
     [
-      'tracing enabled, with Integrations.BrowserTracing as an array',
+      'tracing enabled, with BrowserTracing as an array',
       [],
-      { tracesSampleRate: 1, integrations: [new Integrations.BrowserTracing()] },
+      { tracesSampleRate: 1, integrations: [new BrowserTracing()] },
       ['BrowserTracing'],
     ],
     [
-      'tracing enabled, with Integrations.BrowserTracing as a function',
+      'tracing enabled, with BrowserTracing as a function',
       [],
-      { tracesSampleRate: 1, integrations: () => [new Integrations.BrowserTracing()] },
+      { tracesSampleRate: 1, integrations: () => [new BrowserTracing()] },
       ['BrowserTracing'],
     ],
-    [
-      'tracing enabled, with another integration as an array',
-      [],
-      { tracesSampleRate: 1, integrations: [new Integrations.Express()] },
-      ['Express', 'BrowserTracing'],
-    ],
-    [
-      'tracing enabled, with another integration as a function',
-      [],
-      { tracesSampleRate: 1, integrations: () => [new Integrations.Express()] },
-      ['Express', 'BrowserTracing'],
-    ],
-    [
-      'tracing disabled, with another integration as an array',
-      [],
-      { integrations: [new Integrations.Express()] },
-      ['Express'],
-    ],
-    [
-      'tracing disabled, with another integration as a function',
-      [],
-      { integrations: () => [new Integrations.Express()] },
-      ['Express'],
-    ],
-    [
-      'merges integrations with user integrations as a function',
-      [new Integrations.Mongo()],
-      {
-        tracesSampleRate: 1,
-        integrations: (defaultIntegrations: Integration[]): Integration[] => [
-          ...defaultIntegrations,
-          new Integrations.Express(),
-        ],
-      },
-      ['Mongo', 'Express', 'BrowserTracing'],
-    ],
-  ])('%s', (_testName, defaultIntegrations: Integration[], options: GatsbyOptions, expectedIntNames: string[]) => {
-    gatsbyInit(options);
-    const integrations: UserIntegrations = reactInit.mock.calls[0][0].integrations;
-    const arrIntegrations = Array.isArray(integrations) ? integrations : integrations(defaultIntegrations);
-    expect(arrIntegrations).toHaveLength(expectedIntNames.length);
-    arrIntegrations.map((integration, idx) => expect(integration.name).toStrictEqual(expectedIntNames[idx]));
-  });
+  ] as TestArgs[])(
+    '%s',
+    (_testName, defaultIntegrations: Integration[], options: GatsbyOptions, expectedIntNames: string[]) => {
+      gatsbyInit(options);
+      const integrations: UserIntegrations = reactInit.mock.calls[0][0].integrations;
+      const arrIntegrations = Array.isArray(integrations) ? integrations : integrations(defaultIntegrations);
+      expect(arrIntegrations).toHaveLength(expectedIntNames.length);
+      arrIntegrations.map((integration, idx) => expect(integration.name).toStrictEqual(expectedIntNames[idx]));
+    },
+  );
 });

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -1,5 +1,5 @@
 import * as sentryCore from '@sentry/core';
-import { Transaction } from '@sentry/tracing';
+import { Transaction } from '@sentry/core';
 import type { Event } from '@sentry/types';
 import { SentryError } from '@sentry/utils';
 import * as http from 'http';


### PR DESCRIPTION
This PR removes `@sentry/tracing` dependency from Gatsby SDK.

- ⚠️ This removes the node tracing integrations from the `Integrations` export which is technically a breaking change but these cannot be used and was likely a mistake
- It's worth noting that `BrowserTracing` is conditionally added via the config options so it will always be included in the output bundle and cannot be tree-shaken away.