### PR TITLE
fix(core): Always use event message and exception values for `ignoreErrors`

### DIFF
--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -193,7 +193,7 @@ function _getPossibleEventMessages(event: Event): string[] {
     }
   }
 
-  if (__DEBUG_BUILD__ && possibleMessages.length) {
+  if (__DEBUG_BUILD__ && possibleMessages.length === 0) {
     logger.error(`Could not extract message for event ${getEventDescription(event)}`);
   }
 

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -197,8 +197,6 @@ function _getPossibleEventMessages(event: Event): string[] {
     logger.error(`Could not extract message for event ${getEventDescription(event)}`);
   }
 
-  console.log(possibleMessages);
-
   return possibleMessages;
 }
 

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -169,20 +169,37 @@ function _isAllowedUrl(event: Event, allowUrls?: Array<string | RegExp>): boolea
 }
 
 function _getPossibleEventMessages(event: Event): string[] {
+  const possibleMessages: string[] = [];
+
   if (event.message) {
-    return [event.message];
+    possibleMessages.push(event.message);
   }
-  if (event.exception) {
-    const { values } = event.exception;
-    try {
-      const { type = '', value = '' } = (values && values[values.length - 1]) || {};
-      return [`${value}`, `${type}: ${value}`];
-    } catch (oO) {
-      __DEBUG_BUILD__ && logger.error(`Cannot extract message for event ${getEventDescription(event)}`);
-      return [];
+
+  let lastException;
+  try {
+    // @ts-ignore Try catching to save bundle size
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    lastException = event.exception.values[event.exception.values.length - 1];
+  } catch (e) {
+    // try catching to save bundle size checking existence of variables
+  }
+
+  if (lastException) {
+    if (lastException.value) {
+      possibleMessages.push(lastException.value);
+      if (lastException.type) {
+        possibleMessages.push(`${lastException.type}: ${lastException.value}`);
+      }
     }
   }
-  return [];
+
+  if (__DEBUG_BUILD__ && possibleMessages.length) {
+    logger.error(`Could not extract message for event ${getEventDescription(event)}`);
+  }
+
+  console.log(possibleMessages);
+
+  return possibleMessages;
 }
 
 function _isSentryError(event: Event): boolean {

--- a/packages/core/test/lib/integrations/inboundfilters.test.ts
+++ b/packages/core/test/lib/integrations/inboundfilters.test.ts
@@ -125,6 +125,18 @@ const EXCEPTION_EVENT: Event = {
   },
 };
 
+const EXCEPTION_EVENT_WITH_MESSAGE_AND_VALUE: Event = {
+  message: 'ChunkError',
+  exception: {
+    values: [
+      {
+        type: 'SyntaxError',
+        value: 'unidentified ? at line 1337',
+      },
+    ],
+  },
+};
+
 const EXCEPTION_EVENT_WITH_FRAMES: Event = {
   exception: {
     values: [
@@ -335,6 +347,17 @@ describe('InboundFilters', () => {
           ignoreErrors: [/^SyntaxError/],
         });
         expect(eventProcessor(EXCEPTION_EVENT, {})).toBe(null);
+      });
+
+      it('should consider both `event.message` and the last exceptions `type` and `value`', () => {
+        const messageEventProcessor = createInboundFiltersEventProcessor({
+          ignoreErrors: [/^ChunkError/],
+        });
+        const valueEventProcessor = createInboundFiltersEventProcessor({
+          ignoreErrors: [/^SyntaxError/],
+        });
+        expect(messageEventProcessor(EXCEPTION_EVENT_WITH_MESSAGE_AND_VALUE, {})).toBe(null);
+        expect(valueEventProcessor(EXCEPTION_EVENT_WITH_MESSAGE_AND_VALUE, {})).toBe(null);
       });
     });
   });


### PR DESCRIPTION
Previously when event had a `message`, the SDK didn't look into the exception value to filter for `ignoreErrors`.

This PR changes the behaviour so that `event.message` and `exception.value` + `exception.` are always both considered for filtering.

Ref: https://github.com/getsentry/sentry-javascript/issues/2520