### PR TITLE
fix(integrations): capture exception if any arg to console method is an error

### DIFF
--- a/packages/integrations/src/captureconsole.ts
+++ b/packages/integrations/src/captureconsole.ts
@@ -55,14 +55,15 @@ export class CaptureConsole implements Integration {
             });
 
             let message = safeJoin(args, ' ');
+            const error = args.find(arg => arg instanceof Error);
             if (level === 'assert') {
               if (args[0] === false) {
                 message = `Assertion failed: ${safeJoin(args.slice(1), ' ') || 'console.assert'}`;
                 scope.setExtra('arguments', args.slice(1));
                 hub.captureMessage(message);
               }
-            } else if (level === 'error' && args[0] instanceof Error) {
-              hub.captureException(args[0]);
+            } else if (level === 'error' && error) {
+              hub.captureException(error);
             } else {
               hub.captureMessage(message);
             }

--- a/packages/integrations/test/captureconsole.test.ts
+++ b/packages/integrations/test/captureconsole.test.ts
@@ -243,6 +243,20 @@ describe('CaptureConsole setup', () => {
     expect(mockHub.captureException).toHaveBeenCalledWith(someError);
   });
 
+  it('should capture exception when console logs an error object in any of the args when level set to "error"', () => {
+    const captureConsoleIntegration = new CaptureConsole({ levels: ['error'] });
+    captureConsoleIntegration.setupOnce(
+      () => undefined,
+      () => getMockHubWithIntegration(captureConsoleIntegration),
+    );
+
+    const someError = new Error('some error');
+    global.console.error('Something went wrong', someError);
+
+    expect(mockHub.captureException).toHaveBeenCalledTimes(1);
+    expect(mockHub.captureException).toHaveBeenCalledWith(someError);
+  });
+
   it('should capture message on `console.log` when no levels are provided in constructor', () => {
     const captureConsoleIntegration = new CaptureConsole();
     captureConsoleIntegration.setupOnce(


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

This PR adds support for capturing an exception for the any error in a console method call (only the first error instance), not just if the first argument is an error.

This is a problem for us because timestamps are always the first argument in console calls and we often add a context message before the error.