### PR TITLE
fix(interactions): Fix bug where interaction transactions were finishing twice

### DIFF
--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -329,7 +329,7 @@ export class BrowserTracing implements Integration {
       const { idleTimeout, finalTimeout, heartbeatInterval } = this.options;
 
       const op = 'ui.action.click';
-      if (inflightInteractionTransaction) {
+      if (inflightInteractionTransaction && !inflightInteractionTransaction.endTimestamp) {
         inflightInteractionTransaction.finish();
         inflightInteractionTransaction = undefined;
       }


### PR DESCRIPTION
While debugging, I noticed that interaction transactions were consistently having their `finish` method called twice: Once when the `idleTimeout` completes, and another when a new interaction transaction is started.

This is because we keep a reference to `inflightInteractionTransaction` and call `finish` on it if it is not `undefined`. However, the reference remains in the case where it completes due to `idleTimeout`, so `finish` gets called on it again even though it's already completed.

We can avoid this simply by checking if `inflightInteractionTransaction` does not have an `endTimestamp`, since the presence of `endTimestamp` indicates that the transaction has been finalized.