### PR TITLE
fix(tracing-internal): Avoid classifying protocol-relative URLs as same-origin urls

### DIFF
--- a/packages/tracing-internal/src/browser/request.ts
+++ b/packages/tracing-internal/src/browser/request.ts
@@ -10,7 +10,7 @@ import {
   stringMatchesSomePattern,
 } from '@sentry/utils';
 
-export const DEFAULT_TRACE_PROPAGATION_TARGETS = ['localhost', /^\/[^/]/];
+export const DEFAULT_TRACE_PROPAGATION_TARGETS = ['localhost', /^\/(?!\/)/];
 
 /** Options for Request Instrumentation */
 export interface RequestInstrumentationOptions {

--- a/packages/tracing-internal/src/browser/request.ts
+++ b/packages/tracing-internal/src/browser/request.ts
@@ -10,7 +10,7 @@ import {
   stringMatchesSomePattern,
 } from '@sentry/utils';
 
-export const DEFAULT_TRACE_PROPAGATION_TARGETS = ['localhost', /^\//];
+export const DEFAULT_TRACE_PROPAGATION_TARGETS = ['localhost', /^\/[^/]/];
 
 /** Options for Request Instrumentation */
 export interface RequestInstrumentationOptions {

--- a/packages/tracing-internal/test/browser/request.test.ts
+++ b/packages/tracing-internal/test/browser/request.test.ts
@@ -401,6 +401,7 @@ describe('shouldAttachHeaders', () => {
       'http://somewhere.com/test/localhost/123',
       'http://somewhere.com/test?url=localhost:3000&test=123',
       '//localhost:3000/test',
+      '/',
     ])('return `true` for urls matching defaults (%s)', url => {
       expect(shouldAttachHeaders(url, undefined)).toBe(true);
     });

--- a/packages/tracing-internal/test/browser/request.test.ts
+++ b/packages/tracing-internal/test/browser/request.test.ts
@@ -400,12 +400,16 @@ describe('shouldAttachHeaders', () => {
       'http://localhost:3000/test',
       'http://somewhere.com/test/localhost/123',
       'http://somewhere.com/test?url=localhost:3000&test=123',
+      '//localhost:3000/test',
     ])('return `true` for urls matching defaults (%s)', url => {
       expect(shouldAttachHeaders(url, undefined)).toBe(true);
     });
 
-    it.each(['notmydoman/api/test', 'example.com'])('return `false` for urls not matching defaults (%s)', url => {
-      expect(shouldAttachHeaders(url, undefined)).toBe(false);
-    });
+    it.each(['notmydoman/api/test', 'example.com', '//example.com'])(
+      'return `false` for urls not matching defaults (%s)',
+      url => {
+        expect(shouldAttachHeaders(url, undefined)).toBe(false);
+      },
+    );
   });
 });


### PR DESCRIPTION
Bored at the airport (4h delay) lol 

To fix #8099, we need to adjust our `tracePropagationTargets` default regex to account for protocol-relative URLs. These were previously classified as same-origin, relative URLs, causing tracing headers to be attached which in turn potentially caused CORS errors for users. 

closes #8099