### PR TITLE
ci: Fix CodeQL by skipping tsconfig.json

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+paths-ignore:
+  # Our tsconfig files contain comments, which CodeQL complains about
+  - '**/tsconfig.json'
+  - '**/tsconfig.*.json'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -74,3 +74,5 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
+        with:
+          config-file: ./.github/codeql/codeql-config.yml


### PR DESCRIPTION
Not sure if this is fixing it, but seeing a lot of errors/skipped stuff in there anyhow for the tsconfig files, so IMHO it's fine to skip this anyhow.