### PR TITLE
feat: Remove tslib

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -129,12 +129,7 @@
         "${fileBasename}"
       ],
 
-      "skipFiles": [
-        "<node_internals>/**",
-        // this prevents us from landing in a neverending cycle of TS async-polyfill functions as we're stepping through
-        // our code
-        "${workspaceFolder}/node_modules/tslib/**/*"
-      ],
+      "skipFiles": ["<node_internals>/**"],
       "sourceMaps": true,
       // this controls which files are sourcemapped
       "outFiles": [

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "size-limit": "~9.0.0",
     "ts-jest": "^27.1.4",
     "ts-node": "10.9.1",
-    "tslib": "2.4.1",
     "typedoc": "^0.18.0",
     "typescript": "4.9.5",
     "vitest": "^0.29.2",

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -27,8 +27,7 @@
     "@sentry/core": "7.74.1",
     "@sentry/replay": "7.74.1",
     "@sentry/types": "7.74.1",
-    "@sentry/utils": "7.74.1",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "@sentry/utils": "7.74.1"
   },
   "devDependencies": {
     "@sentry-internal/integration-shims": "7.74.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,8 +24,7 @@
   },
   "dependencies": {
     "@sentry/types": "7.74.1",
-    "@sentry/utils": "7.74.1",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "@sentry/utils": "7.74.1"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",

--- a/packages/e2e-tests/test-applications/sveltekit/package.json
+++ b/packages/e2e-tests/test-applications/sveltekit/package.json
@@ -27,7 +27,6 @@
     "svelte": "^3.54.0",
     "svelte-check": "^3.0.1",
     "ts-node": "10.9.1",
-    "tslib": "2.4.1",
     "typescript": "^5.0.0",
     "vite": "^4.2.0",
     "wait-port": "1.0.4"

--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -25,8 +25,7 @@
   "dependencies": {
     "@sentry/core": "7.70.0",
     "@sentry/types": "7.70.0",
-    "@sentry/utils": "7.70.0",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "@sentry/utils": "7.70.0"
   },
   "scripts": {
     "build": "run-p build:transpile build:types build:bundle",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -25,8 +25,7 @@
   "dependencies": {
     "@sentry/core": "7.74.1",
     "@sentry/types": "7.74.1",
-    "@sentry/utils": "7.74.1",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "@sentry/utils": "7.74.1"
   },
   "scripts": {
     "build": "run-p build:transpile build:types",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -26,8 +26,7 @@
     "@sentry/core": "7.74.1",
     "@sentry/types": "7.74.1",
     "@sentry/utils": "7.74.1",
-    "localforage": "^1.8.1",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "localforage": "^1.8.1"
   },
   "devDependencies": {
     "@sentry/browser": "7.74.1",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -36,8 +36,7 @@
     "chalk": "3.0.0",
     "resolve": "1.22.8",
     "rollup": "2.78.0",
-    "stacktrace-parser": "^0.1.10",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "stacktrace-parser": "^0.1.10"
   },
   "devDependencies": {
     "@types/resolve": "1.20.3",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -28,8 +28,7 @@
     "@sentry/types": "7.74.1",
     "@sentry/utils": "7.74.1",
     "cookie": "^0.5.0",
-    "https-proxy-agent": "^5.0.0",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "https-proxy-agent": "^5.0.0"
   },
   "devDependencies": {
     "@types/cookie": "0.5.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,8 +26,7 @@
     "@sentry/browser": "7.74.1",
     "@sentry/types": "7.74.1",
     "@sentry/utils": "7.74.1",
-    "hoist-non-react-statics": "^3.3.2",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "hoist-non-react-statics": "^3.3.2"
   },
   "peerDependencies": {
     "react": "15.x || 16.x || 17.x || 18.x"

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -34,7 +34,6 @@
     "@sentry/types": "7.74.1",
     "@sentry/utils": "7.74.1",
     "glob": "^10.3.4",
-    "tslib": "^2.4.1 || ^1.9.3",
     "yargs": "^17.6.0"
   },
   "devDependencies": {

--- a/packages/replay-worker/package.json
+++ b/packages/replay-worker/package.json
@@ -46,8 +46,7 @@
   },
   "homepage": "https://docs.sentry.io/platforms/javascript/session-replay/",
   "devDependencies": {
-    "@types/pako": "^2.0.0",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "@types/pako": "^2.0.0"
   },
   "dependencies": {
     "pako": "^2.1.0"

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -54,8 +54,7 @@
     "@sentry-internal/replay-worker": "7.74.1",
     "@sentry-internal/rrweb": "2.0.1",
     "@sentry-internal/rrweb-snapshot": "2.0.1",
-    "jsdom-worker": "^0.2.1",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "jsdom-worker": "^0.2.1"
   },
   "dependencies": {
     "@sentry/core": "7.74.1",

--- a/packages/serverless/package.json
+++ b/packages/serverless/package.json
@@ -28,8 +28,7 @@
     "@sentry/types": "7.74.1",
     "@sentry/utils": "7.74.1",
     "@types/aws-lambda": "^8.10.62",
-    "@types/express": "^4.17.14",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "@types/express": "^4.17.14"
   },
   "devDependencies": {
     "@google-cloud/bigquery": "^5.3.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -26,8 +26,7 @@
     "@sentry/browser": "7.74.1",
     "@sentry/types": "7.74.1",
     "@sentry/utils": "7.74.1",
-    "magic-string": "^0.30.0",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "magic-string": "^0.30.0"
   },
   "peerDependencies": {
     "svelte": "3.x || 4.x"

--- a/packages/tracing-internal/package.json
+++ b/packages/tracing-internal/package.json
@@ -25,8 +25,7 @@
   "dependencies": {
     "@sentry/core": "7.74.1",
     "@sentry/types": "7.74.1",
-    "@sentry/utils": "7.74.1",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "@sentry/utils": "7.74.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.14"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -23,8 +23,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/types": "7.74.1",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "@sentry/types": "7.74.1"
   },
   "devDependencies": {
     "@types/array.prototype.flat": "^1.2.1",

--- a/packages/vercel-edge/package.json
+++ b/packages/vercel-edge/package.json
@@ -25,8 +25,7 @@
   "dependencies": {
     "@sentry/core": "7.74.1",
     "@sentry/types": "7.74.1",
-    "@sentry/utils": "7.74.1",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "@sentry/utils": "7.74.1"
   },
   "devDependencies": {
     "@edge-runtime/jest-environment": "2.2.3",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -26,8 +26,7 @@
     "@sentry/browser": "7.74.1",
     "@sentry/core": "7.74.1",
     "@sentry/types": "7.74.1",
-    "@sentry/utils": "7.74.1",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "@sentry/utils": "7.74.1"
   },
   "peerDependencies": {
     "vue": "2.x || 3.x"

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -25,8 +25,7 @@
   "dependencies": {
     "@sentry/browser": "7.74.1",
     "@sentry/types": "7.74.1",
-    "@sentry/utils": "7.74.1",
-    "tslib": "^2.4.1 || ^1.9.3"
+    "@sentry/utils": "7.74.1"
   },
   "scripts": {
     "build": "run-p build:transpile build:bundle build:types",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29387,11 +29387,6 @@ tslib@2.3.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
   integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
-tslib@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
-  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
-
 tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"


### PR DESCRIPTION
Inspired by https://github.com/getsentry/sentry-javascript/issues/9199, let's try removing tslib.

Kept it with the angular package because I wasn't sure if angular build process needs it, but we can remove it if not needed.