### PR TITLE
feat(node): Add `http.method` to node http spans

### DIFF
--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -189,7 +189,7 @@ function _createWrappedRequestMethodFactory(
 
       const requestSpanData: SanitizedRequestData = {
         url: requestUrl,
-        method: requestOptions.method || 'GET',
+        'http.method': requestOptions.method || 'GET',
       };
       if (requestOptions.hash) {
         // strip leading "#"

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -187,9 +187,10 @@ function _createWrappedRequestMethodFactory(
 
       const scope = getCurrentHub().getScope();
 
+      const method = requestOptions.method || 'GET';
       const requestSpanData: SanitizedRequestData = {
         url: requestUrl,
-        'http.method': requestOptions.method || 'GET',
+        'http.method': method,
       };
       if (requestOptions.hash) {
         // strip leading "#"
@@ -205,7 +206,7 @@ function _createWrappedRequestMethodFactory(
 
         if (parentSpan) {
           requestSpan = parentSpan.startChild({
-            description: `${requestSpanData.method} ${requestSpanData.url}`,
+            description: `${method} ${requestSpanData.url}`,
             op: 'http.client',
             data: requestSpanData,
           });

--- a/packages/node/src/integrations/undici/index.ts
+++ b/packages/node/src/integrations/undici/index.ts
@@ -111,7 +111,10 @@ export class Undici implements Integration {
         const shouldCreateSpan = this._options.shouldCreateSpanForRequest(stringUrl);
 
         if (shouldCreateSpan) {
-          const data: Record<string, unknown> = {};
+          const method = request.method || 'GET';
+          const data: Record<string, unknown> = {
+            'http.method': method,
+          };
           const params = url.searchParams.toString();
           if (params) {
             data['http.query'] = `?${params}`;
@@ -119,10 +122,9 @@ export class Undici implements Integration {
           if (url.hash) {
             data['http.fragment'] = url.hash;
           }
-
           const span = activeSpan.startChild({
             op: 'http.client',
-            description: `${request.method || 'GET'} ${stripUrlQueryAndFragment(stringUrl)}`,
+            description: `${method} ${stripUrlQueryAndFragment(stringUrl)}`,
             data,
           });
           request.__sentry__ = span;

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -208,7 +208,7 @@ describe('tracing', () => {
     // our span is at index 1 because the transaction itself is at index 0
     expect(spans[1].description).toEqual('GET http://dogs.are.great/spaniel');
     expect(spans[1].op).toEqual('http.client');
-    expect(spans[1].data.method).toEqual('GET');
+    expect(spans[1].data['http.method']).toEqual('GET');
     expect(spans[1].data.url).toEqual('http://dogs.are.great/spaniel');
     expect(spans[1].data['http.query']).toEqual('tail=wag&cute=true');
     expect(spans[1].data['http.fragment']).toEqual('learn-more');

--- a/packages/node/test/integrations/undici.test.ts
+++ b/packages/node/test/integrations/undici.test.ts
@@ -56,6 +56,9 @@ conditionalTest({ min: 16 })('Undici integration', () => {
       {
         description: 'GET http://localhost:18099/',
         op: 'http.client',
+        data: {
+          'http.method': 'GET',
+        },
       },
     ],
     [
@@ -66,6 +69,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
         description: 'GET http://localhost:18099/',
         op: 'http.client',
         data: {
+          'http.method': 'GET',
           'http.query': '?foo=bar',
         },
       },
@@ -76,6 +80,9 @@ conditionalTest({ min: 16 })('Undici integration', () => {
       { method: 'POST' },
       {
         description: 'POST http://localhost:18099/',
+        data: {
+          'http.method': 'POST',
+        },
       },
     ],
     [
@@ -84,6 +91,9 @@ conditionalTest({ min: 16 })('Undici integration', () => {
       { method: 'POST' },
       {
         description: 'POST http://localhost:18099/',
+        data: {
+          'http.method': 'POST',
+        },
       },
     ],
     [

--- a/packages/sveltekit/src/client/load.ts
+++ b/packages/sveltekit/src/client/load.ts
@@ -152,7 +152,7 @@ function instrumentSvelteKitFetch(originalFetch: SvelteKitFetch): SvelteKitFetch
 
       const requestData: SanitizedRequestData = {
         url: getSanitizedUrlString(urlObject),
-        method,
+        'http.method': method,
         ...(urlObject.search && { 'http.query': urlObject.search.substring(1) }),
         ...(urlObject.hash && { 'http.hash': urlObject.hash.substring(1) }),
       };
@@ -190,7 +190,7 @@ function instrumentSvelteKitFetch(originalFetch: SvelteKitFetch): SvelteKitFetch
       if (createSpan) {
         fetchPromise = trace(
           {
-            name: `${requestData.method} ${requestData.url}`, // this will become the description of the span
+            name: `${method} ${requestData.url}`, // this will become the description of the span
             op: 'http.client',
             data: requestData,
           },

--- a/packages/sveltekit/src/server/load.ts
+++ b/packages/sveltekit/src/server/load.ts
@@ -115,6 +115,9 @@ export function wrapServerLoadWithSentry<T extends (...args: any) => any>(origSe
           source: routeId ? 'route' : 'url',
           dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,
         },
+        data: {
+          'http.method': event.request.method,
+        },
         ...traceparentData,
       };
 

--- a/packages/sveltekit/test/client/load.test.ts
+++ b/packages/sveltekit/test/client/load.test.ts
@@ -205,7 +205,7 @@ describe('wrapLoadWithSentry', () => {
           op: 'http.client',
           name: 'GET example.com/api/users/',
           data: {
-            method: 'GET',
+            'http.method': 'GET',
             url: 'example.com/api/users/',
             'http.hash': 'testfragment',
             'http.query': 'id=123',
@@ -219,7 +219,7 @@ describe('wrapLoadWithSentry', () => {
           op: 'http.client',
           name: 'POST example.com/api/users/',
           data: {
-            method: 'POST',
+            'http.method': 'POST',
             url: 'example.com/api/users/',
             'http.hash': 'testfragment',
             'http.query': 'id=123',
@@ -233,7 +233,7 @@ describe('wrapLoadWithSentry', () => {
           op: 'http.client',
           name: 'POST example.com/api/users/',
           data: {
-            method: 'POST',
+            'http.method': 'POST',
             url: 'example.com/api/users/',
             'http.hash': 'testfragment',
             'http.query': 'id=123',
@@ -247,7 +247,7 @@ describe('wrapLoadWithSentry', () => {
           op: 'http.client',
           name: 'GET /api/users',
           data: {
-            method: 'GET',
+            'http.method': 'GET',
             url: '/api/users',
             'http.query': 'id=123',
           },

--- a/packages/sveltekit/test/server/load.test.ts
+++ b/packages/sveltekit/test/server/load.test.ts
@@ -64,6 +64,7 @@ const MOCK_LOAD_NO_ROUTE_ARGS: any = {
 const MOCK_SERVER_ONLY_LOAD_ARGS: any = {
   ...MOCK_LOAD_ARGS,
   request: {
+    method: 'GET',
     headers: {
       get: (key: string) => {
         if (key === 'sentry-trace') {
@@ -87,6 +88,7 @@ const MOCK_SERVER_ONLY_LOAD_ARGS: any = {
 const MOCK_SERVER_ONLY_NO_TRACE_LOAD_ARGS: any = {
   ...MOCK_LOAD_ARGS,
   request: {
+    method: 'GET',
     headers: {
       get: (_: string) => {
         return null;
@@ -98,6 +100,7 @@ const MOCK_SERVER_ONLY_NO_TRACE_LOAD_ARGS: any = {
 const MOCK_SERVER_ONLY_NO_BAGGAGE_LOAD_ARGS: any = {
   ...MOCK_LOAD_ARGS,
   request: {
+    method: 'GET',
     headers: {
       get: (key: string) => {
         if (key === 'sentry-trace') {
@@ -268,6 +271,9 @@ describe('wrapServerLoadWithSentry calls trace', () => {
         parentSpanId: '1234567890abcdef',
         status: 'ok',
         traceId: '1234567890abcdef1234567890abcdef',
+        data: {
+          'http.method': 'GET',
+        },
         metadata: {
           dynamicSamplingContext: {
             environment: 'production',
@@ -296,6 +302,9 @@ describe('wrapServerLoadWithSentry calls trace', () => {
         op: 'function.sveltekit.server.load',
         name: '/users/[id]',
         status: 'ok',
+        data: {
+          'http.method': 'GET',
+        },
         metadata: {
           source: 'route',
         },
@@ -318,6 +327,9 @@ describe('wrapServerLoadWithSentry calls trace', () => {
         parentSpanId: '1234567890abcdef',
         status: 'ok',
         traceId: '1234567890abcdef1234567890abcdef',
+        data: {
+          'http.method': 'GET',
+        },
         metadata: {
           dynamicSamplingContext: {},
           source: 'route',
@@ -343,6 +355,9 @@ describe('wrapServerLoadWithSentry calls trace', () => {
         parentSpanId: '1234567890abcdef',
         status: 'ok',
         traceId: '1234567890abcdef1234567890abcdef',
+        data: {
+          'http.method': 'GET',
+        },
         metadata: {
           dynamicSamplingContext: {
             environment: 'production',

--- a/packages/types/src/request.ts
+++ b/packages/types/src/request.ts
@@ -18,7 +18,7 @@ export type QueryParams = string | { [key: string]: string } | Array<[string, st
  */
 export type SanitizedRequestData = {
   url: string;
-  method: string;
+  'http.method': string;
   'http.fragment'?: string;
   'http.query'?: string;
 };


### PR DESCRIPTION
See: https://github.com/getsentry/sentry-javascript/pull/7990

Following https://develop.sentry.dev/sdk/performance/span-data-conventions/, set http.method instead of method for http spans generated by http/undici integrations.

ref https://github.com/getsentry/team-webplatform-meta/issues/60