### PR TITLE
build(release): Add `statusProvider` context check for craft

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,6 +1,11 @@
 minVersion: '0.23.1'
 changelogPolicy: simple
 preReleaseCommand: bash scripts/craft-pre-release.sh
+statusProvider:
+  name: github
+  config:
+    contexts:
+      - All required tests passed or skipped
 targets:
   # NPM Targets
   ## 1. Base Packages, node or browser SDKs depend on


### PR DESCRIPTION
To ensure we wait for the correct check to pass before continuing with publishing.
I think it is correct to use the "human readable" name of the check (??), at least the [example](https://github.com/getsentry/craft/#status-provider) looks similar. This is an example for what we are waiting for: https://github.com/getsentry/sentry-javascript/actions/runs/5715683859/job/15486522728

If I understand this correctly, this was completely broken and just looked for any (??) successful check..?!

See https://github.com/getsentry/craft/issues/482
