### PR TITLE
docs: Reference `@sentry/migr8` in migration docs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,13 @@
 # Deprecations in 7.x
 
+You can use [@sentry/migr8](https://github.com/getsentry/sentry-migr8) to automatically update your SDK usage and fix most deprecations:
+
+```bash
+npx @sentry/migr8
+```
+
+This will let you select which updates to run, and automatically update your code. Make sure to still review all code changes!
+
 ## Deprecate `timestampWithMs` export - #7878
 
 The `timestampWithMs` util is deprecated in favor of using `timestampInSeconds`.


### PR DESCRIPTION
Add a reference to migr8 in the migration docs 🚀 