### PR TITLE
fix(sveltekit): Explicitly export Node SDK exports

### DIFF
--- a/packages/sveltekit/src/index.client.ts
+++ b/packages/sveltekit/src/index.client.ts
@@ -1,7 +1,1 @@
 export * from './client';
-
-/**
- * This const serves no purpose besides being an identifier for this file that the SDK multiplexer loader can use to
- * determine that this is in fact a file that wants to be multiplexed.
- */
-export const _SENTRY_SDK_MULTIPLEXER = true;

--- a/packages/sveltekit/src/index.server.ts
+++ b/packages/sveltekit/src/index.server.ts
@@ -1,10 +1,2 @@
 export * from './server';
 export * from './config';
-
-// This file is the main entrypoint on the server and/or when the package is `require`d
-
-/**
- * This const serves no purpose besides being an identifier for this file that the SDK multiplexer loader can use to
- * determine that this is in fact a file that wants to be multiplexed.
- */
-export const _SENTRY_SDK_MULTIPLEXER = true;

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -1,5 +1,54 @@
+// Node SDK exports
+// Unfortunately, we cannot `exprt * from '@sentry/node'` because our CJS output mistakenly
+// puts these exports into a `default` rather than on the top-level namespace.
+// Hence, we export everything from the Node SDK explicitly:
+export {
+  addGlobalEventProcessor,
+  addBreadcrumb,
+  captureException,
+  captureEvent,
+  captureMessage,
+  configureScope,
+  createTransport,
+  extractTraceparentData,
+  getActiveTransaction,
+  getHubFromCarrier,
+  getCurrentHub,
+  Hub,
+  makeMain,
+  Scope,
+  startTransaction,
+  SDK_VERSION,
+  setContext,
+  setExtra,
+  setExtras,
+  setTag,
+  setTags,
+  setUser,
+  spanStatusfromHttpCode,
+  trace,
+  withScope,
+  autoDiscoverNodePerformanceMonitoringIntegrations,
+  makeNodeTransport,
+  defaultIntegrations,
+  defaultStackParser,
+  lastEventId,
+  flush,
+  close,
+  getSentryRelease,
+  addRequestDataToEvent,
+  DEFAULT_USER_INCLUDES,
+  extractRequestData,
+  deepReadDirSync,
+  Integrations,
+  Handlers,
+} from '@sentry/node';
+
+// We can still leave this for the carrier init and type exports
 export * from '@sentry/node';
 
+// -------------------------
+// SvelteKit SDK exports:
 export { init } from './sdk';
 export { handleErrorWithSentry } from './handleError';
 export { wrapLoadWithSentry } from './load';

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -1,6 +1,7 @@
 // Node SDK exports
-// Unfortunately, we cannot `exprt * from '@sentry/node'` because our CJS output mistakenly
-// puts these exports into a `default` rather than on the top-level namespace.
+// Unfortunately, we cannot `exprt * from '@sentry/node'` because in prod builds,
+// Vite puts these exports into a `default` property (Sentry.default) rather than
+// on the top - level namespace.
 // Hence, we export everything from the Node SDK explicitly:
 export {
   addGlobalEventProcessor,


### PR DESCRIPTION
This PR fixes Node SDK exports not being available in prod builds. For example, calling `Sentry.withScope(...)` throws an error because `withScope` is not defined on the top-level namespace. This is because for CJS, Vite puts wildcard-exported properties into the `default` property rather than onto the namespace in production builds.