### PR TITLE
fix(node): Disable `LocalVariables` integration on Node < v18

### DIFF
--- a/packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
+++ b/packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
@@ -1,13 +1,10 @@
 import type { Event } from '@sentry/node';
-import { parseSemver } from '@sentry/utils';
 import * as childProcess from 'child_process';
 import * as path from 'path';
 
-const nodeMajor = parseSemver(process.version.slice(1)).major || 1;
+import { conditionalTest } from '../../../utils';
 
-const testIf = (condition: boolean, t: jest.It) => (condition ? t : t.skip);
-
-describe('LocalVariables integration', () => {
+conditionalTest({ min: 18 })('LocalVariables integration', () => {
   test('Should not include local variables by default', done => {
     expect.assertions(2);
 
@@ -57,7 +54,7 @@ describe('LocalVariables integration', () => {
     });
   });
 
-  testIf(nodeMajor > 10, test)('Should include local variables with ESM', done => {
+  test('Should include local variables with ESM', done => {
     expect.assertions(4);
 
     const testScriptPath = path.resolve(__dirname, 'local-variables-caught.mjs');

--- a/packages/node/src/integrations/localvariables.ts
+++ b/packages/node/src/integrations/localvariables.ts
@@ -1,8 +1,8 @@
 import type { Event, EventProcessor, Exception, Hub, Integration, StackFrame, StackParser } from '@sentry/types';
-import { parseSemver } from '@sentry/utils';
 import type { Debugger, InspectorNotification, Runtime, Session } from 'inspector';
 import { LRUMap } from 'lru_map';
 
+import { NODE_VERSION } from '../nodeVersion';
 import type { NodeClientOptions } from '../types';
 
 type Variables = Record<string, unknown>;
@@ -284,7 +284,7 @@ export class LocalVariables implements Integration {
   ): void {
     // Only setup this integration if the Node version is >= v18
     // https://github.com/getsentry/sentry-javascript/issues/7697
-    const supportedNodeVersion = (parseSemver(process.version).major || 0) >= 18;
+    const supportedNodeVersion = (NODE_VERSION.major || 0) >= 18;
 
     if (this._session && clientOptions?.includeLocalVariables && supportedNodeVersion) {
       this._session.configureAndConnect(

--- a/packages/node/src/integrations/localvariables.ts
+++ b/packages/node/src/integrations/localvariables.ts
@@ -1,10 +1,10 @@
 import type { Event, EventProcessor, Exception, Hub, Integration, StackFrame, StackParser } from '@sentry/types';
+import { logger } from '@sentry/utils';
 import type { Debugger, InspectorNotification, Runtime, Session } from 'inspector';
 import { LRUMap } from 'lru_map';
 
 import { NODE_VERSION } from '../nodeVersion';
 import type { NodeClientOptions } from '../types';
-import { logger } from '@sentry/utils';
 
 type Variables = Record<string, unknown>;
 type OnPauseEvent = InspectorNotification<Debugger.PausedEventDataType>;

--- a/packages/node/test/integrations/localvariables.test.ts
+++ b/packages/node/test/integrations/localvariables.test.ts
@@ -5,7 +5,10 @@ import type { LRUMap } from 'lru_map';
 import { defaultStackParser } from '../../src';
 import type { DebugSession, FrameVariables } from '../../src/integrations/localvariables';
 import { createCallbackList, LocalVariables } from '../../src/integrations/localvariables';
+import { NODE_VERSION } from '../../src/nodeVersion';
 import { getDefaultNodeClientOptions } from '../../test/helper/node-client-options';
+
+const describeIf = (condition: boolean) => (condition ? describe : describe.skip);
 
 interface ThrowOn {
   configureAndConnect?: boolean;
@@ -145,7 +148,7 @@ const exceptionEvent100Frames = {
   },
 };
 
-describe('LocalVariables', () => {
+describeIf(NODE_VERSION >= 18)('LocalVariables', () => {
   it('Adds local variables to stack frames', async () => {
     expect.assertions(7);
 


### PR DESCRIPTION
It looks like the v8 inspector API has some incompatibilities with domains and async which cause them to not be GC'd in a reasonable timeframe for it to be used in production applications.

This PR causes the `LocalVariables` integration not to be enabled if the Node version is less than v18.
