### PR TITLE
fix(nextjs): Use `basePath` option for `tunnelRoute`

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -865,7 +865,10 @@ function addValueInjectionLoader(
 
   const isomorphicValues = {
     // `rewritesTunnel` set by the user in Next.js config
-    __sentryRewritesTunnelPath__: userSentryOptions.tunnelRoute !== undefined ? `${userNextConfig.basePath ?? ''}${userSentryOptions.tunnelRoute}` : undefined,
+    __sentryRewritesTunnelPath__:
+      userSentryOptions.tunnelRoute !== undefined
+        ? `${userNextConfig.basePath ?? ''}${userSentryOptions.tunnelRoute}`
+        : undefined,
 
     // The webpack plugin's release injection breaks the `app` directory so we inject the release manually here instead.
     // Having a release defined in dev-mode spams releases in Sentry so we only set one in non-dev mode

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -865,7 +865,7 @@ function addValueInjectionLoader(
 
   const isomorphicValues = {
     // `rewritesTunnel` set by the user in Next.js config
-    __sentryRewritesTunnelPath__: `${userNextConfig.basePath ?? ''}${userSentryOptions.tunnelRoute}`,
+    __sentryRewritesTunnelPath__: userSentryOptions.tunnelRoute !== undefined ? `${userNextConfig.basePath ?? ''}${userSentryOptions.tunnelRoute}` : undefined,
 
     // The webpack plugin's release injection breaks the `app` directory so we inject the release manually here instead.
     // Having a release defined in dev-mode spams releases in Sentry so we only set one in non-dev mode

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -865,7 +865,7 @@ function addValueInjectionLoader(
 
   const isomorphicValues = {
     // `rewritesTunnel` set by the user in Next.js config
-    __sentryRewritesTunnelPath__: userSentryOptions.tunnelRoute,
+    __sentryRewritesTunnelPath__: `${userNextConfig.basePath ?? ''}${userSentryOptions.tunnelRoute}`,
 
     // The webpack plugin's release injection breaks the `app` directory so we inject the release manually here instead.
     // Having a release defined in dev-mode spams releases in Sentry so we only set one in non-dev mode


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/8293

Prepends the tunnel route with [Next.js' `basePath` option](https://nextjs.org/docs/app/api-reference/next-config-js/basePath) if it is set.

h/t to @inlet for noting figuring out that the rewrite was already correct. Thought that this was gonna be a bit more involved.