### PR TITLE
test(nextjs): Fix test that got skipped in CI check of #7990

### DIFF
--- a/packages/nextjs/test/integration/test/client/tracingFetch.test.ts
+++ b/packages/nextjs/test/integration/test/client/tracingFetch.test.ts
@@ -31,7 +31,7 @@ test('should correctly instrument `fetch` for performance tracing', async ({ pag
   expect(transaction[0].spans).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        data: { method: 'GET', url: 'http://example.com', type: 'fetch' },
+        data: expect.objectContaining({ method: 'GET', url: 'http://example.com', type: 'fetch' }),
         description: 'GET http://example.com',
         op: 'http.client',
         parent_span_id: expect.any(String),


### PR DESCRIPTION
The Next.js integration tests got skipped in #7990 but would have failed. This PR fixes the tests.