### PR TITLE
feat(core): Add multiplexed transport

### DIFF
--- a/.github/workflows/gitflow-sync-develop.yml
+++ b/.github/workflows/gitflow-sync-develop.yml
@@ -39,13 +39,13 @@ jobs:
           github_token: ${{ secrets.REPO_SCOPED_TOKEN }}
 
       - name: Enable automerge for PR
-        run: gh pr merge --merge --auto "1"
+        if: steps.open-pr.outputs.pr_number != ''
+        run: gh pr merge --merge --auto "${{ steps.open-pr.outputs.pr_number }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # https://github.com/marketplace/actions/auto-approve
       - name: Auto approve PR
-        # Always skip this for now, until we got a proper bot setup
         if: steps.open-pr.outputs.pr_number != ''
         uses: hmarr/auto-approve-action@v3
         with:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,6 +37,7 @@ export { BaseClient } from './baseclient';
 export { initAndBind } from './sdk';
 export { createTransport } from './transports/base';
 export { makeOfflineTransport } from './transports/offline';
+export { makeMultiplexedTransport } from './transports/multiplexed';
 export { SDK_VERSION } from './version';
 export { getIntegrationsToSetup } from './integration';
 export { FunctionToString, InboundFilters } from './integrations';

--- a/packages/core/src/transports/multiplexed.ts
+++ b/packages/core/src/transports/multiplexed.ts
@@ -15,10 +15,12 @@ interface MatchParam {
   /** The envelope to be sent */
   envelope: Envelope;
   /**
-   * A function that returns an event from the envelope if one exists
+   * A function that returns an event from the envelope if one exists. You can optionally pass an array of envelope item
+   * types to filter by - only envelopes matching the given types will be multiplexed.
+   *
    * @param types Defaults to ['event', 'transaction', 'profile', 'replay_event']
    */
-  getEvent(...types: EnvelopeItemType[]): Event | undefined;
+  getEvent(types?: EnvelopeItemType[]): Event | undefined;
 }
 
 type Matcher = (param: MatchParam) => string[];
@@ -58,10 +60,9 @@ export function makeMultiplexedTransport<TO extends BaseTransportOptions>(
     }
 
     async function send(envelope: Envelope): Promise<void | TransportMakeRequestResponse> {
-      function getEvent(...types: EnvelopeItemType[]): Event | undefined {
-        const eventTypes: EnvelopeItemType[] = types.length
-          ? types
-          : ['event', 'transaction', 'profile', 'replay_event'];
+      function getEvent(types?: EnvelopeItemType[]): Event | undefined {
+        const eventTypes: EnvelopeItemType[] =
+          types && types.length ? types : ['event', 'transaction', 'profile', 'replay_event'];
         return eventFromEnvelope(envelope, eventTypes);
       }
 

--- a/packages/core/src/transports/multiplexed.ts
+++ b/packages/core/src/transports/multiplexed.ts
@@ -1,0 +1,84 @@
+import type {
+  BaseTransportOptions,
+  Envelope,
+  Event,
+  EventItem,
+  Transport,
+  TransportMakeRequestResponse,
+} from '@sentry/types';
+import { dsnFromString, forEachEnvelopeItem } from '@sentry/utils';
+
+import { getEnvelopeEndpointWithUrlEncodedAuth } from '../api';
+
+interface MatchParam {
+  // The envelope to be sent
+  envelope: Envelope;
+  // A function that returns an event from the envelope if one exists
+  getEvent(): Event | undefined;
+}
+
+type Matcher = (param: MatchParam) => string[];
+
+function eventFromEnvelope(env: Envelope): Event | undefined {
+  let event: Event | undefined;
+
+  forEachEnvelopeItem(env, (item, type) => {
+    if (type === 'event' || type === 'transaction') {
+      event = Array.isArray(item) ? (item as EventItem)[1] : undefined;
+    }
+    // bail out if we found an event
+    return !!event;
+  });
+
+  return event;
+}
+
+/**
+ * Creates a transport that can send events to different DSNs depending on the envelope contents.
+ */
+export function makeMultiplexedTransport<TO extends BaseTransportOptions>(
+  createTransport: (options: TO) => Transport,
+  matcher: Matcher,
+): (options: TO) => Transport {
+  return options => {
+    const fallbackTransport = createTransport(options);
+    const otherTransports: Record<string, Transport> = {};
+
+    function getTransport(dsn: string): Transport {
+      if (!otherTransports[dsn]) {
+        const url = getEnvelopeEndpointWithUrlEncodedAuth(dsnFromString(dsn));
+        otherTransports[dsn] = createTransport({ ...options, url });
+      }
+
+      return otherTransports[dsn];
+    }
+
+    async function send(envelope: Envelope): Promise<void | TransportMakeRequestResponse> {
+      function getEvent(): Event | undefined {
+        return eventFromEnvelope(envelope);
+      }
+
+      const transports = matcher({ envelope, getEvent }).map(([dsn]) => getTransport(dsn));
+
+      // If we have no transports to send to, use the fallback transport
+      if (transports.length === 0) {
+        transports.push(fallbackTransport);
+      }
+
+      const results = await Promise.all(transports.map(transport => transport.send(envelope)));
+
+      return results[0];
+    }
+
+    async function flush(timeout: number | undefined): Promise<boolean> {
+      const allTransports = [...Object.keys(otherTransports).map(dsn => otherTransports[dsn]), fallbackTransport];
+      const results = await Promise.all(allTransports.map(transport => transport.flush(timeout)));
+      return results.every(r => r);
+    }
+
+    return {
+      send,
+      flush,
+    };
+  };
+}

--- a/packages/core/src/transports/multiplexed.ts
+++ b/packages/core/src/transports/multiplexed.ts
@@ -23,7 +23,7 @@ function eventFromEnvelope(env: Envelope): Event | undefined {
   let event: Event | undefined;
 
   forEachEnvelopeItem(env, (item, type) => {
-    if (type === 'event' || type === 'transaction') {
+    if (type === 'event') {
       event = Array.isArray(item) ? (item as EventItem)[1] : undefined;
     }
     // bail out if we found an event
@@ -58,7 +58,7 @@ export function makeMultiplexedTransport<TO extends BaseTransportOptions>(
         return eventFromEnvelope(envelope);
       }
 
-      const transports = matcher({ envelope, getEvent }).map(([dsn]) => getTransport(dsn));
+      const transports = matcher({ envelope, getEvent }).map(dsn => getTransport(dsn));
 
       // If we have no transports to send to, use the fallback transport
       if (transports.length === 0) {

--- a/packages/core/src/transports/multiplexed.ts
+++ b/packages/core/src/transports/multiplexed.ts
@@ -12,9 +12,12 @@ import { dsnFromString, forEachEnvelopeItem } from '@sentry/utils';
 import { getEnvelopeEndpointWithUrlEncodedAuth } from '../api';
 
 interface MatchParam {
-  // The envelope to be sent
+  /** The envelope to be sent */
   envelope: Envelope;
-  // A function that returns an event from the envelope if one exists
+  /**
+   * A function that returns an event from the envelope if one exists
+   * @param types Defaults to ['event', 'transaction', 'profile', 'replay_event']
+   */
   getEvent(...types: EnvelopeItemType[]): Event | undefined;
 }
 

--- a/packages/core/test/lib/transports/multiplexed.test.ts
+++ b/packages/core/test/lib/transports/multiplexed.test.ts
@@ -15,6 +15,11 @@ const ERROR_ENVELOPE = createEnvelope<EventEnvelope>({ event_id: 'aa3ff046696b4b
   [{ type: 'event' }, ERROR_EVENT] as EventItem,
 ]);
 
+const TRANSACTION_ENVELOPE = createEnvelope<EventEnvelope>(
+  { event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2', sent_at: '123' },
+  [[{ type: 'transaction' }, { event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2' }] as EventItem],
+);
+
 const DEFAULT_DISCARDED_EVENTS: ClientReport['discarded_events'] = [
   {
     reason: 'before_send',
@@ -136,5 +141,22 @@ describe('makeMultiplexedTransport', () => {
 
     const transport = makeTransport({ url: DSN1_URL, ...transportOptions });
     await transport.send(CLIENT_REPORT_ENVELOPE);
+  });
+
+  it('callback getEvent can ignore transactions', async () => {
+    expect.assertions(2);
+
+    const makeTransport = makeMultiplexedTransport(
+      createTestTransport(url => {
+        expect(url).toBe(DSN2_URL);
+      }),
+      ({ getEvent }) => {
+        expect(getEvent('event')).toBeUndefined();
+        return [DSN2];
+      },
+    );
+
+    const transport = makeTransport({ url: DSN1_URL, ...transportOptions });
+    await transport.send(TRANSACTION_ENVELOPE);
   });
 });

--- a/packages/core/test/lib/transports/multiplexed.test.ts
+++ b/packages/core/test/lib/transports/multiplexed.test.ts
@@ -151,7 +151,7 @@ describe('makeMultiplexedTransport', () => {
         expect(url).toBe(DSN2_URL);
       }),
       ({ getEvent }) => {
-        expect(getEvent('event')).toBeUndefined();
+        expect(getEvent(['event'])).toBeUndefined();
         return [DSN2];
       },
     );

--- a/packages/core/test/lib/transports/multiplexed.test.ts
+++ b/packages/core/test/lib/transports/multiplexed.test.ts
@@ -1,0 +1,125 @@
+import type { BaseTransportOptions, EventEnvelope, EventItem, Transport } from '@sentry/types';
+import { createEnvelope, dsnFromString } from '@sentry/utils';
+
+import { createTransport, getEnvelopeEndpointWithUrlEncodedAuth, makeMultiplexedTransport } from '../../../src';
+
+const DSN1 = 'https://1234@5678.ingest.sentry.io/4321';
+const DSN1_URL = getEnvelopeEndpointWithUrlEncodedAuth(dsnFromString(DSN1));
+
+const DSN2 = 'https://5678@1234.ingest.sentry.io/8765';
+const DSN2_URL = getEnvelopeEndpointWithUrlEncodedAuth(dsnFromString(DSN2));
+
+const ERROR_EVENT = { event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2' };
+const ERROR_ENVELOPE = createEnvelope<EventEnvelope>({ event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2', sent_at: '123' }, [
+  [{ type: 'event' }, ERROR_EVENT] as EventItem,
+]);
+
+const TRANSACTION_ENVELOPE = createEnvelope<EventEnvelope>(
+  { event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2', sent_at: '123' },
+  [[{ type: 'transaction' }, { event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2' }] as EventItem],
+);
+
+type Assertion = (url: string, body: string | Uint8Array) => void;
+
+const createTestTransport = (...assertions: Assertion[]): ((options: BaseTransportOptions) => Transport) => {
+  return (options: BaseTransportOptions) =>
+    createTransport(options, request => {
+      return new Promise(resolve => {
+        const assertion = assertions.shift();
+        if (!assertion) {
+          throw new Error('No assertion left');
+        }
+        assertion(options.url, request.body);
+        resolve({ statusCode: 200 });
+      });
+    });
+};
+
+const transportOptions = {
+  recordDroppedEvent: () => undefined, // noop
+  textEncoder: new TextEncoder(),
+};
+
+describe('makeMultiplexedTransport', () => {
+  it('Falls back to options DSN when no match', async () => {
+    expect.assertions(1);
+
+    const makeTransport = makeMultiplexedTransport(
+      createTestTransport(url => {
+        expect(url).toBe(DSN1_URL);
+      }),
+      () => [],
+    );
+
+    const transport = makeTransport({ url: DSN1_URL, ...transportOptions });
+    await transport.send(ERROR_ENVELOPE);
+  });
+
+  it('DSN can be overridden via match callback', async () => {
+    expect.assertions(1);
+
+    const makeTransport = makeMultiplexedTransport(
+      createTestTransport(url => {
+        expect(url).toBe(DSN2_URL);
+      }),
+      () => [DSN2],
+    );
+
+    const transport = makeTransport({ url: DSN1_URL, ...transportOptions });
+    await transport.send(ERROR_ENVELOPE);
+  });
+
+  it('match callback can return multiple DSNs', async () => {
+    expect.assertions(2);
+
+    const makeTransport = makeMultiplexedTransport(
+      createTestTransport(
+        url => {
+          expect(url).toBe(DSN1_URL);
+        },
+        url => {
+          expect(url).toBe(DSN2_URL);
+        },
+      ),
+      () => [DSN1, DSN2],
+    );
+
+    const transport = makeTransport({ url: DSN1_URL, ...transportOptions });
+    await transport.send(ERROR_ENVELOPE);
+  });
+
+  it('callback getEvent returns event', async () => {
+    expect.assertions(3);
+
+    const makeTransport = makeMultiplexedTransport(
+      createTestTransport(url => {
+        expect(url).toBe(DSN2_URL);
+      }),
+      ({ envelope, getEvent }) => {
+        expect(envelope).toBe(ERROR_ENVELOPE);
+        expect(getEvent()).toBe(ERROR_EVENT);
+        return [DSN2];
+      },
+    );
+
+    const transport = makeTransport({ url: DSN1_URL, ...transportOptions });
+    await transport.send(ERROR_ENVELOPE);
+  });
+
+  it('callback getEvent returns undefined if not event', async () => {
+    expect.assertions(2);
+
+    const makeTransport = makeMultiplexedTransport(
+      createTestTransport(url => {
+        expect(url).toBe(DSN2_URL);
+      }),
+      ({ getEvent }) => {
+        expect(getEvent()).toBeUndefined();
+        return [DSN2];
+      },
+    );
+
+    const transport = makeTransport({ url: DSN1_URL, ...transportOptions });
+    await transport.send(TRANSACTION_ENVELOPE);
+  });
+});

--- a/packages/core/test/lib/transports/multiplexed.test.ts
+++ b/packages/core/test/lib/transports/multiplexed.test.ts
@@ -1,5 +1,6 @@
 import type { BaseTransportOptions, EventEnvelope, EventItem, Transport } from '@sentry/types';
 import { createEnvelope, dsnFromString } from '@sentry/utils';
+import { TextEncoder } from 'util';
 
 import { createTransport, getEnvelopeEndpointWithUrlEncodedAuth, makeMultiplexedTransport } from '../../../src';
 


### PR DESCRIPTION
Closes #5185

Adds `makeMultiplexedTransport` which can be used to create a Transport that sends envelopes to different, even multiple DSNs depending on the content of the envelope. 

It takes two parameters:
- A transport creation function that is used to create transports when required
- A match callback with the following type:
```ts
interface MatchParam {
  // The envelope to be sent
  envelope: Envelope;
  // A function that returns an event from the envelope if one exists
  getEvent(): Event | undefined;
}

type Matcher = (param: MatchParam) => string[];
```

Currently, the DSN passed to init is used as a fallback if the match callback returns zero DSNs. I'm not 100% happy with this as in the example below, the DSN passed to init will never be used but is required for the client to send events.

## Send everything to two DSNs

```ts
import { makeMultiplexedTransport } from '@sentry/core';
import { init, makeFetchTransport } from '@sentry/browser';

const DSN1 = '__DSN1__';
const DSN2 = '__DSN2__';

init({
  dsn: DSN1, // <- init dsn never gets used but need to be valid
  transport: makeMultiplexedTransport(makeFetchTransport, () => [DSN1, DSN2])
});
```

## Override DSN from capture point

```ts
import { makeMultiplexedTransport } from '@sentry/core';
import { init, captureException, makeFetchTransport } from '@sentry/browser';

function dsnFromTag({ getEvent }) {
  const event = getEvent();
  return event?.tags?.DSN_OVERRIDE ? [event.tags.DSN_OVERRIDE] : [];
}

init({
  dsn: '__FALLBACK_DSN__',
  transport: makeMultiplexedTransport(makeFetchTransport, dsnFromTag)
});

captureException(new Error('oh no!', scope => {
  scope.addTag('DSN_OVERRIDE', '__ANOTHER_DSN__');
  return scope;
});
```

## Different DSNs for different features

```ts
import { makeMultiplexedTransport } from '@sentry/core';
import { init, captureException, makeFetchTransport } from '@sentry/browser';

function dsnFromFeature({ getEvent }) {
  const event = getEvent();
  switch(event?.tags?.feature) {
    case 'cart':
      return ['__CART_DSN__'];
    case 'gallery':
      return ['__GALLERY_DSN__'];
  }
  return []
}

init({
  dsn: '__FALLBACK_DSN__',
  transport: makeMultiplexedTransport(makeFetchTransport, dsnFromFeature)
});

captureException(new Error('oh no!', scope => {
  scope.addTag('feature', 'cart');
  return scope;
});
```
