### PR TITLE
fix(browser): Adjust `transportOptions` to support offline transport options

### DIFF
--- a/packages/browser/src/transports/offline.ts
+++ b/packages/browser/src/transports/offline.ts
@@ -79,7 +79,7 @@ export function pop(store: Store): Promise<Uint8Array | string | undefined> {
   });
 }
 
-interface BrowserOfflineTransportOptions extends OfflineTransportOptions {
+export interface BrowserOfflineTransportOptions extends OfflineTransportOptions {
   /**
    * Name of indexedDb database to store envelopes in
    * Default: 'sentry-offline'

--- a/packages/browser/src/transports/types.ts
+++ b/packages/browser/src/transports/types.ts
@@ -1,6 +1,10 @@
 import type { BaseTransportOptions } from '@sentry/types';
 
-export interface BrowserTransportOptions extends BaseTransportOptions {
+import type { BrowserOfflineTransportOptions } from './offline';
+
+type BaseTransportAndOfflineTransportOptions = BaseTransportOptions & BrowserOfflineTransportOptions;
+
+export interface BrowserTransportOptions extends BaseTransportAndOfflineTransportOptions {
   /** Fetch API init parameters. Used by the FetchTransport */
   fetchOptions?: RequestInit;
   /** Custom headers for the transport. Used by the XHRTransport and FetchTransport */


### PR DESCRIPTION
As reported in #7766, our `transportOptions` init field currently isn't typed correctly to accept `BrowserOfflineTransportOptions`, causing type errors when trying to configure the offline transport. This PR fixes this bug by making `BrowserTransportOptions` extend `BrowserOfflineTransportOptions`.

closes #7766