### PR TITLE
chore(repo): Add Astro package in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -30,6 +30,7 @@ body:
         If you're using the CDN bundles, please specify the exact bundle (e.g. `bundle.tracing.min.js`) in your SDK
         setup.
       options:
+        - '@sentry/astro'
         - '@sentry/browser'
         - '@sentry/angular'
         - '@sentry/angular-ivy'

--- a/.github/workflows/issue-package-label.yml
+++ b/.github/workflows/issue-package-label.yml
@@ -29,6 +29,9 @@ jobs:
           # Note: Since this is handled as a regex, and JSON parse wrangles slashes /, we just use `.` instead
           map: |
             {
+              "@sentry.astro": {
+                "label": "Package: Astro"
+              },
               "@sentry.browser": {
                 "label": "Package: Browser"
               },


### PR DESCRIPTION
This PR adds @sentry/astro as a selectable option in the bug report template and adjusts the automatic package label assignment action along with it. 

ref #9182 
