### PR TITLE
fix(tracing): Instrument Prisma client in constructor of integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,7 @@ jobs:
               - 'scripts/**'
               - 'packages/core/**'
               - 'packages/tracing/**'
+              - 'packages/tracing-internal/**'
               - 'packages/utils/**'
               - 'packages/types/**'
               - 'packages/integrations/**'

--- a/packages/tracing-internal/src/node/integrations/prisma.ts
+++ b/packages/tracing-internal/src/node/integrations/prisma.ts
@@ -67,12 +67,11 @@ export class Prisma implements Integration {
     if (isValidPrismaClient(options.client) && !options.client._sentryInstrumented) {
       addNonEnumerableProperty(options.client as any, '_sentryInstrumented', true);
 
-      if (shouldDisableAutoInstrumentation(getCurrentHub)) {
-        __DEBUG_BUILD__ && logger.log('Prisma Integration is skipped because of instrumenter configuration.');
-        return;
-      }
-
       options.client.$use((params, next: (params: PrismaMiddlewareParams) => Promise<unknown>) => {
+        if (shouldDisableAutoInstrumentation(getCurrentHub)) {
+          return next(params);
+        }
+
         const action = params.action;
         const model = params.model;
         return trace(

--- a/packages/tracing-internal/src/node/integrations/prisma.ts
+++ b/packages/tracing-internal/src/node/integrations/prisma.ts
@@ -1,7 +1,6 @@
-import type { Hub } from '@sentry/core';
-import { trace } from '@sentry/core';
-import type { EventProcessor, Integration } from '@sentry/types';
-import { logger } from '@sentry/utils';
+import { getCurrentHub, trace } from '@sentry/core';
+import type { Integration } from '@sentry/types';
+import { addNonEnumerableProperty, logger } from '@sentry/utils';
 
 import { shouldDisableAutoInstrumentation } from './utils/node-utils';
 
@@ -36,6 +35,7 @@ type PrismaMiddleware<T = unknown> = (
 ) => Promise<T>;
 
 interface PrismaClient {
+  _sentryInstrumented?: boolean;
   $use: (cb: PrismaMiddleware) => void;
 }
 
@@ -56,16 +56,30 @@ export class Prisma implements Integration {
   public name: string = Prisma.id;
 
   /**
-   * Prisma ORM Client Instance
-   */
-  private readonly _client?: PrismaClient;
-
-  /**
    * @inheritDoc
    */
   public constructor(options: { client?: unknown } = {}) {
-    if (isValidPrismaClient(options.client)) {
-      this._client = options.client;
+    // We instrument the PrismaClient inside the constructor and not inside `setupOnce` because in some cases of server-side
+    // bundling (Next.js) multiple Prisma clients can be instantiated, even though users don't intend to. When instrumenting
+    // in setupOnce we can only ever instrument one client.
+    // https://github.com/getsentry/sentry-javascript/issues/7216#issuecomment-1602375012
+    // In the future we might explore providing a dedicated PrismaClient middleware instead of this hack.
+    if (isValidPrismaClient(options.client) && !options.client._sentryInstrumented) {
+      addNonEnumerableProperty(options.client as any, '_sentryInstrumented', true);
+
+      if (shouldDisableAutoInstrumentation(getCurrentHub)) {
+        __DEBUG_BUILD__ && logger.log('Prisma Integration is skipped because of instrumenter configuration.');
+        return;
+      }
+
+      options.client.$use((params, next: (params: PrismaMiddlewareParams) => Promise<unknown>) => {
+        const action = params.action;
+        const model = params.model;
+        return trace(
+          { name: model ? `${model} ${action}` : action, op: 'db.sql.prisma', data: { 'db.system': 'prisma' } },
+          () => next(params),
+        );
+      });
     } else {
       __DEBUG_BUILD__ &&
         logger.warn(
@@ -77,24 +91,7 @@ export class Prisma implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    if (!this._client) {
-      __DEBUG_BUILD__ && logger.error('PrismaIntegration is missing a Prisma Client Instance');
-      return;
-    }
-
-    if (shouldDisableAutoInstrumentation(getCurrentHub)) {
-      __DEBUG_BUILD__ && logger.log('Prisma Integration is skipped because of instrumenter configuration.');
-      return;
-    }
-
-    this._client.$use((params, next: (params: PrismaMiddlewareParams) => Promise<unknown>) => {
-      const action = params.action;
-      const model = params.model;
-      return trace(
-        { name: model ? `${model} ${action}` : action, op: 'db.sql.prisma', data: { 'db.system': 'prisma' } },
-        () => next(params),
-      );
-    });
+  public setupOnce(): void {
+    // Noop - here for backwards compatibility
   }
 }

--- a/packages/tracing/test/integrations/node/prisma.test.ts
+++ b/packages/tracing/test/integrations/node/prisma.test.ts
@@ -1,7 +1,6 @@
 /* eslint-disable deprecation/deprecation */
 import * as sentryCore from '@sentry/core';
 import { Hub } from '@sentry/core';
-import { logger } from '@sentry/utils';
 
 import { Integrations } from '../../../src';
 import { getTestClient } from '../../testutils';

--- a/packages/tracing/test/integrations/node/prisma.test.ts
+++ b/packages/tracing/test/integrations/node/prisma.test.ts
@@ -1,10 +1,7 @@
 /* eslint-disable deprecation/deprecation */
-/* eslint-disable @typescript-eslint/unbound-method */
-import { Hub, Scope } from '@sentry/core';
 import { logger } from '@sentry/utils';
 
 import { Integrations } from '../../../src';
-import { getTestClient } from '../../testutils';
 
 const mockTrace = jest.fn();
 
@@ -41,10 +38,7 @@ describe('setupOnce', function () {
   const Client: PrismaClient = new PrismaClient();
 
   beforeAll(() => {
-    new Integrations.Prisma({ client: Client }).setupOnce(
-      () => undefined,
-      () => new Hub(undefined, new Scope()),
-    );
+    new Integrations.Prisma({ client: Client });
   });
 
   beforeEach(() => {
@@ -65,14 +59,7 @@ describe('setupOnce', function () {
   it("doesn't attach when using otel instrumenter", () => {
     const loggerLogSpy = jest.spyOn(logger, 'log');
 
-    const client = getTestClient({ instrumenter: 'otel' });
-    const hub = new Hub(client);
-
-    const integration = new Integrations.Prisma({ client: Client });
-    integration.setupOnce(
-      () => {},
-      () => hub,
-    );
+    new Integrations.Prisma({ client: Client });
 
     expect(loggerLogSpy).toBeCalledWith('Prisma Integration is skipped because of instrumenter configuration.');
   });


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/7216

Adds the Prisma middleware to trace DB calls inside the Sentry Prisma integration constructor instead of inside the `setupOnce` call. Reason being some server-side bundling scenarios (Next.js) where Prisma clients are unintentionally created multiple times. We can only instrument one Prisma client with `setupOnce` hence we move it into the constructor, which is usually called in the same situations as the `PrismaClient` constructor.

For more info view: https://github.com/getsentry/sentry-javascript/issues/7216#issuecomment-1602375012 (This PR implements option 2)