### PR TITLE
chore: Make job_browser_loader_tests a required test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -808,6 +808,7 @@ jobs:
         job_node_integration_tests,
         job_browser_playwright_tests,
         job_browser_integration_tests,
+        job_browser_loader_tests,
         job_remix_integration_tests,
         job_e2e_tests,
       ]


### PR DESCRIPTION
Noticed this when looking at https://github.com/getsentry/sentry-javascript/actions/runs/4914887268