### PR TITLE
fix(node-experimental): Require parent span for `pg` spans

### DIFF
--- a/packages/node-experimental/src/integrations/postgres.ts
+++ b/packages/node-experimental/src/integrations/postgres.ts
@@ -30,6 +30,7 @@ export class Postgres extends NodePerformanceIntegration<void> implements Integr
   public setupInstrumentation(): void | Instrumentation[] {
     return [
       new PgInstrumentation({
+        requireParentSpan: true,
         requestHook(span) {
           addOriginToOtelSpan(span, 'auto.db.otel.postgres');
         },


### PR DESCRIPTION
We do not want to create e.g. pool connection transactions etc (for now at least), so let's enable this flag.