### PR TITLE
feat(serverless): Remove `@sentry/tracing` dependency from serverless SDK

### DIFF
--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@sentry/node": "7.44.2",
-    "@sentry/tracing": "7.44.2",
     "@sentry/types": "7.44.2",
     "@sentry/utils": "7.44.2",
     "@types/aws-lambda": "^8.10.62",

--- a/packages/serverless/scripts/buildLambdaLayer.ts
+++ b/packages/serverless/scripts/buildLambdaLayer.ts
@@ -17,7 +17,7 @@ async function buildLambdaLayer(): Promise<void> {
   // Create the main SDK bundle
   // TODO: Check if we can get rid of this, after the lerna 6/nx update??
   await ensureBundleBuildPrereqs({
-    dependencies: ['@sentry/utils', '@sentry/hub', '@sentry/core', '@sentry/tracing', '@sentry/node'],
+    dependencies: ['@sentry/utils', '@sentry/hub', '@sentry/core', '@sentry/node'],
   });
   run('yarn rollup --config rollup.aws.config.js');
 

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -20,6 +20,7 @@ export {
   captureMessage,
   configureScope,
   createTransport,
+  getActiveTransaction,
   getCurrentHub,
   getHubFromCarrier,
   makeMain,


### PR DESCRIPTION
There wasn't much to do here.
