### PR TITLE
fix(nextjs): Fix `RequestAsyncStorage` fallback path

### DIFF
--- a/packages/nextjs/src/config/loaders/wrappingLoader.ts
+++ b/packages/nextjs/src/config/loaders/wrappingLoader.ts
@@ -189,7 +189,7 @@ export default function wrappingLoader(
       }
       templateCode = templateCode.replace(
         /__SENTRY_NEXTJS_REQUEST_ASYNC_STORAGE_SHIM__/g,
-        '@sentry/nextjs/build/esm/config/templates/requestAsyncStorageShim.js',
+        '@sentry/nextjs/esm/config/templates/requestAsyncStorageShim.js',
       );
     }
 


### PR DESCRIPTION
Fixes bug reported in https://github.com/getsentry/sentry-javascript/issues/9092#issuecomment-1736144117

This code path is in theory an invariant but people seem to be hitting it and the _fallback_ started failing because the path was wrong.