### PR TITLE
feat(tracing): Bring http timings out of experiment

### DIFF
--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -81,13 +81,6 @@ export interface BrowserTracingOptions extends RequestInstrumentationOptions {
   enableLongTask: boolean;
 
   /**
-   * If true, Sentry will capture http timings and add them to the corresponding http spans.
-   *
-   * Default: true
-   */
-  enableHTTPTimings: boolean;
-
-  /**
    * _metricOptions allows the user to send options to change how metrics are collected.
    *
    * _metricOptions is currently experimental.
@@ -146,7 +139,7 @@ const DEFAULT_BROWSER_TRACING_OPTIONS: BrowserTracingOptions = {
   startTransactionOnLocationChange: true,
   startTransactionOnPageLoad: true,
   enableLongTask: true,
-  enableHTTPTimings: true,
+  _experiments: {},
   ...defaultRequestInstrumentationOptions,
 };
 
@@ -285,9 +278,7 @@ export class BrowserTracing implements Integration {
       traceXHR,
       tracePropagationTargets,
       shouldCreateSpanForRequest,
-      _experiments: {
-        enableHTTPTimings,
-      },
+      enableHTTPTimings,
     });
   }
 

--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -81,6 +81,13 @@ export interface BrowserTracingOptions extends RequestInstrumentationOptions {
   enableLongTask: boolean;
 
   /**
+   * If true, Sentry will capture http timings and add them to the corresponding http spans.
+   *
+   * Default: true
+   */
+  enableHTTPTimings: boolean;
+
+  /**
    * _metricOptions allows the user to send options to change how metrics are collected.
    *
    * _metricOptions is currently experimental.
@@ -105,7 +112,6 @@ export interface BrowserTracingOptions extends RequestInstrumentationOptions {
   _experiments: Partial<{
     enableLongTask: boolean;
     enableInteractions: boolean;
-    enableHTTPTimings: boolean;
     onStartRouteTransaction: (t: Transaction | undefined, ctx: TransactionContext, getCurrentHub: () => Hub) => void;
   }>;
 
@@ -140,6 +146,7 @@ const DEFAULT_BROWSER_TRACING_OPTIONS: BrowserTracingOptions = {
   startTransactionOnLocationChange: true,
   startTransactionOnPageLoad: true,
   enableLongTask: true,
+  enableHTTPTimings: true,
   ...defaultRequestInstrumentationOptions,
 };
 
@@ -230,6 +237,7 @@ export class BrowserTracing implements Integration {
       traceFetch,
       traceXHR,
       shouldCreateSpanForRequest,
+      enableHTTPTimings,
       _experiments,
     } = this.options;
 
@@ -278,7 +286,7 @@ export class BrowserTracing implements Integration {
       tracePropagationTargets,
       shouldCreateSpanForRequest,
       _experiments: {
-        enableHTTPTimings: _experiments.enableHTTPTimings,
+        enableHTTPTimings,
       },
     });
   }

--- a/packages/tracing-internal/test/browser/browsertracing.test.ts
+++ b/packages/tracing-internal/test/browser/browsertracing.test.ts
@@ -95,6 +95,7 @@ conditionalTest({ min: 10 })('BrowserTracing', () => {
 
     expect(browserTracing.options).toEqual({
       enableLongTask: true,
+      _experiments: {},
       ...TRACING_DEFAULTS,
       markBackgroundTransactions: true,
       routingInstrumentation: instrumentRoutingWithDefaults,
@@ -132,6 +133,7 @@ conditionalTest({ min: 10 })('BrowserTracing', () => {
 
     expect(browserTracing.options).toEqual({
       enableLongTask: false,
+      _experiments: {},
       ...TRACING_DEFAULTS,
       markBackgroundTransactions: true,
       routingInstrumentation: instrumentRoutingWithDefaults,
@@ -246,7 +248,7 @@ conditionalTest({ min: 10 })('BrowserTracing', () => {
           traceFetch: true,
           traceXHR: true,
           tracePropagationTargets: ['something'],
-          _experiments: {},
+          enableHTTPTimings: true,
         });
       });
 
@@ -260,7 +262,7 @@ conditionalTest({ min: 10 })('BrowserTracing', () => {
         });
 
         expect(instrumentOutgoingRequestsMock).toHaveBeenCalledWith({
-          _experiments: {},
+          enableHTTPTimings: true,
           traceFetch: true,
           traceXHR: true,
           tracePropagationTargets: ['something-else'],


### PR DESCRIPTION
### Summary
This brings HTTP timings out of experiment, with an option to turn them off still. For now we'll be hiding them in the UI until we've figure out which ones we want to display.

