### PR TITLE
fix(core): Filter internal API frames for synthetic frames

### DIFF
--- a/packages/utils/src/stacktrace.ts
+++ b/packages/utils/src/stacktrace.ts
@@ -6,7 +6,7 @@ import { node } from './node-stack-trace';
 const STACKTRACE_FRAME_LIMIT = 50;
 // Used to sanitize webpack (error: *) wrapped stack errors
 const WEBPACK_ERROR_REGEXP = /\(error: (.*)\)/;
-const STRIP_FRAME_REGEXP = /captureMessage|captureException/
+const STRIP_FRAME_REGEXP = /captureMessage|captureException/;
 
 /**
  * Creates a stack parser with the supplied line parsers

--- a/packages/utils/test/stacktrace.test.ts
+++ b/packages/utils/test/stacktrace.test.ts
@@ -98,12 +98,12 @@ describe('Stacktrace', () => {
 
     it('applies frames limit after the stripping, not before', () => {
       const stack = Array.from({ length: 55 }).map((_, i) => {
-        return { colno: 1, lineno: 4, filename: 'anything.js', function: `${i}` }
+        return { colno: 1, lineno: 4, filename: 'anything.js', function: `${i}` };
       });
 
-      stack.unshift({ colno: 1, lineno: 4, filename: 'anything.js', function: 'captureMessage' })
-      stack.unshift({ colno: 1, lineno: 4, filename: 'anything.js', function: 'captureMessage' })
-      stack.push({ colno: 1, lineno: 4, filename: 'anything.js', function: 'sentryWrapped' })
+      stack.unshift({ colno: 1, lineno: 4, filename: 'anything.js', function: 'captureMessage' });
+      stack.unshift({ colno: 1, lineno: 4, filename: 'anything.js', function: 'captureMessage' });
+      stack.push({ colno: 1, lineno: 4, filename: 'anything.js', function: 'sentryWrapped' });
 
       // Should remove 2x `captureMessage`, `sentryWrapped`, and then limit frames to default 50.
       const frames = stripSentryFramesAndReverse(stack);


### PR DESCRIPTION
As well as fixes the ordering of operations and removes some redundant code.
The stack should be trimmed _after_ filtering.

Fixes https://github.com/getsentry/sentry-javascript/issues/8396