### PR TITLE
build(deno): Clean up build output

### DIFF
--- a/packages/deno/.gitignore
+++ b/packages/deno/.gitignore
@@ -1,0 +1,1 @@
+build-types

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -35,7 +35,7 @@
     "build:types:tsc": "tsc -p tsconfig.types.json",
     "build:types:bundle": "rollup -c rollup.types.config.js",
     "circularDepCheck": "madge --circular src/index.ts",
-    "clean": "rimraf build coverage",
+    "clean": "rimraf build build-types coverage",
     "prefix": "yarn deno-types",
     "fix": "run-s fix:eslint fix:prettier",
     "fix:eslint": "eslint . --format stylish --fix",

--- a/packages/deno/rollup.types.config.js
+++ b/packages/deno/rollup.types.config.js
@@ -1,7 +1,9 @@
+// @ts-check
 import dts from 'rollup-plugin-dts';
+import { defineConfig } from 'rollup';
 
-export default {
-  input: './build/index.d.ts',
+export default defineConfig({
+  input: './build-types/index.d.ts',
   output: [{ file: 'build/index.d.ts', format: 'es' }],
   plugins: [
     dts({ respectExternal: true }),
@@ -14,4 +16,4 @@ export default {
       },
     },
   ],
-};
+});

--- a/packages/deno/tsconfig.types.json
+++ b/packages/deno/tsconfig.types.json
@@ -2,8 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
-    "declarationMap": true,
+    "declarationMap": false,
     "emitDeclarationOnly": true,
-    "outDir": "build"
+    "outDir": "build-types"
   }
 }


### PR DESCRIPTION
Cleans up the distributed files in the Deno package by putting the intermediary type declarations into a separate folder.

Also disables declaration map generation as we bundle the type definitions so the declaration maps won't work anyhow.