### PR TITLE
fix: Do refresh buffered sessions

### DIFF
--- a/packages/browser-integration-tests/suites/replay/bufferMode/test.ts
+++ b/packages/browser-integration-tests/suites/replay/bufferMode/test.ts
@@ -245,7 +245,7 @@ sentryTest(
 
     await page.evaluate(async () => {
       const replayIntegration = (window as unknown as Window & { Replay: Replay }).Replay;
-      await replayIntegration.flush({continueRecording: false});
+      await replayIntegration.flush({ continueRecording: false });
     });
 
     const req0 = await reqPromise0;

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -394,6 +394,12 @@ export class ReplayContainer implements ReplayContainerInterface {
       // Reset all "capture on error" configuration before
       // starting a new recording
       this.recordingMode = 'session';
+
+      // Once this session ends, we do not want to refresh it
+      if (this.session) {
+        this.session.shouldRefresh = false;
+        this._maybeSaveSession();
+      }
       this.startRecording();
     }
   }

--- a/packages/replay/src/session/Session.ts
+++ b/packages/replay/src/session/Session.ts
@@ -21,6 +21,7 @@ export function makeSession(session: Partial<Session> & { sampled: Sampled }): S
     lastActivity,
     segmentId,
     sampled,
+    shouldRefresh: true,
   };
 }
 

--- a/packages/replay/src/session/getSession.ts
+++ b/packages/replay/src/session/getSession.ts
@@ -36,8 +36,9 @@ export function getSession({
 
     if (!isExpired) {
       return { type: 'saved', session };
-    } else if (session.sampled === 'buffer') {
-      // Buffered samples should not be re-created when expired, but instead we stop when the replay is done
+    } else if (!session.shouldRefresh) {
+      // In this case, stop
+      // This is the case if we have an error session that is completed (=triggered an error)
       const discardedSession = makeSession({ sampled: false });
       return { type: 'new', session: discardedSession };
     } else {

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -395,6 +395,12 @@ export interface Session {
    * Is the session sampled? `false` if not sampled, otherwise, `session` or `buffer`
    */
   sampled: Sampled;
+
+  /**
+   * If this is false, the session should not be refreshed when it was inactive.
+   * This can be the case if you had a buffered session which is now recording because an error happened.
+   */
+  shouldRefresh: boolean;
 }
 
 export interface EventBuffer {

--- a/packages/replay/test/unit/session/fetchSession.test.ts
+++ b/packages/replay/test/unit/session/fetchSession.test.ts
@@ -28,6 +28,7 @@ describe('Unit | session | fetchSession', () => {
       segmentId: 0,
       sampled: 'session',
       started: 1648827162630,
+      shouldRefresh: true,
     });
   });
 
@@ -43,6 +44,7 @@ describe('Unit | session | fetchSession', () => {
       segmentId: 0,
       sampled: false,
       started: 1648827162630,
+      shouldRefresh: true,
     });
   });
 

--- a/packages/replay/test/unit/session/getSession.test.ts
+++ b/packages/replay/test/unit/session/getSession.test.ts
@@ -24,6 +24,7 @@ function createMockSession(when: number = Date.now()) {
     lastActivity: when,
     started: when,
     sampled: 'session',
+    shouldRefresh: true,
   });
 }
 
@@ -59,6 +60,7 @@ describe('Unit | session | getSession', () => {
       lastActivity: expect.any(Number),
       sampled: 'session',
       started: expect.any(Number),
+      shouldRefresh: true,
     });
 
     // Should not have anything in storage
@@ -129,6 +131,7 @@ describe('Unit | session | getSession', () => {
       lastActivity: expect.any(Number),
       sampled: 'session',
       started: expect.any(Number),
+      shouldRefresh: true,
     });
 
     // Should not have anything in storage
@@ -138,6 +141,7 @@ describe('Unit | session | getSession', () => {
       lastActivity: expect.any(Number),
       sampled: 'session',
       started: expect.any(Number),
+      shouldRefresh: true,
     });
   });
 
@@ -164,6 +168,7 @@ describe('Unit | session | getSession', () => {
       lastActivity: now,
       sampled: 'session',
       started: now,
+      shouldRefresh: true,
     });
   });
 


### PR DESCRIPTION
This adjusts the PR to handle buffered sessions that expire.

Basically, a buffered session should be sampled normally unless it has been converted from a buffered -> session. Only when an error was captured and the session _then_ expires, we do not want to start a new session.

This fixes https://github.com/getsentry/sentry-javascript/pull/7768