### PR TITLE
fix(core): Temporarily store debug IDs in stack frame and only put them into `debug_meta` before sending

### DIFF
--- a/packages/core/src/utils/prepareEvent.ts
+++ b/packages/core/src/utils/prepareEvent.ts
@@ -214,13 +214,11 @@ export function applyDebugMeta(event: Event): void {
   event.debug_meta.images = event.debug_meta.images || [];
   const images = event.debug_meta.images;
   Object.keys(filenameDebugIdMap).forEach(filename => {
-    if (filenameDebugIdMap[filename]) {
-      images.push({
-        type: 'sourcemap',
-        code_file: filename,
-        debug_id: filenameDebugIdMap[filename],
-      });
-    }
+    images.push({
+      type: 'sourcemap',
+      code_file: filename,
+      debug_id: filenameDebugIdMap[filename],
+    });
   });
 }
 

--- a/packages/core/src/utils/prepareEvent.ts
+++ b/packages/core/src/utils/prepareEvent.ts
@@ -75,8 +75,11 @@ export function prepareEvent(
   }
 
   return result.then(evt => {
-    // TODO explain why this is here
     if (evt) {
+      // We apply the debug_meta field only after all event processors have ran, so that if any event processors modified
+      // file names (e.g.the RewriteFrames integration) the filename -> debug ID relationship isn't destroyed.
+      // This should not cause any PII issues, since we're only moving data that is already on the event and not adding
+      // any new data
       applyDebugMeta(evt);
     }
 

--- a/packages/core/test/lib/prepareEvent.test.ts
+++ b/packages/core/test/lib/prepareEvent.test.ts
@@ -1,14 +1,14 @@
 import type { Event } from '@sentry/types';
 import { createStackParser, GLOBAL_OBJ } from '@sentry/utils';
 
-import { applyDebugMetadata } from '../../src/utils/prepareEvent';
+import { applyDebugIds, applyDebugMeta } from '../../src/utils/prepareEvent';
 
-describe('applyDebugMetadata', () => {
+describe('applyDebugIds', () => {
   afterEach(() => {
     GLOBAL_OBJ._sentryDebugIds = undefined;
   });
 
-  it('should put debug source map images in debug_meta field', () => {
+  it("should put debug IDs into an event's stack frames", () => {
     GLOBAL_OBJ._sentryDebugIds = {
       'filename1.js\nfilename1.js': 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa',
       'filename2.js\nfilename2.js': 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbb',
@@ -34,7 +34,63 @@ describe('applyDebugMetadata', () => {
       },
     };
 
-    applyDebugMetadata(event, stackParser);
+    applyDebugIds(event, stackParser);
+
+    expect(event.exception?.values?.[0].stacktrace?.frames).toContainEqual({
+      filename: 'filename1.js',
+      debug_id: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa',
+    });
+
+    expect(event.exception?.values?.[0].stacktrace?.frames).toContainEqual({
+      filename: 'filename2.js',
+      debug_id: 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbb',
+    });
+
+    // expect not to contain an image for the stack frame that doesn't have a corresponding debug id
+    expect(event.exception?.values?.[0].stacktrace?.frames).not.toContainEqual(
+      expect.objectContaining({
+        filename3: 'filename3.js',
+        debug_id: expect.any(String),
+      }),
+    );
+
+    // expect not to contain an image for the debug id mapping that isn't contained in the stack trace
+    expect(event.exception?.values?.[0].stacktrace?.frames).not.toContainEqual(
+      expect.objectContaining({
+        filename3: 'filename4.js',
+        debug_id: 'cccccccc-cccc-4ccc-cccc-cccccccccc',
+      }),
+    );
+  });
+});
+
+describe('applyDebugMeta', () => {
+  it("should move the debug IDs inside an event's stack frame into the debug_meta field", () => {
+    const event: Event = {
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                { filename: 'filename1.js', debug_id: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa' },
+                { filename: 'filename2.js', debug_id: 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbb' },
+                { filename: 'filename1.js', debug_id: 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaa' },
+                { filename: 'filename3.js' },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    applyDebugMeta(event);
+
+    expect(event.exception?.values?.[0].stacktrace?.frames).toEqual([
+      { filename: 'filename1.js' },
+      { filename: 'filename2.js' },
+      { filename: 'filename1.js' },
+      { filename: 'filename3.js' },
+    ]);
 
     expect(event.debug_meta?.images).toContainEqual({
       type: 'sourcemap',
@@ -47,22 +103,5 @@ describe('applyDebugMetadata', () => {
       code_file: 'filename2.js',
       debug_id: 'bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbb',
     });
-
-    // expect not to contain an image for the stack frame that doesn't have a corresponding debug id
-    expect(event.debug_meta?.images).not.toContainEqual(
-      expect.objectContaining({
-        type: 'sourcemap',
-        code_file: 'filename3.js',
-      }),
-    );
-
-    // expect not to contain an image for the debug id mapping that isn't contained in the stack trace
-    expect(event.debug_meta?.images).not.toContainEqual(
-      expect.objectContaining({
-        type: 'sourcemap',
-        code_file: 'filename4.js',
-        debug_id: 'cccccccc-cccc-4ccc-cccc-cccccccccc',
-      }),
-    );
   });
 });


### PR DESCRIPTION
We are currently facing the problem that the `RewriteFrames` integration, that is existing in many users setups, is breaking debug IDs. This is especially annoying when moving from the old release based source map process to the new debug ID based process.

How is the `RewriteFrames` integration is breaking debug IDs? Stack frames are linked to debug IDs via the `filename` value inside stack frames in the event and the `debug_file` value inside the `debug_meta` field. `filename` and `debug_file` are both generated *at event creation* (before any event processors run) and need to exactly match. When a `RewriteFrames` integration is active, it may register an event processor that modifies the `filename`. This causes the `filename` -> `debug_file` relationship to break, causing the entire debug ID process to break.

This PR aims to fix this by putting `debug_id` values directly on the stack frame objects inside events and only transferring them over to `debug_meta` after all event processors ran, right before the event is sent. This way, we guarantee that the stack frames will always point to a debug ID (if there is one).