### PR TITLE
fix(replay): Fix `hasCheckout` handling

### DIFF
--- a/packages/replay/src/eventBuffer/EventBufferProxy.ts
+++ b/packages/replay/src/eventBuffer/EventBufferProxy.ts
@@ -99,12 +99,14 @@ export class EventBufferProxy implements EventBuffer {
 
   /** Switch the used buffer to the compression worker. */
   private async _switchToCompressionWorker(): Promise<void> {
-    const { events } = this._fallback;
+    const { events, hasCheckout } = this._fallback;
 
     const addEventPromises: Promise<void>[] = [];
     for (const event of events) {
       addEventPromises.push(this._compression.addEvent(event));
     }
+
+    this._compression.hasCheckout = hasCheckout;
 
     // We switch over to the new buffer immediately - any further events will be added
     // after the previously buffered ones

--- a/packages/replay/src/util/addEvent.ts
+++ b/packages/replay/src/util/addEvent.ts
@@ -52,6 +52,9 @@ export async function addEvent(
   try {
     if (isCheckout && replay.recordingMode === 'buffer') {
       replay.eventBuffer.clear();
+    }
+
+    if (isCheckout) {
       replay.eventBuffer.hasCheckout = true;
     }
 


### PR DESCRIPTION
1. Make sure it is correctly kept when doing the compression worker switchover
2. Make sure it is correctly set for `session` recordings