### PR TITLE
test(e2e): Ensure sveltekit E2E test work with prereleases

### DIFF
--- a/packages/e2e-tests/test-applications/sveltekit/package.json
+++ b/packages/e2e-tests/test-applications/sveltekit/package.json
@@ -27,5 +27,11 @@
     "vite": "^4.2.0",
     "wait-port": "1.0.4"
   },
+  "pnpm": {
+    "overrides": {
+      "@sentry/node": "*",
+      "@sentry/tracing": "*"
+    }
+  },
   "type": "module"
 }


### PR DESCRIPTION
Since @sentry/sveltekit depends on @sentry/vite-plugin, which in turn depens on `@sentry/node@^7.19.0` & `@sentry/tracing@^7.19.0`, this fails to install in E2E tests for pre-release versions (e.g. `7.57.0-beta.0`), as the prerelease does not satisfy the range `^7.19.0`. So we override this to `*` to ensure this works as expected.

(Side note: We should maybe update @sentry/sveltekit to use the latest @sentry/vite-plugin?)
