### PR TITLE
feat(remix): Mark errors caught from Remix instrumentation as unhandled

### DIFF
--- a/packages/remix/src/client/errors.tsx
+++ b/packages/remix/src/client/errors.tsx
@@ -43,7 +43,7 @@ export function captureRemixErrorBoundaryError(error: unknown): void {
       scope.addEventProcessor(event => {
         addExceptionMechanism(event, {
           type: 'instrument',
-          handled: true,
+          handled: false,
           data: eventData,
         });
         return event;

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -104,7 +104,7 @@ export async function captureRemixServerException(err: unknown, name: string, re
     scope.addEventProcessor(event => {
       addExceptionMechanism(event, {
         type: 'instrument',
-        handled: true,
+        handled: false,
         data: {
           function: name,
         },

--- a/packages/remix/test/integration/test/client/errorboundary.test.ts
+++ b/packages/remix/test/integration/test/client/errorboundary.test.ts
@@ -27,6 +27,7 @@ test('should capture React component errors.', async ({ page }) => {
             type: 'React ErrorBoundary Error',
             value: 'Sentry React Component Error',
             stacktrace: { frames: expect.any(Array) },
+            mechanism: { type: 'chained', handled: false },
           },
         ]
       : []),
@@ -34,7 +35,9 @@ test('should capture React component errors.', async ({ page }) => {
       type: 'Error',
       value: 'Sentry React Component Error',
       stacktrace: { frames: expect.any(Array) },
-      mechanism: { type: useV2 ? 'instrument' : 'generic', handled: true },
+      // In v2 this error will be marked unhandled, in v1 its handled because of LinkedErrors
+      // This should be fine though because the error boundary's error is marked unhandled
+      mechanism: { type: useV2 ? 'instrument' : 'generic', handled: !useV2 },
     },
   ]);
 });

--- a/packages/remix/test/integration/test/client/errorboundary.test.ts
+++ b/packages/remix/test/integration/test/client/errorboundary.test.ts
@@ -34,7 +34,7 @@ test('should capture React component errors.', async ({ page }) => {
       type: 'Error',
       value: 'Sentry React Component Error',
       stacktrace: { frames: expect.any(Array) },
-      mechanism: { type: useV2 ? 'instrument' : 'generic', handled: false },
+      mechanism: { type: useV2 ? 'instrument' : 'generic', handled: true },
     },
   ]);
 });

--- a/packages/remix/test/integration/test/client/errorboundary.test.ts
+++ b/packages/remix/test/integration/test/client/errorboundary.test.ts
@@ -11,7 +11,7 @@ test('should capture React component errors.', async ({ page }) => {
 
   const [pageloadEnvelope, errorEnvelope] = envelopes;
 
-  expect(pageloadEnvelope.contexts?.trace.op).toBe('pageload');
+  expect(pageloadEnvelope.contexts?.trace?.op).toBe('pageload');
   expect(pageloadEnvelope.tags?.['routing.instrumentation']).toBe('remix-router');
   expect(pageloadEnvelope.type).toBe('transaction');
   expect(pageloadEnvelope.transaction).toBe(
@@ -34,7 +34,7 @@ test('should capture React component errors.', async ({ page }) => {
       type: 'Error',
       value: 'Sentry React Component Error',
       stacktrace: { frames: expect.any(Array) },
-      mechanism: { type: useV2 ? 'instrument' : 'generic', handled: true },
+      mechanism: { type: useV2 ? 'instrument' : 'generic', handled: false },
     },
   ]);
 });

--- a/packages/remix/test/integration/test/server/action.test.ts
+++ b/packages/remix/test/integration/test/server/action.test.ts
@@ -83,7 +83,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
               data: {
                 function: useV2 ? 'remix.server' : 'action',
               },
-              handled: true,
+              handled: false,
               type: 'instrument',
             },
           },
@@ -203,7 +203,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
               data: {
                 function: useV2 ? 'remix.server' : 'loader',
               },
-              handled: true,
+              handled: false,
               type: 'instrument',
             },
           },
@@ -256,7 +256,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
               data: {
                 function: useV2 ? 'ErrorResponse' : 'action',
               },
-              handled: true,
+              handled: false,
               type: 'instrument',
             },
           },
@@ -311,7 +311,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
               data: {
                 function: useV2 ? 'ErrorResponse' : 'action',
               },
-              handled: true,
+              handled: false,
               type: 'instrument',
             },
           },
@@ -364,7 +364,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
               data: {
                 function: useV2 ? 'ErrorResponse' : 'action',
               },
-              handled: true,
+              handled: false,
               type: 'instrument',
             },
           },
@@ -419,7 +419,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
               data: {
                 function: useV2 ? 'ErrorResponse' : 'action',
               },
-              handled: true,
+              handled: false,
               type: 'instrument',
             },
           },

--- a/packages/remix/test/integration/test/server/loader.test.ts
+++ b/packages/remix/test/integration/test/server/loader.test.ts
@@ -41,7 +41,7 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
               data: {
                 function: useV2 ? 'remix.server' : 'loader',
               },
-              handled: true,
+              handled: false,
               type: 'instrument',
             },
           },
@@ -140,7 +140,7 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
               data: {
                 function: useV2 ? 'remix.server' : 'loader',
               },
-              handled: true,
+              handled: false,
               type: 'instrument',
             },
           },


### PR DESCRIPTION
This PR is part of a series of PRs adjusting the exception mechanism's `handled` value.

For more details see #8890 

### Changed Instrumentation

This PR addresses the mechanisms set in the Remix package, more concretely in

* `captureRemixErrorBoundaryError` (TBD)
* `captureRemixServerException`

ref #6073