### PR TITLE
feat(node): Auto-select best `AsyncContextStrategy` for Node.js version

### DIFF
--- a/packages/node/src/async/index.ts
+++ b/packages/node/src/async/index.ts
@@ -1,0 +1,17 @@
+import { NODE_VERSION } from '../nodeVersion';
+import { setDomainAsyncContextStrategy } from './domain';
+import { setHooksAsyncContextStrategy } from './hooks';
+
+/**
+ * Sets the correct async context strategy for Node.js
+ *
+ * Node.js >= 14 uses AsyncLocalStorage
+ * Node.js < 14 uses domains
+ */
+export function setNodeAsyncContextStrategy(): void {
+  if (NODE_VERSION >= 14) {
+    setHooksAsyncContextStrategy();
+  } else {
+    setDomainAsyncContextStrategy();
+  }
+}

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -15,7 +15,7 @@ import {
   stackParserFromStackParserOptions,
 } from '@sentry/utils';
 
-import { setDomainAsyncContextStrategy } from './async/domain';
+import { setNodeAsyncContextStrategy } from './async';
 import { NodeClient } from './client';
 import {
   Console,
@@ -111,7 +111,7 @@ export const defaultIntegrations = [
 export function init(options: NodeOptions = {}): void {
   const carrier = getMainCarrier();
 
-  setDomainAsyncContextStrategy();
+  setNodeAsyncContextStrategy();
 
   const autoloadedIntegrations = carrier.__SENTRY__?.integrations || [];
 

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -12,7 +12,7 @@ import {
   init,
   NodeClient,
 } from '../src';
-import { setDomainAsyncContextStrategy } from '../src/async/domain';
+import { setNodeAsyncContextStrategy } from '../src/async';
 import { ContextLines, LinkedErrors } from '../src/integrations';
 import { defaultStackParser } from '../src/sdk';
 import type { NodeClientOptions } from '../src/types';
@@ -288,7 +288,7 @@ describe('SentryNode', () => {
         },
         dsn,
       });
-      setDomainAsyncContextStrategy();
+      setNodeAsyncContextStrategy();
       const client = new NodeClient(options);
 
       runWithAsyncContext(hub => {


### PR DESCRIPTION
Automatically select the best `AsyncContextStrategy` for the Node.js version.
- Node.js >= 14 uses `AsyncLocalStorage`
- Node.js < 14 uses domains