### PR TITLE
feat(nextjs): Mark errors caught from NextJS wrappers as unhandled

### DIFF
--- a/packages/nextjs/src/common/_error.ts
+++ b/packages/nextjs/src/common/_error.ts
@@ -45,7 +45,7 @@ export async function captureUnderscoreErrorException(contextOrProps: ContextOrP
     scope.addEventProcessor(event => {
       addExceptionMechanism(event, {
         type: 'instrument',
-        handled: true,
+        handled: false,
         data: {
           function: '_error.getInitialProps',
         },

--- a/packages/nextjs/src/common/utils/wrapperUtils.ts
+++ b/packages/nextjs/src/common/utils/wrapperUtils.ts
@@ -46,7 +46,7 @@ export function withErrorInstrumentation<F extends (...args: any[]) => any>(
     try {
       return await origFunction.apply(this, origFunctionArguments);
     } catch (e) {
-      // TODO: Extract error logic from `withSentry` in here or create a new wrapper with said logic or something like that.#
+      // TODO: Extract error logic from `withSentry` in here or create a new wrapper with said logic or something like that.
       captureException(e, scope => {
         scope.addEventProcessor(event => {
           addExceptionMechanism(event, {

--- a/packages/nextjs/src/common/utils/wrapperUtils.ts
+++ b/packages/nextjs/src/common/utils/wrapperUtils.ts
@@ -4,7 +4,6 @@ import {
   getCurrentHub,
   runWithAsyncContext,
   startTransaction,
-  withScope,
 } from '@sentry/core';
 import type { Span, Transaction } from '@sentry/types';
 import { addExceptionMechanism, isString, tracingContextFromHeaders } from '@sentry/utils';

--- a/packages/nextjs/src/common/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapApiHandlerWithSentry.ts
@@ -190,7 +190,7 @@ export function withSentry(apiHandler: NextApiHandler, parameterizedRoute?: stri
               currentScope.addEventProcessor(event => {
                 addExceptionMechanism(event, {
                   type: 'instrument',
-                  handled: true,
+                  handled: false,
                   data: {
                     wrapped_handler: wrappingTarget.name,
                     function: 'withSentry',

--- a/packages/nextjs/src/common/wrapServerComponentWithSentry.ts
+++ b/packages/nextjs/src/common/wrapServerComponentWithSentry.ts
@@ -5,7 +5,7 @@ import {
   runWithAsyncContext,
   startTransaction,
 } from '@sentry/core';
-import { tracingContextFromHeaders } from '@sentry/utils';
+import { addExceptionMechanism, tracingContextFromHeaders } from '@sentry/utils';
 
 import { isNotFoundNavigationError, isRedirectNavigationError } from '../common/nextNavigationErrorUtils';
 import type { ServerComponentContext } from '../common/types';
@@ -62,7 +62,17 @@ export function wrapServerComponentWithSentry<F extends (...args: any[]) => any>
             // We don't want to report redirects
           } else {
             transaction.setStatus('internal_error');
-            captureException(e);
+
+            captureException(e, scope => {
+              scope.addEventProcessor(event => {
+                addExceptionMechanism(event, {
+                  handled: false,
+                });
+                return event;
+              });
+
+              return scope;
+            });
           }
 
           transaction.finish();


### PR DESCRIPTION
This PR is part of a series of PRs adjusting the exception mechanism's `handled` value.

For more details see #8890 

### Changed Instrumentation

This PR addresses the mechanisms set in the NextJS package, more concretely in

* `captureUnderscoreException` 
* `wrapApiHandlerWithSentry`
* `callDataFetcherTraced`
* `withErrorInstrumentation`
* `wrapServerComponentWithSentry`

ref #6073