### PR TITLE
fix(node): More relevant warning message when tracing extensions are missing

### DIFF
--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -374,11 +374,19 @@ export class Hub implements HubInterface {
     const result = this._callExtensionMethod<Transaction>('startTransaction', context, customSamplingContext);
 
     if (__DEBUG_BUILD__ && !result) {
-      // eslint-disable-next-line no-console
-      console.warn(`Tracing extension 'startTransaction' has not been added. Call 'addTracingExtensions' before calling 'init':
+      const client = this.getClient();
+      if (!client) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          "Tracing extension 'startTransaction' is missing. You should 'init' the SDK before calling 'startTransaction'",
+        );
+      } else {
+        // eslint-disable-next-line no-console
+        console.warn(`Tracing extension 'startTransaction' has not been added. Call 'addTracingExtensions' before calling 'init':
 Sentry.addTracingExtensions();
 Sentry.init({...});
 `);
+      }
     }
 
     return result;


### PR DESCRIPTION
Closes #8624

For SDKs where it's required to call `addTracingExtensions()`, ie. the browser, is it still important to call it before init?