### PR TITLE
ref(core): Introduce protected `_getBreadcrumbs()` on scope

### DIFF
--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -328,6 +328,13 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
+  public getBreadcrumbs(): Breadcrumb[] {
+    return this._breadcrumbs;
+  }
+
+  /**
+   * @inheritDoc
+   */
   public update(captureContext?: CaptureContext): this {
     if (!captureContext) {
       return this;
@@ -515,8 +522,9 @@ export class Scope implements ScopeInterface {
 
     this._applyFingerprint(event);
 
-    event.breadcrumbs = [...(event.breadcrumbs || []), ...this._breadcrumbs];
-    event.breadcrumbs = event.breadcrumbs.length > 0 ? event.breadcrumbs : undefined;
+    const scopeBreadcrumbs = this.getBreadcrumbs();
+    const breadcrumbs = [...(event.breadcrumbs || []), ...scopeBreadcrumbs];
+    event.breadcrumbs = breadcrumbs.length > 0 ? breadcrumbs : undefined;
 
     event.sdkProcessingMetadata = {
       ...event.sdkProcessingMetadata,

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -328,13 +328,6 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public getBreadcrumbs(): Breadcrumb[] {
-    return this._breadcrumbs;
-  }
-
-  /**
-   * @inheritDoc
-   */
   public update(captureContext?: CaptureContext): this {
     if (!captureContext) {
       return this;
@@ -522,7 +515,7 @@ export class Scope implements ScopeInterface {
 
     this._applyFingerprint(event);
 
-    const scopeBreadcrumbs = this.getBreadcrumbs();
+    const scopeBreadcrumbs = this._getBreadcrumbs();
     const breadcrumbs = [...(event.breadcrumbs || []), ...scopeBreadcrumbs];
     event.breadcrumbs = breadcrumbs.length > 0 ? breadcrumbs : undefined;
 
@@ -557,6 +550,13 @@ export class Scope implements ScopeInterface {
    */
   public getPropagationContext(): PropagationContext {
     return this._propagationContext;
+  }
+
+  /**
+   * Get the breadcrumbs for this scope.
+   */
+  protected _getBreadcrumbs(): Breadcrumb[] {
+    return this._breadcrumbs;
   }
 
   /**

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -129,6 +129,11 @@ export interface Scope {
   setSession(session?: Session): this;
 
   /**
+   * Get all breadcrumbs for this scope.
+   */
+  getBreadcrumbs(): Breadcrumb[];
+
+  /**
    * Returns the `RequestSession` if there is one
    */
   getRequestSession(): RequestSession | undefined;

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -129,11 +129,6 @@ export interface Scope {
   setSession(session?: Session): this;
 
   /**
-   * Get all breadcrumbs for this scope.
-   */
-  getBreadcrumbs(): Breadcrumb[];
-
-  /**
    * Returns the `RequestSession` if there is one
    */
   getRequestSession(): RequestSession | undefined;


### PR DESCRIPTION
Making it easier to potentially change this e.g. for POTEL.
