### PR TITLE
feat(serverlesss): allow disabling transaction traces

### DIFF
--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -52,7 +52,7 @@ export interface WrapperOptions {
    * You may want to disable this if you use express within Lambda (use tracingHandler instead).
    * @default true
    */
-  startTransaction: boolean;
+  startTrace: boolean;
 }
 
 export const defaultIntegrations: Integration[] = [...Sentry.defaultIntegrations, new AWSServices({ optional: true })];
@@ -235,7 +235,7 @@ export function wrapHandler<TEvent, TResult>(
     captureTimeoutWarning: true,
     timeoutWarningLimit: 500,
     captureAllSettledReasons: false,
-    startTransaction: true,
+    startTrace: true,
     ...wrapOptions,
   };
   let timeoutWarningTimer: NodeJS.Timeout;
@@ -294,7 +294,7 @@ export function wrapHandler<TEvent, TResult>(
     const hub = getCurrentHub();
 
     let transaction: Sentry.Transaction | undefined;
-    if (options.startTransaction) {
+    if (options.startTrace) {
       const eventWithHeaders = event as { headers?: { [key: string]: string } };
 
       const sentryTrace =
@@ -324,7 +324,7 @@ export function wrapHandler<TEvent, TResult>(
     let rv: TResult;
     try {
       enhanceScopeWithEnvironmentData(scope, context, START_TIME);
-      if (options.startTransaction) {
+      if (options.startTrace) {
         enhanceScopeWithTransactionData(scope, context);
         // We put the transaction on the scope so users can attach children to it
         scope.setSpan(transaction);

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -47,6 +47,12 @@ export interface WrapperOptions {
    * @default false
    */
   captureAllSettledReasons: boolean;
+  /**
+   * Automatically trace all handler invocations.
+   * You may want to disable this if you use express within Lambda (use tracingHandler instead).
+   * @default true
+   */
+  startTransaction: boolean;
 }
 
 export const defaultIntegrations: Integration[] = [...Sentry.defaultIntegrations, new AWSServices({ optional: true })];
@@ -178,11 +184,6 @@ function tryGetRemainingTimeInMillis(context: Context): number {
  * @param startTime performance.now() when wrapHandler was invoked
  */
 function enhanceScopeWithEnvironmentData(scope: Scope, context: Context, startTime: number): void {
-  scope.setTransactionName(context.functionName);
-
-  scope.setTag('server_name', process.env._AWS_XRAY_DAEMON_ADDRESS || process.env.SENTRY_NAME || hostname());
-  scope.setTag('url', `awslambda:///${context.functionName}`);
-
   scope.setContext('aws.lambda', {
     aws_request_id: context.awsRequestId,
     function_name: context.functionName,
@@ -205,6 +206,18 @@ function enhanceScopeWithEnvironmentData(scope: Scope, context: Context, startTi
 }
 
 /**
+ * Adds additional transaction-related information from the environment and AWS Context to the Sentry Scope.
+ *
+ * @param scope Scope that should be enhanced
+ * @param context AWS Lambda context that will be used to extract some part of the data
+ */
+function enhanceScopeWithTransactionData(scope: Scope, context: Context): void {
+  scope.setTransactionName(context.functionName);
+  scope.setTag('server_name', process.env._AWS_XRAY_DAEMON_ADDRESS || process.env.SENTRY_NAME || hostname());
+  scope.setTag('url', `awslambda:///${context.functionName}`);
+}
+
+/**
  * Wraps a lambda handler adding it error capture and tracing capabilities.
  *
  * @param handler Handler
@@ -222,6 +235,7 @@ export function wrapHandler<TEvent, TResult>(
     captureTimeoutWarning: true,
     timeoutWarningLimit: 500,
     captureAllSettledReasons: false,
+    startTransaction: true,
     ...wrapOptions,
   };
   let timeoutWarningTimer: NodeJS.Timeout;
@@ -279,36 +293,42 @@ export function wrapHandler<TEvent, TResult>(
 
     const hub = getCurrentHub();
 
-    const eventWithHeaders = event as { headers?: { [key: string]: string } };
+    let transaction: Sentry.Transaction | undefined;
+    if (options.startTransaction) {
+      const eventWithHeaders = event as { headers?: { [key: string]: string } };
 
-    const sentryTrace =
-      eventWithHeaders.headers && isString(eventWithHeaders.headers['sentry-trace'])
-        ? eventWithHeaders.headers['sentry-trace']
-        : undefined;
-    const baggage = eventWithHeaders.headers?.baggage;
-    const { traceparentData, dynamicSamplingContext, propagationContext } = tracingContextFromHeaders(
-      sentryTrace,
-      baggage,
-    );
-    hub.getScope().setPropagationContext(propagationContext);
+      const sentryTrace =
+        eventWithHeaders.headers && isString(eventWithHeaders.headers['sentry-trace'])
+          ? eventWithHeaders.headers['sentry-trace']
+          : undefined;
+      const baggage = eventWithHeaders.headers?.baggage;
+      const { traceparentData, dynamicSamplingContext, propagationContext } = tracingContextFromHeaders(
+        sentryTrace,
+        baggage,
+      );
+      hub.getScope().setPropagationContext(propagationContext);
 
-    const transaction = hub.startTransaction({
-      name: context.functionName,
-      op: 'function.aws.lambda',
-      origin: 'auto.function.serverless',
-      ...traceparentData,
-      metadata: {
-        dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,
-        source: 'component',
-      },
-    }) as Sentry.Transaction | undefined;
+      transaction = hub.startTransaction({
+        name: context.functionName,
+        op: 'function.aws.lambda',
+        origin: 'auto.function.serverless',
+        ...traceparentData,
+        metadata: {
+          dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,
+          source: 'component',
+        },
+      });
+    }
 
     const scope = hub.pushScope();
     let rv: TResult;
     try {
       enhanceScopeWithEnvironmentData(scope, context, START_TIME);
-      // We put the transaction on the scope so users can attach children to it
-      scope.setSpan(transaction);
+      if (options.startTransaction) {
+        enhanceScopeWithTransactionData(scope, context);
+        // We put the transaction on the scope so users can attach children to it
+        scope.setSpan(transaction);
+      }
       rv = await asyncHandler(event, context);
 
       // We manage lambdas that use Promise.allSettled by capturing the errors of failed promises

--- a/packages/serverless/test/__mocks__/@sentry/node.ts
+++ b/packages/serverless/test/__mocks__/@sentry/node.ts
@@ -50,6 +50,7 @@ export const resetMocks = (): void => {
   fakeHub.pushScope.mockClear();
   fakeHub.popScope.mockClear();
   fakeHub.getScope.mockClear();
+  fakeHub.startTransaction.mockClear();
 
   fakeScope.addEventProcessor.mockClear();
   fakeScope.setTransactionName.mockClear();

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -183,12 +183,12 @@ describe('AWSLambda', () => {
       expect(SentryNode.captureException).toBeCalledTimes(2);
     });
 
-    // "wrapHandler() ... successful execution" tests the default of startTransaction enabled
-    test('startTransaction disabled', async () => {
+    // "wrapHandler() ... successful execution" tests the default of startTrace enabled
+    test('startTrace disabled', async () => {
       expect.assertions(3);
 
       const handler: Handler = async (_event, _context) => 42;
-      const wrappedHandler = wrapHandler(handler, { startTransaction: false });
+      const wrappedHandler = wrapHandler(handler, { startTrace: false });
       await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
 
       // @ts-expect-error see "Why @ts-expect-error" note


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

## Background
- My team runs Express inside Lambda - we have a monolithic Lambda function with express handling routing, middleware, etc
- We are using `@sentry/node` today, and tried adding `@sentry/serverless` for it's timeout warning, auto-handling of `flush`, and links to cloudwatch logs
- But this caused all of our performance transaction traces to have an incorrect name (and various other tag + context issues)

## Proposal
- A new `startTransaction` boolean flag that turns on/off the transaction tracing feature of `@sentry/serverless`
- This will allow our team to use `@sentry/serverless`, but still rely on express `tracingHandler` for performance traces
- This also follows the general approach of the serverless package, where each feature is gated by a wrapOptions flag

## Alternatives
- We tried various ways to have the express transaction name override the Lambda one, but couldn't get that working
- If there is a way to do that without needing a PR like this, that would be great!

## For reviewers
- I'd recommend hiding whitespace when reviewing