### PR TITLE
chore(repo): Fix Package: SvelteKit/Svelte label assignment workflow

### DIFF
--- a/.github/workflows/issue-package-label.yml
+++ b/.github/workflows/issue-package-label.yml
@@ -62,11 +62,11 @@ jobs:
               "@sentry.serverless": {
                 "label": "Package: Serverless"
               },
-              "@sentry.svelte": {
-                "label": "Package: svelte"
-              },
               "@sentry.sveltekit": {
                 "label": "Package: SvelteKit"
+              },
+              "@sentry.svelte": {
+                "label": "Package: svelte"
               },
               "@sentry.vue": {
                 "label": "Package: vue"


### PR DESCRIPTION
New SvelteKit issues were assigned the `Package: Svelte` label instead of `Package: Sveltekit`. Changing the order of the GHA check regexes _should_ fix this. 
