### PR TITLE
fix(node): Remove ANR `debug` option and instead add logger.isEnabled()

### DIFF
--- a/packages/node-integration-tests/suites/anr/basic.js
+++ b/packages/node-integration-tests/suites/anr/basic.js
@@ -10,13 +10,14 @@ setTimeout(() => {
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
+  debug: true,
   beforeSend: event => {
     // eslint-disable-next-line no-console
     console.log(JSON.stringify(event));
   },
 });
 
-Sentry.enableAnrDetection({ captureStackTrace: true, anrThreshold: 200, debug: true }).then(() => {
+Sentry.enableAnrDetection({ captureStackTrace: true, anrThreshold: 200 }).then(() => {
   function longWork() {
     for (let i = 0; i < 100; i++) {
       const salt = crypto.randomBytes(128).toString('base64');

--- a/packages/node-integration-tests/suites/anr/basic.mjs
+++ b/packages/node-integration-tests/suites/anr/basic.mjs
@@ -10,13 +10,14 @@ setTimeout(() => {
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
+  debug: true,
   beforeSend: event => {
     // eslint-disable-next-line no-console
     console.log(JSON.stringify(event));
   },
 });
 
-await Sentry.enableAnrDetection({ captureStackTrace: true, anrThreshold: 200, debug: true });
+await Sentry.enableAnrDetection({ captureStackTrace: true, anrThreshold: 200 });
 
 function longWork() {
   for (let i = 0; i < 100; i++) {

--- a/packages/node-integration-tests/suites/anr/forked.js
+++ b/packages/node-integration-tests/suites/anr/forked.js
@@ -10,13 +10,14 @@ setTimeout(() => {
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
+  debug: true,
   beforeSend: event => {
     // eslint-disable-next-line no-console
     console.log(JSON.stringify(event));
   },
 });
 
-Sentry.enableAnrDetection({ captureStackTrace: true, anrThreshold: 200, debug: true }).then(() => {
+Sentry.enableAnrDetection({ captureStackTrace: true, anrThreshold: 200 }).then(() => {
   function longWork() {
     for (let i = 0; i < 100; i++) {
       const salt = crypto.randomBytes(128).toString('base64');

--- a/packages/node-integration-tests/suites/anr/test.ts
+++ b/packages/node-integration-tests/suites/anr/test.ts
@@ -5,6 +5,22 @@ import * as path from 'path';
 
 const NODE_VERSION = parseSemver(process.versions.node).major || 0;
 
+/** The output will contain logging so we need to find the line that parses as JSON */
+function parseJsonLine<T>(input: string): T {
+  return (
+    input
+      .split('\n')
+      .map(line => {
+        try {
+          return JSON.parse(line) as T;
+        } catch {
+          return undefined;
+        }
+      })
+      .filter(a => a) as T[]
+  )[0];
+}
+
 describe('should report ANR when event loop blocked', () => {
   test('CJS', done => {
     // The stack trace is different when node < 12
@@ -15,7 +31,7 @@ describe('should report ANR when event loop blocked', () => {
     const testScriptPath = path.resolve(__dirname, 'basic.js');
 
     childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (_, stdout) => {
-      const event = JSON.parse(stdout) as Event;
+      const event = parseJsonLine<Event>(stdout);
 
       expect(event.exception?.values?.[0].mechanism).toEqual({ type: 'ANR' });
       expect(event.exception?.values?.[0].type).toEqual('ApplicationNotResponding');
@@ -42,7 +58,7 @@ describe('should report ANR when event loop blocked', () => {
     const testScriptPath = path.resolve(__dirname, 'basic.mjs');
 
     childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (_, stdout) => {
-      const event = JSON.parse(stdout) as Event;
+      const event = parseJsonLine<Event>(stdout);
 
       expect(event.exception?.values?.[0].mechanism).toEqual({ type: 'ANR' });
       expect(event.exception?.values?.[0].type).toEqual('ApplicationNotResponding');
@@ -64,7 +80,7 @@ describe('should report ANR when event loop blocked', () => {
     const testScriptPath = path.resolve(__dirname, 'forker.js');
 
     childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (_, stdout) => {
-      const event = JSON.parse(stdout) as Event;
+      const event = parseJsonLine<Event>(stdout);
 
       expect(event.exception?.values?.[0].mechanism).toEqual({ type: 'ANR' });
       expect(event.exception?.values?.[0].type).toEqual('ApplicationNotResponding');

--- a/packages/node/src/anr/index.ts
+++ b/packages/node/src/anr/index.ts
@@ -36,7 +36,7 @@ interface Options {
    */
   captureStackTrace: boolean;
   /**
-   * Log debug information.
+   * @deprecated Use 'init' debug option instead
    */
   debug: boolean;
 }
@@ -94,9 +94,7 @@ function startInspector(startPort: number = 9229): string | undefined {
 
 function startChildProcess(options: Options): void {
   function log(message: string, ...args: unknown[]): void {
-    if (options.debug) {
-      logger.log(`[ANR] ${message}`, ...args);
-    }
+    logger.log(`[ANR] ${message}`, ...args);
   }
 
   try {
@@ -111,7 +109,7 @@ function startChildProcess(options: Options): void {
 
     const child = spawn(process.execPath, [options.entryScript], {
       env,
-      stdio: options.debug ? ['inherit', 'inherit', 'inherit', 'ipc'] : ['ignore', 'ignore', 'ignore', 'ipc'],
+      stdio: logger.isEnabled() ? ['inherit', 'inherit', 'inherit', 'ipc'] : ['ignore', 'ignore', 'ignore', 'ipc'],
     });
     // The child process should not keep the main process alive
     child.unref();
@@ -142,9 +140,7 @@ function startChildProcess(options: Options): void {
 
 function handleChildProcess(options: Options): void {
   function log(message: string): void {
-    if (options.debug) {
-      logger.log(`[ANR child process] ${message}`);
-    }
+    logger.log(`[ANR child process] ${message}`);
   }
 
   process.title = 'sentry-anr';
@@ -233,6 +229,7 @@ export function enableAnrDetection(options: Partial<Options>): Promise<void> {
     pollInterval: options.pollInterval || DEFAULT_INTERVAL,
     anrThreshold: options.anrThreshold || DEFAULT_HANG_THRESHOLD,
     captureStackTrace: !!options.captureStackTrace,
+    // eslint-disable-next-line deprecation/deprecation
     debug: !!options.debug,
   };
 

--- a/packages/utils/src/logger.ts
+++ b/packages/utils/src/logger.ts
@@ -19,6 +19,7 @@ export const originalConsoleMethods: {
 interface Logger extends LoggerConsoleMethods {
   disable(): void;
   enable(): void;
+  isEnabled(): boolean;
 }
 
 /**
@@ -63,6 +64,7 @@ function makeLogger(): Logger {
     disable: () => {
       enabled = false;
     },
+    isEnabled: () => enabled,
   };
 
   if (__DEBUG_BUILD__) {


### PR DESCRIPTION
A separate `debug` option for `enableAnrDetection` is confusing and is not required if we add an `isEnabled()` function to the logger.
