### PR TITLE
fix(sveltekit): Avoid capturing "Not Found" errors in server `handleError` wrapper

### DIFF
--- a/packages/sveltekit/src/server/handleError.ts
+++ b/packages/sveltekit/src/server/handleError.ts
@@ -21,6 +21,10 @@ function defaultErrorHandler({ error }: Parameters<HandleServerError>[0]): Retur
  */
 export function handleErrorWithSentry(handleError: HandleServerError = defaultErrorHandler): HandleServerError {
   return (input: { error: unknown; event: RequestEvent }): ReturnType<HandleServerError> => {
+    if (isNotFoundError(input)) {
+      return handleError(input);
+    }
+
     captureException(input.error, scope => {
       scope.addEventProcessor(event => {
         addExceptionMechanism(event, {
@@ -34,4 +38,24 @@ export function handleErrorWithSentry(handleError: HandleServerError = defaultEr
 
     return handleError(input);
   };
+}
+
+/**
+ * When a page request fails because the page is not found, SvelteKit throws a "Not found" error.
+ * In the error handler here, we can't access the response yet (which we do in the load instrumentation),
+ * so we have to check if the error is a "Not found" error by checking if the route id is missing and
+ * by checking the error message on top of the raw stack trace.
+ */
+function isNotFoundError(input: { error: unknown; event: RequestEvent }): boolean {
+  const { error, event } = input;
+  const hasNoRouteId = event.route == null || event.route.id == null;
+  const rawStack: string =
+    (error != null &&
+      typeof error === 'object' &&
+      'stack' in error &&
+      typeof error.stack === 'string' &&
+      error.stack) ||
+    '';
+
+  return hasNoRouteId && rawStack.startsWith('Error: Not found:');
 }

--- a/packages/sveltekit/src/server/handleError.ts
+++ b/packages/sveltekit/src/server/handleError.ts
@@ -48,7 +48,9 @@ export function handleErrorWithSentry(handleError: HandleServerError = defaultEr
  */
 function isNotFoundError(input: { error: unknown; event: RequestEvent }): boolean {
   const { error, event } = input;
-  const hasNoRouteId = event.route == null || event.route.id == null;
+
+  const hasNoRouteId = !event.route || !event.route.id;
+
   const rawStack: string =
     (error != null &&
       typeof error === 'object' &&

--- a/packages/sveltekit/test/server/handleError.test.ts
+++ b/packages/sveltekit/test/server/handleError.test.ts
@@ -47,6 +47,23 @@ describe('handleError', () => {
     mockScope = new Scope();
   });
 
+  it('doesn\'t capture "Not found" errors for incorrect navigations', async () => {
+    const wrappedHandleError = handleErrorWithSentry();
+    const mockError = new Error('Not found: /asdf/123');
+    const mockEvent = {
+      url: new URL('https://myDomain.com/asdf/123'),
+      route: { id: null }, // <-- this is what SvelteKit puts in the event when the page is not found
+      // ...
+    } as RequestEvent;
+
+    const returnVal = await wrappedHandleError({ error: mockError, event: mockEvent });
+
+    expect(returnVal).not.toBeDefined();
+    expect(mockCaptureException).toHaveBeenCalledTimes(0);
+    expect(mockAddExceptionMechanism).toHaveBeenCalledTimes(0);
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+  });
+
   describe('calls captureException', () => {
     it('invokes the default handler if no handleError func is provided', async () => {
       const wrappedHandleError = handleErrorWithSentry();


### PR DESCRIPTION
Incoming page load requests on the server side for unknown/invalid routes will throw a `Error: Not found: /unknown/route` error in the server `handleError` hook. In our wrapper, we don't want to catch these errors (similarly to 404 errors in the `wrapLoadWithSentry` wrapper). 