### PR TITLE
fix(nextjs): Instrument route handlers when they're jsx or tsx

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -182,7 +182,7 @@ export function constructWebpackConfigFunction(
       const normalizedAbsoluteResourcePath = normalizeLoaderResourcePath(resourcePath);
       return (
         normalizedAbsoluteResourcePath.startsWith(appDirPath + path.sep) &&
-        !!normalizedAbsoluteResourcePath.match(/[\\/]route\.(js|ts)$/)
+        !!normalizedAbsoluteResourcePath.match(/[\\/]route\.(js|jsx|ts|tsx)$/)
       );
     };
 


### PR DESCRIPTION
Ref: https://github.com/vercel/next.js/discussions/57252

It is apparently allowed for route handler files to have `jsx` and `tsx` file extensions, even though it says otherwise in the Next.js docs: https://nextjs.org/docs/app/building-your-application/routing/route-handlers#convention

This PR will cause the SDK to also instrument route handlers with `jsx` and `tsx` extensions.