### PR TITLE
fix: Ensure we never mutate options passed to `init`

### DIFF
--- a/packages/angular/src/sdk.ts
+++ b/packages/angular/src/sdk.ts
@@ -1,6 +1,7 @@
 import { VERSION } from '@angular/core';
 import type { BrowserOptions } from '@sentry/browser';
 import { defaultIntegrations, init as browserInit, SDK_VERSION, setContext } from '@sentry/browser';
+import type { SdkMetadata } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import { IS_DEBUG_BUILD } from './flags';
@@ -9,8 +10,21 @@ import { IS_DEBUG_BUILD } from './flags';
  * Inits the Angular SDK
  */
 export function init(options: BrowserOptions): void {
-  options._metadata = options._metadata || {};
-  options._metadata.sdk = {
+  const opts = {
+    _metadata: {} as SdkMetadata,
+    // Filter out TryCatch integration as it interferes with our Angular `ErrorHandler`:
+    // TryCatch would catch certain errors before they reach the `ErrorHandler` and thus provide a
+    // lower fidelity error than what `SentryErrorHandler` (see errorhandler.ts) would provide.
+    // see:
+    //  - https://github.com/getsentry/sentry-javascript/issues/5417#issuecomment-1453407097
+    //  - https://github.com/getsentry/sentry-javascript/issues/2744
+    defaultIntegrations: defaultIntegrations.filter(integration => {
+      return integration.name !== 'TryCatch';
+    }),
+    ...options,
+  };
+
+  opts._metadata.sdk = opts._metadata.sdk || {
     name: 'sentry.javascript.angular',
     packages: [
       {
@@ -21,20 +35,8 @@ export function init(options: BrowserOptions): void {
     version: SDK_VERSION,
   };
 
-  // Filter out TryCatch integration as it interferes with our Angular `ErrorHandler`:
-  // TryCatch would catch certain errors before they reach the `ErrorHandler` and thus provide a
-  // lower fidelity error than what `SentryErrorHandler` (see errorhandler.ts) would provide.
-  // see:
-  //  - https://github.com/getsentry/sentry-javascript/issues/5417#issuecomment-1453407097
-  //  - https://github.com/getsentry/sentry-javascript/issues/2744
-  if (options.defaultIntegrations === undefined) {
-    options.defaultIntegrations = defaultIntegrations.filter(integration => {
-      return integration.name !== 'TryCatch';
-    });
-  }
-
   checkAndSetAngularVersion();
-  browserInit(options);
+  browserInit(opts);
 }
 
 function checkAndSetAngularVersion(): void {

--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -44,14 +44,17 @@ const globalWithInjectedValues = global as typeof global & {
 
 /** Inits the Sentry NextJS SDK on the browser with the React SDK. */
 export function init(options: BrowserOptions): void {
-  applyTunnelRouteOption(options);
-  buildMetadata(options, ['nextjs', 'react']);
+  const opts = {
+    environment: getVercelEnv(true) || process.env.NODE_ENV,
+    ...options,
+  };
 
-  options.environment = options.environment || getVercelEnv(true) || process.env.NODE_ENV;
+  applyTunnelRouteOption(opts);
+  buildMetadata(opts, ['nextjs', 'react']);
 
-  addClientIntegrations(options);
+  addClientIntegrations(opts);
 
-  reactInit(options);
+  reactInit(opts);
 
   configureScope(scope => {
     scope.setTag('runtime', 'browser');

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -1,4 +1,5 @@
 import { SDK_VERSION } from '@sentry/core';
+import type { SdkMetadata } from '@sentry/types';
 import type { VercelEdgeOptions } from '@sentry/vercel-edge';
 import { init as vercelEdgeInit } from '@sentry/vercel-edge';
 
@@ -6,8 +7,12 @@ export type EdgeOptions = VercelEdgeOptions;
 
 /** Inits the Sentry NextJS SDK on the Edge Runtime. */
 export function init(options: VercelEdgeOptions = {}): void {
-  options._metadata = options._metadata || {};
-  options._metadata.sdk = options._metadata.sdk || {
+  const opts = {
+    _metadata: {} as SdkMetadata,
+    ...options,
+  };
+
+  opts._metadata.sdk = opts._metadata.sdk || {
     name: 'sentry.javascript.nextjs',
     packages: [
       {
@@ -18,7 +23,7 @@ export function init(options: VercelEdgeOptions = {}): void {
     version: SDK_VERSION,
   };
 
-  vercelEdgeInit(options);
+  vercelEdgeInit(opts);
 }
 
 /**

--- a/packages/react/src/sdk.ts
+++ b/packages/react/src/sdk.ts
@@ -1,12 +1,17 @@
 import type { BrowserOptions } from '@sentry/browser';
 import { init as browserInit, SDK_VERSION } from '@sentry/browser';
+import type { SdkMetadata } from '@sentry/types';
 
 /**
  * Inits the React SDK
  */
 export function init(options: BrowserOptions): void {
-  options._metadata = options._metadata || {};
-  options._metadata.sdk = options._metadata.sdk || {
+  const opts = {
+    _metadata: {} as SdkMetadata,
+    ...options,
+  };
+
+  opts._metadata.sdk = opts._metadata.sdk || {
     name: 'sentry.javascript.react',
     packages: [
       {
@@ -16,5 +21,5 @@ export function init(options: BrowserOptions): void {
     ],
     version: SDK_VERSION,
   };
-  browserInit(options);
+  browserInit(opts);
 }

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -2,7 +2,7 @@
 import type { Scope } from '@sentry/node';
 import * as Sentry from '@sentry/node';
 import { captureException, captureMessage, flush, getCurrentHub, withScope } from '@sentry/node';
-import type { Integration } from '@sentry/types';
+import type { Integration, SdkMetadata } from '@sentry/types';
 import { isString, logger, tracingContextFromHeaders } from '@sentry/utils';
 // NOTE: I have no idea how to fix this right now, and don't want to waste more time, as it builds just fine — Kamil
 // eslint-disable-next-line import/no-unresolved
@@ -61,12 +61,13 @@ interface AWSLambdaOptions extends Sentry.NodeOptions {
  * @see {@link Sentry.init}
  */
 export function init(options: AWSLambdaOptions = {}): void {
-  if (options.defaultIntegrations === undefined) {
-    options.defaultIntegrations = defaultIntegrations;
-  }
+  const opts = {
+    _metadata: {} as SdkMetadata,
+    defaultIntegrations,
+    ...options,
+  };
 
-  options._metadata = options._metadata || {};
-  options._metadata.sdk = {
+  opts._metadata.sdk = opts._metadata.sdk || {
     name: 'sentry.javascript.serverless',
     integrations: ['AWSLambda'],
     packages: [
@@ -78,7 +79,7 @@ export function init(options: AWSLambdaOptions = {}): void {
     version: Sentry.SDK_VERSION,
   };
 
-  Sentry.init(options);
+  Sentry.init(opts);
   Sentry.addGlobalEventProcessor(serverlessEventProcessor);
 }
 

--- a/packages/serverless/src/gcpfunction/index.ts
+++ b/packages/serverless/src/gcpfunction/index.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/node';
-import type { Integration } from '@sentry/types';
+import type { Integration, SdkMetadata } from '@sentry/types';
 
 import { GoogleCloudGrpc } from '../google-cloud-grpc';
 import { GoogleCloudHttp } from '../google-cloud-http';
@@ -19,12 +19,13 @@ export const defaultIntegrations: Integration[] = [
  * @see {@link Sentry.init}
  */
 export function init(options: Sentry.NodeOptions = {}): void {
-  if (options.defaultIntegrations === undefined) {
-    options.defaultIntegrations = defaultIntegrations;
-  }
+  const opts = {
+    _metadata: {} as SdkMetadata,
+    defaultIntegrations,
+    ...options,
+  };
 
-  options._metadata = options._metadata || {};
-  options._metadata.sdk = {
+  opts._metadata.sdk = opts._metadata.sdk || {
     name: 'sentry.javascript.serverless',
     integrations: ['GCPFunction'],
     packages: [
@@ -36,6 +37,6 @@ export function init(options: Sentry.NodeOptions = {}): void {
     version: Sentry.SDK_VERSION,
   };
 
-  Sentry.init(options);
+  Sentry.init(opts);
   Sentry.addGlobalEventProcessor(serverlessEventProcessor);
 }

--- a/packages/svelte/src/sdk.ts
+++ b/packages/svelte/src/sdk.ts
@@ -1,13 +1,17 @@
 import type { BrowserOptions } from '@sentry/browser';
 import { addGlobalEventProcessor, init as browserInit, SDK_VERSION } from '@sentry/browser';
-import type { EventProcessor } from '@sentry/types';
+import type { EventProcessor, SdkMetadata } from '@sentry/types';
 import { getDomElement } from '@sentry/utils';
 /**
  * Inits the Svelte SDK
  */
 export function init(options: BrowserOptions): void {
-  options._metadata = options._metadata || {};
-  options._metadata.sdk = options._metadata.sdk || {
+  const opts = {
+    _metadata: {} as SdkMetadata,
+    ...options,
+  };
+
+  opts._metadata.sdk = opts._metadata.sdk || {
     name: 'sentry.javascript.svelte',
     packages: [
       {
@@ -17,8 +21,7 @@ export function init(options: BrowserOptions): void {
     ],
     version: SDK_VERSION,
   };
-
-  browserInit(options);
+  browserInit(opts);
 
   detectAndReportSvelteKit();
 }


### PR DESCRIPTION
In various places we mutate the `options` passed to `init()`, which is a) not a great pattern and b) may break if users pass in frozen or similar objects (for whatever reason).

I also normalized this to ensure a passed in `_metadata.sdk` always takes precedent (we had this in most places, but not all).

Closes https://github.com/getsentry/sentry-javascript/issues/9155
