### PR TITLE
fix(types): Update signature of `processEvent` integration hook

### DIFF
--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -36,5 +36,5 @@ export interface Integration {
    * Return `null` to drop the event, or mutate the event & return it.
    * This receives the client that the integration was installed for as third argument.
    */
-  processEvent?(event: Event, hint: EventHint | undefined, client: Client): Event | null | PromiseLike<Event | null>;
+  processEvent?(event: Event, hint: EventHint, client: Client): Event | null | PromiseLike<Event | null>;
 }


### PR DESCRIPTION
Tim pointed out that this does not match the `addEventProcessor` signature (where the hint is always available). This was just incorrectly copied from the `preprocessEvent` hook, but that works differently.

This should be backwards compatible, because any usage of the hook before will still work as we just narrowed down what is passed to the method.