### PR TITLE
ref(sveltekit): Inject init plugin only if sentry config files exist

### DIFF
--- a/packages/sveltekit/src/config/vitePlugins.ts
+++ b/packages/sveltekit/src/config/vitePlugins.ts
@@ -60,7 +60,11 @@ function addSentryConfigFileImport(
   return { code: ms.toString(), map: ms.generateMap() };
 }
 
-function getUserConfigFile(projectDir: string, platform: 'server' | 'client'): string | undefined {
+/**
+ * Looks up the sentry.{@param platform}.config.(ts|js) file
+ * @returns the file path to the file or undefined if it doesn't exist
+ */
+export function getUserConfigFile(projectDir: string, platform: 'server' | 'client'): string | undefined {
   const possibilities = [`sentry.${platform}.config.ts`, `sentry.${platform}.config.js`];
 
   for (const filename of possibilities) {
@@ -69,5 +73,5 @@ function getUserConfigFile(projectDir: string, platform: 'server' | 'client'): s
     }
   }
 
-  throw new Error(`Cannot find '${possibilities[0]}' or '${possibilities[1]}' in '${projectDir}'.`);
+  return undefined;
 }

--- a/packages/sveltekit/test/config/withSentryViteConfig.test.ts
+++ b/packages/sveltekit/test/config/withSentryViteConfig.test.ts
@@ -1,7 +1,17 @@
+import type fs from 'fs';
 import type { Plugin, UserConfig } from 'vite';
+import { vi } from 'vitest';
 
 import { withSentryViteConfig } from '../../src/config/withSentryViteConfig';
 
+let existsFile = true;
+vi.mock('fs', async () => {
+  const original = await vi.importActual<typeof fs>('fs');
+  return {
+    ...original,
+    existsSync: vi.fn().mockImplementation(() => existsFile),
+  };
+});
 describe('withSentryViteConfig', () => {
   const originalConfig = {
     plugins: [{ name: 'foo' }],
@@ -114,5 +124,29 @@ describe('withSentryViteConfig', () => {
     expect(plugins[0].name).toBe('sentry-init-injection-plugin');
 
     expect((sentrifiedConfig as UserConfig).server?.fs?.allow).toStrictEqual(['.']);
+  });
+
+  it("doesn't add the inject init plugin or the server config if sentry config files don't exist", () => {
+    existsFile = false;
+
+    const sentrifiedConfig = withSentryViteConfig({
+      plugins: [{ name: 'some plugin' }],
+      test: {
+        include: ['src/**/*.{test,spec}.{js,ts}'],
+      },
+      server: {
+        fs: {
+          allow: ['./bar'],
+        },
+      },
+    } as UserConfig);
+
+    expect(typeof sentrifiedConfig).toBe('object');
+    const plugins = (sentrifiedConfig as UserConfig).plugins as Plugin[];
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0].name).toBe('some plugin');
+    expect((sentrifiedConfig as UserConfig).server?.fs?.allow).toStrictEqual(['./bar']);
+
+    existsFile = false;
   });
 });


### PR DESCRIPTION
To make our Sentry SDK setup easier, we'll instruct users to init the SDK in the hooks files rather than in the dedicated sentry.client|server.config.js files (#7653). To support this change, this PR makes the injection of our `injectSentryInitPlugin` into the users' build config depend on the existence of said sentry config files. If they don't exist, there's no need to add the plugin or adjust the server config.