### PR TITLE
fix(sveltekit): Termporarily disable serverside load tracing

### DIFF
--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -9,7 +9,7 @@ export * from './server';
 
 import type { Integration, Options, StackParser } from '@sentry/types';
 // eslint-disable-next-line import/no-unresolved
-import type { HandleClientError, HandleServerError, ServerLoad } from '@sveltejs/kit';
+import type { HandleClientError, HandleServerError, Load, ServerLoad } from '@sveltejs/kit';
 
 import type * as clientSdk from './client';
 import type * as serverSdk from './server';
@@ -21,7 +21,7 @@ export declare function handleErrorWithSentry<T extends HandleClientError | Hand
   handleError?: T,
 ): ReturnType<T>;
 
-export declare function wrapLoadWithSentry<S extends ServerLoad>(origLoad: S): S;
+export declare function wrapLoadWithSentry<S extends ServerLoad | Load>(origLoad: S): S;
 
 // We export a merged Integrations object so that users can (at least typing-wise) use all integrations everywhere.
 export declare const Integrations: typeof clientSdk.Integrations & typeof serverSdk.Integrations;

--- a/packages/sveltekit/test/server/load.test.ts
+++ b/packages/sveltekit/test/server/load.test.ts
@@ -101,7 +101,8 @@ describe('wrapLoadWithSentry', () => {
     expect(mockCaptureException).toHaveBeenCalledTimes(1);
   });
 
-  it('calls trace function', async () => {
+  // TODO: enable this once we figured out how tracing the load function doesn't result in creating a new transaction
+  it.skip('calls trace function', async () => {
     async function load({ params }: Parameters<ServerLoad>[0]): Promise<ReturnType<ServerLoad>> {
       return {
         post: params.id,


### PR DESCRIPTION
We discovered that our serverside `handleLoadWithSentry` wrapper caused two distinct transactions being created on page loads - one for the page load request and one for the `load` function (if one exists for that page). This shouldn't happen. We need to investigate how to fix this. 

As a short-term solution, we disable tracing on the serverside load wrapper to not avoid quota increase for our users.

Note: I basically removed the `trace` call and added back the error reporting logic. However, I adjusted types to accept `ServerLoad` and `Load` functions as discovered in #7581 

ref #7526 
