### PR TITLE
build(node-experimental): Update fastify instrumentation & E2E test

### DIFF
--- a/packages/e2e-tests/test-applications/node-experimental-fastify-app/tests/transactions.test.ts
+++ b/packages/e2e-tests/test-applications/node-experimental-fastify-app/tests/transactions.test.ts
@@ -47,7 +47,7 @@ test('Sends an API route transaction', async ({ baseURL }) => {
             'http.route': '/test-transaction',
             'otel.kind': 'INTERNAL',
           },
-          description: 'request handler - anonymous',
+          description: 'request handler - fastify -> app-auto-0',
           parent_span_id: expect.any(String),
           span_id: expect.any(String),
           start_timestamp: expect.any(Number),

--- a/packages/node-experimental/package.json
+++ b/packages/node-experimental/package.json
@@ -28,7 +28,7 @@
     "@opentelemetry/context-async-hooks": "~1.17.0",
     "@opentelemetry/instrumentation": "~0.43.0",
     "@opentelemetry/instrumentation-express": "~0.33.1",
-    "@opentelemetry/instrumentation-fastify": "~0.32.2",
+    "@opentelemetry/instrumentation-fastify": "~0.32.3",
     "@opentelemetry/instrumentation-graphql": "~0.35.1",
     "@opentelemetry/instrumentation-http": "~0.43.0",
     "@opentelemetry/instrumentation-mongodb": "~0.37.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4367,13 +4367,13 @@
     "@opentelemetry/semantic-conventions" "^1.0.0"
     "@types/express" "4.17.17"
 
-"@opentelemetry/instrumentation-fastify@~0.32.2":
-  version "0.32.2"
-  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.32.2.tgz#4af882938d3c05f7c7f5f860095e568728a2d838"
-  integrity sha512-DKa7SgxTtZ0O1ngGtAdwr/g8XguYw6KvLNME+J8rt6QpWQM+xytS0bg4atZAyt6aeYr/kO1sMrGXSlHEEYWIhg==
+"@opentelemetry/instrumentation-fastify@~0.32.3":
+  version "0.32.3"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.32.3.tgz#2c0640c986018d1a41dfff3d9c3bfe3b5b1cf62d"
+  integrity sha512-vRFVoEJXcu6nNpJ61H5syDb84PirOd4b3u8yl8Bcorrr6firGYBQH4pEIVB4PkQWlmi3sLOifqS3VAO2VRloEQ==
   dependencies:
     "@opentelemetry/core" "^1.8.0"
-    "@opentelemetry/instrumentation" "^0.41.2"
+    "@opentelemetry/instrumentation" "^0.44.0"
     "@opentelemetry/semantic-conventions" "^1.0.0"
 
 "@opentelemetry/instrumentation-graphql@~0.35.1":
@@ -4464,6 +4464,17 @@
   version "0.43.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.43.0.tgz#749521415df03396f969bf42341fcb4acd2e9c7b"
   integrity sha512-S1uHE+sxaepgp+t8lvIDuRgyjJWisAb733198kwQTUc9ZtYQ2V2gmyCtR1x21ePGVLoMiX/NWY7WA290hwkjJQ==
+  dependencies:
+    "@types/shimmer" "^1.0.2"
+    import-in-the-middle "1.4.2"
+    require-in-the-middle "^7.1.1"
+    semver "^7.5.2"
+    shimmer "^1.2.1"
+
+"@opentelemetry/instrumentation@^0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.44.0.tgz#194f16fc96671575b6bd73d3fadffb5aa4497e67"
+  integrity sha512-B6OxJTRRCceAhhnPDBshyQO7K07/ltX3quOLu0icEvPK9QZ7r9P1y0RQX8O5DxB4vTv4URRkxkg+aFU/plNtQw==
   dependencies:
     "@types/shimmer" "^1.0.2"
     import-in-the-middle "1.4.2"


### PR DESCRIPTION
E2E tests started failing for fastify because of 0.32.3 (https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-fastify/CHANGELOG.md) being released. This includes this change https://github.com/open-telemetry/opentelemetry-js-contrib/pull/1680 (which actually we wrote xD) that changes some span names, which lead to E2E test failing.