### PR TITLE
fix(sveltekit): Adjust `handleErrorWithSentry` type

### DIFF
--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -17,9 +17,7 @@ import type * as serverSdk from './server';
 /** Initializes Sentry SvelteKit SDK */
 export declare function init(options: Options | clientSdk.BrowserOptions | serverSdk.NodeOptions): void;
 
-export declare function handleErrorWithSentry<T extends HandleClientError | HandleServerError>(
-  handleError?: T,
-): T;
+export declare function handleErrorWithSentry<T extends HandleClientError | HandleServerError>(handleError?: T): T;
 
 /**
  * Wrap a universal load function (e.g. +page.js or +layout.js) with Sentry functionality

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -19,7 +19,7 @@ export declare function init(options: Options | clientSdk.BrowserOptions | serve
 
 export declare function handleErrorWithSentry<T extends HandleClientError | HandleServerError>(
   handleError?: T,
-): ReturnType<T>;
+): T;
 
 /**
  * Wrap a universal load function (e.g. +page.js or +layout.js) with Sentry functionality


### PR DESCRIPTION
`handleErrorWithSentry`, which is wrapper function, should be identity function (`f(x) => x`).

Implementation is fine, just the type mismatch from implementation.

https://github.com/getsentry/sentry-javascript/blob/cd0bc3b58d4f4144783997d446eeff960c29b8d2/packages/sveltekit/src/server/handleError.ts#L22-L41