### PR TITLE
fix(sveltekit): Only instrument SvelteKit `fetch` if the SDK client is valid

### DIFF
--- a/packages/sveltekit/test/client/load.test.ts
+++ b/packages/sveltekit/test/client/load.test.ts
@@ -1,4 +1,3 @@
-import * as sentryCore from '@sentry/core';
 import { addTracingExtensions, Scope } from '@sentry/svelte';
 import { baggageHeaderToDynamicSamplingContext } from '@sentry/utils';
 import type { Load } from '@sveltejs/kit';


### PR DESCRIPTION
In the client-side SvelteKit fetch instrumentation, our previous type cast when retrieving the SDK client was wrong, causing us to not guard the fetch instrumentation correctly if the client was undefined. (We did account for the `getClientById` method but missed the more obvious case)

fixes #8290