### PR TITLE
fix(sveltekit): Use `sentry.properties` file when uploading source maps

### DIFF
--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -42,6 +42,7 @@ export async function makeCustomSentryVitePlugin(options?: SentryVitePluginOptio
   const svelteConfig = await loadSvelteConfig();
 
   const outputDir = await getAdapterOutputDir(svelteConfig);
+  const hasSentryProperties = fs.existsSync(path.resolve(process.cwd(), 'sentry.properties'));
 
   const defaultPluginOptions: SentryVitePluginOptions = {
     include: [
@@ -49,6 +50,7 @@ export async function makeCustomSentryVitePlugin(options?: SentryVitePluginOptio
       { paths: [`${outputDir}/server/chunks`] },
       { paths: [`${outputDir}/server`], ignore: ['chunks/**'] },
     ],
+    configFile: hasSentryProperties ? 'sentry.properties' : undefined,
   };
 
   const mergedOptions = {


### PR DESCRIPTION
When setting up the SDK with the wizard (once that's shipped), a `sentry.properties` file will be created with org and project slug information. To pick this up without any additional user config of the Vite plugin, we need to point the plugin to this file. This PR fixes this "missing" behaviour.

(Note: This change can be merged regardless of the wizard state IMO)

sort of ref: https://github.com/getsentry/sentry-wizard/issues/244