### PR TITLE
fix(nextjs): Only re-export default export if it exists

### DIFF
--- a/packages/nextjs/src/config/templates/sentryInitWrapperTemplate.ts
+++ b/packages/nextjs/src/config/templates/sentryInitWrapperTemplate.ts
@@ -4,8 +4,14 @@ import '__SENTRY_CONFIG_IMPORT_PATH__';
 
 // @ts-ignore This is the file we're wrapping
 // eslint-disable-next-line import/no-unresolved
-export * from '__SENTRY_WRAPPING_TARGET_FILE__';
+import * as wrappee from '__SENTRY_WRAPPING_TARGET_FILE__';
+
+// @ts-ignore default either exists, or it doesn't - we don't care
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+const defaultExport = wrappee.default;
 
 // @ts-ignore This is the file we're wrapping
 // eslint-disable-next-line import/no-unresolved
-export { default } from '__SENTRY_WRAPPING_TARGET_FILE__';
+export * from '__SENTRY_WRAPPING_TARGET_FILE__';
+
+export default defaultExport;


### PR DESCRIPTION
Injecting the Sentry config code failed when there wasn't a default export in a file that is supposed to be wrapped (e.g. a middleware file that only has a `middleware` export).

This PR fixes this by accessing the `.default` property dynamically and either re-exporting the default export or `undefined`.