### PR TITLE
fix(nextjs): Request for no HSTS in tunnel route endpoint

### DIFF
--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -112,7 +112,7 @@ function setUpTunnelRewriteRules(userNextConfig: NextConfigObject, tunnelPath: s
           value: '(?<projectid>.*)',
         },
       ],
-      destination: 'https://o:orgid.ingest.sentry.io/api/:projectid/envelope/',
+      destination: 'https://o:orgid.ingest.sentry.io/api/:projectid/envelope/?hsts=0',
     };
 
     if (typeof originalRewrites !== 'function') {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/8931

Since the tunnel route usually goes through user's domains and our ingest endpoint has HSTS we were unintentionally promoting user's requests which are unrelated to Sentry to https. This PR fixes that by setting the `hsts=0` query param on the tunnel request to the ingest endpoint which will disable hsts for the responses as implemented in https://github.com/getsentry/ops/pull/7832.

Should wait for https://github.com/getsentry/ops/pull/7832 to land before merging.