### PR TITLE
fix(serverless): Account when transaction undefined

### DIFF
--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -328,7 +328,7 @@ export function wrapHandler<TEvent, TResult>(
         dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,
         source: 'component',
       },
-    });
+    }) as Sentry.Transaction | undefined;
 
     const scope = hub.pushScope();
     let rv: TResult;
@@ -350,7 +350,7 @@ export function wrapHandler<TEvent, TResult>(
       throw e;
     } finally {
       clearTimeout(timeoutWarningTimer);
-      transaction.finish();
+      transaction?.finish();
       hub.popScope();
       await flush(options.flushTimeout).catch(e => {
         __DEBUG_BUILD__ && logger.error(e);

--- a/packages/serverless/src/gcpfunction/cloud_events.ts
+++ b/packages/serverless/src/gcpfunction/cloud_events.ts
@@ -36,7 +36,7 @@ function _wrapCloudEventFunction(
       name: context.type || '<unknown>',
       op: 'function.gcp.cloud_event',
       metadata: { source: 'component' },
-    });
+    }) as ReturnType<typeof hub.startTransaction> | undefined;
 
     // getCurrentHub() is expected to use current active domain as a carrier
     // since functions-framework creates a domain for each incoming request.
@@ -51,7 +51,7 @@ function _wrapCloudEventFunction(
       if (args[0] !== null && args[0] !== undefined) {
         captureException(args[0]);
       }
-      transaction.finish();
+      transaction?.finish();
 
       void flush(options.flushTimeout)
         .then(null, e => {

--- a/packages/serverless/src/gcpfunction/events.ts
+++ b/packages/serverless/src/gcpfunction/events.ts
@@ -38,7 +38,7 @@ function _wrapEventFunction<F extends EventFunction | EventFunctionWithCallback>
       name: context.eventType,
       op: 'function.gcp.event',
       metadata: { source: 'component' },
-    });
+    }) as ReturnType<typeof hub.startTransaction> | undefined;
 
     // getCurrentHub() is expected to use current active domain as a carrier
     // since functions-framework creates a domain for each incoming request.
@@ -53,7 +53,7 @@ function _wrapEventFunction<F extends EventFunction | EventFunctionWithCallback>
       if (args[0] !== null && args[0] !== undefined) {
         captureException(args[0]);
       }
-      transaction.finish();
+      transaction?.finish();
 
       void flush(options.flushTimeout)
         .then(null, e => {

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -92,7 +92,7 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
         dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,
         source: 'route',
       },
-    });
+    }) as ReturnType<typeof hub.startTransaction> | undefined;
 
     // getCurrentHub() is expected to use current active domain as a carrier
     // since functions-framework creates a domain for each incoming request.
@@ -115,8 +115,8 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
     const _end = res.end;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     res.end = function (chunk?: any | (() => void), encoding?: string | (() => void), cb?: () => void): any {
-      transaction.setHttpStatus(res.statusCode);
-      transaction.finish();
+      transaction?.setHttpStatus(res.statusCode);
+      transaction?.finish();
 
       void flush(options.flushTimeout)
         .then(null, e => {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/7826

If tracing extensions are not added, make sure we identify that `hub.startTransaction` can return undefined.