### PR TITLE
feat(replay): Keep min. 30s of data in buffer & worker mode

### DIFF
--- a/packages/replay-worker/src/handleMessage.ts
+++ b/packages/replay-worker/src/handleMessage.ts
@@ -1,47 +1,89 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { compress, Compressor } from './Compressor';
-
-const compressor = new Compressor();
+import { Compressor } from './Compressor';
 
 interface Handlers {
-  clear: () => void;
+  clear: (mode?: string) => void;
   addEvent: (data: string) => void;
   finish: () => Uint8Array;
-  compress: (data: string) => Uint8Array;
 }
 
-const handlers: Handlers = {
-  clear: () => {
-    compressor.clear();
-  },
+class CompressionHandler implements Handlers {
+  private _compressor: Compressor;
+  private _bufferCompressor?: Compressor;
 
-  addEvent: (data: string) => {
-    return compressor.addEvent(data);
-  },
+  public constructor() {
+    this._compressor = new Compressor();
+  }
 
-  finish: () => {
-    return compressor.finish();
-  },
+  public clear(mode?: string): void {
+    /*
+      In buffer mode, we want to make sure to always keep the last round of events around.
+      So when the time comes and we finish the buffer, we can ensure that we have at least one set of events.
+      Without this change, it can happen that you finish right after the last checkout (=clear),
+      and thus have no (or very few) events buffered.
 
-  compress: (data: string) => {
-    return compress(data);
-  },
-};
+      Now, in buffer mode, we basically have to compressors, which are swapped and reset on clear:
+      * On first `clear` in buffer mode, we initialize the buffer compressor.
+        The regular compressor keeps running as the "current" one
+      * On consequitive `clear` calls, we swap the buffer compressor in as the "current" one, and initialize a new buffer compressor
+        This will clear any events that were buffered before the _last_ clear call.
+
+      This sadly means we need to keep the buffer twice in memory. But it's a tradeoff we have to make.
+    */
+    if (mode === 'buffer') {
+      // This means it is the first clear in buffer mode - just initialize a new compressor for the alternate compressor
+      if (!this._bufferCompressor) {
+        this._bufferCompressor = new Compressor();
+      } else {
+        // Else, swap the alternative compressor in as "normal" compressor, and initialize a new alterntive compressor
+        this._compressor = this._bufferCompressor;
+        this._bufferCompressor = new Compressor();
+      }
+      return;
+    }
+
+    /*
+      In non-buffer mode, we just clear the current compressor (and make sure an eventual buffer compressor is reset)
+    */
+    this._bufferCompressor = undefined;
+
+    this._compressor.clear();
+  }
+
+  public addEvent(data: string): void {
+    if (this._bufferCompressor) {
+      this._bufferCompressor.addEvent(data);
+    }
+
+    return this._compressor.addEvent(data);
+  }
+
+  public finish(): Uint8Array {
+    if (this._bufferCompressor) {
+      this._bufferCompressor.clear();
+      this._bufferCompressor = undefined;
+    }
+
+    return this._compressor.finish();
+  }
+}
+
+const handlers = new CompressionHandler();
 
 /**
  * Handler for worker messages.
  */
-export function handleMessage(e: MessageEvent): void {
-  const method = e.data.method as string;
-  const id = e.data.id as number;
-  const data = e.data.arg as string;
+export function handleMessage(event: MessageEvent): void {
+  const data = event.data as {
+    method: keyof Handlers;
+    id: number;
+    arg: string;
+  };
 
-  // @ts-ignore this syntax is actually fine
-  if (method in handlers && typeof handlers[method] === 'function') {
+  const { method, id, arg } = data;
+
+  if (typeof handlers[method] === 'function') {
     try {
-      // @ts-ignore this syntax is actually fine
-      const response = handlers[method](data);
-      // @ts-ignore this syntax is actually fine
+      const response = handlers[method](arg);
       postMessage({
         id,
         method,
@@ -49,12 +91,11 @@ export function handleMessage(e: MessageEvent): void {
         response,
       });
     } catch (err) {
-      // @ts-ignore this syntax is actually fine
       postMessage({
         id,
         method,
         success: false,
-        response: err.message,
+        response: (err as Error).message,
       });
 
       // eslint-disable-next-line no-console

--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -26,8 +26,8 @@ export const DEFAULT_FLUSH_MIN_DELAY = 5_000;
 // was the same as `wait`
 export const DEFAULT_FLUSH_MAX_DELAY = 5_500;
 
-/* How long to wait for error checkouts */
-export const BUFFER_CHECKOUT_TIME = 60_000;
+/* How long to wait for buffer checkouts. */
+export const BUFFER_CHECKOUT_TIME = 30_000;
 
 export const RETRY_BASE_INTERVAL = 5000;
 export const RETRY_MAX_COUNT = 3;

--- a/packages/replay/src/eventBuffer/EventBufferProxy.ts
+++ b/packages/replay/src/eventBuffer/EventBufferProxy.ts
@@ -1,4 +1,4 @@
-import type { ReplayRecordingData } from '@sentry/types';
+import type { ReplayRecordingData, ReplayRecordingMode } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import type { AddEventResult, EventBuffer, RecordingEvent } from '../types';
@@ -36,8 +36,8 @@ export class EventBufferProxy implements EventBuffer {
   }
 
   /** @inheritdoc */
-  public clear(): void {
-    return this._used.clear();
+  public clear(recordingMode: ReplayRecordingMode): void {
+    return this._used.clear(recordingMode);
   }
 
   /** @inheritdoc */

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -167,6 +167,7 @@ export class ReplayContainer implements ReplayContainerInterface {
     // If neither sample rate is > 0, then do nothing - user will need to call one of
     // `start()` or `startBuffering` themselves.
     if (errorSampleRate <= 0 && sessionSampleRate <= 0) {
+      __DEBUG_BUILD__ && logger.log('[Replay] No sample rate set, not initializing.');
       return;
     }
 
@@ -193,6 +194,8 @@ export class ReplayContainer implements ReplayContainerInterface {
       // prior SDK version.
       this.recordingMode = 'buffer';
     }
+
+    __DEBUG_BUILD__ && logger.log(`[Replay] Session initialized in mode ${this.recordingMode}`);
 
     this._initializeRecording();
   }

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -449,7 +449,7 @@ export interface EventBuffer {
   /**
    * Clear the event buffer.
    */
-  clear(): void;
+  clear(recordingMode: ReplayRecordingMode): void;
 
   /**
    * Add an event to the event buffer.

--- a/packages/replay/src/util/addEvent.ts
+++ b/packages/replay/src/util/addEvent.ts
@@ -35,7 +35,7 @@ export async function addEvent(
 
   try {
     if (isCheckout) {
-      replay.eventBuffer.clear();
+      replay.eventBuffer.clear(replay.recordingMode);
     }
 
     return await replay.eventBuffer.addEvent(event);

--- a/packages/replay/test/unit/eventBuffer/EventBufferArray.test.ts
+++ b/packages/replay/test/unit/eventBuffer/EventBufferArray.test.ts
@@ -23,7 +23,7 @@ describe('Unit | eventBuffer | EventBufferArray', () => {
     buffer.addEvent(TEST_EVENT);
 
     // clear() is called by addEvent when isCheckout is true
-    buffer.clear();
+    buffer.clear('session');
     buffer.addEvent(TEST_EVENT);
     const result = await buffer.finish();
 


### PR DESCRIPTION
This re-implements https://github.com/getsentry/sentry-javascript/pull/7025 with a new strategy.
It only keeps min. 30s when using the compression worker (without the worker, the same strategy as now is used, only that it will keep up to 30s max). This may be acceptable, I think? We could also try to implement this for the event array buffer as well, but the question is if we want to do that or say "good enough" this way.

Probably needs a bit more manual testing as well, but wanted to put this up so we can talk about it at least.

Closes https://github.com/getsentry/sentry-javascript/issues/6908