### PR TITLE
fix(sveltekit): Remove invalid return in fetch proxy script

### DIFF
--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -59,9 +59,10 @@ function sendErrorToSentry(e: unknown): unknown {
 
 const FETCH_PROXY_SCRIPT = `
     const f = window.fetch;
-    if(!f){return}
-    window._sentryFetchProxy = function(...a){return f(...a)}
-    window.fetch = function(...a){return window._sentryFetchProxy(...a)}
+    if(f){
+      window._sentryFetchProxy = function(...a){return f(...a)}
+      window.fetch = function(...a){return window._sentryFetchProxy(...a)}
+    }
 `;
 
 export const transformPageChunk: NonNullable<ResolveOptions['transformPageChunk']> = ({ html }) => {


### PR DESCRIPTION
![image](https://github.com/getsentry/sentry-javascript/assets/8420481/0d05568d-fdeb-40f5-b231-bed4811fb7e2)

(This bug didn't impact anyone as the fetch proxy script wasn't released yet)