### PR TITLE
ci: Fix issue state check

### DIFF
--- a/.github/workflows/label-last-commenter.yml
+++ b/.github/workflows/label-last-commenter.yml
@@ -16,7 +16,7 @@ jobs:
           github.event.comment.author_association != 'COLLABORATOR'
           && github.event.comment.author_association != 'MEMBER'
           && github.event.comment.author_association != 'OWNER'
-          && !github.event.issue.closed
+          && github.event.issue.state == 'open'
         uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: 'Waiting for: Team'


### PR DESCRIPTION
Not sure where I got the `closed` stuff from, but this seems to be actually correct based on https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#issues.

Noticed this was incorrectly running for closed issues as well.