### PR TITLE
fix(integrations): Ensure HttpClient integration works with Axios

### DIFF
--- a/packages/browser-integration-tests/package.json
+++ b/packages/browser-integration-tests/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
     "@playwright/test": "^1.31.1",
+    "axios": "1.3.4",
     "babel-loader": "^8.2.2",
     "html-webpack-plugin": "^5.5.0",
     "pako": "^2.1.0",

--- a/packages/browser-integration-tests/suites/integrations/httpclient/axios/subject.js
+++ b/packages/browser-integration-tests/suites/integrations/httpclient/axios/subject.js
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+axios.get('http://localhost:7654/foo').then(response => {
+  console.log(response.data);
+});

--- a/packages/browser-integration-tests/suites/integrations/httpclient/axios/subject.js
+++ b/packages/browser-integration-tests/suites/integrations/httpclient/axios/subject.js
@@ -1,5 +1,9 @@
 import axios from 'axios';
 
-axios.get('http://localhost:7654/foo').then(response => {
-  console.log(response.data);
-});
+axios
+  .get('http://localhost:7654/foo', {
+    headers: { Accept: 'application/json', 'Content-Type': 'application/json', Cache: 'no-cache' },
+  })
+  .then(response => {
+    console.log(response.data);
+  });

--- a/packages/browser-integration-tests/suites/integrations/httpclient/axios/test.ts
+++ b/packages/browser-integration-tests/suites/integrations/httpclient/axios/test.ts
@@ -49,7 +49,6 @@ sentryTest(
         headers: {
           Accept: 'application/json',
           Cache: 'no-cache',
-          'Content-Type': 'application/json',
         },
       },
       contexts: {

--- a/packages/browser-integration-tests/suites/integrations/httpclient/axios/test.ts
+++ b/packages/browser-integration-tests/suites/integrations/httpclient/axios/test.ts
@@ -1,0 +1,67 @@
+import { expect } from '@playwright/test';
+import type { Event } from '@sentry/types';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
+
+sentryTest(
+  'should assign request and response context from a failed 500 XHR request',
+  async ({ getLocalTestPath, page }) => {
+    const url = await getLocalTestPath({ testDir: __dirname });
+
+    await page.route('**/foo', route => {
+      return route.fulfill({
+        status: 500,
+        body: JSON.stringify({
+          error: {
+            message: 'Internal Server Error',
+          },
+        }),
+        headers: {
+          'Content-Type': 'text/html',
+        },
+      });
+    });
+
+    const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
+
+    expect(eventData.exception?.values).toHaveLength(1);
+
+    // Not able to get the cookies from the request/response because of Playwright bug
+    // https://github.com/microsoft/playwright/issues/11035
+    expect(eventData).toMatchObject({
+      message: 'HTTP Client Error with status code: 500',
+      exception: {
+        values: [
+          {
+            type: 'Error',
+            value: 'HTTP Client Error with status code: 500',
+            mechanism: {
+              type: 'http.client',
+              handled: true,
+            },
+          },
+        ],
+      },
+      request: {
+        url: 'http://localhost:7654/foo',
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          Cache: 'no-cache',
+          'Content-Type': 'application/json',
+        },
+      },
+      contexts: {
+        response: {
+          status_code: 500,
+          body_size: 45,
+          headers: {
+            'content-type': 'text/html',
+            'content-length': '45',
+          },
+        },
+      },
+    });
+  },
+);

--- a/packages/replay/test/unit/coreHandlers/handleXhr.test.ts
+++ b/packages/replay/test/unit/coreHandlers/handleXhr.test.ts
@@ -1,4 +1,4 @@
-import type { HandlerDataXhr, SentryWrappedXMLHttpRequest } from '@sentry/types';
+import type { HandlerDataXhr, SentryWrappedXMLHttpRequest, SentryXhrData } from '@sentry/types';
 
 import { handleXhr } from '../../../src/coreHandlers/handleXhr';
 
@@ -9,6 +9,7 @@ const DEFAULT_DATA: HandlerDataXhr = {
       method: 'GET',
       url: '/api/0/organizations/sentry/',
       status_code: 200,
+      request_headers: {},
     },
   } as SentryWrappedXMLHttpRequest,
   startTimestamp: 10000,
@@ -45,7 +46,7 @@ describe('Unit | coreHandlers | handleXhr', () => {
       xhr: {
         ...DEFAULT_DATA.xhr,
         __sentry_xhr__: {
-          ...DEFAULT_DATA.xhr.__sentry_xhr__,
+          ...(DEFAULT_DATA.xhr.__sentry_xhr__ as SentryXhrData),
           request_body_size: 123,
           response_body_size: 456,
         },

--- a/packages/types/src/instrument.ts
+++ b/packages/types/src/instrument.ts
@@ -15,6 +15,7 @@ export interface SentryXhrData {
   body?: XHRSendInput;
   request_body_size?: number;
   response_body_size?: number;
+  request_headers: Record<string, string>;
 }
 
 export interface HandlerDataXhr {

--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -227,9 +227,10 @@ export function parseFetchArgs(fetchArgs: unknown[]): { method: string; url: str
     };
   }
 
+  const arg = fetchArgs[0];
   return {
-    url: getUrlFromResource(fetchArgs[0] as FetchResource),
-    method: 'GET',
+    url: getUrlFromResource(arg as FetchResource),
+    method: hasProp(arg, 'method') ? String(arg.method).toUpperCase() : 'GET',
   };
 }
 

--- a/packages/utils/test/instrument.test.ts
+++ b/packages/utils/test/instrument.test.ts
@@ -1,0 +1,30 @@
+import { parseFetchArgs } from '../src/instrument';
+
+describe('instrument', () => {
+  describe('parseFetchArgs', () => {
+    it.each([
+      ['string URL only', ['http://example.com'], { method: 'GET', url: 'http://example.com' }],
+      ['URL object only', [new URL('http://example.com')], { method: 'GET', url: 'http://example.com/' }],
+      ['Request URL only', [{ url: 'http://example.com' }], { method: 'GET', url: 'http://example.com' }],
+      [
+        'string URL & options',
+        ['http://example.com', { method: 'post' }],
+        { method: 'POST', url: 'http://example.com' },
+      ],
+      [
+        'URL object & options',
+        [new URL('http://example.com'), { method: 'post' }],
+        { method: 'POST', url: 'http://example.com/' },
+      ],
+      [
+        'Request URL & options',
+        [{ url: 'http://example.com' }, { method: 'post' }],
+        { method: 'POST', url: 'http://example.com' },
+      ],
+    ])('%s', (_name, args, expected) => {
+      const actual = parseFetchArgs(args as unknown[]);
+
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/packages/utils/test/instrument.test.ts
+++ b/packages/utils/test/instrument.test.ts
@@ -7,6 +7,11 @@ describe('instrument', () => {
       ['URL object only', [new URL('http://example.com')], { method: 'GET', url: 'http://example.com/' }],
       ['Request URL only', [{ url: 'http://example.com' }], { method: 'GET', url: 'http://example.com' }],
       [
+        'Request URL & method only',
+        [{ url: 'http://example.com', method: 'post' }],
+        { method: 'POST', url: 'http://example.com' },
+      ],
+      [
         'string URL & options',
         ['http://example.com', { method: 'post' }],
         { method: 'POST', url: 'http://example.com' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6686,6 +6686,15 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
+axios@1.3.4, axios@^1.2.2:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.3.4.tgz#f5760cefd9cfb51fd2481acf88c05f67c4523024"
+  integrity sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 axios@^0.27.2:
   version "0.27.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
@@ -6698,15 +6707,6 @@ axios@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.2.0.tgz#1cb65bd75162c70e9f8d118a905126c4a201d383"
   integrity sha512-zT7wZyNYu3N5Bu0wuZ6QccIf93Qk1eV8LOewxgjOZFd2DenOs98cJ7+Y6703d0wkaXGY6/nZd4EweJaHz9uzQw==
-  dependencies:
-    follow-redirects "^1.15.0"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
-axios@^1.2.2:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.3.4.tgz#f5760cefd9cfb51fd2481acf88c05f67c4523024"
-  integrity sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==
   dependencies:
     follow-redirects "^1.15.0"
     form-data "^4.0.0"


### PR DESCRIPTION
This updates the `HttpClient` integration to use the "regular" instrumentation handling, ensuring this works with Axios.

This also adds `request_headers` to the xhr info (which we'll also need for replay). 

It also ensures that we always correctly get the method/url from fetch options, even when they are other valid objects.

Closes https://github.com/getsentry/sentry-javascript/issues/7615