### PR TITLE
feat(replay): Improve click target detection

### DIFF
--- a/packages/browser-integration-tests/suites/replay/customEvents/template.html
+++ b/packages/browser-integration-tests/suites/replay/customEvents/template.html
@@ -5,13 +5,9 @@
   </head>
   <body>
     <div role="button" id="error" class="btn btn-error" aria-label="An Error">An Error</div>
-    <button>
-      <img id="img"
-        alt="Alt Text"
-      />
+    <button title="Button title">
+      <img id="img" alt="Alt Text" />
     </button>
-    <button class="sentry-unmask" aria-label="Unmasked label">
-      Unmasked
-    </button>
+    <button class="sentry-unmask" aria-label="Unmasked label">Unmasked</button>
   </body>
 </html>

--- a/packages/browser-integration-tests/suites/replay/customEvents/test.ts
+++ b/packages/browser-integration-tests/suites/replay/customEvents/test.ts
@@ -135,16 +135,15 @@ sentryTest(
       expect.arrayContaining([
         {
           ...expectedClickBreadcrumb,
-          message: 'body > button > img#img[alt="Alt Text"]',
+          message: 'body > button[title="Button title"]',
           data: {
             nodeId: expect.any(Number),
             node: {
               attributes: {
-                alt: 'Alt Text',
-                id: 'img',
+                title: '****** *****',
               },
               id: expect.any(Number),
-              tagName: 'img',
+              tagName: 'button',
               textContent: '',
             },
           },

--- a/packages/replay/test/unit/coreHandlers/handleDom.test.ts
+++ b/packages/replay/test/unit/coreHandlers/handleDom.test.ts
@@ -1,0 +1,130 @@
+import type { DomHandlerData } from '../../../src/coreHandlers/handleDom';
+import { handleDom } from '../../../src/coreHandlers/handleDom';
+
+describe('Unit | coreHandlers | handleDom', () => {
+  test('it works with a basic click event on a div', () => {
+    const parent = document.createElement('body');
+    const target = document.createElement('div');
+    target.classList.add('my-class', 'other-class');
+    parent.appendChild(target);
+
+    const handlerData: DomHandlerData = {
+      name: 'click',
+      event: {
+        target,
+      },
+    };
+    const actual = handleDom(handlerData);
+    expect(actual).toEqual({
+      category: 'ui.click',
+      data: {},
+      message: 'body > div.my-class.other-class',
+      timestamp: expect.any(Number),
+      type: 'default',
+    });
+  });
+
+  test('it works with a basic click event on a button', () => {
+    const parent = document.createElement('body');
+    const target = document.createElement('button');
+    target.classList.add('my-class', 'other-class');
+    parent.appendChild(target);
+
+    const handlerData: DomHandlerData = {
+      name: 'click',
+      event: {
+        target,
+      },
+    };
+    const actual = handleDom(handlerData);
+    expect(actual).toEqual({
+      category: 'ui.click',
+      data: {},
+      message: 'body > button.my-class.other-class',
+      timestamp: expect.any(Number),
+      type: 'default',
+    });
+  });
+
+  test('it works with a basic click event on a span inside of <button>', () => {
+    const parent = document.createElement('body');
+    const interactive = document.createElement('button');
+    interactive.classList.add('my-class', 'other-class');
+    parent.appendChild(interactive);
+
+    const target = document.createElement('span');
+    interactive.appendChild(target);
+
+    const handlerData: DomHandlerData = {
+      name: 'click',
+      event: {
+        target,
+      },
+    };
+    const actual = handleDom(handlerData);
+    expect(actual).toEqual({
+      category: 'ui.click',
+      data: {},
+      message: 'body > button.my-class.other-class',
+      timestamp: expect.any(Number),
+      type: 'default',
+    });
+  });
+
+  test('it works with a basic click event on a span inside of <a>', () => {
+    const parent = document.createElement('body');
+    const interactive = document.createElement('a');
+    interactive.classList.add('my-class', 'other-class');
+    parent.appendChild(interactive);
+
+    const target = document.createElement('span');
+    interactive.appendChild(target);
+
+    const handlerData: DomHandlerData = {
+      name: 'click',
+      event: {
+        target,
+      },
+    };
+    const actual = handleDom(handlerData);
+    expect(actual).toEqual({
+      category: 'ui.click',
+      data: {},
+      message: 'body > a.my-class.other-class',
+      timestamp: expect.any(Number),
+      type: 'default',
+    });
+  });
+
+  test('it works with very deep nesting', () => {
+    const parent = document.createElement('body');
+
+    let current: HTMLElement = parent;
+    for (let i = 0; i < 20; i++) {
+      const next = document.createElement('div');
+      next.classList.add(`level-${i}`, `level-other-${i}`);
+      current.appendChild(next);
+      current = next;
+    }
+
+    const target = document.createElement('div');
+    target.classList.add('my-class', 'other-class');
+    current.appendChild(target);
+
+    const handlerData: DomHandlerData = {
+      name: 'click',
+      event: {
+        target,
+      },
+    };
+    const actual = handleDom(handlerData);
+    expect(actual).toEqual({
+      category: 'ui.click',
+      data: {},
+      message:
+        'div.level-16.level-other-16 > div.level-17.level-other-17 > div.level-18.level-other-18 > div.level-19.level-other-19 > div.my-class.other-class',
+      timestamp: expect.any(Number),
+      type: 'default',
+    });
+  });
+});


### PR DESCRIPTION
This does two things:

1. When capturing clicks, we specifically look for button & a elements as parents, using them as target if applicable.
2. Increase max. text length of selectors, to have better visibility. Note we always cap this at 5 levels deep, still.

This is rather defensive for now, by only checking for button & a. This will not check for general interactivity - there are other cases to look for as well, e.g. `[tabindex]` etc. However, IMHO this has also potential to break, if people have weird HTML. So I think this should be a good enough start with very low potential for false positives.

Fixes https://github.com/getsentry/sentry-javascript/issues/7659