### PR TITLE
meta(changelog): Add @sentry/tracing notes to 7.46.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@ const sentryMiddleware = t.middleware(
 const sentrifiedProcedure = t.procedure.use(sentryMiddleware);
 ```
 
+- **feat(tracing)**: Remove requirement for `@sentry/tracing` package
+
+With `7.46.0` you no longer require the `@sentry/tracing` package to use tracing and performance monitoring with the Sentry JavaScript SDKs. The `@sentry/tracing` package will be removed in a future major release, but can still be used with no changes.
+
+Please see the [Migration docs](./MIGRATION.md/#remove-requirement-for-sentrytracing-package-since-7460) for more details.
+
 - **fix(node)**: Convert debugging code to callbacks to fix memory leak in `LocalVariables` integration (#7637)
 
 This fixes a memory leak in the opt-in [`LocalVariables` integration](https://blog.sentry.io/2023/02/01/local-variables-for-nodejs-in-sentry/), which adds local variables to the stacktraces sent to Sentry. The minimum recommended version to use the `LocalVariables` is now `7.46.0`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,61 @@
 # Deprecations in 7.x
 
+## Remove requirement for `@sentry/tracing` package (since 7.46.0)
+
+With `7.46.0` you no longer require the `@sentry/tracing` package to use tracing and performance monitoring with the Sentry JavaScript SDKs. The `@sentry/tracing` package will be removed in a future major release, but can still be used in the meantime.
+
+#### Browser:
+
+```js
+// Before
+import * as Sentry from "@sentry/browser";
+import { BrowserTracing } from "@sentry/tracing";
+
+Sentry.init({
+  dsn: '__DSN__',
+  tracesSampleRate: 1.0,
+  integrations: [
+    new BrowserTracing(),
+  ],
+});
+
+// After
+import * as Sentry from "@sentry/browser";
+
+Sentry.init({
+  dsn: '__DSN__',
+  tracesSampleRate: 1.0,
+  integrations: [
+    new Sentry.BrowserTracing(),
+  ],
+});
+```
+
+#### Node:
+
+```js
+// Before
+const Sentry = require("@sentry/node");
+require("@sentry/tracing");
+
+Sentry.init({
+  dsn: '__DSN__',
+  tracesSampleRate: 1.0,
+});
+
+// After
+const Sentry = require("@sentry/node");
+
+Sentry.init({
+  dsn: '__DSN__',
+  tracesSampleRate: 1.0,
+  integrations: [
+    // Automatically instrument Node.js libraries and frameworks
+    ...Sentry.autoDiscoverNodePerformanceMonitoringIntegrations(),
+  ],
+});
+```
+
 ## Replay options changed (since 7.35.0) - #6645
 
 Some options for replay have been depracted in favor of new APIs.


### PR DESCRIPTION
Merging straight to master as `7.46.0` was already merged with #7666