### PR TITLE
fix(nextjs): Restore tree shaking capabilities

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -79,5 +79,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
We messed up in #6592 and destroyed tree shaking capabilities for webpack by entirely removing the `sideEffects` field in the package.json. This PR adds it back so tree shaking should be possible again.

Hopefully fixes https://github.com/getsentry/sentry-javascript/issues/7680