### PR TITLE
feat(replay): Add `getReplayId()` method

### DIFF
--- a/packages/replay/README.md
+++ b/packages/replay/README.md
@@ -140,7 +140,7 @@ A session starts when the Session Replay SDK is first loaded and initialized. Th
 
 ### Accessing the Replay Session ID
 
-You can get the ID of the currently running session via `replay.getSessionId()`.
+You can get the ID of the currently running session via `replay.getReplayId()`.
 This will return `undefined` if no session is ongoing.
 
 ### Replay Captures Only on Errors

--- a/packages/replay/README.md
+++ b/packages/replay/README.md
@@ -138,6 +138,11 @@ A session starts when the Session Replay SDK is first loaded and initialized. Th
 
 [^1]: An 'interaction' refers to either a mouse click or a browser navigation event.
 
+### Accessing the Replay Session ID
+
+You can get the ID of the currently running session via `replay.getSessionId()`.
+This will return `undefined` if no session is ongoing.
+
 ### Replay Captures Only on Errors
 
 Alternatively, rather than recording an entire session, you can capture a replay only when an error occurs. In this case, the integration will buffer up to one minute worth of events prior to the error being thrown. It will continue to record the session following the rules above regarding session life and activity. Read the [sampling](#Sampling) section for configuration options.

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -226,6 +226,17 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
     return this._replay.flushImmediate();
   }
 
+  /**
+   * Get the current session ID.
+   */
+  public getSessionId(): string | undefined {
+    if (!this._replay || !this._replay.isEnabled()) {
+      return;
+    }
+
+    return this._replay.getSessionId();
+  }
+
   /** Setup the integration. */
   private _setup(): void {
     // Client is not available in constructor, so we need to wait until setupOnce

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -229,7 +229,7 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
   /**
    * Get the current session ID.
    */
-  public getSessionId(): string | undefined {
+  public getReplayId(): string | undefined {
     if (!this._replay || !this._replay.isEnabled()) {
       return;
     }

--- a/packages/replay/test/integration/getReplayId.test.ts
+++ b/packages/replay/test/integration/getReplayId.test.ts
@@ -3,7 +3,7 @@ import { useFakeTimers } from '../utils/use-fake-timers';
 
 useFakeTimers();
 
-describe('Integration | getSessionId', () => {
+describe('Integration | getReplayId', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -15,12 +15,12 @@ describe('Integration | getSessionId', () => {
       },
     });
 
-    expect(integration.getSessionId()).toBeDefined();
-    expect(integration.getSessionId()).toEqual(replay.session?.id);
+    expect(integration.getReplayId()).toBeDefined();
+    expect(integration.getReplayId()).toEqual(replay.session?.id);
 
     // When stopped, it is undefined
     integration.stop();
 
-    expect(integration.getSessionId()).toBeUndefined();
+    expect(integration.getReplayId()).toBeUndefined();
   });
 });

--- a/packages/replay/test/integration/getSessionId.test.ts
+++ b/packages/replay/test/integration/getSessionId.test.ts
@@ -1,0 +1,26 @@
+import { mockSdk } from '../mocks/mockSdk';
+import { useFakeTimers } from '../utils/use-fake-timers';
+
+useFakeTimers();
+
+describe('Integration | getSessionId', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('works', async () => {
+    const { integration, replay } = await mockSdk({
+      replayOptions: {
+        stickySession: true,
+      },
+    });
+
+    expect(integration.getSessionId()).toBeDefined();
+    expect(integration.getSessionId()).toEqual(replay.session?.id);
+
+    // When stopped, it is undefined
+    integration.stop();
+
+    expect(integration.getSessionId()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This adds a public `getReplayId()` method to the replay integration to get the ID of the ongoing session.

Closes https://github.com/getsentry/sentry-javascript/issues/7795