### PR TITLE
meta(ci): Final FINAL fix for issue package labelling

### DIFF
--- a/.github/workflows/issue-package-label.yml
+++ b/.github/workflows/issue-package-label.yml
@@ -74,10 +74,10 @@ jobs:
               "@sentry.wasm": {
                 "label": "Package: wasm"
               },
-              "Sentry Browser Loader": {
+              "Sentry.Browser.Loader": {
                 "label": "Package-Meta: Loader"
               },
-              "Sentry Browser CDN bundle": {
+              "Sentry.Browser.CDN.bundle": {
                 "label": "Package-Meta: CDN"
               }
             }


### PR DESCRIPTION
Turns out the action trims whitespace, which leads to this failing. Damn - but it should work with `.` inside as well. A bit hacky, but well...