### PR TITLE
ref(tracing): Extract propagation context from meta tags

### DIFF
--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -1,14 +1,8 @@
 /* eslint-disable max-lines */
 import type { Hub, IdleTransaction } from '@sentry/core';
-import {
-  addTracingExtensions,
-  extractTraceparentData,
-  getActiveTransaction,
-  startIdleTransaction,
-  TRACING_DEFAULTS,
-} from '@sentry/core';
+import { addTracingExtensions, getActiveTransaction, startIdleTransaction, TRACING_DEFAULTS } from '@sentry/core';
 import type { EventProcessor, Integration, Transaction, TransactionContext, TransactionSource } from '@sentry/types';
-import { baggageHeaderToDynamicSamplingContext, getDomElement, logger } from '@sentry/utils';
+import { getDomElement, logger, tracingContextFromHeaders } from '@sentry/utils';
 
 import { registerBackgroundTabDetection } from './backgroundtab';
 import {
@@ -297,24 +291,29 @@ export class BrowserTracing implements Integration {
       return undefined;
     }
 
+    const hub = this._getCurrentHub();
+
     const { beforeNavigate, idleTimeout, finalTimeout, heartbeatInterval } = this.options;
 
     const isPageloadTransaction = context.op === 'pageload';
 
-    const sentryTraceMetaTagValue = isPageloadTransaction ? getMetaContent('sentry-trace') : null;
-    const baggageMetaTagValue = isPageloadTransaction ? getMetaContent('baggage') : null;
-
-    const traceParentData = sentryTraceMetaTagValue ? extractTraceparentData(sentryTraceMetaTagValue) : undefined;
-    const dynamicSamplingContext = baggageMetaTagValue
-      ? baggageHeaderToDynamicSamplingContext(baggageMetaTagValue)
-      : undefined;
+    const sentryTrace = isPageloadTransaction ? getMetaContent('sentry-trace') : '';
+    const baggage = isPageloadTransaction ? getMetaContent('baggage') : '';
+    const { traceparentData, dynamicSamplingContext, propagationContext } = tracingContextFromHeaders(
+      sentryTrace,
+      baggage,
+    );
+    // Only set propagation context on pageload transactions.
+    if (isPageloadTransaction) {
+      hub.getScope().setPropagationContext(propagationContext);
+    }
 
     const expandedContext: TransactionContext = {
       ...context,
-      ...traceParentData,
+      ...traceparentData,
       metadata: {
         ...context.metadata,
-        dynamicSamplingContext: traceParentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,
+        dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,
       },
       trimEnd: true,
     };
@@ -341,7 +340,6 @@ export class BrowserTracing implements Integration {
 
     __DEBUG_BUILD__ && logger.log(`[Tracing] Starting ${finalContext.op} transaction on scope`);
 
-    const hub = this._getCurrentHub();
     const { location } = WINDOW;
 
     const idleTransaction = startIdleTransaction(
@@ -424,11 +422,11 @@ export class BrowserTracing implements Integration {
 }
 
 /** Returns the value of a meta tag */
-export function getMetaContent(metaName: string): string | null {
+export function getMetaContent(metaName: string): string | undefined {
   // Can't specify generic to `getDomElement` because tracing can be used
   // in a variety of environments, have to disable `no-unsafe-member-access`
   // as a result.
   const metaTag = getDomElement(`meta[name=${metaName}]`);
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  return metaTag ? metaTag.getAttribute('content') : null;
+  return metaTag ? metaTag.getAttribute('content') : undefined;
 }

--- a/packages/tracing-internal/src/browser/request.ts
+++ b/packages/tracing-internal/src/browser/request.ts
@@ -214,7 +214,7 @@ export function shouldAttachHeaders(url: string, tracePropagationTargets: (strin
  *
  * @returns Span if a span was created, otherwise void.
  */
-function fetchCallback(
+export function fetchCallback(
   handlerData: FetchData,
   shouldCreateSpan: (url: string) => boolean,
   shouldAttachHeaders: (url: string) => boolean,
@@ -364,7 +364,7 @@ export function addTracingHeadersToFetchRequest(
  *
  * @returns Span if a span was created, otherwise void.
  */
-function xhrCallback(
+export function xhrCallback(
   handlerData: XHRData,
   shouldCreateSpan: (url: string) => boolean,
   shouldAttachHeaders: (url: string) => boolean,

--- a/packages/tracing-internal/test/browser/browsertracing.test.ts
+++ b/packages/tracing-internal/test/browser/browsertracing.test.ts
@@ -94,7 +94,6 @@ describe('BrowserTracing', () => {
     const browserTracing = createBrowserTracing();
 
     expect(browserTracing.options).toEqual({
-      _experiments: {},
       enableLongTask: true,
       ...TRACING_DEFAULTS,
       markBackgroundTransactions: true,
@@ -113,9 +112,6 @@ describe('BrowserTracing', () => {
     });
 
     expect(browserTracing.options).toEqual({
-      _experiments: {
-        enableLongTask: false,
-      },
       enableLongTask: false,
       ...TRACING_DEFAULTS,
       markBackgroundTransactions: true,
@@ -123,6 +119,9 @@ describe('BrowserTracing', () => {
       startTransactionOnLocationChange: true,
       startTransactionOnPageLoad: true,
       ...defaultRequestInstrumentationOptions,
+      _experiments: {
+        enableLongTask: false,
+      },
     });
   });
 
@@ -132,7 +131,6 @@ describe('BrowserTracing', () => {
     });
 
     expect(browserTracing.options).toEqual({
-      _experiments: {},
       enableLongTask: false,
       ...TRACING_DEFAULTS,
       markBackgroundTransactions: true,
@@ -248,6 +246,7 @@ describe('BrowserTracing', () => {
           traceFetch: true,
           traceXHR: true,
           tracePropagationTargets: ['something'],
+          _experiments: {},
         });
       });
 
@@ -261,6 +260,7 @@ describe('BrowserTracing', () => {
         });
 
         expect(instrumentOutgoingRequestsMock).toHaveBeenCalledWith({
+          _experiments: {},
           traceFetch: true,
           traceXHR: true,
           tracePropagationTargets: ['something-else'],
@@ -546,7 +546,7 @@ describe('BrowserTracing', () => {
         document.head.innerHTML = '<meta name="cat-cafe">';
 
         const metaTagValue = getMetaContent('dogpark');
-        expect(metaTagValue).toBe(null);
+        expect(metaTagValue).toBe(undefined);
       });
 
       it('can pick the correct tag out of multiple options', () => {

--- a/packages/tracing-internal/test/browser/metrics/index.test.ts
+++ b/packages/tracing-internal/test/browser/metrics/index.test.ts
@@ -14,6 +14,7 @@ describe('_addMeasureSpans', () => {
       name: 'measure-1',
       duration: 10,
       startTime: 12,
+      detail: undefined,
     };
 
     const timeOrigin = 100;

--- a/packages/tracing-internal/test/browser/request.test.ts
+++ b/packages/tracing-internal/test/browser/request.test.ts
@@ -240,6 +240,7 @@ describe('callbacks', () => {
       expect(finishedSpan.data).toEqual({
         'http.response_content_length': 123,
         'http.method': 'GET',
+        'http.response.status_code': 404,
         type: 'fetch',
         url: 'http://dogs.are.great/',
       });

--- a/packages/tracing-internal/test/browser/router.test.ts
+++ b/packages/tracing-internal/test/browser/router.test.ts
@@ -46,6 +46,7 @@ describe('instrumentRoutingWithDefaults', () => {
       name: 'blank',
       op: 'pageload',
       metadata: { source: 'url' },
+      startTimestamp: expect.any(Number),
     });
   });
 


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/8352

This PR makes sure the `BrowserTracing` integration updates the propagation context based on meta tags. To ensure we don't keep the same propagation context, we continuously update it every time a route change should happen (navigation).

Note that we have a bunch of test changes here. This is because we actually weren't running any of the tracing tests in CI because of a blanket ignore we use (this logic is all in `@sentry-internal/tracing`. I'm fixing this in a follow up PR. https://github.com/getsentry/sentry-javascript/blob/e02c27f4ba8288ff4172a6793c955ae3806714e7/package.json#L28-L29


