### PR TITLE
test(e2e): Fix typing in error routes in Next.js e2e tests

### DIFF
--- a/packages/e2e-tests/test-applications/nextjs-app-dir/app/route-handlers/[param]/edge/route.ts
+++ b/packages/e2e-tests/test-applications/nextjs-app-dir/app/route-handlers/[param]/edge/route.ts
@@ -6,6 +6,6 @@ export async function PATCH() {
   return NextResponse.json({ name: 'John Doe' }, { status: 401 });
 }
 
-export async function DELETE() {
+export async function DELETE(): Promise<Response> {
   throw new Error('route-handler-edge-error');
 }

--- a/packages/e2e-tests/test-applications/nextjs-app-dir/app/route-handlers/[param]/error/route.ts
+++ b/packages/e2e-tests/test-applications/nextjs-app-dir/app/route-handlers/[param]/error/route.ts
@@ -1,3 +1,3 @@
-export async function PUT() {
+export async function PUT(): Promise<Response> {
   throw new Error('route-handler-error');
 }


### PR DESCRIPTION
Next.js introduced type checking for the return values of API routes which failed on the routes where we returned errors. This PR fixes that.