### PR TITLE
fix(sveltekit): Fix `<meta>` tag injection

### DIFF
--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -40,10 +40,10 @@ export const transformPageChunk: NonNullable<ResolveOptions['transformPageChunk'
   if (transaction) {
     const traceparentData = transaction.toTraceparent();
     const dynamicSamplingContext = dynamicSamplingContextToSentryBaggageHeader(transaction.getDynamicSamplingContext());
-    const content = `<meta name="sentry-trace" content="${traceparentData}"/>
-      <meta name="baggage" content="${dynamicSamplingContext}"/>
-      %sveltekit.head%`;
-    return html.replace('%sveltekit.head%', content);
+    const content = `<head>
+      <meta name="sentry-trace" content="${traceparentData}"/>
+      <meta name="baggage" content="${dynamicSamplingContext}"/>`;
+    return html.replace('<head>', content);
   }
 
   return html;

--- a/packages/sveltekit/test/server/handle.test.ts
+++ b/packages/sveltekit/test/server/handle.test.ts
@@ -271,7 +271,6 @@ describe('transformPageChunk', () => {
       <meta charset="utf-8" />
       <link rel="icon" href="%sveltekit.assets%/favicon.png" />
       <meta name="viewport" content="width=device-width" />
-      %sveltekit.head%
     </head>
     <body data-sveltekit-preload-data="hover">
       <div style="display: contents">%sveltekit.body%</div>


### PR DESCRIPTION
Just noticed in my test app that apparently the `%sveltekit.head%` isn't present in the html that's passed to `transformPageChunk`. Hence our `<meta>` tag injection logic introduced in #7574  didn't find the anchor point where to inject the tags. This PR fixes the injection, by simply appending it to an open `<head>` tag. It's not pretty but it should do the trick 🤞 (we can revisit if this breaks folks).

Tested with one of my kit test apps and now, FE and BE transactions are connected:
<img width="806" alt="image" src="https://user-images.githubusercontent.com/8420481/227576972-948849d4-e0cc-4365-b6b2-a582d2fd55cd.png">

ref #7526 
