### PR TITLE
fix: Memoize `AsyncLocalStorage` instance

### DIFF
--- a/packages/nextjs/src/edge/asyncLocalStorageAsyncContextStrategy.ts
+++ b/packages/nextjs/src/edge/asyncLocalStorageAsyncContextStrategy.ts
@@ -11,6 +11,8 @@ interface AsyncLocalStorage<T> {
 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
 const MaybeGlobalAsyncLocalStorage = (GLOBAL_OBJ as any).AsyncLocalStorage;
 
+let asyncStorage: AsyncLocalStorage<Hub>;
+
 /**
  * Sets the async context strategy to use AsyncLocalStorage which should be available in the edge runtime.
  */
@@ -23,7 +25,9 @@ export function setAsyncLocalStorageAsyncContextStrategy(): void {
     return;
   }
 
-  const asyncStorage: AsyncLocalStorage<Hub> = new MaybeGlobalAsyncLocalStorage();
+  if (!asyncStorage) {
+    asyncStorage = new MaybeGlobalAsyncLocalStorage();
+  }
 
   function getCurrentHub(): Hub | undefined {
     return asyncStorage.getStore();

--- a/packages/node/src/async/hooks.ts
+++ b/packages/node/src/async/hooks.ts
@@ -12,11 +12,15 @@ type AsyncLocalStorageConstructor = { new <T>(): AsyncLocalStorage<T> };
 // AsyncLocalStorage only exists in async_hook after Node v12.17.0 or v13.10.0
 type NewerAsyncHooks = typeof async_hooks & { AsyncLocalStorage: AsyncLocalStorageConstructor };
 
+let asyncStorage: AsyncLocalStorage<Hub>;
+
 /**
  * Sets the async context strategy to use AsyncLocalStorage which requires Node v12.17.0 or v13.10.0.
  */
 export function setHooksAsyncContextStrategy(): void {
-  const asyncStorage = new (async_hooks as NewerAsyncHooks).AsyncLocalStorage<Hub>();
+  if (!asyncStorage) {
+    asyncStorage = new (async_hooks as NewerAsyncHooks).AsyncLocalStorage<Hub>();
+  }
 
   function getCurrentHub(): Hub | undefined {
     return asyncStorage.getStore();


### PR DESCRIPTION
Attempts to fix the memory leak reported in https://github.com/getsentry/sentry-javascript/issues/8829 by memoizing the `AsyncLocalStorage` instance we create when setting the async context strategy.

Note for reviewers: Can you think of any problems this may cause?