### PR TITLE
fix(sveltekit): Avoid creating the Sentry Vite plugin in dev mode

### DIFF
--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -78,7 +78,7 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
     );
   }
 
-  if (mergedOptions.autoUploadSourceMaps) {
+  if (mergedOptions.autoUploadSourceMaps && process.env.NODE_ENV !== 'development') {
     const pluginOptions = {
       ...mergedOptions.sourceMapsUploadOptions,
       debug: mergedOptions.debug, // override the plugin's debug flag with the one from the top-level options

--- a/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
+++ b/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
@@ -38,6 +38,19 @@ describe('sentryVite()', () => {
     expect(plugins).toHaveLength(1);
   });
 
+  it("doesn't return the custom sentry source maps plugin if `NODE_ENV` is development", async () => {
+    const previousEnv = process.env.NODE_ENV;
+
+    process.env.NODE_ENV = 'development';
+    const plugins = await sentrySvelteKit({ autoUploadSourceMaps: true, autoInstrument: true });
+    const instrumentPlugin = plugins[0];
+
+    expect(plugins).toHaveLength(1);
+    expect(instrumentPlugin.name).toEqual('sentry-auto-instrumentation');
+
+    process.env.NODE_ENV = previousEnv;
+  });
+
   it("doesn't return the auto instrument plugin if autoInstrument is `false`", async () => {
     const plugins = await sentrySvelteKit({ autoInstrument: false });
     expect(plugins).toHaveLength(1);


### PR DESCRIPTION
To upload source maps in SvelteKit, we create a custom plugin building on top of the Sentry Vite plugin, which creates a Sentry hub to collect telemetry. The problem is that in the current version of the Sentry Vite plugin, the hub is set as the current hub (`makeMain`) as soon as the plugin is created, causing tags from the plugin to leak to the user's Sentry projects in errors and transactions. 

This will be fixed in the new major of the vite plugin but we should nevertheless avoid this for now. Hence, this PR fixes this leakage by simply not creating the plugin when we're in dev mode. 