### PR TITLE
test(e2e): Use `latest || *` instead of `*` as version

### DIFF
--- a/packages/e2e-tests/README.md
+++ b/packages/e2e-tests/README.md
@@ -79,7 +79,8 @@ fields:
 **An important thing to note:** In the context of the `buildCommand` the fake test registry is available at
 `http://localhost:4873`. It hosts all of our packages as if they were to be published with the state of the current
 branch. This means we can install the packages from this registry via the `.npmrc` configuration as seen above. If you
-add Sentry dependencies to your test application, you should set the dependency versions set to `*`:
+add Sentry dependencies to your test application, you should set the dependency versions set to `latest || *` in order
+for it to work with both regular and prerelease versions:
 
 ```jsonc
 // package.json
@@ -91,7 +92,7 @@ add Sentry dependencies to your test application, you should set the dependency 
     "test": "echo \"Hello world!\""
   },
   "dependencies": {
-    "@sentry/node": "*"
+    "@sentry/node": "latest || *"
   }
 }
 ```

--- a/packages/e2e-tests/test-applications/create-next-app/package.json
+++ b/packages/e2e-tests/test-applications/create-next-app/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@next/font": "13.0.7",
-    "@sentry/nextjs": "*",
+    "@sentry/nextjs": "latest || *",
     "@types/node": "18.11.17",
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.9",

--- a/packages/e2e-tests/test-applications/create-react-app/package.json
+++ b/packages/e2e-tests/test-applications/create-react-app/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@sentry/react": "*",
-    "@sentry/tracing": "*",
+    "@sentry/react": "latest || *",
+    "@sentry/tracing": "latest || *",
     "@testing-library/jest-dom": "5.14.1",
     "@testing-library/react": "13.0.0",
     "@testing-library/user-event": "13.2.1",

--- a/packages/e2e-tests/test-applications/create-remix-app/package.json
+++ b/packages/e2e-tests/test-applications/create-remix-app/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@sentry/remix": "*",
+    "@sentry/remix": "latest || *",
     "@remix-run/css-bundle": "^1.16.1",
     "@remix-run/node": "^1.16.1",
     "@remix-run/react": "^1.16.1",

--- a/packages/e2e-tests/test-applications/nextjs-app-dir/package.json
+++ b/packages/e2e-tests/test-applications/nextjs-app-dir/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@next/font": "13.0.7",
-    "@sentry/nextjs": "*",
+    "@sentry/nextjs": "latest || *",
     "@types/node": "18.11.17",
     "@types/react": "18.0.26",
     "@types/react-dom": "18.0.9",

--- a/packages/e2e-tests/test-applications/nextjs-app-dir/test-recipe.json
+++ b/packages/e2e-tests/test-applications/nextjs-app-dir/test-recipe.json
@@ -16,7 +16,7 @@
   "canaryVersions": [
     {
       "dependencyOverrides": {
-        "next": "latest"
+        "next": "latest || *"
       }
     },
     {

--- a/packages/e2e-tests/test-applications/node-express-app/package.json
+++ b/packages/e2e-tests/test-applications/node-express-app/package.json
@@ -8,10 +8,10 @@
     "test": "playwright test"
   },
   "dependencies": {
-    "@sentry/integrations": "*",
-    "@sentry/node": "*",
-    "@sentry/tracing": "*",
-    "@sentry/types": "*",
+    "@sentry/integrations": "latest || *",
+    "@sentry/node": "latest || *",
+    "@sentry/tracing": "latest || *",
+    "@sentry/types": "latest || *",
     "express": "4.18.2",
     "@types/express": "4.17.17",
     "@types/node": "18.15.1",

--- a/packages/e2e-tests/test-applications/react-create-hash-router/package.json
+++ b/packages/e2e-tests/test-applications/react-create-hash-router/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@sentry/react": "*",
+    "@sentry/react": "latest || *",
     "@testing-library/jest-dom": "5.14.1",
     "@testing-library/react": "13.0.0",
     "@testing-library/user-event": "13.2.1",

--- a/packages/e2e-tests/test-applications/react-create-hash-router/test-recipe.json
+++ b/packages/e2e-tests/test-applications/react-create-hash-router/test-recipe.json
@@ -11,8 +11,8 @@
   "canaryVersions": [
     {
       "dependencyOverrides": {
-        "react": "latest",
-        "react-dom": "latest"
+        "react": "latest || *",
+        "react-dom": "latest || *"
       }
     }
   ]

--- a/packages/e2e-tests/test-applications/standard-frontend-react-tracing-import/package.json
+++ b/packages/e2e-tests/test-applications/standard-frontend-react-tracing-import/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@sentry/react": "*",
-    "@sentry/tracing": "*",
+    "@sentry/react": "latest || *",
+    "@sentry/tracing": "latest || *",
     "@testing-library/jest-dom": "5.14.1",
     "@testing-library/react": "13.0.0",
     "@testing-library/user-event": "13.2.1",

--- a/packages/e2e-tests/test-applications/standard-frontend-react/package.json
+++ b/packages/e2e-tests/test-applications/standard-frontend-react/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@sentry/react": "*",
+    "@sentry/react": "latest || *",
     "@testing-library/jest-dom": "5.14.1",
     "@testing-library/react": "13.0.0",
     "@testing-library/user-event": "13.2.1",

--- a/packages/e2e-tests/test-applications/standard-frontend-react/test-recipe.json
+++ b/packages/e2e-tests/test-applications/standard-frontend-react/test-recipe.json
@@ -18,8 +18,8 @@
   "canaryVersions": [
     {
       "dependencyOverrides": {
-        "react": "latest",
-        "react-dom": "latest"
+        "react": "latest || *",
+        "react-dom": "latest || *"
       }
     }
   ]

--- a/packages/e2e-tests/test-applications/sveltekit/package.json
+++ b/packages/e2e-tests/test-applications/sveltekit/package.json
@@ -12,7 +12,7 @@
     "test:dev": "TEST_ENV=development playwright test"
   },
   "dependencies": {
-    "@sentry/sveltekit": "*"
+    "@sentry/sveltekit": "latest || *"
   },
   "devDependencies": {
     "@playwright/test": "^1.27.1",
@@ -29,8 +29,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@sentry/node": "*",
-      "@sentry/tracing": "*"
+      "@sentry/node": "latest || *",
+      "@sentry/tracing": "latest || *"
     }
   },
   "type": "module"


### PR DESCRIPTION
Due to the [way pnpm handles versions](https://github.com/pnpm/pnpm/issues/6463), the version `*` we use in E2E tests is actually incorrect, because it installs the _lowest_ version it can find, e.g. 0.1.0. This is usually not a problem as when we use verdaccio, there is only a single version in the repository. however, when running things locally/debugging stuff, and you run `pnpm install` without verdaccio, stuff fails. This updates the versions used in E2E tests to `latest || *`, which results in a correct resolution.