### PR TITLE
fix(replay): Do not export types from `@sentry-internal/rrweb`

### DIFF
--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -1,5 +1,6 @@
 export { Replay } from './integration';
 export type {
+  eventWithTime,
   BreadcrumbFrame,
   BreadcrumbFrameEvent,
   OptionFrameEvent,
@@ -8,7 +9,3 @@ export type {
   SpanFrame,
   SpanFrameEvent,
 } from './types';
-export { EventType } from '@sentry-internal/rrweb';
-export { NodeType } from '@sentry-internal/rrweb-snapshot';
-export type { eventWithTime, fullSnapshotEvent } from '@sentry-internal/rrweb';
-export type { serializedNodeWithId } from '@sentry-internal/rrweb-snapshot';

--- a/packages/replay/test/integration/beforeAddRecordingEvent.test.ts
+++ b/packages/replay/test/integration/beforeAddRecordingEvent.test.ts
@@ -1,8 +1,9 @@
+import type { EventType } from '@sentry-internal/rrweb';
 import * as SentryCore from '@sentry/core';
 import type { Transport } from '@sentry/types';
 import * as SentryUtils from '@sentry/utils';
 
-import type { EventType, Replay } from '../../src';
+import type { Replay } from '../../src';
 import type { ReplayContainer } from '../../src/replay';
 import { clearSession } from '../../src/session/clearSession';
 import * as SendReplayRequest from '../../src/util/sendReplayRequest';


### PR DESCRIPTION
This breaks, as we do not have these packages as dependencies but devDependencies, but the types are not inlined...

This was introduced here: https://github.com/getsentry/sentry-javascript/pull/8284

Fixes https://github.com/getsentry/sentry-javascript/issues/8326
