### PR TITLE
fix(utils): Make xhr instrumentation independent of parallel running SDK versions

### DIFF
--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -15,6 +15,7 @@ import {
   logger,
   parseUrl,
   safeJoin,
+  SENTRY_XHR_DATA_KEY,
   severityLevelFromString,
 } from '@sentry/utils';
 
@@ -225,12 +226,14 @@ function _consoleBreadcrumb(handlerData: HandlerData & { args: unknown[]; level:
 function _xhrBreadcrumb(handlerData: HandlerData & HandlerDataXhr): void {
   const { startTimestamp, endTimestamp } = handlerData;
 
+  const sentryXhrData = handlerData.xhr[SENTRY_XHR_DATA_KEY];
+
   // We only capture complete, non-sentry requests
-  if (!startTimestamp || !endTimestamp || !handlerData.xhr.__sentry_xhr__) {
+  if (!startTimestamp || !endTimestamp || !sentryXhrData) {
     return;
   }
 
-  const { method, url, status_code, body } = handlerData.xhr.__sentry_xhr__;
+  const { method, url, status_code, body } = sentryXhrData;
 
   const data: XhrBreadcrumbData = {
     method,

--- a/packages/integrations/src/httpclient.ts
+++ b/packages/integrations/src/httpclient.ts
@@ -12,6 +12,7 @@ import {
   addInstrumentationHandler,
   GLOBAL_OBJ,
   logger,
+  SENTRY_XHR_DATA_KEY,
   supportsNativeFetch,
 } from '@sentry/utils';
 
@@ -322,11 +323,13 @@ export class HttpClient implements Integration {
       (handlerData: HandlerDataXhr & { xhr: SentryWrappedXMLHttpRequest & XMLHttpRequest }) => {
         const { xhr } = handlerData;
 
-        if (!xhr.__sentry_xhr__) {
+        const sentryXhrData = xhr[SENTRY_XHR_DATA_KEY];
+
+        if (!sentryXhrData) {
           return;
         }
 
-        const { method, request_headers: headers } = xhr.__sentry_xhr__;
+        const { method, request_headers: headers } = sentryXhrData;
 
         if (!method) {
           return;

--- a/packages/replay/src/coreHandlers/handleXhr.ts
+++ b/packages/replay/src/coreHandlers/handleXhr.ts
@@ -1,4 +1,5 @@
 import type { HandlerDataXhr } from '@sentry/types';
+import { SENTRY_XHR_DATA_KEY } from '@sentry/utils';
 
 import type { NetworkRequestData, ReplayContainer, ReplayPerformanceEntry } from '../types';
 import { addNetworkBreadcrumb } from './util/addNetworkBreadcrumb';
@@ -7,12 +8,14 @@ import { addNetworkBreadcrumb } from './util/addNetworkBreadcrumb';
 export function handleXhr(handlerData: HandlerDataXhr): ReplayPerformanceEntry<NetworkRequestData> | null {
   const { startTimestamp, endTimestamp, xhr } = handlerData;
 
-  if (!startTimestamp || !endTimestamp || !xhr.__sentry_xhr__) {
+  const sentryXhrData = xhr[SENTRY_XHR_DATA_KEY];
+
+  if (!startTimestamp || !endTimestamp || !sentryXhrData) {
     return null;
   }
 
   // This is only used as a fallback, so we know the body sizes are never set here
-  const { method, url, status_code: statusCode } = xhr.__sentry_xhr__;
+  const { method, url, status_code: statusCode } = sentryXhrData;
 
   if (url === undefined) {
     return null;

--- a/packages/replay/test/unit/coreHandlers/handleXhr.test.ts
+++ b/packages/replay/test/unit/coreHandlers/handleXhr.test.ts
@@ -1,11 +1,12 @@
 import type { HandlerDataXhr, SentryWrappedXMLHttpRequest, SentryXhrData } from '@sentry/types';
+import { SENTRY_XHR_DATA_KEY } from '@sentry/utils';
 
 import { handleXhr } from '../../../src/coreHandlers/handleXhr';
 
 const DEFAULT_DATA: HandlerDataXhr = {
   args: ['GET', '/api/0/organizations/sentry/'],
   xhr: {
-    __sentry_xhr__: {
+    [SENTRY_XHR_DATA_KEY]: {
       method: 'GET',
       url: '/api/0/organizations/sentry/',
       status_code: 200,
@@ -45,8 +46,8 @@ describe('Unit | coreHandlers | handleXhr', () => {
       ...DEFAULT_DATA,
       xhr: {
         ...DEFAULT_DATA.xhr,
-        __sentry_xhr__: {
-          ...(DEFAULT_DATA.xhr.__sentry_xhr__ as SentryXhrData),
+        [SENTRY_XHR_DATA_KEY]: {
+          ...(DEFAULT_DATA.xhr[SENTRY_XHR_DATA_KEY] as SentryXhrData),
           request_body_size: 123,
           response_body_size: 456,
         },

--- a/packages/tracing-internal/test/browser/request.test.ts
+++ b/packages/tracing-internal/test/browser/request.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable deprecation/deprecation */
 import * as sentryCore from '@sentry/core';
 import * as utils from '@sentry/utils';
+import { SENTRY_XHR_DATA_KEY } from '@sentry/utils';
 
 import type { Transaction } from '../../../tracing/src';
 import { addExtensionMethods, Span, spanStatusfromHttpCode } from '../../../tracing/src';
@@ -234,7 +235,7 @@ describe('callbacks', () => {
     beforeEach(() => {
       xhrHandlerData = {
         xhr: {
-          __sentry_xhr__: {
+          [SENTRY_XHR_DATA_KEY]: {
             method: 'GET',
             url: 'http://dogs.are.great/',
             status_code: 200,
@@ -328,7 +329,7 @@ describe('callbacks', () => {
         ...xhrHandlerData,
         endTimestamp,
       };
-      postRequestXHRHandlerData.xhr!.__sentry_xhr__!.status_code = 404;
+      postRequestXHRHandlerData.xhr![SENTRY_XHR_DATA_KEY]!.status_code = 404;
 
       // triggered by response coming back
       xhrCallback(postRequestXHRHandlerData, alwaysCreateSpan, alwaysAttachHeaders, spans);
@@ -342,7 +343,7 @@ describe('callbacks', () => {
       const postRequestXHRHandlerData = {
         ...{
           xhr: {
-            __sentry_xhr__: xhrHandlerData.xhr?.__sentry_xhr__,
+            [SENTRY_XHR_DATA_KEY]: xhrHandlerData.xhr?.[SENTRY_XHR_DATA_KEY],
           },
         },
         startTimestamp,

--- a/packages/types/src/instrument.ts
+++ b/packages/types/src/instrument.ts
@@ -4,10 +4,11 @@
 type XHRSendInput = unknown;
 
 export interface SentryWrappedXMLHttpRequest {
-  __sentry_xhr__?: SentryXhrData;
+  __sentry_xhr_v2__?: SentryXhrData;
   __sentry_own_request__?: boolean;
 }
 
+// WARNING: When the shape of this type is changed bump the version in `SentryWrappedXMLHttpRequest`
 export interface SentryXhrData {
   method?: string;
   url?: string;


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/7783

XHR instrumentations of multiple parallel running SDK versions were clashing. We now instead use a field that should be bumped every time we change the layout of the type in a non-backwards compatible way.