### PR TITLE
fix(overhead-metrics): Remove unneeded @ts-expect-error

### DIFF
--- a/packages/overhead-metrics/src/perf/sampler.ts
+++ b/packages/overhead-metrics/src/perf/sampler.ts
@@ -23,7 +23,6 @@ export class TimeBasedMap<T> extends Map<TimestampSeconds, T> {
    *
    */
   public toJSON(): JsonObject<T> {
-    // @ts-expect-error this actually exists
     return Object.fromEntries(this.entries());
   }
 }


### PR DESCRIPTION
Should fix failing CI on develop rn.