### PR TITLE
fix(sveltekit): Ensure target file exists before applying auto instrumentation

### DIFF
--- a/packages/sveltekit/src/vite/autoInstrument.ts
+++ b/packages/sveltekit/src/vite/autoInstrument.ts
@@ -90,6 +90,12 @@ export function makeAutoInstrumentationPlugin(options: AutoInstrumentPluginOptio
  * @returns `true` if we can wrap the given file, `false` otherwise
  */
 export async function canWrapLoad(id: string, debug: boolean): Promise<boolean> {
+  // Some 3rd party plugins add ids to the build that actually don't exist.
+  // We need to check for that here, otherwise users get get a build errirs.
+  if (!fs.existsSync(id)) {
+    return false;
+  }
+
   const code = (await fs.promises.readFile(id, 'utf8')).toString();
   const mod = parseModule(code);
 

--- a/packages/sveltekit/test/vite/autoInstrument.test.ts
+++ b/packages/sveltekit/test/vite/autoInstrument.test.ts
@@ -21,6 +21,12 @@ vi.mock('fs', async () => {
         return fileContent || DEFAULT_CONTENT;
       }),
     },
+    existsSync: vi.fn().mockImplementation(id => {
+      if (id === '+page.virtual.ts') {
+        return false;
+      }
+      return true;
+    }),
   };
 });
 
@@ -198,15 +204,20 @@ describe('canWrapLoad', () => {
     'export const loadNotLoad = () => {}; export const prerender = true;',
     'export function aload(){}; export const prerender = true;',
     'export function loader(){}; export const prerender = true;',
-    'let loademe = false; export {loadme}',
+    'let loadme = false; export {loadme}',
     'const a = {load: true}; export {a}',
     'if (s === "load") {}',
     'const a = load ? load : false',
     '// const load = () => {}',
     '/* export const load = () => {} */ export const prerender = true;',
     '/* export const notLoad = () => { const a = getSomething() as load; } */ export const prerender = true;',
-  ])('returns `false` if no load declaration exists', async (_, code) => {
+  ])('returns `false` if no load declaration exists', async code => {
     fileContent = code;
-    expect(await canWrapLoad('+page.ts', false)).toEqual(true);
+    expect(await canWrapLoad('+page.ts', false)).toEqual(false);
+  });
+
+  it("returns `false` if the passed file id doesn't exist", async () => {
+    fileContent = DEFAULT_CONTENT;
+    expect(await canWrapLoad('+page.virtual.ts', false)).toEqual(false);
   });
 });


### PR DESCRIPTION
In our auto instrumentation Vite plugin for SvelteKit, we read `+(page|layout)(.server).(js|ts)` files' code to determine if we should add our wrapper to the file or not. We previously didn't check for a file id's existence before reading the file if the id matched that certain pattern, wrongly assuming that these ids would always map to actually existing files. 

It seems like Vite plugins such as Houdini's plugin add file ids to the build for files that actually don't exist (#8846, #8854) . When our plugin's `load` hook was called for such an id, it then tried to access and read the file which caused a build error.

This patch now adds a file existence guard to ensure we simply no-op for these files. 

(Wild guess: Houdini adds `load` functions for all (some?) routes so that it can do its graph QL magic under the hood. Meaning, if we no-op at build time, these functions might not be instrumented with Sentry spans. It's probably not the end of the world as errors should still be caught by the `handleError` hook. But let's see. I already cc'd the Houdini maintainers in #8846 to let them know of this). 

closes #8846
closes #8854