### PR TITLE
fix(node): reduce deepReadDirSync runtime complexity

### DIFF
--- a/packages/node/src/utils.ts
+++ b/packages/node/src/utils.ts
@@ -27,10 +27,11 @@ export function deepReadDirSync(targetDir: string): string[] {
       const itemAbsPath = path.join(currentDirAbsPath, itemName);
 
       if (fs.statSync(itemAbsPath).isDirectory()) {
-        return [...absPaths, ...deepReadCurrentDir(itemAbsPath)];
+        return absPaths.concat(deepReadCurrentDir(itemAbsPath));
       }
 
-      return [...absPaths, itemAbsPath];
+      absPaths.push(itemAbsPath);
+      return absPaths;
     }, []);
   };
 


### PR DESCRIPTION
I'm experimenting with some eslint rules to detect runtime performance issues and part of my testing was to run it on sentry-javascript and sentry codebase. There are currently only two rules, one for detecting On^2 in reduce callbacks and a rule for detecting unnecessary array spread operators (which the codebase doesn't seem to use much of anyways). 

The reduce rule found one instance where the reducer runtime complexity is exponential (due to the accumulator being spread on each iteration). The fix is to treat the accumulator as mutable and avoid shallow copies inside each iteration.

(gh is not very helpful with reviewer suggestions so tagging @lforst and @AbhiPrasad, but feel free to reassign)