### PR TITLE
meta(deno): Use https git protocol in deno release target

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -73,7 +73,7 @@ targets:
   - name: commit-on-git-repository
     # This will publish on the Deno registry
     archive: /^sentry-deno-\d.*\.tgz$/
-    repositoryUrl: git@github.com:getsentry/sentry-deno.git
+    repositoryUrl: https://github.com/getsentry/sentry-deno.git
     stripComponents: 1
     branch: main
     createTag: true


### PR DESCRIPTION
ssh ran into the issue of not having the right known-hosts defined, let's try https.

We're probably gonna run into authentification issues now.