### PR TITLE
fix(serverless): Don't mark all errors as unhandled

### DIFF
--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -14,7 +14,7 @@ import { performance } from 'perf_hooks';
 import { types } from 'util';
 
 import { AWSServices } from './awsservices';
-import { markEventUnhandled, serverlessEventProcessor } from './utils';
+import { markEventUnhandled } from './utils';
 
 export * from '@sentry/node';
 
@@ -88,7 +88,6 @@ export function init(options: AWSLambdaOptions = {}): void {
   };
 
   Sentry.init(opts);
-  Sentry.addGlobalEventProcessor(serverlessEventProcessor);
 }
 
 /** */

--- a/packages/serverless/src/gcpfunction/index.ts
+++ b/packages/serverless/src/gcpfunction/index.ts
@@ -3,7 +3,6 @@ import type { Integration, SdkMetadata } from '@sentry/types';
 
 import { GoogleCloudGrpc } from '../google-cloud-grpc';
 import { GoogleCloudHttp } from '../google-cloud-http';
-import { serverlessEventProcessor } from '../utils';
 
 export * from './http';
 export * from './events';
@@ -38,5 +37,4 @@ export function init(options: Sentry.NodeOptions = {}): void {
   };
 
   Sentry.init(opts);
-  Sentry.addGlobalEventProcessor(serverlessEventProcessor);
 }

--- a/packages/serverless/src/utils.ts
+++ b/packages/serverless/src/utils.ts
@@ -1,22 +1,6 @@
 import { runWithAsyncContext } from '@sentry/core';
-import type { Event } from '@sentry/node';
 import type { Scope } from '@sentry/types';
 import { addExceptionMechanism } from '@sentry/utils';
-
-/**
- * Event processor that will override SDK details to point to the serverless SDK instead of Node,
- * as well as set correct mechanism type, which should be set to `handled: false`.
- * We do it like this so that we don't introduce any side-effects in this module, which makes it tree-shakeable.
- * @param event Event
- * @param integration Name of the serverless integration ('AWSLambda', 'GCPFunction', etc)
- */
-export function serverlessEventProcessor(event: Event): Event {
-  addExceptionMechanism(event, {
-    handled: false,
-  });
-
-  return event;
-}
 
 /**
  * @param fn function to run

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -534,30 +534,5 @@ describe('AWSLambda', () => {
         }),
       );
     });
-
-    test('enhance event with correct mechanism value', () => {
-      const eventWithSomeData = {
-        exception: {
-          values: [{}],
-        },
-      };
-
-      // @ts-expect-error see "Why @ts-expect-error" note
-      Sentry.addGlobalEventProcessor.mockImplementationOnce(cb => cb(eventWithSomeData));
-      Sentry.AWSLambda.init({});
-
-      expect(eventWithSomeData).toEqual({
-        exception: {
-          values: [
-            {
-              mechanism: {
-                handled: false,
-                type: 'generic',
-              },
-            },
-          ],
-        },
-      });
-    });
   });
 });

--- a/packages/serverless/test/gcpfunction.test.ts
+++ b/packages/serverless/test/gcpfunction.test.ts
@@ -684,30 +684,5 @@ describe('GCPFunction', () => {
         }),
       );
     });
-
-    test('enhance event with correct mechanism value', () => {
-      const eventWithSomeData = {
-        exception: {
-          values: [{}],
-        },
-      };
-
-      // @ts-expect-error see "Why @ts-expect-error" note
-      Sentry.addGlobalEventProcessor.mockImplementationOnce(cb => cb(eventWithSomeData));
-      Sentry.GCPFunction.init({});
-
-      expect(eventWithSomeData).toEqual({
-        exception: {
-          values: [
-            {
-              mechanism: {
-                handled: false,
-                type: 'generic',
-              },
-            },
-          ],
-        },
-      });
-    });
   });
 });


### PR DESCRIPTION
Given we merged in https://github.com/getsentry/sentry-javascript/pull/8907, we can now remove the global handlers that indiscriminately tags all events as unhandled.

fixes https://github.com/getsentry/sentry-javascript/issues/5408 