### PR TITLE
fix(gatsby): Don't crash build when auth token is missing

### DIFF
--- a/packages/gatsby/gatsby-node.js
+++ b/packages/gatsby/gatsby-node.js
@@ -46,8 +46,13 @@ exports.onCreateWebpackConfig = ({ plugins, getConfig, actions }) => {
           // Handle sentry-cli configuration errors when the user has not done it not to break
           // the build.
           errorHandler(err, invokeErr) {
-            const { message } = err;
+            const message = err.message && err.message.toLowerCase() || '';
             if (message.includes('organization slug is required') || message.includes('project slug is required')) {
+              return;
+            }
+            if (message.includes('authentication credentials were not provided')) {
+              // eslint-disable-next-line no-console
+              console.warn('Sentry Logger [Warn]: Cannot upload source maps due to missing SENTRY_AUTH_TOKEN env variable.')
               return;
             }
             invokeErr(err);

--- a/packages/gatsby/gatsby-node.js
+++ b/packages/gatsby/gatsby-node.js
@@ -48,11 +48,13 @@ exports.onCreateWebpackConfig = ({ plugins, getConfig, actions }) => {
           errorHandler(err, invokeErr) {
             const message = err.message && err.message.toLowerCase() || '';
             if (message.includes('organization slug is required') || message.includes('project slug is required')) {
+              // eslint-disable-next-line no-console
+              console.log('Sentry [Info]: Not uploading source maps due to missing SENTRY_ORG and SENTRY_PROJECT env variables.')
               return;
             }
             if (message.includes('authentication credentials were not provided')) {
               // eslint-disable-next-line no-console
-              console.warn('Sentry Logger [Warn]: Cannot upload source maps due to missing SENTRY_AUTH_TOKEN env variable.')
+              console.warn('Sentry [Warn]: Cannot upload source maps due to missing SENTRY_AUTH_TOKEN env variable.')
               return;
             }
             invokeErr(err);
@@ -98,7 +100,7 @@ function injectSentryConfig(config, configFile) {
     } else {
       // eslint-disable-next-line no-console
       console.error(
-        `Sentry Logger [Error]: Could not inject SDK initialization code into ${prop}, unexpected format: `,
+        `Sentry [Error]: Could not inject SDK initialization code into ${prop}, unexpected format: `,
         typeof value,
       );
     }


### PR DESCRIPTION
Our Gatsby SDK ships with the webpack plugin to automatically upload source maps (TIL).
 
When building for production, the webpack causes a crash if no auth token is specified. We decided that builds shouldn't crash because of a misconfiguration of our plugin, so this PR fixes that (see #7427 and #7846). Instead, we'll log a warning in this case.
Note: I opted to not log a warning if ORG or PROJECT were not specified because in this case one could argue that users don't want to upload at all. This is identical to the previous behaviour. Happy to change that though, if reviewers think we should notify users anyway.

closes #7852 