### PR TITLE
fix(nextjs): Make `withSentryConfig` isomorphic

### DIFF
--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -123,6 +123,13 @@ function addClientIntegrations(options: BrowserOptions): void {
   options.integrations = integrations;
 }
 
+/**
+ * Just a passthrough in case this is imported from the client.
+ */
+export function withSentryConfig<T>(exportedUserNextConfig: T): T {
+  return exportedUserNextConfig;
+}
+
 export {
   // eslint-disable-next-line deprecation/deprecation
   withSentryServerSideGetInitialProps,

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -126,6 +126,13 @@ export function lastEventId(): string | undefined {
   return getCurrentHub().lastEventId();
 }
 
+/**
+ * Just a passthrough in case this is imported from the client.
+ */
+export function withSentryConfig<T>(exportedUserNextConfig: T): T {
+  return exportedUserNextConfig;
+}
+
 export { flush } from './utils/flush';
 
 export * from '@sentry/core';

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -39,6 +39,8 @@ export declare const withErrorBoundary: typeof clientSdk.withErrorBoundary;
 export declare const Span: typeof edgeSdk.Span;
 export declare const Transaction: typeof edgeSdk.Transaction;
 
+export { withSentryConfig } from './config';
+
 /**
  * @deprecated Use `wrapApiHandlerWithSentry` instead
  */


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/5511