### PR TITLE
ref(replay): Improve internal logging

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -1139,6 +1139,7 @@ export class ReplayContainer implements ReplayContainerInterface {
         `[Replay] Session duration (${Math.floor(duration / 1000)}s) is too ${
           tooShort ? 'short' : 'long'
         }, not sending replay.`,
+        this._options._experiments.traceInternals,
       );
 
       if (tooShort) {

--- a/packages/replay/src/util/log.ts
+++ b/packages/replay/src/util/log.ts
@@ -12,17 +12,21 @@ export function logInfo(message: string, shouldAddBreadcrumb?: boolean): void {
   logger.info(message);
 
   if (shouldAddBreadcrumb) {
-    const hub = getCurrentHub();
-    hub.addBreadcrumb(
-      {
-        category: 'console',
-        data: {
-          logger: 'replay',
+    // Wait a tick here to avoid race conditions for some initial logs
+    // which may be added before replay is initialized
+    setTimeout(() => {
+      const hub = getCurrentHub();
+      hub.addBreadcrumb(
+        {
+          category: 'console',
+          data: {
+            logger: 'replay',
+          },
+          level: 'info',
+          message,
         },
-        level: 'info',
-        message,
-      },
-      { level: 'info' },
-    );
+        { level: 'info' },
+      );
+    }, 0);
   }
 }


### PR DESCRIPTION
This delays adding the internal replay logging breadcrumbs to the next tick, to avoid race conditions on initial logs where replay may not be initialized yet.

With this, you should get proper log breadcrumbs in a replay for itself:

```
[Replay] Created new session 00:00
[Replay] Starting replay in session mode 00:00
```