### PR TITLE
fix(astro): Convert init file paths to POSIX paths

### DIFF
--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -55,7 +55,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
 
         if (pathToClientInit) {
           options.debug && console.log(`[sentry-astro] Using ${pathToClientInit} for client init.`);
-          injectScript('page', buildSdkInitFileImportSnippet(pathToClientInit));
+          injectScript('page', buildSdkInitFileImportSnippet(pathToPosix(pathToClientInit)));
         } else {
           options.debug && console.log('[sentry-astro] Using default client init.');
           injectScript('page', buildClientSnippet(options || {}));
@@ -63,7 +63,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
 
         if (pathToServerInit) {
           options.debug && console.log(`[sentry-astro] Using ${pathToServerInit} for server init.`);
-          injectScript('page-ssr', buildSdkInitFileImportSnippet(pathToServerInit));
+          injectScript('page-ssr', buildSdkInitFileImportSnippet(pathToPosix(pathToServerInit)));
         } else {
           options.debug && console.log('[sentry-astro] Using default server init.');
           injectScript('page-ssr', buildServerSnippet(options || {}));
@@ -78,4 +78,8 @@ function findDefaultSdkInitFile(type: 'server' | 'client'): string | undefined {
   return fileExtensions
     .map(ext => path.resolve(path.join(process.cwd(), `sentry.${type}.config.${ext}`)))
     .find(filename => fs.existsSync(filename));
+}
+
+function pathToPosix(originalPath: string): string {
+  return originalPath.split(path.sep).join(path.posix.sep);
 }

--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -55,7 +55,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
 
         if (pathToClientInit) {
           options.debug && console.log(`[sentry-astro] Using ${pathToClientInit} for client init.`);
-          injectScript('page', buildSdkInitFileImportSnippet(pathToPosix(pathToClientInit)));
+          injectScript('page', buildSdkInitFileImportSnippet(pathToClientInit));
         } else {
           options.debug && console.log('[sentry-astro] Using default client init.');
           injectScript('page', buildClientSnippet(options || {}));
@@ -63,7 +63,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
 
         if (pathToServerInit) {
           options.debug && console.log(`[sentry-astro] Using ${pathToServerInit} for server init.`);
-          injectScript('page-ssr', buildSdkInitFileImportSnippet(pathToPosix(pathToServerInit)));
+          injectScript('page-ssr', buildSdkInitFileImportSnippet(pathToServerInit));
         } else {
           options.debug && console.log('[sentry-astro] Using default server init.');
           injectScript('page-ssr', buildServerSnippet(options || {}));
@@ -78,8 +78,4 @@ function findDefaultSdkInitFile(type: 'server' | 'client'): string | undefined {
   return fileExtensions
     .map(ext => path.resolve(path.join(process.cwd(), `sentry.${type}.config.${ext}`)))
     .find(filename => fs.existsSync(filename));
-}
-
-function pathToPosix(originalPath: string): string {
-  return originalPath.split(path.sep).join(path.posix.sep);
 }

--- a/packages/astro/src/integration/snippets.ts
+++ b/packages/astro/src/integration/snippets.ts
@@ -6,7 +6,7 @@ import type { SentryOptions } from './types';
  * Creates a snippet that imports a Sentry.init file.
  */
 export function buildSdkInitFileImportSnippet(filePath: string): string {
-  return `import "${filePath.split(path.sep).join(path.posix.sep)}";`;
+  return `import "${pathToPosix(filePath)}";`;
 }
 
 /**
@@ -71,3 +71,7 @@ const buildClientIntegrations = (options: SentryOptions): string => {
 
   return integrations.join(', ');
 };
+
+function pathToPosix(originalPath: string): string {
+  return originalPath.split(path.sep).join(path.posix.sep);
+}

--- a/packages/astro/src/integration/snippets.ts
+++ b/packages/astro/src/integration/snippets.ts
@@ -1,10 +1,12 @@
+import * as path from 'path';
+
 import type { SentryOptions } from './types';
 
 /**
  * Creates a snippet that imports a Sentry.init file.
  */
 export function buildSdkInitFileImportSnippet(filePath: string): string {
-  return `import "${filePath}";`;
+  return `import "${filePath.split(path.sep).join(path.posix.sep)}";`;
 }
 
 /**


### PR DESCRIPTION
To inject a custom client/server Sentry.init call into the user bundles, we simply import from the file.
However, it seems like Vite can't resolve an absolute windows path in an import statement:

```
import 'C:\path\to\my\sentry.client.config.ts'
```

This PR converts non-posix paths to a POSIX conforming path first which should fix this limitation. This bug was reported on Discord and I asked to user to test the fix in their local setup which they confirmed to be working.  

Note: Omitted tests here because it's quite hard to get `path.sep` to return the actual windows `\\` separator instead of the OS one. Can revisit if reviewers prefer to have this properly covered.