### PR TITLE
build(angular): Fix Nx dependency graph for Angular

### DIFF
--- a/packages/angular-ivy/package.json
+++ b/packages/angular-ivy/package.json
@@ -61,5 +61,16 @@
   "volta": {
     "extends": "../../package.json"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "nx": {
+    "targets": {
+      "build:transpile": {
+        "dependsOn": [
+          "^build:transpile",
+          "^build:transpile:uncached",
+          "^build:types"
+        ]
+      }
+    }
+  }
 }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -65,5 +65,16 @@
   "volta": {
     "extends": "../../package.json"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "nx": {
+    "targets": {
+      "build:transpile": {
+        "dependsOn": [
+          "^build:transpile",
+          "^build:transpile:uncached",
+          "^build:types"
+        ]
+      }
+    }
+  }
 }


### PR DESCRIPTION
Angular `build:transpile` actually depends on types, so we need to reflect that - otherwise, `yarn build:dev` fails if no types are built yet.

Steps to reproduce:

```sh
yarn clean
yarn build:dev
```

Used to fail before this.

Supersedes https://github.com/getsentry/sentry-javascript/pull/8840