### PR TITLE
feat(node): Add abnormal session support for ANR

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -57,6 +57,10 @@ export function updateSession(session: Session, context: SessionContext = {}): v
 
   session.timestamp = context.timestamp || timestampInSeconds();
 
+  if (context.abnormal_mechanism) {
+    session.abnormal_mechanism = context.abnormal_mechanism;
+  }
+
   if (context.ignoreDuration) {
     session.ignoreDuration = context.ignoreDuration;
   }
@@ -143,6 +147,7 @@ function sessionToJSON(session: Session): SerializedSession {
     errors: session.errors,
     did: typeof session.did === 'number' || typeof session.did === 'string' ? `${session.did}` : undefined,
     duration: session.duration,
+    abnormal_mechanism: session.abnormal_mechanism,
     attrs: {
       release: session.release,
       environment: session.environment,

--- a/packages/node-integration-tests/suites/anr/basic-session.js
+++ b/packages/node-integration-tests/suites/anr/basic-session.js
@@ -13,7 +13,6 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   debug: true,
-  autoSessionTracking: false,
   transport,
 });
 

--- a/packages/node-integration-tests/suites/anr/basic.mjs
+++ b/packages/node-integration-tests/suites/anr/basic.mjs
@@ -2,6 +2,8 @@ import * as crypto from 'crypto';
 
 import * as Sentry from '@sentry/node';
 
+const { transport } = await import('./test-transport.js');
+
 // close both processes after 5 seconds
 setTimeout(() => {
   process.exit();
@@ -11,10 +13,8 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   debug: true,
-  beforeSend: event => {
-    // eslint-disable-next-line no-console
-    console.log(JSON.stringify(event));
-  },
+  autoSessionTracking: false,
+  transport,
 });
 
 await Sentry.enableAnrDetection({ captureStackTrace: true, anrThreshold: 200 });

--- a/packages/node-integration-tests/suites/anr/forked.js
+++ b/packages/node-integration-tests/suites/anr/forked.js
@@ -2,6 +2,8 @@ const crypto = require('crypto');
 
 const Sentry = require('@sentry/node');
 
+const { transport } = require('./test-transport.js');
+
 // close both processes after 5 seconds
 setTimeout(() => {
   process.exit();
@@ -11,10 +13,8 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   debug: true,
-  beforeSend: event => {
-    // eslint-disable-next-line no-console
-    console.log(JSON.stringify(event));
-  },
+  autoSessionTracking: false,
+  transport,
 });
 
 Sentry.enableAnrDetection({ captureStackTrace: true, anrThreshold: 200 }).then(() => {

--- a/packages/node-integration-tests/suites/anr/test-transport.js
+++ b/packages/node-integration-tests/suites/anr/test-transport.js
@@ -1,0 +1,17 @@
+const { TextEncoder, TextDecoder } = require('util');
+
+const { createTransport } = require('@sentry/core');
+const { parseEnvelope } = require('@sentry/utils');
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+// A transport that just logs the envelope payloads to console for checking in tests
+exports.transport = () => {
+  return createTransport({ recordDroppedEvent: () => {}, textEncoder }, async request => {
+    const env = parseEnvelope(request.body, textEncoder, textDecoder);
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(env[1][0][1]));
+    return { statusCode: 200 };
+  });
+};

--- a/packages/node-integration-tests/suites/anr/test.ts
+++ b/packages/node-integration-tests/suites/anr/test.ts
@@ -1,4 +1,5 @@
 import type { Event } from '@sentry/node';
+import type { SerializedSession } from '@sentry/types';
 import { parseSemver } from '@sentry/utils';
 import * as childProcess from 'child_process';
 import * as path from 'path';
@@ -6,19 +7,21 @@ import * as path from 'path';
 const NODE_VERSION = parseSemver(process.versions.node).major || 0;
 
 /** The output will contain logging so we need to find the line that parses as JSON */
-function parseJsonLine<T>(input: string): T {
-  return (
-    input
-      .split('\n')
-      .map(line => {
-        try {
-          return JSON.parse(line) as T;
-        } catch {
-          return undefined;
-        }
-      })
-      .filter(a => a) as T[]
-  )[0];
+function parseJsonLines<T extends unknown[]>(input: string, expected: number): T {
+  const results = input
+    .split('\n')
+    .map(line => {
+      try {
+        return JSON.parse(line) as T;
+      } catch {
+        return undefined;
+      }
+    })
+    .filter(a => a) as T;
+
+  expect(results.length).toEqual(expected);
+
+  return results;
 }
 
 describe('should report ANR when event loop blocked', () => {
@@ -26,12 +29,12 @@ describe('should report ANR when event loop blocked', () => {
     // The stack trace is different when node < 12
     const testFramesDetails = NODE_VERSION >= 12;
 
-    expect.assertions(testFramesDetails ? 6 : 4);
+    expect.assertions(testFramesDetails ? 7 : 5);
 
     const testScriptPath = path.resolve(__dirname, 'basic.js');
 
     childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (_, stdout) => {
-      const event = parseJsonLine<Event>(stdout);
+      const [event] = parseJsonLines<[Event]>(stdout, 1);
 
       expect(event.exception?.values?.[0].mechanism).toEqual({ type: 'ANR' });
       expect(event.exception?.values?.[0].type).toEqual('ApplicationNotResponding');
@@ -53,12 +56,12 @@ describe('should report ANR when event loop blocked', () => {
       return;
     }
 
-    expect.assertions(6);
+    expect.assertions(7);
 
     const testScriptPath = path.resolve(__dirname, 'basic.mjs');
 
     childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (_, stdout) => {
-      const event = parseJsonLine<Event>(stdout);
+      const [event] = parseJsonLines<[Event]>(stdout, 1);
 
       expect(event.exception?.values?.[0].mechanism).toEqual({ type: 'ANR' });
       expect(event.exception?.values?.[0].type).toEqual('ApplicationNotResponding');
@@ -71,16 +74,44 @@ describe('should report ANR when event loop blocked', () => {
     });
   });
 
+  test('With session', done => {
+    // The stack trace is different when node < 12
+    const testFramesDetails = NODE_VERSION >= 12;
+
+    expect.assertions(testFramesDetails ? 9 : 7);
+
+    const testScriptPath = path.resolve(__dirname, 'basic-session.js');
+
+    childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (_, stdout) => {
+      const [session, event] = parseJsonLines<[SerializedSession, Event]>(stdout, 2);
+
+      expect(event.exception?.values?.[0].mechanism).toEqual({ type: 'ANR' });
+      expect(event.exception?.values?.[0].type).toEqual('ApplicationNotResponding');
+      expect(event.exception?.values?.[0].value).toEqual('Application Not Responding for at least 200 ms');
+      expect(event.exception?.values?.[0].stacktrace?.frames?.length).toBeGreaterThan(4);
+
+      if (testFramesDetails) {
+        expect(event.exception?.values?.[0].stacktrace?.frames?.[2].function).toEqual('?');
+        expect(event.exception?.values?.[0].stacktrace?.frames?.[3].function).toEqual('longWork');
+      }
+
+      expect(session.status).toEqual('abnormal');
+      expect(session.abnormal_mechanism).toEqual('anr_foreground');
+
+      done();
+    });
+  });
+
   test('from forked process', done => {
     // The stack trace is different when node < 12
     const testFramesDetails = NODE_VERSION >= 12;
 
-    expect.assertions(testFramesDetails ? 6 : 4);
+    expect.assertions(testFramesDetails ? 7 : 5);
 
     const testScriptPath = path.resolve(__dirname, 'forker.js');
 
     childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (_, stdout) => {
-      const event = parseJsonLine<Event>(stdout);
+      const [event] = parseJsonLines<[Event]>(stdout, 1);
 
       expect(event.exception?.values?.[0].mechanism).toEqual({ type: 'ANR' });
       expect(event.exception?.values?.[0].type).toEqual('ApplicationNotResponding');

--- a/packages/node/src/anr/index.ts
+++ b/packages/node/src/anr/index.ts
@@ -174,8 +174,13 @@ function handleChildProcess(options: Options): void {
       log('Sending abnormal session');
       updateSession(session, { status: 'abnormal', abnormal_mechanism: 'anr_foreground' });
       getCurrentHub().getClient()?.sendSession(session);
-      // Notify the main process that the session has ended so the session can be cleared from the scope
-      process.send?.('session-ended');
+
+      try {
+        // Notify the main process that the session has ended so the session can be cleared from the scope
+        process.send?.('session-ended');
+      } catch (_) {
+        // ignore
+      }
     }
 
     captureEvent(createAnrEvent(options.anrThreshold, frames));

--- a/packages/types/src/session.ts
+++ b/packages/types/src/session.ts
@@ -21,7 +21,7 @@ export interface Session {
   errors: number;
   user?: User | null;
   ignoreDuration: boolean;
-
+  abnormal_mechanism?: string;
   /**
    * Overrides default JSON serialization of the Session because
    * the Sentry servers expect a slightly different schema of a session
@@ -76,6 +76,7 @@ export interface SerializedSession {
   duration?: number;
   status: SessionStatus;
   errors: number;
+  abnormal_mechanism?: string;
   attrs?: {
     release?: string;
     environment?: string;


### PR DESCRIPTION
This PR:
- Adds the `abnormal_mechanism` property to session types
- Passes the latest session from main process to ANR process
- If ANR is triggered and there's an active session, send the abnormal session
- Adds a test to check for the session update

~~This PR makes no attempt to suppress further session updates from the main app process.~~ How does Sentry backend treat conflicting session updates?

Ref: https://github.com/getsentry/sentry-electron/issues/774
 
