### PR TITLE
fix(replay): Do not add replay_id to DSC while buffering

### DIFF
--- a/packages/browser-integration-tests/suites/replay/dsc/init.js
+++ b/packages/browser-integration-tests/suites/replay/dsc/init.js
@@ -13,6 +13,7 @@ Sentry.init({
   integrations: [new Integrations.BrowserTracing({ tracingOrigins: [/.*/] }), window.Replay],
   environment: 'production',
   tracesSampleRate: 1,
+  // Needs manual start!
   replaysSessionSampleRate: 0.0,
-  replaysOnErrorSampleRate: 1.0,
+  replaysOnErrorSampleRate: 0.0,
 });

--- a/packages/replay/src/util/addGlobalListeners.ts
+++ b/packages/replay/src/util/addGlobalListeners.ts
@@ -35,7 +35,8 @@ export function addGlobalListeners(replay: ReplayContainer): void {
     client.on('afterSendEvent', handleAfterSendEvent(replay));
     client.on('createDsc', (dsc: DynamicSamplingContext) => {
       const replayId = replay.getSessionId();
-      if (replayId && replay.isEnabled()) {
+      // We do not want to set the DSC when in buffer mode, as that means the replay has not been sent (yet)
+      if (replayId && replay.isEnabled() && replay.recordingMode === 'session') {
         dsc.replay_id = replayId;
       }
     });


### PR DESCRIPTION
We only want to add the replay_id to the DSC when the session is in `session` mode, as while buffering the replay may not even be sent.

Closes https://github.com/getsentry/sentry-javascript/issues/8013