### PR TITLE
fix(core): Run client eventProcessors before global ones

### DIFF
--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -467,7 +467,11 @@ export class Scope implements ScopeInterface {
    * @param hint Object containing additional information about the original exception, for use by the event processors.
    * @hidden
    */
-  public applyToEvent(event: Event, hint: EventHint = {}): PromiseLike<Event | null> {
+  public applyToEvent(
+    event: Event,
+    hint: EventHint = {},
+    additionalEventProcessors?: EventProcessor[],
+  ): PromiseLike<Event | null> {
     if (this._extra && Object.keys(this._extra).length) {
       event.extra = { ...this._extra, ...event.extra };
     }
@@ -517,7 +521,12 @@ export class Scope implements ScopeInterface {
       propagationContext: this._propagationContext,
     };
 
-    return notifyEventProcessors([...getGlobalEventProcessors(), ...this._eventProcessors], event, hint);
+    // TODO (v8): Update this order to be: Global > Client > Scope
+    return notifyEventProcessors(
+      [...(additionalEventProcessors || []), ...getGlobalEventProcessors(), ...this._eventProcessors],
+      event,
+      hint,
+    );
   }
 
   /**

--- a/packages/core/src/utils/prepareEvent.ts
+++ b/packages/core/src/utils/prepareEvent.ts
@@ -55,6 +55,8 @@ export function prepareEvent(
   // We prepare the result here with a resolved Event.
   let result = resolvedSyncPromise<Event | null>(prepared);
 
+  const clientEventProcessors = client && client.getEventProcessors ? client.getEventProcessors() : [];
+
   // This should be the last thing called, since we want that
   // {@link Hub.addEventProcessor} gets the finished prepared event.
   //
@@ -73,31 +75,27 @@ export function prepareEvent(
     }
 
     // In case we have a hub we reassign it.
-    result = finalScope.applyToEvent(prepared, hint);
+    result = finalScope.applyToEvent(prepared, hint, clientEventProcessors);
   } else {
-    // Apply global event processors even if there is no scope
-    result = notifyEventProcessors(getGlobalEventProcessors(), prepared, hint);
+    // Apply client & global event processors even if there is no scope
+    // TODO (v8): Update the order to be Global > Client
+    result = notifyEventProcessors([...clientEventProcessors, ...getGlobalEventProcessors()], prepared, hint);
   }
 
-  return result
-    .then(evt => {
-      // Process client-scoped event processors
-      return client && client.getEventProcessors ? notifyEventProcessors(client.getEventProcessors(), evt, hint) : evt;
-    })
-    .then(evt => {
-      if (evt) {
-        // We apply the debug_meta field only after all event processors have ran, so that if any event processors modified
-        // file names (e.g.the RewriteFrames integration) the filename -> debug ID relationship isn't destroyed.
-        // This should not cause any PII issues, since we're only moving data that is already on the event and not adding
-        // any new data
-        applyDebugMeta(evt);
-      }
+  return result.then(evt => {
+    if (evt) {
+      // We apply the debug_meta field only after all event processors have ran, so that if any event processors modified
+      // file names (e.g.the RewriteFrames integration) the filename -> debug ID relationship isn't destroyed.
+      // This should not cause any PII issues, since we're only moving data that is already on the event and not adding
+      // any new data
+      applyDebugMeta(evt);
+    }
 
-      if (typeof normalizeDepth === 'number' && normalizeDepth > 0) {
-        return normalizeEvent(evt, normalizeDepth, normalizeMaxBreadth);
-      }
-      return evt;
-    });
+    if (typeof normalizeDepth === 'number' && normalizeDepth > 0) {
+      return normalizeEvent(evt, normalizeDepth, normalizeMaxBreadth);
+    }
+    return evt;
+  });
 }
 
 /**


### PR DESCRIPTION
I noticed that while from an API POV the current behavior makes kind-of sense IMHO:

1. Run global event processors
2. Run scope event processors
3. Run client event processors

It is potentially breaking, as if we rewrite integrations to use the new client processors, their processing will run after any user global event processors, leading to potentially unexpected outcomes.

So this PR changes this to instead run them in this order:

1. Run client event processors
2. Run global event processors
3. Run scope event processors

Which should be more stable for now. 

In v8, we should update this to run a more sensible order:

1. Global
2. Client
3. Scope