### PR TITLE
test(remix): Update integration tests to Remix 1.17.0

### DIFF
--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -7,16 +7,16 @@
     "start": "remix-serve build"
   },
   "dependencies": {
-    "@remix-run/express": "1.9.0",
-    "@remix-run/node": "1.9.0",
-    "@remix-run/react": "1.9.0",
-    "@remix-run/serve": "1.9.0",
+    "@remix-run/express": "1.17.0",
+    "@remix-run/node": "1.17.0",
+    "@remix-run/react": "1.17.0",
+    "@remix-run/serve": "1.17.0",
     "@sentry/remix": "file:../..",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@remix-run/dev": "1.9.0",
+    "@remix-run/dev": "1.17.0",
     "@types/react": "^17.0.47",
     "@types/react-dom": "^17.0.17",
     "nock": "^13.1.0",

--- a/packages/remix/test/integration/test/client/root-loader.test.ts
+++ b/packages/remix/test/integration/test/client/root-loader.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, Page } from '@playwright/test';
 
 async function getRouteData(page: Page): Promise<any> {
-  return page.evaluate('window.__remixContext.routeData').catch(err => {
+  return page.evaluate('window.__remixContext.state.loaderData').catch(err => {
     console.warn(err);
 
     return {};


### PR DESCRIPTION
Updates the version of Remix used in integration tests to the latest 1.17.0, which is needed to test `handleError` and `defer` features.