### PR TITLE
ci: Ensure we pass correct token to auto-merge step

### DIFF
--- a/.github/workflows/gitflow-sync-develop.yml
+++ b/.github/workflows/gitflow-sync-develop.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Enable automerge for PR
         run: gh pr merge --merge --auto "1"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # https://github.com/marketplace/actions/auto-approve
       - name: Auto approve PR


### PR DESCRIPTION
Forgot about this when we migrated this.