### PR TITLE
fix(nextjs): Gracefully handle undefined `beforeFiles` in rewrites

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -53,9 +53,9 @@ export type NextConfigObject = {
   rewrites?: () => Promise<
     | NextRewrite[]
     | {
-        beforeFiles: NextRewrite[];
-        afterFiles: NextRewrite[];
-        fallback: NextRewrite[];
+        beforeFiles?: NextRewrite[];
+        afterFiles?: NextRewrite[];
+        fallback?: NextRewrite[];
       }
   >;
 };

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -104,7 +104,7 @@ function setUpTunnelRewriteRules(userNextConfig: NextConfigObject, tunnelPath: s
     } else {
       return {
         ...originalRewritesResult,
-        beforeFiles: [injectedRewrite, ...originalRewritesResult.beforeFiles || []],
+        beforeFiles: [injectedRewrite, ...(originalRewritesResult.beforeFiles || [])],
       };
     }
   };

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -104,7 +104,7 @@ function setUpTunnelRewriteRules(userNextConfig: NextConfigObject, tunnelPath: s
     } else {
       return {
         ...originalRewritesResult,
-        beforeFiles: [injectedRewrite, ...originalRewritesResult.beforeFiles],
+        beforeFiles: [injectedRewrite, ...originalRewritesResult.beforeFiles || []],
       };
     }
   };


### PR DESCRIPTION
fix error:

```
> Build error occurred
TypeError: originalRewritesResult.beforeFiles is not iterable
    at userNextConfig.rewrites (/home/bertho/dev/oa/node_modules/@sentry/nextjs/cjs/config/withSentryConfig.js:107:66)
    at async loadRewrites (/home/bertho/dev/oa/node_modules/next/dist/lib/load-custom-routes.js:401:23)
    at async Promise.all (index 1)
    at async Object.loadCustomRoutes [as default] (/home/bertho/dev/oa/node_modules/next/dist/lib/load-custom-routes.js:13:44)
    at async Span.traceAsyncFn (/home/bertho/dev/oa/node_modules/next/dist/trace/trace.js:79:20)
    at async /home/bertho/dev/oa/node_modules/next/dist/build/index.js:79:34
    at async Span.traceAsyncFn (/home/bertho/dev/oa/node_modules/next/dist/trace/trace.js:79:20)
    at async Object.build [as default] (/home/bertho/dev/oa/node_modules/next/dist/build/index.js:65:29)
```

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
