### PR TITLE
fix(react): Compare location against `basename`-prefixed route.

### DIFF
--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -78,6 +78,7 @@ function getNormalizedName(
   routes: RouteObject[],
   location: Location,
   branches: RouteMatch[],
+  basename: string = '',
 ): [string, TransactionSource] {
   if (!routes || routes.length === 0) {
     return [location.pathname, 'url'];
@@ -99,7 +100,8 @@ function getNormalizedName(
         if (path) {
           const newPath = path[0] === '/' || pathBuilder[pathBuilder.length - 1] === '/' ? path : `/${path}`;
           pathBuilder += newPath;
-          if (branch.pathname === location.pathname) {
+
+          if (basename + branch.pathname === location.pathname) {
             if (
               // If the route defined on the element is something like
               // <Route path="/stores/:storeId/products/:productId" element={<div>Product</div>} />
@@ -108,9 +110,9 @@ function getNormalizedName(
               // We should not count wildcard operators in the url segments calculation
               pathBuilder.slice(-2) !== '/*'
             ) {
-              return [newPath, 'route'];
+              return [basename + newPath, 'route'];
             }
-            return [pathBuilder, 'route'];
+            return [basename + pathBuilder, 'route'];
           }
         }
       }
@@ -126,12 +128,14 @@ function updatePageloadTransaction(
   matches?: AgnosticDataRouteMatch,
   basename?: string,
 ): void {
+  console.debug('matches', matches);
+
   const branches = Array.isArray(matches)
     ? matches
     : (_matchRoutes(routes, location, basename) as unknown as RouteMatch[]);
 
   if (activeTransaction && branches) {
-    activeTransaction.setName(...getNormalizedName(routes, location, branches));
+    activeTransaction.setName(...getNormalizedName(routes, location, branches, basename));
   }
 }
 
@@ -149,7 +153,7 @@ function handleNavigation(
       activeTransaction.finish();
     }
 
-    const [name, source] = getNormalizedName(routes, location, branches);
+    const [name, source] = getNormalizedName(routes, location, branches, basename);
     activeTransaction = _customStartTransaction({
       name,
       op: 'navigation',

--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -128,8 +128,6 @@ function updatePageloadTransaction(
   matches?: AgnosticDataRouteMatch,
   basename?: string,
 ): void {
-  console.debug('matches', matches);
-
   const branches = Array.isArray(matches)
     ? matches
     : (_matchRoutes(routes, location, basename) as unknown as RouteMatch[]);


### PR DESCRIPTION
Fixes: #9061

Following up: https://github.com/getsentry/sentry-javascript/pull/8457 which apparently did not cover parameterized paths.