### PR TITLE
fix(nextjs): Mark value injection loader result as uncacheable

### DIFF
--- a/packages/nextjs/src/config/loaders/types.ts
+++ b/packages/nextjs/src/config/loaders/types.ts
@@ -1,27 +1,62 @@
 import type webpack from 'webpack';
 
 export type LoaderThis<Options> = {
-  /** Path to the file being loaded */
+  /**
+   * Path to the file being loaded
+   *
+   * https://webpack.js.org/api/loaders/#thisresourcepath
+   */
   resourcePath: string;
 
-  /** Query at the end of resolved file name ("../some-folder/some-module?foobar" -> resourceQuery: "?foobar") */
+  /**
+   * Query at the end of resolved file name ("../some-folder/some-module?foobar" -> resourceQuery: "?foobar")
+   *
+   * https://webpack.js.org/api/loaders/#thisresourcequery
+   */
   resourceQuery: string;
 
-  // Function to add outside file used by loader to `watch` process
+  /**
+   * Function to add outside file used by loader to `watch` process
+   *
+   * https://webpack.js.org/api/loaders/#thisadddependency
+   */
   addDependency: (filepath: string) => void;
 
-  // Marks a loader as asynchronous
+  /**
+   * Marks a loader result as cacheable.
+   *
+   * https://webpack.js.org/api/loaders/#thiscacheable
+   */
+  cacheable: (flag: boolean) => void;
+
+  /**
+   * Marks a loader as asynchronous
+   *
+   * https://webpack.js.org/api/loaders/#thisasync
+   */
   async: webpack.loader.LoaderContext['async'];
 
-  // Return errors, code, and sourcemaps from an asynchronous loader
+  /**
+   * Return errors, code, and sourcemaps from an asynchronous loader
+   *
+   * https://webpack.js.org/api/loaders/#thiscallback
+   */
   callback: webpack.loader.LoaderContext['callback'];
 } & (
   | {
-      // Loader options in Webpack 4
+      /**
+       * Loader options in Webpack 4
+       *
+       * https://webpack.js.org/api/loaders/#thisquery
+       */
       query: Options;
     }
   | {
-      // Loader options in Webpack 5
+      /**
+       * Loader options in Webpack 5
+       *
+       * https://webpack.js.org/api/loaders/#thisgetoptionsschema
+       */
       getOptions: () => Options;
     }
 );

--- a/packages/nextjs/src/config/loaders/valueInjectionLoader.ts
+++ b/packages/nextjs/src/config/loaders/valueInjectionLoader.ts
@@ -15,6 +15,9 @@ export default function valueInjectionLoader(this: LoaderThis<LoaderOptions>, us
   // We know one or the other will be defined, depending on the version of webpack being used
   const { values } = 'getOptions' in this ? this.getOptions() : this.query;
 
+  // We do not want to cache injected values across builds
+  this.cacheable(false);
+
   // Define some global proxy that works on server and on the browser.
   let injectedCode = 'var _sentryCollisionFreeGlobalObject = typeof window === "undefined" ? global : window;\n';
 

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -855,7 +855,8 @@ function addValueInjectionLoader(
     __sentryRewritesTunnelPath__: userSentryOptions.tunnelRoute,
 
     // The webpack plugin's release injection breaks the `app` directory so we inject the release manually here instead.
-    SENTRY_RELEASE: { id: getSentryRelease(buildContext.buildId) },
+    // Having a release defined in dev-mode spams releases in Sentry so we only set one in non-dev mode
+    SENTRY_RELEASE: buildContext.dev ? undefined : { id: getSentryRelease(buildContext.buildId) },
   };
 
   const serverValues = {


### PR DESCRIPTION
Attempting to adress https://github.com/getsentry/sentry-javascript/issues/5734

Tested with Vercel CLI. Not sure if it works for auto deploys yet. Let's see.