### PR TITLE
ref(core): Remove check for scope in `_sendSessionUpdate`

### DIFF
--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -446,13 +446,10 @@ export class Hub implements HubInterface {
    */
   private _sendSessionUpdate(): void {
     const { scope, client } = this.getStackTop();
-    if (!scope) return;
 
     const session = scope.getSession();
-    if (session) {
-      if (client && client.captureSession) {
-        client.captureSession(session);
-      }
+    if (session && client && client.captureSession) {
+      client.captureSession(session);
     }
   }
 


### PR DESCRIPTION
With the changes in https://github.com/getsentry/sentry-javascript/pull/7551, this is no longer required. Let's save some bytes!