### PR TITLE
feat(integrations): Introduce `processEvent` hook on `Integration`

### DIFF
--- a/packages/browser/src/integrations/dedupe.ts
+++ b/packages/browser/src/integrations/dedupe.ts
@@ -1,4 +1,4 @@
-import type { Event, EventProcessor, Exception, Hub, Integration, StackFrame } from '@sentry/types';
+import type { Event, Exception, Integration, StackFrame } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 /** Deduplication filter */
@@ -22,36 +22,32 @@ export class Dedupe implements Integration {
     this.name = Dedupe.id;
   }
 
+  /** @inheritDoc */
+  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+    // noop
+  }
+
   /**
    * @inheritDoc
    */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    const eventProcessor: EventProcessor = currentEvent => {
-      // We want to ignore any non-error type events, e.g. transactions or replays
-      // These should never be deduped, and also not be compared against as _previousEvent.
-      if (currentEvent.type) {
-        return currentEvent;
-      }
-
-      const self = getCurrentHub().getIntegration(Dedupe);
-      if (self) {
-        // Juuust in case something goes wrong
-        try {
-          if (_shouldDropEvent(currentEvent, self._previousEvent)) {
-            __DEBUG_BUILD__ && logger.warn('Event dropped due to being a duplicate of previously captured event.');
-            return null;
-          }
-        } catch (_oO) {
-          return (self._previousEvent = currentEvent);
-        }
-
-        return (self._previousEvent = currentEvent);
-      }
+  public processEvent(currentEvent: Event): Event | null {
+    // We want to ignore any non-error type events, e.g. transactions or replays
+    // These should never be deduped, and also not be compared against as _previousEvent.
+    if (currentEvent.type) {
       return currentEvent;
-    };
+    }
 
-    eventProcessor.id = this.name;
-    addGlobalEventProcessor(eventProcessor);
+    // Juuust in case something goes wrong
+    try {
+      if (_shouldDropEvent(currentEvent, this._previousEvent)) {
+        __DEBUG_BUILD__ && logger.warn('Event dropped due to being a duplicate of previously captured event.');
+        return null;
+      }
+    } catch (_oO) {
+      return (this._previousEvent = currentEvent);
+    }
+
+    return (this._previousEvent = currentEvent);
   }
 }
 

--- a/packages/browser/src/integrations/httpcontext.ts
+++ b/packages/browser/src/integrations/httpcontext.ts
@@ -1,4 +1,3 @@
-import { addGlobalEventProcessor, getCurrentHub } from '@sentry/core';
 import type { Event, Integration } from '@sentry/types';
 
 import { WINDOW } from '../helpers';
@@ -23,28 +22,28 @@ export class HttpContext implements Integration {
    * @inheritDoc
    */
   public setupOnce(): void {
-    addGlobalEventProcessor((event: Event) => {
-      if (getCurrentHub().getIntegration(HttpContext)) {
-        // if none of the information we want exists, don't bother
-        if (!WINDOW.navigator && !WINDOW.location && !WINDOW.document) {
-          return event;
-        }
+    // noop
+  }
 
-        // grab as much info as exists and add it to the event
-        const url = (event.request && event.request.url) || (WINDOW.location && WINDOW.location.href);
-        const { referrer } = WINDOW.document || {};
-        const { userAgent } = WINDOW.navigator || {};
-
-        const headers = {
-          ...(event.request && event.request.headers),
-          ...(referrer && { Referer: referrer }),
-          ...(userAgent && { 'User-Agent': userAgent }),
-        };
-        const request = { ...event.request, ...(url && { url }), headers };
-
-        return { ...event, request };
-      }
+  /** @inheritDoc */
+  public processEvent(event: Event): Event {
+    // if none of the information we want exists, don't bother
+    if (!WINDOW.navigator && !WINDOW.location && !WINDOW.document) {
       return event;
-    });
+    }
+
+    // grab as much info as exists and add it to the event
+    const url = (event.request && event.request.url) || (WINDOW.location && WINDOW.location.href);
+    const { referrer } = WINDOW.document || {};
+    const { userAgent } = WINDOW.navigator || {};
+
+    const headers = {
+      ...(event.request && event.request.headers),
+      ...(referrer && { Referer: referrer }),
+      ...(userAgent && { 'User-Agent': userAgent }),
+    };
+    const request = { ...event.request, ...(url && { url }), headers };
+
+    return { ...event, request };
   }
 }

--- a/packages/browser/src/profiling/integration.ts
+++ b/packages/browser/src/profiling/integration.ts
@@ -35,7 +35,7 @@ export class BrowserProfilingIntegration implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
+  public setupOnce(_addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
     this.getCurrentHub = getCurrentHub;
     const client = this.getCurrentHub().getClient() as BrowserClient;
 

--- a/packages/core/src/eventProcessors.ts
+++ b/packages/core/src/eventProcessors.ts
@@ -1,0 +1,51 @@
+import type { Event, EventHint, EventProcessor } from '@sentry/types';
+import { getGlobalSingleton, isThenable, logger, SyncPromise } from '@sentry/utils';
+
+/**
+ * Returns the global event processors.
+ */
+export function getGlobalEventProcessors(): EventProcessor[] {
+  return getGlobalSingleton<EventProcessor[]>('globalEventProcessors', () => []);
+}
+
+/**
+ * Add a EventProcessor to be kept globally.
+ * @param callback EventProcessor to add
+ */
+export function addGlobalEventProcessor(callback: EventProcessor): void {
+  getGlobalEventProcessors().push(callback);
+}
+
+/**
+ * Process an array of event processors, returning the processed event (or `null` if the event was dropped).
+ */
+export function notifyEventProcessors(
+  processors: EventProcessor[],
+  event: Event | null,
+  hint: EventHint,
+  index: number = 0,
+): PromiseLike<Event | null> {
+  return new SyncPromise<Event | null>((resolve, reject) => {
+    const processor = processors[index];
+    if (event === null || typeof processor !== 'function') {
+      resolve(event);
+    } else {
+      const result = processor({ ...event }, hint) as Event | null;
+
+      __DEBUG_BUILD__ &&
+        processor.id &&
+        result === null &&
+        logger.log(`Event processor "${processor.id}" dropped event`);
+
+      if (isThenable(result)) {
+        void result
+          .then(final => notifyEventProcessors(processors, final, hint, index + 1).then(resolve))
+          .then(null, reject);
+      } else {
+        void notifyEventProcessors(processors, result, hint, index + 1)
+          .then(resolve)
+          .then(null, reject);
+      }
+    }
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,7 +36,8 @@ export {
 } from './hub';
 export { makeSession, closeSession, updateSession } from './session';
 export { SessionFlusher } from './sessionflusher';
-export { addGlobalEventProcessor, Scope } from './scope';
+export { Scope } from './scope';
+export { addGlobalEventProcessor } from './eventProcessors';
 export { getEnvelopeEndpointWithUrlEncodedAuth, getReportDialogEndpoint } from './api';
 export { BaseClient } from './baseclient';
 export { ServerRuntimeClient } from './server-runtime-client';

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -1,4 +1,4 @@
-import type { Event, EventProcessor, Hub, Integration, StackFrame } from '@sentry/types';
+import type { Client, Event, EventHint, Integration, StackFrame } from '@sentry/types';
 import { getEventDescription, logger, stringMatchesSomePattern } from '@sentry/utils';
 
 // "Script error." is hard coded into browsers for errors that it can't read.
@@ -48,23 +48,15 @@ export class InboundFilters implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(addGlobalEventProcessor: (processor: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    const eventProcess: EventProcessor = (event: Event) => {
-      const hub = getCurrentHub();
-      if (hub) {
-        const self = hub.getIntegration(InboundFilters);
-        if (self) {
-          const client = hub.getClient();
-          const clientOptions = client ? client.getOptions() : {};
-          const options = _mergeOptions(self._options, clientOptions);
-          return _shouldDropEvent(event, options) ? null : event;
-        }
-      }
-      return event;
-    };
+  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+    // noop
+  }
 
-    eventProcess.id = this.name;
-    addGlobalEventProcessor(eventProcess);
+  /** @inheritDoc */
+  public processEvent(event: Event, _eventHint: EventHint, client: Client): Event | null {
+    const clientOptions = client.getOptions();
+    const options = _mergeOptions(this._options, clientOptions);
+    return _shouldDropEvent(event, options) ? null : event;
   }
 }
 

--- a/packages/integrations/src/contextlines.ts
+++ b/packages/integrations/src/contextlines.ts
@@ -1,4 +1,4 @@
-import type { Event, EventProcessor, Hub, Integration, StackFrame } from '@sentry/types';
+import type { Event, Integration, StackFrame } from '@sentry/types';
 import { addContextToFrame, GLOBAL_OBJ, stripUrlQueryAndFragment } from '@sentry/utils';
 
 const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
@@ -44,17 +44,20 @@ export class ContextLines implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    addGlobalEventProcessor(event => {
-      const self = getCurrentHub().getIntegration(ContextLines);
-      if (!self) {
-        return event;
-      }
-      return this.addSourceContext(event);
-    });
+  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+    // noop
   }
 
-  /** Processes an event and adds context lines */
+  /** @inheritDoc */
+  public processEvent(event: Event): Event {
+    return this.addSourceContext(event);
+  }
+
+  /**
+   * Processes an event and adds context lines.
+   *
+   * TODO (v8): Make this internal/private
+   */
   public addSourceContext(event: Event): Event {
     const doc = WINDOW.document;
     const htmlFilename = WINDOW.location && stripUrlQueryAndFragment(WINDOW.location.href);

--- a/packages/integrations/src/dedupe.ts
+++ b/packages/integrations/src/dedupe.ts
@@ -1,4 +1,4 @@
-import type { Event, EventProcessor, Exception, Hub, Integration, StackFrame } from '@sentry/types';
+import type { Event, Exception, Integration, StackFrame } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 /** Deduplication filter */
@@ -22,36 +22,32 @@ export class Dedupe implements Integration {
     this.name = Dedupe.id;
   }
 
+  /** @inheritDoc */
+  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+    // noop
+  }
+
   /**
    * @inheritDoc
    */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    const eventProcessor: EventProcessor = currentEvent => {
-      // We want to ignore any non-error type events, e.g. transactions or replays
-      // These should never be deduped, and also not be compared against as _previousEvent.
-      if (currentEvent.type) {
-        return currentEvent;
-      }
-
-      const self = getCurrentHub().getIntegration(Dedupe);
-      if (self) {
-        // Juuust in case something goes wrong
-        try {
-          if (_shouldDropEvent(currentEvent, self._previousEvent)) {
-            __DEBUG_BUILD__ && logger.warn('Event dropped due to being a duplicate of previously captured event.');
-            return null;
-          }
-        } catch (_oO) {
-          return (self._previousEvent = currentEvent);
-        }
-
-        return (self._previousEvent = currentEvent);
-      }
+  public processEvent(currentEvent: Event): Event | null {
+    // We want to ignore any non-error type events, e.g. transactions or replays
+    // These should never be deduped, and also not be compared against as _previousEvent.
+    if (currentEvent.type) {
       return currentEvent;
-    };
+    }
 
-    eventProcessor.id = this.name;
-    addGlobalEventProcessor(eventProcessor);
+    // Juuust in case something goes wrong
+    try {
+      if (_shouldDropEvent(currentEvent, this._previousEvent)) {
+        __DEBUG_BUILD__ && logger.warn('Event dropped due to being a duplicate of previously captured event.');
+        return null;
+      }
+    } catch (_oO) {
+      return (this._previousEvent = currentEvent);
+    }
+
+    return (this._previousEvent = currentEvent);
   }
 }
 

--- a/packages/integrations/src/extraerrordata.ts
+++ b/packages/integrations/src/extraerrordata.ts
@@ -1,9 +1,9 @@
-import type { Contexts, Event, EventHint, EventProcessor, ExtendedError, Hub, Integration } from '@sentry/types';
+import type { Contexts, Event, EventHint, ExtendedError, Integration } from '@sentry/types';
 import { addNonEnumerableProperty, isError, isPlainObject, logger, normalize } from '@sentry/utils';
 
 /** JSDoc */
 interface ExtraErrorDataOptions {
-  depth?: number;
+  depth: number;
 }
 
 /** Patch toString calls to return proper name for wrapped functions */
@@ -24,7 +24,7 @@ export class ExtraErrorData implements Integration {
   /**
    * @inheritDoc
    */
-  public constructor(options?: ExtraErrorDataOptions) {
+  public constructor(options?: Partial<ExtraErrorDataOptions>) {
     this.name = ExtraErrorData.id;
 
     this._options = {
@@ -36,94 +36,99 @@ export class ExtraErrorData implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    addGlobalEventProcessor((event: Event, hint: EventHint) => {
-      const self = getCurrentHub().getIntegration(ExtraErrorData);
-      if (!self) {
-        return event;
-      }
-      return self.enhanceEventWithErrorData(event, hint);
-    });
+  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+    // noop
+  }
+
+  /** @inheritDoc */
+  public processEvent(event: Event, hint: EventHint): Event {
+    return this.enhanceEventWithErrorData(event, hint);
   }
 
   /**
-   * Attaches extracted information from the Error object to extra field in the Event
+   * Attaches extracted information from the Error object to extra field in the Event.
+   *
+   * TODO (v8): Drop this public function.
    */
   public enhanceEventWithErrorData(event: Event, hint: EventHint = {}): Event {
-    if (!hint.originalException || !isError(hint.originalException)) {
-      return event;
-    }
-    const exceptionName = (hint.originalException as ExtendedError).name || hint.originalException.constructor.name;
+    return _enhanceEventWithErrorData(event, hint, this._options.depth);
+  }
+}
 
-    const errorData = this._extractErrorData(hint.originalException as ExtendedError);
-
-    if (errorData) {
-      const contexts: Contexts = {
-        ...event.contexts,
-      };
-
-      const normalizedErrorData = normalize(errorData, this._options.depth);
-
-      if (isPlainObject(normalizedErrorData)) {
-        // We mark the error data as "already normalized" here, because we don't want other normalization procedures to
-        // potentially truncate the data we just already normalized, with a certain depth setting.
-        addNonEnumerableProperty(normalizedErrorData, '__sentry_skip_normalization__', true);
-        contexts[exceptionName] = normalizedErrorData;
-      }
-
-      return {
-        ...event,
-        contexts,
-      };
-    }
-
+function _enhanceEventWithErrorData(event: Event, hint: EventHint = {}, depth: number): Event {
+  if (!hint.originalException || !isError(hint.originalException)) {
     return event;
   }
+  const exceptionName = (hint.originalException as ExtendedError).name || hint.originalException.constructor.name;
 
-  /**
-   * Extract extra information from the Error object
-   */
-  private _extractErrorData(error: ExtendedError): Record<string, unknown> | null {
-    // We are trying to enhance already existing event, so no harm done if it won't succeed
-    try {
-      const nativeKeys = [
-        'name',
-        'message',
-        'stack',
-        'line',
-        'column',
-        'fileName',
-        'lineNumber',
-        'columnNumber',
-        'toJSON',
-      ];
+  const errorData = _extractErrorData(hint.originalException as ExtendedError);
 
-      const extraErrorInfo: Record<string, unknown> = {};
+  if (errorData) {
+    const contexts: Contexts = {
+      ...event.contexts,
+    };
 
-      // We want only enumerable properties, thus `getOwnPropertyNames` is redundant here, as we filter keys anyway.
-      for (const key of Object.keys(error)) {
-        if (nativeKeys.indexOf(key) !== -1) {
-          continue;
-        }
-        const value = error[key];
-        extraErrorInfo[key] = isError(value) ? value.toString() : value;
-      }
+    const normalizedErrorData = normalize(errorData, depth);
 
-      // Check if someone attached `toJSON` method to grab even more properties (eg. axios is doing that)
-      if (typeof error.toJSON === 'function') {
-        const serializedError = error.toJSON() as Record<string, unknown>;
-
-        for (const key of Object.keys(serializedError)) {
-          const value = serializedError[key];
-          extraErrorInfo[key] = isError(value) ? value.toString() : value;
-        }
-      }
-
-      return extraErrorInfo;
-    } catch (oO) {
-      __DEBUG_BUILD__ && logger.error('Unable to extract extra data from the Error object:', oO);
+    if (isPlainObject(normalizedErrorData)) {
+      // We mark the error data as "already normalized" here, because we don't want other normalization procedures to
+      // potentially truncate the data we just already normalized, with a certain depth setting.
+      addNonEnumerableProperty(normalizedErrorData, '__sentry_skip_normalization__', true);
+      contexts[exceptionName] = normalizedErrorData;
     }
 
-    return null;
+    return {
+      ...event,
+      contexts,
+    };
   }
+
+  return event;
+}
+
+/**
+ * Extract extra information from the Error object
+ */
+function _extractErrorData(error: ExtendedError): Record<string, unknown> | null {
+  // We are trying to enhance already existing event, so no harm done if it won't succeed
+  try {
+    const nativeKeys = [
+      'name',
+      'message',
+      'stack',
+      'line',
+      'column',
+      'fileName',
+      'lineNumber',
+      'columnNumber',
+      'toJSON',
+    ];
+
+    const extraErrorInfo: Record<string, unknown> = {};
+
+    // We want only enumerable properties, thus `getOwnPropertyNames` is redundant here, as we filter keys anyway.
+    for (const key of Object.keys(error)) {
+      if (nativeKeys.indexOf(key) !== -1) {
+        continue;
+      }
+      const value = error[key];
+      extraErrorInfo[key] = isError(value) ? value.toString() : value;
+    }
+
+    // Check if someone attached `toJSON` method to grab even more properties (eg. axios is doing that)
+    if (typeof error.toJSON === 'function') {
+      const serializedError = error.toJSON() as Record<string, unknown>;
+
+      for (const key of Object.keys(serializedError)) {
+        const value = serializedError[key];
+        extraErrorInfo[key] = isError(value) ? value.toString() : value;
+      }
+    }
+
+    return extraErrorInfo;
+  } catch (oO) {
+    __DEBUG_BUILD__ && logger.error('Unable to extract extra data from the Error object:', oO);
+  }
+
+  return null;
 }

--- a/packages/integrations/src/rewriteframes.ts
+++ b/packages/integrations/src/rewriteframes.ts
@@ -1,4 +1,4 @@
-import type { Event, EventProcessor, Hub, Integration, StackFrame, Stacktrace } from '@sentry/types';
+import type { Event, Integration, StackFrame, Stacktrace } from '@sentry/types';
 import { basename, relative } from '@sentry/utils';
 
 type StackFrameIteratee = (frame: StackFrame) => StackFrame;
@@ -43,17 +43,18 @@ export class RewriteFrames implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    addGlobalEventProcessor(event => {
-      const self = getCurrentHub().getIntegration(RewriteFrames);
-      if (self) {
-        return self.process(event);
-      }
-      return event;
-    });
+  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+    // noop
   }
 
-  /** JSDoc */
+  /** @inheritDoc */
+  public processEvent(event: Event): Event {
+    return this.process(event);
+  }
+
+  /**
+   * TODO (v8): Make this private/internal
+   */
   public process(originalEvent: Event): Event {
     let processedEvent = originalEvent;
 

--- a/packages/integrations/src/sessiontiming.ts
+++ b/packages/integrations/src/sessiontiming.ts
@@ -1,4 +1,4 @@
-import type { Event, EventProcessor, Hub, Integration } from '@sentry/types';
+import type { Event, Integration } from '@sentry/types';
 
 /** This function adds duration since Sentry was initialized till the time event was sent */
 export class SessionTiming implements Integration {
@@ -23,18 +23,17 @@ export class SessionTiming implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    addGlobalEventProcessor(event => {
-      const self = getCurrentHub().getIntegration(SessionTiming);
-      if (self) {
-        return self.process(event);
-      }
-      return event;
-    });
+  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+    // noop
+  }
+
+  /** @inheritDoc */
+  public processEvent(event: Event): Event {
+    return this.process(event);
   }
 
   /**
-   * @inheritDoc
+   * TODO (v8): make this private/internal
    */
   public process(event: Event): Event {
     const now = Date.now();

--- a/packages/integrations/src/transaction.ts
+++ b/packages/integrations/src/transaction.ts
@@ -1,4 +1,4 @@
-import type { Event, EventProcessor, Hub, Integration, StackFrame } from '@sentry/types';
+import type { Event, Integration, StackFrame } from '@sentry/types';
 
 /** Add node transaction to the event */
 export class Transaction implements Integration {
@@ -19,43 +19,40 @@ export class Transaction implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    addGlobalEventProcessor(event => {
-      const self = getCurrentHub().getIntegration(Transaction);
-      if (self) {
-        return self.process(event);
-      }
-      return event;
-    });
+  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+    // noop
+  }
+
+  /** @inheritDoc */
+  public processEvent(event: Event): Event {
+    return this.processEvent(event);
   }
 
   /**
-   * @inheritDoc
+   * TODO (v8): Make this private/internal
    */
   public process(event: Event): Event {
-    const frames = this._getFramesFromEvent(event);
+    const frames = _getFramesFromEvent(event);
 
     // use for loop so we don't have to reverse whole frames array
     for (let i = frames.length - 1; i >= 0; i--) {
       const frame = frames[i];
 
       if (frame.in_app === true) {
-        event.transaction = this._getTransaction(frame);
+        event.transaction = _getTransaction(frame);
         break;
       }
     }
 
     return event;
   }
+}
 
-  /** JSDoc */
-  private _getFramesFromEvent(event: Event): StackFrame[] {
-    const exception = event.exception && event.exception.values && event.exception.values[0];
-    return (exception && exception.stacktrace && exception.stacktrace.frames) || [];
-  }
+function _getFramesFromEvent(event: Event): StackFrame[] {
+  const exception = event.exception && event.exception.values && event.exception.values[0];
+  return (exception && exception.stacktrace && exception.stacktrace.frames) || [];
+}
 
-  /** JSDoc */
-  private _getTransaction(frame: StackFrame): string {
-    return frame.module || frame.function ? `${frame.module || '?'}/${frame.function || '?'}` : '<unknown>';
-  }
+function _getTransaction(frame: StackFrame): string {
+  return frame.module || frame.function ? `${frame.module || '?'}/${frame.function || '?'}` : '<unknown>';
 }

--- a/packages/integrations/test/dedupe.test.ts
+++ b/packages/integrations/test/dedupe.test.ts
@@ -1,4 +1,4 @@
-import type { Event as SentryEvent, EventProcessor, Exception, Hub, StackFrame, Stacktrace } from '@sentry/types';
+import type { Event as SentryEvent, Exception, StackFrame, Stacktrace } from '@sentry/types';
 
 import { _shouldDropEvent, Dedupe } from '../src/dedupe';
 
@@ -176,47 +176,29 @@ describe('Dedupe', () => {
     });
   });
 
-  describe('setupOnce', () => {
-    let dedupeFunc: EventProcessor;
-
-    beforeEach(function () {
-      const integration = new Dedupe();
-      const addGlobalEventProcessor = (callback: EventProcessor) => {
-        dedupeFunc = callback;
-      };
-
-      const getCurrentHub = () => {
-        return {
-          getIntegration() {
-            return integration;
-          },
-        } as unknown as Hub;
-      };
-
-      integration.setupOnce(addGlobalEventProcessor, getCurrentHub);
-    });
-
+  describe('processEvent', () => {
     it('ignores consecutive errors', () => {
-      expect(dedupeFunc(clone(exceptionEvent), {})).not.toBeNull();
-      expect(dedupeFunc(clone(exceptionEvent), {})).toBeNull();
-      expect(dedupeFunc(clone(exceptionEvent), {})).toBeNull();
+      const integration = new Dedupe();
+
+      expect(integration.processEvent(clone(exceptionEvent))).not.toBeNull();
+      expect(integration.processEvent(clone(exceptionEvent))).toBeNull();
+      expect(integration.processEvent(clone(exceptionEvent))).toBeNull();
     });
 
     it('ignores transactions between errors', () => {
-      expect(dedupeFunc(clone(exceptionEvent), {})).not.toBeNull();
+      const integration = new Dedupe();
+
+      expect(integration.processEvent(clone(exceptionEvent))).not.toBeNull();
       expect(
-        dedupeFunc(
-          {
-            event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2',
-            message: 'someMessage',
-            transaction: 'wat',
-            type: 'transaction',
-          },
-          {},
-        ),
+        integration.processEvent({
+          event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2',
+          message: 'someMessage',
+          transaction: 'wat',
+          type: 'transaction',
+        }),
       ).not.toBeNull();
-      expect(dedupeFunc(clone(exceptionEvent), {})).toBeNull();
-      expect(dedupeFunc(clone(exceptionEvent), {})).toBeNull();
+      expect(integration.processEvent(clone(exceptionEvent))).toBeNull();
+      expect(integration.processEvent(clone(exceptionEvent))).toBeNull();
     });
   });
 });

--- a/packages/node/src/integrations/context.ts
+++ b/packages/node/src/integrations/context.ts
@@ -6,7 +6,6 @@ import type {
   CultureContext,
   DeviceContext,
   Event,
-  EventProcessor,
   Integration,
   OsContext,
 } from '@sentry/types';
@@ -63,17 +62,26 @@ export class Context implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void): void {
-    addGlobalEventProcessor(event => this.addContext(event));
+  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+    // noop
   }
 
-  /** Processes an event and adds context */
+  /** @inheritDoc */
+  public processEvent(event: Event): Promise<Event> {
+    return this.addContext(event);
+  }
+
+  /**
+   * Processes an event and adds context.
+   *
+   * TODO (v8): Make this private/internal.
+   */
   public async addContext(event: Event): Promise<Event> {
     if (this._cachedContext === undefined) {
       this._cachedContext = this._getContexts();
     }
 
-    const updatedContext = this._updateContext(await this._cachedContext);
+    const updatedContext = _updateContext(await this._cachedContext);
 
     event.contexts = {
       ...event.contexts,
@@ -85,22 +93,6 @@ export class Context implements Integration {
     };
 
     return event;
-  }
-
-  /**
-   * Updates the context with dynamic values that can change
-   */
-  private _updateContext(contexts: Contexts): Contexts {
-    // Only update properties if they exist
-    if (contexts?.app?.app_memory) {
-      contexts.app.app_memory = process.memoryUsage().rss;
-    }
-
-    if (contexts?.device?.free_memory) {
-      contexts.device.free_memory = os.freemem();
-    }
-
-    return contexts;
   }
 
   /**
@@ -135,6 +127,22 @@ export class Context implements Integration {
 
     return contexts;
   }
+}
+
+/**
+ * Updates the context with dynamic values that can change
+ */
+function _updateContext(contexts: Contexts): Contexts {
+  // Only update properties if they exist
+  if (contexts?.app?.app_memory) {
+    contexts.app.app_memory = process.memoryUsage().rss;
+  }
+
+  if (contexts?.device?.free_memory) {
+    contexts.device.free_memory = os.freemem();
+  }
+
+  return contexts;
 }
 
 /**

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -1,4 +1,4 @@
-import type { Event, EventProcessor, Hub, Integration, StackFrame } from '@sentry/types';
+import type { Event, Integration, StackFrame } from '@sentry/types';
 import { addContextToFrame } from '@sentry/utils';
 import { readFile } from 'fs';
 import { LRUMap } from 'lru_map';
@@ -56,17 +56,20 @@ export class ContextLines implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    addGlobalEventProcessor(event => {
-      const self = getCurrentHub().getIntegration(ContextLines);
-      if (!self) {
-        return event;
-      }
-      return this.addSourceContext(event);
-    });
+  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+    // noop
   }
 
-  /** Processes an event and adds context lines */
+  /** @inheritDoc */
+  public processEvent(event: Event): Promise<Event> {
+    return this.addSourceContext(event);
+  }
+
+  /**
+   * Processes an event and adds context lines.
+   *
+   * TODO (v8): Make this internal/private
+   *  */
   public async addSourceContext(event: Event): Promise<Event> {
     // keep a lookup map of which files we've already enqueued to read,
     // so we don't enqueue the same file multiple times which would cause multiple i/o reads
@@ -117,7 +120,11 @@ export class ContextLines implements Integration {
     return event;
   }
 
-  /** Adds context lines to frames */
+  /**
+   * Adds context lines to frames.
+   *
+   * TODO (v8): Make this internal/private
+   */
   public addSourceContextToFrames(frames: StackFrame[]): void {
     for (const frame of frames) {
       // Only add context if we have a filename and it hasn't already been added

--- a/packages/node/src/integrations/modules.ts
+++ b/packages/node/src/integrations/modules.ts
@@ -1,4 +1,4 @@
-import type { EventProcessor, Hub, Integration } from '@sentry/types';
+import type { Event, Integration } from '@sentry/types';
 import { existsSync, readFileSync } from 'fs';
 import { dirname, join } from 'path';
 
@@ -80,26 +80,26 @@ export class Modules implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    addGlobalEventProcessor(event => {
-      if (!getCurrentHub().getIntegration(Modules)) {
-        return event;
-      }
-      return {
-        ...event,
-        modules: {
-          ...event.modules,
-          ...this._getModules(),
-        },
-      };
-    });
+  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+    // noop
   }
 
-  /** Fetches the list of modules and the versions loaded by the entry file for your node.js app. */
-  private _getModules(): { [key: string]: string } {
-    if (!moduleCache) {
-      moduleCache = collectModules();
-    }
-    return moduleCache;
+  /** @inheritDoc */
+  public processEvent(event: Event): Event {
+    return {
+      ...event,
+      modules: {
+        ...event.modules,
+        ..._getModules(),
+      },
+    };
   }
+}
+
+/** Fetches the list of modules and the versions loaded by the entry file for your node.js app. */
+function _getModules(): { [key: string]: string } {
+  if (!moduleCache) {
+    moduleCache = collectModules();
+  }
+  return moduleCache;
 }

--- a/packages/node/test/integrations/requestdata.test.ts
+++ b/packages/node/test/integrations/requestdata.test.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub, Hub, makeMain } from '@sentry/core';
+import { getCurrentHub } from '@sentry/core';
 import type { Event, EventProcessor, PolymorphicRequest } from '@sentry/types';
 import * as http from 'http';
 
@@ -10,7 +10,6 @@ import * as requestDataModule from '../../src/requestdata';
 import { getDefaultNodeClientOptions } from '../helper/node-client-options';
 
 const addRequestDataToEventSpy = jest.spyOn(requestDataModule, 'addRequestDataToEvent');
-const requestDataEventProcessor = jest.fn();
 
 const headers = { ears: 'furry', nose: 'wet', tongue: 'spotted', cookie: 'favorite=zukes' };
 const method = 'wagging';
@@ -19,10 +18,7 @@ const hostname = 'the.dog.park';
 const path = '/by/the/trees/';
 const queryString = 'chase=me&please=thankyou';
 
-function initWithRequestDataIntegrationOptions(integrationOptions: RequestDataIntegrationOptions): void {
-  const setMockEventProcessor = (eventProcessor: EventProcessor) =>
-    requestDataEventProcessor.mockImplementationOnce(eventProcessor);
-
+function initWithRequestDataIntegrationOptions(integrationOptions: RequestDataIntegrationOptions): EventProcessor {
   const requestDataIntegration = new RequestData({
     ...integrationOptions,
   });
@@ -33,12 +29,15 @@ function initWithRequestDataIntegrationOptions(integrationOptions: RequestDataIn
       integrations: [requestDataIntegration],
     }),
   );
-  client.setupIntegrations = () => requestDataIntegration.setupOnce(setMockEventProcessor, getCurrentHub);
-  client.getIntegration = () => requestDataIntegration as any;
 
-  const hub = new Hub(client);
+  getCurrentHub().bindClient(client);
 
-  makeMain(hub);
+  const eventProcessors = client['_eventProcessors'] as EventProcessor[];
+  const eventProcessor = eventProcessors.find(processor => processor.id === 'RequestData');
+
+  expect(eventProcessor).toBeDefined();
+
+  return eventProcessor!;
 }
 
 describe('`RequestData` integration', () => {
@@ -61,9 +60,9 @@ describe('`RequestData` integration', () => {
 
   describe('option conversion', () => {
     it('leaves `ip` and `user` at top level of `include`', () => {
-      initWithRequestDataIntegrationOptions({ include: { ip: false, user: true } });
+      const requestDataEventProcessor = initWithRequestDataIntegrationOptions({ include: { ip: false, user: true } });
 
-      requestDataEventProcessor(event);
+      void requestDataEventProcessor(event, {});
 
       const passedOptions = addRequestDataToEventSpy.mock.calls[0][2];
 
@@ -71,9 +70,9 @@ describe('`RequestData` integration', () => {
     });
 
     it('moves `transactionNamingScheme` to `transaction` include', () => {
-      initWithRequestDataIntegrationOptions({ transactionNamingScheme: 'path' });
+      const requestDataEventProcessor = initWithRequestDataIntegrationOptions({ transactionNamingScheme: 'path' });
 
-      requestDataEventProcessor(event);
+      void requestDataEventProcessor(event, {});
 
       const passedOptions = addRequestDataToEventSpy.mock.calls[0][2];
 
@@ -81,9 +80,11 @@ describe('`RequestData` integration', () => {
     });
 
     it('moves `true` request keys into `request` include, but omits `false` ones', async () => {
-      initWithRequestDataIntegrationOptions({ include: { data: true, cookies: false } });
+      const requestDataEventProcessor = initWithRequestDataIntegrationOptions({
+        include: { data: true, cookies: false },
+      });
 
-      requestDataEventProcessor(event);
+      void requestDataEventProcessor(event, {});
 
       const passedOptions = addRequestDataToEventSpy.mock.calls[0][2];
 
@@ -92,9 +93,11 @@ describe('`RequestData` integration', () => {
     });
 
     it('moves `true` user keys into `user` include, but omits `false` ones', async () => {
-      initWithRequestDataIntegrationOptions({ include: { user: { id: true, email: false } } });
+      const requestDataEventProcessor = initWithRequestDataIntegrationOptions({
+        include: { user: { id: true, email: false } },
+      });
 
-      requestDataEventProcessor(event);
+      void requestDataEventProcessor(event, {});
 
       const passedOptions = addRequestDataToEventSpy.mock.calls[0][2];
 
@@ -109,12 +112,12 @@ describe('`RequestData` integration', () => {
       const res = new http.ServerResponse(req);
       const next = jest.fn();
 
-      initWithRequestDataIntegrationOptions({ transactionNamingScheme: 'path' });
+      const requestDataEventProcessor = initWithRequestDataIntegrationOptions({ transactionNamingScheme: 'path' });
 
       sentryRequestMiddleware(req, res, next);
 
       await getCurrentHub().getScope()!.applyToEvent(event, {});
-      requestDataEventProcessor(event);
+      await requestDataEventProcessor(event, {});
 
       const passedOptions = addRequestDataToEventSpy.mock.calls[0][2];
 
@@ -138,12 +141,12 @@ describe('`RequestData` integration', () => {
       const wrappedGCPFunction = mockGCPWrapper(jest.fn(), { include: { transaction: 'methodPath' } });
       const res = new http.ServerResponse(req);
 
-      initWithRequestDataIntegrationOptions({ transactionNamingScheme: 'path' });
+      const requestDataEventProcessor = initWithRequestDataIntegrationOptions({ transactionNamingScheme: 'path' });
 
       wrappedGCPFunction(req, res);
 
       await getCurrentHub().getScope()!.applyToEvent(event, {});
-      requestDataEventProcessor(event);
+      await requestDataEventProcessor(event, {});
 
       const passedOptions = addRequestDataToEventSpy.mock.calls[0][2];
 

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -5,6 +5,7 @@ import type { DataCategory } from './datacategory';
 import type { DsnComponents } from './dsn';
 import type { DynamicSamplingContext, Envelope } from './envelope';
 import type { Event, EventHint } from './event';
+import type { EventProcessor } from './eventprocessor';
 import type { Integration, IntegrationClass } from './integration';
 import type { ClientOptions } from './options';
 import type { Scope } from './scope';
@@ -119,6 +120,13 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    * still events in the queue when the timeout is reached.
    */
   flush(timeout?: number): PromiseLike<boolean>;
+
+  /**
+   * Adds an event processor that applies to any event processed by this client.
+   *
+   * TODO (v8): Make this a required method.
+   */
+  addEventProcessor?(eventProcessor: EventProcessor): void;
 
   /** Returns the client's instance of the given integration class, it any. */
   getIntegration<T extends Integration>(integration: IntegrationClass<T>): T | null;

--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -30,4 +30,10 @@ export interface Integration {
    * An optional hook that allows to preprocess an event _before_ it is passed to all other event processors.
    */
   preprocessEvent?(event: Event, hint: EventHint | undefined, client: Client): void;
+
+  /**
+   * An optional hook that allows to process an event.
+   * Return `null` to drop the event, or mutate the event & return it.
+   */
+  processEvent?(event: Event, hint: EventHint | undefined, client: Client): Event | null | PromiseLike<Event | null>;
 }


### PR DESCRIPTION
This adds a new (optional) `processEvent` hook on the `Integration` interface, which allows to register an event processor **for the current client only**.

This has actually correct semantics in that the processor will only be registered for the client that the integration is added for. This is done by adding a new `addEventProcessor` method on the baseclient, which for now are called after all global & scope event processors.

Previously, all integrations always registered a _global_ event processor, which is not really necessary. With this, we can be much more focused & also skip checking for existence of the integration on the client etc.