### PR TITLE
chore(astro): Add Astro package to Craft NPM targets

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -88,6 +88,9 @@ targets:
   - name: npm
     id: '@sentry/gatsby'
     includeNames: /^sentry-gatsby-\d.*\.tgz$/
+  - name: npm
+    id: '@sentry/astro'
+    includeNames: /^sentry-astro-\d.*\.tgz$/
 
   ## 7. Other Packages
   ## 7.1


### PR DESCRIPTION
This PR adds the `@sentry/astro` NPM publishing target so that we can publish the SDK with the next release.

ref #9182 