### PR TITLE
ref(core): Avoid unnecessary breadcrumbs array mutations

### DIFF
--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -419,7 +419,11 @@ export class Scope implements ScopeInterface {
       timestamp: dateTimestampInSeconds(),
       ...breadcrumb,
     };
-    this._breadcrumbs = [...this._breadcrumbs, mergedBreadcrumb].slice(-maxCrumbs);
+
+    const breadcrumbs = this._breadcrumbs;
+    breadcrumbs.push(mergedBreadcrumb);
+    this._breadcrumbs = breadcrumbs.length > maxCrumbs ? breadcrumbs.slice(-maxCrumbs) : breadcrumbs;
+
     this._notifyScopeListeners();
 
     return this;


### PR DESCRIPTION
This is a micro improvement, but maybe worth it as we can have a lot of breadcrumbs. This ensures we only create a new breadcrumbs array if we exceed the limit.

In contrast, currently we'll always create two copies of the breadcrumbs for each added breadcrumb (first for the array spread, then we copy it through the slice), even if we don't really need to do this.