### PR TITLE
fix(node): fill in span data from http request options object

### DIFF
--- a/packages/node/src/integrations/utils/http.ts
+++ b/packages/node/src/integrations/utils/http.ts
@@ -168,6 +168,21 @@ export function normalizeRequestArgs(
     requestOptions = urlToOptions(requestArgs[0]);
   } else {
     requestOptions = requestArgs[0];
+
+    try {
+      const parsed = new URL(
+        requestOptions.path || '',
+        `${requestOptions.protocol || 'http:'}//${requestOptions.hostname}`,
+      );
+      requestOptions = {
+        pathname: parsed.pathname,
+        search: parsed.search,
+        hash: parsed.hash,
+        ...requestOptions,
+      };
+    } catch (e) {
+      // ignore
+    }
   }
 
   // if the options were given separately from the URL, fold them in

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -298,6 +298,25 @@ describe('tracing', () => {
     expect(spans[1].data['http.fragment']).toEqual('learn-more');
   });
 
+  it('fills in span data from http.RequestOptions object', () => {
+    nock('http://dogs.are.great').get('/spaniel?tail=wag&cute=true#learn-more').reply(200);
+
+    const transaction = createTransactionOnScope();
+    const spans = (transaction as unknown as Span).spanRecorder?.spans as Span[];
+
+    http.request({ method: 'GET', host: 'dogs.are.great', path: '/spaniel?tail=wag&cute=true#learn-more' });
+
+    expect(spans.length).toEqual(2);
+
+    // our span is at index 1 because the transaction itself is at index 0
+    expect(spans[1].description).toEqual('GET http://dogs.are.great/spaniel');
+    expect(spans[1].op).toEqual('http.client');
+    expect(spans[1].data['http.method']).toEqual('GET');
+    expect(spans[1].data.url).toEqual('http://dogs.are.great/spaniel');
+    expect(spans[1].data['http.query']).toEqual('tail=wag&cute=true');
+    expect(spans[1].data['http.fragment']).toEqual('learn-more');
+  });
+
   it.each([
     ['user:pwd', '[Filtered]:[Filtered]@'],
     ['user:', '[Filtered]:@'],


### PR DESCRIPTION
Currently, span data is missing for Node.js requests created with options object as the only argument, such as `http.request(options)`.

