### PR TITLE
fix(replay): Better session storage check

### DIFF
--- a/packages/replay/src/util/hasSessionStorage.ts
+++ b/packages/replay/src/util/hasSessionStorage.ts
@@ -2,5 +2,10 @@ import { WINDOW } from '../constants';
 
 /** If sessionStorage is available. */
 export function hasSessionStorage(): boolean {
-  return 'sessionStorage' in WINDOW && !!WINDOW.sessionStorage;
+  try {
+    // This can throw, e.g. when being accessed in a sandboxed iframe
+    return 'sessionStorage' in WINDOW && !!WINDOW.sessionStorage;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
Apparently accessing sessionStorage in an iframe with certain permissions can result in a throw, so we try-catch this to ensure we do not produce any errors.

Closes https://github.com/getsentry/sentry-javascript/issues/8392