### PR TITLE
ci: Fix `cache-hit` typo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,7 @@ jobs:
           key: ${{ steps.compute_lockfile_hash.outputs.hash }}
 
       - name: Install dependencies
-        if: steps.cache_dependencies.outputs.cache_hit != 'true'
+        if: steps.cache_dependencies.outputs.cache-hit != 'true'
         run: yarn install --ignore-engines --frozen-lockfile
     outputs:
       dependency_cache_key: ${{ steps.compute_lockfile_hash.outputs.hash }}


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/8445