### PR TITLE
ref(node): Refactor node integrations to use `processEvent`

### DIFF
--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -55,14 +55,13 @@ export class ContextLines implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    addGlobalEventProcessor(event => {
-      const self = getCurrentHub().getIntegration(ContextLines);
-      if (!self) {
-        return event;
-      }
-      return this.addSourceContext(event);
-    });
+  public setupOnce(_addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
+    // noop
+  }
+
+  /** @inheritDoc */
+  public processEvent(event: Event): Promise<Event> {
+    return this.addSourceContext(event);
   }
 
   /** Processes an event and adds context lines */

--- a/packages/node/src/integrations/contextlines.ts
+++ b/packages/node/src/integrations/contextlines.ts
@@ -55,13 +55,14 @@ export class ContextLines implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(_addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    // noop
-  }
-
-  /** @inheritDoc */
-  public processEvent(event: Event): Promise<Event> {
-    return this.addSourceContext(event);
+  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
+    addGlobalEventProcessor(event => {
+      const self = getCurrentHub().getIntegration(ContextLines);
+      if (!self) {
+        return event;
+      }
+      return this.addSourceContext(event);
+    });
   }
 
   /** Processes an event and adds context lines */

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -186,13 +186,16 @@ describe('SentryNode', () => {
         dsn,
         integrations: [new ContextLines()],
       });
-      getCurrentHub().bindClient(new NodeClient(options));
+      const client = new NodeClient(options);
+      getCurrentHub().bindClient(client);
       getCurrentScope().setTag('test', '1');
       try {
         throw new Error('test');
       } catch (e) {
         captureException(e);
       }
+
+     void client.flush();
     });
 
     test('capture a linked exception with pre/post context', done => {

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -165,24 +165,24 @@ describe('SentryNode', () => {
       }
     });
 
-    test('capture an exception with pre/post context', done => {
-      expect.assertions(10);
+    test('capture an exception with pre/post context', async () => {
+      const beforeSend = jest.fn((event: Event) => {
+        expect(event.tags).toEqual({ test: '1' });
+        expect(event.exception).not.toBeUndefined();
+        expect(event.exception!.values![0]).not.toBeUndefined();
+        expect(event.exception!.values![0].stacktrace!).not.toBeUndefined();
+        expect(event.exception!.values![0].stacktrace!.frames![1]).not.toBeUndefined();
+        expect(event.exception!.values![0].stacktrace!.frames![1].pre_context).not.toBeUndefined();
+        expect(event.exception!.values![0].stacktrace!.frames![1].post_context).not.toBeUndefined();
+        expect(event.exception!.values![0].type).toBe('Error');
+        expect(event.exception!.values![0].value).toBe('test');
+        expect(event.exception!.values![0].stacktrace).toBeTruthy();
+        return null;
+      });
+
       const options = getDefaultNodeClientOptions({
         stackParser: defaultStackParser,
-        beforeSend: (event: Event) => {
-          expect(event.tags).toEqual({ test: '1' });
-          expect(event.exception).not.toBeUndefined();
-          expect(event.exception!.values![0]).not.toBeUndefined();
-          expect(event.exception!.values![0].stacktrace!).not.toBeUndefined();
-          expect(event.exception!.values![0].stacktrace!.frames![1]).not.toBeUndefined();
-          expect(event.exception!.values![0].stacktrace!.frames![1].pre_context).not.toBeUndefined();
-          expect(event.exception!.values![0].stacktrace!.frames![1].post_context).not.toBeUndefined();
-          expect(event.exception!.values![0].type).toBe('Error');
-          expect(event.exception!.values![0].value).toBe('test');
-          expect(event.exception!.values![0].stacktrace).toBeTruthy();
-          done();
-          return null;
-        },
+        beforeSend,
         dsn,
         integrations: [new ContextLines()],
       });
@@ -195,7 +195,9 @@ describe('SentryNode', () => {
         captureException(e);
       }
 
-     void client.flush();
+      await client.flush();
+
+      expect(beforeSend).toHaveBeenCalledTimes(1);
     });
 
     test('capture a linked exception with pre/post context', done => {


### PR DESCRIPTION
This refactors Node integrations to use `processEvent`.

Missing is the LocalVariables integration, as that is more complicated and may need to be refactored in a different way to properly work.