### PR TITLE
chore(vue): Add attribution license

### DIFF
--- a/packages/vue/src/errorhandler.ts
+++ b/packages/vue/src/errorhandler.ts
@@ -1,7 +1,7 @@
 import { getCurrentHub } from '@sentry/browser';
 
-import { formatComponentName, generateComponentTrace } from './components';
 import type { Options, ViewModel, Vue } from './types';
+import { formatComponentName, generateComponentTrace } from './vendor/components';
 
 type UnknownFunc = (...args: unknown[]) => void;
 

--- a/packages/vue/src/tracing.ts
+++ b/packages/vue/src/tracing.ts
@@ -2,9 +2,9 @@ import { getCurrentHub } from '@sentry/browser';
 import type { Span, Transaction } from '@sentry/types';
 import { logger, timestampInSeconds } from '@sentry/utils';
 
-import { formatComponentName } from './components';
 import { DEFAULT_HOOKS } from './constants';
 import type { Hook, Operation, TracingOptions, ViewModel, Vue } from './types';
+import { formatComponentName } from './vendor/components';
 
 const VUE_OP = 'ui.vue';
 

--- a/packages/vue/src/vendor/components.ts
+++ b/packages/vue/src/vendor/components.ts
@@ -1,6 +1,30 @@
-import type { ViewModel } from './types';
+import type { ViewModel } from '../types';
 
-// Vendored directly from https://github.com/vuejs/vue/blob/master/src/core/util/debug.js with types only changes.
+// Vendored from https://github.com/vuejs/vue/blob/612fb89547711cacb030a3893a0065b785802860/src/core/util/debug.js
+// with types only changes.
+
+// The MIT License (MIT)
+
+// Copyright (c) 2013-present, Yuxi (Evan) You
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 const classifyRE = /(?:^|[-_])(\w)/g;
 const classify = (str: string): string => str.replace(classifyRE, c => c.toUpperCase()).replace(/[-_]/g, '');
 

--- a/packages/vue/test/errorHandler.test.ts
+++ b/packages/vue/test/errorHandler.test.ts
@@ -1,8 +1,8 @@
 import { getCurrentHub } from '@sentry/browser';
 
-import { generateComponentTrace } from '../src/components';
 import { attachErrorHandler } from '../src/errorhandler';
 import type { Operation, Options, ViewModel, Vue } from '../src/types';
+import { generateComponentTrace } from '../src/vendor/components';
 
 describe('attachErrorHandler', () => {
   describe('attachProps', () => {

--- a/packages/vue/test/vendor/components.test.ts
+++ b/packages/vue/test/vendor/components.test.ts
@@ -1,4 +1,4 @@
-import { formatComponentName } from '../src/components';
+import { formatComponentName } from '../../src/vendor/components';
 
 describe('formatComponentName', () => {
   describe('when the vm is not defined', () => {


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/7560

Add MIT license to code vendored from vuejs.
