### PR TITLE
fix(tracing): Set correct parent span id on fetch sentry-trace header

### DIFF
--- a/packages/tracing-internal/src/browser/request.ts
+++ b/packages/tracing-internal/src/browser/request.ts
@@ -340,7 +340,7 @@ export function fetchCallback(
     const options: { [key: string]: any } = handlerData.args[1];
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-    options.headers = addTracingHeadersToFetchRequest(request, client, scope, options);
+    options.headers = addTracingHeadersToFetchRequest(request, client, scope, options, span);
   }
 
   return span;
@@ -360,8 +360,9 @@ export function addTracingHeadersToFetchRequest(
         }
       | PolymorphicRequestHeaders;
   },
+  requestSpan?: Span,
 ): PolymorphicRequestHeaders | undefined {
-  const span = scope.getSpan();
+  const span = requestSpan || scope.getSpan();
 
   const transaction = span && span.transaction;
 

--- a/packages/tracing-internal/test/browser/request.test.ts
+++ b/packages/tracing-internal/test/browser/request.test.ts
@@ -218,7 +218,7 @@ describe('callbacks', () => {
       expect(newSpan).toBeUndefined();
     });
 
-    it.only('uses active span to generate sentry-trace header', () => {
+    it('uses active span to generate sentry-trace header', () => {
       const spans: Record<string, Span> = {};
       // triggered by request being sent
       fetchCallback(fetchHandlerData, alwaysCreateSpan, alwaysAttachHeaders, spans);


### PR DESCRIPTION
In slack we reported a bug where there seemed to be the wrong parent span id attached to outgoing `sentry-trace` headers: https://sentry.slack.com/archives/CDXAKMGTU/p1690830621077679

This ends up being because the `addTracingHeadersToFetchRequest` attempts to use the transaction instead of the active request span to generate the outgoing `sentry-trace` header.

This fixes that by adding the span to the `addTracingHeadersToFetchRequest` method.