### PR TITLE
fix(nextjs): Fix HMR by inserting new entrypoints at the end

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -587,7 +587,7 @@ function addFilesToExistingEntryPoint(
   let newEntryPoint = currentEntryPoint;
 
   if (typeof currentEntryPoint === 'string' || Array.isArray(currentEntryPoint)) {
-    const newEntryPoint = arrayify(currentEntryPoint);
+    newEntryPoint = arrayify(currentEntryPoint);
 
     if (isDevMode) {
       // Inserting at beginning breaks dev mode so we insert at the end

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -570,21 +570,23 @@ export function getUserConfigFilePath(projectDir: string, platform: 'server' | '
  *
  * @param entryProperty The existing `entry` config object
  * @param entryPointName The key where the file should be injected
- * @param filepaths An array of paths to the injected files
+ * @param filesToInsert An array of paths to the injected files
  */
 function addFilesToExistingEntryPoint(
   entryProperty: EntryPropertyObject,
   entryPointName: string,
-  filepaths: string[],
+  filesToInsert: string[],
 ): void {
+  // BIG FAT NOTE: Order of insertion seems to matter here. If we insert the new files before the `currentEntrypoint`s, the Next.js dev server breaks.
+
   // can be a string, array of strings, or object whose `import` property is one of those two
   const currentEntryPoint = entryProperty[entryPointName];
   let newEntryPoint = currentEntryPoint;
 
   if (typeof currentEntryPoint === 'string') {
-    newEntryPoint = [...filepaths, currentEntryPoint];
+    newEntryPoint = [currentEntryPoint, ...filesToInsert];
   } else if (Array.isArray(currentEntryPoint)) {
-    newEntryPoint = [...filepaths, ...currentEntryPoint];
+    newEntryPoint = [...currentEntryPoint, ...filesToInsert];
   }
   // descriptor object (webpack 5+)
   else if (typeof currentEntryPoint === 'object' && 'import' in currentEntryPoint) {
@@ -592,9 +594,9 @@ function addFilesToExistingEntryPoint(
     let newImportValue;
 
     if (typeof currentImportValue === 'string') {
-      newImportValue = [...filepaths, currentImportValue];
+      newImportValue = [currentImportValue, ...filesToInsert];
     } else {
-      newImportValue = [...filepaths, ...currentImportValue];
+      newImportValue = [...currentImportValue, ...filesToInsert];
     }
 
     newEntryPoint = {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/9067

The order in which we insert the SDK into the webpack entrypoints seems to matter in dev mode. Maybe the dev init script is somehow referenced by index. 🤷‍♂️

There is a slight nuanced consideration here in which the SDK may now be initialized too late to catch any errors generated by Next.js which we insert at the end only in dev mode.