### PR TITLE
fix(node-experimental): Ensure we only create HTTP spans when outgoing

### DIFF
--- a/packages/node-experimental/src/utils/getRequestSpanData.ts
+++ b/packages/node-experimental/src/utils/getRequestSpanData.ts
@@ -2,16 +2,11 @@ import type { Span as OtelSpan } from '@opentelemetry/sdk-trace-base';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import type { SanitizedRequestData } from '@sentry/types';
 import { getSanitizedUrlString, parseUrl } from '@sentry/utils';
-import type { ClientRequest, IncomingMessage, ServerResponse } from 'http';
 
 /**
  * Get sanitizied request data from an OTEL span.
  */
-export function getRequestSpanData(
-  span: OtelSpan,
-  _request: ClientRequest | IncomingMessage,
-  _response: IncomingMessage | ServerResponse,
-): SanitizedRequestData {
+export function getRequestSpanData(span: OtelSpan): SanitizedRequestData {
   const data: SanitizedRequestData = {
     url: span.attributes[SemanticAttributes.HTTP_URL] as string,
     'http.method': (span.attributes[SemanticAttributes.HTTP_METHOD] as string) || 'GET',


### PR DESCRIPTION
This is a fork of https://github.com/getsentry/sentry-javascript/pull/8937, with only the "uncontroversial" stuff, mainly fixing that we only create HTTP breadcrumbs for _outgoing_ requests.

In addition, this also migrates to using `requestHook` and `responseHook` instead of `applyCustomAttributesOnSpan`. We may have to revisit this later, but these hooks seem to have a better context awareness (=they are called in a more reasonable OTEL context, which gives the callbacks there better access to scope data etc). However that means we cannot (easily) pass both request and response as breadcrumb hints - not sure how important that is to us... For now I'd say that's OK.

Note that also `requestHook` is only called when the request finishes, so we already have all the response OTEL span attributes correctly set there.