### PR TITLE
feat(tracing): Ensure `pageload` transaction starts at timeOrigin

### DIFF
--- a/packages/browser-integration-tests/suites/tracing/browsertracing/pageload/init.js
+++ b/packages/browser-integration-tests/suites/tracing/browsertracing/pageload/init.js
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/browser';
+import { Integrations } from '@sentry/tracing';
+
+window.Sentry = Sentry;
+window._testBaseTimestamp = performance.timeOrigin / 1000;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [new Integrations.BrowserTracing()],
+  tracesSampleRate: 1,
+});

--- a/packages/browser-integration-tests/suites/tracing/browsertracing/pageload/test.ts
+++ b/packages/browser-integration-tests/suites/tracing/browsertracing/pageload/test.ts
@@ -16,7 +16,7 @@ sentryTest('should create a pageload transaction', async ({ getLocalTestPath, pa
 
   const { start_timestamp: startTimestamp } = eventData;
 
-  expect(startTimestamp).toBeCloseTo(timeOrigin);
+  expect(startTimestamp).toBeCloseTo(timeOrigin, 1);
 
   expect(eventData.contexts?.trace?.op).toBe('pageload');
   expect(eventData.spans?.length).toBeGreaterThan(0);

--- a/packages/browser-integration-tests/suites/tracing/browsertracing/pageloadDelayed/init.js
+++ b/packages/browser-integration-tests/suites/tracing/browsertracing/pageloadDelayed/init.js
@@ -1,0 +1,14 @@
+import * as Sentry from '@sentry/browser';
+import { Integrations } from '@sentry/tracing';
+
+window.Sentry = Sentry;
+window._testBaseTimestamp = performance.timeOrigin / 1000;
+
+setTimeout(() => {
+  window._testTimeoutTimestamp = (performance.timeOrigin + performance.now()) / 1000;
+  Sentry.init({
+    dsn: 'https://public@dsn.ingest.sentry.io/1337',
+    integrations: [new Integrations.BrowserTracing()],
+    tracesSampleRate: 1,
+  });
+}, 250);

--- a/packages/browser-integration-tests/suites/tracing/browsertracing/pageloadDelayed/test.ts
+++ b/packages/browser-integration-tests/suites/tracing/browsertracing/pageloadDelayed/test.ts
@@ -17,7 +17,7 @@ sentryTest('should create a pageload transaction when initialized delayed', asyn
 
   const { start_timestamp: startTimestamp } = eventData;
 
-  expect(startTimestamp).toBeCloseTo(timeOrigin);
+  expect(startTimestamp).toBeCloseTo(timeOrigin, 1);
   expect(startTimestamp).toBeLessThan(timeoutTimestamp);
 
   expect(eventData.contexts?.trace?.op).toBe('pageload');

--- a/packages/browser-integration-tests/suites/tracing/browsertracing/pageloadDelayed/test.ts
+++ b/packages/browser-integration-tests/suites/tracing/browsertracing/pageloadDelayed/test.ts
@@ -4,7 +4,7 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest, shouldSkipTracingTest } from '../../../../utils/helpers';
 
-sentryTest('should create a pageload transaction', async ({ getLocalTestPath, page }) => {
+sentryTest('should create a pageload transaction when initialized delayed', async ({ getLocalTestPath, page }) => {
   if (shouldSkipTracingTest()) {
     sentryTest.skip();
   }
@@ -13,10 +13,12 @@ sentryTest('should create a pageload transaction', async ({ getLocalTestPath, pa
 
   const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
   const timeOrigin = await page.evaluate<number>('window._testBaseTimestamp');
+  const timeoutTimestamp = await page.evaluate<number>('window._testTimeoutTimestamp');
 
   const { start_timestamp: startTimestamp } = eventData;
 
   expect(startTimestamp).toBeCloseTo(timeOrigin);
+  expect(startTimestamp).toBeLessThan(timeoutTimestamp);
 
   expect(eventData.contexts?.trace?.op).toBe('pageload');
   expect(eventData.spans?.length).toBeGreaterThan(0);

--- a/packages/tracing-internal/src/browser/router.ts
+++ b/packages/tracing-internal/src/browser/router.ts
@@ -1,5 +1,5 @@
 import type { Transaction, TransactionContext } from '@sentry/types';
-import { addInstrumentationHandler, logger } from '@sentry/utils';
+import { addInstrumentationHandler, browserPerformanceTimeOrigin, logger } from '@sentry/utils';
 
 import { WINDOW } from './types';
 
@@ -22,6 +22,8 @@ export function instrumentRoutingWithDefaults<T extends Transaction>(
   if (startTransactionOnPageLoad) {
     activeTransaction = customStartTransaction({
       name: WINDOW.location.pathname,
+      // pageload should always start at timeOrigin
+      startTimestamp: browserPerformanceTimeOrigin,
       op: 'pageload',
       metadata: { source: 'url' },
     });


### PR DESCRIPTION
This adjusts the `pageload` transaction to ensure its start is always the timeOrigin.
This should help with e.g. lazy loading sentry, where we still want this to be accurate.