### PR TITLE
fix(replay): ensure `replay_id` is not added to DSC if session expired

### DIFF
--- a/packages/replay/src/util/addGlobalListeners.ts
+++ b/packages/replay/src/util/addGlobalListeners.ts
@@ -40,7 +40,11 @@ export function addGlobalListeners(replay: ReplayContainer): void {
       const replayId = replay.getSessionId();
       // We do not want to set the DSC when in buffer mode, as that means the replay has not been sent (yet)
       if (replayId && replay.isEnabled() && replay.recordingMode === 'session') {
-        dsc.replay_id = replayId;
+        // Ensure to check that the session is still active - it could have expired in the meanwhile
+        const isSessionActive = replay.checkAndHandleExpiredSession();
+        if (isSessionActive) {
+          dsc.replay_id = replayId;
+        }
       }
     });
 


### PR DESCRIPTION
We noticed we still sometimes see "too long sessions", and it seems this is because of errors being tagged with a replay long after the session expired. After some digging, this may be because we do not check session expiration when adding the `replay_id` to the DSC. This PR fixes this.

I thought about adding a test for this, but feels this is _a lot of_ work with all the timing issues etc., so I figure this is OK to do as-is, as this is pretty straightforward... WDYT?