### PR TITLE
feat(tracing): Add db connection attributes for mysql spans

### DIFF
--- a/packages/node-integration-tests/suites/tracing/auto-instrument/mysql/test.ts
+++ b/packages/node-integration-tests/suites/tracing/auto-instrument/mysql/test.ts
@@ -14,6 +14,9 @@ test('should auto-instrument `mysql` package.', async () => {
         op: 'db',
         data: {
           'db.system': 'mysql',
+          'db.user': 'root',
+          'server.address': expect.any(String),
+          'server.port': expect.any(Number),
         },
       },
 
@@ -22,6 +25,9 @@ test('should auto-instrument `mysql` package.', async () => {
         op: 'db',
         data: {
           'db.system': 'mysql',
+          'db.user': 'root',
+          'server.address': expect.any(String),
+          'server.port': expect.any(Number),
         },
       },
     ],


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/8771

Align mysql spans with https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/mssql.md

needed for starfish views.