### PR TITLE
fix(nextjs): Fix resolution of request async storage module

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -34,11 +34,13 @@
     "@sentry/vercel-edge": "7.74.0",
     "@sentry/webpack-plugin": "1.20.0",
     "chalk": "3.0.0",
+    "resolve": "1.22.8",
     "rollup": "2.78.0",
     "stacktrace-parser": "^0.1.10",
     "tslib": "^2.4.1 || ^1.9.3"
   },
   "devDependencies": {
+    "@types/resolve": "1.20.3",
     "@types/webpack": "^4.41.31",
     "eslint-plugin-react": "^7.31.11",
     "next": "10.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6206,7 +6206,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/resolve@^1.17.0":
+"@types/resolve@1.20.3", "@types/resolve@^1.17.0":
   version "1.20.3"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.3.tgz#066742d69a0bbba8c5d7d517f82e1140ddeb3c3c"
   integrity sha512-NH5oErHOtHZYcjCtg69t26aXEk4BN2zLWqf7wnDZ+dpe0iR7Rds1SPGEItl3fca21oOe0n3OCnZ4W7jBxu7FOw==
@@ -26363,6 +26363,15 @@ resolve@1.20.0:
   dependencies:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
+
+resolve@1.22.8:
+  version "1.22.8"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
+  integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
+  dependencies:
+    is-core-module "^2.13.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.22.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.8.1:
   version "1.22.1"


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/9120
Adresses https://github.com/getsentry/sentry-javascript/issues/9092#issuecomment-1754003176

Previously we failed to properly locate Next.js' `request-async-storage` module in monorepo setups because we were limiting our search to a subset of paths in `webpackConfig.resolve.modules`.

Example:
- `webpackConfig.resolve.modules` contained `["<absolute_path_to_monorepo>/packages/<project_with_next_js>/node_modules", "<absolute_path_to_monorepo>/packages/<project_with_next_js>"]`
- `request-async-storage` is located at `/<absolute_path_to_monorepo>/node_modules/next/dist/client/components/request-async-storage.external.js`
- Since since `request-async-storage` was not in `webpackConfig.resolve.modules` or any subpaths, we marked it as not resolved.

New solution: We look upwards from the webpack resolvable paths in the folder tree using the default node resolving algorithm to look for the nearest `next` installation. Once found, we try to look for the the `request-async-storage` modules inside that installation. 

#### Additional considerations

I don't know whether it is enough to check the webpack resolvable locations. Even worse, I don't know whether looking upwards from the webpack resolvable locations is problematic because it might not resemble what webpack is doing.

#### Adding a dependency

We are using the `resolve` package because it let's us look upwards from a certain location without using stuff like `require.resolve` which might trip up webpack.

