### PR TITLE
feat(sveltekit): Auto-detect SvelteKit adapters

### DIFF
--- a/packages/sveltekit/src/vite/detectAdapter.ts
+++ b/packages/sveltekit/src/vite/detectAdapter.ts
@@ -1,0 +1,58 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Supported @sveltejs/adapters-[adapter] SvelteKit adapters
+ */
+export type SupportedSvelteKitAdapters = 'node' | 'auto' | 'vercel' | 'other';
+
+type PackageJson = {
+  dependencies?: Record<string, Record<string, string>>;
+  devDependencies?: Record<string, Record<string, string>>;
+} & Record<string, unknown>;
+
+/**
+ * Tries to detect the used adapter for SvelteKit by looking at the dependencies.
+ * returns the name of the adapter or 'other' if no supported adapter was found.
+ */
+export async function detectAdapter(): Promise<SupportedSvelteKitAdapters> {
+  const pkgJson = await loadPackageJson();
+
+  const allDependencies = [...Object.keys(pkgJson.dependencies || {}), ...Object.keys(pkgJson.devDependencies || {})];
+
+  if (allDependencies.find(dep => dep === '@sveltejs/adapter-vercel')) {
+    return 'vercel';
+  }
+  if (allDependencies.find(dep => dep === '@sveltejs/adapter-node')) {
+    return 'node';
+  }
+  if (allDependencies.find(dep => dep === '@sveltejs/adapter-auto')) {
+    return 'auto';
+  }
+
+  return 'other';
+}
+
+/**
+ * Imports the pacakge.json file and returns the parsed JSON object.
+ */
+async function loadPackageJson(): Promise<PackageJson> {
+  const pkgFile = path.join(process.cwd(), 'package.json');
+
+  try {
+    if (!fs.existsSync(pkgFile)) {
+      throw `${pkgFile} does not exist}`;
+    }
+
+    const pkgJsonContent = (await fs.promises.readFile(pkgFile, 'utf-8')).toString();
+
+    return JSON.parse(pkgJsonContent);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn("[Sentry SvelteKit Plugin] Couldn't load package.json:");
+    // eslint-disable-next-line no-console
+    console.log(e);
+
+    return {};
+  }
+}

--- a/packages/sveltekit/src/vite/detectAdapter.ts
+++ b/packages/sveltekit/src/vite/detectAdapter.ts
@@ -1,3 +1,4 @@
+import type { Package } from '@sentry/types';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -6,42 +7,48 @@ import * as path from 'path';
  */
 export type SupportedSvelteKitAdapters = 'node' | 'auto' | 'vercel' | 'other';
 
-type PackageJson = {
-  dependencies?: Record<string, Record<string, string>>;
-  devDependencies?: Record<string, Record<string, string>>;
-} & Record<string, unknown>;
-
 /**
  * Tries to detect the used adapter for SvelteKit by looking at the dependencies.
  * returns the name of the adapter or 'other' if no supported adapter was found.
  */
-export async function detectAdapter(): Promise<SupportedSvelteKitAdapters> {
+export async function detectAdapter(debug?: boolean): Promise<SupportedSvelteKitAdapters> {
   const pkgJson = await loadPackageJson();
 
   const allDependencies = [...Object.keys(pkgJson.dependencies || {}), ...Object.keys(pkgJson.devDependencies || {})];
 
+  let adapter: SupportedSvelteKitAdapters = 'other';
   if (allDependencies.find(dep => dep === '@sveltejs/adapter-vercel')) {
-    return 'vercel';
-  }
-  if (allDependencies.find(dep => dep === '@sveltejs/adapter-node')) {
-    return 'node';
-  }
-  if (allDependencies.find(dep => dep === '@sveltejs/adapter-auto')) {
-    return 'auto';
+    adapter = 'vercel';
+  } else if (allDependencies.find(dep => dep === '@sveltejs/adapter-node')) {
+    adapter = 'node';
+  } else if (allDependencies.find(dep => dep === '@sveltejs/adapter-auto')) {
+    adapter = 'auto';
   }
 
-  return 'other';
+  if (debug) {
+    if (adapter === 'other') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[Sentry SvelteKit Plugin] Couldn't detect SvelteKit adapter. Please set the 'adapter' option manually.",
+      );
+    } else {
+      // eslint-disable-next-line no-console
+      console.log(`[Sentry SvelteKit Plugin] Detected SvelteKit ${adapter} adapter`);
+    }
+  }
+
+  return adapter;
 }
 
 /**
  * Imports the pacakge.json file and returns the parsed JSON object.
  */
-async function loadPackageJson(): Promise<PackageJson> {
+async function loadPackageJson(): Promise<Partial<Package>> {
   const pkgFile = path.join(process.cwd(), 'package.json');
 
   try {
     if (!fs.existsSync(pkgFile)) {
-      throw `${pkgFile} does not exist}`;
+      throw `File ${pkgFile} doesn't exist}`;
     }
 
     const pkgJsonContent = (await fs.promises.readFile(pkgFile, 'utf-8')).toString();

--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -3,6 +3,8 @@ import type { Plugin } from 'vite';
 
 import type { AutoInstrumentSelection } from './autoInstrument';
 import { makeAutoInstrumentationPlugin } from './autoInstrument';
+import type { SupportedSvelteKitAdapters } from './detectAdapter';
+import { detectAdapter } from './detectAdapter';
 import { makeCustomSentryVitePlugin } from './sourceMaps';
 
 type SourceMapsUploadOptions = {
@@ -39,6 +41,24 @@ export type SentrySvelteKitPluginOptions = {
    * @default false.
    */
   debug?: boolean;
+
+  /**
+   * Specify which SvelteKit adapter you're using.
+   * By default, the SDK will attempt auto-detect the used adapter at build time and apply the
+   * correct config for source maps upload or auto-instrumentation.
+   *
+   * Currently, the SDK supports the following adapters:
+   * - node (@sveltejs/adapter-node)
+   * - auto (@sveltejs/adapter-auto) only Vercel
+   * - vercel (@sveltejs/adapter-auto) only Serverless functions, no edge runtime
+   *
+   * Set this option, if the SDK detects the wrong adapter or you want to use an adapter
+   * that is not in this list. If you specify 'other', you'll most likely need to configure
+   * source maps upload yourself.
+   *
+   * @default {} the SDK attempts to auto-detect the used adapter at build time
+   */
+  adapter?: SupportedSvelteKitAdapters;
 } & SourceMapsUploadOptions &
   AutoInstrumentOptions;
 
@@ -79,6 +99,10 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
   }
 
   if (mergedOptions.autoUploadSourceMaps && process.env.NODE_ENV !== 'development') {
+    // TODO: pass to makeCosutmSentryVitePlugin
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const adapter = mergedOptions.adapter || (await detectAdapter());
+
     const pluginOptions = {
       ...mergedOptions.sourceMapsUploadOptions,
       debug: mergedOptions.debug, // override the plugin's debug flag with the one from the top-level options

--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -79,6 +79,7 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
   const mergedOptions = {
     ...DEFAULT_PLUGIN_OPTIONS,
     ...options,
+    adapter: options.adapter || (await detectAdapter(options.debug || false)),
   };
 
   const sentryPlugins: Plugin[] = [];
@@ -99,10 +100,6 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
   }
 
   if (mergedOptions.autoUploadSourceMaps && process.env.NODE_ENV !== 'development') {
-    // TODO: pass to makeCosutmSentryVitePlugin
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const adapter = mergedOptions.adapter || (await detectAdapter());
-
     const pluginOptions = {
       ...mergedOptions.sourceMapsUploadOptions,
       debug: mergedOptions.debug, // override the plugin's debug flag with the one from the top-level options

--- a/packages/sveltekit/test/vite/detectAdapter.test.ts
+++ b/packages/sveltekit/test/vite/detectAdapter.test.ts
@@ -1,0 +1,63 @@
+import { vi } from 'vitest';
+
+import { detectAdapter } from '../../src/vite/detectAdapter';
+
+let existsFile = true;
+const pkgJson = {
+  dependencies: {},
+};
+describe('detectAdapter', () => {
+  beforeEach(() => {
+    existsFile = true;
+    vi.clearAllMocks();
+    pkgJson.dependencies = {};
+  });
+
+  vi.mock('fs', () => {
+    return {
+      existsSync: () => existsFile,
+      promises: {
+        readFile: () => {
+          return Promise.resolve(JSON.stringify(pkgJson));
+        },
+      },
+    };
+  });
+
+  it.each(['auto', 'vercel', 'node'])('returns the adapter name (adapter %s)', async adapter => {
+    pkgJson.dependencies[`@sveltejs/adapter-${adapter}`] = '1.0.0';
+    const detectedAdapter = await detectAdapter();
+    expect(detectedAdapter).toEqual(adapter);
+  });
+
+  it('returns "other" if no supported adapter was found', async () => {
+    pkgJson.dependencies['@sveltejs/adapter-netlify'] = '1.0.0';
+    const detectedAdapter = await detectAdapter();
+    expect(detectedAdapter).toEqual('other');
+  });
+
+  it('returns "other" if package.json isnt available and emits a warning log', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    existsFile = false;
+    const detectedAdapter = await detectAdapter();
+    expect(detectedAdapter).toEqual('other');
+
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefers all other adapters over adapter auto', async () => {
+    pkgJson.dependencies['@sveltejs/adapter-auto'] = '1.0.0';
+    pkgJson.dependencies['@sveltejs/adapter-vercel'] = '1.0.0';
+    pkgJson.dependencies['@sveltejs/adapter-node'] = '1.0.0';
+
+    const detectedAdapter = await detectAdapter();
+    expect(detectedAdapter).toEqual('vercel');
+
+    delete pkgJson.dependencies['@sveltejs/adapter-vercel'];
+    const detectedAdapter2 = await detectAdapter();
+    expect(detectedAdapter2).toEqual('node');
+  });
+});

--- a/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
+++ b/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
@@ -17,6 +17,13 @@ vi.mock('fs', async () => {
   };
 });
 
+vi.spyOn(console, 'log').mockImplementation(() => {
+  /* noop */
+});
+vi.spyOn(console, 'warn').mockImplementation(() => {
+  /* noop */
+});
+
 describe('sentryVite()', () => {
   it('returns an array of Vite plugins', async () => {
     const plugins = await sentrySvelteKit();

--- a/packages/types/src/package.ts
+++ b/packages/types/src/package.ts
@@ -2,4 +2,6 @@
 export interface Package {
   name: string;
   version: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
 }


### PR DESCRIPTION
First step for Vercel support: Detecting the used SvelteKit adapter.

(This currently does nothing other than detecting the adapter; next step is to configure the source maps plugin correctly for the respective adapters)

ref #8085 
