### PR TITLE
chore(repo): Update craft config to add SvelteKit SDK release registry entry

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -52,5 +52,7 @@ targets:
         onlyIfPresent: /^sentry-remix-\d.*\.tgz$/
       'npm:@sentry/svelte':
         onlyIfPresent: /^sentry-svelte-\d.*\.tgz$/
+      'npm:@sentry/sveltekit':
+        onlyIfPresent: /^sentry-sveltekit-\d.*\.tgz$/
       'npm:@sentry/opentelemetry-node':
         onlyIfPresent: /^sentry-opentelemetry-node-\d.*\.tgz$/


### PR DESCRIPTION
I just noticed I forgot to add SvelteKit to the release registry target in our craft config after we merged the first [manual entry](https://github.com/getsentry/sentry-release-registry/tree/master/packages/npm/%40sentry/sveltekit). We should be good to add the entry now as missing a version shouldn't be a problem.
