### PR TITLE
chore(ci): Make "Required Tests passed" job depend on artifact upload and other required jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -921,3 +921,14 @@ jobs:
         with:
           name: ${{ steps.process.outputs.artifactName }}
           path: ${{ steps.process.outputs.artifactPath }}
+
+  job_ready_to_release:
+    name: Ready to release
+    needs: [job_required_tests, job_artifacts, job_size_check, job_lint, job_circular_dep_check]
+    if: needs.job_get_metadata.outputs.is_release == 'true'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure')
+        run: |
+          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -855,8 +855,8 @@ jobs:
         timeout-minutes: 5
         run: yarn test:assert
 
-  job_required_tests:
-    name: All required tests passed or skipped
+  job_required_jobs_passed:
+    name: All required jobs passed or were skipped
     needs:
       [
         job_build,
@@ -870,6 +870,9 @@ jobs:
         job_browser_loader_tests,
         job_remix_integration_tests,
         job_e2e_tests,
+        job_artifacts,
+        job_lint,
+        job_circular_dep_check,
       ]
     # Always run this, even if a dependent job failed
     if: always()
@@ -921,14 +924,3 @@ jobs:
         with:
           name: ${{ steps.process.outputs.artifactName }}
           path: ${{ steps.process.outputs.artifactPath }}
-
-  job_ready_to_release:
-    name: Ready to release
-    needs: [job_required_tests, job_artifacts, job_size_check, job_lint, job_circular_dep_check]
-    if: needs.job_get_metadata.outputs.is_release == 'true'
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check for failures
-        if: contains(needs.*.result, 'failure')
-        run: |
-          echo "One of the dependent jobs have failed. You may need to re-run it." && exit 1


### PR DESCRIPTION
This PR adjusts our final "Required Tests Passed" CI job to not only depend on required _test_ jobs but on _all_ required jobs. Specifically, this adds

* Lint
* Circular deps check
* Most importantly: Upload Artifacts

With this change, we can configure craft's status provider to specifically wait for this job which should fix the artifacts download timeout (https://github.com/getsentry/craft/issues/482). It's worth noting that this PR will only fix this timeout in our repo and in a way we're adjusting to the status provider check. However, given that we're apparently the only repo where this happens, it's probably justified and it makes things more explicit. 

This will also allow us to unmark Lint and Circular Deps Check as required in the GH UI as we're now relying on the job for it.