### PR TITLE
fix(browser): DOMException SecurityError stacktrace parsing bug

### DIFF
--- a/packages/browser/test/unit/tracekit/misc.test.ts
+++ b/packages/browser/test/unit/tracekit/misc.test.ts
@@ -26,4 +26,107 @@ describe('Tracekit - Misc Tests', () => {
       },
     });
   });
+
+  it.only('should parse SecurityError', () => {
+    const SECURITY_ERROR = {
+      name: 'SecurityError',
+      message: 'Blocked a frame with origin "https://SENTRY_URL.sentry.io" from accessing a cross-origin frame.',
+      stack:
+        'SecurityError: Blocked a frame with origin "https://SENTRY_URL.sentry.io" from accessing a cross-origin frame.\n' +
+        '   at Error: Blocked a frame with origin "(https://SENTRY_URL.sentry.io" from accessing a cross-origin frame.)\n' +
+        '   at castFn(../node_modules/@sentry-internal/rrweb/es/rrweb/packages/rrweb/src/replay/index.js:368:76)\n' +
+        '   at castFn(../node_modules/@sentry-internal/rrweb/es/rrweb/packages/rrweb/src/replay/index.js:409:17)\n' +
+        '   at Replayer.applyEventsSynchronously(../node_modules/@sentry-internal/rrweb/es/rrweb/packages/rrweb/src/replay/index.js:325:13)\n' +
+        '   at <object>.actions.play(../node_modules/@sentry-internal/rrweb/es/rrweb/packages/rrweb/src/replay/machine.js:132:17)\n' +
+        '   at <anonymous>(../node_modules/@sentry-internal/rrweb/es/rrweb/ext/@xstate/fsm/es/index.js:15:2595)\n' +
+        '   at Array.forEach(<anonymous>)\n' +
+        '   at l(../node_modules/@sentry-internal/rrweb/es/rrweb/ext/@xstate/fsm/es/index.js:15:2551)\n' +
+        '   at c.send(../node_modules/@sentry-internal/rrweb/es/rrweb/ext/@xstate/fsm/es/index.js:15:2741)\n' +
+        '   at Replayer.play(../node_modules/@sentry-internal/rrweb/es/rrweb/packages/rrweb/src/replay/index.js:220:26)\n' +
+        '   at Replayer.pause(../node_modules/@sentry-internal/rrweb/es/rrweb/packages/rrweb/src/replay/index.js:235:18)\n' +
+        '   at playTimer.current(./app/components/replays/replayContext.tsx:397:62)\n' +
+        '   at sentryWrapped(../node_modules/@sentry/browser/esm/helpers.js:90:17)',
+    };
+    const ex = exceptionFromError(parser, SECURITY_ERROR);
+
+    expect(ex).toEqual({
+      type: 'SecurityError',
+      value: 'Blocked a frame with origin "https://SENTRY_URL.sentry.io" from accessing a cross-origin frame.',
+      stacktrace: {
+        frames: [
+          {
+            filename: './app/components/replays/replayContext.tsx',
+            function: 'playTimer.current',
+            in_app: true,
+            lineno: 397,
+            colno: 62,
+          },
+          {
+            filename: '../node_modules/@sentry-internal/rrweb/es/rrweb/packages/rrweb/src/replay/index.js',
+            function: 'Replayer.pause',
+            in_app: true,
+            lineno: 235,
+            colno: 18,
+          },
+          {
+            filename: '../node_modules/@sentry-internal/rrweb/es/rrweb/packages/rrweb/src/replay/index.js',
+            function: 'Replayer.play',
+            in_app: true,
+            lineno: 220,
+            colno: 26,
+          },
+          {
+            filename: '../node_modules/@sentry-internal/rrweb/es/rrweb/ext/@xstate/fsm/es/index.js',
+            function: 'c.send',
+            in_app: true,
+            lineno: 15,
+            colno: 2741,
+          },
+          {
+            filename: '../node_modules/@sentry-internal/rrweb/es/rrweb/ext/@xstate/fsm/es/index.js',
+            function: 'l',
+            in_app: true,
+            lineno: 15,
+            colno: 2551,
+          },
+          { filename: '<anonymous>', function: 'Array.forEach', in_app: true },
+          {
+            filename: '../node_modules/@sentry-internal/rrweb/es/rrweb/ext/@xstate/fsm/es/index.js',
+            function: '<anonymous>',
+            in_app: true,
+            lineno: 15,
+            colno: 2595,
+          },
+          {
+            filename: '../node_modules/@sentry-internal/rrweb/es/rrweb/packages/rrweb/src/replay/machine.js',
+            function: '<object>.actions.play',
+            in_app: true,
+            lineno: 132,
+            colno: 17,
+          },
+          {
+            filename: '../node_modules/@sentry-internal/rrweb/es/rrweb/packages/rrweb/src/replay/index.js',
+            function: 'Replayer.applyEventsSynchronously',
+            in_app: true,
+            lineno: 325,
+            colno: 13,
+          },
+          {
+            filename: '../node_modules/@sentry-internal/rrweb/es/rrweb/packages/rrweb/src/replay/index.js',
+            function: 'castFn',
+            in_app: true,
+            lineno: 409,
+            colno: 17,
+          },
+          {
+            filename: '../node_modules/@sentry-internal/rrweb/es/rrweb/packages/rrweb/src/replay/index.js',
+            function: 'castFn',
+            in_app: true,
+            lineno: 368,
+            colno: 76,
+          },
+        ],
+      },
+    });
+  });
 });

--- a/packages/browser/test/unit/tracekit/misc.test.ts
+++ b/packages/browser/test/unit/tracekit/misc.test.ts
@@ -27,7 +27,7 @@ describe('Tracekit - Misc Tests', () => {
     });
   });
 
-  it.only('should parse SecurityError', () => {
+  it('should parse SecurityError', () => {
     const SECURITY_ERROR = {
       name: 'SecurityError',
       message: 'Blocked a frame with origin "https://SENTRY_URL.sentry.io" from accessing a cross-origin frame.',

--- a/packages/utils/src/stacktrace.ts
+++ b/packages/utils/src/stacktrace.ts
@@ -35,6 +35,12 @@ export function createStackParser(...parsers: StackLineParser[]): StackParser {
       // Remove webpack (error: *) wrappers
       const cleanedLine = WEBPACK_ERROR_REGEXP.test(line) ? line.replace(WEBPACK_ERROR_REGEXP, '$1') : line;
 
+      // https://github.com/getsentry/sentry-javascript/issues/7813
+      // Skip Error: lines
+      if (cleanedLine.match(/\S*Error: /)) {
+        continue;
+      }
+
       for (const parser of sortedParsers) {
         const frame = parser(cleanedLine);
 


### PR DESCRIPTION
Closes #7813

It looks like stack lines containing `Error: ` were picked erroneously up by the gecko parser. This PR strips lines that match this pattern.