### PR TITLE
test(e2e): Add canary tests for react e2e tests

### DIFF
--- a/packages/e2e-tests/test-applications/create-react-app/test-recipe.json
+++ b/packages/e2e-tests/test-applications/create-react-app/test-recipe.json
@@ -2,5 +2,19 @@
   "$schema": "../../test-recipe-schema.json",
   "testApplicationName": "create-react-app",
   "buildCommand": "pnpm install && pnpm build",
-  "tests": []
+  "tests": [],
+  "canaryVersions": [
+    {
+      "dependencyOverrides": {
+        "react": "canary",
+        "react-dom": "canary"
+      }
+    },
+    {
+      "dependencyOverrides": {
+        "react": "canary",
+        "react-dom": "canary"
+      }
+    }
+  ]
 }

--- a/packages/e2e-tests/test-applications/create-react-app/test-recipe.json
+++ b/packages/e2e-tests/test-applications/create-react-app/test-recipe.json
@@ -9,12 +9,6 @@
         "react": "canary",
         "react-dom": "canary"
       }
-    },
-    {
-      "dependencyOverrides": {
-        "react": "canary",
-        "react-dom": "canary"
-      }
     }
   ]
 }


### PR DESCRIPTION
See: https://react.dev/community/versioning-policy

React is going to do more stuff in experimental/canary channels. Let's make sure the basics still work and build.