### PR TITLE
chore(node-integration-tests): Improve local testing experience

### DIFF
--- a/packages/node-integration-tests/package.json
+++ b/packages/node-integration-tests/package.json
@@ -37,7 +37,7 @@
     "mysql": "^2.18.1",
     "nock": "^13.1.0",
     "pg": "^8.7.3",
-    "yargs": "^17.7.2"
+    "yargs": "^16.2.0"
   },
   "config": {
     "mongodbMemoryServer": {

--- a/packages/node-integration-tests/package.json
+++ b/packages/node-integration-tests/package.json
@@ -36,7 +36,8 @@
     "mongodb-memory-server-global": "^7.6.3",
     "mysql": "^2.18.1",
     "nock": "^13.1.0",
-    "pg": "^8.7.3"
+    "pg": "^8.7.3",
+    "yargs": "^17.7.2"
   },
   "config": {
     "mongodbMemoryServer": {

--- a/packages/node-integration-tests/utils/run-tests.ts
+++ b/packages/node-integration-tests/utils/run-tests.ts
@@ -1,6 +1,18 @@
 /* eslint-disable no-console */
 import childProcess from 'child_process';
 import os from 'os';
+import yargs from 'yargs';
+
+const args = yargs
+  .option('t', {
+    alias: 'testNamePattern',
+    type: 'string',
+    description: 'Filter for a specific test spec\nsee: https://jestjs.io/docs/cli#--testnamepatternregex',
+  })
+  .option('watch', {
+    type: 'boolean',
+    description: 'Run tests in watch mode\nsee: https://jestjs.io/docs/cli#--watch',
+  }).argv;
 
 // This variable will act as a job queue that is consumed by a number of worker threads. Each item represents a test to run.
 const testPaths = childProcess.execSync('jest --listTests', { encoding: 'utf8' }).trim().split('\n');
@@ -14,7 +26,17 @@ const workers = os.cpus().map(async (_, i) => {
     const testPath = testPaths.pop();
     console.log(`(Worker ${i}) Running test "${testPath}"`);
     await new Promise<void>(resolve => {
-      const jestProcess = childProcess.spawn('jest', ['--runTestsByPath', testPath as string, '--forceExit']);
+      const jestArgs = ['--runTestsByPath', testPath as string, '--forceExit'];
+
+      if (args.t) {
+        jestArgs.push('-t', args.t);
+      }
+
+      if (args.watch) {
+        jestArgs.push('--watch');
+      }
+
+      const jestProcess = childProcess.spawn('jest', jestArgs);
 
       // We're collecting the output and logging it all at once instead of inheriting stdout and stderr, so that
       // test outputs of the individual workers aren't interwoven, in case they print at the same time.
@@ -36,6 +58,7 @@ const workers = os.cpus().map(async (_, i) => {
       });
 
       jestProcess.on('exit', exitcode => {
+        output = checkSkippedAllTests(output, i, testPath);
         console.log(`(Worker ${i}) Finished test "${testPath}"`);
         console.log(output);
         if (exitcode !== 0) {
@@ -61,3 +84,20 @@ void Promise.all(workers).then(() => {
     process.exit(0);
   }
 });
+
+/**
+ * Suppress jest output for test suites where all tests were skipped.
+ * This only clutters the logs and we can safely print a one-liner instead.
+ */
+function checkSkippedAllTests(output: string, workerNumber: number, testPath: string | undefined): string {
+  const regex = /Tests:\s+(\d+) skipped, (\d+) total/gm;
+  const matches = regex.exec(output);
+  if (matches) {
+    const skipped = Number(matches[1]);
+    const total = Number(matches[2]);
+    if (!isNaN(skipped) && !isNaN(total) && total === skipped) {
+      return `(Worker ${workerNumber}) > Skipped all (${total} tests) in ${testPath}`;
+    }
+  }
+  return output;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -28909,6 +28909,19 @@ yargs@^17.0.0, yargs@^17.5.1, yargs@^17.6.0, yargs@^17.6.2:
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
 
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
 yauzl@^2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -28909,19 +28909,6 @@ yargs@^17.0.0, yargs@^17.5.1, yargs@^17.6.0, yargs@^17.6.2:
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
 
-yargs@^17.7.2:
-  version "17.7.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
-  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
-  dependencies:
-    cliui "^8.0.1"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
-    y18n "^5.0.5"
-    yargs-parser "^21.1.1"
-
 yauzl@^2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"


### PR DESCRIPTION
This PR adds a few improvements to the node integration tests:
* Re-add support for `-t` arg to filter for specific tests
* Re-add support for `--watch` flag
* Reduce logging for test suites where all tests were skipped. This makes running one specific (e.g. new or modified) test a much better experience locally as you don't have to go through 100s lines of unnecessary console output. Happy to even reduce it further to log nothing at all if reviewers prefer that. 
* Add `yargs` to parse arguments (and provide help)

Came up while modifying a node integration test for #8715 and finding out that running them locally is super annoying 😅 