### PR TITLE
feat(core): Cache processed stacks for debug IDs

### DIFF
--- a/packages/core/src/utils/prepareEvent.ts
+++ b/packages/core/src/utils/prepareEvent.ts
@@ -114,7 +114,7 @@ function applyClientOptions(event: Event, options: ClientOptions): void {
   }
 }
 
-const debugIdStackParserCache = new Map<StackParser, Map<string, StackFrame[]>>();
+const debugIdStackParserCache = new WeakMap<StackParser, Map<string, StackFrame[]>>();
 
 /**
  * Applies debug metadata images to the event in order to apply source maps by looking up their debug ID.

--- a/packages/core/src/utils/prepareEvent.ts
+++ b/packages/core/src/utils/prepareEvent.ts
@@ -1,4 +1,4 @@
-import type { ClientOptions, Event, EventHint, StackParser } from '@sentry/types';
+import type { ClientOptions, Event, EventHint, StackFrame, StackParser } from '@sentry/types';
 import { dateTimestampInSeconds, GLOBAL_OBJ, normalize, resolvedSyncPromise, truncate, uuid4 } from '@sentry/utils';
 
 import { DEFAULT_ENVIRONMENT } from '../constants';
@@ -114,6 +114,8 @@ function applyClientOptions(event: Event, options: ClientOptions): void {
   }
 }
 
+const debugIdStackParserCache = new Map<StackParser, Map<string, StackFrame[]>>();
+
 /**
  * Applies debug metadata images to the event in order to apply source maps by looking up their debug ID.
  */
@@ -124,9 +126,26 @@ export function applyDebugMetadata(event: Event, stackParser: StackParser): void
     return;
   }
 
+  let debugIdStackFramesCache: Map<string, StackFrame[]>;
+  const cachedDebugIdStackFrameCache = debugIdStackParserCache.get(stackParser);
+  if (cachedDebugIdStackFrameCache) {
+    debugIdStackFramesCache = cachedDebugIdStackFrameCache;
+  } else {
+    debugIdStackFramesCache = new Map<string, StackFrame[]>();
+    debugIdStackParserCache.set(stackParser, debugIdStackFramesCache);
+  }
+
   // Build a map of filename -> debug_id
   const filenameDebugIdMap = Object.keys(debugIdMap).reduce<Record<string, string>>((acc, debugIdStackTrace) => {
-    const parsedStack = stackParser(debugIdStackTrace);
+    let parsedStack: StackFrame[];
+    const cachedParsedStack = debugIdStackFramesCache.get(debugIdStackTrace);
+    if (cachedParsedStack) {
+      parsedStack = cachedParsedStack;
+    } else {
+      parsedStack = stackParser(debugIdStackTrace);
+      debugIdStackFramesCache.set(debugIdStackTrace, parsedStack);
+    }
+
     for (let i = parsedStack.length - 1; i >= 0; i--) {
       const stackFrame = parsedStack[i];
       if (stackFrame.filename) {


### PR DESCRIPTION
Cache processed debug ID stack frames so we don't have to recompute them every error event.