### PR TITLE
ci: Get release tag name from event

### DIFF
--- a/.github/workflows/release-size-info.yml
+++ b/.github/workflows/release-size-info.yml
@@ -17,18 +17,9 @@ jobs:
     name: 'Add size-limit info to release'
 
     steps:
-      # https://github.com/actions-ecosystem/action-regex-match
-      - name: Extract version from ref
-        uses: actions-ecosystem/action-regex-match@v2
-        id: head_version
-        with:
-          # Parse version from head ref, which is refs/tags/<tag_name>
-          text: ${{ env.GITHUB_REF }}
-          regex: '^refs\/tags\/([\d.]+)$'
-
       - name: Get version
         id: get_version
-        run: echo "version=${{ github.event.inputs.version || steps.head_version.outputs.group1 }}" >> $GITHUB_OUTPUT
+        run: echo "version=${{ github.event.inputs.version || github.event.release.tag_name }}" >> $GITHUB_OUTPUT
 
       - name: Update Github Release
         if: steps.get_version.outputs.version != ''


### PR DESCRIPTION
The size adding doesn't seem to be working anymore.
Looking at e.g. https://github.com/getsentry/sentry-javascript/actions/runs/4477866410/jobs/7869927544

it seems that `env.GITHUB_REF` is not set anymore, even though it is documented here: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release

So I _think_ this should actually work even better (no regex needed). 