### PR TITLE
ref(node): Remove unnecessary emitters option from async context abstraction

### DIFF
--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -45,8 +45,6 @@ const DEFAULT_BREADCRUMBS = 100;
 export interface RunWithAsyncContextOptions {
   /** Whether to reuse an existing async context if one exists. Defaults to false. */
   reuseExisting?: boolean;
-  /** Instances that should be referenced and retained in the new context */
-  emitters?: unknown[];
 }
 
 /**

--- a/packages/nextjs/src/server/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/server/wrapApiHandlerWithSentry.ts
@@ -202,7 +202,6 @@ export function withSentry(apiHandler: NextApiHandler, parameterizedRoute?: stri
             throw objectifiedErr;
           }
         },
-        { emitters: [req, res] },
       );
 
       // Since API route handlers are all async, nextjs always awaits the return value (meaning it's fine for us to return

--- a/packages/node/src/async/domain.ts
+++ b/packages/node/src/async/domain.ts
@@ -1,7 +1,6 @@
 import type { Carrier, Hub, RunWithAsyncContextOptions } from '@sentry/core';
 import { ensureHubOnCarrier, getHubFromCarrier, setAsyncContextStrategy, setHubOnCarrier } from '@sentry/core';
 import * as domain from 'domain';
-import { EventEmitter } from 'events';
 
 function getActiveDomain<T>(): T | undefined {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
@@ -31,23 +30,11 @@ function runWithAsyncContext<T>(callback: (hub: Hub) => T, options: RunWithAsync
   const activeDomain = getActiveDomain<domain.Domain & Carrier>();
 
   if (activeDomain && options?.reuseExisting) {
-    for (const emitter of options.emitters || []) {
-      if (emitter instanceof EventEmitter) {
-        activeDomain.add(emitter);
-      }
-    }
-
     // We're already in a domain, so we don't need to create a new one, just call the callback with the current hub
     return callback(getHubFromCarrier(activeDomain));
   }
 
   const local = domain.create() as domain.Domain & Carrier;
-
-  for (const emitter of options.emitters || []) {
-    if (emitter instanceof EventEmitter) {
-      local.add(emitter);
-    }
-  }
 
   const parentHub = activeDomain ? getHubFromCarrier(activeDomain) : undefined;
   const newHub = createNewHub(parentHub);

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -187,43 +187,40 @@ export function requestHandler(
           });
       };
     }
-    runWithAsyncContext(
-      currentHub => {
-        currentHub.configureScope(scope => {
-          scope.setSDKProcessingMetadata({
-            request: req,
-            // TODO (v8): Stop passing this
-            requestDataOptionsFromExpressHandler: requestDataOptions,
-          });
-
-          const client = currentHub.getClient<NodeClient>();
-          if (isAutoSessionTrackingEnabled(client)) {
-            const scope = currentHub.getScope();
-            if (scope) {
-              // Set `status` of `RequestSession` to Ok, at the beginning of the request
-              scope.setRequestSession({ status: 'ok' });
-            }
-          }
+    runWithAsyncContext(currentHub => {
+      currentHub.configureScope(scope => {
+        scope.setSDKProcessingMetadata({
+          request: req,
+          // TODO (v8): Stop passing this
+          requestDataOptionsFromExpressHandler: requestDataOptions,
         });
 
-        res.once('finish', () => {
-          const client = currentHub.getClient<NodeClient>();
-          if (isAutoSessionTrackingEnabled(client)) {
-            setImmediate(() => {
+        const client = currentHub.getClient<NodeClient>();
+        if (isAutoSessionTrackingEnabled(client)) {
+          const scope = currentHub.getScope();
+          if (scope) {
+            // Set `status` of `RequestSession` to Ok, at the beginning of the request
+            scope.setRequestSession({ status: 'ok' });
+          }
+        }
+      });
+
+      res.once('finish', () => {
+        const client = currentHub.getClient<NodeClient>();
+        if (isAutoSessionTrackingEnabled(client)) {
+          setImmediate(() => {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            if (client && (client as any)._captureRequestSession) {
+              // Calling _captureRequestSession to capture request session at the end of the request by incrementing
+              // the correct SessionAggregates bucket i.e. crashed, errored or exited
               // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              if (client && (client as any)._captureRequestSession) {
-                // Calling _captureRequestSession to capture request session at the end of the request by incrementing
-                // the correct SessionAggregates bucket i.e. crashed, errored or exited
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                (client as any)._captureRequestSession();
-              }
-            });
-          }
-        });
-        next();
-      },
-      { emitters: [req, res] },
-    );
+              (client as any)._captureRequestSession();
+            }
+          });
+        }
+      });
+      next();
+    });
   };
 }
 


### PR DESCRIPTION
Event emitters added to domains are only used when attaching an error handler to the domains itself: https://nodejs.org/docs/latest-v19.x/api/domain.html#domainaddemitter

Because we do not do that in the SDK, it is unnecessary to add them. This PR removes the API around this in the async context abstraction.