### PR TITLE
chore: Fix bug in changelog about `runWithAsyncContext`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ If you want to manually add async context isolation to your application, you can
 import * as Sentry from '@sentry/node';
 
 const requestHandler = (ctx, next) => {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     Sentry.runWithAsyncContext(async () => {
       const hub = Sentry.getCurrentHub();
 
@@ -37,8 +37,9 @@ const requestHandler = (ctx, next) => {
           })
         )
       );
-
-      await next();
+      
+ 
+      await next().catch(reject);
       resolve();
     });
   });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,11 @@ const requestHandler = (ctx, next) => {
       );
       
  
-      await next().catch(reject);
+      try {
+        await next();
+      } catch (err) {
+        reject(err);
+      }
       resolve();
     });
   });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,7 @@ const requestHandler = (ctx, next) => {
           })
         )
       );
-      
- 
+
       try {
         await next();
       } catch (err) {


### PR DESCRIPTION
Without this, errors slip past any app error handling and directly crash the process.