### PR TITLE
feat(core): Add `addIntegration` utility

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -23,6 +23,7 @@ export type { ReportDialogOptions } from './helpers';
 export {
   addGlobalEventProcessor,
   addBreadcrumb,
+  addIntegration,
   captureException,
   captureEvent,
   captureMessage,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -26,6 +26,7 @@ export type { BunOptions } from './types';
 export {
   addGlobalEventProcessor,
   addBreadcrumb,
+  addIntegration,
   captureException,
   captureEvent,
   captureMessage,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,7 +46,7 @@ export { createTransport } from './transports/base';
 export { makeOfflineTransport } from './transports/offline';
 export { makeMultiplexedTransport } from './transports/multiplexed';
 export { SDK_VERSION } from './version';
-export { getIntegrationsToSetup } from './integration';
+export { getIntegrationsToSetup, addIntegration } from './integration';
 export { FunctionToString, InboundFilters } from './integrations';
 export { prepareEvent } from './utils/prepareEvent';
 export { createCheckInEnvelope } from './checkin';

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -124,6 +124,18 @@ export function setupIntegration(client: Client, integration: Integration, integ
   __DEBUG_BUILD__ && logger.log(`Integration installed: ${integration.name}`);
 }
 
+/** Add an integration to the current hub's client. */
+export function addIntegration(integration: Integration): void {
+  const client = getCurrentHub().getClient();
+
+  if (!client || !client.addIntegration) {
+    __DEBUG_BUILD__ && logger.warn(`Cannot add integration "${integration.name}" because no SDK Client is available.`);
+    return;
+  }
+
+  client.addIntegration(integration);
+}
+
 // Polyfill for Array.findIndex(), which is not supported in ES5
 function findIndex<T>(arr: T[], callback: (item: T) => boolean): number {
   for (let i = 0; i < arr.length; i++) {

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -78,6 +78,9 @@ describe('BaseClient', () => {
     });
 
     test('handles being passed an invalid Dsn', () => {
+      // Hide warning logs in the test
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+
       const options = getDefaultTestClientOptions({ dsn: 'abc' });
       const client = new TestClient(options);
 

--- a/packages/core/test/lib/transports/multiplexed.test.ts
+++ b/packages/core/test/lib/transports/multiplexed.test.ts
@@ -88,6 +88,9 @@ describe('makeMultiplexedTransport', () => {
   });
 
   it('Falls back to options DSN when a matched DSN is invalid', async () => {
+    // Hide warning logs in the test
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
     expect.assertions(1);
 
     const makeTransport = makeMultiplexedTransport(
@@ -99,6 +102,8 @@ describe('makeMultiplexedTransport', () => {
 
     const transport = makeTransport({ url: DSN1_URL, ...transportOptions });
     await transport.send(ERROR_ENVELOPE);
+
+    jest.clearAllMocks();
   });
 
   it('DSN can be overridden via match callback', async () => {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -26,6 +26,7 @@ export type { NodeOptions } from './types';
 export {
   addGlobalEventProcessor,
   addBreadcrumb,
+  addIntegration,
   captureException,
   captureEvent,
   captureMessage,

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -15,6 +15,7 @@ export {
   Scope,
   addBreadcrumb,
   addGlobalEventProcessor,
+  addIntegration,
   autoDiscoverNodePerformanceMonitoringIntegrations,
   captureEvent,
   captureException,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -6,6 +6,7 @@
 export {
   addGlobalEventProcessor,
   addBreadcrumb,
+  addIntegration,
   captureException,
   captureEvent,
   captureMessage,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -25,6 +25,7 @@ export type { VercelEdgeOptions } from './types';
 export {
   addGlobalEventProcessor,
   addBreadcrumb,
+  addIntegration,
   captureException,
   captureEvent,
   captureMessage,


### PR DESCRIPTION
To make it easier to async add integrations later, which is useful e.g. for replay but also for other cases.

Now instead of:

```js
const client = Sentry.getCurrentHub().getClient();
if (client && client.addIntegration) {
  client.addIntegration(new Sentry.Replay());
}
```

You can just do:

```js
Sentry.addIntegration(new Sentry.Replay());
```

Relates to:
* https://github.com/getsentry/sentry-javascript/pull/9138
* https://github.com/getsentry/sentry-javascript/pull/9180
