### PR TITLE
fix(browser): Mark errors caught from `TryCatch` integration as unhandled

### DIFF
--- a/packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/test.ts
+++ b/packages/browser-integration-tests/suites/public-api/instrumentation/eventListener/test.ts
@@ -17,7 +17,7 @@ sentryTest(
       value: 'event_listener_error',
       mechanism: {
         type: 'instrument',
-        handled: true,
+        handled: false,
       },
       stacktrace: {
         frames: expect.any(Array),

--- a/packages/browser-integration-tests/suites/sessions/update-session/test.ts
+++ b/packages/browser-integration-tests/suites/sessions/update-session/test.ts
@@ -17,7 +17,7 @@ sentryTest('should update session when an error is thrown.', async ({ getLocalTe
   expect(updatedSession).toBeDefined();
   expect(updatedSession.init).toBe(false);
   expect(updatedSession.errors).toBe(1);
-  expect(updatedSession.status).toBe('ok');
+  expect(updatedSession.status).toBe('crashed');
   expect(pageloadSession.sid).toBe(updatedSession.sid);
 });
 

--- a/packages/browser/src/integrations/trycatch.ts
+++ b/packages/browser/src/integrations/trycatch.ts
@@ -113,7 +113,7 @@ function _wrapTimeFunction(original: () => void): () => number {
     args[0] = wrap(originalCallback, {
       mechanism: {
         data: { function: getFunctionName(original) },
-        handled: true,
+        handled: false,
         type: 'instrument',
       },
     });
@@ -134,7 +134,7 @@ function _wrapRAF(original: any): (callback: () => void) => any {
             function: 'requestAnimationFrame',
             handler: getFunctionName(original),
           },
-          handled: true,
+          handled: false,
           type: 'instrument',
         },
       }),
@@ -160,7 +160,7 @@ function _wrapXHR(originalSend: () => void): () => void {
                 function: prop,
                 handler: getFunctionName(original),
               },
-              handled: true,
+              handled: false,
               type: 'instrument',
             },
           };
@@ -220,7 +220,7 @@ function _wrapEventTarget(target: string): void {
                 handler: getFunctionName(fn),
                 target,
               },
-              handled: true,
+              handled: false,
               type: 'instrument',
             },
           });
@@ -239,7 +239,7 @@ function _wrapEventTarget(target: string): void {
               handler: getFunctionName(fn),
               target,
             },
-            handled: true,
+            handled: false,
             type: 'instrument',
           },
         }),


### PR DESCRIPTION
This PR is the first of a series of PRs which adjust the exception mechanism to be set to `handled: false` whenever our SDK-internal instrumentation catches an error. I decided to split these changes up by SDK package to revert specific changes more easily, and more clearly show which change has which consequences (e.g. on tests). 

Right now, we sometimes set `handled: true` which often incorrectly classifies actually unhandled errors (from the perspective of a user) as handled. Consequently, users who triage Sentry issue based on the exception mechanism might triage an actually unhandled error as handled. 

The goal of fixing handled/unhandled is that all errors caught by us are marked as unhandled while user-invoked calls (e.g. `Sentry.captureException` are continued to be marked as handled). 

### Changed Instrumentation

This PR addresses the mechanisms set in the browser package. Most of our instrumentation in the browser SDK already sets the mechanism correctly. Only the `RewriteFrames` integration required adjustments.

### Consequences of this change

While the change itself is simple, there are SDK- and product-wide consequences to it:

* Sessions in which errors occurred that were incorrectly given `handled: true`, previously finished with `status 'ok'`. These sessions now finish with `status: 'crashed'`.
* The increase in "crashed" sessions potentially leads to a decreased release health in users' releases. 
* We cannot say for sure that users didn't handle errors that we now mark as unhandled. So while before we produced false positives (in the sense of classifying an exception as handled), we now create false negatives. To be clear, we had false positives and negatives before and will continue to have both with this change. It might just shift a little into the other direction.

The concept of a "crashed session" doesn't make much sense in browser world, given that the browser very rarely actually crashes. This is very well explained in https://github.com/getsentry/sentry-javascript/issues/6073#issue-1425856093. As we all know, release health therefore doesn't make too much sense for browser-based applications. 
