### PR TITLE
build(deno): Treeshake deno package

### DIFF
--- a/packages/deno/rollup.config.js
+++ b/packages/deno/rollup.config.js
@@ -1,9 +1,12 @@
+// @ts-check
 import nodeResolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import sucrase from '@rollup/plugin-sucrase';
+import { defineConfig } from 'rollup';
 
-export default {
+export default defineConfig({
   input: ['src/index.ts'],
+  treeshake: 'smallest',
   output: {
     dir: 'build',
     sourcemap: true,
@@ -21,4 +24,4 @@ export default {
     commonjs(),
     sucrase({ transforms: ['typescript'] }),
   ],
-};
+});


### PR DESCRIPTION
I noticed the deno build output contained some odd pieces of code (the vendored session replay compression) so I figured we are not properly tree shaking.

This PR increases level of tree-shaking we do which will decrease the bundle size to the bare minimum.