### PR TITLE
fix(e2e): Resolve `@sentry/node` dependency in bundler plugins to current version

### DIFF
--- a/packages/e2e-tests/test-applications/debug-id-sourcemaps/package.json
+++ b/packages/e2e-tests/test-applications/debug-id-sourcemaps/package.json
@@ -19,7 +19,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@sentry/node": "$@sentry/node"
+      "@sentry/node": "latest || *",
+      "@sentry/utils": "latest || *"
     }
   },
   "volta": {

--- a/packages/e2e-tests/test-applications/debug-id-sourcemaps/package.json
+++ b/packages/e2e-tests/test-applications/debug-id-sourcemaps/package.json
@@ -17,6 +17,11 @@
     "vitest": "^0.34.6",
     "@sentry/rollup-plugin": "2.8.0"
   },
+  "pnpm": {
+    "overrides": {
+      "@sentry/node": "$@sentry/node"
+    }
+  },
   "volta": {
     "extends": "../../package.json"
   }


### PR DESCRIPTION
Alpha builds are blocked bc of this: https://github.com/getsentry/sentry-javascript/actions/runs/6575412255/job/17864293589#step:10:76