### PR TITLE
Revert "build(release): Add `statusProvider` context check for craft (#8685)

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,11 +1,6 @@
 minVersion: '0.23.1'
 changelogPolicy: simple
 preReleaseCommand: bash scripts/craft-pre-release.sh
-statusProvider:
-  name: github
-  config:
-    contexts:
-      - All required tests passed or skipped
 targets:
   # NPM Targets
   ## 1. Base Packages, node or browser SDKs depend on


### PR DESCRIPTION
Seems like the `context` passed isn't found which is blocking our release. Reverting for now until we know how to configure the status provider correctly (https://github.com/getsentry/craft/issues/482).

#uncraft