### PR TITLE
fix(node): Remove dom lib types

### DIFF
--- a/packages/node/src/integrations/undici/types.ts
+++ b/packages/node/src/integrations/undici/types.ts
@@ -1,6 +1,7 @@
 // Vendored from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/5a94716c6788f654aea7999a5fc28f4f1e7c48ad/types/node/diagnostics_channel.d.ts
 
 import type { Span } from '@sentry/core';
+import type { URL } from 'url';
 
 // License:
 // This project is licensed under the MIT license.
@@ -224,7 +225,7 @@ export interface UndiciRequest {
   method?: string;
   path: string;
   headers: string;
-  addHeader(key: string, value: string): Request;
+  addHeader(key: string, value: string): RequestWithSentry;
 }
 
 export interface UndiciResponse {

--- a/packages/node/src/requestdata.ts
+++ b/packages/node/src/requestdata.ts
@@ -320,11 +320,5 @@ function extractQueryParams(req: PolymorphicRequest): string | Record<string, un
     originalUrl = `http://dogs.are.great${originalUrl}`;
   }
 
-  return (
-    req.query ||
-    (typeof URL !== undefined && new URL(originalUrl).search.replace('?', '')) ||
-    // In Node 8, `URL` isn't in the global scope, so we have to use the built-in module from Node
-    url.parse(originalUrl).query ||
-    undefined
-  );
+  return req.query || new url.URL(originalUrl).search.replace('?', '') || undefined;
 }

--- a/packages/node/test/async/domain.test.ts
+++ b/packages/node/test/async/domain.test.ts
@@ -119,7 +119,7 @@ describe('domains', () => {
         if (d2done) {
           done();
         }
-      });
+      }, 0);
     });
 
     runWithAsyncContext(() => {
@@ -131,7 +131,7 @@ describe('domains', () => {
         if (d1done) {
           done();
         }
-      });
+      }, 0);
     });
   });
 });

--- a/packages/node/test/async/hooks.test.ts
+++ b/packages/node/test/async/hooks.test.ts
@@ -130,7 +130,7 @@ conditionalTest({ min: 12 })('async_hooks', () => {
         if (d2done) {
           done();
         }
-      });
+      }, 0);
     });
 
     runWithAsyncContext(() => {
@@ -142,7 +142,7 @@ conditionalTest({ min: 12 })('async_hooks', () => {
         if (d1done) {
           done();
         }
-      });
+      }, 0);
     });
   });
 });

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -4,6 +4,6 @@
   "include": ["src/**/*"],
 
   "compilerOptions": {
-    // package-specific options
+    "lib": ["es6"]
   }
 }


### PR DESCRIPTION
I've been having issues with the `setTimeout` return type in the node SDK, mostly when running tests:
```
Property 'unref' does not exist on type 'number'.
```

It turns out we've got dom lib types in the base tsconfig which means these have ended up in node SDK. 

This PR ensures we only have `es6` and no dom lib types and then fixes all the resulting errors.
