### PR TITLE
ref(e2e): Update Remix recipe build command

### DIFF
--- a/packages/e2e-tests/test-applications/create-remix-app/test-recipe.json
+++ b/packages/e2e-tests/test-applications/create-remix-app/test-recipe.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../test-recipe-schema.json",
   "testApplicationName": "create-remix-app",
-  "buildCommand": "pnpm install && pnpm build",
+  "buildCommand": "pnpm install && pnpm build && pnpm start",
   "tests": []
 }


### PR DESCRIPTION
without `&& pnpm start` the test will always pass as the error really only appears when lauching the application.

Related to https://github.com/getsentry/sentry-javascript/pull/8286