### PR TITLE
fix(node): Redact URL authority only in breadcrumbs and spans

### DIFF
--- a/packages/node/src/integrations/utils/http.ts
+++ b/packages/node/src/integrations/utils/http.ts
@@ -48,7 +48,8 @@ export function extractUrl(requestOptions: RequestOptions): string {
     !requestOptions.port || requestOptions.port === 80 || requestOptions.port === 443 ? '' : `:${requestOptions.port}`;
   // do not include search or hash in span descriptions, per https://develop.sentry.dev/sdk/data-handling/#structuring-data
   const path = requestOptions.pathname || '/';
-  const authority = requestOptions.auth ? `${requestOptions.auth}@` : '';
+  // // always filter authority, see https://develop.sentry.dev/sdk/data-handling/#structuring-data
+  const authority = requestOptions.auth ? '[Filtered]:[Filtered]@' : '';
 
   return `${protocol}//${authority}${hostname}${port}${path}`;
 }
@@ -123,8 +124,7 @@ export function urlToOptions(url: URL): RequestOptions {
     options.port = Number(url.port);
   }
   if (url.username || url.password) {
-    // always filter authority, see https://develop.sentry.dev/sdk/data-handling/#structuring-data
-    options.auth = '[Filtered]:[Filtered]';
+    options.auth = `${url.username}:${url.password}`;
   }
   return options;
 }

--- a/packages/node/src/integrations/utils/http.ts
+++ b/packages/node/src/integrations/utils/http.ts
@@ -48,7 +48,7 @@ export function extractUrl(requestOptions: RequestOptions): string {
     !requestOptions.port || requestOptions.port === 80 || requestOptions.port === 443 ? '' : `:${requestOptions.port}`;
   // do not include search or hash in span descriptions, per https://develop.sentry.dev/sdk/data-handling/#structuring-data
   const path = requestOptions.pathname || '/';
-  // // always filter authority, see https://develop.sentry.dev/sdk/data-handling/#structuring-data
+  // always filter authority, see https://develop.sentry.dev/sdk/data-handling/#structuring-data
   const authority = requestOptions.auth ? '[Filtered]:[Filtered]@' : '';
 
   return `${protocol}//${authority}${hostname}${port}${path}`;

--- a/packages/node/src/integrations/utils/http.ts
+++ b/packages/node/src/integrations/utils/http.ts
@@ -49,9 +49,14 @@ export function extractUrl(requestOptions: RequestOptions): string {
   // do not include search or hash in span descriptions, per https://develop.sentry.dev/sdk/data-handling/#structuring-data
   const path = requestOptions.pathname || '/';
   // always filter authority, see https://develop.sentry.dev/sdk/data-handling/#structuring-data
-  const authority = requestOptions.auth ? '[Filtered]:[Filtered]@' : '';
+  const authority = requestOptions.auth ? redactAuthority(requestOptions.auth) : '';
 
   return `${protocol}//${authority}${hostname}${port}${path}`;
+}
+
+function redactAuthority(auth: string): string {
+  const [user, password] = auth.split(':');
+  return `${user ? '[Filtered]' : ''}:${password ? '[Filtered]' : ''}@`;
 }
 
 /**

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -229,6 +229,20 @@ describe('tracing', () => {
     expect(spans[1].description).toEqual('GET http://[Filtered]:[Filtered]@dogs.are.great/');
   });
 
+  it.only('filters the authority (password) in span description', () => {
+    nock('http://username:password@dogs.are.great').get('/').reply(200);
+
+    const transaction = createTransactionOnScope();
+    const spans = (transaction as unknown as Span).spanRecorder?.spans as Span[];
+
+    http.get('http://:password@dogs.are.great/');
+
+    expect(spans.length).toEqual(2);
+
+    // our span is at index 1 because the transaction itself is at index 0
+    expect(spans[1].description).toEqual('GET http://[Filtered]:[Filtered]@dogs.are.great/');
+  });
+
   describe('Tracing options', () => {
     beforeEach(() => {
       // hacky way of restoring monkey patched functions


### PR DESCRIPTION
In #7667 we missed that our `urlToOptions` helper function is actually called to normalize request options that are then passed to the actual http client. Meaning, we shouldn't have redacted the authority in this function but at a later time when we extract the sanitized version (`extractUrl`). This PR changes the redaction location accordingly and hence fixes requests with authority not being sent properly. 

closes #7724 