### PR TITLE
feat(ci): Cache `node_modules` in flaky test detector

### DIFF
--- a/.github/workflows/flaky-test-detector.yml
+++ b/.github/workflows/flaky-test-detector.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: 'package.json'
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn install --ignore-engines --frozen-lockfile
 


### PR DESCRIPTION
This should cut down on the `yarn install` step.

Take a look at these two runs:

[Uncached](https://github.com/getsentry/sentry-javascript/actions/runs/5822280069/job/15786564103) - 4s setup node + 3m8s to yarn install (2m 31s post setup node to save cache)
[Cached](https://github.com/getsentry/sentry-javascript/actions/runs/5822280069/job/15793082951) - 42s setup node + 1m42s to yarn install