### PR TITLE
fix(nextjs): Silence warning about usage of `process` in runtimes where it is not available

### DIFF
--- a/packages/utils/src/isBrowser.ts
+++ b/packages/utils/src/isBrowser.ts
@@ -3,7 +3,6 @@ import { GLOBAL_OBJ } from './worldwide';
 
 /**
  * Returns true if we are in the browser.
- * @deprecated
  */
 export function isBrowser(): boolean {
   // eslint-disable-next-line no-restricted-globals


### PR DESCRIPTION
The `isBrowser` function ~is not used anywhere but~ accesses `process` and makes Next.js print a warning since `process` is not available in the Edge runtime.

~This PR deprecates the function (because it is unused) and uses `global.process` instead which seems to outsmart Next.js' static code analyzer.~

Also added tests to prevent stuff like this in the future: https://github.com/getsentry/sentry-javascript/pull/9382