### PR TITLE
fix(replay): Ensure we still truncate large bodies if they are failed JSON

### DIFF
--- a/packages/replay/src/coreHandlers/util/networkUtils.ts
+++ b/packages/replay/src/coreHandlers/util/networkUtils.ts
@@ -201,8 +201,8 @@ function normalizeNetworkBody(body: string | undefined): {
       };
     } catch {
       return {
-        body,
-        warnings: ['INVALID_JSON'],
+        body: exceedsSizeLimit ? `${body.slice(0, NETWORK_BODY_MAX_SIZE)}…` : body,
+        warnings: exceedsSizeLimit ? ['INVALID_JSON', 'TEXT_TRUNCATED'] : ['INVALID_JSON'],
       };
     }
   }


### PR DESCRIPTION
This also incorporates feedback from @Lms24 to properly handle the case when we both fail to parse JSON AND still truncate the body.