### PR TITLE
ref(replay): improve dedupe logic

### DIFF
--- a/packages/replay/src/coreHandlers/performanceObserver.ts
+++ b/packages/replay/src/coreHandlers/performanceObserver.ts
@@ -1,4 +1,4 @@
-import type { AllPerformanceEntry, ReplayContainer } from '../types';
+import type { ReplayContainer } from '../types';
 import { dedupePerformanceEntries } from '../util/dedupePerformanceEntries';
 
 /**
@@ -8,11 +8,7 @@ export function setupPerformanceObserver(replay: ReplayContainer): PerformanceOb
   const performanceObserverHandler = (list: PerformanceObserverEntryList): void => {
     // For whatever reason the observer was returning duplicate navigation
     // entries (the other entry types were not duplicated).
-    const newPerformanceEntries = dedupePerformanceEntries(
-      replay.performanceEvents,
-      list.getEntries() as AllPerformanceEntry[],
-    );
-    replay.performanceEvents = newPerformanceEntries;
+    replay.performanceEvents = dedupePerformanceEntries(list.getEntries());
   };
 
   const performanceObserver = new PerformanceObserver(performanceObserverHandler);

--- a/packages/replay/src/coreHandlers/performanceObserver.ts
+++ b/packages/replay/src/coreHandlers/performanceObserver.ts
@@ -8,7 +8,7 @@ export function setupPerformanceObserver(replay: ReplayContainer): PerformanceOb
   const performanceObserverHandler = (list: PerformanceObserverEntryList): void => {
     // For whatever reason the observer was returning duplicate navigation
     // entries (the other entry types were not duplicated).
-    replay.performanceEvents = dedupePerformanceEntries(list.getEntries());
+    replay.performanceEvents = dedupePerformanceEntries(list.getEntries(), replay.performanceEvents);
   };
 
   const performanceObserver = new PerformanceObserver(performanceObserverHandler);

--- a/packages/replay/src/util/dedupePerformanceEntries.ts
+++ b/packages/replay/src/util/dedupePerformanceEntries.ts
@@ -1,3 +1,21 @@
+function skipDuplicates(queue: PerformanceEntry[], curr: PerformanceEntry, pos: number): number {
+  let skipCount = 0;
+  let nextNode: PerformanceEntry = queue[pos + skipCount + 1];
+  while (
+    nextNode &&
+    // Cheap reference check first, then compare keys. Since entries are sorted by startTime, compare that first.
+    (nextNode === curr ||
+      (nextNode.startTime === curr.startTime &&
+        nextNode.duration === curr.duration &&
+        nextNode.name === curr.name &&
+        nextNode.entryType === curr.entryType &&
+        (nextNode as PerformanceResourceTiming).transferSize === (curr as PerformanceResourceTiming).transferSize))
+  ) {
+    skipCount++;
+    nextNode = queue[pos + skipCount + 1];
+  }
+  return skipCount;
+}
 /**
  * Deduplicates performance entries list - assumes a sorted list as input as per
  * the spec https://w3c.github.io/performance-timeline/#dom-performance-getentries.
@@ -11,58 +29,81 @@
  * @param list {PerformanceEntryList}
  * @returns PerformanceEntryList
  */
-export function dedupePerformanceEntries(list: PerformanceEntryList): PerformanceEntryList {
-  const deduped: PerformanceEntryList = [];
-  let lcpEntry: PerformancePaintTiming | undefined;
-
+// eslint-disable-next-line complexity
+export function dedupePerformanceEntries(
+  list: PerformanceEntryList,
+  previousList: PerformanceEntryList,
+): PerformanceEntryList {
   let i = 0;
-  while (i < list.length) {
-    const entry = list[i];
-    // Assign latest lcp entry if it is the latest entry
-    // or if we dont currently have an lcp entry
-    if (entry.entryType === 'largest-contentful-paint' && (!lcpEntry || entry.startTime > lcpEntry.startTime)) {
-      lcpEntry = entry;
+  let n = 0;
+
+  if (!list.length && !previousList.length) {
+    return [];
+  }
+
+  const next = (queue: string): void => {
+    if (queue === 'current') {
       i++;
+    } else {
+      n++;
+    }
+  };
+
+  const deduped: PerformanceEntryList = [];
+  let lcpEntryIndex: number | undefined;
+
+  while (i < list.length || n < previousList.length) {
+    const current = list[i];
+    const previous = previousList[n];
+
+    const queueType = !previous
+      ? 'current'
+      : !current
+      ? 'previous'
+      : list[i].startTime <= previousList[n].startTime
+      ? 'current'
+      : 'previous';
+
+    const entry = queueType === 'current' ? list[i] : previousList[n];
+
+    // Assign latest lcp entry if it is the latest entry
+    // or if we dont currently have an lcp entry.
+    if (entry.entryType === 'largest-contentful-paint') {
+      if (lcpEntryIndex === undefined || entry.startTime > deduped[lcpEntryIndex].startTime) {
+        if (lcpEntryIndex === undefined) {
+          deduped.push(entry);
+          lcpEntryIndex = deduped.length - 1;
+        } else {
+          deduped[lcpEntryIndex] = entry;
+        }
+      }
+      next(queueType);
       continue;
     }
 
     if (entry.entryType === 'navigation') {
       if (entry.duration <= 0) {
-        i++;
+        next(queueType);
         continue;
       }
 
       // By default, any entry is considered new and we peek ahead to see how many duplicates there are.
       // We can rely on the peek behavior as the spec states that entries are sorted by startTime. As we peek,
       // we keep a count of how many duplicates we see and skip over them.
-      let skipCount = 0;
-      let next: PerformanceEntry = list[i + skipCount + 1];
-      while (
-        next &&
-        // Cheap reference check first, then compare keys. Since entries are sorted by startTime, compare that first.
-        (next === entry ||
-          (next.startTime === entry.startTime &&
-            next.duration === entry.duration &&
-            next.name === entry.name &&
-            next.entryType === entry.entryType &&
-            (next as PerformanceResourceTiming).transferSize === (entry as PerformanceResourceTiming).transferSize))
-      ) {
-        skipCount++;
-        next = list[i + skipCount + 1];
-      }
+      const jumpToCurrent = skipDuplicates(list, entry, i);
+      const jumpToPrevious = skipDuplicates(previousList, entry, n);
 
       // Jump to next entry after the duplicates
-      i = i + 1 + skipCount;
+      i = jumpToCurrent ? jumpToCurrent + i + 1 : i + (queueType === 'current' ? 1 : 0);
+      n = jumpToPrevious ? jumpToPrevious + n + 1 : n + (queueType === 'previous' ? 1 : 0);
+
       deduped.push(entry);
       continue;
     }
 
     deduped.push(entry);
-    i++;
+    next(queueType);
   }
 
-  if (lcpEntry) {
-    deduped.push(lcpEntry);
-  }
   return deduped;
 }

--- a/packages/replay/test/unit/util/dedupePerformanceEntries.test.ts
+++ b/packages/replay/test/unit/util/dedupePerformanceEntries.test.ts
@@ -3,15 +3,19 @@ import { PerformanceEntryLcp } from './../../fixtures/performanceEntry/lcp';
 import { PerformanceEntryNavigation } from './../../fixtures/performanceEntry/navigation';
 import { PerformanceEntryResource } from './../../fixtures/performanceEntry/resource';
 
+function sortByTimeStamp(a: PerformanceEntry, b: PerformanceEntry) {
+  return a.startTime - b.startTime;
+}
+
 describe('Unit | util | dedupePerformanceEntries', () => {
   it('does nothing with a single entry', function () {
     const entries = [PerformanceEntryNavigation()];
-    expect(dedupePerformanceEntries([], entries)).toEqual(entries);
+    expect(dedupePerformanceEntries(entries)).toEqual(entries);
   });
 
   it('dedupes 2 duplicate entries correctly', function () {
     const entries = [PerformanceEntryNavigation(), PerformanceEntryNavigation()];
-    expect(dedupePerformanceEntries([], entries)).toEqual([entries[0]]);
+    expect(dedupePerformanceEntries(entries)).toEqual([entries[0]]);
   });
 
   it('dedupes multiple+mixed entries from new list', function () {
@@ -22,20 +26,8 @@ describe('Unit | util | dedupePerformanceEntries', () => {
     });
     const c = PerformanceEntryNavigation({ startTime: 2, type: 'reload' });
     const d = PerformanceEntryResource({ startTime: 1.5 });
-    const entries = [a, a, b, d, b, c];
-    expect(dedupePerformanceEntries([], entries)).toEqual([a, b, d, c]);
-  });
-
-  it('dedupes from initial list and new list', function () {
-    const a = PerformanceEntryNavigation({ startTime: 0 });
-    const b = PerformanceEntryNavigation({
-      startTime: 1,
-      name: 'https://foo.bar/',
-    });
-    const c = PerformanceEntryNavigation({ startTime: 2, type: 'reload' });
-    const d = PerformanceEntryNavigation({ startTime: 1000 });
-    const entries = [a, a, b, b, c];
-    expect(dedupePerformanceEntries([a, d], entries)).toEqual([a, b, c, d]);
+    const entries = [a, a, b, b, d, c];
+    expect(dedupePerformanceEntries(entries)).toEqual([a, b, d, c]);
   });
 
   it('selects the latest lcp value given multiple lcps in new list', function () {
@@ -43,8 +35,8 @@ describe('Unit | util | dedupePerformanceEntries', () => {
     const b = PerformanceEntryLcp({ startTime: 100, name: 'b' });
     const c = PerformanceEntryLcp({ startTime: 200, name: 'c' });
     const d = PerformanceEntryLcp({ startTime: 5, name: 'd' }); // don't assume they are ordered
-    const entries = [a, b, c, d];
-    expect(dedupePerformanceEntries([], entries)).toEqual([a, c]);
+    const entries = [a, b, c, d].sort(sortByTimeStamp);
+    expect(dedupePerformanceEntries(entries)).toEqual([a, c]);
   });
 
   it('selects the latest lcp value from new list, given multiple lcps in new list with an existing lcp', function () {
@@ -52,8 +44,8 @@ describe('Unit | util | dedupePerformanceEntries', () => {
     const b = PerformanceEntryLcp({ startTime: 100, name: 'b' });
     const c = PerformanceEntryLcp({ startTime: 200, name: 'c' });
     const d = PerformanceEntryLcp({ startTime: 5, name: 'd' }); // don't assume they are ordered
-    const entries = [b, c, d];
-    expect(dedupePerformanceEntries([a, d], entries)).toEqual([a, c]);
+    const entries = [a, b, c, d].sort(sortByTimeStamp);
+    expect(dedupePerformanceEntries(entries)).toEqual([a, c]);
   });
 
   it('selects the existing lcp value given multiple lcps in new list with an existing lcp having the latest startTime', function () {
@@ -61,7 +53,7 @@ describe('Unit | util | dedupePerformanceEntries', () => {
     const b = PerformanceEntryLcp({ startTime: 100, name: 'b' });
     const c = PerformanceEntryLcp({ startTime: 200, name: 'c' });
     const d = PerformanceEntryLcp({ startTime: 5, name: 'd' }); // don't assume they are ordered
-    const entries = [b, d];
-    expect(dedupePerformanceEntries([a, c], entries)).toEqual([a, c]);
+    const entries = [a, b, c, d].sort(sortByTimeStamp);
+    expect(dedupePerformanceEntries(entries)).toEqual([a, c]);
   });
 });

--- a/packages/replay/test/unit/util/dedupePerformanceEntries.test.ts
+++ b/packages/replay/test/unit/util/dedupePerformanceEntries.test.ts
@@ -35,8 +35,6 @@ describe('Unit | util | dedupePerformanceEntries', () => {
     const c = PerformanceEntryNavigation({ startTime: 2, type: 'reload' });
     const d = PerformanceEntryNavigation({ startTime: 1000 });
     const entries = [a, a, b, b, c].sort((a, b) => a.startTime - b.startTime);
-
-    const expected = dedupePerformanceEntries([a, d], entries);
     expect(dedupePerformanceEntries([a, d], entries)).toEqual([a, b, c, d]);
   });
 

--- a/packages/replay/test/unit/util/dedupePerformanceEntries.test.ts
+++ b/packages/replay/test/unit/util/dedupePerformanceEntries.test.ts
@@ -66,9 +66,9 @@ describe('Unit | util | dedupePerformanceEntries', () => {
   });
 
   it('dedupes when the list is the same', () => {
-    const a = PerformanceEntryNavigation({startTime: Number.NEGATIVE_INFINITY});
+    const a = PerformanceEntryNavigation({ startTime: Number.NEGATIVE_INFINITY });
     expect(dedupePerformanceEntries([a], [a])).toEqual([a]);
-  })
+  });
 
   it('does not spin forever in weird edge cases', function () {
     expect(dedupePerformanceEntries([], [])).toEqual([]);
@@ -78,22 +78,27 @@ describe('Unit | util | dedupePerformanceEntries', () => {
       Math.floor(Math.random() * (max - min + 1)) + min;
 
     const starts = [-100, 0, 100, Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY, NaN, undefined];
-    const entries = [PerformanceEntryLcp, PerformanceEntryNavigation, PerformanceEntryResource]
+    const entries = [PerformanceEntryLcp, PerformanceEntryNavigation, PerformanceEntryResource];
 
-    for(let i = 0; i < 100; i++) {
-      const previousEntries: any[] = []
-      const currEntries: any[] = []
-      for(let j = 0; j < randomNumberBetweenInclusive(0, 10); j++) {
+    for (let i = 0; i < 100; i++) {
+      const previousEntries: any[] = [];
+      const currEntries: any[] = [];
+      for (let j = 0; j < randomNumberBetweenInclusive(0, 10); j++) {
         // @ts-expect-error
-        previousEntries.push(randomFrom(entries)({ startTime: randomFrom(starts)}));
+        previousEntries.push(randomFrom(entries)({ startTime: randomFrom(starts) }));
       }
-      for(let j = 0; j < randomNumberBetweenInclusive(0, 10); j++) {
+      for (let j = 0; j < randomNumberBetweenInclusive(0, 10); j++) {
         // @ts-expect-error
-        currEntries.push(randomFrom(entries)({ startTime: randomFrom(starts)}));
+        currEntries.push(randomFrom(entries)({ startTime: randomFrom(starts) }));
       }
 
-      expect(() => dedupePerformanceEntries(previousEntries, currEntries)).not.toThrow()
-      expect(() => dedupePerformanceEntries(previousEntries.sort((a,b) => a.startTime - b.startTime), currEntries.sort((a,b) => a.startTime - b.startTime))).not.toThrow()
+      expect(() => dedupePerformanceEntries(previousEntries, currEntries)).not.toThrow();
+      expect(() =>
+        dedupePerformanceEntries(
+          previousEntries.sort((a, b) => a.startTime - b.startTime),
+          currEntries.sort((a, b) => a.startTime - b.startTime),
+        ),
+      ).not.toThrow();
     }
-  })
+  });
 });


### PR DESCRIPTION
dedupePerformanceEntries showed up in a couple of browser profiles so I took the liberty of optimizing it. Since [perf buffer registries](https://w3c.github.io/timing-entrytypes-registry/#registry) can grow large in cases of SPA's, the execution time will grow and could become a bottleneck (this is still the case after my change)

The optimization relies on the fact that entries are [sorted by startTime](https://w3c.github.io/performance-timeline/#filter-buffer-map-by-name-and-type) - since the list is sorted, we can do this in On vs On^2 time as we do not need to check the entire list of entries for duplicates, but we can just check the range of value i<x<=list size. 

A possible further optimization would be to only query performance for getEntriesByType(navigation) and only dedupe those (same for LCP), which would allow us to skip iterating over elements that we are not detecting duplicates for anyways.

I ran a quick benchmark and confirmed the new dedupe is ~85% faster (on an input of ~200 perf entries)

Side note: since it seems that some perf registries are unbounded, it might make sense to add some safeguarding in place to guard from very large lists or prioritize certain entries over others.