### PR TITLE
ref(sveltekit): Distinguish span ops of server-only and universal load functions

### DIFF
--- a/packages/sveltekit/src/server/load.ts
+++ b/packages/sveltekit/src/server/load.ts
@@ -58,7 +58,7 @@ export function wrapLoadWithSentry<T extends ServerLoad | Load>(origLoad: T): T 
       const { traceparentData, dynamicSamplingContext } = getTracePropagationData(event);
 
       const traceLoadContext: TransactionContext = {
-        op: 'function.sveltekit.load',
+        op: `function.sveltekit${isServerOnlyLoad(event) ? '.server' : ''}.load`,
         name: routeId ? routeId : event.url.pathname,
         status: 'ok',
         metadata: {

--- a/packages/sveltekit/test/server/load.test.ts
+++ b/packages/sveltekit/test/server/load.test.ts
@@ -202,7 +202,7 @@ describe('wrapLoadWithSentry', () => {
         expect(mockTrace).toHaveBeenCalledTimes(1);
         expect(mockTrace).toHaveBeenCalledWith(
           {
-            op: 'function.sveltekit.load',
+            op: 'function.sveltekit.server.load',
             name: '/users/[id]',
             parentSampled: true,
             parentSpanId: '1234567890abcdef',
@@ -233,7 +233,7 @@ describe('wrapLoadWithSentry', () => {
         expect(mockTrace).toHaveBeenCalledTimes(1);
         expect(mockTrace).toHaveBeenCalledWith(
           {
-            op: 'function.sveltekit.load',
+            op: 'function.sveltekit.server.load',
             name: '/users/[id]',
             status: 'ok',
             metadata: {
@@ -252,7 +252,7 @@ describe('wrapLoadWithSentry', () => {
         expect(mockTrace).toHaveBeenCalledTimes(1);
         expect(mockTrace).toHaveBeenCalledWith(
           {
-            op: 'function.sveltekit.load',
+            op: 'function.sveltekit.server.load',
             name: '/users/[id]',
             parentSampled: true,
             parentSpanId: '1234567890abcdef',


### PR DESCRIPTION
This PR adjust the span ops of `load` functions to distinguish between spans of server-only and universal `load` functions (`+page.ts` vs `+page.server.ts`):

<img width="1109" alt="image" src="https://user-images.githubusercontent.com/8420481/227516441-97dff0be-6b24-4bf5-b30a-c91101aee388.png">

* Server-only load span op: `function.sveltekit.server.load`
* Universal load span op: `function.sveltekit.load`

ref #7526  