### PR TITLE
feat(node-experimental): Sync OTEL context with Sentry AsyncContext

### DIFF
--- a/packages/node-experimental/package.json
+++ b/packages/node-experimental/package.json
@@ -37,6 +37,7 @@
     "@opentelemetry/instrumentation-pg": "~0.36.0",
     "@opentelemetry/sdk-trace-node": "~1.15.0",
     "@opentelemetry/semantic-conventions": "~1.15.0",
+    "@opentelemetry/context-async-hooks": "~1.15.0",
     "@prisma/instrumentation": "~5.0.0",
     "@sentry/core": "7.66.0",
     "@sentry/node": "7.66.0",

--- a/packages/node-experimental/src/sdk/init.ts
+++ b/packages/node-experimental/src/sdk/init.ts
@@ -6,6 +6,7 @@ import { Http } from '../integrations/http';
 import type { NodeExperimentalOptions } from '../types';
 import { NodeExperimentalClient } from './client';
 import { initOtel } from './initOtel';
+import { setOtelContextAsyncContextStrategy } from './otelAsyncContextStrategy';
 
 const ignoredDefaultIntegrations = ['Http', 'Undici'];
 
@@ -35,4 +36,5 @@ export function init(options: NodeExperimentalOptions | undefined = {}): void {
 
   // Always init Otel, even if tracing is disabled, because we need it for trace propagation & the HTTP integration
   initOtel();
+  setOtelContextAsyncContextStrategy();
 }

--- a/packages/node-experimental/src/sdk/initOtel.ts
+++ b/packages/node-experimental/src/sdk/initOtel.ts
@@ -4,6 +4,7 @@ import { getCurrentHub } from '@sentry/core';
 import { SentryPropagator, SentrySpanProcessor } from '@sentry/opentelemetry-node';
 
 import type { NodeExperimentalClient } from './client';
+import { setOtelContextAsyncContextStrategy } from './otelContextAsyncContextStrategy';
 
 /**
  * Initialize OpenTelemetry for Node.
@@ -26,6 +27,8 @@ export function initOtel(): () => void {
   provider.register({
     propagator: new SentryPropagator(),
   });
+
+  setOtelContextAsyncContextStrategy();
 
   // Cleanup function
   return () => {

--- a/packages/node-experimental/src/sdk/initOtel.ts
+++ b/packages/node-experimental/src/sdk/initOtel.ts
@@ -4,7 +4,7 @@ import { getCurrentHub } from '@sentry/core';
 import { SentryPropagator, SentrySpanProcessor } from '@sentry/opentelemetry-node';
 
 import type { NodeExperimentalClient } from './client';
-import { setOtelContextAsyncContextStrategy } from './otelContextAsyncContextStrategy';
+import { SentryContextManager } from './otelContextManager';
 
 /**
  * Initialize OpenTelemetry for Node.
@@ -23,12 +23,15 @@ export function initOtel(): () => void {
   });
   provider.addSpanProcessor(new SentrySpanProcessor());
 
+  // We use a custom context manager to keep context in sync with sentry scope
+  const contextManager = new SentryContextManager();
+  contextManager.enable();
+
   // Initialize the provider
   provider.register({
     propagator: new SentryPropagator(),
+    contextManager,
   });
-
-  setOtelContextAsyncContextStrategy();
 
   // Cleanup function
   return () => {

--- a/packages/node-experimental/src/sdk/otelAsyncContextStrategy.ts
+++ b/packages/node-experimental/src/sdk/otelAsyncContextStrategy.ts
@@ -6,6 +6,7 @@ import { OTEL_CONTEXT_HUB_KEY } from './otelContextManager';
 
 /**
  * Sets the async context strategy to use follow the OTEL context under the hood.
+ * We handle forking a hub inside of our custom OTEL Context Manager (./otelContextManager.ts)
  */
 export function setOtelContextAsyncContextStrategy(): void {
   function getCurrentHub(): Hub | undefined {

--- a/packages/node-experimental/src/sdk/otelContextAsyncContextStrategy.ts
+++ b/packages/node-experimental/src/sdk/otelContextAsyncContextStrategy.ts
@@ -1,0 +1,43 @@
+import * as api from '@opentelemetry/api';
+import type { Carrier, Hub, RunWithAsyncContextOptions } from '@sentry/core';
+import { ensureHubOnCarrier, getHubFromCarrier, setAsyncContextStrategy } from '@sentry/core';
+
+const hubKey = api.createContextKey('sentry_hub');
+
+/**
+ * Sets the async context strategy to use follow the OTEL context under the hood.
+ */
+export function setOtelContextAsyncContextStrategy(): void {
+  function getCurrentHub(): Hub | undefined {
+    const ctx = api.context.active();
+
+    // Returning undefined means the global hub will be used
+    return ctx.getValue(hubKey) as Hub | undefined;
+  }
+
+  function createNewHub(parent: Hub | undefined): Hub {
+    const carrier: Carrier = {};
+    ensureHubOnCarrier(carrier, parent);
+    return getHubFromCarrier(carrier);
+  }
+
+  function runWithAsyncContext<T>(callback: () => T, options: RunWithAsyncContextOptions): T {
+    const existingHub = getCurrentHub();
+
+    if (existingHub && options?.reuseExisting) {
+      // We're already in an async context, so we don't need to create a new one
+      // just call the callback with the current hub
+      return callback();
+    }
+
+    const newHub = createNewHub(existingHub);
+
+    const ctx = api.context.active();
+
+    return api.context.with(ctx.setValue(hubKey, newHub), () => {
+      return callback();
+    });
+  }
+
+  setAsyncContextStrategy({ getCurrentHub, runWithAsyncContext });
+}

--- a/packages/node-experimental/src/sdk/otelContextManager.ts
+++ b/packages/node-experimental/src/sdk/otelContextManager.ts
@@ -1,0 +1,32 @@
+import type { Context } from '@opentelemetry/api';
+import * as api from '@opentelemetry/api';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import type { Carrier, Hub } from '@sentry/core';
+import { ensureHubOnCarrier, getCurrentHub, getHubFromCarrier } from '@sentry/core';
+
+export const OTEL_CONTEXT_HUB_KEY = api.createContextKey('sentry_hub');
+
+function createNewHub(parent: Hub | undefined): Hub {
+  const carrier: Carrier = {};
+  ensureHubOnCarrier(carrier, parent);
+  return getHubFromCarrier(carrier);
+}
+
+/** TODO docs */
+export class SentryContextManager extends AsyncLocalStorageContextManager {
+  /**
+   * Overwrite with() of the original AsyncLocalStorageContextManager
+   * to ensure we also create a new hub per context.
+   */
+  public with<A extends unknown[], F extends (...args: A) => ReturnType<F>>(
+    context: Context,
+    fn: F,
+    thisArg?: ThisParameterType<F>,
+    ...args: A
+  ): ReturnType<F> {
+    const existingHub = getCurrentHub();
+    const newHub = createNewHub(existingHub);
+
+    return super.with(context.setValue(OTEL_CONTEXT_HUB_KEY, newHub), fn, thisArg, ...args);
+  }
+}

--- a/packages/node-experimental/src/sdk/otelContextManager.ts
+++ b/packages/node-experimental/src/sdk/otelContextManager.ts
@@ -12,7 +12,13 @@ function createNewHub(parent: Hub | undefined): Hub {
   return getHubFromCarrier(carrier);
 }
 
-/** TODO docs */
+/**
+ * This is a custom ContextManager for OpenTelemetry, which extends the default AsyncLocalStorageContextManager.
+ * It ensures that we create a new hub per context, so that the OTEL Context & the Sentry Hub are always in sync.
+ *
+ * Note that we currently only support AsyncHooks with this,
+ * but since this should work for Node 14+ anyhow that should be good enough.
+ */
 export class SentryContextManager extends AsyncLocalStorageContextManager {
   /**
    * Overwrite with() of the original AsyncLocalStorageContextManager

--- a/yarn.lock
+++ b/yarn.lock
@@ -3733,6 +3733,11 @@
   dependencies:
     tslib "^2.3.1"
 
+"@opentelemetry/context-async-hooks@~1.15.0":
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/context-async-hooks/-/context-async-hooks-1.15.2.tgz#116bd5fef231137198d5bf551e8c0521fbdfe928"
+  integrity sha512-VAMHG67srGFQDG/N2ns5AyUT9vUcoKpZ/NpJ5fDQIPfJd7t3ju+aHwvDsMcrYBWuCh03U3Ky6o16+872CZchBg==
+
 "@opentelemetry/context-base@^0.12.0":
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.12.0.tgz#4906ae27359d3311e3dea1b63770a16f60848550"


### PR DESCRIPTION
This PR implements a strategy to sync the OpenTelemetry Context with our own Hub forking for AsyncContext.

This works by fully relying on OpenTelemetry to handle async context isolation/forking.

1. We implement a custom OTEL ContextManager that wraps the default AsyncHooks manager, but makes sure to also fork the hub for each context change & puts the hub on the OTEL context so we can retrieve it.
2. Then, we also have a custom Sentry AsyncContextStrategy which just refers to OTEL context and picks the hub from there we put there in 1.

This means we do not need to do any context forking ourselves anymore, so no need for e.g. `Sentry.Handlers.requestHandler()` and stuff like this.

It _should_ also mean that Sentry & OTEL should be as in sync as possible.

Some notes:
* Currently only works for AsyncHooks, which should be fine I guess. Could also be exteded to work with other implementations as well.