### PR TITLE
ref(browser): Refactor sentry breadcrumb to use hook

### DIFF
--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -15,8 +15,6 @@ import { createClientReportEnvelope, dsnToString, getSDKSource, logger } from '@
 
 import { eventFromException, eventFromMessage } from './eventbuilder';
 import { WINDOW } from './helpers';
-import type { Breadcrumbs } from './integrations';
-import { BREADCRUMB_INTEGRATION_ID } from './integrations/breadcrumbs';
 import type { BrowserTransportOptions } from './transports/types';
 import { createUserFeedbackEnvelope } from './userfeedback';
 
@@ -89,26 +87,6 @@ export class BrowserClient extends BaseClient<BrowserClientOptions> {
     hint?: EventHint,
   ): PromiseLike<Event> {
     return eventFromMessage(this._options.stackParser, message, level, hint, this._options.attachStacktrace);
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public sendEvent(event: Event, hint?: EventHint): void {
-    // We only want to add the sentry event breadcrumb when the user has the breadcrumb integration installed and
-    // activated its `sentry` option.
-    // We also do not want to use the `Breadcrumbs` class here directly, because we do not want it to be included in
-    // bundles, if it is not used by the SDK.
-    // This all sadly is a bit ugly, but we currently don't have a "pre-send" hook on the integrations so we do it this
-    // way for now.
-    const breadcrumbIntegration = this.getIntegrationById(BREADCRUMB_INTEGRATION_ID) as Breadcrumbs | undefined;
-    // We check for definedness of `addSentryBreadcrumb` in case users provided their own integration with id
-    // "Breadcrumbs" that does not have this function.
-    if (breadcrumbIntegration && breadcrumbIntegration.addSentryBreadcrumb) {
-      breadcrumbIntegration.addSentryBreadcrumb(event);
-    }
-
-    super.sendEvent(event, hint);
   }
 
   /**

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -322,6 +322,8 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    * @inheritDoc
    */
   public sendEvent(event: Event, hint: EventHint = {}): void {
+    this.emit('beforeSendEvent', event, hint);
+
     if (this._dsn) {
       let env = createEventEnvelope(event, this._dsn, this._options._metadata, this._options.tunnel);
 
@@ -382,6 +384,9 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   public on(hook: 'beforeEnvelope', callback: (envelope: Envelope) => void): void;
 
   /** @inheritdoc */
+  public on(hook: 'beforeSendEvent', callback: (event: Event, hint?: EventHint) => void): void;
+
+  /** @inheritdoc */
   public on(
     hook: 'afterSendEvent',
     callback: (event: Event, sendResponse: TransportMakeRequestResponse | void) => void,
@@ -411,6 +416,9 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
 
   /** @inheritdoc */
   public emit(hook: 'beforeEnvelope', envelope: Envelope): void;
+
+  /** @inheritdoc */
+  public emit(hook: 'beforeSendEvent', event: Event, hint?: EventHint): void;
 
   /** @inheritdoc */
   public emit(hook: 'afterSendEvent', event: Event, sendResponse: TransportMakeRequestResponse | void): void;

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -177,6 +177,11 @@ export interface Client<O extends ClientOptions = ClientOptions> {
   on?(hook: 'beforeEnvelope', callback: (envelope: Envelope) => void): void;
 
   /**
+   * Register a callback for before an event is sent.
+   */
+  on?(hook: 'beforeSendEvent', callback: (event: Event, hint?: EventHint | void) => void): void;
+
+  /**
    * Register a callback for when an event has been sent.
    */
   on?(
@@ -211,6 +216,12 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    * second argument.
    */
   emit?(hook: 'beforeEnvelope', envelope: Envelope): void;
+
+  /*
+   * Fire a hook event before sending an event. Expects to be given an Event & EventHint as the
+   * second/third argument.
+   */
+  emit?(hook: 'beforeSendEvent', event: Event, hint?: EventHint): void;
 
   /*
    * Fire a hook event after sending an event. Expects to be given an Event as the


### PR DESCRIPTION
Noticed that this is a bit tightly coupled in the browser client, and could be simplified by using a hook.