### PR TITLE
fix(node-experimental): Update auto integration lookup & readme

### DIFF
--- a/packages/node-experimental/README.md
+++ b/packages/node-experimental/README.md
@@ -50,9 +50,25 @@ Currently, this SDK:
 * Will capture errors (same as @sentry/node)
 * Auto-instrument for performance - see below for which performance integrations are available.
 
+### Manual Instrumentation
+
 **Manual instrumentation is not supported!**
 This is because the current Sentry-Performance-APIs like `Sentry.startTransaction()` are not compatible with the OpenTelemetry tracing model.
 We may add manual tracing capabilities in a later version.
+
+### ESM Support
+
+Due to the way OpenTelemetry handles instrumentation, this only works out of the box for CommonJS (`require`) applications.
+
+
+There is experimental support for running OpenTelemetry with ESM (`"type": "module"`):
+
+```bash
+node --experimental-loader=@opentelemetry/instrumentation/hook.mjs ./app.js
+```
+
+See [OpenTelemetry Instrumentation Docs](https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-instrumentation#instrumentation-for-es-modules-in-nodejs-experimental) for details on this -
+but note that this is a) experimental, and b) does not work with all integrations.
 
 ## Available (Performance) Integrations
 

--- a/packages/node-experimental/src/integrations/NodePerformanceIntegration.ts
+++ b/packages/node-experimental/src/integrations/NodePerformanceIntegration.ts
@@ -1,20 +1,39 @@
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 
-/** TODO */
+/**
+ * The base node performance integration.
+ */
 export abstract class NodePerformanceIntegration<IntegrationOptions> {
   protected _options: IntegrationOptions;
   protected _unload?: () => void;
+  protected _instrumentations?: Instrumentation[] | undefined;
+
+  public abstract name: string;
 
   public constructor(options: IntegrationOptions) {
     this._options = options;
   }
 
   /**
+   * Load the instrumentation(s) for this integration.
+   * Returns `true` if the instrumentations were loaded, else false.
+   */
+  public loadInstrumentations(): boolean {
+    try {
+      this._instrumentations = this.setupInstrumentation(this._options) || undefined;
+    } catch (error) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
    * @inheritDoc
    */
   public setupOnce(): void {
-    const instrumentations = this.setupInstrumentation(this._options);
+    const instrumentations = this._instrumentations || this.setupInstrumentation(this._options);
 
     if (!instrumentations) {
       return;

--- a/packages/node-experimental/src/integrations/express.ts
+++ b/packages/node-experimental/src/integrations/express.ts
@@ -2,7 +2,7 @@ import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { ExpressInstrumentation } from '@opentelemetry/instrumentation-express';
 import type { Integration } from '@sentry/types';
 
-import { NodePerformanceIntegration } from './lazy';
+import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
  * Express integration

--- a/packages/node-experimental/src/integrations/fastify.ts
+++ b/packages/node-experimental/src/integrations/fastify.ts
@@ -2,7 +2,7 @@ import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { FastifyInstrumentation } from '@opentelemetry/instrumentation-fastify';
 import type { Integration } from '@sentry/types';
 
-import { NodePerformanceIntegration } from './lazy';
+import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
  * Express integration

--- a/packages/node-experimental/src/integrations/graphql.ts
+++ b/packages/node-experimental/src/integrations/graphql.ts
@@ -2,7 +2,7 @@ import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { GraphQLInstrumentation } from '@opentelemetry/instrumentation-graphql';
 import type { Integration } from '@sentry/types';
 
-import { NodePerformanceIntegration } from './lazy';
+import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
  * GraphQL integration

--- a/packages/node-experimental/src/integrations/mongo.ts
+++ b/packages/node-experimental/src/integrations/mongo.ts
@@ -2,7 +2,7 @@ import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { MongoDBInstrumentation } from '@opentelemetry/instrumentation-mongodb';
 import type { Integration } from '@sentry/types';
 
-import { NodePerformanceIntegration } from './lazy';
+import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
  * MongoDB integration

--- a/packages/node-experimental/src/integrations/mongoose.ts
+++ b/packages/node-experimental/src/integrations/mongoose.ts
@@ -2,7 +2,7 @@ import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { MongooseInstrumentation } from '@opentelemetry/instrumentation-mongoose';
 import type { Integration } from '@sentry/types';
 
-import { NodePerformanceIntegration } from './lazy';
+import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
  * Mongoose integration

--- a/packages/node-experimental/src/integrations/mysql.ts
+++ b/packages/node-experimental/src/integrations/mysql.ts
@@ -2,7 +2,7 @@ import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { MySQLInstrumentation } from '@opentelemetry/instrumentation-mysql';
 import type { Integration } from '@sentry/types';
 
-import { NodePerformanceIntegration } from './lazy';
+import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
  * MySQL integration

--- a/packages/node-experimental/src/integrations/mysql2.ts
+++ b/packages/node-experimental/src/integrations/mysql2.ts
@@ -2,7 +2,7 @@ import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { MySQL2Instrumentation } from '@opentelemetry/instrumentation-mysql2';
 import type { Integration } from '@sentry/types';
 
-import { NodePerformanceIntegration } from './lazy';
+import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
  * MySQL2 integration

--- a/packages/node-experimental/src/integrations/nest.ts
+++ b/packages/node-experimental/src/integrations/nest.ts
@@ -2,7 +2,7 @@ import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { NestInstrumentation } from '@opentelemetry/instrumentation-nestjs-core';
 import type { Integration } from '@sentry/types';
 
-import { NodePerformanceIntegration } from './lazy';
+import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
  * Nest framework integration

--- a/packages/node-experimental/src/integrations/postgres.ts
+++ b/packages/node-experimental/src/integrations/postgres.ts
@@ -2,7 +2,7 @@ import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
 import type { Integration } from '@sentry/types';
 
-import { NodePerformanceIntegration } from './lazy';
+import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
  * Postgres integration

--- a/packages/node-experimental/src/integrations/prisma.ts
+++ b/packages/node-experimental/src/integrations/prisma.ts
@@ -2,7 +2,7 @@ import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { PrismaInstrumentation } from '@prisma/instrumentation';
 import type { Integration } from '@sentry/types';
 
-import { NodePerformanceIntegration } from './lazy';
+import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
  * Prisma integration


### PR DESCRIPTION
This updates the way we auto-lookup integrations.

Due to how OTEL instrumentation works, we actually do not need any dynamic require. Otel instrumentation will generally always work, it only actually instruments when something is required/imported. So all integration _will_ be added, they will simply do nothing if the package is not used.

This also updates the readme to clarify this & restrictions.