### PR TITLE
test(e2e): Add test for Next.js middleware

### DIFF
--- a/packages/e2e-tests/test-applications/nextjs-app-dir/middleware.ts
+++ b/packages/e2e-tests/test-applications/nextjs-app-dir/middleware.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware() {
+  return NextResponse.next();
+}
+
+// See "Matching Paths" below to learn more
+export const config = {
+  matcher: ['/api/endpoint-behind-middleware'],
+};

--- a/packages/e2e-tests/test-applications/nextjs-app-dir/pages/api/endpoint-behind-middleware.ts
+++ b/packages/e2e-tests/test-applications/nextjs-app-dir/pages/api/endpoint-behind-middleware.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type Data = {
+  name: string;
+};
+
+export default function handler(req: NextApiRequest, res: NextApiResponse<Data>) {
+  res.status(200).json({ name: 'John Doe' });
+}


### PR DESCRIPTION
Adds tests for Next.js middleware.

Ref: https://github.com/getsentry/sentry-javascript/issues/6906