### PR TITLE
chore(core): Remove eslint warnings

### DIFF
--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -1673,7 +1673,7 @@ describe('BaseClient', () => {
         }),
       );
 
-      // @ts-ignore
+      // @ts-expect-error Accessing private transport API
       const mockSend = jest.spyOn(client._transport, 'send');
 
       const errorEvent: Event = { message: 'error' };
@@ -1701,7 +1701,7 @@ describe('BaseClient', () => {
         }),
       );
 
-      // @ts-ignore
+      // @ts-expect-error Accessing private transport API
       const mockSend = jest.spyOn(client._transport, 'send');
 
       const transactionEvent: Event = { type: 'transaction', event_id: 'tr1' };
@@ -1731,7 +1731,7 @@ describe('BaseClient', () => {
         }),
       );
 
-      // @ts-ignore
+      // @ts-expect-error Accessing private transport API
       const mockSend = jest.spyOn(client._transport, 'send').mockImplementation(() => {
         return Promise.reject('send error');
       });
@@ -1763,7 +1763,7 @@ describe('BaseClient', () => {
         }),
       );
 
-      // @ts-ignore
+      // @ts-expect-error Accessing private transport API
       const mockSend = jest.spyOn(client._transport, 'send').mockImplementation(() => {
         return Promise.resolve({ statusCode: 200 });
       });


### PR DESCRIPTION
```
> @sentry/core:lint

$ run-s lint:prettier lint:eslint
$ prettier --check "{src,test,scripts}/**/**.ts"
Checking formatting...
All matched files use Prettier code style!
$ eslint . --format stylish

/home/runner/work/sentry-javascript/sentry-javascript/packages/core/test/lib/base.test.ts
  1676:7  warning  Include a description after the "@ts-ignore" directive to explain why the @ts-ignore is necessary. The description must be 3 characters or longer  @typescript-eslint/ban-ts-comment
  1704:7  warning  Include a description after the "@ts-ignore" directive to explain why the @ts-ignore is necessary. The description must be 3 characters or longer  @typescript-eslint/ban-ts-comment
  1734:7  warning  Include a description after the "@ts-ignore" directive to explain why the @ts-ignore is necessary. The description must be 3 characters or longer  @typescript-eslint/ban-ts-comment
  1766:7  warning  Include a description after the "@ts-ignore" directive to explain why the @ts-ignore is necessary. The description must be 3 characters or longer  @typescript-eslint/ban-ts-comment
```