### PR TITLE
fix(core): Use last error for `ignoreErrors` check

### DIFF
--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -152,8 +152,9 @@ function _getPossibleEventMessages(event: Event): string[] {
     return [event.message];
   }
   if (event.exception) {
+    const { values } = event.exception;
     try {
-      const { type = '', value = '' } = (event.exception.values && event.exception.values[0]) || {};
+      const { type = '', value = '' } = (values && values[values.length - 1]) || {};
       return [`${value}`, `${type}: ${value}`];
     } catch (oO) {
       __DEBUG_BUILD__ && logger.error(`Cannot extract message for event ${getEventDescription(event)}`);

--- a/packages/core/test/lib/integrations/inboundfilters.test.ts
+++ b/packages/core/test/lib/integrations/inboundfilters.test.ts
@@ -143,6 +143,21 @@ const EXCEPTION_EVENT_WITH_FRAMES: Event = {
   },
 };
 
+const EXCEPTION_EVENT_WITH_LINKED_ERRORS: Event = {
+  exception: {
+    values: [
+      {
+        type: 'ReferenceError',
+        value: '`tooManyTreats` is not defined',
+      },
+      {
+        type: 'TypeError',
+        value: 'incorrect type given for parameter `chewToy`: Shoe',
+      },
+    ],
+  },
+};
+
 const SENTRY_EVENT: Event = {
   exception: {
     values: [
@@ -269,6 +284,20 @@ describe('InboundFilters', () => {
     it('uses default filters', () => {
       const eventProcessor = createInboundFiltersEventProcessor();
       expect(eventProcessor(SCRIPT_ERROR_EVENT, {})).toBe(null);
+    });
+
+    it('filters on last exception when multiple present', () => {
+      const eventProcessor = createInboundFiltersEventProcessor({
+        ignoreErrors: ['incorrect type given for parameter `chewToy`'],
+      });
+      expect(eventProcessor(EXCEPTION_EVENT_WITH_LINKED_ERRORS, {})).toBe(null);
+    });
+
+    it("doesn't filter on `cause` exception when multiple present", () => {
+      const eventProcessor = createInboundFiltersEventProcessor({
+        ignoreErrors: ['`tooManyTreats` is not defined'],
+      });
+      expect(eventProcessor(EXCEPTION_EVENT_WITH_LINKED_ERRORS, {})).toBe(EXCEPTION_EVENT_WITH_LINKED_ERRORS);
     });
 
     describe('on exception', () => {


### PR DESCRIPTION
This fixes a helper function used in our implementation of `ignoreErrors` so that in the case of linked errors, it filters on the primary error (the one directly caught by `captureException`) rather than the error in [its `cause` property](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause). See https://github.com/getsentry/sentry-javascript/issues/8079 for screenshots and a more detailed explanation.

Fixes https://github.com/getsentry/sentry-javascript/issues/8079.