### PR TITLE
fix(browser): correct timestamp on pageload profiles

### DIFF
--- a/packages/browser/src/profiling/integration.ts
+++ b/packages/browser/src/profiling/integration.ts
@@ -75,6 +75,7 @@ export class BrowserProfilingIntegration implements Integration {
         for (const profiledTransaction of profiledTransactionEvents) {
           const context = profiledTransaction && profiledTransaction.contexts;
           const profile_id = context && context['profile'] && context['profile']['profile_id'];
+          const start_timestamp = context && context['profile'] && context['profile']['start_timestamp'];
 
           if (typeof profile_id !== 'string') {
             __DEBUG_BUILD__ &&
@@ -99,7 +100,12 @@ export class BrowserProfilingIntegration implements Integration {
             continue;
           }
 
-          const profileEvent = createProfilingEvent(profile_id, profile, profiledTransaction as ProfiledEvent);
+          const profileEvent = createProfilingEvent(
+            profile_id,
+            start_timestamp as number | undefined,
+            profile,
+            profiledTransaction as ProfiledEvent,
+          );
           if (profileEvent) {
             profilesToAddToEnvelope.push(profileEvent);
           }

--- a/packages/browser/test/unit/profiling/integration.test.ts
+++ b/packages/browser/test/unit/profiling/integration.test.ts
@@ -58,8 +58,8 @@ describe('BrowserProfilingIntegration', () => {
     expect(send).toHaveBeenCalledTimes(1);
 
     const profile = send.mock.calls?.[0]?.[0]?.[1]?.[1]?.[1];
-    const transaction = send.mock.calls?.[0]?.[0]?.[1]?.[0]?.[1]
-    const profile_timestamp_ms = new Date(profile.timestamp).getTime()
+    const transaction = send.mock.calls?.[0]?.[0]?.[1]?.[0]?.[1];
+    const profile_timestamp_ms = new Date(profile.timestamp).getTime();
     const transaction_timestamp_ms = new Date(transaction.start_timestamp * 1e3).getTime();
 
     expect(profile_timestamp_ms).toBeGreaterThan(transaction_timestamp_ms);

--- a/packages/browser/test/unit/profiling/integration.test.ts
+++ b/packages/browser/test/unit/profiling/integration.test.ts
@@ -5,11 +5,6 @@ import { BrowserProfilingIntegration } from '../../../src/profiling/integration'
 import type { JSSelfProfile } from '../../../src/profiling/jsSelfProfiling';
 
 describe('BrowserProfilingIntegration', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.useRealTimers();
-    // We will mock the carrier as if it has been initialized by the SDK, else everything is short circuited
-  });
   it('pageload profiles follow regular transaction code path', async () => {
     const stopProfile = jest.fn().mockImplementation((): Promise<JSSelfProfile> => {
       return Promise.resolve({
@@ -63,6 +58,11 @@ describe('BrowserProfilingIntegration', () => {
     expect(send).toHaveBeenCalledTimes(1);
 
     const profile = send.mock.calls?.[0]?.[0]?.[1]?.[1]?.[1];
+    const transaction = send.mock.calls?.[0]?.[0]?.[1]?.[0]?.[1]
+    const profile_timestamp_ms = new Date(profile.timestamp).getTime()
+    const transaction_timestamp_ms = new Date(transaction.start_timestamp * 1e3).getTime();
+
+    expect(profile_timestamp_ms).toBeGreaterThan(transaction_timestamp_ms);
     expect(profile.profile.frames[0]).toMatchObject({ function: 'pageload_fn', lineno: 1, colno: 1 });
   });
 });


### PR DESCRIPTION
Since there is an unknown elapsed time between document response and profile start, setting profile timestamp = transaction start timestamp can significantly skew our profile and cause alignment issue in the product. This updates the pageload profiles to create independent timestamps.