### PR TITLE
fix(nextjs): Strip query params from transaction names of navigations to unknown routes

### DIFF
--- a/packages/nextjs/src/client/performance.ts
+++ b/packages/nextjs/src/client/performance.ts
@@ -143,7 +143,8 @@ export function nextRouterInstrumentation(
 
   if (startTransactionOnLocationChange) {
     Router.events.on('routeChangeStart', (navigationTarget: string) => {
-      const matchedRoute = getNextRouteFromPathname(stripUrlQueryAndFragment(navigationTarget));
+      const strippedNavigationTarget = stripUrlQueryAndFragment(navigationTarget);
+      const matchedRoute = getNextRouteFromPathname(strippedNavigationTarget);
 
       let transactionName: string;
       let transactionSource: TransactionSource;
@@ -152,7 +153,7 @@ export function nextRouterInstrumentation(
         transactionName = matchedRoute;
         transactionSource = 'route';
       } else {
-        transactionName = navigationTarget;
+        transactionName = strippedNavigationTarget;
         transactionSource = 'url';
       }
 

--- a/packages/nextjs/test/performance/client.test.ts
+++ b/packages/nextjs/test/performance/client.test.ts
@@ -231,6 +231,7 @@ describe('nextRouterInstrumentation', () => {
       ['/news', '/news', 'route'],
       ['/news/', '/news', 'route'],
       ['/some-route-that-is-not-defined-12332', '/some-route-that-is-not-defined-12332', 'url'], // unknown route
+      ['/some-route-that-is-not-defined-12332?q=42', '/some-route-that-is-not-defined-12332', 'url'], // unknown route w/ query param
       ['/posts/42', '/posts/[id]', 'route'],
       ['/posts/42/', '/posts/[id]', 'route'],
       ['/posts/42?someParam=1', '/posts/[id]', 'route'], // query params are ignored


### PR DESCRIPTION
It seems that the NextJS SDK is sometimes sending query parameters in transaction names as discovered by @jjbayer. This PR fixes a possible scenario in which this could happen, namely a navigation to an unknown route. While I can show the regression with a unit test, I'm not sure if this scenario could happen in an actual application. 

Internal conversation: https://sentry.slack.com/archives/C28MX5WAJ/p1685689501514019

