### PR TITLE
fix(utils): Avoid `pre_context` and `context_line` overlap if frame lineno is out of bounds

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -153,7 +153,7 @@ export function addContextToFrame(lines: string[], frame: StackFrame, linesOfCon
   }
 
   const maxLines = lines.length;
-  const sourceLine = Math.max(Math.min(maxLines, frame.lineno - 1), 0);
+  const sourceLine = Math.max(Math.min(maxLines - 1, frame.lineno - 1), 0);
 
   frame.pre_context = lines
     .slice(Math.max(0, sourceLine - linesOfContext), sourceLine)

--- a/packages/utils/test/misc.test.ts
+++ b/packages/utils/test/misc.test.ts
@@ -185,6 +185,16 @@ describe('addContextToFrame', () => {
     expect(frame.context_line).toEqual('14: n');
     expect(frame.post_context).toEqual([]);
   });
+
+  test('truncate line if too long', () => {
+    const frame: StackFrame = {
+      lineno: 1,
+    };
+    addContextToFrame(['1234567890'.repeat(100)], frame);
+    expect(frame.pre_context).toEqual([]);
+    expect(frame.context_line).toEqual(`${'1234567890'.repeat(14)} {snip}`);
+    expect(frame.post_context).toEqual([]);
+  });
 });
 
 describe('addExceptionMechanism', () => {

--- a/packages/utils/test/misc.test.ts
+++ b/packages/utils/test/misc.test.ts
@@ -181,7 +181,7 @@ describe('addContextToFrame', () => {
       lineno: 999,
     };
     addContextToFrame(lines, frame);
-    expect(frame.pre_context).toEqual(['10: j', '11: k', '12: l', '13: m', '14: n']);
+    expect(frame.pre_context).toEqual(['9: i', '10: j', '11: k', '12: l', '13: m']);
     expect(frame.context_line).toEqual('14: n');
     expect(frame.post_context).toEqual([]);
   });


### PR DESCRIPTION
When adding context lines to a stack frame we need to handle the edge case that the frame's `lineno` is greater than the length of source code lines we obtained (this can happen for various reasons). We do this by assigning the last line of the source code lines array to the `context_line` and assigning the preceding lines as `pre_context`.  

However, I noticed while finishing up #8699 that, that in `addContextToFrame` we were off by one for the `pre_context` line determination, causing overlap between `pre_context` and `context_line`. I'm pretty sure we want to avoid this, so this PR removes the overlap by fixing the off-by one error. 

Adjusted the overlap test to show the change in behaviour and added a new one to ensure we correctly truncate too long lines.

