### PR TITLE
test(nextjs): Add response content length to assertion

### DIFF
--- a/packages/nextjs/test/integration/test/client/tracingFetch.test.ts
+++ b/packages/nextjs/test/integration/test/client/tracingFetch.test.ts
@@ -40,6 +40,7 @@ test('should correctly instrument `fetch` for performance tracing', async ({ pag
         timestamp: expect.any(Number),
         trace_id: expect.any(String),
         status: expect.any(String),
+        'http.response_content_length': expect.any(String),
       }),
     ]),
   );


### PR DESCRIPTION
Seems this sneaked by https://github.com/getsentry/sentry-javascript/pull/8139

Needed so we can release.