### PR TITLE
feat(tracing): Add `PropagationContext` to scope 

### DIFF
--- a/packages/browser-integration-tests/suites/replay/captureReplay/test.ts
+++ b/packages/browser-integration-tests/suites/replay/captureReplay/test.ts
@@ -56,7 +56,6 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
       version: SDK_VERSION,
       name: 'sentry.javascript.browser',
     },
-    sdkProcessingMetadata: expect.any(Object),
     request: {
       url: expect.stringContaining('/dist/index.html'),
       headers: {
@@ -94,7 +93,6 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
       version: SDK_VERSION,
       name: 'sentry.javascript.browser',
     },
-    sdkProcessingMetadata: expect.any(Object),
     request: {
       url: expect.stringContaining('/dist/index.html'),
       headers: {

--- a/packages/browser-integration-tests/suites/replay/captureReplay/test.ts
+++ b/packages/browser-integration-tests/suites/replay/captureReplay/test.ts
@@ -56,7 +56,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
       version: SDK_VERSION,
       name: 'sentry.javascript.browser',
     },
-    sdkProcessingMetadata: {},
+    sdkProcessingMetadata: expect.any(Object),
     request: {
       url: expect.stringContaining('/dist/index.html'),
       headers: {
@@ -94,7 +94,7 @@ sentryTest('should capture replays (@sentry/browser export)', async ({ getLocalT
       version: SDK_VERSION,
       name: 'sentry.javascript.browser',
     },
-    sdkProcessingMetadata: {},
+    sdkProcessingMetadata: expect.any(Object),
     request: {
       url: expect.stringContaining('/dist/index.html'),
       headers: {

--- a/packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
+++ b/packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
@@ -56,7 +56,6 @@ sentryTest('should capture replays (@sentry/replay export)', async ({ getLocalTe
       version: SDK_VERSION,
       name: 'sentry.javascript.browser',
     },
-    sdkProcessingMetadata: expect.any(Object),
     request: {
       url: expect.stringContaining('/dist/index.html'),
       headers: {
@@ -94,7 +93,6 @@ sentryTest('should capture replays (@sentry/replay export)', async ({ getLocalTe
       version: SDK_VERSION,
       name: 'sentry.javascript.browser',
     },
-    sdkProcessingMetadata: expect.any(Object),
     request: {
       url: expect.stringContaining('/dist/index.html'),
       headers: {

--- a/packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
+++ b/packages/browser-integration-tests/suites/replay/captureReplayFromReplayPackage/test.ts
@@ -56,7 +56,7 @@ sentryTest('should capture replays (@sentry/replay export)', async ({ getLocalTe
       version: SDK_VERSION,
       name: 'sentry.javascript.browser',
     },
-    sdkProcessingMetadata: {},
+    sdkProcessingMetadata: expect.any(Object),
     request: {
       url: expect.stringContaining('/dist/index.html'),
       headers: {
@@ -94,7 +94,7 @@ sentryTest('should capture replays (@sentry/replay export)', async ({ getLocalTe
       version: SDK_VERSION,
       name: 'sentry.javascript.browser',
     },
-    sdkProcessingMetadata: {},
+    sdkProcessingMetadata: expect.any(Object),
     request: {
       url: expect.stringContaining('/dist/index.html'),
       headers: {

--- a/packages/browser-integration-tests/utils/replayEventTemplates.ts
+++ b/packages/browser-integration-tests/utils/replayEventTemplates.ts
@@ -30,7 +30,7 @@ const DEFAULT_REPLAY_EVENT = {
     version: SDK_VERSION,
     name: 'sentry.javascript.browser',
   },
-  sdkProcessingMetadata: {},
+  sdkProcessingMetadata: expect.any(Object),
   request: {
     url: expect.stringContaining('/dist/index.html'),
     headers: {

--- a/packages/browser-integration-tests/utils/replayEventTemplates.ts
+++ b/packages/browser-integration-tests/utils/replayEventTemplates.ts
@@ -30,7 +30,6 @@ const DEFAULT_REPLAY_EVENT = {
     version: SDK_VERSION,
     name: 'sentry.javascript.browser',
   },
-  sdkProcessingMetadata: expect.any(Object),
   request: {
     url: expect.stringContaining('/dist/index.html'),
     headers: {

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -533,6 +533,14 @@ export class Scope implements ScopeInterface {
   }
 
   /**
+   * @inheritdoc
+   */
+  public setPropagationContext(context: PropagationContext): this {
+    this._propagationContext = context;
+    return this;
+  }
+
+  /**
    * This will be called after {@link applyToEvent} is finished.
    */
   protected _notifyEventProcessors(

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -492,6 +492,28 @@ describe('BaseClient', () => {
       );
     });
 
+    test('it adds a trace context all events', () => {
+      expect.assertions(1);
+
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN });
+      const client = new TestClient(options);
+      const scope = new Scope();
+
+      client.captureEvent({ message: 'message' }, { event_id: 'wat' }, scope);
+
+      expect(TestClient.instance!.event!).toEqual(
+        expect.objectContaining({
+          contexts: {
+            trace: {
+              parent_span_id: undefined,
+              span_id: expect.any(String),
+              trace_id: expect.any(String),
+            },
+          },
+        }),
+      );
+    });
+
     test('adds `event_id` from hint if available', () => {
       expect.assertions(1);
 

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -243,7 +243,11 @@ describe('Scope', () => {
         expect(processedEvent!.transaction).toEqual('/abc');
         expect(processedEvent!.breadcrumbs![0]).toHaveProperty('message', 'test');
         expect(processedEvent!.contexts).toEqual({ os: { id: '1' } });
-        expect(processedEvent!.sdkProcessingMetadata).toEqual({ dogs: 'are great!' });
+        expect(processedEvent!.sdkProcessingMetadata).toEqual({
+          dogs: 'are great!',
+          // @ts-expect-error accessing private property for test
+          propagationContext: scope._propagationContext,
+        });
       });
     });
 

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -12,6 +12,21 @@ describe('Scope', () => {
     GLOBAL_OBJ.__SENTRY__.globalEventProcessors = undefined;
   });
 
+  describe('init', () => {
+    test('it creates a propagation context', () => {
+      const scope = new Scope();
+
+      // @ts-ignore asserting on private properties
+      expect(scope._propagationContext).toEqual({
+        traceId: expect.any(String),
+        spanId: expect.any(String),
+        sampled: false,
+        dsc: undefined,
+        parentSpanId: undefined,
+      });
+    });
+  });
+
   describe('attributes modification', () => {
     test('setFingerprint', () => {
       const scope = new Scope();
@@ -193,6 +208,14 @@ describe('Scope', () => {
       expect(parentScope.getRequestSession()).toEqual({ status: 'ok' });
       expect(scope.getRequestSession()).toEqual({ status: 'ok' });
     });
+
+    test('should clone propagation context', () => {
+      const parentScope = new Scope();
+      const scope = Scope.clone(parentScope);
+
+      // @ts-ignore accessing private property for test
+      expect(scope._propagationContext).toEqual(parentScope._propagationContext);
+    });
   });
 
   describe('applyToEvent', () => {
@@ -339,7 +362,7 @@ describe('Scope', () => {
       scope.setSpan(span);
       const event: Event = {
         contexts: {
-          trace: { a: 'c' },
+          trace: { a: 'c' } as any,
         },
       };
       return scope.applyToEvent(event).then(processedEvent => {
@@ -383,6 +406,8 @@ describe('Scope', () => {
 
   test('clear', () => {
     const scope = new Scope();
+    // @ts-expect-error accessing private property
+    const oldPropagationContext = scope._propagationContext;
     scope.setExtra('a', 2);
     scope.setTag('a', 'b');
     scope.setUser({ id: '1' });
@@ -393,6 +418,14 @@ describe('Scope', () => {
     scope.clear();
     expect((scope as any)._extra).toEqual({});
     expect((scope as any)._requestSession).toEqual(undefined);
+    // @ts-expect-error accessing private property
+    expect(scope._propagationContext).toEqual({
+      traceId: expect.any(String),
+      spanId: expect.any(String),
+      sampled: false,
+    });
+    // @ts-expect-error accessing private property
+    expect(scope._propagationContext).not.toEqual(oldPropagationContext);
   });
 
   test('clearBreadcrumbs', () => {
@@ -486,6 +519,8 @@ describe('Scope', () => {
       expect(updatedScope._level).toEqual('warning');
       expect(updatedScope._fingerprint).toEqual(['bar']);
       expect(updatedScope._requestSession.status).toEqual('ok');
+      // @ts-ignore accessing private property for test
+      expect(updatedScope._propagationContext).toEqual(localScope._propagationContext);
     });
 
     test('given an empty instance of Scope, it should preserve all the original scope data', () => {
@@ -518,7 +553,13 @@ describe('Scope', () => {
         tags: { bar: '3', baz: '4' },
         user: { id: '42' },
         requestSession: { status: 'errored' as RequestSessionStatus },
+        propagationContext: {
+          traceId: '8949daf83f4a4a70bee4c1eb9ab242ed',
+          spanId: 'a024ad8fea82680e',
+          sampled: true,
+        },
       };
+
       const updatedScope = scope.update(localAttributes) as any;
 
       expect(updatedScope._tags).toEqual({
@@ -540,6 +581,11 @@ describe('Scope', () => {
       expect(updatedScope._level).toEqual('warning');
       expect(updatedScope._fingerprint).toEqual(['bar']);
       expect(updatedScope._requestSession).toEqual({ status: 'errored' });
+      expect(updatedScope._propagationContext).toEqual({
+        traceId: '8949daf83f4a4a70bee4c1eb9ab242ed',
+        spanId: 'a024ad8fea82680e',
+        sampled: true,
+      });
     });
   });
 

--- a/packages/node/test/async/domain.test.ts
+++ b/packages/node/test/async/domain.test.ts
@@ -1,5 +1,5 @@
-import { getCurrentHub, Hub, runWithAsyncContext, setAsyncContextStrategy } from '@sentry/core';
-import * as domain from 'domain';
+import type { Hub } from '@sentry/core';
+import { getCurrentHub, runWithAsyncContext, setAsyncContextStrategy } from '@sentry/core';
 
 import { setDomainAsyncContextStrategy } from '../../src/async/domain';
 
@@ -7,13 +7,6 @@ describe('domains', () => {
   afterAll(() => {
     // clear the strategy
     setAsyncContextStrategy(undefined);
-  });
-
-  test('without domain', () => {
-    // @ts-ignore property active does not exist on domain
-    expect(domain.active).toBeFalsy();
-    const hub = getCurrentHub();
-    expect(hub).toEqual(new Hub());
   });
 
   test('hub scope inheritance', () => {

--- a/packages/node/test/async/hooks.test.ts
+++ b/packages/node/test/async/hooks.test.ts
@@ -1,4 +1,5 @@
-import { getCurrentHub, Hub, runWithAsyncContext, setAsyncContextStrategy } from '@sentry/core';
+import type { Hub } from '@sentry/core';
+import { getCurrentHub, runWithAsyncContext, setAsyncContextStrategy } from '@sentry/core';
 
 import { setHooksAsyncContextStrategy } from '../../src/async/hooks';
 import { conditionalTest } from '../utils';
@@ -7,11 +8,6 @@ conditionalTest({ min: 12 })('async_hooks', () => {
   afterAll(() => {
     // clear the strategy
     setAsyncContextStrategy(undefined);
-  });
-
-  test('without context', () => {
-    const hub = getCurrentHub();
-    expect(hub).toEqual(new Hub());
   });
 
   test('without strategy hubs should be equal', () => {

--- a/packages/replay/src/util/sendReplayRequest.ts
+++ b/packages/replay/src/util/sendReplayRequest.ts
@@ -93,6 +93,12 @@ export async function sendReplayRequest({
   }
   */
 
+  // Prevent this data (which, if it exists, was used in earlier steps in the processing pipeline) from being sent to
+  // sentry. (Note: Our use of this property comes and goes with whatever we might be debugging, whatever hacks we may
+  // have temporarily added, etc. Even if we don't happen to be using it at some point in the future, let's not get rid
+  // of this `delete`, lest we miss putting it back in the next time the property is in use.)
+  delete replayEvent.sdkProcessingMetadata;
+
   const envelope = createReplayEnvelope(replayEvent, preparedRecordingData, dsn, client.getOptions().tunnel);
 
   let response: void | TransportMakeRequestResponse;

--- a/packages/replay/test/unit/util/prepareReplayEvent.test.ts
+++ b/packages/replay/test/unit/util/prepareReplayEvent.test.ts
@@ -82,7 +82,7 @@ describe('Unit | util | prepareReplayEvent', () => {
         name: 'sentry.javascript.testSdk',
         version: '1.0.0',
       },
-      sdkProcessingMetadata: {},
+      sdkProcessingMetadata: expect.any(Object),
       breadcrumbs: undefined,
     });
   });

--- a/packages/types/src/context.ts
+++ b/packages/types/src/context.ts
@@ -8,6 +8,7 @@ export interface Contexts extends Record<string, Context | undefined> {
   os?: OsContext;
   culture?: CultureContext;
   response?: ResponseContext;
+  trace?: TraceContext;
 }
 
 export interface AppContext extends Record<string, unknown> {

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -70,6 +70,9 @@ export interface Hub {
   /** Returns the client of the top stack. */
   getClient(): Client | undefined;
 
+  /** Returns the scope of the top stack */
+  getScope(): Scope;
+
   /**
    * Captures an exception event and sends it to Sentry.
    *

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -83,7 +83,7 @@ export type { Span, SpanContext } from './span';
 export type { StackFrame } from './stackframe';
 export type { Stacktrace, StackParser, StackLineParser, StackLineParserFn } from './stacktrace';
 export type { TextEncoderInternal } from './textencoder';
-export type { TracePropagationTargets } from './tracing';
+export type { PropagationContext, TracePropagationTargets } from './tracing';
 export type {
   CustomSamplingContext,
   SamplingContext,

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -7,6 +7,7 @@ import type { Primitive } from './misc';
 import type { RequestSession, Session } from './session';
 import type { Severity, SeverityLevel } from './severity';
 import type { Span } from './span';
+import type { PropagationContext } from './tracing';
 import type { Transaction } from './transaction';
 import type { User } from './user';
 
@@ -23,6 +24,7 @@ export interface ScopeContext {
   tags: { [key: string]: Primitive };
   fingerprint: string[];
   requestSession: RequestSession;
+  propagationContext: PropagationContext;
 }
 
 /**

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -187,4 +187,9 @@ export interface Scope {
    * Add data which will be accessible during event processing but won't get sent to Sentry
    */
   setSDKProcessingMetadata(newData: { [key: string]: unknown }): this;
+
+  /**
+   * Add propagation context to the scope, used for distributed tracing
+   */
+  setPropagationContext(context: PropagationContext): this;
 }

--- a/packages/types/src/tracing.ts
+++ b/packages/types/src/tracing.ts
@@ -1,1 +1,11 @@
+import type { DynamicSamplingContext } from './envelope';
+
 export type TracePropagationTargets = (string | RegExp)[];
+
+export interface PropagationContext {
+  traceId: string;
+  spanId: string;
+  parentSpanId: string;
+  sampled: boolean;
+  dsc: DynamicSamplingContext;
+}

--- a/packages/types/src/tracing.ts
+++ b/packages/types/src/tracing.ts
@@ -5,7 +5,7 @@ export type TracePropagationTargets = (string | RegExp)[];
 export interface PropagationContext {
   traceId: string;
   spanId: string;
-  parentSpanId: string;
   sampled: boolean;
-  dsc: DynamicSamplingContext;
+  parentSpanId?: string;
+  dsc?: DynamicSamplingContext;
 }


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/8352

For more details about PropagationContext, see https://www.notion.so/sentry/Tracing-without-performance-efab307eb7f64e71a04f09dc72722530

Building off of work in both https://github.com/getsentry/sentry-javascript/pull/8403 and https://github.com/getsentry/sentry-javascript/pull/8418, this PR adds `PropagationContext` and uses that to always set a trace context on outgoing error events.

Currently if there is an active span on the scope, we automatically attach that span's trace context to all outgoing events. Now, we want to rely on either the active span or fallback to the propagation context to ensure that there is always a trace being generated and propagated.

Next up we'll work on updating the node/browser SDKs to update the propagation context. For example, we should update the propagation context for node based on the incoming sentry-trace/baggage headers.