### PR TITLE
feat(tracing): Deprecate `@sentry/tracing` exports

### DIFF
--- a/packages/tracing-internal/test/browser/backgroundtab.test.ts
+++ b/packages/tracing-internal/test/browser/backgroundtab.test.ts
@@ -19,6 +19,7 @@ describe('registerBackgroundTabDetection', () => {
     makeMain(hub);
 
     // If we do not add extension methods, invoking hub.startTransaction returns undefined
+    // eslint-disable-next-line deprecation/deprecation
     addExtensionMethods();
 
     // @ts-ignore need to override global document

--- a/packages/tracing-internal/test/browser/browsertracing.test.ts
+++ b/packages/tracing-internal/test/browser/browsertracing.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import { Hub, makeMain, TRACING_DEFAULTS } from '@sentry/core';
 import * as hubExtensions from '@sentry/core';
 import type { BaseTransportOptions, ClientOptions, DsnComponents } from '@sentry/types';

--- a/packages/tracing-internal/test/browser/request.test.ts
+++ b/packages/tracing-internal/test/browser/request.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import * as sentryCore from '@sentry/core';
 import * as utils from '@sentry/utils';
 

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -34,7 +34,6 @@ import {
 // here.
 /**
  * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
- *
  * `BrowserTracing` can be imported from `@sentry/browser` or your framework SDK
  *
  * import { BrowserTracing } from '@sentry/browser';
@@ -47,7 +46,6 @@ export const BrowserTracing = BrowserTracingT;
 // here.
 /**
  * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
- *
  * `BrowserTracing` can be imported from `@sentry/browser` or your framework SDK
  *
  * import { BrowserTracing } from '@sentry/browser';
@@ -189,7 +187,6 @@ export type RequestInstrumentationOptions = RequestInstrumentationOptionsT;
 export const Integrations = {
   /**
    * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
-   *
    * `BrowserTracing` can be imported from `@sentry/browser` or your framework SDK
    *
    * import { BrowserTracing } from '@sentry/browser';
@@ -199,7 +196,6 @@ export const Integrations = {
   BrowserTracing: BrowserTracing,
   /**
    * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
-   *
    * `Apollo` can be imported from `@sentry/node`
    *
    * import { Integrations } from '@sentry/node';
@@ -209,7 +205,6 @@ export const Integrations = {
   Apollo: Apollo,
   /**
    * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
-   *
    * `Express` can be imported from `@sentry/node`
    *
    * import { Integrations } from '@sentry/node';
@@ -219,7 +214,6 @@ export const Integrations = {
   Express: Express,
   /**
    * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
-   *
    * `GraphQL` can be imported from `@sentry/node`
    *
    * import { Integrations } from '@sentry/node';
@@ -229,7 +223,6 @@ export const Integrations = {
   GraphQL: GraphQL,
   /**
    * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
-   *
    * `Mongo` can be imported from `@sentry/node`
    *
    * import { Integrations } from '@sentry/node';
@@ -239,7 +232,6 @@ export const Integrations = {
   Mongo: Mongo,
   /**
    * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
-   *
    * `Mysql` can be imported from `@sentry/node`
    *
    * import { Integrations } from '@sentry/node';
@@ -249,7 +241,6 @@ export const Integrations = {
   Mysql: Mysql,
   /**
    * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
-   *
    * `Postgres` can be imported from `@sentry/node`
    *
    * import { Integrations } from '@sentry/node';
@@ -259,7 +250,6 @@ export const Integrations = {
   Postgres: Postgres,
   /**
    * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
-   *
    * `Prisma` can be imported from `@sentry/node`
    *
    * import { Integrations } from '@sentry/node';

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -1,47 +1,271 @@
-export {
-  // BrowserTracing is already exported as part of `Integrations` below (and for the moment will remain so for
-  // backwards compatibility), but that interferes with treeshaking, so we also export it separately
-  // here.
-  BrowserTracing,
-  BROWSER_TRACING_INTEGRATION_ID,
-  IdleTransaction,
-  Span,
-  // eslint-disable-next-line deprecation/deprecation
-  SpanStatus,
-  TRACEPARENT_REGEXP,
-  Transaction,
-  addExtensionMethods,
-  defaultRequestInstrumentationOptions,
-  extractTraceparentData,
-  instrumentOutgoingRequests,
-  getActiveTransaction,
-  hasTracingEnabled,
-  spanStatusfromHttpCode,
-  startIdleTransaction,
-  stripUrlQueryAndFragment,
+import type {
+  RequestInstrumentationOptions as RequestInstrumentationOptionsT,
+  SpanStatusType as SpanStatusTypeT,
 } from '@sentry-internal/tracing';
-export type { RequestInstrumentationOptions, SpanStatusType } from '@sentry-internal/tracing';
-
 import {
-  addExtensionMethods,
+  addExtensionMethods as addExtensionMethodsT,
   Apollo,
-  BrowserTracing,
+  BROWSER_TRACING_INTEGRATION_ID as BROWSER_TRACING_INTEGRATION_ID_T,
+  BrowserTracing as BrowserTracingT,
+  defaultRequestInstrumentationOptions as defaultRequestInstrumentationOptionsT,
   Express,
+  extractTraceparentData as extractTraceparentDataT,
+  getActiveTransaction as getActiveTransactionT,
   GraphQL,
+  hasTracingEnabled as hasTracingEnabledT,
+  IdleTransaction as IdleTransactionT,
+  instrumentOutgoingRequests as instrumentOutgoingRequestsT,
   Mongo,
   Mysql,
   Postgres,
   Prisma,
+  Span as SpanT,
+  // eslint-disable-next-line deprecation/deprecation
+  SpanStatus as SpanStatusT,
+  spanStatusfromHttpCode as spanStatusfromHttpCodeT,
+  startIdleTransaction as startIdleTransactionT,
+  stripUrlQueryAndFragment as stripUrlQueryAndFragmentT,
+  TRACEPARENT_REGEXP as TRACEPARENT_REGEXP_T,
+  Transaction as TransactionT,
 } from '@sentry-internal/tracing';
 
+// BrowserTracing is already exported as part of `Integrations` below (and for the moment will remain so for
+// backwards compatibility), but that interferes with treeshaking, so we also export it separately
+// here.
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ *
+ * `BrowserTracing` can be imported from `@sentry/browser` or your framework SDK
+ *
+ * import { BrowserTracing } from '@sentry/browser';
+ * new BrowserTracing()
+ */
+export const BrowserTracing = BrowserTracingT;
+
+// BrowserTracing is already exported as part of `Integrations` below (and for the moment will remain so for
+// backwards compatibility), but that interferes with treeshaking, so we also export it separately
+// here.
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ *
+ * `BrowserTracing` can be imported from `@sentry/browser` or your framework SDK
+ *
+ * import { BrowserTracing } from '@sentry/browser';
+ * new BrowserTracing()
+ */
+export type BrowserTracing = BrowserTracingT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ */
+export const addExtensionMethods = addExtensionMethodsT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ *
+ * `getActiveTransaction` can be imported from `@sentry/node`, `@sentry/browser`, or your framework SDK
+ */
+export const getActiveTransaction = getActiveTransactionT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ *
+ * `extractTraceparentData` can be imported from `@sentry/node`, `@sentry/browser`, or your framework SDK
+ */
+export const extractTraceparentData = extractTraceparentDataT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ *
+ * `spanStatusfromHttpCode` can be imported from `@sentry/node`, `@sentry/browser`, or your framework SDK
+ */
+export const spanStatusfromHttpCode = spanStatusfromHttpCodeT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ *
+ * `SpanStatusType` can be imported from `@sentry/node`, `@sentry/browser`, or your framework SDK
+ */
+export type SpanStatusType = SpanStatusTypeT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ *
+ * `Transaction` can be imported from `@sentry/node`, `@sentry/browser`, or your framework SDK
+ */
+export const Transaction = TransactionT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ *
+ * `Transaction` can be imported from `@sentry/node`, `@sentry/browser`, or your framework SDK
+ */
+export type Transaction = TransactionT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ *
+ * `Span` can be imported from `@sentry/node`, `@sentry/browser`, or your framework SDK
+ */
+export const Span = SpanT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ *
+ * `Span` can be imported from `@sentry/node`, `@sentry/browser`, or your framework SDK
+ */
+export type Span = SpanT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ */
+export const BROWSER_TRACING_INTEGRATION_ID = BROWSER_TRACING_INTEGRATION_ID_T;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ *
+ * `defaultRequestInstrumentationOptions` can be imported from `@sentry/browser`, or your framework SDK
+ */
+export const defaultRequestInstrumentationOptions = defaultRequestInstrumentationOptionsT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ *
+ * `hasTracingEnabled` can be imported from `@sentry/utils`
+ */
+export const hasTracingEnabled = hasTracingEnabledT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ *
+ * `stripUrlQueryAndFragment` can be imported from `@sentry/utils`
+ */
+export const stripUrlQueryAndFragment = stripUrlQueryAndFragmentT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ *
+ * `TRACEPARENT_REGEXP` can be imported from `@sentry/utils`
+ */
+export const TRACEPARENT_REGEXP = TRACEPARENT_REGEXP_T;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ */
+export const IdleTransaction = IdleTransactionT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ */
+export type IdleTransaction = IdleTransactionT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ */
+export const instrumentOutgoingRequests = instrumentOutgoingRequestsT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ */
+export const startIdleTransaction = startIdleTransactionT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ */
+// eslint-disable-next-line deprecation/deprecation
+export const SpanStatus = SpanStatusT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ */
+// eslint-disable-next-line deprecation/deprecation
+export type SpanStatus = SpanStatusT;
+
+/**
+ * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+ */
+export type RequestInstrumentationOptions = RequestInstrumentationOptionsT;
+
 export const Integrations = {
+  /**
+   * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+   *
+   * `BrowserTracing` can be imported from `@sentry/browser` or your framework SDK
+   *
+   * import { BrowserTracing } from '@sentry/browser';
+   * new BrowserTracing()
+   */
+  // eslint-disable-next-line deprecation/deprecation
   BrowserTracing: BrowserTracing,
+  /**
+   * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+   *
+   * `Apollo` can be imported from `@sentry/node`
+   *
+   * import { Integrations } from '@sentry/node';
+   * new Integrations.Apollo({ ... })
+   */
+  // eslint-disable-next-line deprecation/deprecation
   Apollo: Apollo,
+  /**
+   * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+   *
+   * `Express` can be imported from `@sentry/node`
+   *
+   * import { Integrations } from '@sentry/node';
+   * new Integrations.Express({ ... })
+   */
+  // eslint-disable-next-line deprecation/deprecation
   Express: Express,
+  /**
+   * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+   *
+   * `GraphQL` can be imported from `@sentry/node`
+   *
+   * import { Integrations } from '@sentry/node';
+   * new Integrations.GraphQL({ ... })
+   */
+  // eslint-disable-next-line deprecation/deprecation
   GraphQL: GraphQL,
+  /**
+   * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+   *
+   * `Mongo` can be imported from `@sentry/node`
+   *
+   * import { Integrations } from '@sentry/node';
+   * new Integrations.Mongo({ ... })
+   */
+  // eslint-disable-next-line deprecation/deprecation
   Mongo: Mongo,
+  /**
+   * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+   *
+   * `Mysql` can be imported from `@sentry/node`
+   *
+   * import { Integrations } from '@sentry/node';
+   * new Integrations.Mysql({ ... })
+   */
+  // eslint-disable-next-line deprecation/deprecation
   Mysql: Mysql,
+  /**
+   * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+   *
+   * `Postgres` can be imported from `@sentry/node`
+   *
+   * import { Integrations } from '@sentry/node';
+   * new Integrations.Postgres({ ... })
+   */
+  // eslint-disable-next-line deprecation/deprecation
   Postgres: Postgres,
+  /**
+   * @deprecated `@sentry/tracing` has been deprecated and will be removed in the next major version.
+   *
+   * `Prisma` can be imported from `@sentry/node`
+   *
+   * import { Integrations } from '@sentry/node';
+   * new Integrations.Prisma({ ... })
+   */
+  // eslint-disable-next-line deprecation/deprecation
   Prisma: Prisma,
 };
 
@@ -51,5 +275,5 @@ declare const __SENTRY_TRACING__: boolean;
 // Guard for tree
 if (typeof __SENTRY_TRACING__ === 'undefined' || __SENTRY_TRACING__) {
   // We are patching the global object with our hub extension methods
-  addExtensionMethods();
+  addExtensionMethodsT();
 }

--- a/packages/tracing/test/hub.test.ts
+++ b/packages/tracing/test/hub.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { BrowserClient } from '@sentry/browser';
 import { Hub, makeMain } from '@sentry/core';

--- a/packages/tracing/test/index.test.ts
+++ b/packages/tracing/test/index.test.ts
@@ -24,6 +24,7 @@ describe('index', () => {
     });
 
     it('contains BrowserTracing', () => {
+      // eslint-disable-next-line deprecation/deprecation
       expect(Integrations.BrowserTracing).toEqual(BrowserTracing);
     });
   });

--- a/packages/tracing/test/integrations/apollo-nestjs.test.ts
+++ b/packages/tracing/test/integrations/apollo-nestjs.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Hub, Scope } from '@sentry/core';
 import { logger } from '@sentry/utils';

--- a/packages/tracing/test/integrations/apollo.test.ts
+++ b/packages/tracing/test/integrations/apollo.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Hub, Scope } from '@sentry/core';
 import { logger } from '@sentry/utils';

--- a/packages/tracing/test/integrations/graphql.test.ts
+++ b/packages/tracing/test/integrations/graphql.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Hub, Scope } from '@sentry/core';
 import { logger } from '@sentry/utils';

--- a/packages/tracing/test/integrations/node/mongo.test.ts
+++ b/packages/tracing/test/integrations/node/mongo.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Hub, Scope } from '@sentry/core';
 import { logger } from '@sentry/utils';

--- a/packages/tracing/test/integrations/node/postgres.test.ts
+++ b/packages/tracing/test/integrations/node/postgres.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Hub, Scope } from '@sentry/core';
 import { logger } from '@sentry/utils';

--- a/packages/tracing/test/integrations/node/prisma.test.ts
+++ b/packages/tracing/test/integrations/node/prisma.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Hub, Scope } from '@sentry/core';
 import { logger } from '@sentry/utils';

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import { BrowserClient } from '@sentry/browser';
 import { Hub, makeMain, Scope } from '@sentry/core';
 import type { BaseTransportOptions, ClientOptions, TransactionSource } from '@sentry/types';

--- a/packages/tracing/test/transaction.test.ts
+++ b/packages/tracing/test/transaction.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import { BrowserClient, Hub } from '@sentry/browser';
 
 import { addExtensionMethods, Transaction } from '../src';

--- a/packages/tracing/test/utils.test.ts
+++ b/packages/tracing/test/utils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import { extractTraceparentData, hasTracingEnabled } from '../src';
 
 describe('hasTracingEnabled (deprecated)', () => {


### PR DESCRIPTION
Because we're using an older version of TypeScript, [jsdocs overrides for re-exported types is not supported](https://github.com/microsoft/TypeScript/issues/42684).

This means that they need to be redeclared and for classes, we need to re-export them as both a value and a type!

For the most used and obvious types, I've added text to the deprecation notice to help users migrate.