### PR TITLE
chore(publish): Publish NPM packages in order of dependency tree

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -2,6 +2,107 @@ minVersion: '0.23.1'
 changelogPolicy: simple
 preReleaseCommand: bash scripts/craft-pre-release.sh
 targets:
+  # NPM Targets
+  ## 1. Base Packages, node or browser SDKs depend on
+  ## 1.1 Types
+  - name: npm
+    id: npm:@sentry/types
+    includeNames: /^sentry-types-\d.*\.tgz$/
+  ## 1.2 Utils
+  - name: npm
+    id: npm:@sentry/utils
+    includeNames: /^sentry-utils-\d.*\.tgz$/
+  ## 1.3 Core SDK
+  - name: npm
+    id: npm:@sentry/core
+    includeNames: /^sentry-core-\d.*\.tgz$/
+  ## 1.4 Tracing package
+  - name: npm
+    id: npm:@sentry-internal/tracing
+    includeNames: /^sentry-internal-tracing-\d.*\.tgz$/
+  ## 1.5 Replay package (browser only)
+  - name: npm
+    id: npm:@sentry/replay
+    includeNames: /^sentry-replay-\d.*\.tgz$/
+
+  ## 2. Browser & Node SDKs
+  - name: npm
+    id: npm:@sentry/browser
+    includeNames: /^sentry-browser-\d.*\.tgz$/
+  - name: npm
+    id: npm:@sentry/node
+    includeNames: /^sentry-node-\d.*\.tgz$/
+
+  ## 3 Browser-based Packages
+  - name: npm
+    id: npm:@sentry/angular-ivy
+    includeNames: /^sentry-angular-ivy-\d.*\.tgz$/
+  - name: npm
+    id: npm:@sentry/angular
+    includeNames: /^sentry-angular-\d.*\.tgz$/
+  - name: npm
+    id: npm:@sentry/ember
+    includeNames: /^sentry-ember-\d.*\.tgz$/
+  - name: npm
+    id: npm:@sentry/react
+    includeNames: /^sentry-react-\d.*\.tgz$/
+  - name: npm
+    id: npm:@sentry/svelte
+    includeNames: /^sentry-svelte-\d.*\.tgz$/
+  - name: npm
+    id: npm:@sentry/vue
+    includeNames: /^sentry-vue-\d.*\.tgz$/
+  - name: npm
+    id: npm:@sentry/wasm
+    includeNames: /^sentry-wasm-\d.*\.tgz$/
+  - name: npm
+    id: npm:@sentry/integrations
+    includeNames: /^sentry-integrations-\d.*\.tgz$/
+
+  ## 4. Node-based Packages
+  - name: npm
+    id: npm:@sentry/serverless
+    includeNames: /^sentry-serverless-\d.*\.tgz$/
+  - name: npm
+    id: npm@sentry/opentelemetry-node
+    includeNames: /^sentry-opentelemetry-node-\d.*\.tgz$/
+
+  ## 5. Fullstack/Meta Frameworks (depending on Node and Browser or Framework SDKs)
+  - name: npm
+    id: npm@sentry/nextjs
+    includeNames: /^sentry-nextjs-\d.*\.tgz$/
+  - name: npm
+    id: npm@sentry/remix
+    includeNames: /^sentry-remix-\d.*\.tgz$/
+  - name: npm
+    id: npm@sentry/sveltekit
+    includeNames: /^sentry-sveltekit-\d.*\.tgz$/
+  - name: npm
+    id: npm@sentry/gatsby
+    includeNames: /^sentry-gatsby-\d.*\.tgz$/
+
+  ## 6. Other Packages
+  ## 6.1
+  - name: npm
+    id: npm@sentry-internal/typescript
+    includeNames: /^sentry-internal-typescript-\d.*\.tgz$/
+  - name: npm
+    id: npm@sentry-internal/eslint-plugin-sdk
+    includeNames: /^sentry-internal-eslint-plugin-sdk-\d.*\.tgz$/
+  ## 6.2
+  - name: npm
+    id: npm@sentry-internal/eslint-config-sdk
+    includeNames: /^sentry-internal-eslint-config-sdk-\d.*\.tgz$/
+
+  ## 7. Deprecated packages we still release (but no packages depend on them anymore)
+  - name: npm
+    id: npm:@sentry/hub
+    includeNames: /^sentry-hub-\d.*\.tgz$/
+  - name: npm
+    id: npm:@sentry/tracing
+    includeNames: /^sentry-tracing-\d.*\.tgz$/
+
+  # AWS Lambda Layer target
   - name: aws-lambda-layer
     includeNames: /^sentry-node-serverless-\d+.\d+.\d+(-(beta|alpha)\.\d+)?\.zip$/
     layerName: SentryNodeServerlessSDK
@@ -14,6 +115,8 @@ targets:
           - nodejs16.x
           - nodejs18.x
     license: MIT
+
+  # CDN Bundle Target
   - name: gcs
     includeNames: /.*\.js.*$/
     bucket: sentry-js-sdk
@@ -21,9 +124,12 @@ targets:
       - path: /{{version}}/
         metadata:
           cacheControl: 'public, max-age=31536000'
+
+  # Github Release Target
   - name: github
     includeNames: /^sentry-.*$/
-  - name: npm
+
+  # Sentry Release Registry Target
   - name: registry
     sdks:
       'npm:@sentry/browser':

--- a/.craft.yml
+++ b/.craft.yml
@@ -6,100 +6,100 @@ targets:
   ## 1. Base Packages, node or browser SDKs depend on
   ## 1.1 Types
   - name: npm
-    id: npm:@sentry/types
+    id: "@sentry/types"
     includeNames: /^sentry-types-\d.*\.tgz$/
   ## 1.2 Utils
   - name: npm
-    id: npm:@sentry/utils
+    id: "@sentry/utils"
     includeNames: /^sentry-utils-\d.*\.tgz$/
   ## 1.3 Core SDK
   - name: npm
-    id: npm:@sentry/core
+    id: "@sentry/core"
     includeNames: /^sentry-core-\d.*\.tgz$/
   ## 1.4 Tracing package
   - name: npm
-    id: npm:@sentry-internal/tracing
+    id: "@sentry-internal/tracing"
     includeNames: /^sentry-internal-tracing-\d.*\.tgz$/
   ## 1.5 Replay package (browser only)
   - name: npm
-    id: npm:@sentry/replay
+    id: "@sentry/replay"
     includeNames: /^sentry-replay-\d.*\.tgz$/
 
   ## 2. Browser & Node SDKs
   - name: npm
-    id: npm:@sentry/browser
+    id: "@sentry/browser"
     includeNames: /^sentry-browser-\d.*\.tgz$/
   - name: npm
-    id: npm:@sentry/node
+    id: "@sentry/node"
     includeNames: /^sentry-node-\d.*\.tgz$/
 
   ## 3 Browser-based Packages
   - name: npm
-    id: npm:@sentry/angular-ivy
+    id: "@sentry/angular-ivy"
     includeNames: /^sentry-angular-ivy-\d.*\.tgz$/
   - name: npm
-    id: npm:@sentry/angular
+    id: "@sentry/angular"
     includeNames: /^sentry-angular-\d.*\.tgz$/
   - name: npm
-    id: npm:@sentry/ember
+    id: "@sentry/ember"
     includeNames: /^sentry-ember-\d.*\.tgz$/
   - name: npm
-    id: npm:@sentry/react
+    id: "@sentry/react"
     includeNames: /^sentry-react-\d.*\.tgz$/
   - name: npm
-    id: npm:@sentry/svelte
+    id: "@sentry/svelte"
     includeNames: /^sentry-svelte-\d.*\.tgz$/
   - name: npm
-    id: npm:@sentry/vue
+    id: "@sentry/vue"
     includeNames: /^sentry-vue-\d.*\.tgz$/
   - name: npm
-    id: npm:@sentry/wasm
+    id: "@sentry/wasm"
     includeNames: /^sentry-wasm-\d.*\.tgz$/
   - name: npm
-    id: npm:@sentry/integrations
+    id: "@sentry/integrations"
     includeNames: /^sentry-integrations-\d.*\.tgz$/
 
   ## 4. Node-based Packages
   - name: npm
-    id: npm:@sentry/serverless
+    id: "@sentry/serverless"
     includeNames: /^sentry-serverless-\d.*\.tgz$/
   - name: npm
-    id: npm@sentry/opentelemetry-node
+    id: "@sentry/opentelemetry-node"
     includeNames: /^sentry-opentelemetry-node-\d.*\.tgz$/
 
   ## 5. Fullstack/Meta Frameworks (depending on Node and Browser or Framework SDKs)
   - name: npm
-    id: npm@sentry/nextjs
+    id: "@sentry/nextjs"
     includeNames: /^sentry-nextjs-\d.*\.tgz$/
   - name: npm
-    id: npm@sentry/remix
+    id: "@sentry/remix"
     includeNames: /^sentry-remix-\d.*\.tgz$/
   - name: npm
-    id: npm@sentry/sveltekit
+    id: "@sentry/sveltekit"
     includeNames: /^sentry-sveltekit-\d.*\.tgz$/
   - name: npm
-    id: npm@sentry/gatsby
+    id: "@sentry/gatsby"
     includeNames: /^sentry-gatsby-\d.*\.tgz$/
 
   ## 6. Other Packages
   ## 6.1
   - name: npm
-    id: npm@sentry-internal/typescript
+    id: "@sentry-internal/typescript"
     includeNames: /^sentry-internal-typescript-\d.*\.tgz$/
   - name: npm
-    id: npm@sentry-internal/eslint-plugin-sdk
+    id: "@sentry-internal/eslint-plugin-sdk"
     includeNames: /^sentry-internal-eslint-plugin-sdk-\d.*\.tgz$/
   ## 6.2
   - name: npm
-    id: npm@sentry-internal/eslint-config-sdk
+    id: "@sentry-internal/eslint-config-sdk"
     includeNames: /^sentry-internal-eslint-config-sdk-\d.*\.tgz$/
 
   ## 7. Deprecated packages we still release (but no packages depend on them anymore)
   - name: npm
-    id: npm:@sentry/hub
+    id: "@sentry/hub"
     includeNames: /^sentry-hub-\d.*\.tgz$/
   - name: npm
-    id: npm:@sentry/tracing
+    id: "@sentry/tracing"
     includeNames: /^sentry-tracing-\d.*\.tgz$/
 
   # AWS Lambda Layer target
@@ -118,6 +118,7 @@ targets:
 
   # CDN Bundle Target
   - name: gcs
+    id: "browser-cdn-bundles"
     includeNames: /.*\.js.*$/
     bucket: sentry-js-sdk
     paths:

--- a/docs/new-sdk-release-checklist.md
+++ b/docs/new-sdk-release-checklist.md
@@ -58,8 +58,13 @@ When you’re ready to make the first release, there are a couple of steps that 
 - [ ]  1) If not yet done, be sure to remove the `private: true` property from your SDK’s `package.json`. Additionally, ensure that `"publishConfig": {"access": "public"}` is set.
 - [ ]  2) Make sure that the new SDK is **not added** in`[craft.yml](https://github.com/getsentry/sentry-javascript/blob/master/.craft.yml)` as a target for the **Sentry release registry**\
 *Once this is added, craft will try to publish an entry in the next release which does not work and caused failed release runs in the past*
-- [ ]  3) Make sure the new SDK is not excluded from the github & npm targets in `.craft.yml`
-- [ ]  4) Cut a new release (as usual, via GH release action and Craft)
+- [ ]  3) Add an `npm` target in `craft.yml` for the new package. Make sure to insert it in the right place, after all the Sentry dependencies of your package but before packages that depend on your new package (if applicable).
+    ```yml
+    - name: npm
+      id: npm:@sentry/[yourPackage]
+      includeNames: /^sentry-[yourPackage]-\d.*\.tgz$/
+    ```
+- [ ]  4) Cut a new release (as usual, see [Publishing Release](https://github.com/getsentry/sentry-javascript/blob/develop/docs/publishing-a-release.md))
 
 ### After the Release
 


### PR DESCRIPTION
Following up on #inc-456, this PR splits the previously universal `npm` target that took care of publishing all packages at once into multiple targets (one for each package).
This will ensure that packages are published in the correct order of their sentry dependency tree (e.g. core -> browser -> react, etc..) Furthermore, this theoretically also lets us disable the release of individual packages (which we might want to do if a package was already released). 

In addition, this PR now moves NPM targets before other targets, so that no GH releases are created if the actual publishing of artifacts failed previously.

The drawback of this solution is that we have to manually add a new target for new packages we added. Therefore, this PR also adjusts our new package release checklist to do this before cutting the first release. Given that we had failing releases in the past because of incorrectly configured new packages, this might actually be beneficial. 

With this change, craft is configured to process the following targets in the given order:
```
[
    "npm[@sentry/types]",
    "npm[@sentry/utils]",
    "npm[@sentry/core]",
    "npm[@sentry-internal/tracing]",
    "npm[@sentry/replay]",
    "npm[@sentry/browser]",
    "npm[@sentry/node]",
    "npm[@sentry/angular-ivy]",
    "npm[@sentry/angular]",
    "npm[@sentry/ember]",
    "npm[@sentry/react]",
    "npm[@sentry/svelte]",
    "npm[@sentry/vue]",
    "npm[@sentry/wasm]",
    "npm[@sentry/integrations]",
    "npm[@sentry/serverless]",
    "npm[@sentry/opentelemetry-node]",
    "npm[@sentry/nextjs]",
    "npm[@sentry/remix]",
    "npm[@sentry/sveltekit]",
    "npm[@sentry/gatsby]",
    "npm[@sentry-internal/typescript]",
    "npm[@sentry-internal/eslint-plugin-sdk]",
    "npm[@sentry-internal/eslint-config-sdk]",
    "npm[@sentry/hub]",
    "npm[@sentry/tracing]",
    "aws-lambda-layer",
    "gcs[browser-cdn-bundles]",
    "github",
    "registry"
]
```

We might want to further group targets to packages (and split up registry targets while at it) but I think for now, we try this publishing approach and avoid creating another ~25 additional targets.

I tested this new config locally with a local craft installation and `--dry-run` and it seems to pick up the correct packages for each target (and it'll error if a package was not found). 