### PR TITLE
fix(node): Leaking transactions due to `AsyncLocalStorage` and circular reference

### DIFF
--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -587,6 +587,16 @@ export function setAsyncContextStrategy(strategy: AsyncContextStrategy | undefin
 }
 
 /**
+ * Has a global async context strategy been set
+ */
+export function hasAsyncContextStrategy(): boolean {
+  // Get main carrier (global for every environment)
+  const registry = getMainCarrier();
+  registry.__SENTRY__ = registry.__SENTRY__ || {};
+  return !!registry.__SENTRY__.acs;
+}
+
+/**
  * Runs the supplied callback in its own async context. Async Context strategies are defined per SDK.
  *
  * @param callback The callback to run in its own async context

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -410,9 +410,11 @@ describe('tracingHandler', () => {
     const finishSpan = jest.spyOn(span, 'finish');
     const finishTransaction = jest.spyOn(transaction, 'finish');
 
+    const hub = sentryCore.getCurrentHub();
     let sentEvent: Event;
-    jest.spyOn((transaction as any)._hub, 'captureEvent').mockImplementation(event => {
+    jest.spyOn(hub, 'captureEvent').mockImplementation(event => {
       sentEvent = event as Event;
+      return '';
     });
 
     sentryTracingMiddleware(req, res, next);


### PR DESCRIPTION
Closes #7982

Since in node, we can rely on `AsyncLocalStorage` to isolate multiple hubs, we do not need to hold a reference to a specific hub on the transaction. However, since the browser doesn't have a way to isolate hubs yet, removing the hub link has the potential to break transactions for those customers using multiple manually created hubs.

This PR makes it so the hub reference is only added when no async context strategy has been set (ie. in the browser). 
