### PR TITLE
ref: Remove all usages of ts-ignore

### DIFF
--- a/packages/angular/test/errorhandler.test.ts
+++ b/packages/angular/test/errorhandler.test.ts
@@ -532,7 +532,7 @@ describe('SentryErrorHandler', () => {
           }),
         };
 
-        // @ts-ignore this is a minmal hub, we're missing a few props but that's ok
+        // @ts-expect-error this is a minmal hub, we're missing a few props but that's ok
         jest.spyOn(SentryBrowser, 'getCurrentHub').mockImplementationOnce(() => {
           return { getClient: () => client };
         });

--- a/packages/browser-integration-tests/suites/replay/bufferMode/test.ts
+++ b/packages/browser-integration-tests/suites/replay/bufferMode/test.ts
@@ -68,7 +68,7 @@ sentryTest(
     expect(
       await page.evaluate(() => {
         const replayIntegration = (window as unknown as Window & { Replay: InstanceType<typeof Replay> }).Replay;
-        // @ts-ignore private
+        // @ts-expect-error private
         const replay = replayIntegration._replay;
         replayIntegration.startBuffering();
         return replay.isEnabled();
@@ -210,7 +210,7 @@ sentryTest(
     expect(
       await page.evaluate(() => {
         const replayIntegration = (window as unknown as Window & { Replay: InstanceType<typeof Replay> }).Replay;
-        // @ts-ignore private
+        // @ts-expect-error private
         const replay = replayIntegration._replay;
         replayIntegration.startBuffering();
         return replay.isEnabled();

--- a/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestBody/test.ts
+++ b/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestBody/test.ts
@@ -41,7 +41,7 @@ sentryTest('captures text request body', async ({ getLocalTestPath, page, browse
       method: 'POST',
       body: 'input body',
     }).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */
@@ -120,7 +120,7 @@ sentryTest('captures JSON request body', async ({ getLocalTestPath, page, browse
       method: 'POST',
       body: '{"foo":"bar"}',
     }).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */
@@ -203,7 +203,7 @@ sentryTest('captures non-text request body', async ({ getLocalTestPath, page, br
       method: 'POST',
       body: body,
     }).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */
@@ -282,7 +282,7 @@ sentryTest('captures text request body when matching relative URL', async ({ get
       method: 'POST',
       body: 'input body',
     }).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */
@@ -359,7 +359,7 @@ sentryTest('does not capture request body when URL does not match', async ({ get
       method: 'POST',
       body: 'input body',
     }).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */

--- a/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/test.ts
+++ b/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestHeaders/test.ts
@@ -38,7 +38,7 @@ sentryTest('handles empty/missing request headers', async ({ getLocalTestPath, p
     fetch('http://localhost:7654/foo', {
       method: 'POST',
     }).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */
@@ -117,7 +117,7 @@ sentryTest('captures request headers as POJO', async ({ getLocalTestPath, page, 
         'X-Test-Header': 'test-value',
       },
     }).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */
@@ -201,7 +201,7 @@ sentryTest('captures request headers on Request', async ({ getLocalTestPath, pag
     });
     /* eslint-disable */
     fetch(request).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */
@@ -284,7 +284,7 @@ sentryTest('captures request headers as Headers instance', async ({ getLocalTest
       method: 'POST',
       headers,
     }).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */
@@ -367,7 +367,7 @@ sentryTest('does not captures request headers if URL does not match', async ({ g
         'X-Test-Header': 'test-value',
       },
     }).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */

--- a/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestSize/test.ts
+++ b/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureRequestSize/test.ts
@@ -39,7 +39,7 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
       method: 'POST',
       body: '{"foo":"bar"}',
     }).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */
@@ -125,7 +125,7 @@ sentryTest('captures request size from non-text request body', async ({ getLocal
       method: 'POST',
       body: blob,
     }).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */

--- a/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseBody/test.ts
+++ b/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseBody/test.ts
@@ -41,7 +41,7 @@ sentryTest('captures text response body', async ({ getLocalTestPath, page, brows
     fetch('http://localhost:7654/foo', {
       method: 'POST',
     }).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */
@@ -122,7 +122,7 @@ sentryTest('captures JSON response body', async ({ getLocalTestPath, page, brows
     fetch('http://localhost:7654/foo', {
       method: 'POST',
     }).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */
@@ -203,7 +203,7 @@ sentryTest('captures non-text response body', async ({ getLocalTestPath, page, b
     fetch('http://localhost:7654/foo', {
       method: 'POST',
     }).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */
@@ -282,7 +282,7 @@ sentryTest('does not capture response body when URL does not match', async ({ ge
     fetch('http://localhost:7654/bar', {
       method: 'POST',
     }).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */

--- a/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/test.ts
+++ b/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseHeaders/test.ts
@@ -38,7 +38,7 @@ sentryTest('handles empty headers', async ({ getLocalTestPath, page, browserName
   await page.evaluate(() => {
     /* eslint-disable */
     fetch('http://localhost:7654/foo').then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */
@@ -113,7 +113,7 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page }) => {
   await page.evaluate(() => {
     /* eslint-disable */
     fetch('http://localhost:7654/foo').then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */
@@ -194,7 +194,7 @@ sentryTest('does not capture response headers if URL does not match', async ({ g
   await page.evaluate(() => {
     /* eslint-disable */
     fetch('http://localhost:7654/bar').then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */

--- a/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseSize/test.ts
+++ b/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/fetch/captureResponseSize/test.ts
@@ -43,7 +43,7 @@ sentryTest('captures response size from Content-Length header if available', asy
   await page.evaluate(() => {
     /* eslint-disable */
     fetch('http://localhost:7654/foo').then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */
@@ -131,7 +131,7 @@ sentryTest('captures response size without Content-Length header', async ({ getL
   await page.evaluate(() => {
     /* eslint-disable */
     fetch('http://localhost:7654/foo').then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */
@@ -218,7 +218,7 @@ sentryTest('captures response size from non-text response body', async ({ getLoc
     fetch('http://localhost:7654/foo', {
       method: 'POST',
     }).then(() => {
-      // @ts-ignore Sentry is a global
+      // @ts-expect-error Sentry is a global
       Sentry.captureException('test error');
     });
     /* eslint-enable */

--- a/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestBody/test.ts
+++ b/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestBody/test.ts
@@ -43,7 +43,7 @@ sentryTest('captures text request body', async ({ getLocalTestPath, page, browse
 
     xhr.addEventListener('readystatechange', function () {
       if (xhr.readyState === 4) {
-        // @ts-ignore Sentry is a global
+        // @ts-expect-error Sentry is a global
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
@@ -124,7 +124,7 @@ sentryTest('captures JSON request body', async ({ getLocalTestPath, page, browse
 
     xhr.addEventListener('readystatechange', function () {
       if (xhr.readyState === 4) {
-        // @ts-ignore Sentry is a global
+        // @ts-expect-error Sentry is a global
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
@@ -209,7 +209,7 @@ sentryTest('captures non-text request body', async ({ getLocalTestPath, page, br
 
     xhr.addEventListener('readystatechange', function () {
       if (xhr.readyState === 4) {
-        // @ts-ignore Sentry is a global
+        // @ts-expect-error Sentry is a global
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
@@ -290,7 +290,7 @@ sentryTest('captures text request body when matching relative URL', async ({ get
 
     xhr.addEventListener('readystatechange', function () {
       if (xhr.readyState === 4) {
-        // @ts-ignore Sentry is a global
+        // @ts-expect-error Sentry is a global
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
@@ -371,7 +371,7 @@ sentryTest('does not capture request body when URL does not match', async ({ get
 
     xhr.addEventListener('readystatechange', function () {
       if (xhr.readyState === 4) {
-        // @ts-ignore Sentry is a global
+        // @ts-expect-error Sentry is a global
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });

--- a/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestHeaders/test.ts
+++ b/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestHeaders/test.ts
@@ -47,7 +47,7 @@ sentryTest('captures request headers', async ({ getLocalTestPath, page, browserN
 
     xhr.addEventListener('readystatechange', function () {
       if (xhr.readyState === 4) {
-        // @ts-ignore Sentry is a global
+        // @ts-expect-error Sentry is a global
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
@@ -135,7 +135,7 @@ sentryTest(
 
       xhr.addEventListener('readystatechange', function () {
         if (xhr.readyState === 4) {
-          // @ts-ignore Sentry is a global
+          // @ts-expect-error Sentry is a global
           setTimeout(() => Sentry.captureException('test error', 0));
         }
       });

--- a/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestSize/test.ts
+++ b/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureRequestSize/test.ts
@@ -43,7 +43,7 @@ sentryTest('captures request body size when body is sent', async ({ getLocalTest
 
     xhr.addEventListener('readystatechange', function () {
       if (xhr.readyState === 4) {
-        // @ts-ignore Sentry is a global
+        // @ts-expect-error Sentry is a global
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
@@ -134,7 +134,7 @@ sentryTest('captures request size from non-text request body', async ({ getLocal
 
     xhr.addEventListener('readystatechange', function () {
       if (xhr.readyState === 4) {
-        // @ts-ignore Sentry is a global
+        // @ts-expect-error Sentry is a global
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });

--- a/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseBody/test.ts
+++ b/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseBody/test.ts
@@ -47,7 +47,7 @@ sentryTest('captures text response body', async ({ getLocalTestPath, page, brows
 
     xhr.addEventListener('readystatechange', function () {
       if (xhr.readyState === 4) {
-        // @ts-ignore Sentry is a global
+        // @ts-expect-error Sentry is a global
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
@@ -132,7 +132,7 @@ sentryTest('captures JSON response body', async ({ getLocalTestPath, page, brows
 
     xhr.addEventListener('readystatechange', function () {
       if (xhr.readyState === 4) {
-        // @ts-ignore Sentry is a global
+        // @ts-expect-error Sentry is a global
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
@@ -217,7 +217,7 @@ sentryTest('captures non-text response body', async ({ getLocalTestPath, page, b
 
     xhr.addEventListener('readystatechange', function () {
       if (xhr.readyState === 4) {
-        // @ts-ignore Sentry is a global
+        // @ts-expect-error Sentry is a global
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
@@ -304,7 +304,7 @@ sentryTest(
 
       xhr.addEventListener('readystatechange', function () {
         if (xhr.readyState === 4) {
-          // @ts-ignore Sentry is a global
+          // @ts-expect-error Sentry is a global
           setTimeout(() => Sentry.captureException('test error', 0));
         }
       });

--- a/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseHeaders/test.ts
+++ b/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseHeaders/test.ts
@@ -50,7 +50,7 @@ sentryTest('captures response headers', async ({ getLocalTestPath, page, browser
 
     xhr.addEventListener('readystatechange', function () {
       if (xhr.readyState === 4) {
-        // @ts-ignore Sentry is a global
+        // @ts-expect-error Sentry is a global
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
@@ -141,7 +141,7 @@ sentryTest(
 
       xhr.addEventListener('readystatechange', function () {
         if (xhr.readyState === 4) {
-          // @ts-ignore Sentry is a global
+          // @ts-expect-error Sentry is a global
           setTimeout(() => Sentry.captureException('test error', 0));
         }
       });

--- a/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseSize/test.ts
+++ b/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseSize/test.ts
@@ -48,7 +48,7 @@ sentryTest(
 
       xhr.addEventListener('readystatechange', function () {
         if (xhr.readyState === 4) {
-          // @ts-ignore Sentry is a global
+          // @ts-expect-error Sentry is a global
           setTimeout(() => Sentry.captureException('test error', 0));
         }
       });
@@ -144,7 +144,7 @@ sentryTest('captures response size without Content-Length header', async ({ getL
 
     xhr.addEventListener('readystatechange', function () {
       if (xhr.readyState === 4) {
-        // @ts-ignore Sentry is a global
+        // @ts-expect-error Sentry is a global
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });
@@ -237,7 +237,7 @@ sentryTest('captures response size for non-string bodies', async ({ getLocalTest
 
     xhr.addEventListener('readystatechange', function () {
       if (xhr.readyState === 4) {
-        // @ts-ignore Sentry is a global
+        // @ts-expect-error Sentry is a global
         setTimeout(() => Sentry.captureException('test error', 0));
       }
     });

--- a/packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
+++ b/packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
@@ -146,13 +146,13 @@ sentryTest(
     expect(replayEvent4).toEqual(
       getExpectedReplayEvent({
         segment_id: 4,
-        // @ts-ignore this is fine
+        // @ts-expect-error this is fine
         urls: [expect.stringContaining('page-0.html')],
         request: {
-          // @ts-ignore this is fine
+          // @ts-expect-error this is fine
           url: expect.stringContaining('page-0.html'),
           headers: {
-            // @ts-ignore this is fine
+            // @ts-expect-error this is fine
             'User-Agent': expect.stringContaining(''),
           },
         },
@@ -172,10 +172,10 @@ sentryTest(
         segment_id: 5,
         urls: [],
         request: {
-          // @ts-ignore this is fine
+          // @ts-expect-error this is fine
           url: expect.stringContaining('page-0.html'),
           headers: {
-            // @ts-ignore this is fine
+            // @ts-expect-error this is fine
             'User-Agent': expect.stringContaining(''),
           },
         },
@@ -219,10 +219,10 @@ sentryTest(
         urls: ['/spa'],
 
         request: {
-          // @ts-ignore this is fine
+          // @ts-expect-error this is fine
           url: expect.stringContaining('page-0.html'),
           headers: {
-            // @ts-ignore this is fine
+            // @ts-expect-error this is fine
             'User-Agent': expect.stringContaining(''),
           },
         },
@@ -243,10 +243,10 @@ sentryTest(
         urls: [],
 
         request: {
-          // @ts-ignore this is fine
+          // @ts-expect-error this is fine
           url: expect.stringContaining('page-0.html'),
           headers: {
-            // @ts-ignore this is fine
+            // @ts-expect-error this is fine
             'User-Agent': expect.stringContaining(''),
           },
         },

--- a/packages/browser-integration-tests/suites/wasm/test.ts
+++ b/packages/browser-integration-tests/suites/wasm/test.ts
@@ -29,7 +29,7 @@ sentryTest(
     await page.goto(url);
 
     const event = await page.evaluate(async () => {
-      // @ts-ignore this function exists
+      // @ts-expect-error this function exists
       return window.getEvent();
     });
 

--- a/packages/browser-integration-tests/utils/replayHelpers.ts
+++ b/packages/browser-integration-tests/utils/replayHelpers.ts
@@ -401,6 +401,6 @@ function normalizeNumberAttribute(num: number): string {
 
 /** Get a request from either a request or a response */
 function getRequest(resOrReq: Request | Response): Request {
-  // @ts-ignore we check this
+  // @ts-expect-error we check this
   return typeof resOrReq.request === 'function' ? (resOrReq as Response).request() : (resOrReq as Request);
 }

--- a/packages/browser/src/integrations/dedupe.ts
+++ b/packages/browser/src/integrations/dedupe.ts
@@ -204,7 +204,7 @@ function _getFramesFromEvent(event: Event): StackFrame[] | undefined {
 
   if (exception) {
     try {
-      // @ts-ignore Object could be undefined
+      // @ts-expect-error Object could be undefined
       return exception.values[0].stacktrace.frames;
     } catch (_oO) {
       return undefined;

--- a/packages/browser/src/profiling/hubextensions.ts
+++ b/packages/browser/src/profiling/hubextensions.ts
@@ -71,7 +71,7 @@ export function wrapTransactionWithProfiling(transaction: Transaction): Transact
     return transaction;
   }
 
-  // @ts-ignore profilesSampleRate is not part of the browser options yet
+  // @ts-expect-error profilesSampleRate is not part of the browser options yet
   const profilesSampleRate: number | boolean | undefined = options.profilesSampleRate;
 
   // Since this is coming from the user (or from a function provided by the user), who knows what we might get. (The

--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -44,7 +44,7 @@ function isUserAgentData(data: unknown): data is UserAgentData {
   return typeof data === 'object' && data !== null && 'getHighEntropyValues' in data;
 }
 
-// @ts-ignore userAgentData is not part of the navigator interface yet
+// @ts-expect-error userAgentData is not part of the navigator interface yet
 const userAgentData = WINDOW.navigator && WINDOW.navigator.userAgentData;
 
 if (isUserAgentData(userAgentData)) {
@@ -290,7 +290,7 @@ export function addProfilesToEnvelope(envelope: Envelope, profiles: Profile[]): 
   }
 
   for (const profile of profiles) {
-    // @ts-ignore untyped envelope
+    // @ts-expect-error untyped envelope
     envelope[1].push([{ type: 'profile' }, profile]);
   }
   return envelope;

--- a/packages/browser/src/transports/offline.ts
+++ b/packages/browser/src/transports/offline.ts
@@ -28,9 +28,9 @@ type Store = <T>(callback: (store: IDBObjectStore) => T | PromiseLike<T>) => Pro
 
 function promisifyRequest<T = undefined>(request: IDBRequest<T> | IDBTransaction): Promise<T> {
   return new Promise<T>((resolve, reject) => {
-    // @ts-ignore - file size hacks
+    // @ts-expect-error - file size hacks
     request.oncomplete = request.onsuccess = () => resolve(request.result);
-    // @ts-ignore - file size hacks
+    // @ts-expect-error - file size hacks
     request.onabort = request.onerror = () => reject(request.error);
   });
 }

--- a/packages/browser/test/unit/integrations/helpers.test.ts
+++ b/packages/browser/test/unit/integrations/helpers.test.ts
@@ -12,13 +12,13 @@ describe('internal wrap()', () => {
     const num = 42;
 
     expect(wrap(fn)).not.toBe(fn);
-    // @ts-ignore Issue with `WrappedFunction` type from wrap fn
+    // @ts-expect-error Issue with `WrappedFunction` type from wrap fn
     expect(wrap(obj)).toBe(obj);
-    // @ts-ignore Issue with `WrappedFunction` type from wrap fn
+    // @ts-expect-error Issue with `WrappedFunction` type from wrap fn
     expect(wrap(arr)).toBe(arr);
-    // @ts-ignore Issue with `WrappedFunction` type from wrap fn
+    // @ts-expect-error Issue with `WrappedFunction` type from wrap fn
     expect(wrap(str)).toBe(str);
-    // @ts-ignore Issue with `WrappedFunction` type from wrap fn
+    // @ts-expect-error Issue with `WrappedFunction` type from wrap fn
     expect(wrap(num)).toBe(num);
   });
 
@@ -134,7 +134,7 @@ describe('internal wrap()', () => {
         return;
       },
     };
-    // @ts-ignore eventFn does not have property handleEvent
+    // @ts-expect-error eventFn does not have property handleEvent
     context.eventFn.handleEvent = function (): void {
       expect(this).toBe(context);
     };

--- a/packages/browser/test/unit/profiling/hubextensions.test.ts
+++ b/packages/browser/test/unit/profiling/hubextensions.test.ts
@@ -1,7 +1,7 @@
 import { TextDecoder, TextEncoder } from 'util';
-// @ts-ignore patch the encoder on the window, else importing JSDOM fails (deleted in afterAll)
+// @ts-expect-error patch the encoder on the window, else importing JSDOM fails (deleted in afterAll)
 const patchedEncoder = (!global.window.TextEncoder && (global.window.TextEncoder = TextEncoder)) || true;
-// @ts-ignore patch the encoder on the window, else importing JSDOM fails (deleted in afterAll)
+// @ts-expect-error patch the encoder on the window, else importing JSDOM fails (deleted in afterAll)
 const patchedDecoder = (!global.window.TextDecoder && (global.window.TextDecoder = TextDecoder)) || true;
 
 import { getCurrentHub } from '@sentry/core';
@@ -10,21 +10,21 @@ import { JSDOM } from 'jsdom';
 
 import { onProfilingStartRouteTransaction } from '../../../src';
 
-// @ts-ignore store a reference so we can reset it later
+// @ts-expect-error store a reference so we can reset it later
 const globalDocument = global.document;
-// @ts-ignore store a reference so we can reset it later
+// @ts-expect-error store a reference so we can reset it later
 const globalWindow = global.window;
-// @ts-ignore store a reference so we can reset it later
+// @ts-expect-error store a reference so we can reset it later
 const globalLocation = global.location;
 
 describe('BrowserProfilingIntegration', () => {
   beforeEach(() => {
     const dom = new JSDOM();
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.document = dom.window.document;
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.window = dom.window;
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.location = dom.window.location;
 
     const hub = getCurrentHub();
@@ -49,22 +49,22 @@ describe('BrowserProfilingIntegration', () => {
 
   // Reset back to previous values
   afterEach(() => {
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.document = globalDocument;
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.window = globalWindow;
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.location = globalLocation;
   });
   afterAll(() => {
-    // @ts-ignore patch the encoder on the window, else importing JSDOM fails
+    // @ts-expect-error patch the encoder on the window, else importing JSDOM fails
     patchedEncoder && delete global.window.TextEncoder;
-    // @ts-ignore patch the encoder on the window, else importing JSDOM fails
+    // @ts-expect-error patch the encoder on the window, else importing JSDOM fails
     patchedDecoder && delete global.window.TextDecoder;
   });
 
   it('does not throw if Profiler is not available', () => {
-    // @ts-ignore force api to be undefined
+    // @ts-expect-error force api to be undefined
     global.window.Profiler = undefined;
     // set sampled to true so that profiling does not early return
     const mockTransaction = { sampled: true } as Transaction;
@@ -83,7 +83,7 @@ describe('BrowserProfilingIntegration', () => {
     // set sampled to true so that profiling does not early return
     const mockTransaction = { sampled: true } as Transaction;
 
-    // @ts-ignore override with our own constructor
+    // @ts-expect-error override with our own constructor
     global.window.Profiler = Profiler;
     expect(() => onProfilingStartRouteTransaction(mockTransaction)).not.toThrow();
     expect(spy).toHaveBeenCalled();

--- a/packages/browser/test/unit/profiling/utils.test.ts
+++ b/packages/browser/test/unit/profiling/utils.test.ts
@@ -1,7 +1,7 @@
 import { TextDecoder, TextEncoder } from 'util';
-// @ts-ignore patch the encoder on the window, else importing JSDOM fails (deleted in afterAll)
+// @ts-expect-error patch the encoder on the window, else importing JSDOM fails (deleted in afterAll)
 const patchedEncoder = (!global.window.TextEncoder && (global.window.TextEncoder = TextEncoder)) || true;
-// @ts-ignore patch the encoder on the window, else importing JSDOM fails (deleted in afterAll)
+// @ts-expect-error patch the encoder on the window, else importing JSDOM fails (deleted in afterAll)
 const patchedDecoder = (!global.window.TextDecoder && (global.window.TextDecoder = TextDecoder)) || true;
 
 import { JSDOM } from 'jsdom';
@@ -19,38 +19,38 @@ const makeJSProfile = (partial: Partial<JSSelfProfile> = {}): JSSelfProfile => {
   };
 };
 
-// @ts-ignore store a reference so we can reset it later
+// @ts-expect-error store a reference so we can reset it later
 const globalDocument = global.document;
-// @ts-ignore store a reference so we can reset it later
+// @ts-expect-error store a reference so we can reset it later
 const globalWindow = global.window;
-// @ts-ignore store a reference so we can reset it later
+// @ts-expect-error store a reference so we can reset it later
 const globalLocation = global.location;
 
 describe('convertJSSelfProfileToSampledFormat', () => {
   beforeEach(() => {
     const dom = new JSDOM();
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.document = dom.window.document;
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.window = dom.window;
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.location = dom.window.location;
   });
 
   // Reset back to previous values
   afterEach(() => {
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.document = globalDocument;
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.window = globalWindow;
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.location = globalLocation;
   });
 
   afterAll(() => {
-    // @ts-ignore patch the encoder on the window, else importing JSDOM fails
+    // @ts-expect-error patch the encoder on the window, else importing JSDOM fails
     patchedEncoder && delete global.window.TextEncoder;
-    // @ts-ignore patch the encoder on the window, else importing JSDOM fails
+    // @ts-expect-error patch the encoder on the window, else importing JSDOM fails
     patchedDecoder && delete global.window.TextDecoder;
   });
 

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -407,7 +407,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
       this._hooks[hook] = [];
     }
 
-    // @ts-ignore We assue the types are correct
+    // @ts-expect-error We assue the types are correct
     this._hooks[hook].push(callback);
   }
 
@@ -435,7 +435,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   /** @inheritdoc */
   public emit(hook: string, ...rest: unknown[]): void {
     if (this._hooks[hook]) {
-      // @ts-ignore we cannot enforce the callback to match the hook
+      // @ts-expect-error we cannot enforce the callback to match the hook
       this._hooks[hook].forEach(callback => callback(...rest));
     }
   }

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -435,7 +435,6 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   /** @inheritdoc */
   public emit(hook: string, ...rest: unknown[]): void {
     if (this._hooks[hook]) {
-      // @ts-expect-error we cannot enforce the callback to match the hook
       this._hooks[hook].forEach(callback => callback(...rest));
     }
   }

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -497,7 +497,7 @@ Sentry.init({...});
   /**
    * Calls global extension method and binding current instance to the function call
    */
-  // @ts-ignore Function lacks ending return statement and return type does not include 'undefined'. ts(2366)
+  // @ts-expect-error Function lacks ending return statement and return type does not include 'undefined'. ts(2366)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _callExtensionMethod<T>(method: string, ...args: any[]): T {
     const carrier = getMainCarrier();

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -187,7 +187,7 @@ function _getPossibleEventMessages(event: Event): string[] {
 
 function _isSentryError(event: Event): boolean {
   try {
-    // @ts-ignore can't be a sentry error if undefined
+    // @ts-expect-error can't be a sentry error if undefined
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     return event.exception.values[0].type === 'SentryError';
   } catch (e) {
@@ -212,7 +212,7 @@ function _getEventFilterUrl(event: Event): string | null {
   try {
     let frames;
     try {
-      // @ts-ignore we only care about frames if the whole thing here is defined
+      // @ts-expect-error we only care about frames if the whole thing here is defined
       frames = event.exception.values[0].stacktrace.frames;
     } catch (e) {
       // ignore

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -722,7 +722,7 @@ describe('BaseClient', () => {
     test('skips empty integrations', () => {
       const options = getDefaultTestClientOptions({
         dsn: PUBLIC_DSN,
-        // @ts-ignore we want to force invalid integrations here
+        // @ts-expect-error we want to force invalid integrations here
         integrations: [new TestIntegration(), null, undefined],
       });
       const client = new TestClient(options);
@@ -1046,7 +1046,7 @@ describe('BaseClient', () => {
 
       for (const val of invalidValues) {
         const beforeSend = jest.fn(() => val);
-        // @ts-ignore we need to test regular-js behavior
+        // @ts-expect-error we need to test regular-js behavior
         const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, beforeSend });
         const client = new TestClient(options);
         const loggerWarnSpy = jest.spyOn(logger, 'warn');
@@ -1067,7 +1067,7 @@ describe('BaseClient', () => {
 
       for (const val of invalidValues) {
         const beforeSendTransaction = jest.fn(() => val);
-        // @ts-ignore we need to test regular-js behavior
+        // @ts-expect-error we need to test regular-js behavior
         const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, beforeSendTransaction });
         const client = new TestClient(options);
         const loggerWarnSpy = jest.spyOn(logger, 'warn');

--- a/packages/core/test/lib/hint.test.ts
+++ b/packages/core/test/lib/hint.test.ts
@@ -16,7 +16,7 @@ describe('Hint', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    // @ts-ignore for testing
+    // @ts-expect-error for testing
     delete GLOBAL_OBJ.__SENTRY__;
   });
 

--- a/packages/core/test/lib/serverruntimeclient.test.ts
+++ b/packages/core/test/lib/serverruntimeclient.test.ts
@@ -78,7 +78,7 @@ describe('ServerRuntimeClient', () => {
       });
       client = new ServerRuntimeClient(options);
 
-      // @ts-ignore accessing private method
+      // @ts-expect-error accessing private method
       const sendEnvelopeSpy = jest.spyOn(client, '_sendEnvelope');
 
       const id = client.captureCheckIn(
@@ -145,7 +145,7 @@ describe('ServerRuntimeClient', () => {
       const options = getDefaultClientOptions({ dsn: PUBLIC_DSN, serverName: 'bar', enabled: false });
       client = new ServerRuntimeClient(options);
 
-      // @ts-ignore accessing private method
+      // @ts-expect-error accessing private method
       const sendEnvelopeSpy = jest.spyOn(client, '_sendEnvelope');
 
       client.captureCheckIn({ monitorSlug: 'foo', status: 'in_progress' });

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -48,7 +48,7 @@ describe('startActiveSpan', () => {
     });
 
     it('should return the same value as the callback if transactions are undefined', async () => {
-      // @ts-ignore we are force overriding the transaction return to be undefined
+      // @ts-expect-error we are force overriding the transaction return to be undefined
       // The `startTransaction` types are actually wrong - it can return undefined
       // if tracingExtensions are not enabled
       jest.spyOn(hub, 'startTransaction').mockReturnValue(undefined);

--- a/packages/core/test/lib/transports/offline.test.ts
+++ b/packages/core/test/lib/transports/offline.test.ts
@@ -27,7 +27,7 @@ const ERROR_ENVELOPE = createEnvelope<EventEnvelope>({ event_id: 'aa3ff046696b4b
 ]);
 
 const REPLAY_EVENT: ReplayEvent = {
-  // @ts-ignore private api
+  // @ts-expect-error private api
   type: 'replay_event',
   timestamp: 1670837008.634,
   error_ids: ['errorId'],

--- a/packages/core/test/lib/transports/offline.test.ts
+++ b/packages/core/test/lib/transports/offline.test.ts
@@ -27,7 +27,6 @@ const ERROR_ENVELOPE = createEnvelope<EventEnvelope>({ event_id: 'aa3ff046696b4b
 ]);
 
 const REPLAY_EVENT: ReplayEvent = {
-  // @ts-expect-error private api
   type: 'replay_event',
   timestamp: 1670837008.634,
   error_ids: ['errorId'],

--- a/packages/e2e-tests/test-applications/nextjs-app-dir/tests/async-context-edge.test.ts
+++ b/packages/e2e-tests/test-applications/nextjs-app-dir/tests/async-context-edge.test.ts
@@ -15,8 +15,8 @@ test('Should allow for async context isolation in the edge SDK', async ({ reques
   const outerSpan = asyncContextEdgerouteTransaction.spans?.find(span => span.description === 'outer-span');
   const innerSpan = asyncContextEdgerouteTransaction.spans?.find(span => span.description === 'inner-span');
 
-  // @ts-ignore parent_span_id exists
+  // @ts-expect-error parent_span_id exists
   expect(outerSpan?.parent_span_id).toStrictEqual(asyncContextEdgerouteTransaction.contexts?.trace?.span_id);
-  // @ts-ignore parent_span_id exists
+  // @ts-expect-error parent_span_id exists
   expect(innerSpan?.parent_span_id).toStrictEqual(asyncContextEdgerouteTransaction.contexts?.trace?.span_id);
 });

--- a/packages/e2e-tests/test-applications/sveltekit/test/transaction.test.ts
+++ b/packages/e2e-tests/test-applications/sveltekit/test/transaction.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-// @ts-ignore ok ok
+// @ts-expect-error ok ok
 import { waitForTransaction } from '../event-proxy-server.ts';
 import axios, { AxiosError } from 'axios';
 

--- a/packages/hub/test/global.test.ts
+++ b/packages/hub/test/global.test.ts
@@ -28,7 +28,7 @@ describe('global', () => {
     const newestHub = new Hub(undefined, undefined, 999999);
     GLOBAL_OBJ.__SENTRY__.hub = newestHub;
     const fn = jest.fn().mockImplementation(function (...args: []) {
-      // @ts-ignore typescript complains that this can be `any`
+      // @ts-expect-error typescript complains that this can be `any`
       expect(this).toBe(newestHub);
       expect(args).toEqual([1, 2, 3]);
     });

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -17,7 +17,7 @@ describe('Scope', () => {
     test('it creates a propagation context', () => {
       const scope = new Scope();
 
-      // @ts-ignore asserting on private properties
+      // @ts-expect-error asserting on private properties
       expect(scope._propagationContext).toEqual({
         traceId: expect.any(String),
         spanId: expect.any(String),
@@ -230,7 +230,7 @@ describe('Scope', () => {
       const parentScope = new Scope();
       const scope = Scope.clone(parentScope);
 
-      // @ts-ignore accessing private property for test
+      // @ts-expect-error accessing private property for test
       expect(scope._propagationContext).toEqual(parentScope._propagationContext);
     });
   });
@@ -304,13 +304,13 @@ describe('Scope', () => {
       const scope = new Scope();
       const event: Event = {};
 
-      // @ts-ignore we want to be able to assign string value
+      // @ts-expect-error we want to be able to assign string value
       event.fingerprint = 'foo';
       await scope.applyToEvent(event).then(processedEvent => {
         expect(processedEvent!.fingerprint).toEqual(['foo']);
       });
 
-      // @ts-ignore we want to be able to assign string value
+      // @ts-expect-error we want to be able to assign string value
       event.fingerprint = 'bar';
       await scope.applyToEvent(event).then(processedEvent => {
         expect(processedEvent!.fingerprint).toEqual(['bar']);
@@ -478,7 +478,7 @@ describe('Scope', () => {
     });
 
     test('given neither function, Scope or plain object, returns original scope', () => {
-      // @ts-ignore we want to be able to update scope with string
+      // @ts-expect-error we want to be able to update scope with string
       const updatedScope = scope.update('wat');
       expect(updatedScope).toEqual(scope);
     });
@@ -540,7 +540,7 @@ describe('Scope', () => {
       expect(updatedScope._level).toEqual('warning');
       expect(updatedScope._fingerprint).toEqual(['bar']);
       expect(updatedScope._requestSession.status).toEqual('ok');
-      // @ts-ignore accessing private property for test
+      // @ts-expect-error accessing private property for test
       expect(updatedScope._propagationContext).toEqual(localScope._propagationContext);
     });
 

--- a/packages/integrations/src/dedupe.ts
+++ b/packages/integrations/src/dedupe.ts
@@ -204,7 +204,7 @@ function _getFramesFromEvent(event: Event): StackFrame[] | undefined {
 
   if (exception) {
     try {
-      // @ts-ignore Object could be undefined
+      // @ts-expect-error Object could be undefined
       return exception.values[0].stacktrace.frames;
     } catch (_oO) {
       return undefined;

--- a/packages/integrations/test/captureconsole.test.ts
+++ b/packages/integrations/test/captureconsole.test.ts
@@ -116,7 +116,7 @@ describe('CaptureConsole setup', () => {
 
   it('setup should fail gracefully when console is not available', () => {
     const consoleRef = GLOBAL_OBJ.console;
-    // @ts-ignore remove console
+    // @ts-expect-error remove console
     delete GLOBAL_OBJ.console;
 
     const captureConsoleIntegration = new CaptureConsole();

--- a/packages/integrations/test/extraerrordata.test.ts
+++ b/packages/integrations/test/extraerrordata.test.ts
@@ -69,7 +69,7 @@ describe('ExtraErrorData()', () => {
 
   it('should not remove previous data existing in extra field', () => {
     event = {
-      // @ts-ignore Allow contexts on event
+      // @ts-expect-error Allow contexts on event
       contexts: {
         foo: { bar: 42 },
       },
@@ -107,7 +107,7 @@ describe('ExtraErrorData()', () => {
 
   it('should return event if there is no originalException', () => {
     const enhancedEvent = extraErrorData.enhanceEventWithErrorData(event, {
-      // @ts-ignore Allow event to have extra properties
+      // @ts-expect-error Allow event to have extra properties
       notOriginalException: 'fooled you',
     });
 

--- a/packages/integrations/test/extraerrordata.test.ts
+++ b/packages/integrations/test/extraerrordata.test.ts
@@ -69,7 +69,6 @@ describe('ExtraErrorData()', () => {
 
   it('should not remove previous data existing in extra field', () => {
     event = {
-      // @ts-expect-error Allow contexts on event
       contexts: {
         foo: { bar: 42 },
       },

--- a/packages/integrations/test/rewriteframes.test.ts
+++ b/packages/integrations/test/rewriteframes.test.ts
@@ -108,7 +108,7 @@ describe('RewriteFrames', () => {
     });
 
     it('ignore exception without StackTrace', () => {
-      // @ts-ignore Validates that the Stacktrace does not exist before validating the test.
+      // @ts-expect-error Validates that the Stacktrace does not exist before validating the test.
       expect(exceptionWithoutStackTrace.exception?.values[0].stacktrace).toEqual(undefined);
       const event = rewriteFrames.process(exceptionWithoutStackTrace);
       expect(event.exception!.values![0].stacktrace).toEqual(undefined);

--- a/packages/nextjs/src/config/templates/apiWrapperTemplate.ts
+++ b/packages/nextjs/src/config/templates/apiWrapperTemplate.ts
@@ -6,7 +6,7 @@
  * this causes both TS and ESLint to complain, hence the pragma comments below.
  */
 
-// @ts-ignore See above
+// @ts-expect-error See above
 // eslint-disable-next-line import/no-unresolved
 import * as origModule from '__SENTRY_WRAPPING_TARGET_FILE__';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -68,6 +68,6 @@ export default wrappedHandler;
 
 // Re-export anything exported by the page module we're wrapping. When processing this code, Rollup is smart enough to
 // not include anything whose name matchs something we've explicitly exported above.
-// @ts-ignore See above
+// @ts-expect-error See above
 // eslint-disable-next-line import/no-unresolved
 export * from '__SENTRY_WRAPPING_TARGET_FILE__';

--- a/packages/nextjs/src/config/templates/middlewareWrapperTemplate.ts
+++ b/packages/nextjs/src/config/templates/middlewareWrapperTemplate.ts
@@ -5,7 +5,7 @@
  * this causes both TS and ESLint to complain, hence the pragma comments below.
  */
 
-// @ts-ignore See above
+// @ts-expect-error See above
 // eslint-disable-next-line import/no-unresolved
 import * as origModule from '__SENTRY_WRAPPING_TARGET_FILE__';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -47,6 +47,6 @@ export default userProvidedDefaultHandler ? Sentry.wrapMiddlewareWithSentry(user
 
 // Re-export anything exported by the page module we're wrapping. When processing this code, Rollup is smart enough to
 // not include anything whose name matchs something we've explicitly exported above.
-// @ts-ignore See above
+// @ts-expect-error See above
 // eslint-disable-next-line import/no-unresolved
 export * from '__SENTRY_WRAPPING_TARGET_FILE__';

--- a/packages/nextjs/src/config/templates/pageWrapperTemplate.ts
+++ b/packages/nextjs/src/config/templates/pageWrapperTemplate.ts
@@ -6,7 +6,7 @@
  * this causes both TS and ESLint to complain, hence the pragma comments below.
  */
 
-// @ts-ignore See above
+// @ts-expect-error See above
 // eslint-disable-next-line import/no-unresolved
 import * as wrapee from '__SENTRY_WRAPPING_TARGET_FILE__';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -52,6 +52,6 @@ export default pageComponent;
 
 // Re-export anything exported by the page module we're wrapping. When processing this code, Rollup is smart enough to
 // not include anything whose name matchs something we've explicitly exported above.
-// @ts-ignore See above
+// @ts-expect-error See above
 // eslint-disable-next-line import/no-unresolved
 export * from '__SENTRY_WRAPPING_TARGET_FILE__';

--- a/packages/nextjs/src/config/templates/routeHandlerWrapperTemplate.ts
+++ b/packages/nextjs/src/config/templates/routeHandlerWrapperTemplate.ts
@@ -1,8 +1,8 @@
-// @ts-ignore Because we cannot be sure if the RequestAsyncStorage module exists (it is not part of the Next.js public
+// @ts-expect-error Because we cannot be sure if the RequestAsyncStorage module exists (it is not part of the Next.js public
 // API) we use a shim if it doesn't exist. The logic for this is in the wrapping loader.
 // eslint-disable-next-line import/no-unresolved
 import { requestAsyncStorage } from '__SENTRY_NEXTJS_REQUEST_ASYNC_STORAGE_SHIM__';
-// @ts-ignore See above
+// @ts-expect-error See above
 // eslint-disable-next-line import/no-unresolved
 import * as routeModule from '__SENTRY_WRAPPING_TARGET_FILE__';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -58,11 +58,11 @@ function wrapHandler<T>(handler: T, method: 'GET' | 'POST' | 'PUT' | 'PATCH' | '
   });
 }
 
-// @ts-ignore See above
+// @ts-expect-error See above
 // eslint-disable-next-line import/no-unresolved
 export * from '__SENTRY_WRAPPING_TARGET_FILE__';
 
-// @ts-ignore This is the file we're wrapping
+// @ts-expect-error This is the file we're wrapping
 // eslint-disable-next-line import/no-unresolved
 export { default } from '__SENTRY_WRAPPING_TARGET_FILE__';
 

--- a/packages/nextjs/src/config/templates/sentryInitWrapperTemplate.ts
+++ b/packages/nextjs/src/config/templates/sentryInitWrapperTemplate.ts
@@ -1,11 +1,11 @@
-// @ts-ignore This will be replaced with the user's sentry config gile
+// @ts-expect-error This will be replaced with the user's sentry config gile
 // eslint-disable-next-line import/no-unresolved
 import '__SENTRY_CONFIG_IMPORT_PATH__';
 
-// @ts-ignore This is the file we're wrapping
+// @ts-expect-error This is the file we're wrapping
 // eslint-disable-next-line import/no-unresolved
 export * from '__SENTRY_WRAPPING_TARGET_FILE__';
 
-// @ts-ignore This is the file we're wrapping
+// @ts-expect-error This is the file we're wrapping
 // eslint-disable-next-line import/no-unresolved
 export { default } from '__SENTRY_WRAPPING_TARGET_FILE__';

--- a/packages/nextjs/src/config/templates/serverComponentWrapperTemplate.ts
+++ b/packages/nextjs/src/config/templates/serverComponentWrapperTemplate.ts
@@ -1,8 +1,8 @@
-// @ts-ignore Because we cannot be sure if the RequestAsyncStorage module exists (it is not part of the Next.js public
+// @ts-expect-error Because we cannot be sure if the RequestAsyncStorage module exists (it is not part of the Next.js public
 // API) we use a shim if it doesn't exist. The logic for this is in the wrapping loader.
 // eslint-disable-next-line import/no-unresolved
 import { requestAsyncStorage } from '__SENTRY_NEXTJS_REQUEST_ASYNC_STORAGE_SHIM__';
-// @ts-ignore We use `__SENTRY_WRAPPING_TARGET_FILE__` as a placeholder for the path to the file being wrapped.
+// @ts-expect-error We use `__SENTRY_WRAPPING_TARGET_FILE__` as a placeholder for the path to the file being wrapped.
 // eslint-disable-next-line import/no-unresolved
 import * as serverComponentModule from '__SENTRY_WRAPPING_TARGET_FILE__';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -51,7 +51,7 @@ if (typeof serverComponent === 'function') {
 
 // Re-export anything exported by the page module we're wrapping. When processing this code, Rollup is smart enough to
 // not include anything whose name matchs something we've explicitly exported above.
-// @ts-ignore See above
+// @ts-expect-error See above
 // eslint-disable-next-line import/no-unresolved
 export * from '__SENTRY_WRAPPING_TARGET_FILE__';
 

--- a/packages/nextjs/src/config/withSentryConfig.ts
+++ b/packages/nextjs/src/config/withSentryConfig.ts
@@ -119,7 +119,7 @@ function setUpTunnelRewriteRules(userNextConfig: NextConfigObject, tunnelPath: s
       return [injectedRewrite];
     }
 
-    // @ts-ignore Expected 0 arguments but got 1 - this is from the future-proofing mentioned above, so we don't care about it
+    // @ts-expect-error Expected 0 arguments but got 1 - this is from the future-proofing mentioned above, so we don't care about it
     const originalRewritesResult = await originalRewrites(...args);
 
     if (Array.isArray(originalRewritesResult)) {

--- a/packages/nextjs/test/clientSdk.test.ts
+++ b/packages/nextjs/test/clientSdk.test.ts
@@ -72,12 +72,12 @@ describe('Client init()', () => {
   it('sets runtime on scope', () => {
     const currentScope = getCurrentHub().getScope();
 
-    // @ts-ignore need access to protected _tags attribute
+    // @ts-expect-error need access to protected _tags attribute
     expect(currentScope._tags).toEqual({});
 
     init({});
 
-    // @ts-ignore need access to protected _tags attribute
+    // @ts-expect-error need access to protected _tags attribute
     expect(currentScope._tags).toEqual({ runtime: 'browser' });
   });
 

--- a/packages/nextjs/test/config/webpack/constructWebpackConfig.test.ts
+++ b/packages/nextjs/test/config/webpack/constructWebpackConfig.test.ts
@@ -41,7 +41,7 @@ describe('constructWebpackConfigFunction()', () => {
     // Run the user's webpack config function, so we can check the results against ours. Delete `entry` because we'll
     // test it separately, and besides, it's one that we *should* be overwriting.
     const materializedUserWebpackConfig = userNextConfig.webpack!(serverWebpackConfig, serverBuildContext);
-    // @ts-ignore `entry` may be required in real life, but we don't need it for our tests
+    // @ts-expect-error `entry` may be required in real life, but we don't need it for our tests
     delete materializedUserWebpackConfig.entry;
 
     expect(finalWebpackConfig).toEqual(expect.objectContaining(materializedUserWebpackConfig));

--- a/packages/nextjs/test/edge/edgeWrapperUtils.test.ts
+++ b/packages/nextjs/test/edge/edgeWrapperUtils.test.ts
@@ -7,12 +7,12 @@ import { withEdgeWrapping } from '../../src/common/utils/edgeWrapperUtils';
 // constructor but the client isn't used in these tests.
 addTracingExtensions();
 
-// @ts-ignore Request does not exist on type Global
+// @ts-expect-error Request does not exist on type Global
 const origRequest = global.Request;
-// @ts-ignore Response does not exist on type Global
+// @ts-expect-error Response does not exist on type Global
 const origResponse = global.Response;
 
-// @ts-ignore Request does not exist on type Global
+// @ts-expect-error Request does not exist on type Global
 global.Request = class Request {
   headers = {
     get() {
@@ -21,13 +21,13 @@ global.Request = class Request {
   };
 };
 
-// @ts-ignore Response does not exist on type Global
+// @ts-expect-error Response does not exist on type Global
 global.Response = class Request {};
 
 afterAll(() => {
-  // @ts-ignore Request does not exist on type Global
+  // @ts-expect-error Request does not exist on type Global
   global.Request = origRequest;
-  // @ts-ignore Response does not exist on type Global
+  // @ts-expect-error Response does not exist on type Global
   global.Response = origResponse;
 });
 

--- a/packages/nextjs/test/edge/transport.test.ts
+++ b/packages/nextjs/test/edge/transport.test.ts
@@ -27,13 +27,13 @@ class Headers {
 
 const mockFetch = jest.fn();
 
-// @ts-ignore fetch is not on global
+// @ts-expect-error fetch is not on global
 const oldFetch = global.fetch;
-// @ts-ignore fetch is not on global
+// @ts-expect-error fetch is not on global
 global.fetch = mockFetch;
 
 afterAll(() => {
-  // @ts-ignore fetch is not on global
+  // @ts-expect-error fetch is not on global
   global.fetch = oldFetch;
 });
 

--- a/packages/nextjs/test/edge/withSentryAPI.test.ts
+++ b/packages/nextjs/test/edge/withSentryAPI.test.ts
@@ -6,12 +6,12 @@ import { wrapApiHandlerWithSentry } from '../../src/edge';
 // constructor but the client isn't used in these tests.
 coreSdk.addTracingExtensions();
 
-// @ts-ignore Request does not exist on type Global
+// @ts-expect-error Request does not exist on type Global
 const origRequest = global.Request;
-// @ts-ignore Response does not exist on type Global
+// @ts-expect-error Response does not exist on type Global
 const origResponse = global.Response;
 
-// @ts-ignore Request does not exist on type Global
+// @ts-expect-error Request does not exist on type Global
 global.Request = class Request {
   headers = {
     get() {
@@ -22,13 +22,13 @@ global.Request = class Request {
   method = 'POST';
 };
 
-// @ts-ignore Response does not exist on type Global
+// @ts-expect-error Response does not exist on type Global
 global.Response = class Request {};
 
 afterAll(() => {
-  // @ts-ignore Request does not exist on type Global
+  // @ts-expect-error Request does not exist on type Global
   global.Request = origRequest;
-  // @ts-ignore Response does not exist on type Global
+  // @ts-expect-error Response does not exist on type Global
   global.Response = origResponse;
 });
 

--- a/packages/nextjs/test/integration/pages/[id]/withInitialProps.tsx
+++ b/packages/nextjs/test/integration/pages/[id]/withInitialProps.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 const WithInitialPropsPage = ({ data }: { data: string }) => (
   <>
     <h1>WithInitialPropsPage {data}</h1>
-    {/* @ts-expect-error https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
+    {/* @ts-ignore https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
     <Link href="/1337/withServerSideProps" passHref legacyBehavior>
       <a id="server-side-props-page">Go to withServerSideProps</a>
     </Link>

--- a/packages/nextjs/test/integration/pages/[id]/withInitialProps.tsx
+++ b/packages/nextjs/test/integration/pages/[id]/withInitialProps.tsx
@@ -3,8 +3,7 @@ import Link from 'next/link';
 const WithInitialPropsPage = ({ data }: { data: string }) => (
   <>
     <h1>WithInitialPropsPage {data}</h1>
-    {/*
-      // @ts-expect-error https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
+    {/* @ts-expect-error https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
     <Link href="/1337/withServerSideProps" passHref legacyBehavior>
       <a id="server-side-props-page">Go to withServerSideProps</a>
     </Link>

--- a/packages/nextjs/test/integration/pages/[id]/withInitialProps.tsx
+++ b/packages/nextjs/test/integration/pages/[id]/withInitialProps.tsx
@@ -4,7 +4,7 @@ const WithInitialPropsPage = ({ data }: { data: string }) => (
   <>
     <h1>WithInitialPropsPage {data}</h1>
     {/*
-      // @ts-ignore https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
+      // @ts-expect-error https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
     <Link href="/1337/withServerSideProps" passHref legacyBehavior>
       <a id="server-side-props-page">Go to withServerSideProps</a>
     </Link>

--- a/packages/nextjs/test/integration/pages/[id]/withServerSideProps.tsx
+++ b/packages/nextjs/test/integration/pages/[id]/withServerSideProps.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 const WithServerSidePropsPage = ({ data }: { data: string }) => (
   <>
     <h1>WithServerSidePropsPage {data}</h1>
-    {/* @ts-expect-error https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
+    {/* @ts-ignore https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
     <Link href="/3c2e87573d/withInitialProps" passHref legacyBehavior>
       <a id="initial-props-page">Go to withInitialProps</a>
     </Link>

--- a/packages/nextjs/test/integration/pages/[id]/withServerSideProps.tsx
+++ b/packages/nextjs/test/integration/pages/[id]/withServerSideProps.tsx
@@ -4,7 +4,7 @@ const WithServerSidePropsPage = ({ data }: { data: string }) => (
   <>
     <h1>WithServerSidePropsPage {data}</h1>
     {/*
-      // @ts-ignore https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
+      // @ts-expect-error https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
     <Link href="/3c2e87573d/withInitialProps" passHref legacyBehavior>
       <a id="initial-props-page">Go to withInitialProps</a>
     </Link>

--- a/packages/nextjs/test/integration/pages/[id]/withServerSideProps.tsx
+++ b/packages/nextjs/test/integration/pages/[id]/withServerSideProps.tsx
@@ -3,8 +3,7 @@ import Link from 'next/link';
 const WithServerSidePropsPage = ({ data }: { data: string }) => (
   <>
     <h1>WithServerSidePropsPage {data}</h1>
-    {/*
-      // @ts-expect-error https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
+    {/* @ts-expect-error https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
     <Link href="/3c2e87573d/withInitialProps" passHref legacyBehavior>
       <a id="initial-props-page">Go to withInitialProps</a>
     </Link>

--- a/packages/nextjs/test/integration/pages/alsoHealthy.tsx
+++ b/packages/nextjs/test/integration/pages/alsoHealthy.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 
 const HealthyPage = (): JSX.Element => (
-  // @ts-ignore https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag
+  // @ts-expect-error https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag
   <Link href="/healthy" passHref legacyBehavior>
     <a id="healthy">Healthy</a>
   </Link>

--- a/packages/nextjs/test/integration/pages/alsoHealthy.tsx
+++ b/packages/nextjs/test/integration/pages/alsoHealthy.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 
 const HealthyPage = (): JSX.Element => (
-  // @ts-expect-error https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag
+  // @ts-ignore https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag
   <Link href="/healthy" passHref legacyBehavior>
     <a id="healthy">Healthy</a>
   </Link>

--- a/packages/nextjs/test/integration/pages/api/requireTest.ts
+++ b/packages/nextjs/test/integration/pages/api/requireTest.ts
@@ -6,7 +6,7 @@ if (process.env.NEXT_PUBLIC_SOME_FALSE_ENV_VAR === 'enabled') {
 
 const handler = async (_req: NextApiRequest, res: NextApiResponse): Promise<void> => {
   require('@sentry/nextjs').captureException; // Should not throw unless the wrapping loader messes up cjs imports
-  // @ts-ignore
+  // @ts-expect-error
   require.context('.'); // This is a webpack utility call. Should not throw unless the wrapping loader messes it up by mangling.
   res.status(200).json({ success: true });
 };

--- a/packages/nextjs/test/integration/pages/crashed.tsx
+++ b/packages/nextjs/test/integration/pages/crashed.tsx
@@ -1,10 +1,10 @@
 const CrashedPage = (): JSX.Element => {
   // Magic to naively trigger onerror to make session crashed and allow for SSR
   try {
-    // @ts-ignore
+    // @ts-expect-error
     if (typeof window !== 'undefined' && typeof window.onerror === 'function') {
       // Lovely oldschool browsers syntax with 5 arguments <3
-      // @ts-ignore
+      // @ts-expect-error
       window.onerror(null, null, null, null, new Error('Crashed'));
     }
   } catch (_e) {

--- a/packages/nextjs/test/integration/pages/crashed.tsx
+++ b/packages/nextjs/test/integration/pages/crashed.tsx
@@ -1,7 +1,6 @@
 const CrashedPage = (): JSX.Element => {
   // Magic to naively trigger onerror to make session crashed and allow for SSR
   try {
-    // @ts-expect-error
     if (typeof window !== 'undefined' && typeof window.onerror === 'function') {
       // Lovely oldschool browsers syntax with 5 arguments <3
       // @ts-expect-error

--- a/packages/nextjs/test/integration/pages/healthy.tsx
+++ b/packages/nextjs/test/integration/pages/healthy.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 
 const HealthyPage = (): JSX.Element => (
-  // @ts-ignore https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag
+  // @ts-expect-error https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag
   <Link href="/alsoHealthy" passHref legacyBehavior>
     <a id="alsoHealthy">AlsoHealthy</a>
   </Link>

--- a/packages/nextjs/test/integration/pages/healthy.tsx
+++ b/packages/nextjs/test/integration/pages/healthy.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 
 const HealthyPage = (): JSX.Element => (
-  // @ts-expect-error https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag
+  // @ts-ignore https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag
   <Link href="/alsoHealthy" passHref legacyBehavior>
     <a id="alsoHealthy">AlsoHealthy</a>
   </Link>

--- a/packages/nextjs/test/integration/pages/users/index.tsx
+++ b/packages/nextjs/test/integration/pages/users/index.tsx
@@ -20,7 +20,7 @@ const WithStaticProps = ({ items }: Props) => (
     <List items={items} />
     <p>
       {/*
-      // @ts-expect-error https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
+      // @ts-ignore https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
       <Link href="/" passHref legacyBehavior>
         <a>Go home</a>
       </Link>

--- a/packages/nextjs/test/integration/pages/users/index.tsx
+++ b/packages/nextjs/test/integration/pages/users/index.tsx
@@ -20,7 +20,7 @@ const WithStaticProps = ({ items }: Props) => (
     <List items={items} />
     <p>
       {/*
-      // @ts-ignore https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
+      // @ts-expect-error https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag */}
       <Link href="/" passHref legacyBehavior>
         <a>Go home</a>
       </Link>

--- a/packages/nextjs/test/integration/test/client/tracingClientGetInitialProps.test.ts
+++ b/packages/nextjs/test/integration/test/client/tracingClientGetInitialProps.test.ts
@@ -19,7 +19,7 @@ test('should instrument `getInitialProps` for performance tracing', async ({ pag
   const nextDataTag = await page.waitForSelector('#__NEXT_DATA__', { state: 'attached' });
   const nextDataTagValue = JSON.parse(await nextDataTag.evaluate(tag => (tag as HTMLElement).innerText));
 
-  // @ts-ignore - We know `contexts` is defined in the Transaction envelope
+  // @ts-expect-error - We know `contexts` is defined in the Transaction envelope
   const traceId = transaction[0].contexts.trace.trace_id;
 
   expect(traceId).toBeDefined();

--- a/packages/nextjs/test/integration/test/client/tracingClientGetServerSideProps.test.ts
+++ b/packages/nextjs/test/integration/test/client/tracingClientGetServerSideProps.test.ts
@@ -19,7 +19,7 @@ test('should instrument `getServerSideProps` for performance tracing', async ({ 
   const nextDataTag = await page.waitForSelector('#__NEXT_DATA__', { state: 'attached' });
   const nextDataTagValue = JSON.parse(await nextDataTag.evaluate(tag => (tag as HTMLElement).innerText));
 
-  // @ts-ignore - We know `contexts` is defined in the Transaction envelope
+  // @ts-expect-error - We know `contexts` is defined in the Transaction envelope
   const traceId = transaction[0].contexts.trace.trace_id;
 
   expect(traceId).toBeDefined();

--- a/packages/nextjs/test/integration/test/client/tracingFetch.test.ts
+++ b/packages/nextjs/test/integration/test/client/tracingFetch.test.ts
@@ -27,7 +27,7 @@ test('should correctly instrument `fetch` for performance tracing', async ({ pag
     },
   });
 
-  // @ts-ignore - We know that `spans` is inside Transaction envelopes
+  // @ts-expect-error - We know that `spans` is inside Transaction envelopes
   expect(transaction[0].spans).toEqual(
     expect.arrayContaining([
       expect.objectContaining({

--- a/packages/nextjs/test/integration/test/server/utils/helpers.ts
+++ b/packages/nextjs/test/integration/test/server/utils/helpers.ts
@@ -7,7 +7,7 @@ import next from 'next';
 import { AddressInfo } from 'net';
 
 // Type not exported from NextJS
-// @ts-ignore
+// @ts-expect-error
 export const createNextServer = async config => {
   const app = next({ ...config, customServer: false }); // customServer: false because: https://github.com/vercel/next.js/pull/49805#issuecomment-1557321794
   const handle = app.getRequestHandler();

--- a/packages/nextjs/test/serverSdk.test.ts
+++ b/packages/nextjs/test/serverSdk.test.ts
@@ -21,7 +21,7 @@ function findIntegrationByName(integrations: Integration[] = [], name: string): 
 describe('Server init()', () => {
   afterEach(() => {
     jest.clearAllMocks();
-    // @ts-ignore for testing
+    // @ts-expect-error for testing
     delete GLOBAL_OBJ.__SENTRY__;
     delete process.env.VERCEL;
   });
@@ -73,12 +73,12 @@ describe('Server init()', () => {
   it('sets runtime on scope', () => {
     const currentScope = getCurrentHub().getScope();
 
-    // @ts-ignore need access to protected _tags attribute
+    // @ts-expect-error need access to protected _tags attribute
     expect(currentScope._tags).toEqual({});
 
     init({});
 
-    // @ts-ignore need access to protected _tags attribute
+    // @ts-expect-error need access to protected _tags attribute
     expect(currentScope._tags).toEqual({ runtime: 'node' });
   });
 
@@ -93,7 +93,7 @@ describe('Server init()', () => {
 
     init({});
 
-    // @ts-ignore need access to protected _tags attribute
+    // @ts-expect-error need access to protected _tags attribute
     expect(currentScope._tags.vercel).toBeUndefined();
   });
 
@@ -135,9 +135,9 @@ describe('Server init()', () => {
 
         expect(globalHub.getClient()).toEqual(expect.any(NodeClient));
         expect(domainHub.getClient()).toBe(globalHub.getClient());
-        // @ts-ignore need access to protected _tags attribute
+        // @ts-expect-error need access to protected _tags attribute
         expect(globalHub.getScope()._tags).toEqual({ runtime: 'node' });
-        // @ts-ignore need access to protected _tags attribute
+        // @ts-expect-error need access to protected _tags attribute
         expect(domainHub.getScope()._tags).toEqual({ runtime: 'node', dogs: 'areGreat' });
       });
     });

--- a/packages/node-experimental/test/sdk/init.test.ts
+++ b/packages/node-experimental/test/sdk/init.test.ts
@@ -29,7 +29,7 @@ describe('init()', () => {
   });
 
   afterEach(() => {
-    // @ts-ignore - Reset the default integrations of node sdk to original
+    // @ts-expect-error - Reset the default integrations of node sdk to original
     sdk.defaultIntegrations = defaultIntegrationsBackup;
   });
 
@@ -39,7 +39,7 @@ describe('init()', () => {
       new MockIntegration('Mock integration 1.2'),
     ];
 
-    // @ts-ignore - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
+    // @ts-expect-error - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
     sdk.defaultIntegrations = mockDefaultIntegrations;
 
     init({ dsn: PUBLIC_DSN, defaultIntegrations: false });
@@ -55,7 +55,7 @@ describe('init()', () => {
       new MockIntegration('Some mock integration 2.2'),
     ];
 
-    // @ts-ignore - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
+    // @ts-expect-error - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
     sdk.defaultIntegrations = mockDefaultIntegrations;
 
     const mockIntegrations = [
@@ -78,7 +78,7 @@ describe('init()', () => {
       new MockIntegration('Some mock integration 3.2'),
     ];
 
-    // @ts-ignore - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
+    // @ts-expect-error - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
     sdk.defaultIntegrations = mockDefaultIntegrations;
 
     const newIntegration = new MockIntegration('Some mock integration 3.3');
@@ -104,7 +104,7 @@ describe('init()', () => {
       new MockIntegration('Some mock integration 4.2'),
     ];
 
-    // @ts-ignore - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
+    // @ts-expect-error - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
     sdk.defaultIntegrations = mockDefaultIntegrations;
 
     const autoPerformanceIntegration = new MockIntegration('Some mock integration 4.4');

--- a/packages/node-integration-tests/suites/sessions/server.ts
+++ b/packages/node-integration-tests/suites/sessions/server.ts
@@ -13,15 +13,15 @@ app.use(Sentry.Handlers.requestHandler());
 
 // ### Taken from manual tests ###
 // Hack that resets the 60s default flush interval, and replaces it with just a one second interval
-// @ts-ignore: need access to `_sessionFlusher`
+// @ts-expect-error: need access to `_sessionFlusher`
 const flusher = (Sentry.getCurrentHub()?.getClient() as Sentry.NodeClient)?._sessionFlusher;
 
-// @ts-ignore: need access to `_intervalId`
+// @ts-expect-error: need access to `_intervalId`
 let flusherIntervalId = flusher?._intervalId;
 
 clearInterval(flusherIntervalId);
 
-// @ts-ignore: need access to `_intervalId`
+// @ts-expect-error: need access to `_intervalId`
 flusherIntervalId = flusher?._intervalId = setInterval(() => flusher?.flush(), 2000);
 
 setTimeout(() => clearInterval(flusherIntervalId), 4000);

--- a/packages/node-integration-tests/suites/sessions/server.ts
+++ b/packages/node-integration-tests/suites/sessions/server.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import type { SessionFlusher } from '@sentry/core';
 import * as Sentry from '@sentry/node';
 import express from 'express';
 
@@ -13,16 +14,13 @@ app.use(Sentry.Handlers.requestHandler());
 
 // ### Taken from manual tests ###
 // Hack that resets the 60s default flush interval, and replaces it with just a one second interval
-// @ts-expect-error: need access to `_sessionFlusher`
-const flusher = (Sentry.getCurrentHub()?.getClient() as Sentry.NodeClient)?._sessionFlusher;
+const flusher = (Sentry.getCurrentHub()?.getClient() as Sentry.NodeClient)['_sessionFlusher'] as SessionFlusher;
 
-// @ts-expect-error: need access to `_intervalId`
-let flusherIntervalId = flusher?._intervalId;
+let flusherIntervalId = flusher && flusher['_intervalId'];
 
 clearInterval(flusherIntervalId);
 
-// @ts-expect-error: need access to `_intervalId`
-flusherIntervalId = flusher?._intervalId = setInterval(() => flusher?.flush(), 2000);
+flusherIntervalId = flusher['_intervalId'] = setInterval(() => flusher?.flush(), 2000);
 
 setTimeout(() => clearInterval(flusherIntervalId), 4000);
 

--- a/packages/node/src/integrations/requestdata.ts
+++ b/packages/node/src/integrations/requestdata.ts
@@ -79,7 +79,7 @@ export class RequestData implements Integration {
       ...DEFAULT_OPTIONS,
       ...options,
       include: {
-        // @ts-ignore It's mad because `method` isn't a known `include` key. (It's only here and not set by default in
+        // @ts-expect-error It's mad because `method` isn't a known `include` key. (It's only here and not set by default in
         // `addRequestDataToEvent` for legacy reasons. TODO (v8): Change that.)
         method: true,
         ...DEFAULT_OPTIONS.include,

--- a/packages/node/src/integrations/undici/index.ts
+++ b/packages/node/src/integrations/undici/index.ts
@@ -50,7 +50,7 @@ export interface UndiciOptions {
 //
 // function debug(...args: any): void {
 //   // Use a function like this one when debugging inside an AsyncHook callback
-//   // @ts-ignore any
+//   // @ts-expect-error any
 //   writeFileSync('log.out', `${format(...args)}\n`, { flag: 'a' });
 // }
 

--- a/packages/node/test/client.test.ts
+++ b/packages/node/test/client.test.ts
@@ -291,7 +291,7 @@ describe('NodeClient', () => {
       });
       client = new NodeClient(options);
 
-      // @ts-ignore accessing private method
+      // @ts-expect-error accessing private method
       const sendEnvelopeSpy = jest.spyOn(client, '_sendEnvelope');
 
       const id = client.captureCheckIn(
@@ -358,7 +358,7 @@ describe('NodeClient', () => {
       const options = getDefaultNodeClientOptions({ dsn: PUBLIC_DSN, serverName: 'bar', enabled: false });
       client = new NodeClient(options);
 
-      // @ts-ignore accessing private method
+      // @ts-expect-error accessing private method
       const sendEnvelopeSpy = jest.spyOn(client, '_sendEnvelope');
 
       client.captureCheckIn({ monitorSlug: 'foo', status: 'in_progress' });

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -316,7 +316,7 @@ describe('SentryNode', () => {
       });
       getCurrentHub().bindClient(new NodeClient(options));
       try {
-        // @ts-ignore allow function declarations in strict mode
+        // @ts-expect-error allow function declarations in strict mode
         // eslint-disable-next-line no-inner-declarations
         function testy(): void {
           throw new Error('test');

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -316,7 +316,6 @@ describe('SentryNode', () => {
       });
       getCurrentHub().bindClient(new NodeClient(options));
       try {
-        // @ts-expect-error allow function declarations in strict mode
         // eslint-disable-next-line no-inner-declarations
         function testy(): void {
           throw new Error('test');

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -321,9 +321,9 @@ describe('tracing', () => {
   describe('Tracing options', () => {
     beforeEach(() => {
       // hacky way of restoring monkey patched functions
-      // @ts-ignore TS doesn't let us assign to this but we want to
+      // @ts-expect-error TS doesn't let us assign to this but we want to
       http.get = originalHttpGet;
-      // @ts-ignore TS doesn't let us assign to this but we want to
+      // @ts-expect-error TS doesn't let us assign to this but we want to
       http.request = originalHttpRequest;
     });
 

--- a/packages/node/test/integrations/undici.test.ts
+++ b/packages/node/test/integrations/undici.test.ts
@@ -400,9 +400,9 @@ function setupTestServer() {
 function patchUndici(userOptions: Partial<UndiciOptions>): () => void {
   try {
     const undici = hub.getClient()!.getIntegration(Undici);
-    // @ts-ignore need to access private property
+    // @ts-expect-error need to access private property
     options = { ...undici._options };
-    // @ts-ignore need to access private property
+    // @ts-expect-error need to access private property
     undici._options = Object.assign(undici._options, userOptions);
   } catch (_) {
     throw new Error('Could not undo patching of undici');

--- a/packages/node/test/requestdata.test.ts
+++ b/packages/node/test/requestdata.test.ts
@@ -95,7 +95,7 @@ describe.each([parseRequest, addRequestDataToEvent])(
         test(`${fn.name}.user doesnt blow up when someone passes non-object value`, () => {
           const reqWithUser = {
             ...mockReq,
-            // @ts-ignore user is not assignable to object
+            // @ts-expect-error user is not assignable to object
             user: 'wat',
           };
 

--- a/packages/node/test/requestdata.test.ts
+++ b/packages/node/test/requestdata.test.ts
@@ -95,7 +95,6 @@ describe.each([parseRequest, addRequestDataToEvent])(
         test(`${fn.name}.user doesnt blow up when someone passes non-object value`, () => {
           const reqWithUser = {
             ...mockReq,
-            // @ts-expect-error user is not assignable to object
             user: 'wat',
           };
 

--- a/packages/node/test/sdk.test.ts
+++ b/packages/node/test/sdk.test.ts
@@ -24,7 +24,7 @@ describe('init()', () => {
   });
 
   afterEach(() => {
-    // @ts-ignore - Reset the default integrations of node sdk to original
+    // @ts-expect-error - Reset the default integrations of node sdk to original
     sdk.defaultIntegrations = defaultIntegrationsBackup;
   });
 
@@ -34,7 +34,7 @@ describe('init()', () => {
       new MockIntegration('Mock integration 1.2'),
     ];
 
-    // @ts-ignore - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
+    // @ts-expect-error - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
     sdk.defaultIntegrations = mockDefaultIntegrations;
 
     init({ dsn: PUBLIC_DSN, defaultIntegrations: false });
@@ -49,7 +49,7 @@ describe('init()', () => {
       new MockIntegration('Some mock integration 2.2'),
     ];
 
-    // @ts-ignore - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
+    // @ts-expect-error - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
     sdk.defaultIntegrations = mockDefaultIntegrations;
 
     const mockIntegrations = [
@@ -71,7 +71,7 @@ describe('init()', () => {
       new MockIntegration('Some mock integration 3.2'),
     ];
 
-    // @ts-ignore - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
+    // @ts-expect-error - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
     sdk.defaultIntegrations = mockDefaultIntegrations;
 
     const newIntegration = new MockIntegration('Some mock integration 3.3');

--- a/packages/node/test/transports/http.test.ts
+++ b/packages/node/test/transports/http.test.ts
@@ -212,7 +212,7 @@ describe('makeNewHttpTransport()', () => {
   describe('proxy', () => {
     const proxyAgentSpy = jest
       .spyOn(httpProxyAgent, 'HttpsProxyAgent')
-      // @ts-ignore
+      // @ts-expect-error
       .mockImplementation(() => new http.Agent({ keepAlive: false, maxSockets: 30, timeout: 2000 }));
 
     it('can be configured through option', () => {

--- a/packages/node/test/transports/https.test.ts
+++ b/packages/node/test/transports/https.test.ts
@@ -183,7 +183,7 @@ describe('makeNewHttpsTransport()', () => {
   describe('proxy', () => {
     const proxyAgentSpy = jest
       .spyOn(httpProxyAgent, 'HttpsProxyAgent')
-      // @ts-ignore
+      // @ts-expect-error
       .mockImplementation(() => new http.Agent({ keepAlive: false, maxSockets: 30, timeout: 2000 }));
 
     it('can be configured through option', () => {

--- a/packages/opentelemetry-node/test/propagator.test.ts
+++ b/packages/opentelemetry-node/test/propagator.test.ts
@@ -46,7 +46,7 @@ describe('SentryPropagator', () => {
           publicKey: 'abc',
         }),
       };
-      // @ts-ignore Use mock client for unit tests
+      // @ts-expect-error Use mock client for unit tests
       const hub: Hub = new Hub(client);
       makeMain(hub);
 

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -66,7 +66,7 @@ describe('SentrySpanProcessor', () => {
 
   function getContext(transaction: Transaction) {
     const transactionWithContext = transaction as unknown as Transaction;
-    // @ts-ignore accessing private property
+    // @ts-expect-error accessing private property
     return transactionWithContext._contexts;
   }
 
@@ -876,7 +876,7 @@ describe('SentrySpanProcessor', () => {
       parentOtelSpan.end();
     });
 
-    // @ts-ignore Accessing private attributes
+    // @ts-expect-error Accessing private attributes
     expect(sentryTransaction._hub.getScope()._tags.foo).toEqual('bar');
   });
 });

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -876,7 +876,6 @@ describe('SentrySpanProcessor', () => {
       parentOtelSpan.end();
     });
 
-    // @ts-expect-error Accessing private attributes
     expect(sentryTransaction._hub.getScope()._tags.foo).toEqual('bar');
   });
 });

--- a/packages/overhead-metrics/src/perf/sampler.ts
+++ b/packages/overhead-metrics/src/perf/sampler.ts
@@ -23,7 +23,7 @@ export class TimeBasedMap<T> extends Map<TimestampSeconds, T> {
    *
    */
   public toJSON(): JsonObject<T> {
-    // @ts-ignore this actually exists
+    // @ts-expect-error this actually exists
     return Object.fromEntries(this.entries());
   }
 }

--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -168,7 +168,7 @@ export function withSentryRouting<P extends Record<string, any>, R extends React
       activeTransaction.setName(props.computedMatch.path, 'route');
     }
 
-    // @ts-ignore Setting more specific React Component typing for `R` generic above
+    // @ts-expect-error Setting more specific React Component typing for `R` generic above
     // will break advanced type inference done by react router params:
     // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/13dc4235c069e25fe7ee16e11f529d909f9f3ff8/types/react-router/index.d.ts#L154-L164
     return <Route {...props} />;
@@ -176,7 +176,7 @@ export function withSentryRouting<P extends Record<string, any>, R extends React
 
   WrappedRoute.displayName = `sentryRoute(${componentDisplayName})`;
   hoistNonReactStatics(WrappedRoute, Route);
-  // @ts-ignore Setting more specific React Component typing for `R` generic above
+  // @ts-expect-error Setting more specific React Component typing for `R` generic above
   // will break advanced type inference done by react router params:
   // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/13dc4235c069e25fe7ee16e11f529d909f9f3ff8/types/react-router/index.d.ts#L154-L164
   return WrappedRoute;

--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -202,14 +202,14 @@ export function withSentryReactRouterV6Routing<P extends Record<string, any>, R 
       [location, navigationType],
     );
 
-    // @ts-ignore Setting more specific React Component typing for `R` generic above
+    // @ts-expect-error Setting more specific React Component typing for `R` generic above
     // will break advanced type inference done by react router params
     return <Routes {...props} />;
   };
 
   hoistNonReactStatics(SentryRoutes, Routes);
 
-  // @ts-ignore Setting more specific React Component typing for `R` generic above
+  // @ts-expect-error Setting more specific React Component typing for `R` generic above
   // will break advanced type inference done by react router params
   return SentryRoutes;
 }

--- a/packages/react/test/errorboundary.test.tsx
+++ b/packages/react/test/errorboundary.test.tsx
@@ -88,7 +88,7 @@ describe('ErrorBoundary', () => {
 
   it('renders null if not given a valid `fallback` prop', () => {
     const { container } = render(
-      // @ts-ignore Passing wrong type on purpose
+      // @ts-expect-error Passing wrong type on purpose
       <ErrorBoundary fallback="Not a ReactElement">
         <Bam />
       </ErrorBoundary>,
@@ -99,7 +99,7 @@ describe('ErrorBoundary', () => {
 
   it('renders null if not given a valid `fallback` prop function', () => {
     const { container } = render(
-      // @ts-ignore Passing wrong type on purpose
+      // @ts-expect-error Passing wrong type on purpose
       <ErrorBoundary fallback={() => 'Not a ReactElement'}>
         <Bam />
       </ErrorBoundary>,
@@ -308,9 +308,9 @@ describe('ErrorBoundary', () => {
         const firstError = new Error('bam');
         const secondError = new Error('bam2');
         const thirdError = new Error('bam3');
-        // @ts-ignore Need to set cause on error
+        // @ts-expect-error Need to set cause on error
         secondError.cause = firstError;
-        // @ts-ignore Need to set cause on error
+        // @ts-expect-error Need to set cause on error
         thirdError.cause = secondError;
         throw thirdError;
       }
@@ -349,9 +349,9 @@ describe('ErrorBoundary', () => {
       function CustomBam(): JSX.Element {
         const firstError = new Error('bam');
         const secondError = new Error('bam2');
-        // @ts-ignore Need to set cause on error
+        // @ts-expect-error Need to set cause on error
         firstError.cause = secondError;
-        // @ts-ignore Need to set cause on error
+        // @ts-expect-error Need to set cause on error
         secondError.cause = firstError;
         throw firstError;
       }
@@ -429,7 +429,7 @@ describe('ErrorBoundary', () => {
     it('shows a Sentry Report Dialog with correct options if client has hooks', () => {
       let callback: any;
       const hub = getCurrentHub();
-      // @ts-ignore mock client
+      // @ts-expect-error mock client
       hub.bindClient({
         on: (name: string, cb: any) => {
           callback = cb;

--- a/packages/react/test/reactrouterv6.4.test.tsx
+++ b/packages/react/test/reactrouterv6.4.test.tsx
@@ -16,7 +16,7 @@ import { reactRouterV6Instrumentation, wrapCreateBrowserRouter } from '../src';
 import type { CreateRouterFunction } from '../src/types';
 
 beforeAll(() => {
-  // @ts-ignore need to override global Request because it's not in the jest environment (even with an
+  // @ts-expect-error need to override global Request because it's not in the jest environment (even with an
   // `@jest-environment jsdom` directive, for some reason)
   global.Request = Request;
 });
@@ -63,7 +63,7 @@ describe('React Router v6.4', () => {
         },
       );
 
-      // @ts-ignore router is fine
+      // @ts-expect-error router is fine
       render(<RouterProvider router={router} />);
 
       expect(mockStartTransaction).toHaveBeenCalledTimes(1);
@@ -100,7 +100,7 @@ describe('React Router v6.4', () => {
         },
       );
 
-      // @ts-ignore router is fine
+      // @ts-expect-error router is fine
       render(<RouterProvider router={router} />);
 
       expect(mockStartTransaction).toHaveBeenCalledTimes(2);
@@ -139,7 +139,7 @@ describe('React Router v6.4', () => {
         },
       );
 
-      // @ts-ignore router is fine
+      // @ts-expect-error router is fine
       render(<RouterProvider router={router} />);
 
       expect(mockStartTransaction).toHaveBeenCalledTimes(2);
@@ -178,7 +178,7 @@ describe('React Router v6.4', () => {
         },
       );
 
-      // @ts-ignore router is fine
+      // @ts-expect-error router is fine
       render(<RouterProvider router={router} />);
 
       expect(mockStartTransaction).toHaveBeenCalledTimes(2);
@@ -229,7 +229,7 @@ describe('React Router v6.4', () => {
         },
       );
 
-      // @ts-ignore router is fine
+      // @ts-expect-error router is fine
       render(<RouterProvider router={router} />);
 
       expect(mockStartTransaction).toHaveBeenCalledTimes(2);
@@ -264,7 +264,7 @@ describe('React Router v6.4', () => {
         },
       );
 
-      // @ts-ignore router is fine
+      // @ts-expect-error router is fine
       render(<RouterProvider router={router} />);
 
       expect(mockStartTransaction).toHaveBeenCalledTimes(1);
@@ -298,7 +298,7 @@ describe('React Router v6.4', () => {
         },
       );
 
-      // @ts-ignore router is fine
+      // @ts-expect-error router is fine
       render(<RouterProvider router={router} />);
 
       expect(mockStartTransaction).toHaveBeenCalledTimes(2);

--- a/packages/remix/src/client/performance.tsx
+++ b/packages/remix/src/client/performance.tsx
@@ -108,7 +108,7 @@ export function withSentry<P extends Record<string, unknown>, R extends React.FC
         !isNodeEnv() &&
         logger.warn('Remix SDK was unable to wrap your root because of one or more missing parameters.');
 
-      // @ts-ignore Setting more specific React Component typing for `R` generic above
+      // @ts-expect-error Setting more specific React Component typing for `R` generic above
       // will break advanced type inference done by react router params
       return <OrigApp {...props} />;
     }
@@ -154,18 +154,18 @@ export function withSentry<P extends Record<string, unknown>, R extends React.FC
 
     isBaseLocation = false;
 
-    // @ts-ignore Setting more specific React Component typing for `R` generic above
+    // @ts-expect-error Setting more specific React Component typing for `R` generic above
     // will break advanced type inference done by react router params
     return <OrigApp {...props} />;
   };
 
   if (options.wrapWithErrorBoundary) {
-    // @ts-ignore Setting more specific React Component typing for `R` generic above
+    // @ts-expect-error Setting more specific React Component typing for `R` generic above
     // will break advanced type inference done by react router params
     return withErrorBoundary(SentryRoot, options.errorBoundaryOptions);
   }
 
-  // @ts-ignore Setting more specific React Component typing for `R` generic above
+  // @ts-expect-error Setting more specific React Component typing for `R` generic above
   // will break advanced type inference done by react router params
   return SentryRoot;
 }

--- a/packages/remix/src/utils/web-fetch.ts
+++ b/packages/remix/src/utils/web-fetch.ts
@@ -141,11 +141,11 @@ export const normalizeRemixRequest = (request: RemixRequest): Record<string, any
     port: parsedURL.port,
     hash: parsedURL.hash,
     search: parsedURL.search,
-    // @ts-ignore - it does not has a query
+    // @ts-expect-error - it does not has a query
     query: parsedURL.query,
     href: parsedURL.href,
     method: request.method,
-    // @ts-ignore - not sure what this supposed to do
+    // @ts-expect-error - not sure what this supposed to do
     headers: headers[Symbol.for('nodejs.util.inspect.custom')](),
     insecureHTTPParser: request.insecureHTTPParser,
     agent,

--- a/packages/remix/test/index.client.test.ts
+++ b/packages/remix/test/index.client.test.ts
@@ -41,12 +41,12 @@ describe('Client init()', () => {
   it('sets runtime on scope', () => {
     const currentScope = getCurrentHub().getScope();
 
-    // @ts-ignore need access to protected _tags attribute
+    // @ts-expect-error need access to protected _tags attribute
     expect(currentScope._tags).toEqual({});
 
     init({});
 
-    // @ts-ignore need access to protected _tags attribute
+    // @ts-expect-error need access to protected _tags attribute
     expect(currentScope._tags).toEqual({ runtime: 'browser' });
   });
 });

--- a/packages/remix/test/index.server.test.ts
+++ b/packages/remix/test/index.server.test.ts
@@ -49,12 +49,12 @@ describe('Server init()', () => {
   it('sets runtime on scope', () => {
     const currentScope = getCurrentHub().getScope();
 
-    // @ts-ignore need access to protected _tags attribute
+    // @ts-expect-error need access to protected _tags attribute
     expect(currentScope._tags).toEqual({});
 
     init({});
 
-    // @ts-ignore need access to protected _tags attribute
+    // @ts-expect-error need access to protected _tags attribute
     expect(currentScope._tags).toEqual({ runtime: 'node' });
   });
 

--- a/packages/replay-worker/src/_worker.ts
+++ b/packages/replay-worker/src/_worker.ts
@@ -3,7 +3,7 @@ import { handleMessage } from './handleMessage';
 addEventListener('message', handleMessage);
 
 // Immediately send a message when worker loads, so we know the worker is ready
-// @ts-ignore this syntax is actually fine
+// @ts-expect-error this syntax is actually fine
 postMessage({
   id: undefined,
   method: 'init',

--- a/packages/replay-worker/src/handleMessage.ts
+++ b/packages/replay-worker/src/handleMessage.ts
@@ -36,12 +36,12 @@ export function handleMessage(e: MessageEvent): void {
   const id = e.data.id as number;
   const data = e.data.arg as string;
 
-  // @ts-ignore this syntax is actually fine
+  // @ts-expect-error this syntax is actually fine
   if (method in handlers && typeof handlers[method] === 'function') {
     try {
-      // @ts-ignore this syntax is actually fine
+      // @ts-expect-error this syntax is actually fine
       const response = handlers[method](data);
-      // @ts-ignore this syntax is actually fine
+      // @ts-expect-error this syntax is actually fine
       postMessage({
         id,
         method,
@@ -49,7 +49,7 @@ export function handleMessage(e: MessageEvent): void {
         response,
       });
     } catch (err) {
-      // @ts-ignore this syntax is actually fine
+      // @ts-expect-error this syntax is actually fine
       postMessage({
         id,
         method,

--- a/packages/replay-worker/test/unit/Compressor.test.ts
+++ b/packages/replay-worker/test/unit/Compressor.test.ts
@@ -29,7 +29,7 @@ describe('Compressor', () => {
   it('throws on invalid/undefined events', () => {
     const compressor = new Compressor();
 
-    // @ts-ignore ignoring type for test
+    // @ts-expect-error ignoring type for test
     expect(() => void compressor.addEvent(undefined)).toThrow();
 
     const compressed = compressor.finish();

--- a/packages/replay/jest.setup.ts
+++ b/packages/replay/jest.setup.ts
@@ -82,17 +82,17 @@ function checkCallForSentReplay(
   const envelopeItems = call?.[1] || [[], []];
   const [[replayEventHeader, replayEventPayload], [recordingHeader, recordingPayload] = []] = envelopeItems;
 
-  // @ts-ignore recordingPayload is always a string in our tests
+  // @ts-expect-error recordingPayload is always a string in our tests
   const [recordingPayloadHeader, recordingData] = recordingPayload?.split('\n') || [];
 
   const actualObj: Required<SentReplayExpected> = {
-    // @ts-ignore Custom envelope
+    // @ts-expect-error Custom envelope
     envelopeHeader: envelopeHeader,
-    // @ts-ignore Custom envelope
+    // @ts-expect-error Custom envelope
     replayEventHeader: replayEventHeader,
-    // @ts-ignore Custom envelope
+    // @ts-expect-error Custom envelope
     replayEventPayload: replayEventPayload,
-    // @ts-ignore Custom envelope
+    // @ts-expect-error Custom envelope
     recordingHeader: recordingHeader,
     recordingPayloadHeader: recordingPayloadHeader && JSON.parse(recordingPayloadHeader),
     recordingData,
@@ -180,7 +180,7 @@ const toHaveSentReplay = function (
     }
   }
 
-  // @ts-ignore use before assigned
+  // @ts-expect-error use before assigned
   const { results, call, pass } = result;
 
   const options = {

--- a/packages/replay/src/coreHandlers/util/networkUtils.ts
+++ b/packages/replay/src/coreHandlers/util/networkUtils.ts
@@ -185,7 +185,7 @@ export function getAllowedHeaders(headers: Record<string, string>, allowedHeader
 function _serializeFormData(formData: FormData): string {
   // This is a bit simplified, but gives us a decent estimate
   // This converts e.g. { name: 'Anne Smith', age: 13 } to 'name=Anne+Smith&age=13'
-  // @ts-ignore passing FormData to URLSearchParams actually works
+  // @ts-expect-error passing FormData to URLSearchParams actually works
   return new URLSearchParams(formData).toString();
 }
 

--- a/packages/replay/src/util/addMemoryEntry.ts
+++ b/packages/replay/src/util/addMemoryEntry.ts
@@ -19,7 +19,7 @@ export async function addMemoryEntry(replay: ReplayContainer): Promise<Array<Add
   try {
     return Promise.all(
       createPerformanceSpans(replay, [
-        // @ts-ignore memory doesn't exist on type Performance as the API is non-standard (we check that it exists above)
+        // @ts-expect-error memory doesn't exist on type Performance as the API is non-standard (we check that it exists above)
         createMemoryEntry(WINDOW.performance.memory),
       ]),
     );

--- a/packages/replay/src/util/createPerformanceEntries.ts
+++ b/packages/replay/src/util/createPerformanceEntries.ts
@@ -14,7 +14,6 @@ import type {
 } from '../types';
 
 // Map entryType -> function to normalize data for event
-// @ts-expect-error TODO: entry type does not fit the create* functions entry type
 const ENTRY_TYPES: Record<
   string,
   (entry: AllPerformanceEntry) => null | ReplayPerformanceEntry<AllPerformanceEntryData>

--- a/packages/replay/src/util/createPerformanceEntries.ts
+++ b/packages/replay/src/util/createPerformanceEntries.ts
@@ -14,17 +14,17 @@ import type {
 } from '../types';
 
 // Map entryType -> function to normalize data for event
-// @ts-ignore TODO: entry type does not fit the create* functions entry type
+// @ts-expect-error TODO: entry type does not fit the create* functions entry type
 const ENTRY_TYPES: Record<
   string,
   (entry: AllPerformanceEntry) => null | ReplayPerformanceEntry<AllPerformanceEntryData>
 > = {
-  // @ts-ignore TODO: entry type does not fit the create* functions entry type
+  // @ts-expect-error TODO: entry type does not fit the create* functions entry type
   resource: createResourceEntry,
   paint: createPaintEntry,
-  // @ts-ignore TODO: entry type does not fit the create* functions entry type
+  // @ts-expect-error TODO: entry type does not fit the create* functions entry type
   navigation: createNavigationEntry,
-  // @ts-ignore TODO: entry type does not fit the create* functions entry type
+  // @ts-expect-error TODO: entry type does not fit the create* functions entry type
   ['largest-contentful-paint']: createLargestContentfulPaint,
 };
 

--- a/packages/replay/src/util/isRrwebError.ts
+++ b/packages/replay/src/util/isRrwebError.ts
@@ -8,7 +8,7 @@ export function isRrwebError(event: Event, hint: EventHint): boolean {
     return false;
   }
 
-  // @ts-ignore this may be set by rrweb when it finds errors
+  // @ts-expect-error this may be set by rrweb when it finds errors
   if (hint.originalException && hint.originalException.__rrweb__) {
     return true;
   }

--- a/packages/replay/src/util/sendReplay.ts
+++ b/packages/replay/src/util/sendReplay.ts
@@ -45,7 +45,7 @@ export async function sendReplay(
 
       try {
         // In case browsers don't allow this property to be writable
-        // @ts-ignore This needs lib es2022 and newer
+        // @ts-expect-error This needs lib es2022 and newer
         error.cause = err;
       } catch {
         // nothing to do

--- a/packages/replay/src/util/sendReplayRequest.ts
+++ b/packages/replay/src/util/sendReplayRequest.ts
@@ -110,7 +110,7 @@ export async function sendReplayRequest({
 
     try {
       // In case browsers don't allow this property to be writable
-      // @ts-ignore This needs lib es2022 and newer
+      // @ts-expect-error This needs lib es2022 and newer
       error.cause = err;
     } catch {
       // nothing to do

--- a/packages/replay/test/integration/coreHandlers/handleAfterSendEvent.test.ts
+++ b/packages/replay/test/integration/coreHandlers/handleAfterSendEvent.test.ts
@@ -153,7 +153,7 @@ describe('Integration | coreHandlers | handleAfterSendEvent', () => {
     }));
 
     const client = getCurrentHub().getClient()!;
-    // @ts-ignore make sure to remove this
+    // @ts-expect-error make sure to remove this
     delete client.getTransport()!.send.__sentry__baseTransport__;
 
     const error1 = Error({ event_id: 'err1' });

--- a/packages/replay/test/integration/coreHandlers/handleGlobalEvent.test.ts
+++ b/packages/replay/test/integration/coreHandlers/handleGlobalEvent.test.ts
@@ -35,7 +35,7 @@ describe('Integration | coreHandlers | handleGlobalEvent', () => {
       breadcrumbs: [{ type: 'fakecrumb' }],
     };
 
-    // @ts-ignore replay event type
+    // @ts-expect-error replay event type
     expect(handleGlobalEventListener(replay)(replayEvent, {})).toEqual({
       type: REPLAY_EVENT_NAME,
     });
@@ -105,7 +105,7 @@ describe('Integration | coreHandlers | handleGlobalEvent', () => {
   it('tags errors and transactions with replay id for session samples', async () => {
     let integration: ReplayIntegration;
     ({ replay, integration } = await resetSdkMock({}));
-    // @ts-ignore protected but ok to use for testing
+    // @ts-expect-error protected but ok to use for testing
     integration._initialize();
     const transaction = Transaction();
     const error = Error();
@@ -313,7 +313,7 @@ describe('Integration | coreHandlers | handleGlobalEvent', () => {
     };
 
     const originalException = new window.Error('some exception');
-    // @ts-ignore this could be set by rrweb
+    // @ts-expect-error this could be set by rrweb
     originalException.__rrweb__ = true;
 
     expect(handleGlobalEventListener(replay)(errorEvent, { originalException })).toEqual(null);

--- a/packages/replay/test/integration/flush.test.ts
+++ b/packages/replay/test/integration/flush.test.ts
@@ -58,13 +58,13 @@ describe('Integration | flush', () => {
       }),
     );
 
-    // @ts-ignore private API
+    // @ts-expect-error private API
     mockFlush = jest.spyOn(replay, '_flush');
 
-    // @ts-ignore private API
+    // @ts-expect-error private API
     mockRunFlush = jest.spyOn(replay, '_runFlush');
 
-    // @ts-ignore private API
+    // @ts-expect-error private API
     mockAddPerformanceEntries = jest.spyOn(replay, '_addPerformanceEntries');
 
     mockAddPerformanceEntries.mockImplementation(async () => {

--- a/packages/replay/test/integration/sampling.test.ts
+++ b/packages/replay/test/integration/sampling.test.ts
@@ -19,7 +19,7 @@ describe('Integration | sampling', () => {
       },
     });
 
-    // @ts-ignore private API
+    // @ts-expect-error private API
     const spyAddListeners = jest.spyOn(replay, '_addListeners');
     jest.runAllTimers();
 
@@ -54,10 +54,10 @@ describe('Integration | sampling', () => {
       autoStart: false, // Needs to be false in order to spy on replay
     });
 
-    // @ts-ignore private API
+    // @ts-expect-error private API
     const spyAddListeners = jest.spyOn(replay, '_addListeners');
 
-    // @ts-ignore protected
+    // @ts-expect-error protected
     integration._initialize();
 
     jest.runAllTimers();

--- a/packages/replay/test/integration/session.test.ts
+++ b/packages/replay/test/integration/session.test.ts
@@ -367,7 +367,7 @@ describe('Integration | session', () => {
     expect(replay).not.toHaveSameSession(initialSession);
     expect(mockRecord.takeFullSnapshot).toHaveBeenCalled();
     expect(replay).not.toHaveLastSentReplay();
-    // @ts-ignore private
+    // @ts-expect-error private
     expect(replay._stopRecording).toBeDefined();
 
     // Now do a click

--- a/packages/replay/test/integration/stop.test.ts
+++ b/packages/replay/test/integration/stop.test.ts
@@ -35,7 +35,7 @@ describe('Integration | stop', () => {
 
     ({ replay, integration } = await mockSdk());
 
-    // @ts-ignore private API
+    // @ts-expect-error private API
     mockRunFlush = jest.spyOn(replay, '_runFlush');
 
     jest.runAllTimers();

--- a/packages/replay/test/mocks/resetSdkMock.ts
+++ b/packages/replay/test/mocks/resetSdkMock.ts
@@ -46,7 +46,7 @@ export async function resetSdkMock({ replayOptions, sentryOptions, autoStart }: 
   jest.setSystemTime(new Date(BASE_TIMESTAMP));
 
   return {
-    // @ts-ignore use before assign
+    // @ts-expect-error use before assign
     domHandler,
     mockRecord,
     replay,

--- a/packages/replay/test/unit/coreHandlers/handleScope.test.ts
+++ b/packages/replay/test/unit/coreHandlers/handleScope.test.ts
@@ -20,7 +20,7 @@ describe('Unit | coreHandlers | handleScope', () => {
     } as unknown as Scope;
 
     function addBreadcrumb(breadcrumb: Breadcrumb) {
-      // @ts-ignore using private member
+      // @ts-expect-error using private member
       scope._breadcrumbs.push(breadcrumb);
     }
 

--- a/packages/replay/test/unit/eventBuffer/EventBufferCompressionWorker.test.ts
+++ b/packages/replay/test/unit/eventBuffer/EventBufferCompressionWorker.test.ts
@@ -121,7 +121,7 @@ describe('Unit | eventBuffer | EventBufferCompressionWorker', () => {
     await buffer.addEvent(TEST_EVENT);
     await buffer.addEvent(TEST_EVENT);
 
-    // @ts-ignore Mock this private so it triggers an error
+    // @ts-expect-error Mock this private so it triggers an error
     jest.spyOn(buffer._compression._worker, 'postMessage').mockImplementationOnce(() => {
       return Promise.reject('test worker error');
     });
@@ -142,7 +142,7 @@ describe('Unit | eventBuffer | EventBufferCompressionWorker', () => {
     await buffer.addEvent({ data: { o: 1 }, timestamp: BASE_TIMESTAMP, type: 3 });
     await buffer.addEvent({ data: { o: 2 }, timestamp: BASE_TIMESTAMP, type: 3 });
 
-    // @ts-ignore Mock this private so it triggers an error
+    // @ts-expect-error Mock this private so it triggers an error
     jest.spyOn(buffer._compression._worker, 'postMessage').mockImplementationOnce(() => {
       return Promise.reject('test worker error');
     });

--- a/packages/replay/test/unit/util/addEvent.test.ts
+++ b/packages/replay/test/unit/util/addEvent.test.ts
@@ -22,7 +22,7 @@ describe('Unit | util | addEvent', () => {
 
     await (replay.eventBuffer as EventBufferProxy).ensureWorkerIsLoaded();
 
-    // @ts-ignore Mock this private so it triggers an error
+    // @ts-expect-error Mock this private so it triggers an error
     jest.spyOn(replay.eventBuffer._compression._worker, 'postMessage').mockImplementationOnce(() => {
       return Promise.reject('test worker error');
     });

--- a/packages/replay/test/unit/util/createPerformanceEntry.test.ts
+++ b/packages/replay/test/unit/util/createPerformanceEntry.test.ts
@@ -54,7 +54,7 @@ describe('Unit | util | createPerformanceEntries', () => {
       workerTiming: [],
     } as const;
 
-    // @ts-ignore Needs a PerformanceEntry mock
+    // @ts-expect-error Needs a PerformanceEntry mock
     expect(createPerformanceEntries([data])).toEqual([]);
   });
 

--- a/packages/replay/test/unit/util/createReplayEnvelope.test.ts
+++ b/packages/replay/test/unit/util/createReplayEnvelope.test.ts
@@ -7,7 +7,7 @@ describe('Unit | util | createReplayEnvelope', () => {
   const REPLAY_ID = 'MY_REPLAY_ID';
 
   const replayEvent: ReplayEvent = {
-    // @ts-ignore private api
+    // @ts-expect-error private api
     type: 'replay_event',
     timestamp: 1670837008.634,
     error_ids: ['errorId'],

--- a/packages/replay/test/unit/util/createReplayEnvelope.test.ts
+++ b/packages/replay/test/unit/util/createReplayEnvelope.test.ts
@@ -7,7 +7,6 @@ describe('Unit | util | createReplayEnvelope', () => {
   const REPLAY_ID = 'MY_REPLAY_ID';
 
   const replayEvent: ReplayEvent = {
-    // @ts-expect-error private api
     type: 'replay_event',
     timestamp: 1670837008.634,
     error_ids: ['errorId'],

--- a/packages/replay/test/unit/util/prepareReplayEvent.test.ts
+++ b/packages/replay/test/unit/util/prepareReplayEvent.test.ts
@@ -39,7 +39,7 @@ describe('Unit | util | prepareReplayEvent', () => {
 
     const replayId = 'replay-ID';
     const event: ReplayEvent = {
-      // @ts-ignore private api
+      // @ts-expect-error private api
       type: REPLAY_EVENT_NAME,
       timestamp: 1670837008.634,
       error_ids: ['error-ID'],

--- a/packages/replay/test/unit/util/prepareReplayEvent.test.ts
+++ b/packages/replay/test/unit/util/prepareReplayEvent.test.ts
@@ -39,7 +39,6 @@ describe('Unit | util | prepareReplayEvent', () => {
 
     const replayId = 'replay-ID';
     const event: ReplayEvent = {
-      // @ts-expect-error private api
       type: REPLAY_EVENT_NAME,
       timestamp: 1670837008.634,
       error_ids: ['error-ID'],

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -42,15 +42,15 @@ const fakeCallback: Callback = (err, result) => {
 };
 
 function expectScopeSettings(fakeTransactionContext: any) {
-  // @ts-ignore see "Why @ts-ignore" note
+  // @ts-expect-error see "Why @ts-ignore" note
   const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
-  // @ts-ignore see "Why @ts-ignore" note
+  // @ts-expect-error see "Why @ts-ignore" note
   expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-  // @ts-ignore see "Why @ts-ignore" note
+  // @ts-expect-error see "Why @ts-ignore" note
   expect(SentryNode.fakeScope.setTag).toBeCalledWith('server_name', expect.anything());
-  // @ts-ignore see "Why @ts-ignore" note
+  // @ts-expect-error see "Why @ts-ignore" note
   expect(SentryNode.fakeScope.setTag).toBeCalledWith('url', 'awslambda:///functionName');
-  // @ts-ignore see "Why @ts-ignore" note
+  // @ts-expect-error see "Why @ts-ignore" note
   expect(SentryNode.fakeScope.setContext).toBeCalledWith(
     'aws.lambda',
     expect.objectContaining({
@@ -61,7 +61,7 @@ function expectScopeSettings(fakeTransactionContext: any) {
       remaining_time_in_millis: 100,
     }),
   );
-  // @ts-ignore see "Why @ts-ignore" note
+  // @ts-expect-error see "Why @ts-ignore" note
   expect(SentryNode.fakeScope.setContext).toBeCalledWith(
     'aws.cloudwatch.logs',
     expect.objectContaining({
@@ -79,7 +79,7 @@ describe('AWSLambda', () => {
   });
 
   afterEach(() => {
-    // @ts-ignore see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-ignore" note
     SentryNode.resetMocks();
   });
 
@@ -106,7 +106,7 @@ describe('AWSLambda', () => {
       await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
 
       expect(Sentry.captureMessage).toBeCalled();
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeScope.setTag).toBeCalledWith('timeout', '1s');
     });
 
@@ -154,7 +154,7 @@ describe('AWSLambda', () => {
       );
 
       expect(Sentry.captureMessage).toBeCalled();
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeScope.setTag).toBeCalledWith('timeout', '1m40s');
     });
 
@@ -200,10 +200,10 @@ describe('AWSLambda', () => {
       };
 
       expect(rv).toStrictEqual(42);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       expectScopeSettings(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalledWith(2000);
     });
@@ -227,11 +227,11 @@ describe('AWSLambda', () => {
           metadata: { source: 'component' },
         };
 
-        // @ts-ignore see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-ignore" note
         expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
         expectScopeSettings(fakeTransactionContext);
         expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-        // @ts-ignore see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-ignore" note
         expect(SentryNode.fakeTransaction.finish).toBeCalled();
         expect(SentryNode.flush).toBeCalledWith(2000);
       }
@@ -258,7 +258,7 @@ describe('AWSLambda', () => {
       };
 
       const handler: Handler = (_event, _context, callback) => {
-        // @ts-ignore see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-ignore" note
         expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(
           expect.objectContaining({
             parentSpanId: '1121201211212012',
@@ -306,11 +306,11 @@ describe('AWSLambda', () => {
           metadata: { dynamicSamplingContext: {}, source: 'component' },
         };
 
-        // @ts-ignore see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-ignore" note
         expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
         expectScopeSettings(fakeTransactionContext);
         expect(SentryNode.captureException).toBeCalledWith(e, expect.any(Function));
-        // @ts-ignore see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-ignore" note
         expect(SentryNode.fakeTransaction.finish).toBeCalled();
         expect(SentryNode.flush).toBeCalled();
       }
@@ -335,10 +335,10 @@ describe('AWSLambda', () => {
       };
 
       expect(rv).toStrictEqual(42);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       expectScopeSettings(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
     });
@@ -373,11 +373,11 @@ describe('AWSLambda', () => {
           metadata: { source: 'component' },
         };
 
-        // @ts-ignore see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-ignore" note
         expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
         expectScopeSettings(fakeTransactionContext);
         expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-        // @ts-ignore see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-ignore" note
         expect(SentryNode.fakeTransaction.finish).toBeCalled();
         expect(SentryNode.flush).toBeCalled();
       }
@@ -417,10 +417,10 @@ describe('AWSLambda', () => {
       };
 
       expect(rv).toStrictEqual(42);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       expectScopeSettings(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
     });
@@ -455,11 +455,11 @@ describe('AWSLambda', () => {
           metadata: { source: 'component' },
         };
 
-        // @ts-ignore see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-ignore" note
         expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
         expectScopeSettings(fakeTransactionContext);
         expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-        // @ts-ignore see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-ignore" note
         expect(SentryNode.fakeTransaction.finish).toBeCalled();
         expect(SentryNode.flush).toBeCalled();
       }
@@ -479,14 +479,14 @@ describe('AWSLambda', () => {
       await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
     } catch (e) {
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       const scopeFunction = SentryNode.captureException.mock.calls[0][1];
       const event: Event = { exception: { values: [{}] } };
       let evtProcessor: ((e: Event) => Event) | undefined = undefined;
       scopeFunction({ addEventProcessor: jest.fn().mockImplementation(proc => (evtProcessor = proc)) });
 
       expect(evtProcessor).toBeInstanceOf(Function);
-      // @ts-ignore just mocking around...
+      // @ts-expect-error just mocking around...
       expect(evtProcessor(event).exception.values[0].mechanism).toEqual({
         handled: false,
         type: 'generic',
@@ -524,7 +524,7 @@ describe('AWSLambda', () => {
         },
       };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       Sentry.addGlobalEventProcessor.mockImplementationOnce(cb => cb(eventWithSomeData));
       Sentry.AWSLambda.init({});
 

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -10,7 +10,7 @@ import * as Sentry from '../src';
 const { wrapHandler } = Sentry.AWSLambda;
 
 /**
- * Why @ts-ignore some Sentry.X calls
+ * Why @ts-expect-error some Sentry.X calls
  *
  * A hack-ish way to contain everything related to mocks in the same __mocks__ file.
  * Thanks to this, we don't have to do more magic than necessary. Just add and export desired method and assert on it.
@@ -42,15 +42,15 @@ const fakeCallback: Callback = (err, result) => {
 };
 
 function expectScopeSettings(fakeTransactionContext: any) {
-  // @ts-expect-error see "Why @ts-ignore" note
+  // @ts-expect-error see "Why @ts-expect-error" note
   const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
-  // @ts-expect-error see "Why @ts-ignore" note
+  // @ts-expect-error see "Why @ts-expect-error" note
   expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-  // @ts-expect-error see "Why @ts-ignore" note
+  // @ts-expect-error see "Why @ts-expect-error" note
   expect(SentryNode.fakeScope.setTag).toBeCalledWith('server_name', expect.anything());
-  // @ts-expect-error see "Why @ts-ignore" note
+  // @ts-expect-error see "Why @ts-expect-error" note
   expect(SentryNode.fakeScope.setTag).toBeCalledWith('url', 'awslambda:///functionName');
-  // @ts-expect-error see "Why @ts-ignore" note
+  // @ts-expect-error see "Why @ts-expect-error" note
   expect(SentryNode.fakeScope.setContext).toBeCalledWith(
     'aws.lambda',
     expect.objectContaining({
@@ -61,7 +61,7 @@ function expectScopeSettings(fakeTransactionContext: any) {
       remaining_time_in_millis: 100,
     }),
   );
-  // @ts-expect-error see "Why @ts-ignore" note
+  // @ts-expect-error see "Why @ts-expect-error" note
   expect(SentryNode.fakeScope.setContext).toBeCalledWith(
     'aws.cloudwatch.logs',
     expect.objectContaining({
@@ -79,7 +79,7 @@ describe('AWSLambda', () => {
   });
 
   afterEach(() => {
-    // @ts-expect-error see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-expect-error" note
     SentryNode.resetMocks();
   });
 
@@ -106,7 +106,7 @@ describe('AWSLambda', () => {
       await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
 
       expect(Sentry.captureMessage).toBeCalled();
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setTag).toBeCalledWith('timeout', '1s');
     });
 
@@ -154,7 +154,7 @@ describe('AWSLambda', () => {
       );
 
       expect(Sentry.captureMessage).toBeCalled();
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setTag).toBeCalledWith('timeout', '1m40s');
     });
 
@@ -200,10 +200,10 @@ describe('AWSLambda', () => {
       };
 
       expect(rv).toStrictEqual(42);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       expectScopeSettings(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalledWith(2000);
     });
@@ -227,11 +227,11 @@ describe('AWSLambda', () => {
           metadata: { source: 'component' },
         };
 
-        // @ts-expect-error see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-expect-error" note
         expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
         expectScopeSettings(fakeTransactionContext);
         expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-        // @ts-expect-error see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-expect-error" note
         expect(SentryNode.fakeTransaction.finish).toBeCalled();
         expect(SentryNode.flush).toBeCalledWith(2000);
       }
@@ -258,7 +258,7 @@ describe('AWSLambda', () => {
       };
 
       const handler: Handler = (_event, _context, callback) => {
-        // @ts-expect-error see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-expect-error" note
         expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(
           expect.objectContaining({
             parentSpanId: '1121201211212012',
@@ -306,11 +306,11 @@ describe('AWSLambda', () => {
           metadata: { dynamicSamplingContext: {}, source: 'component' },
         };
 
-        // @ts-expect-error see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-expect-error" note
         expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
         expectScopeSettings(fakeTransactionContext);
         expect(SentryNode.captureException).toBeCalledWith(e, expect.any(Function));
-        // @ts-expect-error see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-expect-error" note
         expect(SentryNode.fakeTransaction.finish).toBeCalled();
         expect(SentryNode.flush).toBeCalled();
       }
@@ -335,10 +335,10 @@ describe('AWSLambda', () => {
       };
 
       expect(rv).toStrictEqual(42);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       expectScopeSettings(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
     });
@@ -373,11 +373,11 @@ describe('AWSLambda', () => {
           metadata: { source: 'component' },
         };
 
-        // @ts-expect-error see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-expect-error" note
         expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
         expectScopeSettings(fakeTransactionContext);
         expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-        // @ts-expect-error see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-expect-error" note
         expect(SentryNode.fakeTransaction.finish).toBeCalled();
         expect(SentryNode.flush).toBeCalled();
       }
@@ -417,10 +417,10 @@ describe('AWSLambda', () => {
       };
 
       expect(rv).toStrictEqual(42);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
       expectScopeSettings(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
     });
@@ -455,11 +455,11 @@ describe('AWSLambda', () => {
           metadata: { source: 'component' },
         };
 
-        // @ts-expect-error see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-expect-error" note
         expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
         expectScopeSettings(fakeTransactionContext);
         expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-        // @ts-expect-error see "Why @ts-ignore" note
+        // @ts-expect-error see "Why @ts-expect-error" note
         expect(SentryNode.fakeTransaction.finish).toBeCalled();
         expect(SentryNode.flush).toBeCalled();
       }
@@ -479,7 +479,7 @@ describe('AWSLambda', () => {
       await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
     } catch (e) {
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       const scopeFunction = SentryNode.captureException.mock.calls[0][1];
       const event: Event = { exception: { values: [{}] } };
       let evtProcessor: ((e: Event) => Event) | undefined = undefined;
@@ -524,7 +524,7 @@ describe('AWSLambda', () => {
         },
       };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       Sentry.addGlobalEventProcessor.mockImplementationOnce(cb => cb(eventWithSomeData));
       Sentry.AWSLambda.init({});
 

--- a/packages/serverless/test/awsservices.test.ts
+++ b/packages/serverless/test/awsservices.test.ts
@@ -16,7 +16,7 @@ describe('AWSServices', () => {
     new AWSServices().setupOnce();
   });
   afterEach(() => {
-    // @ts-ignore see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-ignore" note
     SentryNode.resetMocks();
   });
   afterAll(() => {
@@ -30,13 +30,13 @@ describe('AWSServices', () => {
       nock('https://foo.s3.amazonaws.com').get('/bar').reply(200, 'contents');
       const data = await s3.getObject({ Bucket: 'foo', Key: 'bar' }).promise();
       expect(data.Body?.toString('utf-8')).toEqual('contents');
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'http.client',
         origin: 'auto.http.serverless',
         description: 'aws.s3.getObject foo',
       });
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeSpan.finish).toBeCalled();
     });
 
@@ -48,7 +48,7 @@ describe('AWSServices', () => {
         expect(data.Body?.toString('utf-8')).toEqual('contents');
         done();
       });
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'http.client',
         origin: 'auto.http.serverless',
@@ -64,7 +64,7 @@ describe('AWSServices', () => {
       nock('https://lambda.eu-north-1.amazonaws.com').post('/2015-03-31/functions/foo/invocations').reply(201, 'reply');
       const data = await lambda.invoke({ FunctionName: 'foo' }).promise();
       expect(data.Payload?.toString('utf-8')).toEqual('reply');
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'http.client',
         origin: 'auto.http.serverless',

--- a/packages/serverless/test/awsservices.test.ts
+++ b/packages/serverless/test/awsservices.test.ts
@@ -5,7 +5,7 @@ import * as nock from 'nock';
 import { AWSServices } from '../src/awsservices';
 
 /**
- * Why @ts-ignore some Sentry.X calls
+ * Why @ts-expect-error some Sentry.X calls
  *
  * A hack-ish way to contain everything related to mocks in the same __mocks__ file.
  * Thanks to this, we don't have to do more magic than necessary. Just add and export desired method and assert on it.
@@ -16,7 +16,7 @@ describe('AWSServices', () => {
     new AWSServices().setupOnce();
   });
   afterEach(() => {
-    // @ts-expect-error see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-expect-error" note
     SentryNode.resetMocks();
   });
   afterAll(() => {
@@ -30,13 +30,13 @@ describe('AWSServices', () => {
       nock('https://foo.s3.amazonaws.com').get('/bar').reply(200, 'contents');
       const data = await s3.getObject({ Bucket: 'foo', Key: 'bar' }).promise();
       expect(data.Body?.toString('utf-8')).toEqual('contents');
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'http.client',
         origin: 'auto.http.serverless',
         description: 'aws.s3.getObject foo',
       });
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeSpan.finish).toBeCalled();
     });
 
@@ -48,7 +48,7 @@ describe('AWSServices', () => {
         expect(data.Body?.toString('utf-8')).toEqual('contents');
         done();
       });
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'http.client',
         origin: 'auto.http.serverless',
@@ -64,7 +64,7 @@ describe('AWSServices', () => {
       nock('https://lambda.eu-north-1.amazonaws.com').post('/2015-03-31/functions/foo/invocations').reply(201, 'reply');
       const data = await lambda.invoke({ FunctionName: 'foo' }).promise();
       expect(data.Payload?.toString('utf-8')).toEqual('reply');
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'http.client',
         origin: 'auto.http.serverless',

--- a/packages/serverless/test/gcpfunction.test.ts
+++ b/packages/serverless/test/gcpfunction.test.ts
@@ -22,7 +22,7 @@ import type {
 
 describe('GCPFunction', () => {
   afterEach(() => {
-    // @ts-ignore see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-ignore" note
     SentryNode.resetMocks();
   });
 
@@ -117,16 +117,16 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_http',
         metadata: { source: 'route' },
       };
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.setHttpStatus).toBeCalledWith(200);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalledWith(2000);
     });
@@ -160,10 +160,10 @@ describe('GCPFunction', () => {
         },
       };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       // expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(expect.objectContaining(fakeTransactionContext));
     });
 
@@ -191,15 +191,15 @@ describe('GCPFunction', () => {
         parentSampled: false,
         metadata: { dynamicSamplingContext: {}, source: 'route' },
       };
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
     });
@@ -254,7 +254,7 @@ describe('GCPFunction', () => {
       }),
     );
 
-    // @ts-ignore see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-ignore" note
     expect(SentryNode.fakeScope.setSDKProcessingMetadata).toHaveBeenCalledWith({
       request: {
         method: 'POST',
@@ -282,14 +282,14 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_event',
         metadata: { source: 'component' },
       };
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalledWith(2000);
     });
@@ -310,15 +310,15 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_event',
         metadata: { source: 'component' },
       };
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
     });
@@ -343,14 +343,14 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_event',
         metadata: { source: 'component' },
       };
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalledWith(2000);
     });
@@ -375,15 +375,15 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_event',
         metadata: { source: 'component' },
       };
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
     });
@@ -405,14 +405,14 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_event',
         metadata: { source: 'component' },
       };
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalledWith(2000);
     });
@@ -433,15 +433,15 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_event',
         metadata: { source: 'component' },
       };
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
     });
@@ -462,12 +462,12 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_event',
         metadata: { source: 'component' },
       };
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
     });
@@ -485,14 +485,14 @@ describe('GCPFunction', () => {
 
     expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
 
-    // @ts-ignore just mocking around...
+    // @ts-expect-error just mocking around...
     const scopeFunction = SentryNode.captureException.mock.calls[0][1];
     const event: Event = { exception: { values: [{}] } };
     let evtProcessor: ((e: Event) => Event) | undefined = undefined;
     scopeFunction({ addEventProcessor: jest.fn().mockImplementation(proc => (evtProcessor = proc)) });
 
     expect(evtProcessor).toBeInstanceOf(Function);
-    // @ts-ignore just mocking around...
+    // @ts-expect-error just mocking around...
     expect(evtProcessor(event).exception.values[0].mechanism).toEqual({
       handled: false,
       type: 'generic',
@@ -505,7 +505,7 @@ describe('GCPFunction', () => {
     const handler: EventFunction = (_data, _context) => 42;
     const wrappedHandler = wrapEventFunction(handler);
     await handleEvent(wrappedHandler);
-    // @ts-ignore see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-ignore" note
     expect(SentryNode.fakeScope.setContext).toBeCalledWith('gcp.function.context', {
       eventType: 'event.type',
       resource: 'some.resource',
@@ -528,14 +528,14 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_cloud_event',
         metadata: { source: 'component' },
       };
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalledWith(2000);
     });
@@ -556,15 +556,15 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_cloud_event',
         metadata: { source: 'component' },
       };
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
     });
@@ -586,14 +586,14 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_cloud_event',
         metadata: { source: 'component' },
       };
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalledWith(2000);
     });
@@ -614,15 +614,15 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_cloud_event',
         metadata: { source: 'component' },
       };
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
     });
@@ -643,12 +643,12 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_cloud_event',
         metadata: { source: 'component' },
       };
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
 
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
@@ -661,7 +661,7 @@ describe('GCPFunction', () => {
     const handler: CloudEventFunction = _context => 42;
     const wrappedHandler = wrapCloudEventFunction(handler);
     await handleCloudEvent(wrappedHandler);
-    // @ts-ignore see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-ignore" note
     expect(SentryNode.fakeScope.setContext).toBeCalledWith('gcp.function.context', { type: 'event.type' });
   });
 
@@ -695,7 +695,7 @@ describe('GCPFunction', () => {
         },
       };
 
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       Sentry.addGlobalEventProcessor.mockImplementationOnce(cb => cb(eventWithSomeData));
       Sentry.GCPFunction.init({});
 

--- a/packages/serverless/test/gcpfunction.test.ts
+++ b/packages/serverless/test/gcpfunction.test.ts
@@ -14,7 +14,7 @@ import type {
   Response,
 } from '../src/gcpfunction/general';
 /**
- * Why @ts-ignore some Sentry.X calls
+ * Why @ts-expect-error some Sentry.X calls
  *
  * A hack-ish way to contain everything related to mocks in the same __mocks__ file.
  * Thanks to this, we don't have to do more magic than necessary. Just add and export desired method and assert on it.
@@ -22,7 +22,7 @@ import type {
 
 describe('GCPFunction', () => {
   afterEach(() => {
-    // @ts-expect-error see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-expect-error" note
     SentryNode.resetMocks();
   });
 
@@ -117,16 +117,16 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_http',
         metadata: { source: 'route' },
       };
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.setHttpStatus).toBeCalledWith(200);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalledWith(2000);
     });
@@ -160,11 +160,8 @@ describe('GCPFunction', () => {
         },
       };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-
-      // @ts-expect-error see "Why @ts-ignore" note
-      // expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(expect.objectContaining(fakeTransactionContext));
     });
 
     test('capture error', async () => {
@@ -191,15 +188,15 @@ describe('GCPFunction', () => {
         parentSampled: false,
         metadata: { dynamicSamplingContext: {}, source: 'route' },
       };
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
     });
@@ -254,7 +251,7 @@ describe('GCPFunction', () => {
       }),
     );
 
-    // @ts-expect-error see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-expect-error" note
     expect(SentryNode.fakeScope.setSDKProcessingMetadata).toHaveBeenCalledWith({
       request: {
         method: 'POST',
@@ -282,14 +279,14 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_event',
         metadata: { source: 'component' },
       };
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalledWith(2000);
     });
@@ -310,15 +307,15 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_event',
         metadata: { source: 'component' },
       };
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
     });
@@ -343,14 +340,14 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_event',
         metadata: { source: 'component' },
       };
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalledWith(2000);
     });
@@ -375,15 +372,15 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_event',
         metadata: { source: 'component' },
       };
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
     });
@@ -405,14 +402,14 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_event',
         metadata: { source: 'component' },
       };
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalledWith(2000);
     });
@@ -433,15 +430,15 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_event',
         metadata: { source: 'component' },
       };
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
     });
@@ -462,12 +459,12 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_event',
         metadata: { source: 'component' },
       };
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
     });
@@ -505,7 +502,7 @@ describe('GCPFunction', () => {
     const handler: EventFunction = (_data, _context) => 42;
     const wrappedHandler = wrapEventFunction(handler);
     await handleEvent(wrappedHandler);
-    // @ts-expect-error see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-expect-error" note
     expect(SentryNode.fakeScope.setContext).toBeCalledWith('gcp.function.context', {
       eventType: 'event.type',
       resource: 'some.resource',
@@ -528,14 +525,14 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_cloud_event',
         metadata: { source: 'component' },
       };
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalledWith(2000);
     });
@@ -556,15 +553,15 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_cloud_event',
         metadata: { source: 'component' },
       };
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
     });
@@ -586,14 +583,14 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_cloud_event',
         metadata: { source: 'component' },
       };
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalledWith(2000);
     });
@@ -614,15 +611,15 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_cloud_event',
         metadata: { source: 'component' },
       };
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.finish).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
     });
@@ -643,12 +640,12 @@ describe('GCPFunction', () => {
         origin: 'auto.function.serverless.gcp_cloud_event',
         metadata: { source: 'component' },
       };
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       const fakeTransaction = { ...SentryNode.fakeTransaction, ...fakeTransactionContext };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeHub.startTransaction).toBeCalledWith(fakeTransactionContext);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setSpan).toBeCalledWith(fakeTransaction);
 
       expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
@@ -661,7 +658,7 @@ describe('GCPFunction', () => {
     const handler: CloudEventFunction = _context => 42;
     const wrappedHandler = wrapCloudEventFunction(handler);
     await handleCloudEvent(wrappedHandler);
-    // @ts-expect-error see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-expect-error" note
     expect(SentryNode.fakeScope.setContext).toBeCalledWith('gcp.function.context', { type: 'event.type' });
   });
 
@@ -695,7 +692,7 @@ describe('GCPFunction', () => {
         },
       };
 
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       Sentry.addGlobalEventProcessor.mockImplementationOnce(cb => cb(eventWithSomeData));
       Sentry.GCPFunction.init({});
 

--- a/packages/serverless/test/google-cloud-grpc.test.ts
+++ b/packages/serverless/test/google-cloud-grpc.test.ts
@@ -85,7 +85,7 @@ describe('GoogleCloudGrpc tracing', () => {
     nock('https://www.googleapis.com').post('/oauth2/v4/token').reply(200, []);
   });
   afterEach(() => {
-    // @ts-ignore see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-ignore" note
     SentryNode.resetMocks();
     spyConnect.mockClear();
   });
@@ -96,9 +96,9 @@ describe('GoogleCloudGrpc tracing', () => {
 
   // We use google cloud pubsub as an example of grpc service for which we can trace requests.
   describe('pubsub', () => {
-    // @ts-ignore see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-ignore" note
     const dnsLookup = dns.lookup as jest.Mock;
-    // @ts-ignore see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-ignore" note
     const resolveTxt = dns.resolveTxt as jest.Mock;
     dnsLookup.mockImplementation((hostname, ...args) => {
       expect(hostname).toEqual('pubsub.googleapis.com');
@@ -126,7 +126,7 @@ describe('GoogleCloudGrpc tracing', () => {
       mockHttp2Session().mockUnaryRequest(Buffer.from('00000000120a1031363337303834313536363233383630', 'hex'));
       const resp = await pubsub.topic('nicetopic').publish(Buffer.from('data'));
       expect(resp).toEqual('1637084156623860');
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'grpc.pubsub',
         origin: 'auto.grpc.serverless',

--- a/packages/serverless/test/google-cloud-grpc.test.ts
+++ b/packages/serverless/test/google-cloud-grpc.test.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import { GoogleCloudGrpc } from '../src/google-cloud-grpc';
 
 /**
- * Why @ts-ignore some Sentry.X calls
+ * Why @ts-expect-error some Sentry.X calls
  *
  * A hack-ish way to contain everything related to mocks in the same __mocks__ file.
  * Thanks to this, we don't have to do more magic than necessary. Just add and export desired method and assert on it.
@@ -85,7 +85,7 @@ describe('GoogleCloudGrpc tracing', () => {
     nock('https://www.googleapis.com').post('/oauth2/v4/token').reply(200, []);
   });
   afterEach(() => {
-    // @ts-expect-error see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-expect-error" note
     SentryNode.resetMocks();
     spyConnect.mockClear();
   });
@@ -96,9 +96,9 @@ describe('GoogleCloudGrpc tracing', () => {
 
   // We use google cloud pubsub as an example of grpc service for which we can trace requests.
   describe('pubsub', () => {
-    // @ts-expect-error see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-expect-error" note
     const dnsLookup = dns.lookup as jest.Mock;
-    // @ts-expect-error see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-expect-error" note
     const resolveTxt = dns.resolveTxt as jest.Mock;
     dnsLookup.mockImplementation((hostname, ...args) => {
       expect(hostname).toEqual('pubsub.googleapis.com');
@@ -126,7 +126,7 @@ describe('GoogleCloudGrpc tracing', () => {
       mockHttp2Session().mockUnaryRequest(Buffer.from('00000000120a1031363337303834313536363233383630', 'hex'));
       const resp = await pubsub.topic('nicetopic').publish(Buffer.from('data'));
       expect(resp).toEqual('1637084156623860');
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'grpc.pubsub',
         origin: 'auto.grpc.serverless',

--- a/packages/serverless/test/google-cloud-http.test.ts
+++ b/packages/serverless/test/google-cloud-http.test.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import { GoogleCloudHttp } from '../src/google-cloud-http';
 
 /**
- * Why @ts-ignore some Sentry.X calls
+ * Why @ts-expect-error some Sentry.X calls
  *
  * A hack-ish way to contain everything related to mocks in the same __mocks__ file.
  * Thanks to this, we don't have to do more magic than necessary. Just add and export desired method and assert on it.
@@ -23,7 +23,7 @@ describe('GoogleCloudHttp tracing', () => {
       .reply(200, '{"access_token":"a.b.c","expires_in":3599,"token_type":"Bearer"}');
   });
   afterEach(() => {
-    // @ts-expect-error see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-expect-error" note
     SentryNode.resetMocks();
   });
   afterAll(() => {
@@ -57,13 +57,13 @@ describe('GoogleCloudHttp tracing', () => {
         );
       const resp = await bigquery.query('SELECT true AS foo');
       expect(resp).toEqual([[{ foo: true }]]);
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'http.client.bigquery',
         origin: 'auto.http.serverless',
         description: 'POST /jobs',
       });
-      // @ts-expect-error see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'http.client.bigquery',
         origin: 'auto.http.serverless',

--- a/packages/serverless/test/google-cloud-http.test.ts
+++ b/packages/serverless/test/google-cloud-http.test.ts
@@ -23,7 +23,7 @@ describe('GoogleCloudHttp tracing', () => {
       .reply(200, '{"access_token":"a.b.c","expires_in":3599,"token_type":"Bearer"}');
   });
   afterEach(() => {
-    // @ts-ignore see "Why @ts-ignore" note
+    // @ts-expect-error see "Why @ts-ignore" note
     SentryNode.resetMocks();
   });
   afterAll(() => {
@@ -57,13 +57,13 @@ describe('GoogleCloudHttp tracing', () => {
         );
       const resp = await bigquery.query('SELECT true AS foo');
       expect(resp).toEqual([[{ foo: true }]]);
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'http.client.bigquery',
         origin: 'auto.http.serverless',
         description: 'POST /jobs',
       });
-      // @ts-ignore see "Why @ts-ignore" note
+      // @ts-expect-error see "Why @ts-ignore" note
       expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'http.client.bigquery',
         origin: 'auto.http.serverless',

--- a/packages/sveltekit/src/vite/sourceMaps.ts
+++ b/packages/sveltekit/src/vite/sourceMaps.ts
@@ -5,7 +5,7 @@ import { sentryVitePlugin } from '@sentry/vite-plugin';
 import * as child_process from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-// @ts-ignore -sorcery has no types :(
+// @ts-expect-error -sorcery has no types :(
 // eslint-disable-next-line import/default
 import * as sorcery from 'sorcery';
 import type { Plugin } from 'vite';
@@ -115,7 +115,7 @@ export async function makeCustomSentryVitePlugin(options?: CustomSentryVitePlugi
           moduleSideEffects: true,
         };
       }
-      // @ts-ignore - this hook exists on the plugin!
+      // @ts-expect-error - this hook exists on the plugin!
       return sentryPlugin.resolveId(id, _importer, _ref);
     },
 
@@ -146,7 +146,7 @@ export async function makeCustomSentryVitePlugin(options?: CustomSentryVitePlugi
         const globalValuesImport = `; import "${VIRTUAL_GLOBAL_VALUES_FILE}";`;
         modifiedCode = `${code}\n${globalValuesImport}\n`;
       }
-      // @ts-ignore - this hook exists on the plugin!
+      // @ts-expect-error - this hook exists on the plugin!
       return sentryPlugin.transform(modifiedCode, id);
     },
 
@@ -204,7 +204,7 @@ export async function makeCustomSentryVitePlugin(options?: CustomSentryVitePlugi
       });
 
       try {
-        // @ts-ignore - this hook exists on the plugin!
+        // @ts-expect-error - this hook exists on the plugin!
         await sentryPlugin.writeBundle();
       } catch (_) {
         // eslint-disable-next-line no-console
@@ -230,7 +230,7 @@ function getFiles(dir: string): string[] {
   }
   const dirents = fs.readdirSync(dir, { withFileTypes: true });
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-expect-error
   const files: string[] = dirents.map(dirent => {
     const resFileOrDir = path.resolve(dir, dirent.name);
     return dirent.isDirectory() ? getFiles(resFileOrDir) : resFileOrDir;

--- a/packages/sveltekit/src/vite/svelteConfig.ts
+++ b/packages/sveltekit/src/vite/svelteConfig.ts
@@ -22,7 +22,7 @@ export async function loadSvelteConfig(): Promise<Config> {
     if (!fs.existsSync(configFile)) {
       return {};
     }
-    // @ts-ignore - we explicitly want to import the svelte config here.
+    // @ts-expect-error - we explicitly want to import the svelte config here.
     const svelteConfigModule = await import(`${url.pathToFileURL(configFile).href}`);
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -83,7 +83,7 @@ async function getNodeAdapterOutputDir(svelteConfig: Config): Promise<string> {
       outputDir = dest.replace(/\/client.*/, '');
       throw new Error('We got what we came for, throwing to exit the adapter');
     },
-    // @ts-ignore - No need to implement the other methods
+    // @ts-expect-error - No need to implement the other methods
     log: {
       // eslint-disable-next-line @typescript-eslint/no-empty-function -- this should be a noop
       minor() {},
@@ -96,7 +96,7 @@ async function getNodeAdapterOutputDir(svelteConfig: Config): Promise<string> {
 
     config: {
       kit: {
-        // @ts-ignore - the builder expects a validated config but for our purpose it's fine to just pass this partial config
+        // @ts-expect-error - the builder expects a validated config but for our purpose it's fine to just pass this partial config
         paths: {
           base: svelteConfig.kit?.paths?.base || '',
         },

--- a/packages/sveltekit/test/client/router.test.ts
+++ b/packages/sveltekit/test/client/router.test.ts
@@ -64,7 +64,7 @@ describe('sveltekitRoutingInstrumentation', () => {
     });
 
     // We emit an update to the `page` store to simulate the SvelteKit router lifecycle
-    // @ts-ignore This is fine because we testUtils/stores.ts defines `page` as a writable store
+    // @ts-expect-error This is fine because we testUtils/stores.ts defines `page` as a writable store
     page.set({ route: { id: 'testRoute' } });
 
     // This should update the transaction name with the parameterized route:
@@ -81,7 +81,7 @@ describe('sveltekitRoutingInstrumentation', () => {
     svelteKitRoutingInstrumentation(mockedStartTransaction, false, false);
 
     // We emit an update to the `navigating` store to simulate the SvelteKit navigation lifecycle
-    // @ts-ignore This is fine because we testUtils/stores.ts defines `navigating` as a writable store
+    // @ts-expect-error This is fine because we testUtils/stores.ts defines `navigating` as a writable store
     navigating.set({
       from: { route: { id: '/users' }, url: { pathname: '/users' } },
       to: { route: { id: '/users/[id]' }, url: { pathname: '/users/7762' } },
@@ -95,7 +95,7 @@ describe('sveltekitRoutingInstrumentation', () => {
     svelteKitRoutingInstrumentation(mockedStartTransaction, false, true);
 
     // We emit an update to the `navigating` store to simulate the SvelteKit navigation lifecycle
-    // @ts-ignore This is fine because we testUtils/stores.ts defines `navigating` as a writable store
+    // @ts-expect-error This is fine because we testUtils/stores.ts defines `navigating` as a writable store
     navigating.set({
       from: { route: { id: '/users' }, url: { pathname: '/users' } },
       to: { route: { id: '/users/[id]' }, url: { pathname: '/users/7762' } },
@@ -124,7 +124,7 @@ describe('sveltekitRoutingInstrumentation', () => {
     expect(returnedTransaction?.setTag).toHaveBeenCalledWith('from', '/users');
 
     // We emit `null` here to simulate the end of the navigation lifecycle
-    // @ts-ignore this is fine
+    // @ts-expect-error this is fine
     navigating.set(null);
 
     expect(routingSpanFinishSpy).toHaveBeenCalledTimes(1);
@@ -135,7 +135,7 @@ describe('sveltekitRoutingInstrumentation', () => {
       svelteKitRoutingInstrumentation(mockedStartTransaction, false, true);
 
       // We emit an update to the `navigating` store to simulate the SvelteKit navigation lifecycle
-      // @ts-ignore This is fine because we testUtils/stores.ts defines `navigating` as a writable store
+      // @ts-expect-error This is fine because we testUtils/stores.ts defines `navigating` as a writable store
       navigating.set({
         from: { route: { id: '/users/[id]' }, url: { pathname: '/users/7762' } },
         to: { route: { id: '/users/[id]' }, url: { pathname: '/users/7762' } },
@@ -147,7 +147,7 @@ describe('sveltekitRoutingInstrumentation', () => {
     it('starts a navigation transaction if the raw navigation origin and destination are not equal', () => {
       svelteKitRoutingInstrumentation(mockedStartTransaction, false, true);
 
-      // @ts-ignore This is fine
+      // @ts-expect-error This is fine
       navigating.set({
         from: { route: { id: '/users/[id]' }, url: { pathname: '/users/7762' } },
         to: { route: { id: '/users/[id]' }, url: { pathname: '/users/223412' } },
@@ -180,7 +180,7 @@ describe('sveltekitRoutingInstrumentation', () => {
 
       // window.location.pathame is "/" in tests
 
-      // @ts-ignore This is fine
+      // @ts-expect-error This is fine
       navigating.set({
         to: { route: {}, url: { pathname: '/' } },
       });

--- a/packages/sveltekit/test/client/sdk.test.ts
+++ b/packages/sveltekit/test/client/sdk.test.ts
@@ -41,12 +41,12 @@ describe('Sentry client SDK', () => {
     it('sets the runtime tag on the scope', () => {
       const currentScope = getCurrentHub().getScope();
 
-      // @ts-ignore need access to protected _tags attribute
+      // @ts-expect-error need access to protected _tags attribute
       expect(currentScope._tags).toEqual({});
 
       init({ dsn: 'https://public@dsn.ingest.sentry.io/1337' });
 
-      // @ts-ignore need access to protected _tags attribute
+      // @ts-expect-error need access to protected _tags attribute
       expect(currentScope._tags).toEqual({ runtime: 'browser' });
     });
 
@@ -88,7 +88,7 @@ describe('Sentry client SDK', () => {
         // This is the closest we can get to unit-testing the `__SENTRY_TRACING__` tree-shaking guard
         // IRL, the code to add the integration would most likely be removed by the bundler.
 
-        // @ts-ignore this is fine in the test
+        // @ts-expect-error this is fine in the test
         globalThis.__SENTRY_TRACING__ = false;
 
         init({
@@ -102,7 +102,7 @@ describe('Sentry client SDK', () => {
         expect(integrationsToInit).not.toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
         expect(browserTracing).toBeUndefined();
 
-        // @ts-ignore this is fine in the test
+        // @ts-expect-error this is fine in the test
         delete globalThis.__SENTRY_TRACING__;
       });
 

--- a/packages/sveltekit/test/server/load.test.ts
+++ b/packages/sveltekit/test/server/load.test.ts
@@ -364,7 +364,7 @@ describe('wrapServerLoadWithSentry calls trace', () => {
 
   it('falls back to the raw url if `event.route.id` is not available', async () => {
     const event = getServerOnlyArgs();
-    // @ts-ignore - this is fine (just tests here)
+    // @ts-expect-error - this is fine (just tests here)
     delete event.route;
     const wrappedLoad = wrapServerLoadWithSentry(serverLoad);
     await wrappedLoad(event);

--- a/packages/sveltekit/test/server/sdk.test.ts
+++ b/packages/sveltekit/test/server/sdk.test.ts
@@ -39,12 +39,12 @@ describe('Sentry server SDK', () => {
     it('sets the runtime tag on the scope', () => {
       const currentScope = getCurrentHub().getScope();
 
-      // @ts-ignore need access to protected _tags attribute
+      // @ts-expect-error need access to protected _tags attribute
       expect(currentScope._tags).toEqual({});
 
       init({ dsn: 'https://public@dsn.ingest.sentry.io/1337' });
 
-      // @ts-ignore need access to protected _tags attribute
+      // @ts-expect-error need access to protected _tags attribute
       expect(currentScope._tags).toEqual({ runtime: 'node' });
     });
   });

--- a/packages/sveltekit/test/server/utils.test.ts
+++ b/packages/sveltekit/test/server/utils.test.ts
@@ -80,7 +80,7 @@ describe('rewriteFramesIteratee', () => {
     };
 
     const originalRewriteFrames = new RewriteFrames();
-    // @ts-ignore this property exists
+    // @ts-expect-error this property exists
     const defaultIteratee = originalRewriteFrames._iteratee;
 
     const defaultResult = defaultIteratee({ ...frame });

--- a/packages/sveltekit/test/vite/autoInstrument.test.ts
+++ b/packages/sveltekit/test/vite/autoInstrument.test.ts
@@ -12,10 +12,10 @@ let fileContent: string | undefined;
 vi.mock('fs', async () => {
   const actual = await vi.importActual('fs');
   return {
-    // @ts-ignore this exists, I promise!
+    // @ts-expect-error this exists, I promise!
     ...actual,
     promises: {
-      // @ts-ignore this also exists, I promise!
+      // @ts-expect-error this also exists, I promise!
       ...actual.promises,
       readFile: vi.fn().mockImplementation(() => {
         return fileContent || DEFAULT_CONTENT;
@@ -61,7 +61,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
   ])('transform %s files', (path: string) => {
     it('wraps universal load if `load` option is `true`', async () => {
       const plugin = makeAutoInstrumentationPlugin({ debug: false, load: true, serverLoad: true });
-      // @ts-ignore this exists
+      // @ts-expect-error this exists
       const loadResult = await plugin.load(path);
       expect(loadResult).toEqual(
         'import { wrapLoadWithSentry } from "@sentry/sveltekit";' +
@@ -77,7 +77,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
         load: false,
         serverLoad: false,
       });
-      // @ts-ignore this exists
+      // @ts-expect-error this exists
       const loadResult = await plugin.load(path);
       expect(loadResult).toEqual(null);
     });
@@ -95,7 +95,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
   ])('transform %s files', (path: string) => {
     it('wraps universal load if `load` option is `true`', async () => {
       const plugin = makeAutoInstrumentationPlugin({ debug: false, load: false, serverLoad: true });
-      // @ts-ignore this exists
+      // @ts-expect-error this exists
       const loadResult = await plugin.load(path);
       expect(loadResult).toEqual(
         'import { wrapServerLoadWithSentry } from "@sentry/sveltekit";' +
@@ -111,7 +111,7 @@ describe('makeAutoInstrumentationPlugin()', () => {
         load: false,
         serverLoad: false,
       });
-      // @ts-ignore this exists
+      // @ts-expect-error this exists
       const loadResult = await plugin.load(path);
       expect(loadResult).toEqual(null);
     });

--- a/packages/sveltekit/test/vite/injectGlobalValues.test.ts
+++ b/packages/sveltekit/test/vite/injectGlobalValues.test.ts
@@ -3,7 +3,7 @@ import { getGlobalValueInjectionCode } from '../../src/vite/injectGlobalValues';
 describe('getGlobalValueInjectionCode', () => {
   it('returns code that injects values into the global object', () => {
     const injectionCode = getGlobalValueInjectionCode({
-      // @ts-ignore - just want to test this with multiple values
+      // @ts-expect-error - just want to test this with multiple values
       something: 'else',
       __sentry_sveltekit_output_dir: '.svelte-kit/output',
     });

--- a/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
+++ b/packages/sveltekit/test/vite/sentrySvelteKitPlugins.test.ts
@@ -7,10 +7,10 @@ import * as sourceMaps from '../../src/vite/sourceMaps';
 vi.mock('fs', async () => {
   const actual = await vi.importActual('fs');
   return {
-    // @ts-ignore this exists, I promise!
+    // @ts-expect-error this exists, I promise!
     ...actual,
     promises: {
-      // @ts-ignore this also exists, I promise!
+      // @ts-expect-error this also exists, I promise!
       ...actual.promises,
       readFile: vi.fn().mockReturnValue('foo'),
     },

--- a/packages/sveltekit/test/vite/sourceMaps.test.ts
+++ b/packages/sveltekit/test/vite/sourceMaps.test.ts
@@ -43,7 +43,7 @@ describe('makeCustomSentryVitePlugin()', () => {
   describe('Custom sentry vite plugin', () => {
     it('enables source map generation', async () => {
       const plugin = await makeCustomSentryVitePlugin();
-      // @ts-ignore this function exists!
+      // @ts-expect-error this function exists!
       const sentrifiedConfig = plugin.config({ build: { foo: {} }, test: {} });
       expect(sentrifiedConfig).toEqual({
         build: {
@@ -56,7 +56,7 @@ describe('makeCustomSentryVitePlugin()', () => {
 
     it('injects the output dir into the server hooks file', async () => {
       const plugin = await makeCustomSentryVitePlugin();
-      // @ts-ignore this function exists!
+      // @ts-expect-error this function exists!
       const transformedCode = await plugin.transform('foo', '/src/hooks.server.ts');
       const expectedtransformedCode = 'foo\n; import "\0sentry-inject-global-values-file";\n';
       expect(mockedSentryVitePlugin.transform).toHaveBeenCalledWith(expectedtransformedCode, '/src/hooks.server.ts');
@@ -65,9 +65,9 @@ describe('makeCustomSentryVitePlugin()', () => {
 
     it('uploads source maps during the SSR build', async () => {
       const plugin = await makeCustomSentryVitePlugin();
-      // @ts-ignore this function exists!
+      // @ts-expect-error this function exists!
       plugin.configResolved({ build: { ssr: true } });
-      // @ts-ignore this function exists!
+      // @ts-expect-error this function exists!
       plugin.closeBundle();
       expect(mockedSentryVitePlugin.writeBundle).toHaveBeenCalledTimes(1);
     });
@@ -75,9 +75,9 @@ describe('makeCustomSentryVitePlugin()', () => {
     it("doesn't upload source maps during the non-SSR builds", async () => {
       const plugin = await makeCustomSentryVitePlugin();
 
-      // @ts-ignore this function exists!
+      // @ts-expect-error this function exists!
       plugin.configResolved({ build: { ssr: false } });
-      // @ts-ignore this function exists!
+      // @ts-expect-error this function exists!
       plugin.closeBundle();
       expect(mockedSentryVitePlugin.writeBundle).not.toHaveBeenCalled();
     });
@@ -93,12 +93,12 @@ describe('makeCustomSentryVitePlugin()', () => {
 
     const plugin = await makeCustomSentryVitePlugin();
 
-    // @ts-ignore this function exists!
+    // @ts-expect-error this function exists!
     expect(plugin.closeBundle).not.toThrow();
 
-    // @ts-ignore this function exists!
+    // @ts-expect-error this function exists!
     plugin.configResolved({ build: { ssr: true } });
-    // @ts-ignore this function exists!
+    // @ts-expect-error this function exists!
     plugin.closeBundle();
 
     expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to upload source maps'));

--- a/packages/sveltekit/test/vitest.setup.ts
+++ b/packages/sveltekit/test/vitest.setup.ts
@@ -13,8 +13,8 @@ export function setup() {
 }
 
 if (!globalThis.fetch) {
-  // @ts-ignore - Needed for vitest to work with our fetch instrumentation
+  // @ts-expect-error - Needed for vitest to work with our fetch instrumentation
   globalThis.Request = class Request {};
-  // @ts-ignore - Needed for vitest to work with our fetch instrumentation
+  // @ts-expect-error - Needed for vitest to work with our fetch instrumentation
   globalThis.Response = class Response {};
 }

--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -22,7 +22,7 @@ function msToSec(time: number): number {
 }
 
 function getBrowserPerformanceAPI(): Performance | undefined {
-  // @ts-ignore we want to make sure all of these are available, even if TS is sure they are
+  // @ts-expect-error we want to make sure all of these are available, even if TS is sure they are
   return WINDOW && WINDOW.addEventListener && WINDOW.performance;
 }
 
@@ -40,7 +40,7 @@ let _clsEntry: LayoutShift | undefined;
 export function startTrackingWebVitals(): () => void {
   const performance = getBrowserPerformanceAPI();
   if (performance && browserPerformanceTimeOrigin) {
-    // @ts-ignore we want to make sure all of these are available, even if TS is sure they are
+    // @ts-expect-error we want to make sure all of these are available, even if TS is sure they are
     if (performance.mark) {
       WINDOW.performance.mark('sentry-tracing-init');
     }

--- a/packages/tracing-internal/test/browser/backgroundtab.test.ts
+++ b/packages/tracing-internal/test/browser/backgroundtab.test.ts
@@ -11,7 +11,7 @@ conditionalTest({ min: 10 })('registerBackgroundTabDetection', () => {
   let hub: Hub;
   beforeEach(() => {
     const dom = new JSDOM();
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.document = dom.window.document;
 
     const options = getDefaultBrowserClientOptions({ tracesSampleRate: 1 });
@@ -22,7 +22,7 @@ conditionalTest({ min: 10 })('registerBackgroundTabDetection', () => {
     // eslint-disable-next-line deprecation/deprecation
     addExtensionMethods();
 
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.document.addEventListener = jest.fn((event, callback) => {
       events[event] = callback;
     });
@@ -34,7 +34,7 @@ conditionalTest({ min: 10 })('registerBackgroundTabDetection', () => {
   });
 
   it('does not creates an event listener if global document is undefined', () => {
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.document = undefined;
     registerBackgroundTabDetection();
     expect(events).toMatchObject({});
@@ -51,7 +51,7 @@ conditionalTest({ min: 10 })('registerBackgroundTabDetection', () => {
     hub.configureScope(scope => scope.setSpan(transaction));
 
     // Simulate document visibility hidden event
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.document.hidden = true;
     events.visibilitychange();
 

--- a/packages/tracing-internal/test/browser/browsertracing.test.ts
+++ b/packages/tracing-internal/test/browser/browsertracing.test.ts
@@ -50,11 +50,11 @@ jest.mock('./../../src/browser/request', () => {
 
 beforeAll(() => {
   const dom = new JSDOM();
-  // @ts-ignore need to override global document
+  // @ts-expect-error need to override global document
   WINDOW.document = dom.window.document;
-  // @ts-ignore need to override global document
+  // @ts-expect-error need to override global document
   WINDOW.window = dom.window;
-  // @ts-ignore need to override global document
+  // @ts-expect-error need to override global document
   WINDOW.location = dom.window.location;
 });
 
@@ -307,7 +307,7 @@ conditionalTest({ min: 10 })('BrowserTracing', () => {
             ...options,
           });
 
-          // @ts-ignore accessing private property
+          // @ts-expect-error accessing private property
           expect(inst._hasSetTracePropagationTargets).toBe(hasSet);
         },
       );

--- a/packages/tracing-internal/test/browser/browsertracing.test.ts
+++ b/packages/tracing-internal/test/browser/browsertracing.test.ts
@@ -54,7 +54,6 @@ beforeAll(() => {
   WINDOW.document = dom.window.document;
   // @ts-expect-error need to override global document
   WINDOW.window = dom.window;
-  // @ts-expect-error need to override global document
   WINDOW.location = dom.window.location;
 });
 

--- a/packages/tracing-internal/test/browser/request.test.ts
+++ b/packages/tracing-internal/test/browser/request.test.ts
@@ -18,7 +18,7 @@ import { TestClient } from '../utils/TestClient';
 
 beforeAll(() => {
   addExtensionMethods();
-  // @ts-ignore need to override global Request because it's not in the jest environment (even with an
+  // @ts-expect-error need to override global Request because it's not in the jest environment (even with an
   // `@jest-environment jsdom` directive, for some reason)
   global.Request = {};
 });

--- a/packages/tracing-internal/test/browser/router.test.ts
+++ b/packages/tracing-internal/test/browser/router.test.ts
@@ -22,11 +22,11 @@ conditionalTest({ min: 16 })('instrumentRoutingWithDefaults', () => {
   const customStartTransaction = jest.fn().mockReturnValue({ finish: mockFinish });
   beforeEach(() => {
     const dom = new JSDOM();
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.document = dom.window.document;
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.window = dom.window;
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.location = dom.window.location;
 
     customStartTransaction.mockClear();
@@ -34,7 +34,7 @@ conditionalTest({ min: 16 })('instrumentRoutingWithDefaults', () => {
   });
 
   it('does not start transactions if global location is undefined', () => {
-    // @ts-ignore need to override global document
+    // @ts-expect-error need to override global document
     global.location = undefined;
     instrumentRoutingWithDefaults(customStartTransaction);
     expect(customStartTransaction).toHaveBeenCalledTimes(0);

--- a/packages/tracing/test/idletransaction.test.ts
+++ b/packages/tracing/test/idletransaction.test.ts
@@ -87,7 +87,7 @@ describe('IdleTransaction', () => {
       );
       transaction.initSpanRecorder(10);
 
-      // @ts-ignore need to pass in hub
+      // @ts-expect-error need to pass in hub
       const otherTransaction = new Transaction({ name: 'bar' }, hub);
       hub.getScope().setSpan(otherTransaction);
 

--- a/packages/tracing/test/transaction.test.ts
+++ b/packages/tracing/test/transaction.test.ts
@@ -71,7 +71,7 @@ describe('`Transaction` class', () => {
         key2: 'val2',
       });
 
-      // @ts-ignore accessing private property
+      // @ts-expect-error accessing private property
       expect(transaction._contexts).toEqual({
         foo: {
           key: 'val',
@@ -90,7 +90,7 @@ describe('`Transaction` class', () => {
         key3: 'val3',
       });
 
-      // @ts-ignore accessing private property
+      // @ts-expect-error accessing private property
       expect(transaction._contexts).toEqual({
         foo: {
           key3: 'val3',
@@ -108,7 +108,7 @@ describe('`Transaction` class', () => {
         anotherKey: 'anotherVal',
       });
 
-      // @ts-ignore accessing private property
+      // @ts-expect-error accessing private property
       expect(transaction._contexts).toEqual({
         foo: {
           key: 'val',
@@ -128,7 +128,7 @@ describe('`Transaction` class', () => {
       });
       transaction.setContext('foo', null);
 
-      // @ts-ignore accessing private property
+      // @ts-expect-error accessing private property
       expect(transaction._contexts).toEqual({});
     });
 

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -30,6 +30,6 @@ export function isBrowserBundle(): boolean {
  * Get source of SDK.
  */
 export function getSDKSource(): SdkSource {
-  // @ts-ignore __SENTRY_SDK_SOURCE__ is injected by rollup during build process
+  // @ts-expect-error __SENTRY_SDK_SOURCE__ is injected by rollup during build process
   return __SENTRY_SDK_SOURCE__;
 }

--- a/packages/utils/src/supports.ts
+++ b/packages/utils/src/supports.ts
@@ -31,7 +31,7 @@ export function supportsDOMError(): boolean {
   try {
     // Chrome: VM89:1 Uncaught TypeError: Failed to construct 'DOMError':
     // 1 argument required, but only 0 present.
-    // @ts-ignore It really needs 1 argument, not 0.
+    // @ts-expect-error It really needs 1 argument, not 0.
     new DOMError('');
     return true;
   } catch (e) {

--- a/packages/utils/test/browser.test.ts
+++ b/packages/utils/test/browser.test.ts
@@ -4,7 +4,7 @@ import { getDomElement, htmlTreeAsString } from '../src/browser';
 
 beforeAll(() => {
   const dom = new JSDOM();
-  // @ts-ignore need to override global document
+  // @ts-expect-error need to override global document
   global.document = dom.window.document;
 });
 

--- a/packages/utils/test/is.test.ts
+++ b/packages/utils/test/is.test.ts
@@ -25,7 +25,7 @@ if (supportsDOMError()) {
   describe('isDOMError()', () => {
     test('should work as advertised', () => {
       expect(isDOMError(new Error())).toEqual(false);
-      // @ts-ignore See: src/supports.ts for details
+      // @ts-expect-error See: src/supports.ts for details
       expect(isDOMError(new DOMError(''))).toEqual(true);
     });
   });
@@ -105,7 +105,7 @@ describe('isInstanceOf()', () => {
     }
     expect(isInstanceOf(new Error('wat'), Error)).toEqual(true);
     expect(isInstanceOf(new Date(), Date)).toEqual(true);
-    // @ts-ignore Foo implicity has any type, doesn't have constructor
+    // @ts-expect-error Foo implicity has any type, doesn't have constructor
     expect(isInstanceOf(new Foo(), Foo)).toEqual(true);
 
     expect(isInstanceOf(new Error('wat'), Foo)).toEqual(false);

--- a/packages/utils/test/normalize.test.ts
+++ b/packages/utils/test/normalize.test.ts
@@ -368,7 +368,7 @@ describe('normalize()', () => {
       B.prototype.toJSON = () => 2;
       const c: any = [];
       c.toJSON = () => 3;
-      // @ts-ignore target lacks a construct signature
+      // @ts-expect-error target lacks a construct signature
       expect(normalize([{ a }, { b: new B() }, c])).toEqual([{ a: 1 }, { b: 2 }, 3]);
     });
 

--- a/packages/utils/test/object.test.ts
+++ b/packages/utils/test/object.test.ts
@@ -67,7 +67,7 @@ describe('fill()', () => {
       foo: (): number => 42,
     } as any;
     const name = 'foo';
-    // @ts-ignore cb has any type
+    // @ts-expect-error cb has any type
     const replacement = cb => cb;
 
     fill(source, name, replacement);
@@ -85,7 +85,7 @@ describe('fill()', () => {
     const bar = {};
     source.foo.prototype = bar;
     const name = 'foo';
-    // @ts-ignore cb has any type
+    // @ts-expect-error cb has any type
     const replacement = cb => cb;
 
     fill(source, name, replacement);

--- a/packages/utils/test/syncpromise.test.ts
+++ b/packages/utils/test/syncpromise.test.ts
@@ -86,7 +86,6 @@ describe('SyncPromise', () => {
         // @ts-expect-error Argument of type 'PromiseLike<string>' is not assignable to parameter of type 'SyncPromise<string>'
         .then(val => f(resolvedSyncPromise('x'), val))
         .then(val => f(b, val))
-        // @ts-expect-error Argument of type 'SyncPromise<string>' is not assignable to parameter of type 'string'
         .then(val => f(a, val))
         .then(val => {
           expect(val).toBe(res);

--- a/packages/utils/test/syncpromise.test.ts
+++ b/packages/utils/test/syncpromise.test.ts
@@ -83,10 +83,10 @@ describe('SyncPromise', () => {
 
     return (
       c
-        // @ts-ignore Argument of type 'PromiseLike<string>' is not assignable to parameter of type 'SyncPromise<string>'
+        // @ts-expect-error Argument of type 'PromiseLike<string>' is not assignable to parameter of type 'SyncPromise<string>'
         .then(val => f(resolvedSyncPromise('x'), val))
         .then(val => f(b, val))
-        // @ts-ignore Argument of type 'SyncPromise<string>' is not assignable to parameter of type 'string'
+        // @ts-expect-error Argument of type 'SyncPromise<string>' is not assignable to parameter of type 'string'
         .then(val => f(a, val))
         .then(val => {
           expect(val).toBe(res);

--- a/packages/utils/test/worldwide.test.ts
+++ b/packages/utils/test/worldwide.test.ts
@@ -3,7 +3,7 @@ import { GLOBAL_OBJ } from '../src/worldwide';
 describe('GLOBAL_OBJ', () => {
   test('should return the same object', () => {
     const backup = global.process;
-    // @ts-ignore for testing
+    // @ts-expect-error for testing
     delete global.process;
     const first = GLOBAL_OBJ;
     const second = GLOBAL_OBJ;

--- a/packages/vue/test/errorHandler.test.ts
+++ b/packages/vue/test/errorHandler.test.ts
@@ -354,10 +354,10 @@ const testHarness = ({
   if (enableConsole) {
     // I need to re-assign the whole console
     // because at some point it can be set to undefined
-    // @ts-ignore for the sake of testing
+    // @ts-expect-error for the sake of testing
     console = { error: consoleErrorSpy };
   } else {
-    // @ts-ignore for the sake of testing
+    // @ts-expect-error for the sake of testing
     console = undefined;
   }
   /* eslint-enable no-global-assign */


### PR DESCRIPTION
While reviewing https://github.com/getsentry/sentry-javascript/pull/8972, I realized we can now switch to `ts-expect-error` which will report if ignoring an error is not needed.

After this PR gets merged in, I'll update our eslint rules to disallow `ts-ignore` but allow`ts-expect-error`.

- https://typescript-eslint.io/rules/ban-ts-comment/
- https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#-ts-expect-error-comments