### PR TITLE
feat(replay): Do not restart replays on "keydown"

### DIFF
--- a/packages/replay/src/coreHandlers/handleKeyboardEvent.ts
+++ b/packages/replay/src/coreHandlers/handleKeyboardEvent.ts
@@ -12,8 +12,9 @@ export function handleKeyboardEvent(replay: ReplayContainer, event: KeyboardEven
     return;
   }
 
-  replay.triggerUserActivity();
-
+  // NOTE: Do not consider this "user activity" because it can lead to
+  // noisy/low-value replays (e.g. user comes back from idle, hits alt-tab, new
+  // session with a single "keydown" breadcrumb is created)
   const breadcrumb = getKeyboardBreadcrumb(event);
 
   if (!breadcrumb) {

--- a/packages/replay/src/coreHandlers/handleKeyboardEvent.ts
+++ b/packages/replay/src/coreHandlers/handleKeyboardEvent.ts
@@ -12,9 +12,11 @@ export function handleKeyboardEvent(replay: ReplayContainer, event: KeyboardEven
     return;
   }
 
-  // NOTE: Do not consider this "user activity" because it can lead to
+  // Update user activity, but do not restart recording as it can create
   // noisy/low-value replays (e.g. user comes back from idle, hits alt-tab, new
   // session with a single "keydown" breadcrumb is created)
+  replay.updateUserActivity();
+
   const breadcrumb = getKeyboardBreadcrumb(event);
 
   if (!breadcrumb) {

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -481,6 +481,18 @@ export class ReplayContainer implements ReplayContainerInterface {
   }
 
   /**
+   * Updates the user activity timestamp *without* resuming
+   * recording. Some user events (e.g. keydown) can be create
+   * low-value replays that only contain the keypress as a
+   * breadcrumb. Instead this would require other events to
+   * create a new replay after a session has expired.
+   */
+  public updateUserActivity(): void {
+    this._updateUserActivity();
+    this._updateSessionActivity();
+  }
+
+  /**
    * Only flush if `this.recordingMode === 'session'`
    */
   public conditionalFlush(): Promise<void> {

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -542,6 +542,7 @@ export interface ReplayContainer {
   flushImmediate(): Promise<void>;
   cancelFlush(): void;
   triggerUserActivity(): void;
+  updateUserActivity(): void;
   addUpdate(cb: AddUpdateCallback): void;
   getOptions(): ReplayPluginOptions;
   getSessionId(): string | undefined;


### PR DESCRIPTION
This is causing some low-value replays. If you search sentry for replays with duration < 5 seconds, you will see that most of them are re-newed sessions from idle that only have a "keydown" breadcrumb. I suspect users are alt-tabbing out of an idle Sentry page. Removing for now until we have a better way to detect when a session is truly resumed via keydown event.
