### PR TITLE
ref: Replace `setup` with `preprocessEvent` on Integration interface

### DIFF
--- a/packages/browser/src/integrations/linkederrors.ts
+++ b/packages/browser/src/integrations/linkederrors.ts
@@ -1,4 +1,4 @@
-import type { Client, Integration } from '@sentry/types';
+import type { Client, Event, EventHint, Integration } from '@sentry/types';
 import { applyAggregateErrorsToEvent } from '@sentry/utils';
 
 import { exceptionFromError } from '../eventbuilder';
@@ -50,23 +50,17 @@ export class LinkedErrors implements Integration {
   /**
    * @inheritDoc
    */
-  public setup(client: Client): void {
-    if (!client.on) {
-      return;
-    }
+  public preprocessEvent(event: Event, hint: EventHint | undefined, client: Client): void {
+    const options = client.getOptions();
 
-    client.on('preprocessEvent', (event, hint) => {
-      const options = client.getOptions();
-
-      applyAggregateErrorsToEvent(
-        exceptionFromError,
-        options.stackParser,
-        options.maxValueLength,
-        this._key,
-        this._limit,
-        event,
-        hint,
-      );
-    });
+    applyAggregateErrorsToEvent(
+      exceptionFromError,
+      options.stackParser,
+      options.maxValueLength,
+      this._key,
+      this._limit,
+      event,
+      hint,
+    );
   }
 }

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -106,7 +106,11 @@ export function setupIntegration(client: Client, integration: Integration, integ
     installedIntegrations.push(integration.name);
   }
 
-  integration.setup && integration.setup(client);
+  if (client.on && typeof integration.preprocessEvent === 'function') {
+    const callback = integration.preprocessEvent.bind(integration);
+    client.on('preprocessEvent', (event, hint) => callback(event, hint, client));
+  }
+
   __DEBUG_BUILD__ && logger.log(`Integration installed: ${integration.name}`);
 }
 

--- a/packages/node/src/integrations/linkederrors.ts
+++ b/packages/node/src/integrations/linkederrors.ts
@@ -1,4 +1,4 @@
-import type { Client, Integration } from '@sentry/types';
+import type { Client, Event, EventHint, Integration } from '@sentry/types';
 import { applyAggregateErrorsToEvent } from '@sentry/utils';
 
 import { exceptionFromError } from '../eventbuilder';
@@ -44,23 +44,17 @@ export class LinkedErrors implements Integration {
   /**
    * @inheritDoc
    */
-  public setup(client: Client): void {
-    if (!client.on) {
-      return;
-    }
+  public preprocessEvent(event: Event, hint: EventHint | undefined, client: Client): void {
+    const options = client.getOptions();
 
-    client.on('preprocessEvent', (event, hint) => {
-      const options = client.getOptions();
-
-      applyAggregateErrorsToEvent(
-        exceptionFromError,
-        options.stackParser,
-        options.maxValueLength,
-        this._key,
-        this._limit,
-        event,
-        hint,
-      );
-    });
+    applyAggregateErrorsToEvent(
+      exceptionFromError,
+      options.stackParser,
+      options.maxValueLength,
+      this._key,
+      this._limit,
+      event,
+      hint,
+    );
   }
 }

--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -1,4 +1,5 @@
 import type { Client } from './client';
+import type { Event, EventHint } from './event';
 import type { EventProcessor } from './eventprocessor';
 import type { Hub } from './hub';
 
@@ -26,7 +27,7 @@ export interface Integration {
   setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void;
 
   /**
-   * An optional hook that is called for each client, vs. only once.
+   * An optional hook that allows to preprocess an event _before_ it is passed to all other event processors.
    */
-  setup?(client: Client): void;
+  preprocessEvent?(event: Event, hint: EventHint | undefined, client: Client): void;
 }


### PR DESCRIPTION
A change to https://github.com/getsentry/sentry-javascript/pull/8956 based on feedback. 

I figured it makes sense to also pass the client (as in the one concrete example we have we actually need it 😅 ) - not sure if this should be the first or last argument, but IMHO you probably don't need this always and then it is nicer to have (event, hint) as the API...?