### PR TITLE
fix(remix): Remove unnecessary dependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "yarn@1.22.19",
   "private": true,
   "scripts": {
     "build": "node ./scripts/verify-packages-versions.js && run-s build:types build:transpile build:bundle",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "packageManager": "yarn@1.22.19",
   "private": true,
   "scripts": {
     "build": "node ./scripts/verify-packages-versions.js && run-s build:types build:transpile build:bundle",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -22,12 +22,10 @@
   "dependencies": {
     "@sentry/cli": "2.2.0",
     "@sentry/core": "7.46.0",
-    "@sentry/integrations": "7.46.0",
     "@sentry/node": "7.46.0",
     "@sentry/react": "7.46.0",
     "@sentry/types": "7.46.0",
     "@sentry/utils": "7.46.0",
-    "@sentry/webpack-plugin": "1.19.0",
     "tslib": "^1.9.3",
     "yargs": "^17.6.0"
   },


### PR DESCRIPTION
Webpack and intergration are not used in remix app. Webpack even brings older cli version which makes sentry even bigger.

https://packagephobia.com/result?p=@sentry/remix@7.46.0

<img width="868" alt="image" src="https://user-images.githubusercontent.com/5635476/229346059-c24473cb-02f8-433f-b008-c5e879dc8347.png">


Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
