### PR TITLE
fix(serverless): Export `autoDiscoverNodePerformanceMonitoringIntegrations` from SDK

### DIFF
--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -15,6 +15,7 @@ export {
   Scope,
   addBreadcrumb,
   addGlobalEventProcessor,
+  autoDiscoverNodePerformanceMonitoringIntegrations,
   captureEvent,
   captureException,
   captureMessage,


### PR DESCRIPTION
When refactoring our `@sentry/tracing` package and exporting tracing related integrations from SDK packages, we apparently forgot to export `autoDiscoverNodePerformanceMonitoringIntegrations` from the Serverless SDK. This PR re-adds the export.

ref https://github.com/getsentry/sentry-docs/issues/7221