### PR TITLE
fix(sveltekit): Rewrite server-side stack frames to match source maps

### DIFF
--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@sentry-internal/tracing": "7.47.0",
     "@sentry/core": "7.47.0",
+    "@sentry/integrations": "7.47.0",
     "@sentry/node": "7.47.0",
     "@sentry/svelte": "7.47.0",
     "@sentry/types": "7.47.0",

--- a/packages/sveltekit/src/server/sdk.ts
+++ b/packages/sveltekit/src/server/sdk.ts
@@ -1,4 +1,5 @@
 import { configureScope } from '@sentry/core';
+import { RewriteFrames } from '@sentry/integrations';
 import type { NodeOptions } from '@sentry/node';
 import { init as initNodeSdk, Integrations } from '@sentry/node';
 import { addOrUpdateIntegration } from '@sentry/utils';
@@ -23,4 +24,5 @@ export function init(options: NodeOptions): void {
 
 function addServerIntegrations(options: NodeOptions): void {
   options.integrations = addOrUpdateIntegration(new Integrations.Undici(), options.integrations || []);
+  options.integrations = addOrUpdateIntegration(new RewriteFrames(), options.integrations || []);
 }

--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -9,7 +9,11 @@ import type { Plugin } from 'vite';
 
 const DEFAULT_PLUGIN_OPTIONS: SentryVitePluginOptions = {
   // TODO: Read these values from the node adapter somehow as the out dir can be changed in the adapter options
-  include: ['build/server', 'build/client'],
+  include: [
+    { paths: ['build/client'] },
+    { paths: ['build/server/chunks'] },
+    { paths: ['build/server'], ignore: ['chunks/**'] },
+  ],
 };
 
 // sorcery has no types, so these are some basic type definitions:


### PR DESCRIPTION
This PR adds the `RewriteFrames` integration to match the server-side stack frames with the uploaded source maps.

ref #7669  
