### PR TITLE
feat(browser): Export request instrumentation options

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -21,7 +21,12 @@ const INTEGRATIONS = {
 export { INTEGRATIONS as Integrations };
 
 export { Replay } from '@sentry/replay';
-export { BrowserTracing, defaultRequestInstrumentationOptions } from '@sentry-internal/tracing';
+export {
+  BrowserTracing,
+  defaultRequestInstrumentationOptions,
+  instrumentOutgoingRequests,
+} from '@sentry-internal/tracing';
+export type { RequestInstrumentationOptions } from '@sentry-internal/tracing';
 export {
   addTracingExtensions,
   extractTraceparentData,


### PR DESCRIPTION
When reviewing https://github.com/getsentry/sentry-react-native/pull/2958, I noticed that `@sentry-internal/tracing` is only required as a dep of `@sentry/react-native` because of `instrumentOutgoingRequests` and `RequestInstrumentationOptions`.

Let's re-export those from the browser package so that react native can get rid of the `@sentry-internal/tracing` dependency, which should make it easier for them to migrate later on.