### PR TITLE
chore(e2e-tests): Use Node 18 for E2E tests.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -818,7 +818,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version-file: 'package.json'
+          node-version-file: 'packages/e2e-tests/package.json'
       - name: Restore caches
         uses: ./.github/actions/restore-cache
         env:
@@ -833,7 +833,7 @@ jobs:
       - name: Get node version
         id: versions
         run: |
-          echo "echo node=$(jq -r '.volta.node' package.json)" >> $GITHUB_OUTPUT
+          echo "echo node=$(jq -r '.volta.node' packages/e2e-tests/package.json)" >> $GITHUB_OUTPUT
 
       - name: Validate Verdaccio
         run: yarn test:validate

--- a/packages/e2e-tests/Dockerfile.publish-packages
+++ b/packages/e2e-tests/Dockerfile.publish-packages
@@ -1,5 +1,5 @@
 # This Dockerfile exists for the purpose of using a specific node/npm version (ie. the same we use in CI) to run npm publish with
-ARG NODE_VERSION=16.19.0
+ARG NODE_VERSION=18.17.1
 FROM node:${NODE_VERSION}
 
 WORKDIR /sentry-javascript/packages/e2e-tests

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -2,9 +2,6 @@
   "name": "@sentry-internal/e2e-tests",
   "version": "7.68.0",
   "license": "MIT",
-  "engines": {
-    "node": ">=10"
-  },
   "private": true,
   "scripts": {
     "fix": "run-s fix:eslint fix:prettier",
@@ -32,6 +29,7 @@
     "yaml": "2.2.2"
   },
   "volta": {
-    "extends": "../../package.json"
+    "node": "18.17.1",
+    "yarn": "1.22.19"
   }
 }

--- a/packages/e2e-tests/test-applications/create-next-app/package.json
+++ b/packages/e2e-tests/test-applications/create-next-app/package.json
@@ -25,7 +25,6 @@
     "@playwright/test": "^1.27.1"
   },
   "volta": {
-    "node": "16.19.0",
-    "yarn": "1.22.19"
+    "extends": "../../package.json"
   }
 }

--- a/packages/e2e-tests/test-applications/create-next-app/playwright.config.ts
+++ b/packages/e2e-tests/test-applications/create-next-app/playwright.config.ts
@@ -1,6 +1,11 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
+// Fix urls not resolving to localhost on Node v17+
+// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
+import { setDefaultResultOrder } from 'dns';
+setDefaultResultOrder('ipv4first');
+
 const testEnv = process.env.TEST_ENV;
 
 if (!testEnv) {

--- a/packages/e2e-tests/test-applications/create-react-app/package.json
+++ b/packages/e2e-tests/test-applications/create-react-app/package.json
@@ -48,7 +48,6 @@
     ]
   },
   "volta": {
-    "node": "16.19.0",
-    "yarn": "1.22.19"
+    "extends": "../../package.json"
   }
 }

--- a/packages/e2e-tests/test-applications/create-remix-app/package.json
+++ b/packages/e2e-tests/test-applications/create-remix-app/package.json
@@ -31,5 +31,8 @@
   },
   "engines": {
     "node": ">=14"
+  },
+  "volta": {
+    "extends": "../../package.json"
   }
 }

--- a/packages/e2e-tests/test-applications/nextjs-app-dir/package.json
+++ b/packages/e2e-tests/test-applications/nextjs-app-dir/package.json
@@ -32,7 +32,6 @@
     "@sentry/utils": "latest || *"
   },
   "volta": {
-    "node": "16.19.0",
-    "yarn": "1.22.19"
+    "extends": "../../package.json"
   }
 }

--- a/packages/e2e-tests/test-applications/nextjs-app-dir/playwright.config.ts
+++ b/packages/e2e-tests/test-applications/nextjs-app-dir/playwright.config.ts
@@ -1,6 +1,11 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 
+// Fix urls not resolving to localhost on Node v17+
+// See: https://github.com/axios/axios/issues/3821#issuecomment-1413727575
+import { setDefaultResultOrder } from 'dns';
+setDefaultResultOrder('ipv4first');
+
 const testEnv = process.env.TEST_ENV;
 
 if (!testEnv) {

--- a/packages/e2e-tests/test-applications/node-express-app/package.json
+++ b/packages/e2e-tests/test-applications/node-express-app/package.json
@@ -24,7 +24,6 @@
     "@playwright/test": "^1.27.1"
   },
   "volta": {
-    "node": "16.19.0",
-    "yarn": "1.22.19"
+    "extends": "../../package.json"
   }
 }

--- a/packages/e2e-tests/test-applications/react-create-hash-router/package.json
+++ b/packages/e2e-tests/test-applications/react-create-hash-router/package.json
@@ -51,7 +51,6 @@
     "serve": "14.0.1"
   },
   "volta": {
-    "node": "16.19.0",
-    "yarn": "1.22.19"
+    "extends": "../../package.json"
   }
 }

--- a/packages/e2e-tests/test-applications/standard-frontend-react-tracing-import/package.json
+++ b/packages/e2e-tests/test-applications/standard-frontend-react-tracing-import/package.json
@@ -51,7 +51,6 @@
     "serve": "14.0.1"
   },
   "volta": {
-    "node": "16.19.0",
-    "yarn": "1.22.19"
+    "extends": "../../package.json"
   }
 }

--- a/packages/e2e-tests/test-applications/standard-frontend-react/package.json
+++ b/packages/e2e-tests/test-applications/standard-frontend-react/package.json
@@ -52,7 +52,6 @@
     "serve": "14.0.1"
   },
   "volta": {
-    "node": "16.19.0",
-    "yarn": "1.22.19"
+    "extends": "../../package.json"
   }
 }


### PR DESCRIPTION
Updated Node to v18 (LTS) on E2E tests.

This is needed to properly test Remix v2.

Ref: #8940   