### PR TITLE
build: Fix order for `build:dev` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build": "node ./scripts/verify-packages-versions.js && run-s build:types build:transpile build:bundle",
     "build:bundle": "lerna run build:bundle",
-    "build:dev": "lerna run build:types,build:transpile",
+    "build:dev": " run-s build:types build:transpile",
     "build:dev:filter": "lerna run build:dev --include-filtered-dependencies --include-filtered-dependents --scope",
     "build:transpile": "lerna run build:transpile",
     "build:types": "lerna run build:types",


### PR DESCRIPTION
We actually rely on types being built before transpiling, so we cannot parallelize this - this fails if running this from an unbuilt project.