### PR TITLE
fix(browser): Check for existence of instrumentation targets

### DIFF
--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -248,6 +248,7 @@ export function parseFetchArgs(fetchArgs: unknown[]): { method: string; url: str
 
 /** JSDoc */
 export function instrumentXHR(): void {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   if (!(WINDOW as any).XMLHttpRequest) {
     return;
   }

--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -247,8 +247,8 @@ export function parseFetchArgs(fetchArgs: unknown[]): { method: string; url: str
 }
 
 /** JSDoc */
-function instrumentXHR(): void {
-  if (!('XMLHttpRequest' in WINDOW)) {
+export function instrumentXHR(): void {
+  if (!((WINDOW as any).XMLHttpRequest)) {
     return;
   }
 
@@ -539,8 +539,8 @@ type InstrumentedElement = Element & {
 };
 
 /** JSDoc */
-function instrumentDOM(): void {
-  if (!('document' in WINDOW)) {
+export function instrumentDOM(): void {
+  if (!(WINDOW.document)) {
     return;
   }
 

--- a/packages/utils/src/instrument.ts
+++ b/packages/utils/src/instrument.ts
@@ -248,7 +248,7 @@ export function parseFetchArgs(fetchArgs: unknown[]): { method: string; url: str
 
 /** JSDoc */
 export function instrumentXHR(): void {
-  if (!((WINDOW as any).XMLHttpRequest)) {
+  if (!(WINDOW as any).XMLHttpRequest) {
     return;
   }
 
@@ -540,7 +540,7 @@ type InstrumentedElement = Element & {
 
 /** JSDoc */
 export function instrumentDOM(): void {
-  if (!(WINDOW.document)) {
+  if (!WINDOW.document) {
     return;
   }
 

--- a/packages/utils/test/instrument.test.ts
+++ b/packages/utils/test/instrument.test.ts
@@ -1,6 +1,24 @@
-import { parseFetchArgs } from '../src/instrument';
+import jestMock from 'jest-mock';
+import { instrumentXHR, instrumentDOM, parseFetchArgs } from '../src/instrument';
+
+//@ts-ignore
+jestMock.mock('../src/worldwide', () => ({
+  //Return an empty object with undefined properties
+  getGlobalObject: () => ({
+    document: undefined,
+    XMLHttpRequest: undefined,
+  })
+}))
 
 describe('instrument', () => {
+  describe('polyfilling', () => {
+    it('does not instrumentXHR if no XMLHttpRequest detected', () => {
+      expect(instrumentXHR()).not.toThrow();
+    });
+    it('does not instrumentDOM if no document detected', () => {
+      expect(instrumentDOM()).not.toThrow();
+    });
+  });
   describe('parseFetchArgs', () => {
     it.each([
       ['string URL only', ['http://example.com'], { method: 'GET', url: 'http://example.com' }],

--- a/packages/utils/test/instrument.test.ts
+++ b/packages/utils/test/instrument.test.ts
@@ -1,9 +1,7 @@
-import jestMock from 'jest-mock';
-import { instrumentXHR, instrumentDOM, parseFetchArgs } from '../src/instrument';
+import { instrumentDOM, instrumentXHR, parseFetchArgs } from '../src/instrument';
 
-//@ts-ignore
-jestMock.mock('../src/worldwide', () => ({
-  //Return an empty object with undefined properties
+jest.mock('../src/worldwide', () => ({
+  // Return an empty object with undefined properties
   getGlobalObject: () => ({
     document: undefined,
     XMLHttpRequest: undefined,
@@ -11,14 +9,14 @@ jestMock.mock('../src/worldwide', () => ({
 }));
 
 describe('instrument', () => {
-  describe('polyfilling', () => {
-    it('does not instrumentXHR if no XMLHttpRequest detected', () => {
-      expect(instrumentXHR()).not.toThrow();
-    });
-    it('does not instrumentDOM if no document detected', () => {
-      expect(instrumentDOM()).not.toThrow();
-    });
+  it('instrumentXHR() does not throw if XMLHttpRequest is a key on window but not defined', () => {
+    expect(instrumentXHR).not.toThrow();
   });
+
+  it('instrumentDOM() does not throw if XMLHttpRequest is a key on window but not defined', () => {
+    expect(instrumentDOM).not.toThrow();
+  });
+
   describe('parseFetchArgs', () => {
     it.each([
       ['string URL only', ['http://example.com'], { method: 'GET', url: 'http://example.com' }],

--- a/packages/utils/test/instrument.test.ts
+++ b/packages/utils/test/instrument.test.ts
@@ -7,8 +7,8 @@ jestMock.mock('../src/worldwide', () => ({
   getGlobalObject: () => ({
     document: undefined,
     XMLHttpRequest: undefined,
-  })
-}))
+  }),
+}));
 
 describe('instrument', () => {
   describe('polyfilling', () => {


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ x ] If you've added code that should be tested, please add tests.
- [ x ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

## Description 

There are cases when global objects such as the window object are shimmed that they define properties such as `document`, but the actual value is undefined. This exact situation has been occurring and is causing the instrumentDOM function to throw an error as `'document' in WINDOW` is technically true though the value is falsey. We should rather attempt an actual check of the value being truthy rather than if the property is defined