### PR TITLE
fix(utils): Support crypto.getRandomValues in old Chromium versions

### DIFF
--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -33,11 +33,11 @@ export function uuid4(): string {
     if (crypto && crypto.getRandomValues) {
       getRandomByte = () => {
         // crypto.getRandomValues might return undefined instead of the typed array
-        // in old Chromium versions (e.g. 23.0.1235.0 (151422)) 
+        // in old Chromium versions (e.g. 23.0.1235.0 (151422))
         const typedArray = new Uint8Array(1);
         crypto.getRandomValues(typedArray);
         return typedArray[0];
-      }
+      };
     }
   } catch (_) {
     // some runtimes can crash invoking crypto

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -34,6 +34,8 @@ export function uuid4(): string {
       getRandomByte = () => {
         // crypto.getRandomValues might return undefined instead of the typed array
         // in old Chromium versions (e.g. 23.0.1235.0 (151422))
+        // However, `typedArray` is still filled in-place.
+        // @see https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues#typedarray
         const typedArray = new Uint8Array(1);
         crypto.getRandomValues(typedArray);
         return typedArray[0];

--- a/packages/utils/src/misc.ts
+++ b/packages/utils/src/misc.ts
@@ -31,7 +31,13 @@ export function uuid4(): string {
       return crypto.randomUUID().replace(/-/g, '');
     }
     if (crypto && crypto.getRandomValues) {
-      getRandomByte = () => crypto.getRandomValues(new Uint8Array(1))[0];
+      getRandomByte = () => {
+        // crypto.getRandomValues might return undefined instead of the typed array
+        // in old Chromium versions (e.g. 23.0.1235.0 (151422)) 
+        const typedArray = new Uint8Array(1);
+        crypto.getRandomValues(typedArray);
+        return typedArray[0];
+      }
     }
   } catch (_) {
     // some runtimes can crash invoking crypto

--- a/packages/utils/test/misc.test.ts
+++ b/packages/utils/test/misc.test.ts
@@ -351,7 +351,9 @@ describe('uuid4 generation', () => {
     const cryptoMod = require('crypto');
 
     const getRandomValues = (typedArray: Uint8Array) => {
-      cryptoMod.getRandomValues(typedArray);
+      if (cryptoMod.getRandomValues) {
+        cryptoMod.getRandomValues(typedArray);
+      }
     };
 
     (global as any).crypto = { getRandomValues };

--- a/packages/utils/test/misc.test.ts
+++ b/packages/utils/test/misc.test.ts
@@ -343,6 +343,23 @@ describe('uuid4 generation', () => {
       expect(uuid4()).toMatch(uuid4Regex);
     }
   });
+
+  // Corner case related to crypto.getRandomValues being only
+  // semi-implemented (e.g. Chromium 23.0.1235.0 (151422))
+  it('returns valid uuid v4 even if crypto.getRandomValues does not return a typed array', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const cryptoMod = require('crypto');
+
+    const getRandomValues = (typedArray: Uint8Array) => {
+      cryptoMod.getRandomValues(typedArray);
+    };
+
+    (global as any).crypto = { getRandomValues };
+
+    for (let index = 0; index < 1_000; index++) {
+      expect(uuid4()).toMatch(uuid4Regex);
+    }
+  });
 });
 
 describe('arrayify()', () => {


### PR DESCRIPTION
- [X] If you've added code that should be tested, please add tests.
- [X] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Fixes https://github.com/getsentry/sentry-javascript/issues/9250

Here is my proposal to fix `getRandomByte` function throwing an error due to `crypto.getRandomValues` returning `undefined` in old browser engines like Chromium 23.

This error could be fixed as well by using a polyfill in every project that imports and uses Sentry but, since the change of this PR only involved keeping the `Uint8Array` reference in a variable, I thought it would be worth it to give it a try.
