### PR TITLE
chore(ci): Add `job_required_jobs_passed` as a status provider context

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,6 +1,11 @@
 minVersion: '0.23.1'
 changelogPolicy: simple
 preReleaseCommand: bash scripts/craft-pre-release.sh
+statusProvider:
+  name: github
+  config:
+    contexts:
+      - job_required_jobs_passed
 targets:
   # NPM Targets
   ## 1. Base Packages, node or browser SDKs depend on


### PR DESCRIPTION
Honestly, this is more a guess than anything else. Might be that we need to add `jobs.job_required_jobs_passed`, might be that it doesn't work at all. 

I tried reproducing which contexts are available by directly calling the GH API but it seems like I don't get any statuses for a given commit, regardless of if the commit's CI is currently running or completed. I guess we'll know soon enough once we release...

