### PR TITLE
fix(replay): Ensure `replay_id` is not captured when session is expired

### DIFF
--- a/packages/replay/src/coreHandlers/handleGlobalEvent.ts
+++ b/packages/replay/src/coreHandlers/handleGlobalEvent.ts
@@ -35,6 +35,12 @@ export function handleGlobalEventListener(
         return event;
       }
 
+      // Ensure we do not add replay_id if the session is expired
+      const isSessionActive = replay.checkAndHandleExpiredSession();
+      if (!isSessionActive) {
+        return event;
+      }
+
       // Unless `captureExceptions` is enabled, we want to ignore errors coming from rrweb
       // As there can be a bunch of stuff going wrong in internals there, that we don't want to bubble up to users
       if (isRrwebError(event, hint) && !replay.getOptions()._experiments.captureExceptions) {


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-javascript/issues/9106