### PR TITLE
fix(core): Narrow filters for health check transactions

### DIFF
--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -6,11 +6,11 @@ import { getEventDescription, logger, stringMatchesSomePattern } from '@sentry/u
 const DEFAULT_IGNORE_ERRORS = [/^Script error\.?$/, /^Javascript error: Script error\.? on line 0$/];
 
 const DEFAULT_IGNORE_TRANSACTIONS = [
-  /^.*healthcheck.*$/,
-  /^.*healthy.*$/,
-  /^.*live.*$/,
-  /^.*ready.*$/,
-  /^.*heartbeat.*$/,
+  /^.*\/healthcheck$/,
+  /^.*\/healthy$/,
+  /^.*\/live$/,
+  /^.*\/ready$/,
+  /^.*\/heartbeat$/,
   /^.*\/health$/,
   /^.*\/healthz$/,
 ];

--- a/packages/core/test/lib/integrations/inboundfilters.test.ts
+++ b/packages/core/test/lib/integrations/inboundfilters.test.ts
@@ -230,6 +230,11 @@ const TRANSACTION_EVENT_HEALTH_3: Event = {
   type: 'transaction',
 };
 
+const TRANSACTION_EVENT_NO_HEALTH_CHECK: Event = {
+  transaction: 'GET /delivery',
+  type: 'transaction',
+};
+
 describe('InboundFilters', () => {
   describe('_isSentryError', () => {
     it('should work as expected', () => {
@@ -428,6 +433,18 @@ describe('InboundFilters', () => {
       expect(eventProcessor(TRANSACTION_EVENT_HEALTH_2, {})).toBe(TRANSACTION_EVENT_HEALTH_2);
       expect(eventProcessor(TRANSACTION_EVENT_HEALTH_3, {})).toBe(TRANSACTION_EVENT_HEALTH_3);
     });
+
+    it.each(['/delivery', '/already', '/healthysnacks'])(
+      "doesn't filter out transactions that have similar names to health check ones (%s)",
+      transaction => {
+        const eventProcessor = createInboundFiltersEventProcessor();
+        const evt: Event = {
+          transaction,
+          type: 'transaction',
+        };
+        expect(eventProcessor(evt, {})).toBe(evt);
+      },
+    );
   });
 
   describe('denyUrls/allowUrls', () => {

--- a/packages/core/test/lib/integrations/inboundfilters.test.ts
+++ b/packages/core/test/lib/integrations/inboundfilters.test.ts
@@ -230,11 +230,6 @@ const TRANSACTION_EVENT_HEALTH_3: Event = {
   type: 'transaction',
 };
 
-const TRANSACTION_EVENT_NO_HEALTH_CHECK: Event = {
-  transaction: 'GET /delivery',
-  type: 'transaction',
-};
-
 describe('InboundFilters', () => {
   describe('_isSentryError', () => {
     it('should work as expected', () => {


### PR DESCRIPTION
As reported [internally via Slack](https://sentry.slack.com/archives/C28MX5WAJ/p1697448093989649), our filters for health check transactions (which we unfortunately added to the SDK a while ago) were partially far too broad, filtering out transactions like `/delivery` because they matched the `/^.*live.*$/` regex. This PR narrows down the regexes so that they no longer only require a partial but a full match. 

I'd still rather nuke the entire filters array, given that we [filter on the backend](https://docs.sentry.io/product/data-management-settings/filtering/#transactions-coming-from-healthcheck) anyway, but there's a point to be made that the filters in the SDK avoid unnecessary traffic to Relay. 

ref https://github.com/getsentry/team-webplatform-meta/issues/70
