### PR TITLE
feat(serverless): Mark errors caught in Serverless handlers as unhandled

### DIFF
--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -14,7 +14,7 @@ import { performance } from 'perf_hooks';
 import { types } from 'util';
 
 import { AWSServices } from './awsservices';
-import { serverlessEventProcessor } from './utils';
+import { markEventUnhandled, serverlessEventProcessor } from './utils';
 
 export * from '@sentry/node';
 
@@ -312,11 +312,11 @@ export function wrapHandler<TEvent, TResult>(
       if (options.captureAllSettledReasons && Array.isArray(rv) && isPromiseAllSettledResult(rv)) {
         const reasons = getRejectedReasons(rv);
         reasons.forEach(exception => {
-          captureException(exception);
+          captureException(exception, scope => markEventUnhandled(scope));
         });
       }
     } catch (e) {
-      captureException(e);
+      captureException(e, scope => markEventUnhandled(scope));
       throw e;
     } finally {
       clearTimeout(timeoutWarningTimer);

--- a/packages/serverless/src/gcpfunction/cloud_events.ts
+++ b/packages/serverless/src/gcpfunction/cloud_events.ts
@@ -1,7 +1,7 @@
 import { captureException, flush, getCurrentHub } from '@sentry/node';
 import { isThenable, logger } from '@sentry/utils';
 
-import { domainify, proxyFunction } from '../utils';
+import { domainify, markEventUnhandled, proxyFunction } from '../utils';
 import type { CloudEventFunction, CloudEventFunctionWithCallback, WrapperOptions } from './general';
 
 export type CloudEventFunctionWrapperOptions = WrapperOptions;
@@ -50,7 +50,7 @@ function _wrapCloudEventFunction(
 
     const newCallback = domainify((...args: unknown[]) => {
       if (args[0] !== null && args[0] !== undefined) {
-        captureException(args[0]);
+        captureException(args[0], scope => markEventUnhandled(scope));
       }
       transaction?.finish();
 
@@ -68,13 +68,13 @@ function _wrapCloudEventFunction(
       try {
         fnResult = (fn as CloudEventFunctionWithCallback)(context, newCallback);
       } catch (err) {
-        captureException(err);
+        captureException(err, scope => markEventUnhandled(scope));
         throw err;
       }
 
       if (isThenable(fnResult)) {
         fnResult.then(null, err => {
-          captureException(err);
+          captureException(err, scope => markEventUnhandled(scope));
           throw err;
         });
       }

--- a/packages/serverless/src/gcpfunction/events.ts
+++ b/packages/serverless/src/gcpfunction/events.ts
@@ -1,7 +1,7 @@
 import { captureException, flush, getCurrentHub } from '@sentry/node';
 import { isThenable, logger } from '@sentry/utils';
 
-import { domainify, proxyFunction } from '../utils';
+import { domainify, markEventUnhandled, proxyFunction } from '../utils';
 import type { EventFunction, EventFunctionWithCallback, WrapperOptions } from './general';
 
 export type EventFunctionWrapperOptions = WrapperOptions;
@@ -52,7 +52,7 @@ function _wrapEventFunction<F extends EventFunction | EventFunctionWithCallback>
 
     const newCallback = domainify((...args: unknown[]) => {
       if (args[0] !== null && args[0] !== undefined) {
-        captureException(args[0]);
+        captureException(args[0], scope => markEventUnhandled(scope));
       }
       transaction?.finish();
 
@@ -72,13 +72,13 @@ function _wrapEventFunction<F extends EventFunction | EventFunctionWithCallback>
       try {
         fnResult = (fn as EventFunctionWithCallback)(data, context, newCallback);
       } catch (err) {
-        captureException(err);
+        captureException(err, scope => markEventUnhandled(scope));
         throw err;
       }
 
       if (isThenable(fnResult)) {
         fnResult.then(null, err => {
-          captureException(err);
+          captureException(err, scope => markEventUnhandled(scope));
           throw err;
         });
       }

--- a/packages/serverless/src/gcpfunction/http.ts
+++ b/packages/serverless/src/gcpfunction/http.ts
@@ -2,7 +2,7 @@ import type { AddRequestDataToEventOptions } from '@sentry/node';
 import { captureException, flush, getCurrentHub } from '@sentry/node';
 import { isString, isThenable, logger, stripUrlQueryAndFragment, tracingContextFromHeaders } from '@sentry/utils';
 
-import { domainify, proxyFunction } from './../utils';
+import { domainify, markEventUnhandled, proxyFunction } from './../utils';
 import type { HttpFunction, WrapperOptions } from './general';
 
 // TODO (v8 / #5257): Remove this whole old/new business and just use the new stuff
@@ -122,13 +122,13 @@ function _wrapHttpFunction(fn: HttpFunction, wrapOptions: Partial<HttpFunctionWr
     try {
       fnResult = fn(req, res);
     } catch (err) {
-      captureException(err);
+      captureException(err, scope => markEventUnhandled(scope));
       throw err;
     }
 
     if (isThenable(fnResult)) {
       fnResult.then(null, err => {
-        captureException(err);
+        captureException(err, scope => markEventUnhandled(scope));
         throw err;
       });
     }

--- a/packages/serverless/src/utils.ts
+++ b/packages/serverless/src/utils.ts
@@ -1,5 +1,6 @@
 import { runWithAsyncContext } from '@sentry/core';
 import type { Event } from '@sentry/node';
+import { Scope } from '@sentry/types';
 import { addExceptionMechanism } from '@sentry/utils';
 
 /**
@@ -54,4 +55,16 @@ export function proxyFunction<A extends any[], R, F extends (...args: A) => R>(
   }
 
   return new Proxy(source, handler);
+}
+
+/**
+ * Marks an event as unhandled by adding a span processor to the passed scope.
+ */
+export function markEventUnhandled(scope: Scope): Scope {
+  scope.addEventProcessor(event => {
+    addExceptionMechanism(event, { handled: false });
+    return event;
+  });
+
+  return scope;
 }

--- a/packages/serverless/src/utils.ts
+++ b/packages/serverless/src/utils.ts
@@ -1,6 +1,6 @@
 import { runWithAsyncContext } from '@sentry/core';
 import type { Event } from '@sentry/node';
-import { Scope } from '@sentry/types';
+import type { Scope } from '@sentry/types';
 import { addExceptionMechanism } from '@sentry/utils';
 
 /**


### PR DESCRIPTION
This PR is part of a series of PRs adjusting the exception mechanism's `handled` value.

For more details see #8890 

### Changed Instrumentation

This PR addresses the mechanisms set in the Serverless package, more concretely in

* AWS Lambda handler
* GCP http, function, cloudEvent handlers

ref #6073