### PR TITLE
ref(serverless): Extract propagation context

### DIFF
--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -3,7 +3,7 @@ import type { Scope } from '@sentry/node';
 import * as Sentry from '@sentry/node';
 import { captureException, captureMessage, flush, getCurrentHub, withScope } from '@sentry/node';
 import type { Integration } from '@sentry/types';
-import { baggageHeaderToDynamicSamplingContext, extractTraceparentData, isString, logger } from '@sentry/utils';
+import { isString, logger, tracingContextFromHeaders } from '@sentry/utils';
 // NOTE: I have no idea how to fix this right now, and don't want to waste more time, as it builds just fine — Kamil
 // eslint-disable-next-line import/no-unresolved
 import type { Context, Handler } from 'aws-lambda';
@@ -274,17 +274,20 @@ export function wrapHandler<TEvent, TResult>(
       }, timeoutWarningDelay) as unknown as NodeJS.Timeout;
     }
 
-    // Applying `sentry-trace` to context
-    let traceparentData;
-    const eventWithHeaders = event as { headers?: { [key: string]: string } };
-    if (eventWithHeaders.headers && isString(eventWithHeaders.headers['sentry-trace'])) {
-      traceparentData = extractTraceparentData(eventWithHeaders.headers['sentry-trace']);
-    }
-
-    const baggageHeader = eventWithHeaders.headers && eventWithHeaders.headers.baggage;
-    const dynamicSamplingContext = baggageHeaderToDynamicSamplingContext(baggageHeader);
-
     const hub = getCurrentHub();
+
+    const eventWithHeaders = event as { headers?: { [key: string]: string } };
+
+    const sentryTrace =
+      eventWithHeaders.headers && isString(eventWithHeaders.headers['sentry-trace'])
+        ? eventWithHeaders.headers['sentry-trace']
+        : undefined;
+    const baggage = eventWithHeaders.headers?.baggage;
+    const { traceparentData, dynamicSamplingContext, propagationContext } = tracingContextFromHeaders(
+      sentryTrace,
+      baggage,
+    );
+    hub.getScope().setPropagationContext(propagationContext);
 
     const transaction = hub.startTransaction({
       name: context.functionName,

--- a/packages/serverless/test/__mocks__/@sentry/node.ts
+++ b/packages/serverless/test/__mocks__/@sentry/node.ts
@@ -22,6 +22,7 @@ export const fakeScope = {
   setSpan: jest.fn(),
   getTransaction: jest.fn(() => fakeTransaction),
   setSDKProcessingMetadata: jest.fn(),
+  setPropagationContext: jest.fn(),
 };
 export const fakeSpan = {
   finish: jest.fn(),


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/8352

Introduce the `tracingContextFromHeaders` (first used in https://github.com/getsentry/sentry-javascript/pull/8422) to simplify how trace context is generated by serverless tracing handlers. Then set the propagation context accordingly.