### PR TITLE
fix(replay): Ensure we do not set replayId on dsc if replay is disabled

### DIFF
--- a/packages/browser-integration-tests/suites/replay/dsc/init.js
+++ b/packages/browser-integration-tests/suites/replay/dsc/init.js
@@ -16,8 +16,3 @@ Sentry.init({
   replaysSessionSampleRate: 0.0,
   replaysOnErrorSampleRate: 1.0,
 });
-
-Sentry.configureScope(scope => {
-  scope.setUser({ id: 'user123', segment: 'segmentB' });
-  scope.setTransactionName('testTransactionDSC');
-});

--- a/packages/browser-integration-tests/suites/replay/dsc/test.ts
+++ b/packages/browser-integration-tests/suites/replay/dsc/test.ts
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test';
+import type * as Sentry from '@sentry/browser';
 import type { EventEnvelopeHeaders } from '@sentry/types';
 
 import { sentryTest } from '../../../utils/fixtures';
@@ -9,6 +10,8 @@ import {
 } from '../../../utils/helpers';
 import { getReplaySnapshot, shouldSkipReplayTest, waitForReplayRunning } from '../../../utils/replayHelpers';
 
+type TestWindow = Window & { Sentry: typeof Sentry; Replay: Sentry.Replay };
+
 sentryTest('should add replay_id to dsc of transactions', async ({ getLocalTestPath, page, browserName }) => {
   // This is flaky on webkit, so skipping there...
   if (shouldSkipReplayTest() || shouldSkipTracingTest() || browserName === 'webkit') {
@@ -17,6 +20,13 @@ sentryTest('should add replay_id to dsc of transactions', async ({ getLocalTestP
 
   const url = await getLocalTestPath({ testDir: __dirname });
   await page.goto(url);
+
+  await page.evaluate(() => {
+    (window as unknown as TestWindow).Sentry.configureScope(scope => {
+      scope.setUser({ id: 'user123', segment: 'segmentB' });
+      scope.setTransactionName('testTransactionDSC');
+    });
+  });
 
   const envHeader = await getFirstSentryEnvelopeRequest<EventEnvelopeHeaders>(page, url, envelopeHeaderRequestParser);
 
@@ -35,3 +45,41 @@ sentryTest('should add replay_id to dsc of transactions', async ({ getLocalTestP
     replay_id: replay.session?.id,
   });
 });
+
+sentryTest(
+  'should not add replay_id to dsc of transactions if replay is not enabled',
+  async ({ getLocalTestPath, page, browserName }) => {
+    // This is flaky on webkit, so skipping there...
+    if (shouldSkipReplayTest() || shouldSkipTracingTest() || browserName === 'webkit') {
+      sentryTest.skip();
+    }
+
+    const url = await getLocalTestPath({ testDir: __dirname });
+    await page.goto(url);
+
+    await page.evaluate(() => {
+      (window as unknown as TestWindow).Replay.stop();
+
+      (window as unknown as TestWindow).Sentry.configureScope(scope => {
+        scope.setUser({ id: 'user123', segment: 'segmentB' });
+        scope.setTransactionName('testTransactionDSC');
+      });
+    });
+
+    const envHeader = await getFirstSentryEnvelopeRequest<EventEnvelopeHeaders>(page, url, envelopeHeaderRequestParser);
+
+    await waitForReplayRunning(page);
+    const replay = await getReplaySnapshot(page);
+
+    expect(replay.session?.id).toBeDefined();
+
+    expect(envHeader.trace).toBeDefined();
+    expect(envHeader.trace).toEqual({
+      environment: 'production',
+      user_segment: 'segmentB',
+      sample_rate: '1',
+      trace_id: expect.any(String),
+      public_key: 'public',
+    });
+  },
+);

--- a/packages/replay/src/util/addGlobalListeners.ts
+++ b/packages/replay/src/util/addGlobalListeners.ts
@@ -35,7 +35,7 @@ export function addGlobalListeners(replay: ReplayContainer): void {
     client.on('afterSendEvent', handleAfterSendEvent(replay));
     client.on('createDsc', (dsc: DynamicSamplingContext) => {
       const replayId = replay.getSessionId();
-      if (replayId) {
+      if (replayId && replay.isEnabled()) {
         dsc.replay_id = replayId;
       }
     });


### PR DESCRIPTION
I noticed that we are actually setting the replayId on the DSC even if the replay has stopped. IMHO this doesn't make a lot of sense, so I added this guard.