### PR TITLE
ref(serverless): Remove relay extension from AWS layer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,43 +253,6 @@ jobs:
       # `job_build` can't see `job_install_deps` and what it returned)
       dependency_cache_key: ${{ needs.job_install_deps.outputs.dependency_cache_key }}
 
-  job_pack_aws_lambda_layer:
-    name: Pack and Upload AWS Lambda Layer
-    needs: [job_get_metadata, job_build]
-    # only upload the zipped layer file if we're about to release
-    if: startsWith(github.ref, 'refs/heads/release/')
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ env.HEAD_COMMIT }}
-      - name: Set up Node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: 'package.json'
-      - name: Restore caches
-        uses: ./.github/actions/restore-cache
-        env:
-          DEPENDENCY_CACHE_KEY: ${{ needs.job_build.outputs.dependency_cache_key }}
-
-      - name: Get SDK version
-        # `jq` reads JSON files, and `tee` pipes its input to the given location and to stdout. (Adding `-a` is the
-        # equivalent of using >> rather than >.)
-        run: |
-          export SDK_VERSION=$(cat packages/core/package.json | jq --raw-output '.version')
-          echo "SDK_VERSION=$SDK_VERSION" | tee -a $GITHUB_ENV
-      - name: Move dist-serverless to root directory (requirement for zipping action)
-        run: |
-          mv ./packages/serverless/build/aws/dist-serverless .
-      - name: Create and upload final zip file
-        uses: getsentry/action-build-aws-lambda-extension@v1
-        with:
-          artifact_name: ${{ env.HEAD_COMMIT }}
-          zip_file_name: sentry-node-serverless-${{ env.SDK_VERSION }}.zip
-          build_cache_paths: ${{ env.CACHED_BUILD_PATHS }}
-          build_cache_key: ${{ env.BUILD_CACHE_KEY }}
-
   job_size_check:
     name: Size Check
     needs: [job_get_metadata, job_build]
@@ -399,6 +362,7 @@ jobs:
             ${{ github.workspace }}/packages/integrations/build/bundles/**
             ${{ github.workspace }}/packages/replay/build/bundles/**
             ${{ github.workspace }}/packages/**/*.tgz
+            ${{ github.workspace }}/packages/serverless/build/aws/dist-serverless/*.zip
 
   job_browser_unit_tests:
     name: Browser Unit Tests

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -34,8 +34,7 @@
     "find-up": "^5.0.0",
     "google-gax": "^2.9.0",
     "nock": "^13.0.4",
-    "npm-packlist": "^2.1.4",
-    "read-pkg": "^5.2.0"
+    "npm-packlist": "^2.1.4"
   },
   "scripts": {
     "build": "run-p build:transpile build:types build:bundle",

--- a/packages/serverless/scripts/buildLambdaLayer.ts
+++ b/packages/serverless/scripts/buildLambdaLayer.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as rimraf from 'rimraf';
 
 import { ensureBundleBuildPrereqs } from '../../../scripts/ensure-bundle-deps';
+import { version } from '../package.json';
 
 /**
  * Run the given shell command, piping the shell process's `stdin`, `stdout`, and `stderr` to that of the current
@@ -46,6 +47,11 @@ async function buildLambdaLayer(): Promise<void> {
     '../build/npm/cjs/awslambda-auto.js',
     'build/aws/dist-serverless/nodejs/node_modules/@sentry/serverless/dist/awslambda-auto.js',
   );
+
+  const zipFilename = `sentry-node-serverless-${version}.zip`;
+  console.log(`Creating final layer zip file ${zipFilename}.`);
+  // need to preserve the symlink above with -y
+  run(`zip -r -y ${zipFilename} .`, { cwd: 'build/aws/dist-serverless' });
 }
 
 void buildLambdaLayer();

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -3,14 +3,7 @@ import type { Scope } from '@sentry/node';
 import * as Sentry from '@sentry/node';
 import { captureException, captureMessage, flush, getCurrentHub, withScope } from '@sentry/node';
 import type { Integration } from '@sentry/types';
-import {
-  baggageHeaderToDynamicSamplingContext,
-  dsnFromString,
-  dsnToString,
-  extractTraceparentData,
-  isString,
-  logger,
-} from '@sentry/utils';
+import { baggageHeaderToDynamicSamplingContext, extractTraceparentData, isString, logger } from '@sentry/utils';
 // NOTE: I have no idea how to fix this right now, and don't want to waste more time, as it builds just fine — Kamil
 // eslint-disable-next-line import/no-unresolved
 import type { Context, Handler } from 'aws-lambda';
@@ -56,27 +49,6 @@ export interface WrapperOptions {
 
 export const defaultIntegrations: Integration[] = [...Sentry.defaultIntegrations, new AWSServices({ optional: true })];
 
-/**
- * Changes a Dsn to point to the `relay` server running in the Lambda Extension.
- *
- * This is only used by the serverless integration for AWS Lambda.
- *
- * @param originalDsn The original Dsn of the customer.
- * @returns Dsn pointing to Lambda extension.
- */
-function extensionRelayDSN(originalDsn: string | undefined): string | undefined {
-  if (originalDsn === undefined) {
-    return undefined;
-  }
-
-  const dsn = dsnFromString(originalDsn);
-  dsn.host = 'localhost';
-  dsn.port = '5333';
-  dsn.protocol = 'http';
-
-  return dsnToString(dsn);
-}
-
 interface AWSLambdaOptions extends Sentry.NodeOptions {
   /**
    * Internal field that is set to `true` when init() is called by the Sentry AWS Lambda layer.
@@ -105,12 +77,6 @@ export function init(options: AWSLambdaOptions = {}): void {
     ],
     version: Sentry.SDK_VERSION,
   };
-
-  // If invoked by the Sentry Lambda Layer point the SDK to the Lambda Extension (inside the layer) instead of the host
-  // specified in the DSN
-  if (options._invokedByLambdaLayer) {
-    options.dsn = extensionRelayDSN(options.dsn);
-  }
 
   Sentry.init(options);
   Sentry.addGlobalEventProcessor(serverlessEventProcessor);

--- a/packages/serverless/tsconfig.json
+++ b/packages/serverless/tsconfig.json
@@ -5,6 +5,7 @@
 
   "compilerOptions": {
     // package-specific options
-    "target": "ES2018"
+    "target": "ES2018",
+    "resolveJsonModule": true
   }
 }

--- a/scripts/aws-delete-local-layers.sh
+++ b/scripts/aws-delete-local-layers.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Deletes all versions of the layer specified in LAYER_NAME in one region.
+#
+
+set -euo pipefail
+
+# override default AWS region
+export AWS_REGION=eu-central-1
+
+LAYER_NAME=SentryNodeServerlessSDK-local-dev
+VERSION="0"
+
+while [[ $VERSION != "1" ]]
+do
+  VERSION=$(aws lambda list-layer-versions --layer-name $LAYER_NAME | jq '.LayerVersions[0].Version')
+  aws lambda delete-layer-version --layer-name $LAYER_NAME --version-number $VERSION
+done

--- a/scripts/aws-deploy-local-layer.sh
+++ b/scripts/aws-deploy-local-layer.sh
@@ -16,74 +16,23 @@ rm -rf dist-serverless/
 rm -rf ./packages/serverless/build
 rm -rf ./packages/serverless/dist
 rm -rf ./packages/serverless/node_modules
-rm -f sentry-node-serverless-*.zip
 
 # Creating Lambda layer
 echo "Creating Lambda layer in ./packages/serverless/build/aws/dist-serverless..."
 cd packages/serverless
 yarn build
-cd ../../
 echo "Done creating Lambda layer in ./packages/serverless/build/aws/dist-serverless."
 
-# Move dist-serverless/ to the root folder for the action to pick it up.
-# This is only needed in this script, because in GitHub workflow
-# this is done with the upload-artifact/download-artifact actions
-echo "Copying Lambda layer in ./packages/serverless/build/aws/dist-serverless to working directory..."
-mv ./packages/serverless/build/aws/dist-serverless .
-echo "Done copying Lambda layer in ./packages/serverless/build/aws/dist-serverless to working directory."
-
-# IMPORTANT:
-# Please make sure that this does the same as the GitHub action that
-# is building the Lambda layer in production!
-# see: https://github.com/getsentry/action-build-aws-lambda-extension/blob/main/action.yml#L23-L40
-
-echo "Downloading relay..."
-# Make directory (if not existing)
-mkdir -p dist-serverless/relay
-# Download releay from release registry to dist-serverless/relay/relay
-curl -0 --silent \
-    --output dist-serverless/relay/relay \
-    "$(curl -s https://release-registry.services.sentry.io/apps/relay/latest | jq -r .files.\"relay-Linux-x86_64\".url)"
-# Make file executable
-chmod +x dist-serverless/relay/relay
-echo "Done downloading relay."
-
-echo "Creating start script..."
-# Make directory (if not existing)
-mkdir -p dist-serverless/extensions
-# Create 'sentry-lambda-extension' script that starts relay.
-# The file has to have exactly this name, because the executable files of
-# Lambda extensions need to have same file name as the name that they use
-# to register with AWS Lambda environment
-cat > dist-serverless/extensions/sentry-lambda-extension << EOT
-#!/bin/bash
-set -euo pipefail
-exec /opt/relay/relay run \
-    --mode=proxy \
-    --shutdown-timeout=2 \
-    --upstream-dsn="\$SENTRY_DSN" \
-    --aws-runtime-api="\$AWS_LAMBDA_RUNTIME_API"
-EOT
-# Make script executable
-chmod +x dist-serverless/extensions/sentry-lambda-extension
-echo "Done creating start script."
-
-# Zip Lambda layer and included Lambda extension
-echo "Zipping Lambda layer and included Lambda extension..."
-cd dist-serverless/
-zip -r -y ../sentry-node-serverless-x.x.x-dev.zip .
-cd ..
-echo "Done Zipping Lambda layer and included Lambda extension to ./sentry-node-serverless-x.x.x-dev.zip."
-
 # Deploying zipped Lambda layer to AWS
-echo "Deploying zipped Lambda layer to AWS..."
+ZIP=$(ls build/aws/dist-serverless | grep sentry-node-serverless | head -n 1)
+echo "Deploying zipped Lambda layer $ZIP to AWS..."
 
 aws lambda publish-layer-version \
   --layer-name "SentryNodeServerlessSDK-local-dev" \
   --region "eu-central-1" \
-  --zip-file "fileb://sentry-node-serverless-x.x.x-dev.zip" \
+  --zip-file "fileb://build/aws/dist-serverless/$ZIP" \
   --description "Local test build of SentryNodeServerlessSDK (can be deleted)" \
-  --no-cli-pager
+  --compatible-runtimes nodejs10.x nodejs12.x nodejs14.x nodejs16.x nodejs18.x
 
 echo "Done deploying zipped Lambda layer to AWS as 'SentryNodeServerlessSDK-local-dev'."
 


### PR DESCRIPTION
we're reverting back to the older setup since the whole 'relay as AWS extension' experiment didn't really work out.

* remove gh action that bundles relay
* remove port override in DSN
* zip in place as part of `buildLambdaLayer`

part of https://github.com/getsentry/team-webplatform-meta/issues/58
see python PR - https://github.com/getsentry/sentry-python/pull/2068