### PR TITLE
fix(sveltekit): Avoid invalidating data on route changes in `wrapServerLoadWithSentry`

### DIFF
--- a/packages/sveltekit/src/server/load.ts
+++ b/packages/sveltekit/src/server/load.ts
@@ -123,7 +123,7 @@ export function wrapServerLoadWithSentry<T extends (...args: any) => any>(origSe
       // server `load` function's data on every route change.
       // To work around this, we use `Object.getOwnPropertyDescriptor` which doesn't invoke the proxy.
       // https://github.com/sveltejs/kit/blob/e133aba479fa9ba0e7f9e71512f5f937f0247e2c/packages/kit/src/runtime/server/page/load_data.js#L111C3-L124
-      const routeId = Object.getOwnPropertyDescriptor(event.route, 'id')?.value as string | undefined;
+      const routeId = event.route && (Object.getOwnPropertyDescriptor(event.route, 'id')?.value as string | undefined);
       // const routeId = event.route.id;
 
       const { dynamicSamplingContext, traceparentData, propagationContext } = getTracePropagationData(event);

--- a/packages/sveltekit/src/server/load.ts
+++ b/packages/sveltekit/src/server/load.ts
@@ -124,7 +124,6 @@ export function wrapServerLoadWithSentry<T extends (...args: any) => any>(origSe
       // To work around this, we use `Object.getOwnPropertyDescriptor` which doesn't invoke the proxy.
       // https://github.com/sveltejs/kit/blob/e133aba479fa9ba0e7f9e71512f5f937f0247e2c/packages/kit/src/runtime/server/page/load_data.js#L111C3-L124
       const routeId = event.route && (Object.getOwnPropertyDescriptor(event.route, 'id')?.value as string | undefined);
-      // const routeId = event.route.id;
 
       const { dynamicSamplingContext, traceparentData, propagationContext } = getTracePropagationData(event);
       getCurrentHub().getScope().setPropagationContext(propagationContext);


### PR DESCRIPTION
As reported in #8610, our SvelteKit SDK caused server load data to be invalidated, resulting in said functions being called on every route change. I initially thought this was related to our Kit-specific client fetch instrumentation which turned out not to be causing this. Instead, the culprit is our `wrapServerLoadWithSentry` wrapper:

In the wrapper, we access `event.route.id` to determine the route of the load function for the span description. Internally, SvelteKit puts a proxy on certain `event` properties, such as `event.route`. In case any property of `event.route` was accessed, [SvelteKit marks this](https://github.com/sveltejs/kit/blob/e133aba479fa9ba0e7f9e71512f5f937f0247e2c/packages/kit/src/runtime/server/page/load_data.js#L111-L124) internally and send along a flag to the client. On a route change, the client would [check this flag](https://github.com/sveltejs/kit/blob/e133aba479fa9ba0e7f9e71512f5f937f0247e2c/packages/kit/src/runtime/client/client.js#L572) and mark the route as invalidated, thereby causing a [call to the load function](https://github.com/sveltejs/kit/blob/e133aba479fa9ba0e7f9e71512f5f937f0247e2c/packages/kit/src/runtime/client/client.js#L641) on each navigation. 

Took me quite a while to find the cause but thanks to @kamilogorek we found a fix to access the route id without invoking the proxy. 

closes #8610 
 