### PR TITLE
chore(angular): Clarify `@sentry/angular` and `@sentry/angular-ivy` version compatibility

### DIFF
--- a/packages/angular-ivy/README.md
+++ b/packages/angular-ivy/README.md
@@ -16,7 +16,7 @@
 
 ## Angular Version Compatibility
 
-This SDK officially supports Angular 12-15 with Angular's new rendering engine, Ivy.
+This SDK officially supports Angular 12 and newer with Angular's new rendering engine, Ivy.
 
 If you're using Angular 10, 11 or a newer Angular version with View Engine instead of Ivy, please use [`@sentry/angular`](https://github.com/getsentry/sentry-javascript/blob/develop/packages/angular/README.md).
 

--- a/packages/angular-ivy/README.md
+++ b/packages/angular-ivy/README.md
@@ -16,7 +16,7 @@
 
 ## Angular Version Compatibility
 
-This SDK officially supports Angular 12 and newer with Angular's new rendering engine, Ivy.
+This SDK officially supports Angular 12 to 16 with Angular's new rendering engine, Ivy.
 
 If you're using Angular 10, 11 or a newer Angular version with View Engine instead of Ivy, please use [`@sentry/angular`](https://github.com/getsentry/sentry-javascript/blob/develop/packages/angular/README.md).
 

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -17,7 +17,11 @@
 
 ## Angular Version Compatibility
 
-The latest version of this SDK officially supports Angular 10-13. If you are using an older version of Angular and experience problems with the Angular SDK, we recommend downgrading the SDK to version 6.x.
+**Important**: This package is not compatible with Angular 16 or newer. Please use [`@sentry/angular-ivy`](https://github.com/getsentry/sentry-javascript/tree/master/packages/angular-ivy) instead.
+
+If you're using Angular 12 or newer, we recommend using `@sentry/angular-ivy` for better support with Angular's rendering engine Ivy.
+
+This SDK stilll officially supports Angular 10-15. If you are using an older version of Angular and experience problems with the Angular SDK, we recommend downgrading the SDK to version 6.x.
 
 ## General
 

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -19,7 +19,7 @@
 
 **Important**: This package is not compatible with Angular 16 or newer. Please use [`@sentry/angular-ivy`](https://github.com/getsentry/sentry-javascript/tree/master/packages/angular-ivy) instead.
 
-If you're using Angular 12 or newer, we recommend using `@sentry/angular-ivy` for better support with Angular's rendering engine Ivy.
+If you're using Angular 12 or newer, we recommend using `@sentry/angular-ivy` for native support with Angular's rendering engine Ivy.
 
 This SDK stilll officially supports Angular 10-15. If you are using an older version of Angular and experience problems with the Angular SDK, we recommend downgrading the SDK to version 6.x.
 


### PR DESCRIPTION
With the release of Angular 16, `ngcc` was finally removed from the framework which means that our `@sentry/angular` package is no longer compatible with this and future versions. Therefore, this PR updates the Readme to point people towards `@sentry/angular-ivy`. 

Peer dep bump is happening in #8035 

IMO there's no docs change necessary, as the [current Angular docs](https://docs.sentry.io/platforms/javascript/guides/angular/) already recommend Ivy for NG12 and newer.

I tested our SDK (Ivy) with Angular 16 and everything seems to be working as expected, including route parameterization and the various component tracking features. Meaning these two PRs should be enough to support Angular 16 🚀    