### PR TITLE
fix(replay): Ensure we debounce flush if replay too short

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -1132,11 +1132,18 @@ export class ReplayContainer implements ReplayContainerInterface {
 
     // If session is too short, or too long (allow some wiggle room over maxSessionLife), do not send it
     // This _should_ not happen, but it may happen if flush is triggered due to a page activity change or similar
-    if (duration < this._options.minReplayDuration || duration > this.timeouts.maxSessionLife + 5_000) {
+    const tooShort = duration < this._options.minReplayDuration;
+    const tooLong = duration > this.timeouts.maxSessionLife + 5_000;
+    if (tooShort || tooLong) {
       logInfo(
-        `[Replay] Session duration (${Math.floor(duration / 1000)}s) is too short or too long, not sending replay.`,
-        this._options._experiments.traceInternals,
+        `[Replay] Session duration (${Math.floor(duration / 1000)}s) is too ${
+          tooShort ? 'short' : 'long'
+        }, not sending replay.`,
       );
+
+      if (tooShort) {
+        this._debouncedFlush();
+      }
       return;
     }
 

--- a/packages/replay/test/integration/flush.test.ts
+++ b/packages/replay/test/integration/flush.test.ts
@@ -280,6 +280,12 @@ describe('Integration | flush', () => {
 
     expect(mockFlush).toHaveBeenCalledTimes(1);
     expect(mockSendReplay).toHaveBeenCalledTimes(0);
+
+    // it should re-schedule the flush, so once the min. duration is reached it should automatically send it
+    await advanceTimers(100_000 - DEFAULT_FLUSH_MIN_DELAY);
+
+    expect(mockFlush).toHaveBeenCalledTimes(20);
+    expect(mockSendReplay).toHaveBeenCalledTimes(1);
   });
 
   it('does not flush if session is too long', async () => {


### PR DESCRIPTION
This fix ensures that if we try to flush a replay that is too short, we will debounce flush it again after the min. duration is reached.