### PR TITLE
test(deno): Refer to local files in tests

### DIFF
--- a/packages/deno/test/__snapshots__/mod.test.ts.snap
+++ b/packages/deno/test/__snapshots__/mod.test.ts.snap
@@ -15,7 +15,7 @@ snapshot[`captureException 1`] = `
     },
     runtime: {
       name: "deno",
-      version: "1.36.0",
+      version: "1.37.1",
     },
     trace: {
       span_id: "{{id}}",
@@ -46,35 +46,35 @@ snapshot[`captureException 1`] = `
               filename: "ext:cli/40_testing.js",
               function: "outerWrapped",
               in_app: false,
-              lineno: 427,
+              lineno: 488,
             },
             {
               colno: 33,
               filename: "ext:cli/40_testing.js",
               function: "exitSanitizer",
               in_app: false,
-              lineno: 413,
+              lineno: 474,
             },
             {
               colno: 31,
               filename: "ext:cli/40_testing.js",
               function: "resourceSanitizer",
               in_app: false,
-              lineno: 364,
+              lineno: 425,
             },
             {
               colno: 33,
               filename: "ext:cli/40_testing.js",
               function: "asyncOpSanitizer",
               in_app: false,
-              lineno: 148,
+              lineno: 192,
             },
             {
               colno: 11,
               filename: "ext:cli/40_testing.js",
               function: "innerWrapped",
               in_app: false,
-              lineno: 482,
+              lineno: 543,
             },
             {
               colno: 24,
@@ -176,7 +176,7 @@ snapshot[`captureMessage 1`] = `
     },
     runtime: {
       name: "deno",
-      version: "1.36.0",
+      version: "1.37.1",
     },
     trace: {
       span_id: "{{id}}",

--- a/packages/deno/test/__snapshots__/mod.test.ts.snap
+++ b/packages/deno/test/__snapshots__/mod.test.ts.snap
@@ -15,7 +15,7 @@ snapshot[`captureException 1`] = `
     },
     runtime: {
       name: "deno",
-      version: "1.37.1",
+      version: "1.36.0",
     },
     trace: {
       span_id: "{{id}}",
@@ -46,35 +46,35 @@ snapshot[`captureException 1`] = `
               filename: "ext:cli/40_testing.js",
               function: "outerWrapped",
               in_app: false,
-              lineno: 488,
+              lineno: 427,
             },
             {
               colno: 33,
               filename: "ext:cli/40_testing.js",
               function: "exitSanitizer",
               in_app: false,
-              lineno: 474,
+              lineno: 413,
             },
             {
               colno: 31,
               filename: "ext:cli/40_testing.js",
               function: "resourceSanitizer",
               in_app: false,
-              lineno: 425,
+              lineno: 364,
             },
             {
               colno: 33,
               filename: "ext:cli/40_testing.js",
               function: "asyncOpSanitizer",
               in_app: false,
-              lineno: 192,
+              lineno: 148,
             },
             {
               colno: 11,
               filename: "ext:cli/40_testing.js",
               function: "innerWrapped",
               in_app: false,
-              lineno: 543,
+              lineno: 482,
             },
             {
               colno: 24,
@@ -82,7 +82,7 @@ snapshot[`captureException 1`] = `
               filename: "app:///test/mod.test.ts",
               function: "<anonymous>",
               in_app: true,
-              lineno: 43,
+              lineno: 42,
               post_context: [
                 "",
                 "  await delay(200);",
@@ -108,7 +108,7 @@ snapshot[`captureException 1`] = `
               filename: "app:///test/mod.test.ts",
               function: "something",
               in_app: true,
-              lineno: 40,
+              lineno: 39,
               post_context: [
                 "  }",
                 "",
@@ -176,7 +176,7 @@ snapshot[`captureMessage 1`] = `
     },
     runtime: {
       name: "deno",
-      version: "1.37.1",
+      version: "1.36.0",
     },
     trace: {
       span_id: "{{id}}",

--- a/packages/deno/test/mod.test.ts
+++ b/packages/deno/test/mod.test.ts
@@ -1,13 +1,12 @@
 import { assertEquals } from 'https://deno.land/std@0.202.0/assert/assert_equals.ts';
 import { assertSnapshot } from 'https://deno.land/std@0.202.0/testing/snapshot.ts';
 
-import type { Event, Integration } from '../../types';
-import { createStackParser, nodeStackLineParser } from '../../utils';
+import { createStackParser, nodeStackLineParser } from '../../utils/build/esm/index.js';
 import { defaultIntegrations, DenoClient, Hub, Scope } from '../build/index.js';
 import { getNormalizedEvent } from './normalize.ts';
 import { makeTestTransport } from './transport.ts';
 
-function getTestClient(callback: (event?: Event) => void, integrations: Integration[] = []): [Hub, DenoClient] {
+function getTestClient(callback: (event?: Event) => void, integrations: any[] = []): [Hub, DenoClient] {
   const client = new DenoClient({
     dsn: 'https://233a45e5efe34c47a3536797ce15dafa@nothing.here/5650507',
     debug: true,
@@ -15,7 +14,7 @@ function getTestClient(callback: (event?: Event) => void, integrations: Integrat
     stackParser: createStackParser(nodeStackLineParser()),
     transport: makeTestTransport(envelope => {
       callback(getNormalizedEvent(envelope));
-    }),
+    }) as any,
   });
 
   const scope = new Scope();

--- a/packages/deno/test/mod.test.ts
+++ b/packages/deno/test/mod.test.ts
@@ -1,8 +1,8 @@
 import { assertEquals } from 'https://deno.land/std@0.202.0/assert/assert_equals.ts';
 import { assertSnapshot } from 'https://deno.land/std@0.202.0/testing/snapshot.ts';
-import type { Event, Integration } from 'npm:@sentry/types';
-import { createStackParser, nodeStackLineParser } from 'npm:@sentry/utils';
 
+import type { Event, Integration } from '../../types';
+import { createStackParser, nodeStackLineParser } from '../../utils';
 import { defaultIntegrations, DenoClient, Hub, Scope } from '../build/index.js';
 import { getNormalizedEvent } from './normalize.ts';
 import { makeTestTransport } from './transport.ts';

--- a/packages/deno/test/normalize.ts
+++ b/packages/deno/test/normalize.ts
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
-import type { Envelope, Event, Session, Transaction } from 'npm:@sentry/types';
-import { forEachEnvelopeItem } from 'npm:@sentry/utils';
+import type { Envelope, Event, Session, Transaction } from '../../types';
+import { forEachEnvelopeItem } from '../../utils';
 
 type EventOrSession = Event | Transaction | Session;
 

--- a/packages/deno/test/normalize.ts
+++ b/packages/deno/test/normalize.ts
@@ -1,21 +1,20 @@
 /* eslint-disable complexity */
-import type { Envelope, Event, Session, Transaction } from '../../types';
-import { forEachEnvelopeItem } from '../../utils';
+import { forEachEnvelopeItem } from '../../utils/build/esm/index.js';
 
-type EventOrSession = Event | Transaction | Session;
+type EventOrSession = any;
 
-export function getNormalizedEvent(envelope: Envelope): Event | undefined {
-  let event: Event | undefined;
+export function getNormalizedEvent(envelope: any): any | undefined {
+  let event: any | undefined;
 
-  forEachEnvelopeItem(envelope, item => {
+  forEachEnvelopeItem(envelope, (item: any) => {
     const [headers, body] = item;
 
     if (headers.type === 'event') {
-      event = body as Event;
+      event = body;
     }
   });
 
-  return normalize(event) as Event | undefined;
+  return normalize(event) as any | undefined;
 }
 
 export function normalize(event: EventOrSession | undefined): EventOrSession | undefined {
@@ -24,14 +23,14 @@ export function normalize(event: EventOrSession | undefined): EventOrSession | u
   }
 
   if (eventIsSession(event)) {
-    return normalizeSession(event as Session);
+    return normalizeSession(event);
   } else {
-    return normalizeEvent(event as Event);
+    return normalizeEvent(event);
   }
 }
 
 export function eventIsSession(data: EventOrSession): boolean {
-  return !!(data as Session)?.sid;
+  return !!data?.sid;
 }
 
 /**
@@ -40,7 +39,7 @@ export function eventIsSession(data: EventOrSession): boolean {
  * All properties that are timestamps, versions, ids or variables that may vary
  * by platform are replaced with placeholder strings
  */
-function normalizeSession(session: Session): Session {
+function normalizeSession(session: any): any {
   if (session.sid) {
     session.sid = '{{id}}';
   }
@@ -66,7 +65,7 @@ function normalizeSession(session: Session): Session {
  * All properties that are timestamps, versions, ids or variables that may vary
  * by platform are replaced with placeholder strings
  */
-function normalizeEvent(event: Event): Event {
+function normalizeEvent(event: any): any {
   if (event.sdk?.version) {
     event.sdk.version = '{{version}}';
   }
@@ -157,7 +156,7 @@ function normalizeEvent(event: Event): Event {
   if (event.exception?.values?.[0].stacktrace?.frames) {
     // Exlcude Deno frames since these may change between versions
     event.exception.values[0].stacktrace.frames = event.exception.values[0].stacktrace.frames.filter(
-      frame => !frame.filename?.includes('deno:'),
+      (frame: any) => !frame.filename?.includes('deno:'),
     );
   }
 


### PR DESCRIPTION
We cannot depend on the npm version of files in the deno tests because our typings are gonna drift apart.

This is an ugly "slap any onto everything" to unblock hack.