### PR TITLE
fix(sveltekit): Wrap `load` when typed explicitly

### DIFF
--- a/packages/sveltekit/src/vite/autoInstrument.ts
+++ b/packages/sveltekit/src/vite/autoInstrument.ts
@@ -98,7 +98,9 @@ export async function canWrapLoad(id: string, debug: boolean): Promise<boolean> 
     debug && console.log(`Skipping wrapping ${id} because it already contains Sentry code`);
   }
 
-  const hasLoadDeclaration = /((const|let|var|function)\s+load\s*(=|\())|as\s+load\s*(,|})/gm.test(codeWithoutComments);
+  const hasLoadDeclaration = /((const|let|var|function)\s+load\s*(=|\(|:))|as\s+load\s*(,|})/gm.test(
+    codeWithoutComments,
+  );
   if (!hasLoadDeclaration) {
     // eslint-disable-next-line no-console
     debug && console.log(`Skipping wrapping ${id} because it doesn't declare a \`load\` function`);

--- a/packages/sveltekit/test/vite/autoInstrument.test.ts
+++ b/packages/sveltekit/test/vite/autoInstrument.test.ts
@@ -176,6 +176,12 @@ describe('canWrapLoad', () => {
        async function somethingElse(){};
        export { somethingElse as  load, foo }`,
     ],
+
+    [
+      'export variable declaration - inline function with assigned type',
+      `import type { LayoutLoad } from './$types';
+       export const load :  LayoutLoad = async () => { return { props: { msg: "hi" } } }`,
+    ],
   ])('returns `true` if a load declaration  (%s) exists and no Sentry code was found', async (_, code) => {
     fileContent = code;
     expect(await canWrapLoad('+page.ts', false)).toEqual(true);


### PR DESCRIPTION
- When `load` is explicitly typed (using `LayoutLoad`, `PageLoad`, etc.), auto-instrumentation fails.
- The SvelteKit docs suggest using the `satisfies` operator everywhere, but this is not strictly enforced. Prior to support for `satisfies` in TypeScript 4.9, the docs also suggested using explicit types, and were updated once support was more common. ([PR](https://github.com/sveltejs/kit/pull/7861))
- Update the [`hasLoadDeclaration` regex](https://github.com/getsentry/sentry-javascript/blob/2cc7708c0a3ab526716fc4998f59d2104e6f3be3/packages/sveltekit/src/vite/autoInstrument.ts#L101) introduced in #7994 to also check for cases when there is an explicit type.
- Simplified example of a `+layout.ts`file that would be skipped:
	```ts
	import type { LayoutLoad } from "./$types";
    export const load : LayoutLoad = async () => { return { props: { msg: "hi" } } }
    
	// message when debugging: 
	// Skipping wrapping /src/routes/nested/+layout.ts because it doesn't declare a `load` function
	```

---

Before submitting a pull request, please take a look at our [Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
