### PR TITLE
ref: Move `isBrowser` util fn from `replay` to `util`

### DIFF
--- a/packages/replay/jest.setup.ts
+++ b/packages/replay/jest.setup.ts
@@ -10,8 +10,10 @@ import type { ReplayContainer, Session } from './src/types';
 
 type MockTransport = jest.MockedFunction<Transport['send']>;
 
-jest.mock('./src/util/isBrowser', () => {
+jest.mock('@sentry/utils', () => {
+  const original = jest.requireActual('@sentry/utils');
   return {
+    ...original,
     isBrowser: () => true,
   };
 });

--- a/packages/replay/jest.setup.ts
+++ b/packages/replay/jest.setup.ts
@@ -2,6 +2,7 @@
 import { getCurrentHub } from '@sentry/core';
 import type { ReplayRecordingData, Transport } from '@sentry/types';
 import { TextEncoder } from 'util';
+import * as SentryUtils from '@sentry/utils';
 
 import type { ReplayContainer, Session } from './src/types';
 
@@ -10,13 +11,7 @@ import type { ReplayContainer, Session } from './src/types';
 
 type MockTransport = jest.MockedFunction<Transport['send']>;
 
-jest.mock('@sentry/utils', () => {
-  const original = jest.requireActual('@sentry/utils');
-  return {
-    ...original,
-    isBrowser: () => true,
-  };
-});
+jest.spyOn(SentryUtils, 'isBrowser').mockImplementation(() => true);
 
 type EnvelopeHeader = {
   event_id: string;

--- a/packages/replay/jest.setup.ts
+++ b/packages/replay/jest.setup.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { getCurrentHub } from '@sentry/core';
 import type { ReplayRecordingData, Transport } from '@sentry/types';
-import { TextEncoder } from 'util';
 import * as SentryUtils from '@sentry/utils';
+import { TextEncoder } from 'util';
 
 import type { ReplayContainer, Session } from './src/types';
 

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -1,6 +1,6 @@
 import { getCurrentHub } from '@sentry/core';
 import type { BrowserClientReplayOptions, Integration } from '@sentry/types';
-import { dropUndefinedKeys } from '@sentry/utils';
+import { dropUndefinedKeys, isBrowser } from '@sentry/utils';
 
 import {
   DEFAULT_FLUSH_MAX_DELAY,
@@ -12,7 +12,6 @@ import {
 import { ReplayContainer } from './replay';
 import type { RecordingOptions, ReplayConfiguration, ReplayPluginOptions, SendBufferedReplayOptions } from './types';
 import { getPrivacyOptions } from './util/getPrivacyOptions';
-import { isBrowser } from './util/isBrowser';
 import { maskAttribute } from './util/maskAttribute';
 
 const MEDIA_SELECTORS =

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -5,6 +5,7 @@ export * from './error';
 export * from './worldwide';
 export * from './instrument';
 export * from './is';
+export * from './isBrowser';
 export * from './logger';
 export * from './memo';
 export * from './misc';

--- a/packages/utils/src/isBrowser.ts
+++ b/packages/utils/src/isBrowser.ts
@@ -1,4 +1,4 @@
-import { isNodeEnv } from '@sentry/utils';
+import { isNodeEnv } from './node';
 
 /**
  * Returns true if we are in the browser.


### PR DESCRIPTION
We need this in the new feedback integration.
