### PR TITLE
ci: Improve last commenter action

### DIFF
--- a/.github/workflows/label-last-commenter.yml
+++ b/.github/workflows/label-last-commenter.yml
@@ -5,13 +5,11 @@ on:
     types: [created]
 
 jobs:
-  deploy:
+  toggle_labels:
+    name: Toggle Labels
     runs-on: ubuntu-latest
     if: ${{ !github.event.issue.pull_request }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
       - name: Add label if commenter is not member
         if: |
           github.event.comment.author_association != 'COLLABORATOR'

--- a/.github/workflows/label-last-commenter.yml
+++ b/.github/workflows/label-last-commenter.yml
@@ -11,10 +11,12 @@ jobs:
     if: ${{ !github.event.issue.pull_request }}
     steps:
       - name: Add label if commenter is not member
+        # Note: We only add the label if the issue is still open
         if: |
           github.event.comment.author_association != 'COLLABORATOR'
           && github.event.comment.author_association != 'MEMBER'
           && github.event.comment.author_association != 'OWNER'
+          && !github.event.issue.closed
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: 'Waiting for: Team'


### PR DESCRIPTION
Noticed some improvements for this action:

* Add a proper name
* We do not need to run checkout, I believe, which should make this slightly faster too.