### PR TITLE
fix(core): Fix racecondition that modifies in-flight sessions

### DIFF
--- a/packages/core/src/envelope.ts
+++ b/packages/core/src/envelope.ts
@@ -48,7 +48,7 @@ export function createSessionEnvelope(
   };
 
   const envelopeItem: SessionItem =
-    'aggregates' in session ? [{ type: 'sessions' }, session] : [{ type: 'session' }, session];
+    'aggregates' in session ? [{ type: 'sessions' }, session] : [{ type: 'session' }, session.toJSON()];
 
   return createEnvelope<SessionEnvelope>(envelopeHeaders, [envelopeItem]);
 }

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -4,7 +4,7 @@ import type { DsnComponents } from './dsn';
 import type { Event } from './event';
 import type { ReplayEvent, ReplayRecordingData } from './replay';
 import type { SdkInfo } from './sdkinfo';
-import type { Session, SessionAggregates } from './session';
+import type { SerializedSession, Session, SessionAggregates } from './session';
 import type { Transaction } from './transaction';
 import type { UserFeedback } from './user';
 
@@ -76,7 +76,8 @@ export type EventItem = BaseEnvelopeItem<EventItemHeaders, Event>;
 export type AttachmentItem = BaseEnvelopeItem<AttachmentItemHeaders, string | Uint8Array>;
 export type UserFeedbackItem = BaseEnvelopeItem<UserFeedbackItemHeaders, UserFeedback>;
 export type SessionItem =
-  | BaseEnvelopeItem<SessionItemHeaders, Session>
+  // TODO(v8): Only allow serialized session here (as opposed to Session or SerializedSesison)
+  | BaseEnvelopeItem<SessionItemHeaders, Session | SerializedSession>
   | BaseEnvelopeItem<SessionAggregatesItemHeaders, SessionAggregates>;
 export type ClientReportItem = BaseEnvelopeItem<ClientReportItemHeaders, ClientReport>;
 export type CheckInItem = BaseEnvelopeItem<CheckInItemHeaders, SerializedCheckIn>;


### PR DESCRIPTION
The critical code section is here: https://github.com/getsentry/sentry-javascript/blob/a663a9c7ff0b463c299b8f561104ea393eb62118/packages/core/src/baseclient.ts#L216-L218

We call `updateSession(session, { init: false })` right after calling `this.sendSession(session)`. The problem is, since we're only passing a reference (i.e. an object) to `updateSession`, the instance of `session` is updated before it is serialized and sent - leading to a faulty `init: false` flag in the first session request.

This PR serializes - effectively copying - the session before entering async territory, thus not modifying the "in-flight" session.
