### PR TITLE
feat(node-experimental): Add NodeFetch integration

### DIFF
--- a/packages/e2e-tests/test-applications/node-experimental-fastify-app/src/app.js
+++ b/packages/e2e-tests/test-applications/node-experimental-fastify-app/src/app.js
@@ -38,6 +38,13 @@ app.get('/test-outgoing-http', async function (req, res) {
   res.send(data);
 });
 
+app.get('/test-outgoing-fetch', async function (req, res) {
+  const response = await fetch('http://localhost:3030/test-inbound-headers');
+  const data = await response.json();
+
+  res.send(data);
+});
+
 app.get('/test-transaction', async function (req, res) {
   Sentry.startSpan({ name: 'test-span' }, () => {
     Sentry.startSpan({ name: 'child-span' }, () => {});

--- a/packages/e2e-tests/test-applications/node-experimental-fastify-app/tests/propagation.test.ts
+++ b/packages/e2e-tests/test-applications/node-experimental-fastify-app/tests/propagation.test.ts
@@ -98,3 +98,94 @@ test('Propagates trace for outgoing http requests', async ({ baseURL }) => {
     }),
   );
 });
+
+test('Propagates trace for outgoing fetch requests', async ({ baseURL }) => {
+  const inboundTransactionPromise = waitForTransaction('node-experimental-fastify-app', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      transactionEvent?.transaction === 'GET /test-inbound-headers'
+    );
+  });
+
+  const outboundTransactionPromise = waitForTransaction('node-experimental-fastify-app', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'http.server' &&
+      transactionEvent?.transaction === 'GET /test-outgoing-fetch'
+    );
+  });
+
+  const { data } = await axios.get(`${baseURL}/test-outgoing-fetch`);
+
+  const inboundTransaction = await inboundTransactionPromise;
+  const outboundTransaction = await outboundTransactionPromise;
+
+  const traceId = outboundTransaction?.contexts?.trace?.trace_id;
+  const outgoingHttpSpan = outboundTransaction?.spans?.find(span => span.op === 'http.client') as
+    | ReturnType<Span['toJSON']>
+    | undefined;
+
+  expect(outgoingHttpSpan).toBeDefined();
+
+  const outgoingHttpSpanId = outgoingHttpSpan?.span_id;
+
+  expect(traceId).toEqual(expect.any(String));
+
+  // data is passed through from the inbound request, to verify we have the correct headers set
+  const inboundHeaderSentryTrace = data.headers?.['sentry-trace'];
+  const inboundHeaderBaggage = data.headers?.['baggage'];
+
+  expect(inboundHeaderSentryTrace).toEqual(`${traceId}-${outgoingHttpSpanId}-1`);
+  expect(inboundHeaderBaggage).toBeDefined();
+
+  const baggage = (inboundHeaderBaggage || '').split(',');
+  expect(baggage).toEqual(
+    expect.arrayContaining([
+      'sentry-environment=qa',
+      `sentry-trace_id=${traceId}`,
+      expect.stringMatching(/sentry-public_key=/),
+    ]),
+  );
+
+  expect(outboundTransaction).toEqual(
+    expect.objectContaining({
+      contexts: expect.objectContaining({
+        trace: {
+          data: {
+            url: 'http://localhost:3030/test-outgoing-fetch',
+            'otel.kind': 'SERVER',
+            'http.response.status_code': 200,
+          },
+          op: 'http.server',
+          span_id: expect.any(String),
+          status: 'ok',
+          tags: {
+            'http.status_code': 200,
+          },
+          trace_id: traceId,
+        },
+      }),
+    }),
+  );
+
+  expect(inboundTransaction).toEqual(
+    expect.objectContaining({
+      contexts: expect.objectContaining({
+        trace: {
+          data: {
+            url: 'http://localhost:3030/test-inbound-headers',
+            'otel.kind': 'SERVER',
+            'http.response.status_code': 200,
+          },
+          op: 'http.server',
+          parent_span_id: outgoingHttpSpanId,
+          span_id: expect.any(String),
+          status: 'ok',
+          tags: {
+            'http.status_code': 200,
+          },
+          trace_id: traceId,
+        },
+      }),
+    }),
+  );
+});

--- a/packages/node-experimental/package.json
+++ b/packages/node-experimental/package.json
@@ -45,7 +45,8 @@
     "@sentry/node": "7.73.0",
     "@sentry/opentelemetry-node": "7.73.0",
     "@sentry/types": "7.73.0",
-    "@sentry/utils": "7.73.0"
+    "@sentry/utils": "7.73.0",
+    "opentelemetry-instrumentation-fetch-node": "1.1.0"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",

--- a/packages/node-experimental/src/integrations/index.ts
+++ b/packages/node-experimental/src/integrations/index.ts
@@ -26,6 +26,7 @@ export {
 
 export { Express } from './express';
 export { Http } from './http';
+export { NodeFetch } from './node-fetch';
 export { Fastify } from './fastify';
 export { GraphQL } from './graphql';
 export { Mongo } from './mongo';

--- a/packages/node-experimental/src/integrations/node-fetch.ts
+++ b/packages/node-experimental/src/integrations/node-fetch.ts
@@ -1,0 +1,123 @@
+import type { Span } from '@opentelemetry/api';
+import { SpanKind } from '@opentelemetry/api';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { hasTracingEnabled } from '@sentry/core';
+import type { EventProcessor, Hub, Integration } from '@sentry/types';
+import { FetchInstrumentation } from 'opentelemetry-instrumentation-fetch-node';
+
+import { OTEL_ATTR_ORIGIN } from '../constants';
+import type { NodeExperimentalClient } from '../sdk/client';
+import { getCurrentHub } from '../sdk/hub';
+import { getRequestSpanData } from '../utils/getRequestSpanData';
+import { getSpanKind } from '../utils/getSpanKind';
+
+interface NodeFetchOptions {
+  /**
+   * Whether breadcrumbs should be recorded for requests
+   * Defaults to true
+   */
+  breadcrumbs?: boolean;
+
+  /**
+   * Whether tracing spans should be created for requests
+   * Defaults to false
+   */
+  spans?: boolean;
+}
+
+/**
+ * Fetch instrumentation based on opentelemetry-instrumentation-fetch.
+ * This instrumentation does two things:
+ * * Create breadcrumbs for outgoing requests
+ * * Create spans for outgoing requests
+ */
+export class NodeFetch implements Integration {
+  /**
+   * @inheritDoc
+   */
+  public static id: string = 'NodeFetch';
+
+  /**
+   * @inheritDoc
+   */
+  public name: string;
+
+  /**
+   * If spans for HTTP requests should be captured.
+   */
+  public shouldCreateSpansForRequests: boolean;
+
+  private _unload?: () => void;
+  private readonly _breadcrumbs: boolean;
+  // If this is undefined, use default behavior based on client settings
+  private readonly _spans: boolean | undefined;
+
+  /**
+   * @inheritDoc
+   */
+  public constructor(options: NodeFetchOptions = {}) {
+    this.name = NodeFetch.id;
+    this._breadcrumbs = typeof options.breadcrumbs === 'undefined' ? true : options.breadcrumbs;
+    this._spans = typeof options.spans === 'undefined' ? undefined : options.spans;
+
+    // Properly set in setupOnce based on client settings
+    this.shouldCreateSpansForRequests = false;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public setupOnce(_addGlobalEventProcessor: (callback: EventProcessor) => void, _getCurrentHub: () => Hub): void {
+    // No need to instrument if we don't want to track anything
+    if (!this._breadcrumbs && this._spans === false) {
+      return;
+    }
+
+    const client = getCurrentHub().getClient<NodeExperimentalClient>();
+    const clientOptions = client?.getOptions();
+
+    // This is used in the sampler function
+    this.shouldCreateSpansForRequests =
+      typeof this._spans === 'boolean' ? this._spans : hasTracingEnabled(clientOptions);
+
+    // Register instrumentations we care about
+    this._unload = registerInstrumentations({
+      instrumentations: [
+        new FetchInstrumentation({
+          onRequest: ({ span }: { span: Span }) => {
+            this._updateSpan(span);
+            this._addRequestBreadcrumb(span);
+          },
+        }),
+      ],
+    });
+  }
+
+  /**
+   *  Unregister this integration.
+   */
+  public unregister(): void {
+    this._unload?.();
+  }
+
+  /** Update the span with data we need. */
+  private _updateSpan(span: Span): void {
+    span.setAttribute(OTEL_ATTR_ORIGIN, 'auto.http.otel.node_fetch');
+  }
+
+  /** Add a breadcrumb for outgoing requests. */
+  private _addRequestBreadcrumb(span: Span): void {
+    if (!this._breadcrumbs || getSpanKind(span) !== SpanKind.CLIENT) {
+      return;
+    }
+
+    const data = getRequestSpanData(span);
+    getCurrentHub().addBreadcrumb({
+      category: 'http',
+      data: {
+        ...data,
+      },
+      type: 'http',
+    });
+  }
+}

--- a/packages/node-experimental/src/sdk/init.ts
+++ b/packages/node-experimental/src/sdk/init.ts
@@ -1,20 +1,29 @@
 import { hasTracingEnabled } from '@sentry/core';
 import { defaultIntegrations as defaultNodeIntegrations, init as initNode } from '@sentry/node';
+import type { Integration } from '@sentry/types';
+import { parseSemver } from '@sentry/utils';
 
 import { getAutoPerformanceIntegrations } from '../integrations/getAutoPerformanceIntegrations';
 import { Http } from '../integrations/http';
+import { NodeFetch } from '../integrations/node-fetch';
 import type { NodeExperimentalOptions } from '../types';
 import { NodeExperimentalClient } from './client';
 import { getCurrentHub } from './hub';
 import { initOtel } from './initOtel';
 import { setOtelContextAsyncContextStrategy } from './otelAsyncContextStrategy';
 
+const NODE_VERSION: ReturnType<typeof parseSemver> = parseSemver(process.versions.node);
 const ignoredDefaultIntegrations = ['Http', 'Undici'];
 
-export const defaultIntegrations = [
+export const defaultIntegrations: Integration[] = [
   ...defaultNodeIntegrations.filter(i => !ignoredDefaultIntegrations.includes(i.name)),
   new Http(),
 ];
+
+// Only add NodeFetch if Node >= 16, as previous versions do not support it
+if (NODE_VERSION.major && NODE_VERSION.major >= 16) {
+  defaultIntegrations.push(new NodeFetch());
+}
 
 /**
  * Initialize Sentry for Node.

--- a/packages/tracing-internal/test/browser/backgroundtab.test.ts
+++ b/packages/tracing-internal/test/browser/backgroundtab.test.ts
@@ -33,7 +33,7 @@ conditionalTest({ min: 10 })('registerBackgroundTabDetection', () => {
     hub.configureScope(scope => scope.setSpan(undefined));
   });
 
-  it('does not creates an event listener if global document is undefined', () => {
+  it('does not create an event listener if global document is undefined', () => {
     // @ts-expect-error need to override global document
     global.document = undefined;
     registerBackgroundTabDetection();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4460,7 +4460,7 @@
     semver "^7.5.1"
     shimmer "^1.2.1"
 
-"@opentelemetry/instrumentation@0.43.0", "@opentelemetry/instrumentation@~0.43.0":
+"@opentelemetry/instrumentation@0.43.0", "@opentelemetry/instrumentation@^0.43.0", "@opentelemetry/instrumentation@~0.43.0":
   version "0.43.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/instrumentation/-/instrumentation-0.43.0.tgz#749521415df03396f969bf42341fcb4acd2e9c7b"
   integrity sha512-S1uHE+sxaepgp+t8lvIDuRgyjJWisAb733198kwQTUc9ZtYQ2V2gmyCtR1x21ePGVLoMiX/NWY7WA290hwkjJQ==
@@ -22702,6 +22702,15 @@ opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
+
+opentelemetry-instrumentation-fetch-node@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/opentelemetry-instrumentation-fetch-node/-/opentelemetry-instrumentation-fetch-node-1.1.0.tgz#f51d79862390f3a694fa91c35c4383e037a04c11"
+  integrity sha512-mSEpyRfwv6t1L+VvqTw5rCzNr3bVTsGE4/dcZruhFWivXFKl8pqm6W0LWPxHrEvwufw1eK9VmUgalfY0jjMl8Q==
+  dependencies:
+    "@opentelemetry/api" "^1.6.0"
+    "@opentelemetry/instrumentation" "^0.43.0"
+    "@opentelemetry/semantic-conventions" "^1.17.0"
 
 opn@^5.5.0:
   version "5.5.0"


### PR DESCRIPTION
This adds a new `NodeFetch` integration that is enabled by default.

We use [opentelemetry-instrumentation-node-fetch](https://github.com/gas-buddy/opentelemetry-instrumentation-fetch-node) under the hood, which seems to have the best support/functionality.

I also added an E2E test verifying it actually works and also propagates correctly.