### PR TITLE
ref(serverless): Properly deprecate `rethrowAfterCapture` option

### DIFF
--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -34,7 +34,9 @@ export type AsyncHandler<T extends Handler> = (
 
 export interface WrapperOptions {
   flushTimeout: number;
-  // TODO: DEPRECATED - remove `rethrowAfterCapture` in v7
+  /**
+   * @deprecated This option is unused since v6 and will be removed in v8.
+   */
   rethrowAfterCapture?: boolean;
   callbackWaitsForEmptyEventLoop: boolean;
   captureTimeoutWarning: boolean;


### PR DESCRIPTION
This is unused since v6 but we never got around to actually remove this, so let's properly deprecate this for v8.