### PR TITLE
feat(replay): Improve types for replay recording events

### DIFF
--- a/packages/replay/src/coreHandlers/handleScope.ts
+++ b/packages/replay/src/coreHandlers/handleScope.ts
@@ -12,6 +12,10 @@ let _LAST_BREADCRUMB: null | Breadcrumb = null;
 
 type BreadcrumbWithCategory = Required<Pick<Breadcrumb, 'category'>>;
 
+function isBreadcrumbWithCategory(breadcrumb: Breadcrumb): breadcrumb is BreadcrumbWithCategory {
+  return !!breadcrumb.category;
+}
+
 export const handleScopeListener: (replay: ReplayContainer) => (scope: Scope) => void =
   (replay: ReplayContainer) =>
   (scope: Scope): void => {
@@ -47,7 +51,7 @@ export function handleScope(scope: Scope): Breadcrumb | null {
   _LAST_BREADCRUMB = newBreadcrumb;
 
   if (
-    typeof newBreadcrumb.category !== 'string' ||
+    !isBreadcrumbWithCategory(newBreadcrumb) ||
     ['fetch', 'xhr', 'sentry.event', 'sentry.transaction'].includes(newBreadcrumb.category) ||
     newBreadcrumb.category.startsWith('ui.')
   ) {
@@ -55,10 +59,10 @@ export function handleScope(scope: Scope): Breadcrumb | null {
   }
 
   if (newBreadcrumb.category === 'console') {
-    return normalizeConsoleBreadcrumb(newBreadcrumb as BreadcrumbWithCategory);
+    return normalizeConsoleBreadcrumb(newBreadcrumb);
   }
 
-  return createBreadcrumb(newBreadcrumb as BreadcrumbWithCategory);
+  return createBreadcrumb(newBreadcrumb);
 }
 
 /** exported for tests only */

--- a/packages/replay/src/coreHandlers/handleSlowClick.ts
+++ b/packages/replay/src/coreHandlers/handleSlowClick.ts
@@ -101,7 +101,7 @@ function handleSlowClick(
   const breadcrumb = {
     message: clickBreadcrumb.message,
     timestamp: clickBreadcrumb.timestamp,
-    category: 'ui.slowClickDetected' as const,
+    category: 'ui.slowClickDetected',
     data: {
       ...clickBreadcrumb.data,
       url: WINDOW.location.href,

--- a/packages/replay/src/coreHandlers/handleSlowClick.ts
+++ b/packages/replay/src/coreHandlers/handleSlowClick.ts
@@ -101,7 +101,7 @@ function handleSlowClick(
   const breadcrumb = {
     message: clickBreadcrumb.message,
     timestamp: clickBreadcrumb.timestamp,
-    category: 'ui.slowClickDetected',
+    category: 'ui.slowClickDetected' as const,
     data: {
       ...clickBreadcrumb.data,
       url: WINDOW.location.href,

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -1,9 +1,9 @@
 export { Replay } from './integration';
 export type {
+  BreadcrumbFrame,
+  BreadcrumbFrameEvent,
   ReplayFrame,
   ReplayFrameEvent,
-  CrumbFrame,
-  CrumbFrameEvent,
   SpanFrame,
   SpanFrameEvent,
 } from './types/replayFrame';

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -1,1 +1,9 @@
 export { Replay } from './integration';
+export type {
+  ReplayFrame,
+  ReplayFrameEvent,
+  CrumbFrame,
+  CrumbFrameEvent,
+  SpanFrame,
+  SpanFrameEvent,
+} from './types/replayFrame';

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -779,7 +779,7 @@ export class ReplayContainer implements ReplayContainerInterface {
    */
   private _handleWindowBlur: () => void = () => {
     const breadcrumb = createBreadcrumb({
-      category: 'ui.blur',
+      category: 'ui.blur' as const,
     });
 
     // Do not count blur as a user action -- it's part of the process of them
@@ -792,7 +792,7 @@ export class ReplayContainer implements ReplayContainerInterface {
    */
   private _handleWindowFocus: () => void = () => {
     const breadcrumb = createBreadcrumb({
-      category: 'ui.focus',
+      category: 'ui.focus' as const,
     });
 
     // Do not count focus as a user action -- instead wait until they focus and
@@ -1095,7 +1095,7 @@ export class ReplayContainer implements ReplayContainerInterface {
     // We can show this in the UI as an information with potential performance improvements
     if (count > mutationBreadcrumbLimit || overMutationLimit) {
       const breadcrumb = createBreadcrumb({
-        category: 'replay.mutations',
+        category: 'replay.mutations' as const,
         data: {
           count,
           limit: overMutationLimit,

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */ // TODO: We might want to split this file up
 import { EventType, record } from '@sentry-internal/rrweb';
 import { captureException, getCurrentHub } from '@sentry/core';
-import type { Breadcrumb, ReplayRecordingMode, Transaction } from '@sentry/types';
+import type { ReplayRecordingMode, Transaction } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import {
@@ -21,6 +21,7 @@ import type {
   AddEventResult,
   AddUpdateCallback,
   AllPerformanceEntry,
+  BreadcrumbFrame,
   EventBuffer,
   InternalEventContext,
   PopEventContext,
@@ -808,7 +809,7 @@ export class ReplayContainer implements ReplayContainerInterface {
   /**
    * Tasks to run when we consider a page to be hidden (via blurring and/or visibility)
    */
-  private _doChangeToBackgroundTasks(breadcrumb?: Breadcrumb): void {
+  private _doChangeToBackgroundTasks(breadcrumb?: BreadcrumbFrame): void {
     if (!this.session) {
       return;
     }
@@ -828,7 +829,7 @@ export class ReplayContainer implements ReplayContainerInterface {
   /**
    * Tasks to run when we consider a page to be visible (via focus and/or visibility)
    */
-  private _doChangeToForegroundTasks(breadcrumb?: Breadcrumb): void {
+  private _doChangeToForegroundTasks(breadcrumb?: BreadcrumbFrame): void {
     if (!this.session) {
       return;
     }
@@ -881,7 +882,7 @@ export class ReplayContainer implements ReplayContainerInterface {
   /**
    * Helper to create (and buffer) a replay breadcrumb from a core SDK breadcrumb
    */
-  private _createCustomBreadcrumb(breadcrumb: Breadcrumb): void {
+  private _createCustomBreadcrumb(breadcrumb: BreadcrumbFrame): void {
     this.addUpdate(() => {
       void this.throttledAddEvent({
         type: EventType.Custom,

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -779,7 +779,7 @@ export class ReplayContainer implements ReplayContainerInterface {
    */
   private _handleWindowBlur: () => void = () => {
     const breadcrumb = createBreadcrumb({
-      category: 'ui.blur' as const,
+      category: 'ui.blur',
     });
 
     // Do not count blur as a user action -- it's part of the process of them
@@ -792,7 +792,7 @@ export class ReplayContainer implements ReplayContainerInterface {
    */
   private _handleWindowFocus: () => void = () => {
     const breadcrumb = createBreadcrumb({
-      category: 'ui.focus' as const,
+      category: 'ui.focus',
     });
 
     // Do not count focus as a user action -- instead wait until they focus and
@@ -1095,7 +1095,7 @@ export class ReplayContainer implements ReplayContainerInterface {
     // We can show this in the UI as an information with potential performance improvements
     if (count > mutationBreadcrumbLimit || overMutationLimit) {
       const breadcrumb = createBreadcrumb({
-        category: 'replay.mutations' as const,
+        category: 'replay.mutations',
         data: {
           count,
           limit: overMutationLimit,

--- a/packages/replay/src/types/index.ts
+++ b/packages/replay/src/types/index.ts
@@ -1,0 +1,4 @@
+export * from './performance';
+export * from './replay';
+export * from './replayFrame';
+export * from './rrweb';

--- a/packages/replay/src/types/performance.ts
+++ b/packages/replay/src/types/performance.ts
@@ -1,0 +1,160 @@
+export type AllPerformanceEntry = PerformancePaintTiming | PerformanceResourceTiming | PerformanceNavigationTiming;
+
+// PerformancePaintTiming and PerformanceNavigationTiming are only available with TS 4.4 and newer
+// Therefore, we're exporting them here to make them available in older TS versions
+export type PerformancePaintTiming = PerformanceEntry;
+export type PerformanceNavigationTiming = PerformanceEntry &
+  PerformanceResourceTiming & {
+    type: string;
+    transferSize: number;
+
+    /**
+     * A DOMHighResTimeStamp representing the time immediately before the user agent
+     * sets the document's readyState to "interactive".
+     */
+    domInteractive: number;
+
+    /**
+     * A DOMHighResTimeStamp representing the time immediately before the current
+     * document's DOMContentLoaded event handler starts.
+     */
+    domContentLoadedEventStart: number;
+    /**
+     * A DOMHighResTimeStamp representing the time immediately after the current
+     * document's DOMContentLoaded event handler completes.
+     */
+    domContentLoadedEventEnd: number;
+
+    /**
+     * A DOMHighResTimeStamp representing the time immediately before the current
+     * document's load event handler starts.
+     */
+    loadEventStart: number;
+
+    /**
+     * A DOMHighResTimeStamp representing the time immediately after the current
+     * document's load event handler completes.
+     */
+    loadEventEnd: number;
+
+    /**
+     * A DOMHighResTimeStamp representing the time immediately before the user agent
+     * sets the document's readyState to "complete".
+     */
+    domComplete: number;
+
+    /**
+     * A number representing the number of redirects since the last non-redirect
+     * navigation in the current browsing context.
+     */
+    redirectCount: number;
+  };
+export type ExperimentalPerformanceResourceTiming = PerformanceResourceTiming & {
+  // Experimental, see: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/responseStatus
+  // Requires Chrome 109
+  responseStatus?: number;
+};
+
+export type PaintData = undefined;
+
+/**
+ * See https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming
+ *
+ * Note `navigation.push` will not have any data
+ */
+export type NavigationData = Partial<
+  Pick<
+    PerformanceNavigationTiming,
+    | 'decodedBodySize'
+    | 'encodedBodySize'
+    | 'duration'
+    | 'domInteractive'
+    | 'domContentLoadedEventEnd'
+    | 'domContentLoadedEventStart'
+    | 'loadEventStart'
+    | 'loadEventEnd'
+    | 'domComplete'
+    | 'redirectCount'
+  >
+> & {
+  /**
+   * Transfer size of resource
+   */
+  size?: number;
+};
+
+export type ResourceData = Pick<PerformanceResourceTiming, 'decodedBodySize' | 'encodedBodySize'> & {
+  /**
+   * Transfer size of resource
+   */
+  size: number;
+  /**
+   * HTTP status code. Note this is experimental and not available on all browsers.
+   */
+  statusCode?: number;
+};
+
+export interface LargestContentfulPaintData {
+  /**
+   * Render time (in ms) of the LCP
+   */
+  value: number;
+  size: number;
+  /**
+   * The recording id of the LCP node. -1 if not found
+   */
+  nodeId?: number;
+}
+
+/**
+ * Entries that come from window.performance
+ */
+export type AllPerformanceEntryData = PaintData | NavigationData | ResourceData | LargestContentfulPaintData;
+
+export interface MemoryData {
+  memory: {
+    jsHeapSizeLimit: number;
+    totalJSHeapSize: number;
+    usedJSHeapSize: number;
+  };
+}
+
+export interface NetworkRequestData {
+  method?: string;
+  statusCode?: number;
+  requestBodySize?: number;
+  responseBodySize?: number;
+}
+
+export interface HistoryData {
+  previous: string;
+}
+
+export type AllEntryData = AllPerformanceEntryData | MemoryData | NetworkRequestData | HistoryData;
+
+export interface ReplayPerformanceEntry<T> {
+  /**
+   * One of these types https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry/entryType
+   */
+  type: string;
+
+  /**
+   * A more specific description of the performance entry
+   */
+  name: string;
+
+  /**
+   * The start timestamp in seconds
+   */
+  start: number;
+
+  /**
+   * The end timestamp in seconds
+   */
+  end: number;
+
+  /**
+   * Additional unstructured data to be included
+   */
+  data: T;
+}

--- a/packages/replay/src/types/replay.ts
+++ b/packages/replay/src/types/replay.ts
@@ -8,13 +8,14 @@ import type {
   XhrBreadcrumbHint,
 } from '@sentry/types';
 
+import type { AllPerformanceEntry } from './performance';
 import type { eventWithTime, recordOptions } from './types/rrweb';
 import type { SKIPPED, THROTTLED } from './util/throttle';
 
+export * from './types/replayFrame';
+
 export type RecordingEvent = eventWithTime;
 export type RecordingOptions = recordOptions;
-
-export type AllPerformanceEntry = PerformancePaintTiming | PerformanceResourceTiming | PerformanceNavigationTiming;
 
 export interface SendReplayData {
   recordingData: ReplayRecordingData;
@@ -40,138 +41,6 @@ export interface WorkerRequest {
   method: 'clear' | 'addEvent' | 'finish';
   arg?: string;
 }
-
-// PerformancePaintTiming and PerformanceNavigationTiming are only available with TS 4.4 and newer
-// Therefore, we're exporting them here to make them available in older TS versions
-export type PerformancePaintTiming = PerformanceEntry;
-export type PerformanceNavigationTiming = PerformanceEntry &
-  PerformanceResourceTiming & {
-    type: string;
-    transferSize: number;
-
-    /**
-     * A DOMHighResTimeStamp representing the time immediately before the user agent
-     * sets the document's readyState to "interactive".
-     */
-    domInteractive: number;
-
-    /**
-     * A DOMHighResTimeStamp representing the time immediately before the current
-     * document's DOMContentLoaded event handler starts.
-     */
-    domContentLoadedEventStart: number;
-    /**
-     * A DOMHighResTimeStamp representing the time immediately after the current
-     * document's DOMContentLoaded event handler completes.
-     */
-    domContentLoadedEventEnd: number;
-
-    /**
-     * A DOMHighResTimeStamp representing the time immediately before the current
-     * document's load event handler starts.
-     */
-    loadEventStart: number;
-
-    /**
-     * A DOMHighResTimeStamp representing the time immediately after the current
-     * document's load event handler completes.
-     */
-    loadEventEnd: number;
-
-    /**
-     * A DOMHighResTimeStamp representing the time immediately before the user agent
-     * sets the document's readyState to "complete".
-     */
-    domComplete: number;
-
-    /**
-     * A number representing the number of redirects since the last non-redirect
-     * navigation in the current browsing context.
-     */
-    redirectCount: number;
-  };
-export type ExperimentalPerformanceResourceTiming = PerformanceResourceTiming & {
-  // Experimental, see: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/responseStatus
-  // Requires Chrome 109
-  responseStatus?: number;
-};
-
-export type PaintData = undefined;
-
-/**
- * See https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming
- *
- * Note `navigation.push` will not have any data
- */
-export type NavigationData = Partial<
-  Pick<
-    PerformanceNavigationTiming,
-    | 'decodedBodySize'
-    | 'encodedBodySize'
-    | 'duration'
-    | 'domInteractive'
-    | 'domContentLoadedEventEnd'
-    | 'domContentLoadedEventStart'
-    | 'loadEventStart'
-    | 'loadEventEnd'
-    | 'domComplete'
-    | 'redirectCount'
-  >
-> & {
-  /**
-   * Transfer size of resource
-   */
-  size?: number;
-};
-
-export type ResourceData = Pick<PerformanceResourceTiming, 'decodedBodySize' | 'encodedBodySize'> & {
-  /**
-   * Transfer size of resource
-   */
-  size: number;
-  /**
-   * HTTP status code. Note this is experimental and not available on all browsers.
-   */
-  statusCode?: number;
-};
-
-export interface LargestContentfulPaintData {
-  /**
-   * Render time (in ms) of the LCP
-   */
-  value: number;
-  size: number;
-  /**
-   * The recording id of the LCP node. -1 if not found
-   */
-  nodeId?: number;
-}
-
-/**
- * Entries that come from window.performance
- */
-export type AllPerformanceEntryData = PaintData | NavigationData | ResourceData | LargestContentfulPaintData;
-
-export interface MemoryData {
-  memory: {
-    jsHeapSizeLimit: number;
-    totalJSHeapSize: number;
-    usedJSHeapSize: number;
-  };
-}
-
-export interface NetworkRequestData {
-  method?: string;
-  statusCode?: number;
-  requestBodySize?: number;
-  responseBodySize?: number;
-}
-
-export interface HistoryData {
-  previous: string;
-}
-
-export type AllEntryData = AllPerformanceEntryData | MemoryData | NetworkRequestData | HistoryData;
 
 /**
  * The response from the worker
@@ -563,33 +432,6 @@ export interface ReplayContainer {
   checkAndHandleExpiredSession(): boolean | void;
   setInitialState(): void;
   getCurrentRoute(): string | undefined;
-}
-
-export interface ReplayPerformanceEntry<T> {
-  /**
-   * One of these types https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry/entryType
-   */
-  type: string;
-
-  /**
-   * A more specific description of the performance entry
-   */
-  name: string;
-
-  /**
-   * The start timestamp in seconds
-   */
-  start: number;
-
-  /**
-   * The end timestamp in seconds
-   */
-  end: number;
-
-  /**
-   * Additional unstructured data to be included
-   */
-  data: T;
 }
 
 type RequestBody = null | Blob | BufferSource | FormData | URLSearchParams | string;

--- a/packages/replay/src/types/replay.ts
+++ b/packages/replay/src/types/replay.ts
@@ -8,13 +8,12 @@ import type {
   XhrBreadcrumbHint,
 } from '@sentry/types';
 
+import type { SKIPPED, THROTTLED } from '../util/throttle';
 import type { AllPerformanceEntry } from './performance';
-import type { eventWithTime, recordOptions } from './types/rrweb';
-import type { SKIPPED, THROTTLED } from './util/throttle';
+import type { ReplayFrameEvent } from './replayFrame';
+import type { eventWithTime, recordOptions } from './rrweb';
 
-export * from './types/replayFrame';
-
-export type RecordingEvent = eventWithTime;
+export type RecordingEvent = ReplayFrameEvent | eventWithTime;
 export type RecordingOptions = recordOptions;
 
 export interface SendReplayData {
@@ -55,7 +54,7 @@ export interface WorkerResponse {
 export type AddEventResult = void;
 
 export interface BeforeAddRecordingEvent {
-  (event: RecordingEvent): RecordingEvent | null | undefined;
+  (event: ReplayFrameEvent): ReplayFrameEvent | null | undefined;
 }
 
 export interface ReplayNetworkOptions {

--- a/packages/replay/src/types/replayFrame.ts
+++ b/packages/replay/src/types/replayFrame.ts
@@ -1,0 +1,137 @@
+import type { customEvent } from '@sentry-internal/rrweb';
+import type { Breadcrumb, FetchBreadcrumbData, XhrBreadcrumbData } from '@sentry/types';
+
+import type { AllEntryData } from './performance';
+
+interface BaseReplayFrame {
+  timestamp: number;
+  /**
+   * For compatibility reasons
+   */
+  type: string;
+  category: string;
+  data?: Record<string, any>;
+  message?: string;
+}
+
+interface BaseDomFrameData {
+  nodeId?: number;
+  node?: {
+    id: number;
+    tagName: string;
+    textContent: string;
+    attributes: Record<string, unknown>;
+  };
+}
+
+/* Crumbs from Core SDK */
+interface ConsoleFrameData {
+  logger: string;
+  arguments?: any[];
+}
+interface ConsoleFrame extends BaseReplayFrame {
+  category: 'console';
+  level: Breadcrumb['level'];
+  message: string;
+  data: ConsoleFrameData;
+}
+
+type ClickFrameData = BaseDomFrameData;
+interface ClickFrame extends BaseReplayFrame {
+  category: 'ui.click';
+  message: string;
+  data: ClickFrameData;
+}
+
+interface FetchFrame extends BaseReplayFrame {
+  category: 'fetch';
+  type: 'http';
+  data: FetchBreadcrumbData;
+}
+
+interface InputFrame extends BaseReplayFrame {
+  category: 'ui.input';
+  message: string;
+}
+
+interface XhrFrame extends BaseReplayFrame {
+  category: 'xhr';
+  type: 'http';
+  data: XhrBreadcrumbData;
+}
+
+/* Crumbs from Replay */
+interface MutationFrameData {
+  count: number;
+  limit: boolean;
+}
+interface MutationFrame extends BaseReplayFrame {
+  category: 'replay.mutations';
+  data: MutationFrameData;
+}
+
+interface KeyboardEventFrameData extends BaseDomFrameData {
+  metaKey: boolean;
+  shiftKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  key: string;
+}
+interface KeyboardEventFrame extends BaseReplayFrame {
+  category: 'ui.keyDown';
+  data: KeyboardEventFrameData;
+}
+
+interface BlurFrame extends BaseReplayFrame {
+  category: 'ui.blur';
+}
+
+interface FocusFrame extends BaseReplayFrame {
+  category: 'ui.focus';
+}
+
+interface SlowClickFrameData extends ClickFrameData {
+  url: string;
+  timeAfterClickFs: number;
+  endReason: string;
+}
+interface SlowClickFrame extends BaseReplayFrame {
+  category: 'ui.slowClickDetected';
+  data: SlowClickFrameData;
+}
+
+export type CrumbFrame =
+  | ConsoleFrame
+  | ClickFrame
+  | FetchFrame
+  | InputFrame
+  | XhrFrame
+  | KeyboardEventFrame
+  | BlurFrame
+  | FocusFrame
+  | SlowClickFrame
+  | MutationFrame
+  | BaseReplayFrame;
+
+export interface SpanFrame {
+  op: string;
+  description: string;
+  startTimestamp: number;
+  endTimestamp: number;
+  data: AllEntryData;
+}
+
+export type ReplayFrame = CrumbFrame | SpanFrame;
+
+export interface CrumbFrameEventData {
+  tag: 'breadcrumb';
+  payload: CrumbFrame;
+}
+export interface SpanFrameEventData {
+  tag: 'performanceSpan';
+  payload: SpanFrame;
+}
+
+export type CrumbFrameEvent = customEvent<CrumbFrameEventData>;
+export type SpanFrameEvent = customEvent<SpanFrameEventData>;
+export type ReplayFrameEvent = CrumbFrameEvent | SpanFrameEvent;

--- a/packages/replay/src/types/replayFrame.ts
+++ b/packages/replay/src/types/replayFrame.ts
@@ -10,7 +10,7 @@ interface BaseReplayFrame {
    */
   type: string;
   category: string;
-  data?: Record<string, unknown>;
+  data?: Record<string, any>;
   message?: string;
 }
 
@@ -20,7 +20,7 @@ interface BaseDomFrameData {
     id: number;
     tagName: string;
     textContent: string;
-    attributes: Record<string, unknown>;
+    attributes: Record<string, any>;
   };
 }
 

--- a/packages/replay/src/util/addEvent.ts
+++ b/packages/replay/src/util/addEvent.ts
@@ -1,9 +1,13 @@
 import { getCurrentHub } from '@sentry/core';
 import { logger } from '@sentry/utils';
 
-import type { AddEventResult, RecordingEvent, ReplayContainer } from '../types';
+import type { AddEventResult, RecordingEvent, ReplayContainer, ReplayFrameEvent } from '../types';
 import { EventType } from '../types/rrweb';
 import { timestampToMs } from './timestampToMs';
+
+function isCustomEvent(event: RecordingEvent): event is ReplayFrameEvent {
+  return event.type === EventType.Custom;
+}
 
 /**
  * Add an event to the event buffer.
@@ -42,7 +46,7 @@ export async function addEvent(
     const replayOptions = replay.getOptions();
 
     const eventAfterPossibleCallback =
-      typeof replayOptions.beforeAddRecordingEvent === 'function' && event.type === EventType.Custom
+      typeof replayOptions.beforeAddRecordingEvent === 'function' && isCustomEvent(event)
         ? replayOptions.beforeAddRecordingEvent(event)
         : event;
 

--- a/packages/replay/src/util/createBreadcrumb.ts
+++ b/packages/replay/src/util/createBreadcrumb.ts
@@ -1,11 +1,11 @@
-import type { CrumbFrame } from '../types/replayFrame';
+import type { BreadcrumbFrame } from '../types/replayFrame';
 
 /**
  * Create a breadcrumb for a replay.
  */
 export function createBreadcrumb(
-  breadcrumb: Omit<CrumbFrame, 'timestamp' | 'type'> & Partial<Pick<CrumbFrame, 'timestamp'>>,
-): CrumbFrame {
+  breadcrumb: Omit<BreadcrumbFrame, 'timestamp' | 'type'> & Partial<Pick<BreadcrumbFrame, 'timestamp'>>,
+): BreadcrumbFrame {
   return {
     timestamp: Date.now() / 1000,
     type: 'default',

--- a/packages/replay/src/util/createBreadcrumb.ts
+++ b/packages/replay/src/util/createBreadcrumb.ts
@@ -1,13 +1,11 @@
-import type { Breadcrumb } from '@sentry/types';
-
-type RequiredProperties = 'category' | 'message';
+import type { CrumbFrame } from '../types/replayFrame';
 
 /**
  * Create a breadcrumb for a replay.
  */
 export function createBreadcrumb(
-  breadcrumb: Pick<Breadcrumb, RequiredProperties> & Partial<Omit<Breadcrumb, RequiredProperties>>,
-): Breadcrumb {
+  breadcrumb: Omit<CrumbFrame, 'timestamp' | 'type'> & Partial<Pick<CrumbFrame, 'timestamp'>>,
+): CrumbFrame {
   return {
     timestamp: Date.now() / 1000,
     type: 'default',

--- a/packages/replay/src/util/handleRecordingEmit.ts
+++ b/packages/replay/src/util/handleRecordingEmit.ts
@@ -1,7 +1,7 @@
 import { logger } from '@sentry/utils';
 
 import { saveSession } from '../session/saveSession';
-import type { AddEventResult, RecordingEvent, ReplayContainer } from '../types';
+import type { AddEventResult, OptionFrameEvent, RecordingEvent, ReplayContainer } from '../types';
 import { EventType } from '../types/rrweb';
 import { addEvent } from './addEvent';
 
@@ -121,7 +121,7 @@ export function getHandleRecordingEmit(replay: ReplayContainer): RecordingEmitCa
 /**
  * Exported for tests
  */
-export function createOptionsEvent(replay: ReplayContainer): RecordingEvent {
+export function createOptionsEvent(replay: ReplayContainer): OptionFrameEvent {
   const options = replay.getOptions();
   return {
     type: EventType.Custom,

--- a/packages/replay/test/integration/beforeAddRecordingEvent.test.ts
+++ b/packages/replay/test/integration/beforeAddRecordingEvent.test.ts
@@ -37,7 +37,7 @@ describe('Integration | beforeAddRecordingEvent', () => {
     ({ replay, integration } = await mockSdk({
       replayOptions: {
         beforeAddRecordingEvent: event => {
-          const eventData = event.data as Record<string, any>;
+          const eventData = event.data;
 
           if (eventData.tag === 'breadcrumb' && eventData.payload.category === 'ui.click') {
             return {

--- a/packages/replay/test/integration/coreHandlers/handleScope.test.ts
+++ b/packages/replay/test/integration/coreHandlers/handleScope.test.ts
@@ -23,10 +23,10 @@ describe('Integration | coreHandlers | handleScope', () => {
 
     expect(mockHandleScopeListener).toHaveBeenCalledTimes(1);
 
-    getCurrentHub().getScope()?.addBreadcrumb({ message: 'testing' });
+    getCurrentHub().getScope()?.addBreadcrumb({ category: 'console', message: 'testing' });
 
     expect(mockHandleScope).toHaveBeenCalledTimes(1);
-    expect(mockHandleScope).toHaveReturnedWith(expect.objectContaining({ message: 'testing' }));
+    expect(mockHandleScope).toHaveReturnedWith(expect.objectContaining({ category: 'console', message: 'testing' }));
 
     mockHandleScope.mockClear();
 

--- a/packages/replay/test/unit/coreHandlers/handleScope.test.ts
+++ b/packages/replay/test/unit/coreHandlers/handleScope.test.ts
@@ -63,21 +63,21 @@ describe('Unit | coreHandlers | handleScope', () => {
 
   describe('normalizeConsoleBreadcrumb', () => {
     it('handles console messages with no arguments', () => {
-      const breadcrumb: Breadcrumb = { category: 'console', message: 'test' };
+      const breadcrumb = { category: 'console', message: 'test' };
       const actual = HandleScope.normalizeConsoleBreadcrumb(breadcrumb);
 
       expect(actual).toMatchObject({ category: 'console', message: 'test' });
     });
 
     it('handles console messages with empty arguments', () => {
-      const breadcrumb: Breadcrumb = { category: 'console', message: 'test', data: { arguments: [] } };
+      const breadcrumb = { category: 'console', message: 'test', data: { arguments: [] } };
       const actual = HandleScope.normalizeConsoleBreadcrumb(breadcrumb);
 
       expect(actual).toMatchObject({ category: 'console', message: 'test', data: { arguments: [] } });
     });
 
     it('handles console messages with simple arguments', () => {
-      const breadcrumb: Breadcrumb = {
+      const breadcrumb = {
         category: 'console',
         message: 'test',
         data: { arguments: [1, 'a', true, null, undefined] },
@@ -94,7 +94,7 @@ describe('Unit | coreHandlers | handleScope', () => {
     });
 
     it('truncates large strings', () => {
-      const breadcrumb: Breadcrumb = {
+      const breadcrumb = {
         category: 'console',
         message: 'test',
         data: {
@@ -114,7 +114,7 @@ describe('Unit | coreHandlers | handleScope', () => {
     });
 
     it('truncates large JSON objects', () => {
-      const breadcrumb: Breadcrumb = {
+      const breadcrumb = {
         category: 'console',
         message: 'test',
         data: {

--- a/packages/replay/test/unit/util/handleRecordingEmit.test.ts
+++ b/packages/replay/test/unit/util/handleRecordingEmit.test.ts
@@ -1,7 +1,7 @@
 import { EventType } from '@sentry-internal/rrweb';
 
 import { BASE_TIMESTAMP } from '../..';
-import type { RecordingEvent } from '../../../src/types';
+import type { OptionFrameEvent } from '../../../src/types';
 import * as SentryAddEvent from '../../../src/util/addEvent';
 import { createOptionsEvent, getHandleRecordingEmit } from '../../../src/util/handleRecordingEmit';
 import { setupReplayContainer } from '../../utils/setupReplayContainer';
@@ -9,7 +9,7 @@ import { useFakeTimers } from '../../utils/use-fake-timers';
 
 useFakeTimers();
 
-let optionsEvent: RecordingEvent;
+let optionsEvent: OptionFrameEvent;
 
 describe('Unit | util | handleRecordingEmit', () => {
   let addEventMock: jest.SpyInstance;


### PR DESCRIPTION
More specific types for our replay recording events. These are exported so that our UI can use them as well.

![image](https://github.com/getsentry/sentry-javascript/assets/79684/8b5d3ff1-ac44-4f30-b1b2-0057b98ec4b7)
