### PR TITLE
feat(node): Add basic cloud resource context

### DIFF
--- a/packages/types/src/context.ts
+++ b/packages/types/src/context.ts
@@ -9,6 +9,7 @@ export interface Contexts extends Record<string, Context | undefined> {
   culture?: CultureContext;
   response?: ResponseContext;
   trace?: TraceContext;
+  cloud_resource?: CloudResourceContext;
 }
 
 export interface AppContext extends Record<string, unknown> {
@@ -92,4 +93,14 @@ export interface TraceContext extends Record<string, unknown> {
   status?: string;
   tags?: { [key: string]: Primitive };
   trace_id: string;
+}
+
+export interface CloudResourceContext extends Record<string, unknown> {
+  ['cloud.provider']?: string;
+  ['cloud.account.id']?: string;
+  ['cloud.region']?: string;
+  ['cloud.availability_zone']?: string;
+  ['cloud.platform']?: string;
+  ['host.id']?: string;
+  ['host.type']?: string;
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,7 +9,16 @@ export type {
 } from './breadcrumb';
 export type { Client } from './client';
 export type { ClientReport, Outcome, EventDropReason } from './clientreport';
-export type { Context, Contexts, DeviceContext, OsContext, AppContext, CultureContext, TraceContext } from './context';
+export type {
+  Context,
+  Contexts,
+  DeviceContext,
+  OsContext,
+  AppContext,
+  CultureContext,
+  TraceContext,
+  CloudResourceContext,
+} from './context';
 export type { DataCategory } from './datacategory';
 export type { DsnComponents, DsnLike, DsnProtocol } from './dsn';
 export type { DebugImage, DebugMeta } from './debugMeta';


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/8747

Adds a bit of [cloud resource context](https://develop.sentry.dev/sdk/event-payloads/contexts/#cloud-resource-context) based on environment variables that may or may not be available in certain cloud environments.

Note that I didn't manually check all of these environment variables but based them off of stuff I've found on the internet. I tried to put links to the places where I found them but for some of them I lost the link. For these instances GitHub codesearch shows a few results though so I kinda trust them.