### PR TITLE
ref(replay): Remove unused `_triggerFullSnapshot`

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -942,19 +942,6 @@ export class ReplayContainer implements ReplayContainerInterface {
   }
 
   /**
-   * Trigger rrweb to take a full snapshot which will cause this plugin to
-   * create a new Replay event.
-   */
-  private _triggerFullSnapshot(checkout = true): void {
-    try {
-      logInfo('[Replay] Taking full rrweb snapshot');
-      record.takeFullSnapshot(checkout);
-    } catch (err) {
-      this._handleException(err);
-    }
-  }
-
-  /**
    * Update user activity (across session lifespans)
    */
   private _updateUserActivity(_lastActivity: number = Date.now()): void {


### PR DESCRIPTION
This is not used since we reworked our session refresh flow to just start>stop.