### PR TITLE
test(replay): Reduce flush delay for shorter tests

### DIFF
--- a/packages/browser-integration-tests/suites/replay/bufferMode/init.js
+++ b/packages/browser-integration-tests/suites/replay/bufferMode/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 1000,
-  flushMaxDelay: 1000,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
 });
 
 Sentry.init({

--- a/packages/browser-integration-tests/suites/replay/compression/init.js
+++ b/packages/browser-integration-tests/suites/replay/compression/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
   useCompression: true,
 });
 

--- a/packages/browser-integration-tests/suites/replay/customEvents/init.js
+++ b/packages/browser-integration-tests/suites/replay/customEvents/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
   useCompression: false,
   blockAllMedia: false,
 });

--- a/packages/browser-integration-tests/suites/replay/errors/droppedError/init.js
+++ b/packages/browser-integration-tests/suites/replay/errors/droppedError/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
 });
 
 Sentry.init({

--- a/packages/browser-integration-tests/suites/replay/errors/errorModeCustomTransport/init.js
+++ b/packages/browser-integration-tests/suites/replay/errors/errorModeCustomTransport/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
 });
 
 Sentry.init({

--- a/packages/browser-integration-tests/suites/replay/errors/errorNotSent/init.js
+++ b/packages/browser-integration-tests/suites/replay/errors/errorNotSent/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
 });
 
 Sentry.init({

--- a/packages/browser-integration-tests/suites/replay/errors/errorsInSession/init.js
+++ b/packages/browser-integration-tests/suites/replay/errors/errorsInSession/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
 });
 
 Sentry.init({

--- a/packages/browser-integration-tests/suites/replay/errors/init.js
+++ b/packages/browser-integration-tests/suites/replay/errors/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 1000,
-  flushMaxDelay: 1000,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
 });
 
 Sentry.init({

--- a/packages/browser-integration-tests/suites/replay/flushing/init.js
+++ b/packages/browser-integration-tests/suites/replay/flushing/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
   useCompression: false,
 });
 

--- a/packages/browser-integration-tests/suites/replay/keyboardEvents/init.js
+++ b/packages/browser-integration-tests/suites/replay/keyboardEvents/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 1000,
-  flushMaxDelay: 1000,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
 });
 
 Sentry.init({

--- a/packages/browser-integration-tests/suites/replay/largeMutations/defaultOptions/init.js
+++ b/packages/browser-integration-tests/suites/replay/largeMutations/defaultOptions/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
 });
 
 Sentry.init({

--- a/packages/browser-integration-tests/suites/replay/largeMutations/mutationLimit/init.js
+++ b/packages/browser-integration-tests/suites/replay/largeMutations/mutationLimit/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
   mutationLimit: 250,
 });
 

--- a/packages/browser-integration-tests/suites/replay/multiple-pages/init.js
+++ b/packages/browser-integration-tests/suites/replay/multiple-pages/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
 });
 
 Sentry.init({

--- a/packages/browser-integration-tests/suites/replay/requests/init.js
+++ b/packages/browser-integration-tests/suites/replay/requests/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
   useCompression: false,
 });
 

--- a/packages/browser-integration-tests/suites/replay/sessionExpiry/init.js
+++ b/packages/browser-integration-tests/suites/replay/sessionExpiry/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
 });
 
 Sentry.init({

--- a/packages/browser-integration-tests/suites/replay/sessionInactive/init.js
+++ b/packages/browser-integration-tests/suites/replay/sessionInactive/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
 });
 
 Sentry.init({

--- a/packages/browser-integration-tests/suites/replay/sessionMaxAge/init.js
+++ b/packages/browser-integration-tests/suites/replay/sessionMaxAge/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
 });
 
 Sentry.init({

--- a/packages/browser-integration-tests/suites/replay/slowClick/disable/init.js
+++ b/packages/browser-integration-tests/suites/replay/slowClick/disable/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
   slowClickTimeout: 0,
 });
 

--- a/packages/browser-integration-tests/suites/replay/slowClick/init.js
+++ b/packages/browser-integration-tests/suites/replay/slowClick/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
   slowClickTimeout: 3100,
   slowClickIgnoreSelectors: ['.ignore-class', '[ignore-attribute]'],
 });

--- a/packages/browser-integration-tests/suites/replay/unicode/compressed/init.js
+++ b/packages/browser-integration-tests/suites/replay/unicode/compressed/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
   useCompression: true,
   maskAllText: false,
 });

--- a/packages/browser-integration-tests/suites/replay/unicode/uncompressed/init.js
+++ b/packages/browser-integration-tests/suites/replay/unicode/uncompressed/init.js
@@ -2,8 +2,8 @@ import * as Sentry from '@sentry/browser';
 
 window.Sentry = Sentry;
 window.Replay = new Sentry.Replay({
-  flushMinDelay: 500,
-  flushMaxDelay: 500,
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
   useCompression: false,
   maskAllText: false,
 });


### PR DESCRIPTION
Just noticed that this is inconsistent, and by using a shorter value we can slightly reduce test times (as we need to wait shorter).