### PR TITLE
test(replay): Skip firefox for flakey tests

### DIFF
--- a/packages/browser-integration-tests/suites/replay/sessionExpiry/test.ts
+++ b/packages/browser-integration-tests/suites/replay/sessionExpiry/test.ts
@@ -14,8 +14,9 @@ import {
 // Session should expire after 2s - keep in sync with init.js
 const SESSION_TIMEOUT = 2000;
 
-sentryTest('handles an expired session', async ({ getLocalTestPath, page }) => {
-  if (shouldSkipReplayTest()) {
+sentryTest('handles an expired session', async ({ browserName, getLocalTestPath, page }) => {
+  // This test seems to only be flakey on firefox
+  if (shouldSkipReplayTest() || ['firefox'].includes(browserName)) {
     sentryTest.skip();
   }
 

--- a/packages/browser-integration-tests/suites/replay/slowClick/mutation/test.ts
+++ b/packages/browser-integration-tests/suites/replay/slowClick/mutation/test.ts
@@ -63,8 +63,9 @@ sentryTest('mutation after threshold results in slow click', async ({ getLocalTe
   expect(slowClickBreadcrumbs[0]?.data?.timeAfterClickMs).toBeLessThan(2000);
 });
 
-sentryTest('immediate mutation does not trigger slow click', async ({ getLocalTestUrl, page }) => {
-  if (shouldSkipReplayTest()) {
+sentryTest('immediate mutation does not trigger slow click', async ({ browserName, getLocalTestUrl, page }) => {
+  // This test seems to only be flakey on firefox
+  if (shouldSkipReplayTest() || ['firefox'].includes(browserName)) {
     sentryTest.skip();
   }
 


### PR DESCRIPTION
These tests seem to only flake on firefox?
