### PR TITLE
ref(node-otel): Avoid exporting internals & refactor attribute adding

### DIFF
--- a/packages/node-experimental/src/integrations/express.ts
+++ b/packages/node-experimental/src/integrations/express.ts
@@ -1,8 +1,8 @@
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { ExpressInstrumentation } from '@opentelemetry/instrumentation-express';
-import { addOtelSpanData } from '@sentry/opentelemetry-node';
 import type { Integration } from '@sentry/types';
 
+import { addOriginToOtelSpan } from '../utils/addOriginToSpan';
 import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
@@ -31,9 +31,7 @@ export class Express extends NodePerformanceIntegration<void> implements Integra
     return [
       new ExpressInstrumentation({
         requestHook(span) {
-          addOtelSpanData(span.spanContext().spanId, {
-            origin: 'auto.http.otel.express',
-          });
+          addOriginToOtelSpan(span, 'auto.http.otel.express');
         },
       }),
     ];

--- a/packages/node-experimental/src/integrations/fastify.ts
+++ b/packages/node-experimental/src/integrations/fastify.ts
@@ -1,8 +1,8 @@
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { FastifyInstrumentation } from '@opentelemetry/instrumentation-fastify';
-import { addOtelSpanData } from '@sentry/opentelemetry-node';
 import type { Integration } from '@sentry/types';
 
+import { addOriginToOtelSpan } from '../utils/addOriginToSpan';
 import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
@@ -31,9 +31,7 @@ export class Fastify extends NodePerformanceIntegration<void> implements Integra
     return [
       new FastifyInstrumentation({
         requestHook(span) {
-          addOtelSpanData(span.spanContext().spanId, {
-            origin: 'auto.http.otel.fastify',
-          });
+          addOriginToOtelSpan(span, 'auto.http.otel.fastify');
         },
       }),
     ];

--- a/packages/node-experimental/src/integrations/graphql.ts
+++ b/packages/node-experimental/src/integrations/graphql.ts
@@ -1,8 +1,8 @@
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { GraphQLInstrumentation } from '@opentelemetry/instrumentation-graphql';
-import { addOtelSpanData } from '@sentry/opentelemetry-node';
 import type { Integration } from '@sentry/types';
 
+import { addOriginToOtelSpan } from '../utils/addOriginToSpan';
 import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
@@ -32,9 +32,7 @@ export class GraphQL extends NodePerformanceIntegration<void> implements Integra
       new GraphQLInstrumentation({
         ignoreTrivialResolveSpans: true,
         responseHook(span) {
-          addOtelSpanData(span.spanContext().spanId, {
-            origin: 'auto.graphql.otel-graphql',
-          });
+          addOriginToOtelSpan(span, 'auto.graphql.otel.graphql');
         },
       }),
     ];

--- a/packages/node-experimental/src/integrations/mongo.ts
+++ b/packages/node-experimental/src/integrations/mongo.ts
@@ -1,8 +1,8 @@
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { MongoDBInstrumentation } from '@opentelemetry/instrumentation-mongodb';
-import { addOtelSpanData } from '@sentry/opentelemetry-node';
 import type { Integration } from '@sentry/types';
 
+import { addOriginToOtelSpan } from '../utils/addOriginToSpan';
 import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
@@ -31,9 +31,7 @@ export class Mongo extends NodePerformanceIntegration<void> implements Integrati
     return [
       new MongoDBInstrumentation({
         responseHook(span) {
-          addOtelSpanData(span.spanContext().spanId, {
-            origin: 'auto.db.otel-mongo',
-          });
+          addOriginToOtelSpan(span, 'auto.db.otel.mongo');
         },
       }),
     ];

--- a/packages/node-experimental/src/integrations/mongoose.ts
+++ b/packages/node-experimental/src/integrations/mongoose.ts
@@ -1,8 +1,8 @@
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { MongooseInstrumentation } from '@opentelemetry/instrumentation-mongoose';
-import { addOtelSpanData } from '@sentry/opentelemetry-node';
 import type { Integration } from '@sentry/types';
 
+import { addOriginToOtelSpan } from '../utils/addOriginToSpan';
 import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
@@ -31,9 +31,7 @@ export class Mongoose extends NodePerformanceIntegration<void> implements Integr
     return [
       new MongooseInstrumentation({
         responseHook(span) {
-          addOtelSpanData(span.spanContext().spanId, {
-            origin: 'auto.db.otel-mongoose',
-          });
+          addOriginToOtelSpan(span, 'auto.db.otel.mongoose');
         },
       }),
     ];

--- a/packages/node-experimental/src/integrations/mysql2.ts
+++ b/packages/node-experimental/src/integrations/mysql2.ts
@@ -1,8 +1,8 @@
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { MySQL2Instrumentation } from '@opentelemetry/instrumentation-mysql2';
-import { addOtelSpanData } from '@sentry/opentelemetry-node';
 import type { Integration } from '@sentry/types';
 
+import { addOriginToOtelSpan } from '../utils/addOriginToSpan';
 import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
@@ -31,9 +31,7 @@ export class Mysql2 extends NodePerformanceIntegration<void> implements Integrat
     return [
       new MySQL2Instrumentation({
         responseHook(span) {
-          addOtelSpanData(span.spanContext().spanId, {
-            origin: 'auto.db.otel-mysql2',
-          });
+          addOriginToOtelSpan(span, 'auto.db.otel.mysql2');
         },
       }),
     ];

--- a/packages/node-experimental/src/integrations/postgres.ts
+++ b/packages/node-experimental/src/integrations/postgres.ts
@@ -1,8 +1,8 @@
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
-import { addOtelSpanData } from '@sentry/opentelemetry-node';
 import type { Integration } from '@sentry/types';
 
+import { addOriginToOtelSpan } from '../utils/addOriginToSpan';
 import { NodePerformanceIntegration } from './NodePerformanceIntegration';
 
 /**
@@ -31,9 +31,7 @@ export class Postgres extends NodePerformanceIntegration<void> implements Integr
     return [
       new PgInstrumentation({
         requestHook(span) {
-          addOtelSpanData(span.spanContext().spanId, {
-            origin: 'auto.db.otel-postgres',
-          });
+          addOriginToOtelSpan(span, 'auto.db.otel.postgres');
         },
       }),
     ];

--- a/packages/node-experimental/src/utils/addOriginToSpan.ts
+++ b/packages/node-experimental/src/utils/addOriginToSpan.ts
@@ -1,0 +1,13 @@
+import type { Span as OtelSpan } from '@opentelemetry/api';
+import { _INTERNAL_getSentrySpan } from '@sentry/opentelemetry-node';
+import type { SpanOrigin } from '@sentry/types';
+
+/** Adds an origin to an OTEL Span. */
+export function addOriginToOtelSpan(otelSpan: OtelSpan, origin: SpanOrigin): void {
+  const sentrySpan = _INTERNAL_getSentrySpan(otelSpan.spanContext().spanId);
+  if (!sentrySpan) {
+    return;
+  }
+
+  sentrySpan.origin = origin;
+}

--- a/packages/opentelemetry-node/src/index.ts
+++ b/packages/opentelemetry-node/src/index.ts
@@ -1,3 +1,19 @@
+import { getSentrySpan } from './spanprocessor';
+
 export { SentrySpanProcessor } from './spanprocessor';
 export { SentryPropagator } from './propagator';
-export * from './utils/spanData';
+
+/* eslint-disable deprecation/deprecation */
+export { addOtelSpanData, getOtelSpanData, clearOtelSpanData } from './utils/spanData';
+export type { AdditionalOtelSpanData } from './utils/spanData';
+/* eslint-enable deprecation/deprecation */
+
+/**
+ * This is only exported for internal use.
+ * Semver etc. does not apply here, this is subject to change at any time!
+ * This is explicitly _NOT_ public because we may have to change the underlying way we store/handle spans,
+ * which may make this API unusable without further notice.
+ *
+ * @private
+ */
+export { getSentrySpan as _INTERNAL_getSentrySpan };

--- a/packages/opentelemetry-node/src/utils/spanData.ts
+++ b/packages/opentelemetry-node/src/utils/spanData.ts
@@ -1,9 +1,14 @@
+/* eslint-disable deprecation/deprecation */
+import { Transaction } from '@sentry/core';
 import type { Context, SpanOrigin } from '@sentry/types';
+
+import { getSentrySpan } from '../spanprocessor';
 
 type SentryTags = Record<string, string>;
 type SentryData = Record<string, unknown>;
 type Contexts = Record<string, Context>;
 
+/** @deprecated This will be removed in v8. */
 export interface AdditionalOtelSpanData {
   data: SentryData;
   tags: SentryTags;
@@ -14,21 +19,59 @@ export interface AdditionalOtelSpanData {
 
 const OTEL_SPAN_DATA_MAP: Map<string, AdditionalOtelSpanData> = new Map<string, AdditionalOtelSpanData>();
 
-/** Add data that should be added to the sentry span resulting from the given otel span ID. */
-export function addOtelSpanData(otelSpanId: string, data: Partial<AdditionalOtelSpanData>): void {
-  OTEL_SPAN_DATA_MAP.set(otelSpanId, { data: {}, tags: {}, contexts: {}, metadata: {}, ...data });
-}
-
-/** Get additional data for a Sentry span. */
-export function getOtelSpanData(otelSpanId: string): AdditionalOtelSpanData {
-  if (OTEL_SPAN_DATA_MAP.has(otelSpanId)) {
-    return OTEL_SPAN_DATA_MAP.get(otelSpanId) as AdditionalOtelSpanData;
+/**
+ * Add data that should be added to the sentry span resulting from the given otel span ID.
+ * @deprecated This will be removed in v8. This was never meant to be public API.
+ */
+export function addOtelSpanData(
+  otelSpanId: string,
+  { data, tags, contexts, metadata, origin }: Partial<AdditionalOtelSpanData>,
+): void {
+  const sentrySpan = getSentrySpan(otelSpanId);
+  if (!sentrySpan) {
+    return;
   }
 
+  if (data) {
+    Object.keys(data).forEach(prop => {
+      const value = data[prop];
+      sentrySpan.setData(prop, value);
+    });
+  }
+
+  if (tags) {
+    Object.keys(tags).forEach(prop => {
+      sentrySpan.setTag(prop, tags[prop]);
+    });
+  }
+
+  if (origin) {
+    sentrySpan.origin = origin;
+  }
+
+  if (sentrySpan instanceof Transaction) {
+    if (metadata) {
+      sentrySpan.setMetadata(metadata);
+    }
+
+    if (contexts) {
+      Object.keys(contexts).forEach(prop => {
+        sentrySpan.setContext(prop, contexts[prop]);
+      });
+    }
+  }
+}
+
+/**
+ * @deprecated This will do nothing and will be removed in v8.
+ */
+export function getOtelSpanData(_otelSpanId: string): AdditionalOtelSpanData {
   return { data: {}, tags: {}, contexts: {}, metadata: {} };
 }
 
-/** Add data that should be added to the sentry span resulting from the given otel span ID. */
+/**
+ * @deprecated This will do nothing and will be removed in v8.
+ */
 export function clearOtelSpanData(otelSpanId: string): void {
   OTEL_SPAN_DATA_MAP.delete(otelSpanId);
 }


### PR DESCRIPTION
I noticed that we kind of extended the public API by exporting some things from opentelemetry-node that we need in node-experimental. I am deprecating these internals as I'm refactoring some things to be a bit cleaner IMHO. 

The one export we actually need outside I am exporting as `_INTERNAL_getSentrySpan` to make it clear this is not meant to be used otherwise. The main reason I am not just exporting this is that this _may_ have to change if we change how we internally store/handle spans - e.g. if we move away from the map this is just not possible to have anymore, and I do not want to lock us into having to support this in the future.