### PR TITLE
fix(node): Use `finish` event instead of patching `res.end`

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -143,20 +143,6 @@ export function requestHandler(
     res: http.ServerResponse,
     next: (error?: any) => void,
   ): void {
-    if (options && options.flushTimeout && options.flushTimeout > 0) {
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      const _end = res.end;
-      res.end = function (chunk?: any | (() => void), encoding?: string | (() => void), cb?: () => void): void {
-        void flush(options.flushTimeout)
-          .then(() => {
-            _end.call(this, chunk, encoding, cb);
-          })
-          .then(null, e => {
-            DEBUG_BUILD && logger.error(e);
-            _end.call(this, chunk, encoding, cb);
-          });
-      };
-    }
     return withIsolationScope(isolationScope => {
       isolationScope.setSDKProcessingMetadata({
         request: req,
@@ -179,6 +165,12 @@ export function requestHandler(
               // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
               (client as any)._captureRequestSession();
             }
+          });
+        }
+
+        if (options && options.flushTimeout && options.flushTimeout > 0) {
+          void flush(options.flushTimeout).then(null, e => {
+            DEBUG_BUILD && logger.error(e);
           });
         }
       });

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -148,6 +148,7 @@ describe('requestHandler', () => {
     const sentryRequestMiddleware = requestHandler({ flushTimeout: 1337 });
     sentryRequestMiddleware(req, res, next);
     res.end('ok');
+    res.emit('finish');
 
     setImmediate(() => {
       expect(flush).toHaveBeenCalledWith(1337);
@@ -162,6 +163,7 @@ describe('requestHandler', () => {
     const sentryRequestMiddleware = requestHandler({ flushTimeout: 1337 });
     sentryRequestMiddleware(req, res, next);
     res.end('ok');
+    res.emit('finish');
 
     setImmediate(() => {
       expect(res.finished).toBe(true);

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -68,25 +68,15 @@ function _wrapHttpFunction(fn: HttpFunction, options: Partial<WrapperOptions>): 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
             (res as any).__sentry_transaction = span;
           }
-
-          // eslint-disable-next-line @typescript-eslint/unbound-method
-          const _end = res.end;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          res.end = function (chunk?: any | (() => void), encoding?: string | (() => void), cb?: () => void): any {
+          res.once('finish', (): void => {
             if (span) {
               setHttpStatus(span, res.statusCode);
               span.end();
             }
-
-            // eslint-disable-next-line @typescript-eslint/no-floating-promises
-            flush(flushTimeout)
-              .then(null, e => {
-                DEBUG_BUILD && logger.error(e);
-              })
-              .then(() => {
-                _end.call(this, chunk, encoding, cb);
-              });
-          };
+            void flush(options.flushTimeout).then(null, (e: unknown) => {
+              DEBUG_BUILD && logger.error(e);
+            });
+          });
 
           return handleCallbackErrors(
             () => fn(req, res),


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Closes https://github.com/getsentry/sentry-javascript/issues/8848
