### PR TITLE
feat(node): Replace usages of domain `run` and `bind` with `runWithHub`

### DIFF
--- a/packages/nextjs/src/server/utils/wrapperUtils.ts
+++ b/packages/nextjs/src/server/utils/wrapperUtils.ts
@@ -1,7 +1,7 @@
 import { captureException, getActiveTransaction, getCurrentHub, startTransaction } from '@sentry/core';
+import { runWithHub } from '@sentry/node';
 import type { Transaction } from '@sentry/types';
 import { baggageHeaderToDynamicSamplingContext, extractTraceparentData } from '@sentry/utils';
-import * as domain from 'domain';
 import type { IncomingMessage, ServerResponse } from 'http';
 
 import { platformSupportsStreaming } from './platformSupportsStreaming';
@@ -75,7 +75,7 @@ export function withTracedServerSideDataFetcher<F extends (...args: any[]) => Pr
   },
 ): (...params: Parameters<F>) => Promise<ReturnType<F>> {
   return async function (this: unknown, ...args: Parameters<F>): Promise<ReturnType<F>> {
-    return domain.create().bind(async () => {
+    return runWithHub(async () => {
       let requestTransaction: Transaction | undefined = getTransactionFromRequest(req);
       let dataFetcherSpan;
 
@@ -154,7 +154,7 @@ export function withTracedServerSideDataFetcher<F extends (...args: any[]) => Pr
           await flushQueue();
         }
       }
-    })();
+    });
   };
 }
 

--- a/packages/nextjs/src/server/wrapServerComponentWithSentry.ts
+++ b/packages/nextjs/src/server/wrapServerComponentWithSentry.ts
@@ -1,6 +1,6 @@
 import { addTracingExtensions, captureException, getCurrentHub, startTransaction } from '@sentry/core';
+import { runWithHub } from '@sentry/node';
 import { baggageHeaderToDynamicSamplingContext, extractTraceparentData } from '@sentry/utils';
-import * as domain from 'domain';
 
 import { isNotFoundNavigationError, isRedirectNavigationError } from '../common/nextNavigationErrorUtils';
 import type { ServerComponentContext } from '../common/types';
@@ -21,7 +21,7 @@ export function wrapServerComponentWithSentry<F extends (...args: any[]) => any>
   // hook. 🤯
   return new Proxy(appDirComponent, {
     apply: (originalFunction, thisArg, args) => {
-      return domain.create().bind(() => {
+      return runWithHub(() => {
         let maybePromiseResult;
 
         const traceparentData = context.sentryTraceHeader
@@ -85,7 +85,7 @@ export function wrapServerComponentWithSentry<F extends (...args: any[]) => any>
           transaction.finish();
           return maybePromiseResult;
         }
-      })();
+      });
     },
   });
 }

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -57,7 +57,7 @@ export { NodeClient } from './client';
 export { makeNodeTransport } from './transports';
 export { defaultIntegrations, init, defaultStackParser, lastEventId, flush, close, getSentryRelease } from './sdk';
 export { addRequestDataToEvent, DEFAULT_USER_INCLUDES, extractRequestData } from './requestdata';
-export { deepReadDirSync } from './utils';
+export { deepReadDirSync, runWithHub } from './utils';
 
 import { getMainCarrier, Integrations as CoreIntegrations } from '@sentry/core';
 import * as domain from 'domain';

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */
 import { getActiveTransaction, hasTracingEnabled } from '@sentry/core';
 import type { Hub } from '@sentry/node';
-import { captureException, getCurrentHub } from '@sentry/node';
+import { captureException, getCurrentHub, runWithHub } from '@sentry/node';
 import type { Transaction, TransactionSource, WrappedFunction } from '@sentry/types';
 import {
   addExceptionMechanism,
@@ -13,7 +13,6 @@ import {
   loadModule,
   logger,
 } from '@sentry/utils';
-import * as domain from 'domain';
 
 import type {
   AppData,
@@ -314,13 +313,11 @@ function wrapRequestHandler(origRequestHandler: RequestHandler, build: ServerBui
   const pkg = loadModule<ReactRouterDomPkg>('react-router-dom');
 
   return async function (this: unknown, request: RemixRequest, loadContext?: unknown): Promise<Response> {
-    const local = domain.create();
-
     // Waiting for the next tick to make sure that the domain is active
     // https://github.com/nodejs/node/issues/40999#issuecomment-1002719169
     await new Promise(resolve => setImmediate(resolve));
 
-    return local.bind(async () => {
+    return runWithHub(async () => {
       const hub = getCurrentHub();
       const options = hub.getClient()?.getOptions();
       const scope = hub.getScope();
@@ -365,7 +362,7 @@ function wrapRequestHandler(origRequestHandler: RequestHandler, build: ServerBui
       transaction.finish();
 
       return res;
-    })();
+    });
   };
 }
 

--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -1,10 +1,9 @@
 /* eslint-disable @sentry-internal/sdk/no-optional-chaining */
 import type { Span } from '@sentry/core';
 import { getActiveTransaction, getCurrentHub, trace } from '@sentry/core';
-import { captureException } from '@sentry/node';
+import { captureException, runWithHub } from '@sentry/node';
 import { addExceptionMechanism, dynamicSamplingContextToSentryBaggageHeader, objectify } from '@sentry/utils';
 import type { Handle, ResolveOptions } from '@sveltejs/kit';
-import * as domain from 'domain';
 
 import { getTracePropagationData } from './utils';
 
@@ -67,9 +66,9 @@ export const sentryHandle: Handle = input => {
   if (getCurrentHub().getScope().getSpan()) {
     return instrumentHandle(input);
   }
-  return domain.create().bind(() => {
+  return runWithHub(() => {
     return instrumentHandle(input);
-  })();
+  });
 };
 
 function instrumentHandle({ event, resolve }: Parameters<Handle>[0]): ReturnType<Handle> {


### PR DESCRIPTION
Ref: #7691

The plan is to to make async context scope tracking configurable and the first step is to have the existing domain solution working from a single function.