### PR TITLE
fix(sveltekit): Avoid capturing redirects and 4xx Http errors in request Handlers

### DIFF
--- a/packages/sveltekit/src/common/utils.ts
+++ b/packages/sveltekit/src/common/utils.ts
@@ -1,4 +1,4 @@
-import type { Redirect } from '@sveltejs/kit';
+import type { HttpError, Redirect } from '@sveltejs/kit';
 
 export type SentryWrappedFlag = {
   /**
@@ -21,4 +21,11 @@ export function isRedirect(error: unknown): error is Redirect {
   const hasValidStatus =
     'status' in error && typeof error.status === 'number' && error.status >= 300 && error.status <= 308;
   return hasValidLocation && hasValidStatus;
+}
+
+/**
+ * Determines if a thrown "error" is a HttpError
+ */
+export function isHttpError(err: unknown): err is HttpError {
+  return typeof err === 'object' && err !== null && 'status' in err && 'body' in err;
 }

--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -5,12 +5,21 @@ import { captureException } from '@sentry/node';
 import { addExceptionMechanism, dynamicSamplingContextToSentryBaggageHeader, objectify } from '@sentry/utils';
 import type { Handle, ResolveOptions } from '@sveltejs/kit';
 
+import { isHttpError, isRedirect } from '../common/utils';
 import { getTracePropagationData } from './utils';
 
 function sendErrorToSentry(e: unknown): unknown {
   // In case we have a primitive, wrap it in the equivalent wrapper class (string -> String, etc.) so that we can
   // store a seen flag on it.
   const objectifiedErr = objectify(e);
+
+  // similarly to the `load` function, we don't want to capture 4xx errors or redirects
+  if (
+    isRedirect(objectifiedErr) ||
+    (isHttpError(objectifiedErr) && objectifiedErr.status < 500 && objectifiedErr.status >= 400)
+  ) {
+    return objectifiedErr;
+  }
 
   captureException(objectifiedErr, scope => {
     scope.addEventProcessor(event => {

--- a/packages/sveltekit/src/server/load.ts
+++ b/packages/sveltekit/src/server/load.ts
@@ -3,18 +3,14 @@ import { trace } from '@sentry/core';
 import { captureException } from '@sentry/node';
 import type { TransactionContext } from '@sentry/types';
 import { addExceptionMechanism, addNonEnumerableProperty, objectify } from '@sentry/utils';
-import type { HttpError, LoadEvent, ServerLoadEvent } from '@sveltejs/kit';
+import type { LoadEvent, ServerLoadEvent } from '@sveltejs/kit';
 
 import type { SentryWrappedFlag } from '../common/utils';
-import { isRedirect } from '../common/utils';
+import { isHttpError, isRedirect } from '../common/utils';
 import { getTracePropagationData } from './utils';
 
 type PatchedLoadEvent = LoadEvent & SentryWrappedFlag;
 type PatchedServerLoadEvent = ServerLoadEvent & SentryWrappedFlag;
-
-function isHttpError(err: unknown): err is HttpError {
-  return typeof err === 'object' && err !== null && 'status' in err && 'body' in err;
-}
 
 function sendErrorToSentry(e: unknown): unknown {
   // In case we have a primitive, wrap it in the equivalent wrapper class (string -> String, etc.) so that we can

--- a/packages/sveltekit/test/common/utils.test.ts
+++ b/packages/sveltekit/test/common/utils.test.ts
@@ -1,4 +1,6 @@
-import { isRedirect } from '../../src/common/utils';
+import { redirect } from '@sveltejs/kit';
+
+import { isHttpError, isRedirect } from '../../src/common/utils';
 
 describe('isRedirect', () => {
   it.each([
@@ -22,4 +24,20 @@ describe('isRedirect', () => {
   ])('returns `false` for invalid Redirect objects', redirectObject => {
     expect(isRedirect(redirectObject)).toBe(false);
   });
+});
+
+describe('isHttpError', () => {
+  it.each([
+    { status: 404, body: 'Not found' },
+    { status: 500, body: 'Internal server error' },
+  ])('returns `true` for valid HttpError objects (%s)', httpErrorObject => {
+    expect(isHttpError(httpErrorObject)).toBe(true);
+  });
+
+  it.each([new Error(), redirect(301, '/users/id'), 'string error', { status: 404 }, { body: 'Not found' }])(
+    'returns `false` for other thrown objects (%s)',
+    httpErrorObject => {
+      expect(isHttpError(httpErrorObject)).toBe(false);
+    },
+  );
 });


### PR DESCRIPTION
This PR stops sending thrown redirects (which is how you redirect to another route in SvelteKit on the server side) and 4xx Http errors to Sentry. This change is identical to #7731 which introduced these filters to `load` functions. Back then we missed that the same errors can also be thrown in request handlers.

fixes #8214 