### PR TITLE
test(nextjs): Pin Nextjs 13 integration tests to `next@13.4.9`

### DIFF
--- a/packages/nextjs/test/integration/next-env.d.ts
+++ b/packages/nextjs/test/integration/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/nextjs/test/integration/next-env.d.ts
+++ b/packages/nextjs/test/integration/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/packages/nextjs/test/run-integration-tests.sh
+++ b/packages/nextjs/test/run-integration-tests.sh
@@ -67,13 +67,21 @@ for NEXTJS_VERSION in 10 11 12 13; do
     rm -rf node_modules .next .env.local 2>/dev/null || true
 
     echo "[nextjs@$NEXTJS_VERSION] Installing dependencies..."
+
     # set the desired version of next long enough to run yarn, and then restore the old version (doing the restoration now
     # rather than during overall cleanup lets us look for "latest" in every loop)
+
+    if [ "$NEXTJS_VERSION" -eq "13" ]; then
+      SPECIFIC_NEXT_VERSION="13.4.9"
+    else
+      SPECIFIC_NEXT_VERSION="$NEXTJS_VERSION.x"
+    fi
+
     cp package.json package.json.bak
     if [[ $(uname) == "Darwin" ]]; then
-      sed -i "" /"next.*latest"/s/latest/"${NEXTJS_VERSION}.x"/ package.json
+      sed -i "" /"next.*latest"/s/latest/"${SPECIFIC_NEXT_VERSION}"/ package.json
     else
-      sed -i /"next.*latest"/s/latest/"${NEXTJS_VERSION}.x"/ package.json
+      sed -i /"next.*latest"/s/latest/"${SPECIFIC_NEXT_VERSION}"/ package.json
     fi
 
     # Next.js v13 requires React 18.2.0


### PR DESCRIPTION
As long as our SDK and `next@13.4.10` aren't compatible, we need to hard-pin our NextJS integration tests to `13.4.9` to unblock our CI.  

We need to revert this PR once we figured out 13.4.10! (Set a reminder for myself)

ref #8541 