### PR TITLE
feat(core): Introduce `processEvent` hook on `Integration`

### DIFF
--- a/packages/core/src/eventProcessors.ts
+++ b/packages/core/src/eventProcessors.ts
@@ -1,0 +1,51 @@
+import type { Event, EventHint, EventProcessor } from '@sentry/types';
+import { getGlobalSingleton, isThenable, logger, SyncPromise } from '@sentry/utils';
+
+/**
+ * Returns the global event processors.
+ */
+export function getGlobalEventProcessors(): EventProcessor[] {
+  return getGlobalSingleton<EventProcessor[]>('globalEventProcessors', () => []);
+}
+
+/**
+ * Add a EventProcessor to be kept globally.
+ * @param callback EventProcessor to add
+ */
+export function addGlobalEventProcessor(callback: EventProcessor): void {
+  getGlobalEventProcessors().push(callback);
+}
+
+/**
+ * Process an array of event processors, returning the processed event (or `null` if the event was dropped).
+ */
+export function notifyEventProcessors(
+  processors: EventProcessor[],
+  event: Event | null,
+  hint: EventHint,
+  index: number = 0,
+): PromiseLike<Event | null> {
+  return new SyncPromise<Event | null>((resolve, reject) => {
+    const processor = processors[index];
+    if (event === null || typeof processor !== 'function') {
+      resolve(event);
+    } else {
+      const result = processor({ ...event }, hint) as Event | null;
+
+      __DEBUG_BUILD__ &&
+        processor.id &&
+        result === null &&
+        logger.log(`Event processor "${processor.id}" dropped event`);
+
+      if (isThenable(result)) {
+        void result
+          .then(final => notifyEventProcessors(processors, final, hint, index + 1).then(resolve))
+          .then(null, reject);
+      } else {
+        void notifyEventProcessors(processors, result, hint, index + 1)
+          .then(resolve)
+          .then(null, reject);
+      }
+    }
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,7 +36,8 @@ export {
 } from './hub';
 export { makeSession, closeSession, updateSession } from './session';
 export { SessionFlusher } from './sessionflusher';
-export { addGlobalEventProcessor, Scope } from './scope';
+export { Scope } from './scope';
+export { addGlobalEventProcessor } from './eventProcessors';
 export { getEnvelopeEndpointWithUrlEncodedAuth, getReportDialogEndpoint } from './api';
 export { BaseClient } from './baseclient';
 export { ServerRuntimeClient } from './server-runtime-client';

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -5,6 +5,7 @@ import type { DataCategory } from './datacategory';
 import type { DsnComponents } from './dsn';
 import type { DynamicSamplingContext, Envelope } from './envelope';
 import type { Event, EventHint } from './event';
+import type { EventProcessor } from './eventprocessor';
 import type { Integration, IntegrationClass } from './integration';
 import type { ClientOptions } from './options';
 import type { Scope } from './scope';
@@ -119,6 +120,13 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    * still events in the queue when the timeout is reached.
    */
   flush(timeout?: number): PromiseLike<boolean>;
+
+  /**
+   * Adds an event processor that applies to any event processed by this client.
+   *
+   * TODO (v8): Make this a required method.
+   */
+  addEventProcessor?(eventProcessor: EventProcessor): void;
 
   /** Returns the client's instance of the given integration class, it any. */
   getIntegration<T extends Integration>(integration: IntegrationClass<T>): T | null;

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -128,6 +128,13 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    */
   addEventProcessor?(eventProcessor: EventProcessor): void;
 
+  /**
+   * Get all added event processors for this client.
+   *
+   * TODO (v8): Make this a required method.
+   */
+  getEventProcessors?(): EventProcessor[];
+
   /** Returns the client's instance of the given integration class, it any. */
   getIntegration<T extends Integration>(integration: IntegrationClass<T>): T | null;
 

--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -30,4 +30,11 @@ export interface Integration {
    * An optional hook that allows to preprocess an event _before_ it is passed to all other event processors.
    */
   preprocessEvent?(event: Event, hint: EventHint | undefined, client: Client): void;
+
+  /**
+   * An optional hook that allows to process an event.
+   * Return `null` to drop the event, or mutate the event & return it.
+   * This receives the client that the integration was installed for as third argument.
+   */
+  processEvent?(event: Event, hint: EventHint | undefined, client: Client): Event | null | PromiseLike<Event | null>;
 }


### PR DESCRIPTION
This adds a new (optional) `processEvent` hook on the `Integration` interface, which allows to register an event processor **for the current client only**.

This has actually correct semantics in that the processor will only be registered for the client that the integration is added for. This is done by adding a new `addEventProcessor` method on the client, which for now are called after all global & scope event processors.

Previously, all integrations always registered a _global_ event processor, which is not really necessary. With this, we can be much more focused & also skip checking for existence of the integration on the client etc.

Supersedes https://github.com/getsentry/sentry-javascript/pull/9015