### PR TITLE
ref(node-experimental): Reorder files into `opentelemetry` folder

### DIFF
--- a/packages/node-experimental/src/constants.ts
+++ b/packages/node-experimental/src/constants.ts
@@ -1,0 +1,3 @@
+import { createContextKey } from '@opentelemetry/api';
+
+export const OTEL_CONTEXT_HUB_KEY = createContextKey('sentry_hub');

--- a/packages/node-experimental/src/opentelemetry/contextManager.ts
+++ b/packages/node-experimental/src/opentelemetry/contextManager.ts
@@ -1,11 +1,9 @@
 import type { Context } from '@opentelemetry/api';
-import * as api from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import type { Carrier, Hub } from '@sentry/core';
 
-import { ensureHubOnCarrier, getCurrentHub, getHubFromCarrier } from './hub';
-
-export const OTEL_CONTEXT_HUB_KEY = api.createContextKey('sentry_hub');
+import { OTEL_CONTEXT_HUB_KEY } from '../constants';
+import { ensureHubOnCarrier, getCurrentHub, getHubFromCarrier } from './../sdk/hub';
 
 function createNewHub(parent: Hub | undefined): Hub {
   const carrier: Carrier = {};

--- a/packages/node-experimental/src/sdk/initOtel.ts
+++ b/packages/node-experimental/src/sdk/initOtel.ts
@@ -5,7 +5,7 @@ import { SentryPropagator, SentrySpanProcessor } from '@sentry/opentelemetry-nod
 import { logger } from '@sentry/utils';
 
 import type { NodeExperimentalClient } from '../types';
-import { SentryContextManager } from './otelContextManager';
+import { SentryContextManager } from './../opentelemetry/contextManager';
 
 /**
  * Initialize OpenTelemetry for Node.

--- a/packages/node-experimental/src/sdk/otelAsyncContextStrategy.ts
+++ b/packages/node-experimental/src/sdk/otelAsyncContextStrategy.ts
@@ -2,7 +2,7 @@ import * as api from '@opentelemetry/api';
 import type { Hub, RunWithAsyncContextOptions } from '@sentry/core';
 import { setAsyncContextStrategy } from '@sentry/core';
 
-import { OTEL_CONTEXT_HUB_KEY } from './otelContextManager';
+import { OTEL_CONTEXT_HUB_KEY } from '../constants';
 
 /**
  * Sets the async context strategy to use follow the OTEL context under the hood.


### PR DESCRIPTION
To keep things better together, and in preparation for follow up PRs with more OTEL-specific stuff.

Nothing functionally changes here, this is just to keep follow up PRs more readable as there is a lot going on...