### PR TITLE
fix(publish): Remove version command from vercel-edge package

### DIFF
--- a/packages/vercel-edge/package.json
+++ b/packages/vercel-edge/package.json
@@ -54,7 +54,6 @@
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
     "test": "jest",
     "test:watch": "jest --watch",
-    "version": "node ../../scripts/versionbump.js src/version.ts",
     "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push"
   },
   "volta": {


### PR DESCRIPTION
Seems there was a leftover from `@sentry/core` in the new `@sentry/vercel-edge` package which caused our release preparation script to fail when bumping the package versions. 

I think we should be good to directly merge this into master as master will resync into develop after the release 🤞  
