### PR TITLE
chore(node): upgrade cookie to ^0.5.0

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -27,13 +27,13 @@
     "@sentry/core": "7.69.0",
     "@sentry/types": "7.69.0",
     "@sentry/utils": "7.69.0",
-    "cookie": "^0.4.1",
+    "cookie": "^0.5.0",
     "https-proxy-agent": "^5.0.0",
     "lru_map": "^0.3.3",
     "tslib": "^2.4.1 || ^1.9.3"
   },
   "devDependencies": {
-    "@types/cookie": "0.3.2",
+    "@types/cookie": "0.5.2",
     "@types/express": "^4.17.14",
     "@types/lru-cache": "^5.1.0",
     "@types/node": "~10.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4867,10 +4867,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cookie@0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.2.tgz#453f4b14b25da6a8ea4494842dedcbf0151deef9"
-  integrity sha512-aHQA072E10/8iUQsPH7mQU/KUyQBZAGzTVRCUvnSz8mSvbrYsP4xEO2RSA0Pjltolzi0j8+8ixrm//Hr4umPzw==
+"@types/cookie@0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.5.2.tgz#9bf9d62c838c85a07c92fdf2334c2c14fd9c59a9"
+  integrity sha512-DBpRoJGKJZn7RY92dPrgoMew8xCWc2P71beqsjyhEI/Ds9mOyVmBwtekyfhpwFIVt1WrxTonFifiOZ62V8CnNA==
 
 "@types/cookie@^0.4.0", "@types/cookie@^0.4.1":
   version "0.4.1"


### PR DESCRIPTION
The current version of cookies includes several performance improvements.
https://github.com/jshttp/cookie/releases
And in general, I would like to bring the dependencies to the current versions in order to reduce duplication of the same dependencies, but with different versions.

Before:
```
├─┬ @sentry-internal/node-integration-tests@7.68.0 -> ./packages/node-integration-tests
│ └─┬ express@4.18.2
│   └── cookie@0.5.0
├─┬ @sentry/browser@7.68.0 -> ./packages/browser
│ └─┬ karma@6.3.16 invalid: "1 || 2 || 3 || 4" from node_modules/karma-typescript
│   └─┬ socket.io@4.5.3
│     └─┬ engine.io@6.2.0
│       └── cookie@0.4.2 deduped
├─┬ @sentry/node@7.68.0 -> ./packages/node
│ └── cookie@0.4.2
├─┬ @sentry/remix@7.68.0 -> ./packages/remix
│ └─┬ @remix-run/node@1.5.1
│   └─┬ @remix-run/server-runtime@1.5.1
│     └── cookie@0.4.2 deduped
└─┬ @sentry/sveltekit@7.68.0 -> ./packages/sveltekit
  └─┬ @sveltejs/kit@1.15.2
    └── cookie@0.5.0
```
After:
```
├─┬ @sentry-internal/node-integration-tests@7.68.0 -> ./packages/node-integration-tests
│ └─┬ express@4.18.2
│   └── cookie@0.5.0 deduped
├─┬ @sentry/browser@7.68.0 -> ./packages/browser
│ └─┬ karma@6.3.16 invalid: "1 || 2 || 3 || 4" from node_modules/karma-typescript
│   └─┬ socket.io@4.5.3
│     └─┬ engine.io@6.2.0
│       └── cookie@0.4.2
├─┬ @sentry/node@7.68.0 -> ./packages/node
│ └── cookie@0.5.0
├─┬ @sentry/remix@7.68.0 -> ./packages/remix
│ └─┬ @remix-run/node@1.5.1
│   └─┬ @remix-run/server-runtime@1.5.1
│     └── cookie@0.4.2
└─┬ @sentry/sveltekit@7.68.0 -> ./packages/sveltekit
  └─┬ @sveltejs/kit@1.15.2
    └── cookie@0.5.0 deduped
```
