### PR TITLE
feat(core): Add helpers to get module metadata from injected code

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,7 @@ export { prepareEvent } from './utils/prepareEvent';
 export { createCheckInEnvelope } from './checkin';
 export { hasTracingEnabled } from './utils/hasTracingEnabled';
 export { DEFAULT_ENVIRONMENT } from './constants';
+export { getMetadataForUrl, addMetadataToStackFrames, stripMetadataFromStackFrames } from './metadata';
 
 import * as Integrations from './integrations';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,7 +46,6 @@ export { prepareEvent } from './utils/prepareEvent';
 export { createCheckInEnvelope } from './checkin';
 export { hasTracingEnabled } from './utils/hasTracingEnabled';
 export { DEFAULT_ENVIRONMENT } from './constants';
-export { getMetadataForUrl, addMetadataToStackFrames, stripMetadataFromStackFrames } from './metadata';
 
 import * as Integrations from './integrations';
 

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -52,38 +52,46 @@ export function getMetadataForUrl(parser: StackParser, filename: string): any | 
  * Metadata is injected by the Sentry bundler plugins using the `_experiments.moduleMetadata` config option.
  */
 export function addMetadataToStackFrames(parser: StackParser, event: Event): void {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  event.exception!.values!.forEach(exception => {
-    if (!exception.stacktrace) {
-      return;
-    }
-
-    for (const frame of exception.stacktrace.frames || []) {
-      if (!frame.filename) {
-        continue;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    event.exception!.values!.forEach(exception => {
+      if (!exception.stacktrace) {
+        return;
       }
 
-      const metadata = getMetadataForUrl(parser, frame.filename);
+      for (const frame of exception.stacktrace.frames || []) {
+        if (!frame.filename) {
+          continue;
+        }
 
-      if (metadata) {
-        frame.module_metadata = metadata;
+        const metadata = getMetadataForUrl(parser, frame.filename);
+
+        if (metadata) {
+          frame.module_metadata = metadata;
+        }
       }
-    }
-  });
+    });
+  } catch (_) {
+    // To save bundle size we're just try catching here instead of checking for the existence of all the different objects.
+  }
 }
 
 /**
  * Strips metadata from stack frames.
  */
 export function stripMetadataFromStackFrames(event: Event): void {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  event.exception!.values!.forEach(exception => {
-    if (!exception.stacktrace) {
-      return;
-    }
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    event.exception!.values!.forEach(exception => {
+      if (!exception.stacktrace) {
+        return;
+      }
 
-    for (const frame of exception.stacktrace.frames || []) {
-      delete frame.module_metadata;
-    }
-  });
+      for (const frame of exception.stacktrace.frames || []) {
+        delete frame.module_metadata;
+      }
+    });
+  } catch (_) {
+    // To save bundle size we're just try catching here instead of checking for the existence of all the different objects.
+  }
 }

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -1,4 +1,4 @@
-import type { Event, StackFrame, StackParser } from '@sentry/types';
+import type { Event, StackParser } from '@sentry/types';
 import { GLOBAL_OBJ } from '@sentry/utils';
 
 function ensureMetadataStacksAreParsed(parser: StackParser): void {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -1,0 +1,87 @@
+import type { Event, StackFrame, StackParser } from '@sentry/types';
+import { GLOBAL_OBJ } from '@sentry/utils';
+
+function ensureMetadataStacksAreParsed(parser: StackParser): void {
+  if (!GLOBAL_OBJ.__MODULE_METADATA__) {
+    return;
+  }
+
+  for (const stack of Object.keys(GLOBAL_OBJ.__MODULE_METADATA__)) {
+    const metadata = GLOBAL_OBJ.__MODULE_METADATA__[stack];
+
+    // If this stack has already been parsed, skip it
+    if (metadata == false) {
+      continue;
+    }
+
+    // Ensure this stack doesn't get parsed again
+    GLOBAL_OBJ.__MODULE_METADATA__[stack] = false;
+
+    const frames = parser(stack);
+
+    // Go through the frames starting from the top of the stack and find the first one with a filename
+    for (const frame of frames.reverse()) {
+      if (frame.filename) {
+        // Save the metadata for this filename
+        GLOBAL_OBJ.__MODULE_METADATA_PARSED__ = GLOBAL_OBJ.__MODULE_METADATA_PARSED__ || {};
+        GLOBAL_OBJ.__MODULE_METADATA_PARSED__[frame.filename] = metadata;
+        break;
+      }
+    }
+  }
+}
+
+/**
+ * Retrieve metadata for a specific JavaScript file URL.
+ *
+ * Metadata is injected by the Sentry bundler plugins using the `_experiments.moduleMetadata` config option.
+ */
+export function getMetadataForUrl(parser: StackParser, url: string): object | undefined {
+  ensureMetadataStacksAreParsed(parser);
+
+  const metadataObj = GLOBAL_OBJ.__MODULE_METADATA_PARSED__ || {};
+
+  return metadataObj[url];
+}
+
+/**
+ * Adds metadata to stack frames.
+ *
+ * Metadata is injected by the Sentry bundler plugins using the `_experiments.moduleMetadata` config option.
+ */
+export function addMetadataToStackFrames(parser: StackParser, event: Event): void {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  event.exception!.values!.forEach(exception => {
+    if (!exception.stacktrace) {
+      return;
+    }
+
+    for (const frame of exception.stacktrace.frames || []) {
+      if (!frame.filename) {
+        continue;
+      }
+
+      const metadata = getMetadataForUrl(parser, frame.filename);
+
+      if (metadata) {
+        frame.module_metadata = metadata;
+      }
+    }
+  });
+}
+
+/**
+ * Strips metadata from stack frames.
+ */
+export function stripMetadataFromStackFrames(event: Event): void {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  event.exception!.values!.forEach(exception => {
+    if (!exception.stacktrace) {
+      return;
+    }
+
+    for (const frame of exception.stacktrace.frames || []) {
+      delete frame.module_metadata;
+    }
+  });
+}

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -1,35 +1,34 @@
 import type { Event, StackParser } from '@sentry/types';
 import { GLOBAL_OBJ } from '@sentry/utils';
 
-/**
- * Keys are source filenames/urls, values are metadata objects.
- */
-let filenameMetadataMap: Record<string, object> | undefined;
+/** Keys are source filename/url, values are metadata objects. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const filenameMetadataMap = new Map<string, any>();
+/** Set of stack strings that have already been parsed. */
+const parsedStacks = new Set<string>();
 
 function ensureMetadataStacksAreParsed(parser: StackParser): void {
-  if (!GLOBAL_OBJ.__MODULE_METADATA__) {
+  if (!GLOBAL_OBJ._sentryModuleMetadata) {
     return;
   }
 
-  for (const stack of Object.keys(GLOBAL_OBJ.__MODULE_METADATA__)) {
-    const metadata = GLOBAL_OBJ.__MODULE_METADATA__[stack];
+  for (const stack of Object.keys(GLOBAL_OBJ._sentryModuleMetadata)) {
+    const metadata = GLOBAL_OBJ._sentryModuleMetadata[stack];
 
-    // If this stack has already been parsed, we can skip it
-    if (metadata == false) {
+    if (parsedStacks.has(stack)) {
       continue;
     }
 
     // Ensure this stack doesn't get parsed again
-    GLOBAL_OBJ.__MODULE_METADATA__[stack] = false;
+    parsedStacks.add(stack);
 
     const frames = parser(stack);
 
     // Go through the frames starting from the top of the stack and find the first one with a filename
     for (const frame of frames.reverse()) {
       if (frame.filename) {
-        filenameMetadataMap = filenameMetadataMap || {};
         // Save the metadata for this filename
-        filenameMetadataMap[frame.filename] = metadata;
+        filenameMetadataMap.set(frame.filename, metadata);
         break;
       }
     }
@@ -41,9 +40,10 @@ function ensureMetadataStacksAreParsed(parser: StackParser): void {
  *
  * Metadata is injected by the Sentry bundler plugins using the `_experiments.moduleMetadata` config option.
  */
-export function getMetadataForUrl(parser: StackParser, url: string): object | undefined {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getMetadataForUrl(parser: StackParser, filename: string): any | undefined {
   ensureMetadataStacksAreParsed(parser);
-  return filenameMetadataMap ? filenameMetadataMap[url] : undefined;
+  return filenameMetadataMap.get(filename);
 }
 
 /**

--- a/packages/core/test/lib/metadata.test.ts
+++ b/packages/core/test/lib/metadata.test.ts
@@ -1,0 +1,102 @@
+import type { Event } from '@sentry/types';
+import { createStackParser, GLOBAL_OBJ, nodeStackLineParser } from '@sentry/utils';
+
+import { addMetadataToStackFrames, getMetadataForUrl, stripMetadataFromStackFrames } from '../../src';
+
+const parser = createStackParser(nodeStackLineParser());
+
+const stack = new Error().stack || '';
+
+const event: Event = {
+  exception: {
+    values: [
+      {
+        stacktrace: {
+          frames: [
+            {
+              filename: '<anonymous>',
+              function: 'new Promise',
+            },
+            {
+              filename: '/tmp/utils.js',
+              function: 'Promise.then.completed',
+              lineno: 391,
+              colno: 28,
+            },
+            {
+              filename: __filename,
+              function: 'Object.<anonymous>',
+              lineno: 9,
+              colno: 19,
+            },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+describe('Metadata', () => {
+  beforeEach(() => {
+    GLOBAL_OBJ.__MODULE_METADATA__ = GLOBAL_OBJ.__MODULE_METADATA__ || {};
+    GLOBAL_OBJ.__MODULE_METADATA__[stack] = { team: 'frontend' };
+  });
+
+  it('is parsed', () => {
+    const metadata = getMetadataForUrl(parser, __filename);
+
+    expect(metadata).toEqual({ team: 'frontend' });
+    // should now be false so it doesn't get parsed again
+    expect(GLOBAL_OBJ.__MODULE_METADATA__?.[stack]).toBe(false);
+  });
+
+  it('is added and stripped from stack frames', () => {
+    addMetadataToStackFrames(parser, event);
+
+    expect(event.exception?.values?.[0].stacktrace?.frames).toEqual([
+      {
+        filename: '<anonymous>',
+        function: 'new Promise',
+      },
+      {
+        filename: '/tmp/utils.js',
+        function: 'Promise.then.completed',
+        lineno: 391,
+        colno: 28,
+      },
+      {
+        filename: __filename,
+        function: 'Object.<anonymous>',
+        lineno: 9,
+        colno: 19,
+        module_metadata: {
+          team: 'frontend',
+        },
+      },
+    ]);
+
+    // should now be false so it doesn't get parsed again
+    expect(GLOBAL_OBJ.__MODULE_METADATA__?.[stack]).toBe(false);
+
+    stripMetadataFromStackFrames(event);
+
+    expect(event.exception?.values?.[0].stacktrace?.frames).toEqual([
+      {
+        filename: '<anonymous>',
+        function: 'new Promise',
+      },
+      {
+        filename: '/tmp/utils.js',
+        function: 'Promise.then.completed',
+        lineno: 391,
+        colno: 28,
+      },
+      {
+        filename: __filename,
+        function: 'Object.<anonymous>',
+        lineno: 9,
+        colno: 19,
+      },
+    ]);
+  });
+});

--- a/packages/core/test/lib/metadata.test.ts
+++ b/packages/core/test/lib/metadata.test.ts
@@ -1,7 +1,7 @@
 import type { Event } from '@sentry/types';
 import { createStackParser, GLOBAL_OBJ, nodeStackLineParser } from '@sentry/utils';
 
-import { addMetadataToStackFrames, getMetadataForUrl, stripMetadataFromStackFrames } from '../../src';
+import { addMetadataToStackFrames, getMetadataForUrl, stripMetadataFromStackFrames } from '../../src/metadata';
 
 const parser = createStackParser(nodeStackLineParser());
 
@@ -38,16 +38,14 @@ const event: Event = {
 
 describe('Metadata', () => {
   beforeEach(() => {
-    GLOBAL_OBJ.__MODULE_METADATA__ = GLOBAL_OBJ.__MODULE_METADATA__ || {};
-    GLOBAL_OBJ.__MODULE_METADATA__[stack] = { team: 'frontend' };
+    GLOBAL_OBJ._sentryModuleMetadata = GLOBAL_OBJ._sentryModuleMetadata || {};
+    GLOBAL_OBJ._sentryModuleMetadata[stack] = { team: 'frontend' };
   });
 
   it('is parsed', () => {
     const metadata = getMetadataForUrl(parser, __filename);
 
     expect(metadata).toEqual({ team: 'frontend' });
-    // should now be false so it doesn't get parsed again
-    expect(GLOBAL_OBJ.__MODULE_METADATA__?.[stack]).toBe(false);
   });
 
   it('is added and stripped from stack frames', () => {
@@ -74,9 +72,6 @@ describe('Metadata', () => {
         },
       },
     ]);
-
-    // should now be false so it doesn't get parsed again
-    expect(GLOBAL_OBJ.__MODULE_METADATA__?.[stack]).toBe(false);
 
     stripMetadataFromStackFrames(event);
 

--- a/packages/types/src/stackframe.ts
+++ b/packages/types/src/stackframe.ts
@@ -15,4 +15,5 @@ export interface StackFrame {
   addr_mode?: string;
   vars?: { [key: string]: any };
   debug_id?: string;
+  module_metadata?: object;
 }

--- a/packages/types/src/stackframe.ts
+++ b/packages/types/src/stackframe.ts
@@ -15,5 +15,5 @@ export interface StackFrame {
   addr_mode?: string;
   vars?: { [key: string]: any };
   debug_id?: string;
-  module_metadata?: object;
+  module_metadata?: any;
 }

--- a/packages/utils/src/worldwide.ts
+++ b/packages/utils/src/worldwide.ts
@@ -58,10 +58,9 @@ export interface InternalGlobal {
   /**
    * Raw module metadata that is injected by bundler plugins.
    *
-   * Keys are `error.stack` strings, values are metadata objects.
-   * Once the stack has been parsed, the value is set to `false` so they do not get parsed multiple times.
+   * Keys are `error.stack` strings, values are the metadata.
    */
-  __MODULE_METADATA__?: Record<string, object | false>;
+  _sentryModuleMetadata?: Record<string, any>;
 }
 
 // The code below for 'isGlobalObj' and 'GLOBAL_OBJ' was copied from core-js before modification

--- a/packages/utils/src/worldwide.ts
+++ b/packages/utils/src/worldwide.ts
@@ -62,12 +62,6 @@ export interface InternalGlobal {
    * Once the stack has been parsed, the value is set to `false` so they do not get parsed multiple times.
    */
   __MODULE_METADATA__?: Record<string, object | false>;
-  /**
-   * Parsed module metadata.
-   *
-   * Keys are source filenames/urls, values are metadata objects.
-   */
-  __MODULE_METADATA_PARSED__?: Record<string, object>;
 }
 
 // The code below for 'isGlobalObj' and 'GLOBAL_OBJ' was copied from core-js before modification

--- a/packages/utils/src/worldwide.ts
+++ b/packages/utils/src/worldwide.ts
@@ -55,6 +55,19 @@ export interface InternalGlobal {
       [key: string]: Function;
     };
   };
+  /**
+   * Raw module metadata that is injected by bundler plugins.
+   *
+   * Keys are `error.stack` strings, values are metadata objects.
+   * Once the stack has been parsed, the value is set to `false` so they do not get parsed multiple times.
+   */
+  __MODULE_METADATA__?: Record<string, object | false>;
+  /**
+   * Parsed module metadata.
+   *
+   * Keys are source filenames/urls, values are metadata objects.
+   */
+  __MODULE_METADATA_PARSED__?: Record<string, object>;
 }
 
 // The code below for 'isGlobalObj' and 'GLOBAL_OBJ' was copied from core-js before modification


### PR DESCRIPTION
Part of the code required to better support Module Federation/Micro Frontends.

The webpack bundler will be able to optionally inject metadata into each bundle chunk (https://github.com/getsentry/sentry-javascript-bundler-plugins/pull/334). 

This PR adds code that:
- Adds `module_metadata` to `StackFrame`
- Adds `getMetadataForUrl` that gets metadata for a path/URL
  - Parses the stacks on demand to get the relevant filename for a chunk and associated injected metadata 
- Adds `addMetadataToStackFrames` that populates `module_metadata` in stack frames with metadata when available
- Adds `stripMetadataFromStackFrames` that strips `module_metadata` from stack frames


