### PR TITLE
chore: Update vite plugin link

### DIFF
--- a/packages/sveltekit/README.md
+++ b/packages/sveltekit/README.md
@@ -194,7 +194,7 @@ export default {
 ### Configuring Source maps upload
 
 Under `sourceMapsUploadOptions`, you can also specify all additional options supported by the
-[Sentry Vite Plugin](https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/main/packages/vite-plugin/README.md#configuration).
+[Sentry Vite Plugin](https://www.npmjs.com/package/@sentry/vite-plugin).
 This might be useful if you're using adapters other than the Node adapter or have a more customized build setup.
 
 ```js


### PR DESCRIPTION
The previous link resulted in a 404 error: https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/main/packages/vite-plugin/README.md#configuration

I have changed it to the npm link with all options: https://www.npmjs.com/package/@sentry/vite-plugin

Could also use this link: https://github.com/getsentry/sentry-javascript-bundler-plugins/blob/main/packages/vite-plugin/README_TEMPLATE.md but it does not seem well maintained

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
