### PR TITLE
ref: Deprecate `extractTraceParentData` from `@sentry/core` & downstream packages

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,6 +8,12 @@ npx @sentry/migr8@latest
 
 This will let you select which updates to run, and automatically update your code. Make sure to still review all code changes!
 
+## Deprecate `extractTraceParentData` export from `@sentry/core` & downstream packages
+
+Instead, import this directly from `@sentry/utils`.
+
+Generally, in most cases you should probably use `continueTrace` instead, which abstracts this away from you and handles scope propagation for you.
+
 ## Deprecate `timestampWithMs` export - #7878
 
 The `timestampWithMs` util is deprecated in favor of using `timestampInSeconds`.

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -16,6 +16,7 @@ export {
   withMonitor,
   configureScope,
   createTransport,
+  // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
   getActiveTransaction,
   getHubFromCarrier,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -42,6 +42,7 @@ export type { RequestInstrumentationOptions } from '@sentry-internal/tracing';
 export {
   addTracingExtensions,
   setMeasurement,
+  // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
   getActiveTransaction,
   spanStatusfromHttpCode,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -33,6 +33,7 @@ export {
   close,
   configureScope,
   createTransport,
+  // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
   flush,
   getActiveTransaction,

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -3,6 +3,7 @@ export { IdleTransaction, TRACING_DEFAULTS } from './idletransaction';
 export type { BeforeFinishCallback } from './idletransaction';
 export { Span, spanStatusfromHttpCode } from './span';
 export { Transaction } from './transaction';
+// eslint-disable-next-line deprecation/deprecation
 export { extractTraceparentData, getActiveTransaction } from './utils';
 // eslint-disable-next-line deprecation/deprecation
 export { SpanStatus } from './spanstatus';

--- a/packages/core/src/tracing/utils.ts
+++ b/packages/core/src/tracing/utils.ts
@@ -1,21 +1,8 @@
 import type { Transaction } from '@sentry/types';
+import { extractTraceparentData as _extractTraceparentData } from '@sentry/utils';
 
 import type { Hub } from '../hub';
 import { getCurrentHub } from '../hub';
-
-/**
- * The `extractTraceparentData` function and `TRACEPARENT_REGEXP` constant used
- * to be declared in this file. It was later moved into `@sentry/utils` as part of a
- * move to remove `@sentry/tracing` dependencies from `@sentry/node` (`extractTraceparentData`
- * is the only tracing function used by `@sentry/node`).
- *
- * These exports are kept here for backwards compatability's sake.
- *
- * TODO(v7): Reorganize these exports
- *
- * See https://github.com/getsentry/sentry-javascript/issues/4642 for more details.
- */
-export { TRACEPARENT_REGEXP, extractTraceparentData } from '@sentry/utils';
 
 /** Grabs active transaction off scope, if any */
 export function getActiveTransaction<T extends Transaction>(maybeHub?: Hub): T | undefined {
@@ -26,3 +13,17 @@ export function getActiveTransaction<T extends Transaction>(maybeHub?: Hub): T |
 
 // so it can be used in manual instrumentation without necessitating a hard dependency on @sentry/utils
 export { stripUrlQueryAndFragment } from '@sentry/utils';
+
+/**
+ * The `extractTraceparentData` function and `TRACEPARENT_REGEXP` constant used
+ * to be declared in this file. It was later moved into `@sentry/utils` as part of a
+ * move to remove `@sentry/tracing` dependencies from `@sentry/node` (`extractTraceparentData`
+ * is the only tracing function used by `@sentry/node`).
+ *
+ * These exports are kept here for backwards compatability's sake.
+ *
+ * See https://github.com/getsentry/sentry-javascript/issues/4642 for more details.
+ *
+ * @deprecated Import this function from `@sentry/utils` instead
+ */
+export const extractTraceparentData = _extractTraceparentData;

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -31,7 +31,9 @@ export {
   close,
   configureScope,
   createTransport,
+  // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
+  continueTrace,
   flush,
   getActiveTransaction,
   getHubFromCarrier,

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -32,6 +32,7 @@ export {
   close,
   configureScope,
   createTransport,
+  // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
   flush,
   getActiveTransaction,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -33,6 +33,7 @@ export {
   close,
   configureScope,
   createTransport,
+  // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
   flush,
   getActiveTransaction,

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -19,6 +19,7 @@ export {
   captureMessage,
   configureScope,
   createTransport,
+  // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
   getActiveTransaction,
   getHubFromCarrier,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -14,6 +14,7 @@ export {
   withMonitor,
   configureScope,
   createTransport,
+  // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
   getActiveTransaction,
   getHubFromCarrier,

--- a/packages/tracing-internal/src/exports/index.ts
+++ b/packages/tracing-internal/src/exports/index.ts
@@ -1,4 +1,5 @@
 export {
+  // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
   getActiveTransaction,
   hasTracingEnabled,

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -20,7 +20,6 @@ import {
   Postgres,
   Prisma,
   Span as SpanT,
-  // eslint-disable-next-line deprecation/deprecation
   SpanStatus as SpanStatusT,
   spanStatusfromHttpCode as spanStatusfromHttpCodeT,
   startIdleTransaction as startIdleTransactionT,
@@ -70,6 +69,7 @@ export const getActiveTransaction = getActiveTransactionT;
  *
  * `extractTraceparentData` can be imported from `@sentry/node`, `@sentry/browser`, or your framework SDK
  */
+// eslint-disable-next-line deprecation/deprecation
 export const extractTraceparentData = extractTraceparentDataT;
 
 /**

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -32,6 +32,7 @@ export {
   close,
   configureScope,
   createTransport,
+  // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
   flush,
   getActiveTransaction,


### PR DESCRIPTION
Instead, users should import this from `@sentry/utils`.

This was also re-exported from all downstream packages (e.g. `@sentry/browser`, `@sentry/node`). I don't think this is something users need to import from there...? If you need this, installing `@sentry/utils` is probably fine? 

Else if we think we want to keep exporting this, we can also remove the comment, but then we should just properly move this from utils to core and instead remove the utils export, I'd say.