### PR TITLE
build(lint): Remove unneeded `@ts-expect` comments

### DIFF
--- a/packages/replay-worker/src/_worker.ts
+++ b/packages/replay-worker/src/_worker.ts
@@ -3,7 +3,6 @@ import { handleMessage } from './handleMessage';
 addEventListener('message', handleMessage);
 
 // Immediately send a message when worker loads, so we know the worker is ready
-// @ts-expect-error this syntax is actually fine
 postMessage({
   id: undefined,
   method: 'init',

--- a/packages/replay-worker/src/handleMessage.ts
+++ b/packages/replay-worker/src/handleMessage.ts
@@ -41,7 +41,6 @@ export function handleMessage(e: MessageEvent): void {
     try {
       // @ts-expect-error this syntax is actually fine
       const response = handlers[method](data);
-      // @ts-expect-error this syntax is actually fine
       postMessage({
         id,
         method,
@@ -49,7 +48,6 @@ export function handleMessage(e: MessageEvent): void {
         response,
       });
     } catch (err) {
-      // @ts-expect-error this syntax is actually fine
       postMessage({
         id,
         method,


### PR DESCRIPTION
Noticed warnings for this during build.