### PR TITLE
fix(core): Ensure global event processors are always applied to event

### DIFF
--- a/packages/core/src/utils/prepareEvent.ts
+++ b/packages/core/src/utils/prepareEvent.ts
@@ -2,7 +2,7 @@ import type { Client, ClientOptions, Event, EventHint, StackFrame, StackParser }
 import { dateTimestampInSeconds, GLOBAL_OBJ, normalize, resolvedSyncPromise, truncate, uuid4 } from '@sentry/utils';
 
 import { DEFAULT_ENVIRONMENT } from '../constants';
-import { notifyEventProcessors } from '../eventProcessors';
+import { getGlobalEventProcessors, notifyEventProcessors } from '../eventProcessors';
 import { Scope } from '../scope';
 
 /**
@@ -74,6 +74,9 @@ export function prepareEvent(
 
     // In case we have a hub we reassign it.
     result = finalScope.applyToEvent(prepared, hint);
+  } else {
+    // Apply global event processors even if there is no scope
+    result = notifyEventProcessors(getGlobalEventProcessors(), prepared, hint);
   }
 
   return result

--- a/packages/node/test/manual/release-health/runner.js
+++ b/packages/node/test/manual/release-health/runner.js
@@ -15,7 +15,7 @@ for (const dir of scenariosDirs) {
 
 const processes = scenarios.map(([filename, filepath]) => {
   return new Promise(resolve => {
-    const scenarioProcess = spawn('node', [filepath]);
+    const scenarioProcess = spawn('node', [filepath], { timeout: 10000 });
     const output = [];
     const errors = [];
 

--- a/packages/node/test/manual/release-health/session-aggregates/aggregates-disable-single-session.js
+++ b/packages/node/test/manual/release-health/session-aggregates/aggregates-disable-single-session.js
@@ -12,6 +12,9 @@ function cleanUpAndExitSuccessfully() {
 }
 
 function assertSessionAggregates(session, expected) {
+  if (!session.aggregates) {
+    return;
+  }
   // For loop is added here just in the rare occasion that the session count do not land in the same aggregate
   // bucket
   session.aggregates.forEach(function (_, idx) {


### PR DESCRIPTION
Even if no scope is passed.

I guess this is kind of behavior changing, but I'd argue it is just fixing an unexpected behaviour that's not actually intuitive/logical - that global event processors are only applied if a scope is provided.

I extracted this out from https://github.com/getsentry/sentry-javascript/pull/9032, as I figured this is actually a reasonable change on it's own, so it's easier to reason about this in it's own PR.
