### PR TITLE
feat: Add Bun SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,6 +162,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ env.HEAD_COMMIT }}
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v1
       - name: Set up Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,6 +164,8 @@ jobs:
           ref: ${{ env.HEAD_COMMIT }}
       - name: Set up Bun
         uses: oven-sh/setup-bun@v1
+      - name: Test Bun
+        run: bun help
       - name: Set up Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -380,8 +380,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.DEFAULT_NODE_VERSION }}
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v1
       - name: Restore caches
         uses: ./.github/actions/restore-cache
         env:
@@ -390,6 +388,34 @@ jobs:
         env:
           NODE_VERSION: 16
         run: yarn test-ci-browser
+      - name: Compute test coverage
+        uses: codecov/codecov-action@v3
+
+  job_bun_unit_tests:
+    name: Bun Unit Tests
+    needs: [job_get_metadata, job_build]
+    timeout-minutes: 10
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.HEAD_COMMIT }}
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v1
+      - name: Restore caches
+        uses: ./.github/actions/restore-cache
+        env:
+          DEPENDENCY_CACHE_KEY: ${{ needs.job_build.outputs.dependency_cache_key }}
+      - name: Run tests
+        run: |
+          yarn test-ci-bun
       - name: Compute test coverage
         uses: codecov/codecov-action@v3
 
@@ -411,8 +437,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v1
       - name: Restore caches
         uses: ./.github/actions/restore-cache
         env:
@@ -868,6 +892,7 @@ jobs:
         job_build,
         job_browser_build_tests,
         job_browser_unit_tests,
+        job_bun_unit_tests,
         job_node_unit_tests,
         job_nextjs_integration_test,
         job_node_integration_tests,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -380,6 +380,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.DEFAULT_NODE_VERSION }}
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v1
       - name: Restore caches
         uses: ./.github/actions/restore-cache
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,10 +162,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ env.HEAD_COMMIT }}
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v1
-      - name: Test Bun
-        run: bun help
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
@@ -413,6 +409,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v1
       - name: Restore caches
         uses: ./.github/actions/restore-cache
         env:

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "packages/angular-ivy",
     "packages/browser",
     "packages/browser-integration-tests",
+    "packages/bun",
     "packages/core",
     "packages/e2e-tests",
     "packages/ember",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
     "postpublish": "lerna run --stream --concurrency 1 postpublish",
     "test": "lerna run --ignore \"@sentry-internal/{browser-integration-tests,e2e-tests,integration-shims,node-integration-tests,overhead-metrics}\" test",
     "test:unit": "lerna run --ignore \"@sentry-internal/{browser-integration-tests,e2e-tests,integration-shims,node-integration-tests,overhead-metrics}\" test:unit",
-    "test-ci-browser": "lerna run test --ignore \"@sentry/{node,node-experimental,opentelemetry-node,serverless,nextjs,remix,gatsby,sveltekit}\" --ignore \"@sentry-internal/{browser-integration-tests,e2e-tests,integration-shims,node-integration-tests,overhead-metrics}\"",
+    "test-ci-browser": "lerna run test --ignore \"@sentry/{bun,node,node-experimental,opentelemetry-node,serverless,nextjs,remix,gatsby,sveltekit}\" --ignore \"@sentry-internal/{browser-integration-tests,e2e-tests,integration-shims,node-integration-tests,overhead-metrics}\"",
     "test-ci-node": "ts-node ./scripts/node-unit-tests.ts",
+    "test-ci-bun": "lerna run test --scope @sentry/bun",
     "test:update-snapshots": "lerna run test:update-snapshots",
     "yalc:publish": "lerna run yalc:publish"
   },

--- a/packages/bun/.eslintrc.js
+++ b/packages/bun/.eslintrc.js
@@ -1,0 +1,12 @@
+module.exports = {
+  env: {
+    node: true,
+  },
+  extends: ['../../.eslintrc.js'],
+  rules: {
+    '@sentry-internal/sdk/no-optional-chaining': 'off',
+    '@sentry-internal/sdk/no-nullish-coalescing': 'off',
+    '@sentry-internal/sdk/no-unsupported-es6-methods': 'off',
+    '@sentry-internal/sdk/no-class-field-initializers': 'off',
+  },
+};

--- a/packages/bun/LICENSE
+++ b/packages/bun/LICENSE
@@ -1,0 +1,14 @@
+Copyright (c) 2019 Sentry (https://sentry.io) and individual contributors. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/bun/LICENSE
+++ b/packages/bun/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Sentry (https://sentry.io) and individual contributors. All rights reserved.
+Copyright (c) 2023 Sentry (https://sentry.io) and individual contributors. All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 documentation files (the "Software"), to deal in the Software without restriction, including without limitation the

--- a/packages/bun/README.md
+++ b/packages/bun/README.md
@@ -1,0 +1,62 @@
+<p align="center">
+  <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-wordmark-dark-280x84.png" alt="Sentry" width="280" height="84">
+  </a>
+</p>
+
+# Official Sentry SDK for NodeJS
+
+[![npm version](https://img.shields.io/npm/v/@sentry/node.svg)](https://www.npmjs.com/package/@sentry/node)
+[![npm dm](https://img.shields.io/npm/dm/@sentry/node.svg)](https://www.npmjs.com/package/@sentry/node)
+[![npm dt](https://img.shields.io/npm/dt/@sentry/node.svg)](https://www.npmjs.com/package/@sentry/node)
+
+## Links
+
+- [Official SDK Docs](https://docs.sentry.io/quickstart/)
+- [TypeDoc](http://getsentry.github.io/sentry-javascript/)
+
+## Usage
+
+To use this SDK, call `init(options)` as early as possible in the main entry module. This will initialize the SDK and
+hook into the environment. Note that you can turn off almost all side effects using the respective options.
+
+```javascript
+// ES5 Syntax
+const Sentry = require('@sentry/node');
+// ES6 Syntax
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: '__DSN__',
+  // ...
+});
+```
+
+To set context information or send manual events, use the exported functions of `@sentry/node`. Note that these
+functions will not perform any action before you have called `init()`:
+
+```javascript
+// Set user information, as well as tags and further extras
+Sentry.configureScope(scope => {
+  scope.setExtra('battery', 0.7);
+  scope.setTag('user_mode', 'admin');
+  scope.setUser({ id: '4711' });
+  // scope.clear();
+});
+
+// Add a breadcrumb for future events
+Sentry.addBreadcrumb({
+  message: 'My Breadcrumb',
+  // ...
+});
+
+// Capture exceptions, messages or manual events
+Sentry.captureMessage('Hello, world!');
+Sentry.captureException(new Error('Good bye'));
+Sentry.captureEvent({
+  message: 'Manual',
+  stacktrace: [
+    // ...
+  ],
+});
+```

--- a/packages/bun/README.md
+++ b/packages/bun/README.md
@@ -4,11 +4,11 @@
   </a>
 </p>
 
-# Official Sentry SDK for NodeJS
+# Official Sentry SDK for Bun
 
-[![npm version](https://img.shields.io/npm/v/@sentry/node.svg)](https://www.npmjs.com/package/@sentry/node)
-[![npm dm](https://img.shields.io/npm/dm/@sentry/node.svg)](https://www.npmjs.com/package/@sentry/node)
-[![npm dt](https://img.shields.io/npm/dt/@sentry/node.svg)](https://www.npmjs.com/package/@sentry/node)
+[![npm version](https://img.shields.io/npm/v/@sentry/bun.svg)](https://www.npmjs.com/package/@sentry/bun)
+[![npm dm](https://img.shields.io/npm/dm/@sentry/bun.svg)](https://www.npmjs.com/package/@sentry/bun)
+[![npm dt](https://img.shields.io/npm/dt/@sentry/bun.svg)](https://www.npmjs.com/package/@sentry/bun)
 
 ## Links
 
@@ -22,9 +22,9 @@ hook into the environment. Note that you can turn off almost all side effects us
 
 ```javascript
 // ES5 Syntax
-const Sentry = require('@sentry/node');
+const Sentry = require('@sentry/bun');
 // ES6 Syntax
-import * as Sentry from '@sentry/node';
+import * as Sentry from '@sentry/bun';
 
 Sentry.init({
   dsn: '__DSN__',
@@ -32,7 +32,7 @@ Sentry.init({
 });
 ```
 
-To set context information or send manual events, use the exported functions of `@sentry/node`. Note that these
+To set context information or send manual events, use the exported functions of `@sentry/bun`. Note that these
 functions will not perform any action before you have called `init()`:
 
 ```javascript

--- a/packages/bun/README.md
+++ b/packages/bun/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 
-# Official Sentry SDK for Bun
+# Official Sentry SDK for Bun (Beta)
 
 [![npm version](https://img.shields.io/npm/v/@sentry/bun.svg)](https://www.npmjs.com/package/@sentry/bun)
 [![npm dm](https://img.shields.io/npm/dm/@sentry/bun.svg)](https://www.npmjs.com/package/@sentry/bun)

--- a/packages/bun/README.md
+++ b/packages/bun/README.md
@@ -15,6 +15,8 @@
 - [Official SDK Docs](https://docs.sentry.io/quickstart/)
 - [TypeDoc](http://getsentry.github.io/sentry-javascript/)
 
+The Sentry Bun SDK is in beta. Please help us improve the SDK by [reporting any issues or giving us feedback](https://github.com/getsentry/sentry-javascript/issues).
+
 ## Usage
 
 To use this SDK, call `init(options)` as early as possible in the main entry module. This will initialize the SDK and
@@ -60,3 +62,17 @@ Sentry.captureEvent({
   ],
 });
 ```
+
+It's not possible to capture unhandled exceptions, unhandled promise rejections now - Bun is working on adding support for it.
+[Github Issue](https://github.com/oven-sh/bun/issues/5091) follow this issue. To report errors to Sentry, you have to manually try-catch and call `Sentry.captureException` in the catch block.
+
+```ts
+import * as Sentry from '@sentry/bun';
+
+try {
+  throw new Error('test');
+} catch (e) {
+  Sentry.captureException(e);
+}
+```
+

--- a/packages/bun/jest.config.js
+++ b/packages/bun/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../jest/jest.config.js');

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -9,7 +9,7 @@
   "engines": {
     "node": ">=8"
   },
-  "main": "build/cjs/index.js",
+  "main": "build/esm/index.js",
   "module": "build/esm/index.js",
   "types": "build/types/index.d.ts",
   "typesVersions": {
@@ -25,7 +25,6 @@
   "dependencies": {
     "@sentry/core": "7.69.0",
     "@sentry/node": "7.69.0",
-    "@sentry/opentelemetry-node": "7.69.0",
     "@sentry/types": "7.69.0",
     "@sentry/utils": "7.69.0"
   },
@@ -44,7 +43,7 @@
     "build:transpile:watch": "rollup -c rollup.npm.config.js --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:tarball": "ts-node ../../scripts/prepack.ts && npm pack ./build",
-    "circularDepCheck": "node -v",
+    "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf build coverage sentry-node-*.tgz",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",
@@ -61,5 +60,12 @@
   "volta": {
     "extends": "../../package.json"
   },
-  "sideEffects": false
+  "sideEffects": false,
+  "madge":{
+    "detectiveOptions": {
+      "ts": {
+        "skipTypeImports": true
+      }
+    }
+  }
 }

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -44,7 +44,7 @@
     "build:transpile:watch": "rollup -c rollup.npm.config.js --watch",
     "build:types:watch": "tsc -p tsconfig.types.json --watch",
     "build:tarball": "ts-node ../../scripts/prepack.ts && npm pack ./build",
-    "circularDepCheck": "madge --circular src/index.ts",
+    "circularDepCheck": "node -v",
     "clean": "rimraf build coverage sentry-node-*.tgz",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -29,6 +29,9 @@
     "@sentry/types": "7.69.0",
     "@sentry/utils": "7.69.0"
   },
+  "devDependencies": {
+    "bun-types": "latest"
+  },
   "scripts": {
     "build": "run-p build:transpile build:types",
     "build:dev": "yarn build",

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -52,12 +52,10 @@
     "lint": "run-s lint:prettier lint:eslint",
     "lint:eslint": "eslint . --format stylish",
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
-    "test": "run-s test:jest test:express test:webpack test:release-health",
-    "test:express": "node test/manual/express-scope-separation/start.js",
-    "test:jest": "jest",
-    "test:release-health": "node test/manual/release-health/runner.js",
-    "test:webpack": "cd test/manual/webpack-async-context/ && yarn --silent && node npm-build.js",
-    "test:watch": "jest --watch",
+    "install:bun": "node ./scripts/install-bun.js",
+    "test": "run-s install:bun test:bun",
+    "test:bun": "bun test",
+    "test:watch": "bun test --watch",
     "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@sentry/bun",
+  "version": "7.69.0",
+  "description": "Official Sentry SDK for bun",
+  "repository": "git://github.com/getsentry/sentry-javascript.git",
+  "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/bun",
+  "author": "Sentry",
+  "license": "MIT",
+  "engines": {
+    "node": ">=8"
+  },
+  "main": "build/cjs/index.js",
+  "module": "build/esm/index.js",
+  "types": "build/types/index.d.ts",
+  "typesVersions": {
+    "<4.9": {
+      "build/npm/types/index.d.ts": [
+        "build/npm/types-ts3.8/index.d.ts"
+      ]
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@sentry/core": "7.69.0",
+    "@sentry/node": "7.69.0",
+    "@sentry/opentelemetry-node": "7.69.0",
+    "@sentry/types": "7.69.0",
+    "@sentry/utils": "7.69.0"
+  },
+  "scripts": {
+    "build": "run-p build:transpile build:types",
+    "build:dev": "yarn build",
+    "build:transpile": "rollup -c rollup.npm.config.js",
+    "build:types": "run-s build:types:core build:types:downlevel",
+    "build:types:core": "tsc -p tsconfig.types.json",
+    "build:types:downlevel": "yarn downlevel-dts build/types build/types-ts3.8 --to ts3.8",
+    "build:watch": "run-p build:transpile:watch build:types:watch",
+    "build:dev:watch": "yarn build:watch",
+    "build:transpile:watch": "rollup -c rollup.npm.config.js --watch",
+    "build:types:watch": "tsc -p tsconfig.types.json --watch",
+    "build:tarball": "ts-node ../../scripts/prepack.ts && npm pack ./build",
+    "circularDepCheck": "madge --circular src/index.ts",
+    "clean": "rimraf build coverage sentry-node-*.tgz",
+    "fix": "run-s fix:eslint fix:prettier",
+    "fix:eslint": "eslint . --format stylish --fix",
+    "fix:prettier": "prettier --write \"{src,test,scripts}/**/**.ts\"",
+    "lint": "run-s lint:prettier lint:eslint",
+    "lint:eslint": "eslint . --format stylish",
+    "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
+    "test": "run-s test:jest test:express test:webpack test:release-health",
+    "test:express": "node test/manual/express-scope-separation/start.js",
+    "test:jest": "jest",
+    "test:release-health": "node test/manual/release-health/runner.js",
+    "test:webpack": "cd test/manual/webpack-async-context/ && yarn --silent && node npm-build.js",
+    "test:watch": "jest --watch",
+    "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "sideEffects": false
+}

--- a/packages/bun/rollup.npm.config.js
+++ b/packages/bun/rollup.npm.config.js
@@ -1,0 +1,3 @@
+import { makeBaseNPMConfig, makeNPMConfigVariants } from '../../rollup/index.js';
+
+export default makeNPMConfigVariants(makeBaseNPMConfig());

--- a/packages/bun/rollup.npm.config.js
+++ b/packages/bun/rollup.npm.config.js
@@ -1,3 +1,6 @@
 import { makeBaseNPMConfig, makeNPMConfigVariants } from '../../rollup/index.js';
 
-export default makeNPMConfigVariants(makeBaseNPMConfig());
+const config = makeNPMConfigVariants(makeBaseNPMConfig());
+
+// remove cjs from config array config[0].output.format == cjs
+export default [config[1]];

--- a/packages/bun/scripts/install-bun.js
+++ b/packages/bun/scripts/install-bun.js
@@ -1,0 +1,44 @@
+const { exec } = require('child_process');
+const https = require('https');
+
+// Define the URL of the Bash script for bun installation
+const installScriptUrl = 'https://bun.sh/install';
+
+// Check if bun is installed
+exec('bun -version', error => {
+  if (error) {
+    console.error('bun is not installed. Installing...');
+    // Download and execute the installation script
+    https
+      .get(installScriptUrl, res => {
+        if (res.statusCode !== 200) {
+          console.error(`Failed to download the installation script (HTTP ${res.statusCode})`);
+          process.exit(1);
+        }
+
+        res.setEncoding('utf8');
+        let scriptData = '';
+
+        res.on('data', chunk => {
+          scriptData += chunk;
+        });
+
+        res.on('end', () => {
+          // Execute the downloaded script
+          exec(scriptData, installError => {
+            if (installError) {
+              console.error('Failed to install bun:', installError);
+              process.exit(1);
+            }
+            console.log('bun has been successfully installed.');
+          });
+        });
+      })
+      .on('error', e => {
+        console.error('Failed to download the installation script:', e);
+        process.exit(1);
+      });
+  } else {
+    // Bun is installed
+  }
+});

--- a/packages/bun/scripts/install-bun.js
+++ b/packages/bun/scripts/install-bun.js
@@ -1,5 +1,8 @@
 /* eslint-disable no-console */
-
+if (process.env.CI) {
+  // This script is not needed in CI we install bun via GH actions
+  return;
+}
 const { exec } = require('child_process');
 const https = require('https');
 

--- a/packages/bun/scripts/install-bun.js
+++ b/packages/bun/scripts/install-bun.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 const { exec } = require('child_process');
 const https = require('https');
 

--- a/packages/bun/src/client.ts
+++ b/packages/bun/src/client.ts
@@ -1,9 +1,9 @@
-import { type ServerRuntimeClientOptions } from '@sentry/core';
+import type { ServerRuntimeClientOptions } from '@sentry/core';
 import { SDK_VERSION, ServerRuntimeClient } from '@sentry/core';
 import * as os from 'os';
 import { TextEncoder } from 'util';
 
-import { type BunClientOptions } from './types';
+import type { BunClientOptions } from './types';
 
 /**
  * The Sentry Node SDK Client.

--- a/packages/bun/src/client.ts
+++ b/packages/bun/src/client.ts
@@ -1,7 +1,6 @@
 import type { ServerRuntimeClientOptions } from '@sentry/core';
 import { SDK_VERSION, ServerRuntimeClient } from '@sentry/core';
 import * as os from 'os';
-import { TextEncoder } from 'util';
 
 import type { BunClientOptions } from './types';
 

--- a/packages/bun/src/client.ts
+++ b/packages/bun/src/client.ts
@@ -38,7 +38,7 @@ export class BunClient extends ServerRuntimeClient<BunClientOptions> {
     const clientOptions: ServerRuntimeClientOptions = {
       ...options,
       platform: 'bun',
-      runtime: { name: 'bun', version: global.process.version },
+      runtime: { name: 'bun', version: Bun.version },
       serverName: options.serverName || global.process.env.SENTRY_NAME || os.hostname(),
     };
 

--- a/packages/bun/src/client.ts
+++ b/packages/bun/src/client.ts
@@ -1,0 +1,47 @@
+import type { ServerRuntimeClientOptions } from '@sentry/core';
+import { SDK_VERSION, ServerRuntimeClient } from '@sentry/core';
+import * as os from 'os';
+import { TextEncoder } from 'util';
+
+import type { BunClientOptions } from './types';
+
+/**
+ * The Sentry Node SDK Client.
+ *
+ * @see BunClientOptions for documentation on configuration options.
+ * @see SentryClient for usage documentation.
+ */
+export class BunClient extends ServerRuntimeClient<BunClientOptions> {
+  /**
+   * Creates a new Node SDK instance.
+   * @param options Configuration options for this SDK.
+   */
+  public constructor(options: BunClientOptions) {
+    options._metadata = options._metadata || {};
+    options._metadata.sdk = options._metadata.sdk || {
+      name: 'sentry.javascript.bun',
+      packages: [
+        {
+          name: 'npm:@sentry/bun',
+          version: SDK_VERSION,
+        },
+      ],
+      version: SDK_VERSION,
+    };
+
+    // Until node supports global TextEncoder in all versions we support, we are forced to pass it from util
+    options.transportOptions = {
+      textEncoder: new TextEncoder(),
+      ...options.transportOptions,
+    };
+
+    const clientOptions: ServerRuntimeClientOptions = {
+      ...options,
+      platform: 'bun',
+      runtime: { name: 'bun', version: global.process.version },
+      serverName: options.serverName || global.process.env.SENTRY_NAME || os.hostname(),
+    };
+
+    super(clientOptions);
+  }
+}

--- a/packages/bun/src/client.ts
+++ b/packages/bun/src/client.ts
@@ -1,9 +1,9 @@
-import type { ServerRuntimeClientOptions } from '@sentry/core';
+import { type ServerRuntimeClientOptions } from '@sentry/core';
 import { SDK_VERSION, ServerRuntimeClient } from '@sentry/core';
 import * as os from 'os';
 import { TextEncoder } from 'util';
 
-import type { BunClientOptions } from './types';
+import { type BunClientOptions } from './types';
 
 /**
  * The Sentry Node SDK Client.

--- a/packages/bun/src/client.ts
+++ b/packages/bun/src/client.ts
@@ -29,12 +29,6 @@ export class BunClient extends ServerRuntimeClient<BunClientOptions> {
       version: SDK_VERSION,
     };
 
-    // Until node supports global TextEncoder in all versions we support, we are forced to pass it from util
-    options.transportOptions = {
-      textEncoder: new TextEncoder(),
-      ...options.transportOptions,
-    };
-
     const clientOptions: ServerRuntimeClientOptions = {
       ...options,
       platform: 'bun',

--- a/packages/bun/src/client.ts
+++ b/packages/bun/src/client.ts
@@ -5,14 +5,14 @@ import * as os from 'os';
 import type { BunClientOptions } from './types';
 
 /**
- * The Sentry Node SDK Client.
+ * The Sentry Bun SDK Client.
  *
  * @see BunClientOptions for documentation on configuration options.
  * @see SentryClient for usage documentation.
  */
 export class BunClient extends ServerRuntimeClient<BunClientOptions> {
   /**
-   * Creates a new Node SDK instance.
+   * Creates a new Bun SDK instance.
    * @param options Configuration options for this SDK.
    */
   public constructor(options: BunClientOptions) {

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -20,8 +20,8 @@ export type {
 } from '@sentry/types';
 export type { AddRequestDataToEventOptions } from '@sentry/utils';
 
-export type { TransactionNamingScheme } from './requestdata';
-export type { NodeOptions } from './types';
+export type { TransactionNamingScheme } from '@sentry/node';
+export type { BunOptions } from './types';
 
 export {
   addGlobalEventProcessor,
@@ -63,26 +63,19 @@ export {
   startSpanManual,
 } from '@sentry/core';
 export type { SpanStatusType } from '@sentry/core';
-export { autoDiscoverNodePerformanceMonitoringIntegrations } from './tracing';
+export { autoDiscoverNodePerformanceMonitoringIntegrations } from '@sentry/node';
 
-export { NodeClient } from './client';
-export { makeNodeTransport } from './transports';
-export type { NodeTransportOptions } from './transports';
-export { defaultIntegrations, init, defaultStackParser, getSentryRelease } from './sdk';
-export { addRequestDataToEvent, DEFAULT_USER_INCLUDES, extractRequestData } from './requestdata';
-export { deepReadDirSync } from './utils';
-export { getModuleFromFilename } from './module';
+export { BunClient } from './client';
+export { makeNodeTransport } from '@sentry/node';
+export type { NodeTransportOptions } from '@sentry/node';
+export { defaultIntegrations, init } from './sdk';
 
 import { Integrations as CoreIntegrations } from '@sentry/core';
-
-import * as Handlers from './handlers';
-import * as NodeIntegrations from './integrations';
-import * as TracingIntegrations from './tracing/integrations';
+import { Integrations as NodeIntegrations } from '@sentry/node';
 
 const INTEGRATIONS = {
   ...CoreIntegrations,
   ...NodeIntegrations,
-  ...TracingIntegrations,
 };
 
-export { INTEGRATIONS as Integrations, Handlers };
+export { INTEGRATIONS as Integrations };

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -57,8 +57,6 @@ export {
   setMeasurement,
   getActiveSpan,
   startSpan,
-  // eslint-disable-next-line deprecation/deprecation
-  startActiveSpan,
   startInactiveSpan,
   startSpanManual,
 } from '@sentry/core';

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -66,8 +66,6 @@ export type { SpanStatusType } from '@sentry/core';
 export { autoDiscoverNodePerformanceMonitoringIntegrations } from '@sentry/node';
 
 export { BunClient } from './client';
-export { makeNodeTransport } from '@sentry/node';
-export type { NodeTransportOptions } from '@sentry/node';
 export { defaultIntegrations, init } from './sdk';
 
 import { Integrations as CoreIntegrations } from '@sentry/core';

--- a/packages/bun/src/sdk.ts
+++ b/packages/bun/src/sdk.ts
@@ -1,0 +1,94 @@
+/* eslint-disable max-lines */
+import { Integrations as CoreIntegrations } from '@sentry/core';
+import { init as initNode, Integrations as NodeIntegrations } from '@sentry/node';
+
+import { BunClient } from './client';
+import { makeFetchTransport } from './transports';
+import type { BunOptions } from './types';
+
+export const defaultIntegrations = [
+  // Common
+  new CoreIntegrations.InboundFilters(),
+  new CoreIntegrations.FunctionToString(),
+  // Native Wrappers
+  new NodeIntegrations.Console(),
+  new NodeIntegrations.Http(),
+  new NodeIntegrations.Undici(),
+  // Global Handlers # TODO
+  // new NodeIntegrations.OnUncaughtException(),
+  // new NodeIntegrations.OnUnhandledRejection(),
+  // Event Info
+  new NodeIntegrations.ContextLines(),
+  // new NodeIntegrations.LocalVariables(), # does't work with Bun
+  new NodeIntegrations.Context(),
+  new NodeIntegrations.Modules(),
+  new NodeIntegrations.RequestData(),
+  // Misc
+  new NodeIntegrations.LinkedErrors(),
+];
+
+/**
+ * The Sentry Bun SDK Client.
+ *
+ * To use this SDK, call the {@link init} function as early as possible in the
+ * main entry module. To set context information or send manual events, use the
+ * provided methods.
+ *
+ * @example
+ * ```
+ *
+ * const { init } = require('@sentry/bun');
+ *
+ * init({
+ *   dsn: '__DSN__',
+ *   // ...
+ * });
+ * ```
+ *
+ * @example
+ * ```
+ *
+ * const { configureScope } = require('@sentry/node');
+ * configureScope((scope: Scope) => {
+ *   scope.setExtra({ battery: 0.7 });
+ *   scope.setTag({ user_mode: 'admin' });
+ *   scope.setUser({ id: '4711' });
+ * });
+ * ```
+ *
+ * @example
+ * ```
+ *
+ * const { addBreadcrumb } = require('@sentry/node');
+ * addBreadcrumb({
+ *   message: 'My Breadcrumb',
+ *   // ...
+ * });
+ * ```
+ *
+ * @example
+ * ```
+ *
+ * const Sentry = require('@sentry/node');
+ * Sentry.captureMessage('Hello, world!');
+ * Sentry.captureException(new Error('Good bye'));
+ * Sentry.captureEvent({
+ *   message: 'Manual',
+ *   stacktrace: [
+ *     // ...
+ *   ],
+ * });
+ * ```
+ *
+ * @see {@link BunOptions} for documentation on configuration options.
+ */
+export function init(options: BunOptions = {}): void {
+  options.clientClass = BunClient;
+  options.transport = options.transport || makeFetchTransport;
+
+  options.defaultIntegrations =
+    options.defaultIntegrations === false
+      ? []
+      : [...(Array.isArray(options.defaultIntegrations) ? options.defaultIntegrations : defaultIntegrations)];
+  initNode(options);
+}

--- a/packages/bun/src/sdk.ts
+++ b/packages/bun/src/sdk.ts
@@ -14,7 +14,7 @@ export const defaultIntegrations = [
   new NodeIntegrations.Console(),
   new NodeIntegrations.Http(),
   new NodeIntegrations.Undici(),
-  // Global Handlers # TODO
+  // Global Handlers # TODO (waiting for https://github.com/oven-sh/bun/issues/5091)
   // new NodeIntegrations.OnUncaughtException(),
   // new NodeIntegrations.OnUnhandledRejection(),
   // Event Info

--- a/packages/bun/src/transports/index.ts
+++ b/packages/bun/src/transports/index.ts
@@ -1,0 +1,38 @@
+import { createTransport } from '@sentry/core';
+import type { BaseTransportOptions, Transport, TransportMakeRequestResponse, TransportRequest } from '@sentry/types';
+import { rejectedSyncPromise } from '@sentry/utils';
+
+export interface BunTransportOptions extends BaseTransportOptions {
+  /** Custom headers for the transport. Used by the XHRTransport and FetchTransport */
+  headers?: { [key: string]: string };
+}
+
+/**
+ * Creates a Transport that uses the Fetch API to send events to Sentry.
+ */
+export function makeFetchTransport(options: BunTransportOptions): Transport {
+  function makeRequest(request: TransportRequest): PromiseLike<TransportMakeRequestResponse> {
+    const requestOptions: RequestInit = {
+      body: request.body,
+      method: 'POST',
+      referrerPolicy: 'origin',
+      headers: options.headers,
+    };
+
+    try {
+      return fetch(options.url, requestOptions).then(response => {
+        return {
+          statusCode: response.status,
+          headers: {
+            'x-sentry-rate-limits': response.headers.get('X-Sentry-Rate-Limits'),
+            'retry-after': response.headers.get('Retry-After'),
+          },
+        };
+      });
+    } catch (e) {
+      return rejectedSyncPromise(e);
+    }
+  }
+
+  return createTransport(options, makeRequest);
+}

--- a/packages/bun/src/types.ts
+++ b/packages/bun/src/types.ts
@@ -1,7 +1,7 @@
-import type { NodeTransportOptions } from '@sentry/node';
 import type { ClientOptions, Options, TracePropagationTargets } from '@sentry/types';
 
 import type { BunClient } from './client';
+import type { BunTransportOptions } from './transports';
 
 export interface BaseBunOptions {
   /**
@@ -59,10 +59,10 @@ export interface BaseBunOptions {
  * Configuration options for the Sentry Node SDK
  * @see @sentry/types Options for more information.
  */
-export interface BunOptions extends Options<NodeTransportOptions>, BaseBunOptions {}
+export interface BunOptions extends Options<BunTransportOptions>, BaseBunOptions {}
 
 /**
  * Configuration options for the Sentry Node SDK Client class
  * @see BunClient for more information.
  */
-export interface BunClientOptions extends ClientOptions<NodeTransportOptions>, BaseBunOptions {}
+export interface BunClientOptions extends ClientOptions<BunTransportOptions>, BaseBunOptions {}

--- a/packages/bun/src/types.ts
+++ b/packages/bun/src/types.ts
@@ -1,7 +1,7 @@
-import type { ClientOptions, Options, TracePropagationTargets } from '@sentry/types';
+import { type ClientOptions, type Options, type TracePropagationTargets } from '@sentry/types';
 
-import type { BunClient } from './client';
-import type { BunTransportOptions } from './transports';
+import { type BunClient } from './client';
+import { type BunTransportOptions } from './transports';
 
 export interface BaseBunOptions {
   /**

--- a/packages/bun/src/types.ts
+++ b/packages/bun/src/types.ts
@@ -56,13 +56,13 @@ export interface BaseBunOptions {
 }
 
 /**
- * Configuration options for the Sentry Node SDK
+ * Configuration options for the Sentry Bun SDK
  * @see @sentry/types Options for more information.
  */
 export interface BunOptions extends Options<BunTransportOptions>, BaseBunOptions {}
 
 /**
- * Configuration options for the Sentry Node SDK Client class
+ * Configuration options for the Sentry Bun SDK Client class
  * @see BunClient for more information.
  */
 export interface BunClientOptions extends ClientOptions<BunTransportOptions>, BaseBunOptions {}

--- a/packages/bun/src/types.ts
+++ b/packages/bun/src/types.ts
@@ -1,7 +1,7 @@
-import { type ClientOptions, type Options, type TracePropagationTargets } from '@sentry/types';
+import type { ClientOptions, Options, TracePropagationTargets } from '@sentry/types';
 
-import { type BunClient } from './client';
-import { type BunTransportOptions } from './transports';
+import type { BunClient } from './client';
+import type { BunTransportOptions } from './transports';
 
 export interface BaseBunOptions {
   /**

--- a/packages/bun/src/types.ts
+++ b/packages/bun/src/types.ts
@@ -1,0 +1,68 @@
+import type { NodeTransportOptions } from '@sentry/node';
+import type { ClientOptions, Options, TracePropagationTargets } from '@sentry/types';
+
+import type { BunClient } from './client';
+
+export interface BaseBunOptions {
+  /**
+   * List of strings/regex controlling to which outgoing requests
+   * the SDK will attach tracing headers.
+   *
+   * By default the SDK will attach those headers to all outgoing
+   * requests. If this option is provided, the SDK will match the
+   * request URL of outgoing requests against the items in this
+   * array, and only attach tracing headers if a match was found.
+   *
+   * @example
+   * ```js
+   * Sentry.init({
+   *   tracePropagationTargets: ['api.site.com'],
+   * });
+   * ```
+   */
+  tracePropagationTargets?: TracePropagationTargets;
+
+  /** Sets an optional server name (device name) */
+  serverName?: string;
+
+  /**
+   * Specify a custom BunClient to be used. Must extend BunClient!
+   * This is not a public, supported API, but used internally only.
+   *
+   * @hidden
+   *  */
+  clientClass?: typeof BunClient;
+
+  // TODO (v8): Remove this in v8
+  /**
+   * @deprecated Moved to constructor options of the `Http` and `Undici` integration.
+   * @example
+   * ```js
+   * Sentry.init({
+   *   integrations: [
+   *     new Sentry.Integrations.Http({
+   *       tracing: {
+   *         shouldCreateSpanForRequest: (url: string) => false,
+   *       }
+   *     });
+   *   ],
+   * });
+   * ```
+   */
+  shouldCreateSpanForRequest?(this: void, url: string): boolean;
+
+  /** Callback that is executed when a fatal global error occurs. */
+  onFatalError?(this: void, error: Error): void;
+}
+
+/**
+ * Configuration options for the Sentry Node SDK
+ * @see @sentry/types Options for more information.
+ */
+export interface BunOptions extends Options<NodeTransportOptions>, BaseBunOptions {}
+
+/**
+ * Configuration options for the Sentry Node SDK Client class
+ * @see BunClient for more information.
+ */
+export interface BunClientOptions extends ClientOptions<NodeTransportOptions>, BaseBunOptions {}

--- a/packages/bun/test/sdk.test.ts
+++ b/packages/bun/test/sdk.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from 'bun:test';
+
+import { init } from '../src/index';
+
+test("calling init shouldn't fail", () => {
+  init({
+    dsn: 'https://00000000000000000000000000000000@o000000.ingest.sentry.io/0000000',
+  });
+  expect(true).toBe(true);
+});

--- a/packages/bun/test/sdk.test.ts
+++ b/packages/bun/test/sdk.test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
 import { expect, test } from 'bun:test';
 
 import { init } from '../src/index';

--- a/packages/bun/tsconfig.json
+++ b/packages/bun/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+
+  "include": ["src/**/*"],
+
+  "compilerOptions": {
+    // package-specific options
+  }
+}

--- a/packages/bun/tsconfig.json
+++ b/packages/bun/tsconfig.json
@@ -4,6 +4,21 @@
   "include": ["src/**/*"],
 
   "compilerOptions": {
-    // package-specific options
+    "types": ["bun-types"],
+    "lib": ["esnext"],
+    "module": "esnext",
+    "target": "esnext",
+
+    // if TS 4.x or earlier
+    "moduleResolution": "nodenext",
+
+    "jsx": "react-jsx", // support JSX
+    "allowJs": true, // allow importing `.js` from `.ts`
+    "esModuleInterop": true, // allow default imports for CommonJS modules
+
+    // best practices
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
   }
 }

--- a/packages/bun/tsconfig.test.json
+++ b/packages/bun/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+
+  "include": ["test/**/*"],
+
+  "compilerOptions": {
+    // should include all types from `./tsconfig.json` plus types for all test frameworks used
+    "types": ["node", "jest"]
+
+    // other package-specific, test-specific options
+  }
+}

--- a/packages/bun/tsconfig.types.json
+++ b/packages/bun/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "build/types"
+  }
+}

--- a/packages/e2e-tests/verdaccio-config/config.yaml
+++ b/packages/e2e-tests/verdaccio-config/config.yaml
@@ -50,6 +50,12 @@ packages:
     unpublish: $all
     # proxy: npmjs # Don't proxy for E2E tests!
 
+  '@sentry/bun':
+    access: $all
+    publish: $all
+    unpublish: $all
+    # proxy: npmjs # Don't proxy for E2E tests!
+
   '@sentry/core':
     access: $all
     publish: $all

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -67,7 +67,6 @@ export { autoDiscoverNodePerformanceMonitoringIntegrations } from './tracing';
 
 export { NodeClient } from './client';
 export { makeNodeTransport } from './transports';
-export type { NodeTransportOptions } from './transports';
 export { defaultIntegrations, init, defaultStackParser, getSentryRelease } from './sdk';
 export { addRequestDataToEvent, DEFAULT_USER_INCLUDES, extractRequestData } from './requestdata';
 export { deepReadDirSync } from './utils';

--- a/scripts/node-unit-tests.ts
+++ b/scripts/node-unit-tests.ts
@@ -13,6 +13,7 @@ const DEFAULT_SKIP_TESTS_PACKAGES = [
   '@sentry/svelte',
   '@sentry/replay',
   '@sentry/wasm',
+  '@sentry/bun',
 ];
 
 // These packages don't support Node 8 for syntax or dependency reasons.

--- a/yarn.lock
+++ b/yarn.lock
@@ -9067,6 +9067,11 @@ builtins@^5.0.0, builtins@^5.0.1:
   dependencies:
     semver "^7.0.0"
 
+bun-types@latest:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bun-types/-/bun-types-1.0.1.tgz#8bcb10ae3a1548a39f0932fdb365f4b3a649efba"
+  integrity sha512-7NrXqhMIaNKmWn2dSWEQ50znMZqrN/5Z0NBMXvQTRu/+Y1CvoXRznFy0pnqLe024CeZgVdXoEpARNO1JZLAPGw==
+
 busboy@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"


### PR DESCRIPTION
- [x] `circularDepCheck` is failing for reasons I don't understand - we have the same dep chain in node and doesn't fail there
- [x] Installing bun in GH actions isn't working

Nice to have:
- [ ] consider monkey patching `Bun.serve` for auto instrumentation of transactions
- [ ] global error handlers https://github.com/oven-sh/bun/issues/5091


ref: https://github.com/getsentry/sentry-javascript/discussions/7979

Docs: https://github.com/getsentry/sentry-docs/pull/7858
Platform Icon: https://github.com/getsentry/platformicons/pull/102