### PR TITLE
feat(vue): Mark errors caught in Vue wrappers as unhandled

### DIFF
--- a/packages/vue/src/errorhandler.ts
+++ b/packages/vue/src/errorhandler.ts
@@ -1,4 +1,5 @@
 import { getCurrentHub } from '@sentry/browser';
+import { addExceptionMechanism } from '@sentry/utils';
 
 import type { Options, ViewModel, Vue } from './types';
 import { formatComponentName, generateComponentTrace } from './vendor/components';
@@ -31,6 +32,14 @@ export const attachErrorHandler = (app: Vue, options: Options): void => {
     setTimeout(() => {
       getCurrentHub().withScope(scope => {
         scope.setContext('vue', metadata);
+
+        scope.addEventProcessor(event => {
+          addExceptionMechanism(event, {
+            handled: false,
+          });
+          return event;
+        });
+
         getCurrentHub().captureException(error);
       });
     });

--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -1,8 +1,8 @@
 import { captureException, WINDOW } from '@sentry/browser';
 import type { Transaction, TransactionContext, TransactionSource } from '@sentry/types';
+import { addExceptionMechanism } from '@sentry/utils';
 
 import { getActiveTransaction } from './tracing';
-import { addExceptionMechanism } from '@sentry/utils';
 
 interface VueRouterInstrumationOptions {
   /**

--- a/packages/vue/test/router.test.ts
+++ b/packages/vue/test/router.test.ts
@@ -72,7 +72,8 @@ describe('vueRouterInstrumentation()', () => {
     onErrorCallback(testError);
 
     expect(captureExceptionSpy).toHaveBeenCalledTimes(1);
-    expect(captureExceptionSpy).toHaveBeenCalledWith(testError);
+    // second function is the scope callback
+    expect(captureExceptionSpy).toHaveBeenCalledWith(testError, expect.any(Function));
   });
 
   it.each([


### PR DESCRIPTION
This PR is part of a series of PRs adjusting the exception mechanism's `handled` value.

For more details see #8890 

### Changed Instrumentation

This PR addresses the mechanisms set in the Vue package, more concretely in

* our Vue error handler 
* our Vue routing instrumentation

ref #6073