### PR TITLE
feat(types): Add statsd envelope types

### DIFF
--- a/packages/types/src/datacategory.ts
+++ b/packages/types/src/datacategory.ts
@@ -23,4 +23,6 @@ export type DataCategory =
   // Profile event type
   | 'profile'
   // Check-in event (monitor)
-  | 'monitor';
+  | 'monitor'
+  // Unknown data category
+  | 'unknown';

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -34,7 +34,8 @@ export type EnvelopeItemType =
   | 'profile'
   | 'replay_event'
   | 'replay_recording'
-  | 'check_in';
+  | 'check_in'
+  | 'statsd';
 
 export type BaseEnvelopeHeaders = {
   [key: string]: unknown;
@@ -72,6 +73,7 @@ type ClientReportItemHeaders = { type: 'client_report' };
 type ReplayEventItemHeaders = { type: 'replay_event' };
 type ReplayRecordingItemHeaders = { type: 'replay_recording'; length: number };
 type CheckInItemHeaders = { type: 'check_in' };
+type StatsdItemHeaders = { type: 'statsd' };
 
 export type EventItem = BaseEnvelopeItem<EventItemHeaders, Event>;
 export type AttachmentItem = BaseEnvelopeItem<AttachmentItemHeaders, string | Uint8Array>;
@@ -84,18 +86,21 @@ export type ClientReportItem = BaseEnvelopeItem<ClientReportItemHeaders, ClientR
 export type CheckInItem = BaseEnvelopeItem<CheckInItemHeaders, SerializedCheckIn>;
 type ReplayEventItem = BaseEnvelopeItem<ReplayEventItemHeaders, ReplayEvent>;
 type ReplayRecordingItem = BaseEnvelopeItem<ReplayRecordingItemHeaders, ReplayRecordingData>;
+export type StatsdItem = BaseEnvelopeItem<StatsdItemHeaders, string>;
 
 export type EventEnvelopeHeaders = { event_id: string; sent_at: string; trace?: DynamicSamplingContext };
 type SessionEnvelopeHeaders = { sent_at: string };
 type CheckInEnvelopeHeaders = { trace?: DynamicSamplingContext };
 type ClientReportEnvelopeHeaders = BaseEnvelopeHeaders;
 type ReplayEnvelopeHeaders = BaseEnvelopeHeaders;
+type StatsdEnvelopeHeaders = BaseEnvelopeHeaders;
 
 export type EventEnvelope = BaseEnvelope<EventEnvelopeHeaders, EventItem | AttachmentItem | UserFeedbackItem>;
 export type SessionEnvelope = BaseEnvelope<SessionEnvelopeHeaders, SessionItem>;
 export type ClientReportEnvelope = BaseEnvelope<ClientReportEnvelopeHeaders, ClientReportItem>;
 export type ReplayEnvelope = [ReplayEnvelopeHeaders, [ReplayEventItem, ReplayRecordingItem]];
 export type CheckInEvelope = BaseEnvelope<CheckInEnvelopeHeaders, CheckInItem>;
+export type StatsdEnvelope = BaseEnvelope<StatsdEnvelopeHeaders, StatsdItem>;
 
 export type Envelope = EventEnvelope | SessionEnvelope | ClientReportEnvelope | ReplayEnvelope | CheckInEvelope;
 export type EnvelopeItem = Envelope[1][number];

--- a/packages/utils/src/envelope.ts
+++ b/packages/utils/src/envelope.ts
@@ -208,6 +208,8 @@ const ITEM_TYPE_TO_DATA_CATEGORY_MAP: Record<EnvelopeItemType, DataCategory> = {
   replay_event: 'replay',
   replay_recording: 'replay',
   check_in: 'monitor',
+  // TODO: This is a temporary workaround until we have a proper data category for metrics
+  statsd: 'unknown',
 };
 
 /**


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/9262

As per https://github.com/getsentry/sentry-python/pull/2385, add support for statsd envelope.

once https://github.com/getsentry/sentry-javascript/pull/9296 is merged in, we can think about adding this to the web-vital instrumentation.