### PR TITLE
ref(replay): Capture parametrized route

### DIFF
--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -4,6 +4,7 @@ import type {
   ReplayRecordingData,
   ReplayRecordingMode,
   SentryWrappedXMLHttpRequest,
+  Transaction,
   XhrBreadcrumbHint,
 } from '@sentry/types';
 
@@ -535,6 +536,7 @@ export interface ReplayContainer {
   session: Session | undefined;
   recordingMode: ReplayRecordingMode;
   timeouts: Timeouts;
+  lastTransaction?: Transaction;
   throttledAddEvent: (
     event: RecordingEvent,
     isCheckout?: boolean,
@@ -559,6 +561,7 @@ export interface ReplayContainer {
   getSessionId(): string | undefined;
   checkAndHandleExpiredSession(): boolean | void;
   setInitialState(): void;
+  getCurrentRoute(): string | undefined;
 }
 
 export interface ReplayPerformanceEntry<T> {

--- a/packages/replay/src/util/addGlobalListeners.ts
+++ b/packages/replay/src/util/addGlobalListeners.ts
@@ -40,6 +40,16 @@ export function addGlobalListeners(replay: ReplayContainer): void {
         dsc.replay_id = replayId;
       }
     });
+
+    client.on('startTransaction', transaction => {
+      replay.lastTransaction = transaction;
+    });
+
+    // We may be missing the initial startTransaction due to timing issues,
+    // so we capture it on finish again.
+    client.on('finishTransaction', transaction => {
+      replay.lastTransaction = transaction;
+    });
   }
 }
 


### PR DESCRIPTION
This is a draft of capturing the current parametrized route for Replay. We'll want to have that for slow click capturing, but maybe also at other places... this is only available when performance is used.

Feel free to adjust/merge/close this when needed.