### PR TITLE
fix: Defer tracing decision to downstream SDKs when using SDK without performance

### DIFF
--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -1,5 +1,4 @@
 /* eslint-disable max-lines */
-import { updateSession } from './session';
 import type {
   Attachment,
   Breadcrumb,
@@ -33,6 +32,8 @@ import {
   SyncPromise,
   uuid4,
 } from '@sentry/utils';
+
+import { updateSession } from './session';
 
 /**
  * Default value for maximum number of breadcrumbs added to an event.

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+import { updateSession } from './session';
 import type {
   Attachment,
   Breadcrumb,
@@ -32,8 +33,6 @@ import {
   SyncPromise,
   uuid4,
 } from '@sentry/utils';
-
-import { updateSession } from './session';
 
 /**
  * Default value for maximum number of breadcrumbs added to an event.
@@ -636,6 +635,5 @@ function generatePropagationContext(): PropagationContext {
   return {
     traceId: uuid4(),
     spanId: uuid4().substring(16),
-    sampled: false,
   };
 }

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -20,7 +20,7 @@ describe('Scope', () => {
       expect(scope._propagationContext).toEqual({
         traceId: expect.any(String),
         spanId: expect.any(String),
-        sampled: false,
+        sampled: undefined,
         dsc: undefined,
         parentSpanId: undefined,
       });
@@ -442,7 +442,7 @@ describe('Scope', () => {
     expect(scope._propagationContext).toEqual({
       traceId: expect.any(String),
       spanId: expect.any(String),
-      sampled: false,
+      sampled: undefined,
     });
     // @ts-expect-error accessing private property
     expect(scope._propagationContext).not.toEqual(oldPropagationContext);

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -208,10 +208,11 @@ describe('tracing', () => {
     const baggageHeader = request.getHeader('baggage') as string;
 
     const parts = sentryTraceHeader.split('-');
-    expect(parts.length).toEqual(3);
+
+    // Should not include sampling decision since we don't wanna influence the tracing decisions downstream
+    expect(parts.length).toEqual(2);
     expect(parts[0]).toEqual(traceId);
     expect(parts[1]).toEqual(expect.any(String));
-    expect(parts[2]).toEqual('0');
 
     expect(baggageHeader).toEqual(
       `sentry-environment=production,sentry-release=1.0.0,sentry-user_segment=segmentA,sentry-public_key=dogsarebadatkeepingsecrets,sentry-trace_id=${traceId}`,

--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -1,9 +1,4 @@
 /* eslint-disable max-lines */
-import type { Hub, IdleTransaction } from '@sentry/core';
-import { addTracingExtensions, getActiveTransaction, startIdleTransaction, TRACING_DEFAULTS } from '@sentry/core';
-import type { EventProcessor, Integration, Transaction, TransactionContext, TransactionSource } from '@sentry/types';
-import { getDomElement, logger, tracingContextFromHeaders } from '@sentry/utils';
-
 import { registerBackgroundTabDetection } from './backgroundtab';
 import {
   addPerformanceEntries,
@@ -15,6 +10,10 @@ import type { RequestInstrumentationOptions } from './request';
 import { defaultRequestInstrumentationOptions, instrumentOutgoingRequests } from './request';
 import { instrumentRoutingWithDefaults } from './router';
 import { WINDOW } from './types';
+import type { Hub, IdleTransaction } from '@sentry/core';
+import { addTracingExtensions, getActiveTransaction, startIdleTransaction, TRACING_DEFAULTS } from '@sentry/core';
+import type { EventProcessor, Integration, Transaction, TransactionContext, TransactionSource } from '@sentry/types';
+import { getDomElement, logger, tracingContextFromHeaders } from '@sentry/utils';
 
 export const BROWSER_TRACING_INTEGRATION_ID = 'BrowserTracing';
 
@@ -363,7 +362,7 @@ export class BrowserTracing implements Integration {
         traceId: idleTransaction.traceId,
         spanId: idleTransaction.spanId,
         parentSpanId: idleTransaction.parentSpanId,
-        sampled: !!idleTransaction.sampled,
+        sampled: idleTransaction.sampled,
       });
     }
 

--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -1,4 +1,9 @@
 /* eslint-disable max-lines */
+import type { Hub, IdleTransaction } from '@sentry/core';
+import { addTracingExtensions, getActiveTransaction, startIdleTransaction, TRACING_DEFAULTS } from '@sentry/core';
+import type { EventProcessor, Integration, Transaction, TransactionContext, TransactionSource } from '@sentry/types';
+import { getDomElement, logger, tracingContextFromHeaders } from '@sentry/utils';
+
 import { registerBackgroundTabDetection } from './backgroundtab';
 import {
   addPerformanceEntries,
@@ -10,10 +15,6 @@ import type { RequestInstrumentationOptions } from './request';
 import { defaultRequestInstrumentationOptions, instrumentOutgoingRequests } from './request';
 import { instrumentRoutingWithDefaults } from './router';
 import { WINDOW } from './types';
-import type { Hub, IdleTransaction } from '@sentry/core';
-import { addTracingExtensions, getActiveTransaction, startIdleTransaction, TRACING_DEFAULTS } from '@sentry/core';
-import type { EventProcessor, Integration, Transaction, TransactionContext, TransactionSource } from '@sentry/types';
-import { getDomElement, logger, tracingContextFromHeaders } from '@sentry/utils';
 
 export const BROWSER_TRACING_INTEGRATION_ID = 'BrowserTracing';
 

--- a/packages/types/src/tracing.ts
+++ b/packages/types/src/tracing.ts
@@ -5,7 +5,7 @@ export type TracePropagationTargets = (string | RegExp)[];
 export interface PropagationContext {
   traceId: string;
   spanId: string;
-  sampled: boolean;
+  sampled?: boolean;
   parentSpanId?: string;
   dsc?: DynamicSamplingContext;
 }

--- a/packages/utils/src/tracing.ts
+++ b/packages/utils/src/tracing.ts
@@ -1,7 +1,6 @@
-import type { DynamicSamplingContext, PropagationContext, TraceparentData } from '@sentry/types';
-
 import { baggageHeaderToDynamicSamplingContext } from './baggage';
 import { uuid4 } from './misc';
+import type { DynamicSamplingContext, PropagationContext, TraceparentData } from '@sentry/types';
 
 export const TRACEPARENT_REGEXP = new RegExp(
   '^[ \\t]*' + // whitespace
@@ -61,7 +60,7 @@ export function tracingContextFromHeaders(
   const propagationContext: PropagationContext = {
     traceId: traceId || uuid4(),
     spanId: uuid4().substring(16),
-    sampled: parentSampled === undefined ? false : parentSampled,
+    sampled: parentSampled,
   };
 
   if (parentSpanId) {

--- a/packages/utils/src/tracing.ts
+++ b/packages/utils/src/tracing.ts
@@ -1,6 +1,7 @@
+import type { DynamicSamplingContext, PropagationContext, TraceparentData } from '@sentry/types';
+
 import { baggageHeaderToDynamicSamplingContext } from './baggage';
 import { uuid4 } from './misc';
-import type { DynamicSamplingContext, PropagationContext, TraceparentData } from '@sentry/types';
 
 export const TRACEPARENT_REGEXP = new RegExp(
   '^[ \\t]*' + // whitespace


### PR DESCRIPTION
Currently, since the introduction of "Tracing without Performance", we always set a negative sampling decision on the tracing context when there is not an active transaction. This could get problematic because we might overrule the sampling decisions for all downstream SDKs when there are no active transactions and when we're the head-SDK.

[Per spec](https://develop.sentry.dev/sdk/performance/#header-sentry-trace), it is allowed to leave away the sampling decision in the `sentry-trace` header. The use-case for this is to defer the sampling decision, which is exactly what we want to do.