### PR TITLE
fix(remix): Add explicit `@sentry/node` exports.

### DIFF
--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -6,9 +6,55 @@ import { instrumentServer } from './utils/instrumentServer';
 import { buildMetadata } from './utils/metadata';
 import type { RemixOptions } from './utils/remixOptions';
 
+// We need to explicitly export @sentry/node as they end up under `default` in ESM builds
+// See: https://github.com/getsentry/sentry-javascript/issues/8474
+export {
+  addGlobalEventProcessor,
+  addBreadcrumb,
+  captureException,
+  captureEvent,
+  captureMessage,
+  configureScope,
+  createTransport,
+  extractTraceparentData,
+  getActiveTransaction,
+  getHubFromCarrier,
+  getCurrentHub,
+  Hub,
+  makeMain,
+  Scope,
+  startTransaction,
+  SDK_VERSION,
+  setContext,
+  setExtra,
+  setExtras,
+  setTag,
+  setTags,
+  setUser,
+  spanStatusfromHttpCode,
+  trace,
+  withScope,
+  autoDiscoverNodePerformanceMonitoringIntegrations,
+  makeNodeTransport,
+  defaultIntegrations,
+  defaultStackParser,
+  lastEventId,
+  flush,
+  close,
+  getSentryRelease,
+  addRequestDataToEvent,
+  DEFAULT_USER_INCLUDES,
+  extractRequestData,
+  deepReadDirSync,
+  Integrations,
+  Handlers,
+} from '@sentry/node';
+
+// Keeping the `*` exports for backwards compatibility and types
+export * from '@sentry/node';
+
 export { ErrorBoundary, withErrorBoundary } from '@sentry/react';
 export { remixRouterInstrumentation, withSentry } from './performance/client';
-export * from '@sentry/node';
 export { wrapExpressCreateRequestHandler } from './utils/serverAdapters/express';
 
 function sdkAlreadyInitialized(): boolean {

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -11,6 +11,7 @@ import type { RemixOptions } from './utils/remixOptions';
 export {
   addGlobalEventProcessor,
   addBreadcrumb,
+  captureCheckIn,
   captureException,
   captureEvent,
   captureMessage,


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-javascript/issues/8474

Manually tested on latest epic-stack with reproduction at https://github.com/epicweb-dev/epic-stack/issues/289