### PR TITLE
feat(node): Export `getModule` for Electron SDK

### DIFF
--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -60,6 +60,7 @@ export { makeNodeTransport } from './transports';
 export { defaultIntegrations, init, defaultStackParser, lastEventId, flush, close, getSentryRelease } from './sdk';
 export { addRequestDataToEvent, DEFAULT_USER_INCLUDES, extractRequestData } from './requestdata';
 export { deepReadDirSync } from './utils';
+export { getModule } from './module';
 
 import { Integrations as CoreIntegrations } from '@sentry/core';
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -60,7 +60,7 @@ export { makeNodeTransport } from './transports';
 export { defaultIntegrations, init, defaultStackParser, lastEventId, flush, close, getSentryRelease } from './sdk';
 export { addRequestDataToEvent, DEFAULT_USER_INCLUDES, extractRequestData } from './requestdata';
 export { deepReadDirSync } from './utils';
-export { getModule } from './module';
+export { getModuleFromFilename } from './module';
 
 import { Integrations as CoreIntegrations } from '@sentry/core';
 

--- a/packages/node/src/module.ts
+++ b/packages/node/src/module.ts
@@ -10,7 +10,7 @@ function normalizeWindowsPath(path: string): string {
 }
 
 /** Gets the module from a filename */
-export function getModule(
+export function getModuleFromFilename(
   filename: string | undefined,
   normalizeWindowsPathSeparator: boolean = isWindowsPlatform,
 ): string | undefined {

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -31,7 +31,7 @@ import {
   RequestData,
   Undici,
 } from './integrations';
-import { getModule } from './module';
+import { getModuleFromFilename } from './module';
 import { makeNodeTransport } from './transports';
 import type { NodeClientOptions, NodeOptions } from './types';
 
@@ -267,7 +267,7 @@ export function getSentryRelease(fallback?: string): string | undefined {
 }
 
 /** Node.js stack parser */
-export const defaultStackParser: StackParser = createStackParser(nodeStackLineParser(getModule));
+export const defaultStackParser: StackParser = createStackParser(nodeStackLineParser(getModuleFromFilename));
 
 /**
  * Enable automatic Session Tracking for the node process.

--- a/packages/node/test/module.test.ts
+++ b/packages/node/test/module.test.ts
@@ -1,4 +1,4 @@
-import { getModule } from '../src/module';
+import { getModuleFromFilename } from '../src/module';
 
 function withFilename(fn: () => void, filename: string) {
   const prevFilename = require.main?.filename;
@@ -15,16 +15,16 @@ function withFilename(fn: () => void, filename: string) {
   }
 }
 
-describe('getModule', () => {
+describe('getModuleFromFilename', () => {
   test('Windows', () => {
     withFilename(() => {
-      expect(getModule('C:\\Users\\users\\Tim\\Desktop\\node_modules\\module.js', true)).toEqual('module');
+      expect(getModuleFromFilename('C:\\Users\\users\\Tim\\Desktop\\node_modules\\module.js', true)).toEqual('module');
     }, 'C:\\Users\\Tim\\app.js');
   });
 
   test('POSIX', () => {
     withFilename(() => {
-      expect(getModule('/Users/users/Tim/Desktop/node_modules/module.js')).toEqual('module');
+      expect(getModuleFromFilename('/Users/users/Tim/Desktop/node_modules/module.js')).toEqual('module');
     }, '/Users/Tim/app.js');
   });
 });


### PR DESCRIPTION
I'm looking to fix [this Electron issue](https://github.com/getsentry/sentry-electron/issues/686) and need access to the `getModule` function but it's not currently exported.

Since we're now exporting this, I've renamed it to `getModuleFromFilename` since that better describes what it does...