### PR TITLE
test(deno): Fix runtime normalization

### DIFF
--- a/packages/deno/test/__snapshots__/mod.test.ts.snap
+++ b/packages/deno/test/__snapshots__/mod.test.ts.snap
@@ -15,7 +15,7 @@ snapshot[`captureException 1`] = `
     },
     runtime: {
       name: "deno",
-      version: "1.37.1",
+      version: "{{version}}",
     },
     trace: {
       span_id: "{{id}}",
@@ -176,7 +176,7 @@ snapshot[`captureMessage 1`] = `
     },
     runtime: {
       name: "deno",
-      version: "1.37.1",
+      version: "{{version}}",
     },
     trace: {
       span_id: "{{id}}",

--- a/packages/deno/test/normalize.ts
+++ b/packages/deno/test/normalize.ts
@@ -90,12 +90,9 @@ function normalizeEvent(event: any): any {
     event.contexts.v8.version = '{{version}}';
   }
 
-  if (event.contexts?.deno) {
-    if (event.contexts.deno?.version) {
-      event.contexts.deno.version = '{{version}}';
-    }
-    if (event.contexts.deno?.target) {
-      event.contexts.deno.target = '{{target}}';
+  if (event.contexts?.runtime) {
+    if (event.contexts.runtime?.version) {
+      event.contexts.runtime.version = '{{version}}';
     }
   }
 


### PR DESCRIPTION
We wrongly accessed the context for the event normalization.

And we had normalization logic that didn't do anything (target).