### PR TITLE
fix(sveltekit): Flush in server wrappers before exiting

### DIFF
--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @sentry-internal/sdk/no-optional-chaining */
 import type { Span } from '@sentry/core';
-import { flush, getActiveTransaction, getCurrentHub, runWithAsyncContext, startSpan } from '@sentry/core';
+import { getActiveTransaction, getCurrentHub, runWithAsyncContext, startSpan } from '@sentry/core';
 import { captureException } from '@sentry/node';
 import { addExceptionMechanism, dynamicSamplingContextToSentryBaggageHeader, objectify } from '@sentry/utils';
 import type { Handle, ResolveOptions } from '@sveltejs/kit';

--- a/packages/sveltekit/src/server/load.ts
+++ b/packages/sveltekit/src/server/load.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @sentry-internal/sdk/no-optional-chaining */
-import { flush, getCurrentHub, startSpan } from '@sentry/core';
+import { getCurrentHub, startSpan } from '@sentry/core';
 import { captureException } from '@sentry/node';
 import type { TransactionContext } from '@sentry/types';
 import { addExceptionMechanism, addNonEnumerableProperty, objectify } from '@sentry/utils';
@@ -159,7 +159,6 @@ export function wrapServerLoadWithSentry<T extends (...args: any) => any>(origSe
         sendErrorToSentry(e);
         throw e;
       } finally {
-        await flush(4000);
         await flushIfServerless();
       }
     },

--- a/packages/sveltekit/src/server/load.ts
+++ b/packages/sveltekit/src/server/load.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @sentry-internal/sdk/no-optional-chaining */
-import { flush, getCurrentHub, startSpan, trace } from '@sentry/core';
+import { flush, getCurrentHub, startSpan } from '@sentry/core';
 import { captureException } from '@sentry/node';
 import type { TransactionContext } from '@sentry/types';
 import { addExceptionMechanism, addNonEnumerableProperty, objectify } from '@sentry/utils';
@@ -81,8 +81,8 @@ export function wrapLoadWithSentry<T extends (...args: any) => any>(origLoad: T)
       };
 
       try {
-        const loadResult = await startSpan(traceLoadContext, () => wrappingTarget.apply(thisArg, args));
-        return loadResult;
+        // We need to await before returning, otherwise we won't catch any errors thrown by the load function
+        return await startSpan(traceLoadContext, () => wrappingTarget.apply(thisArg, args));
       } catch (e) {
         sendErrorToSentry(e);
         throw e;
@@ -153,8 +153,8 @@ export function wrapServerLoadWithSentry<T extends (...args: any) => any>(origSe
       };
 
       try {
-        const serverLoadResult = await startSpan(traceLoadContext, () => wrappingTarget.apply(thisArg, args));
-        return serverLoadResult;
+        // We need to await before returning, otherwise we won't catch any errors thrown by the load function
+        return await startSpan(traceLoadContext, () => wrappingTarget.apply(thisArg, args));
       } catch (e: unknown) {
         sendErrorToSentry(e);
         throw e;

--- a/packages/sveltekit/test/server/handle.test.ts
+++ b/packages/sveltekit/test/server/handle.test.ts
@@ -23,7 +23,7 @@ vi.mock('@sentry/node', async () => {
   };
 });
 
-const mockAddExceptionMechanism = vi.fn(() => console.trace());
+const mockAddExceptionMechanism = vi.fn();
 
 vi.mock('@sentry/utils', async () => {
   const original = (await vi.importActual('@sentry/utils')) as any;

--- a/packages/sveltekit/test/server/handle.test.ts
+++ b/packages/sveltekit/test/server/handle.test.ts
@@ -23,7 +23,7 @@ vi.mock('@sentry/node', async () => {
   };
 });
 
-const mockAddExceptionMechanism = vi.fn();
+const mockAddExceptionMechanism = vi.fn(() => console.trace());
 
 vi.mock('@sentry/utils', async () => {
   const original = (await vi.importActual('@sentry/utils')) as any;

--- a/packages/sveltekit/test/server/load.test.ts
+++ b/packages/sveltekit/test/server/load.test.ts
@@ -194,7 +194,7 @@ describe.each([
   });
 
   it('adds an exception mechanism', async () => {
-    vi.spyOn(mockScope, 'addEventProcessor').mockImplementationOnce(callback => {
+    const addEventProcessorSpy = vi.spyOn(mockScope, 'addEventProcessor').mockImplementationOnce(callback => {
       void callback({}, { event_id: 'fake-event-id' });
       return mockScope;
     });
@@ -209,7 +209,7 @@ describe.each([
     const res = wrappedLoad(getServerOnlyArgs());
     await expect(res).rejects.toThrow();
 
-    // expect(addEventProcessorSpy).toHaveBeenCalledTimes(1);
+    expect(addEventProcessorSpy).toHaveBeenCalledTimes(1);
     expect(mockAddExceptionMechanism).toBeCalledTimes(1);
     expect(mockAddExceptionMechanism).toBeCalledWith(
       {},

--- a/packages/sveltekit/test/server/load.test.ts
+++ b/packages/sveltekit/test/server/load.test.ts
@@ -134,8 +134,6 @@ afterEach(() => {
   mockAddExceptionMechanism.mockClear();
   mockStartSpan.mockClear();
   mockScope = new Scope();
-  // @ts-expect-error - this is fine (just tests here)
-  mockScope.mockClear?.call(mockScope);
 });
 
 describe.each([
@@ -195,12 +193,12 @@ describe.each([
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
 
-  vi.spyOn(mockScope, 'addEventProcessor').mockImplementationOnce(callback => {
-    void callback({}, { event_id: 'fake-event-id' });
-    return mockScope;
-  });
+  it('adds an exception mechanism', async () => {
+    vi.spyOn(mockScope, 'addEventProcessor').mockImplementationOnce(callback => {
+      void callback({}, { event_id: 'fake-event-id' });
+      return mockScope;
+    });
 
-  it.only('adds an exception mechanism', async () => {
     async function load({ params }) {
       return {
         post: getById(params.id),
@@ -212,7 +210,7 @@ describe.each([
     await expect(res).rejects.toThrow();
 
     // expect(addEventProcessorSpy).toHaveBeenCalledTimes(1);
-    expect(mockAddExceptionMechanism).toHaveBeenCalledTimes(1);
+    expect(mockAddExceptionMechanism).toBeCalledTimes(1);
     expect(mockAddExceptionMechanism).toBeCalledWith(
       {},
       { handled: false, type: 'sveltekit', data: { function: 'load' } },


### PR DESCRIPTION
When deploying to Vercel (non-edge), server code is converted into Lambda functions. These functions have a tendency to freeze/shut down before the SDK is able to flush out events, causing events to be dropped. We already handle this in NextJS by manually calling `flush`. This PR applies the (almost) same logic to SvelteKit's server side instrumentation.

Since I was already at it, I replaced the `trace` calls with `startSpan` which is the newer API.

fixes #8855 