### PR TITLE
fix(remix): Export `Integrations` type declaration as union type

### DIFF
--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -15,7 +15,7 @@ import type { RemixOptions } from './utils/remixOptions';
 export declare function init(options: RemixOptions): void;
 
 // We export a merged Integrations object so that users can (at least typing-wise) use all integrations everywhere.
-export const Integrations = { ...clientSdk.Integrations, ...serverSdk.Integrations };
+export declare const Integrations: typeof clientSdk.Integrations & typeof serverSdk.Integrations;
 
 export declare const defaultIntegrations: Integration[];
 export declare const defaultStackParser: StackParser;


### PR DESCRIPTION
This PR changes the isomorphic type declarations of `Sentry.Integrations` to a union type rather than an object. This stops `tsc` from resolving the types of the individual integration types which caused errors due to incorrect path resolvings of dependencies of `@sentry/remix`. With this change we now declare `Sentry.Integrations` in Remix identically to how we do it in NextJS and SvelteKit.

<details><summary>Details</summary>
<p>


Here's the incorrect TSC output from 7.45 to 7.50 (after #7575 was merged)

```typescript
export * from './index.client';
export * from './index.server';
import type { Integration, StackParser } from '@sentry/types';
import * as clientSdk from './index.client';
import type { RemixOptions } from './utils/remixOptions';
/** Initializes Sentry Remix SDK */
export declare function init(options: RemixOptions): void;
export declare const Integrations: {
    Apollo: typeof import("@sentry-internal/tracing").Apollo;
    Express: typeof import("@sentry-internal/tracing").Express;
    GraphQL: typeof import("@sentry-internal/tracing").GraphQL;
    Mongo: typeof import("@sentry-internal/tracing").Mongo;
    Mysql: typeof import("@sentry-internal/tracing").Mysql;
    Postgres: typeof import("@sentry-internal/tracing").Postgres;
    Prisma: typeof import("@sentry-internal/tracing").Prisma;
    Console: typeof import("@sentry/node/build/types/integrations").Console;
    Http: typeof import("@sentry/node/build/types/integrations").Http;
    OnUncaughtException: typeof import("@sentry/node/build/types/integrations").OnUncaughtException;
    OnUnhandledRejection: typeof import("@sentry/node/build/types/integrations").OnUnhandledRejection;
    LinkedErrors: typeof import("@sentry/node/build/types/integrations").LinkedErrors;
    Modules: typeof import("@sentry/node/build/types/integrations").Modules;
    ContextLines: typeof import("@sentry/node/build/types/integrations").ContextLines;
    Context: typeof import("@sentry/node/build/types/integrations").Context;
    RequestData: typeof import("@sentry/node/build/types/integrations").RequestData;
    LocalVariables: typeof import("@sentry/node/build/types/integrations").LocalVariables;
    Undici: typeof import("@sentry/node/build/types/integrations").Undici;
    FunctionToString: typeof clientSdk.FunctionToString;
    InboundFilters: typeof clientSdk.InboundFilters;
    GlobalHandlers: typeof clientSdk.GlobalHandlers;
    TryCatch: typeof clientSdk.TryCatch;
    Breadcrumbs: typeof clientSdk.Breadcrumbs;
    HttpContext: typeof clientSdk.HttpContext;
    Dedupe: typeof clientSdk.Dedupe;
};
export declare const defaultIntegrations: Integration[];
export declare const defaultStackParser: StackParser;
export declare const close: typeof clientSdk.close;
export declare const flush: typeof clientSdk.flush;
export declare const lastEventId: typeof clientSdk.lastEventId;
//# sourceMappingURL=index.types.d.ts.map
```

and here's the fixed output:

```ts
export * from './index.client';
export * from './index.server';
import type { Integration, StackParser } from '@sentry/types';
import * as clientSdk from './index.client';
import * as serverSdk from './index.server';
import type { RemixOptions } from './utils/remixOptions';
/** Initializes Sentry Remix SDK */
export declare function init(options: RemixOptions): void;
export declare const Integrations: typeof clientSdk.Integrations & typeof serverSdk.Integrations;
export declare const defaultIntegrations: Integration[];
export declare const defaultStackParser: StackParser;
export declare const close: typeof clientSdk.close;
export declare const flush: typeof clientSdk.flush;
export declare const lastEventId: typeof clientSdk.lastEventId;
//# sourceMappingURL=index.types.d.ts.map
```


</p>
</details> 

closes #8001