### PR TITLE
feat(types): Add tracePropagationTargets to top level options

### DIFF
--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -20,6 +20,12 @@ interface TracingOptions {
    * requests. If this option is provided, the SDK will match the
    * request URL of outgoing requests against the items in this
    * array, and only attach tracing headers if a match was found.
+   *
+   * @deprecated Use top level `tracePropagationTargets` option instead.
+   * ```
+   * Sentry.init({
+   *   tracePropagationTargets: ['api.site.com'],
+   * })
    */
   tracePropagationTargets?: TracePropagationTargets;
 
@@ -156,6 +162,7 @@ function _createWrappedRequestMethodFactory(
   };
 
   const shouldAttachTraceData = (url: string): boolean => {
+    // eslint-disable-next-line deprecation/deprecation
     if (tracingOptions?.tracePropagationTargets === undefined) {
       return true;
     }
@@ -165,6 +172,7 @@ function _createWrappedRequestMethodFactory(
       return cachedDecision;
     }
 
+    // eslint-disable-next-line deprecation/deprecation
     const decision = stringMatchesSomePattern(url, tracingOptions.tracePropagationTargets);
     headersUrlMap.set(url, decision);
     return decision;

--- a/packages/node/src/types.ts
+++ b/packages/node/src/types.ts
@@ -1,4 +1,4 @@
-import type { ClientOptions, Options, SamplingContext, TracePropagationTargets } from '@sentry/types';
+import type { ClientOptions, Options, SamplingContext } from '@sentry/types';
 
 import type { NodeTransportOptions } from './transports';
 
@@ -31,24 +31,6 @@ export interface BaseNodeOptions {
    * Requires the `LocalVariables` integration.
    */
   includeLocalVariables?: boolean;
-
-  /**
-   * List of strings/regex controlling to which outgoing requests
-   * the SDK will attach tracing headers.
-   *
-   * By default the SDK will attach those headers to all outgoing
-   * requests. If this option is provided, the SDK will match the
-   * request URL of outgoing requests against the items in this
-   * array, and only attach tracing headers if a match was found.
-   *
-   * @example
-   * ```js
-   * Sentry.init({
-   *   tracePropagationTargets: ['api.site.com'],
-   * });
-   * ```
-   */
-  tracePropagationTargets?: TracePropagationTargets;
 
   // TODO (v8): Remove this in v8
   /**

--- a/packages/types/src/options.ts
+++ b/packages/types/src/options.ts
@@ -5,6 +5,7 @@ import type { Integration } from './integration';
 import type { CaptureContext } from './scope';
 import type { SdkMetadata } from './sdkmetadata';
 import type { StackLineParser, StackParser } from './stacktrace';
+import type { TracePropagationTargets } from './tracing';
 import type { SamplingContext } from './transaction';
 import type { BaseTransportOptions, Transport } from './transport';
 
@@ -220,6 +221,24 @@ export interface ClientOptions<TO extends BaseTransportOptions = BaseTransportOp
    * Requires the use of the `InboundFilters` integration.
    */
   denyUrls?: Array<string | RegExp>;
+
+  /**
+   * List of strings/regex controlling to which outgoing requests
+   * the SDK will attach tracing headers.
+   *
+   * By default the SDK will attach those headers to all outgoing
+   * requests. If this option is provided, the SDK will match the
+   * request URL of outgoing requests against the items in this
+   * array, and only attach tracing headers if a match was found.
+   *
+   * @example
+   * ```js
+   * Sentry.init({
+   *   tracePropagationTargets: ['api.site.com'],
+   * });
+   * ```
+   */
+  tracePropagationTargets?: TracePropagationTargets;
 
   /**
    * Function to compute tracing sample rate dynamically and filter unwanted traces.


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/8352

Move `tracePropagationTargets` to top level options since it's required for tracing without performance support.

Next step here is to refactor `BrowserTracing` to use the top level option and open a docs PR for this change.