### PR TITLE
fix(nextjs): Guard for non-absolute paths when injecting sentry config

### DIFF
--- a/packages/nextjs/src/config/loaders/wrappingLoader.ts
+++ b/packages/nextjs/src/config/loaders/wrappingLoader.ts
@@ -202,16 +202,13 @@ export default function wrappingLoader(
       templateCode = templateCode.replace(/__COMPONENT_TYPE__/g, 'Unknown');
     }
 
-    if (sentryConfigFilePath) {
-      let importPath = sentryConfigFilePath;
-
-      // absolute paths do not work with Windows
-      // https://github.com/getsentry/sentry-javascript/issues/8133
-      if (path.isAbsolute(importPath)) {
-        importPath = path.relative(path.dirname(this.resourcePath), importPath);
-      }
-
-      templateCode = `import "${importPath.replace(/\\/g, '/')}";\n`.concat(templateCode);
+    // We check whether `this.resourcePath` is absolute because there is no contract by webpack that says it is absolute,
+    // however we can only create relative paths to the sentry config from absolute paths.Examples where this could possibly be non - absolute are virtual modules.
+    if (sentryConfigFilePath && path.isAbsolute(this.resourcePath)) {
+      const sentryConfigImportPath = path
+        .relative(path.dirname(this.resourcePath), sentryConfigFilePath) // Absolute paths do not work with Windows: https://github.com/getsentry/sentry-javascript/issues/8133
+        .replace(/\\/g, '/');
+      templateCode = `import "${sentryConfigImportPath}";\n`.concat(templateCode);
     }
   } else if (wrappingTargetKind === 'middleware') {
     templateCode = middlewareWrapperTemplateCode;


### PR DESCRIPTION
Builds on #8142