### PR TITLE
ref(replay): Improve status logging

### DIFF
--- a/packages/replay/jest.setup.ts
+++ b/packages/replay/jest.setup.ts
@@ -129,21 +129,24 @@ function checkCallForSentReplay(
 }
 
 /**
-* Only want calls that send replay events, i.e. ignore error events
-*/
+ * Only want calls that send replay events, i.e. ignore error events
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getReplayCalls(calls: any[][][]): any[][][] {
-  return calls.map(call => {
-    const arg = call[0];
+  return calls
+    .map(call => {
+      const arg = call[0];
       if (arg.length !== 2) {
         return [];
       }
 
-      if (!arg[1][0].find(({type}: {type: string}) => ['replay_event', 'replay_recording'].includes(type))) {
+      if (!arg[1][0].find(({ type }: { type: string }) => ['replay_event', 'replay_recording'].includes(type))) {
         return [];
       }
 
-      return [ arg ];
-  }).filter(Boolean);
+      return [arg];
+    })
+    .filter(Boolean);
 }
 
 /**
@@ -159,9 +162,11 @@ const toHaveSentReplay = function (
 
   let result: CheckCallForSentReplayResult;
 
-  const expectedKeysLength = expected ? ('sample' in expected ? Object.keys(expected.sample) : Object.keys(expected)).length : 0;
+  const expectedKeysLength = expected
+    ? ('sample' in expected ? Object.keys(expected.sample) : Object.keys(expected)).length
+    : 0;
 
-  const replayCalls = getReplayCalls(calls)
+  const replayCalls = getReplayCalls(calls);
 
   for (const currentCall of replayCalls) {
     result = checkCallForSentReplay.call(this, currentCall[0], expected);
@@ -213,7 +218,7 @@ const toHaveLastSentReplay = function (
   expected?: SentReplayExpected | { sample: SentReplayExpected; inverse: boolean },
 ) {
   const { calls } = (getCurrentHub().getClient()?.getTransport()?.send as MockTransport).mock;
-  const replayCalls = getReplayCalls(calls)
+  const replayCalls = getReplayCalls(calls);
 
   const lastCall = replayCalls[calls.length - 1]?.[0];
 

--- a/packages/replay/src/eventBuffer/EventBufferProxy.ts
+++ b/packages/replay/src/eventBuffer/EventBufferProxy.ts
@@ -2,6 +2,7 @@ import type { ReplayRecordingData } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import type { AddEventResult, EventBuffer, EventBufferType, RecordingEvent } from '../types';
+import { logInfo } from '../util/log';
 import { EventBufferArray } from './EventBufferArray';
 import { EventBufferCompressionWorker } from './EventBufferCompressionWorker';
 
@@ -79,7 +80,7 @@ export class EventBufferProxy implements EventBuffer {
     } catch (error) {
       // If the worker fails to load, we fall back to the simple buffer.
       // Nothing more to do from our side here
-      __DEBUG_BUILD__ && logger.log('[Replay] Failed to load the compression worker, falling back to simple buffer');
+      logInfo('[Replay] Failed to load the compression worker, falling back to simple buffer');
       return;
     }
 

--- a/packages/replay/src/eventBuffer/WorkerHandler.ts
+++ b/packages/replay/src/eventBuffer/WorkerHandler.ts
@@ -1,6 +1,7 @@
 import { logger } from '@sentry/utils';
 
 import type { WorkerRequest, WorkerResponse } from '../types';
+import { logInfo } from '../util/log';
 
 /**
  * Event buffer that uses a web worker to compress events.
@@ -55,7 +56,7 @@ export class WorkerHandler {
    * Destroy the worker.
    */
   public destroy(): void {
-    __DEBUG_BUILD__ && logger.log('[Replay] Destroying compression worker');
+    logInfo('[Replay] Destroying compression worker');
     this._worker.terminate();
   }
 

--- a/packages/replay/src/eventBuffer/index.ts
+++ b/packages/replay/src/eventBuffer/index.ts
@@ -1,7 +1,7 @@
 import { getWorkerURL } from '@sentry-internal/replay-worker';
-import { logger } from '@sentry/utils';
 
 import type { EventBuffer } from '../types';
+import { logInfo } from '../util/log';
 import { EventBufferArray } from './EventBufferArray';
 import { EventBufferProxy } from './EventBufferProxy';
 
@@ -18,15 +18,15 @@ export function createEventBuffer({ useCompression }: CreateEventBufferParams): 
     try {
       const workerUrl = getWorkerURL();
 
-      __DEBUG_BUILD__ && logger.log('[Replay] Using compression worker');
+      logInfo('[Replay] Using compression worker');
       const worker = new Worker(workerUrl);
       return new EventBufferProxy(worker);
     } catch (error) {
-      __DEBUG_BUILD__ && logger.log('[Replay] Failed to create compression worker');
+      logInfo('[Replay] Failed to create compression worker');
       // Fall back to use simple event buffer array
     }
   }
 
-  __DEBUG_BUILD__ && logger.log('[Replay] Using simple buffer');
+  logInfo('[Replay] Using simple buffer');
   return new EventBufferArray();
 }

--- a/packages/replay/src/session/createSession.ts
+++ b/packages/replay/src/session/createSession.ts
@@ -1,5 +1,3 @@
-import { logger } from '@sentry/utils';
-
 import type { Sampled, Session, SessionOptions } from '../types';
 import { isSampled } from '../util/isSampled';
 import { saveSession } from './saveSession';
@@ -22,8 +20,6 @@ export function createSession({ sessionSampleRate, allowBuffering, stickySession
   const session = makeSession({
     sampled,
   });
-
-  __DEBUG_BUILD__ && logger.log(`[Replay] Creating new session: ${session.id}`);
 
   if (stickySession) {
     saveSession(session);

--- a/packages/replay/src/session/fetchSession.ts
+++ b/packages/replay/src/session/fetchSession.ts
@@ -1,12 +1,13 @@
 import { REPLAY_SESSION_KEY, WINDOW } from '../constants';
 import type { Session } from '../types';
 import { hasSessionStorage } from '../util/hasSessionStorage';
+import { logInfo } from '../util/log';
 import { makeSession } from './Session';
 
 /**
  * Fetches a session from storage
  */
-export function fetchSession(): Session | null {
+export function fetchSession(traceInternals?: boolean): Session | null {
   if (!hasSessionStorage()) {
     return null;
   }
@@ -20,6 +21,8 @@ export function fetchSession(): Session | null {
     }
 
     const sessionObj = JSON.parse(sessionStringFromStorage) as Session;
+
+    logInfo('[Replay] Loading existing session', traceInternals);
 
     return makeSession(sessionObj);
   } catch {

--- a/packages/replay/src/session/getSession.ts
+++ b/packages/replay/src/session/getSession.ts
@@ -1,7 +1,6 @@
-import { logger } from '@sentry/utils';
-
 import type { Session, SessionOptions, Timeouts } from '../types';
 import { isSessionExpired } from '../util/isSessionExpired';
+import { logInfo } from '../util/log';
 import { createSession } from './createSession';
 import { fetchSession } from './fetchSession';
 import { makeSession } from './Session';
@@ -13,6 +12,8 @@ interface GetSessionParams extends SessionOptions {
    * The current session (e.g. if stickySession is off)
    */
   currentSession?: Session;
+
+  traceInternals?: boolean;
 }
 
 /**
@@ -24,9 +25,10 @@ export function getSession({
   stickySession,
   sessionSampleRate,
   allowBuffering,
+  traceInternals,
 }: GetSessionParams): { type: 'new' | 'saved'; session: Session } {
   // If session exists and is passed, use it instead of always hitting session storage
-  const session = currentSession || (stickySession && fetchSession());
+  const session = currentSession || (stickySession && fetchSession(traceInternals));
 
   if (session) {
     // If there is a session, check if it is valid (e.g. "last activity" time
@@ -42,9 +44,10 @@ export function getSession({
       // and when this session is expired, it will not be renewed until user
       // reloads.
       const discardedSession = makeSession({ sampled: false });
+      logInfo('[Replay] Session should not be refreshed', traceInternals);
       return { type: 'new', session: discardedSession };
     } else {
-      __DEBUG_BUILD__ && logger.log('[Replay] Session has expired');
+      logInfo('[Replay] Session has expired', traceInternals);
     }
     // Otherwise continue to create a new session
   }
@@ -54,6 +57,7 @@ export function getSession({
     sessionSampleRate,
     allowBuffering,
   });
+  logInfo('[Replay] Created new session', traceInternals);
 
   return { type: 'new', session: newSession };
 }

--- a/packages/replay/src/types/replayFrame.ts
+++ b/packages/replay/src/types/replayFrame.ts
@@ -11,6 +11,8 @@ import type {
 } from './performance';
 import type { EventType } from './rrweb';
 
+type AnyRecord = Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+
 interface BaseBreadcrumbFrame {
   timestamp: number;
   /**
@@ -18,7 +20,7 @@ interface BaseBreadcrumbFrame {
    */
   type: string;
   category: string;
-  data?: Record<string, any>;
+  data?: AnyRecord;
   message?: string;
 }
 
@@ -28,7 +30,7 @@ interface BaseDomFrameData {
     id: number;
     tagName: string;
     textContent: string;
-    attributes: Record<string, any>;
+    attributes: AnyRecord;
   };
 }
 
@@ -141,7 +143,7 @@ interface BaseSpanFrame {
   description: string;
   startTimestamp: number;
   endTimestamp: number;
-  data?: undefined | Record<string, any>;
+  data?: undefined | AnyRecord;
 }
 
 interface HistoryFrame extends BaseSpanFrame {

--- a/packages/replay/src/util/handleRecordingEmit.ts
+++ b/packages/replay/src/util/handleRecordingEmit.ts
@@ -4,6 +4,7 @@ import { logger } from '@sentry/utils';
 import { saveSession } from '../session/saveSession';
 import type { AddEventResult, OptionFrameEvent, RecordingEvent, ReplayContainer } from '../types';
 import { addEvent } from './addEvent';
+import { logInfo } from './log';
 
 type RecordingEmitCallback = (event: RecordingEvent, isCheckout?: boolean) => void;
 
@@ -72,10 +73,10 @@ export function getHandleRecordingEmit(replay: ReplayContainer): RecordingEmitCa
       if (replay.recordingMode === 'buffer' && replay.session && replay.eventBuffer) {
         const earliestEvent = replay.eventBuffer.getEarliestTimestamp();
         if (earliestEvent) {
-          // eslint-disable-next-line no-console
-          const log = replay.getOptions()._experiments.traceInternals ? console.info : logger.info;
-          __DEBUG_BUILD__ &&
-            log(`[Replay] Updating session start time to earliest event in buffer at ${earliestEvent}`);
+          logInfo(
+            `[Replay] Updating session start time to earliest event in buffer to ${new Date(earliestEvent)}`,
+            replay.getOptions()._experiments.traceInternals,
+          );
 
           replay.session.started = earliestEvent;
 

--- a/packages/replay/src/util/log.ts
+++ b/packages/replay/src/util/log.ts
@@ -1,0 +1,28 @@
+import { getCurrentHub } from '@sentry/core';
+import { logger } from '@sentry/utils';
+
+/**
+ * Log a message in debug mode, and add a breadcrumb when _experiment.traceInternals is enabled.
+ */
+export function logInfo(message: string, shouldAddBreadcrumb?: boolean): void {
+  if (!__DEBUG_BUILD__) {
+    return;
+  }
+
+  logger.info(message);
+
+  if (shouldAddBreadcrumb) {
+    const hub = getCurrentHub();
+    hub.addBreadcrumb(
+      {
+        category: 'console',
+        data: {
+          logger: 'replay',
+        },
+        level: 'info',
+        message,
+      },
+      { level: 'info' },
+    );
+  }
+}

--- a/packages/replay/src/util/sendReplayRequest.ts
+++ b/packages/replay/src/util/sendReplayRequest.ts
@@ -1,10 +1,10 @@
 import { getCurrentHub } from '@sentry/core';
 import type { ReplayEvent, TransportMakeRequestResponse } from '@sentry/types';
-import { logger } from '@sentry/utils';
 
 import { REPLAY_EVENT_NAME, UNABLE_TO_SEND_REPLAY } from '../constants';
 import type { SendReplayData } from '../types';
 import { createReplayEnvelope } from './createReplayEnvelope';
+import { logInfo } from './log';
 import { prepareRecordingData } from './prepareRecordingData';
 import { prepareReplayEvent } from './prepareReplayEvent';
 
@@ -55,7 +55,7 @@ export async function sendReplayRequest({
   if (!replayEvent) {
     // Taken from baseclient's `_processEvent` method, where this is handled for errors/transactions
     client.recordDroppedEvent('event_processor', 'replay', baseEvent);
-    __DEBUG_BUILD__ && logger.log('An event processor returned `null`, will not send event.');
+    logInfo('An event processor returned `null`, will not send event.');
     return;
   }
 


### PR DESCRIPTION
This streamlines & improves logging for replay status, adding more logs for certain things to be better able to see what's going on, and adapting the `traceInternals` setting to result in console breadcrumbs being added (which should show up both in replay and for e.g. sentry errors etc).

While at it I also fixed some `any` eslint warnings in replay.

ref: https://github.com/getsentry/sentry-javascript/issues/8400