### PR TITLE
ref(replay): Ensure we only clear for buffer mode

### DIFF
--- a/packages/replay/src/util/addEvent.ts
+++ b/packages/replay/src/util/addEvent.ts
@@ -40,7 +40,7 @@ export async function addEvent(
   }
 
   try {
-    if (isCheckout) {
+    if (isCheckout && replay.recordingMode === 'buffer') {
       replay.eventBuffer.clear();
     }
 


### PR DESCRIPTION
This _shouldn't_ happen, but it makes sense to guard so we only clear the event buffer cache on checkouts when in `buffer` mode. I guess the behavior of rrweb is not 100% defined in that it _cannot_ generate a new checkout in non-buffer mode 🤔 better safe than sorry.

FWIW I don't think that is the cause of our too-long-empty-replays issue right now, but 🤷 it doesn't hurt anyhow to be cautious here.