### PR TITLE
types(browser): add browser profiling client options

### DIFF
--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -1,6 +1,7 @@
 import type { Scope } from '@sentry/core';
 import { BaseClient, SDK_VERSION } from '@sentry/core';
 import type {
+  BrowserClientProfilingOptions,
   BrowserClientReplayOptions,
   ClientOptions,
   Event,
@@ -23,7 +24,9 @@ import { createUserFeedbackEnvelope } from './userfeedback';
  * Configuration options for the Sentry Browser SDK.
  * @see @sentry/types Options for more information.
  */
-export type BrowserOptions = Options<BrowserTransportOptions> & BrowserClientReplayOptions;
+export type BrowserOptions = Options<BrowserTransportOptions> &
+  BrowserClientReplayOptions &
+  BrowserClientProfilingOptions;
 
 /**
  * Configuration options for the Sentry Browser SDK Client class

--- a/packages/types/src/browseroptions.ts
+++ b/packages/types/src/browseroptions.ts
@@ -16,3 +16,11 @@ export type BrowserClientReplayOptions = {
    */
   replaysOnErrorSampleRate?: number;
 };
+
+export type BrowserClientProfilingOptions = {
+  /**
+   * The sample rate for profiling
+   * 1.0 will profile all transactions and 0 will profile none.
+   */
+  profilesSampleRate?: number;
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -115,5 +115,5 @@ export type { WrappedFunction } from './wrappedfunction';
 export type { Instrumenter } from './instrumenter';
 export type { HandlerDataFetch, HandlerDataXhr, SentryXhrData, SentryWrappedXMLHttpRequest } from './instrument';
 
-export type { BrowserClientReplayOptions } from './browseroptions';
+export type { BrowserClientReplayOptions, BrowserClientProfilingOptions } from './browseroptions';
 export type { CheckIn, MonitorConfig, SerializedCheckIn } from './checkin';


### PR DESCRIPTION
Adds the profilesSampleRate type to browser client options. I followed the example of replay and created a new type with profiling related options.