### PR TITLE
ref(tracing-internal): Deprecate `tracePropagationTargets` in `BrowserTracing`

### DIFF
--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -34,6 +34,8 @@ interface TracingOptions {
    * array, and only attach tracing headers if a match was found.
    *
    * @deprecated Use top level `tracePropagationTargets` option instead.
+   * This option will be removed in v8.
+   *
    * ```
    * Sentry.init({
    *   tracePropagationTargets: ['api.site.com'],

--- a/packages/sveltekit/test/client/sdk.test.ts
+++ b/packages/sveltekit/test/client/sdk.test.ts
@@ -109,9 +109,7 @@ describe('Sentry client SDK', () => {
       it('Merges a user-provided BrowserTracing integration with the automatically added one', () => {
         init({
           dsn: 'https://public@dsn.ingest.sentry.io/1337',
-          integrations: [
-            new BrowserTracing({ tracePropagationTargets: ['myDomain.com'], startTransactionOnLocationChange: false }),
-          ],
+          integrations: [new BrowserTracing({ finalTimeout: 10, startTransactionOnLocationChange: false })],
           enableTracing: true,
         });
 
@@ -126,8 +124,7 @@ describe('Sentry client SDK', () => {
         expect(browserTracing).toBeDefined();
 
         // This shows that the user-configured options are still here
-        expect(options.tracePropagationTargets).toEqual(['myDomain.com']);
-        expect(options.startTransactionOnLocationChange).toBe(false);
+        expect(options.finalTimeout).toEqual(10);
 
         // But we force the routing instrumentation to be ours
         expect(options.routingInstrumentation).toEqual(svelteKitRoutingInstrumentation);

--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -248,6 +248,7 @@ export class BrowserTracing implements Integration {
     // This is done as it minimizes bundle size (we don't have to have undefined checks).
     //
     // If both 1 and either one of 2 or 3 are set (from above), we log out a warning.
+    // eslint-disable-next-line deprecation/deprecation
     const tracePropagationTargets = clientOptionsTracePropagationTargets || this.options.tracePropagationTargets;
     if (__DEBUG_BUILD__ && this._hasSetTracePropagationTargets && clientOptionsTracePropagationTargets) {
       logger.warn(

--- a/packages/tracing-internal/src/browser/request.ts
+++ b/packages/tracing-internal/src/browser/request.ts
@@ -27,6 +27,9 @@ export interface RequestInstrumentationOptions {
    * List of strings and/or regexes used to determine which outgoing requests will have `sentry-trace` and `baggage`
    * headers attached.
    *
+   * @deprecated Use top-level `tracePropagationTargets` option in `Sentry.init` instead.
+   * This option will be removed in v8.
+   *
    * Default: ['localhost', /^\//] {@see DEFAULT_TRACE_PROPAGATION_TARGETS}
    */
   tracePropagationTargets: Array<string | RegExp>;

--- a/packages/tracing-internal/src/browser/request.ts
+++ b/packages/tracing-internal/src/browser/request.ts
@@ -27,7 +27,7 @@ export interface RequestInstrumentationOptions {
    * List of strings and/or regexes used to determine which outgoing requests will have `sentry-trace` and `baggage`
    * headers attached.
    *
-   * @deprecated Use top-level `tracePropagationTargets` option in `Sentry.init` instead.
+   * @deprecated Use the top-level `tracePropagationTargets` option in `Sentry.init` instead.
    * This option will be removed in v8.
    *
    * Default: ['localhost', /^\//] @see {DEFAULT_TRACE_PROPAGATION_TARGETS}

--- a/packages/tracing-internal/src/browser/request.ts
+++ b/packages/tracing-internal/src/browser/request.ts
@@ -128,6 +128,7 @@ export function instrumentOutgoingRequests(_options?: Partial<RequestInstrumenta
   const {
     traceFetch,
     traceXHR,
+    // eslint-disable-next-line deprecation/deprecation
     tracePropagationTargets,
     // eslint-disable-next-line deprecation/deprecation
     tracingOrigins,

--- a/packages/tracing-internal/src/browser/request.ts
+++ b/packages/tracing-internal/src/browser/request.ts
@@ -30,7 +30,7 @@ export interface RequestInstrumentationOptions {
    * @deprecated Use top-level `tracePropagationTargets` option in `Sentry.init` instead.
    * This option will be removed in v8.
    *
-   * Default: ['localhost', /^\//] {@see DEFAULT_TRACE_PROPAGATION_TARGETS}
+   * Default: ['localhost', /^\//] @see {DEFAULT_TRACE_PROPAGATION_TARGETS}
    */
   tracePropagationTargets: Array<string | RegExp>;
 


### PR DESCRIPTION
This PR deprecates `BrowserTracing`'s `tracePropagationTargets` option in favour of the top-level Sentry.init option. 

When introducing Tracing without Performance, we opted to [promote `tracePropagationTargets` to a top-level option](https://github.com/getsentry/sentry-javascript/pull/8395). We deprecated the integration-level option in Node's `Http` integration but not in `BrowserTracing`. This PR fixes that.

I also adjusted #6230 accordingly

(+ some minor JSdoc adjustments)


closes #8851 