### PR TITLE
fix(sveltekit): Improve server-side grouping by removing stack frame module

### DIFF
--- a/packages/sveltekit/src/server/sdk.ts
+++ b/packages/sveltekit/src/server/sdk.ts
@@ -5,6 +5,7 @@ import { init as initNodeSdk, Integrations } from '@sentry/node';
 import { addOrUpdateIntegration } from '@sentry/utils';
 
 import { applySdkMetadata } from '../common/metadata';
+import { rewriteFramesIteratee } from './utils';
 
 /**
  *
@@ -24,5 +25,8 @@ export function init(options: NodeOptions): void {
 
 function addServerIntegrations(options: NodeOptions): void {
   options.integrations = addOrUpdateIntegration(new Integrations.Undici(), options.integrations || []);
-  options.integrations = addOrUpdateIntegration(new RewriteFrames(), options.integrations || []);
+  options.integrations = addOrUpdateIntegration(
+    new RewriteFrames({ iteratee: rewriteFramesIteratee }),
+    options.integrations || [],
+  );
 }

--- a/packages/sveltekit/src/server/utils.ts
+++ b/packages/sveltekit/src/server/utils.ts
@@ -1,5 +1,5 @@
-import type { DynamicSamplingContext, TraceparentData } from '@sentry/types';
-import { baggageHeaderToDynamicSamplingContext, extractTraceparentData } from '@sentry/utils';
+import type { DynamicSamplingContext, StackFrame, TraceparentData } from '@sentry/types';
+import { baggageHeaderToDynamicSamplingContext, basename, extractTraceparentData } from '@sentry/utils';
 import type { RequestEvent } from '@sveltejs/kit';
 
 /**
@@ -16,4 +16,41 @@ export function getTracePropagationData(event: RequestEvent): {
   const dynamicSamplingContext = baggageHeaderToDynamicSamplingContext(baggageHeader);
 
   return { traceparentData, dynamicSamplingContext };
+}
+
+/**
+ * A custom iteratee function for the `RewriteFrames` integration.
+ *
+ * Does the same as the default iteratee, but also removes the `module` property from the
+ * frame to improve issue grouping.
+ *
+ * For some reason, our stack trace processing pipeline isn't able to resolve the bundled
+ * module name to the original file name correctly, leading to individual error groups for
+ * each module. Removing the `module` field makes the grouping algorithm fall back to the
+ * `filename` field, which is correctly resolved and hence grouping works as expected.
+ */
+export function rewriteFramesIteratee(frame: StackFrame): StackFrame {
+  if (!frame.filename) {
+    return frame;
+  }
+
+  const prefix = 'app:///';
+
+  // Check if the frame filename begins with `/` or a Windows-style prefix such as `C:\`
+  const isWindowsFrame = /^[a-zA-Z]:\\/.test(frame.filename);
+  const startsWithSlash = /^\//.test(frame.filename);
+  if (isWindowsFrame || startsWithSlash) {
+    const filename = isWindowsFrame
+      ? frame.filename
+          .replace(/^[a-zA-Z]:/, '') // remove Windows-style prefix
+          .replace(/\\/g, '/') // replace all `\\` instances with `/`
+      : frame.filename;
+
+    const base = basename(filename);
+    frame.filename = `${prefix}${base}`;
+  }
+
+  delete frame.module;
+
+  return frame;
 }


### PR DESCRIPTION
This PR adds a custom `RewriteFrames` iteratee to the server SDK which 

* Does exactly the same thing as the default iteratee if simply initializiung `RewriteFrames()` without custom options
* Removes the `module` field from each stack frame

Removing the `module` field improves grouping because for some reason, our stack trace processing pipeline isn't able to resolve the bundled module name to the original file name correctly, leading to a new issue group for the same error, every time the app is built. I suspect this is because of the unique Ids that Vite assigns to modules or due to something that sorcery does when flattening source maps. By removing `module` field the grouping algorithm falls back to the `filename` field, which is correctly resolved and hence grouping works as expected.

ref #7669 
