### PR TITLE
feat(replay): Promote `mutatationBreadcrumbLimit` and `mutationLimit` to regular feature

### DIFF
--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -60,6 +60,9 @@ export class Replay implements Integration {
     maskAllInputs = true,
     blockAllMedia = true,
 
+    mutationBreadcrumbLimit = 750,
+    mutationLimit = 1500,
+
     networkDetailAllowUrls = [],
     networkCaptureBodies = true,
     networkRequestHeaders = [],
@@ -127,6 +130,8 @@ export class Replay implements Integration {
       blockAllMedia,
       maskAllInputs,
       maskAllText,
+      mutationBreadcrumbLimit,
+      mutationLimit,
       networkDetailAllowUrls,
       networkCaptureBodies,
       networkRequestHeaders: _getMergedNetworkHeaders(networkRequestHeaders),
@@ -135,6 +140,22 @@ export class Replay implements Integration {
 
       _experiments,
     };
+
+    if (typeof _experiments.mutationBreadcrumbLimit === 'number') {
+      // eslint-disable-next-line
+      console.warn(
+        `[Replay] \`mutationBreadcrumbLimit\` is no longer an experiment. To configure, pass to the
+Replay constructor. e.g.: Sentry.Replay({ mutationBreadcrumbLimit: 750 });`,
+      );
+    }
+
+    if (typeof _experiments.mutationLimit === 'number') {
+      // eslint-disable-next-line
+      console.warn(
+        `[Replay] \`mutationLimit\` is no longer an experiment. To configure, pass to the
+Replay constructor. e.g.: Sentry.Replay({ mutationLimit: 1500 });`,
+      );
+    }
 
     if (typeof sessionSampleRate === 'number') {
       // eslint-disable-next-line

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -1056,8 +1056,9 @@ export class ReplayContainer implements ReplayContainerInterface {
   private _onMutationHandler = (mutations: unknown[]): boolean => {
     const count = mutations.length;
 
-    const mutationLimit = this._options._experiments.mutationLimit || 0;
-    const mutationBreadcrumbLimit = this._options._experiments.mutationBreadcrumbLimit || 1000;
+    const mutationLimit = this._options.mutationLimit || this._options._experiments.mutationLimit || 0;
+    const mutationBreadcrumbLimit =
+      this._options.mutationBreadcrumbLimit || this._options._experiments.mutationBreadcrumbLimit || 1000;
     const overMutationLimit = mutationLimit && count > mutationLimit;
 
     // Create a breadcrumb if a lot of mutations happen at the same time
@@ -1067,15 +1068,15 @@ export class ReplayContainer implements ReplayContainerInterface {
         category: 'replay.mutations',
         data: {
           count,
+          limit: overMutationLimit,
         },
       });
       this._createCustomBreadcrumb(breadcrumb);
     }
 
+    // Stop replay if over the mutation limit
     if (overMutationLimit) {
-      // We want to skip doing an incremental snapshot if there are too many mutations
-      // Instead, we do a full snapshot
-      this._triggerFullSnapshot(false);
+      void this.stop();
       return false;
     }
 

--- a/packages/replay/src/types.ts
+++ b/packages/replay/src/types.ts
@@ -286,6 +286,23 @@ export interface ReplayPluginOptions extends ReplayNetworkOptions {
   beforeAddRecordingEvent?: BeforeAddRecordingEvent;
 
   /**
+   * Threshold of number of mutations that will be processed before creating a warning breadcrumb.
+   */
+  /**
+   * A high number of DOM mutations (in a single event loop) can cause
+   * performance regressions in end-users' browsers. This setting will create
+   * a breadcrumb in the recording when the limit has been reached.
+   */
+  mutationBreadcrumbLimit?: number;
+
+  /**
+   * A high number of DOM mutations (in a single event loop) can cause
+   * performance regressions in end-users' browsers. This setting will cause
+   * recording to stop when the limit has been reached.
+   */
+  mutationLimit?: number;
+
+  /**
    * _experiments allows users to enable experimental or internal features.
    * We don't consider such features as part of the public API and hence we don't guarantee semver for them.
    * Experimental features can be added, changed or removed at any time.


### PR DESCRIPTION
Instead of taking a fullsnapshot when `mutationLimit` is reached, lets be aggressive and stop the replay to ensure end-users are not negatively affected performance wise.

The default for showing a breadcrumb is at 750 mutations, and the default limit to stop recording is 1500 mutations.
