### PR TITLE
fix(replay): Resume replay recording if paused when session is expired

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -645,7 +645,11 @@ export class ReplayContainer implements ReplayContainerInterface {
     }
 
     // Session is expired, trigger a full snapshot (which will create a new session)
-    this._triggerFullSnapshot();
+    if (this.isPaused()) {
+      this.resume();
+    } else {
+      this._triggerFullSnapshot();
+    }
 
     return false;
   }


### PR DESCRIPTION
Previously was attempting to take full snapshot when replay recording was not active.

Fixes https://github.com/getsentry/sentry-javascript/issues/8885
