### PR TITLE
chore(astro): Add Astro integration keywords

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -7,7 +7,6 @@
   "keywords": [
     "withastro",
     "astro-component",
-    "analytics",
     "sentry",
     "apm"
   ],

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -4,6 +4,13 @@
   "description": "Official Sentry SDK for Astro",
   "repository": "git://github.com/getsentry/sentry-javascript.git",
   "homepage": "https://github.com/getsentry/sentry-javascript/tree/master/packages/astro",
+  "keywords": [
+    "withastro",
+    "astro-component",
+    "analytics",
+    "sentry",
+    "apm"
+  ],
   "author": "Sentry",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Adding [specific keywords](https://docs.astro.build/en/reference/publish-to-npm/#integrations-library) to an NPM package makes them show up in [Astro's integration library page](https://astro.build/integrations/). This PR adds them to the Astro package.json. 
While `analytics` isn't the perfect category for Sentry, it still fit better than all others, so I went with it. 

When we're ready we should also file an issue with Astro to add a Sentry logo in the library.

Separate PR because I'd only merge this once we're comfortable with publishing. 

ref #9182 