### PR TITLE
test(nextjs): Unbreak Next.js integration tests

### DIFF
--- a/packages/nextjs/test/integration/test/server/utils/helpers.ts
+++ b/packages/nextjs/test/integration/test/server/utils/helpers.ts
@@ -9,7 +9,7 @@ import next from 'next';
 // Type not exported from NextJS
 // @ts-ignore
 export const createNextServer = async config => {
-  const app = next(config);
+  const app = next({ ...config, customServer: false }); // customServer: false because: https://github.com/vercel/next.js/pull/49805#issuecomment-1557321794
   const handle = app.getRequestHandler();
   await app.prepare();
 


### PR DESCRIPTION
Honestly, I don't even know what or how we're fixing a problem with the tests here but we know wehere it came from: https://github.com/vercel/next.js/pull/49805