### PR TITLE
fix(angular): Filter out `TryCatch` integration by default

### DIFF
--- a/packages/angular/test/sdk.test.ts
+++ b/packages/angular/test/sdk.test.ts
@@ -1,6 +1,6 @@
 import * as SentryBrowser from '@sentry/browser';
 
-import { init } from '../src/sdk';
+import { defaultIntegrations, init } from '../src/index';
 
 describe('init', () => {
   it('sets the Angular version (if available) in the global scope', () => {
@@ -12,5 +12,34 @@ describe('init', () => {
     // (and hence the dependency version of Angular core we installed (see package.json))
     expect(setContextSpy).toHaveBeenCalledTimes(1);
     expect(setContextSpy).toHaveBeenCalledWith('angular', { version: 10 });
+  });
+
+  describe('filtering out the `TryCatch` integration', () => {
+    const browserInitSpy = jest.spyOn(SentryBrowser, 'init');
+
+    beforeEach(() => {
+      browserInitSpy.mockClear();
+    });
+
+    it('filters if `defaultIntegrations` is not set', () => {
+      init({});
+
+      expect(browserInitSpy).toHaveBeenCalledTimes(1);
+
+      const options = browserInitSpy.mock.calls[0][0] || {};
+      expect(options.defaultIntegrations).not.toContainEqual(expect.objectContaining({ name: 'TryCatch' }));
+    });
+
+    it.each([false as const, defaultIntegrations])(
+      "doesn't filter if `defaultIntegrations` is set to %s",
+      defaultIntegrations => {
+        init({ defaultIntegrations });
+
+        expect(browserInitSpy).toHaveBeenCalledTimes(1);
+
+        const options = browserInitSpy.mock.calls[0][0] || {};
+        expect(options.defaultIntegrations).toEqual(defaultIntegrations);
+      },
+    );
   });
 });


### PR DESCRIPTION
As explained in https://github.com/getsentry/sentry-javascript/issues/5417#issuecomment-1453407097, the `TryCatch` default integration interferes with the `SentryErrorHander` error handler of the Angular(-Ivy) SDKs by catching certain errors too early, before the Angular SDK-specific error handler can catch them. This caused missing data on the event in some or duplicated errors in other cases.

This PR filters out the `TryCatch` by default, as long as users didn't set `defaultIntegrations` in their SDK init. Therefore, it makes the previously provided [workaround](https://github.com/getsentry/sentry-javascript/issues/5417#issuecomment-1453407097) obsolete.

The fix isn't ideal for two reasons but IMO we should nevertheless do this now to fix a long lasting problem and clean things up in v8:
- If users did not set up `SentryErrorHandler` as documented, certain errors might not be caught anymore. However, I don't think we should degrade the Sentry experience for everyone who set up the SDK correctly to account for this edge case. 
- We cannot remove the `TryCatch` integration from the exported `defaultIntegrations` array of the SDK as this would be a breaking change. This also means that the integration will be bundled and only filtered at runtime for now. I've added the removal of the integration to our v8 deprecation/removals list (#5194).

closes #2744
ref #5417