### PR TITLE
feat(sveltekit): Read adapter output directory from `svelte.config.js`

### DIFF
--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -37,7 +37,7 @@ const DEFAULT_PLUGIN_OPTIONS: SentrySvelteKitPluginOptions = {
  * Sentry adds a few additional properties to your Vite config.
  * Make sure, it is registered before the SvelteKit plugin.
  */
-export function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}): Plugin[] {
+export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}): Promise<Plugin[]> {
   const mergedOptions = {
     ...DEFAULT_PLUGIN_OPTIONS,
     ...options,
@@ -50,7 +50,7 @@ export function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}): Plu
       ...mergedOptions.sourceMapsUploadOptions,
       debug: mergedOptions.debug, // override the plugin's debug flag with the one from the top-level options
     };
-    sentryPlugins.push(makeCustomSentryVitePlugin(pluginOptions));
+    sentryPlugins.push(await makeCustomSentryVitePlugin(pluginOptions));
   }
 
   return sentryPlugins;

--- a/packages/sveltekit/src/vite/svelteConfig.ts
+++ b/packages/sveltekit/src/vite/svelteConfig.ts
@@ -1,0 +1,94 @@
+/* eslint-disable @sentry-internal/sdk/no-optional-chaining */
+
+import type { Builder, Config } from '@sveltejs/kit';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as url from 'url';
+
+/**
+ * Imports the svelte.config.js file and returns the config object.
+ * The sveltekit plugins import the config in the same way.
+ * See: https://github.com/sveltejs/kit/blob/master/packages/kit/src/core/config/index.js#L63
+ */
+export async function loadSvelteConfig(): Promise<Config> {
+  // This can only be .js (see https://github.com/sveltejs/kit/pull/4031#issuecomment-1049475388)
+  const SVELTE_CONFIG_FILE = 'svelte.config.js';
+
+  const configFile = path.join(process.cwd(), SVELTE_CONFIG_FILE);
+
+  try {
+    if (!fs.existsSync(configFile)) {
+      return {};
+    }
+    // @ts-ignore - we explicitly want to import the svelte config here.
+    const svelteConfigModule = await import(`${url.pathToFileURL(configFile).href}`);
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    return (svelteConfigModule?.default as Config) || {};
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn("[Source Maps Plugin] Couldn't load svelte.config.js:");
+    // eslint-disable-next-line no-console
+    console.log(e);
+
+    return {};
+  }
+}
+
+/**
+ * Attempts to read a custom output directory that can be specidied in the options
+ * of a SvelteKit adapter. If no custom output directory is specified, the default
+ * directory is returned.
+ *
+ * To get the directory, we have to apply a hack and call the adapter's adapt method
+ * with a custom adapter `Builder` that only calls the `writeClient` method.
+ * This method is the first method that is called with the output directory.
+ * Once we obtained the output directory, we throw an error to exit the adapter.
+ *
+ * see: https://github.com/sveltejs/kit/blob/master/packages/adapter-node/index.js#L17
+ *
+ */
+export async function getAdapterOutputDir(svelteConfig: Config): Promise<string> {
+  // 'build' is the default output dir for the node adapter
+  let outputDir = 'build';
+
+  if (!svelteConfig.kit?.adapter) {
+    return outputDir;
+  }
+
+  const adapter = svelteConfig.kit.adapter;
+
+  const adapterBuilder: Builder = {
+    writeClient(dest: string) {
+      outputDir = dest.replace(/\/client.*/, '');
+      throw new Error('We got what we came for, throwing to exit the adapter');
+    },
+    // @ts-ignore - No need to implement the other methods
+    log: {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function -- this should be a noop
+      minor() {},
+    },
+    getBuildDirectory: () => '',
+    // eslint-disable-next-line @typescript-eslint/no-empty-function -- this should be a noop
+    rimraf: () => {},
+    // eslint-disable-next-line @typescript-eslint/no-empty-function -- this should be a noop
+    mkdirp: () => {},
+
+    config: {
+      kit: {
+        // @ts-ignore - the builder expects a validated config but for our purpose it's fine to just pass this partial config
+        paths: {
+          base: svelteConfig.kit?.paths?.base || '',
+        },
+      },
+    },
+  };
+
+  try {
+    await adapter.adapt(adapterBuilder);
+  } catch (_) {
+    // We expect the adapter to throw in writeClient!
+  }
+
+  return outputDir;
+}

--- a/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
+++ b/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
@@ -4,26 +4,26 @@ import { sentrySvelteKit } from '../../src/vite/sentryVitePlugins';
 import * as sourceMaps from '../../src/vite/sourceMaps';
 
 describe('sentryVite()', () => {
-  it('returns an array of Vite plugins', () => {
-    const plugins = sentrySvelteKit();
+  it('returns an array of Vite plugins', async () => {
+    const plugins = await sentrySvelteKit();
     expect(plugins).toBeInstanceOf(Array);
     expect(plugins).toHaveLength(1);
   });
 
-  it('returns the custom sentry source maps plugin by default', () => {
-    const plugins = sentrySvelteKit();
+  it('returns the custom sentry source maps plugin by default', async () => {
+    const plugins = await sentrySvelteKit();
     const plugin = plugins[0];
     expect(plugin.name).toEqual('sentry-vite-plugin-custom');
   });
 
-  it("doesn't return the custom sentry source maps plugin if autoUploadSourcemaps is `false`", () => {
-    const plugins = sentrySvelteKit({ autoUploadSourceMaps: false });
+  it("doesn't return the custom sentry source maps plugin if autoUploadSourcemaps is `false`", async () => {
+    const plugins = await sentrySvelteKit({ autoUploadSourceMaps: false });
     expect(plugins).toHaveLength(0);
   });
 
-  it('passes user-specified vite pugin options to the custom sentry source maps plugin', () => {
+  it('passes user-specified vite pugin options to the custom sentry source maps plugin', async () => {
     const makePluginSpy = vi.spyOn(sourceMaps, 'makeCustomSentryVitePlugin');
-    const plugins = sentrySvelteKit({
+    const plugins = await sentrySvelteKit({
       debug: true,
       sourceMapsUploadOptions: {
         include: ['foo.js'],

--- a/packages/sveltekit/test/vite/svelteConfig.test.ts
+++ b/packages/sveltekit/test/vite/svelteConfig.test.ts
@@ -1,0 +1,58 @@
+import { vi } from 'vitest';
+
+import { getAdapterOutputDir, loadSvelteConfig } from '../../src/vite/svelteConfig';
+
+let existsFile;
+
+describe('loadSvelteConfig', () => {
+  vi.mock('fs', () => {
+    return {
+      existsSync: () => existsFile,
+    };
+  });
+
+  vi.mock(`${process.cwd()}/svelte.config.js`, () => {
+    return {
+      default: {
+        kit: {
+          adapter: {},
+        },
+      },
+    };
+  });
+
+  beforeEach(() => {
+    existsFile = true;
+    vi.clearAllMocks();
+  });
+
+  it('returns the svelte config', async () => {
+    const config = await loadSvelteConfig();
+    expect(config).toStrictEqual({
+      kit: {
+        adapter: {},
+      },
+    });
+  });
+
+  it('returns an empty object if svelte.config.js does not exist', async () => {
+    existsFile = false;
+
+    const config = await loadSvelteConfig();
+    expect(config).toStrictEqual({});
+  });
+});
+
+describe('getAdapterOutputDir', () => {
+  const mockedAdapter = {
+    name: 'mocked-adapter',
+    adapt(builder) {
+      builder.writeClient('customBuildDir');
+    },
+  };
+
+  it('returns the output directory of the adapter', async () => {
+    const outputDir = await getAdapterOutputDir({ kit: { adapter: mockedAdapter } });
+    expect(outputDir).toEqual('customBuildDir');
+  });
+});

--- a/packages/sveltekit/test/vite/svelteConfig.test.ts
+++ b/packages/sveltekit/test/vite/svelteConfig.test.ts
@@ -21,6 +21,17 @@ describe('loadSvelteConfig', () => {
     };
   });
 
+  // url apparently doesn't exist in the test environment, therefore we mock it:
+  vi.mock('url', () => {
+    return {
+      pathToFileURL: path => {
+        return {
+          href: path,
+        };
+      },
+    };
+  });
+
   beforeEach(() => {
     existsFile = true;
     vi.clearAllMocks();


### PR DESCRIPTION
Needs #7862 

With this PR, our source maps upload plugin is able to read `svelte.config.js`. This is necessary to automatically find the output directory that users can specify when setting up the Node adapter. 
This is a "little" hacky though, because we can't just access the output dir variable. Instead, we actually invoke the adapter (which we can access) and pass a minimal, mostly no-op adapter builder, which will report back the output directory. 

(I'm sure this is gonna backfire some day but let's just do it anyway lol)

the good news:

closes #7669 