### PR TITLE
feat(core): Add cron monitor wrapper helper

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -13,7 +13,7 @@ export {
   captureEvent,
   captureMessage,
   captureCheckIn,
-  withCheckIn,
+  withMonitor,
   configureScope,
   createTransport,
   extractTraceparentData,

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -13,6 +13,7 @@ export {
   captureEvent,
   captureMessage,
   captureCheckIn,
+  withCheckIn,
   configureScope,
   createTransport,
   extractTraceparentData,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -55,6 +55,7 @@ export {
   trace,
   withScope,
   captureCheckIn,
+  withCheckIn,
   setMeasurement,
   getActiveSpan,
   startSpan,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -55,7 +55,7 @@ export {
   trace,
   withScope,
   captureCheckIn,
-  withCheckIn,
+  withMonitor,
   setMeasurement,
   getActiveSpan,
   startSpan,

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -7,6 +7,7 @@ import type {
   EventHint,
   Extra,
   Extras,
+  FinishedCheckIn,
   MonitorConfig,
   Primitive,
   Severity,
@@ -14,7 +15,7 @@ import type {
   TransactionContext,
   User,
 } from '@sentry/types';
-import { logger, uuid4 } from '@sentry/utils';
+import { isThenable, logger, timestampInSeconds, uuid4 } from '@sentry/utils';
 
 import type { Hub } from './hub';
 import { getCurrentHub } from './hub';
@@ -208,6 +209,49 @@ export function captureCheckIn(checkIn: CheckIn, upsertMonitorConfig?: MonitorCo
   }
 
   return uuid4();
+}
+
+/**
+ * Wraps a callback with a cron monitor check in. The check in will be sent to Sentry when the callback finishes.
+ *
+ * @param monitorSlug The distinct slug of the monitor.
+ * @param upsertMonitorConfig An optional object that describes a monitor config. Use this if you want
+ * to create a monitor automatically when sending a check in.
+ */
+export function withCheckIn<T>(
+  monitorSlug: CheckIn['monitorSlug'],
+  callback: () => T,
+  upsertMonitorConfig?: MonitorConfig,
+): T {
+  const checkInId = captureCheckIn({ monitorSlug, status: 'in_progress' }, upsertMonitorConfig);
+  const now = timestampInSeconds();
+
+  function finishCheckIn(status: FinishedCheckIn['status']): void {
+    captureCheckIn({ monitorSlug, status, checkInId, duration: timestampInSeconds() - now });
+  }
+
+  let maybePromiseResult: T;
+  try {
+    maybePromiseResult = callback();
+  } catch (e) {
+    finishCheckIn('error');
+    throw e;
+  }
+
+  if (isThenable(maybePromiseResult)) {
+    Promise.resolve(maybePromiseResult).then(
+      () => {
+        finishCheckIn('ok');
+      },
+      () => {
+        finishCheckIn('error');
+      },
+    );
+  } else {
+    finishCheckIn('ok');
+  }
+
+  return maybePromiseResult;
 }
 
 /**

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -218,7 +218,7 @@ export function captureCheckIn(checkIn: CheckIn, upsertMonitorConfig?: MonitorCo
  * @param upsertMonitorConfig An optional object that describes a monitor config. Use this if you want
  * to create a monitor automatically when sending a check in.
  */
-export function withCheckIn<T>(
+export function withMonitor<T>(
   monitorSlug: CheckIn['monitorSlug'],
   callback: () => T,
   upsertMonitorConfig?: MonitorConfig,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export * from './tracing';
 export {
   addBreadcrumb,
   captureCheckIn,
+  withCheckIn,
   captureException,
   captureEvent,
   captureMessage,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,7 +7,7 @@ export * from './tracing';
 export {
   addBreadcrumb,
   captureCheckIn,
-  withCheckIn,
+  withMonitor,
   captureException,
   captureEvent,
   captureMessage,

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -53,6 +53,7 @@ export {
   trace,
   withScope,
   captureCheckIn,
+  withCheckIn,
   setMeasurement,
   getActiveSpan,
   startSpan,

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -53,7 +53,7 @@ export {
   trace,
   withScope,
   captureCheckIn,
-  withCheckIn,
+  withMonitor,
   setMeasurement,
   getActiveSpan,
   startSpan,

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -51,6 +51,7 @@ export {
   trace,
   withScope,
   captureCheckIn,
+  withCheckIn,
 } from '@sentry/node';
 
 export type {

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -51,7 +51,7 @@ export {
   trace,
   withScope,
   captureCheckIn,
-  withCheckIn,
+  withMonitor,
 } from '@sentry/node';
 
 export type {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -55,6 +55,7 @@ export {
   trace,
   withScope,
   captureCheckIn,
+  withCheckIn,
   setMeasurement,
   getActiveSpan,
   startSpan,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -55,7 +55,7 @@ export {
   trace,
   withScope,
   captureCheckIn,
-  withCheckIn,
+  withMonitor,
   setMeasurement,
   getActiveSpan,
   startSpan,

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -13,7 +13,7 @@ export {
   addGlobalEventProcessor,
   addBreadcrumb,
   captureCheckIn,
-  withCheckIn,
+  withMonitor,
   captureException,
   captureEvent,
   captureMessage,

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -13,6 +13,7 @@ export {
   addGlobalEventProcessor,
   addBreadcrumb,
   captureCheckIn,
+  withCheckIn,
   captureException,
   captureEvent,
   captureMessage,

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -21,6 +21,7 @@ export {
   captureException,
   captureMessage,
   captureCheckIn,
+  withCheckIn,
   configureScope,
   createTransport,
   getActiveTransaction,

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -21,7 +21,7 @@ export {
   captureException,
   captureMessage,
   captureCheckIn,
-  withCheckIn,
+  withMonitor,
   configureScope,
   createTransport,
   getActiveTransaction,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -11,7 +11,7 @@ export {
   captureEvent,
   captureMessage,
   captureCheckIn,
-  withCheckIn,
+  withMonitor,
   configureScope,
   createTransport,
   extractTraceparentData,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -11,6 +11,7 @@ export {
   captureEvent,
   captureMessage,
   captureCheckIn,
+  withCheckIn,
   configureScope,
   createTransport,
   extractTraceparentData,

--- a/packages/types/src/checkin.ts
+++ b/packages/types/src/checkin.ts
@@ -43,7 +43,7 @@ export interface SerializedCheckIn {
   };
 }
 
-interface InProgressCheckIn {
+export interface InProgressCheckIn {
   // The distinct slug of the monitor.
   monitorSlug: SerializedCheckIn['monitor_slug'];
   // The status of the check-in.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -125,4 +125,4 @@ export type { Instrumenter } from './instrumenter';
 export type { HandlerDataFetch, HandlerDataXhr, SentryXhrData, SentryWrappedXMLHttpRequest } from './instrument';
 
 export type { BrowserClientReplayOptions, BrowserClientProfilingOptions } from './browseroptions';
-export type { CheckIn, MonitorConfig, SerializedCheckIn } from './checkin';
+export type { CheckIn, MonitorConfig, FinishedCheckIn, InProgressCheckIn, SerializedCheckIn } from './checkin';

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -54,7 +54,7 @@ export {
   trace,
   withScope,
   captureCheckIn,
-  withCheckIn,
+  withMonitor,
   setMeasurement,
   getActiveSpan,
   startSpan,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -54,6 +54,7 @@ export {
   trace,
   withScope,
   captureCheckIn,
+  withCheckIn,
   setMeasurement,
   getActiveSpan,
   startSpan,


### PR DESCRIPTION
In https://github.com/getsentry/sentry-javascript/pull/8039 we added functionality for `Sentry.captureCheckIn` as part of Sentry's [cron monitoring product](https://docs.sentry.io/product/crons/).

This PR adds `Sentry.withMonitor`, a wrapping function similar to `Sentry.startSpan` that wraps a callback with a cron monitor. Under the hood it uses `Sentry.captureCheckIn`, but having this as a callback means that users don't have to think about passing `checkInId` around.

```ts
import * as Sentry from '@sentry/node';

// with monitor will send checkin when callback is started/finished
// works with async and sync callbacks.
const result = Sentry.withMonitor(
  'dailyEmail',
  () => {
    // withCheckIn return value is same return value here
    return sendEmail();
  },
  {
    schedule: {
      type: 'crontab',
      value: '0 * * * *',
    },
    // 🇨🇦🫡
    timezone: 'Canada/Eastern',
  },
);
```