### PR TITLE
fix(node): Log entire error object in OnUncaughtException

### DIFF
--- a/packages/node-integration-tests/suites/public-api/OnUncaughtException/log-entire-error-to-console.js
+++ b/packages/node-integration-tests/suites/public-api/OnUncaughtException/log-entire-error-to-console.js
@@ -1,0 +1,7 @@
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+});
+
+throw new Error('foo', { cause: 'bar' });

--- a/packages/node-integration-tests/suites/public-api/OnUncaughtException/test.ts
+++ b/packages/node-integration-tests/suites/public-api/OnUncaughtException/test.ts
@@ -28,6 +28,18 @@ describe('OnUncaughtException integration', () => {
     });
   });
 
+  test('should log entire error object to console stderr', done => {
+    expect.assertions(1);
+
+    const testScriptPath = path.resolve(__dirname, 'log-entire-error-to-console.js');
+
+    childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (err, stdout, stderr) => {
+      expect(stderr).toEqual(expect.stringMatching(/Error: foo(\n.*)+ \[cause\]: 'bar'/gm));
+
+      done();
+    });
+  });
+
   describe('with `exitEvenIfOtherHandlersAreRegistered` set to false', () => {
     test('should close process on uncaught error with no additional listeners registered', done => {
       expect.assertions(3);

--- a/packages/node/src/integrations/utils/errorhandling.ts
+++ b/packages/node/src/integrations/utils/errorhandling.ts
@@ -10,7 +10,7 @@ const DEFAULT_SHUTDOWN_TIMEOUT = 2000;
  */
 export function logAndExitProcess(error: Error): void {
   // eslint-disable-next-line no-console
-  console.error(error && error.stack ? error.stack : error);
+  console.error(error);
 
   const client = getCurrentHub().getClient<NodeClient>();
 


### PR DESCRIPTION
In our `OnUncaughtException` integration, we have to emulate Node's default behaviour of logging errors to the console. 
For some reason though, we only logged the stack trace of an `error` with a stack trace instead of the entire error object. 

As reported in #8856, this causes additional properties on the error (such as `cause`) not to be logged anymore which doesn't reflect Node's default behaviour (see issue for comparison). This PR simplifies the `console.error` call to just always log the entire `error`.

I tried tracing back why we do this but it seems like we added this when moving from `raven-node` to `@sentry/node`. I didn't find this before in Raven and there's no explanation as to why we started doing it in @sentry/node. So I guess it should be fine to change this. 

Side-node: As already mentioned in  https://github.com/getsentry/sentry-javascript/issues/1661#issuecomment-1068543675, we should consider moving to [`UnhandledExceptionMonitor`](https://nodejs.org/api/process.html#event-uncaughtexceptionmonitor) in v8, especially if we drop Node <12 support. 

closes #8856