### PR TITLE
fix(node): Check buffer length when attempting to parse ANR frame

### DIFF
--- a/packages/node/src/anr/websocket.ts
+++ b/packages/node/src/anr/websocket.ts
@@ -296,6 +296,13 @@ class WebSocketInterface extends EventEmitter {
       return;
     }
 
+    // There needs to be atleast two values in the buffer for us to parse
+    // a frame from it.
+    // See: https://github.com/getsentry/sentry-javascript/issues/9307
+    if (buff.length <= 1) {
+      return;
+    }
+
     const frame = parseFrame(buff);
 
     if (isCompleteFrame(frame)) {


### PR DESCRIPTION
fixes https://github.com/getsentry/sentry-javascript/issues/9307

Reading from the buffer requires the buffer to have at least two items, which we now account for. Not sure how exactly this can happen though.