### PR TITLE
feat(replay): Restrict network JSON bodies to max depth

### DIFF
--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -489,12 +489,17 @@ export type FetchHint = FetchBreadcrumbHint & {
   response: Response;
 };
 
-export type NetworkBody = Record<string, unknown> | string;
+export type JsonObject = Record<string, unknown>;
+export type JsonArray = unknown[];
+
+export type NetworkBody = JsonObject | JsonArray | string;
 
 type NetworkMetaError = 'MAX_BODY_SIZE_EXCEEDED';
+export type NetworkMetaWarning = 'MAX_JSON_DEPTH_EXCEEDED';
 
 interface NetworkMeta {
   errors?: NetworkMetaError[];
+  warnings?: NetworkMetaWarning[];
 }
 
 export interface ReplayNetworkRequestOrResponse {


### PR DESCRIPTION
This restricts JSON bodies for replay network breadcrumbs to a max. depth of 6. If exceeding this, it will:

* Replace child nodes with `[~MaxDepth]`
* Add a warning to the `_meta` key: `MAX_JSON_DEPTH_EXCEEDED`

This is not perfect, but relatively straightforward.

## Caveats

We still do the check for `MAX_BODY_SIZE_EXCEEDED` _before_ doing this check. The reason is that otherwise we need to always process this first, serialize it again, get the length, in order to check this - feels like a lot of overhead 😬 IMHO this is OK for now (so no processing & skipping over 300k, below that we limit to 6 levels deep).

Closes https://github.com/getsentry/sentry-javascript/issues/7531