### PR TITLE
chore(ci): Add Node 20 to the test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -465,7 +465,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12, 14, 16, 18, 20]
+        node: [10, 12, 14, 16, 18]
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3
@@ -728,7 +728,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14, 16, 18, 20]
+        node: [14, 16, 18]
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -433,7 +433,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [8, 10, 12, 14, 16, 18]
+        node: [8, 10, 12, 14, 16, 18, 20]
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3
@@ -465,7 +465,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12, 14, 16, 18]
+        node: [10, 12, 14, 16, 18, 20]
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3
@@ -698,7 +698,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12, 14, 16, 18]
+        node: [10, 12, 14, 16, 18, 20]
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3
@@ -728,7 +728,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14, 16, 18]
+        node: [14, 16, 18, 20]
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v3


### PR DESCRIPTION
https://nodejs.org/en/blog/announcements/v20-release-announce

From reviewing the CHANGELOG (https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V20.md), there seems to be no changes that will affect us in the code.

See v19 CHANGELOG: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V19.md

Notable things we can maybe pursue:
- Tracing Channel in `diagnostic_channel` API https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V19.md#tracing-channel-in-diagnostic_channel
- Add context about permissions: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#permission-model
- ESM loader hooks

PR to add node 18 to SDK Ci: https://github.com/getsentry/sentry-javascript/pull/5049