### PR TITLE
fix(node): Only require `inspector` when needed

### DIFF
--- a/packages/node/src/anr/index.ts
+++ b/packages/node/src/anr/index.ts
@@ -1,7 +1,6 @@
 import type { Event, StackFrame } from '@sentry/types';
 import { logger } from '@sentry/utils';
 import { spawn } from 'child_process';
-import * as inspector from 'inspector';
 
 import { addGlobalEventProcessor, captureEvent, flush } from '..';
 import { captureStackTrace } from './debugger';
@@ -98,12 +97,19 @@ function sendEvent(blockedMs: number, frames?: StackFrame[]): void {
   });
 }
 
+interface InspectorApi {
+  open: (port: number) => void;
+  url: () => string | undefined;
+}
+
 /**
  * Starts the node debugger and returns the inspector url.
  *
  * When inspector.url() returns undefined, it means the port is already in use so we try the next port.
  */
 function startInspector(startPort: number = 9229): string | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const inspector: InspectorApi = require('inspector');
   let inspectorUrl: string | undefined = undefined;
   let port = startPort;
 


### PR DESCRIPTION
Closes #9146

I did try to use `await import('inspector')` but I get:

`Dynamic imports are only supported when the '--module' flag is set to 'es2020', 'es2022', 'esnext', 'commonjs', 'amd', 'system', 'umd', 'node16', or 'nodenext'. ts(1323)`

It looks like we don't have any module target in the tsconfig.
