### PR TITLE
fix(express): Strip query and fragment from tracing URLs (#6586)

### DIFF
--- a/packages/tracing-internal/src/node/integrations/express.ts
+++ b/packages/tracing-internal/src/node/integrations/express.ts
@@ -1,6 +1,12 @@
 /* eslint-disable max-lines */
 import type { Hub, Integration, PolymorphicRequest, Transaction } from '@sentry/types';
-import { extractPathForTransaction, getNumberOfUrlSegments, isRegExp, logger } from '@sentry/utils';
+import {
+  extractPathForTransaction,
+  getNumberOfUrlSegments,
+  isRegExp,
+  logger,
+  stripUrlQueryAndFragment,
+} from '@sentry/utils';
 
 import { shouldDisableAutoInstrumentation } from './utils/node-utils';
 
@@ -335,7 +341,7 @@ function instrumentRouter(appOrRouter: ExpressRouter): void {
     if (urlLength === routeLength) {
       if (!req._hasParameters) {
         if (req._reconstructedRoute !== req.originalUrl) {
-          req._reconstructedRoute = req.originalUrl;
+          req._reconstructedRoute = req.originalUrl ? stripUrlQueryAndFragment(req.originalUrl) : req.originalUrl;
         }
       }
 


### PR DESCRIPTION
Fixes #6586 by adding a call to `stripUrlQueryAndFragment()` according to the discussion here https://github.com/getsentry/sentry-javascript/issues/6586#issuecomment-1557485816