### PR TITLE
feat(tracing): Use `http.method` for span data

### DIFF
--- a/packages/tracing-internal/src/browser/request.ts
+++ b/packages/tracing-internal/src/browser/request.ts
@@ -195,6 +195,7 @@ export function fetchCallback(
       data: {
         ...handlerData.fetchData,
         type: 'fetch',
+        'http.method': handlerData.fetchData.method,
       },
       description: `${handlerData.fetchData.method} ${handlerData.fetchData.url}`,
       op: 'http.client',
@@ -334,7 +335,7 @@ export function xhrCallback(
       data: {
         ...sentryXhrData.data,
         type: 'xhr',
-        method: sentryXhrData.method,
+        'http.method': sentryXhrData.method,
         url: sentryXhrData.url,
       },
       description: `${sentryXhrData.method} ${sentryXhrData.url}`,

--- a/packages/tracing-internal/test/browser/request.test.ts
+++ b/packages/tracing-internal/test/browser/request.test.ts
@@ -74,7 +74,7 @@ describe('callbacks', () => {
 
     const fetchSpan = {
       data: {
-        method: 'GET',
+        'http.method': 'GET',
         url: 'http://dogs.are.great/',
         type: 'fetch',
       },
@@ -156,7 +156,7 @@ describe('callbacks', () => {
       expect(newSpan).toBeDefined();
       expect(newSpan).toBeInstanceOf(Span);
       expect(newSpan.data).toEqual({
-        method: 'GET',
+        'http.method': 'GET',
         type: 'fetch',
         url: 'http://dogs.are.great/',
       });
@@ -220,7 +220,7 @@ describe('callbacks', () => {
 
     const xhrSpan = {
       data: {
-        method: 'GET',
+        'http.method': 'GET',
         url: 'http://dogs.are.great/',
         type: 'xhr',
       },
@@ -295,7 +295,7 @@ describe('callbacks', () => {
 
       expect(newSpan).toBeInstanceOf(Span);
       expect(newSpan.data).toEqual({
-        method: 'GET',
+        'http.method': 'GET',
         type: 'xhr',
         url: 'http://dogs.are.great/',
       });


### PR DESCRIPTION
Following https://develop.sentry.dev/sdk/performance/span-data-conventions/, set `http.method` instead of `method` for http spans generated by fetch/xhr.

ref https://github.com/getsentry/team-webplatform-meta/issues/60