### PR TITLE
test: Refactor playwright bundle generation

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,2 @@
 *.md
 .nxcache
-packages/browser-integration-tests/fixtures

--- a/packages/browser-integration-tests/.eslintrc.js
+++ b/packages/browser-integration-tests/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     'loader-suites/**/subject.js',
     'scripts/**',
     'fixtures/**',
+    'tmp/**',
   ],
   parserOptions: {
     sourceType: 'module',

--- a/packages/browser-integration-tests/.gitignore
+++ b/packages/browser-integration-tests/.gitignore
@@ -1,1 +1,2 @@
 test-results
+tmp

--- a/packages/browser-integration-tests/.prettierignore
+++ b/packages/browser-integration-tests/.prettierignore
@@ -1,0 +1,2 @@
+tmp
+fixtures

--- a/packages/browser-integration-tests/loader-suites/loader/noOnLoad/sdkLoadedInMeanwhile/test.ts
+++ b/packages/browser-integration-tests/loader-suites/loader/noOnLoad/sdkLoadedInMeanwhile/test.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { sentryTest, TEST_HOST } from '../../../../utils/fixtures';
-import { LOADER_CONFIGS } from '../../../../utils/generatePage';
+import { LOADER_CONFIGS } from '../../../../utils/generatePlugin';
 import { envelopeRequestParser, waitForErrorRequest } from '../../../../utils/helpers';
 
 const bundle = process.env.PW_BUNDLE || '';

--- a/packages/browser-integration-tests/package.json
+++ b/packages/browser-integration-tests/package.json
@@ -8,7 +8,7 @@
   },
   "private": true,
   "scripts": {
-    "clean": "rimraf -g suites/**/dist loader-suites/**/dist",
+    "clean": "rimraf -g suites/**/dist loader-suites/**/dist tmp",
     "install-browsers": "playwright install --with-deps",
     "lint": "run-s lint:prettier lint:eslint",
     "lint:eslint": "eslint . --format stylish",
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@types/glob": "8.0.0",
+    "@types/node": "^14.6.4",
     "glob": "8.0.3"
   },
   "volta": {

--- a/packages/browser-integration-tests/playwright.config.ts
+++ b/packages/browser-integration-tests/playwright.config.ts
@@ -7,5 +7,8 @@ const config: PlaywrightTestConfig = {
   // Use 3 workers on CI, else use defaults (based on available CPU cores)
   // Note that 3 is a random number selected to work well with our CI setup
   workers: process.env.CI ? 3 : undefined,
+
+  globalSetup: require.resolve('./playwright.setup.ts'),
 };
+
 export default config;

--- a/packages/browser-integration-tests/playwright.setup.ts
+++ b/packages/browser-integration-tests/playwright.setup.ts
@@ -1,5 +1,5 @@
 import setupStaticAssets from './utils/staticAssets';
 
-export default function globalSetup(): void {
-  setupStaticAssets();
+export default function globalSetup(): Promise<void> {
+  return setupStaticAssets();
 }

--- a/packages/browser-integration-tests/playwright.setup.ts
+++ b/packages/browser-integration-tests/playwright.setup.ts
@@ -1,0 +1,5 @@
+import setupStaticAssets from './utils/staticAssets';
+
+export default function globalSetup(): void {
+  setupStaticAssets();
+}

--- a/packages/browser-integration-tests/utils/fixtures.ts
+++ b/packages/browser-integration-tests/utils/fixtures.ts
@@ -3,7 +3,7 @@ import { test as base } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
 
-import { generateLoader, generatePage } from './generatePage';
+import { generatePage } from './generatePage';
 
 export const TEST_HOST = 'http://sentry-test.io';
 
@@ -53,7 +53,6 @@ const sentryTest = base.extend<TestFixtures>({
       const pagePath = `${TEST_HOST}/index.html`;
 
       await build(testDir);
-      generateLoader(testDir);
 
       // Serve all assets under
       if (!skipRouteHandler) {

--- a/packages/browser-integration-tests/utils/generatePage.ts
+++ b/packages/browser-integration-tests/utils/generatePage.ts
@@ -1,87 +1,9 @@
-import { existsSync, mkdirSync, readFileSync, symlinkSync, unlinkSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync } from 'fs';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
-import path from 'path';
 import webpack from 'webpack';
 
 import webpackConfig from '../webpack.config';
-import { TEST_HOST } from './fixtures';
 import SentryScenarioGenerationPlugin from './generatePlugin';
-
-const LOADER_TEMPLATE = readFileSync(path.join(__dirname, '../fixtures/loader.js'), 'utf-8');
-
-export const LOADER_CONFIGS: Record<string, { bundle: string; options: Record<string, unknown>; lazy: boolean }> = {
-  loader_base: {
-    bundle: 'browser/build/bundles/bundle.es5.min.js',
-    options: {},
-    lazy: true,
-  },
-  loader_eager: {
-    bundle: 'browser/build/bundles/bundle.es5.min.js',
-    options: {},
-    lazy: false,
-  },
-  loader_debug: {
-    bundle: 'browser/build/bundles/bundle.es5.debug.min.js',
-    options: { debug: true },
-    lazy: true,
-  },
-  loader_tracing: {
-    bundle: 'browser/build/bundles/bundle.tracing.es5.min.js',
-    options: { tracesSampleRate: 1 },
-    lazy: false,
-  },
-  loader_replay: {
-    bundle: 'browser/build/bundles/bundle.replay.min.js',
-    options: { replaysSessionSampleRate: 1, replaysOnErrorSampleRate: 1 },
-    lazy: false,
-  },
-  loader_tracing_replay: {
-    bundle: 'browser/build/bundles/bundle.tracing.replay.debug.min.js',
-    options: { tracesSampleRate: 1, replaysSessionSampleRate: 1, replaysOnErrorSampleRate: 1, debug: true },
-    lazy: false,
-  },
-};
-
-const bundleKey = process.env.PW_BUNDLE || '';
-
-export function generateLoader(outPath: string): void {
-  const localPath = `${outPath}/dist`;
-
-  if (!existsSync(localPath)) {
-    return;
-  }
-
-  // Generate loader files
-  const loaderConfig = LOADER_CONFIGS[bundleKey];
-
-  if (!loaderConfig) {
-    throw new Error(`Unknown loader bundle key: ${bundleKey}`);
-  }
-
-  const localCdnBundlePath = path.join(localPath, 'cdn.bundle.js');
-
-  try {
-    unlinkSync(localCdnBundlePath);
-  } catch {
-    // ignore if this didn't exist
-  }
-
-  const cdnSourcePath = path.resolve(__dirname, `../../${loaderConfig.bundle}`);
-  symlinkSync(cdnSourcePath, localCdnBundlePath);
-
-  const loaderPath = path.join(localPath, 'loader.js');
-  const loaderContent = LOADER_TEMPLATE.replace('__LOADER_BUNDLE__', `'${TEST_HOST}/cdn.bundle.js'`)
-    .replace(
-      '__LOADER_OPTIONS__',
-      JSON.stringify({
-        dsn: 'https://public@dsn.ingest.sentry.io/1337',
-        ...loaderConfig.options,
-      }),
-    )
-    .replace('__LOADER_LAZY__', loaderConfig.lazy ? 'true' : 'false');
-
-  writeFileSync(loaderPath, loaderContent, 'utf-8');
-}
 
 export async function generatePage(
   initPath: string,
@@ -110,7 +32,7 @@ export async function generatePage(
             filename: '[name].bundle.js',
           },
           plugins: [
-            new SentryScenarioGenerationPlugin(),
+            new SentryScenarioGenerationPlugin(localPath),
             new HtmlWebpackPlugin({
               filename: outPageName,
               template: templatePath,

--- a/packages/browser-integration-tests/utils/staticAssets.ts
+++ b/packages/browser-integration-tests/utils/staticAssets.ts
@@ -3,12 +3,12 @@ import path from 'path';
 
 export const STATIC_DIR = path.join(__dirname, '../tmp/static');
 
-export default function setupStaticAssets(): void {
+export default async function setupStaticAssets(): Promise<void> {
   if (fs.existsSync(STATIC_DIR)) {
-    fs.rmSync(STATIC_DIR, { recursive: true });
+    await fs.promises.rm(STATIC_DIR, { recursive: true });
   }
 
-  fs.mkdirSync(STATIC_DIR, { recursive: true });
+  await fs.promises.mkdir(STATIC_DIR, { recursive: true });
 }
 
 export function addStaticAsset(localOutPath: string, fileName: string, cb: () => string): void {

--- a/packages/browser-integration-tests/utils/staticAssets.ts
+++ b/packages/browser-integration-tests/utils/staticAssets.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+
+export const STATIC_DIR = path.join(__dirname, '../tmp/static');
+
+export default function setupStaticAssets(): void {
+  if (fs.existsSync(STATIC_DIR)) {
+    fs.rmSync(STATIC_DIR, { recursive: true });
+  }
+
+  fs.mkdirSync(STATIC_DIR, { recursive: true });
+}
+
+export function addStaticAsset(localOutPath: string, fileName: string, cb: () => string): void {
+  const newPath = path.join(STATIC_DIR, fileName);
+
+  // Only copy files once
+  if (!fs.existsSync(newPath)) {
+    fs.writeFileSync(newPath, cb(), 'utf-8');
+  }
+
+  symlinkAsset(newPath, path.join(localOutPath, fileName));
+}
+
+export function addStaticAssetSymlink(localOutPath: string, originalPath: string, fileName: string): void {
+  const newPath = path.join(STATIC_DIR, fileName);
+
+  // Only copy files once
+  if (!fs.existsSync(newPath)) {
+    fs.symlinkSync(originalPath, newPath);
+  }
+
+  symlinkAsset(newPath, path.join(localOutPath, fileName));
+}
+
+function symlinkAsset(originalPath: string, targetPath: string): void {
+  try {
+    fs.unlinkSync(targetPath);
+  } catch {
+    // ignore errors here
+  }
+
+  try {
+    fs.linkSync(originalPath, targetPath);
+  } catch (error) {
+    // only ignore these kind of errors
+    if (!`${error}`.includes('file already exists')) {
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
While working on https://github.com/getsentry/sentry-javascript/pull/8024, I noticed that bundle tests were failing, because we couldn't really run the playwright tests in bundle mode when serving the app on a URL instead via `file://`. This is because of the way we reference bundle files, which have been referenced as e.g. `<script src="/Users/francesco/git/sentry-javascript/packages/browser/build/bundle.min.js">`. This doesn't play well with serving from a URL like `https://sentry-test.io/cdn.bundle.js`.

In order to make this work and streamline this, I refactored this to instead keep a `tmp/static` folder for all of the integration tests, where we can cache static files that are the same for all test runs (e.g. cdn.bundle.js, the integrations or loader.js). Where possible, we make those symlinks. Then we put a symlink to _these_ files into the `dist` folder of each test, and can reference them from there. This works in both file & URL serving mode.
