### PR TITLE
fix(astro): Make Replay and Browsertracing integrations tree-shakeable

### DIFF
--- a/packages/astro/src/integration/snippets.ts
+++ b/packages/astro/src/integration/snippets.ts
@@ -16,7 +16,7 @@ export function buildClientSnippet(options: SentryOptions): string {
 
 Sentry.init({
   ${buildCommonInitOptions(options)}
-  integrations: [new Sentry.BrowserTracing(), new Sentry.Replay()],
+  integrations: [${buildClientIntegrations(options)}],
   replaysSessionSampleRate: ${options.replaysSessionSampleRate ?? 0.1},
   replaysOnErrorSampleRate: ${options.replaysOnErrorSampleRate ?? 1.0},
 });`;
@@ -43,3 +43,28 @@ const buildCommonInitOptions = (options: SentryOptions): string => `dsn: ${
   tracesSampleRate: ${options.tracesSampleRate ?? 1.0},${
   options.sampleRate ? `\n  sampleRate: ${options.sampleRate},` : ''
 }`;
+
+/**
+ * We don't include the `BrowserTracing` integration if the tracesSampleRate is set to 0.
+ * Likewise, we don't include the `Replay` integration if the replaysSessionSampleRate
+ * and replaysOnErrorSampleRate are set to 0.
+ *
+ * This way, we avoid unnecessarily adding the integrations and thereby enable tree shaking of the integrations.
+ */
+const buildClientIntegrations = (options: SentryOptions): string => {
+  const integrations: string[] = [];
+
+  if (options.tracesSampleRate == null || options.tracesSampleRate) {
+    integrations.push('new Sentry.BrowserTracing()');
+  }
+  if (
+    options.replaysSessionSampleRate == null ||
+    options.replaysSessionSampleRate ||
+    options.replaysOnErrorSampleRate == null ||
+    options.replaysOnErrorSampleRate
+  ) {
+    integrations.push('new Sentry.Replay()');
+  }
+
+  return integrations.join(', ');
+};

--- a/packages/astro/test/integration/snippets.test.ts
+++ b/packages/astro/test/integration/snippets.test.ts
@@ -49,6 +49,42 @@ describe('buildClientSnippet', () => {
       });"
     `);
   });
+
+  it('does not include BrowserTracing if tracesSampleRate is 0', () => {
+    const snippet = buildClientSnippet({ tracesSampleRate: 0 });
+    expect(snippet).toMatchInlineSnapshot(`
+      "import * as Sentry from \\"@sentry/astro\\";
+
+      Sentry.init({
+        dsn: import.meta.env.PUBLIC_SENTRY_DSN,
+        debug: false,
+        environment: import.meta.env.PUBLIC_VERCEL_ENV,
+        release: import.meta.env.PUBLIC_VERCEL_GIT_COMMIT_SHA,
+        tracesSampleRate: 0,
+        integrations: [new Sentry.Replay()],
+        replaysSessionSampleRate: 0.1,
+        replaysOnErrorSampleRate: 1,
+      });"
+    `);
+  });
+});
+
+it('does not include Replay if replay sample ratest are 0', () => {
+  const snippet = buildClientSnippet({ replaysSessionSampleRate: 0, replaysOnErrorSampleRate: 0 });
+  expect(snippet).toMatchInlineSnapshot(`
+    "import * as Sentry from \\"@sentry/astro\\";
+
+    Sentry.init({
+      dsn: import.meta.env.PUBLIC_SENTRY_DSN,
+      debug: false,
+      environment: import.meta.env.PUBLIC_VERCEL_ENV,
+      release: import.meta.env.PUBLIC_VERCEL_GIT_COMMIT_SHA,
+      tracesSampleRate: 1,
+      integrations: [new Sentry.BrowserTracing()],
+      replaysSessionSampleRate: 0,
+      replaysOnErrorSampleRate: 0,
+    });"
+  `);
 });
 
 describe('buildServerSnippet', () => {


### PR DESCRIPTION
This PR fixes a Sentry.init code generation bug that always added `BrowserTracing` and `Replay` to the client init code, even if sample rates were specifically set to 0. This prohibited tree shaking of these integrations if users disabled them by setting the respective sample rates. 