### PR TITLE
fix(node): Ensure mysql integration works without callback

### DIFF
--- a/packages/node-integration-tests/suites/tracing-new/auto-instrument/mysql/withoutCallback/test.ts
+++ b/packages/node-integration-tests/suites/tracing-new/auto-instrument/mysql/withoutCallback/test.ts
@@ -8,6 +8,10 @@ test('should auto-instrument `mysql` package when using query without callback',
 
   assertSentryTransaction(envelope[2], {
     transaction: 'Test Transaction',
+    tags: {
+      result_done: 'yes',
+      result_done2: 'yes',
+    },
     spans: [
       {
         description: 'SELECT 1 + 1 AS solution',


### PR DESCRIPTION
Turns out my "improvement" here actually broke streaming the query response 😬 as in that case you may not provide a callback.

This PR fixes this by using `query.on('end')` instead in that case to finish the span.

Fixes https://github.com/getsentry/sentry-javascript/issues/9207