### PR TITLE
feat(react): Mark errors captured from ErrorBoundary as unhandled

### DIFF
--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -1,6 +1,6 @@
 import type { ReportDialogOptions, Scope } from '@sentry/browser';
 import { captureException, getCurrentHub, showReportDialog, withScope } from '@sentry/browser';
-import { isError, logger } from '@sentry/utils';
+import { addExceptionMechanism, isError, logger } from '@sentry/utils';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
 
@@ -138,7 +138,14 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
       if (beforeCapture) {
         beforeCapture(scope, error, componentStack);
       }
+
+      scope.addEventProcessor(event => {
+        addExceptionMechanism(event, { handled: false })
+        return event;
+      })
+
       const eventId = captureException(error, { contexts: { react: { componentStack } } });
+
       if (onError) {
         onError(error, componentStack, eventId);
       }


### PR DESCRIPTION
This PR is part of a series of PRs adjusting the exception mechanism's `handled` value.

For more details see #8890 

### Changed Instrumentation

This PR addresses the mechanisms set in the React package, more concretely in our `ErrorBoundary`. 

ref #6073