### PR TITLE
test: Fix flaky replay DSC test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -511,7 +511,7 @@ jobs:
     needs: [job_get_metadata, job_build]
     if: needs.job_get_metadata.outputs.changed_browser_integration == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-20.04
-    timeout-minutes: 15
+    timeout-minutes: 18
     strategy:
       fail-fast: false
       matrix:

--- a/packages/browser-integration-tests/suites/replay/dsc/test.ts
+++ b/packages/browser-integration-tests/suites/replay/dsc/test.ts
@@ -5,8 +5,10 @@ import type { EventEnvelopeHeaders } from '@sentry/types';
 import { sentryTest } from '../../../utils/fixtures';
 import {
   envelopeHeaderRequestParser,
+  envelopeRequestParser,
   getFirstSentryEnvelopeRequest,
   shouldSkipTracingTest,
+  waitForTransactionRequest,
 } from '../../../utils/helpers';
 import { getReplaySnapshot, shouldSkipReplayTest, waitForReplayRunning } from '../../../utils/replayHelpers';
 
@@ -21,6 +23,8 @@ sentryTest('should add replay_id to dsc of transactions', async ({ getLocalTestP
   const url = await getLocalTestPath({ testDir: __dirname });
   await page.goto(url);
 
+  await waitForReplayRunning(page);
+
   await page.evaluate(() => {
     (window as unknown as TestWindow).Sentry.configureScope(scope => {
       scope.setUser({ id: 'user123', segment: 'segmentB' });
@@ -30,7 +34,6 @@ sentryTest('should add replay_id to dsc of transactions', async ({ getLocalTestP
 
   const envHeader = await getFirstSentryEnvelopeRequest<EventEnvelopeHeaders>(page, url, envelopeHeaderRequestParser);
 
-  await waitForReplayRunning(page);
   const replay = await getReplaySnapshot(page);
 
   expect(replay.session?.id).toBeDefined();
@@ -65,6 +68,10 @@ sentryTest(
     const url = await getLocalTestPath({ testDir: __dirname });
     await page.goto(url);
 
+    await waitForReplayRunning(page);
+
+    const transactionReq = waitForTransactionRequest(page);
+
     await page.evaluate(async () => {
       await (window as unknown as TestWindow).Replay.stop();
 
@@ -74,12 +81,13 @@ sentryTest(
       });
     });
 
-    const envHeader = await getFirstSentryEnvelopeRequest<EventEnvelopeHeaders>(page, url, envelopeHeaderRequestParser);
+    const req0 = await transactionReq;
 
-    await waitForReplayRunning(page);
+    const envHeader = envelopeRequestParser(req0, 0) as EventEnvelopeHeaders;
+
     const replay = await getReplaySnapshot(page);
 
-    expect(replay.session?.id).toBeDefined();
+    expect(replay.session).toBeUndefined();
 
     expect(envHeader.trace).toBeDefined();
     expect(envHeader.trace).toEqual({


### PR DESCRIPTION
Also one test was actually incorrect.

Also extending browser integration test max. time a bit as I had a few times where we exceeded 15min, sadly.
