### PR TITLE
fix(serverless): Export captureCheckIn

### DIFF
--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -18,6 +18,7 @@ export {
   captureEvent,
   captureException,
   captureMessage,
+  captureCheckIn,
   configureScope,
   createTransport,
   getActiveTransaction,


### PR DESCRIPTION
Export `captureCheckIn` from `@sentry/serverless` so it can be used from there.