### PR TITLE
feat(core): Extend `AsyncContextStrategy` to allow reuse of existing context

### DIFF
--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -54,8 +54,16 @@ const DEFAULT_BREADCRUMBS = 100;
  * Strategy used to track async context.
  */
 export interface AsyncContextStrategy {
+  /**
+   * Gets the current async context. Returns undefined if there is no current async context.
+   */
   getCurrentHub: () => Hub | undefined;
-  runWithAsyncContext<T>(callback: (hub: Hub) => T, ...args: unknown[]): T;
+  /**
+   * Runs the supplied callback in its own async context.
+   * @param reuseExisting Whether to reuse an existing async context if one exists.
+   * @param args Instances that should be referenced and retained in the new context.
+   */
+  runWithAsyncContext<T>(callback: (hub: Hub) => T, reuseExisting: boolean, ...args: unknown[]): T;
 }
 
 /**
@@ -585,11 +593,15 @@ export function setAsyncContextStrategy(strategy: AsyncContextStrategy | undefin
  *
  * Runs the given callback function with the global async context strategy
  */
-export function runWithAsyncContext<T>(callback: (hub: Hub) => T, ...args: unknown[]): T {
+export function runWithAsyncContext<T>(
+  callback: (hub: Hub) => T,
+  reuseExisting: boolean = false,
+  ...args: unknown[]
+): T {
   const registry = getMainCarrier();
 
   if (registry.__SENTRY__ && registry.__SENTRY__.acs) {
-    return registry.__SENTRY__.acs.runWithAsyncContext(callback, ...args);
+    return registry.__SENTRY__.acs.runWithAsyncContext(callback, reuseExisting, ...args);
   }
 
   // if there was no strategy, fallback to just calling the callback

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -591,7 +591,9 @@ export function setAsyncContextStrategy(strategy: AsyncContextStrategy | undefin
 /**
  * @private Private API with no semver guarantees!
  *
- * Runs the given callback function with the global async context strategy
+ * Runs the supplied callback in its own async context.
+ * @param reuseExisting Whether to reuse an existing async context if one exists. Defaults to false.
+ * @param args Instances that should be referenced and retained in the new context.
  */
 export function runWithAsyncContext<T>(
   callback: (hub: Hub) => T,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 export type { ClientClass } from './sdk';
-export type { AsyncContextStrategy, Carrier, Layer } from './hub';
+export type { AsyncContextStrategy, Carrier, Layer, RunWithAsyncContextOptions } from './hub';
 export type { OfflineStore, OfflineTransportOptions } from './transports/offline';
 
 export * from './tracing';

--- a/packages/node/src/async/domain.ts
+++ b/packages/node/src/async/domain.ts
@@ -1,4 +1,4 @@
-import type { Carrier, Hub } from '@sentry/core';
+import type { Carrier, Hub, RunWithAsyncContextOptions } from '@sentry/core';
 import {
   ensureHubOnCarrier,
   getCurrentHub as getCurrentHubCore,
@@ -26,10 +26,10 @@ function getCurrentHub(): Hub | undefined {
   return getHubFromCarrier(activeDomain);
 }
 
-function runWithAsyncContext<T, A>(callback: (hub: Hub) => T, reuseExisting: boolean, ...args: A[]): T {
-  const local = reuseExisting ? getActiveDomain<domain.Domain>() || domain.create() : domain.create();
+function runWithAsyncContext<T>(callback: (hub: Hub) => T, options: RunWithAsyncContextOptions): T {
+  const local = options?.reuseExisting ? getActiveDomain<domain.Domain>() || domain.create() : domain.create();
 
-  for (const emitter of args) {
+  for (const emitter of options.args || []) {
     if (emitter instanceof EventEmitter) {
       local.add(emitter);
     }

--- a/packages/node/test/async/domain.test.ts
+++ b/packages/node/test/async/domain.test.ts
@@ -36,6 +36,29 @@ describe('domains', () => {
     });
   });
 
+  test('domain within a domain not reused', () => {
+    setDomainAsyncContextStrategy();
+
+    runWithAsyncContext(hub1 => {
+      runWithAsyncContext(hub2 => {
+        expect(hub1).not.toBe(hub2);
+      });
+    });
+  });
+
+  test('domain within a domain reused when requested', () => {
+    setDomainAsyncContextStrategy();
+
+    runWithAsyncContext(hub1 => {
+      runWithAsyncContext(
+        hub2 => {
+          expect(hub1).toBe(hub2);
+        },
+        { reuseExisting: true },
+      );
+    });
+  });
+
   test('concurrent domain hubs', done => {
     setDomainAsyncContextStrategy();
 


### PR DESCRIPTION
This PR extends `runWithAsyncContext` on `AsyncContextStrategy` to allow reuse of existing context rather than creating a new sub-context.

I've also added more jsdocs since the functions are getting more complex.
