### PR TITLE
fix(replay): Ensure we normalize scope breadcrumbs to max. depth to avoid circular ref

### DIFF
--- a/packages/replay/src/coreHandlers/util/addBreadcrumbEvent.ts
+++ b/packages/replay/src/coreHandlers/util/addBreadcrumbEvent.ts
@@ -27,7 +27,7 @@ export function addBreadcrumbEvent(replay: ReplayContainer, breadcrumb: Breadcru
       timestamp: (breadcrumb.timestamp || 0) * 1000,
       data: {
         tag: 'breadcrumb',
-        payload: normalize(breadcrumb),
+        payload: normalize(breadcrumb, 10),
       },
     });
 

--- a/packages/replay/src/coreHandlers/util/addBreadcrumbEvent.ts
+++ b/packages/replay/src/coreHandlers/util/addBreadcrumbEvent.ts
@@ -27,7 +27,8 @@ export function addBreadcrumbEvent(replay: ReplayContainer, breadcrumb: Breadcru
       timestamp: (breadcrumb.timestamp || 0) * 1000,
       data: {
         tag: 'breadcrumb',
-        payload: normalize(breadcrumb, 10),
+        // normalize to max. 10 depth and 1_000 properties per object
+        payload: normalize(breadcrumb, 10, 1_000),
       },
     });
 


### PR DESCRIPTION
After some in-depth debugging, I figured out that the replay may lock up if we do not normalize the scope breadcrumbs to a given depth.

This seems to fix the provided reproduction for me, and seems like a reasonable change overall.
10 is more or less a random value, but seems reasonable for me for this case? 

it gets slower and slower with an increasing value there, becoming basically unusable around ~18-20.

I did some further digging, and the problem is that around a normalization of 20, it becomes crazy large:

```js
console.log(JSON.stringify(normalize(breadcrumb, 20)));
```

results in a 60MB string 🤯 

This is a simple first step to ensure we normalize _all_ breadcrumbs to a max. depth. This applies to scope & dom breadcrumbs from Sentry itself.

This is not really a _fix_ per se, as it could still be massive in shallow size. But it should help generally, and is perf-free (or even positive), as we are already walking this in `normalize` anyhow.

Ref https://github.com/getsentry/team-replay/issues/67