### PR TITLE
ref(svelte): Add Svelte 4 as a peer dependency

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -23,7 +23,7 @@
     "tslib": "^1.9.3"
   },
   "peerDependencies": {
-    "svelte": "3.x"
+    "svelte": "3.x || 4.x"
   },
   "devDependencies": {
     "@testing-library/svelte": "^3.2.1",


### PR DESCRIPTION
Svelte 4 [preview builds](https://www.npmjs.com/package/svelte/v/4.0.0-next.0) are out. I tested `4.0.0-next.0` with a standalone Svelte SPA (without Kit) and the SDK still works, including our component tracking feature. 
I think it's safe to add Svelte 4 as a valid peer dependency for this package.

Note, this doesn't yet address compatibility of Svelte 4 with the SvelteKit SDK. 

(feel free to take over/merge this PR at any time)