### PR TITLE
ref(replay): More graceful `sessionStorage` check

### DIFF
--- a/packages/replay/src/session/clearSession.ts
+++ b/packages/replay/src/session/clearSession.ts
@@ -1,5 +1,6 @@
 import { REPLAY_SESSION_KEY, WINDOW } from '../../src/constants';
 import type { ReplayContainer } from '../../src/types';
+import { hasSessionStorage } from '../util/hasSessionStorage';
 
 /**
  * Removes the session from Session Storage and unsets session in replay instance
@@ -13,9 +14,7 @@ export function clearSession(replay: ReplayContainer): void {
  * Deletes a session from storage
  */
 function deleteSession(): void {
-  const hasSessionStorage = 'sessionStorage' in WINDOW;
-
-  if (!hasSessionStorage) {
+  if (!hasSessionStorage()) {
     return;
   }
 

--- a/packages/replay/src/session/fetchSession.ts
+++ b/packages/replay/src/session/fetchSession.ts
@@ -1,14 +1,13 @@
 import { REPLAY_SESSION_KEY, WINDOW } from '../constants';
 import type { Session } from '../types';
+import { hasSessionStorage } from '../util/hasSessionStorage';
 import { makeSession } from './Session';
 
 /**
  * Fetches a session from storage
  */
 export function fetchSession(): Session | null {
-  const hasSessionStorage = 'sessionStorage' in WINDOW;
-
-  if (!hasSessionStorage) {
+  if (!hasSessionStorage()) {
     return null;
   }
 

--- a/packages/replay/src/session/saveSession.ts
+++ b/packages/replay/src/session/saveSession.ts
@@ -1,12 +1,12 @@
 import { REPLAY_SESSION_KEY, WINDOW } from '../constants';
 import type { Session } from '../types';
+import { hasSessionStorage } from '../util/hasSessionStorage';
 
 /**
  * Save a session to session storage.
  */
 export function saveSession(session: Session): void {
-  const hasSessionStorage = 'sessionStorage' in WINDOW;
-  if (!hasSessionStorage) {
+  if (!hasSessionStorage()) {
     return;
   }
 

--- a/packages/replay/src/util/hasSessionStorage.ts
+++ b/packages/replay/src/util/hasSessionStorage.ts
@@ -1,0 +1,6 @@
+import { WINDOW } from '../constants';
+
+/** If sessionStorage is available. */
+export function hasSessionStorage(): boolean {
+  return 'sessionStorage' in WINDOW && !!WINDOW.sessionStorage;
+}


### PR DESCRIPTION
It seems in some environments `sessionStorage` my be unset to `null` or similar. To be extra careful, we can guard for existence as well there.

Fixes https://github.com/getsentry/sentry-javascript/issues/8392
