### PR TITLE
chore(astro): Add `astro-integration` keyword

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -7,6 +7,7 @@
   "keywords": [
     "withastro",
     "astro-component",
+    "astro-integration",
     "sentry",
     "apm"
   ],


### PR DESCRIPTION
Turns out, to make our Astro package show up in Astro's integration library, we need to add another keyword that's only [mentioned here](https://docs.astro.build/en/reference/integrations-reference/#allow-installation-with-astro-add) and not in Astro's [NPM publishing guide](https://docs.astro.build/en/reference/publish-to-npm/#keywords).

With this keyword added (and once we cut the next release), our SDK should show up in the library 🤞 

(I'd like to get this out relatively soonish so that we can write docs that actually use `npx astro add` as opposed to installing the package manually).

ref #9093 