### PR TITLE
feat(replay): Detect rage click (WIP)

### DIFF
--- a/packages/replay/src/coreHandlers/handleRageClick.ts
+++ b/packages/replay/src/coreHandlers/handleRageClick.ts
@@ -1,0 +1,36 @@
+import type { Breadcrumb } from '@sentry/types';
+import { timestampInSeconds } from '@sentry/utils';
+
+import { WINDOW } from '../constants';
+import type { ReplayContainer } from '../types';
+import { addBreadcrumbEvent } from './util/addBreadcrumbEvent';
+
+let clickCounter = 0;
+
+const RAGE_CLICK_TIME = 1_000;
+
+/**
+ * Detect if a rage click happened.
+ * This is defined if more than 4 clicks happen in 1s.
+ */
+export function detectRageClick(replay: ReplayContainer, clickBreadcrumb: Breadcrumb): void {
+  clickCounter++;
+
+  if (clickCounter === 4) {
+    const breadcrumb = {
+      message: clickBreadcrumb.message,
+      timestamp: timestampInSeconds(),
+      category: 'ui.rageClickDetected',
+      data: {
+        ...clickBreadcrumb.data,
+        url: WINDOW.location.href,
+        route: replay.getCurrentRoute(),
+        metric: true,
+      },
+    };
+
+    addBreadcrumbEvent(replay, breadcrumb);
+  }
+
+  setTimeout(() => clickCounter--, RAGE_CLICK_TIME);
+}


### PR DESCRIPTION
This is a very simple implementation to possibly detect rage clicks.

This does not take into account much, but allows us to do a super lean implementation. If we want to take into account more information (e.g. how long did it take to reach dead click, how many clicks in total, what was the initial clicked element), we'll need to keep track of all that, which is possible but makes this a lot more complex - I wonder if we need that?

Closes https://github.com/getsentry/sentry-javascript/issues/8300