### PR TITLE
chore(astro): Add Release Registry Craft target for Astro

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -167,6 +167,8 @@ targets:
         onlyIfPresent: /^sentry-angular-ivy-\d.*\.tgz$/
       'npm:@sentry/angular':
         onlyIfPresent: /^sentry-angular-\d.*\.tgz$/
+      'npm:@sentry/astro':
+        onlyIfPresent: /^sentry-astro-\d.*\.tgz$/
       'npm:@sentry/wasm':
         onlyIfPresent: /^sentry-wasm-\d.*\.tgz$/
       'npm:@sentry/nextjs':


### PR DESCRIPTION
Adds the RR target for Astro to our craft config. First RR entry was already created manually: https://github.com/getsentry/sentry-release-registry/pull/128 

ref: https://github.com/getsentry/sentry-javascript/issues/9182