### PR TITLE
fix(replay): Handle multiple clicks in a short time

### DIFF
--- a/packages/replay/src/coreHandlers/handleClick.ts
+++ b/packages/replay/src/coreHandlers/handleClick.ts
@@ -136,6 +136,14 @@ export class ClickDetector implements ReplayClickDetector {
       clickCount: 0,
       node,
     };
+
+    // If there was a click in the last 1s on the same element, ignore it - only keep a single reference per second
+    if (
+      this._clicks.some(click => click.node === newClick.node && Math.abs(click.timestamp - newClick.timestamp) < 1)
+    ) {
+      return;
+    }
+
     this._clicks.push(newClick);
 
     // If this is the first new click, set a timeout to check for multi clicks


### PR DESCRIPTION
We assumed that the click debounce should only let one click per second through. however, that does not work if clicking different elements quickly (as it only debounces a single click/element). This adds a guard to ensure we only handle a single click breadcrumb per second.

Fixes https://github.com/getsentry/sentry/issues/54293