### PR TITLE
ref(node): Clean up Undici options

### DIFF
--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -32,19 +32,19 @@ export interface BaseNodeOptions {
    */
   includeLocalVariables?: boolean;
 
-  // TODO (v8): Remove this in v8
   /**
-   * @deprecated Moved to constructor options of the `Http` integration.
+   * List of strings/regex controlling to which outgoing requests
+   * the SDK will attach tracing headers.
+   *
+   * By default the SDK will attach those headers to all outgoing
+   * requests. If this option is provided, the SDK will match the
+   * request URL of outgoing requests against the items in this
+   * array, and only attach tracing headers if a match was found.
+   *
    * @example
    * ```js
    * Sentry.init({
-   *   integrations: [
-   *     new Sentry.Integrations.Http({
-   *       tracing: {
-   *         tracePropagationTargets: ['api.site.com'],
-   *       }
-   *     });
-   *   ],
+   *   tracePropagationTargets: ['api.site.com'],
    * });
    * ```
    */
@@ -52,7 +52,7 @@ export interface BaseNodeOptions {
 
   // TODO (v8): Remove this in v8
   /**
-   * @deprecated Moved to constructor options of the `Http` integration.
+   * @deprecated Moved to constructor options of the `Http` and `Undici` integration.
    * @example
    * ```js
    * Sentry.init({


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-javascript/issues/7624

This PR does a couple of things.

1. Undeprecates `tracePropagationTargets` as a top level option in Node options.
2. Only generates spans/breadcrumbs on a hub if the Undici integration is active.
3. Moves `shouldCreateSpanForRequest` into an option in the Undici integration.
4. Cleans up patching in the test to make it easier to understand.

After these changes get merged in we can add Undici by default to both next.js and sveltekit. We can then think about adding it by default to the Node SDK.