### PR TITLE
test(nextjs): Don't run integration tests for Next.js >= 13 when Node.js < 16

### DIFF
--- a/packages/nextjs/test/run-integration-tests.sh
+++ b/packages/nextjs/test/run-integration-tests.sh
@@ -33,10 +33,6 @@ mv next.config.js next.config.js.bak
 
 for NEXTJS_VERSION in 10 11 12 13; do
   for USE_APPDIR in true false; do
-    if ([ "$NEXTJS_VERSION" -lt "13" ] || [ "$NODE_MAJOR" -lt "16" ]) && [ "$USE_APPDIR" == true ]; then
-      # App dir doesn not work on Next.js < 13 or Node.js < 16
-      continue
-    fi
 
     # export this to the env so that we can behave differently depending on which version of next we're testing, without
     # having to pass this value from function to function to function to the one spot, deep in some callstack, where we
@@ -57,8 +53,8 @@ for NEXTJS_VERSION in 10 11 12 13; do
       exit 0
     fi
 
-    # Next.js v13 requires at least Node v14
-    if [ "$NODE_MAJOR" -lt "14" ] && [ "$NEXTJS_VERSION" -ge "13" ]; then
+    # Next.js v13 requires at least Node v16
+    if [ "$NODE_MAJOR" -lt "16" ] && [ "$NEXTJS_VERSION" -ge "13" ]; then
       echo "[nextjs@$NEXTJS_VERSION] Not compatible with Node $NODE_MAJOR"
       exit 0
     fi


### PR DESCRIPTION
The newest Next.js version introduced a hammer operator `||=` somewhere in the non-app dir code and this breaks Next.js 13 for everybody using Node.js < 16. This is why we need our tests to skip that case.