### PR TITLE
fix(vue): Don't call `next` in Vue router 4 instrumentation

### DIFF
--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -39,7 +39,7 @@ export type Route = {
 
 interface VueRouter {
   onError: (fn: (err: Error) => void) => void;
-  beforeEach: (fn: (to: Route, from: Route, next: () => void) => void) => void;
+  beforeEach: (fn: (to: Route, from: Route, next?: () => void) => void) => void;
 }
 
 /**
@@ -129,7 +129,12 @@ export function vueRouterInstrumentation(
         });
       }
 
-      next();
+      // Vue Router 4 no longer exposes the `next` function, so we need to
+      // check if it's available before calling it.
+      // `next` needs to be called in Vue Router 3 so that the hook is resolved.
+      if (next) {
+        next();
+      }
     });
   };
 }


### PR DESCRIPTION
Vue Router 4 no longer exposes a `next` resolver function to call inside a `beforeEach` [router guard callback](https://router.vuejs.org/guide/advanced/navigation-guards.html#global-before-guards). Instead it will resolve the hook when the callback function returns.

This PR checks if `next` is available and adjusts the types accordingly. 

fixes #8349
