### PR TITLE
meta(ci): Fix label mapper

### DIFF
--- a/.github/workflows/issue-package-label.yml
+++ b/.github/workflows/issue-package-label.yml
@@ -28,49 +28,49 @@ jobs:
           key: ${{ steps.packageName.outputs.group1 }}
           map: |
             {
-              "@sentry/browser": {
+              "@sentry\/browser": {
                 "label": "Package: Browser"
               },
-              "@sentry/angular": {
+              "@sentry\/angular": {
                 "label": "Package: Angular"
               },
-              "@sentry/angular-ivy": {
+              "@sentry\/angular-ivy": {
                 "label": "Package: Angular"
               },
-              "@sentry/ember": {
+              "@sentry\/ember": {
                 "label": "Package: ember"
               },
-              "@sentry/gatsby": {
+              "@sentry\/gatsby": {
                 "label": "Package: gatbsy"
               },
-              "@sentry/nextjs": {
+              "@sentry\/nextjs": {
                 "label": "Package: Nextjs"
               },
-              "@sentry/node": {
+              "@sentry\/node": {
                 "label": "Package: Node"
               },
-              "@sentry/opentelemetry-node": {
+              "@sentry\/opentelemetry-node": {
                 "label": "Package: otel-node"
               },
-              "@sentry/react": {
+              "@sentry\/react": {
                 "label": "Package: react"
               },
-              "@sentry/remix": {
+              "@sentry\/remix": {
                 "label": "Package: remix"
               },
-              "@sentry/serverless": {
+              "@sentry\/serverless": {
                 "label": "Package: Serverless"
               },
-              "@sentry/svelte": {
+              "@sentry\/svelte": {
                 "label": "Package: svelte"
               },
-              "@sentry/sveltekit": {
+              "@sentry\/sveltekit": {
                 "label": "Package: SvelteKit"
               },
-              "@sentry/vue": {
+              "@sentry\/vue": {
                 "label": "Package: vue"
               },
-              "@sentry/wasm": {
+              "@sentry\/wasm": {
                 "label": "Package: wasm"
               },
               "Sentry Browser Loader": {


### PR DESCRIPTION
Oops, apparently keys are regexes, so need to escape them I think:

https://github.com/getsentry/sentry-javascript/actions/runs/5655218559/job/15319870320

Let's see if that fixes it...