### PR TITLE
fix(utils): `dirname` and `basename` should handle Windows paths

### DIFF
--- a/packages/utils/src/path.ts
+++ b/packages/utils/src/path.ts
@@ -51,7 +51,7 @@ function normalizeArray(parts: string[], allowAboveRoot?: boolean): string[] {
 
 // Split a filename into [root, dir, basename, ext], unix version
 // 'root' is just a slash, or nothing.
-const splitPathRe = /^(\/?|)([\s\S]*?)((?:\.{1,2}|[^/]+?|)(\.[^./]*|))(?:[/]*)$/;
+const splitPathRe = /^(\S+:\\|\/?)([\s\S]*?)((?:\.{1,2}|[^/\\]+?|)(\.[^./\\]*|))(?:[/\\]*)$/;
 /** JSDoc */
 function splitPath(filename: string): string[] {
   const parts = splitPathRe.exec(filename);

--- a/packages/utils/test/path.test.ts
+++ b/packages/utils/test/path.test.ts
@@ -1,0 +1,29 @@
+import { basename, dirname } from '../src/path';
+
+describe('path', () => {
+  describe('basename', () => {
+    test('unix', () => {
+      expect(basename('/foo/bar/baz/asdf/quux.html')).toEqual('quux.html');
+      expect(basename('../baz/asdf/quux.html')).toEqual('quux.html');
+      expect(basename('quux.html')).toEqual('quux.html');
+    });
+    test('windows', () => {
+      expect(basename('c:\\foo\\bar\\baz\\asdf\\quux.html')).toEqual('quux.html');
+      expect(basename('..\\bar\\baz\\asdf\\quux.html')).toEqual('quux.html');
+      expect(basename('quux.html')).toEqual('quux.html');
+    });
+  });
+
+  describe('dirname', () => {
+    test('unix', () => {
+      expect(dirname('/foo/bar/baz/asdf/quux.html')).toEqual('/foo/bar/baz/asdf');
+      expect(dirname('../baz/asdf/quux.html')).toEqual('../baz/asdf');
+      expect(dirname('/quux.html')).toEqual('/');
+    });
+    test('windows', () => {
+      expect(dirname('C:\\foo\\bar\\baz\\asdf\\quux.html')).toEqual('C:\\foo\\bar\\baz\\asdf');
+      expect(dirname('..\\bar\\baz\\asdf\\quux.html')).toEqual('..\\bar\\baz\\asdf');
+      expect(dirname('quux.html')).toEqual('.');
+    });
+  });
+});


### PR DESCRIPTION
The Electron SDK uses `basename` to get the file name without path but this returned the full path on Windows.

This PR adds Windows support to the regex and adds some tests.