### PR TITLE
test: Use `getLocalTestUrl` instead of `getLocalTestPath` for xhr tests

### DIFF
--- a/packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/get/test.ts
+++ b/packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/get/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('captures Breadcrumb for basic GET request', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('captures Breadcrumb for basic GET request', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.route('**/foo', route => {
     return route.fulfill({

--- a/packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/post/test.ts
+++ b/packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/post/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('captures Breadcrumb for POST request', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('captures Breadcrumb for POST request', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.route('**/foo', route => {
     return route.fulfill({

--- a/packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/get/test.ts
+++ b/packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/get/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('captures Breadcrumb for basic GET request', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('captures Breadcrumb for basic GET request', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.route('**/foo', route => {
     return route.fulfill({

--- a/packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/post/test.ts
+++ b/packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/post/test.ts
@@ -4,8 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('captures Breadcrumb for POST request', async ({ getLocalTestPath, page }) => {
-  const url = await getLocalTestPath({ testDir: __dirname });
+sentryTest('captures Breadcrumb for POST request', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
 
   await page.route('**/foo', route => {
     return route.fulfill({


### PR DESCRIPTION
Hoping this unflakes some stuff...

Closes https://github.com/getsentry/sentry-javascript/issues/8717