### PR TITLE
fix(replay): Mark ui.slowClickDetected `clickCount` as optional

### DIFF
--- a/packages/replay/src/types/replayFrame.ts
+++ b/packages/replay/src/types/replayFrame.ts
@@ -91,7 +91,7 @@ interface SlowClickFrameData extends ClickFrameData {
   route?: string;
   timeAfterClickMs: number;
   endReason: string;
-  clickCount: number;
+  clickCount?: number;
 }
 export interface SlowClickFrame extends BaseBreadcrumbFrame {
   category: 'ui.slowClickDetected';


### PR DESCRIPTION
This field was added as part of v7.56.0, but `SlowClickFrameData` was created before that. Having `clickCount` be required breaks backwards compatibility, it should be optional.

