### PR TITLE
ref(tracing): Add FID element to frontend transactions

### DIFF
--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -10,7 +10,7 @@ import { onFID } from '../web-vitals/getFID';
 import { onLCP } from '../web-vitals/getLCP';
 import { getVisibilityWatcher } from '../web-vitals/lib/getVisibilityWatcher';
 import { observe } from '../web-vitals/lib/observe';
-import type { NavigatorDeviceMemory, NavigatorNetworkInformation, PerformanceEventTiming } from '../web-vitals/types';
+import type { NavigatorDeviceMemory, NavigatorNetworkInformation } from '../web-vitals/types';
 import { _startChild, isMeasurementValue } from './utils';
 
 /**
@@ -161,7 +161,7 @@ function _trackFID(): void {
     __DEBUG_BUILD__ && logger.log('[Measurements] Adding FID');
     _measurements['fid'] = { value: metric.value, unit: 'millisecond' };
     _measurements['mark.fid'] = { value: timeOrigin + startTime, unit: 'second' };
-     _fidEntry = entry;
+     _fidEntry = entry as PerformanceEventTiming;
   });
 }
 
@@ -503,7 +503,7 @@ function _tagMetricInfo(transaction: Transaction): void {
     );
   }
 
-  
+
   // Capture FID properties
   if (_fidEntry && _fidEntry.target) {
     transaction.setTag('fid.element', htmlTreeAsString(_fidEntry.target));


### PR DESCRIPTION
This will add the FID element so that it's possible to tell which element is involved in the delay, which is extremely helpful for debugging.
