### PR TITLE
ref(tracing): Re-add BrowserTracing static ID

### DIFF
--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -157,18 +157,18 @@ const DEFAULT_BROWSER_TRACING_OPTIONS: BrowserTracingOptions = {
  * any routing library. This integration uses {@see IdleTransaction} to create transactions.
  */
 export class BrowserTracing implements Integration {
-  // This class currently doesn't have a static `id` field like the other integration classes, because it prevented
-  // @sentry/tracing from being treeshaken. Tree shakers do not like static fields, because they behave like side effects.
-  // TODO: Come up with a better plan, than using static fields on integration classes, and use that plan on all
-  // integrations.
-
-  /** Browser Tracing integration options */
-  public options: BrowserTracingOptions;
+  /**
+   * @inheritDoc
+   */
+  public static id: string = BROWSER_TRACING_INTEGRATION_ID;
 
   /**
    * @inheritDoc
    */
   public name: string = BROWSER_TRACING_INTEGRATION_ID;
+
+  /** Browser Tracing integration options */
+  public options: BrowserTracingOptions;
 
   private _getCurrentHub?: () => Hub;
 


### PR DESCRIPTION
This was removed in https://github.com/getsentry/sentry-javascript/pull/5166 due to tree shaking concerns, however we have had a static ID for replay and it has been working fine so far.
