### PR TITLE
fix(nextjs): Guard for case where `getInitialProps` may return undefined

### DIFF
--- a/packages/nextjs/src/common/wrapGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGetInitialPropsWithSentry.ts
@@ -46,7 +46,7 @@ export function wrapGetInitialPropsWithSentry(origGetInitialProps: GetInitialPro
         const initialProps: {
           _sentryTraceData?: string;
           _sentryBaggage?: string;
-        } = await tracedGetInitialProps.apply(thisArg, args);
+        } = (await tracedGetInitialProps.apply(thisArg, args)) ?? {}; // Next.js allows undefined to be returned from a getInitialPropsFunction.
 
         const requestTransaction = getTransactionFromRequest(req) ?? hub.getScope().getTransaction();
         if (requestTransaction) {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/9066

Consideration: If users return undefined we will override that with an object, which is arguably fine since when undefined is returned you will likely not depend on it in any way.