### PR TITLE
fix(utils): default `normalize()` to a max. of 100 levels deep instead of Inifnity

### DIFF
--- a/packages/utils/src/normalize.ts
+++ b/packages/utils/src/normalize.ts
@@ -33,7 +33,7 @@ type ObjOrArray<T> = { [key: string]: T };
  * @returns A normalized version of the object, or `"**non-serializable**"` if any errors are thrown during normalization.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function normalize(input: unknown, depth: number = +Infinity, maxProperties: number = +Infinity): any {
+export function normalize(input: unknown, depth: number = 100, maxProperties: number = +Infinity): any {
   try {
     // since we're at the outermost level, we don't provide a key
     return visit('', input, depth, maxProperties);

--- a/packages/utils/test/normalize.test.ts
+++ b/packages/utils/test/normalize.test.ts
@@ -86,6 +86,65 @@ describe('normalize()', () => {
       expect(normalize(obj)).toEqual({ name: 'Alice', identity: { self: '[Circular ~]' } });
     });
 
+    test('circular objects with proxy', () => {
+      const obj1 = { name: 'Alice', child: null } as any;
+      const obj2 = { name: 'John', child: null } as any;
+
+      function getObj1(target: any, prop: string | number | symbol): any {
+        return prop === 'child'
+          ? new Proxy(obj2, {
+              get(t, p) {
+                return getObj2(t, p);
+              },
+            })
+          : target[prop];
+      }
+
+      function getObj2(target: any, prop: string | number | symbol): any {
+        return prop === 'child'
+          ? new Proxy(obj1, {
+              get(t, p) {
+                return getObj1(t, p);
+              },
+            })
+          : target[prop];
+      }
+
+      const proxy1 = new Proxy(obj1, {
+        get(target, prop) {
+          return getObj1(target, prop);
+        },
+      });
+
+      const actual = normalize(proxy1);
+
+      // This generates 100 nested objects, as we cannot identify the circular reference since they are dynamic proxies
+      // However, this test verifies that we can normalize at all, and do not fail out
+      expect(actual).toEqual({
+        name: 'Alice',
+        child: { name: 'John', child: expect.objectContaining({ name: 'Alice', child: expect.any(Object) }) },
+      });
+
+      let last = actual;
+      for (let i = 0; i < 99; i++) {
+        expect(last).toEqual(
+          expect.objectContaining({
+            name: expect.any(String),
+            child: expect.any(Object),
+          }),
+        );
+        last = last.child;
+      }
+
+      // Last one is transformed to [Object]
+      expect(last).toEqual(
+        expect.objectContaining({
+          name: expect.any(String),
+          child: '[Object]',
+        }),
+      );
+    });
+
     test('deep circular objects', () => {
       const obj = { name: 'Alice', child: { name: 'Bob' } } as any;
       obj.child.self = obj.child;


### PR DESCRIPTION
This is to avoid infinite recursion that we cannot detect, e.g. when using dynamic proxies.

Fixes https://github.com/getsentry/sentry-javascript/issues/7947 (hopefully).
