### PR TITLE
chore(angular): Upgrade `peerDependencies` to Angular 16

### DIFF
--- a/packages/angular-ivy/package.json
+++ b/packages/angular-ivy/package.json
@@ -15,9 +15,9 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@angular/common": ">= 12.x <= 15.x",
-    "@angular/core": ">= 12.x <= 15.x",
-    "@angular/router": ">= 12.x <= 15.x",
+    "@angular/common": ">= 12.x <= 16.x",
+    "@angular/core": ">= 12.x <= 16.x",
+    "@angular/router": ">= 12.x <= 16.x",
     "rxjs": "^6.5.5 || ^7.x"
   },
   "dependencies": {

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -15,9 +15,9 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@angular/common": ">= 10.x <= 16.x",
-    "@angular/core": ">= 10.x <= 16.x",
-    "@angular/router": ">= 10.x <= 16.x",
+    "@angular/common": ">= 10.x <= 15.x",
+    "@angular/core": ">= 10.x <= 15.x",
+    "@angular/router": ">= 10.x <= 15.x",
     "rxjs": "^6.5.5 || ^7.x"
   },
   "dependencies": {

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -15,9 +15,9 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@angular/common": ">= 10.x <= 15.x",
-    "@angular/core": ">= 10.x <= 15.x",
-    "@angular/router": ">= 10.x <= 15.x",
+    "@angular/common": ">= 10.x <= 16.x",
+    "@angular/core": ">= 10.x <= 16.x",
+    "@angular/router": ">= 10.x <= 16.x",
     "rxjs": "^6.5.5 || ^7.x"
   },
   "dependencies": {


### PR DESCRIPTION
With the official release on Angular 16, and no notable changes to how Sentry should work within this new version we can safely update the peerDependencies to include Angular 16.
