### PR TITLE
fix(profiling): align to SDK selected time origin

### DIFF
--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -217,7 +217,9 @@ export function convertJSSelfProfileToSampledFormat(input: JSSelfProfile): Profi
   // when that happens, we need to ensure we are correcting the profile timings so the two timelines stay in sync.
   // Since JS self profiling time origin is always initialized to performance.timeOrigin, we need to adjust for
   // the drift between the SDK selected value and our profile time origin.
-  const adjustForOriginChange = performance.timeOrigin - (browserPerformanceTimeOrigin || performance.timeOrigin);
+  const origin =
+    typeof performance.timeOrigin === 'number' ? performance.timeOrigin : browserPerformanceTimeOrigin || 0;
+  const adjustForOriginChange = origin - (browserPerformanceTimeOrigin || origin);
 
   for (let i = 0; i < input.samples.length; i++) {
     const jsSample = input.samples[i];

--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -3,9 +3,8 @@
 import { DEFAULT_ENVIRONMENT, getCurrentHub } from '@sentry/core';
 import type { DebugImage, Envelope, Event, StackFrame, StackParser } from '@sentry/types';
 import type { Profile, ThreadCpuProfile } from '@sentry/types/src/profiling';
-import { forEachEnvelopeItem, GLOBAL_OBJ, logger, uuid4 } from '@sentry/utils';
+import { browserPerformanceTimeOrigin, forEachEnvelopeItem, GLOBAL_OBJ, logger, uuid4 } from '@sentry/utils';
 
-import { browserPerformanceTimeOrigin } from '../../../utils/src/time';
 import { WINDOW } from '../helpers';
 import type { JSSelfProfile, JSSelfProfileStack } from './jsSelfProfiling';
 


### PR DESCRIPTION
This was causing drift between profiling and transaction timelines