### PR TITLE
experiment with using propagation context (Part 3 of TwP)

### DIFF
--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -541,6 +541,13 @@ export class Scope implements ScopeInterface {
   }
 
   /**
+   * @inheritdoc
+   */
+  public getPropagationContext(): PropagationContext {
+    return this._propagationContext;
+  }
+
+  /**
    * This will be called after {@link applyToEvent} is finished.
    */
   protected _notifyEventProcessors(

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -1,6 +1,6 @@
 export { startIdleTransaction, addTracingExtensions } from './hubextensions';
 export { IdleTransaction, TRACING_DEFAULTS } from './idletransaction';
-export { Span, spanStatusfromHttpCode } from './span';
+export { Span, spanStatusfromHttpCode, spanContextToTraceparent } from './span';
 export { Transaction } from './transaction';
 export { extractTraceparentData, getActiveTransaction } from './utils';
 // eslint-disable-next-line deprecation/deprecation

--- a/packages/core/src/tracing/span.ts
+++ b/packages/core/src/tracing/span.ts
@@ -265,11 +265,7 @@ export class Span implements SpanInterface {
    * @inheritDoc
    */
   public toTraceparent(): string {
-    let sampledString = '';
-    if (this.sampled !== undefined) {
-      sampledString = this.sampled ? '-1' : '-0';
-    }
-    return `${this.traceId}-${this.spanId}${sampledString}`;
+    return spanContextToTraceparent(this.traceId, this.spanId, this.sampled);
   }
 
   /**
@@ -437,4 +433,14 @@ export function spanStatusfromHttpCode(httpStatus: number): SpanStatusType {
   }
 
   return 'unknown_error';
+}
+
+/** Generate sentry-trace header from span context */
+export function spanContextToTraceparent(traceId: string, maybeSpanId?: string, sampled?: boolean): string {
+  let sampledString = '';
+  if (sampled !== undefined) {
+    sampledString = sampled ? '-1' : '-0';
+  }
+  const spanId = maybeSpanId || uuid4().substring(16);
+  return `${traceId}-${spanId}${sampledString}`;
 }

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -189,6 +189,11 @@ export interface Scope {
   setSDKProcessingMetadata(newData: { [key: string]: unknown }): this;
 
   /**
+   * Returns propagation context on the scope.
+   */
+  getPropagationContext(): PropagationContext;
+
+  /**
    * Add propagation context to the scope, used for distributed tracing
    */
   setPropagationContext(context: PropagationContext): this;

--- a/packages/utils/src/baggage.ts
+++ b/packages/utils/src/baggage.ts
@@ -83,8 +83,11 @@ export function baggageHeaderToDynamicSamplingContext(
  */
 export function dynamicSamplingContextToSentryBaggageHeader(
   // this also takes undefined for convenience and bundle size in other places
-  dynamicSamplingContext: Partial<DynamicSamplingContext>,
+  dynamicSamplingContext?: Partial<DynamicSamplingContext>,
 ): string | undefined {
+  if (!dynamicSamplingContext) {
+    return undefined;
+  }
   // Prefix all DSC keys with "sentry-" and put them into a new object
   const sentryPrefixedDSC = Object.entries(dynamicSamplingContext).reduce<Record<string, string>>(
     (acc, [dscKey, dscValue]) => {


### PR DESCRIPTION
This is a draft PR that represents my experiments with implementing tracing without performance (aka using propagation context to generate `sentry-trace` if there is no span).

This is Part 3 on https://github.com/getsentry/sentry-javascript/issues/8352 

I've already identified some nice to have refactors we can make here, so I'm going to open up a new PR that does some fundamental changes to propagation context. Notably, I don't think we need to store `spanId` on propagation context