### PR TITLE
ref(replay): Explicitly clear eventBuffer for checkout events

### DIFF
--- a/packages/replay/src/eventBuffer/EventBufferArray.ts
+++ b/packages/replay/src/eventBuffer/EventBufferArray.ts
@@ -24,14 +24,8 @@ export class EventBufferArray implements EventBuffer {
   }
 
   /** @inheritdoc */
-  public async addEvent(event: RecordingEvent, isCheckout?: boolean): Promise<AddEventResult> {
-    if (isCheckout) {
-      this.events = [event];
-      return;
-    }
-
+  public async addEvent(event: RecordingEvent): Promise<AddEventResult> {
     this.events.push(event);
-    return;
   }
 
   /** @inheritdoc */
@@ -44,6 +38,11 @@ export class EventBufferArray implements EventBuffer {
       this.events = [];
       resolve(JSON.stringify(eventsRet));
     });
+  }
+
+  /** @inheritdoc */
+  public clear(): void {
+    this.events = [];
   }
 
   /** @inheritdoc */

--- a/packages/replay/src/eventBuffer/EventBufferProxy.ts
+++ b/packages/replay/src/eventBuffer/EventBufferProxy.ts
@@ -36,6 +36,11 @@ export class EventBufferProxy implements EventBuffer {
   }
 
   /** @inheritdoc */
+  public clear(): void {
+    return this._used.clear();
+  }
+
+  /** @inheritdoc */
   public getEarliestTimestamp(): number | null {
     return this._used.getEarliestTimestamp();
   }
@@ -45,8 +50,8 @@ export class EventBufferProxy implements EventBuffer {
    *
    * Returns true if event was successfully added.
    */
-  public addEvent(event: RecordingEvent, isCheckout?: boolean): Promise<AddEventResult> {
-    return this._used.addEvent(event, isCheckout);
+  public addEvent(event: RecordingEvent): Promise<AddEventResult> {
+    return this._used.addEvent(event);
   }
 
   /** @inheritDoc */

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -447,12 +447,16 @@ export interface EventBuffer {
   destroy(): void;
 
   /**
+   * Clear the event buffer.
+   */
+  clear(): void;
+
+  /**
    * Add an event to the event buffer.
-   * `isCheckout` is true if this is either the very first event, or an event triggered by `checkoutEveryNms`.
    *
    * Returns a promise that resolves if the event was successfully added, else rejects.
    */
-  addEvent(event: RecordingEvent, isCheckout?: boolean): Promise<AddEventResult>;
+  addEvent(event: RecordingEvent): Promise<AddEventResult>;
 
   /**
    * Clears and returns the contents of the buffer.

--- a/packages/replay/src/util/addEvent.ts
+++ b/packages/replay/src/util/addEvent.ts
@@ -34,7 +34,11 @@ export async function addEvent(
   }
 
   try {
-    return await replay.eventBuffer.addEvent(event, isCheckout);
+    if (isCheckout) {
+      replay.eventBuffer.clear();
+    }
+
+    return await replay.eventBuffer.addEvent(event);
   } catch (error) {
     __DEBUG_BUILD__ && logger.error(error);
     await replay.stop('addEvent');

--- a/packages/replay/test/unit/eventBuffer/EventBufferArray.test.ts
+++ b/packages/replay/test/unit/eventBuffer/EventBufferArray.test.ts
@@ -22,7 +22,9 @@ describe('Unit | eventBuffer | EventBufferArray', () => {
     buffer.addEvent(TEST_EVENT);
     buffer.addEvent(TEST_EVENT);
 
-    buffer.addEvent(TEST_EVENT, true);
+    // clear() is called by addEvent when isCheckout is true
+    buffer.clear();
+    buffer.addEvent(TEST_EVENT);
     const result = await buffer.finish();
 
     expect(result).toEqual(JSON.stringify([TEST_EVENT]));

--- a/packages/replay/test/unit/eventBuffer/EventBufferCompressionWorker.test.ts
+++ b/packages/replay/test/unit/eventBuffer/EventBufferCompressionWorker.test.ts
@@ -42,8 +42,9 @@ describe('Unit | eventBuffer | EventBufferCompressionWorker', () => {
     await buffer.addEvent(TEST_EVENT);
     await buffer.addEvent(TEST_EVENT);
 
-    // This should clear previous buffer
-    await buffer.addEvent({ ...TEST_EVENT, type: 2 }, true);
+    // clear() is called by addEvent when isCheckout is true
+    buffer.clear();
+    await buffer.addEvent({ ...TEST_EVENT, type: 2 });
 
     const result = await buffer.finish();
     expect(result).toBeInstanceOf(Uint8Array);
@@ -135,7 +136,7 @@ describe('Unit | eventBuffer | EventBufferCompressionWorker', () => {
     // Ensure worker is ready
     await buffer.ensureWorkerIsLoaded();
 
-    await buffer.addEvent({ data: { o: 1 }, timestamp: BASE_TIMESTAMP, type: 3 }, true);
+    await buffer.addEvent({ data: { o: 1 }, timestamp: BASE_TIMESTAMP, type: 3 });
     await buffer.addEvent({ data: { o: 2 }, timestamp: BASE_TIMESTAMP, type: 3 });
 
     // @ts-ignore Mock this private so it triggers an error


### PR DESCRIPTION
This too is a partial extraction of https://github.com/getsentry/sentry-javascript/pull/7025, to prepare for this & break this up in multiple parts.

This will make it easier in a follow up step to handle clearing a bit different when in buffer mode, to keep more data in store.