### PR TITLE
fix(node): Add availablility check on current hub to Node `ContextLines` integration

### DIFF
--- a/packages/node-integration-tests/suites/public-api/captureException/catched-error/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureException/catched-error/test.ts
@@ -15,7 +15,21 @@ test('should work inside catch block', async () => {
             handled: true,
           },
           stacktrace: {
-            frames: expect.any(Array),
+            frames: expect.arrayContaining([
+              expect.objectContaining({
+                context_line: "  throw new Error('catched_error');",
+                pre_context: [
+                  '',
+                  'Sentry.init({',
+                  "  dsn: 'https://public@dsn.ingest.sentry.io/1337',",
+                  "  release: '1.0',",
+                  '});',
+                  '',
+                  'try {',
+                ],
+                post_context: ['} catch (err) {', '  Sentry.captureException(err);', '}', ''],
+              }),
+            ]),
           },
         },
       ],

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -1,4 +1,4 @@
-import type { Event, EventProcessor, Integration, StackFrame } from '@sentry/types';
+import type { Event, EventProcessor, Hub, Integration, StackFrame } from '@sentry/types';
 import { addContextToFrame } from '@sentry/utils';
 import { readFile } from 'fs';
 import { LRUMap } from 'lru_map';
@@ -56,8 +56,14 @@ export class ContextLines implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void): void {
-    addGlobalEventProcessor(event => this.addSourceContext(event));
+  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
+    addGlobalEventProcessor(event => {
+      const self = getCurrentHub().getIntegration(ContextLines);
+      if (!self) {
+        return event;
+      }
+      return this.addSourceContext(event);
+    });
   }
 
   /** Processes an event and adds context lines */

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -193,6 +193,7 @@ describe('SentryNode', () => {
           return null;
         },
         dsn,
+        integrations: [new ContextLines()],
       });
       getCurrentHub().bindClient(new NodeClient(options));
       configureScope((scope: Scope) => {


### PR DESCRIPTION
This came up in https://github.com/getsentry/sentry-javascript/pull/8699#discussion_r1280867001, so let's fix it.