### PR TITLE
ref(tests): Update replay integration tests to avoid flakes.

### DIFF
--- a/packages/browser-integration-tests/suites/replay/bufferMode/test.ts
+++ b/packages/browser-integration-tests/suites/replay/bufferMode/test.ts
@@ -84,12 +84,13 @@ sentryTest(
     await reqErrorPromise;
     expect(callsToSentry).toEqual(2);
 
-    await page.evaluate(async () => {
-      const replayIntegration = (window as unknown as Window & { Replay: Replay }).Replay;
-      await replayIntegration.flush();
-    });
-
-    const req0 = await reqPromise0;
+    const [, req0] = await Promise.all([
+      await page.evaluate(async () => {
+        const replayIntegration = (window as unknown as Window & { Replay: Replay }).Replay;
+        await replayIntegration.flush();
+      }),
+      reqPromise0,
+    ]);
 
     // 2 errors, 1 flush
     await reqErrorPromise;
@@ -226,12 +227,13 @@ sentryTest(
     await reqErrorPromise;
     expect(callsToSentry).toEqual(2);
 
-    await page.evaluate(async () => {
-      const replayIntegration = (window as unknown as Window & { Replay: Replay }).Replay;
-      await replayIntegration.flush({ continueRecording: false });
-    });
-
-    const req0 = await reqPromise0;
+    const [, req0] = await Promise.all([
+      page.evaluate(async () => {
+        const replayIntegration = (window as unknown as Window & { Replay: Replay }).Replay;
+        await replayIntegration.flush({ continueRecording: false });
+      }),
+      reqPromise0,
+    ]);
 
     // 2 errors, 1 flush
     await reqErrorPromise;
@@ -346,9 +348,13 @@ sentryTest(
 
     // Error sample rate is now at 1.0, this error should create a replay
     const reqErrorPromise1 = waitForErrorRequest(page);
-    await page.click('#error2');
-    // 1 unsampled error, 1 sampled error -> 1 flush
-    const req0 = await reqPromise0;
+    const [, req0] = await Promise.all([
+      page.click('#error2'),
+
+      // 1 unsampled error, 1 sampled error -> 1 flush
+      reqPromise0,
+    ]);
+
     const reqError1 = await reqErrorPromise1;
     const errorEvent1 = envelopeRequestParser(reqError1);
     expect(callsToSentry).toEqual(3);

--- a/packages/browser-integration-tests/suites/replay/bufferMode/test.ts
+++ b/packages/browser-integration-tests/suites/replay/bufferMode/test.ts
@@ -84,12 +84,12 @@ sentryTest(
     await reqErrorPromise;
     expect(callsToSentry).toEqual(2);
 
-    const [, req0] = await Promise.all([
+    const [req0] = await Promise.all([
+      reqPromise0,
       await page.evaluate(async () => {
         const replayIntegration = (window as unknown as Window & { Replay: Replay }).Replay;
         await replayIntegration.flush();
       }),
-      reqPromise0,
     ]);
 
     // 2 errors, 1 flush
@@ -227,12 +227,12 @@ sentryTest(
     await reqErrorPromise;
     expect(callsToSentry).toEqual(2);
 
-    const [, req0] = await Promise.all([
+    const [req0] = await Promise.all([
+      reqPromise0,
       page.evaluate(async () => {
         const replayIntegration = (window as unknown as Window & { Replay: Replay }).Replay;
         await replayIntegration.flush({ continueRecording: false });
       }),
-      reqPromise0,
     ]);
 
     // 2 errors, 1 flush
@@ -348,11 +348,10 @@ sentryTest(
 
     // Error sample rate is now at 1.0, this error should create a replay
     const reqErrorPromise1 = waitForErrorRequest(page);
-    const [, req0] = await Promise.all([
-      page.click('#error2'),
-
+    const [req0] = await Promise.all([
       // 1 unsampled error, 1 sampled error -> 1 flush
       reqPromise0,
+      page.click('#error2'),
     ]);
 
     const reqError1 = await reqErrorPromise1;

--- a/packages/browser-integration-tests/suites/replay/bufferMode/test.ts
+++ b/packages/browser-integration-tests/suites/replay/bufferMode/test.ts
@@ -86,7 +86,7 @@ sentryTest(
 
     const [req0] = await Promise.all([
       reqPromise0,
-      await page.evaluate(async () => {
+     page.evaluate(async () => {
         const replayIntegration = (window as unknown as Window & { Replay: Replay }).Replay;
         await replayIntegration.flush();
       }),

--- a/packages/browser-integration-tests/suites/replay/bufferMode/test.ts
+++ b/packages/browser-integration-tests/suites/replay/bufferMode/test.ts
@@ -86,7 +86,7 @@ sentryTest(
 
     const [req0] = await Promise.all([
       reqPromise0,
-     page.evaluate(async () => {
+      page.evaluate(async () => {
         const replayIntegration = (window as unknown as Window & { Replay: Replay }).Replay;
         await replayIntegration.flush();
       }),

--- a/packages/browser-integration-tests/suites/replay/captureConsoleLog/test.ts
+++ b/packages/browser-integration-tests/suites/replay/captureConsoleLog/test.ts
@@ -37,7 +37,8 @@ sentryTest('should capture console messages in replay', async ({ getLocalTestPat
   await page.click('[data-log]');
 
   // Sometimes this doesn't seem to trigger, so we trigger it twice to be sure...
-  const [, , req1] = await Promise.all([page.click('[data-log]'), forceFlushReplay(), reqPromise1]);
+  const [req1] = await Promise.all([reqPromise1, page.click('[data-log]')]);
+  await forceFlushReplay();
 
   const { breadcrumbs } = getCustomRecordingEvents(req1);
 
@@ -86,7 +87,8 @@ sentryTest('should capture very large console logs', async ({ getLocalTestPath, 
     5_000,
   );
 
-  const [, , req1] = await Promise.all([page.click('[data-log-large]'), forceFlushReplay(), reqPromise1]);
+  const [req1] = await Promise.all([reqPromise1, page.click('[data-log-large]')]);
+  await forceFlushReplay();
 
   const { breadcrumbs } = getCustomRecordingEvents(req1);
 

--- a/packages/browser-integration-tests/suites/replay/errors/errorMode/test.ts
+++ b/packages/browser-integration-tests/suites/replay/errors/errorMode/test.ts
@@ -50,26 +50,25 @@ sentryTest(
 
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    await page.goto(url);
-    await page.click('#go-background');
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    await Promise.all([
+      page.goto(url),
+      page.click('#go-background'),
+      new Promise(resolve => setTimeout(resolve, 1000)),
+    ]);
 
     expect(callsToSentry).toEqual(0);
 
-    await page.click('#error');
-    const req0 = await reqPromise0;
+    const [, req0] = await Promise.all([page.click('#error'), reqPromise0]);
 
     expect(callsToSentry).toEqual(2); // 1 error, 1 replay event
 
-    await page.click('#go-background');
-    const req1 = await reqPromise1;
-    await reqErrorPromise;
+    const [, req1] = await Promise.all([page.click('#go-background'), reqPromise1, reqErrorPromise]);
 
     expect(callsToSentry).toEqual(3); // 1 error, 2 replay events
 
     await page.click('#log');
-    await page.click('#go-background');
-    const req2 = await reqPromise2;
+
+    const [, req2] = await Promise.all([page.click('#go-background'), reqPromise2]);
 
     const event0 = getReplayEvent(req0);
     const content0 = getReplayRecordingContent(req0);

--- a/packages/browser-integration-tests/suites/replay/errors/errorMode/test.ts
+++ b/packages/browser-integration-tests/suites/replay/errors/errorMode/test.ts
@@ -58,17 +58,17 @@ sentryTest(
 
     expect(callsToSentry).toEqual(0);
 
-    const [, req0] = await Promise.all([page.click('#error'), reqPromise0]);
+    const [req0] = await Promise.all([reqPromise0, page.click('#error')]);
 
     expect(callsToSentry).toEqual(2); // 1 error, 1 replay event
 
-    const [, req1] = await Promise.all([page.click('#go-background'), reqPromise1, reqErrorPromise]);
+    const [req1] = await Promise.all([reqPromise1, page.click('#go-background'), reqErrorPromise]);
 
     expect(callsToSentry).toEqual(3); // 1 error, 2 replay events
 
     await page.click('#log');
 
-    const [, req2] = await Promise.all([page.click('#go-background'), reqPromise2]);
+    const [req2] = await Promise.all([reqPromise2, page.click('#go-background')]);
 
     const event0 = getReplayEvent(req0);
     const content0 = getReplayRecordingContent(req0);

--- a/packages/browser-integration-tests/suites/replay/largeMutations/defaultOptions/test.ts
+++ b/packages/browser-integration-tests/suites/replay/largeMutations/defaultOptions/test.ts
@@ -10,8 +10,6 @@ sentryTest(
       sentryTest.skip();
     }
 
-    const reqPromise0 = waitForReplayRequest(page, 0);
-
     await page.route('https://dsn.ingest.sentry.io/**/*', route => {
       return route.fulfill({
         status: 200,
@@ -20,28 +18,23 @@ sentryTest(
       });
     });
 
+    const reqPromise0 = waitForReplayRequest(page, 0);
+
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    await page.goto(url);
-    const res0 = await reqPromise0;
+    const [, res0] = await Promise.all([page.goto(url), reqPromise0]);
 
     const reqPromise1 = waitForReplayRequest(page);
 
-    void page.click('#button-add');
-    await forceFlushReplay();
-    const res1 = await reqPromise1;
+    const [, , res1] = await Promise.all([page.click('#button-add'), forceFlushReplay(), reqPromise1]);
 
     const reqPromise2 = waitForReplayRequest(page);
 
-    void page.click('#button-modify');
-    await forceFlushReplay();
-    const res2 = await reqPromise2;
+    const [, , res2] = await Promise.all([page.click('#button-modify'), forceFlushReplay(), reqPromise2]);
 
     const reqPromise3 = waitForReplayRequest(page);
 
-    void page.click('#button-remove');
-    await forceFlushReplay();
-    const res3 = await reqPromise3;
+    const [, , res3] = await Promise.all([page.click('#button-remove'), forceFlushReplay(), reqPromise3]);
 
     const replayData0 = getReplayRecordingContent(res0);
     const replayData1 = getReplayRecordingContent(res1);

--- a/packages/browser-integration-tests/suites/replay/largeMutations/defaultOptions/test.ts
+++ b/packages/browser-integration-tests/suites/replay/largeMutations/defaultOptions/test.ts
@@ -18,23 +18,12 @@ sentryTest(
       });
     });
 
-    const reqPromise0 = waitForReplayRequest(page, 0);
-
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    const [, res0] = await Promise.all([page.goto(url), reqPromise0]);
-
-    const reqPromise1 = waitForReplayRequest(page);
-
-    const [, , res1] = await Promise.all([page.click('#button-add'), forceFlushReplay(), reqPromise1]);
-
-    const reqPromise2 = waitForReplayRequest(page);
-
-    const [, , res2] = await Promise.all([page.click('#button-modify'), forceFlushReplay(), reqPromise2]);
-
-    const reqPromise3 = waitForReplayRequest(page);
-
-    const [, , res3] = await Promise.all([page.click('#button-remove'), forceFlushReplay(), reqPromise3]);
+    const [res0] = await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
+    const [res1] = await Promise.all([waitForReplayRequest(page), page.click('#button-add'), forceFlushReplay()]);
+    const [res2] = await Promise.all([waitForReplayRequest(page), page.click('#button-modify'), forceFlushReplay()]);
+    const [res3] = await Promise.all([waitForReplayRequest(page), page.click('#button-remove'), forceFlushReplay()]);
 
     const replayData0 = getReplayRecordingContent(res0);
     const replayData1 = getReplayRecordingContent(res1);

--- a/packages/browser-integration-tests/suites/replay/largeMutations/defaultOptions/test.ts
+++ b/packages/browser-integration-tests/suites/replay/largeMutations/defaultOptions/test.ts
@@ -21,9 +21,16 @@ sentryTest(
     const url = await getLocalTestPath({ testDir: __dirname });
 
     const [res0] = await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
-    const [res1] = await Promise.all([waitForReplayRequest(page), page.click('#button-add'), forceFlushReplay()]);
-    const [res2] = await Promise.all([waitForReplayRequest(page), page.click('#button-modify'), forceFlushReplay()]);
-    const [res3] = await Promise.all([waitForReplayRequest(page), page.click('#button-remove'), forceFlushReplay()]);
+    await forceFlushReplay();
+
+    const [res1] = await Promise.all([waitForReplayRequest(page), page.click('#button-add')]);
+    await forceFlushReplay();
+
+    const [res2] = await Promise.all([waitForReplayRequest(page), page.click('#button-modify')]);
+    await forceFlushReplay();
+
+    const [res3] = await Promise.all([waitForReplayRequest(page), page.click('#button-remove')]);
+    await forceFlushReplay();
 
     const replayData0 = getReplayRecordingContent(res0);
     const replayData1 = getReplayRecordingContent(res1);

--- a/packages/browser-integration-tests/suites/replay/largeMutations/mutationLimit/test.ts
+++ b/packages/browser-integration-tests/suites/replay/largeMutations/mutationLimit/test.ts
@@ -27,20 +27,24 @@ sentryTest(
 
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    const [, res0] = await Promise.all([page.goto(url), reqPromise0]);
+    const [res0] = await Promise.all([reqPromise0, page.goto(url)]);
+    await forceFlushReplay();
 
     const reqPromise1 = waitForReplayRequest(page);
 
-    const [, , res1] = await Promise.all([page.click('#button-add'), forceFlushReplay(), reqPromise1]);
+    const [res1] = await Promise.all([reqPromise1, page.click('#button-add')]);
+    await forceFlushReplay();
 
     // replay should be stopped due to mutation limit
     let replay = await getReplaySnapshot(page);
     expect(replay.session).toBe(undefined);
     expect(replay._isEnabled).toBe(false);
 
-    await Promise.all([page.click('#button-modify'), await forceFlushReplay()]);
+    await page.click('#button-modify');
+    await forceFlushReplay();
 
-    await Promise.all([page.click('#button-remove'), await forceFlushReplay()]);
+    await page.click('#button-remove');
+    await forceFlushReplay();
 
     const replayData0 = getReplayRecordingContent(res0);
     expect(replayData0.fullSnapshots.length).toBe(1);

--- a/packages/browser-integration-tests/suites/replay/maxReplayDuration/test.ts
+++ b/packages/browser-integration-tests/suites/replay/maxReplayDuration/test.ts
@@ -35,7 +35,9 @@ sentryTest('keeps track of max duration across reloads', async ({ getLocalTestPa
 
   await new Promise(resolve => setTimeout(resolve, MAX_REPLAY_DURATION / 2 + 100));
 
-  const [, , req0, req1] = await Promise.all([
+  const [req0, req1] = await Promise.all([
+    reqPromise0,
+    reqPromise1,
     page.click('#button1'),
     page.evaluate(
       `Object.defineProperty(document, 'visibilityState', {
@@ -47,8 +49,6 @@ sentryTest('keeps track of max duration across reloads', async ({ getLocalTestPa
 
   document.dispatchEvent(new Event('visibilitychange'));`,
     ),
-    reqPromise0,
-    reqPromise1,
   ]);
 
   const replayEvent0 = getReplayEvent(req0);

--- a/packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
+++ b/packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
@@ -56,8 +56,7 @@ sentryTest(
 
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    await page.goto(url);
-    const req0 = await reqPromise0;
+    const [, req0] = await Promise.all([page.goto(url), reqPromise0]);
     const replayEvent0 = getReplayEvent(req0);
     const recording0 = getReplayRecordingContent(req0);
 
@@ -65,9 +64,8 @@ sentryTest(
     expect(normalize(recording0.fullSnapshots)).toMatchSnapshot('seg-0-snap-full');
     expect(recording0.incrementalSnapshots.length).toEqual(0);
 
-    await page.click('#go-background');
+    const [, req1] = await Promise.all([page.click('#go-background'), reqPromise1]);
 
-    const req1 = await reqPromise1;
     const replayEvent1 = getReplayEvent(req1);
     const recording1 = getReplayRecordingContent(req1);
 
@@ -97,9 +95,8 @@ sentryTest(
     // -----------------------------------------------------------------------------------------
     // Test page reload
 
-    await page.reload();
+    const [, req2] = await Promise.all([page.reload(), reqPromise2]);
 
-    const req2 = await reqPromise2;
     const replayEvent2 = getReplayEvent(req2);
     const recording2 = getReplayRecordingContent(req2);
 
@@ -107,9 +104,8 @@ sentryTest(
     expect(normalize(recording2.fullSnapshots)).toMatchSnapshot('seg-2-snap-full');
     expect(recording2.incrementalSnapshots.length).toEqual(0);
 
-    await page.click('#go-background');
+    const [, req3] = await Promise.all([page.click('#go-background'), reqPromise3]);
 
-    const req3 = await reqPromise3;
     const replayEvent3 = getReplayEvent(req3);
     const recording3 = getReplayRecordingContent(req3);
 
@@ -137,9 +133,8 @@ sentryTest(
     // -----------------------------------------------------------------------------------------
     // Test subsequent link navigation to another page
 
-    await page.click('a');
+    const [, req4] = await Promise.all([page.click('a'), reqPromise4]);
 
-    const req4 = await reqPromise4;
     const replayEvent4 = getReplayEvent(req4);
     const recording4 = getReplayRecordingContent(req4);
 
@@ -161,9 +156,8 @@ sentryTest(
     expect(normalize(recording4.fullSnapshots)).toMatchSnapshot('seg-4-snap-full');
     expect(recording4.incrementalSnapshots.length).toEqual(0);
 
-    await page.click('#go-background');
+    const [, req5] = await Promise.all([page.click('#go-background'), reqPromise5]);
 
-    const req5 = await reqPromise5;
     const replayEvent5 = getReplayEvent(req5);
     const recording5 = getReplayRecordingContent(req5);
 
@@ -207,9 +201,8 @@ sentryTest(
     // -----------------------------------------------------------------------------------------
     // Test subsequent navigation without a page reload (i.e. SPA navigation)
 
-    await page.click('#spa-navigation');
+    const [, req6] = await Promise.all([page.click('#spa-navigation'), reqPromise6]);
 
-    const req6 = await reqPromise6;
     const replayEvent6 = getReplayEvent(req6);
     const recording6 = getReplayRecordingContent(req6);
 
@@ -231,9 +224,8 @@ sentryTest(
     expect(recording6.fullSnapshots.length).toEqual(0);
     expect(normalize(recording6.incrementalSnapshots)).toMatchSnapshot('seg-6-snap-incremental');
 
-    await page.click('#go-background');
+    const [, req7] = await Promise.all([page.click('#go-background'), reqPromise7]);
 
-    const req7 = await reqPromise7;
     const replayEvent7 = getReplayEvent(req7);
     const recording7 = getReplayRecordingContent(req7);
 
@@ -279,9 +271,11 @@ sentryTest(
     //   // -----------------------------------------------------------------------------------------
     //   // And just to finish this off, let's go back to the index page
 
-    await page.click('a');
+    const [, req8] = await Promise.all([
+      page.click('a'),
+      reqPromise8
+    ]);
 
-    const req8 = await reqPromise8;
     const replayEvent8 = getReplayEvent(req8);
     const recording8 = getReplayRecordingContent(req8);
 
@@ -293,9 +287,11 @@ sentryTest(
     expect(normalize(recording8.fullSnapshots)).toMatchSnapshot('seg-8-snap-full');
     expect(recording8.incrementalSnapshots.length).toEqual(0);
 
-    await page.click('#go-background');
+    const [, req9] = await Promise.all([
+      page.click('#go-background'),
+      reqPromise9
+    ]);
 
-    const req9 = await reqPromise9;
     const replayEvent9 = getReplayEvent(req9);
     const recording9 = getReplayRecordingContent(req9);
 

--- a/packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
+++ b/packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
@@ -56,7 +56,7 @@ sentryTest(
 
     const url = await getLocalTestPath({ testDir: __dirname });
 
-    const [, req0] = await Promise.all([page.goto(url), reqPromise0]);
+    const [req0] = await Promise.all([reqPromise0, page.goto(url)]);
     const replayEvent0 = getReplayEvent(req0);
     const recording0 = getReplayRecordingContent(req0);
 
@@ -64,7 +64,7 @@ sentryTest(
     expect(normalize(recording0.fullSnapshots)).toMatchSnapshot('seg-0-snap-full');
     expect(recording0.incrementalSnapshots.length).toEqual(0);
 
-    const [, req1] = await Promise.all([page.click('#go-background'), reqPromise1]);
+    const [req1] = await Promise.all([reqPromise1, page.click('#go-background')]);
 
     const replayEvent1 = getReplayEvent(req1);
     const recording1 = getReplayRecordingContent(req1);
@@ -95,7 +95,7 @@ sentryTest(
     // -----------------------------------------------------------------------------------------
     // Test page reload
 
-    const [, req2] = await Promise.all([page.reload(), reqPromise2]);
+    const [req2] = await Promise.all([reqPromise2, page.reload()]);
 
     const replayEvent2 = getReplayEvent(req2);
     const recording2 = getReplayRecordingContent(req2);
@@ -104,7 +104,7 @@ sentryTest(
     expect(normalize(recording2.fullSnapshots)).toMatchSnapshot('seg-2-snap-full');
     expect(recording2.incrementalSnapshots.length).toEqual(0);
 
-    const [, req3] = await Promise.all([page.click('#go-background'), reqPromise3]);
+    const [req3] = await Promise.all([reqPromise3, page.click('#go-background')]);
 
     const replayEvent3 = getReplayEvent(req3);
     const recording3 = getReplayRecordingContent(req3);
@@ -133,7 +133,7 @@ sentryTest(
     // -----------------------------------------------------------------------------------------
     // Test subsequent link navigation to another page
 
-    const [, req4] = await Promise.all([page.click('a'), reqPromise4]);
+    const [req4] = await Promise.all([reqPromise4, page.click('a')]);
 
     const replayEvent4 = getReplayEvent(req4);
     const recording4 = getReplayRecordingContent(req4);
@@ -156,7 +156,7 @@ sentryTest(
     expect(normalize(recording4.fullSnapshots)).toMatchSnapshot('seg-4-snap-full');
     expect(recording4.incrementalSnapshots.length).toEqual(0);
 
-    const [, req5] = await Promise.all([page.click('#go-background'), reqPromise5]);
+    const [req5] = await Promise.all([reqPromise5, page.click('#go-background')]);
 
     const replayEvent5 = getReplayEvent(req5);
     const recording5 = getReplayRecordingContent(req5);
@@ -201,7 +201,7 @@ sentryTest(
     // -----------------------------------------------------------------------------------------
     // Test subsequent navigation without a page reload (i.e. SPA navigation)
 
-    const [, req6] = await Promise.all([page.click('#spa-navigation'), reqPromise6]);
+    const [req6] = await Promise.all([reqPromise6, page.click('#spa-navigation')]);
 
     const replayEvent6 = getReplayEvent(req6);
     const recording6 = getReplayRecordingContent(req6);
@@ -224,7 +224,7 @@ sentryTest(
     expect(recording6.fullSnapshots.length).toEqual(0);
     expect(normalize(recording6.incrementalSnapshots)).toMatchSnapshot('seg-6-snap-incremental');
 
-    const [, req7] = await Promise.all([page.click('#go-background'), reqPromise7]);
+    const [req7] = await Promise.all([reqPromise7, page.click('#go-background')]);
 
     const replayEvent7 = getReplayEvent(req7);
     const recording7 = getReplayRecordingContent(req7);
@@ -271,7 +271,7 @@ sentryTest(
     //   // -----------------------------------------------------------------------------------------
     //   // And just to finish this off, let's go back to the index page
 
-    const [, req8] = await Promise.all([page.click('a'), reqPromise8]);
+    const [req8] = await Promise.all([reqPromise8, page.click('a')]);
 
     const replayEvent8 = getReplayEvent(req8);
     const recording8 = getReplayRecordingContent(req8);
@@ -284,7 +284,7 @@ sentryTest(
     expect(normalize(recording8.fullSnapshots)).toMatchSnapshot('seg-8-snap-full');
     expect(recording8.incrementalSnapshots.length).toEqual(0);
 
-    const [, req9] = await Promise.all([page.click('#go-background'), reqPromise9]);
+    const [req9] = await Promise.all([reqPromise9, page.click('#go-background')]);
 
     const replayEvent9 = getReplayEvent(req9);
     const recording9 = getReplayRecordingContent(req9);

--- a/packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
+++ b/packages/browser-integration-tests/suites/replay/multiple-pages/test.ts
@@ -271,10 +271,7 @@ sentryTest(
     //   // -----------------------------------------------------------------------------------------
     //   // And just to finish this off, let's go back to the index page
 
-    const [, req8] = await Promise.all([
-      page.click('a'),
-      reqPromise8
-    ]);
+    const [, req8] = await Promise.all([page.click('a'), reqPromise8]);
 
     const replayEvent8 = getReplayEvent(req8);
     const recording8 = getReplayRecordingContent(req8);
@@ -287,10 +284,7 @@ sentryTest(
     expect(normalize(recording8.fullSnapshots)).toMatchSnapshot('seg-8-snap-full');
     expect(recording8.incrementalSnapshots.length).toEqual(0);
 
-    const [, req9] = await Promise.all([
-      page.click('#go-background'),
-      reqPromise9
-    ]);
+    const [, req9] = await Promise.all([page.click('#go-background'), reqPromise9]);
 
     const replayEvent9 = getReplayEvent(req9);
     const recording9 = getReplayRecordingContent(req9);

--- a/packages/browser-integration-tests/suites/replay/requests/test.ts
+++ b/packages/browser-integration-tests/suites/replay/requests/test.ts
@@ -69,14 +69,13 @@ sentryTest('replay recording should contain XHR request span', async ({ getLocal
   const reqPromise0 = waitForReplayRequest(page, 0);
   const reqPromise1 = waitForReplayRequest(page, 1);
 
-
   const url = await getLocalTestPath({ testDir: __dirname });
 
   const [, req0] = await Promise.all([Promise.all([page.goto(url), page.click('#go-background')]), reqPromise0]);
 
   const { performanceSpans: spans0 } = getReplayRecordingContent(req0);
 
-  await Promise.all([page.click('#xhr'), page.waitForResponse('https://example.com')])
+  await Promise.all([page.click('#xhr'), page.waitForResponse('https://example.com')]);
 
   const { performanceSpans: spans1 } = getReplayRecordingContent(await reqPromise1);
 

--- a/packages/browser-integration-tests/suites/replay/requests/test.ts
+++ b/packages/browser-integration-tests/suites/replay/requests/test.ts
@@ -31,13 +31,11 @@ sentryTest('replay recording should contain fetch request span', async ({ getLoc
 
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  const [, req0] = await Promise.all([Promise.all([page.goto(url), page.click('#go-background')]), reqPromise0]);
+  const [req0] = await Promise.all([reqPromise0, page.goto(url), page.click('#go-background')]);
 
   const { performanceSpans: spans0 } = getReplayRecordingContent(req0);
 
-  const receivedResponse = page.waitForResponse('https://example.com');
-
-  await Promise.all([page.click('#fetch'), receivedResponse]);
+  await Promise.all([page.waitForResponse('https://example.com'), page.click('#fetch')]);
 
   const { performanceSpans: spans1 } = getReplayRecordingContent(await reqPromise1);
 
@@ -71,11 +69,11 @@ sentryTest('replay recording should contain XHR request span', async ({ getLocal
 
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  const [, req0] = await Promise.all([Promise.all([page.goto(url), page.click('#go-background')]), reqPromise0]);
+  const [req0] = await Promise.all([reqPromise0, page.goto(url), page.click('#go-background')]);
 
   const { performanceSpans: spans0 } = getReplayRecordingContent(req0);
 
-  await Promise.all([page.click('#xhr'), page.waitForResponse('https://example.com')]);
+  await Promise.all([page.waitForResponse('https://example.com'), page.click('#xhr')]);
 
   const { performanceSpans: spans1 } = getReplayRecordingContent(await reqPromise1);
 

--- a/packages/browser-integration-tests/suites/replay/slowClick/clickTargets/test.ts
+++ b/packages/browser-integration-tests/suites/replay/slowClick/clickTargets/test.ts
@@ -35,8 +35,6 @@ import { getCustomRecordingEvents, shouldSkipReplayTest, waitForReplayRequest } 
         sentryTest.skip();
       }
 
-      const reqPromise0 = waitForReplayRequest(page, 0);
-
       await page.route('https://dsn.ingest.sentry.io/**/*', route => {
         return route.fulfill({
           status: 200,
@@ -47,18 +45,19 @@ import { getCustomRecordingEvents, shouldSkipReplayTest, waitForReplayRequest } 
 
       const url = await getLocalTestUrl({ testDir: __dirname });
 
-      await page.goto(url);
-      await reqPromise0;
+      await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
 
-      const reqPromise1 = waitForReplayRequest(page, (event, res) => {
-        const { breadcrumbs } = getCustomRecordingEvents(res);
+      const [req1] = await Promise.all([
+        waitForReplayRequest(page, (event, res) => {
+          const { breadcrumbs } = getCustomRecordingEvents(res);
 
-        return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.slowClickDetected');
-      });
+          return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.slowClickDetected');
+        }),
 
-      await page.click(`#${id}`);
+        page.click(`#${id}`),
+      ]);
 
-      const { breadcrumbs } = getCustomRecordingEvents(await reqPromise1);
+      const { breadcrumbs } = getCustomRecordingEvents(req1);
 
       const slowClickBreadcrumbs = breadcrumbs.filter(breadcrumb => breadcrumb.category === 'ui.slowClickDetected');
 
@@ -92,8 +91,6 @@ import { getCustomRecordingEvents, shouldSkipReplayTest, waitForReplayRequest } 
         sentryTest.skip();
       }
 
-      const reqPromise0 = waitForReplayRequest(page, 0);
-
       await page.route('https://dsn.ingest.sentry.io/**/*', route => {
         return route.fulfill({
           status: 200,
@@ -104,18 +101,18 @@ import { getCustomRecordingEvents, shouldSkipReplayTest, waitForReplayRequest } 
 
       const url = await getLocalTestUrl({ testDir: __dirname });
 
-      await page.goto(url);
-      await reqPromise0;
+      await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
 
-      const reqPromise1 = waitForReplayRequest(page, (event, res) => {
-        const { breadcrumbs } = getCustomRecordingEvents(res);
+      const [req1] = await Promise.all([
+        waitForReplayRequest(page, (event, res) => {
+          const { breadcrumbs } = getCustomRecordingEvents(res);
 
-        return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.click');
-      });
+          return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.click');
+        }),
+        page.click(`#${id}`),
+      ]);
 
-      await page.click(`#${id}`);
-
-      const { breadcrumbs } = getCustomRecordingEvents(await reqPromise1);
+      const { breadcrumbs } = getCustomRecordingEvents(req1);
 
       expect(breadcrumbs).toEqual([
         {

--- a/packages/browser-integration-tests/suites/replay/slowClick/ignore/test.ts
+++ b/packages/browser-integration-tests/suites/replay/slowClick/ignore/test.ts
@@ -8,8 +8,6 @@ sentryTest('click is ignored on ignoreSelectors', async ({ getLocalTestUrl, page
     sentryTest.skip();
   }
 
-  const reqPromise0 = waitForReplayRequest(page, 0);
-
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
     return route.fulfill({
       status: 200,
@@ -20,18 +18,18 @@ sentryTest('click is ignored on ignoreSelectors', async ({ getLocalTestUrl, page
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  await page.goto(url);
-  await reqPromise0;
+  await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
 
-  const reqPromise1 = waitForReplayRequest(page, (event, res) => {
-    const { breadcrumbs } = getCustomRecordingEvents(res);
+  const [req1] = await Promise.all([
+    waitForReplayRequest(page, (event, res) => {
+      const { breadcrumbs } = getCustomRecordingEvents(res);
 
-    return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.click');
-  });
+      return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.click');
+    }),
+    page.click('#mutationIgnoreButton'),
+  ]);
 
-  await page.click('#mutationIgnoreButton');
-
-  const { breadcrumbs } = getCustomRecordingEvents(await reqPromise1);
+  const { breadcrumbs } = getCustomRecordingEvents(req1);
 
   expect(breadcrumbs).toEqual([
     {
@@ -60,8 +58,6 @@ sentryTest('click is ignored on div', async ({ getLocalTestUrl, page }) => {
     sentryTest.skip();
   }
 
-  const reqPromise0 = waitForReplayRequest(page, 0);
-
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
     return route.fulfill({
       status: 200,
@@ -72,18 +68,19 @@ sentryTest('click is ignored on div', async ({ getLocalTestUrl, page }) => {
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  await page.goto(url);
-  await reqPromise0;
+  await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
 
-  const reqPromise1 = waitForReplayRequest(page, (event, res) => {
-    const { breadcrumbs } = getCustomRecordingEvents(res);
+  const [req1] = await Promise.all([
+    waitForReplayRequest(page, (event, res) => {
+      const { breadcrumbs } = getCustomRecordingEvents(res);
 
-    return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.click');
-  });
+      return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.click');
+    }),
 
-  await page.click('#mutationDiv');
+    await page.click('#mutationDiv'),
+  ]);
 
-  const { breadcrumbs } = getCustomRecordingEvents(await reqPromise1);
+  const { breadcrumbs } = getCustomRecordingEvents(req1);
 
   expect(breadcrumbs).toEqual([
     {

--- a/packages/browser-integration-tests/suites/replay/slowClick/mutation/test.ts
+++ b/packages/browser-integration-tests/suites/replay/slowClick/mutation/test.ts
@@ -8,8 +8,6 @@ sentryTest('mutation after threshold results in slow click', async ({ forceFlush
     sentryTest.skip();
   }
 
-  const reqPromise0 = waitForReplayRequest(page, 0);
-
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
     return route.fulfill({
       status: 200,
@@ -20,19 +18,20 @@ sentryTest('mutation after threshold results in slow click', async ({ forceFlush
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  await page.goto(url);
+  await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
   await forceFlushReplay();
-  await reqPromise0;
 
-  const reqPromise1 = waitForReplayRequest(page, (event, res) => {
-    const { breadcrumbs } = getCustomRecordingEvents(res);
+  const [req1] = await Promise.all([
+    waitForReplayRequest(page, (event, res) => {
+      const { breadcrumbs } = getCustomRecordingEvents(res);
 
-    return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.slowClickDetected');
-  });
+      return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.slowClickDetected');
+    }),
 
-  await page.click('#mutationButton');
+    page.click('#mutationButton'),
+  ]);
 
-  const { breadcrumbs } = getCustomRecordingEvents(await reqPromise1);
+  const { breadcrumbs } = getCustomRecordingEvents(req1);
 
   const slowClickBreadcrumbs = breadcrumbs.filter(breadcrumb => breadcrumb.category === 'ui.slowClickDetected');
 
@@ -69,8 +68,6 @@ sentryTest('multiple clicks are counted', async ({ getLocalTestUrl, page }) => {
     sentryTest.skip();
   }
 
-  const reqPromise0 = waitForReplayRequest(page, 0);
-
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
     return route.fulfill({
       status: 200,
@@ -81,18 +78,18 @@ sentryTest('multiple clicks are counted', async ({ getLocalTestUrl, page }) => {
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  await page.goto(url);
-  await reqPromise0;
+  await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
 
-  const reqPromise1 = waitForReplayRequest(page, (event, res) => {
-    const { breadcrumbs } = getCustomRecordingEvents(res);
+  const [req1] = await Promise.all([
+    waitForReplayRequest(page, (event, res) => {
+      const { breadcrumbs } = getCustomRecordingEvents(res);
 
-    return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.slowClickDetected');
-  });
+      return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.slowClickDetected');
+    }),
+    page.click('#mutationButton', { clickCount: 4 }),
+  ]);
 
-  void page.click('#mutationButton', { clickCount: 4 });
-
-  const { breadcrumbs } = getCustomRecordingEvents(await reqPromise1);
+  const { breadcrumbs } = getCustomRecordingEvents(req1);
 
   const slowClickBreadcrumbs = breadcrumbs.filter(breadcrumb => breadcrumb.category === 'ui.slowClickDetected');
   const multiClickBreadcrumbs = breadcrumbs.filter(breadcrumb => breadcrumb.category === 'ui.multiClick');
@@ -131,8 +128,6 @@ sentryTest('immediate mutation does not trigger slow click', async ({ forceFlush
     sentryTest.skip();
   }
 
-  const reqPromise0 = waitForReplayRequest(page, 0);
-
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
     return route.fulfill({
       status: 200,
@@ -143,19 +138,19 @@ sentryTest('immediate mutation does not trigger slow click', async ({ forceFlush
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  await page.goto(url);
+  await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
   await forceFlushReplay();
-  await reqPromise0;
 
-  const reqPromise1 = waitForReplayRequest(page, (event, res) => {
-    const { breadcrumbs } = getCustomRecordingEvents(res);
+  const [req1] = await Promise.all([
+    waitForReplayRequest(page, (event, res) => {
+      const { breadcrumbs } = getCustomRecordingEvents(res);
 
-    return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.click');
-  });
+      return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.click');
+    }),
+    page.click('#mutationButtonImmediately'),
+  ]);
 
-  await page.click('#mutationButtonImmediately');
-
-  const { breadcrumbs } = getCustomRecordingEvents(await reqPromise1);
+  const { breadcrumbs } = getCustomRecordingEvents(req1);
 
   expect(breadcrumbs).toEqual([
     {
@@ -183,8 +178,6 @@ sentryTest('inline click handler does not trigger slow click', async ({ forceFlu
     sentryTest.skip();
   }
 
-  const reqPromise0 = waitForReplayRequest(page, 0);
-
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
     return route.fulfill({
       status: 200,
@@ -195,19 +188,19 @@ sentryTest('inline click handler does not trigger slow click', async ({ forceFlu
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  await page.goto(url);
+  await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
   await forceFlushReplay();
-  await reqPromise0;
 
-  const reqPromise1 = waitForReplayRequest(page, (event, res) => {
-    const { breadcrumbs } = getCustomRecordingEvents(res);
+  const [req1] = await Promise.all([
+    waitForReplayRequest(page, (event, res) => {
+      const { breadcrumbs } = getCustomRecordingEvents(res);
 
-    return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.click');
-  });
+      return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.click');
+    }),
+    page.click('#mutationButtonInline'),
+  ]);
 
-  await page.click('#mutationButtonInline');
-
-  const { breadcrumbs } = getCustomRecordingEvents(await reqPromise1);
+  const { breadcrumbs } = getCustomRecordingEvents(req1);
 
   expect(breadcrumbs).toEqual([
     {
@@ -235,8 +228,6 @@ sentryTest('mouseDown events are considered', async ({ getLocalTestUrl, page }) 
     sentryTest.skip();
   }
 
-  const reqPromise0 = waitForReplayRequest(page, 0);
-
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
     return route.fulfill({
       status: 200,
@@ -247,18 +238,18 @@ sentryTest('mouseDown events are considered', async ({ getLocalTestUrl, page }) 
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  await page.goto(url);
-  await reqPromise0;
+  await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
 
-  const reqPromise1 = waitForReplayRequest(page, (event, res) => {
-    const { breadcrumbs } = getCustomRecordingEvents(res);
+  const [req1] = await Promise.all([
+    waitForReplayRequest(page, (event, res) => {
+      const { breadcrumbs } = getCustomRecordingEvents(res);
 
-    return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.click');
-  });
+      return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.click');
+    }),
+    page.click('#mouseDownButton'),
+  ]);
 
-  await page.click('#mouseDownButton');
-
-  const { breadcrumbs } = getCustomRecordingEvents(await reqPromise1);
+  const { breadcrumbs } = getCustomRecordingEvents(req1);
 
   expect(breadcrumbs).toEqual([
     {

--- a/packages/browser-integration-tests/suites/replay/slowClick/scroll/test.ts
+++ b/packages/browser-integration-tests/suites/replay/slowClick/scroll/test.ts
@@ -8,8 +8,6 @@ sentryTest('immediate scroll does not trigger slow click', async ({ getLocalTest
     sentryTest.skip();
   }
 
-  const reqPromise0 = waitForReplayRequest(page, 0);
-
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
     return route.fulfill({
       status: 200,
@@ -20,18 +18,18 @@ sentryTest('immediate scroll does not trigger slow click', async ({ getLocalTest
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  await page.goto(url);
-  await reqPromise0;
+  await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
 
-  const reqPromise1 = waitForReplayRequest(page, (event, res) => {
-    const { breadcrumbs } = getCustomRecordingEvents(res);
+  const [req1] = await Promise.all([
+    waitForReplayRequest(page, (event, res) => {
+      const { breadcrumbs } = getCustomRecordingEvents(res);
 
-    return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.click');
-  });
+      return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.click');
+    }),
+    page.click('#scrollButton'),
+  ]);
 
-  await page.click('#scrollButton');
-
-  const { breadcrumbs } = getCustomRecordingEvents(await reqPromise1);
+  const { breadcrumbs } = getCustomRecordingEvents(req1);
 
   expect(breadcrumbs).toEqual([
     {
@@ -59,8 +57,6 @@ sentryTest('late scroll triggers slow click', async ({ getLocalTestUrl, page }) 
     sentryTest.skip();
   }
 
-  const reqPromise0 = waitForReplayRequest(page, 0);
-
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
     return route.fulfill({
       status: 200,
@@ -71,18 +67,18 @@ sentryTest('late scroll triggers slow click', async ({ getLocalTestUrl, page }) 
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  await page.goto(url);
-  await reqPromise0;
+  await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
 
-  const reqPromise1 = waitForReplayRequest(page, (event, res) => {
-    const { breadcrumbs } = getCustomRecordingEvents(res);
+  const [req1] = await Promise.all([
+    waitForReplayRequest(page, (event, res) => {
+      const { breadcrumbs } = getCustomRecordingEvents(res);
 
-    return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.slowClickDetected');
-  });
+      return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.slowClickDetected');
+    }),
+    page.click('#scrollLateButton'),
+  ]);
 
-  await page.click('#scrollLateButton');
-
-  const { breadcrumbs } = getCustomRecordingEvents(await reqPromise1);
+  const { breadcrumbs } = getCustomRecordingEvents(req1);
 
   const slowClickBreadcrumbs = breadcrumbs.filter(breadcrumb => breadcrumb.category === 'ui.slowClickDetected');
 

--- a/packages/browser-integration-tests/suites/replay/slowClick/windowOpen/test.ts
+++ b/packages/browser-integration-tests/suites/replay/slowClick/windowOpen/test.ts
@@ -8,8 +8,6 @@ sentryTest('window.open() is considered for slow click', async ({ getLocalTestUr
     sentryTest.skip();
   }
 
-  const reqPromise0 = waitForReplayRequest(page, 0);
-
   await page.route('https://dsn.ingest.sentry.io/**/*', route => {
     return route.fulfill({
       status: 200,
@@ -20,8 +18,7 @@ sentryTest('window.open() is considered for slow click', async ({ getLocalTestUr
 
   const url = await getLocalTestUrl({ testDir: __dirname });
 
-  await page.goto(url);
-  await reqPromise0;
+  await Promise.all([waitForReplayRequest(page, 0), page.goto(url)]);
 
   const reqPromise1 = waitForReplayRequest(page, (event, res) => {
     const { breadcrumbs } = getCustomRecordingEvents(res);


### PR DESCRIPTION
Resolves: https://github.com/getsentry/sentry-javascript/issues/8975

Refactored most flaky replay tests to `Promise.all` pattern to reduce flakiness.