### PR TITLE
feat(tracing): Add custom finishReason for when interaction is interrupted by another

### DIFF
--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -340,6 +340,15 @@ export class IdleTransaction extends Transaction {
     }, this._heartbeatInterval);
   }
 
+  /**
+   * Temporary method used to externally set the transaction's `finishReason`
+   *
+   * ** WARNING**
+   * This is for the purpose of experimentation only and will be removed in the near future, do not use!
+   *
+   * @internal
+   *
+   */
   public setFinishReason(reason: string): void {
     this._finishReason = reason;
   }

--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -90,7 +90,7 @@ export class IdleTransaction extends Transaction {
    */
   private _idleTimeoutID: ReturnType<typeof setTimeout> | undefined;
 
-  private _finishReason: typeof IDLE_TRANSACTION_FINISH_REASONS[number] = IDLE_TRANSACTION_FINISH_REASONS[4];
+  _finishReason: typeof IDLE_TRANSACTION_FINISH_REASONS[number] = IDLE_TRANSACTION_FINISH_REASONS[4];
 
   public constructor(
     transactionContext: TransactionContext,

--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -252,6 +252,19 @@ export class IdleTransaction extends Transaction {
   }
 
   /**
+   * Temporary method used to externally set the transaction's `finishReason`
+   *
+   * ** WARNING**
+   * This is for the purpose of experimentation only and will be removed in the near future, do not use!
+   *
+   * @internal
+   *
+   */
+  public setFinishReason(reason: string): void {
+    this._finishReason = reason;
+  }
+
+  /**
    * Restarts idle timeout, if there is no running idle timeout it will start one.
    */
   private _restartIdleTimeout(endTimestamp?: Parameters<IdleTransaction['finish']>[0]): void {
@@ -338,19 +351,6 @@ export class IdleTransaction extends Transaction {
     setTimeout(() => {
       this._beat();
     }, this._heartbeatInterval);
-  }
-
-  /**
-   * Temporary method used to externally set the transaction's `finishReason`
-   *
-   * ** WARNING**
-   * This is for the purpose of experimentation only and will be removed in the near future, do not use!
-   *
-   * @internal
-   *
-   */
-  public setFinishReason(reason: string): void {
-    this._finishReason = reason;
   }
 }
 

--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -90,7 +90,7 @@ export class IdleTransaction extends Transaction {
    */
   private _idleTimeoutID: ReturnType<typeof setTimeout> | undefined;
 
-  _finishReason: typeof IDLE_TRANSACTION_FINISH_REASONS[number] = IDLE_TRANSACTION_FINISH_REASONS[4];
+  private _finishReason: typeof IDLE_TRANSACTION_FINISH_REASONS[number] = IDLE_TRANSACTION_FINISH_REASONS[4];
 
   public constructor(
     transactionContext: TransactionContext,
@@ -338,6 +338,10 @@ export class IdleTransaction extends Transaction {
     setTimeout(() => {
       this._beat();
     }, this._heartbeatInterval);
+  }
+
+  public setFinishReason(reason: string): void {
+    this._finishReason = reason;
   }
 }
 

--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -330,6 +330,7 @@ export class BrowserTracing implements Integration {
 
       const op = 'ui.action.click';
       if (inflightInteractionTransaction) {
+        inflightInteractionTransaction._finishReason = 'interactionInterrupted';
         inflightInteractionTransaction.finish();
         inflightInteractionTransaction = undefined;
       }

--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -330,7 +330,7 @@ export class BrowserTracing implements Integration {
 
       const op = 'ui.action.click';
       if (inflightInteractionTransaction) {
-        inflightInteractionTransaction._finishReason = 'interactionInterrupted';
+        inflightInteractionTransaction.setFinishReason('interactionInterrupted');
         inflightInteractionTransaction.finish();
         inflightInteractionTransaction = undefined;
       }


### PR DESCRIPTION
I want to track the frequency of this case, since we currently have no way of seeing it. When you click anywhere while another interaction transaction is still in progress, it gets finished. Therefore, we should add a new `finishReason` for this case.

Reminder that `_finishReason` is for the purpose of experimentation only and I will remove it later, please excuse any sloppiness regarding making `_finishReason` public and setting its value externally 😄 