### PR TITLE
fix(node-experimental): Make node-fetch support optional

### DIFF
--- a/packages/node-experimental/package.json
+++ b/packages/node-experimental/package.json
@@ -45,7 +45,9 @@
     "@sentry/node": "7.74.1",
     "@sentry/opentelemetry": "7.74.1",
     "@sentry/types": "7.74.1",
-    "@sentry/utils": "7.74.1",
+    "@sentry/utils": "7.74.1"
+  },
+  "optionalDependencies": {
     "opentelemetry-instrumentation-fetch-node": "1.1.0"
   },
   "scripts": {

--- a/packages/node-experimental/src/integrations/node-fetch.ts
+++ b/packages/node-experimental/src/integrations/node-fetch.ts
@@ -65,17 +65,20 @@ export class NodeFetch extends NodePerformanceIntegration<NodeFetchOptions> impl
 
   /** @inheritDoc */
   public setupInstrumentation(): void | Instrumentation[] {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const FetchInstrumentation = require('opentelemetry-instrumentation-fetch-node');
-
-    return [
-      new FetchInstrumentation({
-        onRequest: ({ span }: { span: Span }) => {
-          this._updateSpan(span);
-          this._addRequestBreadcrumb(span);
-        },
-      }),
-    ];
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { FetchInstrumentation } = require('opentelemetry-instrumentation-fetch-node');
+      return [
+        new FetchInstrumentation({
+          onRequest: ({ span }: { span: Span }) => {
+            this._updateSpan(span);
+            this._addRequestBreadcrumb(span);
+          },
+        }),
+      ];
+    } catch (error) {
+      // Could not load instrumentation
+    }
   }
 
   /**

--- a/packages/node-experimental/src/integrations/node-fetch.ts
+++ b/packages/node-experimental/src/integrations/node-fetch.ts
@@ -4,7 +4,6 @@ import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { hasTracingEnabled } from '@sentry/core';
 import { _INTERNAL, getCurrentHub, getSpanKind } from '@sentry/opentelemetry';
 import type { Integration } from '@sentry/types';
-import { FetchInstrumentation } from 'opentelemetry-instrumentation-fetch-node';
 
 import type { NodeExperimentalClient } from '../types';
 import { addOriginToSpan } from '../utils/addOriginToSpan';
@@ -66,6 +65,9 @@ export class NodeFetch extends NodePerformanceIntegration<NodeFetchOptions> impl
 
   /** @inheritDoc */
   public setupInstrumentation(): void | Instrumentation[] {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const FetchInstrumentation = require('opentelemetry-instrumentation-fetch-node');
+
     return [
       new FetchInstrumentation({
         onRequest: ({ span }: { span: Span }) => {


### PR DESCRIPTION
Installing this on Node <18 produces install time errors, as the package is not compatible, e.g.:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'opentelemetry-instrumentation-fetch-node@1.1.0',
npm WARN EBADENGINE   required: { node: '>18.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.18.0', npm: '8.19.2' }
npm WARN EBADENGINE }
```

We already try-catch the `setupInstrumentation` hook anyhow, so no need to check again here - if this fails we'll just skip running this integration.
