### PR TITLE
test(utils): Add test for global rate limit response with scope

### DIFF
--- a/packages/utils/test/ratelimit.test.ts
+++ b/packages/utils/test/ratelimit.test.ts
@@ -186,4 +186,14 @@ describe('updateRateLimits()', () => {
     const updatedRateLimits = updateRateLimits(rateLimits, { statusCode: 200 }, 0);
     expect(updatedRateLimits).toEqual(rateLimits);
   });
+
+  test('should apply a global rate limit with a scope on a 429 status code', () => {
+    const rateLimits: RateLimits = {};
+    const headers = {
+      'retry-after': null,
+      'x-sentry-rate-limits': '60::organization',
+    };
+    const updatedRateLimits = updateRateLimits(rateLimits, { statusCode: 429, headers }, 0);
+    expect(updatedRateLimits.all).toEqual(60_000);
+  });
 });


### PR DESCRIPTION
This PR just adds a small test to check if the SDK parses a rate limit response that has no category but a scope: `60::organization`. This came up in Slack and in https://github.com/getsentry/ops/pull/6446#discussion_r1150245408.
