### PR TITLE
feat(tracing): Favour client options tracePropagationTargets

### DIFF
--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -214,6 +214,9 @@ export class BrowserTracing implements Integration {
    */
   public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
     this._getCurrentHub = getCurrentHub;
+    const hub = getCurrentHub();
+    const client = hub.getClient();
+    const clientOptions = client && client.getOptions();
 
     const {
       routingInstrumentation: instrumentRouting,
@@ -222,10 +225,12 @@ export class BrowserTracing implements Integration {
       markBackgroundTransactions,
       traceFetch,
       traceXHR,
-      tracePropagationTargets,
       shouldCreateSpanForRequest,
       _experiments,
     } = this.options;
+
+    const tracePropagationTargets =
+      (clientOptions && clientOptions.tracePropagationTargets) || this.options.tracePropagationTargets;
 
     instrumentRouting(
       (context: TransactionContext) => {

--- a/packages/tracing-internal/test/browser/browsertracing.test.ts
+++ b/packages/tracing-internal/test/browser/browsertracing.test.ts
@@ -250,6 +250,22 @@ describe('BrowserTracing', () => {
           tracePropagationTargets: ['something'],
         });
       });
+
+      it('uses `tracePropagationTargets` set by client over integration set targets', () => {
+        jest.clearAllMocks();
+        hub.getClient()!.getOptions().tracePropagationTargets = ['something-else'];
+        const sampleTracePropagationTargets = ['something'];
+        createBrowserTracing(true, {
+          routingInstrumentation: customInstrumentRouting,
+          tracePropagationTargets: sampleTracePropagationTargets,
+        });
+
+        expect(instrumentOutgoingRequestsMock).toHaveBeenCalledWith({
+          traceFetch: true,
+          traceXHR: true,
+          tracePropagationTargets: ['something-else'],
+        });
+      });
     });
 
     describe('beforeNavigate', () => {


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/8352

As we work toward adding tracing without performance support, this PR updates the `BrowserTracing` integration to use and favor the top level `tracePropagationTargets` option if it exists.

This option was made top level in https://github.com/getsentry/sentry-javascript/pull/8395

`tracePropagationTargets` is now part of the unified API for distributed tracing. It's also expected that electron/react native will behave the same way as well. This also leaves us the flexibility to extract tracing out of BrowserTracing, or create a new integration that just does tracing but no performance monitoring.

We can make sure this migration is smooth and easy to understand with a good set of docs, which is what I will be working on next. In these docs changes, we'll be updating the automatic instrumentation sections, and formally documented `tracePropagationTargets` as a high level option.