### PR TITLE
feat(sveltekit): Add source maps support for Vercel (lambda)

### DIFF
--- a/packages/sveltekit/.eslintrc.js
+++ b/packages/sveltekit/.eslintrc.js
@@ -17,6 +17,10 @@ module.exports = {
         project: ['tsconfig.test.json'],
       },
     },
+    {
+      files: ['./src/vite/**', './src/server/**'],
+      '@sentry-internal/sdk/no-optional-chaining': 'off',
+    },
   ],
   extends: ['../../.eslintrc.js'],
 };

--- a/packages/sveltekit/.eslintrc.js
+++ b/packages/sveltekit/.eslintrc.js
@@ -18,8 +18,10 @@ module.exports = {
       },
     },
     {
-      files: ['./src/vite/**', './src/server/**'],
-      '@sentry-internal/sdk/no-optional-chaining': 'off',
+      files: ['src/vite/**', 'src/server/**'],
+      rules: {
+        '@sentry-internal/sdk/no-optional-chaining': 'off',
+      },
     },
   ],
   extends: ['../../.eslintrc.js'],

--- a/packages/sveltekit/src/server/utils.ts
+++ b/packages/sveltekit/src/server/utils.ts
@@ -1,5 +1,4 @@
 import type { DynamicSamplingContext, StackFrame, TraceparentData } from '@sentry/types';
-import type { InternalGlobal } from '@sentry/utils';
 import {
   baggageHeaderToDynamicSamplingContext,
   basename,
@@ -11,17 +10,7 @@ import {
 import type { RequestEvent } from '@sveltejs/kit';
 
 import { WRAPPED_MODULE_SUFFIX } from '../vite/autoInstrument';
-
-export type GlobalSentryValues = {
-  __sentry_sveltekit_output_dir?: string;
-};
-
-/**
- * Extend the `global` type with custom properties that are
- * injected by the SvelteKit SDK at build time.
- * @see packages/sveltekit/src/vite/sourcemaps.ts
- */
-export type GlobalWithSentryValues = InternalGlobal & GlobalSentryValues;
+import type { GlobalWithSentryValues } from '../vite/injectGLobalValues';
 
 /**
  * Takes a request event and extracts traceparent and DSC data
@@ -71,7 +60,7 @@ export function rewriteFramesIteratee(frame: StackFrame): StackFrame {
     let strippedFilename;
     if (svelteKitBuildOutDir) {
       strippedFilename = filename.replace(
-        new RegExp(`^.*${escapeStringForRegex(join(svelteKitBuildOutDir, 'server'))}`),
+        new RegExp(`^.*${escapeStringForRegex(join(svelteKitBuildOutDir, 'server'))}/`),
         '',
       );
     } else {

--- a/packages/sveltekit/src/server/utils.ts
+++ b/packages/sveltekit/src/server/utils.ts
@@ -9,14 +9,16 @@ import type { RequestEvent } from '@sveltejs/kit';
 
 import { WRAPPED_MODULE_SUFFIX } from '../vite/autoInstrument';
 
+export type GlobalSentryValues = {
+  __sentry_sveltekit_output_dir?: string;
+};
+
 /**
  * Extend the `global` type with custom properties that are
  * injected by the SvelteKit SDK at build time.
  * @see packages/sveltekit/src/vite/sourcemaps.ts
  */
-export type GlobalWithSentryValues = typeof globalThis & {
-  __sentry_sveltekit_output_dir?: string;
-};
+export type GlobalWithSentryValues = typeof globalThis & GlobalSentryValues;
 
 /**
  * Takes a request event and extracts traceparent and DSC data

--- a/packages/sveltekit/src/server/utils.ts
+++ b/packages/sveltekit/src/server/utils.ts
@@ -65,7 +65,7 @@ export function rewriteFramesIteratee(frame: StackFrame): StackFrame {
 
     let strippedFilename;
     if (svelteKitBuildOutDir) {
-      strippedFilename = filename.replace(new RegExp(`^.*${escapeStringForRegex(svelteKitBuildOutDir)}\/server\/`), '');
+      strippedFilename = filename.replace(new RegExp(`^.*${escapeStringForRegex(svelteKitBuildOutDir)}/server/`), '');
     } else {
       strippedFilename = basename(filename);
     }

--- a/packages/sveltekit/src/server/utils.ts
+++ b/packages/sveltekit/src/server/utils.ts
@@ -10,7 +10,7 @@ import {
 import type { RequestEvent } from '@sveltejs/kit';
 
 import { WRAPPED_MODULE_SUFFIX } from '../vite/autoInstrument';
-import type { GlobalWithSentryValues } from '../vite/injectGLobalValues';
+import type { GlobalWithSentryValues } from '../vite/injectGlobalValues';
 
 /**
  * Takes a request event and extracts traceparent and DSC data

--- a/packages/sveltekit/src/vite/injectGlobalValues.ts
+++ b/packages/sveltekit/src/vite/injectGlobalValues.ts
@@ -1,0 +1,41 @@
+import type { InternalGlobal } from '@sentry/utils';
+
+export type GlobalSentryValues = {
+  __sentry_sveltekit_output_dir?: string;
+};
+
+/**
+ * Extend the `global` type with custom properties that are
+ * injected by the SvelteKit SDK at build time.
+ * @see packages/sveltekit/src/vite/sourcemaps.ts
+ */
+export type GlobalWithSentryValues = InternalGlobal & GlobalSentryValues;
+
+export const VIRTUAL_GLOBAL_VALUES_FILE = '\0sentry-inject-global-values-file';
+
+/**
+ * @returns code that injects @param globalSentryValues into the global scope.
+ */
+export function getGlobalValueInjectionCode(globalSentryValues: GlobalSentryValues): string {
+  if (Object.keys(globalSentryValues).length === 0) {
+    return '';
+  }
+
+  const sentryGlobal = '_global';
+
+  const globalCode = `var ${sentryGlobal} =
+  typeof window !== 'undefined' ?
+    window :
+    typeof globalThis !== 'undefined' ?
+      globalThis :
+      typeof global !== 'undefined' ?
+        global :
+        typeof self !== 'undefined' ?
+          self :
+          {};`;
+  const injectedValuesCode = Object.entries(globalSentryValues)
+    .map(([key, value]) => `${sentryGlobal}["${key}"] = ${JSON.stringify(value)};`)
+    .join('\n');
+
+  return `${globalCode}\n${injectedValuesCode}\n`;
+}

--- a/packages/sveltekit/src/vite/injectGlobalValues.ts
+++ b/packages/sveltekit/src/vite/injectGlobalValues.ts
@@ -14,7 +14,7 @@ export type GlobalWithSentryValues = InternalGlobal & GlobalSentryValues;
 export const VIRTUAL_GLOBAL_VALUES_FILE = '\0sentry-inject-global-values-file';
 
 /**
- * @returns code that injects @param globalSentryValues into the global scope.
+ * @returns code that injects @param globalSentryValues into the global object.
  */
 export function getGlobalValueInjectionCode(globalSentryValues: GlobalSentryValues): string {
   if (Object.keys(globalSentryValues).length === 0) {

--- a/packages/sveltekit/src/vite/sentryVitePlugins.ts
+++ b/packages/sveltekit/src/vite/sentryVitePlugins.ts
@@ -103,6 +103,7 @@ export async function sentrySvelteKit(options: SentrySvelteKitPluginOptions = {}
     const pluginOptions = {
       ...mergedOptions.sourceMapsUploadOptions,
       debug: mergedOptions.debug, // override the plugin's debug flag with the one from the top-level options
+      adapter: mergedOptions.adapter,
     };
     sentryPlugins.push(await makeCustomSentryVitePlugin(pluginOptions));
   }

--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -61,7 +61,7 @@ export async function makeCustomSentryVitePlugin(options?: CustomSentryVitePlugi
   const hasSentryProperties = fs.existsSync(path.resolve(process.cwd(), 'sentry.properties'));
 
   const defaultPluginOptions: SentryVitePluginOptions = {
-    include: [{ paths: [`${outputDir}/client`] }, { paths: [`${outputDir}/server`] }],
+    include: [`${outputDir}/client`, `${outputDir}/server`],
     configFile: hasSentryProperties ? 'sentry.properties' : undefined,
     release,
   };

--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -114,7 +114,7 @@ export async function makeCustomSentryVitePlugin(options?: CustomSentryVitePlugi
 
     transform: async (code, id) => {
       let modifiedCode = code;
-      const isServerHooksFile = new RegExp(`\/${escapeStringForRegex(serverHooksFile)}(\.(js|ts|mjs|mts))?`).test(id);
+      const isServerHooksFile = new RegExp(`\/${escapeStringForRegex(serverHooksFile)}(.(js|ts|mjs|mts))?`).test(id);
 
       if (isServerHooksFile) {
         let injectedCode = `global.__sentry_sveltekit_output_dir = "${outputDir || 'undefined'}";\n`;

--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -12,8 +12,8 @@ import type { Plugin } from 'vite';
 
 import { WRAPPED_MODULE_SUFFIX } from './autoInstrument';
 import type { SupportedSvelteKitAdapters } from './detectAdapter';
-import type { GlobalSentryValues } from './injectGLobalValues';
-import { getGlobalValueInjectionCode, VIRTUAL_GLOBAL_VALUES_FILE } from './injectGLobalValues';
+import type { GlobalSentryValues } from './injectGlobalValues';
+import { getGlobalValueInjectionCode, VIRTUAL_GLOBAL_VALUES_FILE } from './injectGlobalValues';
 import { getAdapterOutputDir, getHooksFileName, loadSvelteConfig } from './svelteConfig';
 
 // sorcery has no types, so these are some basic type definitions:

--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -72,7 +72,7 @@ export async function makeCustomSentryVitePlugin(options?: CustomSentryVitePlugi
   const sentryPlugin: Plugin = sentryVitePlugin(mergedOptions);
 
   const { debug } = mergedOptions;
-  const { buildStart, resolveId, transform, renderChunk } = sentryPlugin;
+  const { buildStart, resolveId, renderChunk } = sentryPlugin;
 
   let isSSRBuild = true;
 
@@ -114,10 +114,10 @@ export async function makeCustomSentryVitePlugin(options?: CustomSentryVitePlugi
 
     transform: async (code, id) => {
       let modifiedCode = code;
-      const isServerHooksFile = new RegExp(`\/${escapeStringForRegex(serverHooksFile)}(.(js|ts|mjs|mts))?`).test(id);
+      const isServerHooksFile = new RegExp(`/${escapeStringForRegex(serverHooksFile)}(.(js|ts|mjs|mts))?`).test(id);
 
       if (isServerHooksFile) {
-        let injectedCode = `global.__sentry_sveltekit_output_dir = "${outputDir || 'undefined'}";\n`;
+        const injectedCode = `global.__sentry_sveltekit_output_dir = "${outputDir || 'undefined'}";\n`;
         modifiedCode = `${code}\n${injectedCode}`;
       }
       // @ts-ignore - this hook exists on the plugin!

--- a/packages/sveltekit/src/vite/svelteConfig.ts
+++ b/packages/sveltekit/src/vite/svelteConfig.ts
@@ -4,6 +4,7 @@ import type { Builder, Config } from '@sveltejs/kit';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as url from 'url';
+import { SupportedSvelteKitAdapters } from './detectAdapter';
 
 /**
  * Imports the svelte.config.js file and returns the config object.
@@ -36,19 +37,37 @@ export async function loadSvelteConfig(): Promise<Config> {
 }
 
 /**
+ * Reads a custom hooks directory from the SvelteKit config. In case no custom hooks
+ * directory is specified, the default directory is returned.
+ */
+export function getHooksFileName(svelteConfig: Config, hookType: 'client' | 'server') {
+  return svelteConfig.kit?.files?.hooks?.[hookType] || `src/hooks.${hookType}`;
+}
+
+/**
  * Attempts to read a custom output directory that can be specidied in the options
  * of a SvelteKit adapter. If no custom output directory is specified, the default
  * directory is returned.
- *
- * To get the directory, we have to apply a hack and call the adapter's adapt method
+ */
+export async function getAdapterOutputDir(svelteConfig: Config, adapter: SupportedSvelteKitAdapters): Promise<string> {
+  if (adapter === 'node') {
+    return await getNodeAdapterOutputDir(svelteConfig);
+  }
+
+  // Auto and Vercel adapters simply use config.kit.outDir
+  // Let's also use this directory for the 'other' case
+  return path.join(svelteConfig.kit?.outDir || '.svelte-kit', 'output');
+}
+
+/**
+ * To get the Node adapter output directory, we have to apply a hack and call the adapter's adapt method
  * with a custom adapter `Builder` that only calls the `writeClient` method.
  * This method is the first method that is called with the output directory.
  * Once we obtained the output directory, we throw an error to exit the adapter.
  *
  * see: https://github.com/sveltejs/kit/blob/master/packages/adapter-node/index.js#L17
- *
  */
-export async function getAdapterOutputDir(svelteConfig: Config): Promise<string> {
+async function getNodeAdapterOutputDir(svelteConfig: Config): Promise<string> {
   // 'build' is the default output dir for the node adapter
   let outputDir = 'build';
 
@@ -56,7 +75,7 @@ export async function getAdapterOutputDir(svelteConfig: Config): Promise<string>
     return outputDir;
   }
 
-  const adapter = svelteConfig.kit.adapter;
+  const nodeAdapter = svelteConfig.kit.adapter;
 
   const adapterBuilder: Builder = {
     writeClient(dest: string) {
@@ -85,7 +104,7 @@ export async function getAdapterOutputDir(svelteConfig: Config): Promise<string>
   };
 
   try {
-    await adapter.adapt(adapterBuilder);
+    await nodeAdapter.adapt(adapterBuilder);
   } catch (_) {
     // We expect the adapter to throw in writeClient!
   }

--- a/packages/sveltekit/src/vite/svelteConfig.ts
+++ b/packages/sveltekit/src/vite/svelteConfig.ts
@@ -4,7 +4,8 @@ import type { Builder, Config } from '@sveltejs/kit';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as url from 'url';
-import { SupportedSvelteKitAdapters } from './detectAdapter';
+
+import type { SupportedSvelteKitAdapters } from './detectAdapter';
 
 /**
  * Imports the svelte.config.js file and returns the config object.
@@ -40,7 +41,7 @@ export async function loadSvelteConfig(): Promise<Config> {
  * Reads a custom hooks directory from the SvelteKit config. In case no custom hooks
  * directory is specified, the default directory is returned.
  */
-export function getHooksFileName(svelteConfig: Config, hookType: 'client' | 'server') {
+export function getHooksFileName(svelteConfig: Config, hookType: 'client' | 'server'): string {
   return svelteConfig.kit?.files?.hooks?.[hookType] || `src/hooks.${hookType}`;
 }
 

--- a/packages/sveltekit/test/server/utils.test.ts
+++ b/packages/sveltekit/test/server/utils.test.ts
@@ -1,7 +1,8 @@
 import { RewriteFrames } from '@sentry/integrations';
 import type { StackFrame } from '@sentry/types';
+import { basename } from '@sentry/utils';
 
-import { getTracePropagationData, rewriteFramesIteratee } from '../../src/server/utils';
+import { getTracePropagationData, GlobalWithSentryValues, rewriteFramesIteratee } from '../../src/server/utils';
 
 const MOCK_REQUEST_EVENT: any = {
   request: {
@@ -69,7 +70,7 @@ describe('rewriteFramesIteratee', () => {
     expect(result).not.toHaveProperty('module');
   });
 
-  it('does the same filename modification as the default RewriteFrames iteratee', () => {
+  it('does the same filename modification as the default RewriteFrames iteratee if no output dir is available', () => {
     const frame: StackFrame = {
       filename: '/some/path/to/server/chunks/3-ab34d22f.js',
       lineno: 1,
@@ -94,4 +95,36 @@ describe('rewriteFramesIteratee', () => {
 
     expect(result).toStrictEqual(defaultResult);
   });
+
+  it.each([
+    ['adapter-node', 'build', '/absolute/path/to/build/server/chunks/3-ab34d22f.js', 'app:///chunks/3-ab34d22f.js'],
+    [
+      'adapter-auto',
+      '.svelte-kit/output',
+      '/absolute/path/to/.svelte-kit/output/server/entries/pages/page.ts.js',
+      'app:///entries/pages/page.ts.js',
+    ],
+  ])(
+    'removes the absolut path to the server output dir, if the output dir is available (%s)',
+    (_, outputDir, frameFilename, modifiedFilename) => {
+      (global as GlobalWithSentryValues).__sentry_sveltekit_output_dir = outputDir;
+
+      const frame: StackFrame = {
+        filename: frameFilename,
+        lineno: 1,
+        colno: 1,
+        module: basename(frameFilename),
+      };
+
+      const result = rewriteFramesIteratee({ ...frame });
+
+      expect(result).toStrictEqual({
+        filename: modifiedFilename,
+        lineno: 1,
+        colno: 1,
+      });
+
+      delete (global as GlobalWithSentryValues).__sentry_sveltekit_output_dir;
+    },
+  );
 });

--- a/packages/sveltekit/test/server/utils.test.ts
+++ b/packages/sveltekit/test/server/utils.test.ts
@@ -2,7 +2,8 @@ import { RewriteFrames } from '@sentry/integrations';
 import type { StackFrame } from '@sentry/types';
 import { basename } from '@sentry/utils';
 
-import { getTracePropagationData, GlobalWithSentryValues, rewriteFramesIteratee } from '../../src/server/utils';
+import type { GlobalWithSentryValues } from '../../src/server/utils';
+import { getTracePropagationData, rewriteFramesIteratee } from '../../src/server/utils';
 
 const MOCK_REQUEST_EVENT: any = {
   request: {
@@ -107,7 +108,7 @@ describe('rewriteFramesIteratee', () => {
   ])(
     'removes the absolut path to the server output dir, if the output dir is available (%s)',
     (_, outputDir, frameFilename, modifiedFilename) => {
-      (global as GlobalWithSentryValues).__sentry_sveltekit_output_dir = outputDir;
+      (globalThis as GlobalWithSentryValues).__sentry_sveltekit_output_dir = outputDir;
 
       const frame: StackFrame = {
         filename: frameFilename,
@@ -124,7 +125,7 @@ describe('rewriteFramesIteratee', () => {
         colno: 1,
       });
 
-      delete (global as GlobalWithSentryValues).__sentry_sveltekit_output_dir;
+      delete (globalThis as GlobalWithSentryValues).__sentry_sveltekit_output_dir;
     },
   );
 });

--- a/packages/sveltekit/test/vite/injectGlobalValues.test.ts
+++ b/packages/sveltekit/test/vite/injectGlobalValues.test.ts
@@ -1,0 +1,34 @@
+import { getGlobalValueInjectionCode } from '../../src/vite/injectGlobalValues';
+
+describe('getGlobalValueInjectionCode', () => {
+  it('returns code that injects values into the global object', () => {
+    const injectionCode = getGlobalValueInjectionCode({
+      // @ts-ignore - just want to test this with multiple values
+      something: 'else',
+      __sentry_sveltekit_output_dir: '.svelte-kit/output',
+    });
+    expect(injectionCode).toEqual(`var _global =
+  typeof window !== 'undefined' ?
+    window :
+    typeof globalThis !== 'undefined' ?
+      globalThis :
+      typeof global !== 'undefined' ?
+        global :
+        typeof self !== 'undefined' ?
+          self :
+          {};
+_global["something"] = "else";
+_global["__sentry_sveltekit_output_dir"] = ".svelte-kit/output";
+`);
+
+    // Check that the code above is in fact valid and works as expected
+    // The return value of eval here is the value of the last expression in the code
+    expect(eval(`${injectionCode}`)).toEqual('.svelte-kit/output');
+
+    delete globalThis.__sentry_sveltekit_output_dir;
+  });
+
+  it('returns empty string if no values are passed', () => {
+    expect(getGlobalValueInjectionCode({})).toEqual('');
+  });
+});

--- a/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
+++ b/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
@@ -72,6 +72,7 @@ describe('sentrySvelteKit()', () => {
         ignore: ['bar.js'],
       },
       autoInstrument: false,
+      adapter: 'vercel',
     });
     const plugin = plugins[0];
 
@@ -80,6 +81,7 @@ describe('sentrySvelteKit()', () => {
       debug: true,
       ignore: ['bar.js'],
       include: ['foo.js'],
+      adapter: 'vercel',
     });
   });
 

--- a/packages/sveltekit/test/vite/sourceMaps.test.ts
+++ b/packages/sveltekit/test/vite/sourceMaps.test.ts
@@ -58,7 +58,7 @@ describe('makeCustomSentryVitePlugin()', () => {
       const plugin = await makeCustomSentryVitePlugin();
       // @ts-ignore this function exists!
       const transformedCode = await plugin.transform('foo', '/src/hooks.server.ts');
-      const expectedtransformedCode = 'foo\nglobalThis["__sentry_sveltekit_output_dir"] = ".svelte-kit/output";\n';
+      const expectedtransformedCode = 'foo\n; import "\0sentry-inject-global-values-file";\n';
       expect(mockedSentryVitePlugin.transform).toHaveBeenCalledWith(expectedtransformedCode, '/src/hooks.server.ts');
       expect(transformedCode).toEqual(expectedtransformedCode);
     });

--- a/packages/sveltekit/test/vite/sourceMaps.test.ts
+++ b/packages/sveltekit/test/vite/sourceMaps.test.ts
@@ -58,7 +58,7 @@ describe('makeCustomSentryVitePlugin()', () => {
       const plugin = await makeCustomSentryVitePlugin();
       // @ts-ignore this function exists!
       const transformedCode = await plugin.transform('foo', '/src/hooks.server.ts');
-      const expectedtransformedCode = 'foo\nglobal.__sentry_sveltekit_output_dir = ".svelte-kit/output";\n';
+      const expectedtransformedCode = 'foo\nglobalThis["__sentry_sveltekit_output_dir"] = ".svelte-kit/output";\n';
       expect(mockedSentryVitePlugin.transform).toHaveBeenCalledWith(expectedtransformedCode, '/src/hooks.server.ts');
       expect(transformedCode).toEqual(expectedtransformedCode);
     });

--- a/packages/sveltekit/test/vite/svelteConfig.test.ts
+++ b/packages/sveltekit/test/vite/svelteConfig.test.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
-import { SupportedSvelteKitAdapters } from '../../src/vite/detectAdapter';
 
+import type { SupportedSvelteKitAdapters } from '../../src/vite/detectAdapter';
 import { getAdapterOutputDir, getHooksFileName, loadSvelteConfig } from '../../src/vite/svelteConfig';
 
 let existsFile;

--- a/packages/sveltekit/test/vite/svelteConfig.test.ts
+++ b/packages/sveltekit/test/vite/svelteConfig.test.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
+import { SupportedSvelteKitAdapters } from '../../src/vite/detectAdapter';
 
-import { getAdapterOutputDir, loadSvelteConfig } from '../../src/vite/svelteConfig';
+import { getAdapterOutputDir, getHooksFileName, loadSvelteConfig } from '../../src/vite/svelteConfig';
 
 let existsFile;
 
@@ -62,8 +63,33 @@ describe('getAdapterOutputDir', () => {
     },
   };
 
-  it('returns the output directory of the adapter', async () => {
-    const outputDir = await getAdapterOutputDir({ kit: { adapter: mockedAdapter } });
+  it('returns the output directory of the Node adapter', async () => {
+    const outputDir = await getAdapterOutputDir({ kit: { adapter: mockedAdapter } }, 'node');
     expect(outputDir).toEqual('customBuildDir');
+  });
+
+  it.each(['vercel', 'auto', 'other'] as SupportedSvelteKitAdapters[])(
+    'returns the config.kit.outdir directory for adapter-%s',
+    async adapter => {
+      const outputDir = await getAdapterOutputDir({ kit: { outDir: 'customOutDir' } }, adapter);
+      expect(outputDir).toEqual('customOutDir/output');
+    },
+  );
+
+  it('falls back to the default out dir for all other adapters if outdir is not specified in the config', async () => {
+    const outputDir = await getAdapterOutputDir({ kit: {} }, 'vercel');
+    expect(outputDir).toEqual('.svelte-kit/output');
+  });
+});
+
+describe('getHooksFileName', () => {
+  it('returns the default hooks file name if no custom hooks file is specified', () => {
+    const hooksFileName = getHooksFileName({}, 'server');
+    expect(hooksFileName).toEqual('src/hooks.server');
+  });
+
+  it('returns the custom hooks file name if specified in the config', () => {
+    const hooksFileName = getHooksFileName({ kit: { files: { hooks: { server: 'serverhooks' } } } }, 'server');
+    expect(hooksFileName).toEqual('serverhooks');
   });
 });


### PR DESCRIPTION
This PR adjusts our automatic source maps upload setup in the SvelteKit SDK to support SvelteKit apps deployed to Vercel. This will only work for Lambda functions/Node runtime; not for the Vercel Edge runtime. 

This required a few changes in our custom vite plugin as well as on the server side of the SDK:

* Based on the used adapter (manually set or detected via #8193) and the `svelte.config.js` we determine the output directory where the generated JS emitted to. 
* The determined output directory is injected into the global object on the server side
* When an error occurs on the server side, we strip the absolute filename of each stack frame so that the relative path of the server-side code within the output directory is left.
* We also use the determined output directory to build the correct `include` entries for the source map upload plugin.

With this change, source maps upload should work for auto and Vercel adapters, as well as for the Node adapter.
As for the Node adapter, the stackframe rewrite behaviour was also changed but it is now more in line with all supported adapters.

ref #8085  
potentially fixes #8218