### PR TITLE
ref: Remove undefined checks for `hub.getScope()`

### DIFF
--- a/packages/e2e-tests/test-applications/nextjs-app-dir/components/transaction-context.tsx
+++ b/packages/e2e-tests/test-applications/nextjs-app-dir/components/transaction-context.tsx
@@ -29,7 +29,7 @@ export function TransactionContextProvider({ children }: PropsWithChildren) {
               transactionActive: false,
               start: (transactionName: string) => {
                 const t = startTransaction({ name: transactionName });
-                getCurrentHub().getScope()?.setSpan(t);
+                getCurrentHub().getScope().setSpan(t);
                 setTransaction(t);
               },
             }

--- a/packages/ember/addon/index.ts
+++ b/packages/ember/addon/index.ts
@@ -63,7 +63,7 @@ export function InitSentryForEmber(_runtimeConfig?: BrowserOptions) {
 }
 
 export const getActiveTransaction = () => {
-  return Sentry.getCurrentHub()?.getScope()?.getTransaction();
+  return Sentry.getCurrentHub().getScope().getTransaction();
 };
 
 export const instrumentRoutePerformance = (BaseRoute: any) => {

--- a/packages/nextjs/src/edge/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/edge/wrapApiHandlerWithSentry.ts
@@ -14,7 +14,7 @@ export function wrapApiHandlerWithSentry<H extends EdgeRouteHandler>(
     apply: (wrappingTarget, thisArg, args: Parameters<H>) => {
       const req = args[0];
 
-      const activeSpan = !!getCurrentHub().getScope()?.getSpan();
+      const activeSpan = getCurrentHub().getScope().getSpan();
 
       const wrappedHandler = withEdgeWrapping(wrappingTarget, {
         spanDescription:

--- a/packages/nextjs/test/edge/withSentryAPI.test.ts
+++ b/packages/nextjs/test/edge/withSentryAPI.test.ts
@@ -73,7 +73,7 @@ describe('wrapApiHandlerWithSentry', () => {
 
   it('should return a function that starts a span on the current transaction with the correct description when there is an active transaction and no request is being passed', async () => {
     const testTransaction = coreSdk.startTransaction({ name: 'testTransaction' });
-    coreSdk.getCurrentHub().getScope()?.setSpan(testTransaction);
+    coreSdk.getCurrentHub().getScope().setSpan(testTransaction);
 
     const startChildSpy = jest.spyOn(testTransaction, 'startChild');
 
@@ -92,6 +92,6 @@ describe('wrapApiHandlerWithSentry', () => {
     );
 
     testTransaction.finish();
-    coreSdk.getCurrentHub().getScope()?.setSpan(undefined);
+    coreSdk.getCurrentHub().getScope().setSpan(undefined);
   });
 });

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/server.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/server.ts
@@ -25,7 +25,7 @@ app.use(Sentry.Handlers.tracingHandler());
 app.use(cors());
 
 app.get('/test/express', (_req, res) => {
-  const transaction = Sentry.getCurrentHub().getScope()?.getTransaction();
+  const transaction = Sentry.getCurrentHub().getScope().getTransaction();
   if (transaction) {
     transaction.traceId = '86f39e84263a4de99c326acab3bfe3bd';
   }

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/server.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/server.ts
@@ -27,7 +27,7 @@ app.use(Sentry.Handlers.tracingHandler());
 app.use(cors());
 
 app.get('/test/express', (_req, res) => {
-  const transaction = Sentry.getCurrentHub().getScope()?.getTransaction();
+  const transaction = Sentry.getCurrentHub().getScope().getTransaction();
   if (transaction) {
     transaction.traceId = '86f39e84263a4de99c326acab3bfe3bd';
     transaction.setMetadata({ source: 'route' });

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -163,7 +163,7 @@ export function requestHandler(
 
     // If Scope contains a Single mode Session, it is removed in favor of using Session Aggregates mode
     const scope = currentHub.getScope();
-    if (scope && scope.getSession()) {
+    if (scope.getSession()) {
       scope.setSession();
     }
   }
@@ -339,7 +339,7 @@ export function trpcMiddleware(options: SentryTrpcMiddlewareOptions = {}) {
   return function <T>({ path, type, next, rawInput }: TrpcMiddlewareArguments<T>): T {
     const hub = getCurrentHub();
     const clientOptions = hub.getClient()?.getOptions();
-    const sentryTransaction = hub.getScope()?.getTransaction();
+    const sentryTransaction = hub.getScope().getTransaction();
 
     if (sentryTransaction) {
       sentryTransaction.setName(`trpc/${path}`, 'route');

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -192,9 +192,7 @@ function _createWrappedRequestMethodFactory(
       }
 
       let requestSpan: Span | undefined;
-      let parentSpan: Span | undefined;
-
-      const scope = getCurrentHub().getScope();
+      const parentSpan = getCurrentHub().getScope().getSpan();
 
       const method = requestOptions.method || 'GET';
       const requestSpanData: SanitizedRequestData = {
@@ -210,9 +208,7 @@ function _createWrappedRequestMethodFactory(
         requestSpanData['http.query'] = requestOptions.search.substring(1);
       }
 
-      if (scope && tracingOptions && shouldCreateSpan(rawRequestUrl)) {
-        parentSpan = scope.getSpan();
-
+      if (tracingOptions && shouldCreateSpan(rawRequestUrl)) {
         if (parentSpan) {
           requestSpan = parentSpan.startChild({
             description: `${method} ${requestSpanData.url}`,

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -276,7 +276,7 @@ function startSessionTracking(): void {
   // such as calling process.exit() or uncaught exceptions.
   // Ref: https://nodejs.org/api/process.html#process_event_beforeexit
   process.on('beforeExit', () => {
-    const session = hub.getScope()?.getSession();
+    const session = hub.getScope().getSession();
     const terminalStates: SessionStatus[] = ['exited', 'crashed'];
     // Only call endSession, if the Session exists on Scope and SessionStatus is not a
     // Terminal Status i.e. Exited or Crashed because

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -319,7 +319,7 @@ describe('tracingHandler', () => {
 
     sentryTracingMiddleware(req, res, next);
 
-    const transaction = sentryCore.getCurrentHub().getScope()?.getTransaction();
+    const transaction = sentryCore.getCurrentHub().getScope().getTransaction();
 
     expect(transaction).toBeDefined();
     expect(transaction).toEqual(
@@ -439,7 +439,7 @@ describe('tracingHandler', () => {
 
     sentryTracingMiddleware(req, res, next);
 
-    const transaction = sentryCore.getCurrentHub().getScope()?.getTransaction();
+    const transaction = sentryCore.getCurrentHub().getScope().getTransaction();
 
     expect(transaction?.metadata.request).toEqual(req);
   });

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -49,7 +49,7 @@ describe('tracing', () => {
       ...customContext,
     });
 
-    hub.getScope()?.setSpan(transaction);
+    hub.getScope().setSpan(transaction);
 
     return transaction;
   }
@@ -266,7 +266,7 @@ describe('tracing', () => {
     function createTransactionAndPutOnScope(hub: Hub) {
       addTracingExtensions();
       const transaction = hub.startTransaction({ name: 'dogpark' });
-      hub.getScope()?.setSpan(transaction);
+      hub.getScope().setSpan(transaction);
       return transaction;
     }
 

--- a/packages/node/test/integrations/requestdata.test.ts
+++ b/packages/node/test/integrations/requestdata.test.ts
@@ -126,7 +126,7 @@ describe('`RequestData` integration', () => {
       type GCPHandler = (req: PolymorphicRequest, res: http.ServerResponse) => void;
       const mockGCPWrapper = (origHandler: GCPHandler, options: Record<string, unknown>): GCPHandler => {
         const wrappedHandler: GCPHandler = (req, res) => {
-          getCurrentHub().getScope()?.setSDKProcessingMetadata({
+          getCurrentHub().getScope().setSDKProcessingMetadata({
             request: req,
             requestDataOptionsFromGCPWrapper: options,
           });

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -114,7 +114,7 @@ describe('SentrySpanProcessor', () => {
         expect(sentrySpan?.spanId).toEqual(childOtelSpan.spanContext().spanId);
         expect(sentrySpan?.parentSpanId).toEqual(sentrySpanTransaction?.spanId);
 
-        expect(hub.getScope()?.getSpan()).toBeUndefined();
+        expect(hub.getScope().getSpan()).toBeUndefined();
 
         child.end(endTime);
 

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -306,7 +306,7 @@ export function startRequestHandlerTransaction(
     },
   });
 
-  hub.getScope()?.setSpan(transaction);
+  hub.getScope().setSpan(transaction);
   return transaction;
 }
 

--- a/packages/replay/src/util/sendReplayRequest.ts
+++ b/packages/replay/src/util/sendReplayRequest.ts
@@ -34,7 +34,7 @@ export async function sendReplayRequest({
   const transport = client && client.getTransport();
   const dsn = client && client.getDsn();
 
-  if (!client || !scope || !transport || !dsn || !session.sampled) {
+  if (!client || !transport || !dsn || !session.sampled) {
     return;
   }
 

--- a/packages/replay/test/integration/coreHandlers/handleScope.test.ts
+++ b/packages/replay/test/integration/coreHandlers/handleScope.test.ts
@@ -23,7 +23,7 @@ describe('Integration | coreHandlers | handleScope', () => {
 
     expect(mockHandleScopeListener).toHaveBeenCalledTimes(1);
 
-    getCurrentHub().getScope()?.addBreadcrumb({ category: 'console', message: 'testing' });
+    getCurrentHub().getScope().addBreadcrumb({ category: 'console', message: 'testing' });
 
     expect(mockHandleScope).toHaveBeenCalledTimes(1);
     expect(mockHandleScope).toHaveReturnedWith(expect.objectContaining({ category: 'console', message: 'testing' }));
@@ -32,7 +32,7 @@ describe('Integration | coreHandlers | handleScope', () => {
 
     // This will trigger breadcrumb/scope listener, but handleScope should return
     // null because breadcrumbs has not changed
-    getCurrentHub().getScope()?.setUser({ email: 'foo@foo.com' });
+    getCurrentHub().getScope().setUser({ email: 'foo@foo.com' });
     expect(mockHandleScope).toHaveBeenCalledTimes(1);
     expect(mockHandleScope).toHaveReturnedWith(null);
   });

--- a/packages/svelte/src/performance.ts
+++ b/packages/svelte/src/performance.ts
@@ -90,7 +90,5 @@ function recordUpdateSpans(componentName: string, initSpan?: Span): void {
 }
 
 function getActiveTransaction(): Transaction | undefined {
-  const currentHub = getCurrentHub();
-  const scope = currentHub && currentHub.getScope();
-  return scope && scope.getTransaction();
+  return getCurrentHub().getScope().getTransaction();
 }

--- a/packages/tracing-internal/src/browser/request.ts
+++ b/packages/tracing-internal/src/browser/request.ts
@@ -195,8 +195,7 @@ export function fetchCallback(
     return;
   }
 
-  const currentScope = getCurrentHub().getScope();
-  const currentSpan = currentScope && currentScope.getSpan();
+  const currentSpan = getCurrentHub().getScope().getSpan();
   const activeTransaction = currentSpan && currentSpan.transaction;
 
   if (currentSpan && activeTransaction) {
@@ -336,8 +335,7 @@ export function xhrCallback(
     return;
   }
 
-  const currentScope = getCurrentHub().getScope();
-  const currentSpan = currentScope && currentScope.getSpan();
+  const currentSpan = getCurrentHub().getScope().getSpan();
   const activeTransaction = currentSpan && currentSpan.transaction;
 
   if (currentSpan && activeTransaction) {

--- a/packages/tracing/test/hub.test.ts
+++ b/packages/tracing/test/hub.test.ts
@@ -44,7 +44,7 @@ describe('Hub', () => {
         scope.setSpan(transaction);
       });
 
-      expect(hub.getScope()?.getTransaction()).toBe(transaction);
+      expect(hub.getScope().getTransaction()).toBe(transaction);
     });
 
     it('should find a transaction which has been set on the scope if sampled = false', () => {
@@ -57,7 +57,7 @@ describe('Hub', () => {
         scope.setSpan(transaction);
       });
 
-      expect(hub.getScope()?.getTransaction()).toBe(transaction);
+      expect(hub.getScope().getTransaction()).toBe(transaction);
     });
 
     it("should not find an open transaction if it's not on the scope", () => {
@@ -66,7 +66,7 @@ describe('Hub', () => {
       makeMain(hub);
       hub.startTransaction({ name: 'dogpark' });
 
-      expect(hub.getScope()?.getTransaction()).toBeUndefined();
+      expect(hub.getScope().getTransaction()).toBeUndefined();
     });
   });
 

--- a/packages/vue/src/tracing.ts
+++ b/packages/vue/src/tracing.ts
@@ -30,8 +30,7 @@ const HOOKS: { [key in Operation]: Hook[] } = {
 
 /** Grabs active transaction off scope, if any */
 export function getActiveTransaction(): Transaction | undefined {
-  const scope = getCurrentHub().getScope();
-  return scope && scope.getTransaction();
+  return getCurrentHub().getScope().getTransaction();
 }
 
 /** Finish top-level span and activity with a debounce configured using `timeout` option */


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/7551 I made it so that scope was always defined when calling `hub.getScope()`. This patch refactors some code (mostly tests) to not check if scope is undefined anymore.

We no longer need to do

```js
const span = hub.getScope()?.getSpan();
```

or

```js
const scope = hub.getScope();
if (scope) {
  scope.addBreadcrumb(...)
}
```