### PR TITLE
test(e2e): Disable concurrent tests for canary tests

### DIFF
--- a/packages/e2e-tests/lib/runAllTestApps.ts
+++ b/packages/e2e-tests/lib/runAllTestApps.ts
@@ -8,7 +8,11 @@ export async function runAllTestApps(
   recipePaths: string[],
   envVarsToInject: Record<string, string | undefined>,
 ): Promise<void> {
-  const maxParallel = process.env.CI ? 3 : 6;
+  const maxParallel = process.env.CANARY_E2E_TEST
+    ? 1 // TODO: figure out why concurrent tests fail for Next.js and remove this concurrency limitation
+    : process.env.CI
+    ? 3
+    : 6;
 
   const recipeInstances = constructRecipeInstances(recipePaths);
 


### PR DESCRIPTION
Due to some concurrency issue in our E2E tests the canary tests are consistently failing. This PR will make the canary tests (hopefully temporarily) non-concurrent so that the canary tests become useful again. 