### PR TITLE
build(cdn): Make integration CDN bundles build in parallel

### DIFF
--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "run-p build:transpile build:types build:bundle",
-    "build:bundle": "ts-node scripts/buildBundles.ts",
+    "build:bundle": "ts-node scripts/buildBundles.ts --parallel",
     "build:dev": "run-p build:transpile build:types",
     "build:transpile": "rollup -c rollup.npm.config.js",
     "build:types": "tsc -p tsconfig.types.json",

--- a/packages/integrations/rollup.bundle.config.js
+++ b/packages/integrations/rollup.bundle.config.js
@@ -12,7 +12,7 @@ const baseBundleConfig = makeBaseBundleConfig({
   entrypoints: [`src/${file}`],
   jsVersion,
   licenseTitle: '@sentry/integrations',
-  outputFileBase: ({ name: entrypoint }) => `bundles/${entrypoint}${jsVersion === 'ES5' ? '.es5' : ''}`,
+  outputFileBase: ({ name: entrypoint }) => `bundles/${entrypoint}${jsVersion === 'es5' ? '.es5' : ''}`,
 });
 
 // TODO We only need `commonjs` for localforage (used in the offline plugin). Once that's fixed, this can come out.

--- a/packages/integrations/scripts/buildBundles.ts
+++ b/packages/integrations/scripts/buildBundles.ts
@@ -33,7 +33,7 @@ async function buildBundle(integration: string, jsVersion: string): Promise<void
 if (runParallel) {
   // We're building a bundle for each integration and each JavaScript version.
   const tasks = getIntegrations().reduce(
-    (tasks, integration) => [...tasks, buildBundle(integration, 'ES5'), buildBundle(integration, 'ES6')],
+    (tasks, integration) => [...tasks, buildBundle(integration, 'es5'), buildBundle(integration, 'es6')],
     [] as Promise<void>[],
   );
 
@@ -49,8 +49,8 @@ if (runParallel) {
 } else {
   void (async () => {
     for (const integration of getIntegrations()) {
-      await buildBundle(integration, 'ES5');
-      await buildBundle(integration, 'ES6');
+      await buildBundle(integration, 'es5');
+      await buildBundle(integration, 'es6');
     }
     // eslint-disable-next-line no-console
     console.log('\nIntegration bundles built successfully');


### PR DESCRIPTION
I noticed we have a `--parallel` flag for building the integration CDN addons, but don't use it. At least locally that drastically improves build time for me (from ~250s to ~70s).

While at it I also aligned the JS version strings we use there in rollup with the browser config.