### PR TITLE
feat(integrations): Mark errors caught from `HttpClient` and `CaptureConsole` integrations as unhandled

### DIFF
--- a/packages/browser-integration-tests/suites/integrations/httpclient/axios/test.ts
+++ b/packages/browser-integration-tests/suites/integrations/httpclient/axios/test.ts
@@ -38,7 +38,7 @@ sentryTest(
             value: 'HTTP Client Error with status code: 500',
             mechanism: {
               type: 'http.client',
-              handled: true,
+              handled: false,
             },
           },
         ],

--- a/packages/browser-integration-tests/suites/integrations/httpclient/fetch/simple/test.ts
+++ b/packages/browser-integration-tests/suites/integrations/httpclient/fetch/simple/test.ts
@@ -38,7 +38,7 @@ sentryTest(
             value: 'HTTP Client Error with status code: 500',
             mechanism: {
               type: 'http.client',
-              handled: true,
+              handled: false,
             },
           },
         ],

--- a/packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequest/test.ts
+++ b/packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequest/test.ts
@@ -36,7 +36,7 @@ sentryTest('works with a Request passed in', async ({ getLocalTestPath, page }) 
           value: 'HTTP Client Error with status code: 500',
           mechanism: {
             type: 'http.client',
-            handled: true,
+            handled: false,
           },
         },
       ],

--- a/packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndBodyAndOptions/test.ts
+++ b/packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndBodyAndOptions/test.ts
@@ -38,7 +38,7 @@ sentryTest(
             value: 'HTTP Client Error with status code: 500',
             mechanism: {
               type: 'http.client',
-              handled: true,
+              handled: false,
             },
           },
         ],

--- a/packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndOptions/test.ts
+++ b/packages/browser-integration-tests/suites/integrations/httpclient/fetch/withRequestAndOptions/test.ts
@@ -36,7 +36,7 @@ sentryTest('works with a Request (without body) & options passed in', async ({ g
           value: 'HTTP Client Error with status code: 500',
           mechanism: {
             type: 'http.client',
-            handled: true,
+            handled: false,
           },
         },
       ],

--- a/packages/browser-integration-tests/suites/integrations/httpclient/xhr/test.ts
+++ b/packages/browser-integration-tests/suites/integrations/httpclient/xhr/test.ts
@@ -38,7 +38,7 @@ sentryTest(
             value: 'HTTP Client Error with status code: 500',
             mechanism: {
               type: 'http.client',
-              handled: true,
+              handled: false,
             },
           },
         ],

--- a/packages/integrations/src/captureconsole.ts
+++ b/packages/integrations/src/captureconsole.ts
@@ -1,5 +1,6 @@
 import type { EventProcessor, Hub, Integration } from '@sentry/types';
 import {
+  addExceptionMechanism,
   addInstrumentationHandler,
   CONSOLE_LEVELS,
   GLOBAL_OBJ,
@@ -64,6 +65,12 @@ function consoleHandler(hub: Hub, args: unknown[], level: string): void {
     scope.setExtra('arguments', args);
     scope.addEventProcessor(event => {
       event.logger = 'console';
+
+      addExceptionMechanism(event, {
+        handled: false,
+        type: 'console',
+      });
+
       return event;
     });
 

--- a/packages/integrations/src/httpclient.ts
+++ b/packages/integrations/src/httpclient.ts
@@ -416,6 +416,7 @@ export class HttpClient implements Integration {
 
     addExceptionMechanism(event, {
       type: 'http.client',
+      handled: false,
     });
 
     return event;


### PR DESCRIPTION
This PR is part of a series of PRs adjusting the exception mechanism's `handled` value.

For more details see #8890 

### Changed Instrumentation

This PR addresses the mechanisms set in the integrations package, more concretely in the 

* `HttpClient`
* `CaptureConsole`

integrations.

ref #6073