### PR TITLE
revert: Expose `sampleTransaction` export from core

### DIFF
--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -19,4 +19,3 @@ export {
 } from './trace';
 export { getDynamicSamplingContextFromClient } from './dynamicSamplingContext';
 export { setMeasurement } from './measurement';
-export { sampleTransaction } from './sampling';


### PR DESCRIPTION
This was previously exported so we can use it in node-experimental, but turns out we can't do that anyhow because we need to sample in OTEL. This has not yet been released, so in order to avoid exporting stuff we don't need public let's revert this export. (I'll leave the actual restructuring of moving this into a dedicated file in, though, because I think it still makes sense that way).