### PR TITLE
feat(replay): Change `flush()` API to record current event buffer

### DIFF
--- a/packages/replay/src/coreHandlers/handleAfterSendEvent.ts
+++ b/packages/replay/src/coreHandlers/handleAfterSendEvent.ts
@@ -53,19 +53,9 @@ export function handleAfterSendEvent(replay: ReplayContainer): AfterSendEventCal
       event.exception &&
       event.message !== UNABLE_TO_SEND_REPLAY // ignore this error because otherwise we could loop indefinitely with trying to capture replay and failing
     ) {
-      setTimeout(async () => {
-        // Allow flush to complete before resuming as a session recording, otherwise
-        // the checkout from `startRecording` may be included in the payload.
-        // Prefer to keep the error replay as a separate (and smaller) segment
-        // than the session replay.
-        await replay.flushImmediate();
-
-        if (replay.stopRecording()) {
-          // Reset all "capture on error" configuration before
-          // starting a new recording
-          replay.recordingMode = 'session';
-          replay.startRecording();
-        }
+      setTimeout(() => {
+        // Capture current event buffer as new replay
+        void replay.capture();
       });
     }
   };

--- a/packages/replay/src/coreHandlers/handleAfterSendEvent.ts
+++ b/packages/replay/src/coreHandlers/handleAfterSendEvent.ts
@@ -55,7 +55,7 @@ export function handleAfterSendEvent(replay: ReplayContainer): AfterSendEventCal
     ) {
       setTimeout(() => {
         // Capture current event buffer as new replay
-        void replay.capture();
+        void replay.sendBufferedReplayOrFlush();
       });
     }
   };

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -216,11 +216,11 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
   }
 
   /**
-   * If not in "session" recording mode, flush event buffer which will create a new replay.
+   * Immediately send all pending events. In buffer-mode, this should be used
+   * to capture the initial replay.
+   *
    * Unless `continueRecording` is false, the replay will continue to record and
    * behave as a "session"-based replay.
-   *
-   * Otherwise, queue up a flush.
    */
   public flush(options?: SendBufferedReplayOptions): Promise<void> | void {
     if (!this._replay || !this._replay.isEnabled()) {

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -4,7 +4,7 @@ import { dropUndefinedKeys } from '@sentry/utils';
 
 import { DEFAULT_FLUSH_MAX_DELAY, DEFAULT_FLUSH_MIN_DELAY } from './constants';
 import { ReplayContainer } from './replay';
-import type { RecordingOptions, ReplayConfiguration, ReplayPluginOptions } from './types';
+import type { RecordingOptions, ReplayConfiguration, ReplayPluginOptions, SendBufferedReplayOptions } from './types';
 import { getPrivacyOptions } from './util/getPrivacyOptions';
 import { isBrowser } from './util/isBrowser';
 
@@ -216,27 +216,18 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
   }
 
   /**
-   * Immediately send all pending events.
+   * If not in "session" recording mode, flush event buffer which will create a new replay.
+   * Unless `continueRecording` is false, the replay will continue to record and
+   * behave as a "session"-based replay.
+   *
+   * Otherwise, queue up a flush.
    */
-  public flush(): Promise<void> | void {
+  public flush(options?: SendBufferedReplayOptions): Promise<void> | void {
     if (!this._replay || !this._replay.isEnabled()) {
       return;
     }
 
-    return this._replay.flushImmediate();
-  }
-
-  /**
-   * If not in "session" recording mode, flush event buffer (i.e. creates a new replay).
-   * Unless `continueRecording` is false, the replay will continue to record and
-   * behave as a "session"-based replay.
-   */
-  public async capture(continueRecording: boolean = true): Promise<void> {
-    if (!this._replay) {
-      return;
-    }
-
-    return this._replay.capture(continueRecording);
+    return this._replay.sendBufferedReplayOrFlush(options);
   }
 
   /** Setup the integration. */

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -226,6 +226,19 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
     return this._replay.flushImmediate();
   }
 
+  /**
+   * If not in "session" recording mode, flush event buffer (i.e. creates a new replay).
+   * Unless `continueRecording` is false, the replay will continue to record and
+   * behave as a "session"-based replay.
+   */
+  public async capture(continueRecording: boolean = true): Promise<void> {
+    if (!this._replay) {
+      return;
+    }
+
+    return this._replay.capture(continueRecording);
+  }
+
   /** Setup the integration. */
   private _setup(): void {
     // Client is not available in constructor, so we need to wait until setupOnce

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -299,9 +299,8 @@ export class ReplayContainer implements ReplayContainerInterface {
    * Otherwise, queue up a flush.
    */
   public async sendBufferedReplayOrFlush({ continueRecording = true }: SendBufferedReplayOptions = {}): Promise<void> {
-    // if in session mode, call debounced flush
     if (this.recordingMode === 'session') {
-      return this._debouncedFlush() as Promise<void>;
+      return this.flushImmediate();
     }
 
     // Allow flush to complete before resuming as a session recording, otherwise

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -311,17 +311,16 @@ export class ReplayContainer implements ReplayContainerInterface {
 
     const hasStoppedRecording = this.stopRecording();
 
-    if (!continueRecording) {
+    if (!continueRecording || !hasStoppedRecording) {
       return;
     }
 
     // Re-start recording, but in "session" recording mode
-    if (hasStoppedRecording) {
-      // Reset all "capture on error" configuration before
-      // starting a new recording
-      this.recordingMode = 'session';
-      this.startRecording();
-    }
+
+    // Reset all "capture on error" configuration before
+    // starting a new recording
+    this.recordingMode = 'session';
+    this.startRecording();
   }
 
   /**

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -309,12 +309,14 @@ export class ReplayContainer implements ReplayContainerInterface {
     // than the session replay.
     await this.flushImmediate();
 
+    const hasStoppedRecording = this.stopRecording();
+
     if (!continueRecording) {
       return;
     }
 
-    // Stop and re-start recording, but in "session" recording mode
-    if (this.stopRecording()) {
+    // Re-start recording, but in "session" recording mode
+    if (hasStoppedRecording) {
       // Reset all "capture on error" configuration before
       // starting a new recording
       this.recordingMode = 'session';

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -19,6 +19,7 @@ import type {
   RecordingOptions,
   ReplayContainer as ReplayContainerInterface,
   ReplayPluginOptions,
+  SendBufferedReplayOptions,
   Session,
   Timeouts,
 } from './types';
@@ -216,7 +217,9 @@ export class ReplayContainer implements ReplayContainerInterface {
 
   /**
    * Stops the recording, if it was running.
-   * Returns true if it was stopped, else false.
+   *
+   * Returns true if it was previously stopped, or is now stopped,
+   *  * else false.
    */
   public stopRecording(): boolean {
     try {
@@ -293,10 +296,10 @@ export class ReplayContainer implements ReplayContainerInterface {
    * Unless `continueRecording` is false, the replay will continue to record and
    * behave as a "session"-based replay.
    */
-  public async capture(continueRecording: boolean = true): Promise<void> {
+  public async sendBufferedReplayOrFlush({ continueRecording = true }: SendBufferedReplayOptions = {}): Promise<void> {
     // Don't allow if in session mode, use `flush()` instead
     if (this.recordingMode === 'session') {
-      return;
+      return this._debouncedFlush() as Promise<void>;
     }
 
     // Allow flush to complete before resuming as a session recording, otherwise

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -219,7 +219,7 @@ export class ReplayContainer implements ReplayContainerInterface {
    * Stops the recording, if it was running.
    *
    * Returns true if it was previously stopped, or is now stopped,
-   *  * else false.
+   * otherwise false.
    */
   public stopRecording(): boolean {
     try {
@@ -292,12 +292,14 @@ export class ReplayContainer implements ReplayContainerInterface {
   }
 
   /**
-   * If not in "session" recording mode, flush event buffer (i.e. creates a new replay).
+   * If not in "session" recording mode, flush event buffer which will create a new replay.
    * Unless `continueRecording` is false, the replay will continue to record and
    * behave as a "session"-based replay.
+   *
+   * Otherwise, queue up a flush.
    */
   public async sendBufferedReplayOrFlush({ continueRecording = true }: SendBufferedReplayOptions = {}): Promise<void> {
-    // Don't allow if in session mode, use `flush()` instead
+    // if in session mode, call debounced flush
     if (this.recordingMode === 'session') {
       return this._debouncedFlush() as Promise<void>;
     }

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -424,6 +424,10 @@ export interface EventBuffer {
 
 export type AddUpdateCallback = () => boolean | void;
 
+export interface SendBufferedReplayOptions {
+  continueRecording?: boolean;
+}
+
 export interface ReplayContainer {
   eventBuffer: EventBuffer | null;
   performanceEvents: AllPerformanceEntry[];
@@ -442,7 +446,7 @@ export interface ReplayContainer {
   resume(): void;
   startRecording(): void;
   stopRecording(): boolean;
-  capture(continueOnError?: boolean): Promise<void>;
+  sendBufferedReplayOrFlush(options?: SendBufferedReplayOptions): Promise<void>;
   flushImmediate(): Promise<void>;
   triggerUserActivity(): void;
   addUpdate(cb: AddUpdateCallback): void;

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -442,7 +442,8 @@ export interface ReplayContainer {
   resume(): void;
   startRecording(): void;
   stopRecording(): boolean;
-  flushImmediate(): void;
+  capture(continueOnError?: boolean): Promise<void>;
+  flushImmediate(): Promise<void>;
   triggerUserActivity(): void;
   addUpdate(cb: AddUpdateCallback): void;
   getOptions(): ReplayPluginOptions;

--- a/packages/replay/test/integration/errorSampleRate.test.ts
+++ b/packages/replay/test/integration/errorSampleRate.test.ts
@@ -173,7 +173,7 @@ describe('Integration | errorSampleRate', () => {
     await new Promise(process.nextTick);
     expect(replay).not.toHaveLastSentReplay();
 
-    replay.sendBufferedReplayOrFlush({continueRecording: false})
+    replay.sendBufferedReplayOrFlush({ continueRecording: false });
 
     await new Promise(process.nextTick);
     jest.advanceTimersByTime(DEFAULT_FLUSH_MIN_DELAY);


### PR DESCRIPTION
This changes the public API: `flush` to:
* in session-mode, call debounced flush instead of flushing immediately
* in non-session mode, record the current event buffer and by default, convert the replay type to "session" and continue recording.
 
Essentially, we have extracted the same logic that was used for "onError" capturing and made it a public API.


Closes #7737 