### PR TITLE
feat(browser): Mark errors caught in `wrap` as unhandled

### DIFF
--- a/packages/browser-integration-tests/suites/public-api/wrap/init.js
+++ b/packages/browser-integration-tests/suites/public-api/wrap/init.js
@@ -1,0 +1,7 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+});

--- a/packages/browser-integration-tests/suites/public-api/wrap/subject.js
+++ b/packages/browser-integration-tests/suites/public-api/wrap/subject.js
@@ -1,0 +1,3 @@
+Sentry.wrap(() => {
+  throw new Error('test');
+});

--- a/packages/browser-integration-tests/suites/public-api/wrap/test.ts
+++ b/packages/browser-integration-tests/suites/public-api/wrap/test.ts
@@ -1,0 +1,21 @@
+import { expect } from '@playwright/test';
+import type { Event } from '@sentry/types';
+
+import { sentryTest } from '../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
+
+sentryTest('should capture an error within `wrap` and mark it as unhandled', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
+
+  expect(eventData.exception?.values).toHaveLength(1);
+  expect(eventData.exception?.values?.[0]).toMatchObject({
+    type: 'Error',
+    value: 'test',
+    mechanism: {
+      type: 'instrument',
+      handled: false,
+    },
+  });
+});

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -198,7 +198,12 @@ export function onLoad(callback: () => void): void {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function wrap(fn: (...args: any) => any): any {
-  return internalWrap(fn)();
+  return internalWrap(fn, {
+    mechanism: {
+      type: 'instrument',
+      handled: false,
+    },
+  })();
 }
 
 function startSessionOnHub(hub: Hub): void {


### PR DESCRIPTION
This PR is part of a series of PRs adjusting the exception mechanism's `handled` value.

For more details see #8890 

### Changed Instrumentation

This PR addresses setting the mechanism in the browser package API `wrap`. I previously didn't know this existed but you live and learn 😅. Decided to keep #8890 atomic and open a separate PR, should we need to revert the changes there. 

Note: we should improve the typing of `wrap` - opened #8897 to track

ref #6073