### PR TITLE
ref(deprecate): Deprecate `timestampWithMs`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,9 @@
 # Deprecations in 7.x
 
+## Deprecate `timestampWithMs` export - #7878
+
+The `timestampWithMs` util is deprecated in favor of using `timestampInSeconds`.
+
 ## Remove requirement for `@sentry/tracing` package (since 7.46.0)
 
 With `7.46.0` you no longer require the `@sentry/tracing` package to use tracing and performance monitoring with the Sentry JavaScript SDKs. The `@sentry/tracing` package will be removed in a future major release, but can still be used in the meantime.

--- a/packages/utils/src/time.ts
+++ b/packages/utils/src/time.ts
@@ -121,7 +121,12 @@ export const dateTimestampInSeconds: () => number = dateTimestampSource.nowSecon
  */
 export const timestampInSeconds: () => number = timestampSource.nowSeconds.bind(timestampSource);
 
-// Re-exported with an old name for backwards-compatibility.
+/**
+ * Re-exported with an old name for backwards-compatibility.
+ * TODO (v8): Remove this
+ *
+ * @deprecated Use `timestampInSeconds` instead.
+ */
 export const timestampWithMs = timestampInSeconds;
 
 /**


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry-javascript/pull/7877 being merged first.