### PR TITLE
chore(node-experimental): Align @sentry/ dependency version

### DIFF
--- a/packages/node-experimental/package.json
+++ b/packages/node-experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/node-experimental",
-  "version": "7.60.0",
+  "version": "7.60.1",
   "description": "Experimental version of a Node SDK using OpenTelemetry for performance instrumentation",
   "repository": "git://github.com/getsentry/sentry-javascript.git",
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/node-experimental",
@@ -38,11 +38,11 @@
     "@opentelemetry/semantic-conventions": "~1.15.0",
     "@opentelemetry/sdk-trace-node": "~1.15.0",
     "@prisma/instrumentation": "~5.0.0",
-    "@sentry/core": "7.60.0",
-    "@sentry/node": "7.60.0",
-    "@sentry/opentelemetry-node": "7.60.0",
-    "@sentry/types": "7.60.0",
-    "@sentry/utils": "7.60.0"
+    "@sentry/core": "7.60.1",
+    "@sentry/node": "7.60.1",
+    "@sentry/opentelemetry-node": "7.60.1",
+    "@sentry/types": "7.60.1",
+    "@sentry/utils": "7.60.1"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",


### PR DESCRIPTION
Just noticed when rebasing a branch that `@sentry/node-experimental` still registered dependencies for 7.60.0 instead of 7.60.1 which causes yarn to download 7.60.0 instead of using the local packages. 