### PR TITLE
feat(replay): Stop replay when event buffer exceeds max. size

### DIFF
--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -44,3 +44,6 @@ export const SLOW_CLICK_THRESHOLD = 3_000;
 export const SLOW_CLICK_SCROLL_TIMEOUT = 300;
 /* Clicks in this time period are considered e.g. double/triple clicks. */
 export const MULTI_CLICK_TIMEOUT = 1_000;
+
+/** When encountering a total segment size exceeding this size, stop the replay (as we cannot properly ingest it). */
+export const REPLAY_MAX_EVENT_BUFFER_SIZE = 20_000_000; // ~20MB

--- a/packages/replay/src/eventBuffer/EventBufferArray.ts
+++ b/packages/replay/src/eventBuffer/EventBufferArray.ts
@@ -1,5 +1,7 @@
+import { REPLAY_MAX_EVENT_BUFFER_SIZE } from '../constants';
 import type { AddEventResult, EventBuffer, EventBufferType, RecordingEvent } from '../types';
 import { timestampToMs } from '../util/timestampToMs';
+import { EventBufferSizeExceededError } from '.';
 
 /**
  * A basic event buffer that does not do any compression.
@@ -8,6 +10,7 @@ import { timestampToMs } from '../util/timestampToMs';
 export class EventBufferArray implements EventBuffer {
   /** All the events that are buffered to be sent. */
   public events: RecordingEvent[];
+  private _totalSize = 0;
 
   public constructor() {
     this.events = [];
@@ -30,6 +33,12 @@ export class EventBufferArray implements EventBuffer {
 
   /** @inheritdoc */
   public async addEvent(event: RecordingEvent): Promise<AddEventResult> {
+    const eventSize = JSON.stringify(event).length;
+    this._totalSize += eventSize;
+    if (this._totalSize > REPLAY_MAX_EVENT_BUFFER_SIZE) {
+      throw new EventBufferSizeExceededError();
+    }
+
     this.events.push(event);
   }
 
@@ -40,7 +49,7 @@ export class EventBufferArray implements EventBuffer {
       // events member so that we do not lose new events while uploading
       // attachment.
       const eventsRet = this.events;
-      this.events = [];
+      this.clear();
       resolve(JSON.stringify(eventsRet));
     });
   }
@@ -48,6 +57,7 @@ export class EventBufferArray implements EventBuffer {
   /** @inheritdoc */
   public clear(): void {
     this.events = [];
+    this._totalSize = 0;
   }
 
   /** @inheritdoc */

--- a/packages/replay/src/eventBuffer/index.ts
+++ b/packages/replay/src/eventBuffer/index.ts
@@ -1,6 +1,7 @@
 import { getWorkerURL } from '@sentry-internal/replay-worker';
 import { logger } from '@sentry/utils';
 
+import { REPLAY_MAX_EVENT_BUFFER_SIZE } from '../constants';
 import type { EventBuffer } from '../types';
 import { EventBufferArray } from './EventBufferArray';
 import { EventBufferProxy } from './EventBufferProxy';
@@ -29,4 +30,11 @@ export function createEventBuffer({ useCompression }: CreateEventBufferParams): 
 
   __DEBUG_BUILD__ && logger.log('[Replay] Using simple buffer');
   return new EventBufferArray();
+}
+
+/** This error indicates that the event buffer size exceeded the limit.. */
+export class EventBufferSizeExceededError extends Error {
+  public constructor() {
+    super(`Event buffer exceeded maximum size of ${REPLAY_MAX_EVENT_BUFFER_SIZE}.`);
+  }
 }

--- a/packages/replay/src/util/addEvent.ts
+++ b/packages/replay/src/util/addEvent.ts
@@ -2,6 +2,7 @@ import { EventType } from '@sentry-internal/rrweb';
 import { getCurrentHub } from '@sentry/core';
 import { logger } from '@sentry/utils';
 
+import { EventBufferSizeExceededError } from '../eventBuffer';
 import type { AddEventResult, RecordingEvent, ReplayContainer, ReplayFrameEvent } from '../types';
 import { timestampToMs } from './timestampToMs';
 
@@ -56,8 +57,10 @@ export async function addEvent(
 
     return await replay.eventBuffer.addEvent(eventAfterPossibleCallback);
   } catch (error) {
+    const reason = error && error instanceof EventBufferSizeExceededError ? 'addEventSizeExceeded' : 'addEvent';
+
     __DEBUG_BUILD__ && logger.error(error);
-    await replay.stop('addEvent');
+    await replay.stop(reason);
 
     const client = getCurrentHub().getClient();
 

--- a/packages/replay/test/unit/eventBuffer/EventBufferArray.test.ts
+++ b/packages/replay/test/unit/eventBuffer/EventBufferArray.test.ts
@@ -1,4 +1,5 @@
-import { createEventBuffer } from './../../../src/eventBuffer';
+import { REPLAY_MAX_EVENT_BUFFER_SIZE } from '../../../src/constants';
+import { createEventBuffer, EventBufferSizeExceededError } from './../../../src/eventBuffer';
 import { BASE_TIMESTAMP } from './../../index';
 
 const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
@@ -43,5 +44,57 @@ describe('Unit | eventBuffer | EventBufferArray', () => {
 
     expect(result1).toEqual(JSON.stringify([TEST_EVENT]));
     expect(result2).toEqual(JSON.stringify([]));
+  });
+
+  describe('size limit', () => {
+    it('rejects if size exceeds limit', async function () {
+      const buffer = createEventBuffer({ useCompression: false });
+
+      const largeEvent = {
+        data: { a: 'a'.repeat(REPLAY_MAX_EVENT_BUFFER_SIZE / 3) },
+        timestamp: BASE_TIMESTAMP,
+        type: 3,
+      };
+
+      await buffer.addEvent(largeEvent);
+      await buffer.addEvent(largeEvent);
+
+      // Now it should error
+      await expect(() => buffer.addEvent(largeEvent)).rejects.toThrowError(EventBufferSizeExceededError);
+    });
+
+    it('resets size limit on clear', async function () {
+      const buffer = createEventBuffer({ useCompression: false });
+
+      const largeEvent = {
+        data: { a: 'a'.repeat(REPLAY_MAX_EVENT_BUFFER_SIZE / 3) },
+        timestamp: BASE_TIMESTAMP,
+        type: 3,
+      };
+
+      await buffer.addEvent(largeEvent);
+      await buffer.addEvent(largeEvent);
+
+      await buffer.clear();
+
+      await buffer.addEvent(largeEvent);
+    });
+
+    it('resets size limit on finish', async function () {
+      const buffer = createEventBuffer({ useCompression: false });
+
+      const largeEvent = {
+        data: { a: 'a'.repeat(REPLAY_MAX_EVENT_BUFFER_SIZE / 3) },
+        timestamp: BASE_TIMESTAMP,
+        type: 3,
+      };
+
+      await buffer.addEvent(largeEvent);
+      await buffer.addEvent(largeEvent);
+
+      await buffer.finish();
+
+      await buffer.addEvent(largeEvent);
+    });
   });
 });

--- a/packages/replay/test/unit/util/addEvent.test.ts
+++ b/packages/replay/test/unit/util/addEvent.test.ts
@@ -1,6 +1,7 @@
 import 'jsdom-worker';
 
 import { BASE_TIMESTAMP } from '../..';
+import { REPLAY_MAX_EVENT_BUFFER_SIZE } from '../../../src/constants';
 import type { EventBufferProxy } from '../../../src/eventBuffer/EventBufferProxy';
 import { addEvent } from '../../../src/util/addEvent';
 import { setupReplayContainer } from '../../utils/setupReplayContainer';
@@ -26,6 +27,33 @@ describe('Unit | util | addEvent', () => {
     });
 
     await addEvent(replay, { data: {}, timestamp: BASE_TIMESTAMP + 10, type: 2 });
+
+    expect(replay.isEnabled()).toEqual(false);
+  });
+
+  it('stops when exceeding buffer size limit', async function () {
+    jest.setSystemTime(BASE_TIMESTAMP);
+
+    const replay = setupReplayContainer({
+      options: {
+        useCompression: true,
+      },
+    });
+
+    const largeEvent = {
+      data: { a: 'a'.repeat(REPLAY_MAX_EVENT_BUFFER_SIZE / 3) },
+      timestamp: BASE_TIMESTAMP,
+      type: 3,
+    };
+
+    await (replay.eventBuffer as EventBufferProxy).ensureWorkerIsLoaded();
+
+    await addEvent(replay, largeEvent);
+    await addEvent(replay, largeEvent);
+
+    expect(replay.isEnabled()).toEqual(true);
+
+    await addEvent(replay, largeEvent);
 
     expect(replay.isEnabled()).toEqual(false);
   });


### PR DESCRIPTION
When the buffer exceeds ~20MB, stop the replay.

Closes https://github.com/getsentry/sentry-javascript/issues/7657
Closes https://github.com/getsentry/team-replay/issues/94