### PR TITLE
fix(replay): Guard against missing key

### DIFF
--- a/packages/replay/src/coreHandlers/handleKeyboardEvent.ts
+++ b/packages/replay/src/coreHandlers/handleKeyboardEvent.ts
@@ -28,7 +28,7 @@ export function getKeyboardBreadcrumb(event: KeyboardEvent): Breadcrumb | null {
   const { metaKey, shiftKey, ctrlKey, altKey, key, target } = event;
 
   // never capture for input fields
-  if (!target || isInputElement(target as HTMLElement)) {
+  if (!target || isInputElement(target as HTMLElement) || !key) {
     return null;
   }
 


### PR DESCRIPTION
`key` _should_ always be there, but let's guard against this as it seems it may be undefined.

Fixes https://github.com/getsentry/sentry-javascript/issues/8237