### PR TITLE
fix(sveltekit): Check for cached requests in client-side fetch instrumentation

### DIFF
--- a/packages/sveltekit/src/client/vendor/buildSelector.ts
+++ b/packages/sveltekit/src/client/vendor/buildSelector.ts
@@ -1,0 +1,57 @@
+/* eslint-disable @sentry-internal/sdk/no-optional-chaining */
+
+// Vendored from https://github.com/sveltejs/kit/blob/1c1ddd5e34fce28e6f89299d6c59162bed087589/packages/kit/src/runtime/client/fetcher.js
+// with types only changes.
+
+// The MIT License (MIT)
+
+// Copyright (c) 2020 [these people](https://github.com/sveltejs/kit/graphs/contributors)
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import { hash } from './hash';
+
+/**
+ * Build the cache key for a given request
+ * @param {URL | RequestInfo} resource
+ * @param {RequestInit} [opts]
+ */
+export function build_selector(resource: URL | RequestInfo, opts: RequestInit | undefined): string {
+  const url = JSON.stringify(resource instanceof Request ? resource.url : resource);
+
+  let selector = `script[data-sveltekit-fetched][data-url=${url}]`;
+
+  if (opts?.headers || opts?.body) {
+    /** @type {import('types').StrictBody[]} */
+    const values = [];
+
+    if (opts.headers) {
+      // @ts-ignore - TS complains but this is a 1:1 copy of the original code and apparently it works
+      values.push([...new Headers(opts.headers)].join(','));
+    }
+
+    if (opts.body && (typeof opts.body === 'string' || ArrayBuffer.isView(opts.body))) {
+      values.push(opts.body);
+    }
+
+    selector += `[data-hash="${hash(...values)}"]`;
+  }
+
+  return selector;
+}

--- a/packages/sveltekit/src/client/vendor/hash.ts
+++ b/packages/sveltekit/src/client/vendor/hash.ts
@@ -1,0 +1,51 @@
+/* eslint-disable no-bitwise */
+
+// Vendored from https://github.com/sveltejs/kit/blob/1c1ddd5e34fce28e6f89299d6c59162bed087589/packages/kit/src/runtime/hash.js
+// with types only changes.
+
+// The MIT License (MIT)
+
+// Copyright (c) 2020 [these people](https://github.com/sveltejs/kit/graphs/contributors)
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import type { StrictBody } from '@sveltejs/kit/types/internal';
+
+/**
+ * Hash using djb2
+ * @param {import('types').StrictBody[]} values
+ */
+export function hash(...values: StrictBody[]): string {
+  let hash = 5381;
+
+  for (const value of values) {
+    if (typeof value === 'string') {
+      let i = value.length;
+      while (i) hash = (hash * 33) ^ value.charCodeAt(--i);
+    } else if (ArrayBuffer.isView(value)) {
+      const buffer = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+      let i = buffer.length;
+      while (i) hash = (hash * 33) ^ buffer[--i];
+    } else {
+      throw new TypeError('value must be a string or TypedArray');
+    }
+  }
+
+  return (hash >>> 0).toString(36);
+}

--- a/packages/sveltekit/src/client/vendor/lookUpCache.ts
+++ b/packages/sveltekit/src/client/vendor/lookUpCache.ts
@@ -1,0 +1,79 @@
+/* eslint-disable no-bitwise */
+
+// Parts of this code are taken from https://github.com/sveltejs/kit/blob/1c1ddd5e34fce28e6f89299d6c59162bed087589/packages/kit/src/runtime/client/fetcher.js
+// Attribution given directly in the function code below
+
+// The MIT License (MIT)
+
+// Copyright (c) 2020 [these people](https://github.com/sveltejs/kit/graphs/contributors)
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import { WINDOW } from '@sentry/svelte';
+import { getDomElement } from '@sentry/utils';
+
+import { build_selector } from './buildSelector';
+
+/**
+ * Checks if a request is cached by looking for a script tag with the same selector as the constructed selector of the request.
+ *
+ * This function is a combination of the cache lookups in sveltekit's internal client-side fetch functions
+ * - initial_fetch (used during hydration) https://github.com/sveltejs/kit/blob/1c1ddd5e34fce28e6f89299d6c59162bed087589/packages/kit/src/runtime/client/fetcher.js#L76
+ * - subsequent_fetch (used afterwards) https://github.com/sveltejs/kit/blob/1c1ddd5e34fce28e6f89299d6c59162bed087589/packages/kit/src/runtime/client/fetcher.js#L98
+ *
+ * Parts of this function's logic is taken from SvelteKit source code.
+ * These lines are annotated with attribution in comments above them.
+ *
+ * @param input first fetch param
+ * @param init second fetch param
+ * @returns true if a cache hit was encountered, false otherwise
+ */
+export function isRequestCached(input: URL | RequestInfo, init: RequestInit | undefined): boolean {
+  // build_selector call copied from https://github.com/sveltejs/kit/blob/1c1ddd5e34fce28e6f89299d6c59162bed087589/packages/kit/src/runtime/client/fetcher.js#L77
+  const selector = build_selector(input, init);
+
+  const script = getDomElement<HTMLScriptElement>(selector);
+
+  if (!script) {
+    return false;
+  }
+
+  // If the script has a data-ttl attribute, we check if we're still in the TTL window:
+  try {
+    // ttl retrieval taken from https://github.com/sveltejs/kit/blob/1c1ddd5e34fce28e6f89299d6c59162bed087589/packages/kit/src/runtime/client/fetcher.js#L83-L84
+    const ttl = Number(script.getAttribute('data-ttl')) * 1000;
+
+    if (isNaN(ttl)) {
+      return false;
+    }
+
+    if (ttl) {
+      // cache hit determination taken from: https://github.com/sveltejs/kit/blob/1c1ddd5e34fce28e6f89299d6c59162bed087589/packages/kit/src/runtime/client/fetcher.js#L105-L106
+      return (
+        WINDOW.performance.now() < ttl &&
+        ['default', 'force-cache', 'only-if-cached', undefined].includes(init && init.cache)
+      );
+    }
+  } catch {
+    return false;
+  }
+
+  // Otherwise, we check if the script has a content and return true in that case
+  return !!script.textContent;
+}

--- a/packages/sveltekit/test/client/load.test.ts
+++ b/packages/sveltekit/test/client/load.test.ts
@@ -1,6 +1,5 @@
 import { addTracingExtensions, Scope } from '@sentry/svelte';
 import { baggageHeaderToDynamicSamplingContext } from '@sentry/utils';
-import * as utils from '@sentry/utils';
 import type { Load } from '@sveltejs/kit';
 import { redirect } from '@sveltejs/kit';
 import { vi } from 'vitest';
@@ -28,9 +27,9 @@ vi.mock('@sentry/svelte', async () => {
   };
 });
 
-vi.spyOn(utils, 'getDomElement').mockImplementation(() => {
+vi.mock('../../src/client/vendor/lookUpCache', () => {
   return {
-    textContent: 'test',
+    isRequestCached: () => false,
   };
 });
 
@@ -440,7 +439,6 @@ describe('wrapLoadWithSentry', () => {
     ['is undefined', undefined],
     ["doesn't have a `getClientById` method", {}],
   ])("doesn't instrument fetch if the client %s", async (_, client) => {
-    // @ts-expect-error: we're mocking the client
     mockedGetClient.mockImplementationOnce(() => client);
 
     async function load(_event: Parameters<Load>[0]): Promise<ReturnType<Load>> {

--- a/packages/sveltekit/test/client/load.test.ts
+++ b/packages/sveltekit/test/client/load.test.ts
@@ -1,5 +1,6 @@
 import { addTracingExtensions, Scope } from '@sentry/svelte';
 import { baggageHeaderToDynamicSamplingContext } from '@sentry/utils';
+import * as utils from '@sentry/utils';
 import type { Load } from '@sveltejs/kit';
 import { redirect } from '@sveltejs/kit';
 import { vi } from 'vitest';
@@ -24,6 +25,12 @@ vi.mock('@sentry/svelte', async () => {
       mockCaptureException(err, cb);
       return original.captureException(err, cb);
     },
+  };
+});
+
+vi.spyOn(utils, 'getDomElement').mockImplementation(() => {
+  return {
+    textContent: 'test',
   };
 });
 

--- a/packages/sveltekit/test/client/vendor/lookUpCache.test.ts
+++ b/packages/sveltekit/test/client/vendor/lookUpCache.test.ts
@@ -1,4 +1,3 @@
-import * as utils from '@sentry/utils';
 import { JSDOM } from 'jsdom';
 import { vi } from 'vitest';
 

--- a/packages/sveltekit/test/client/vendor/lookUpCache.test.ts
+++ b/packages/sveltekit/test/client/vendor/lookUpCache.test.ts
@@ -1,0 +1,68 @@
+import * as utils from '@sentry/utils';
+import { vi } from 'vitest';
+
+import { isRequestCached } from '../../../src/client/vendor/lookUpCache';
+
+let scriptElement: {
+  textContent: string;
+  getAttribute: (name: string) => string | null;
+} | null;
+
+vi.spyOn(utils, 'getDomElement').mockImplementation(() => {
+  return scriptElement;
+});
+
+describe('isRequestCached', () => {
+  it('should return true if a script tag with the same selector as the constructed request selector is found', () => {
+    scriptElement = {
+      textContent: 'test',
+      getAttribute: () => null,
+    };
+
+    expect(isRequestCached('/api/todos/1', undefined)).toBe(true);
+  });
+
+  it('should return false if a script with the same selector as the constructed request selector is not found', () => {
+    scriptElement = null;
+
+    expect(isRequestCached('/api/todos/1', undefined)).toBe(false);
+  });
+
+  it('should return true if a script with the same selector as the constructed request selector is found and its TTL is valid', () => {
+    scriptElement = {
+      textContent: 'test',
+      getAttribute: () => (performance.now() / 1000 + 1).toString(),
+    };
+
+    expect(isRequestCached('/api/todos/1', undefined)).toBe(true);
+  });
+
+  it('should return false if a script with the same selector as the constructed request selector is found and its TTL is expired', () => {
+    scriptElement = {
+      textContent: 'test',
+      getAttribute: () => (performance.now() / 1000 - 1).toString(),
+    };
+
+    expect(isRequestCached('/api/todos/1', undefined)).toBe(false);
+  });
+
+  it("should return false if the TTL is set but can't be parsed", () => {
+    scriptElement = {
+      textContent: 'test',
+      getAttribute: () => 'NotANumber',
+    };
+
+    expect(isRequestCached('/api/todos/1', undefined)).toBe(false);
+  });
+
+  it('should return false if an error was thrown turing TTL evaluation', () => {
+    scriptElement = {
+      textContent: 'test',
+      getAttribute: () => {
+        throw new Error('test');
+      },
+    };
+
+    expect(isRequestCached('/api/todos/1', undefined)).toBe(false);
+  });
+});

--- a/packages/sveltekit/test/client/vendor/lookUpCache.test.ts
+++ b/packages/sveltekit/test/client/vendor/lookUpCache.test.ts
@@ -1,67 +1,45 @@
 import * as utils from '@sentry/utils';
+import { JSDOM } from 'jsdom';
 import { vi } from 'vitest';
 
 import { isRequestCached } from '../../../src/client/vendor/lookUpCache';
 
-let scriptElement: {
-  textContent: string;
-  getAttribute: (name: string) => string | null;
-} | null;
+globalThis.document = new JSDOM().window.document;
 
-vi.spyOn(utils, 'getDomElement').mockImplementation(() => {
-  return scriptElement;
-});
+vi.useFakeTimers().setSystemTime(new Date('2023-06-22'));
+vi.spyOn(performance, 'now').mockReturnValue(1000);
 
 describe('isRequestCached', () => {
   it('should return true if a script tag with the same selector as the constructed request selector is found', () => {
-    scriptElement = {
-      textContent: 'test',
-      getAttribute: () => null,
-    };
+    globalThis.document.body.innerHTML =
+      '<script type="application/json" data-sveltekit-fetched data-url="/api/todos/1">{"status":200}</script>';
 
     expect(isRequestCached('/api/todos/1', undefined)).toBe(true);
   });
 
   it('should return false if a script with the same selector as the constructed request selector is not found', () => {
-    scriptElement = null;
+    globalThis.document.body.innerHTML = '';
 
     expect(isRequestCached('/api/todos/1', undefined)).toBe(false);
   });
 
   it('should return true if a script with the same selector as the constructed request selector is found and its TTL is valid', () => {
-    scriptElement = {
-      textContent: 'test',
-      getAttribute: () => (performance.now() / 1000 + 1).toString(),
-    };
+    globalThis.document.body.innerHTML =
+      '<script type="application/json" data-sveltekit-fetched data-url="/api/todos/1" data-ttl="10">{"status":200}</script>';
 
     expect(isRequestCached('/api/todos/1', undefined)).toBe(true);
   });
 
   it('should return false if a script with the same selector as the constructed request selector is found and its TTL is expired', () => {
-    scriptElement = {
-      textContent: 'test',
-      getAttribute: () => (performance.now() / 1000 - 1).toString(),
-    };
+    globalThis.document.body.innerHTML =
+      '<script type="application/json" data-sveltekit-fetched data-url="/api/todos/1" data-ttl="1">{"status":200}</script>';
 
     expect(isRequestCached('/api/todos/1', undefined)).toBe(false);
   });
 
-  it("should return false if the TTL is set but can't be parsed", () => {
-    scriptElement = {
-      textContent: 'test',
-      getAttribute: () => 'NotANumber',
-    };
-
-    expect(isRequestCached('/api/todos/1', undefined)).toBe(false);
-  });
-
-  it('should return false if an error was thrown turing TTL evaluation', () => {
-    scriptElement = {
-      textContent: 'test',
-      getAttribute: () => {
-        throw new Error('test');
-      },
-    };
+  it("should return false if the TTL is set but can't be parsed as a number", () => {
+    globalThis.document.body.innerHTML =
+      '<script type="application/json" data-sveltekit-fetched data-url="/api/todos/1" data-ttl="notANumber">{"status":200}</script>';
 
     expect(isRequestCached('/api/todos/1', undefined)).toBe(false);
   });

--- a/packages/sveltekit/test/vitest.setup.ts
+++ b/packages/sveltekit/test/vitest.setup.ts
@@ -11,3 +11,9 @@ export function setup() {
     };
   });
 }
+
+if (!globalThis.fetch) {
+  // @ts-ignore dfsf
+  globalThis.Request = class Request {};
+}
+console.log(globalThis.fetch, globalThis.Response, globalThis.Request);

--- a/packages/sveltekit/test/vitest.setup.ts
+++ b/packages/sveltekit/test/vitest.setup.ts
@@ -13,7 +13,6 @@ export function setup() {
 }
 
 if (!globalThis.fetch) {
-  // @ts-ignore dfsf
+  // @ts-ignore - Needed for vitest to work with SvelteKit fetch instrumentation
   globalThis.Request = class Request {};
 }
-console.log(globalThis.fetch, globalThis.Response, globalThis.Request);


### PR DESCRIPTION
As outlined in https://github.com/getsentry/sentry-javascript/issues/8174#issuecomment-1557042801, our current SvelteKit fetch instrumentation breaks SvelteKit's request caching mechanism. This is problematic as `fetch` requests from universal `load` functions were made again on the client side during hydration although the response was already cached from the initial server-side request. 

The reason for the cache miss is that in the instrumentation we add our tracing headers to the requests, which lead to a different cache key than the one produced on the server side.

This PR vendors in code from [the SvelteKit repo](https://github.com/sveltejs/kit) so that we can perform the same cache lookup in our instrumentation. If the lookup was successful (--> cache hit), we won't attach any headers or create breadcrumbs to 1. let Kit's fetch return the cached response and 2. not add spans for a fetch request that didn't even happen. 

Small rant:
I would love to get rid of this code again because it's brittle (hash seed 👀) and adds a good chunk of bundle size. I tried to [fix this](https://github.com/sveltejs/kit/pull/10009) in SvelteKit but the maintainers don't seem to have a big interest in reviewing/merging this. If SvelteKit would just use `window.fetch` and add their caching logic around it (which is def. possible), we could get rid of 100s of LoC in this SDK. 
For the time being though, we need to add this ugly fix to get rid of the cache misses we cause. 

Since this is vendored code, I opted to put it into a `vendor` subdirectory and added the original MIT license from the Sveltekit repo. 

fixes #8174 
