### PR TITLE
feat(node): Improve non-error messages

### DIFF
--- a/packages/node-integration-tests/suites/public-api/captureException/empty-obj/test.ts
+++ b/packages/node-integration-tests/suites/public-api/captureException/empty-obj/test.ts
@@ -9,7 +9,7 @@ test('should capture an empty object', async () => {
       values: [
         {
           type: 'Error',
-          value: 'Non-Error exception captured with keys: [object has no keys]',
+          value: 'Object captured as exception with keys: [object has no keys]',
           mechanism: {
             type: 'generic',
             handled: true,

--- a/packages/remix/test/integration/test/server/action.test.ts
+++ b/packages/remix/test/integration/test/server/action.test.ts
@@ -304,8 +304,8 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
           {
             type: 'Error',
             value: useV2
-              ? 'Non-Error exception captured with keys: data, internal, status, statusText'
-              : 'Non-Error exception captured with keys: data',
+              ? 'Object captured as exception with keys: data, internal, status, statusText'
+              : 'Object captured as exception with keys: data',
             stacktrace: expect.any(Object),
             mechanism: {
               data: {
@@ -412,8 +412,8 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
           {
             type: 'Error',
             value: useV2
-              ? 'Non-Error exception captured with keys: data, internal, status, statusText'
-              : 'Non-Error exception captured with keys: [object has no keys]',
+              ? 'Object captured as exception with keys: data, internal, status, statusText'
+              : 'Object captured as exception with keys: [object has no keys]',
             stacktrace: expect.any(Object),
             mechanism: {
               data: {

--- a/packages/utils/src/eventbuilder.ts
+++ b/packages/utils/src/eventbuilder.ts
@@ -61,7 +61,7 @@ export function eventFromUnknownInput(
     if (isPlainObject(exception)) {
       // This will allow us to group events based on top-level keys
       // which is much better than creating new group when any key/value change
-      const message = `Non-Error exception captured with keys: ${extractExceptionKeysForMessage(exception)}`;
+      const message = `Object captured as exception with keys: ${extractExceptionKeysForMessage(exception)}`;
 
       const hub = getCurrentHub();
       const client = hub.getClient();

--- a/packages/utils/src/eventbuilder.ts
+++ b/packages/utils/src/eventbuilder.ts
@@ -39,6 +39,26 @@ export function exceptionFromError(stackParser: StackParser, error: Error): Exce
   return exception;
 }
 
+function getMessageForObject(exception: object): string {
+  if ('name' in exception && typeof exception.name === 'string') {
+    let message = `'${exception.name}' captured as exception`;
+
+    if ('message' in exception && typeof exception.message === 'string') {
+      message += ` with message '${exception.message}'`;
+    }
+
+    return message;
+  } else if ('message' in exception && typeof exception.message === 'string') {
+    return exception.message;
+  } else {
+    // This will allow us to group events based on top-level keys
+    // which is much better than creating new group when any key/value change
+    return `Object captured as exception with keys: ${extractExceptionKeysForMessage(
+      exception as Record<string, unknown>,
+    )}`;
+  }
+}
+
 /**
  * Builds and Event from a Exception
  * @hidden
@@ -59,10 +79,6 @@ export function eventFromUnknownInput(
 
   if (!isError(exception)) {
     if (isPlainObject(exception)) {
-      // This will allow us to group events based on top-level keys
-      // which is much better than creating new group when any key/value change
-      const message = `Object captured as exception with keys: ${extractExceptionKeysForMessage(exception)}`;
-
       const hub = getCurrentHub();
       const client = hub.getClient();
       const normalizeDepth = client && client.getOptions().normalizeDepth;
@@ -70,6 +86,7 @@ export function eventFromUnknownInput(
         scope.setExtra('__serialized__', normalizeToSize(exception, normalizeDepth));
       });
 
+      const message = getMessageForObject(exception);
       ex = (hint && hint.syntheticException) || new Error(message);
       (ex as Error).message = message;
     } else {

--- a/packages/utils/test/eventbuilder.test.ts
+++ b/packages/utils/test/eventbuilder.test.ts
@@ -1,0 +1,32 @@
+import type { Hub } from '@sentry/types';
+
+import { createStackParser, eventFromUnknownInput, nodeStackLineParser } from '../src';
+
+function getCurrentHub(): Hub {
+  // Some fake hub to get us through
+  return { getClient: () => undefined, configureScope: () => {} } as unknown as Hub;
+}
+
+const stackParser = createStackParser(nodeStackLineParser());
+
+describe('eventFromUnknownInput', () => {
+  test('object with useless props', () => {
+    const event = eventFromUnknownInput(getCurrentHub, stackParser, { foo: { bar: 'baz' }, prop: 1 });
+    expect(event.exception?.values?.[0].value).toBe('Object captured as exception with keys: foo, prop');
+  });
+
+  test('object with name prop', () => {
+    const event = eventFromUnknownInput(getCurrentHub, stackParser, { foo: { bar: 'baz' }, name: 'BadType' });
+    expect(event.exception?.values?.[0].value).toBe("'BadType' captured as exception");
+  });
+
+  test('object with name and message props', () => {
+    const event = eventFromUnknownInput(getCurrentHub, stackParser, { message: 'went wrong', name: 'BadType' });
+    expect(event.exception?.values?.[0].value).toBe("'BadType' captured as exception with message 'went wrong'");
+  });
+
+  test('object with message prop', () => {
+    const event = eventFromUnknownInput(getCurrentHub, stackParser, { foo: { bar: 'baz' }, message: 'Some message' });
+    expect(event.exception?.values?.[0].value).toBe('Some message');
+  });
+});


### PR DESCRIPTION
Closes #6822

This PR changes the messages reported for captured non-Error exceptions.

For the [browser PR](https://github.com/getsentry/sentry-javascript/pull/8374), it was decided not to use the class name due to these being mangled by bundling. Does this apply to node too? 