### PR TITLE
feat(replay): Allow to configure `maxReplayDuration`

### DIFF
--- a/packages/browser-integration-tests/suites/replay/errors/errorsInSession/init.js
+++ b/packages/browser-integration-tests/suites/replay/errors/errorsInSession/init.js
@@ -19,5 +19,4 @@ Sentry.init({
     return event;
   },
   integrations: [window.Replay],
-  debug: true,
 });

--- a/packages/browser-integration-tests/suites/replay/largeMutations/mutationLimit/init.js
+++ b/packages/browser-integration-tests/suites/replay/largeMutations/mutationLimit/init.js
@@ -13,7 +13,6 @@ Sentry.init({
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,
   replaysOnErrorSampleRate: 0.0,
-  debug: true,
 
   integrations: [window.Replay],
 });

--- a/packages/browser-integration-tests/suites/replay/maxReplayDuration/init.js
+++ b/packages/browser-integration-tests/suites/replay/maxReplayDuration/init.js
@@ -5,6 +5,7 @@ window.Replay = new Sentry.Replay({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,
+  maxReplayDuration: 2000,
 });
 
 Sentry.init({
@@ -19,5 +20,4 @@ Sentry.init({
 window.Replay._replay.timeouts = {
   sessionIdlePause: 1000, // this is usually 5min, but we want to test this with shorter times
   sessionIdleExpire: 2000, // this is usually 15min, but we want to test this with shorter times
-  maxSessionLife: 2000, // default: 60min
 };

--- a/packages/browser-integration-tests/suites/replay/maxReplayDuration/test.ts
+++ b/packages/browser-integration-tests/suites/replay/maxReplayDuration/test.ts
@@ -4,7 +4,7 @@ import { sentryTest } from '../../../utils/fixtures';
 import { getExpectedReplayEvent } from '../../../utils/replayEventTemplates';
 import { getReplayEvent, shouldSkipReplayTest, waitForReplayRequest } from '../../../utils/replayHelpers';
 
-const SESSION_MAX_AGE = 2000;
+const MAX_REPLAY_DURATION = 2000;
 
 sentryTest('keeps track of max duration across reloads', async ({ getLocalTestPath, page }) => {
   if (shouldSkipReplayTest()) {
@@ -26,7 +26,7 @@ sentryTest('keeps track of max duration across reloads', async ({ getLocalTestPa
 
   await page.goto(url);
 
-  await new Promise(resolve => setTimeout(resolve, SESSION_MAX_AGE / 2));
+  await new Promise(resolve => setTimeout(resolve, MAX_REPLAY_DURATION / 2));
 
   await page.reload();
   await page.click('#button1');
@@ -34,7 +34,7 @@ sentryTest('keeps track of max duration across reloads', async ({ getLocalTestPa
   // After the second reload, we should have a new session (because we exceeded max age)
   const reqPromise3 = waitForReplayRequest(page, 0);
 
-  await new Promise(resolve => setTimeout(resolve, SESSION_MAX_AGE / 2 + 100));
+  await new Promise(resolve => setTimeout(resolve, MAX_REPLAY_DURATION / 2 + 100));
 
   void page.click('#button1');
   await page.evaluate(`Object.defineProperty(document, 'visibilityState', {

--- a/packages/browser-integration-tests/suites/replay/minReplayDuration/init.js
+++ b/packages/browser-integration-tests/suites/replay/minReplayDuration/init.js
@@ -12,7 +12,6 @@ Sentry.init({
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,
   replaysOnErrorSampleRate: 0.0,
-  debug: true,
 
   integrations: [window.Replay],
 });

--- a/packages/browser-integration-tests/suites/replay/sessionExpiry/init.js
+++ b/packages/browser-integration-tests/suites/replay/sessionExpiry/init.js
@@ -12,7 +12,6 @@ Sentry.init({
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,
   replaysOnErrorSampleRate: 0.0,
-  debug: true,
 
   integrations: [window.Replay],
 });
@@ -20,5 +19,4 @@ Sentry.init({
 window.Replay._replay.timeouts = {
   sessionIdlePause: 1000, // this is usually 5min, but we want to test this with shorter times
   sessionIdleExpire: 2000, // this is usually 15min, but we want to test this with shorter times
-  maxSessionLife: 3600000, // default: 60min
 };

--- a/packages/browser-integration-tests/suites/replay/sessionInactive/init.js
+++ b/packages/browser-integration-tests/suites/replay/sessionInactive/init.js
@@ -12,7 +12,6 @@ Sentry.init({
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,
   replaysOnErrorSampleRate: 0.0,
-  debug: true,
 
   integrations: [window.Replay],
 });
@@ -20,5 +19,4 @@ Sentry.init({
 window.Replay._replay.timeouts = {
   sessionIdlePause: 1000, // this is usually 5min, but we want to test this with shorter times
   sessionIdleExpire: 900000, // defayult: 15min
-  maxSessionLife: 3600000, // default: 60min
 };

--- a/packages/browser-integration-tests/suites/replay/sessionMaxAge/init.js
+++ b/packages/browser-integration-tests/suites/replay/sessionMaxAge/init.js
@@ -5,6 +5,7 @@ window.Replay = new Sentry.Replay({
   flushMinDelay: 200,
   flushMaxDelay: 200,
   minReplayDuration: 0,
+  maxReplayDuration: 4000,
 });
 
 Sentry.init({
@@ -12,7 +13,6 @@ Sentry.init({
   sampleRate: 0,
   replaysSessionSampleRate: 1.0,
   replaysOnErrorSampleRate: 0.0,
-  debug: true,
 
   integrations: [window.Replay],
 });
@@ -20,5 +20,4 @@ Sentry.init({
 window.Replay._replay.timeouts = {
   sessionIdlePause: 300000, // default: 5min
   sessionIdleExpire: 900000, // default: 15min
-  maxSessionLife: 4000, // this is usually 60min, but we want to test this with shorter times
 };

--- a/packages/browser-integration-tests/suites/replay/sessionMaxAge/test.ts
+++ b/packages/browser-integration-tests/suites/replay/sessionMaxAge/test.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../utils/replayHelpers';
 
 // Session should be max. 4s long
-const SESSION_MAX_AGE = 4000;
+const MAX_REPLAY_DURATION = 4000;
 
 /*
   The main difference between this and sessionExpiry test, is that here we wait for the overall time (4s)
@@ -58,7 +58,7 @@ sentryTest('handles session that exceeds max age', async ({ getLocalTestPath, pa
   // Wait for an incremental snapshot
   // Wait half of the session max age (after initial flush), but account for potentially slow runners
   const timePassed1 = Date.now() - startTimestamp;
-  await new Promise(resolve => setTimeout(resolve, Math.max(SESSION_MAX_AGE / 2 - timePassed1, 0)));
+  await new Promise(resolve => setTimeout(resolve, Math.max(MAX_REPLAY_DURATION / 2 - timePassed1, 0)));
   await page.click('#button1');
 
   const req1 = await reqPromise1;
@@ -71,7 +71,7 @@ sentryTest('handles session that exceeds max age', async ({ getLocalTestPath, pa
 
   // Wait for session to expire
   const timePassed2 = Date.now() - startTimestamp;
-  await new Promise(resolve => setTimeout(resolve, Math.max(SESSION_MAX_AGE - timePassed2, 0)));
+  await new Promise(resolve => setTimeout(resolve, Math.max(MAX_REPLAY_DURATION - timePassed2, 0)));
   await page.click('#button2');
 
   const req2 = await reqPromise2;

--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -17,9 +17,6 @@ export const SESSION_IDLE_PAUSE_DURATION = 300_000; // 5 minutes in ms
 // The idle limit for a session after which the session expires.
 export const SESSION_IDLE_EXPIRE_DURATION = 900_000; // 15 minutes in ms
 
-// The maximum length of a session
-export const MAX_SESSION_LIFE = 3_600_000; // 60 minutes in ms
-
 /** Default flush delays */
 export const DEFAULT_FLUSH_MIN_DELAY = 5_000;
 // XXX: Temp fix for our debounce logic where `maxWait` would never occur if it
@@ -50,3 +47,6 @@ export const REPLAY_MAX_EVENT_BUFFER_SIZE = 20_000_000; // ~20MB
 export const MIN_REPLAY_DURATION = 4_999;
 /* The max. allowed value that the minReplayDuration can be set to. */
 export const MIN_REPLAY_DURATION_LIMIT = 15_000;
+
+/** The max. length of a replay. */
+export const MAX_REPLAY_DURATION = 3_600_000; // 60 minutes in ms;

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -5,6 +5,7 @@ import { dropUndefinedKeys } from '@sentry/utils';
 import {
   DEFAULT_FLUSH_MAX_DELAY,
   DEFAULT_FLUSH_MIN_DELAY,
+  MAX_REPLAY_DURATION,
   MIN_REPLAY_DURATION,
   MIN_REPLAY_DURATION_LIMIT,
 } from './constants';
@@ -57,6 +58,7 @@ export class Replay implements Integration {
     flushMinDelay = DEFAULT_FLUSH_MIN_DELAY,
     flushMaxDelay = DEFAULT_FLUSH_MAX_DELAY,
     minReplayDuration = MIN_REPLAY_DURATION,
+    maxReplayDuration = MAX_REPLAY_DURATION,
     stickySession = true,
     useCompression = true,
     _experiments = {},
@@ -136,6 +138,7 @@ export class Replay implements Integration {
       flushMinDelay,
       flushMaxDelay,
       minReplayDuration: Math.min(minReplayDuration, MIN_REPLAY_DURATION_LIMIT),
+      maxReplayDuration: Math.min(maxReplayDuration, MAX_REPLAY_DURATION),
       stickySession,
       sessionSampleRate,
       errorSampleRate,

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -275,8 +275,8 @@ export class ReplayContainer implements ReplayContainerInterface {
     const session = loadOrCreateSession(
       this.session,
       {
-        timeouts: this.timeouts,
         maxReplayDuration: this._options.maxReplayDuration,
+        sessionIdleExpire: this.timeouts.sessionIdleExpire,
         traceInternals: this._options._experiments.traceInternals,
       },
       {
@@ -306,7 +306,7 @@ export class ReplayContainer implements ReplayContainerInterface {
     const session = loadOrCreateSession(
       this.session,
       {
-        timeouts: this.timeouts,
+        sessionIdleExpire: this.timeouts.sessionIdleExpire,
         maxReplayDuration: this._options.maxReplayDuration,
         traceInternals: this._options._experiments.traceInternals,
       },
@@ -764,7 +764,7 @@ export class ReplayContainer implements ReplayContainerInterface {
     const session = loadOrCreateSession(
       this.session,
       {
-        timeouts: this.timeouts,
+        sessionIdleExpire: this.timeouts.sessionIdleExpire,
         maxReplayDuration: this._options.maxReplayDuration,
         traceInternals: this._options._experiments.traceInternals,
       },
@@ -794,7 +794,7 @@ export class ReplayContainer implements ReplayContainerInterface {
     const newSession = maybeRefreshSession(
       currentSession,
       {
-        timeouts: this.timeouts,
+        sessionIdleExpire: this.timeouts.sessionIdleExpire,
         traceInternals: this._options._experiments.traceInternals,
         maxReplayDuration: this._options.maxReplayDuration,
       },

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -276,6 +276,7 @@ export class ReplayContainer implements ReplayContainerInterface {
       this.session,
       {
         timeouts: this.timeouts,
+        maxReplayDuration: this._options.maxReplayDuration,
         traceInternals: this._options._experiments.traceInternals,
       },
       {
@@ -306,6 +307,7 @@ export class ReplayContainer implements ReplayContainerInterface {
       this.session,
       {
         timeouts: this.timeouts,
+        maxReplayDuration: this._options.maxReplayDuration,
         traceInternals: this._options._experiments.traceInternals,
       },
       {
@@ -763,6 +765,7 @@ export class ReplayContainer implements ReplayContainerInterface {
       this.session,
       {
         timeouts: this.timeouts,
+        maxReplayDuration: this._options.maxReplayDuration,
         traceInternals: this._options._experiments.traceInternals,
       },
       {
@@ -793,6 +796,7 @@ export class ReplayContainer implements ReplayContainerInterface {
       {
         timeouts: this.timeouts,
         traceInternals: this._options._experiments.traceInternals,
+        maxReplayDuration: this._options.maxReplayDuration,
       },
       {
         stickySession: Boolean(this._options.stickySession),

--- a/packages/replay/src/session/loadOrCreateSession.ts
+++ b/packages/replay/src/session/loadOrCreateSession.ts
@@ -13,8 +13,10 @@ export function loadOrCreateSession(
   {
     timeouts,
     traceInternals,
+    maxReplayDuration,
   }: {
     timeouts: Timeouts;
+    maxReplayDuration: number;
     traceInternals?: boolean;
   },
   sessionOptions: SessionOptions,
@@ -28,5 +30,5 @@ export function loadOrCreateSession(
     return createSession(sessionOptions);
   }
 
-  return maybeRefreshSession(existingSession, { timeouts, traceInternals }, sessionOptions);
+  return maybeRefreshSession(existingSession, { timeouts, traceInternals, maxReplayDuration }, sessionOptions);
 }

--- a/packages/replay/src/session/loadOrCreateSession.ts
+++ b/packages/replay/src/session/loadOrCreateSession.ts
@@ -1,4 +1,4 @@
-import type { Session, SessionOptions, Timeouts } from '../types';
+import type { Session, SessionOptions } from '../types';
 import { logInfoNextTick } from '../util/log';
 import { createSession } from './createSession';
 import { fetchSession } from './fetchSession';
@@ -11,11 +11,11 @@ import { maybeRefreshSession } from './maybeRefreshSession';
 export function loadOrCreateSession(
   currentSession: Session | undefined,
   {
-    timeouts,
     traceInternals,
+    sessionIdleExpire,
     maxReplayDuration,
   }: {
-    timeouts: Timeouts;
+    sessionIdleExpire: number;
     maxReplayDuration: number;
     traceInternals?: boolean;
   },
@@ -30,5 +30,5 @@ export function loadOrCreateSession(
     return createSession(sessionOptions);
   }
 
-  return maybeRefreshSession(existingSession, { timeouts, traceInternals, maxReplayDuration }, sessionOptions);
+  return maybeRefreshSession(existingSession, { sessionIdleExpire, traceInternals, maxReplayDuration }, sessionOptions);
 }

--- a/packages/replay/src/session/maybeRefreshSession.ts
+++ b/packages/replay/src/session/maybeRefreshSession.ts
@@ -1,4 +1,4 @@
-import type { Session, SessionOptions, Timeouts } from '../types';
+import type { Session, SessionOptions } from '../types';
 import { isSessionExpired } from '../util/isSessionExpired';
 import { logInfoNextTick } from '../util/log';
 import { createSession } from './createSession';
@@ -12,18 +12,18 @@ import { makeSession } from './Session';
 export function maybeRefreshSession(
   session: Session,
   {
-    timeouts,
     traceInternals,
     maxReplayDuration,
+    sessionIdleExpire,
   }: {
-    timeouts: Timeouts;
+    sessionIdleExpire: number;
     maxReplayDuration: number;
     traceInternals?: boolean;
   },
   sessionOptions: SessionOptions,
 ): Session {
   // If not expired, all good, just keep the session
-  if (!isSessionExpired(session, { sessionIdleExpire: timeouts.sessionIdleExpire, maxReplayDuration })) {
+  if (!isSessionExpired(session, { sessionIdleExpire, maxReplayDuration })) {
     return session;
   }
 

--- a/packages/replay/src/session/maybeRefreshSession.ts
+++ b/packages/replay/src/session/maybeRefreshSession.ts
@@ -14,14 +14,16 @@ export function maybeRefreshSession(
   {
     timeouts,
     traceInternals,
+    maxReplayDuration,
   }: {
     timeouts: Timeouts;
+    maxReplayDuration: number;
     traceInternals?: boolean;
   },
   sessionOptions: SessionOptions,
 ): Session {
   // If not expired, all good, just keep the session
-  if (!isSessionExpired(session, timeouts)) {
+  if (!isSessionExpired(session, { sessionIdleExpire: timeouts.sessionIdleExpire, maxReplayDuration })) {
     return session;
   }
 

--- a/packages/replay/src/types/replay.ts
+++ b/packages/replay/src/types/replay.ts
@@ -31,7 +31,6 @@ export interface SendReplayData {
 export interface Timeouts {
   sessionIdlePause: number;
   sessionIdleExpire: number;
-  maxSessionLife: number;
 }
 
 /**
@@ -186,6 +185,12 @@ export interface ReplayPluginOptions extends ReplayNetworkOptions {
    * Note that this is capped at max. 15s.
    */
   minReplayDuration: number;
+
+  /**
+   * The max. duration (in ms) a replay session may be.
+   * This is capped at max. 60min.
+   */
+  maxReplayDuration: number;
 
   /**
    * Callback before adding a custom recording event

--- a/packages/replay/src/util/addEvent.ts
+++ b/packages/replay/src/util/addEvent.ts
@@ -41,9 +41,9 @@ export async function addEvent(
   }
 
   // Throw out events that are +60min from the initial timestamp
-  if (timestampInMs > replay.getContext().initialTimestamp + replay.timeouts.maxSessionLife) {
+  if (timestampInMs > replay.getContext().initialTimestamp + replay.getOptions().maxReplayDuration) {
     logInfo(
-      `[Replay] Skipping event with timestamp ${timestampInMs} because it is after maxSessionLife`,
+      `[Replay] Skipping event with timestamp ${timestampInMs} because it is after maxReplayDuration`,
       replay.getOptions()._experiments.traceInternals,
     );
     return null;

--- a/packages/replay/src/util/isSessionExpired.ts
+++ b/packages/replay/src/util/isSessionExpired.ts
@@ -1,15 +1,22 @@
-import type { Session, Timeouts } from '../types';
+import type { Session } from '../types';
 import { isExpired } from './isExpired';
 
 /**
  * Checks to see if session is expired
  */
-export function isSessionExpired(session: Session, timeouts: Timeouts, targetTime: number = +new Date()): boolean {
+export function isSessionExpired(
+  session: Session,
+  {
+    maxReplayDuration,
+    sessionIdleExpire,
+    targetTime = Date.now(),
+  }: { maxReplayDuration: number; sessionIdleExpire: number; targetTime?: number },
+): boolean {
   return (
     // First, check that maximum session length has not been exceeded
-    isExpired(session.started, timeouts.maxSessionLife, targetTime) ||
+    isExpired(session.started, maxReplayDuration, targetTime) ||
     // check that the idle timeout has not been exceeded (i.e. user has
     // performed an action within the last `sessionIdleExpire` ms)
-    isExpired(session.lastActivity, timeouts.sessionIdleExpire, targetTime)
+    isExpired(session.lastActivity, sessionIdleExpire, targetTime)
   );
 }

--- a/packages/replay/test/integration/errorSampleRate.test.ts
+++ b/packages/replay/test/integration/errorSampleRate.test.ts
@@ -3,7 +3,7 @@ import { captureException, getCurrentHub } from '@sentry/core';
 import {
   BUFFER_CHECKOUT_TIME,
   DEFAULT_FLUSH_MIN_DELAY,
-  MAX_SESSION_LIFE,
+  MAX_REPLAY_DURATION,
   REPLAY_SESSION_KEY,
   SESSION_IDLE_EXPIRE_DURATION,
   WINDOW,
@@ -430,7 +430,7 @@ describe('Integration | errorSampleRate', () => {
   // simply stop the session replay completely and wait for a new page load to
   // resample.
   it.each([
-    ['MAX_SESSION_LIFE', MAX_SESSION_LIFE],
+    ['MAX_REPLAY_DURATION', MAX_REPLAY_DURATION],
     ['SESSION_IDLE_DURATION', SESSION_IDLE_EXPIRE_DURATION],
   ])(
     'stops replay if session had an error and exceeds %s and does not start a new session thereafter',
@@ -494,7 +494,7 @@ describe('Integration | errorSampleRate', () => {
   );
 
   it.each([
-    ['MAX_SESSION_LIFE', MAX_SESSION_LIFE],
+    ['MAX_REPLAY_DURATION', MAX_REPLAY_DURATION],
     ['SESSION_IDLE_EXPIRE_DURATION', SESSION_IDLE_EXPIRE_DURATION],
   ])('continues buffering replay if session had no error and exceeds %s', async (_label, waitTime) => {
     const oldSessionId = replay.session?.id;
@@ -760,7 +760,7 @@ describe('Integration | errorSampleRate', () => {
     jest.runAllTimers();
     await new Promise(process.nextTick);
 
-    jest.advanceTimersByTime(2 * MAX_SESSION_LIFE);
+    jest.advanceTimersByTime(2 * MAX_REPLAY_DURATION);
 
     // in production, this happens at a time interval, here we mock this
     mockRecord.takeFullSnapshot(true);
@@ -785,7 +785,7 @@ describe('Integration | errorSampleRate', () => {
           data: {
             isCheckout: true,
           },
-          timestamp: BASE_TIMESTAMP + 2 * MAX_SESSION_LIFE + DEFAULT_FLUSH_MIN_DELAY + 40,
+          timestamp: BASE_TIMESTAMP + 2 * MAX_REPLAY_DURATION + DEFAULT_FLUSH_MIN_DELAY + 40,
           type: 2,
         },
       ]),
@@ -795,7 +795,7 @@ describe('Integration | errorSampleRate', () => {
     mockRecord.takeFullSnapshot.mockClear();
     (getCurrentHub().getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>).mockClear();
 
-    jest.advanceTimersByTime(MAX_SESSION_LIFE);
+    jest.advanceTimersByTime(MAX_REPLAY_DURATION);
     await new Promise(process.nextTick);
 
     mockRecord._emitter(TEST_EVENT);
@@ -960,7 +960,7 @@ it('handles buffer sessions that previously had an error', async () => {
 
   // Waiting for max life should eventually stop recording
   // We simulate a full checkout which would otherwise be done automatically
-  for (let i = 0; i < MAX_SESSION_LIFE / 60_000; i++) {
+  for (let i = 0; i < MAX_REPLAY_DURATION / 60_000; i++) {
     jest.advanceTimersByTime(60_000);
     await new Promise(process.nextTick);
     mockRecord.takeFullSnapshot(true);
@@ -997,7 +997,7 @@ it('handles buffer sessions that never had an error', async () => {
 
   // Waiting for max life should eventually stop recording
   // We simulate a full checkout which would otherwise be done automatically
-  for (let i = 0; i < MAX_SESSION_LIFE / 60_000; i++) {
+  for (let i = 0; i < MAX_REPLAY_DURATION / 60_000; i++) {
     jest.advanceTimersByTime(60_000);
     await new Promise(process.nextTick);
     mockRecord.takeFullSnapshot(true);

--- a/packages/replay/test/integration/flush.test.ts
+++ b/packages/replay/test/integration/flush.test.ts
@@ -1,6 +1,6 @@
 import * as SentryUtils from '@sentry/utils';
 
-import { DEFAULT_FLUSH_MIN_DELAY, MAX_SESSION_LIFE, WINDOW } from '../../src/constants';
+import { DEFAULT_FLUSH_MIN_DELAY, MAX_REPLAY_DURATION, WINDOW } from '../../src/constants';
 import type { ReplayContainer } from '../../src/replay';
 import { clearSession } from '../../src/session/clearSession';
 import type { EventBuffer } from '../../src/types';
@@ -305,7 +305,7 @@ describe('Integration | flush', () => {
   });
 
   it('does not flush if session is too long', async () => {
-    replay.timeouts.maxSessionLife = 100_000;
+    replay.getOptions().maxReplayDuration = 100_000;
     jest.setSystemTime(BASE_TIMESTAMP);
 
     sessionStorage.clear();
@@ -335,7 +335,7 @@ describe('Integration | flush', () => {
     expect(mockFlush).toHaveBeenCalledTimes(1);
     expect(mockSendReplay).toHaveBeenCalledTimes(0);
 
-    replay.timeouts.maxSessionLife = MAX_SESSION_LIFE;
+    replay.getOptions().maxReplayDuration = MAX_REPLAY_DURATION;
     replay['_checkSession'] = _tmp;
   });
 
@@ -400,7 +400,7 @@ describe('Integration | flush', () => {
     replay.getOptions()._experiments.traceInternals = false;
   });
 
-  it('logs warning if adding event that is after maxSessionLife', async () => {
+  it('logs warning if adding event that is after maxReplayDuration', async () => {
     replay.getOptions()._experiments.traceInternals = true;
 
     sessionStorage.clear();
@@ -416,7 +416,7 @@ describe('Integration | flush', () => {
     replay.eventBuffer!.hasCheckout = true;
 
     // Add event that is too long after session start
-    const TEST_EVENT = getTestEventCheckout({ timestamp: BASE_TIMESTAMP + MAX_SESSION_LIFE + 100 });
+    const TEST_EVENT = getTestEventCheckout({ timestamp: BASE_TIMESTAMP + MAX_REPLAY_DURATION + 100 });
     mockRecord._emitter(TEST_EVENT);
 
     // no checkout!
@@ -440,8 +440,8 @@ describe('Integration | flush', () => {
             data: { logger: 'replay' },
             level: 'info',
             message: `[Replay] Skipping event with timestamp ${
-              BASE_TIMESTAMP + MAX_SESSION_LIFE + 100
-            } because it is after maxSessionLife`,
+              BASE_TIMESTAMP + MAX_REPLAY_DURATION + 100
+            } because it is after maxReplayDuration`,
           },
         },
       },
@@ -456,8 +456,8 @@ describe('Integration | flush', () => {
    * so by the time we actually send the replay it's too late.
    * In this case, we want to stop the replay.
    */
-  it('stops if flushing after maxSessionLife', async () => {
-    replay.timeouts.maxSessionLife = 100_000;
+  it('stops if flushing after maxReplayDuration', async () => {
+    replay.getOptions().maxReplayDuration = 100_000;
 
     sessionStorage.clear();
     clearSession(replay);
@@ -486,7 +486,7 @@ describe('Integration | flush', () => {
     expect(mockSendReplay).toHaveBeenCalledTimes(0);
     expect(replay.isEnabled()).toBe(false);
 
-    replay.timeouts.maxSessionLife = MAX_SESSION_LIFE;
+    replay.getOptions().maxReplayDuration = MAX_REPLAY_DURATION;
 
     // Start again for following tests
     await replay.start();

--- a/packages/replay/test/integration/session.test.ts
+++ b/packages/replay/test/integration/session.test.ts
@@ -3,7 +3,7 @@ import type { Transport } from '@sentry/types';
 
 import {
   DEFAULT_FLUSH_MIN_DELAY,
-  MAX_SESSION_LIFE,
+  MAX_REPLAY_DURATION,
   REPLAY_SESSION_KEY,
   SESSION_IDLE_EXPIRE_DURATION,
   SESSION_IDLE_PAUSE_DURATION,
@@ -332,7 +332,7 @@ describe('Integration | session', () => {
     expect(replay.session).toBe(undefined);
   });
 
-  it('creates a new session if current session exceeds MAX_SESSION_LIFE', async () => {
+  it('creates a new session if current session exceeds MAX_REPLAY_DURATION', async () => {
     jest.clearAllMocks();
 
     const initialSession = { ...replay.session } as Session;
@@ -350,8 +350,8 @@ describe('Integration | session', () => {
       value: new URL(url),
     });
 
-    // Advanced past MAX_SESSION_LIFE
-    const ELAPSED = MAX_SESSION_LIFE + 1;
+    // Advanced past MAX_REPLAY_DURATION
+    const ELAPSED = MAX_REPLAY_DURATION + 1;
     jest.advanceTimersByTime(ELAPSED);
     // Update activity so as to not consider session to be idling
     replay['_updateUserActivity']();

--- a/packages/replay/test/unit/session/loadOrCreateSession.test.ts
+++ b/packages/replay/test/unit/session/loadOrCreateSession.test.ts
@@ -1,5 +1,5 @@
 import {
-  MAX_SESSION_LIFE,
+  MAX_REPLAY_DURATION,
   SESSION_IDLE_EXPIRE_DURATION,
   SESSION_IDLE_PAUSE_DURATION,
   WINDOW,
@@ -27,7 +27,6 @@ const SAMPLE_OPTIONS: SessionOptions = {
 const timeouts: Timeouts = {
   sessionIdlePause: SESSION_IDLE_PAUSE_DURATION,
   sessionIdleExpire: SESSION_IDLE_EXPIRE_DURATION,
-  maxSessionLife: MAX_SESSION_LIFE,
 };
 
 function createMockSession(when: number = Date.now(), id = 'test_session_id') {
@@ -60,6 +59,7 @@ describe('Unit | session | loadOrCreateSession', () => {
         undefined,
         {
           timeouts,
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -91,6 +91,7 @@ describe('Unit | session | loadOrCreateSession', () => {
         undefined,
         {
           timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -122,6 +123,7 @@ describe('Unit | session | loadOrCreateSession', () => {
         currentSession,
         {
           timeouts,
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -142,6 +144,7 @@ describe('Unit | session | loadOrCreateSession', () => {
         undefined,
         {
           timeouts,
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -175,6 +178,7 @@ describe('Unit | session | loadOrCreateSession', () => {
         undefined,
         {
           timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -208,6 +212,7 @@ describe('Unit | session | loadOrCreateSession', () => {
         undefined,
         {
           timeouts: { ...timeouts, sessionIdleExpire: 5000 },
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -237,6 +242,7 @@ describe('Unit | session | loadOrCreateSession', () => {
         currentSession,
         {
           timeouts,
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -267,6 +273,7 @@ describe('Unit | session | loadOrCreateSession', () => {
         currentSession,
         {
           timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -294,6 +301,7 @@ describe('Unit | session | loadOrCreateSession', () => {
         currentSession,
         {
           timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -323,6 +331,7 @@ describe('Unit | session | loadOrCreateSession', () => {
         currentSession,
         {
           timeouts: { ...timeouts, sessionIdleExpire: 5000 },
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -342,6 +351,7 @@ describe('Unit | session | loadOrCreateSession', () => {
         undefined,
         {
           timeouts,
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -366,6 +376,7 @@ describe('Unit | session | loadOrCreateSession', () => {
         undefined,
         {
           timeouts,
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -382,6 +393,7 @@ describe('Unit | session | loadOrCreateSession', () => {
         undefined,
         {
           timeouts,
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,

--- a/packages/replay/test/unit/session/loadOrCreateSession.test.ts
+++ b/packages/replay/test/unit/session/loadOrCreateSession.test.ts
@@ -1,15 +1,10 @@
-import {
-  MAX_REPLAY_DURATION,
-  SESSION_IDLE_EXPIRE_DURATION,
-  SESSION_IDLE_PAUSE_DURATION,
-  WINDOW,
-} from '../../../src/constants';
+import { MAX_REPLAY_DURATION, SESSION_IDLE_EXPIRE_DURATION, WINDOW } from '../../../src/constants';
 import * as CreateSession from '../../../src/session/createSession';
 import * as FetchSession from '../../../src/session/fetchSession';
 import { loadOrCreateSession } from '../../../src/session/loadOrCreateSession';
 import { saveSession } from '../../../src/session/saveSession';
 import { makeSession } from '../../../src/session/Session';
-import type { SessionOptions, Timeouts } from '../../../src/types';
+import type { SessionOptions } from '../../../src/types';
 
 jest.mock('@sentry/utils', () => {
   return {
@@ -24,9 +19,9 @@ const SAMPLE_OPTIONS: SessionOptions = {
   allowBuffering: false,
 };
 
-const timeouts: Timeouts = {
-  sessionIdlePause: SESSION_IDLE_PAUSE_DURATION,
+const DEFAULT_OPTIONS = {
   sessionIdleExpire: SESSION_IDLE_EXPIRE_DURATION,
+  maxReplayDuration: MAX_REPLAY_DURATION,
 };
 
 function createMockSession(when: number = Date.now(), id = 'test_session_id') {
@@ -58,8 +53,7 @@ describe('Unit | session | loadOrCreateSession', () => {
       const session = loadOrCreateSession(
         undefined,
         {
-          timeouts,
-          maxReplayDuration: MAX_REPLAY_DURATION,
+          ...DEFAULT_OPTIONS,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -90,7 +84,7 @@ describe('Unit | session | loadOrCreateSession', () => {
       const session = loadOrCreateSession(
         undefined,
         {
-          timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          sessionIdleExpire: 1000,
           maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
@@ -122,8 +116,7 @@ describe('Unit | session | loadOrCreateSession', () => {
       const session = loadOrCreateSession(
         currentSession,
         {
-          timeouts,
-          maxReplayDuration: MAX_REPLAY_DURATION,
+          ...DEFAULT_OPTIONS,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -143,8 +136,7 @@ describe('Unit | session | loadOrCreateSession', () => {
       const session = loadOrCreateSession(
         undefined,
         {
-          timeouts,
-          maxReplayDuration: MAX_REPLAY_DURATION,
+          ...DEFAULT_OPTIONS,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -177,7 +169,7 @@ describe('Unit | session | loadOrCreateSession', () => {
       const session = loadOrCreateSession(
         undefined,
         {
-          timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          sessionIdleExpire: 1000,
           maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
@@ -211,7 +203,7 @@ describe('Unit | session | loadOrCreateSession', () => {
       const session = loadOrCreateSession(
         undefined,
         {
-          timeouts: { ...timeouts, sessionIdleExpire: 5000 },
+          sessionIdleExpire: 5000,
           maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
@@ -241,8 +233,7 @@ describe('Unit | session | loadOrCreateSession', () => {
       const session = loadOrCreateSession(
         currentSession,
         {
-          timeouts,
-          maxReplayDuration: MAX_REPLAY_DURATION,
+          ...DEFAULT_OPTIONS,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -272,7 +263,7 @@ describe('Unit | session | loadOrCreateSession', () => {
       const session = loadOrCreateSession(
         currentSession,
         {
-          timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          sessionIdleExpire: 1000,
           maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
@@ -300,7 +291,7 @@ describe('Unit | session | loadOrCreateSession', () => {
       const session = loadOrCreateSession(
         currentSession,
         {
-          timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          sessionIdleExpire: 1000,
           maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
@@ -330,7 +321,7 @@ describe('Unit | session | loadOrCreateSession', () => {
       const session = loadOrCreateSession(
         currentSession,
         {
-          timeouts: { ...timeouts, sessionIdleExpire: 5000 },
+          sessionIdleExpire: 5000,
           maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
@@ -350,8 +341,7 @@ describe('Unit | session | loadOrCreateSession', () => {
       const session = loadOrCreateSession(
         undefined,
         {
-          timeouts,
-          maxReplayDuration: MAX_REPLAY_DURATION,
+          ...DEFAULT_OPTIONS,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -375,8 +365,7 @@ describe('Unit | session | loadOrCreateSession', () => {
       const session = loadOrCreateSession(
         undefined,
         {
-          timeouts,
-          maxReplayDuration: MAX_REPLAY_DURATION,
+          ...DEFAULT_OPTIONS,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -392,8 +381,7 @@ describe('Unit | session | loadOrCreateSession', () => {
       const session = loadOrCreateSession(
         undefined,
         {
-          timeouts,
-          maxReplayDuration: MAX_REPLAY_DURATION,
+          ...DEFAULT_OPTIONS,
         },
         {
           ...SAMPLE_OPTIONS,

--- a/packages/replay/test/unit/session/maybeRefreshSession.test.ts
+++ b/packages/replay/test/unit/session/maybeRefreshSession.test.ts
@@ -1,13 +1,8 @@
-import {
-  MAX_REPLAY_DURATION,
-  SESSION_IDLE_EXPIRE_DURATION,
-  SESSION_IDLE_PAUSE_DURATION,
-  WINDOW,
-} from '../../../src/constants';
+import { MAX_REPLAY_DURATION, SESSION_IDLE_EXPIRE_DURATION, WINDOW } from '../../../src/constants';
 import * as CreateSession from '../../../src/session/createSession';
 import { maybeRefreshSession } from '../../../src/session/maybeRefreshSession';
 import { makeSession } from '../../../src/session/Session';
-import type { SessionOptions, Timeouts } from '../../../src/types';
+import type { SessionOptions } from '../../../src/types';
 
 jest.mock('@sentry/utils', () => {
   return {
@@ -22,9 +17,9 @@ const SAMPLE_OPTIONS: SessionOptions = {
   allowBuffering: false,
 };
 
-const timeouts: Timeouts = {
-  sessionIdlePause: SESSION_IDLE_PAUSE_DURATION,
+const DEFAULT_OPTIONS = {
   sessionIdleExpire: SESSION_IDLE_EXPIRE_DURATION,
+  maxReplayDuration: MAX_REPLAY_DURATION,
 };
 
 function createMockSession(when: number = Date.now(), id = 'test_session_id') {
@@ -55,8 +50,7 @@ describe('Unit | session | maybeRefreshSession', () => {
     const session = maybeRefreshSession(
       currentSession,
       {
-        timeouts,
-        maxReplayDuration: MAX_REPLAY_DURATION,
+        ...DEFAULT_OPTIONS,
       },
       {
         ...SAMPLE_OPTIONS,
@@ -75,7 +69,7 @@ describe('Unit | session | maybeRefreshSession', () => {
     const session = maybeRefreshSession(
       currentSession,
       {
-        timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+        sessionIdleExpire: 1000,
         maxReplayDuration: MAX_REPLAY_DURATION,
       },
       {
@@ -115,7 +109,7 @@ describe('Unit | session | maybeRefreshSession', () => {
       const session = maybeRefreshSession(
         currentSession,
         {
-          timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          sessionIdleExpire: 1000,
           maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
@@ -142,7 +136,7 @@ describe('Unit | session | maybeRefreshSession', () => {
       const session = maybeRefreshSession(
         currentSession,
         {
-          timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          sessionIdleExpire: 1000,
           maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
@@ -171,7 +165,7 @@ describe('Unit | session | maybeRefreshSession', () => {
       const session = maybeRefreshSession(
         currentSession,
         {
-          timeouts: { ...timeouts, sessionIdleExpire: 5000 },
+          sessionIdleExpire: 5000,
           maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
@@ -200,7 +194,7 @@ describe('Unit | session | maybeRefreshSession', () => {
       const session = maybeRefreshSession(
         currentSession,
         {
-          timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          sessionIdleExpire: 1000,
           maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
@@ -228,7 +222,7 @@ describe('Unit | session | maybeRefreshSession', () => {
       const session = maybeRefreshSession(
         currentSession,
         {
-          timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          sessionIdleExpire: 1000,
           maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
@@ -256,7 +250,7 @@ describe('Unit | session | maybeRefreshSession', () => {
       const session = maybeRefreshSession(
         currentSession,
         {
-          timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          sessionIdleExpire: 1000,
           maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {

--- a/packages/replay/test/unit/session/maybeRefreshSession.test.ts
+++ b/packages/replay/test/unit/session/maybeRefreshSession.test.ts
@@ -1,5 +1,5 @@
 import {
-  MAX_SESSION_LIFE,
+  MAX_REPLAY_DURATION,
   SESSION_IDLE_EXPIRE_DURATION,
   SESSION_IDLE_PAUSE_DURATION,
   WINDOW,
@@ -25,7 +25,6 @@ const SAMPLE_OPTIONS: SessionOptions = {
 const timeouts: Timeouts = {
   sessionIdlePause: SESSION_IDLE_PAUSE_DURATION,
   sessionIdleExpire: SESSION_IDLE_EXPIRE_DURATION,
-  maxSessionLife: MAX_SESSION_LIFE,
 };
 
 function createMockSession(when: number = Date.now(), id = 'test_session_id') {
@@ -57,6 +56,7 @@ describe('Unit | session | maybeRefreshSession', () => {
       currentSession,
       {
         timeouts,
+        maxReplayDuration: MAX_REPLAY_DURATION,
       },
       {
         ...SAMPLE_OPTIONS,
@@ -76,6 +76,7 @@ describe('Unit | session | maybeRefreshSession', () => {
       currentSession,
       {
         timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+        maxReplayDuration: MAX_REPLAY_DURATION,
       },
       {
         ...SAMPLE_OPTIONS,
@@ -115,6 +116,7 @@ describe('Unit | session | maybeRefreshSession', () => {
         currentSession,
         {
           timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -141,6 +143,7 @@ describe('Unit | session | maybeRefreshSession', () => {
         currentSession,
         {
           timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -169,6 +172,7 @@ describe('Unit | session | maybeRefreshSession', () => {
         currentSession,
         {
           timeouts: { ...timeouts, sessionIdleExpire: 5000 },
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -197,6 +201,7 @@ describe('Unit | session | maybeRefreshSession', () => {
         currentSession,
         {
           timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -224,6 +229,7 @@ describe('Unit | session | maybeRefreshSession', () => {
         currentSession,
         {
           timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,
@@ -251,6 +257,7 @@ describe('Unit | session | maybeRefreshSession', () => {
         currentSession,
         {
           timeouts: { ...timeouts, sessionIdleExpire: 1000 },
+          maxReplayDuration: MAX_REPLAY_DURATION,
         },
         {
           ...SAMPLE_OPTIONS,

--- a/packages/replay/test/unit/util/isSessionExpired.test.ts
+++ b/packages/replay/test/unit/util/isSessionExpired.test.ts
@@ -1,4 +1,4 @@
-import { MAX_SESSION_LIFE, SESSION_IDLE_PAUSE_DURATION } from '../../../src/constants';
+import { MAX_REPLAY_DURATION } from '../../../src/constants';
 import { makeSession } from '../../../src/session/Session';
 import { isSessionExpired } from '../../../src/util/isSessionExpired';
 
@@ -16,57 +16,41 @@ function createSession(extra?: Record<string, any>) {
 describe('Unit | util | isSessionExpired', () => {
   it('session last activity is older than expiry time', function () {
     expect(
-      isSessionExpired(
-        createSession(),
-        {
-          maxSessionLife: MAX_SESSION_LIFE,
-          sessionIdlePause: SESSION_IDLE_PAUSE_DURATION,
-          sessionIdleExpire: 100,
-        },
-        200,
-      ),
+      isSessionExpired(createSession(), {
+        maxReplayDuration: MAX_REPLAY_DURATION,
+        sessionIdleExpire: 100,
+        targetTime: 200,
+      }),
     ).toBe(true); // Session expired at ts = 100
   });
 
   it('session last activity is not older than expiry time', function () {
     expect(
-      isSessionExpired(
-        createSession({ lastActivity: 100 }),
-        {
-          maxSessionLife: MAX_SESSION_LIFE,
-          sessionIdlePause: SESSION_IDLE_PAUSE_DURATION,
-          sessionIdleExpire: 150,
-        },
-        200,
-      ),
+      isSessionExpired(createSession({ lastActivity: 100 }), {
+        maxReplayDuration: MAX_REPLAY_DURATION,
+        sessionIdleExpire: 150,
+        targetTime: 200,
+      }),
     ).toBe(false); // Session expires at ts >= 250
   });
 
   it('session age is not older than max session life', function () {
     expect(
-      isSessionExpired(
-        createSession(),
-        {
-          maxSessionLife: MAX_SESSION_LIFE,
-          sessionIdlePause: SESSION_IDLE_PAUSE_DURATION,
-          sessionIdleExpire: 1_800_000,
-        },
-        50_000,
-      ),
+      isSessionExpired(createSession(), {
+        maxReplayDuration: MAX_REPLAY_DURATION,
+        sessionIdleExpire: 1_800_000,
+        targetTime: 50_000,
+      }),
     ).toBe(false);
   });
 
   it('session age is older than max session life', function () {
     expect(
-      isSessionExpired(
-        createSession(),
-        {
-          maxSessionLife: MAX_SESSION_LIFE,
-          sessionIdlePause: SESSION_IDLE_PAUSE_DURATION,
-          sessionIdleExpire: 1_800_000,
-        },
-        1_800_001,
-      ),
+      isSessionExpired(createSession(), {
+        maxReplayDuration: MAX_REPLAY_DURATION,
+        sessionIdleExpire: 1_800_000,
+        targetTime: 1_800_001,
+      }),
     ).toBe(true); // Session expires at ts >= 1_800_000
   });
 });

--- a/packages/replay/test/utils/setupReplayContainer.ts
+++ b/packages/replay/test/utils/setupReplayContainer.ts
@@ -1,3 +1,4 @@
+import { MAX_REPLAY_DURATION } from '../../src/constants';
 import { createEventBuffer } from '../../src/eventBuffer';
 import { ReplayContainer } from '../../src/replay';
 import { clearSession } from '../../src/session/clearSession';
@@ -7,6 +8,7 @@ const DEFAULT_OPTIONS = {
   flushMinDelay: 100,
   flushMaxDelay: 100,
   minReplayDuration: 0,
+  maxReplayDuration: MAX_REPLAY_DURATION,
   stickySession: false,
   sessionSampleRate: 0,
   errorSampleRate: 1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4414,10 +4414,10 @@
     fflate "^0.4.4"
     mitt "^1.1.3"
 
-"@sentry/bundler-plugin-core@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry/bundler-plugin-core/-/bundler-plugin-core-0.6.0.tgz#70ad3740b2f90cdca1aff5fdbcd7306566a2f51e"
-  integrity sha512-gDPBkFxiOkc525U9pxnGMI5B2DAG0+UCsNuiNgl9+AieDcPSYTwdzfGHytxDZrQgPMvIHEnTAp1VlNB+6UxUGQ==
+"@sentry/bundler-plugin-core@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@sentry/bundler-plugin-core/-/bundler-plugin-core-0.6.1.tgz#6c6a2ff3cdc98cd0ff1c30c59408cee9f067adf2"
+  integrity sha512-EecCJKp9ERM7J93DNDJTvkY78UiD/IfOjBdXWnaUVE0n619O7LfMVjwlXzxRJKl2x05dBE3lDraILLDGxCf6fg==
   dependencies:
     "@sentry/cli" "^2.17.0"
     "@sentry/node" "^7.19.0"
@@ -4463,12 +4463,12 @@
     proxy-from-env "^1.1.0"
     which "^2.0.2"
 
-"@sentry/vite-plugin@^0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry/vite-plugin/-/vite-plugin-0.6.0.tgz#3902a5224d52b06d753a1deeb6b722bf6523840c"
-  integrity sha512-3J1ESvbI5okGJaSWm+gTAOOIa96u4ZwfI/C3n+0HSStz3e4vGiGUh59iNyb1/2m5HFgR5OLaHNfAvlyP8GM/ew==
+"@sentry/vite-plugin@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@sentry/vite-plugin/-/vite-plugin-0.6.1.tgz#31eb744e8d87b1528eed8d41433647727a62e7c0"
+  integrity sha512-qkvKaSOcNhNWcdxRXLSs+8cF3ey0XIRmEzTl8U7sTTcZwuOMHsJB+HsYij6aTGaqsKfP8w1ozVt9szBAiL4//w==
   dependencies:
-    "@sentry/bundler-plugin-core" "0.6.0"
+    "@sentry/bundler-plugin-core" "0.6.1"
 
 "@sentry/webpack-plugin@1.19.0":
   version "1.19.0"


### PR DESCRIPTION
This defaults to 60min, and is capped at max. 60min (=you cannot specify a longer max duration than 60min).

Closes https://github.com/getsentry/sentry-javascript/issues/8758