### PR TITLE
chore: Update migration docs to indicate sentry-migr8 is experimental.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Deprecations in 7.x
 
-You can use [@sentry/migr8](https://www.npmjs.com/package/@sentry/migr8) to automatically update your SDK usage and fix most deprecations:
+You can use the **Experimental** [@sentry/migr8](https://www.npmjs.com/package/@sentry/migr8) to automatically update your SDK usage and fix most deprecations. This requires Node 18+.
 
 ```bash
 npx @sentry/migr8@latest


### PR DESCRIPTION
There was some confusion about this because the migration doc in this repo conflicts with the `highly experimental` tag we put on the README. Also added Node 18+ requirements.

We can change this in migr8 for a future release, but for now let's merge this in to reduce confusion and unblock our users.