### PR TITLE
fix(replay): Improve capture of errorIds/traceIds

### DIFF
--- a/packages/replay/src/coreHandlers/handleGlobalEvent.ts
+++ b/packages/replay/src/coreHandlers/handleGlobalEvent.ts
@@ -17,6 +17,11 @@ export function handleGlobalEventListener(
   const afterSendHandler = includeAfterSendEventHandling ? handleAfterSendEvent(replay) : undefined;
 
   return (event: Event, hint: EventHint) => {
+    // Do nothing if replay has been disabled
+    if (!replay.isEnabled()) {
+      return event;
+    }
+
     if (isReplayEvent(event)) {
       // Replays have separate set of breadcrumbs, do not include breadcrumbs
       // from core SDK

--- a/packages/replay/test/integration/coreHandlers/handleGlobalEvent.test.ts
+++ b/packages/replay/test/integration/coreHandlers/handleGlobalEvent.test.ts
@@ -84,6 +84,24 @@ describe('Integration | coreHandlers | handleGlobalEvent', () => {
     );
   });
 
+  it('does not add replayId if replay is not enabled', async () => {
+    const transaction = Transaction();
+    const error = Error();
+
+    replay['_isEnabled'] = false;
+
+    expect(handleGlobalEventListener(replay)(transaction, {})).toEqual(
+      expect.objectContaining({
+        tags: expect.not.objectContaining({ replayId: expect.anything() }),
+      }),
+    );
+    expect(handleGlobalEventListener(replay)(error, {})).toEqual(
+      expect.objectContaining({
+        tags: expect.not.objectContaining({ replayId: expect.anything() }),
+      }),
+    );
+  });
+
   it('tags errors and transactions with replay id for session samples', async () => {
     let integration: ReplayIntegration;
     ({ replay, integration } = await resetSdkMock({}));


### PR DESCRIPTION
We limit to max. 100 IDs being captured per replay, and ensure we do not capture stuff when replay has been disabled in the meanwhile.

Since our handlers are (sadly) all global, I guess it may have been possible for something "bad" to happen when replay has been disabled in the meanwhile 🤔 

ref https://github.com/getsentry/team-replay/issues/131
ref https://github.com/getsentry/sentry-javascript/issues/8672
