### PR TITLE
fix(nextjs): Check for existence of default export when wrapping pages

### DIFF
--- a/packages/nextjs/src/config/templates/pageWrapperTemplate.ts
+++ b/packages/nextjs/src/config/templates/pageWrapperTemplate.ts
@@ -14,18 +14,18 @@ import * as Sentry from '@sentry/nextjs';
 import type { GetServerSideProps, GetStaticProps, NextPage as NextPageComponent } from 'next';
 
 type NextPageModule = {
-  default: { getInitialProps?: NextPageComponent['getInitialProps'] };
+  default?: { getInitialProps?: NextPageComponent['getInitialProps'] };
   getStaticProps?: GetStaticProps;
   getServerSideProps?: GetServerSideProps;
 };
 
 const userPageModule = wrapee as NextPageModule;
 
-const pageComponent = userPageModule.default;
+const pageComponent = userPageModule?.default;
 
-const origGetInitialProps = pageComponent.getInitialProps;
-const origGetStaticProps = userPageModule.getStaticProps;
-const origGetServerSideProps = userPageModule.getServerSideProps;
+const origGetInitialProps = pageComponent?.getInitialProps;
+const origGetStaticProps = userPageModule?.getStaticProps;
+const origGetServerSideProps = userPageModule?.getServerSideProps;
 
 const getInitialPropsWrappers: Record<string, any> = {
   '/_app': Sentry.wrapAppGetInitialPropsWithSentry,
@@ -35,7 +35,7 @@ const getInitialPropsWrappers: Record<string, any> = {
 
 const getInitialPropsWrapper = getInitialPropsWrappers['__ROUTE__'] || Sentry.wrapGetInitialPropsWithSentry;
 
-if (typeof origGetInitialProps === 'function') {
+if (pageComponent && typeof origGetInitialProps === 'function') {
   pageComponent.getInitialProps = getInitialPropsWrapper(origGetInitialProps) as NextPageComponent['getInitialProps'];
 }
 

--- a/packages/nextjs/src/config/templates/pageWrapperTemplate.ts
+++ b/packages/nextjs/src/config/templates/pageWrapperTemplate.ts
@@ -21,11 +21,11 @@ type NextPageModule = {
 
 const userPageModule = wrapee as NextPageModule;
 
-const pageComponent = userPageModule?.default;
+const pageComponent = userPageModule ? userPageModule.default : undefined;
 
-const origGetInitialProps = pageComponent?.getInitialProps;
-const origGetStaticProps = userPageModule?.getStaticProps;
-const origGetServerSideProps = userPageModule?.getServerSideProps;
+const origGetInitialProps = pageComponent ? pageComponent.getInitialProps : undefined;
+const origGetStaticProps = userPageModule ? userPageModule.getStaticProps : undefined;
+const origGetServerSideProps = userPageModule ? userPageModule.getServerSideProps : undefined;
 
 const getInitialPropsWrappers: Record<string, any> = {
   '/_app': Sentry.wrapAppGetInitialPropsWithSentry,


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/8792

In https://github.com/getsentry/sentry-javascript/issues/8792 a user reports that we read `getInitialProps` from `undefined`. The only place where we read `getInitialProps` is in the page wrapper template. As a fix we simply check for its existence before accessing the field. We don't fully know yet how this can happen, but I guess it can't hurt to introduce this check.
