### PR TITLE
fix(replay): Ensure circular references are handled

### DIFF
--- a/packages/replay/src/eventBuffer/EventBufferArray.ts
+++ b/packages/replay/src/eventBuffer/EventBufferArray.ts
@@ -1,3 +1,5 @@
+import { normalize } from '@sentry/utils';
+
 import type { AddEventResult, EventBuffer, RecordingEvent } from '../types';
 
 /**
@@ -41,7 +43,7 @@ export class EventBufferArray implements EventBuffer {
       // attachment.
       const eventsRet = this.events;
       this.events = [];
-      resolve(JSON.stringify(eventsRet));
+      resolve(JSON.stringify(normalize(eventsRet)));
     });
   }
 }

--- a/packages/replay/src/eventBuffer/EventBufferCompressionWorker.ts
+++ b/packages/replay/src/eventBuffer/EventBufferCompressionWorker.ts
@@ -1,4 +1,5 @@
 import type { ReplayRecordingData } from '@sentry/types';
+import { normalize } from '@sentry/utils';
 
 import type { AddEventResult, EventBuffer, RecordingEvent } from '../types';
 import { WorkerHandler } from './WorkerHandler';
@@ -61,7 +62,7 @@ export class EventBufferCompressionWorker implements EventBuffer {
    * Send the event to the worker.
    */
   private _sendEventToWorker(event: RecordingEvent): Promise<AddEventResult> {
-    return this._worker.postMessage<void>('addEvent', JSON.stringify(event));
+    return this._worker.postMessage<void>('addEvent', JSON.stringify(normalize(event)));
   }
 
   /**

--- a/packages/replay/test/unit/eventBuffer/EventBufferArray.test.ts
+++ b/packages/replay/test/unit/eventBuffer/EventBufferArray.test.ts
@@ -1,3 +1,4 @@
+import type { RecordingEvent } from '../../../src/types';
 import { createEventBuffer } from './../../../src/eventBuffer';
 import { BASE_TIMESTAMP } from './../../index';
 
@@ -41,5 +42,18 @@ describe('Unit | eventBuffer | EventBufferArray', () => {
 
     expect(result1).toEqual(JSON.stringify([TEST_EVENT]));
     expect(result2).toEqual(JSON.stringify([]));
+  });
+
+  it('handles circular references', async function () {
+    const buffer = createEventBuffer({ useCompression: false });
+
+    const event: RecordingEvent = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
+    (event.data as any).child = event;
+
+    buffer.addEvent(event);
+
+    const result = await buffer.finish();
+
+    expect(result).toEqual(`[{"data":{"child":"[Circular ~]"},"timestamp":${BASE_TIMESTAMP},"type":3}]`);
   });
 });


### PR DESCRIPTION
Currently, we can get circular reference exceptions when JSON-stringifing events for replay.
We can fix this by using our `normalize` method.

Closes https://github.com/getsentry/sentry-javascript/issues/7742