### PR TITLE
chore(angular-ivy): Allow Angular 17 in peer dependencies

### DIFF
--- a/packages/angular-ivy/README.md
+++ b/packages/angular-ivy/README.md
@@ -16,7 +16,7 @@
 
 ## Angular Version Compatibility
 
-This SDK officially supports Angular 12 to 16 with Angular's new rendering engine, Ivy.
+This SDK officially supports Angular 12 to 17 with Angular's new rendering engine, Ivy.
 
 If you're using Angular 10, 11 or a newer Angular version with View Engine instead of Ivy, please use [`@sentry/angular`](https://github.com/getsentry/sentry-javascript/blob/develop/packages/angular/README.md).
 

--- a/packages/angular-ivy/package.json
+++ b/packages/angular-ivy/package.json
@@ -15,9 +15,9 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@angular/common": ">= 12.x <= 16.x",
-    "@angular/core": ">= 12.x <= 16.x",
-    "@angular/router": ">= 12.x <= 16.x",
+    "@angular/common": ">= 12.x <= 17.x",
+    "@angular/core": ">= 12.x <= 17.x",
+    "@angular/router": ">= 12.x <= 17.x",
     "rxjs": "^6.5.5 || ^7.x"
   },
   "dependencies": {


### PR DESCRIPTION
This PR bumps our peer deps to allow for Angular 12-17 in the `@sentry/angular-ivy` package. 

With the improved SSR capabilities and Vite being used for SSR Angular apps during dev mode in Angular 17, there is still an issue with our SDK's package format ([APF12](https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/preview#heading=h.k0mh3o8u5hx)) not being compatible with the server-side code. There is a [workaround](https://github.com/getsentry/sentry-javascript/issues/9376#issuecomment-1782513570) to fix this by only importing our SDK in the client side config but I [reached out](https://github.com/angular/angular-cli/issues/26135) to the Angular team to find a proper solution. 

Given that this bug only exists in SSR Angular apps, I'd argue we can already go ahead and make the peer dep bump.
I tested our SDK in a regular, client-only Angular 17 (RC2) app and errors, performance, replay and source maps seem to work. Angular 17 is [scheduled to be released](https://angular.io/guide/releases) in the week of November 6th. 

(Depending on the outcome of https://github.com/angular/angular-cli/issues/26135, we might want to link to the workaround in docs but I'll hold off from doing this just now).
