### PR TITLE
chore(publish): Remove status provider setting from Craft config

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,11 +1,6 @@
 minVersion: '0.23.1'
 changelogPolicy: simple
 preReleaseCommand: bash scripts/craft-pre-release.sh
-statusProvider:
-  name: github
-  config:
-    contexts:
-      - jobs.job_required_jobs_passed
 targets:
   # NPM Targets
   ## 1. Base Packages, node or browser SDKs depend on


### PR DESCRIPTION
So, as explained in https://github.com/getsentry/craft/issues/482#issuecomment-1669812018 (+ the following messages), I believe that in addition to the default behaviour of Craft's GH status provider, also the [`contexts` feature](https://github.com/getsentry/craft#status-provider) is broken. It seems like the [GitHub API endpoint](https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#get-the-combined-status-for-a-specific-reference) we use to get the combined statuses of a commit doesn't return statuses (where the contexts would be included) anymore and it always returns state  `pending` (which seems to be a [known issue](https://github.com/orgs/community/discussions/58407)). 

Considering that there is an annoying but proven workaround to this issue (namely to wait ~30min with accepting the publish run until CI has passed), I'm not going to waste more time with trying to fix this. 

This PR removes the status provider config which will make craft fall back to the (broken) default behaviour. 

(once this is merged to `develop` we need to merge develop into master and cut the release)

