### PR TITLE
ref(replay): Always send `replay_start_timestamp`

### DIFF
--- a/packages/browser-integration-tests/suites/replay/captureReplay/test.ts
+++ b/packages/browser-integration-tests/suites/replay/captureReplay/test.ts
@@ -75,6 +75,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
     trace_ids: [],
     urls: [],
     replay_id: expect.stringMatching(/\w{32}/),
+    replay_start_timestamp: expect.any(Number),
     segment_id: 1,
     replay_type: 'session',
     event_id: expect.stringMatching(/\w{32}/),

--- a/packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
+++ b/packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
@@ -75,6 +75,7 @@ sentryTest('should capture replays (@sentry/replay export)', async ({ getLocalTe
     trace_ids: [],
     urls: [],
     replay_id: expect.stringMatching(/\w{32}/),
+    replay_start_timestamp: expect.any(Number),
     segment_id: 1,
     replay_type: 'session',
     event_id: expect.stringMatching(/\w{32}/),

--- a/packages/browser-integration-tests/suites/replay/customEvents/test.ts
+++ b/packages/browser-integration-tests/suites/replay/customEvents/test.ts
@@ -52,9 +52,7 @@ sentryTest(
     const replayEvent1 = getReplayEvent(await reqPromise1);
     const { performanceSpans: performanceSpans1 } = getCustomRecordingEvents(await reqPromise1);
 
-    expect(replayEvent1).toEqual(
-      getExpectedReplayEvent({ segment_id: 1, urls: [], replay_start_timestamp: undefined }),
-    );
+    expect(replayEvent1).toEqual(getExpectedReplayEvent({ segment_id: 1, urls: [] }));
 
     // We can't guarantee the order of the performance spans, or in which of the two segments they are sent
     // So to avoid flakes, we collect them all and check that they are all there

--- a/packages/browser-integration-tests/suites/replay/errors/errorMode/test.ts
+++ b/packages/browser-integration-tests/suites/replay/errors/errorMode/test.ts
@@ -119,7 +119,6 @@ sentryTest(
       getExpectedReplayEvent({
         contexts: { replay: { error_sample_rate: 1, session_sample_rate: 0 } },
         replay_type: 'error', // although we're in session mode, we still send 'error' as replay_type
-        replay_start_timestamp: undefined,
         segment_id: 1,
         urls: [],
       }),
@@ -135,7 +134,6 @@ sentryTest(
       getExpectedReplayEvent({
         contexts: { replay: { error_sample_rate: 1, session_sample_rate: 0 } },
         replay_type: 'error',
-        replay_start_timestamp: undefined,
         segment_id: 2,
         urls: [],
       }),

--- a/packages/browser-integration-tests/suites/replay/errors/errorsInSession/test.ts
+++ b/packages/browser-integration-tests/suites/replay/errors/errorsInSession/test.ts
@@ -55,7 +55,6 @@ sentryTest(
 
     expect(event1).toEqual(
       getExpectedReplayEvent({
-        replay_start_timestamp: undefined,
         segment_id: 1,
         error_ids: [errorEventId],
         urls: [],
@@ -117,7 +116,6 @@ sentryTest(
 
     expect(event1).toEqual(
       getExpectedReplayEvent({
-        replay_start_timestamp: undefined,
         segment_id: 1,
         error_ids: [], // <-- no error id
         urls: [],

--- a/packages/browser-integration-tests/suites/replay/flushing/test.ts
+++ b/packages/browser-integration-tests/suites/replay/flushing/test.ts
@@ -40,7 +40,7 @@ sentryTest('replay events are flushed after max flush delay was reached', async 
 
   // this must eventually lead to a flush after the max delay was reached
   const replayEvent1 = getReplayEvent(await reqPromise1);
-  expect(replayEvent1).toEqual(getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 1, urls: [] }));
+  expect(replayEvent1).toEqual(getExpectedReplayEvent({ segment_id: 1, urls: [] }));
 
   // trigger mouse click every 100ms, it should still flush after the max delay even if clicks are ongoing
   for (let i = 0; i < 700; i++) {
@@ -54,5 +54,5 @@ sentryTest('replay events are flushed after max flush delay was reached', async 
   }
 
   const replayEvent2 = getReplayEvent(await reqPromise2);
-  expect(replayEvent2).toEqual(getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 2, urls: [] }));
+  expect(replayEvent2).toEqual(getExpectedReplayEvent({ segment_id: 2, urls: [] }));
 });

--- a/packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
+++ b/packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
@@ -71,9 +71,7 @@ sentryTest(
     const replayEvent1 = getReplayEvent(req1);
     const recording1 = getReplayRecordingContent(req1);
 
-    expect(replayEvent1).toEqual(
-      getExpectedReplayEvent({ segment_id: 1, urls: [], replay_start_timestamp: undefined }),
-    );
+    expect(replayEvent1).toEqual(getExpectedReplayEvent({ segment_id: 1, urls: [] }));
     expect(recording1.fullSnapshots.length).toEqual(0);
     expect(normalize(recording1.incrementalSnapshots)).toMatchSnapshot('seg-1-snap-incremental');
 
@@ -105,7 +103,7 @@ sentryTest(
     const replayEvent2 = getReplayEvent(req2);
     const recording2 = getReplayRecordingContent(req2);
 
-    expect(replayEvent2).toEqual(getExpectedReplayEvent({ segment_id: 2, replay_start_timestamp: undefined }));
+    expect(replayEvent2).toEqual(getExpectedReplayEvent({ segment_id: 2 }));
     expect(normalize(recording2.fullSnapshots)).toMatchSnapshot('seg-2-snap-full');
     expect(recording2.incrementalSnapshots.length).toEqual(0);
 
@@ -115,9 +113,7 @@ sentryTest(
     const replayEvent3 = getReplayEvent(req3);
     const recording3 = getReplayRecordingContent(req3);
 
-    expect(replayEvent3).toEqual(
-      getExpectedReplayEvent({ segment_id: 3, urls: [], replay_start_timestamp: undefined }),
-    );
+    expect(replayEvent3).toEqual(getExpectedReplayEvent({ segment_id: 3, urls: [] }));
     expect(recording3.fullSnapshots.length).toEqual(0);
     expect(normalize(recording3.incrementalSnapshots)).toMatchSnapshot('seg-3-snap-incremental');
 
@@ -150,7 +146,6 @@ sentryTest(
     expect(replayEvent4).toEqual(
       getExpectedReplayEvent({
         segment_id: 4,
-        replay_start_timestamp: undefined,
         // @ts-ignore this is fine
         urls: [expect.stringContaining('page-0.html')],
         request: {
@@ -176,7 +171,6 @@ sentryTest(
       getExpectedReplayEvent({
         segment_id: 5,
         urls: [],
-        replay_start_timestamp: undefined,
         request: {
           // @ts-ignore this is fine
           url: expect.stringContaining('page-0.html'),
@@ -223,7 +217,7 @@ sentryTest(
       getExpectedReplayEvent({
         segment_id: 6,
         urls: ['/spa'],
-        replay_start_timestamp: undefined,
+
         request: {
           // @ts-ignore this is fine
           url: expect.stringContaining('page-0.html'),
@@ -247,7 +241,7 @@ sentryTest(
       getExpectedReplayEvent({
         segment_id: 7,
         urls: [],
-        replay_start_timestamp: undefined,
+
         request: {
           // @ts-ignore this is fine
           url: expect.stringContaining('page-0.html'),
@@ -294,7 +288,6 @@ sentryTest(
     expect(replayEvent8).toEqual(
       getExpectedReplayEvent({
         segment_id: 8,
-        replay_start_timestamp: undefined,
       }),
     );
     expect(normalize(recording8.fullSnapshots)).toMatchSnapshot('seg-8-snap-full');
@@ -310,7 +303,6 @@ sentryTest(
       getExpectedReplayEvent({
         segment_id: 9,
         urls: [],
-        replay_start_timestamp: undefined,
       }),
     );
     expect(recording9.fullSnapshots.length).toEqual(0);

--- a/packages/browser-integration-tests/suites/replay/sessionExpiry/test.ts
+++ b/packages/browser-integration-tests/suites/replay/sessionExpiry/test.ts
@@ -50,7 +50,7 @@ sentryTest('handles an expired session', async ({ getLocalTestPath, page }) => {
   const req1 = await reqPromise1;
 
   const replayEvent1 = getReplayEvent(req1);
-  expect(replayEvent1).toEqual(getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 1, urls: [] }));
+  expect(replayEvent1).toEqual(getExpectedReplayEvent({ segment_id: 1, urls: [] }));
 
   const replay = await getReplaySnapshot(page);
   const oldSessionId = replay.session?.id;

--- a/packages/browser-integration-tests/suites/replay/sessionMaxAge/test.ts
+++ b/packages/browser-integration-tests/suites/replay/sessionMaxAge/test.ts
@@ -64,7 +64,7 @@ sentryTest('handles session that exceeds max age', async ({ getLocalTestPath, pa
   const req1 = await reqPromise1;
   const replayEvent1 = getReplayEvent(req1);
 
-  expect(replayEvent1).toEqual(getExpectedReplayEvent({ replay_start_timestamp: undefined, segment_id: 1, urls: [] }));
+  expect(replayEvent1).toEqual(getExpectedReplayEvent({ segment_id: 1, urls: [] }));
 
   const replay1 = await getReplaySnapshot(page);
   const oldSessionId = replay1.session?.id;

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -748,7 +748,6 @@ export class ReplayContainer implements ReplayContainerInterface {
         replayId,
         recordingData,
         segmentId,
-        includeReplayStartTimestamp: segmentId === 0,
         eventContext,
         session: this.session,
         options: this.getOptions(),

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -18,7 +18,6 @@ export interface SendReplayData {
   recordingData: ReplayRecordingData;
   replayId: string;
   segmentId: number;
-  includeReplayStartTimestamp: boolean;
   eventContext: PopEventContext;
   timestamp: number;
   session: Session;

--- a/packages/replay/src/util/sendReplayRequest.ts
+++ b/packages/replay/src/util/sendReplayRequest.ts
@@ -15,7 +15,6 @@ export async function sendReplayRequest({
   recordingData,
   replayId,
   segmentId: segment_id,
-  includeReplayStartTimestamp,
   eventContext,
   timestamp,
   session,
@@ -42,7 +41,7 @@ export async function sendReplayRequest({
 
   const baseEvent: ReplayEvent = {
     type: REPLAY_EVENT_NAME,
-    ...(includeReplayStartTimestamp ? { replay_start_timestamp: initialTimestamp / 1000 } : {}),
+    replay_start_timestamp: initialTimestamp / 1000,
     timestamp: timestamp / 1000,
     error_ids: errorIds,
     trace_ids: traceIds,

--- a/packages/replay/test/integration/flush.test.ts
+++ b/packages/replay/test/integration/flush.test.ts
@@ -179,7 +179,6 @@ describe('Integration | flush', () => {
     expect(mockSendReplay).toHaveBeenLastCalledWith({
       recordingData: expect.any(String),
       replayId: expect.any(String),
-      includeReplayStartTimestamp: true,
       segmentId: 0,
       eventContext: expect.anything(),
       session: expect.any(Object),
@@ -229,7 +228,6 @@ describe('Integration | flush', () => {
     expect(mockSendReplay).toHaveBeenLastCalledWith({
       recordingData: expect.any(String),
       replayId: expect.any(String),
-      includeReplayStartTimestamp: false,
       segmentId: 1,
       eventContext: expect.anything(),
       session: expect.any(Object),


### PR DESCRIPTION
This should be sent with each segment now.
