### PR TITLE
feat(node): Add monitor upsert types

### DIFF
--- a/packages/node/test/checkin.test.ts
+++ b/packages/node/test/checkin.test.ts
@@ -1,7 +1,9 @@
+import type { CheckIn } from '@sentry/types';
+
 import { createCheckInEnvelope } from '../src/checkin';
 
-describe('userFeedback', () => {
-  test('creates user feedback envelope header', () => {
+describe('CheckIn', () => {
+  test('creates a check in envelope header', () => {
     const envelope = createCheckInEnvelope(
       {
         check_in_id: '83a7c03ed0a04e1b97e2e3b18d38f244',
@@ -32,29 +34,93 @@ describe('userFeedback', () => {
     });
   });
 
-  test('creates user feedback envelope item', () => {
-    const envelope = createCheckInEnvelope({
-      check_in_id: '83a7c03ed0a04e1b97e2e3b18d38f244',
-      monitor_slug: 'b7645b8e-b47d-4398-be9a-d16b0dac31cb',
-      status: 'ok',
-      duration: 10.0,
-      release: '1.0.0',
-      environment: 'production',
-    });
+  test.each([
+    [
+      'no monitor config',
+      {
+        check_in_id: '83a7c03ed0a04e1b97e2e3b18d38f244',
+        monitor_slug: 'b7645b8e-b47d-4398-be9a-d16b0dac31cb',
+        status: 'ok',
+        duration: 10.0,
+        release: '1.0.0',
+        environment: 'production',
+      } as CheckIn,
+      {
+        check_in_id: '83a7c03ed0a04e1b97e2e3b18d38f244',
+        monitor_slug: 'b7645b8e-b47d-4398-be9a-d16b0dac31cb',
+        status: 'ok',
+        duration: 10.0,
+        release: '1.0.0',
+        environment: 'production',
+      },
+    ],
+    [
+      'crontab monitor config',
+      {
+        check_in_id: '83a7c03ed0a04e1b97e2e3b18d38f244',
+        monitor_slug: 'b7645b8e-b47d-4398-be9a-d16b0dac31cb',
+        status: 'in_progress',
+        monitor_config: {
+          schedule: {
+            type: 'crontab',
+            value: '0 * * * *',
+          },
+          checkin_margin: 5,
+          max_runtime: 30,
+          timezone: 'America/Los_Angeles',
+        },
+      } as CheckIn,
+      {
+        check_in_id: '83a7c03ed0a04e1b97e2e3b18d38f244',
+        monitor_slug: 'b7645b8e-b47d-4398-be9a-d16b0dac31cb',
+        status: 'in_progress',
+        monitor_config: {
+          schedule: {
+            type: 'crontab',
+            value: '0 * * * *',
+          },
+          checkin_margin: 5,
+          max_runtime: 30,
+          timezone: 'America/Los_Angeles',
+        },
+      },
+    ],
+    [
+      'interval monitor config',
+      {
+        check_in_id: '83a7c03ed0a04e1b97e2e3b18d38f244',
+        monitor_slug: 'b7645b8e-b47d-4398-be9a-d16b0dac31cb',
+        status: 'in_progress',
+        monitor_config: {
+          schedule: {
+            type: 'interval',
+            value: 1234,
+            unit: 'minute',
+          },
+        },
+      } as CheckIn,
+      {
+        check_in_id: '83a7c03ed0a04e1b97e2e3b18d38f244',
+        monitor_slug: 'b7645b8e-b47d-4398-be9a-d16b0dac31cb',
+        status: 'in_progress',
+        monitor_config: {
+          schedule: {
+            type: 'interval',
+            value: 1234,
+            unit: 'minute',
+          },
+        },
+      },
+    ],
+  ])('creates a check in envelope header with %s', (_, checkIn, envelopeItem) => {
+    const envelope = createCheckInEnvelope(checkIn);
 
     expect(envelope[1]).toEqual([
       [
         {
           type: 'check_in',
         },
-        {
-          check_in_id: '83a7c03ed0a04e1b97e2e3b18d38f244',
-          monitor_slug: 'b7645b8e-b47d-4398-be9a-d16b0dac31cb',
-          status: 'ok',
-          duration: 10.0,
-          release: '1.0.0',
-          environment: 'production',
-        },
+        envelopeItem,
       ],
     ]);
   });

--- a/packages/types/src/checkin.ts
+++ b/packages/types/src/checkin.ts
@@ -1,3 +1,17 @@
+interface CrontabSchedule {
+  type: 'crontab';
+  // The crontab schedule string, e.g. 0 * * * *.
+  value: string;
+}
+
+interface IntervalSchedule {
+  type: 'interval';
+  value: number;
+  unit: 'year' | 'month' | 'week' | 'day' | 'hour' | 'minute';
+}
+
+type MonitorSchedule = CrontabSchedule | IntervalSchedule;
+
 // https://develop.sentry.dev/sdk/check-ins/
 export interface CheckIn {
   // Check-In ID (unique and client generated).
@@ -10,4 +24,16 @@ export interface CheckIn {
   duration?: number;
   release?: string;
   environment?: string;
+  monitor_config?: {
+    schedule: MonitorSchedule;
+    // The allowed allowed margin of minutes after the expected check-in time that
+    // the monitor will not be considered missed for.
+    checkin_margin?: number;
+    // The allowed allowed duration in minutes that the monitor may be `in_progress`
+    // for before being considered failed due to timeout.
+    max_runtime?: number;
+    // A tz database string representing the timezone which the monitor's execution schedule is in.
+    // See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone?: string;
+  };
 }


### PR DESCRIPTION
See: https://develop.sentry.dev/sdk/check-ins/#schedule-configuration

ref: https://github.com/getsentry/sentry/issues/43661, https://github.com/getsentry/sentry-javascript/pull/7777

Add types for monitor upsert, and adjust tests accordingly.

Again we're not exposing these APIs, just having the types around so we can add it whenever.