### PR TITLE
ref(node): Don't call `JSON.stringify` on prisma client when logging

### DIFF
--- a/packages/tracing-internal/src/node/integrations/prisma.ts
+++ b/packages/tracing-internal/src/node/integrations/prisma.ts
@@ -84,9 +84,7 @@ export class Prisma implements Integration {
       });
     } else {
       __DEBUG_BUILD__ &&
-        logger.warn(
-          `Unsupported Prisma client provided to PrismaIntegration. Provided client: ${JSON.stringify(options.client)}`,
-        );
+        logger.warn('Unsupported Prisma client provided to PrismaIntegration. Provided client:', options.client);
     }
   }
 


### PR DESCRIPTION
`JSON.stringify` will throw when called on circular structures. This is an unnecessary risk in the prisma integration so we just log it plainly.

Ref: https://github.com/getsentry/sentry-javascript/issues/8532
