### PR TITLE
fix(ember): Avoid pulling in utils at build time

### DIFF
--- a/packages/ember/index.js
+++ b/packages/ember/index.js
@@ -2,8 +2,6 @@
 const fs = require('fs');
 const crypto = require('crypto');
 
-const { dropUndefinedKeys } = require('@sentry/utils');
-
 function readSnippet(fileName) {
   return fs.readFileSync(`${__dirname}/vendor/${fileName}`, 'utf8');
 }
@@ -102,4 +100,16 @@ function isScalar(val) {
 
 function isPlainObject(obj) {
   return typeof obj === 'object' && obj.constructor === Object && obj.toString() === '[object Object]';
+}
+
+function dropUndefinedKeys(obj) {
+  const newObj = {};
+
+  for (const key in obj) {
+    if (obj[key] !== undefined) {
+      newObj[key] = obj[key];
+    }
+  }
+
+  return newObj;
 }


### PR DESCRIPTION
It seems some have an issue because of this, and maybe this is overkill anyhow. So I just inline a minimal version of this into the build file here instead, let's see if that fixes it.

Fixes https://github.com/getsentry/sentry-javascript/issues/9215