### PR TITLE
fix(utils): Truncate aggregate exception values (LinkedErrors)

### DIFF
--- a/packages/browser-integration-tests/suites/public-api/captureException/linkedErrrors/subject.js
+++ b/packages/browser-integration-tests/suites/public-api/captureException/linkedErrrors/subject.js
@@ -1,0 +1,13 @@
+const wat = new Error(`This is a very long message that should be truncated and will be,
+this is a very long message that should be truncated and will be,
+this is a very long message that should be truncated and will be,
+this is a very long message that should be truncated and will be,
+this is a very long message that should be truncated and will be`);
+
+wat.cause = new Error(`This is a very long message that should be truncated and hopefully will be,
+this is a very long message that should be truncated and hopefully will be,
+this is a very long message that should be truncated and hopefully will be,
+this is a very long message that should be truncated and hopefully will be,
+this is a very long message that should be truncated and hopefully will be,`);
+
+Sentry.captureException(wat);

--- a/packages/browser-integration-tests/suites/public-api/captureException/linkedErrrors/test.ts
+++ b/packages/browser-integration-tests/suites/public-api/captureException/linkedErrrors/test.ts
@@ -1,0 +1,41 @@
+import { expect } from '@playwright/test';
+import type { Event } from '@sentry/types';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
+
+sentryTest('should capture a linked error with messages', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
+
+  expect(eventData.exception?.values).toHaveLength(2);
+  expect(eventData.exception?.values?.[0]).toMatchObject({
+    type: 'Error',
+    value: `This is a very long message that should be truncated and hopefully will be,
+this is a very long message that should be truncated and hopefully will be,
+this is a very long message that should be truncated and hopefully will be,
+this is a very long me...`,
+    mechanism: {
+      type: 'chained',
+      handled: true,
+    },
+    stacktrace: {
+      frames: expect.any(Array),
+    },
+  });
+  expect(eventData.exception?.values?.[1]).toMatchObject({
+    type: 'Error',
+    value: `This is a very long message that should be truncated and will be,
+this is a very long message that should be truncated and will be,
+this is a very long message that should be truncated and will be,
+this is a very long message that should be truncated...`,
+    mechanism: {
+      type: 'generic',
+      handled: true,
+    },
+    stacktrace: {
+      frames: expect.any(Array),
+    },
+  });
+});

--- a/packages/browser/src/integrations/linkederrors.ts
+++ b/packages/browser/src/integrations/linkederrors.ts
@@ -54,10 +54,11 @@ export class LinkedErrors implements Integration {
         return event;
       }
 
+      const options = client.getOptions();
       applyAggregateErrorsToEvent(
         exceptionFromError,
-        client.getOptions().stackParser,
-        client.getOptions().maxValueLength,
+        options.stackParser,
+        options.maxValueLength,
         self._key,
         self._limit,
         event,

--- a/packages/browser/src/integrations/linkederrors.ts
+++ b/packages/browser/src/integrations/linkederrors.ts
@@ -57,6 +57,7 @@ export class LinkedErrors implements Integration {
       applyAggregateErrorsToEvent(
         exceptionFromError,
         client.getOptions().stackParser,
+        client.getOptions().maxValueLength,
         self._key,
         self._limit,
         event,

--- a/packages/node/src/integrations/linkederrors.ts
+++ b/packages/node/src/integrations/linkederrors.ts
@@ -50,9 +50,12 @@ export class LinkedErrors implements Integration {
         return event;
       }
 
+      const options = client.getOptions();
+
       applyAggregateErrorsToEvent(
         exceptionFromError,
-        client.getOptions().stackParser,
+        options.stackParser,
+        options.maxValueLength,
         self._key,
         self._limit,
         event,

--- a/packages/utils/src/aggregate-errors.ts
+++ b/packages/utils/src/aggregate-errors.ts
@@ -35,7 +35,9 @@ export function applyAggregateErrorsToEvent(
         event.exception.values,
         originalException,
         0,
-      ), maxValueLimit);
+      ),
+      maxValueLimit,
+    );
   }
 }
 

--- a/packages/utils/src/aggregate-errors.ts
+++ b/packages/utils/src/aggregate-errors.ts
@@ -1,6 +1,7 @@
 import type { Event, EventHint, Exception, ExtendedError, StackParser } from '@sentry/types';
 
 import { isInstanceOf } from './is';
+import { truncate } from './string';
 
 /**
  * Creates exceptions inside `event.exception.values` for errors that are nested on properties based on the `key` parameter.
@@ -8,6 +9,7 @@ import { isInstanceOf } from './is';
 export function applyAggregateErrorsToEvent(
   exceptionFromErrorImplementation: (stackParser: StackParser, ex: Error) => Exception,
   parser: StackParser,
+  maxValueLimit: number = 250,
   key: string,
   limit: number,
   event: Event,
@@ -23,16 +25,17 @@ export function applyAggregateErrorsToEvent(
 
   // We only create exception grouping if there is an exception in the event.
   if (originalException) {
-    event.exception.values = aggregateExceptionsFromError(
-      exceptionFromErrorImplementation,
-      parser,
-      limit,
-      hint.originalException as ExtendedError,
-      key,
-      event.exception.values,
-      originalException,
-      0,
-    );
+    event.exception.values = truncateAggregateExceptions(
+      aggregateExceptionsFromError(
+        exceptionFromErrorImplementation,
+        parser,
+        limit,
+        hint.originalException as ExtendedError,
+        key,
+        event.exception.values,
+        originalException,
+        0,
+      ), maxValueLimit);
   }
 }
 
@@ -122,4 +125,18 @@ function applyExceptionGroupFieldsForChildException(
     exception_id: exceptionId,
     parent_id: parentId,
   };
+}
+
+/**
+ * Truncate the message (exception.value) of all exceptions in the event.
+ * Because this event processor is ran after `applyClientOptions`,
+ * we need to truncate the message of the added exceptions here.
+ */
+function truncateAggregateExceptions(exceptions: Exception[], maxValueLength: number): Exception[] {
+  return exceptions.map(exception => {
+    if (exception.value) {
+      exception.value = truncate(exception.value, maxValueLength);
+    }
+    return exception;
+  });
 }


### PR DESCRIPTION
As reported in #8580, aggregate exceptions' `exception.value` strings weren't truncated correctly in our event preparation pipeline. The tricky part here is that the `LinkedErrors` integration adds the linked/child exceptions to the event in an event processor which is applied only after we truncate the original event. Hence, we need to also truncate the values in the event processor itself. 

closes #8580
 