### PR TITLE
Propagation Context Experiment Draft

### DIFF
--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -11,6 +11,7 @@ import type {
   Extra,
   Extras,
   Primitive,
+  PropagationContext,
   RequestSession,
   Scope as ScopeInterface,
   ScopeContext,
@@ -29,6 +30,7 @@ import {
   isThenable,
   logger,
   SyncPromise,
+  uuid4,
 } from '@sentry/utils';
 
 import { updateSession } from './session';
@@ -95,6 +97,8 @@ export class Scope implements ScopeInterface {
   /** Request Mode Session Status */
   protected _requestSession?: RequestSession;
 
+  protected _propagationContext?: PropagationContext;
+
   // NOTE: Any field which gets added here should get added not only to the constructor but also to the `clone` method.
 
   public constructor() {
@@ -108,6 +112,11 @@ export class Scope implements ScopeInterface {
     this._extra = {};
     this._contexts = {};
     this._sdkProcessingMetadata = {};
+    this._propagationContext = {
+      traceId: uuid4(),
+      spanId: uuid4().substring(16),
+      sampled: false,
+    };
   }
 
   /**
@@ -131,6 +140,9 @@ export class Scope implements ScopeInterface {
       newScope._requestSession = scope._requestSession;
       newScope._attachments = [...scope._attachments];
       newScope._sdkProcessingMetadata = { ...scope._sdkProcessingMetadata };
+      if (scope._propagationContext) {
+        newScope._propagationContext = { ...scope._propagationContext };
+      }
     }
     return newScope;
   }

--- a/packages/core/src/utils/dynamicSampling.ts
+++ b/packages/core/src/utils/dynamicSampling.ts
@@ -1,0 +1,35 @@
+import type { DynamicSamplingContext, Hub } from '@sentry/types';
+import { dropUndefinedKeys } from '@sentry/utils';
+
+import { DEFAULT_ENVIRONMENT } from '../constants';
+import { getCurrentHub } from '../hub';
+
+/**
+ * Create a dynamic sampling context from a hub.
+ */
+export function dynamicSamplingContextFromHub(
+  trace_id: string,
+  hub: Hub = getCurrentHub(),
+): Partial<DynamicSamplingContext> {
+  const client = hub.getClient();
+  if (!client) {
+    return {};
+  }
+
+  const { environment = DEFAULT_ENVIRONMENT, release } = client.getOptions() || {};
+  const { publicKey: public_key } = client.getDsn() || {};
+
+  const { segment: user_segment } = hub.getScope().getUser() || {};
+
+  const dsc = dropUndefinedKeys({
+    environment,
+    release,
+    user_segment,
+    public_key,
+    trace_id,
+  });
+
+  client.emit && client.emit('createDsc', dsc);
+
+  return dsc;
+}

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -70,6 +70,9 @@ export interface Hub {
   /** Returns the client of the top stack. */
   getClient(): Client | undefined;
 
+  /** Returns the scope of the top stack */
+  getScope(): Scope;
+
   /**
    * Captures an exception event and sends it to Sentry.
    *

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -83,7 +83,7 @@ export type { Span, SpanContext } from './span';
 export type { StackFrame } from './stackframe';
 export type { Stacktrace, StackParser, StackLineParser, StackLineParserFn } from './stacktrace';
 export type { TextEncoderInternal } from './textencoder';
-export type { TracePropagationTargets } from './tracing';
+export type { TracePropagationTargets, PropagationContext } from './tracing';
 export type {
   CustomSamplingContext,
   SamplingContext,

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -7,6 +7,7 @@ import type { Primitive } from './misc';
 import type { RequestSession, Session } from './session';
 import type { Severity, SeverityLevel } from './severity';
 import type { Span } from './span';
+import type { PropagationContext } from './tracing';
 import type { Transaction } from './transaction';
 import type { User } from './user';
 
@@ -185,4 +186,19 @@ export interface Scope {
    * Add data which will be accessible during event processing but won't get sent to Sentry
    */
   setSDKProcessingMetadata(newData: { [key: string]: unknown }): this;
+
+  /**
+   * Set current propagation context for the current scope.
+   *
+   * Setting a new propagation context will overwrite all previously
+   * set values.
+   */
+  setPropagationContext(context: PropagationContext): this;
+
+  /**
+   * Get current propagation context for the current scope.
+   *
+   * There will always be a propagation context for the current scope.
+   */
+  getPropagationContext(): PropagationContext;
 }

--- a/packages/types/src/tracing.ts
+++ b/packages/types/src/tracing.ts
@@ -2,9 +2,15 @@ import type { DynamicSamplingContext } from './envelope';
 
 export type TracePropagationTargets = (string | RegExp)[];
 
+/**
+ * Context that contains details about distributed trace
+ *
+ * Generated from incoming `sentry-trace` and `baggage` headers.
+ */
 export interface PropagationContext {
   traceId: string;
   spanId: string;
+  parentSpanId?: string;
   sampled: boolean;
   dsc?: DynamicSamplingContext;
 }

--- a/packages/types/src/tracing.ts
+++ b/packages/types/src/tracing.ts
@@ -1,1 +1,10 @@
+import type { DynamicSamplingContext } from './envelope';
+
 export type TracePropagationTargets = (string | RegExp)[];
+
+export interface PropagationContext {
+  traceId: string;
+  spanId: string;
+  sampled: boolean;
+  dsc?: DynamicSamplingContext;
+}


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/8352

This draft PR represents me playing around with the API of a propagation context (aka distributed tracing context).

To make tracing without performance work, we are required to always have some kind of storage mechanism for distributed tracing context. This propagation context right now is supplemented by the existence of a transaction, which exists as the vehicle to carry this information.

With TwP, we are looking to introduce a source of truth that carries this trace information, that then everything will read from. This source of truth lives on the scope, as it is expected to change with incoming requests (node) or meta tags (browser) changing the trace.

This PR will be closed with the actual PR afterwards, but just wanted a place I can look at my ideas in the time being.