### PR TITLE
feat(core): Add `name` to `Span`

### DIFF
--- a/packages/core/src/tracing/span.ts
+++ b/packages/core/src/tracing/span.ts
@@ -161,6 +161,15 @@ export class Span implements SpanInterface {
     }
   }
 
+  /** An alias for `description` of the Span. */
+  public get name(): string {
+    return this.description || '';
+  }
+  /** Update the name of the span. */
+  public set name(name: string) {
+    this.setName(name);
+  }
+
   /**
    * @inheritDoc
    */

--- a/packages/core/test/lib/tracing/span.test.ts
+++ b/packages/core/test/lib/tracing/span.test.ts
@@ -1,0 +1,32 @@
+import { Span } from '../../../src';
+
+describe('span', () => {
+  it('works with name', () => {
+    const span = new Span({ name: 'span name' });
+    expect(span.name).toEqual('span name');
+    expect(span.description).toEqual('span name');
+  });
+
+  it('works with description', () => {
+    const span = new Span({ description: 'span name' });
+    expect(span.name).toEqual('span name');
+    expect(span.description).toEqual('span name');
+  });
+
+  it('works without name', () => {
+    const span = new Span({});
+    expect(span.name).toEqual('');
+    expect(span.description).toEqual(undefined);
+  });
+
+  it('allows to update the name', () => {
+    const span = new Span({ name: 'span name' });
+    expect(span.name).toEqual('span name');
+    expect(span.description).toEqual('span name');
+
+    span.name = 'new name';
+
+    expect(span.name).toEqual('new name');
+    expect(span.description).toEqual('new name');
+  });
+});

--- a/packages/core/test/lib/tracing/transaction.test.ts
+++ b/packages/core/test/lib/tracing/transaction.test.ts
@@ -1,0 +1,17 @@
+import { Transaction } from '../../../src';
+
+describe('transaction', () => {
+  it('works with name', () => {
+    const transaction = new Transaction({ name: 'span name' });
+    expect(transaction.name).toEqual('span name');
+  });
+
+  it('allows to update the name', () => {
+    const transaction = new Transaction({ name: 'span name' });
+    expect(transaction.name).toEqual('span name');
+
+    transaction.name = 'new name';
+
+    expect(transaction.name).toEqual('new name');
+  });
+});

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -89,6 +89,11 @@ export interface SpanContext {
 /** Span holding trace_id, span_id */
 export interface Span extends SpanContext {
   /**
+   * Human-readable identifier for the span. Identical to span.description.
+   */
+  name: string;
+
+  /**
    * @inheritDoc
    */
   spanId: string;


### PR DESCRIPTION
In order to align `Span` & `Transaction` for usage in new performance APIs, this add `name` to the `Span` that also always returns a string.
