### PR TITLE
chore(publish): Try different status provider context

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -5,7 +5,7 @@ statusProvider:
   name: github
   config:
     contexts:
-      - job_required_jobs_passed
+      - jobs.job_required_jobs_passed
 targets:
   # NPM Targets
   ## 1. Base Packages, node or browser SDKs depend on


### PR DESCRIPTION
Our last publish run failed because `job_required_jobs_passed` was not found as a GH context. Let's continue the guessing game with `jobs.job_required_jobs_passed` which contradicts the craft documentation but is more in line with the GH context documentation. 

ref https://github.com/getsentry/craft/issues/482