### PR TITLE
fix(build): Don't mangle away global debug ID map

### DIFF
--- a/rollup/plugins/bundlePlugins.js
+++ b/rollup/plugins/bundlePlugins.js
@@ -129,6 +129,8 @@ export function makeTerserPlugin() {
           '_integrations',
           // _meta is used to store metadata of replay network events
           '_meta',
+          // Object we inject debug IDs into with bundler plugins
+          '_sentryDebugIds',
         ],
       },
     },


### PR DESCRIPTION
We rely on the `_sentryDebugIds` field for debug ID injection. Unfortunately we mangle away all underscore-prefixed variables in minified bundles unless we disallow mangling for them. This PR fixes that.