### PR TITLE
build: Update size limit config

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -1,93 +1,85 @@
 module.exports = [
+  // Main browser webpack builds
   {
-    name: '@sentry/browser - ES5 CDN Bundle (gzipped + minified)',
-    path: 'packages/browser/build/bundles/bundle.es5.min.js',
-    gzip: true,
-    limit: '30 KB',
-  },
-  {
-    name: '@sentry/browser - ES5 CDN Bundle (minified)',
-    path: 'packages/browser/build/bundles/bundle.es5.min.js',
-    gzip: false,
-    limit: '70 KB',
-  },
-  {
-    name: '@sentry/browser - ES6 CDN Bundle (gzipped + minified)',
-    path: 'packages/browser/build/bundles/bundle.min.js',
-    gzip: true,
-    limit: '28 KB',
-  },
-  {
-    name: '@sentry/browser - ES6 CDN Bundle (minified)',
-    path: 'packages/browser/build/bundles/bundle.min.js',
-    gzip: false,
-    limit: '65 KB',
-  },
-  {
-    name: '@sentry/browser - Webpack (gzipped + minified)',
+    name: '@sentry/browser (incl. Tracing, Replay) - Webpack (gzipped)',
     path: 'packages/browser/build/npm/esm/index.js',
-    import: '{ init }',
+    import: '{ init, Replay, BrowserTracing }',
     gzip: true,
-    limit: '30 KB',
+    limit: '80 KB',
   },
   {
-    name: '@sentry/browser - Webpack (minified)',
+    name: '@sentry/browser (incl. Tracing) - Webpack (gzipped)',
     path: 'packages/browser/build/npm/esm/index.js',
-    import: '{ init }',
-    gzip: false,
-    limit: '76 KB',
-  },
-  {
-    name: '@sentry/react - Webpack (gzipped + minified)',
-    path: 'packages/react/build/esm/index.js',
-    import: '{ init }',
-    gzip: true,
-    limit: '30 KB',
-  },
-  {
-    name: '@sentry/nextjs Client - Webpack (gzipped + minified)',
-    path: 'packages/nextjs/build/esm/client/index.js',
-    import: '{ init }',
-    gzip: true,
-    limit: '57 KB',
-  },
-  {
-    name: '@sentry/browser + @sentry/tracing - ES5 CDN Bundle (gzipped + minified)',
-    path: 'packages/browser/build/bundles/bundle.tracing.es5.min.js',
-    gzip: true,
-    limit: '37 KB',
-  },
-  {
-    name: '@sentry/browser + @sentry/tracing - ES6 CDN Bundle (gzipped + minified)',
-    path: 'packages/browser/build/bundles/bundle.tracing.min.js',
+    import: '{ init, BrowserTracing }',
     gzip: true,
     limit: '35 KB',
   },
   {
-    name: '@sentry/replay ES6 CDN Bundle (gzipped + minified)',
-    path: 'packages/replay/build/bundles/replay.min.js',
+    name: '@sentry/browser - Webpack (gzipped)',
+    path: 'packages/browser/build/npm/esm/index.js',
+    import: '{ init }',
     gzip: true,
-    limit: '52 KB',
-    ignore: ['@sentry/browser', '@sentry/utils', '@sentry/core', '@sentry/types'],
+    limit: '28 KB',
   },
+
+  // Browser CDN bundles (ES6)
   {
-    name: '@sentry/replay - Webpack (gzipped + minified)',
-    path: 'packages/replay/build/npm/esm/index.js',
-    import: '{ Replay }',
-    gzip: true,
-    limit: '48 KB',
-    ignore: ['@sentry/browser', '@sentry/utils', '@sentry/core', '@sentry/types'],
-  },
-  {
-    name: '@sentry/browser + @sentry/tracing + @sentry/replay - ES6 CDN Bundle (gzipped + minified)',
+    name: '@sentry/browser (incl. Tracing, Replay)  - ES6 CDN Bundle (gzipped)',
     path: 'packages/browser/build/bundles/bundle.tracing.replay.min.js',
     gzip: true,
     limit: '80 KB',
   },
   {
-    name: '@sentry/browser + @sentry/replay - ES6 CDN Bundle (gzipped + minified)',
-    path: 'packages/browser/build/bundles/bundle.replay.min.js',
+    name: '@sentry/browser (incl. Tracing) - ES6 CDN Bundle (gzipped)',
+    path: 'packages/browser/build/bundles/bundle.tracing.min.js',
+    gzip: true,
+    limit: '35 KB',
+  },
+  {
+    name: '@sentry/browser - ES6 CDN Bundle (gzipped)',
+    path: 'packages/browser/build/bundles/bundle.min.js',
+    gzip: true,
+    limit: '28 KB',
+  },
+
+  // Browser CDN bundles (ES5)
+  // Replay is not supported in ES5 mode
+  {
+    name: '@sentry/browser (incl. Tracing)- ES5 CDN Bundle (gzipped)',
+    path: 'packages/browser/build/bundles/bundle.tracing.es5.min.js',
+    gzip: true,
+    limit: '35 KB',
+  },
+
+  // React
+  {
+    name: '@sentry/react (incl. Tracing, Replay) - Webpack (gzipped)',
+    path: 'packages/react/build/esm/index.js',
+    import: '{ init, BrowserTYracing, Replay }',
     gzip: true,
     limit: '80 KB',
+  },
+  {
+    name: '@sentry/react - Webpack (gzipped)',
+    path: 'packages/react/build/esm/index.js',
+    import: '{ init }',
+    gzip: true,
+    limit: '30 KB',
+  },
+
+  // Next.js
+  {
+    name: '@sentry/nextjs Client (incl. Tracing, Replay) - Webpack (gzipped)',
+    path: 'packages/nextjs/build/esm/client/index.js',
+    import: '{ init, BrowserTracing, Replay }',
+    gzip: true,
+    limit: '100 KB',
+  },
+  {
+    name: '@sentry/nextjs Client - Webpack (gzipped)',
+    path: 'packages/nextjs/build/esm/client/index.js',
+    import: '{ init }',
+    gzip: true,
+    limit: '57 KB',
   },
 ];

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -24,7 +24,7 @@ module.exports = [
 
   // Browser CDN bundles (ES6)
   {
-    name: '@sentry/browser (incl. Tracing, Replay)  - ES6 CDN Bundle (gzipped)',
+    name: '@sentry/browser (incl. Tracing, Replay) - ES6 CDN Bundle (gzipped)',
     path: 'packages/browser/build/bundles/bundle.tracing.replay.min.js',
     gzip: true,
     limit: '80 KB',
@@ -42,10 +42,30 @@ module.exports = [
     limit: '28 KB',
   },
 
+  // browser CDN bundles (ES6 + non-gzipped)
+  {
+    name: '@sentry/browser (incl. Tracing, Replay) - ES6 CDN Bundle (minified & uncompressed)',
+    path: 'packages/browser/build/bundles/bundle.tracing.replay.min.js',
+    gzip: false,
+    limit: '250 KB',
+  },
+  {
+    name: '@sentry/browser (incl. Tracing) - ES6 CDN Bundle (minified & uncompressed)',
+    path: 'packages/browser/build/bundles/bundle.tracing.min.js',
+    gzip: false,
+    limit: '100 KB',
+  },
+  {
+    name: '@sentry/browser - ES6 CDN Bundle (minified & uncompressed)',
+    path: 'packages/browser/build/bundles/bundle.min.js',
+    gzip: false,
+    limit: '70 KB',
+  },
+
   // Browser CDN bundles (ES5)
   // Replay is not supported in ES5 mode
   {
-    name: '@sentry/browser (incl. Tracing)- ES5 CDN Bundle (gzipped)',
+    name: '@sentry/browser (incl. Tracing) - ES5 CDN Bundle (gzipped)',
     path: 'packages/browser/build/bundles/bundle.tracing.es5.min.js',
     gzip: true,
     limit: '35 KB',


### PR DESCRIPTION
This updates the size limit config a bit, to be a bit more structured.

* Drop all non-gzipped entries. IMHO it is good enough to have the gzipped values, and it makes it a bit clearer and easier to compare. Not sure if we want to add e.g. a single non-gzipped one, but honestly I don't know when we would really care about that?
* Reorder entries (not 100% sure TBH if the order is actually considered in the UI, though 😅 ). 
* Added webpack scenarios exporting just `{ init }`, or `{ init, BrowserTracing }` or `{ init, BrowserTracing, Replay }` to have a realistic coverage of these scenarios.
* Removed some secondary scenarios (e.g. there is just a single ES5 CDN bundle scenario left to cover this, not for all variations, ...