### PR TITLE
feat(utils): Emit warning when logger is disabled during build but `debug` is set to `true`

### DIFF
--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -52,6 +52,8 @@ export function consoleSandbox<T>(callback: () => T): T {
   }
 }
 
+let emittedDebugBuildWarning = false;
+
 function makeLogger(): Logger {
   let enabled = false;
   const logger: Partial<Logger> = {
@@ -76,7 +78,15 @@ function makeLogger(): Logger {
     });
   } else {
     CONSOLE_LEVELS.forEach(name => {
-      logger[name] = () => undefined;
+      logger[name] = () => {
+        if (!emittedDebugBuildWarning) {
+          emittedDebugBuildWarning = true;
+          // eslint-disable-next-line no-console
+          console.warn(
+            `${PREFIX}[warn]: Sentry logger got disabled during build (likely to save bundle size) but \`debug\` is set to \`true\`. Sentry will not emit any more logs.`,
+          );
+        }
+      };
     });
   }
 


### PR DESCRIPTION
When tree shaking the logger and setting `debug: true` it is probably unintentional. Let's warn people.