### PR TITLE
feat(node): Make Undici a default integration.

### DIFF
--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -146,8 +146,6 @@ function addServerIntegrations(options: NodeOptions): void {
     });
   }
 
-  integrations = addOrUpdateIntegration(new Integrations.Undici(), integrations);
-
   options.integrations = integrations;
 }
 

--- a/packages/nextjs/test/serverSdk.test.ts
+++ b/packages/nextjs/test/serverSdk.test.ts
@@ -164,15 +164,6 @@ describe('Server init()', () => {
       expect(consoleIntegration).toBeDefined();
     });
 
-    it('adds the Undici integration', () => {
-      init({});
-
-      const nodeInitOptions = nodeInit.mock.calls[0][0] as ModifiedInitOptions;
-      const undiciIntegration = findIntegrationByName(nodeInitOptions.integrations, 'Undici');
-
-      expect(undiciIntegration).toBeDefined();
-    });
-
     describe('`Http` integration', () => {
       it('adds `Http` integration with tracing enabled if `tracesSampleRate` is set', () => {
         init({ tracesSampleRate: 1.0 });

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -28,6 +28,7 @@ import {
   OnUncaughtException,
   OnUnhandledRejection,
   RequestData,
+  Undici,
 } from './integrations';
 import { getModule } from './module';
 import { makeNodeTransport } from './transports';
@@ -40,6 +41,7 @@ export const defaultIntegrations = [
   // Native Wrappers
   new Console(),
   new Http(),
+  new Undici(),
   // Global Handlers
   new OnUncaughtException(),
   new OnUnhandledRejection(),

--- a/packages/sveltekit/src/server/sdk.ts
+++ b/packages/sveltekit/src/server/sdk.ts
@@ -24,7 +24,6 @@ export function init(options: NodeOptions): void {
 }
 
 function addServerIntegrations(options: NodeOptions): void {
-  options.integrations = addOrUpdateIntegration(new Integrations.Undici(), options.integrations || []);
   options.integrations = addOrUpdateIntegration(
     new RewriteFrames({ iteratee: rewriteFramesIteratee }),
     options.integrations || [],

--- a/packages/sveltekit/src/server/sdk.ts
+++ b/packages/sveltekit/src/server/sdk.ts
@@ -1,7 +1,7 @@
 import { configureScope } from '@sentry/core';
 import { RewriteFrames } from '@sentry/integrations';
 import type { NodeOptions } from '@sentry/node';
-import { init as initNodeSdk, Integrations } from '@sentry/node';
+import { init as initNodeSdk } from '@sentry/node';
 import { addOrUpdateIntegration } from '@sentry/utils';
 
 import { applySdkMetadata } from '../common/metadata';

--- a/packages/sveltekit/test/server/sdk.test.ts
+++ b/packages/sveltekit/test/server/sdk.test.ts
@@ -47,20 +47,5 @@ describe('Sentry server SDK', () => {
       // @ts-ignore need access to protected _tags attribute
       expect(currentScope._tags).toEqual({ runtime: 'node' });
     });
-
-    it('adds the Undici integration', () => {
-      init({});
-
-      expect(nodeInit).toHaveBeenCalledTimes(1);
-      expect(nodeInit).toHaveBeenCalledWith(
-        expect.objectContaining({
-          integrations: expect.arrayContaining([
-            expect.objectContaining({
-              name: 'Undici',
-            }),
-          ]),
-        }),
-      );
-    });
   });
 });


### PR DESCRIPTION
It's been default in Next.js and Sveltekit for a while now, let's make it a default for Node especially since Node 20 is released.