### PR TITLE
feat(core): Add sampling decision to trace envelope header

### DIFF
--- a/packages/browser-integration-tests/suites/replay/dsc/test.ts
+++ b/packages/browser-integration-tests/suites/replay/dsc/test.ts
@@ -49,6 +49,7 @@ sentryTest(
       trace_id: expect.any(String),
       public_key: 'public',
       replay_id: replay.session?.id,
+      sampled: 'true',
     });
   },
 );
@@ -93,6 +94,7 @@ sentryTest(
       sample_rate: '1',
       trace_id: expect.any(String),
       public_key: 'public',
+      sampled: 'true',
     });
   },
 );
@@ -152,6 +154,7 @@ sentryTest(
       trace_id: expect.any(String),
       public_key: 'public',
       replay_id: replay.session?.id,
+      sampled: 'true',
     });
   },
 );
@@ -199,6 +202,7 @@ sentryTest(
       sample_rate: '1',
       trace_id: expect.any(String),
       public_key: 'public',
+      sampled: 'true',
     });
   },
 );

--- a/packages/browser-integration-tests/suites/tracing/envelope-header-transaction-name/test.ts
+++ b/packages/browser-integration-tests/suites/tracing/envelope-header-transaction-name/test.ts
@@ -27,6 +27,7 @@ sentryTest(
       transaction: expect.stringContaining('/index.html'),
       trace_id: expect.any(String),
       public_key: 'public',
+      sampled: 'true',
     });
   },
 );

--- a/packages/browser-integration-tests/suites/tracing/envelope-header/test.ts
+++ b/packages/browser-integration-tests/suites/tracing/envelope-header/test.ts
@@ -30,6 +30,7 @@ sentryTest(
       sample_rate: '1',
       trace_id: expect.any(String),
       public_key: 'public',
+      sampled: 'true',
     });
   },
 );

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -264,6 +264,10 @@ export class Transaction extends SpanClass implements TransactionInterface {
       dsc.transaction = this.name;
     }
 
+    if (this.sampled !== undefined) {
+      dsc.sampled = String(this.sampled);
+    }
+
     // Uncomment if we want to make DSC immutable
     // this._frozenDynamicSamplingContext = dsc;
 

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -271,8 +271,6 @@ export class Transaction extends SpanClass implements TransactionInterface {
     // Uncomment if we want to make DSC immutable
     // this._frozenDynamicSamplingContext = dsc;
 
-    client.emit && client.emit('createDsc', dsc);
-
     return dsc;
   }
 

--- a/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/test.ts
+++ b/packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/test.ts
@@ -14,7 +14,8 @@ test('should attach a `baggage` header to an outgoing request.', async () => {
       host: 'somewhere.not.sentry',
       baggage:
         'sentry-environment=prod,sentry-release=1.0,sentry-user_segment=SegmentA,sentry-public_key=public' +
-        ',sentry-trace_id=86f39e84263a4de99c326acab3bfe3bd,sentry-sample_rate=1,sentry-transaction=GET%20%2Ftest%2Fexpress',
+        ',sentry-trace_id=86f39e84263a4de99c326acab3bfe3bd,sentry-sample_rate=1,sentry-transaction=GET%20%2Ftest%2Fexpress' +
+        ',sentry-sampled=true',
     },
   });
 });

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -192,7 +192,7 @@ describe('tracing', () => {
     expect(parts[2]).toEqual('1');
 
     expect(baggageHeader).toEqual(
-      'sentry-environment=production,sentry-release=1.0.0,sentry-user_segment=segmentA,sentry-public_key=dogsarebadatkeepingsecrets,sentry-trace_id=12312012123120121231201212312012,sentry-sample_rate=1',
+      'sentry-environment=production,sentry-release=1.0.0,sentry-user_segment=segmentA,sentry-public_key=dogsarebadatkeepingsecrets,sentry-trace_id=12312012123120121231201212312012,sentry-sample_rate=1,sentry-sampled=true',
     );
   });
 

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -131,7 +131,8 @@ describe('tracing', () => {
     expect(baggageHeader).toEqual(
       'sentry-environment=production,sentry-release=1.0.0,' +
         'sentry-user_segment=segmentA,sentry-public_key=dogsarebadatkeepingsecrets,' +
-        'sentry-trace_id=12312012123120121231201212312012,sentry-sample_rate=1,sentry-transaction=dogpark',
+        'sentry-trace_id=12312012123120121231201212312012,sentry-sample_rate=1,' +
+        'sentry-transaction=dogpark,sentry-sampled=true',
     );
   });
 
@@ -143,10 +144,10 @@ describe('tracing', () => {
     const request = http.get({ host: 'http://dogs.are.great/', headers: { baggage: 'dog=great' } });
     const baggageHeader = request.getHeader('baggage') as string;
 
-    expect(baggageHeader).toEqual([
-      'dog=great',
-      'sentry-environment=production,sentry-release=1.0.0,sentry-user_segment=segmentA,sentry-public_key=dogsarebadatkeepingsecrets,sentry-trace_id=12312012123120121231201212312012,sentry-sample_rate=1,sentry-transaction=dogpark',
-    ]);
+    expect(baggageHeader[0]).toEqual('dog=great');
+    expect(baggageHeader[1]).toEqual(
+      'sentry-environment=production,sentry-release=1.0.0,sentry-user_segment=segmentA,sentry-public_key=dogsarebadatkeepingsecrets,sentry-trace_id=12312012123120121231201212312012,sentry-sample_rate=1,sentry-transaction=dogpark,sentry-sampled=true',
+    );
   });
 
   it('adds the transaction name to the the baggage header if a valid transaction source is set', async () => {
@@ -159,7 +160,7 @@ describe('tracing', () => {
 
     expect(baggageHeader).toEqual([
       'dog=great',
-      'sentry-environment=production,sentry-release=1.0.0,sentry-user_segment=segmentA,sentry-public_key=dogsarebadatkeepingsecrets,sentry-trace_id=12312012123120121231201212312012,sentry-sample_rate=1,sentry-transaction=dogpark',
+      'sentry-environment=production,sentry-release=1.0.0,sentry-user_segment=segmentA,sentry-public_key=dogsarebadatkeepingsecrets,sentry-trace_id=12312012123120121231201212312012,sentry-sample_rate=1,sentry-transaction=dogpark,sentry-sampled=true',
     ]);
   });
 
@@ -173,7 +174,7 @@ describe('tracing', () => {
 
     expect(baggageHeader).toEqual([
       'dog=great',
-      'sentry-environment=production,sentry-release=1.0.0,sentry-user_segment=segmentA,sentry-public_key=dogsarebadatkeepingsecrets,sentry-trace_id=12312012123120121231201212312012,sentry-sample_rate=1',
+      'sentry-environment=production,sentry-release=1.0.0,sentry-user_segment=segmentA,sentry-public_key=dogsarebadatkeepingsecrets,sentry-trace_id=12312012123120121231201212312012,sentry-sample_rate=1,sentry-sampled=true',
     ]);
   });
 

--- a/packages/node/test/integrations/undici.test.ts
+++ b/packages/node/test/integrations/undici.test.ts
@@ -223,7 +223,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
 
     expect(requestHeaders['sentry-trace'].includes(propagationContext.traceId)).toBe(true);
     expect(requestHeaders['baggage']).toEqual(
-      `sentry-environment=production,sentry-public_key=0,sentry-trace_id=${propagationContext.traceId}`,
+      `sentry-environment=production,sentry-public_key=0,sentry-trace_id=${propagationContext.traceId},sentry-sample_rate=1,sentry-transaction=test-transaction,sentry-sampled=true`,
     );
   });
 

--- a/packages/opentelemetry-node/test/propagator.test.ts
+++ b/packages/opentelemetry-node/test/propagator.test.ts
@@ -85,7 +85,7 @@ describe('SentryPropagator', () => {
               spanId: '6e0c63257de34c92',
               sampled: true,
             },
-            'sentry-environment=production,sentry-release=1.0.0,sentry-public_key=abc,sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b,sentry-transaction=sampled-transaction',
+            'sentry-environment=production,sentry-release=1.0.0,sentry-public_key=abc,sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b,sentry-transaction=sampled-transaction,sentry-sampled=true',
             'd4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-1',
           ],
           [
@@ -101,7 +101,7 @@ describe('SentryPropagator', () => {
               spanId: '6e0c63257de34c92',
               sampled: false,
             },
-            'sentry-environment=production,sentry-release=1.0.0,sentry-public_key=abc,sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b,sentry-transaction=not-sampled-transaction',
+            'sentry-environment=production,sentry-release=1.0.0,sentry-public_key=abc,sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b,sentry-transaction=not-sampled-transaction,sentry-sampled=false',
             'd4cda95b652f4a1592b449d5929fda1b-6e0c63257de34c92-0',
           ],
           [

--- a/packages/opentelemetry-node/test/propagator.test.ts
+++ b/packages/opentelemetry-node/test/propagator.test.ts
@@ -161,7 +161,7 @@ describe('SentryPropagator', () => {
           const baggage = propagation.createBaggage({ foo: { value: 'bar' } });
           propagator.inject(propagation.setBaggage(context, baggage), carrier, defaultTextMapSetter);
           expect(carrier[SENTRY_BAGGAGE_HEADER]).toBe(
-            'foo=bar,sentry-environment=production,sentry-release=1.0.0,sentry-public_key=abc,sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b,sentry-transaction=sampled-transaction',
+            'foo=bar,sentry-environment=production,sentry-release=1.0.0,sentry-public_key=abc,sentry-trace_id=d4cda95b652f4a1592b449d5929fda1b,sentry-transaction=sampled-transaction,sentry-sampled=true',
           );
         });
 

--- a/packages/tracing-internal/test/browser/browsertracing.test.ts
+++ b/packages/tracing-internal/test/browser/browsertracing.test.ts
@@ -636,6 +636,7 @@ conditionalTest({ min: 10 })('BrowserTracing', () => {
           release: '1.0.0',
           environment: 'production',
           public_key: 'pubKey',
+          sampled: 'false',
           trace_id: expect.not.stringMatching('12312012123120121231201212312012'),
         });
       });

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -20,6 +20,7 @@ export type DynamicSamplingContext = {
   transaction?: string;
   user_segment?: string;
   replay_id?: string;
+  sampled?: string;
 };
 
 export type EnvelopeItemType =


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/8482

To save on bundle size, we only add `sampled` to the DSC if there is an active transaction

This matches https://github.com/getsentry/relay/blob/11f1ab455e2d5abc11d05776f8ec4a83cfd8c66e/relay-general/src/protocol/contexts/trace.rs#L109-L112