### PR TITLE
feat: collect timings on profiler stop calls

### DIFF
--- a/packages/browser/src/profiling/cache.ts
+++ b/packages/browser/src/profiling/cache.ts
@@ -1,4 +1,0 @@
-import type { Event } from '@sentry/types';
-import { makeFifoCache } from '@sentry/utils';
-
-export const PROFILING_EVENT_CACHE = makeFifoCache<string, Event>(20);

--- a/packages/browser/src/profiling/hubextensions.ts
+++ b/packages/browser/src/profiling/hubextensions.ts
@@ -172,7 +172,9 @@ export function wrapTransactionWithProfiling(transaction: Transaction): Transact
       return null;
     }
 
-    const stopProfilerSpan = transaction.startChild({ description: 'profiler.stop' });
+    // This is temporary - we will use the collected span data to evaluate
+    // if deferring txn.finish until profiler resolves is a viable approach.
+    const stopProfilerSpan = transaction.startChild({ description: 'profiler.stop', op: 'profiler' });
 
     return profiler
       .stop()

--- a/packages/browser/src/profiling/hubextensions.ts
+++ b/packages/browser/src/profiling/hubextensions.ts
@@ -172,9 +172,13 @@ export function wrapTransactionWithProfiling(transaction: Transaction): Transact
       return null;
     }
 
+    const stopProfilerSpan = transaction.startChild({ description: 'profiler.stop' });
+
     return profiler
       .stop()
       .then((p: JSSelfProfile): null => {
+        stopProfilerSpan.finish();
+
         if (maxDurationTimeoutID) {
           WINDOW.clearTimeout(maxDurationTimeoutID);
           maxDurationTimeoutID = undefined;
@@ -199,6 +203,7 @@ export function wrapTransactionWithProfiling(transaction: Transaction): Transact
         return null;
       })
       .catch(error => {
+        stopProfilerSpan.finish();
         if (__DEBUG_BUILD__) {
           logger.log('[Profiling] error while stopping profiler:', error);
         }


### PR DESCRIPTION
Collect span information on how long the async calls to profiler.stop take which will help us evaluate if calling txn.finish after profiler.stop is a viable approach