### PR TITLE
meta(craft): Add id to Deno target

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -72,6 +72,7 @@ targets:
     includeNames: /^sentry-deno-\d.*\.tgz$/
   - name: commit-on-git-repository
     # This will publish on the Deno registry
+    id: getsentry/deno
     archive: /^sentry-deno-\d.*\.tgz$/
     repositoryUrl: git@github.com:getsentry/sentry-deno.git
     stripComponents: 1


### PR DESCRIPTION
I think this is more or less just a cosmetic change but it will show "getsentry/deno" in the release issue for the target which I believe is valuable.