### PR TITLE
ref(utils): Deprecate `walk` method

### DIFF
--- a/packages/utils/src/normalize.ts
+++ b/packages/utils/src/normalize.ts
@@ -169,7 +169,9 @@ function visit(
   return normalized;
 }
 
-// TODO remove this in v7 (this means the method will no longer be exported, under any name)
+/**
+ * @deprecated This export will be removed in v8.
+ */
 export { visit as walk };
 
 /* eslint-disable complexity */


### PR DESCRIPTION
This was supposed to be removed in v7, but was forgotten.