### PR TITLE
feat(sveltekit): Add partial instrumentation for client-side `fetch`

### DIFF
--- a/packages/sveltekit/src/client/load.ts
+++ b/packages/sveltekit/src/client/load.ts
@@ -1,6 +1,17 @@
-import { trace } from '@sentry/core';
+import { addTracingHeadersToFetchRequest } from '@sentry-internal/tracing';
+import type { BaseClient } from '@sentry/core';
+import { getCurrentHub, trace } from '@sentry/core';
+import type { Breadcrumbs, BrowserTracing } from '@sentry/svelte';
 import { captureException } from '@sentry/svelte';
-import { addExceptionMechanism, objectify } from '@sentry/utils';
+import type { ClientOptions, SanitizedRequestData } from '@sentry/types';
+import {
+  addExceptionMechanism,
+  getSanitizedUrlString,
+  objectify,
+  parseFetchArgs,
+  parseUrl,
+  stringMatchesSomePattern,
+} from '@sentry/utils';
 import type { LoadEvent } from '@sveltejs/kit';
 
 import { isRedirect } from '../common/utils';
@@ -34,7 +45,17 @@ function sendErrorToSentry(e: unknown): unknown {
 }
 
 /**
- * @inheritdoc
+ * Wrap load function with Sentry. This wrapper will
+ *
+ * - catch errors happening during the execution of `load`
+ * - create a load span if performance monitoring is enabled
+ * - attach tracing Http headers to `fech` requests if performance monitoring is enabled to get connected traces.
+ * - add a fetch breadcrumb for every `fetch` request
+ *
+ * Note that tracing Http headers are only attached if the url matches the specified `tracePropagationTargets`
+ * entries to avoid CORS errors.
+ *
+ * @param origLoad SvelteKit user defined load function
  */
 // The liberal generic typing of `T` is necessary because we cannot let T extend `Load`.
 // This function needs to tell TS that it returns exactly the type that it was called with
@@ -47,6 +68,11 @@ export function wrapLoadWithSentry<T extends (...args: any) => any>(origLoad: T)
       // Type casting here because `T` cannot extend `Load` (see comment above function signature)
       const event = args[0] as LoadEvent;
 
+      const patchedEvent = {
+        ...event,
+        fetch: instrumentSvelteKitFetch(event.fetch),
+      };
+
       const routeId = event.route.id;
       return trace(
         {
@@ -57,9 +83,179 @@ export function wrapLoadWithSentry<T extends (...args: any) => any>(origLoad: T)
             source: routeId ? 'route' : 'url',
           },
         },
-        () => wrappingTarget.apply(thisArg, args),
+        () => wrappingTarget.apply(thisArg, [patchedEvent]),
         sendErrorToSentry,
       );
     },
   });
+}
+
+type SvelteKitFetch = LoadEvent['fetch'];
+
+/**
+ * Instruments SvelteKit's client `fetch` implementation which is passed to the client-side universal `load` functions.
+ *
+ * We need to instrument this in addition to the native fetch we instrument in BrowserTracing because SvelteKit
+ * stores the native fetch implementation before our SDK is initialized.
+ *
+ * see: https://github.com/sveltejs/kit/blob/master/packages/kit/src/runtime/client/fetcher.js
+ *
+ * This instrumentation takes the fetch-related options from `BrowserTracing` to determine if we should
+ * instrument fetch for perfomance monitoring, create a span for or attach our tracing headers to the given request.
+ *
+ * To dertermine if breadcrumbs should be recorded, this instrumentation relies on the availability of and the options
+ * set in the `BreadCrumbs` integration.
+ *
+ * @param originalFetch SvelteKit's original fetch implemenetation
+ *
+ * @returns a proxy of SvelteKit's fetch implementation
+ */
+function instrumentSvelteKitFetch(originalFetch: SvelteKitFetch): SvelteKitFetch {
+  const client = getCurrentHub().getClient() as BaseClient<ClientOptions>;
+
+  const browserTracingIntegration =
+    client.getIntegrationById && (client.getIntegrationById('BrowserTracing') as BrowserTracing | undefined);
+  const breadcrumbsIntegration =
+    client.getIntegrationById && (client.getIntegrationById('Breadcrumbs') as Breadcrumbs | undefined);
+
+  const browserTracingOptions = browserTracingIntegration && browserTracingIntegration.options;
+
+  const shouldTraceFetch = browserTracingOptions && browserTracingOptions.traceFetch;
+  const shouldAddFetchBreadcrumb = breadcrumbsIntegration && breadcrumbsIntegration.options.fetch;
+
+  /* Identical check as in BrowserTracing, just that we also need to verify that BrowserTracing is actually installed */
+  const shouldCreateSpan =
+    browserTracingOptions && typeof browserTracingOptions.shouldCreateSpanForRequest === 'function'
+      ? browserTracingOptions.shouldCreateSpanForRequest
+      : (_: string) => shouldTraceFetch;
+
+  /* Identical check as in BrowserTracing, just that we also need to verify that BrowserTracing is actually installed */
+  const shouldAttachHeaders: (url: string) => boolean = url => {
+    return (
+      !!shouldTraceFetch &&
+      stringMatchesSomePattern(url, browserTracingOptions.tracePropagationTargets || ['localhost', /^\//])
+    );
+  };
+
+  return new Proxy(originalFetch, {
+    apply: (wrappingTarget, thisArg, args: Parameters<LoadEvent['fetch']>) => {
+      const [input, init] = args;
+      const { url: rawUrl, method } = parseFetchArgs(args);
+
+      // TODO: extract this to a util function (and use it in breadcrumbs integration as well)
+      if (rawUrl.match(/sentry_key/)) {
+        // We don't create spans or breadcrumbs for fetch requests that contain `sentry_key` (internal sentry requests)
+        return wrappingTarget.apply(thisArg, args);
+      }
+
+      const urlObject = parseUrl(rawUrl);
+
+      const requestData: SanitizedRequestData = {
+        url: getSanitizedUrlString(urlObject),
+        method,
+        ...(urlObject.search && { 'http.query': urlObject.search.substring(1) }),
+        ...(urlObject.hash && { 'http.hash': urlObject.hash.substring(1) }),
+      };
+
+      const patchedInit: RequestInit = { ...init };
+      const activeSpan = getCurrentHub().getScope().getSpan();
+      const activeTransaction = activeSpan && activeSpan.transaction;
+
+      const createSpan = activeTransaction && shouldCreateSpan(rawUrl);
+      const attachHeaders = createSpan && activeTransaction && shouldAttachHeaders(rawUrl);
+
+      // only attach headers if we should create a span
+      if (attachHeaders) {
+        const dsc = activeTransaction.getDynamicSamplingContext();
+
+        const headers = addTracingHeadersToFetchRequest(
+          input as string | Request,
+          dsc,
+          activeSpan,
+          patchedInit as {
+            headers:
+              | {
+                  [key: string]: string[] | string | undefined;
+                }
+              | Request['headers'];
+          },
+        ) as HeadersInit;
+
+        patchedInit.headers = headers;
+      }
+      let fetchPromise: Promise<Response>;
+
+      const patchedFetchArgs = [input, patchedInit];
+
+      if (createSpan) {
+        fetchPromise = trace(
+          {
+            name: `${requestData.method} ${requestData.url}`, // this will become the description of the span
+            op: 'http.client',
+            data: requestData,
+          },
+          span => {
+            const promise: Promise<Response> = wrappingTarget.apply(thisArg, patchedFetchArgs);
+            if (span) {
+              promise.then(res => span.setHttpStatus(res.status)).catch(_ => span.setStatus('internal_error'));
+            }
+            return promise;
+          },
+        );
+      } else {
+        fetchPromise = wrappingTarget.apply(thisArg, patchedFetchArgs);
+      }
+
+      if (shouldAddFetchBreadcrumb) {
+        addFetchBreadcrumb(fetchPromise, requestData, args);
+      }
+
+      return fetchPromise;
+    },
+  });
+}
+
+/* Adds a breadcrumb for the given fetch result */
+function addFetchBreadcrumb(
+  fetchResult: Promise<Response>,
+  requestData: SanitizedRequestData,
+  args: Parameters<SvelteKitFetch>,
+): void {
+  const breadcrumbStartTimestamp = Date.now();
+  fetchResult.then(
+    response => {
+      getCurrentHub().addBreadcrumb(
+        {
+          type: 'http',
+          category: 'fetch',
+          data: {
+            ...requestData,
+            status_code: response.status,
+          },
+        },
+        {
+          input: args,
+          response,
+          startTimestamp: breadcrumbStartTimestamp,
+          endTimestamp: Date.now(),
+        },
+      );
+    },
+    error => {
+      getCurrentHub().addBreadcrumb(
+        {
+          type: 'http',
+          category: 'fetch',
+          level: 'error',
+          data: requestData,
+        },
+        {
+          input: args,
+          data: error,
+          startTimestamp: breadcrumbStartTimestamp,
+          endTimestamp: Date.now(),
+        },
+      );
+    },
+  );
 }

--- a/packages/tracing-internal/src/browser/index.ts
+++ b/packages/tracing-internal/src/browser/index.ts
@@ -3,4 +3,8 @@ export * from '../exports';
 export type { RequestInstrumentationOptions } from './request';
 
 export { BrowserTracing, BROWSER_TRACING_INTEGRATION_ID } from './browsertracing';
-export { instrumentOutgoingRequests, defaultRequestInstrumentationOptions } from './request';
+export {
+  instrumentOutgoingRequests,
+  defaultRequestInstrumentationOptions,
+  addTracingHeadersToFetchRequest,
+} from './request';

--- a/packages/tracing-internal/src/index.ts
+++ b/packages/tracing-internal/src/index.ts
@@ -17,6 +17,7 @@ export {
   BROWSER_TRACING_INTEGRATION_ID,
   instrumentOutgoingRequests,
   defaultRequestInstrumentationOptions,
+  addTracingHeadersToFetchRequest,
 } from './browser';
 
 export type { RequestInstrumentationOptions } from './browser';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -48,7 +48,7 @@ export type { ClientOptions, Options } from './options';
 export type { Package } from './package';
 export type { PolymorphicEvent, PolymorphicRequest } from './polymorphics';
 export type { ReplayEvent, ReplayRecordingData, ReplayRecordingMode } from './replay';
-export type { QueryParams, Request } from './request';
+export type { QueryParams, Request, SanitizedRequestData } from './request';
 export type { Runtime } from './runtime';
 export type { CaptureContext, Scope, ScopeContext } from './scope';
 export type { SdkInfo } from './sdkinfo';

--- a/packages/types/src/request.ts
+++ b/packages/types/src/request.ts
@@ -10,3 +10,15 @@ export interface Request {
 }
 
 export type QueryParams = string | { [key: string]: string } | Array<[string, string]>;
+
+/**
+ * Request data that is considered safe for `span.data` on `http.client` spans
+ * and for `http` breadcrumbs
+ * See https://develop.sentry.dev/sdk/data-handling/#structuring-data
+ */
+export type SanitizedRequestData = {
+  url: string;
+  method: string;
+  'http.fragment'?: string;
+  'http.query'?: string;
+};

--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -210,9 +210,8 @@ function getUrlFromResource(resource: FetchResource): string {
 }
 
 /**
- * Exported only for tests.
- * @hidden
- *  */
+ * Parses the fetch arguments to find the used Http method and the url of the request
+ */
 export function parseFetchArgs(fetchArgs: unknown[]): { method: string; url: string } {
   if (fetchArgs.length === 0) {
     return { method: 'GET', url: '' };

--- a/packages/utils/test/url.test.ts
+++ b/packages/utils/test/url.test.ts
@@ -1,4 +1,4 @@
-import { getNumberOfUrlSegments, stripUrlQueryAndFragment } from '../src/url';
+import { getNumberOfUrlSegments, getSanitizedUrlString, parseUrl, stripUrlQueryAndFragment } from '../src/url';
 
 describe('stripQueryStringAndFragment', () => {
   const urlString = 'http://dogs.are.great:1231/yay/';
@@ -29,5 +29,53 @@ describe('getNumberOfUrlSegments', () => {
     ['regex path', String(/\/api\/post[0-9]/), 2],
   ])('%s', (_: string, input, output) => {
     expect(getNumberOfUrlSegments(input)).toEqual(output);
+  });
+});
+
+describe('getSanitizedUrlString', () => {
+  it.each([
+    ['regular url', 'https://somedomain.com', 'https://somedomain.com'],
+    ['regular url with a path', 'https://somedomain.com/path/to/happiness', 'https://somedomain.com/path/to/happiness'],
+    [
+      'url with standard http port 80',
+      'http://somedomain.com:80/path/to/happiness',
+      'http://somedomain.com/path/to/happiness',
+    ],
+    [
+      'url with standard https port 443',
+      'https://somedomain.com:443/path/to/happiness',
+      'https://somedomain.com/path/to/happiness',
+    ],
+    [
+      'url with non-standard port',
+      'https://somedomain.com:4200/path/to/happiness',
+      'https://somedomain.com:4200/path/to/happiness',
+    ],
+    [
+      'url with query params',
+      'https://somedomain.com:4200/path/to/happiness?auhtToken=abc123&param2=bar',
+      'https://somedomain.com:4200/path/to/happiness',
+    ],
+    [
+      'url with a fragment',
+      'https://somedomain.com/path/to/happiness#somewildfragment123',
+      'https://somedomain.com/path/to/happiness',
+    ],
+    [
+      'url with a fragment and query params',
+      'https://somedomain.com/path/to/happiness#somewildfragment123?auhtToken=abc123&param2=bar',
+      'https://somedomain.com/path/to/happiness',
+    ],
+    [
+      'url with authorization',
+      'https://username:password@somedomain.com',
+      'https://[filtered]:[filtered]@somedomain.com',
+    ],
+    ['same-origin url', '/api/v4/users?id=123', '/api/v4/users'],
+    ['url without a protocol', 'example.com', 'example.com'],
+    ['url without a protocol with a path', 'example.com/sub/path?id=123', 'example.com/sub/path'],
+  ])('returns a sanitized URL for a %s', (_, rawUrl: string, sanitizedURL: string) => {
+    const urlObject = parseUrl(rawUrl);
+    expect(getSanitizedUrlString(urlObject)).toEqual(sanitizedURL);
   });
 });


### PR DESCRIPTION
This PR adds partial instrumentation to the client-side `fetch` passed to the universal `load` functions. It enables distributed traces of fetch calls happening **inside** a `load` function. 

Limitation: `fetch` requests made by SvelteKit (e.g. to call server-only load functions) are **not** touched by this instrumentation because we cannot access the Kit-internal fetch function at this time. Opened an [issue on the SvelteKit repo](https://github.com/sveltejs/kit/issues/9530) to find a solution for this.  

Anyway, here's a fancy screenshot of a successful trace: 

![image](https://user-images.githubusercontent.com/8420481/227983872-9b9c5a78-58bb-43c6-bbc2-ed29b309c803.png)

My guess is that https://github.com/sveltejs/kit/issues/9542 and https://github.com/sveltejs/kit/issues/9530 are gonna take a little while longer to be resolved. I'd say, we add this in for the moment so that we at least get these traces connected. We should take it out/adjust whenever we have `handleLoad` or `handleFetch` available.

ref: #7413 