### PR TITLE
feat(browser): Export makeMultiplexedTransport from browser SDK

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -33,6 +33,7 @@ export {
   getActiveTransaction,
   spanStatusfromHttpCode,
   trace,
+  makeMultiplexedTransport,
 } from '@sentry/core';
 export type { SpanStatusType } from '@sentry/core';
 export type { Span } from '@sentry/types';


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/pull/7926

This is meant to be used in the browser, so let's export this here!

Exporting this from `index.ts` instead of `exports.ts` because we don't want this in the CDN bundles.