### PR TITLE
chore(repo): Change SDK selection order in bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -30,8 +30,8 @@ body:
         If you're using the CDN bundles, please specify the exact bundle (e.g. `bundle.tracing.min.js`) in your SDK
         setup.
       options:
-        - '@sentry/astro'
         - '@sentry/browser'
+        - '@sentry/astro'        
         - '@sentry/angular'
         - '@sentry/angular-ivy'
         - '@sentry/bun'


### PR DESCRIPTION
Changes the order of packages so that `@sentry/browser` again is the default choice (accidentally changed in #9241). I'd prefer if there was no default choice and users actually _had_ to make a selection but I don't think this is possible. 

Changing because in https://github.com/getsentry/sentry-javascript/issues/9279, Astro was incorrectly selected. I'd rather have Browser as the "fallback" than a framework-specific package.