### PR TITLE
docs: Fix comments describing different import styles in readme

### DIFF
--- a/packages/bun/README.md
+++ b/packages/bun/README.md
@@ -23,9 +23,9 @@ To use this SDK, call `init(options)` as early as possible in the main entry mod
 hook into the environment. Note that you can turn off almost all side effects using the respective options.
 
 ```javascript
-// ES5 Syntax
+// CJS Syntax
 const Sentry = require('@sentry/bun');
-// ES6 Syntax
+// ESM Syntax
 import * as Sentry from '@sentry/bun';
 
 Sentry.init({

--- a/packages/node-experimental/README.md
+++ b/packages/node-experimental/README.md
@@ -30,9 +30,9 @@ yarn add @sentry/node-experimental
 ## Usage
 
 ```js
-// ES5 Syntax
+// CJS Syntax
 const Sentry = require('@sentry/node-experimental');
-// ES6 Syntax
+// ESM Syntax
 import * as Sentry from '@sentry/node-experimental';
 
 Sentry.init({

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -21,9 +21,9 @@ To use this SDK, call `init(options)` as early as possible in the main entry mod
 hook into the environment. Note that you can turn off almost all side effects using the respective options.
 
 ```javascript
-// ES5 Syntax
+// CJS syntax
 const Sentry = require('@sentry/node');
-// ES6 Syntax
+// ESM syntax
 import * as Sentry from '@sentry/node';
 
 Sentry.init({

--- a/packages/vercel-edge/README.md
+++ b/packages/vercel-edge/README.md
@@ -23,9 +23,9 @@ To use this SDK, call `init(options)` as early as possible in the main entry mod
 hook into the environment. Note that you can turn off almost all side effects using the respective options.
 
 ```javascript
-// ES5 Syntax
+// CJS Syntax
 const Sentry = require('@sentry/vercel-edge');
-// ES6 Syntax
+// ESM Syntax
 import * as Sentry from '@sentry/vercel-edge';
 
 Sentry.init({


### PR DESCRIPTION
CJS/ESM has nothing to do with ES5 or ES6