### PR TITLE
feat(sveltekit): Auto-wrap `load` functions with proxy module

### DIFF
--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -28,7 +28,6 @@
     "@sentry/types": "7.49.0",
     "@sentry/utils": "7.49.0",
     "@sentry/vite-plugin": "^0.6.0",
-    "magic-string": "^0.30.0",
     "sorcery": "0.11.0"
   },
   "devDependencies": {

--- a/packages/sveltekit/src/server/utils.ts
+++ b/packages/sveltekit/src/server/utils.ts
@@ -2,6 +2,8 @@ import type { DynamicSamplingContext, StackFrame, TraceparentData } from '@sentr
 import { baggageHeaderToDynamicSamplingContext, basename, extractTraceparentData } from '@sentry/utils';
 import type { RequestEvent } from '@sveltejs/kit';
 
+import { WRAPPED_MODULE_SUFFIX } from '../vite/autoInstrument';
+
 /**
  * Takes a request event and extracts traceparent and DSC data
  * from the `sentry-trace` and `baggage` DSC headers.
@@ -51,6 +53,12 @@ export function rewriteFramesIteratee(frame: StackFrame): StackFrame {
   }
 
   delete frame.module;
+
+  // In dev-mode, the WRAPPED_MODULE_SUFFIX is still present in the frame's file name.
+  // We need to remove it to make sure that the frame's filename matches the actual file
+  if (frame.filename.endsWith(WRAPPED_MODULE_SUFFIX)) {
+    frame.filename = frame.filename.slice(0, -WRAPPED_MODULE_SUFFIX.length);
+  }
 
   return frame;
 }

--- a/packages/sveltekit/src/vite/autoInstrument.ts
+++ b/packages/sveltekit/src/vite/autoInstrument.ts
@@ -1,0 +1,123 @@
+/* eslint-disable @sentry-internal/sdk/no-optional-chaining */
+import * as fs from 'fs';
+import * as path from 'path';
+import type { Plugin } from 'vite';
+
+export const WRAPPED_MODULE_SUFFIX = '?sentry-auto-wrap';
+
+export type AutoInstrumentSelection = {
+  /**
+   * If this flag is `true`, the Sentry plugins will automatically instrument the `load` function of
+   * your universal `load` functions declared in your `+page.(js|ts)` and `+layout.(js|ts)` files.
+   *
+   * @default true
+   */
+  load?: boolean;
+
+  /**
+   * If this flag is `true`, the Sentry plugins will automatically instrument the `load` function of
+   * your server-only `load` functions declared in your `+page.server.(js|ts)`
+   * and `+layout.server.(js|ts)` files.
+   *
+   * @default true
+   */
+  serverLoad?: boolean;
+};
+
+type AutoInstrumentPluginOptions = AutoInstrumentSelection & {
+  debug: boolean;
+};
+
+/**
+ * Creates a Vite plugin that automatically instruments the parts of the app
+ * specified in @param options. This includes
+ *
+ * - universal `load` functions from `+page.(js|ts)` and `+layout.(js|ts)` files
+ * - server-only `load` functions from `+page.server.(js|ts)` and `+layout.server.(js|ts)` files
+ *
+ * @returns the plugin
+ */
+export async function makeAutoInstrumentationPlugin(options: AutoInstrumentPluginOptions): Promise<Plugin> {
+  const { load: shouldWrapLoad, serverLoad: shouldWrapServerLoad, debug } = options;
+
+  return {
+    name: 'sentry-auto-instrumentation',
+    // This plugin needs to run as early as possible, before the SvelteKit plugin virtualizes all paths and ids
+    enforce: 'pre',
+
+    async load(id) {
+      const applyUniversalLoadWrapper =
+        shouldWrapLoad &&
+        /^\+(page|layout)\.(js|ts|mjs|mts)$/.test(path.basename(id)) &&
+        (await canWrapLoad(id, debug));
+
+      if (applyUniversalLoadWrapper) {
+        // eslint-disable-next-line no-console
+        debug && console.log(`Wrapping ${id} with Sentry load wrapper`);
+        return getWrapperCode('wrapLoadWithSentry', `${id}${WRAPPED_MODULE_SUFFIX}`);
+      }
+
+      const applyServerLoadWrapper =
+        shouldWrapServerLoad &&
+        /^\+(page|layout)\.server\.(js|ts|mjs|mts)$/.test(path.basename(id)) &&
+        (await canWrapLoad(id, debug));
+
+      if (applyServerLoadWrapper) {
+        // eslint-disable-next-line no-console
+        debug && console.log(`Wrapping ${id} with Sentry load wrapper`);
+        return getWrapperCode('wrapServerLoadWithSentry', `${id}${WRAPPED_MODULE_SUFFIX}`);
+      }
+
+      return null;
+    },
+  };
+}
+
+/**
+ * We only want to apply our wrapper to files that
+ *
+ *  - Have no Sentry code yet in them. This is to avoid double-wrapping or interferance with custom
+ *    Sentry calls.
+ *  - Actually declare a `load` function. The second check of course is not 100% accurate, but it's good enough.
+ *    Injecting our wrapper into files that don't declare a `load` function would result in a build-time warning
+ *    because vite/rollup warns if we reference an export from the user's file in our wrapping code that
+ *    doesn't exist.
+ *
+ * Exported for testing
+ *
+ * @returns `true` if we can wrap the given file, `false` otherwise
+ */
+export async function canWrapLoad(id: string, debug: boolean): Promise<boolean> {
+  const code = (await fs.promises.readFile(id, 'utf8')).toString();
+
+  const codeWithoutComments = code.replace(/(\/\/.*| ?\/\*[^]*?\*\/)(,?)$/gm, '');
+
+  const hasSentryContent = codeWithoutComments.includes('@sentry/sveltekit');
+  if (hasSentryContent) {
+    // eslint-disable-next-line no-console
+    debug && console.log(`Skipping wrappiung ${id} because it already contains Sentry code`);
+  }
+
+  const hasLoadDeclaration = /(const|let|var|function)\s+load\s*(=|\()/gm.test(codeWithoutComments);
+  if (!hasLoadDeclaration) {
+    // eslint-disable-next-line no-console
+    debug && console.log(`Skipping wrappiung ${id} because it doesn't declare a \`load\` function`);
+  }
+
+  return !hasSentryContent && hasLoadDeclaration;
+}
+
+/**
+ * Return wrapper code fo the given module id and wrapping function
+ */
+function getWrapperCode(
+  wrapperFunction: 'wrapLoadWithSentry' | 'wrapServerLoadWithSentry',
+  idWithSuffix: string,
+): string {
+  return (
+    `import { ${wrapperFunction} } from "@sentry/sveltekit";` +
+    `import * as userModule from ${JSON.stringify(idWithSuffix)};` +
+    `export const load = userModule.load ? ${wrapperFunction}(userModule.load) : undefined;` +
+    `export * from ${JSON.stringify(idWithSuffix)};`
+  );
+}

--- a/packages/sveltekit/src/vite/autoInstrument.ts
+++ b/packages/sveltekit/src/vite/autoInstrument.ts
@@ -37,7 +37,7 @@ type AutoInstrumentPluginOptions = AutoInstrumentSelection & {
  *
  * @returns the plugin
  */
-export async function makeAutoInstrumentationPlugin(options: AutoInstrumentPluginOptions): Promise<Plugin> {
+export function makeAutoInstrumentationPlugin(options: AutoInstrumentPluginOptions): Plugin {
   const { load: shouldWrapLoad, serverLoad: shouldWrapServerLoad, debug } = options;
 
   return {

--- a/packages/sveltekit/src/vite/autoInstrument.ts
+++ b/packages/sveltekit/src/vite/autoInstrument.ts
@@ -95,13 +95,13 @@ export async function canWrapLoad(id: string, debug: boolean): Promise<boolean> 
   const hasSentryContent = codeWithoutComments.includes('@sentry/sveltekit');
   if (hasSentryContent) {
     // eslint-disable-next-line no-console
-    debug && console.log(`Skipping wrappiung ${id} because it already contains Sentry code`);
+    debug && console.log(`Skipping wrapping ${id} because it already contains Sentry code`);
   }
 
   const hasLoadDeclaration = /(const|let|var|function)\s+load\s*(=|\()/gm.test(codeWithoutComments);
   if (!hasLoadDeclaration) {
     // eslint-disable-next-line no-console
-    debug && console.log(`Skipping wrappiung ${id} because it doesn't declare a \`load\` function`);
+    debug && console.log(`Skipping wrapping ${id} because it doesn't declare a \`load\` function`);
   }
 
   return !hasSentryContent && hasLoadDeclaration;

--- a/packages/sveltekit/src/vite/autoInstrument.ts
+++ b/packages/sveltekit/src/vite/autoInstrument.ts
@@ -98,7 +98,7 @@ export async function canWrapLoad(id: string, debug: boolean): Promise<boolean> 
     debug && console.log(`Skipping wrapping ${id} because it already contains Sentry code`);
   }
 
-  const hasLoadDeclaration = /(const|let|var|function)\s+load\s*(=|\()/gm.test(codeWithoutComments);
+  const hasLoadDeclaration = /((const|let|var|function)\s+load\s*(=|\())|as\s+load\s*(,|})/gm.test(codeWithoutComments);
   if (!hasLoadDeclaration) {
     // eslint-disable-next-line no-console
     debug && console.log(`Skipping wrapping ${id} because it doesn't declare a \`load\` function`);

--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -71,7 +71,7 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
     };
 
     sentryPlugins.push(
-      await makeAutoInstrumentationPlugin({
+      makeAutoInstrumentationPlugin({
         ...pluginOptions,
         debug: options.debug || false,
       }),

--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -1,12 +1,14 @@
 import type { SentryVitePluginOptions } from '@sentry/vite-plugin';
 import type { Plugin } from 'vite';
 
+import type { AutoInstrumentSelection } from './autoInstrument';
+import { makeAutoInstrumentationPlugin } from './autoInstrument';
 import { makeCustomSentryVitePlugin } from './sourceMaps';
 
 type SourceMapsUploadOptions = {
   /**
    * If this flag is `true`, the Sentry plugins will automatically upload source maps to Sentry.
-   * Defaults to `true`.
+   * @default true`.
    */
   autoUploadSourceMaps?: boolean;
 
@@ -17,16 +19,32 @@ type SourceMapsUploadOptions = {
   sourceMapsUploadOptions?: Partial<SentryVitePluginOptions>;
 };
 
+type AutoInstrumentOptions = {
+  /**
+   * The Sentry plugin will automatically instrument certain parts of your SvelteKit application at build time.
+   * Set this option to `false` to disable this behavior or what is instrumentated by passing an object.
+   *
+   * Auto instrumentation includes:
+   * - Universal `load` functions in `+page.(js|ts)` files
+   * - Server-only `load` functions in `+page.server.(js|ts)` files
+   *
+   * @default true (meaning, the plugin will instrument all of the above)
+   */
+  autoInstrument?: boolean | AutoInstrumentSelection;
+};
+
 export type SentrySvelteKitPluginOptions = {
   /**
    * If this flag is `true`, the Sentry plugins will log some useful debug information.
-   * Defaults to `false`.
+   * @default false.
    */
   debug?: boolean;
-} & SourceMapsUploadOptions;
+} & SourceMapsUploadOptions &
+  AutoInstrumentOptions;
 
 const DEFAULT_PLUGIN_OPTIONS: SentrySvelteKitPluginOptions = {
   autoUploadSourceMaps: true,
+  autoInstrument: true,
   debug: false,
 };
 
@@ -43,7 +61,22 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
     ...options,
   };
 
-  const sentryPlugins = [];
+  const sentryPlugins: Plugin[] = [];
+
+  if (mergedOptions.autoInstrument) {
+    const pluginOptions: AutoInstrumentSelection = {
+      load: true,
+      serverLoad: true,
+      ...(typeof mergedOptions.autoInstrument === 'object' ? mergedOptions.autoInstrument : {}),
+    };
+
+    sentryPlugins.push(
+      await makeAutoInstrumentationPlugin({
+        ...pluginOptions,
+        debug: options.debug || false,
+      }),
+    );
+  }
 
   if (mergedOptions.autoUploadSourceMaps) {
     const pluginOptions = {

--- a/packages/sveltekit/test/vite/autoInstrument.test.ts
+++ b/packages/sveltekit/test/vite/autoInstrument.test.ts
@@ -1,0 +1,204 @@
+import { vi } from 'vitest';
+
+// import { makeAutoInstrumentationPlugin } from '../../src/vite/autoInstrument';
+import * as autoInstument from '../../src/vite/autoInstrument';
+
+const DEFAULT_CONTENT = `
+  export const load = () => {};
+  export const prerender = true;
+`;
+
+let fileContent: string | undefined;
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual('fs');
+  return {
+    // @ts-ignore this exists, I promise!
+    ...actual,
+    promises: {
+      // @ts-ignore this also exists, I promise!
+      ...actual.promises,
+      readFile: vi.fn().mockImplementation(() => {
+        return fileContent || DEFAULT_CONTENT;
+      }),
+    },
+  };
+});
+
+vi.mock('rollup', () => {
+  return {
+    rollup: vi.fn().mockReturnValue({ generate: vi.fn().mockReturnValue({ output: ['transformed'] }) }),
+  };
+});
+
+describe('makeAutoInstrumentationPlugin()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fileContent = undefined;
+  });
+
+  it('returns the auto instrumentation plugin', async () => {
+    const plugin = await autoInstument.makeAutoInstrumentationPlugin({ debug: true, load: true, serverLoad: true });
+    expect(plugin.name).toEqual('sentry-auto-instrumentation');
+    expect(plugin.enforce).toEqual('pre');
+    expect(plugin.load).toEqual(expect.any(Function));
+  });
+
+  describe.each([
+    'path/to/+page.ts',
+    'path/to/+page.js',
+    'path/to/+page.mts',
+    'path/to/+page.mjs',
+    'path/to/+layout.ts',
+    'path/to/+layout.js',
+    'path/to/+layout.mts',
+    'path/to/+layout.mjs',
+  ])('transform %s files', (path: string) => {
+    it('wraps universal load if `load` option is `true`', async () => {
+      const plugin = await autoInstument.makeAutoInstrumentationPlugin({ debug: false, load: true, serverLoad: true });
+      // @ts-ignore this exists
+      const loadResult = await plugin.load(path);
+      expect(loadResult).toEqual(
+        'import { wrapLoadWithSentry } from "@sentry/sveltekit";' +
+          `import * as userModule from "${path}?sentry-auto-wrap";` +
+          'export const load = userModule.load ? wrapLoadWithSentry(userModule.load) : undefined;' +
+          `export * from "${path}?sentry-auto-wrap";`,
+      );
+    });
+
+    it("doesn't wrap universal load if `load` option is `false`", async () => {
+      const plugin = await autoInstument.makeAutoInstrumentationPlugin({
+        debug: false,
+        load: false,
+        serverLoad: false,
+      });
+      // @ts-ignore this exists
+      const loadResult = await plugin.load(path);
+      expect(loadResult).toEqual(null);
+    });
+  });
+
+  describe.each([
+    'path/to/+page.server.ts',
+    'path/to/+page.server.js',
+    'path/to/+page.server.mts',
+    'path/to/+page.server.mjs',
+    'path/to/+layout.server.ts',
+    'path/to/+layout.server.js',
+    'path/to/+layout.server.mts',
+    'path/to/+layout.server.mjs',
+  ])('transform %s files', (path: string) => {
+    it('wraps universal load if `load` option is `true`', async () => {
+      const plugin = await autoInstument.makeAutoInstrumentationPlugin({ debug: false, load: false, serverLoad: true });
+      // @ts-ignore this exists
+      const loadResult = await plugin.load(path);
+      expect(loadResult).toEqual(
+        'import { wrapServerLoadWithSentry } from "@sentry/sveltekit";' +
+          `import * as userModule from "${path}?sentry-auto-wrap";` +
+          'export const load = userModule.load ? wrapServerLoadWithSentry(userModule.load) : undefined;' +
+          `export * from "${path}?sentry-auto-wrap";`,
+      );
+    });
+
+    it("doesn't wrap universal load if `load` option is `false`", async () => {
+      const plugin = await autoInstument.makeAutoInstrumentationPlugin({
+        debug: false,
+        load: false,
+        serverLoad: false,
+      });
+      // @ts-ignore this exists
+      const loadResult = await plugin.load(path);
+      expect(loadResult).toEqual(null);
+    });
+  });
+});
+
+describe('canWrapLoad', () => {
+  afterEach(() => {
+    fileContent = undefined;
+  });
+
+  it.each([
+    ['export variable declaration - function pointer', 'export const load=   loadPageData'],
+    ['export variable declaration - factory function call', 'export const load    =loadPageData()'],
+    ['export variable declaration - inline function', 'export const load = () => { return { props: { msg: "hi" } } }'],
+    [
+      'export variable declaration - inline async function',
+      'export const load = async () => { return { props: { msg: "hi" } } }',
+    ],
+
+    ['export function declaration', 'export function load  (  ){ return { props: { msg: "hi" } } }'],
+    [
+      'export function declaration - with params',
+      `export async function load({fetch}){
+        const res = await fetch('https://example.com');
+        return { props: { msg: res.toString() } }
+      }`,
+    ],
+
+    [
+      'variable declaration (let)',
+      `import {something} from 'somewhere';
+      let load = async () => {};
+      export prerender = true;
+      export { load}`,
+    ],
+    [
+      'variable declaration (var)',
+      `import {something} from 'somewhere';
+      var    load=async () => {};
+      export prerender = true;
+      export { load}`,
+    ],
+
+    [
+      'function declaration',
+      `import {something} from 'somewhere';
+       async function load(){};
+       export { load }`,
+    ],
+    [
+      'function declaration, sentry commented out',
+      `import {something} from 'somewhere';
+       // import * as Sentry from '@sentry/sveltekit';
+       async function load(){};
+       export { load }`,
+    ],
+    [
+      'function declaration, sentry commented out',
+      `import {something} from 'somewhere';
+       /* import * as Sentry from '@sentry/sveltekit'; */
+       async function load(){};
+       export { load }`,
+    ],
+  ])('returns `true` if a load declaration  (%s) exists and no Sentry code was found', async (_, code) => {
+    fileContent = code;
+    expect(await autoInstument.canWrapLoad('+page.ts', false)).toEqual(true);
+  });
+
+  it.each([
+    'export const almostLoad = () => {}; export const prerender = true;',
+    'export const loadNotLoad = () => {}; export const prerender = true;',
+    'export function aload(){}; export const prerender = true;',
+    'export function loader(){}; export const prerender = true;',
+    'let loademe = false; export {loadme}',
+    'const a = {load: true}; export {a}',
+    'if (s === "load") {}',
+    'const a = load ? load : false',
+    '// const load = () => {}',
+    '/* export const load = () => {} */ export const prerender = true;',
+  ])('returns `false` if no load declaration exists', async (_, code) => {
+    fileContent = code;
+    expect(await autoInstument.canWrapLoad('+page.ts', false)).toEqual(true);
+  });
+
+  it('returns `false` if Sentry code was found', async () => {
+    fileContent = 'import * as Sentry from "@sentry/sveltekit";';
+    expect(await autoInstument.canWrapLoad('+page.ts', false)).toEqual(false);
+  });
+
+  it('returns `false` if Sentry code was found', async () => {
+    fileContent = 'import * as Sentry from "@sentry/sveltekit";';
+    expect(await autoInstument.canWrapLoad('+page.ts', false)).toEqual(false);
+  });
+});

--- a/packages/sveltekit/test/vite/autoInstrument.test.ts
+++ b/packages/sveltekit/test/vite/autoInstrument.test.ts
@@ -170,6 +170,12 @@ describe('canWrapLoad', () => {
        async function load(){};
        export { load }`,
     ],
+    [
+      'function declaration with different name',
+      `import { foo } from 'somewhere';
+       async function somethingElse(){};
+       export { somethingElse as  load, foo }`,
+    ],
   ])('returns `true` if a load declaration  (%s) exists and no Sentry code was found', async (_, code) => {
     fileContent = code;
     expect(await canWrapLoad('+page.ts', false)).toEqual(true);
@@ -186,6 +192,7 @@ describe('canWrapLoad', () => {
     'const a = load ? load : false',
     '// const load = () => {}',
     '/* export const load = () => {} */ export const prerender = true;',
+    '/* export const notLoad = () => { const a = getSomething() as load; } */ export const prerender = true;',
   ])('returns `false` if no load declaration exists', async (_, code) => {
     fileContent = code;
     expect(await canWrapLoad('+page.ts', false)).toEqual(true);

--- a/packages/sveltekit/test/vite/autoInstrument.test.ts
+++ b/packages/sveltekit/test/vite/autoInstrument.test.ts
@@ -1,7 +1,6 @@
 import { vi } from 'vitest';
 
-// import { makeAutoInstrumentationPlugin } from '../../src/vite/autoInstrument';
-import * as autoInstument from '../../src/vite/autoInstrument';
+import { canWrapLoad, makeAutoInstrumentationPlugin } from '../../src/vite/autoInstrument';
 
 const DEFAULT_CONTENT = `
   export const load = () => {};
@@ -38,7 +37,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
   });
 
   it('returns the auto instrumentation plugin', async () => {
-    const plugin = await autoInstument.makeAutoInstrumentationPlugin({ debug: true, load: true, serverLoad: true });
+    const plugin = makeAutoInstrumentationPlugin({ debug: true, load: true, serverLoad: true });
     expect(plugin.name).toEqual('sentry-auto-instrumentation');
     expect(plugin.enforce).toEqual('pre');
     expect(plugin.load).toEqual(expect.any(Function));
@@ -55,7 +54,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
     'path/to/+layout.mjs',
   ])('transform %s files', (path: string) => {
     it('wraps universal load if `load` option is `true`', async () => {
-      const plugin = await autoInstument.makeAutoInstrumentationPlugin({ debug: false, load: true, serverLoad: true });
+      const plugin = makeAutoInstrumentationPlugin({ debug: false, load: true, serverLoad: true });
       // @ts-ignore this exists
       const loadResult = await plugin.load(path);
       expect(loadResult).toEqual(
@@ -67,7 +66,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
     });
 
     it("doesn't wrap universal load if `load` option is `false`", async () => {
-      const plugin = await autoInstument.makeAutoInstrumentationPlugin({
+      const plugin = makeAutoInstrumentationPlugin({
         debug: false,
         load: false,
         serverLoad: false,
@@ -89,7 +88,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
     'path/to/+layout.server.mjs',
   ])('transform %s files', (path: string) => {
     it('wraps universal load if `load` option is `true`', async () => {
-      const plugin = await autoInstument.makeAutoInstrumentationPlugin({ debug: false, load: false, serverLoad: true });
+      const plugin = makeAutoInstrumentationPlugin({ debug: false, load: false, serverLoad: true });
       // @ts-ignore this exists
       const loadResult = await plugin.load(path);
       expect(loadResult).toEqual(
@@ -101,7 +100,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
     });
 
     it("doesn't wrap universal load if `load` option is `false`", async () => {
-      const plugin = await autoInstument.makeAutoInstrumentationPlugin({
+      const plugin = makeAutoInstrumentationPlugin({
         debug: false,
         load: false,
         serverLoad: false,
@@ -173,7 +172,7 @@ describe('canWrapLoad', () => {
     ],
   ])('returns `true` if a load declaration  (%s) exists and no Sentry code was found', async (_, code) => {
     fileContent = code;
-    expect(await autoInstument.canWrapLoad('+page.ts', false)).toEqual(true);
+    expect(await canWrapLoad('+page.ts', false)).toEqual(true);
   });
 
   it.each([
@@ -189,16 +188,16 @@ describe('canWrapLoad', () => {
     '/* export const load = () => {} */ export const prerender = true;',
   ])('returns `false` if no load declaration exists', async (_, code) => {
     fileContent = code;
-    expect(await autoInstument.canWrapLoad('+page.ts', false)).toEqual(true);
+    expect(await canWrapLoad('+page.ts', false)).toEqual(true);
   });
 
   it('returns `false` if Sentry code was found', async () => {
     fileContent = 'import * as Sentry from "@sentry/sveltekit";';
-    expect(await autoInstument.canWrapLoad('+page.ts', false)).toEqual(false);
+    expect(await canWrapLoad('+page.ts', false)).toEqual(false);
   });
 
   it('returns `false` if Sentry code was found', async () => {
     fileContent = 'import * as Sentry from "@sentry/sveltekit";';
-    expect(await autoInstument.canWrapLoad('+page.ts', false)).toEqual(false);
+    expect(await canWrapLoad('+page.ts', false)).toEqual(false);
   });
 });

--- a/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
+++ b/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
@@ -1,24 +1,46 @@
 import { vi } from 'vitest';
 
+import * as autoInstrument from '../../src/vite/autoInstrument';
 import { sentrySvelteKit } from '../../src/vite/sentryVitePlugins';
 import * as sourceMaps from '../../src/vite/sourceMaps';
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual('fs');
+  return {
+    // @ts-ignore this exists, I promise!
+    ...actual,
+    promises: {
+      // @ts-ignore this also exists, I promise!
+      ...actual.promises,
+      readFile: vi.fn().mockReturnValue('foo'),
+    },
+  };
+});
 
 describe('sentryVite()', () => {
   it('returns an array of Vite plugins', async () => {
     const plugins = await sentrySvelteKit();
+
     expect(plugins).toBeInstanceOf(Array);
-    expect(plugins).toHaveLength(1);
+    expect(plugins).toHaveLength(2);
   });
 
-  it('returns the custom sentry source maps plugin by default', async () => {
+  it('returns the custom sentry source maps plugin and the auto-instrument plugin by default', async () => {
     const plugins = await sentrySvelteKit();
-    const plugin = plugins[0];
-    expect(plugin.name).toEqual('sentry-vite-plugin-custom');
+    const instrumentPlugin = plugins[0];
+    const sourceMapsPlugin = plugins[1];
+    expect(instrumentPlugin.name).toEqual('sentry-auto-instrumentation');
+    expect(sourceMapsPlugin.name).toEqual('sentry-upload-source-maps');
   });
 
   it("doesn't return the custom sentry source maps plugin if autoUploadSourcemaps is `false`", async () => {
     const plugins = await sentrySvelteKit({ autoUploadSourceMaps: false });
-    expect(plugins).toHaveLength(0);
+    expect(plugins).toHaveLength(1);
+  });
+
+  it("doesn't return the auto instrument plugin if autoInstrument is `false`", async () => {
+    const plugins = await sentrySvelteKit({ autoInstrument: false });
+    expect(plugins).toHaveLength(1);
   });
 
   it('passes user-specified vite pugin options to the custom sentry source maps plugin', async () => {
@@ -29,13 +51,36 @@ describe('sentryVite()', () => {
         include: ['foo.js'],
         ignore: ['bar.js'],
       },
+      autoInstrument: false,
     });
     const plugin = plugins[0];
-    expect(plugin.name).toEqual('sentry-vite-plugin-custom');
+
+    expect(plugin.name).toEqual('sentry-upload-source-maps');
     expect(makePluginSpy).toHaveBeenCalledWith({
       debug: true,
       ignore: ['bar.js'],
       include: ['foo.js'],
+    });
+  });
+
+  it('passes user-specified options to the auto instrument plugin', async () => {
+    const makePluginSpy = vi.spyOn(autoInstrument, 'makeAutoInstrumentationPlugin');
+    const plugins = await sentrySvelteKit({
+      debug: true,
+      autoInstrument: {
+        load: true,
+        serverLoad: false,
+      },
+      // just to ignore the source maps plugin:
+      autoUploadSourceMaps: false,
+    });
+    const plugin = plugins[0];
+
+    expect(plugin.name).toEqual('sentry-auto-instrumentation');
+    expect(makePluginSpy).toHaveBeenCalledWith({
+      debug: true,
+      load: true,
+      serverLoad: false,
     });
   });
 });

--- a/packages/sveltekit/test/vite/sourceMaps.test.ts
+++ b/packages/sveltekit/test/vite/sourceMaps.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
 describe('makeCustomSentryVitePlugin()', () => {
   it('returns the custom sentry source maps plugin', async () => {
     const plugin = await makeCustomSentryVitePlugin();
-    expect(plugin.name).toEqual('sentry-vite-plugin-custom');
+    expect(plugin.name).toEqual('sentry-upload-source-maps');
     expect(plugin.apply).toEqual('build');
     expect(plugin.enforce).toEqual('post');
 


### PR DESCRIPTION
Finally something somewhat robust (at least more than modifying the AST):

This PR introduces auto-wrapping of `load` functions in 
* `+(page|layout).(ts|js)` files (universal loads)
* `+(page|layout).server.(ts|js)` files (server-only loads)

### API

API wise, this is not a breaking change for users, as internally, we just add an additional plugin which is returned by the `sentrySvelteKit` plugin factory function. However, users can add new options to the factory functions, to control auto-wrapping:

```js
sentrySvelteKit({
  autoInstrument: true, // false to disable entirely
  // or
  autoInstrument: {
    load: true,
    serverLoad: false,
  },
  // other options...
  autoUploadSourceMaps: false,
  debug: true,
})
```

### Methodology

(Almost) everything auto-wrapping related happens in a new plugin.
The plugin works by returning wrapping code in the `load` function whenever a file is encountered in which a `load` function should be wrapped. The wrapper imports the user's module but appends a query string to the import path of the original module. This makes the next `load` call to not return the wrapper but the actual user code. 

Unfortunately, the query string makes it to the final source map, meaning that we need to clean up the source map when building. We already flatten the source map anyway, so IMO it's fine to also just remove the string at that time.

This works very well for prod builds. In dev mode, client-side loads are wrapped correctly but unfortunately, server-loads are not wrapped. I didn't figure out why this happens but i vote we go with this approach anyway as it's still much safer than AST manipulation. 

closes #7940 
