### PR TITLE
fix(nextjs): Ignore `tunnelRoute` when doing static exports

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -50,7 +50,7 @@ export type NextConfigObject = {
   // File extensions that count as pages in the `pages/` directory
   pageExtensions?: string[];
   // Whether Next.js should do a static export
-  output?: 'export';
+  output?: string;
   // Paths to reroute when requested
   rewrites?: () => Promise<
     | NextRewrite[]

--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -49,6 +49,8 @@ export type NextConfigObject = {
   publicRuntimeConfig?: { [key: string]: unknown };
   // File extensions that count as pages in the `pages/` directory
   pageExtensions?: string[];
+  // Whether Next.js should do a static export
+  output?: 'export';
   // Paths to reroute when requested
   rewrites?: () => Promise<
     | NextRewrite[]

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -866,7 +866,7 @@ function addValueInjectionLoader(
   const isomorphicValues = {
     // `rewritesTunnel` set by the user in Next.js config
     __sentryRewritesTunnelPath__:
-      userSentryOptions.tunnelRoute !== undefined
+      userSentryOptions.tunnelRoute !== undefined && userNextConfig.output !== 'export'
         ? `${userNextConfig.basePath ?? ''}${userSentryOptions.tunnelRoute}`
         : undefined,
 

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -8,6 +8,8 @@ import type {
 } from './types';
 import { constructWebpackConfigFunction } from './webpack';
 
+let showedExportModeTunnelWarning = false;
+
 /**
  * Add Sentry options to the config to be exported from the user's `next.config.js` file.
  *
@@ -48,7 +50,17 @@ function getFinalConfigObject(
   delete incomingUserNextConfigObject.sentry;
 
   if (userSentryOptions?.tunnelRoute) {
-    setUpTunnelRewriteRules(incomingUserNextConfigObject, userSentryOptions.tunnelRoute);
+    if (incomingUserNextConfigObject.output === 'export') {
+      if (!showedExportModeTunnelWarning) {
+        showedExportModeTunnelWarning = true;
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[@sentry/nextjs] The Sentry Next.js SDK `tunnelRoute` option will not work in combination with Next.js static exports. The `tunnelRoute` option uses serverside features that cannot be accessed in export mode. If you still want to tunnel Sentry events, set up your own tunnel: https://docs.sentry.io/platforms/javascript/troubleshooting/#using-the-tunnel-option',
+        );
+      }
+    } else {
+      setUpTunnelRewriteRules(incomingUserNextConfigObject, userSentryOptions.tunnelRoute);
+    }
   }
 
   return {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/8285

Next.js doesn't allow static exports + rewrites. This PR will stop injecting rewrites on static exports.