### PR TITLE
fix(remix): Don't inject trace/baggage to `redirect` and `catch` responses

### DIFF
--- a/packages/remix/test/integration/app_v1/root.tsx
+++ b/packages/remix/test/integration/app_v1/root.tsx
@@ -34,6 +34,10 @@ export const loader: LoaderFunction = async ({ request }) => {
       throw redirect('/?type=plain');
     case 'returnRedirect':
       return redirect('/?type=plain');
+    case 'throwRedirectToExternal':
+      throw redirect('https://example.com');
+    case 'returnRedirectToExternal':
+      return redirect('https://example.com');
     default: {
       return {};
     }

--- a/packages/remix/test/integration/app_v2/root.tsx
+++ b/packages/remix/test/integration/app_v2/root.tsx
@@ -34,6 +34,10 @@ export const loader: LoaderFunction = async ({ request }) => {
       throw redirect('/?type=plain');
     case 'returnRedirect':
       return redirect('/?type=plain');
+    case 'throwRedirectToExternal':
+      throw redirect('https://example.com');
+    case 'returnRedirectToExternal':
+      return redirect('https://example.com');
     default: {
       return {};
     }

--- a/packages/remix/test/integration/test/client/root-loader.test.ts
+++ b/packages/remix/test/integration/test/client/root-loader.test.ts
@@ -125,6 +125,9 @@ test('should inject `sentry-trace` and `baggage` into root loader throwing a red
 }) => {
   await page.goto('/?type=throwRedirect');
 
+  // We should be successfully redirected to the path.
+  expect(page.url()).toEqual(expect.stringContaining('/?type=plain'));
+
   const { sentryTrace, sentryBaggage } = await extractTraceAndBaggageFromMeta(page);
 
   expect(sentryTrace).toEqual(expect.any(String));
@@ -138,10 +141,13 @@ test('should inject `sentry-trace` and `baggage` into root loader throwing a red
   });
 });
 
-test('should inject `sentry-trace` and `baggage` into root loader returning a redirection to a plain object', async ({
+test('should inject `sentry-trace` and `baggage` into root loader returning a redirection to valid path.', async ({
   page,
 }) => {
   await page.goto('/?type=returnRedirect');
+
+  // We should be successfully redirected to the path.
+  expect(page.url()).toEqual(expect.stringContaining('/?type=plain'));
 
   const { sentryTrace, sentryBaggage } = await extractTraceAndBaggageFromMeta(page);
 
@@ -154,4 +160,28 @@ test('should inject `sentry-trace` and `baggage` into root loader returning a re
     sentryTrace: sentryTrace,
     sentryBaggage: sentryBaggage,
   });
+});
+
+test('should return redirect to an external path with no baggage and trace injected.', async ({ page }) => {
+  await page.goto('/?type=returnRedirectToExternal');
+
+  // We should be successfully redirected to the external path.
+  expect(page.url()).toEqual(expect.stringContaining('https://example.com'));
+
+  const { sentryTrace, sentryBaggage } = await extractTraceAndBaggageFromMeta(page);
+
+  expect(sentryTrace).toBeUndefined();
+  expect(sentryBaggage).toBeUndefined();
+});
+
+test('should throw redirect to an external path with no baggage and trace injected.', async ({ page }) => {
+  await page.goto('/?type=throwRedirectToExternal');
+
+  // We should be successfully redirected to the external path.
+  expect(page.url()).toEqual(expect.stringContaining('https://example.com'));
+
+  const { sentryTrace, sentryBaggage } = await extractTraceAndBaggageFromMeta(page);
+
+  expect(sentryTrace).toBeUndefined();
+  expect(sentryBaggage).toBeUndefined();
 });


### PR DESCRIPTION
Related: https://github.com/epicweb-dev/epic-stack/issues/256

Skips `trace` and `baggage` injections to `redirect` and `catch` responses.

For `redirect` responses: It was breaking the behaviour of redirection. Internal redirection targets should already have their `trace` and `baggage`, so I assume this should not break the connection between services at the end.

`catch` responses do not have bodies, and they are thrown by Remix, so skipping injection as well not to potentially break the internal catch behaviour of Remix.