### PR TITLE
fix(sveltekit): Avoid double-wrapping load functions

### DIFF
--- a/packages/sveltekit/src/client/load.ts
+++ b/packages/sveltekit/src/client/load.ts
@@ -6,6 +6,7 @@ import { captureException } from '@sentry/svelte';
 import type { ClientOptions, SanitizedRequestData } from '@sentry/types';
 import {
   addExceptionMechanism,
+  addNonEnumerableProperty,
   getSanitizedUrlString,
   objectify,
   parseFetchArgs,
@@ -79,8 +80,9 @@ export function wrapLoadWithSentry<T extends (...args: any) => any>(origLoad: T)
       const patchedEvent: PatchedLoadEvent = {
         ...event,
         fetch: instrumentSvelteKitFetch(event.fetch),
-        __sentry_wrapped__: true,
       };
+
+      addNonEnumerableProperty(patchedEvent as unknown as Record<string, unknown>, '__sentry_wrapped__', true);
 
       const routeId = event.route.id;
       return trace(

--- a/packages/sveltekit/src/common/utils.ts
+++ b/packages/sveltekit/src/common/utils.ts
@@ -1,5 +1,13 @@
 import type { Redirect } from '@sveltejs/kit';
 
+export type SentryWrappedFlag = {
+  /**
+   * If this flag is set, we know that the load event was already wrapped once
+   * and we shouldn't wrap it again.
+   */
+  __sentry_wrapped__?: true;
+};
+
 /**
  * Determines if a thrown "error" is a Redirect object which SvelteKit users can throw to redirect to another route
  * see: https://kit.svelte.dev/docs/modules#sveltejs-kit-redirect

--- a/packages/sveltekit/src/server/load.ts
+++ b/packages/sveltekit/src/server/load.ts
@@ -5,8 +5,12 @@ import type { TransactionContext } from '@sentry/types';
 import { addExceptionMechanism, objectify } from '@sentry/utils';
 import type { HttpError, LoadEvent, ServerLoadEvent } from '@sveltejs/kit';
 
+import type { SentryWrappedFlag } from '../common/utils';
 import { isRedirect } from '../common/utils';
 import { getTracePropagationData } from './utils';
+
+type PatchedLoadEvent = LoadEvent & SentryWrappedFlag;
+type PatchedServerLoadEvent = ServerLoadEvent & SentryWrappedFlag;
 
 function isHttpError(err: unknown): err is HttpError {
   return typeof err === 'object' && err !== null && 'status' in err && 'body' in err;
@@ -59,7 +63,18 @@ export function wrapLoadWithSentry<T extends (...args: any) => any>(origLoad: T)
   return new Proxy(origLoad, {
     apply: (wrappingTarget, thisArg, args: Parameters<T>) => {
       // Type casting here because `T` cannot extend `Load` (see comment above function signature)
-      const event = args[0] as LoadEvent;
+      // Also, this event possibly already has a sentry wrapped flag attached
+      const event = args[0] as PatchedLoadEvent;
+
+      if (event.__sentry_wrapped__) {
+        return wrappingTarget.apply(thisArg, args);
+      }
+
+      const patchedEvent: PatchedLoadEvent = {
+        ...event,
+        __sentry_wrapped__: true,
+      };
+
       const routeId = event.route && event.route.id;
 
       const traceLoadContext: TransactionContext = {
@@ -71,7 +86,7 @@ export function wrapLoadWithSentry<T extends (...args: any) => any>(origLoad: T)
         },
       };
 
-      return trace(traceLoadContext, () => wrappingTarget.apply(thisArg, args), sendErrorToSentry);
+      return trace(traceLoadContext, () => wrappingTarget.apply(thisArg, [patchedEvent]), sendErrorToSentry);
     },
   });
 }
@@ -102,7 +117,18 @@ export function wrapServerLoadWithSentry<T extends (...args: any) => any>(origSe
   return new Proxy(origServerLoad, {
     apply: (wrappingTarget, thisArg, args: Parameters<T>) => {
       // Type casting here because `T` cannot extend `ServerLoad` (see comment above function signature)
-      const event = args[0] as ServerLoadEvent;
+      // Also, this event possibly already has a sentry wrapped flag attached
+      const event = args[0] as PatchedServerLoadEvent;
+
+      if (event.__sentry_wrapped__) {
+        return wrappingTarget.apply(thisArg, args);
+      }
+
+      const patchedEvent: PatchedServerLoadEvent = {
+        ...event,
+        __sentry_wrapped__: true,
+      };
+
       const routeId = event.route && event.route.id;
 
       const { dynamicSamplingContext, traceparentData } = getTracePropagationData(event);
@@ -121,7 +147,7 @@ export function wrapServerLoadWithSentry<T extends (...args: any) => any>(origSe
         ...traceparentData,
       };
 
-      return trace(traceLoadContext, () => wrappingTarget.apply(thisArg, args), sendErrorToSentry);
+      return trace(traceLoadContext, () => wrappingTarget.apply(thisArg, [patchedEvent]), sendErrorToSentry);
     },
   });
 }

--- a/packages/sveltekit/src/server/load.ts
+++ b/packages/sveltekit/src/server/load.ts
@@ -2,7 +2,7 @@
 import { trace } from '@sentry/core';
 import { captureException } from '@sentry/node';
 import type { TransactionContext } from '@sentry/types';
-import { addExceptionMechanism, objectify } from '@sentry/utils';
+import { addExceptionMechanism, addNonEnumerableProperty, objectify } from '@sentry/utils';
 import type { HttpError, LoadEvent, ServerLoadEvent } from '@sveltejs/kit';
 
 import type { SentryWrappedFlag } from '../common/utils';
@@ -70,10 +70,7 @@ export function wrapLoadWithSentry<T extends (...args: any) => any>(origLoad: T)
         return wrappingTarget.apply(thisArg, args);
       }
 
-      const patchedEvent: PatchedLoadEvent = {
-        ...event,
-        __sentry_wrapped__: true,
-      };
+      addNonEnumerableProperty(event as unknown as Record<string, unknown>, '__sentry_wrapped__', true);
 
       const routeId = event.route && event.route.id;
 
@@ -86,7 +83,7 @@ export function wrapLoadWithSentry<T extends (...args: any) => any>(origLoad: T)
         },
       };
 
-      return trace(traceLoadContext, () => wrappingTarget.apply(thisArg, [patchedEvent]), sendErrorToSentry);
+      return trace(traceLoadContext, () => wrappingTarget.apply(thisArg, args), sendErrorToSentry);
     },
   });
 }
@@ -124,10 +121,7 @@ export function wrapServerLoadWithSentry<T extends (...args: any) => any>(origSe
         return wrappingTarget.apply(thisArg, args);
       }
 
-      const patchedEvent: PatchedServerLoadEvent = {
-        ...event,
-        __sentry_wrapped__: true,
-      };
+      addNonEnumerableProperty(event as unknown as Record<string, unknown>, '__sentry_wrapped__', true);
 
       const routeId = event.route && event.route.id;
 
@@ -147,7 +141,7 @@ export function wrapServerLoadWithSentry<T extends (...args: any) => any>(origSe
         ...traceparentData,
       };
 
-      return trace(traceLoadContext, () => wrappingTarget.apply(thisArg, [patchedEvent]), sendErrorToSentry);
+      return trace(traceLoadContext, () => wrappingTarget.apply(thisArg, args), sendErrorToSentry);
     },
   });
 }

--- a/packages/sveltekit/test/client/load.test.ts
+++ b/packages/sveltekit/test/client/load.test.ts
@@ -450,4 +450,17 @@ describe('wrapLoadWithSentry', () => {
       { handled: false, type: 'sveltekit', data: { function: 'load' } },
     );
   });
+
+  it("doesn't wrap load more than once if the wrapper was applied multiple times", async () => {
+    async function load({ params }: Parameters<Load>[0]): Promise<ReturnType<Load>> {
+      return {
+        post: params.id,
+      };
+    }
+
+    const wrappedLoad = wrapLoadWithSentry(wrapLoadWithSentry(load));
+    await wrappedLoad(MOCK_LOAD_ARGS);
+
+    expect(mockTrace).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/sveltekit/test/server/load.test.ts
+++ b/packages/sveltekit/test/server/load.test.ts
@@ -48,70 +48,80 @@ function getById(_id?: string) {
   throw new Error('error');
 }
 
-const MOCK_LOAD_ARGS: any = {
-  params: { id: '123' },
-  route: {
-    id: '/users/[id]',
-  },
-  url: new URL('http://localhost:3000/users/123'),
-};
+function getLoadArgs() {
+  return {
+    params: { id: '123' },
+    route: {
+      id: '/users/[id]',
+    },
+    url: new URL('http://localhost:3000/users/123'),
+  };
+}
 
-const MOCK_LOAD_NO_ROUTE_ARGS: any = {
-  params: { id: '123' },
-  url: new URL('http://localhost:3000/users/123'),
-};
+function getLoadArgsWithoutRoute() {
+  return {
+    params: { id: '123' },
+    url: new URL('http://localhost:3000/users/123'),
+  };
+}
 
-const MOCK_SERVER_ONLY_LOAD_ARGS: any = {
-  ...MOCK_LOAD_ARGS,
-  request: {
-    method: 'GET',
-    headers: {
-      get: (key: string) => {
-        if (key === 'sentry-trace') {
-          return '1234567890abcdef1234567890abcdef-1234567890abcdef-1';
-        }
+function getServerOnlyArgs() {
+  return {
+    ...getLoadArgs(),
+    request: {
+      method: 'GET',
+      headers: {
+        get: (key: string) => {
+          if (key === 'sentry-trace') {
+            return '1234567890abcdef1234567890abcdef-1234567890abcdef-1';
+          }
 
-        if (key === 'baggage') {
-          return (
-            'sentry-environment=production,sentry-release=1.0.0,sentry-transaction=dogpark,' +
-            'sentry-user_segment=segmentA,sentry-public_key=dogsarebadatkeepingsecrets,' +
-            'sentry-trace_id=1234567890abcdef1234567890abcdef,sentry-sample_rate=1'
-          );
-        }
+          if (key === 'baggage') {
+            return (
+              'sentry-environment=production,sentry-release=1.0.0,sentry-transaction=dogpark,' +
+              'sentry-user_segment=segmentA,sentry-public_key=dogsarebadatkeepingsecrets,' +
+              'sentry-trace_id=1234567890abcdef1234567890abcdef,sentry-sample_rate=1'
+            );
+          }
 
-        return null;
+          return null;
+        },
       },
     },
-  },
-};
+  };
+}
 
-const MOCK_SERVER_ONLY_NO_TRACE_LOAD_ARGS: any = {
-  ...MOCK_LOAD_ARGS,
-  request: {
-    method: 'GET',
-    headers: {
-      get: (_: string) => {
-        return null;
+function getServerArgsWithoutTracingHeaders() {
+  return {
+    ...getLoadArgs(),
+    request: {
+      method: 'GET',
+      headers: {
+        get: (_: string) => {
+          return null;
+        },
       },
     },
-  },
-};
+  };
+}
 
-const MOCK_SERVER_ONLY_NO_BAGGAGE_LOAD_ARGS: any = {
-  ...MOCK_LOAD_ARGS,
-  request: {
-    method: 'GET',
-    headers: {
-      get: (key: string) => {
-        if (key === 'sentry-trace') {
-          return '1234567890abcdef1234567890abcdef-1234567890abcdef-1';
-        }
+function getServerArgsWithoutBaggageHeader() {
+  return {
+    ...getLoadArgs(),
+    request: {
+      method: 'GET',
+      headers: {
+        get: (key: string) => {
+          if (key === 'sentry-trace') {
+            return '1234567890abcdef1234567890abcdef-1234567890abcdef-1';
+          }
 
-        return null;
+          return null;
+        },
       },
     },
-  },
-};
+  };
+}
 
 beforeAll(() => {
   addTracingExtensions();
@@ -136,7 +146,7 @@ describe.each([
     }
 
     const wrappedLoad = wrapLoadWithSentry(load);
-    const res = wrappedLoad(MOCK_LOAD_ARGS);
+    const res = wrappedLoad(getLoadArgs());
     await expect(res).rejects.toThrow();
 
     expect(mockCaptureException).toHaveBeenCalledTimes(1);
@@ -162,7 +172,7 @@ describe.each([
       }
 
       const wrappedLoad = wrapLoadWithSentry(load);
-      const res = wrappedLoad({ ...MOCK_LOAD_ARGS });
+      const res = wrappedLoad(getLoadArgs());
       await expect(res).rejects.toThrow();
 
       expect(mockCaptureException).toHaveBeenCalledTimes(times);
@@ -170,12 +180,12 @@ describe.each([
   });
 
   it("doesn't call captureException for thrown `Redirect`s", async () => {
-    async function load(_: Parameters<Load>[0]): Promise<ReturnType<Load>> {
+    async function load(_params: any): Promise<ReturnType<Load>> {
       throw redirect(300, 'other/route');
     }
 
     const wrappedLoad = wrapLoadWithSentry(load);
-    const res = wrappedLoad(MOCK_LOAD_ARGS);
+    const res = wrappedLoad(getLoadArgs());
     await expect(res).rejects.toThrow();
 
     expect(mockCaptureException).not.toHaveBeenCalled();
@@ -194,7 +204,7 @@ describe.each([
     }
 
     const wrappedLoad = sentryLoadWrapperFn.call(this, load);
-    const res = wrappedLoad(MOCK_SERVER_ONLY_LOAD_ARGS);
+    const res = wrappedLoad(getServerOnlyArgs());
     await expect(res).rejects.toThrow();
 
     expect(addEventProcessorSpy).toBeCalledTimes(1);
@@ -206,7 +216,7 @@ describe.each([
   });
 });
 describe('wrapLoadWithSentry calls trace', () => {
-  async function load({ params }: Parameters<Load>[0]): Promise<ReturnType<Load>> {
+  async function load({ params }): Promise<ReturnType<Load>> {
     return {
       post: params.id,
     };
@@ -214,7 +224,7 @@ describe('wrapLoadWithSentry calls trace', () => {
 
   it('with the context of the universal load function', async () => {
     const wrappedLoad = wrapLoadWithSentry(load);
-    await wrappedLoad(MOCK_LOAD_ARGS);
+    await wrappedLoad(getLoadArgs());
 
     expect(mockTrace).toHaveBeenCalledTimes(1);
     expect(mockTrace).toHaveBeenCalledWith(
@@ -233,7 +243,7 @@ describe('wrapLoadWithSentry calls trace', () => {
 
   it('falls back to the raw url if `event.route.id` is not available', async () => {
     const wrappedLoad = wrapLoadWithSentry(load);
-    await wrappedLoad(MOCK_LOAD_NO_ROUTE_ARGS);
+    await wrappedLoad(getLoadArgsWithoutRoute());
 
     expect(mockTrace).toHaveBeenCalledTimes(1);
     expect(mockTrace).toHaveBeenCalledWith(
@@ -252,14 +262,14 @@ describe('wrapLoadWithSentry calls trace', () => {
 
   it("doesn't wrap load more than once if the wrapper was applied multiple times", async () => {
     const wrappedLoad = wrapLoadWithSentry(wrapLoadWithSentry(wrapLoadWithSentry(load)));
-    await wrappedLoad(MOCK_LOAD_ARGS);
+    await wrappedLoad(getLoadArgs());
 
     expect(mockTrace).toHaveBeenCalledTimes(1);
   });
 });
 
 describe('wrapServerLoadWithSentry calls trace', () => {
-  async function serverLoad({ params }: Parameters<ServerLoad>[0]): Promise<ReturnType<ServerLoad>> {
+  async function serverLoad({ params }): Promise<ReturnType<ServerLoad>> {
     return {
       post: params.id,
     };
@@ -267,7 +277,7 @@ describe('wrapServerLoadWithSentry calls trace', () => {
 
   it('attaches trace data if available', async () => {
     const wrappedLoad = wrapServerLoadWithSentry(serverLoad);
-    await wrappedLoad(MOCK_SERVER_ONLY_LOAD_ARGS);
+    await wrappedLoad(getServerOnlyArgs());
 
     expect(mockTrace).toHaveBeenCalledTimes(1);
     expect(mockTrace).toHaveBeenCalledWith(
@@ -301,7 +311,7 @@ describe('wrapServerLoadWithSentry calls trace', () => {
 
   it("doesn't attach trace data if it's not available", async () => {
     const wrappedLoad = wrapServerLoadWithSentry(serverLoad);
-    await wrappedLoad(MOCK_SERVER_ONLY_NO_TRACE_LOAD_ARGS);
+    await wrappedLoad(getServerArgsWithoutTracingHeaders());
 
     expect(mockTrace).toHaveBeenCalledTimes(1);
     expect(mockTrace).toHaveBeenCalledWith(
@@ -323,7 +333,7 @@ describe('wrapServerLoadWithSentry calls trace', () => {
 
   it("doesn't attach the DSC data if the baggage header not available", async () => {
     const wrappedLoad = wrapServerLoadWithSentry(serverLoad);
-    await wrappedLoad(MOCK_SERVER_ONLY_NO_BAGGAGE_LOAD_ARGS);
+    await wrappedLoad(getServerArgsWithoutBaggageHeader());
 
     expect(mockTrace).toHaveBeenCalledTimes(1);
     expect(mockTrace).toHaveBeenCalledWith(
@@ -348,7 +358,8 @@ describe('wrapServerLoadWithSentry calls trace', () => {
   });
 
   it('falls back to the raw url if `event.route.id` is not available', async () => {
-    const event = { ...MOCK_SERVER_ONLY_LOAD_ARGS };
+    const event = getServerOnlyArgs();
+    // @ts-ignore - this is fine (just tests here)
     delete event.route;
     const wrappedLoad = wrapServerLoadWithSentry(serverLoad);
     await wrappedLoad(event);
@@ -385,7 +396,7 @@ describe('wrapServerLoadWithSentry calls trace', () => {
 
   it("doesn't wrap server load more than once if the wrapper was applied multiple times", async () => {
     const wrappedLoad = wrapServerLoadWithSentry(wrapServerLoadWithSentry(serverLoad));
-    await wrappedLoad(MOCK_SERVER_ONLY_LOAD_ARGS);
+    await wrappedLoad(getServerOnlyArgs());
 
     expect(mockTrace).toHaveBeenCalledTimes(1);
   });

--- a/packages/sveltekit/test/server/load.test.ts
+++ b/packages/sveltekit/test/server/load.test.ts
@@ -249,6 +249,13 @@ describe('wrapLoadWithSentry calls trace', () => {
       expect.any(Function),
     );
   });
+
+  it("doesn't wrap load more than once if the wrapper was applied multiple times", async () => {
+    const wrappedLoad = wrapLoadWithSentry(wrapLoadWithSentry(wrapLoadWithSentry(load)));
+    await wrappedLoad(MOCK_LOAD_ARGS);
+
+    expect(mockTrace).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('wrapServerLoadWithSentry calls trace', () => {
@@ -374,5 +381,12 @@ describe('wrapServerLoadWithSentry calls trace', () => {
       expect.any(Function),
       expect.any(Function),
     );
+  });
+
+  it("doesn't wrap server load more than once if the wrapper was applied multiple times", async () => {
+    const wrappedLoad = wrapServerLoadWithSentry(wrapServerLoadWithSentry(serverLoad));
+    await wrappedLoad(MOCK_SERVER_ONLY_LOAD_ARGS);
+
+    expect(mockTrace).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
As mentioned in the discussion in https://github.com/getsentry/sentry-javascript/pull/8083/files#r1188707540, applying the `wrap(server)?LoadWithSentry` wrappers multiple times shouldn't lead to double wrapping but instead we should detect if we already wrapped a load function and no-op in this case. This PR patches the respective load events with a flag to detect double wrapping. 

Double wrapping can occur, for instance, if users already applied the load wrapper function to their code but also use auto-wrapping. With this change, we'll still apply the wrapper twice but the second wrapper will simply no-op.

Once this is merged, we can adjust the `canWrapLoad` auto-instrumentation check to no longer bail out of auto-wrapping if Sentry code was detected.   
