### PR TITLE
fix(nextjs): Add loading component type to server component wrapping

### DIFF
--- a/packages/nextjs/src/config/loaders/wrappingLoader.ts
+++ b/packages/nextjs/src/config/loaders/wrappingLoader.ts
@@ -182,6 +182,9 @@ export default function wrappingLoader(
         case 'not-found':
           componentType = 'Not-found';
           break;
+        case 'loading':
+          componentType = 'Loading';
+          break;
         default:
           componentType = 'Unknown';
       }


### PR DESCRIPTION
Ref #6726 

We missed the `loading.tsx` component in the server component wrapping logic.