### PR TITLE
feat(node): Add tracing without performance to Node http integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -661,7 +661,7 @@ jobs:
     needs: [job_get_metadata, job_build]
     if: needs.job_get_metadata.outputs.changed_node == 'true' || github.event_name != 'pull_request'
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/packages/nextjs/test/integration/sentry.client.config.js
+++ b/packages/nextjs/test/integration/sentry.client.config.js
@@ -3,7 +3,7 @@ import { Integrations } from '@sentry/tracing';
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  tracesSampleRate: 1,
+  tracesSampler: () => true,
   debug: process.env.SDK_DEBUG,
 
   integrations: [

--- a/packages/nextjs/test/integration/sentry.edge.config.js
+++ b/packages/nextjs/test/integration/sentry.edge.config.js
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  tracesSampleRate: 1,
+  tracesSampleRate: 1.0,
+  tracePropagationTargets: ['http://example.com'],
   debug: process.env.SDK_DEBUG,
 });

--- a/packages/nextjs/test/integration/sentry.server.config.js
+++ b/packages/nextjs/test/integration/sentry.server.config.js
@@ -2,7 +2,8 @@ import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
-  tracesSampleRate: 1,
+  tracesSampleRate: 1.0,
+  tracePropagationTargets: ['http://example.com'],
   debug: process.env.SDK_DEBUG,
 
   integrations: defaults => [

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/server.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/server.ts
@@ -12,6 +12,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   environment: 'prod',
+  tracePropagationTargets: [/^(?!.*express).*$/],
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/server.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/server.ts
@@ -12,6 +12,8 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   environment: 'prod',
+  // disable requests to /express
+  tracePropagationTargets: [/^(?!.*express).*$/],
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/server.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/server.ts
@@ -12,6 +12,8 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   environment: 'prod',
+  // disable requests to /express
+  tracePropagationTargets: [/^(?!.*express).*$/],
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/server.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/server.ts
@@ -12,6 +12,8 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   environment: 'prod',
+  // disable requests to /express
+  tracePropagationTargets: [/^(?!.*express).*$/],
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,

--- a/packages/node-integration-tests/suites/express/sentry-trace/server.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/server.ts
@@ -12,6 +12,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   environment: 'prod',
+  tracePropagationTargets: [/^(?!.*express).*$/],
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,

--- a/packages/node-integration-tests/suites/express/tracing/server.ts
+++ b/packages/node-integration-tests/suites/express/tracing/server.ts
@@ -7,6 +7,8 @@ const app = express();
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
+  // disable attaching headers to /test/* endpoints
+  tracePropagationTargets: [/^(?!.*test).*$/],
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
 });

--- a/packages/node-integration-tests/utils/index.ts
+++ b/packages/node-integration-tests/utils/index.ts
@@ -202,11 +202,11 @@ export class TestEnv {
    */
   public async getAPIResponse(
     url?: string,
-    headers?: Record<string, string>,
+    headers: Record<string, string> = {},
     endServer: boolean = true,
   ): Promise<unknown> {
     try {
-      const { data } = await axios.get(url || this.url, { headers: headers || {} });
+      const { data } = await axios.get(url || this.url, { headers });
       return data;
     } finally {
       await Sentry.flush();

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -54,6 +54,21 @@ describe('tracing', () => {
     return transaction;
   }
 
+  function getHub(customOptions: Partial<NodeClientOptions> = {}) {
+    const options = getDefaultNodeClientOptions({
+      dsn: 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012',
+      tracesSampleRate: 1.0,
+      integrations: [new HttpIntegration({ tracing: true })],
+      release: '1.0.0',
+      environment: 'production',
+      ...customOptions,
+    });
+    const hub = new Hub(new NodeClient(options));
+    jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
+
+    return hub;
+  }
+
   it("creates a span for each outgoing non-sentry request when there's a transaction on the scope", () => {
     nock('http://dogs.are.great').get('/').reply(200);
 
@@ -160,6 +175,51 @@ describe('tracing', () => {
       'dog=great',
       'sentry-environment=production,sentry-release=1.0.0,sentry-user_segment=segmentA,sentry-public_key=dogsarebadatkeepingsecrets,sentry-trace_id=12312012123120121231201212312012,sentry-sample_rate=1',
     ]);
+  });
+
+  it('generates and uses propagation context to attach baggage and sentry-trace header', async () => {
+    nock('http://dogs.are.great').get('/').reply(200);
+
+    const request = http.get('http://dogs.are.great/');
+    const sentryTraceHeader = request.getHeader('sentry-trace') as string;
+    const baggageHeader = request.getHeader('baggage') as string;
+
+    const parts = sentryTraceHeader.split('-');
+    expect(parts.length).toEqual(3);
+    expect(parts[0]).toEqual('12312012123120121231201212312012');
+    expect(parts[1]).toEqual(expect.any(String));
+    expect(parts[2]).toEqual('1');
+
+    expect(baggageHeader).toEqual(
+      'sentry-environment=production,sentry-release=1.0.0,sentry-user_segment=segmentA,sentry-public_key=dogsarebadatkeepingsecrets,sentry-trace_id=12312012123120121231201212312012,sentry-sample_rate=1',
+    );
+  });
+
+  it('uses incoming propagation context to attach baggage and sentry-trace', async () => {
+    nock('http://dogs.are.great').get('/').reply(200);
+
+    const hub = getHub();
+    hub.getScope().setPropagationContext({
+      traceId: '86f39e84263a4de99c326acab3bfe3bd',
+      spanId: '86f39e84263a4de9',
+      sampled: true,
+      dsc: {
+        trace_id: '86f39e84263a4de99c326acab3bfe3bd',
+        public_key: 'test-public-key',
+      },
+    });
+
+    const request = http.get('http://dogs.are.great/');
+    const sentryTraceHeader = request.getHeader('sentry-trace') as string;
+    const baggageHeader = request.getHeader('baggage') as string;
+
+    const parts = sentryTraceHeader.split('-');
+    expect(parts.length).toEqual(3);
+    expect(parts[0]).toEqual('86f39e84263a4de99c326acab3bfe3bd');
+    expect(parts[1]).toEqual(expect.any(String));
+    expect(parts[2]).toEqual('1');
+
+    expect(baggageHeader).toEqual('sentry-trace_id=86f39e84263a4de99c326acab3bfe3bd,sentry-public_key=test-public-key');
   });
 
   it("doesn't attach the sentry-trace header to outgoing sentry requests", () => {
@@ -272,7 +332,7 @@ describe('tracing', () => {
 
     // TODO (v8): These can be removed once we remove these properties from client options
     describe('as client options', () => {
-      it("doesn't create span if shouldCreateSpanForRequest returns false", () => {
+      it('creates span with propagation context if shouldCreateSpanForRequest returns false', () => {
         const url = 'http://dogs.are.great/api/v1/index/';
         nock(url).get(/.*/).reply(200);
 
@@ -295,8 +355,15 @@ describe('tracing', () => {
         expect(httpSpans.length).toBe(0);
 
         // And headers are not attached without span creation
-        expect(request.getHeader('sentry-trace')).toBeUndefined();
-        expect(request.getHeader('baggage')).toBeUndefined();
+        expect(request.getHeader('sentry-trace')).toBeDefined();
+        expect(request.getHeader('baggage')).toBeDefined();
+
+        const propagationContext = hub.getScope().getPropagationContext();
+
+        expect((request.getHeader('sentry-trace') as string).includes(propagationContext.traceId)).toBe(true);
+        expect(request.getHeader('baggage')).toEqual(
+          `sentry-environment=production,sentry-release=1.0.0,sentry-public_key=dogsarebadatkeepingsecrets,sentry-trace_id=${propagationContext.traceId}`,
+        );
       });
 
       it.each([
@@ -366,7 +433,7 @@ describe('tracing', () => {
     });
 
     describe('as Http integration constructor options', () => {
-      it("doesn't create span if shouldCreateSpanForRequest returns false", () => {
+      it('creates span with propagation context if shouldCreateSpanForRequest returns false', () => {
         const url = 'http://dogs.are.great/api/v1/index/';
         nock(url).get(/.*/).reply(200);
 
@@ -393,8 +460,15 @@ describe('tracing', () => {
         expect(httpSpans.length).toBe(0);
 
         // And headers are not attached without span creation
-        expect(request.getHeader('sentry-trace')).toBeUndefined();
-        expect(request.getHeader('baggage')).toBeUndefined();
+        expect(request.getHeader('sentry-trace')).toBeDefined();
+        expect(request.getHeader('baggage')).toBeDefined();
+
+        const propagationContext = hub.getScope().getPropagationContext();
+
+        expect((request.getHeader('sentry-trace') as string).includes(propagationContext.traceId)).toBe(true);
+        expect(request.getHeader('baggage')).toEqual(
+          `sentry-environment=production,sentry-release=1.0.0,sentry-public_key=dogsarebadatkeepingsecrets,sentry-trace_id=${propagationContext.traceId}`,
+        );
       });
 
       it.each([

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -330,7 +330,6 @@ describe('tracing', () => {
       return transaction;
     }
 
-    // TODO (v8): These can be removed once we remove these properties from client options
     describe('as client options', () => {
       it('creates span with propagation context if shouldCreateSpanForRequest returns false', () => {
         const url = 'http://dogs.are.great/api/v1/index/';

--- a/packages/remix/test/integration/app_v1/entry.server.tsx
+++ b/packages/remix/test/integration/app_v1/entry.server.tsx
@@ -6,6 +6,7 @@ import * as Sentry from '@sentry/remix';
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
+  tracePropagationTargets: [/^(?!.*^\/).*$/],
   // Disabling to test series of envelopes deterministically.
   autoSessionTracking: false,
 });

--- a/packages/remix/test/integration/app_v1/entry.server.tsx
+++ b/packages/remix/test/integration/app_v1/entry.server.tsx
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/remix';
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
-  tracePropagationTargets: [/^(?!.*^\/).*$/],
+  tracePropagationTargets: ['example.org'],
   // Disabling to test series of envelopes deterministically.
   autoSessionTracking: false,
 });

--- a/packages/remix/test/integration/app_v2/entry.server.tsx
+++ b/packages/remix/test/integration/app_v2/entry.server.tsx
@@ -6,6 +6,7 @@ import * as Sentry from '@sentry/remix';
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
+  tracePropagationTargets: [/^(?!.*^\/).*$/],
   // Disabling to test series of envelopes deterministically.
   autoSessionTracking: false,
 });

--- a/packages/remix/test/integration/app_v2/entry.server.tsx
+++ b/packages/remix/test/integration/app_v2/entry.server.tsx
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/remix';
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   tracesSampleRate: 1,
-  tracePropagationTargets: [/^(?!.*^\/).*$/],
+  tracePropagationTargets: ['example.org'],
   // Disabling to test series of envelopes deterministically.
   autoSessionTracking: false,
 });


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/8352

Updates the Node HTTP integration to always attach `sentry-trace` headers to outgoing requests.

This can be controlled with the top level `tracePropagationOptions` option.