### PR TITLE
test(node): Ensure local variables are included for caught exceptions by default

### DIFF
--- a/packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.js
+++ b/packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.js
@@ -4,7 +4,6 @@ const Sentry = require('@sentry/node');
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
-  integrations: [new Sentry.Integrations.LocalVariables({ captureAllExceptions: true })],
   beforeSend: event => {
     // eslint-disable-next-line no-console
     console.log(JSON.stringify(event));

--- a/packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.mjs
+++ b/packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-caught.mjs
@@ -4,7 +4,6 @@ import * as Sentry from '@sentry/node';
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   includeLocalVariables: true,
-  integrations: [new Sentry.Integrations.LocalVariables({ captureAllExceptions: true })],
   beforeSend: event => {
     // eslint-disable-next-line no-console
     console.log(JSON.stringify(event));


### PR DESCRIPTION
We recently updated the `LocalVariables` integration to capture variables for all exceptions by default so these tests should not need to modify the integration default options for these tests to pass.