### PR TITLE
fix(node-experimental): Fix trace origins

### DIFF
--- a/packages/node-experimental/src/integrations/express.ts
+++ b/packages/node-experimental/src/integrations/express.ts
@@ -32,7 +32,7 @@ export class Express extends NodePerformanceIntegration<void> implements Integra
       new ExpressInstrumentation({
         requestHook(span) {
           addOtelSpanData(span.spanContext().spanId, {
-            origin: 'auto.http.otel-express',
+            origin: 'auto.http.otel.express',
           });
         },
       }),

--- a/packages/node-experimental/src/integrations/fastify.ts
+++ b/packages/node-experimental/src/integrations/fastify.ts
@@ -32,7 +32,7 @@ export class Fastify extends NodePerformanceIntegration<void> implements Integra
       new FastifyInstrumentation({
         requestHook(span) {
           addOtelSpanData(span.spanContext().spanId, {
-            origin: 'auto.http.otel-fastify',
+            origin: 'auto.http.otel.fastify',
           });
         },
       }),

--- a/packages/node-experimental/src/integrations/http.ts
+++ b/packages/node-experimental/src/integrations/http.ts
@@ -153,7 +153,7 @@ export class Http implements Integration {
       },
       contexts: {},
       metadata: {},
-      origin: 'auto.http.otel-http',
+      origin: 'auto.http.otel.http',
     };
 
     if (span.kind === SpanKind.SERVER) {


### PR DESCRIPTION
Oops, `origin` cannot contain `-`, this was incorrect.