### PR TITLE
feat(core): Export `BeforeFinishCallback` type

### DIFF
--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -1,5 +1,6 @@
 export { startIdleTransaction, addTracingExtensions } from './hubextensions';
 export { IdleTransaction, TRACING_DEFAULTS } from './idletransaction';
+export type { BeforeFinishCallback } from './idletransaction';
 export { Span, spanStatusfromHttpCode } from './span';
 export { Transaction } from './transaction';
 export { extractTraceparentData, getActiveTransaction } from './utils';


### PR DESCRIPTION
Is used in RN. 

I've noticed that it's not exported when using the older ts 3.8 types and I had to fix the path because the auto resolution only uses `index.ts`.

https://github.com/getsentry/sentry-react-native/pull/3277/files#diff-a40e0a9eea538ea7aa19d0dba8ff412404f62087741ecc695f38736adcebda2eL2