### PR TITLE
build(angular): Avoid loading all `@types/` packages

### DIFF
--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -5,6 +5,10 @@
 
   "compilerOptions": {
     // package-specific options
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    // Avoid loading all @types/... packages as they may not be TS 4.0 compatible
+    // We have no types packages here we directly depend on,
+    // if we ever add some we need to allowlist them here
+    "types": []
   }
 }


### PR DESCRIPTION
As `@sentry/angular` uses TS 4.0, but the default behavior of TS is to load _all_ `@types/xxx` packages it can find in node_modules, the build will fail if _any_ other package uses a types package that uses newer TS features. 

In order to avoid this, we opt out of the automatic types resolution - since we are not using any `@types/xxx` package in angular as of now, this doesn't change anything.

See https://www.typescriptlang.org/tsconfig/types.html for details.