### PR TITLE
fix(node): Strip .mjs and .cjs extensions from module name

### DIFF
--- a/packages/node/src/module.ts
+++ b/packages/node/src/module.ts
@@ -30,7 +30,7 @@ export function getModuleFromFilename(
   // It's specifically a module
   let file = basename;
 
-  if (ext === '.js' || ext === '.mjs') {
+  if (ext === '.js' || ext === '.mjs' || ext === '.cjs') {
     file = file.slice(0, ext.length * -1);
   }
 

--- a/packages/node/src/module.ts
+++ b/packages/node/src/module.ts
@@ -30,8 +30,8 @@ export function getModuleFromFilename(
   // It's specifically a module
   let file = basename;
 
-  if (ext === '.js') {
-    file = file.slice(0, file.length - '.js'.length);
+  if (ext === '.js' || ext === '.mjs') {
+    file = file.slice(0, ext.length * -1);
   }
 
   if (!root && !dir) {

--- a/packages/node/test/module.test.ts
+++ b/packages/node/test/module.test.ts
@@ -27,4 +27,16 @@ describe('getModuleFromFilename', () => {
       expect(getModuleFromFilename('/Users/users/Tim/Desktop/node_modules/module.js')).toEqual('module');
     }, '/Users/Tim/app.js');
   });
+
+  test('POSIX .mjs', () => {
+    withFilename(() => {
+      expect(getModuleFromFilename('/Users/users/Tim/Desktop/node_modules/module.mjs')).toEqual('module');
+    }, '/Users/Tim/app.js');
+  });
+
+  test('POSIX .cjs', () => {
+    withFilename(() => {
+      expect(getModuleFromFilename('/Users/users/Tim/Desktop/node_modules/module.cjs')).toEqual('module');
+    }, '/Users/Tim/app.js');
+  });
 });


### PR DESCRIPTION
We strip `.js` from the module name but not the newser `.mjs` or `.cjs` extensions.
