### PR TITLE
fix(replay): Remove unused parts of pako from build

### DIFF
--- a/packages/replay-worker/package.json
+++ b/packages/replay-worker/package.json
@@ -49,7 +49,8 @@
     "@types/pako": "^2.0.0"
   },
   "dependencies": {
-    "pako": "^2.1.0"
+    "@rollup/plugin-commonjs": "25.0.7",
+    "pako": "2.1.0"
   },
   "engines": {
     "node": ">=12"

--- a/packages/replay-worker/package.json
+++ b/packages/replay-worker/package.json
@@ -46,10 +46,10 @@
   },
   "homepage": "https://docs.sentry.io/platforms/javascript/session-replay/",
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^21.0.1",
     "@types/pako": "^2.0.0"
   },
   "dependencies": {
-    "@rollup/plugin-commonjs": "25.0.7",
     "pako": "2.1.0"
   },
   "engines": {

--- a/packages/replay-worker/rollup.worker.config.js
+++ b/packages/replay-worker/rollup.worker.config.js
@@ -1,6 +1,7 @@
 // inspired by https://justinribeiro.com/chronicle/2020/07/17/building-module-web-workers-for-cross-browser-compatibility-with-rollup/
 
 import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
 import typescript from '@rollup/plugin-typescript';
 import { defineConfig } from 'rollup';
 import { terser } from 'rollup-plugin-terser';
@@ -28,7 +29,9 @@ const config = defineConfig([
       file: './build/npm/esm/worker.ts',
       format: 'esm',
     },
+    treeshake: 'smallest',
     plugins: [
+      commonjs(),
       typescript({ tsconfig: './tsconfig.json', inlineSourceMap: false, sourceMap: false, inlineSources: false }),
       resolve(),
       terser({

--- a/packages/replay-worker/src/Compressor.ts
+++ b/packages/replay-worker/src/Compressor.ts
@@ -1,4 +1,10 @@
-import { constants, Deflate, deflate } from 'pako';
+import type * as PakoTypes from 'pako';
+// @ts-expect-error no types here
+import * as pako from 'pako/lib/deflate.js';
+
+const Deflate = (pako as typeof PakoTypes).Deflate;
+const deflate = (pako as typeof PakoTypes).deflate;
+const constants = (pako as typeof PakoTypes).constants;
 
 /**
  * A stateful compressor that can be used to batch compress events.
@@ -7,7 +13,7 @@ export class Compressor {
   /**
    * pako deflator instance
    */
-  public deflate: Deflate;
+  public deflate: PakoTypes.Deflate;
 
   /**
    * If any events have been added.

--- a/packages/replay-worker/src/Compressor.ts
+++ b/packages/replay-worker/src/Compressor.ts
@@ -2,6 +2,11 @@ import type * as PakoTypes from 'pako';
 // @ts-expect-error no types here
 import * as pako from 'pako/lib/deflate.js';
 
+// NOTE: We have to do this weird workaround because by default,
+// pako does not treeshake when importing from 'pako'.
+// In order to get proper tree shaking, we have to import from 'pako/lib/deflate.js',
+// Which is not great but works
+// types come from @types/pako, so we can safely use them by casting
 const Deflate = (pako as typeof PakoTypes).Deflate;
 const deflate = (pako as typeof PakoTypes).deflate;
 const constants = (pako as typeof PakoTypes).constants;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4753,6 +4753,18 @@
     is-reference "1.2.1"
     magic-string "^0.27.0"
 
+"@rollup/plugin-commonjs@25.0.7":
+  version "25.0.7"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.7.tgz#145cec7589ad952171aeb6a585bbeabd0fd3b4cf"
+  integrity sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    commondir "^1.0.1"
+    estree-walker "^2.0.2"
+    glob "^8.0.3"
+    is-reference "1.2.1"
+    magic-string "^0.30.3"
+
 "@rollup/plugin-commonjs@^15.0.0":
   version "15.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-15.1.0.tgz#1e7d076c4f1b2abf7e65248570e555defc37c238"
@@ -23281,15 +23293,15 @@ pad@^3.2.0:
   dependencies:
     wcwidth "^1.0.1"
 
+pako@2.1.0, pako@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
+  integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
+
 pako@^1.0.3, pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
-
-pako@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-2.1.0.tgz#266cc37f98c7d883545d11335c00fbd4062c9a86"
-  integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
 parallel-transform@^1.1.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4753,18 +4753,6 @@
     is-reference "1.2.1"
     magic-string "^0.27.0"
 
-"@rollup/plugin-commonjs@25.0.7":
-  version "25.0.7"
-  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.7.tgz#145cec7589ad952171aeb6a585bbeabd0fd3b4cf"
-  integrity sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==
-  dependencies:
-    "@rollup/pluginutils" "^5.0.1"
-    commondir "^1.0.1"
-    estree-walker "^2.0.2"
-    glob "^8.0.3"
-    is-reference "1.2.1"
-    magic-string "^0.30.3"
-
 "@rollup/plugin-commonjs@^15.0.0":
   version "15.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-15.1.0.tgz#1e7d076c4f1b2abf7e65248570e555defc37c238"


### PR DESCRIPTION
See https://github.com/nodeca/pako/issues/268, there is some issue with pako tree shaking ootb.

We don't need all the inflation stuff in our bundle.