### PR TITLE
build(sveltekit): Upgrade to Rollup 3

### DIFF
--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -35,12 +35,13 @@
     "@sveltejs/kit": "^1.11.0",
     "svelte": "^3.44.0",
     "typescript": "^4.9.3",
-    "vite": "4.0.0"
+    "vite": "4.0.0",
+    "rollup": "^3.20.2"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",
     "build:dev": "yarn build",
-    "build:transpile": "rollup -c rollup.npm.config.js",
+    "build:transpile": "rollup -c rollup.npm.config.js --bundleConfigAsCjs",
     "build:types": "tsc -p tsconfig.types.json",
     "build:watch": "run-p build:transpile:watch build:types:watch",
     "build:dev:watch": "yarn build:watch",

--- a/packages/sveltekit/rollup.npm.config.js
+++ b/packages/sveltekit/rollup.npm.config.js
@@ -5,6 +5,9 @@ export default makeNPMConfigVariants(
     entrypoints: ['src/index.server.ts', 'src/index.client.ts', 'src/client/index.ts', 'src/server/index.ts'],
     packageSpecificConfig: {
       external: ['$app/stores'],
+      output: {
+        dynamicImportInCjs: true,
+      }
     },
   }),
 );

--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -14,7 +14,7 @@ import * as path from 'path';
 import commonjs from '@rollup/plugin-commonjs';
 import deepMerge from 'deepmerge';
 import license from 'rollup-plugin-license';
-import resolve from '@rollup/plugin-node-resolve';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
 import replace from '@rollup/plugin-replace';
 import { terser } from 'rollup-plugin-terser';
 import typescript from '@rollup/plugin-typescript';
@@ -178,5 +178,9 @@ export function makeTSPlugin(jsVersion) {
 
 // We don't pass these plugins any options which need to be calculated or changed by us, so no need to wrap them in
 // another factory function, as they are themselves already factory functions.
-export { resolve as makeNodeResolvePlugin };
+
+export function makeNodeResolvePlugin() {
+  return nodeResolve();
+}
+
 export { commonjs as makeCommonJSPlugin };

--- a/yarn.lock
+++ b/yarn.lock
@@ -23620,6 +23620,13 @@ rollup@^3.10.0:
   optionalDependencies:
     fsevents "~2.3.2"
 
+rollup@^3.20.2:
+  version "3.20.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.20.2.tgz#f798c600317f216de2e4ad9f4d9ab30a89b690ff"
+  integrity sha512-3zwkBQl7Ai7MFYQE0y1MeQ15+9jsi7XxfrqwTb/9EK8D9C9+//EBR4M+CuA1KODRaNbFez/lWxA5vhEGZp4MUg==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 rollup@^3.7.0:
   version "3.18.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.18.0.tgz#2354ba63ba66d6a09c652c3ea0dbcd9dad72bbde"


### PR DESCRIPTION
This PR bumps rollup from 2.6 to 3.2 - for now just in the SvelteKit SDK. We need this to dynamically import users' `svelte.config.js` files at build time. More specifically, rollup 3 introduces [`output.dynamicImportsInCjs`](https://rollupjs.org/configuration-options/#output-dynamicimportincjs) which stops rollup from converting dynamic `import` statements to dynamic (async) `require` calls. 

ESM and CJS... Just gotta love it.

We can think about updating rollup in the other packages as well but the change is ofc riskier and will probably require a lot more changes. 

sort of ref #7669 