### PR TITLE
test(replay): skip `captures multiple multi clicks` on firefox and webkit

### DIFF
--- a/packages/browser-integration-tests/suites/replay/slowClick/multiClick/test.ts
+++ b/packages/browser-integration-tests/suites/replay/slowClick/multiClick/test.ts
@@ -64,8 +64,9 @@ sentryTest('captures multi click when not detecting slow click', async ({ getLoc
   ]);
 });
 
-sentryTest('captures multiple multi clicks', async ({ getLocalTestUrl, page, forceFlushReplay }) => {
-  if (shouldSkipReplayTest()) {
+sentryTest('captures multiple multi clicks', async ({ getLocalTestUrl, page, forceFlushReplay, browserName }) => {
+  // This test seems to only be flakey on firefox and webkit
+  if (shouldSkipReplayTest() || ['firefox', 'webkit'].includes(browserName)) {
     sentryTest.skip();
   }
 


### PR DESCRIPTION
flake: https://github.com/getsentry/sentry-javascript/actions/runs/5533379572/jobs/10097094046

resolves https://github.com/getsentry/sentry-javascript/issues/8459