### PR TITLE
feat(core): Introduce `Sentry.startActiveSpan` and `Sentry.startSpan`

### DIFF
--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -6,6 +6,6 @@ export { extractTraceparentData, getActiveTransaction } from './utils';
 // eslint-disable-next-line deprecation/deprecation
 export { SpanStatus } from './spanstatus';
 export type { SpanStatusType } from './span';
-export { trace } from './trace';
+export { trace, getActiveSpan, startActiveSpan, startSpan } from './trace';
 export { getDynamicSamplingContextFromClient } from './dynamicSamplingContext';
 export { setMeasurement } from './measurement';

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -34,14 +34,14 @@ export function trace<T>(
 
   const parentSpan = scope.getSpan();
 
-  function getActiveSpan(): Span | undefined {
+  function startActiveSpan(): Span | undefined {
     if (!hasTracingEnabled()) {
       return undefined;
     }
     return parentSpan ? parentSpan.startChild(ctx) : hub.startTransaction(ctx);
   }
 
-  const activeSpan = getActiveSpan();
+  const activeSpan = startActiveSpan();
   scope.setSpan(activeSpan);
 
   function finishAndSetSpan(): void {
@@ -100,14 +100,14 @@ export function startActiveSpan<T>(context: TransactionContext, callback: (span:
 
   const parentSpan = scope.getSpan();
 
-  function getActiveSpan(): Span | undefined {
+  function startActiveSpan(): Span | undefined {
     if (!hasTracingEnabled()) {
       return undefined;
     }
     return parentSpan ? parentSpan.startChild(ctx) : hub.startTransaction(ctx);
   }
 
-  const activeSpan = getActiveSpan();
+  const activeSpan = startActiveSpan();
   scope.setSpan(activeSpan);
 
   function finishAndSetSpan(): void {

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -76,3 +76,100 @@ export function trace<T>(
 
   return maybePromiseResult;
 }
+
+/**
+ * Wraps a function with a transaction/span and finishes the span after the function is done.
+ * The created span is the active span and will be used as parent by other spans created inside the function
+ * and can be accessed via `Sentry.getSpan()`, as long as the function is executed while the scope is active.
+ *
+ * If you want to create a span that is not set as active, use {@link startSpan}.
+ *
+ * Note that if you have not enabled tracing extensions via `addTracingExtensions`
+ * or you didn't set `tracesSampleRate`, this function will not generate spans
+ * and the `span` returned from the callback will be undefined.
+ */
+export function startActiveSpan<T>(context: TransactionContext, callback: (span: Span | undefined) => T): T {
+  const ctx = { ...context };
+  // If a name is set and a description is not, set the description to the name.
+  if (ctx.name !== undefined && ctx.description === undefined) {
+    ctx.description = ctx.name;
+  }
+
+  const hub = getCurrentHub();
+  const scope = hub.getScope();
+
+  const parentSpan = scope.getSpan();
+
+  function getActiveSpan(): Span | undefined {
+    if (!hasTracingEnabled()) {
+      return undefined;
+    }
+    return parentSpan ? parentSpan.startChild(ctx) : hub.startTransaction(ctx);
+  }
+
+  const activeSpan = getActiveSpan();
+  scope.setSpan(activeSpan);
+
+  function finishAndSetSpan(): void {
+    activeSpan && activeSpan.finish();
+    hub.getScope().setSpan(parentSpan);
+  }
+
+  let maybePromiseResult: T;
+  try {
+    maybePromiseResult = callback(activeSpan);
+  } catch (e) {
+    activeSpan && activeSpan.setStatus('internal_error');
+    finishAndSetSpan();
+    throw e;
+  }
+
+  if (isThenable(maybePromiseResult)) {
+    Promise.resolve(maybePromiseResult).then(
+      () => {
+        finishAndSetSpan();
+      },
+      () => {
+        activeSpan && activeSpan.setStatus('internal_error');
+        finishAndSetSpan();
+      },
+    );
+  } else {
+    finishAndSetSpan();
+  }
+
+  return maybePromiseResult;
+}
+
+/**
+ * Creates a span. This span is not set as active, so will not get automatic instrumentation spans
+ * as children or be able to be accessed via `Sentry.getSpan()`.
+ *
+ * If you want to create a span that is set as active, use {@link startActiveSpan}.
+ *
+ * Note that if you have not enabled tracing extensions via `addTracingExtensions`
+ * or you didn't set `tracesSampleRate` or `tracesSampler`, this function will not generate spans
+ * and the `span` returned from the callback will be undefined.
+ */
+export function startSpan(context: TransactionContext): Span | undefined {
+  if (!hasTracingEnabled()) {
+    return undefined;
+  }
+
+  const ctx = { ...context };
+  // If a name is set and a description is not, set the description to the name.
+  if (ctx.name !== undefined && ctx.description === undefined) {
+    ctx.description = ctx.name;
+  }
+
+  const hub = getCurrentHub();
+  const parentSpan = getActiveSpan();
+  return parentSpan ? parentSpan.startChild(ctx) : hub.startTransaction(ctx);
+}
+
+/**
+ * Returns the currently active span.
+ */
+export function getActiveSpan(): Span | undefined {
+  return getCurrentHub().getScope().getSpan();
+}

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -55,6 +55,9 @@ export {
   withScope,
   captureCheckIn,
   setMeasurement,
+  getActiveSpan,
+  startActiveSpan,
+  startSpan,
 } from '@sentry/core';
 export type { SpanStatusType } from '@sentry/core';
 export { autoDiscoverNodePerformanceMonitoringIntegrations } from './tracing';

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -50,4 +50,7 @@ export {
   Handlers,
   Integrations,
   setMeasurement,
+  getActiveSpan,
+  startActiveSpan,
+  startSpan,
 } from '@sentry/node';

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -45,6 +45,9 @@ export {
   Integrations,
   Handlers,
   setMeasurement,
+  getActiveSpan,
+  startActiveSpan,
+  startSpan,
 } from '@sentry/node';
 
 // We can still leave this for the carrier init and type exports


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/8724

```ts
const result = Sentry.startActiveSpan({ name: importantThing }, async () => {
  await someWork();
  return Sentry.startActiveSpan({ op: 'db', name: 'query-stuff' }, () => expensiveQuery());
});
// result === expensiveQuery() 
```