### PR TITLE
fix(node): Make sure we use same ID for checkIns

### DIFF
--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -164,16 +164,19 @@ export class NodeClient extends BaseClient<NodeClientOptions> {
     const options = this.getOptions();
     const { release, environment, tunnel } = options;
 
-    const id = checkIn.checkInId || uuid4();
+    const id = checkIn.status === 'in_progress' ? uuid4() : checkIn.checkInId;
 
     const serializedCheckIn: SerializedCheckIn = {
       check_in_id: id,
       monitor_slug: checkIn.monitorSlug,
       status: checkIn.status,
-      duration: checkIn.duration,
       release,
       environment,
     };
+
+    if (checkIn.status !== 'in_progress') {
+      serializedCheckIn.duration = checkIn.duration;
+    }
 
     if (monitorConfig) {
       serializedCheckIn.monitor_config = {

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -153,8 +153,9 @@ export class NodeClient extends BaseClient<NodeClientOptions> {
    * @param checkIn An object that describes a check in.
    * @param upsertMonitorConfig An optional object that describes a monitor config. Use this if you want
    * to create a monitor automatically when sending a check in.
+   * @returns A string representing the id of the check in.
    */
-  public captureCheckIn(checkIn: CheckIn, monitorConfig?: MonitorConfig): void {
+  public captureCheckIn(checkIn: CheckIn, monitorConfig?: MonitorConfig): string | undefined {
     if (!this._isEnabled()) {
       __DEBUG_BUILD__ && logger.warn('SDK not enabled, will not capture checkin.');
       return;
@@ -163,8 +164,10 @@ export class NodeClient extends BaseClient<NodeClientOptions> {
     const options = this.getOptions();
     const { release, environment, tunnel } = options;
 
+    const id = checkIn.checkInId || uuid4();
+
     const serializedCheckIn: SerializedCheckIn = {
-      check_in_id: uuid4(),
+      check_in_id: id,
       monitor_slug: checkIn.monitorSlug,
       status: checkIn.status,
       duration: checkIn.duration,
@@ -183,6 +186,7 @@ export class NodeClient extends BaseClient<NodeClientOptions> {
 
     const envelope = createCheckInEnvelope(serializedCheckIn, this.getSdkMetadata(), tunnel, this.getDsn());
     void this._sendEnvelope(envelope);
+    return id;
   }
 
   /**

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -164,7 +164,7 @@ export class NodeClient extends BaseClient<NodeClientOptions> {
     const options = this.getOptions();
     const { release, environment, tunnel } = options;
 
-    const id = checkIn.status === 'in_progress' ? uuid4() : checkIn.checkInId;
+    const id = checkIn.status !== 'in_progress' && checkIn.checkInId ? checkIn.checkInId : uuid4();
 
     const serializedCheckIn: SerializedCheckIn = {
       check_in_id: id,

--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -155,16 +155,15 @@ export class NodeClient extends BaseClient<NodeClientOptions> {
    * to create a monitor automatically when sending a check in.
    * @returns A string representing the id of the check in.
    */
-  public captureCheckIn(checkIn: CheckIn, monitorConfig?: MonitorConfig): string | undefined {
+  public captureCheckIn(checkIn: CheckIn, monitorConfig?: MonitorConfig): string {
+    const id = checkIn.status !== 'in_progress' && checkIn.checkInId ? checkIn.checkInId : uuid4();
     if (!this._isEnabled()) {
       __DEBUG_BUILD__ && logger.warn('SDK not enabled, will not capture checkin.');
-      return;
+      return id;
     }
 
     const options = this.getOptions();
     const { release, environment, tunnel } = options;
-
-    const id = checkIn.status !== 'in_progress' && checkIn.checkInId ? checkIn.checkInId : uuid4();
 
     const serializedCheckIn: SerializedCheckIn = {
       check_in_id: id,

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -279,6 +279,7 @@ export function captureCheckIn(
   }
 
   __DEBUG_BUILD__ && logger.warn('Cannot capture check in. No client defined.');
+  return;
 }
 
 /** Node.js stack parser */

--- a/packages/node/test/client.test.ts
+++ b/packages/node/test/client.test.ts
@@ -314,7 +314,7 @@ describe('NodeClient', () => {
           [
             expect.any(Object),
             {
-              check_in_id: expect.any(String),
+              check_in_id: id,
               monitor_slug: 'foo',
               status: 'in_progress',
               release: '1.0.0',

--- a/packages/node/test/client.test.ts
+++ b/packages/node/test/client.test.ts
@@ -361,7 +361,7 @@ describe('NodeClient', () => {
       // @ts-ignore accessing private method
       const sendEnvelopeSpy = jest.spyOn(client, '_sendEnvelope');
 
-      client.captureCheckIn({ monitorSlug: 'foo', status: 'ok', duration: 1222 });
+      client.captureCheckIn({ monitorSlug: 'foo', status: 'in_progress' });
 
       expect(sendEnvelopeSpy).toHaveBeenCalledTimes(0);
     });

--- a/packages/node/test/client.test.ts
+++ b/packages/node/test/client.test.ts
@@ -294,8 +294,8 @@ describe('NodeClient', () => {
       // @ts-ignore accessing private method
       const sendEnvelopeSpy = jest.spyOn(client, '_sendEnvelope');
 
-      client.captureCheckIn(
-        { monitorSlug: 'foo', status: 'ok', duration: 1222 },
+      const id = client.captureCheckIn(
+        { monitorSlug: 'foo', status: 'in_progress' },
         {
           schedule: {
             type: 'crontab',
@@ -315,9 +315,8 @@ describe('NodeClient', () => {
             expect.any(Object),
             {
               check_in_id: expect.any(String),
-              duration: 1222,
               monitor_slug: 'foo',
-              status: 'ok',
+              status: 'in_progress',
               release: '1.0.0',
               environment: 'dev',
               monitor_config: {
@@ -329,6 +328,26 @@ describe('NodeClient', () => {
                 max_runtime: 12333,
                 timezone: 'Canada/Eastern',
               },
+            },
+          ],
+        ],
+      ]);
+
+      client.captureCheckIn({ monitorSlug: 'foo', status: 'ok', duration: 1222, checkInId: id });
+
+      expect(sendEnvelopeSpy).toHaveBeenCalledTimes(2);
+      expect(sendEnvelopeSpy).toHaveBeenCalledWith([
+        expect.any(Object),
+        [
+          [
+            expect.any(Object),
+            {
+              check_in_id: id,
+              monitor_slug: 'foo',
+              duration: 1222,
+              status: 'ok',
+              release: '1.0.0',
+              environment: 'dev',
             },
           ],
         ],

--- a/packages/node/test/sdk.test.ts
+++ b/packages/node/test/sdk.test.ts
@@ -1,5 +1,7 @@
+import { getCurrentHub } from '@sentry/core';
 import type { Integration } from '@sentry/types';
 
+import type { NodeClient } from '../build/types';
 import { init } from '../src/sdk';
 import * as sdk from '../src/sdk';
 
@@ -88,5 +90,23 @@ describe('init()', () => {
     expect(mockDefaultIntegrations[0].setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
     expect(mockDefaultIntegrations[1].setupOnce as jest.Mock).toHaveBeenCalledTimes(0);
     expect(newIntegration.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('captureCheckIn', () => {
+  it('always returns an id', () => {
+    const hub = getCurrentHub();
+    const client = hub.getClient<NodeClient>();
+    expect(client).toBeDefined();
+
+    const captureCheckInSpy = jest.spyOn(client!, 'captureCheckIn');
+
+    // test if captureCheckIn returns an id even if client is not defined
+    hub.bindClient(undefined);
+
+    expect(captureCheckInSpy).toHaveBeenCalledTimes(0);
+    expect(sdk.captureCheckIn({ monitorSlug: 'gogogo', status: 'in_progress' })).toBeTruthy();
+
+    hub.bindClient(client);
   });
 });

--- a/packages/types/src/checkin.ts
+++ b/packages/types/src/checkin.ts
@@ -45,13 +45,13 @@ interface InProgressCheckIn {
   status: 'in_progress';
 }
 
-interface FinishedCheckIn {
+export interface FinishedCheckIn {
   // The distinct slug of the monitor.
   monitorSlug: SerializedCheckIn['monitor_slug'];
   // The status of the check-in.
   status: 'ok' | 'error';
   // Check-In ID (unique and client generated).
-  checkInId?: SerializedCheckIn['check_in_id'];
+  checkInId: SerializedCheckIn['check_in_id'];
   // The duration of the check-in in seconds. Will only take effect if the status is ok or error.
   duration?: SerializedCheckIn['duration'];
 }

--- a/packages/types/src/checkin.ts
+++ b/packages/types/src/checkin.ts
@@ -38,16 +38,25 @@ export interface SerializedCheckIn {
   };
 }
 
-export type CheckIn = {
+interface InProgressCheckIn {
   // The distinct slug of the monitor.
   monitorSlug: SerializedCheckIn['monitor_slug'];
+  // The status of the check-in.
+  status: 'in_progress';
+}
+
+interface FinishedCheckIn {
+  // The distinct slug of the monitor.
+  monitorSlug: SerializedCheckIn['monitor_slug'];
+  // The status of the check-in.
+  status: 'ok' | 'error';
   // Check-In ID (unique and client generated).
   checkInId?: SerializedCheckIn['check_in_id'];
-  // The status of the check-in.
-  status: SerializedCheckIn['status'];
   // The duration of the check-in in seconds. Will only take effect if the status is ok or error.
   duration?: SerializedCheckIn['duration'];
-};
+}
+
+export type CheckIn = InProgressCheckIn | FinishedCheckIn;
 
 type SerializedMonitorConfig = NonNullable<SerializedCheckIn['monitor_config']>;
 

--- a/packages/types/src/checkin.ts
+++ b/packages/types/src/checkin.ts
@@ -38,14 +38,16 @@ export interface SerializedCheckIn {
   };
 }
 
-export interface CheckIn {
+export type CheckIn = {
   // The distinct slug of the monitor.
   monitorSlug: SerializedCheckIn['monitor_slug'];
+  // Check-In ID (unique and client generated).
+  checkInId?: SerializedCheckIn['check_in_id'];
   // The status of the check-in.
   status: SerializedCheckIn['status'];
   // The duration of the check-in in seconds. Will only take effect if the status is ok or error.
   duration?: SerializedCheckIn['duration'];
-}
+};
 
 type SerializedMonitorConfig = NonNullable<SerializedCheckIn['monitor_config']>;
 


### PR DESCRIPTION
Based on work in https://github.com/getsentry/sentry-javascript/pull/8039, this PR fixes a bug where we were adding a unique ID to every check in, which is incorrect behaviour. Instead we now return a `checkInId` every time a check in is captured, which can be used to link check ins together.

Example:

```ts
// 🟡 Notify Sentry your job is running:
const checkInId = Sentry.captureCheckIn({
  monitorSlug: '<monitor-slug>',
  status: 'in_progress',
});

// Execute your scheduled task here...

// 🟢 Notify Sentry your job has completed successfully:
Sentry.captureCheckIn({
  checkInId,
  monitorSlug: '<monitor-slug>',
  status: 'ok',
});
```