### PR TITLE
feat(tracing): allow direct pg module to enable esbuild support

### DIFF
--- a/packages/tracing-internal/src/node/integrations/postgres.ts
+++ b/packages/tracing-internal/src/node/integrations/postgres.ts
@@ -29,6 +29,15 @@ interface PgOptions {
   /**
    * Supply your postgres module directly, instead of having Sentry attempt automatic resolution.
    * Use this if you (a) use a module that's not `pg`, or (b) use a bundler that breaks resolution (e.g. esbuild).
+   *
+   * Usage:
+   * ```
+   * import pg from 'pg';
+   *
+   * Sentry.init({
+   *   integrations: [new Sentry.Integrations.Postgres({ module: pg })],
+   * });
+   * ```
    */
   module?: PGModule;
 }

--- a/packages/tracing/test/integrations/node/postgres.test.ts
+++ b/packages/tracing/test/integrations/node/postgres.test.ts
@@ -148,6 +148,6 @@ describe('setupOnce', () => {
   });
 
   it('has valid module type', () => {
-    new Integrations.Postgres({ module: pg });
+    expect(() => new Integrations.Postgres({ module: pg })).not.toThrow();
   });
 });


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

## Background
- auto database instrumentation fails out of the box with esbuild - see https://github.com/getsentry/sentry-javascript/issues/3293#issuecomment-1739061872

## Proposal
- Allow consumers to pass resolved module for instrumentation directly
- This mirrors [sequelize dialectModule](https://github.com/sequelize/sequelize/blob/b3f03aed681abe0d5e22a9628b083f59f6772305/packages/core/src/sequelize.js#L166)

## Alternatives
- If there's a way to configure esbuild similar to the webpack `commonjsMagicComments`, that should do the trick
- However the proposed solution in this PR seems more robust, especially as more bundlers/minifiers are gaining traction