### PR TITLE
fix(node): Apply source context to linked errors even when it is uncached

### DIFF
--- a/packages/node/test/integrations/linkederrors.test.ts
+++ b/packages/node/test/integrations/linkederrors.test.ts
@@ -20,10 +20,9 @@ describe('LinkedErrors', () => {
       const event = {
         message: 'foo',
       };
-      return linkedErrors._handler(stackParser, event, {}).then((result: any) => {
-        expect(spy.mock.calls.length).toEqual(0);
-        expect(result).toEqual(event);
-      });
+      const result = linkedErrors._handler(stackParser, event, {});
+      expect(spy.mock.calls.length).toEqual(0);
+      expect(result).toEqual(event);
     });
 
     it('should bail out if event contains exception, but no hint', async () => {
@@ -47,24 +46,17 @@ describe('LinkedErrors', () => {
 
     it('should call walkErrorTree if event contains exception and hint with originalException', async () => {
       expect.assertions(1);
-      const spy = jest.spyOn(linkedErrors, '_walkErrorTree').mockImplementation(
-        async () =>
-          new Promise<[]>(resolve => {
-            resolve([]);
-          }),
-      );
+      const spy = jest.spyOn(linkedErrors, '_walkErrorTree').mockImplementation(() => []);
       const one = new Error('originalException');
       const options = getDefaultNodeClientOptions({ stackParser });
       const client = new NodeClient(options);
-      return client.eventFromException(one).then(event =>
-        linkedErrors
-          ._handler(stackParser, event, {
-            originalException: one,
-          })
-          .then((_: any) => {
-            expect(spy.mock.calls.length).toEqual(1);
-          }),
-      );
+      return client.eventFromException(one).then(event => {
+        linkedErrors._handler(stackParser, event, {
+          originalException: one,
+        });
+
+        expect(spy.mock.calls.length).toEqual(1);
+      });
     });
 
     it('should recursively walk error to find linked exceptions and assign them to the event', async () => {
@@ -77,24 +69,22 @@ describe('LinkedErrors', () => {
 
       const options = getDefaultNodeClientOptions({ stackParser });
       const client = new NodeClient(options);
-      return client.eventFromException(one).then(event =>
-        linkedErrors
-          ._handler(stackParser, event, {
-            originalException: one,
-          })
-          .then((result: any) => {
-            expect(result.exception.values.length).toEqual(3);
-            expect(result.exception.values[0].type).toEqual('SyntaxError');
-            expect(result.exception.values[0].value).toEqual('three');
-            expect(result.exception.values[0].stacktrace).toHaveProperty('frames');
-            expect(result.exception.values[1].type).toEqual('TypeError');
-            expect(result.exception.values[1].value).toEqual('two');
-            expect(result.exception.values[1].stacktrace).toHaveProperty('frames');
-            expect(result.exception.values[2].type).toEqual('Error');
-            expect(result.exception.values[2].value).toEqual('one');
-            expect(result.exception.values[2].stacktrace).toHaveProperty('frames');
-          }),
-      );
+      return client.eventFromException(one).then(event => {
+        const result = linkedErrors._handler(stackParser, event, {
+          originalException: one,
+        });
+
+        expect(result.exception.values.length).toEqual(3);
+        expect(result.exception.values[0].type).toEqual('SyntaxError');
+        expect(result.exception.values[0].value).toEqual('three');
+        expect(result.exception.values[0].stacktrace).toHaveProperty('frames');
+        expect(result.exception.values[1].type).toEqual('TypeError');
+        expect(result.exception.values[1].value).toEqual('two');
+        expect(result.exception.values[1].stacktrace).toHaveProperty('frames');
+        expect(result.exception.values[2].type).toEqual('Error');
+        expect(result.exception.values[2].value).toEqual('one');
+        expect(result.exception.values[2].stacktrace).toHaveProperty('frames');
+      });
     });
 
     it('should allow to change walk key', async () => {
@@ -111,24 +101,22 @@ describe('LinkedErrors', () => {
 
       const options = getDefaultNodeClientOptions({ stackParser });
       const client = new NodeClient(options);
-      return client.eventFromException(one).then(event =>
-        linkedErrors
-          ._handler(stackParser, event, {
-            originalException: one,
-          })
-          .then((result: any) => {
-            expect(result.exception.values.length).toEqual(3);
-            expect(result.exception.values[0].type).toEqual('SyntaxError');
-            expect(result.exception.values[0].value).toEqual('three');
-            expect(result.exception.values[0].stacktrace).toHaveProperty('frames');
-            expect(result.exception.values[1].type).toEqual('TypeError');
-            expect(result.exception.values[1].value).toEqual('two');
-            expect(result.exception.values[1].stacktrace).toHaveProperty('frames');
-            expect(result.exception.values[2].type).toEqual('Error');
-            expect(result.exception.values[2].value).toEqual('one');
-            expect(result.exception.values[2].stacktrace).toHaveProperty('frames');
-          }),
-      );
+      return client.eventFromException(one).then(event => {
+        const result = linkedErrors._handler(stackParser, event, {
+          originalException: one,
+        });
+
+        expect(result.exception.values.length).toEqual(3);
+        expect(result.exception.values[0].type).toEqual('SyntaxError');
+        expect(result.exception.values[0].value).toEqual('three');
+        expect(result.exception.values[0].stacktrace).toHaveProperty('frames');
+        expect(result.exception.values[1].type).toEqual('TypeError');
+        expect(result.exception.values[1].value).toEqual('two');
+        expect(result.exception.values[1].stacktrace).toHaveProperty('frames');
+        expect(result.exception.values[2].type).toEqual('Error');
+        expect(result.exception.values[2].value).toEqual('one');
+        expect(result.exception.values[2].stacktrace).toHaveProperty('frames');
+      });
     });
 
     it('should allow to change stack size limit', async () => {
@@ -145,21 +133,19 @@ describe('LinkedErrors', () => {
 
       const options = getDefaultNodeClientOptions({ stackParser });
       const client = new NodeClient(options);
-      return client.eventFromException(one).then(event =>
-        linkedErrors
-          ._handler(stackParser, event, {
-            originalException: one,
-          })
-          .then((result: any) => {
-            expect(result.exception.values.length).toEqual(2);
-            expect(result.exception.values[0].type).toEqual('TypeError');
-            expect(result.exception.values[0].value).toEqual('two');
-            expect(result.exception.values[0].stacktrace).toHaveProperty('frames');
-            expect(result.exception.values[1].type).toEqual('Error');
-            expect(result.exception.values[1].value).toEqual('one');
-            expect(result.exception.values[1].stacktrace).toHaveProperty('frames');
-          }),
-      );
+      return client.eventFromException(one).then(event => {
+        const result = linkedErrors._handler(stackParser, event, {
+          originalException: one,
+        });
+
+        expect(result.exception.values.length).toEqual(2);
+        expect(result.exception.values[0].type).toEqual('TypeError');
+        expect(result.exception.values[0].value).toEqual('two');
+        expect(result.exception.values[0].stacktrace).toHaveProperty('frames');
+        expect(result.exception.values[1].type).toEqual('Error');
+        expect(result.exception.values[1].value).toEqual('one');
+        expect(result.exception.values[1].stacktrace).toHaveProperty('frames');
+      });
     });
   });
 });


### PR DESCRIPTION
When I looked into the linked errors integration to implement support for Aggregate erros I noticed that in the node linked errors integration we had an `await` that did nothing.

This was a bit curios to me since all of the functions in the node linked errors integration were async just because of that await. Looking into it some more it seems that we used the wrong funciton of the context lines integration to attach source context. We were only attaching source context if the file was in our file cache - this operation is synchronous. We  basically just called the wrong fuction of the context lines integration (`addSourceContextToFrames` instead of `addSourceContext`).

This pr changes the node linked errors integration to add source (cached AND uncached) source context to linked errors after they have been attached to the event. Also gets rid of some unnecessary sync promise, async await shenanigans.