### PR TITLE
test(remix): Skip flaky firefox integration tests

### DIFF
--- a/packages/remix/test/integration/test/client/meta-tags.test.ts
+++ b/packages/remix/test/integration/test/client/meta-tags.test.ts
@@ -2,7 +2,13 @@ import { test, expect } from '@playwright/test';
 import { getFirstSentryEnvelopeRequest } from './utils/helpers';
 import { Event } from '@sentry/types';
 
-test('should inject `sentry-trace` and `baggage` meta tags inside the root page.', async ({ page }) => {
+test('should inject `sentry-trace` and `baggage` meta tags inside the root page.', async ({ page, browserName }) => {
+  // This test is flaky on firefox
+  // https://github.com/getsentry/sentry-javascript/issues/8398
+  if (browserName === 'firefox') {
+    test.skip();
+  }
+
   await page.goto('/');
 
   const sentryTraceTag = await page.$('meta[name="sentry-trace"]');
@@ -16,7 +22,16 @@ test('should inject `sentry-trace` and `baggage` meta tags inside the root page.
   expect(sentryBaggageContent).toEqual(expect.any(String));
 });
 
-test('should inject `sentry-trace` and `baggage` meta tags inside a parameterized route.', async ({ page }) => {
+test('should inject `sentry-trace` and `baggage` meta tags inside a parameterized route.', async ({
+  page,
+  browserName,
+}) => {
+  // This test is flaky on firefox
+  // https://github.com/getsentry/sentry-javascript/issues/8398
+  if (browserName === 'firefox') {
+    test.skip();
+  }
+
   await page.goto('/loader-json-response/0');
 
   const sentryTraceTag = await page.$('meta[name="sentry-trace"]');
@@ -30,7 +45,16 @@ test('should inject `sentry-trace` and `baggage` meta tags inside a parameterize
   expect(sentryBaggageContent).toEqual(expect.any(String));
 });
 
-test('should send transactions with corresponding `sentry-trace` and `baggage` inside root page', async ({ page }) => {
+test('should send transactions with corresponding `sentry-trace` and `baggage` inside root page', async ({
+  page,
+  browserName,
+}) => {
+  // This test is flaky on firefox
+  // https://github.com/getsentry/sentry-javascript/issues/8398
+  if (browserName === 'firefox') {
+    test.skip();
+  }
+
   const envelope = await getFirstSentryEnvelopeRequest<Event>(page, '/');
 
   const sentryTraceTag = await page.$('meta[name="sentry-trace"]');
@@ -47,7 +71,14 @@ test('should send transactions with corresponding `sentry-trace` and `baggage` i
 
 test('should send transactions with corresponding `sentry-trace` and `baggage` inside a parameterized route', async ({
   page,
+  browserName,
 }) => {
+  // This test is flaky on firefox
+  // https://github.com/getsentry/sentry-javascript/issues/8398
+  if (browserName === 'firefox') {
+    test.skip();
+  }
+
   const envelope = await getFirstSentryEnvelopeRequest<Event>(page, '/loader-json-response/0');
 
   const sentryTraceTag = await page.$('meta[name="sentry-trace"]');


### PR DESCRIPTION
resolves https://github.com/getsentry/sentry-javascript/issues/8398

Since these tests are flaky on firefox skipping them.