### PR TITLE
fix(browser): Set anonymous `crossorigin` attribute on report dialog

### DIFF
--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -164,6 +164,7 @@ export function showReportDialog(options: ReportDialogOptions = {}, hub: Hub = g
 
   const script = WINDOW.document.createElement('script');
   script.async = true;
+  script.crossOrigin = 'anonymous';
   script.src = getReportDialogEndpoint(dsn, options);
 
   if (options.onLoad) {


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry/issues/49535#issuecomment-1612643524

Since we don't need to authenticate users on the report dialog endpoint we should not send any credentials with the request.

Also prevents COEP blockage: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy#avoiding_coep_blockage_with_cors