### PR TITLE
fix(tracing-internal): Add `sideEffects` field to `package.json`

### DIFF
--- a/packages/tracing-internal/package.json
+++ b/packages/tracing-internal/package.json
@@ -48,5 +48,6 @@
   },
   "volta": {
     "extends": "../../package.json"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
Adds `sideEffects: false` to the `tracing-internal` package so that it can be properly tree shaken by Webpack.
