### PR TITLE
fix(core): Drop long idle transactions

### DIFF
--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -170,8 +170,15 @@ export class IdleTransaction extends Transaction {
       });
 
       __DEBUG_BUILD__ && logger.log('[Tracing] flushing IdleTransaction');
-    } else {
-      __DEBUG_BUILD__ && logger.log('[Tracing] No active IdleTransaction');
+
+      console.log(endTimestamp, this.startTimestamp, this._finalTimeout, this._idleTimeout);
+      console.log(endTimestamp - this.startTimestamp > this._finalTimeout + this._idleTimeout);
+
+      if (endTimestamp - this.startTimestamp < this._finalTimeout + this._idleTimeout) {
+        __DEBUG_BUILD__ && logger.log('[Tracing] IdleTransaction duration exceeded finalTimeout, dropping transaction');
+        this.endTimestamp = endTimestamp;
+        return;
+      }
     }
 
     // if `this._onScope` is `true`, the transaction put itself on the scope when it started


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/8504

If an idle transaction's duration is longer than final timeout + idle timeout, opt to not capture and send it to Sentry.

This should help prevent transactions with durations that don't make sense (too long).

Current issues:
1. this breaks distributed tracing
2. idk how to test it