### PR TITLE
fix(replay): Ensure buffer sessions end after capturing an error

### DIFF
--- a/packages/replay/src/session/Session.ts
+++ b/packages/replay/src/session/Session.ts
@@ -13,6 +13,7 @@ export function makeSession(session: Partial<Session> & { sampled: Sampled }): S
   const lastActivity = session.lastActivity || now;
   const segmentId = session.segmentId || 0;
   const sampled = session.sampled;
+  const shouldRefresh = typeof session.shouldRefresh === 'boolean' ? session.shouldRefresh : true;
 
   return {
     id,
@@ -20,6 +21,6 @@ export function makeSession(session: Partial<Session> & { sampled: Sampled }): S
     lastActivity,
     segmentId,
     sampled,
-    shouldRefresh: true,
+    shouldRefresh,
   };
 }


### PR DESCRIPTION
We haven't been persisting the `shouldRefresh` property of the session. This combined with the fact that we do not update the `sampled` field on the session to `session` when an error occurs, but keep it at `buffer`, means that if a user reloads the page or the session is otherwise re-fetched from sessionStorage, if previously an error occurs, we'll keep buffering forever again (like for a "fresh" buffer session), and if an error happens we convert it again to a `session` session, but since the session ID was never updated this will be "added" to the previous session instead.

I made a reproduction test that failed before and works after this fix.

Fixes https://github.com/getsentry/sentry-javascript/issues/8400