### PR TITLE
fix(nextjs): Fix `requestAsyncStorageShim` path resolution on windows

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -13,6 +13,16 @@
   "module": "build/esm/index.server.js",
   "browser": "build/esm/index.client.js",
   "types": "build/types/index.types.d.ts",
+  "exports": {
+    ".": {
+      "import": "./build/esm/index.server.js",
+      "require": "./build/cjs/index.server.js",
+      "types": "./build/types/index.types.d.ts"
+    },
+    "./requestAsyncStorageShim": {
+      "import": "./build/esm/config/templates/requestAsyncStorageShim.js"
+    }
+  },
   "typesVersions": {
     "<4.9": {
       "build/npm/types/index.d.ts": [

--- a/packages/nextjs/src/config/loaders/wrappingLoader.ts
+++ b/packages/nextjs/src/config/loaders/wrappingLoader.ts
@@ -26,7 +26,6 @@ const pageWrapperTemplateCode = fs.readFileSync(pageWrapperTemplatePath, { encod
 const middlewareWrapperTemplatePath = path.resolve(__dirname, '..', 'templates', 'middlewareWrapperTemplate.js');
 const middlewareWrapperTemplateCode = fs.readFileSync(middlewareWrapperTemplatePath, { encoding: 'utf8' });
 
-const requestAsyncStorageShimPath = path.resolve(__dirname, '..', 'templates', 'requestAsyncStorageShim.js');
 const requestAsyncStorageModuleExists = moduleExists(NEXTJS_REQUEST_ASYNC_STORAGE_MODULE_PATH);
 let showedMissingAsyncStorageModuleWarning = false;
 
@@ -190,7 +189,10 @@ export default function wrappingLoader(
         );
         showedMissingAsyncStorageModuleWarning = true;
       }
-      templateCode = templateCode.replace(/__SENTRY_NEXTJS_REQUEST_ASYNC_STORAGE_SHIM__/g, requestAsyncStorageShimPath);
+      templateCode = templateCode.replace(
+        /__SENTRY_NEXTJS_REQUEST_ASYNC_STORAGE_SHIM__/g,
+        '@sentry/nextjs/requestAsyncStorageShim',
+      );
     }
 
     templateCode = templateCode.replace(/__ROUTE__/g, parameterizedPagesRoute.replace(/\\/g, '\\\\'));


### PR DESCRIPTION
Fixes build error reported in https://github.com/getsentry/sentry-javascript/issues/8133#issuecomment-1689040367