### PR TITLE
ref(sveltekit): Extract propagation context

### DIFF
--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -112,7 +112,8 @@ function instrumentHandle({ event, resolve }: Parameters<Handle>[0], options: Se
     return resolve(event);
   }
 
-  const { traceparentData, dynamicSamplingContext } = getTracePropagationData(event);
+  const { dynamicSamplingContext, traceparentData, propagationContext } = getTracePropagationData(event);
+  getCurrentHub().getScope().setPropagationContext(propagationContext);
 
   return trace(
     {

--- a/packages/sveltekit/src/server/load.ts
+++ b/packages/sveltekit/src/server/load.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @sentry-internal/sdk/no-optional-chaining */
-import { trace } from '@sentry/core';
+import { getCurrentHub, trace } from '@sentry/core';
 import { captureException } from '@sentry/node';
 import type { TransactionContext } from '@sentry/types';
 import { addExceptionMechanism, addNonEnumerableProperty, objectify } from '@sentry/utils';
@@ -121,7 +121,8 @@ export function wrapServerLoadWithSentry<T extends (...args: any) => any>(origSe
 
       const routeId = event.route && event.route.id;
 
-      const { dynamicSamplingContext, traceparentData } = getTracePropagationData(event);
+      const { dynamicSamplingContext, traceparentData, propagationContext } = getTracePropagationData(event);
+      getCurrentHub().getScope().setPropagationContext(propagationContext);
 
       const traceLoadContext: TransactionContext = {
         op: 'function.sveltekit.server.load',

--- a/packages/sveltekit/src/server/utils.ts
+++ b/packages/sveltekit/src/server/utils.ts
@@ -1,12 +1,5 @@
-import type { DynamicSamplingContext, StackFrame, TraceparentData } from '@sentry/types';
-import {
-  baggageHeaderToDynamicSamplingContext,
-  basename,
-  escapeStringForRegex,
-  extractTraceparentData,
-  GLOBAL_OBJ,
-  join,
-} from '@sentry/utils';
+import type { StackFrame } from '@sentry/types';
+import { basename, escapeStringForRegex, GLOBAL_OBJ, join, tracingContextFromHeaders } from '@sentry/utils';
 import type { RequestEvent } from '@sveltejs/kit';
 
 import { WRAPPED_MODULE_SUFFIX } from '../vite/autoInstrument';
@@ -15,17 +8,13 @@ import type { GlobalWithSentryValues } from '../vite/injectGlobalValues';
 /**
  * Takes a request event and extracts traceparent and DSC data
  * from the `sentry-trace` and `baggage` DSC headers.
+ *
+ * Sets propagation context as a side effect.
  */
-export function getTracePropagationData(event: RequestEvent): {
-  traceparentData?: TraceparentData;
-  dynamicSamplingContext?: Partial<DynamicSamplingContext>;
-} {
-  const sentryTraceHeader = event.request.headers.get('sentry-trace');
+export function getTracePropagationData(event: RequestEvent): ReturnType<typeof tracingContextFromHeaders> {
+  const sentryTraceHeader = event.request.headers.get('sentry-trace') || '';
   const baggageHeader = event.request.headers.get('baggage');
-  const traceparentData = sentryTraceHeader ? extractTraceparentData(sentryTraceHeader) : undefined;
-  const dynamicSamplingContext = baggageHeaderToDynamicSamplingContext(baggageHeader);
-
-  return { traceparentData, dynamicSamplingContext };
+  return tracingContextFromHeaders(sentryTraceHeader, baggageHeader);
 }
 
 /**


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/8352

Use the `tracingContextFromHeaders` helper (first used in https://github.com/getsentry/sentry-javascript/pull/8422) to simplify how trace context is generated by the Sveltekit SDK . Then set the propagation context accordingly.