### PR TITLE
ci: Tag issues if last commenter is user

### DIFF
--- a/.github/workflows/label-last-commenter.yml
+++ b/.github/workflows/label-last-commenter.yml
@@ -1,0 +1,31 @@
+name: 'Tag issues with last commenter'
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.issue.pull_request }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Add label if commenter is not member
+        if: |
+          github.event.comment.author_association != 'COLLABORATOR'
+          && github.event.comment.author_association != 'MEMBER'
+          && github.event.comment.author_association != 'OWNER'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: 'Status: User responded'
+
+      - name: Remove label if commenter is member
+        if: |
+          github.event.comment.author_association == 'COLLABORATOR'
+          || github.event.comment.author_association == 'MEMBER'
+          || github.event.comment.author_association == 'OWNER'
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: 'Status: User responded'

--- a/.github/workflows/label-last-commenter.yml
+++ b/.github/workflows/label-last-commenter.yml
@@ -19,7 +19,7 @@ jobs:
           && github.event.comment.author_association != 'OWNER'
         uses: actions-ecosystem/action-add-labels@v1
         with:
-          labels: 'Status: User responded'
+          labels: 'Waiting for: Team'
 
       - name: Remove label if commenter is member
         if: |
@@ -28,4 +28,4 @@ jobs:
           || github.event.comment.author_association == 'OWNER'
         uses: actions-ecosystem/action-remove-labels@v1
         with:
-          labels: 'Status: User responded'
+          labels: 'Waiting for: Team'


### PR DESCRIPTION
We talked about this a bit recently, so I took a quick stab into implementing this. This adds a label `Status: User responded' when a user comments, and removes it when a member responds. In theory, we should be able to use this label to find issues where we forgot to answer.