### PR TITLE
test(e2e): Send `qa` environment to avoid transacitons from being dynamically sampled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -783,19 +783,18 @@ jobs:
         id: versions
         run: |
           echo "echo node=$(jq -r '.volta.node' package.json)" >> $GITHUB_OUTPUT
-      # Temporarily disabling e2e tests
-      # - name: Run E2E tests
-      #   env:
-      #     E2E_TEST_PUBLISH_SCRIPT_NODE_VERSION: ${{ steps.versions.outputs.node }}
-      #     E2E_TEST_AUTH_TOKEN: ${{ secrets.E2E_TEST_AUTH_TOKEN }}
-      #     E2E_TEST_DSN: ${{ secrets.E2E_TEST_DSN }}
-      #     E2E_TEST_SENTRY_ORG_SLUG: 'sentry-javascript-sdks'
-      #     E2E_TEST_SENTRY_TEST_PROJECT: 'sentry-javascript-e2e-tests'
-      #     E2E_TEST_SHARD: ${{ matrix.shard }}
-      #     E2E_TEST_SHARD_AMOUNT: 3
-      #   run: |
-      #     cd packages/e2e-tests
-      #     yarn test:e2e
+      - name: Run E2E tests
+        env:
+          E2E_TEST_PUBLISH_SCRIPT_NODE_VERSION: ${{ steps.versions.outputs.node }}
+          E2E_TEST_AUTH_TOKEN: ${{ secrets.E2E_TEST_AUTH_TOKEN }}
+          E2E_TEST_DSN: ${{ secrets.E2E_TEST_DSN }}
+          E2E_TEST_SENTRY_ORG_SLUG: 'sentry-javascript-sdks'
+          E2E_TEST_SENTRY_TEST_PROJECT: 'sentry-javascript-e2e-tests'
+          E2E_TEST_SHARD: ${{ matrix.shard }}
+          E2E_TEST_SHARD_AMOUNT: 3
+        run: |
+          cd packages/e2e-tests
+          yarn test:e2e
 
   job_required_tests:
     name: All required tests passed or skipped

--- a/packages/e2e-tests/test-applications/create-next-app/sentry.client.config.ts
+++ b/packages/e2e-tests/test-applications/create-next-app/sentry.client.config.ts
@@ -5,6 +5,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1.0,

--- a/packages/e2e-tests/test-applications/create-next-app/sentry.server.config.ts
+++ b/packages/e2e-tests/test-applications/create-next-app/sentry.server.config.ts
@@ -11,6 +11,7 @@ declare global {
 }
 
 Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1.0,

--- a/packages/e2e-tests/test-applications/create-react-app/src/index.tsx
+++ b/packages/e2e-tests/test-applications/create-react-app/src/index.tsx
@@ -7,6 +7,7 @@ import * as Sentry from '@sentry/react';
 import { BrowserTracing } from '@sentry/tracing';
 
 Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   integrations: [new BrowserTracing()],
 

--- a/packages/e2e-tests/test-applications/nextjs-app-dir/sentry.client.config.ts
+++ b/packages/e2e-tests/test-applications/nextjs-app-dir/sentry.client.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:${
     Number(process.env.NEXT_PUBLIC_BASE_PORT) +

--- a/packages/e2e-tests/test-applications/nextjs-app-dir/sentry.edge.config.ts
+++ b/packages/e2e-tests/test-applications/nextjs-app-dir/sentry.edge.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:${
     Number(process.env.NEXT_PUBLIC_BASE_PORT) +

--- a/packages/e2e-tests/test-applications/nextjs-app-dir/sentry.server.config.ts
+++ b/packages/e2e-tests/test-applications/nextjs-app-dir/sentry.server.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   tunnel: `http://localhost:${
     Number(process.env.NEXT_PUBLIC_BASE_PORT) +

--- a/packages/e2e-tests/test-applications/node-express-app/src/app.ts
+++ b/packages/e2e-tests/test-applications/node-express-app/src/app.ts
@@ -10,6 +10,7 @@ declare global {
 }
 
 Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.NEXT_PUBLIC_E2E_TEST_DSN,
   integrations: [new Integrations.HttpClient()],
   debug: true,

--- a/packages/e2e-tests/test-applications/standard-frontend-react-tracing-import/src/index.tsx
+++ b/packages/e2e-tests/test-applications/standard-frontend-react-tracing-import/src/index.tsx
@@ -15,6 +15,7 @@ import Index from './pages/Index';
 import User from './pages/User';
 
 Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [
     new BrowserTracing({

--- a/packages/e2e-tests/test-applications/standard-frontend-react/src/index.tsx
+++ b/packages/e2e-tests/test-applications/standard-frontend-react/src/index.tsx
@@ -16,6 +16,7 @@ import User from './pages/User';
 const replay = new Sentry.Replay();
 
 Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.REACT_APP_E2E_TEST_DSN,
   integrations: [
     new Sentry.BrowserTracing({

--- a/packages/e2e-tests/test-applications/sveltekit/src/hooks.client.ts
+++ b/packages/e2e-tests/test-applications/sveltekit/src/hooks.client.ts
@@ -2,6 +2,7 @@ import { env } from '$env/dynamic/public';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: env.PUBLIC_E2E_TEST_DSN,
   debug: true,
   tunnel: `http://localhost:${

--- a/packages/e2e-tests/test-applications/sveltekit/src/hooks.server.ts
+++ b/packages/e2e-tests/test-applications/sveltekit/src/hooks.server.ts
@@ -2,6 +2,7 @@ import { env } from '$env/dynamic/private';
 import * as Sentry from '@sentry/sveltekit';
 
 Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: env.E2E_TEST_DSN,
   debug: true,
   tunnel: `http://localhost:${Number(env.BASE_PORT) + Number(env.PORT_MODULO) + Number(env.PORT_GAP)}/`, // proxy server


### PR DESCRIPTION
It was dynamic sampling all along.
