### PR TITLE
fix(core): Determine debug ID paths from the top of the stack

### DIFF
--- a/packages/core/src/utils/prepareEvent.ts
+++ b/packages/core/src/utils/prepareEvent.ts
@@ -127,7 +127,8 @@ export function applyDebugMetadata(event: Event, stackParser: StackParser): void
   // Build a map of filename -> debug_id
   const filenameDebugIdMap = Object.keys(debugIdMap).reduce<Record<string, string>>((acc, debugIdStackTrace) => {
     const parsedStack = stackParser(debugIdStackTrace);
-    for (const stackFrame of parsedStack) {
+    for (let i = parsedStack.length - 1; i >= 0; i--) {
+      const stackFrame = parsedStack[i];
       if (stackFrame.filename) {
         acc[stackFrame.filename] = debugIdMap[debugIdStackTrace];
         break;


### PR DESCRIPTION
In node (and probably other platforms too), the bottom frame of a trace often contains native code/filenames. See "internal/main/run_main_module.js" below:

```json
[
  {
    "function": "<anonymous>",
    "module": "run_main_module",
    "filename": "internal/main/run_main_module.js",
    "abs_path": "internal/main/run_main_module.js",
    "lineno": 17,
    "colno": 47,
    "in_app": false
  },
  {
    "function": "Function.executeUserEntryPoint [as runMain]",
    "module": "run_main",
    "filename": "internal/modules/run_main.js",
    "abs_path": "internal/modules/run_main.js",
    "lineno": 75,
    "colno": 12,
    "in_app": false
  },
  {
    "function": "Module._load",
    "module": "loader",
    "filename": "internal/modules/cjs/loader.js",
    "abs_path": "internal/modules/cjs/loader.js",
    "lineno": 790,
    "colno": 12,
    "in_app": false
  },
  {
    "function": "Module.load",
    "module": "loader",
    "filename": "internal/modules/cjs/loader.js",
    "abs_path": "internal/modules/cjs/loader.js",
    "lineno": 950,
    "colno": 32,
    "in_app": false
  },
  {
    "function": "Module._extensions..js",
    "module": "loader",
    "filename": "internal/modules/cjs/loader.js",
    "abs_path": "internal/modules/cjs/loader.js",
    "lineno": 1114,
    "colno": 10,
    "in_app": false
  },
  {
    "function": "Module._compile",
    "module": "loader",
    "filename": "internal/modules/cjs/loader.js",
    "abs_path": "internal/modules/cjs/loader.js",
    "lineno": 1085,
    "colno": 14,
    "in_app": false
  },
  {
    "function": "Object.<anonymous>",
    "module": "entrypoint3",
    "filename": "/Users/lucaforstner/code/github/getsentry/sentry-javascript-bundler-plugins/packages/playground/out/rollup/entrypoint3.js",
    "abs_path": "/Users/lucaforstner/code/github/getsentry/sentry-javascript-bundler-plugins/packages/playground/out/rollup/entrypoint3.js",
    "lineno": 58,
    "colno": 36,
    "in_app": true
  }
]
```

Up until now, for debug ID resolving, we took the first frame that had a filename from the bottom of the stack. When an error occurs, In the lookup logic of the debug IDs we go from the top, meaning that the debug ID will not work when there are native frames/filenames.

This pr fixes this by simply going through the stack frame in reverse.