### PR TITLE
fix(tracing): Ensure we use `s` instead of `ms` for startTimestamp

### DIFF
--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -10,7 +10,7 @@ import { Router } from '@angular/router';
 import { NavigationEnd, NavigationStart, ResolveEnd } from '@angular/router';
 import { getCurrentHub, WINDOW } from '@sentry/browser';
 import type { Span, Transaction, TransactionContext } from '@sentry/types';
-import { logger, stripUrlQueryAndFragment, timestampWithMs } from '@sentry/utils';
+import { logger, stripUrlQueryAndFragment, timestampInSeconds } from '@sentry/utils';
 import type { Observable } from 'rxjs';
 import { Subscription } from 'rxjs';
 import { filter, tap } from 'rxjs/operators';
@@ -258,7 +258,7 @@ export function TraceMethodDecorator(): MethodDecorator {
     const originalMethod = descriptor.value;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     descriptor.value = function (...args: any[]): ReturnType<typeof originalMethod> {
-      const now = timestampWithMs();
+      const now = timestampInSeconds();
       const activeTransaction = getActiveTransaction();
       if (activeTransaction) {
         activeTransaction.startChild({

--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import type { TransactionContext } from '@sentry/types';
-import { logger, timestampWithMs } from '@sentry/utils';
+import { logger, timestampInSeconds } from '@sentry/utils';
 
 import type { Hub } from '../hub';
 import type { Span } from './span';
@@ -46,7 +46,7 @@ export class IdleTransactionSpanRecorder extends SpanRecorder {
     if (span.spanId !== this.transactionSpanId) {
       // We patch span.finish() to pop an activity after setting an endTimestamp.
       span.finish = (endTimestamp?: number) => {
-        span.endTimestamp = typeof endTimestamp === 'number' ? endTimestamp : timestampWithMs();
+        span.endTimestamp = typeof endTimestamp === 'number' ? endTimestamp : timestampInSeconds();
         this._popActivity(span.spanId);
       };
 
@@ -128,7 +128,7 @@ export class IdleTransaction extends Transaction {
   }
 
   /** {@inheritDoc} */
-  public finish(endTimestamp: number = timestampWithMs()): string | undefined {
+  public finish(endTimestamp: number = timestampInSeconds()): string | undefined {
     this._finished = true;
     this.activities = {};
 
@@ -301,13 +301,13 @@ export class IdleTransaction extends Transaction {
     }
 
     if (Object.keys(this.activities).length === 0) {
-      const endTimestamp = timestampWithMs();
+      const endTimestamp = timestampInSeconds();
       if (this._idleTimeoutCanceledPermanently) {
         this._finishReason = IDLE_TRANSACTION_FINISH_REASONS[5];
         this.finish(endTimestamp);
       } else {
         // We need to add the timeout here to have the real endtimestamp of the transaction
-        // Remember timestampWithMs is in seconds, timeout is in ms
+        // Remember timestampInSeconds is in seconds, timeout is in ms
         this._restartIdleTimeout(endTimestamp + this._idleTimeout / 1000);
       }
     }

--- a/packages/core/src/tracing/span.ts
+++ b/packages/core/src/tracing/span.ts
@@ -7,7 +7,7 @@ import type {
   TraceContext,
   Transaction,
 } from '@sentry/types';
-import { dropUndefinedKeys, logger, timestampWithMs, uuid4 } from '@sentry/utils';
+import { dropUndefinedKeys, logger, timestampInSeconds, uuid4 } from '@sentry/utils';
 
 /**
  * Keeps track of finished spans for a given transaction
@@ -71,7 +71,7 @@ export class Span implements SpanInterface {
   /**
    * Timestamp in seconds when the span was created.
    */
-  public startTimestamp: number = timestampWithMs();
+  public startTimestamp: number = timestampInSeconds();
 
   /**
    * Timestamp in seconds when the span ended.
@@ -257,7 +257,7 @@ export class Span implements SpanInterface {
       }
     }
 
-    this.endTimestamp = typeof endTimestamp === 'number' ? endTimestamp : timestampWithMs();
+    this.endTimestamp = typeof endTimestamp === 'number' ? endTimestamp : timestampInSeconds();
   }
 
   /**

--- a/packages/ember/addon/index.ts
+++ b/packages/ember/addon/index.ts
@@ -4,7 +4,7 @@ import { macroCondition, isDevelopingApp, getOwnConfig } from '@embroider/macros
 import { next } from '@ember/runloop';
 import { assert, warn } from '@ember/debug';
 import Ember from 'ember';
-import { timestampWithMs, GLOBAL_OBJ } from '@sentry/utils';
+import { timestampInSeconds, GLOBAL_OBJ } from '@sentry/utils';
 import { GlobalConfig, OwnConfig } from './types';
 
 function _getSentryInitConfig() {
@@ -68,7 +68,7 @@ export const getActiveTransaction = () => {
 
 export const instrumentRoutePerformance = (BaseRoute: any) => {
   const instrumentFunction = async (op: string, description: string, fn: Function, args: any) => {
-    const startTimestamp = timestampWithMs();
+    const startTimestamp = timestampInSeconds();
     const result = await fn(...args);
 
     const currentTransaction = getActiveTransaction();

--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -6,7 +6,7 @@ import { ExtendedBackburner } from '@sentry/ember/runloop';
 import { Span, Transaction } from '@sentry/types';
 import { EmberRunQueues } from '@ember/runloop/-private/types';
 import { getActiveTransaction } from '..';
-import { browserPerformanceTimeOrigin, GLOBAL_OBJ, timestampWithMs } from '@sentry/utils';
+import { browserPerformanceTimeOrigin, GLOBAL_OBJ, timestampInSeconds } from '@sentry/utils';
 import { macroCondition, isTesting, getOwnConfig } from '@embroider/macros';
 import { EmberSentryConfig, GlobalConfig, OwnConfig } from '../types';
 import RouterService from '@ember/routing/router-service';
@@ -182,14 +182,14 @@ function _instrumentEmberRunloop(config: EmberSentryConfig) {
     if (currentQueueSpan) {
       currentQueueSpan.finish();
     }
-    currentQueueStart = timestampWithMs();
+    currentQueueStart = timestampInSeconds();
 
     instrumentedEmberQueues.forEach(queue => {
       scheduleOnce(queue, null, () => {
         scheduleOnce(queue, null, () => {
           // Process this queue using the end of the previous queue.
           if (currentQueueStart) {
-            const now = timestampWithMs();
+            const now = timestampInSeconds();
             const minQueueDuration = minimumRunloopQueueDuration ?? 5;
 
             if ((now - currentQueueStart) * 1000 >= minQueueDuration) {
@@ -210,7 +210,7 @@ function _instrumentEmberRunloop(config: EmberSentryConfig) {
           if (!stillActiveTransaction) {
             return;
           }
-          currentQueueStart = timestampWithMs();
+          currentQueueStart = timestampInSeconds();
         });
       });
     });
@@ -244,7 +244,7 @@ interface RenderEntries {
 function processComponentRenderBefore(payload: Payload, beforeEntries: RenderEntries) {
   const info = {
     payload,
-    now: timestampWithMs(),
+    now: timestampInSeconds(),
   };
   beforeEntries[payload.object] = info;
 }
@@ -261,7 +261,7 @@ function processComponentRenderAfter(
     return;
   }
 
-  const now = timestampWithMs();
+  const now = timestampInSeconds();
   const componentRenderDuration = now - begin.now;
 
   if (componentRenderDuration * 1000 >= minComponentDuration) {

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -3,7 +3,7 @@
 import type { Hub } from '@sentry/browser';
 import { getCurrentHub } from '@sentry/browser';
 import type { Span, Transaction } from '@sentry/types';
-import { timestampWithMs } from '@sentry/utils';
+import { timestampInSeconds } from '@sentry/utils';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
 
@@ -82,7 +82,7 @@ class Profiler extends React.Component<ProfilerProps> {
       // set as data on the span. We just store the prop keys as the values could be potenially very large.
       const changedProps = Object.keys(updateProps).filter(k => updateProps[k] !== this.props.updateProps[k]);
       if (changedProps.length > 0) {
-        const now = timestampWithMs();
+        const now = timestampInSeconds();
         this._updateSpan = this._mountSpan.startChild({
           data: {
             changedProps,
@@ -114,7 +114,7 @@ class Profiler extends React.Component<ProfilerProps> {
       // next activity as a child to the component mount activity.
       this._mountSpan.startChild({
         description: `<${name}>`,
-        endTimestamp: timestampWithMs(),
+        endTimestamp: timestampInSeconds(),
         op: REACT_RENDER_OP,
         startTimestamp: this._mountSpan.endTimestamp,
       });
@@ -195,7 +195,7 @@ function useProfiler(
       if (mountSpan && options.hasRenderSpan) {
         mountSpan.startChild({
           description: `<${name}>`,
-          endTimestamp: timestampWithMs(),
+          endTimestamp: timestampInSeconds(),
           op: REACT_RENDER_OP,
           startTimestamp: mountSpan.endTimestamp,
         });

--- a/packages/tracing-internal/src/browser/router.ts
+++ b/packages/tracing-internal/src/browser/router.ts
@@ -22,8 +22,8 @@ export function instrumentRoutingWithDefaults<T extends Transaction>(
   if (startTransactionOnPageLoad) {
     activeTransaction = customStartTransaction({
       name: WINDOW.location.pathname,
-      // pageload should always start at timeOrigin
-      startTimestamp: browserPerformanceTimeOrigin,
+      // pageload should always start at timeOrigin (and needs to be in s, not ms)
+      startTimestamp: browserPerformanceTimeOrigin ? browserPerformanceTimeOrigin / 1000 : undefined,
       op: 'pageload',
       metadata: { source: 'url' },
     });


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/getsentry/sentry-javascript/pull/7632 due to assuming `timestampWithMs` returns a timestamp in ms (which it does not do). 

Also replaces all usage of `timestampWithMs` with `timestampInSeconds`.

Let's deprecate `timestampWithMs` in a follow up PR.

