### PR TITLE
fix(sveltekit): Log error to console by default in `handleErrorWithSentry`

### DIFF
--- a/packages/sveltekit/src/client/handleError.ts
+++ b/packages/sveltekit/src/client/handleError.ts
@@ -30,8 +30,7 @@ export function handleErrorWithSentry(handleError: HandleClientError = defaultEr
       });
       return scope;
     });
-    if (handleError) {
-      return handleError(input);
-    }
+
+    return handleError(input);
   };
 }

--- a/packages/sveltekit/src/client/handleError.ts
+++ b/packages/sveltekit/src/client/handleError.ts
@@ -6,12 +6,19 @@ import { addExceptionMechanism } from '@sentry/utils';
 // eslint-disable-next-line import/no-unresolved
 import type { HandleClientError, NavigationEvent } from '@sveltejs/kit';
 
+// The SvelteKit default error handler just logs the error to the console
+// see: https://github.com/sveltejs/kit/blob/369e7d6851f543a40c947e033bfc4a9506fdc0a8/packages/kit/src/core/sync/write_client_manifest.js#LL127C2-L127C2
+function defaultErrorHandler({ error }: Parameters<HandleClientError>[0]): ReturnType<HandleClientError> {
+  // eslint-disable-next-line no-console
+  console.error(error);
+}
+
 /**
  * Wrapper for the SvelteKit error handler that sends the error to Sentry.
  *
  * @param handleError The original SvelteKit error handler.
  */
-export function handleErrorWithSentry(handleError?: HandleClientError): HandleClientError {
+export function handleErrorWithSentry(handleError: HandleClientError = defaultErrorHandler): HandleClientError {
   return (input: { error: unknown; event: NavigationEvent }): ReturnType<HandleClientError> => {
     captureException(input.error, scope => {
       scope.addEventProcessor(event => {

--- a/packages/sveltekit/test/client/handleError.test.ts
+++ b/packages/sveltekit/test/client/handleError.test.ts
@@ -55,26 +55,30 @@ describe('handleError', () => {
     mockScope = new Scope();
   });
 
-  it('falls back to default handler when handleError func is not provided', async () => {
-    const wrappedHandleError = handleErrorWithSentry();
-    const mockError = new Error('test');
-    const returnVal = await wrappedHandleError({ error: mockError, event: navigationEvent });
+  describe('calls captureException', () => {
+    it('invokes the default handler if no handleError func is provided', async () => {
+      const wrappedHandleError = handleErrorWithSentry();
+      const mockError = new Error('test');
+      const returnVal = await wrappedHandleError({ error: mockError, event: navigationEvent });
 
-    expect(returnVal).not.toBeDefined();
-    expect(mockCaptureException).toHaveBeenCalledTimes(1);
-    expect(mockCaptureException).toHaveBeenCalledWith(mockError, expect.any(Function));
-    // The default handler logs the error to the console
-    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
-  });
+      expect(returnVal).not.toBeDefined();
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
+      expect(mockCaptureException).toHaveBeenCalledWith(mockError, expect.any(Function));
+      // The default handler logs the error to the console
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    });
 
-  it('calls captureException', async () => {
-    const wrappedHandleError = handleErrorWithSentry(handleError);
-    const mockError = new Error('test');
-    const returnVal = (await wrappedHandleError({ error: mockError, event: navigationEvent })) as any;
+    it('invokes the user-procided error handler', async () => {
+      const wrappedHandleError = handleErrorWithSentry(handleError);
+      const mockError = new Error('test');
+      const returnVal = (await wrappedHandleError({ error: mockError, event: navigationEvent })) as any;
 
-    expect(returnVal.message).toEqual('Whoops!');
-    expect(mockCaptureException).toHaveBeenCalledTimes(1);
-    expect(mockCaptureException).toHaveBeenCalledWith(mockError, expect.any(Function));
+      expect(returnVal.message).toEqual('Whoops!');
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
+      expect(mockCaptureException).toHaveBeenCalledWith(mockError, expect.any(Function));
+      // Check that the default handler wasn't invoked
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(0);
+    });
   });
 
   it('adds an exception mechanism', async () => {

--- a/packages/sveltekit/test/client/handleError.test.ts
+++ b/packages/sveltekit/test/client/handleError.test.ts
@@ -45,14 +45,17 @@ const navigationEvent: NavigationEvent = {
   url: new URL('http://example.org/users/123'),
 };
 
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(_ => {});
+
 describe('handleError', () => {
   beforeEach(() => {
     mockCaptureException.mockClear();
     mockAddExceptionMechanism.mockClear();
+    consoleErrorSpy.mockClear();
     mockScope = new Scope();
   });
 
-  it('works when a handleError func is not provided', async () => {
+  it('falls back to default handler when handleError func is not provided', async () => {
     const wrappedHandleError = handleErrorWithSentry();
     const mockError = new Error('test');
     const returnVal = await wrappedHandleError({ error: mockError, event: navigationEvent });
@@ -60,6 +63,8 @@ describe('handleError', () => {
     expect(returnVal).not.toBeDefined();
     expect(mockCaptureException).toHaveBeenCalledTimes(1);
     expect(mockCaptureException).toHaveBeenCalledWith(mockError, expect.any(Function));
+    // The default handler logs the error to the console
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
   });
 
   it('calls captureException', async () => {

--- a/packages/sveltekit/test/client/handleError.test.ts
+++ b/packages/sveltekit/test/client/handleError.test.ts
@@ -68,7 +68,7 @@ describe('handleError', () => {
       expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('invokes the user-procided error handler', async () => {
+    it('invokes the user-provided error handler', async () => {
       const wrappedHandleError = handleErrorWithSentry(handleError);
       const mockError = new Error('test');
       const returnVal = (await wrappedHandleError({ error: mockError, event: navigationEvent })) as any;

--- a/packages/sveltekit/test/server/handleError.test.ts
+++ b/packages/sveltekit/test/server/handleError.test.ts
@@ -60,7 +60,7 @@ describe('handleError', () => {
       expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('invokes the user-procided error handler', async () => {
+    it('invokes the user-provided error handler', async () => {
       const wrappedHandleError = handleErrorWithSentry(handleError);
       const mockError = new Error('test');
       const returnVal = (await wrappedHandleError({ error: mockError, event: requestEvent })) as any;

--- a/packages/sveltekit/test/server/handleError.test.ts
+++ b/packages/sveltekit/test/server/handleError.test.ts
@@ -37,31 +37,40 @@ function handleError(_input: { error: unknown; event: RequestEvent }): ReturnTyp
 
 const requestEvent = {} as RequestEvent;
 
+const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(_ => {});
+
 describe('handleError', () => {
   beforeEach(() => {
     mockCaptureException.mockClear();
     mockAddExceptionMechanism.mockClear();
+    consoleErrorSpy.mockClear();
     mockScope = new Scope();
   });
 
-  it('works when a handleError func is not provided', async () => {
-    const wrappedHandleError = handleErrorWithSentry();
-    const mockError = new Error('test');
-    const returnVal = await wrappedHandleError({ error: mockError, event: requestEvent });
+  describe('calls captureException', () => {
+    it('invokes the default handler if no handleError func is provided', async () => {
+      const wrappedHandleError = handleErrorWithSentry();
+      const mockError = new Error('test');
+      const returnVal = await wrappedHandleError({ error: mockError, event: requestEvent });
 
-    expect(returnVal).not.toBeDefined();
-    expect(mockCaptureException).toHaveBeenCalledTimes(1);
-    expect(mockCaptureException).toHaveBeenCalledWith(mockError, expect.any(Function));
-  });
+      expect(returnVal).not.toBeDefined();
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
+      expect(mockCaptureException).toHaveBeenCalledWith(mockError, expect.any(Function));
+      // The default handler logs the error to the console
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    });
 
-  it('calls captureException', async () => {
-    const wrappedHandleError = handleErrorWithSentry(handleError);
-    const mockError = new Error('test');
-    const returnVal = (await wrappedHandleError({ error: mockError, event: requestEvent })) as any;
+    it('invokes the user-procided error handler', async () => {
+      const wrappedHandleError = handleErrorWithSentry(handleError);
+      const mockError = new Error('test');
+      const returnVal = (await wrappedHandleError({ error: mockError, event: requestEvent })) as any;
 
-    expect(returnVal.message).toEqual('Whoops!');
-    expect(mockCaptureException).toHaveBeenCalledTimes(1);
-    expect(mockCaptureException).toHaveBeenCalledWith(mockError, expect.any(Function));
+      expect(returnVal.message).toEqual('Whoops!');
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
+      expect(mockCaptureException).toHaveBeenCalledWith(mockError, expect.any(Function));
+      // Check that the default handler wasn't invoked
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(0);
+    });
   });
 
   it('adds an exception mechanism', async () => {


### PR DESCRIPTION
Previously, our `handleErrorWithSentry` wrapper did nothing if users didn't provide a custom error handler as an argument. While IMO it's good that the error handler is an optional parameter, this swallowed errors and didn't log them to the console anymore. 

This PR fixes that by adding a default error handler which our wrapper invokes if no custom handler was provided. The client- and server default handlers log the error to the console, exactly like the default handlers by SvelteKit ([client](https://github.com/sveltejs/kit/blob/369e7d6851f543a40c947e033bfc4a9506fdc0a8/packages/kit/src/core/sync/write_client_manifest.js#LL127C2-L127C2), [server](https://github.com/sveltejs/kit/blob/369e7d6851f543a40c947e033bfc4a9506fdc0a8/packages/kit/src/runtime/server/index.js#L43)).