### PR TITLE
ref: Avoid using global singleton for logger

### DIFF
--- a/packages/browser-integration-tests/suites/public-api/debug/init.js
+++ b/packages/browser-integration-tests/suites/public-api/debug/init.js
@@ -1,0 +1,8 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  debug: true,
+});

--- a/packages/browser-integration-tests/suites/public-api/debug/test.ts
+++ b/packages/browser-integration-tests/suites/public-api/debug/test.ts
@@ -5,6 +5,9 @@ import { expect } from '@playwright/test';
 import { sentryTest } from '../../../utils/fixtures';
 
 sentryTest('logs debug messages correctly', async ({ getLocalTestUrl, page }) => {
+  const bundleKey = process.env.PW_BUNDLE || '';
+  const hasDebug = !bundleKey.includes('_min');
+
   const url = await getLocalTestUrl({ testDir: __dirname });
 
   const consoleMessages: string[] = [];
@@ -17,18 +20,22 @@ sentryTest('logs debug messages correctly', async ({ getLocalTestUrl, page }) =>
 
   await page.evaluate(() => console.log('test log'));
 
-  expect(consoleMessages).toEqual([
-    'Sentry Logger [log]: Integration installed: InboundFilters',
-    'Sentry Logger [log]: Integration installed: FunctionToString',
-    'Sentry Logger [log]: Integration installed: TryCatch',
-    'Sentry Logger [log]: Integration installed: Breadcrumbs',
-    'Sentry Logger [log]: Global Handler attached: onerror',
-    'Sentry Logger [log]: Global Handler attached: onunhandledrejection',
-    'Sentry Logger [log]: Integration installed: GlobalHandlers',
-    'Sentry Logger [log]: Integration installed: LinkedErrors',
-    'Sentry Logger [log]: Integration installed: Dedupe',
-    'Sentry Logger [log]: Integration installed: HttpContext',
-    'Sentry Logger [warn]: Discarded session because of missing or non-string release',
-    'test log',
-  ]);
+  expect(consoleMessages).toEqual(
+    hasDebug
+      ? [
+          'Sentry Logger [log]: Integration installed: InboundFilters',
+          'Sentry Logger [log]: Integration installed: FunctionToString',
+          'Sentry Logger [log]: Integration installed: TryCatch',
+          'Sentry Logger [log]: Integration installed: Breadcrumbs',
+          'Sentry Logger [log]: Global Handler attached: onerror',
+          'Sentry Logger [log]: Global Handler attached: onunhandledrejection',
+          'Sentry Logger [log]: Integration installed: GlobalHandlers',
+          'Sentry Logger [log]: Integration installed: LinkedErrors',
+          'Sentry Logger [log]: Integration installed: Dedupe',
+          'Sentry Logger [log]: Integration installed: HttpContext',
+          'Sentry Logger [warn]: Discarded session because of missing or non-string release',
+          'test log',
+        ]
+      : ['[Sentry] Cannot initialize SDK with `debug` option using a non-debug bundle.', 'test log'],
+  );
 });

--- a/packages/browser-integration-tests/suites/public-api/debug/test.ts
+++ b/packages/browser-integration-tests/suites/public-api/debug/test.ts
@@ -1,0 +1,34 @@
+/* eslint-disable no-console */
+import type { ConsoleMessage } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../utils/fixtures';
+
+sentryTest('logs debug messages correctly', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
+
+  const consoleMessages: string[] = [];
+
+  page.on('console', (msg: ConsoleMessage) => {
+    consoleMessages.push(msg.text());
+  });
+
+  await page.goto(url);
+
+  await page.evaluate(() => console.log('test log'));
+
+  expect(consoleMessages).toEqual([
+    'Sentry Logger [log]: Integration installed: InboundFilters',
+    'Sentry Logger [log]: Integration installed: FunctionToString',
+    'Sentry Logger [log]: Integration installed: TryCatch',
+    'Sentry Logger [log]: Integration installed: Breadcrumbs',
+    'Sentry Logger [log]: Global Handler attached: onerror',
+    'Sentry Logger [log]: Global Handler attached: onunhandledrejection',
+    'Sentry Logger [log]: Integration installed: GlobalHandlers',
+    'Sentry Logger [log]: Integration installed: LinkedErrors',
+    'Sentry Logger [log]: Integration installed: Dedupe',
+    'Sentry Logger [log]: Integration installed: HttpContext',
+    'Sentry Logger [warn]: Discarded session because of missing or non-string release',
+    'test log',
+  ]);
+});

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -9,6 +9,7 @@ describe('Scope', () => {
   afterEach(() => {
     jest.resetAllMocks();
     jest.useRealTimers();
+    GLOBAL_OBJ.__SENTRY__ = GLOBAL_OBJ.__SENTRY__ || {};
     GLOBAL_OBJ.__SENTRY__.globalEventProcessors = undefined;
   });
 

--- a/packages/integrations/test/captureconsole.test.ts
+++ b/packages/integrations/test/captureconsole.test.ts
@@ -1,7 +1,13 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import type { Event, Hub, Integration } from '@sentry/types';
 import type { ConsoleLevel } from '@sentry/utils';
-import { addInstrumentationHandler, CONSOLE_LEVELS, GLOBAL_OBJ, originalConsoleMethods } from '@sentry/utils';
+import {
+  addInstrumentationHandler,
+  CONSOLE_LEVELS,
+  GLOBAL_OBJ,
+  originalConsoleMethods,
+  resetInstrumentationHandlers,
+} from '@sentry/utils';
 
 import { CaptureConsole } from '../src/captureconsole';
 
@@ -54,6 +60,8 @@ describe('CaptureConsole setup', () => {
     CONSOLE_LEVELS.forEach(key => {
       originalConsoleMethods[key] = _originalConsoleMethods[key];
     });
+
+    resetInstrumentationHandlers();
   });
 
   describe('monkeypatching', () => {

--- a/packages/replay/test/mocks/resetSdkMock.ts
+++ b/packages/replay/test/mocks/resetSdkMock.ts
@@ -1,3 +1,6 @@
+import type { EventProcessor } from '@sentry/types';
+import { getGlobalSingleton, resetInstrumentationHandlers } from '@sentry/utils';
+
 import type { Replay as ReplayIntegration } from '../../src';
 import type { ReplayContainer } from '../../src/replay';
 import type { RecordMock } from './../index';
@@ -17,9 +20,11 @@ export async function resetSdkMock({ replayOptions, sentryOptions, autoStart }: 
   jest.setSystemTime(new Date(BASE_TIMESTAMP));
   jest.clearAllMocks();
   jest.resetModules();
-  // NOTE: The listeners added to `addInstrumentationHandler` are leaking
-  // @ts-ignore Don't know if there's a cleaner way to clean up old event processors
-  globalThis.__SENTRY__.globalEventProcessors = [];
+
+  // Clear all handlers that have been registered
+  resetInstrumentationHandlers();
+  getGlobalSingleton<EventProcessor[]>('globalEventProcessors', () => []).length = 0;
+
   const SentryUtils = await import('@sentry/utils');
   jest.spyOn(SentryUtils, 'addInstrumentationHandler').mockImplementation((type, handler: (args: any) => any) => {
     if (type === 'dom') {

--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -94,6 +94,16 @@ export function addInstrumentationHandler(type: InstrumentHandlerType, callback:
   instrument(type);
 }
 
+/**
+ * Reset all instrumentation handlers.
+ * This can be used by tests to ensure we have a clean slate of instrumentation handlers.
+ */
+export function resetInstrumentationHandlers(): void {
+  Object.keys(handlers).forEach(key => {
+    handlers[key as InstrumentHandlerType] = undefined;
+  });
+}
+
 /** JSDoc */
 function triggerHandlers(type: InstrumentHandlerType, data: any): void {
   if (!type || !handlers[type]) {

--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -11,7 +11,7 @@ import type {
 
 import { isString } from './is';
 import type { ConsoleLevel } from './logger';
-import { CONSOLE_LEVELS, logger } from './logger';
+import { CONSOLE_LEVELS, logger, originalConsoleMethods } from './logger';
 import { fill } from './object';
 import { getFunctionName } from './stacktrace';
 import { supportsHistory, supportsNativeFetch } from './supports';
@@ -122,11 +122,6 @@ function triggerHandlers(type: InstrumentHandlerType, data: any): void {
     }
   }
 }
-
-/** Only exported for testing & debugging. */
-export const originalConsoleMethods: {
-  [key in ConsoleLevel]?: (...args: any[]) => void;
-} = {};
 
 /** JSDoc */
 function instrumentConsole(): void {

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -1,4 +1,3 @@
-import { originalConsoleMethods } from './instrument';
 import { GLOBAL_OBJ } from './worldwide';
 
 /** Prefix for logging strings */
@@ -9,6 +8,12 @@ export type ConsoleLevel = (typeof CONSOLE_LEVELS)[number];
 
 type LoggerMethod = (...args: unknown[]) => void;
 type LoggerConsoleMethods = Record<ConsoleLevel, LoggerMethod>;
+
+/** This may be mutated by the console instrumentation. */
+export const originalConsoleMethods: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key in ConsoleLevel]?: (...args: any[]) => void;
+} = {};
 
 /** JSDoc */
 interface Logger extends LoggerConsoleMethods {


### PR DESCRIPTION
Instead of https://github.com/getsentry/sentry-javascript/pull/8873, this tries to simplify the logger to avoid the global lookup.
If you have more than one utils, having multiple loggers would be the least of your problems. So IMHO no need to special case handle this, in the worst case logging should still work somehow 🤔 

Note some test code seems to rely on the global stuff the logger does, which required minor changes there.
This now relies on the `originalConsoleMethods` we keep in the console instrumentation, so no need to look for `__sentry_original__` anymore. If that doesn't exist, nothing to do for us (because we haven't instrumented the console).

Closes https://github.com/getsentry/sentry-javascript/issues/8741