### PR TITLE
build(tracing-internal): Remove circular dependency

### DIFF
--- a/packages/tracing-internal/package.json
+++ b/packages/tracing-internal/package.json
@@ -22,7 +22,6 @@
     "tslib": "^1.9.3"
   },
   "devDependencies": {
-    "@sentry/browser": "7.45.0",
     "@types/express": "^4.17.14"
   },
   "scripts": {

--- a/packages/tracing-internal/test/browser/backgroundtab.test.ts
+++ b/packages/tracing-internal/test/browser/backgroundtab.test.ts
@@ -1,10 +1,10 @@
-import { BrowserClient } from '@sentry/browser';
 import { Hub, makeMain } from '@sentry/core';
 import { JSDOM } from 'jsdom';
 
 import { addExtensionMethods } from '../../../tracing/src';
 import { getDefaultBrowserClientOptions } from '../../../tracing/test/testutils';
 import { registerBackgroundTabDetection } from '../../src/browser/backgroundtab';
+import { TestClient } from '../utils/TestClient';
 
 describe('registerBackgroundTabDetection', () => {
   let events: Record<string, any> = {};
@@ -15,7 +15,7 @@ describe('registerBackgroundTabDetection', () => {
     global.document = dom.window.document;
 
     const options = getDefaultBrowserClientOptions({ tracesSampleRate: 1 });
-    hub = new Hub(new BrowserClient(options));
+    hub = new Hub(new TestClient(options));
     makeMain(hub);
 
     // If we do not add extension methods, invoking hub.startTransaction returns undefined

--- a/packages/tracing-internal/test/browser/browsertracing.test.ts
+++ b/packages/tracing-internal/test/browser/browsertracing.test.ts
@@ -1,4 +1,3 @@
-import { BrowserClient, WINDOW } from '@sentry/browser';
 import { Hub, makeMain, TRACING_DEFAULTS } from '@sentry/core';
 import * as hubExtensions from '@sentry/core';
 import type { BaseTransportOptions, ClientOptions, DsnComponents } from '@sentry/types';
@@ -12,6 +11,8 @@ import type { BrowserTracingOptions } from '../../src/browser/browsertracing';
 import { BrowserTracing, getMetaContent } from '../../src/browser/browsertracing';
 import { defaultRequestInstrumentationOptions } from '../../src/browser/request';
 import { instrumentRoutingWithDefaults } from '../../src/browser/router';
+import { WINDOW } from '../../src/browser/types';
+import { TestClient } from '../utils/TestClient';
 
 let mockChangeHistory: ({ to, from }: { to: string; from?: string }) => void = () => undefined;
 
@@ -61,7 +62,7 @@ describe('BrowserTracing', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     const options = getDefaultBrowserClientOptions({ tracesSampleRate: 1 });
-    hub = new Hub(new BrowserClient(options));
+    hub = new Hub(new TestClient(options));
     makeMain(hub);
     document.head.innerHTML = '';
 
@@ -599,7 +600,7 @@ describe('BrowserTracing', () => {
 
       const tracesSampler = jest.fn();
       const options = getDefaultBrowserClientOptions({ tracesSampler });
-      hub.bindClient(new BrowserClient(options));
+      hub.bindClient(new TestClient(options));
       // setting up the BrowserTracing integration automatically starts a pageload transaction
       createBrowserTracing(true);
 
@@ -616,7 +617,7 @@ describe('BrowserTracing', () => {
 
       const tracesSampler = jest.fn();
       const options = getDefaultBrowserClientOptions({ tracesSampler });
-      hub.bindClient(new BrowserClient(options));
+      hub.bindClient(new TestClient(options));
       // setting up the BrowserTracing integration normally automatically starts a pageload transaction, but that's not
       // what we're testing here
       createBrowserTracing(true, { startTransactionOnPageLoad: false });

--- a/packages/tracing-internal/test/browser/request.test.ts
+++ b/packages/tracing-internal/test/browser/request.test.ts
@@ -1,4 +1,3 @@
-import { BrowserClient } from '@sentry/browser';
 import * as sentryCore from '@sentry/core';
 import * as utils from '@sentry/utils';
 
@@ -7,6 +6,7 @@ import { addExtensionMethods, Span, spanStatusfromHttpCode } from '../../../trac
 import { getDefaultBrowserClientOptions } from '../../../tracing/test/testutils';
 import type { FetchData, XHRData } from '../../src/browser/request';
 import { fetchCallback, instrumentOutgoingRequests, shouldAttachHeaders, xhrCallback } from '../../src/browser/request';
+import { TestClient } from '../utils/TestClient';
 
 beforeAll(() => {
   addExtensionMethods();
@@ -54,7 +54,7 @@ describe('callbacks', () => {
 
   beforeAll(() => {
     const options = getDefaultBrowserClientOptions({ tracesSampleRate: 1 });
-    hub = new sentryCore.Hub(new BrowserClient(options));
+    hub = new sentryCore.Hub(new TestClient(options));
     sentryCore.makeMain(hub);
   });
 

--- a/packages/tracing-internal/test/utils/TestClient.ts
+++ b/packages/tracing-internal/test/utils/TestClient.ts
@@ -1,0 +1,44 @@
+import { BaseClient, createTransport, initAndBind } from '@sentry/core';
+import type { BrowserClientReplayOptions, ClientOptions, Event, SeverityLevel } from '@sentry/types';
+import { resolvedSyncPromise } from '@sentry/utils';
+
+export interface TestClientOptions extends ClientOptions, BrowserClientReplayOptions {}
+
+export class TestClient extends BaseClient<TestClientOptions> {
+  public constructor(options: TestClientOptions) {
+    super(options);
+  }
+
+  public eventFromException(exception: any): PromiseLike<Event> {
+    return resolvedSyncPromise({
+      exception: {
+        values: [
+          {
+            /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+            type: exception.name,
+            value: exception.message,
+            /* eslint-enable @typescript-eslint/no-unsafe-member-access */
+          },
+        ],
+      },
+    });
+  }
+
+  public eventFromMessage(message: string, level: SeverityLevel = 'info'): PromiseLike<Event> {
+    return resolvedSyncPromise({ message, level });
+  }
+}
+
+export function init(options: TestClientOptions): void {
+  initAndBind(TestClient, options);
+}
+
+export function getDefaultClientOptions(options: Partial<ClientOptions> = {}): ClientOptions {
+  return {
+    integrations: [],
+    dsn: 'https://username@domain/123',
+    transport: () => createTransport({ recordDroppedEvent: () => undefined }, _ => resolvedSyncPromise({})),
+    stackParser: () => [],
+    ...options,
+  };
+}


### PR DESCRIPTION
No need to depend on @sentry/browser as devDependency, which Nx complains about.

I copied the TestClient from Replay, where we had the same issue.
