### PR TITLE
test(remix): Add basic test for remix E2E app

### DIFF
--- a/packages/e2e-tests/test-applications/create-next-app/tests/behaviour-client.test.ts
+++ b/packages/e2e-tests/test-applications/create-next-app/tests/behaviour-client.test.ts
@@ -7,7 +7,6 @@ const sentryTestProject = process.env.E2E_TEST_SENTRY_TEST_PROJECT;
 const EVENT_POLLING_TIMEOUT = 30_000;
 
 test('Sends a client-side exception to Sentry', async ({ page }) => {
-  page.on('console', msg => console.log(msg.text()));
   await page.goto('/');
 
   const exceptionButton = page.locator('id=exception-button');

--- a/packages/e2e-tests/test-applications/create-remix-app/package.json
+++ b/packages/e2e-tests/test-applications/create-remix-app/package.json
@@ -6,8 +6,8 @@
     "dev": "remix dev",
     "start": "remix-serve build",
     "typecheck": "tsc",
-    "test:build": "pnpm install && pnpm build",
-    "test:assert": "pnpm -v"
+    "test:build": "pnpm install && npx playwright install && pnpm build",
+    "test:assert": "pnpm playwright test"
   },
   "dependencies": {
     "@sentry/remix": "latest || *",
@@ -20,6 +20,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.36.2",
     "@remix-run/dev": "^1.16.1",
     "@remix-run/eslint-config": "^1.16.1",
     "@types/react": "^18.0.35",

--- a/packages/e2e-tests/test-applications/create-remix-app/playwright.config.ts
+++ b/packages/e2e-tests/test-applications/create-remix-app/playwright.config.ts
@@ -1,0 +1,69 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+import { devices } from '@playwright/test';
+
+const port = 3030;
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+  testDir: './tests',
+  /* Maximum time one test can run for. */
+  timeout: 60 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000,
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: 0,
+  /* Opt out of parallel tests on CI. */
+  workers: 1,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'list',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+    // For now we only test Chrome!
+    // {
+    //   name: 'firefox',
+    //   use: {
+    //     ...devices['Desktop Firefox'],
+    //   },
+    // },
+    // {
+    //   name: 'webkit',
+    //   use: {
+    //     ...devices['Desktop Safari'],
+    //   },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: `PORT=${port} pnpm start`,
+    port,
+  },
+};
+
+export default config;

--- a/packages/e2e-tests/test-applications/create-remix-app/tests/behaviour-client.test.ts
+++ b/packages/e2e-tests/test-applications/create-remix-app/tests/behaviour-client.test.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('Boots up correctly', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.getByRole('heading')).toHaveText('Welcome to Remix');
+});


### PR DESCRIPTION
Replaces https://github.com/getsentry/sentry-javascript/pull/8611

This adds a super basic remix test scenario that handles booting the server & closing it again properly, ensuring tests don't hang but verify that remix boots up as expected.