### PR TITLE
fix(browser): Add replay and profiling options to `BrowserClientOptions`

### DIFF
--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -30,7 +30,9 @@ export type BrowserOptions = Options<BrowserTransportOptions> &
  * Configuration options for the Sentry Browser SDK Client class
  * @see BrowserClient for more information.
  */
-export type BrowserClientOptions = ClientOptions<BrowserTransportOptions>;
+export type BrowserClientOptions = ClientOptions<BrowserTransportOptions> &
+  BrowserClientReplayOptions &
+  BrowserClientProfilingOptions;
 
 /**
  * The Sentry Browser SDK Client.


### PR DESCRIPTION
This PR adds missing replay and profiling options to the `BrowserClientOptions` interface. Previously, we only exposed these types to `BrowserOptions`. This led to type errors for users who directly create a client, without using `Sentry.init` (as reported in #8857).

While one would think that `BrowserClientOptions` is basically a superset of `BrowserOptions` (leaving aside `stackparser`, `integrations` and `transport`) this is in fact not the case, which IMO is the core problem here. `BrowserClientOptions` only inherits the base `Options` (which are shared between browser and node), in addition to transport options. However, changing this so that, `BrowserClientOptions` inherits from `BrowserOptions` is a breaking change, so I opted to just add the missing options to `BrowserClientOptions`. 

Happy to change this if someone has an idea how to properly fix this without a breaking change. 

Furthermore, I'm not sure how to best test this. We could simply add a unit test but having such a test without assertions feels a little awkward to me. Integration tests would probably be the better choice but ours aren't type checked. 
I'll leave it untested for the time being (afaik we don't explicitly test types) but if reviewers prefer a test, I'm happy to come up with something. 

closes #8857