### PR TITLE
feat(sveltekit): Convert `sentryHandle` to a factory function

### DIFF
--- a/packages/sveltekit/README.md
+++ b/packages/sveltekit/README.md
@@ -125,10 +125,10 @@ The Sentry SvelteKit SDK mostly relies on [SvelteKit Hooks](https://kit.svelte.d
     // hooks.server.(js|ts)
     import { sentryHandle } from '@sentry/sveltekit';
 
-    export const handle = sentryHandle;
+    export const handle = sentryHandle();
     // or alternatively, if you already have a handler defined, use the `sequence` function
     // see: https://kit.svelte.dev/docs/modules#sveltejs-kit-hooks-sequence
-    // export const handle = sequence(sentryHandle, yourHandler);
+    // export const handle = sequence(sentryHandle(), yourHandler());
    ```
 
 ### 4. Configuring `load` Functions

--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -53,13 +53,17 @@ export const transformPageChunk: NonNullable<ResolveOptions['transformPageChunk'
  * // src/hooks.server.ts
  * import { sentryHandle } from '@sentry/sveltekit';
  *
- * export const handle = sentryHandle;
+ * export const handle = sentryHandle();
  *
  * // Optionally use the sequence function to add additional handlers.
- * // export const handle = sequence(sentryHandle, yourCustomHandle);
+ * // export const handle = sequence(sentryHandle(), yourCustomHandler);
  * ```
  */
-export const sentryHandle: Handle = input => {
+export function sentryHandle(): Handle {
+  return sentryRequestHandler;
+}
+
+const sentryRequestHandler: Handle = input => {
   // if there is an active transaction, we know that this handle call is nested and hence
   // we don't create a new domain for it. If we created one, nested server calls would
   // create new transactions instead of adding a child span to the currently active span.

--- a/packages/sveltekit/test/server/handle.test.ts
+++ b/packages/sveltekit/test/server/handle.test.ts
@@ -120,7 +120,7 @@ describe('handleSentry', () => {
     it('should return a response', async () => {
       let response: any = undefined;
       try {
-        response = await sentryHandle({ event: mockEvent(), resolve: resolve(type, isError) });
+        response = await sentryHandle()({ event: mockEvent(), resolve: resolve(type, isError) });
       } catch (e) {
         expect(e).toBeInstanceOf(Error);
         expect(e.message).toEqual(type);
@@ -136,7 +136,7 @@ describe('handleSentry', () => {
       });
 
       try {
-        await sentryHandle({ event: mockEvent(), resolve: resolve(type, isError) });
+        await sentryHandle()({ event: mockEvent(), resolve: resolve(type, isError) });
       } catch (e) {
         //
       }
@@ -161,11 +161,11 @@ describe('handleSentry', () => {
       });
 
       try {
-        await sentryHandle({
+        await sentryHandle()({
           event: mockEvent(),
           resolve: async _ => {
             // simulateing a nested load call:
-            await sentryHandle({
+            await sentryHandle()({
               event: mockEvent({ route: { id: 'api/users/details/[id]' } }),
               resolve: resolve(type, isError),
             });
@@ -216,7 +216,7 @@ describe('handleSentry', () => {
       });
 
       try {
-        await sentryHandle({ event, resolve: resolve(type, isError) });
+        await sentryHandle()({ event, resolve: resolve(type, isError) });
       } catch (e) {
         //
       }
@@ -256,7 +256,7 @@ describe('handleSentry', () => {
       });
 
       try {
-        await sentryHandle({ event, resolve: resolve(type, isError) });
+        await sentryHandle()({ event, resolve: resolve(type, isError) });
       } catch (e) {
         //
       }
@@ -280,7 +280,7 @@ describe('handleSentry', () => {
       });
 
       try {
-        await sentryHandle({ event: mockEvent(), resolve: resolve(type, isError) });
+        await sentryHandle()({ event: mockEvent(), resolve: resolve(type, isError) });
       } catch (e) {
         expect(mockCaptureException).toBeCalledTimes(1);
         expect(addEventProcessorSpy).toBeCalledTimes(1);
@@ -296,7 +296,7 @@ describe('handleSentry', () => {
       const mockResolve = vi.fn().mockImplementation(resolve(type, isError));
       const event = mockEvent();
       try {
-        await sentryHandle({ event, resolve: mockResolve });
+        await sentryHandle()({ event, resolve: mockResolve });
       } catch (e) {
         expect(e).toBeInstanceOf(Error);
         expect(e.message).toEqual(type);


### PR DESCRIPTION
This PR converts the `sentyHandle` server-side request handler to a factory function instead of a plain handler. This will allow us more freedom down the line to permit customization by passing options to the handler. 
More details in #7951 

Unfortunately, this is a breaking change but we need to change this now while the SDK is not yet stable. 

closes #7951 