### PR TITLE
fix(node-experimental): Ensure http breadcrumbs are correctly added

### DIFF
--- a/packages/node-experimental/src/integrations/http.ts
+++ b/packages/node-experimental/src/integrations/http.ts
@@ -11,6 +11,7 @@ import type { EventProcessor, Hub, Integration } from '@sentry/types';
 import type { ClientRequest, IncomingMessage, ServerResponse } from 'http';
 
 import type { NodeExperimentalClient } from '../sdk/client';
+import { getParentHub } from '../utils/getParentHub';
 import { getRequestSpanData } from '../utils/getRequestSpanData';
 
 interface TracingOptions {
@@ -95,8 +96,11 @@ export class Http implements Integration {
         new HttpInstrumentation({
           requireParentforOutgoingSpans: true,
           requireParentforIncomingSpans: false,
-          applyCustomAttributesOnSpan: (span, req, res) => {
-            this._onSpan(span as unknown as OtelSpan, req, res);
+          requestHook: (span, req) => {
+            this._updateSentrySpan(span as unknown as OtelSpan, req);
+          },
+          responseHook: (span, res) => {
+            this._addRequestBreadcrumb(span as unknown as OtelSpan, res);
           },
         }),
       ],
@@ -136,64 +140,68 @@ export class Http implements Integration {
     return;
   };
 
-  /** Handle an emitted span from the HTTP instrumentation. */
-  private _onSpan(
-    span: OtelSpan,
-    request: ClientRequest | IncomingMessage,
-    response: IncomingMessage | ServerResponse,
-  ): void {
-    const data = getRequestSpanData(span, request, response);
+  /** Update the Sentry span data based on the OTEL span. */
+  private _updateSentrySpan(span: OtelSpan, request: ClientRequest | IncomingMessage): void {
+    const data = getRequestSpanData(span);
     const { attributes } = span;
 
     const sentrySpan = _INTERNAL_getSentrySpan(span.spanContext().spanId);
-    if (sentrySpan) {
-      sentrySpan.origin = 'auto.http.otel.http';
-
-      const additionalData: Record<string, unknown> = {
-        url: data.url,
-      };
-
-      if (sentrySpan instanceof Transaction && span.kind === SpanKind.SERVER) {
-        sentrySpan.setMetadata({ request });
-      }
-
-      if (attributes[SemanticAttributes.HTTP_STATUS_CODE]) {
-        const statusCode = attributes[SemanticAttributes.HTTP_STATUS_CODE] as string;
-        additionalData['http.response.status_code'] = statusCode;
-
-        sentrySpan.setTag('http.status_code', statusCode);
-      }
-
-      if (data['http.query']) {
-        additionalData['http.query'] = data['http.query'].slice(1);
-      }
-      if (data['http.fragment']) {
-        additionalData['http.fragment'] = data['http.fragment'].slice(1);
-      }
-
-      Object.keys(additionalData).forEach(prop => {
-        const value = additionalData[prop];
-        sentrySpan.setData(prop, value);
-      });
+    if (!sentrySpan) {
+      return;
     }
 
-    if (this._breadcrumbs) {
-      getCurrentHub().addBreadcrumb(
-        {
-          category: 'http',
-          data: {
-            status_code: response.statusCode,
-            ...data,
-          },
-          type: 'http',
-        },
-        {
-          event: 'response',
-          request,
-          response,
-        },
-      );
+    sentrySpan.origin = 'auto.http.otel.http';
+
+    const additionalData: Record<string, unknown> = {
+      url: data.url,
+    };
+
+    if (sentrySpan instanceof Transaction && span.kind === SpanKind.SERVER) {
+      sentrySpan.setMetadata({ request });
     }
+
+    if (attributes[SemanticAttributes.HTTP_STATUS_CODE]) {
+      const statusCode = attributes[SemanticAttributes.HTTP_STATUS_CODE] as string;
+      additionalData['http.response.status_code'] = statusCode;
+
+      sentrySpan.setTag('http.status_code', statusCode);
+    }
+
+    if (data['http.query']) {
+      additionalData['http.query'] = data['http.query'].slice(1);
+    }
+    if (data['http.fragment']) {
+      additionalData['http.fragment'] = data['http.fragment'].slice(1);
+    }
+
+    Object.keys(additionalData).forEach(prop => {
+      const value = additionalData[prop];
+      sentrySpan.setData(prop, value);
+    });
+  }
+
+  /** Add a breadcrumb for outgoing requests. */
+  private _addRequestBreadcrumb(span: OtelSpan, response: IncomingMessage | ServerResponse): void {
+    if (!this._breadcrumbs || span.kind !== SpanKind.CLIENT) {
+      return;
+    }
+
+    const data = getRequestSpanData(span);
+    getParentHub().addBreadcrumb(
+      {
+        category: 'http',
+        data: {
+          status_code: response.statusCode,
+          ...data,
+        },
+        type: 'http',
+      },
+      {
+        event: 'response',
+        // request, ???
+        response,
+      },
+    );
   }
 }
 

--- a/packages/node-experimental/src/sdk/otelContextManager.ts
+++ b/packages/node-experimental/src/sdk/otelContextManager.ts
@@ -5,6 +5,7 @@ import type { Carrier, Hub } from '@sentry/core';
 import { ensureHubOnCarrier, getCurrentHub, getHubFromCarrier } from '@sentry/core';
 
 export const OTEL_CONTEXT_HUB_KEY = api.createContextKey('sentry_hub');
+export const OTEL_CONTEXT_PARENT_KEY = api.createContextKey('sentry_parent_context');
 
 function createNewHub(parent: Hub | undefined): Hub {
   const carrier: Carrier = {};
@@ -33,6 +34,11 @@ export class SentryContextManager extends AsyncLocalStorageContextManager {
     const existingHub = getCurrentHub();
     const newHub = createNewHub(existingHub);
 
-    return super.with(context.setValue(OTEL_CONTEXT_HUB_KEY, newHub), fn, thisArg, ...args);
+    return super.with(
+      context.setValue(OTEL_CONTEXT_HUB_KEY, newHub).setValue(OTEL_CONTEXT_PARENT_KEY, context),
+      fn,
+      thisArg,
+      ...args,
+    );
   }
 }

--- a/packages/node-experimental/src/utils/getParentHub.ts
+++ b/packages/node-experimental/src/utils/getParentHub.ts
@@ -1,0 +1,21 @@
+import * as api from '@opentelemetry/api';
+import { getCurrentHub } from '@sentry/core';
+import type { Hub } from '@sentry/types';
+
+import { OTEL_CONTEXT_HUB_KEY, OTEL_CONTEXT_PARENT_KEY } from '../sdk/otelContextManager';
+
+/**
+ * Get the hub of the parent context.
+ * Can be useful if you e.g. need to add a breadcrumb from inside of an ongoing span.
+ *
+ * Without this, if you e.g. try to add a breadcrumb from an instrumentation's `onSpan` callback or similar,
+ * you'll always attach it to the current hub, which in that case will be hyper specific to the instrumentation.
+ */
+export function getParentHub(): Hub {
+  const ctx = api.context.active();
+  const parentContext = ctx?.getValue(OTEL_CONTEXT_PARENT_KEY) as api.Context | undefined;
+
+  const parentHub = parentContext && (parentContext.getValue(OTEL_CONTEXT_HUB_KEY) as Hub | undefined);
+
+  return parentHub || getCurrentHub();
+}

--- a/packages/node-experimental/src/utils/getRequestSpanData.ts
+++ b/packages/node-experimental/src/utils/getRequestSpanData.ts
@@ -2,16 +2,11 @@ import type { Span as OtelSpan } from '@opentelemetry/sdk-trace-base';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import type { SanitizedRequestData } from '@sentry/types';
 import { getSanitizedUrlString, parseUrl } from '@sentry/utils';
-import type { ClientRequest, IncomingMessage, ServerResponse } from 'http';
 
 /**
  * Get sanitizied request data from an OTEL span.
  */
-export function getRequestSpanData(
-  span: OtelSpan,
-  _request: ClientRequest | IncomingMessage,
-  _response: IncomingMessage | ServerResponse,
-): SanitizedRequestData {
+export function getRequestSpanData(span: OtelSpan): SanitizedRequestData {
   const data: SanitizedRequestData = {
     url: span.attributes[SemanticAttributes.HTTP_URL] as string,
     'http.method': (span.attributes[SemanticAttributes.HTTP_METHOD] as string) || 'GET',


### PR DESCRIPTION
Due to the way OTEL handles context (=scope/hub), I noticed that breadcrumbs added in the http integration are not correctly captured. The reason is that OTEL forks the hub for the http request context, and runs the hooks inside of this forked context. In order to deal with this, we have to actually attach the breadcrumb to the _parent_ Hub in this specific case.

So this code:

```js
app.get("/error", async (request, reply) => {
    console.log('before request');

    await makeRequest(`http://example.com/`);

    console.log('after request');

    Sentry.captureException(new Error(`test error`));

    reply.send({status: "OK"})
  });
```

Results in a correct [transaction](https://sentry-sdks.sentry.io/discover/node-express-otel-experiment:2cf99ab02c8945ccb28b5b9068e8a354/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=replayId&homepage=true&name=All+Events&project=4505799630782464&query=&sort=-timestamp&statsPeriod=24h&yAxis=count%28%29):

![image](https://github.com/getsentry/sentry-javascript/assets/2411343/0ff5cf53-6147-4ec3-bba5-97b5c05b4e42)

and a correct [error](https://sentry-sdks.sentry.io/discover/node-express-otel-experiment:4b8e719515ee4792b19546753262496b/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=replayId&homepage=true&name=All+Events&project=4505799630782464&query=&sort=-timestamp&statsPeriod=24h&yAxis=count%28%29)

![image](https://github.com/getsentry/sentry-javascript/assets/2411343/dcd1ea84-8ec8-4990-885e-9f60d8d6a9b9)

This is a bit hacky, but works as far as I can tell. Here is the code that "triggers" this: https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation-http/src/http.ts#L532. note that the `context.with()` above results in a hub fork for us.

Not sure if there is a more elegant solution for this...? But I guess this is a fundamental challenge when we try to align our hub/scope usage with OTEL context. 

One note on `requestHook` & `responseHook` vs. `applyCustomAttributesOnSpan`: These differ slightly in when/where they are executed. I got less consistent/logical results of hub propagation on that hook, where the `xxxHook` callbacks worked more reliably for me. I think the reason is that `applyCustomAttributesOnSpan` is called a bit later in the request lifecycle... However, the downside is that we do not easily have the request _and_ response available in the callback, so we can't easily add it as a breadcrumb hint (without caching it somewhere, ...). Not sure how important that is to us...
