### PR TITLE
fix(replay): Stop exporting `EventType` from `@sentry-internal/rrweb`

### DIFF
--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -1,5 +1,6 @@
 export { Replay } from './integration';
 export type {
+  EventType,
   eventWithTime,
   BreadcrumbFrame,
   BreadcrumbFrameEvent,

--- a/packages/replay/src/types/replayFrame.ts
+++ b/packages/replay/src/types/replayFrame.ts
@@ -1,4 +1,3 @@
-import type { EventType } from '@sentry-internal/rrweb';
 import type { Breadcrumb } from '@sentry/types';
 
 import type {
@@ -10,6 +9,7 @@ import type {
   PaintData,
   ResourceData,
 } from './performance';
+import type { EventType } from './rrweb';
 
 interface BaseBreadcrumbFrame {
   timestamp: number;

--- a/packages/replay/src/types/rrweb.ts
+++ b/packages/replay/src/types/rrweb.ts
@@ -1,9 +1,18 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import type { EventType } from '@sentry-internal/rrweb';
-
 type blockClass = string | RegExp;
 type maskTextClass = string | RegExp;
+
+/** Duplicate this from @sentry-internal/rrweb so we can export this as well. */
+export enum EventType {
+  DomContentLoaded = 0,
+  Load = 1,
+  FullSnapshot = 2,
+  IncrementalSnapshot = 3,
+  Meta = 4,
+  Custom = 5,
+  Plugin = 6,
+}
 
 /**
  * This is a partial copy of rrweb's eventWithTime type which only contains the properties

--- a/packages/replay/test/integration/beforeAddRecordingEvent.test.ts
+++ b/packages/replay/test/integration/beforeAddRecordingEvent.test.ts
@@ -1,4 +1,3 @@
-import type { EventType } from '@sentry-internal/rrweb';
 import * as SentryCore from '@sentry/core';
 import type { Transport } from '@sentry/types';
 import * as SentryUtils from '@sentry/utils';
@@ -6,6 +5,7 @@ import * as SentryUtils from '@sentry/utils';
 import type { Replay } from '../../src';
 import type { ReplayContainer } from '../../src/replay';
 import { clearSession } from '../../src/session/clearSession';
+import type { EventType } from '../../src/types';
 import * as SendReplayRequest from '../../src/util/sendReplayRequest';
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '../index';
 import { useFakeTimers } from '../utils/use-fake-timers';


### PR DESCRIPTION
To hopefully actually fix https://github.com/getsentry/sentry-javascript/issues/8326, for good this time...!