### PR TITLE
fix: Don't set `referrerPolicy` on serverside fetch transports

### DIFF
--- a/packages/bun/src/transports/index.ts
+++ b/packages/bun/src/transports/index.ts
@@ -15,7 +15,6 @@ export function makeFetchTransport(options: BunTransportOptions): Transport {
     const requestOptions: RequestInit = {
       body: request.body,
       method: 'POST',
-      referrerPolicy: 'origin',
       headers: options.headers,
     };
 

--- a/packages/vercel-edge/src/transports/index.ts
+++ b/packages/vercel-edge/src/transports/index.ts
@@ -83,7 +83,6 @@ export function makeEdgeTransport(options: VercelEdgeTransportOptions): Transpor
     const requestOptions: RequestInit = {
       body: request.body,
       method: 'POST',
-      referrerPolicy: 'origin',
       headers: options.headers,
       ...options.fetchOptions,
     };

--- a/packages/vercel-edge/test/transports/index.test.ts
+++ b/packages/vercel-edge/test/transports/index.test.ts
@@ -57,7 +57,6 @@ describe('Edge Transport', () => {
     expect(mockFetch).toHaveBeenLastCalledWith(DEFAULT_EDGE_TRANSPORT_OPTIONS.url, {
       body: serializeEnvelope(ERROR_ENVELOPE, new TextEncoder()),
       method: 'POST',
-      referrerPolicy: 'origin',
     });
   });
 


### PR DESCRIPTION
I believe it is pointless (if not harmful) to set the `referrerPolicy` field on worker runtime fetch transports.

I think we have this because I copy & pasted it at one point from the browser fetch implemetation.

Fixes https://github.com/getsentry/sentry-javascript/issues/9194