### PR TITLE
test(e2e): use `127.0.0.1` instead of `localhost` for E2E `.npmrc`

### DIFF
--- a/packages/e2e-tests/README.md
+++ b/packages/e2e-tests/README.md
@@ -49,8 +49,8 @@ mkdir test-applications/my-new-test-application # Name of the new folder doesn't
 
 # Create an npm configuration file that uses the fake test registry
 cat > test-applications/my-new-test-application/.npmrc << EOF
-@sentry:registry=http://localhost:4873
-@sentry-internal:registry=http://localhost:4873
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873
 EOF
 ```
 
@@ -60,7 +60,7 @@ Add the new test app to `test-application` matrix in `.github/workflows/build.ym
 want to run a canary test, add it to the `canary.yml` workflow.
 
 **An important thing to note:** In the context of the build/test commands the fake test registry is available at
-`http://localhost:4873`. It hosts all of our packages as if they were to be published with the state of the current
+`http://127.0.0.1:4873`. It hosts all of our packages as if they were to be published with the state of the current
 branch. This means we can install the packages from this registry via the `.npmrc` configuration as seen above. If you
 add Sentry dependencies to your test application, you should set the dependency versions set to `latest || *` in order
 for it to work with both regular and prerelease versions:

--- a/packages/e2e-tests/test-applications/create-next-app/.npmrc
+++ b/packages/e2e-tests/test-applications/create-next-app/.npmrc
@@ -1,2 +1,2 @@
-@sentry:registry=http://localhost:4873
-@sentry-internal:registry=http://localhost:4873
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/packages/e2e-tests/test-applications/create-react-app/.npmrc
+++ b/packages/e2e-tests/test-applications/create-react-app/.npmrc
@@ -1,2 +1,2 @@
-@sentry:registry=http://localhost:4873
-@sentry-internal:registry=http://localhost:4873
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/packages/e2e-tests/test-applications/create-remix-app-v2/.npmrc
+++ b/packages/e2e-tests/test-applications/create-remix-app-v2/.npmrc
@@ -1,2 +1,2 @@
-@sentry:registry=http://localhost:4873
-@sentry-internal:registry=http://localhost:4873
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/packages/e2e-tests/test-applications/create-remix-app/.npmrc
+++ b/packages/e2e-tests/test-applications/create-remix-app/.npmrc
@@ -1,2 +1,2 @@
-@sentry:registry=http://localhost:4873
-@sentry-internal:registry=http://localhost:4873
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/packages/e2e-tests/test-applications/debug-id-sourcemaps/.npmrc
+++ b/packages/e2e-tests/test-applications/debug-id-sourcemaps/.npmrc
@@ -1,2 +1,2 @@
-@sentry:registry=http://localhost:4873
-@sentry-internal:registry=http://localhost:4873
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/packages/e2e-tests/test-applications/generic-ts3.8/.npmrc
+++ b/packages/e2e-tests/test-applications/generic-ts3.8/.npmrc
@@ -1,2 +1,2 @@
-@sentry:registry=http://localhost:4873
-@sentry-internal:registry=http://localhost:4873
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/packages/e2e-tests/test-applications/nextjs-app-dir/.npmrc
+++ b/packages/e2e-tests/test-applications/nextjs-app-dir/.npmrc
@@ -1,2 +1,2 @@
-@sentry:registry=http://localhost:4873
-@sentry-internal:registry=http://localhost:4873
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/packages/e2e-tests/test-applications/node-experimental-fastify-app/.npmrc
+++ b/packages/e2e-tests/test-applications/node-experimental-fastify-app/.npmrc
@@ -1,2 +1,2 @@
-@sentry:registry=http://localhost:4873
-@sentry-internal:registry=http://localhost:4873
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/packages/e2e-tests/test-applications/node-express-app/.npmrc
+++ b/packages/e2e-tests/test-applications/node-express-app/.npmrc
@@ -1,2 +1,2 @@
-@sentry:registry=http://localhost:4873
-@sentry-internal:registry=http://localhost:4873
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/packages/e2e-tests/test-applications/react-create-hash-router/.npmrc
+++ b/packages/e2e-tests/test-applications/react-create-hash-router/.npmrc
@@ -1,2 +1,2 @@
-@sentry:registry=http://localhost:4873
-@sentry-internal:registry=http://localhost:4873
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/packages/e2e-tests/test-applications/react-router-6-use-routes/.npmrc
+++ b/packages/e2e-tests/test-applications/react-router-6-use-routes/.npmrc
@@ -1,2 +1,2 @@
-@sentry:registry=http://localhost:4873
-@sentry-internal:registry=http://localhost:4873
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/packages/e2e-tests/test-applications/standard-frontend-react-tracing-import/.npmrc
+++ b/packages/e2e-tests/test-applications/standard-frontend-react-tracing-import/.npmrc
@@ -1,2 +1,2 @@
-@sentry:registry=http://localhost:4873
-@sentry-internal:registry=http://localhost:4873
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/packages/e2e-tests/test-applications/standard-frontend-react/.npmrc
+++ b/packages/e2e-tests/test-applications/standard-frontend-react/.npmrc
@@ -1,2 +1,2 @@
-@sentry:registry=http://localhost:4873
-@sentry-internal:registry=http://localhost:4873
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/packages/e2e-tests/test-applications/sveltekit/.npmrc
+++ b/packages/e2e-tests/test-applications/sveltekit/.npmrc
@@ -1,2 +1,2 @@
-@sentry:registry=http://localhost:4873
-@sentry-internal:registry=http://localhost:4873
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873

--- a/packages/e2e-tests/test-registry.npmrc
+++ b/packages/e2e-tests/test-registry.npmrc
@@ -1,6 +1,6 @@
-@sentry:registry=http://localhost:4873
-@sentry-internal:registry=http://localhost:4873
-//localhost:4873/:_authToken=some-token
+@sentry:registry=http://127.0.0.1:4873
+@sentry-internal:registry=http://127.0.0.1:4873
+//127.0.0.1:4873/:_authToken=some-token
 
 # Do not notify about npm updates
 update-notifier=false


### PR DESCRIPTION
Locally E2E tests keep hanging due to this, for whatever reason. Probably some DSN issues, but no idea why... Changing this to `127.0.0.1` fixes the problem :O Not sure if this has any downsides...?