### PR TITLE
chore(tracing-internal): Fix eslint warning

### DIFF
--- a/packages/tracing-internal/src/node/integrations/prisma.ts
+++ b/packages/tracing-internal/src/node/integrations/prisma.ts
@@ -65,6 +65,7 @@ export class Prisma implements Integration {
     // https://github.com/getsentry/sentry-javascript/issues/7216#issuecomment-1602375012
     // In the future we might explore providing a dedicated PrismaClient middleware instead of this hack.
     if (isValidPrismaClient(options.client) && !options.client._sentryInstrumented) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       addNonEnumerableProperty(options.client as any, '_sentryInstrumented', true);
 
       options.client.$use((params, next: (params: PrismaMiddlewareParams) => Promise<unknown>) => {


### PR DESCRIPTION
```
> @sentry-internal/tracing:lint

$ run-s lint:prettier lint:eslint
$ prettier --check "{src,test,scripts}/**/**.ts"
Checking formatting...
All matched files use Prettier code style!
$ eslint . --format stylish

/home/runner/work/sentry-javascript/sentry-javascript/packages/tracing-internal/src/node/integrations/prisma.ts
  68:50  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
```