### PR TITLE
fix(wasm): Avoid throwing an error when WASM modules are loaded from blobs

### DIFF
--- a/packages/wasm/src/registry.ts
+++ b/packages/wasm/src/registry.ts
@@ -45,11 +45,22 @@ export function registerModule(module: WebAssembly.Module, url: string): void {
     if (oldIdx >= 0) {
       IMAGES.splice(oldIdx, 1);
     }
+
+    let debugFileUrl = null;
+    if (debugFile) {
+      try {
+        debugFileUrl = new URL(debugFile, url).href;
+      } catch {
+        // debugFile could be a blob URL which causes the URL constructor to throw
+        // for now we just ignore this case
+      }
+    }
+
     IMAGES.push({
       type: 'wasm',
       code_id: buildId,
       code_file: url,
-      debug_file: debugFile ? new URL(debugFile, url).href : null,
+      debug_file: debugFileUrl,
       debug_id: `${buildId.padEnd(32, '0').slice(0, 32)}0`,
     });
   }


### PR DESCRIPTION
Try-catch the URL creation to avoid throwing an error if a funky URL is encountered. 

fixes #8259 

This potentially messes up symbolication but I don't know at this time how/if our wasm integration can even handle modules loaded as blobs. 