### PR TITLE
fix(node-experimental): Ignore OPTIONS & HEAD requests

### DIFF
--- a/packages/node-experimental/src/integrations/http.ts
+++ b/packages/node-experimental/src/integrations/http.ts
@@ -98,6 +98,16 @@ export class Http implements Integration {
             return isSentryHost(host);
           },
 
+          ignoreIncomingRequestHook: request => {
+            const method = request.method?.toUpperCase();
+            // We do not capture OPTIONS/HEAD requests as transactions
+            if (method === 'OPTIONS' || method === 'HEAD') {
+              return true;
+            }
+
+            return false;
+          },
+
           requireParentforOutgoingSpans: true,
           requireParentforIncomingSpans: false,
           requestHook: (span, req) => {


### PR DESCRIPTION
Similar to express, we want to ignore (incoming) OPTIONS & HEAD requests.