### PR TITLE
fix(tracing-internal): Fix trailing slash with query paras in url

### DIFF
--- a/packages/node-integration-tests/suites/express/multiple-routers/complex-router/test.ts
+++ b/packages/node-integration-tests/suites/express/multiple-routers/complex-router/test.ts
@@ -25,3 +25,55 @@ test('should construct correct url with multiple parameterized routers, when par
     });
   }
 });
+
+test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route and original url has query params', async () => {
+  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
+  const event = await env.getEnvelopeRequest({
+    url: env.url.replace('test', 'api/api/v1/sub-router/users/123/posts/456?param=1'),
+    envelopeType: 'transaction',
+  });
+  // parse node.js major version
+  const [major] = process.versions.node.split('.').map(Number);
+  // Split test result base on major node version because regex d flag is support from node 16+
+  if (major >= 16) {
+    assertSentryEvent(event[2] as any, {
+      transaction: 'GET /api/api/v1/sub-router/users/:userId/posts/:postId',
+      transaction_info: {
+        source: 'route',
+      },
+    });
+  } else {
+    assertSentryEvent(event[2] as any, {
+      transaction: 'GET /api/api/v1/sub-router/users/123/posts/:postId',
+      transaction_info: {
+        source: 'route',
+      },
+    });
+  }
+});
+
+test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route and original url ends with trailing slash and has query params', async () => {
+  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
+  const event = await env.getEnvelopeRequest({
+    url: env.url.replace('test', 'api/api/v1/sub-router/users/123/posts/456/?param=1'),
+    envelopeType: 'transaction',
+  });
+  // parse node.js major version
+  const [major] = process.versions.node.split('.').map(Number);
+  // Split test result base on major node version because regex d flag is support from node 16+
+  if (major >= 16) {
+    assertSentryEvent(event[2] as any, {
+      transaction: 'GET /api/api/v1/sub-router/users/:userId/posts/:postId',
+      transaction_info: {
+        source: 'route',
+      },
+    });
+  } else {
+    assertSentryEvent(event[2] as any, {
+      transaction: 'GET /api/api/v1/sub-router/users/123/posts/:postId',
+      transaction_info: {
+        source: 'route',
+      },
+    });
+  }
+});

--- a/packages/tracing-internal/src/node/integrations/express.ts
+++ b/packages/tracing-internal/src/node/integrations/express.ts
@@ -358,7 +358,7 @@ function instrumentRouter(appOrRouter: ExpressRouter): void {
     // Now we check if we are in the "last" part of the route. We determine this by comparing the
     // number of URL segments from the original URL to that of our reconstructed parameterized URL.
     // If we've reached our final destination, we update the transaction name.
-    const urlLength = getNumberOfUrlSegments(req.originalUrl || '') + numExtraSegments;
+    const urlLength = getNumberOfUrlSegments(stripUrlQueryAndFragment(req.originalUrl || '')) + numExtraSegments;
     const routeLength = getNumberOfUrlSegments(req._reconstructedRoute);
 
     if (urlLength === routeLength) {


### PR DESCRIPTION
This PR fix use case when original req url ends with trailing slash and contain query params.
For example:

```
api/v1/users/123/posts/?param=1
```

### Old behavior

sentry build req._reconstructedRoute as:
api/v1/users/123/posts

### New behavior

sentry build req._reconstructedRoute as:
api/v1/users/:userID/posts
