### PR TITLE
fix(replay): bump rrweb to 2.0.1

### DIFF
--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -52,8 +52,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@sentry-internal/replay-worker": "7.73.0",
-    "@sentry-internal/rrweb": "2.0.0",
-    "@sentry-internal/rrweb-snapshot": "2.0.0",
+    "@sentry-internal/rrweb": "2.0.1",
+    "@sentry-internal/rrweb-snapshot": "2.0.1",
     "jsdom-worker": "^0.2.1",
     "tslib": "^2.4.1 || ^1.9.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4977,33 +4977,33 @@
     semver "7.3.2"
     semver-intersect "1.4.0"
 
-"@sentry-internal/rrdom@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.0.0.tgz#326b5f26c76d2077874db7edffd5be3aa72848fb"
-  integrity sha512-PLSw54GWCmxOmJWJ2NGDfz9b+/76IBpGsWnIjBiW7L3NDVuTo705/7+DmKTrDADO7xXAZZRpbuQjqBjV8Mu+yQ==
+"@sentry-internal/rrdom@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.0.1.tgz#5d41892ff26462bb5e2412c2f2c646ef2dcfe0b5"
+  integrity sha512-uPQyq/ANoXSS5HpYkv9qupRSYh/tfbX4xBgM7XZDlApsnD3t6LxAqdAUP//zQO/z+kOHzJVUX5H5uiauqA96Yg==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.0.0"
+    "@sentry-internal/rrweb-snapshot" "2.0.1"
 
-"@sentry-internal/rrweb-snapshot@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.0.0.tgz#6d034f4f65736e990e279842cf1c2868fc9f47dd"
-  integrity sha512-MFpUw2Kuq4OVQn1dv6l/oSPgbHdy8N0oWBeVeHQlBzxugje4i2KU9tf6K7KH2RAce7Bi9r5UgHvCsNG3PNi/XQ==
+"@sentry-internal/rrweb-snapshot@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.0.1.tgz#5467041c33815d7c07ec0e484a85418d31857ddc"
+  integrity sha512-C4fIzcpreOzDXkyPOBwGir9YvLiT9jeTa2WQ96U1RVRiLBvXhEyPKgMxWXQcyYTpzYtGwX9dLfHR29uOejzzxQ==
 
-"@sentry-internal/rrweb-types@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.0.0.tgz#8606e47d98e14580f46f98d5dc5d95bc9ebc8b59"
-  integrity sha512-3dgoh4sbqgY8XwsKh6ofA8WRtUE+qWLHPDMzipp1XefKfEhr6qTtw0riurnJBrO5lD6dJuewK5BWwjcrFb3Gag==
+"@sentry-internal/rrweb-types@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.0.1.tgz#4f465715df2959cde486fe77fdda528d85a3c7f7"
+  integrity sha512-MQRdjsKm/kypHqumsWN+cmFhU0OWWoJSPNxOEG1efbUxZPvZL64tZSrgWimfisIId9TPDn0tr58sBhIgpqgNuw==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.0.0"
+    "@sentry-internal/rrweb-snapshot" "2.0.1"
 
-"@sentry-internal/rrweb@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.0.0.tgz#180e2763b77f83aa24bae964dd2f8c8065ddfc49"
-  integrity sha512-SOyIGjCi1q9ocMOHAAU6DhO2vecRkLk9/zQ6YbIJsUz1vB1ZoF0L1xDlwuL+fGw3HjZ6Wn8RoZWSSiQRokL7lg==
+"@sentry-internal/rrweb@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.0.1.tgz#fa3a60d1e01362ba2ce58583f87bfa076d77ee3b"
+  integrity sha512-X33eL2CioQn0vOgkFVgu9L8LV4D4H48LFz7cqAofnWC5h6n36zsf7eIBpdDJKZ8JCj1z52h9gL5X+X4W2i/yXQ==
   dependencies:
-    "@sentry-internal/rrdom" "2.0.0"
-    "@sentry-internal/rrweb-snapshot" "2.0.0"
-    "@sentry-internal/rrweb-types" "2.0.0"
+    "@sentry-internal/rrdom" "2.0.1"
+    "@sentry-internal/rrweb-snapshot" "2.0.1"
+    "@sentry-internal/rrweb-types" "2.0.1"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"


### PR DESCRIPTION
* Fix checking for patchTarget in initAdoptedStyleSheetObserver [#110](https://github.com/getsentry/rrweb/pull/110)

https://github.com/getsentry/rrweb/blob/sentry-v2/CHANGELOG.md#201