### PR TITLE
fix(node): report errorMiddleware errors as unhandled

### DIFF
--- a/packages/node-integration-tests/suites/express/handle-error/test.ts
+++ b/packages/node-integration-tests/suites/express/handle-error/test.ts
@@ -11,8 +11,8 @@ test('should capture and send Express controller error.', async () => {
       values: [
         {
           mechanism: {
-            type: 'generic',
-            handled: true,
+            type: 'middleware',
+            handled: false,
           },
           type: 'Error',
           value: 'test_error',

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -10,6 +10,7 @@ import {
 import type { Span } from '@sentry/types';
 import type { AddRequestDataToEventOptions } from '@sentry/utils';
 import {
+  addExceptionMechanism,
   addRequestDataToTransaction,
   baggageHeaderToDynamicSamplingContext,
   dropUndefinedKeys,
@@ -303,6 +304,11 @@ export function errorHandler(options?: {
             }
           }
         }
+
+        _scope.addEventProcessor(event => {
+          addExceptionMechanism(event, { type: 'middleware', handled: false });
+          return event;
+        });
 
         const eventId = captureException(error);
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access


### PR DESCRIPTION
I found it confusing that unhandled errors caught by the express.js middleware were being reported as handled

This change updates the behavior to match Sentry-Python's Django integration: https://github.com/getsentry/sentry-python/blob/81afcea403c0ac148d631164de29ed80d6a64840/sentry_sdk/integrations/asgi.py#L58

I could use help testing this

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
