### PR TITLE
ref: Add `no-class-field-initializers` eslint rule

### DIFF
--- a/packages/angular/src/errorhandler.ts
+++ b/packages/angular/src/errorhandler.ts
@@ -83,9 +83,11 @@ class SentryErrorHandler implements AngularErrorHandler {
   protected readonly _options: ErrorHandlerOptions;
 
   /* indicates if we already registered our the afterSendEvent handler */
-  private _registeredAfterSendEventHandler = false;
+  private _registeredAfterSendEventHandler;
 
   public constructor(@Inject('errorHandlerOptions') options?: ErrorHandlerOptions) {
+    this._registeredAfterSendEventHandler = false;
+
     this._options = {
       logErrors: true,
       ...options,

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -145,11 +145,14 @@ export class TraceService implements OnDestroy {
     }),
   );
 
-  private _routingSpan: Span | null = null;
+  private _routingSpan: Span | null;
 
-  private _subscription: Subscription = new Subscription();
+  private _subscription: Subscription;
 
   public constructor(private readonly _router: Router) {
+    this._routingSpan = null;
+    this._subscription = new Subscription();
+
     this._subscription.add(this.navStart$.subscribe());
     this._subscription.add(this.resEnd$.subscribe());
     this._subscription.add(this.navEnd$.subscribe());

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -56,7 +56,7 @@ export class Breadcrumbs implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = Breadcrumbs.id;
+  public name: string;
 
   /**
    * Options of the breadcrumbs integration.
@@ -68,6 +68,7 @@ export class Breadcrumbs implements Integration {
    * @inheritDoc
    */
   public constructor(options?: Partial<BreadcrumbsOptions>) {
+    this.name = Breadcrumbs.id;
     this.options = {
       console: true,
       dom: true,

--- a/packages/browser/src/integrations/dedupe.ts
+++ b/packages/browser/src/integrations/dedupe.ts
@@ -11,12 +11,16 @@ export class Dedupe implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = Dedupe.id;
+  public name: string;
 
   /**
    * @inheritDoc
    */
   private _previousEvent?: Event;
+
+  public constructor() {
+    this.name = Dedupe.id;
+  }
 
   /**
    * @inheritDoc

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -30,7 +30,7 @@ export class GlobalHandlers implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = GlobalHandlers.id;
+  public name: string;
 
   /** JSDoc */
   private readonly _options: GlobalHandlersIntegrations;
@@ -39,17 +39,20 @@ export class GlobalHandlers implements Integration {
    * Stores references functions to installing handlers. Will set to undefined
    * after they have been run so that they are not used twice.
    */
-  private _installFunc: Record<GlobalHandlersIntegrationsOptionKeys, (() => void) | undefined> = {
-    onerror: _installGlobalOnErrorHandler,
-    onunhandledrejection: _installGlobalOnUnhandledRejectionHandler,
-  };
+  private _installFunc: Record<GlobalHandlersIntegrationsOptionKeys, (() => void) | undefined>;
 
   /** JSDoc */
   public constructor(options?: GlobalHandlersIntegrations) {
+    this.name = GlobalHandlers.id;
     this._options = {
       onerror: true,
       onunhandledrejection: true,
       ...options,
+    };
+
+    this._installFunc = {
+      onerror: _installGlobalOnErrorHandler,
+      onunhandledrejection: _installGlobalOnUnhandledRejectionHandler,
     };
   }
   /**

--- a/packages/browser/src/integrations/httpcontext.ts
+++ b/packages/browser/src/integrations/httpcontext.ts
@@ -13,7 +13,11 @@ export class HttpContext implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = HttpContext.id;
+  public name: string;
+
+  public constructor() {
+    this.name = HttpContext.id;
+  }
 
   /**
    * @inheritDoc

--- a/packages/browser/src/integrations/linkederrors.ts
+++ b/packages/browser/src/integrations/linkederrors.ts
@@ -21,7 +21,7 @@ export class LinkedErrors implements Integration {
   /**
    * @inheritDoc
    */
-  public readonly name: string = LinkedErrors.id;
+  public readonly name: string;
 
   /**
    * @inheritDoc
@@ -37,6 +37,7 @@ export class LinkedErrors implements Integration {
    * @inheritDoc
    */
   public constructor(options: Partial<LinkedErrorsOptions> = {}) {
+    this.name = LinkedErrors.id;
     this._key = options.key || DEFAULT_KEY;
     this._limit = options.limit || DEFAULT_LIMIT;
   }

--- a/packages/browser/src/integrations/trycatch.ts
+++ b/packages/browser/src/integrations/trycatch.ts
@@ -56,7 +56,7 @@ export class TryCatch implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = TryCatch.id;
+  public name: string;
 
   /** JSDoc */
   private readonly _options: TryCatchOptions;
@@ -65,6 +65,7 @@ export class TryCatch implements Integration {
    * @inheritDoc
    */
   public constructor(options?: Partial<TryCatchOptions>) {
+    this.name = TryCatch.id;
     this._options = {
       XMLHttpRequest: true,
       eventTarget: true,

--- a/packages/browser/src/profiling/integration.ts
+++ b/packages/browser/src/profiling/integration.ts
@@ -22,8 +22,15 @@ import {
  * @experimental
  */
 export class BrowserProfilingIntegration implements Integration {
-  public readonly name: string = 'BrowserProfilingIntegration';
-  public getCurrentHub?: () => Hub = undefined;
+  public static id: string = 'BrowserProfilingIntegration';
+
+  public readonly name: string;
+
+  public getCurrentHub?: () => Hub;
+
+  public constructor() {
+    this.name = BrowserProfilingIntegration.id;
+  }
 
   /**
    * @inheritDoc

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -93,19 +93,19 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   protected readonly _transport?: Transport;
 
   /** Array of set up integrations. */
-  protected _integrations: IntegrationIndex = {};
+  protected _integrations: IntegrationIndex;
 
   /** Indicates whether this client's integrations have been set up. */
-  protected _integrationsInitialized: boolean = false;
+  protected _integrationsInitialized: boolean;
 
   /** Number of calls being processed */
-  protected _numProcessing: number = 0;
+  protected _numProcessing: number;
 
   /** Holds flushable  */
-  private _outcomes: { [key: string]: number } = {};
+  private _outcomes: { [key: string]: number };
 
   // eslint-disable-next-line @typescript-eslint/ban-types
-  private _hooks: Record<string, Function[]> = {};
+  private _hooks: Record<string, Function[]>;
 
   /**
    * Initializes this client instance.
@@ -114,6 +114,11 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    */
   protected constructor(options: O) {
     this._options = options;
+    this._integrations = {};
+    this._integrationsInitialized = false;
+    this._numProcessing = 0;
+    this._outcomes = {};
+    this._hooks = {};
 
     if (options.dsn) {
       this._dsn = makeDsn(options.dsn);

--- a/packages/core/src/integrations/functiontostring.ts
+++ b/packages/core/src/integrations/functiontostring.ts
@@ -13,7 +13,11 @@ export class FunctionToString implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = FunctionToString.id;
+  public name: string;
+
+  public constructor() {
+    this.name = FunctionToString.id;
+  }
 
   /**
    * @inheritDoc

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -36,9 +36,14 @@ export class InboundFilters implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = InboundFilters.id;
+  public name: string;
 
-  public constructor(private readonly _options: Partial<InboundFiltersOptions> = {}) {}
+  private readonly _options: Partial<InboundFiltersOptions>;
+
+  public constructor(options: Partial<InboundFiltersOptions> = {}) {
+    this.name = InboundFilters.id;
+    this._options = options;
+  }
 
   /**
    * @inheritDoc

--- a/packages/core/src/integrations/metadata.ts
+++ b/packages/core/src/integrations/metadata.ts
@@ -21,7 +21,11 @@ export class ModuleMetadata implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = ModuleMetadata.id;
+  public name: string;
+
+  public constructor() {
+    this.name = ModuleMetadata.id;
+  }
 
   /**
    * @inheritDoc

--- a/packages/core/src/sessionflusher.ts
+++ b/packages/core/src/sessionflusher.ts
@@ -18,15 +18,19 @@ type ReleaseHealthAttributes = {
  * @inheritdoc
  */
 export class SessionFlusher implements SessionFlusherLike {
-  public readonly flushTimeout: number = 60;
-  private _pendingAggregates: Record<number, AggregationCounts> = {};
+  public readonly flushTimeout: number;
+  private _pendingAggregates: Record<number, AggregationCounts>;
   private _sessionAttrs: ReleaseHealthAttributes;
   private _intervalId: ReturnType<typeof setInterval>;
-  private _isEnabled: boolean = true;
+  private _isEnabled: boolean;
   private _client: Client;
 
   public constructor(client: Client, attrs: ReleaseHealthAttributes) {
     this._client = client;
+    this.flushTimeout = 60;
+    this._pendingAggregates = {};
+    this._isEnabled = true;
+
     // Call to setInterval, so that flush is called every 60 seconds
     this._intervalId = setInterval(() => this.flush(), this.flushTimeout * 1000);
     this._sessionAttrs = attrs;

--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -69,28 +69,27 @@ export type BeforeFinishCallback = (transactionSpan: IdleTransaction, endTimesta
  */
 export class IdleTransaction extends Transaction {
   // Activities store a list of active spans
-  public activities: Record<string, boolean> = {};
-
+  public activities: Record<string, boolean>;
   // Track state of activities in previous heartbeat
   private _prevHeartbeatString: string | undefined;
 
   // Amount of times heartbeat has counted. Will cause transaction to finish after 3 beats.
-  private _heartbeatCounter: number = 0;
+  private _heartbeatCounter: number;
 
   // We should not use heartbeat if we finished a transaction
-  private _finished: boolean = false;
+  private _finished: boolean;
 
   // Idle timeout was canceled and we should finish the transaction with the last span end.
-  private _idleTimeoutCanceledPermanently: boolean = false;
+  private _idleTimeoutCanceledPermanently: boolean;
 
-  private readonly _beforeFinishCallbacks: BeforeFinishCallback[] = [];
+  private readonly _beforeFinishCallbacks: BeforeFinishCallback[];
 
   /**
    * Timer that tracks Transaction idleTimeout
    */
   private _idleTimeoutID: ReturnType<typeof setTimeout> | undefined;
 
-  private _finishReason: (typeof IDLE_TRANSACTION_FINISH_REASONS)[number] = IDLE_TRANSACTION_FINISH_REASONS[4];
+  private _finishReason: (typeof IDLE_TRANSACTION_FINISH_REASONS)[number];
 
   public constructor(
     transactionContext: TransactionContext,
@@ -109,6 +108,13 @@ export class IdleTransaction extends Transaction {
     private readonly _onScope: boolean = false,
   ) {
     super(transactionContext, _idleHub);
+
+    this.activities = {};
+    this._heartbeatCounter = 0;
+    this._finished = false;
+    this._idleTimeoutCanceledPermanently = false;
+    this._beforeFinishCallbacks = [];
+    this._finishReason = IDLE_TRANSACTION_FINISH_REASONS[4];
 
     if (_onScope) {
       // We set the transaction here on the scope so error events pick up the trace

--- a/packages/core/src/tracing/span.ts
+++ b/packages/core/src/tracing/span.ts
@@ -16,12 +16,13 @@ import { dropUndefinedKeys, generateSentryTraceHeader, logger, timestampInSecond
  * @hidden
  */
 export class SpanRecorder {
-  public spans: Span[] = [];
+  public spans: Span[];
 
   private readonly _maxlen: number;
 
   public constructor(maxlen: number = 1000) {
     this._maxlen = maxlen;
+    this.spans = [];
   }
 
   /**
@@ -46,12 +47,12 @@ export class Span implements SpanInterface {
   /**
    * @inheritDoc
    */
-  public traceId: string = uuid4();
+  public traceId: string;
 
   /**
    * @inheritDoc
    */
-  public spanId: string = uuid4().substring(16);
+  public spanId: string;
 
   /**
    * @inheritDoc
@@ -71,7 +72,7 @@ export class Span implements SpanInterface {
   /**
    * Timestamp in seconds when the span was created.
    */
-  public startTimestamp: number = timestampInSeconds();
+  public startTimestamp: number;
 
   /**
    * Timestamp in seconds when the span ended.
@@ -91,13 +92,13 @@ export class Span implements SpanInterface {
   /**
    * @inheritDoc
    */
-  public tags: { [key: string]: Primitive } = {};
+  public tags: { [key: string]: Primitive };
 
   /**
    * @inheritDoc
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public data: { [key: string]: any } = {};
+  public data: { [key: string]: any };
 
   /**
    * List of spans that were finalized
@@ -112,7 +113,7 @@ export class Span implements SpanInterface {
   /**
    * The instrumenter that created this span.
    */
-  public instrumenter: Instrumenter = 'sentry';
+  public instrumenter: Instrumenter;
 
   /**
    * You should never call the constructor manually, always use `Sentry.startTransaction()`
@@ -122,6 +123,13 @@ export class Span implements SpanInterface {
    * @hidden
    */
   public constructor(spanContext?: SpanContext) {
+    this.traceId = uuid4();
+    this.spanId = uuid4().substring(16);
+    this.startTimestamp = timestampInSeconds();
+    this.tags = {};
+    this.data = {};
+    this.instrumenter = 'sentry';
+
     if (!spanContext) {
       return this;
     }

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -27,13 +27,13 @@ export class Transaction extends SpanClass implements TransactionInterface {
 
   private _name: string;
 
-  private _measurements: Measurements = {};
+  private _measurements: Measurements;
 
-  private _contexts: Contexts = {};
+  private _contexts: Contexts;
 
   private _trimEnd?: boolean;
 
-  private _frozenDynamicSamplingContext: Readonly<Partial<DynamicSamplingContext>> | undefined = undefined;
+  private _frozenDynamicSamplingContext: Readonly<Partial<DynamicSamplingContext>> | undefined;
 
   /**
    * This constructor should never be called manually. Those instrumenting tracing should use
@@ -44,6 +44,9 @@ export class Transaction extends SpanClass implements TransactionInterface {
    */
   public constructor(transactionContext: TransactionContext, hub?: Hub) {
     super(transactionContext);
+
+    this._measurements = {};
+    this._contexts = {};
 
     this._hub = hub || getCurrentHub();
 

--- a/packages/eslint-config-sdk/src/index.js
+++ b/packages/eslint-config-sdk/src/index.js
@@ -164,6 +164,9 @@ module.exports = {
 
         // Do not allow usage of functions we do not polyfill for ES5
         '@sentry-internal/sdk/no-unsupported-es6-methods': 'error',
+
+        // Do not allow usage of class field initializers
+        '@sentry-internal/sdk/no-class-field-initializers': 'error',
       },
     },
     {

--- a/packages/eslint-plugin-sdk/src/index.js
+++ b/packages/eslint-plugin-sdk/src/index.js
@@ -14,5 +14,6 @@ module.exports = {
     'no-nullish-coalescing': require('./rules/no-nullish-coalescing'),
     'no-eq-empty': require('./rules/no-eq-empty'),
     'no-unsupported-es6-methods': require('./rules/no-unsupported-es6-methods'),
+    'no-class-field-initializers': require('./rules/no-class-field-initializers'),
   },
 };

--- a/packages/eslint-plugin-sdk/src/rules/no-class-field-initializers.js
+++ b/packages/eslint-plugin-sdk/src/rules/no-class-field-initializers.js
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Rule to disallow using class field initializers.
+ * @author Francesco Novy
+ *
+ * Based on https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/state-in-constructor.js
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'disallow usage of class field initializers, because they producer larger bundle size.',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    messages: {
+      forbidden: 'Avoid using class field initializers',
+    },
+    fixable: null,
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      'ClassProperty, PropertyDefinition'(node) {
+        // We do allow arrow functions being initialized directly
+        if (
+          !node.static &&
+          node.value !== null &&
+          node.value.type !== 'ArrowFunctionExpression' &&
+          node.value.type !== 'FunctionExpression' &&
+          node.value.type !== 'CallExpression'
+        ) {
+          context.report({
+            node,
+            message: `Avoid class field initializers. Property "${node.key.name}" should be initialized in the constructor.`,
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/integration-shims/src/BrowserTracing.ts
+++ b/packages/integration-shims/src/BrowserTracing.ts
@@ -14,10 +14,12 @@ class BrowserTracingShim implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = BrowserTracingShim.id;
+  public name: string;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public constructor(_options: any) {
+    this.name = BrowserTracingShim.id;
+
     // eslint-disable-next-line no-console
     console.error('You are using new BrowserTracing() even though this bundle does not include tracing.');
   }

--- a/packages/integration-shims/src/Replay.ts
+++ b/packages/integration-shims/src/Replay.ts
@@ -14,10 +14,12 @@ class ReplayShim implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = ReplayShim.id;
+  public name: string;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public constructor(_options: any) {
+    this.name = ReplayShim.id;
+
     // eslint-disable-next-line no-console
     console.error('You are using new Replay() even though this bundle does not include replay.');
   }

--- a/packages/integrations/src/captureconsole.ts
+++ b/packages/integrations/src/captureconsole.ts
@@ -11,20 +11,19 @@ export class CaptureConsole implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = CaptureConsole.id;
+  public name: string;
 
   /**
    * @inheritDoc
    */
-  private readonly _levels: readonly string[] = CONSOLE_LEVELS;
+  private readonly _levels: readonly string[];
 
   /**
    * @inheritDoc
    */
   public constructor(options: { levels?: string[] } = {}) {
-    if (options.levels) {
-      this._levels = options.levels;
-    }
+    this.name = CaptureConsole.id;
+    this._levels = options.levels || CONSOLE_LEVELS;
   }
 
   /**

--- a/packages/integrations/src/debug.ts
+++ b/packages/integrations/src/debug.ts
@@ -21,11 +21,13 @@ export class Debug implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = Debug.id;
+  public name: string;
 
   private readonly _options: DebugOptions;
 
   public constructor(options?: DebugOptions) {
+    this.name = Debug.id;
+
     this._options = {
       debugger: false,
       stringify: false,

--- a/packages/integrations/src/dedupe.ts
+++ b/packages/integrations/src/dedupe.ts
@@ -11,12 +11,16 @@ export class Dedupe implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = Dedupe.id;
+  public name: string;
 
   /**
    * @inheritDoc
    */
   private _previousEvent?: Event;
+
+  public constructor() {
+    this.name = Dedupe.id;
+  }
 
   /**
    * @inheritDoc

--- a/packages/integrations/src/extraerrordata.ts
+++ b/packages/integrations/src/extraerrordata.ts
@@ -16,7 +16,7 @@ export class ExtraErrorData implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = ExtraErrorData.id;
+  public name: string;
 
   /** JSDoc */
   private readonly _options: ExtraErrorDataOptions;
@@ -25,6 +25,8 @@ export class ExtraErrorData implements Integration {
    * @inheritDoc
    */
   public constructor(options?: ExtraErrorDataOptions) {
+    this.name = ExtraErrorData.id;
+
     this._options = {
       depth: 3,
       ...options,

--- a/packages/integrations/src/httpclient.ts
+++ b/packages/integrations/src/httpclient.ts
@@ -49,7 +49,7 @@ export class HttpClient implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = HttpClient.id;
+  public name: string;
 
   private readonly _options: HttpClientOptions;
 
@@ -64,6 +64,7 @@ export class HttpClient implements Integration {
    * @param options
    */
   public constructor(options?: Partial<HttpClientOptions>) {
+    this.name = HttpClient.id;
     this._options = {
       failedRequestStatusCodes: [[500, 599]],
       failedRequestTargets: [/.*/],

--- a/packages/integrations/src/offline.ts
+++ b/packages/integrations/src/offline.ts
@@ -34,7 +34,7 @@ export class Offline implements Integration {
   /**
    * @inheritDoc
    */
-  public readonly name: string = Offline.id;
+  public readonly name: string;
 
   /**
    * the current hub instance
@@ -55,6 +55,8 @@ export class Offline implements Integration {
    * @inheritDoc
    */
   public constructor(options: { maxStoredEvents?: number } = {}) {
+    this.name = Offline.id;
+
     this.maxStoredEvents = options.maxStoredEvents || 30; // set a reasonable default
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     this.offlineEventStore = localForage.createInstance({

--- a/packages/integrations/src/reportingobserver.ts
+++ b/packages/integrations/src/reportingobserver.ts
@@ -49,23 +49,27 @@ export class ReportingObserver implements Integration {
   /**
    * @inheritDoc
    */
-  public readonly name: string = ReportingObserver.id;
+  public readonly name: string;
 
   /**
    * Returns current hub.
    */
   private _getCurrentHub?: () => Hub;
 
+  private readonly _types: ReportTypes[];
+
   /**
    * @inheritDoc
    */
   public constructor(
-    private readonly _options: {
+    options: {
       types?: ReportTypes[];
-    } = {
-      types: ['crash', 'deprecation', 'intervention'],
-    },
-  ) {}
+    } = {},
+  ) {
+    this.name = ReportingObserver.id;
+
+    this._types = options.types || ['crash', 'deprecation', 'intervention'];
+  }
 
   /**
    * @inheritDoc
@@ -80,7 +84,7 @@ export class ReportingObserver implements Integration {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     const observer = new (WINDOW as any).ReportingObserver(this.handler.bind(this), {
       buffered: true,
-      types: this._options.types,
+      types: this._types,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access

--- a/packages/integrations/src/rewriteframes.ts
+++ b/packages/integrations/src/rewriteframes.ts
@@ -13,7 +13,7 @@ export class RewriteFrames implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = RewriteFrames.id;
+  public name: string;
 
   /**
    * @inheritDoc
@@ -23,18 +23,18 @@ export class RewriteFrames implements Integration {
   /**
    * @inheritDoc
    */
-  private readonly _prefix: string = 'app:///';
+  private readonly _prefix: string;
 
   /**
    * @inheritDoc
    */
   public constructor(options: { root?: string; prefix?: string; iteratee?: StackFrameIteratee } = {}) {
+    this.name = RewriteFrames.id;
+
     if (options.root) {
       this._root = options.root;
     }
-    if (options.prefix) {
-      this._prefix = options.prefix;
-    }
+    this._prefix = options.prefix || 'app:///';
     if (options.iteratee) {
       this._iteratee = options.iteratee;
     }

--- a/packages/integrations/src/sessiontiming.ts
+++ b/packages/integrations/src/sessiontiming.ts
@@ -10,10 +10,15 @@ export class SessionTiming implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = SessionTiming.id;
+  public name: string;
 
   /** Exact time Client was initialized expressed in milliseconds since Unix Epoch. */
-  protected readonly _startTime: number = Date.now();
+  protected readonly _startTime: number;
+
+  public constructor() {
+    this.name = SessionTiming.id;
+    this._startTime = Date.now();
+  }
 
   /**
    * @inheritDoc

--- a/packages/integrations/src/transaction.ts
+++ b/packages/integrations/src/transaction.ts
@@ -10,7 +10,11 @@ export class Transaction implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = Transaction.id;
+  public name: string;
+
+  public constructor() {
+    this.name = Transaction.id;
+  }
 
   /**
    * @inheritDoc

--- a/packages/nextjs/src/edge/transport.ts
+++ b/packages/nextjs/src/edge/transport.ts
@@ -22,11 +22,17 @@ const DEFAULT_TRANSPORT_BUFFER_SIZE = 30;
 export class IsolatedPromiseBuffer {
   // We just have this field because the promise buffer interface requires it.
   // If we ever remove it from the interface we should also remove it here.
-  public $: Array<PromiseLike<TransportMakeRequestResponse>> = [];
+  public $: Array<PromiseLike<TransportMakeRequestResponse>>;
 
-  private _taskProducers: (() => PromiseLike<TransportMakeRequestResponse>)[] = [];
+  private _taskProducers: (() => PromiseLike<TransportMakeRequestResponse>)[];
 
-  public constructor(private readonly _bufferSize: number = DEFAULT_TRANSPORT_BUFFER_SIZE) {}
+  private readonly _bufferSize: number;
+
+  public constructor(_bufferSize = DEFAULT_TRANSPORT_BUFFER_SIZE) {
+    this.$ = [];
+    this._taskProducers = [];
+    this._bufferSize = _bufferSize;
+  }
 
   /**
    * @inheritdoc

--- a/packages/node-experimental/src/integrations/express.ts
+++ b/packages/node-experimental/src/integrations/express.ts
@@ -18,7 +18,12 @@ export class Express extends NodePerformanceIntegration<void> implements Integra
   /**
    * @inheritDoc
    */
-  public name: string = Express.id;
+  public name: string;
+
+  public constructor() {
+    super();
+    this.name = Express.id;
+  }
 
   /** @inheritDoc */
   public setupInstrumentation(): void | Instrumentation[] {

--- a/packages/node-experimental/src/integrations/fastify.ts
+++ b/packages/node-experimental/src/integrations/fastify.ts
@@ -18,7 +18,12 @@ export class Fastify extends NodePerformanceIntegration<void> implements Integra
   /**
    * @inheritDoc
    */
-  public name: string = Fastify.id;
+  public name: string;
+
+  public constructor() {
+    super();
+    this.name = Fastify.id;
+  }
 
   /** @inheritDoc */
   public setupInstrumentation(): void | Instrumentation[] {

--- a/packages/node-experimental/src/integrations/graphql.ts
+++ b/packages/node-experimental/src/integrations/graphql.ts
@@ -18,7 +18,12 @@ export class GraphQL extends NodePerformanceIntegration<void> implements Integra
   /**
    * @inheritDoc
    */
-  public name: string = GraphQL.id;
+  public name: string;
+
+  public constructor() {
+    super();
+    this.name = GraphQL.id;
+  }
 
   /** @inheritDoc */
   public setupInstrumentation(): void | Instrumentation[] {

--- a/packages/node-experimental/src/integrations/http.ts
+++ b/packages/node-experimental/src/integrations/http.ts
@@ -53,21 +53,23 @@ export class Http implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = Http.id;
+  public name: string;
 
   private _unload?: () => void;
   private readonly _breadcrumbs: boolean;
   // undefined: default behavior based on tracing settings
   private readonly _tracing: boolean | undefined;
-  private _shouldCreateSpans: boolean = false;
+  private _shouldCreateSpans: boolean;
   private _shouldCreateSpanForRequest?: (url: string) => boolean;
 
   /**
    * @inheritDoc
    */
   public constructor(options: HttpOptions = {}) {
+    this.name = Http.id;
     this._breadcrumbs = typeof options.breadcrumbs === 'undefined' ? true : options.breadcrumbs;
     this._tracing = typeof options.tracing === 'undefined' ? undefined : !!options.tracing;
+    this._shouldCreateSpans = false;
 
     if (options.tracing && typeof options.tracing === 'object') {
       this._shouldCreateSpanForRequest = options.tracing.shouldCreateSpanForRequest;

--- a/packages/node-experimental/src/integrations/mongo.ts
+++ b/packages/node-experimental/src/integrations/mongo.ts
@@ -18,7 +18,12 @@ export class Mongo extends NodePerformanceIntegration<void> implements Integrati
   /**
    * @inheritDoc
    */
-  public name: string = Mongo.id;
+  public name: string;
+
+  public constructor() {
+    super();
+    this.name = Mongo.id;
+  }
 
   /** @inheritDoc */
   public setupInstrumentation(): void | Instrumentation[] {

--- a/packages/node-experimental/src/integrations/mongoose.ts
+++ b/packages/node-experimental/src/integrations/mongoose.ts
@@ -18,7 +18,12 @@ export class Mongoose extends NodePerformanceIntegration<void> implements Integr
   /**
    * @inheritDoc
    */
-  public name: string = Mongoose.id;
+  public name: string;
+
+  public constructor() {
+    super();
+    this.name = Mongoose.id;
+  }
 
   /** @inheritDoc */
   public setupInstrumentation(): void | Instrumentation[] {

--- a/packages/node-experimental/src/integrations/mysql.ts
+++ b/packages/node-experimental/src/integrations/mysql.ts
@@ -16,9 +16,14 @@ export class Mysql extends NodePerformanceIntegration<void> implements Integrati
   public static id: string = 'Mysql';
 
   /**
-   * @inheritDoc`
+   * @inheritDoc
    */
-  public name: string = Mysql.id;
+  public name: string;
+
+  public constructor() {
+    super();
+    this.name = Mysql.id;
+  }
 
   /** @inheritDoc */
   public setupInstrumentation(): void | Instrumentation[] {

--- a/packages/node-experimental/src/integrations/mysql2.ts
+++ b/packages/node-experimental/src/integrations/mysql2.ts
@@ -16,9 +16,14 @@ export class Mysql2 extends NodePerformanceIntegration<void> implements Integrat
   public static id: string = 'Mysql2';
 
   /**
-   * @inheritDoc`
+   * @inheritDoc
    */
-  public name: string = Mysql2.id;
+  public name: string;
+
+  public constructor() {
+    super();
+    this.name = Mysql2.id;
+  }
 
   /** @inheritDoc */
   public setupInstrumentation(): void | Instrumentation[] {

--- a/packages/node-experimental/src/integrations/nest.ts
+++ b/packages/node-experimental/src/integrations/nest.ts
@@ -16,9 +16,14 @@ export class Nest extends NodePerformanceIntegration<void> implements Integratio
   public static id: string = 'Nest';
 
   /**
-   * @inheritDoc`
+   * @inheritDoc
    */
-  public name: string = Nest.id;
+  public name: string;
+
+  public constructor() {
+    super();
+    this.name = Nest.id;
+  }
 
   /** @inheritDoc */
   public setupInstrumentation(): void | Instrumentation[] {

--- a/packages/node-experimental/src/integrations/postgres.ts
+++ b/packages/node-experimental/src/integrations/postgres.ts
@@ -16,9 +16,14 @@ export class Postgres extends NodePerformanceIntegration<void> implements Integr
   public static id: string = 'Postgres';
 
   /**
-   * @inheritDoc`
+   * @inheritDoc
    */
-  public name: string = Postgres.id;
+  public name: string;
+
+  public constructor() {
+    super();
+    this.name = Postgres.id;
+  }
 
   /** @inheritDoc */
   public setupInstrumentation(): void | Instrumentation[] {

--- a/packages/node-experimental/src/integrations/prisma.ts
+++ b/packages/node-experimental/src/integrations/prisma.ts
@@ -20,9 +20,14 @@ export class Prisma extends NodePerformanceIntegration<void> implements Integrat
   public static id: string = 'Prisma';
 
   /**
-   * @inheritDoc`
+   * @inheritDoc
    */
-  public name: string = Prisma.id;
+  public name: string;
+
+  public constructor() {
+    super();
+    this.name = Prisma.id;
+  }
 
   /** @inheritDoc */
   public setupInstrumentation(): void | Instrumentation[] {

--- a/packages/node/.eslintrc.js
+++ b/packages/node/.eslintrc.js
@@ -7,5 +7,6 @@ module.exports = {
     '@sentry-internal/sdk/no-optional-chaining': 'off',
     '@sentry-internal/sdk/no-nullish-coalescing': 'off',
     '@sentry-internal/sdk/no-unsupported-es6-methods': 'off',
+    '@sentry-internal/sdk/no-class-field-initializers': 'off',
   },
 };

--- a/packages/overhead-metrics/.eslintrc.cjs
+++ b/packages/overhead-metrics/.eslintrc.cjs
@@ -11,6 +11,7 @@ module.exports = {
         '@sentry-internal/sdk/no-optional-chaining': 'off',
         '@sentry-internal/sdk/no-nullish-coalescing': 'off',
         '@sentry-internal/sdk/no-unsupported-es6-methods': 'off',
+        '@sentry-internal/sdk/no-class-field-initializers': 'off',
         'jsdoc/require-jsdoc': 'off',
       },
     },

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -92,14 +92,17 @@ function setCause(error: Error & { cause?: Error }, cause: Error): void {
  * is expected behavior and NOT indicative of a bug with the Sentry React SDK.
  */
 class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  public state: ErrorBoundaryState = INITIAL_STATE;
+  public state: ErrorBoundaryState;
 
-  private readonly _openFallbackReportDialog: boolean = true;
+  private readonly _openFallbackReportDialog: boolean;
 
   private _lastEventId?: string;
 
   public constructor(props: ErrorBoundaryProps) {
     super(props);
+
+    this.state = INITIAL_STATE;
+    this._openFallbackReportDialog = true;
 
     const client = getCurrentHub().getClient();
     if (client && client.on && props.showDialog) {

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -36,11 +36,11 @@ class Profiler extends React.Component<ProfilerProps> {
    * The span of the mount activity
    * Made protected for the React Native SDK to access
    */
-  protected _mountSpan: Span | undefined = undefined;
+  protected _mountSpan: Span | undefined;
   /**
    * The span that represents the duration of time between shouldComponentUpdate and componentDidUpdate
    */
-  protected _updateSpan: Span | undefined = undefined;
+  protected _updateSpan: Span | undefined;
 
   // eslint-disable-next-line @typescript-eslint/member-ordering
   public static defaultProps: Partial<ProfilerProps> = {

--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -7,24 +7,22 @@ import type { Action, Location, ReactRouterInstrumentation } from './types';
 
 // We need to disable eslint no-explict-any because any is required for the
 // react-router typings.
-/* eslint-disable @typescript-eslint/no-explicit-any */
-type Match = { path: string; url: string; params: Record<string, any>; isExact: boolean };
+type Match = { path: string; url: string; params: Record<string, any>; isExact: boolean }; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 export type RouterHistory = {
   location?: Location;
   listen?(cb: (location: Location, action: Action) => void): void;
-} & Record<string, any>;
+} & Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 export type RouteConfig = {
-  [propName: string]: any;
+  [propName: string]: unknown;
   path?: string | string[];
   exact?: boolean;
   component?: JSX.Element;
   routes?: RouteConfig[];
 };
 
-type MatchPath = (pathname: string, props: string | string[] | any, parent?: Match | null) => Match | null;
-/* eslint-enable @typescript-eslint/no-explicit-any */
+type MatchPath = (pathname: string, props: string | string[] | any, parent?: Match | null) => Match | null; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 let activeTransaction: Transaction | undefined;
 

--- a/packages/replay/src/coreHandlers/handleClick.ts
+++ b/packages/replay/src/coreHandlers/handleClick.ts
@@ -28,10 +28,10 @@ export function handleClick(clickDetector: ReplayClickDetector, clickBreadcrumb:
 /** A click detector class that can be used to detect slow or rage clicks on elements. */
 export class ClickDetector implements ReplayClickDetector {
   // protected for testing
-  protected _lastMutation = 0;
-  protected _lastScroll = 0;
+  protected _lastMutation: number;
+  protected _lastScroll: number;
 
-  private _clicks: Click[] = [];
+  private _clicks: Click[];
   private _teardown: undefined | (() => void);
 
   private _threshold: number;
@@ -49,6 +49,10 @@ export class ClickDetector implements ReplayClickDetector {
     // Just for easier testing
     _addBreadcrumbEvent = addBreadcrumbEvent,
   ) {
+    this._lastMutation = 0;
+    this._lastScroll = 0;
+    this._clicks = [];
+
     // We want everything in s, but options are in ms
     this._timeout = slowClickConfig.timeout / 1000;
     this._threshold = slowClickConfig.threshold / 1000;

--- a/packages/replay/src/eventBuffer/EventBufferArray.ts
+++ b/packages/replay/src/eventBuffer/EventBufferArray.ts
@@ -10,10 +10,11 @@ import { EventBufferSizeExceededError } from './error';
 export class EventBufferArray implements EventBuffer {
   /** All the events that are buffered to be sent. */
   public events: RecordingEvent[];
-  private _totalSize = 0;
+  private _totalSize: number;
 
   public constructor() {
     this.events = [];
+    this._totalSize = 0;
   }
 
   /** @inheritdoc */

--- a/packages/replay/src/eventBuffer/EventBufferCompressionWorker.ts
+++ b/packages/replay/src/eventBuffer/EventBufferCompressionWorker.ts
@@ -13,11 +13,12 @@ import { WorkerHandler } from './WorkerHandler';
 export class EventBufferCompressionWorker implements EventBuffer {
   private _worker: WorkerHandler;
   private _earliestTimestamp: number | null;
-  private _totalSize = 0;
+  private _totalSize;
 
   public constructor(worker: Worker) {
     this._worker = new WorkerHandler(worker);
     this._earliestTimestamp = null;
+    this._totalSize = 0;
   }
 
   /** @inheritdoc */

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -35,7 +35,7 @@ export class Replay implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = Replay.id;
+  public name: string;
 
   /**
    * Options to pass to `rrweb.record()`
@@ -100,6 +100,8 @@ export class Replay implements Integration {
     // eslint-disable-next-line deprecation/deprecation
     ignoreClass,
   }: ReplayConfiguration = {}) {
+    this.name = Replay.id;
+
     this._recordingOptions = {
       maskAllInputs,
       maskAllText,

--- a/packages/serverless/src/awsservices.ts
+++ b/packages/serverless/src/awsservices.ts
@@ -25,11 +25,13 @@ export class AWSServices implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = AWSServices.id;
+  public name: string;
 
   private readonly _optional: boolean;
 
   public constructor(options: { optional?: boolean } = {}) {
+    this.name = AWSServices.id;
+
     this._optional = options.optional || false;
   }
 

--- a/packages/serverless/src/google-cloud-grpc.ts
+++ b/packages/serverless/src/google-cloud-grpc.ts
@@ -35,11 +35,13 @@ export class GoogleCloudGrpc implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = GoogleCloudGrpc.id;
+  public name: string;
 
   private readonly _optional: boolean;
 
   public constructor(options: { optional?: boolean } = {}) {
+    this.name = GoogleCloudGrpc.id;
+
     this._optional = options.optional || false;
   }
 

--- a/packages/serverless/src/google-cloud-http.ts
+++ b/packages/serverless/src/google-cloud-http.ts
@@ -22,11 +22,13 @@ export class GoogleCloudHttp implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = GoogleCloudHttp.id;
+  public name: string;
 
   private readonly _optional: boolean;
 
   public constructor(options: { optional?: boolean } = {}) {
+    this.name = GoogleCloudHttp.id;
+
     this._optional = options.optional || false;
   }
 

--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -162,7 +162,7 @@ export class BrowserTracing implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = BROWSER_TRACING_INTEGRATION_ID;
+  public name: string;
 
   private _getCurrentHub?: () => Hub;
 
@@ -171,9 +171,12 @@ export class BrowserTracing implements Integration {
 
   private _collectWebVitals: () => void;
 
-  private _hasSetTracePropagationTargets: boolean = false;
+  private _hasSetTracePropagationTargets: boolean;
 
   public constructor(_options?: Partial<BrowserTracingOptions>) {
+    this.name = BROWSER_TRACING_INTEGRATION_ID;
+    this._hasSetTracePropagationTargets = false;
+
     addTracingExtensions();
 
     if (__DEBUG_BUILD__) {

--- a/packages/tracing-internal/src/node/integrations/apollo.ts
+++ b/packages/tracing-internal/src/node/integrations/apollo.ts
@@ -43,7 +43,7 @@ export class Apollo implements LazyLoadedIntegration<GraphQLModule & ApolloModul
   /**
    * @inheritDoc
    */
-  public name: string = Apollo.id;
+  public name: string;
 
   private readonly _useNest: boolean;
 
@@ -57,6 +57,7 @@ export class Apollo implements LazyLoadedIntegration<GraphQLModule & ApolloModul
       useNestjs: false,
     },
   ) {
+    this.name = Apollo.id;
     this._useNest = !!options.useNestjs;
   }
 

--- a/packages/tracing-internal/src/node/integrations/express.ts
+++ b/packages/tracing-internal/src/node/integrations/express.ts
@@ -94,7 +94,7 @@ export class Express implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = Express.id;
+  public name: string;
 
   /**
    * Express App instance
@@ -106,6 +106,7 @@ export class Express implements Integration {
    * @inheritDoc
    */
   public constructor(options: { app?: Router; router?: Router; methods?: Method[] } = {}) {
+    this.name = Express.id;
     this._router = options.router || options.app;
     this._methods = (Array.isArray(options.methods) ? options.methods : []).concat('use');
   }

--- a/packages/tracing-internal/src/node/integrations/graphql.ts
+++ b/packages/tracing-internal/src/node/integrations/graphql.ts
@@ -19,9 +19,13 @@ export class GraphQL implements LazyLoadedIntegration<GraphQLModule> {
   /**
    * @inheritDoc
    */
-  public name: string = GraphQL.id;
+  public name: string;
 
   private _module?: GraphQLModule;
+
+  public constructor() {
+    this.name = GraphQL.id;
+  }
 
   /** @inheritdoc */
   public loadDependency(): GraphQLModule | undefined {

--- a/packages/tracing-internal/src/node/integrations/mongo.ts
+++ b/packages/tracing-internal/src/node/integrations/mongo.ts
@@ -111,7 +111,7 @@ export class Mongo implements LazyLoadedIntegration<MongoModule> {
   /**
    * @inheritDoc
    */
-  public name: string = Mongo.id;
+  public name: string;
 
   private _operations: Operation[];
   private _describeOperations?: boolean | Operation[];
@@ -123,6 +123,7 @@ export class Mongo implements LazyLoadedIntegration<MongoModule> {
    * @inheritDoc
    */
   public constructor(options: MongoOptions = {}) {
+    this.name = Mongo.id;
     this._operations = Array.isArray(options.operations) ? options.operations : (OPERATIONS as unknown as Operation[]);
     this._describeOperations = 'describeOperations' in options ? options.describeOperations : true;
     this._useMongoose = !!options.useMongoose;

--- a/packages/tracing-internal/src/node/integrations/mysql.ts
+++ b/packages/tracing-internal/src/node/integrations/mysql.ts
@@ -19,9 +19,13 @@ export class Mysql implements LazyLoadedIntegration<MysqlConnection> {
   /**
    * @inheritDoc
    */
-  public name: string = Mysql.id;
+  public name: string;
 
   private _module?: MysqlConnection;
+
+  public constructor() {
+    this.name = Mysql.id;
+  }
 
   /** @inheritdoc */
   public loadDependency(): MysqlConnection | undefined {

--- a/packages/tracing-internal/src/node/integrations/postgres.ts
+++ b/packages/tracing-internal/src/node/integrations/postgres.ts
@@ -27,13 +27,14 @@ export class Postgres implements LazyLoadedIntegration<PGModule> {
   /**
    * @inheritDoc
    */
-  public name: string = Postgres.id;
+  public name: string;
 
   private _usePgNative: boolean;
 
   private _module?: PGModule;
 
   public constructor(options: PgOptions = {}) {
+    this.name = Postgres.id;
     this._usePgNative = !!options.usePgNative;
   }
 

--- a/packages/tracing-internal/src/node/integrations/prisma.ts
+++ b/packages/tracing-internal/src/node/integrations/prisma.ts
@@ -53,12 +53,14 @@ export class Prisma implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = Prisma.id;
+  public name: string;
 
   /**
    * @inheritDoc
    */
   public constructor(options: { client?: unknown } = {}) {
+    this.name = Prisma.id;
+
     // We instrument the PrismaClient inside the constructor and not inside `setupOnce` because in some cases of server-side
     // bundling (Next.js) multiple Prisma clients can be instantiated, even though users don't intend to. When instrumenting
     // in setupOnce we can only ever instrument one client.

--- a/packages/utils/src/syncpromise.ts
+++ b/packages/utils/src/syncpromise.ts
@@ -47,13 +47,16 @@ export function rejectedSyncPromise<T = never>(reason?: any): PromiseLike<T> {
  * but is not async internally
  */
 class SyncPromise<T> implements PromiseLike<T> {
-  private _state: States = States.PENDING;
-  private _handlers: Array<[boolean, (value: T) => void, (reason: any) => any]> = [];
+  private _state: States;
+  private _handlers: Array<[boolean, (value: T) => void, (reason: any) => any]>;
   private _value: any;
 
   public constructor(
     executor: (resolve: (value?: T | PromiseLike<T> | null) => void, reject: (reason?: any) => void) => void,
   ) {
+    this._state = States.PENDING;
+    this._handlers = [];
+
     try {
       executor(this._resolve, this._reject);
     } catch (e) {

--- a/packages/wasm/src/index.ts
+++ b/packages/wasm/src/index.ts
@@ -40,7 +40,11 @@ export class Wasm implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = Wasm.id;
+  public name: string;
+
+  public constructor() {
+    this.name = Wasm.id;
+  }
 
   /**
    * @inheritDoc


### PR DESCRIPTION
Adding a lint rule (see https://github.com/getsentry/sentry-javascript/issues/5316) to enforce initializing of fields in constructor, to reduce bundle size of transpiled code (and streamline this a bit overall).

Closes https://github.com/getsentry/sentry-javascript/issues/5316