### PR TITLE
fix(remix): Guard against missing default export for server instrument

### DIFF
--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -421,18 +421,21 @@ export function instrumentBuild(build: ServerBuild): ServerBuild {
   // Because the build can change between build and runtime.
   // So if there is a new `loader` or`action` or `documentRequest` after build.
   // We should be able to wrap them, as they may not be wrapped before.
-  if (!(wrappedEntry.module.default as WrappedFunction).__sentry_original__) {
+  const defaultExport = wrappedEntry.module.default as undefined | WrappedFunction;
+  if (defaultExport && !defaultExport.__sentry_original__) {
     fill(wrappedEntry.module, 'default', makeWrappedDocumentRequestFunction);
   }
 
   for (const [id, route] of Object.entries(build.routes)) {
     const wrappedRoute = { ...route, module: { ...route.module } };
 
-    if (wrappedRoute.module.action && !(wrappedRoute.module.action as WrappedFunction).__sentry_original__) {
+    const routeAction = wrappedRoute.module.action as undefined | WrappedFunction;
+    if (routeAction && !routeAction.__sentry_original__) {
       fill(wrappedRoute.module, 'action', makeWrappedAction(id));
     }
 
-    if (wrappedRoute.module.loader && !(wrappedRoute.module.loader as WrappedFunction).__sentry_original__) {
+    const routeLoader = wrappedRoute.module.loader as undefined | WrappedFunction;
+    if (routeLoader && !routeLoader.__sentry_original__) {
       fill(wrappedRoute.module, 'loader', makeWrappedLoader(id));
     }
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/8904

I don't know enough about remix to know if/when this can actually happen, but doesn't hurt to guard anyhow!