### PR TITLE
fix(nextjs): fix problem with widenClientFileUpload not working

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -695,7 +695,7 @@ export function getWebpackPluginOptions(
   const defaultPluginOptions = dropUndefinedKeys({
     include: isServer ? serverInclude : clientInclude,
     ignore:
-      isServer || !userSentryOptions.widenClientFileUpload
+      isServer || userSentryOptions.widenClientFileUpload
         ? []
         : // Widening the upload scope is necessarily going to lead to us uploading files we don't need to (ones which
           // don't include any user code). In order to lessen that where we can, exclude the internal nextjs files we know

--- a/packages/nextjs/test/config/webpack/sentryWebpackPlugin.test.ts
+++ b/packages/nextjs/test/config/webpack/sentryWebpackPlugin.test.ts
@@ -179,7 +179,13 @@ describe('Sentry webpack plugin config', () => {
         'SentryCliPlugin',
       ) as SentryWebpackPlugin;
 
-      expect(sentryWebpackPluginInstance.options.ignore).toEqual([]);
+      expect(sentryWebpackPluginInstance.options.ignore).toEqual([
+        'framework-*',
+        'framework.*',
+        'main-*',
+        'polyfills-*',
+        'webpack-*',
+      ]);
     });
 
     it('has the correct value when building client bundles using `widenClientFileUpload` option', async () => {
@@ -195,13 +201,7 @@ describe('Sentry webpack plugin config', () => {
         'SentryCliPlugin',
       ) as SentryWebpackPlugin;
 
-      expect(sentryWebpackPluginInstance.options.ignore).toEqual([
-        'framework-*',
-        'framework.*',
-        'main-*',
-        'polyfills-*',
-        'webpack-*',
-      ]);
+      expect(sentryWebpackPluginInstance.options.ignore).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Problem
`@sentry/nextjs` automatically uploads sourcemaps during `next build`. However, to reduce upload time, uploaded files are limited by default. Files such as `_next/static/chunks/framework-*` and `_next/static/chunks/main-*` are not uploaded by default.

If the `widenClientFileUpload` option is set to `true`, those files will be uploaded as well.

However, looking at the implementation, it seems that when `widenClientFileUpload` is `true` those files are not uploaded, while when it is `false` they are uploaded.

## Solution

Upload those files when `widenClientFileUpload` is `true`, and don't upload them when `false`.

