### PR TITLE
fix(sveltekit): Handle server-only and shared load functions

### DIFF
--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -31,7 +31,6 @@ export function trace<T>(
   const scope = hub.getScope();
 
   const parentSpan = scope.getSpan();
-
   const activeSpan = parentSpan ? parentSpan.startChild(ctx) : hub.startTransaction(ctx);
   scope.setSpan(activeSpan);
 

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -31,6 +31,7 @@ export function trace<T>(
   const scope = hub.getScope();
 
   const parentSpan = scope.getSpan();
+
   const activeSpan = parentSpan ? parentSpan.startChild(ctx) : hub.startTransaction(ctx);
   scope.setSpan(activeSpan);
 

--- a/packages/sveltekit/src/server/load.ts
+++ b/packages/sveltekit/src/server/load.ts
@@ -49,7 +49,7 @@ function sendErrorToSentry(e: unknown): unknown {
  *
  * @param origLoad SvelteKit user defined load function
  */
-export function wrapLoadWithSentry<T extends Load | ServerLoad>(origLoad: T): T {
+export function wrapLoadWithSentry<T extends ServerLoad | Load>(origLoad: T): T {
   return new Proxy(origLoad, {
     apply: (wrappingTarget, thisArg, args: Parameters<ServerLoad | Load>) => {
       const [event] = args;


### PR DESCRIPTION
Previously, our server `wrapLoadWithSentry` assumed that `load` in `+page.ts` and `+page.server.ts` work identically. Unfortunately, the load `event` arg has different contents for both, namely that the server-only load event contains a `request` object while the shared (client and server) load event doesn't. This PR fixes that by distinguishing between the two load types within the wrapper. Users can still use the same wrapper for both cases.

Furthermore, this PR removes the usage of domains in the load wrapper, as on the server-side, we're already in a domain when `handleSentry` is used. Creating another domain here, caused the creation of a new transaction instead of adding the span to the transaction that was created by `handleSentry`. 

ref #7403 
