### PR TITLE
fix(sveltekit): Don't capture thrown `Redirect`s as exceptions

### DIFF
--- a/packages/sveltekit/src/client/load.ts
+++ b/packages/sveltekit/src/client/load.ts
@@ -3,10 +3,17 @@ import { captureException } from '@sentry/svelte';
 import { addExceptionMechanism, objectify } from '@sentry/utils';
 import type { LoadEvent } from '@sveltejs/kit';
 
+import { isRedirect } from '../common/utils';
+
 function sendErrorToSentry(e: unknown): unknown {
   // In case we have a primitive, wrap it in the equivalent wrapper class (string -> String, etc.) so that we can
   // store a seen flag on it.
   const objectifiedErr = objectify(e);
+
+  // We don't want to capture thrown `Redirect`s as these are not errors but expected behaviour
+  if (isRedirect(objectifiedErr)) {
+    return objectifiedErr;
+  }
 
   captureException(objectifiedErr, scope => {
     scope.addEventProcessor(event => {

--- a/packages/sveltekit/src/common/utils.ts
+++ b/packages/sveltekit/src/common/utils.ts
@@ -1,0 +1,16 @@
+import type { Redirect } from '@sveltejs/kit';
+
+/**
+ * Determines if a thrown "error" is a Redirect object which SvelteKit users can throw to redirect to another route
+ * see: https://kit.svelte.dev/docs/modules#sveltejs-kit-redirect
+ * @param error the potential redirect error
+ */
+export function isRedirect(error: unknown): error is Redirect {
+  if (error == null || typeof error !== 'object') {
+    return false;
+  }
+  const hasValidLocation = 'location' in error && typeof error.location === 'string';
+  const hasValidStatus =
+    'status' in error && typeof error.status === 'number' && error.status >= 300 && error.status <= 308;
+  return hasValidLocation && hasValidStatus;
+}

--- a/packages/sveltekit/test/client/load.test.ts
+++ b/packages/sveltekit/test/client/load.test.ts
@@ -1,5 +1,6 @@
 import { addTracingExtensions, Scope } from '@sentry/svelte';
-import { Load, redirect } from '@sveltejs/kit';
+import type { Load } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 import { vi } from 'vitest';
 
 import { wrapLoadWithSentry } from '../../src/client/load';

--- a/packages/sveltekit/test/common/utils.test.ts
+++ b/packages/sveltekit/test/common/utils.test.ts
@@ -1,0 +1,25 @@
+import { isRedirect } from '../../src/common/utils';
+
+describe('isRedirect', () => {
+  it.each([
+    { location: '/users/id', status: 300 },
+    { location: '/users/id', status: 304 },
+    { location: '/users/id', status: 308 },
+    { location: '', status: 308 },
+  ])('returns `true` for valid Redirect objects', redirectObject => {
+    expect(isRedirect(redirectObject)).toBe(true);
+  });
+
+  it.each([
+    300,
+    'redirect',
+    { location: { route: { id: 'users/id' } }, status: 300 },
+    { status: 308 },
+    { location: '/users/id' },
+    { location: '/users/id', status: 201 },
+    { location: '/users/id', status: 400 },
+    { location: '/users/id', status: 500 },
+  ])('returns `false` for invalid Redirect objects', redirectObject => {
+    expect(isRedirect(redirectObject)).toBe(false);
+  });
+});


### PR DESCRIPTION
As outlined in the [SvelteKit docs](https://kit.svelte.dev/docs/load#redirects), users can `throw redirect(300, 'route/to/redirect')` in `load` functions. We don't want to capture these as errors and send them to Sentry.

closes #7719 