### PR TITLE
fix(replay): Handle edge cases & more logging

### DIFF
--- a/packages/browser-integration-tests/suites/replay/sessionMaxAge/init.js
+++ b/packages/browser-integration-tests/suites/replay/sessionMaxAge/init.js
@@ -11,8 +11,6 @@ Sentry.init({
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,
   replaysOnErrorSampleRate: 0.0,
-  debug: true,
-
   integrations: [window.Replay],
 });
 


### PR DESCRIPTION
This is a PR to this feature branch: https://github.com/getsentry/sentry-javascript/pull/8407

* Handle edge case where we stop multiple times (honestly no idea how this should happen, but apparently it can 😬 )
* Add some more logging for state changes

We can hopefully eventually remove the `traceInternals` checks, but for now this is an easy solution for debugging in the beta....