### PR TITLE
fix(nextjs): Filter `RequestAsyncStorage` locations by locations that webpack will resolve

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -988,18 +988,22 @@ function getRequestAsyncStorageModuleLocation(
   const moduleIsWebpackResolvable = (moduleId: string): boolean => {
     let requireResolveLocation: string;
     try {
+      // This will throw if the location is not resolvable at all.
+      // We provide a `paths` filter in order to maximally limit the potential locations to the locations webpack would check.
       requireResolveLocation = require.resolve(moduleId, { paths: webpackResolvableModuleLocations });
     } catch {
       return false;
     }
 
+    // Since the require.resolve approach still looks in "global" node_modules locations like for example "/user/lib/node"
+    // we further need to filter by locations that start with the locations that webpack would check for.
     return absoluteWebpackResolvableModuleLocations.some(resolvableModuleLocation =>
       requireResolveLocation.startsWith(resolvableModuleLocation),
     );
   };
 
   const potentialRequestAsyncStorageLocations = [
-    // Original location of that module
+    // Original location of RequestAsyncStorage
     // https://github.com/vercel/next.js/blob/46151dd68b417e7850146d00354f89930d10b43b/packages/next/src/client/components/request-async-storage.ts
     'next/dist/client/components/request-async-storage',
     // Introduced in Next.js 13.4.20


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/9092

In our previous attempt of fixing we used `require.resolves`' `paths` option which we wanted to limit the locations with to check for the availability of Next.js `RequestAsyncStorage` module.

Unfortunately, `require.resolve` will always check "global" node_modules for when resolving, which means that (old) global installations of Next.js would have still been picked up.

With this PR we additionally check for whether the resolved path would be within the locations webpack would check for resolving the module. This way we shouldn't pick up any global installations of Next.js.