### PR TITLE
fix(remix): Add new sourcemap-upload script files to prepack assets.

### DIFF
--- a/packages/remix/scripts/prepack.ts
+++ b/packages/remix/scripts/prepack.ts
@@ -3,7 +3,12 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-const PACKAGE_ASSETS = ['scripts/sentry-upload-sourcemaps.js', 'scripts/createRelease.js'];
+const PACKAGE_ASSETS = [
+  'scripts/sentry-upload-sourcemaps.js',
+  'scripts/createRelease.js',
+  'scripts/deleteSourcemaps.js',
+  'scripts/injectDebugId.js',
+];
 
 export function prepack(buildDir: string): boolean {
   // copy package-specific assets to build dir


### PR DESCRIPTION
Fixes: #8946

New scripts we added with #8814 were missing in `PACKAGE_ASSETS` for prepacking.

I'll try to find a way to E2E test sourcemap upload scripts. 