### PR TITLE
ref(replay): Streamline rrweb internal error check

### DIFF
--- a/packages/replay/src/util/isRrwebError.ts
+++ b/packages/replay/src/util/isRrwebError.ts
@@ -13,12 +13,5 @@ export function isRrwebError(event: Event, hint: EventHint): boolean {
     return true;
   }
 
-  // Check if any exception originates from rrweb
-  return event.exception.values.some(exception => {
-    if (!exception.stacktrace || !exception.stacktrace.frames || !exception.stacktrace.frames.length) {
-      return false;
-    }
-
-    return exception.stacktrace.frames.some(frame => frame.filename && frame.filename.includes('/rrweb/src/'));
-  });
+  return false;
 }

--- a/packages/replay/test/integration/coreHandlers/handleGlobalEvent.test.ts
+++ b/packages/replay/test/integration/coreHandlers/handleGlobalEvent.test.ts
@@ -267,44 +267,6 @@ describe('Integration | coreHandlers | handleGlobalEvent', () => {
     expect(handleGlobalEventListener(replay)(errorEvent, {})).toEqual(errorEvent);
   });
 
-  it('skips rrweb internal errors', () => {
-    const errorEvent: Event = {
-      exception: {
-        values: [
-          {
-            type: 'TypeError',
-            value: "Cannot read properties of undefined (reading 'contains')",
-            stacktrace: {
-              frames: [
-                {
-                  filename:
-                    'http://example.com/..node_modules/packages/replay/build/npm/esm/node_modules/rrweb/es/rrweb/packages/rrweb/src/record/mutation.js?v=90704e8a',
-                  function: 'MutationBuffer.processMutations',
-                  in_app: true,
-                  lineno: 101,
-                  colno: 23,
-                },
-                {
-                  filename: '<anonymous>',
-                  function: 'Array.forEach',
-                  in_app: true,
-                },
-              ],
-            },
-            mechanism: {
-              type: 'generic',
-              handled: true,
-            },
-          },
-        ],
-      },
-      level: 'error',
-      event_id: 'ff1616b1e13744c6964281349aecc82a',
-    };
-
-    expect(handleGlobalEventListener(replay)(errorEvent, {})).toEqual(null);
-  });
-
   it('skips exception with __rrweb__ set', () => {
     const errorEvent: Event = {
       exception: {


### PR DESCRIPTION
I think we don't really need this anymore, and this doesn't even work anyhow in any minified scenario, so we can safe these bundle bytes & also the work to check this on each error.

Or @billyvg do you see scenarios where this would catch something that the check above wouldn't? 🤔 