### PR TITLE
fix(nextjs): Inject init code via relative path

### DIFF
--- a/packages/nextjs/src/config/loaders/wrappingLoader.ts
+++ b/packages/nextjs/src/config/loaders/wrappingLoader.ts
@@ -203,8 +203,12 @@ export default function wrappingLoader(
     }
 
     if (sentryConfigFilePath && path.isAbsolute(this.resourcePath)) {
-      // We need the import to be relative because webpack cannot process any absolute paths on windows:
-      // ""
+      console.log('TEST LOG', {
+        sentryConfigFilePath,
+        rp: this.resourcePath,
+        imp: path.relative(this.resourcePath, sentryConfigFilePath),
+      });
+      // We need the import to be relative because webpack cannot process any absolute paths on windows
       templateCode = `import "${path.relative(this.resourcePath, sentryConfigFilePath)}";`.concat(templateCode);
     }
   } else if (wrappingTargetKind === 'middleware') {

--- a/packages/nextjs/src/config/loaders/wrappingLoader.ts
+++ b/packages/nextjs/src/config/loaders/wrappingLoader.ts
@@ -202,12 +202,10 @@ export default function wrappingLoader(
       templateCode = templateCode.replace(/__COMPONENT_TYPE__/g, 'Unknown');
     }
 
+    // We check that `this.resourcePath` is absolte because webpack doesn't really have a contract for what the value looks like. It could basically be anything.
     if (sentryConfigFilePath && path.isAbsolute(this.resourcePath)) {
-      const sentryConfigFileImportPath = path
-        .relative(this.resourcePath, sentryConfigFilePath) // Get path relative to current module because webpack can't handle absolute paths on windows: https://github.com/getsentry/sentry-javascript/issues/8133
-        .replace(/\.[^/.]+$/, ''); // Remove the file extension from the import
-
-      // We need the import to be relative because webpack cannot process any absolute paths on windows
+      // Get path relative to current module because webpack can't handle absolute paths on windows: https://github.com/getsentry/sentry-javascript/issues/8133
+      const sentryConfigFileImportPath = path.relative(path.dirname(this.resourcePath), sentryConfigFilePath);
       templateCode = `import "${sentryConfigFileImportPath}";`.concat(templateCode);
     }
   } else if (wrappingTargetKind === 'middleware') {

--- a/packages/nextjs/src/config/loaders/wrappingLoader.ts
+++ b/packages/nextjs/src/config/loaders/wrappingLoader.ts
@@ -79,8 +79,6 @@ export default function wrappingLoader(
     vercelCronsConfig,
   } = 'getOptions' in this ? this.getOptions() : this.query;
 
-  this.resourcePath;
-
   this.async();
 
   let templateCode: string;

--- a/packages/nextjs/src/config/loaders/wrappingLoader.ts
+++ b/packages/nextjs/src/config/loaders/wrappingLoader.ts
@@ -203,13 +203,12 @@ export default function wrappingLoader(
     }
 
     if (sentryConfigFilePath && path.isAbsolute(this.resourcePath)) {
-      console.log('TEST LOG', {
-        sentryConfigFilePath,
-        rp: this.resourcePath,
-        imp: path.relative(this.resourcePath, sentryConfigFilePath),
-      });
+      const sentryConfigFileImportPath = path
+        .relative(this.resourcePath, sentryConfigFilePath) // Get path relative to current module because webpack can't handle absolute paths on windows: https://github.com/getsentry/sentry-javascript/issues/8133
+        .replace(/\.[^/.]+$/, ''); // Remove the file extension from the import
+
       // We need the import to be relative because webpack cannot process any absolute paths on windows
-      templateCode = `import "${path.relative(this.resourcePath, sentryConfigFilePath)}";`.concat(templateCode);
+      templateCode = `import "${sentryConfigFileImportPath}";`.concat(templateCode);
     }
   } else if (wrappingTargetKind === 'middleware') {
     templateCode = middlewareWrapperTemplateCode;

--- a/packages/nextjs/src/config/loaders/wrappingLoader.ts
+++ b/packages/nextjs/src/config/loaders/wrappingLoader.ts
@@ -79,6 +79,8 @@ export default function wrappingLoader(
     vercelCronsConfig,
   } = 'getOptions' in this ? this.getOptions() : this.query;
 
+  this.resourcePath;
+
   this.async();
 
   let templateCode: string;
@@ -202,8 +204,10 @@ export default function wrappingLoader(
       templateCode = templateCode.replace(/__COMPONENT_TYPE__/g, 'Unknown');
     }
 
-    if (sentryConfigFilePath) {
-      templateCode = `import "${sentryConfigFilePath}";`.concat(templateCode);
+    if (sentryConfigFilePath && path.isAbsolute(this.resourcePath)) {
+      // We need the import to be relative because webpack cannot process any absolute paths on windows:
+      // ""
+      templateCode = `import "${path.relative(this.resourcePath, sentryConfigFilePath)}";`.concat(templateCode);
     }
   } else if (wrappingTargetKind === 'middleware') {
     templateCode = middlewareWrapperTemplateCode;


### PR DESCRIPTION
Potentially fixes https://github.com/getsentry/sentry-javascript/issues/8133