### PR TITLE
feat(nextjs): Add `disableLogger` option that automatically tree shakes logger statements

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -1,6 +1,6 @@
 import type { GLOBAL_OBJ } from '@sentry/utils';
 import type { SentryCliPluginOptions } from '@sentry/webpack-plugin';
-import type { WebpackPluginInstance } from 'webpack';
+import type { DefinePlugin, WebpackPluginInstance } from 'webpack';
 
 export type SentryWebpackPluginOptions = SentryCliPluginOptions;
 export type SentryWebpackPlugin = WebpackPluginInstance & { options: SentryWebpackPluginOptions };
@@ -128,6 +128,11 @@ export type UserSentryOptions = {
    * NOTE: This feature only works with Next.js 11+
    */
   tunnelRoute?: string;
+
+  /**
+   * Tree shakes Sentry SDK logger statements from the bundle.
+   */
+  disableLogger?: boolean;
 };
 
 export type NextConfigFunction = (phase: string, defaults: { defaultConfig: NextConfigObject }) => NextConfigObject;
@@ -167,7 +172,10 @@ export type BuildContext = {
   dir: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   config: any;
-  webpack: { version: string };
+  webpack: {
+    version: string;
+    DefinePlugin: typeof DefinePlugin;
+  };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   defaultLoaders: any;
   totalPages: number;

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -295,6 +295,15 @@ export function constructWebpackConfigFunction(
       }
     }
 
+    if (userSentryOptions.disableLogger) {
+      newConfig.plugins = newConfig.plugins || [];
+      newConfig.plugins.push(
+        new buildContext.webpack.DefinePlugin({
+          __SENTRY_DEBUG__: false,
+        }),
+      );
+    }
+
     return newConfig;
   };
 }

--- a/packages/nextjs/test/config/fixtures.ts
+++ b/packages/nextjs/test/config/fixtures.ts
@@ -99,7 +99,7 @@ export function getBuildContext(
       distDir: '.next',
       ...materializedNextConfig,
     } as NextConfigObject,
-    webpack: { version: webpackVersion },
+    webpack: { version: webpackVersion, DefinePlugin: class {} as any },
     defaultLoaders: true,
     totalPages: 2,
     isServer: buildTarget === 'server' || buildTarget === 'edge',


### PR DESCRIPTION
This is just adding a very convenient way of treeshaking the logger we can put into docs snippets and the wizard.