### PR TITLE
ref(replay): Use rrweb for slow click detection

### DIFF
--- a/packages/browser-integration-tests/suites/replay/slowClick/error/init.js
+++ b/packages/browser-integration-tests/suites/replay/slowClick/error/init.js
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+window.Replay = new Sentry.Replay({
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
+  minReplayDuration: 0,
+  slowClickTimeout: 3500,
+});
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  sampleRate: 1,
+  replaysSessionSampleRate: 0.0,
+  replaysOnErrorSampleRate: 1.0,
+
+  integrations: [window.Replay],
+});

--- a/packages/browser-integration-tests/suites/replay/slowClick/error/template.html
+++ b/packages/browser-integration-tests/suites/replay/slowClick/error/template.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <button id="buttonError">Trigger error</button>
+    <button id="buttonErrorMutation">Trigger error</button>
+
+    <script>
+      document.getElementById('buttonError').addEventListener('click', () => {
+        throw new Error('test error happened');
+      });
+
+      document.getElementById('buttonErrorMutation').addEventListener('click', () => {
+        document.getElementById('buttonErrorMutation').innerText = 'Test error happened!';
+
+        throw new Error('test error happened');
+      });
+    </script>
+  </body>
+</html>

--- a/packages/browser-integration-tests/suites/replay/slowClick/error/test.ts
+++ b/packages/browser-integration-tests/suites/replay/slowClick/error/test.ts
@@ -1,0 +1,140 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import {
+  getCustomRecordingEvents,
+  getReplayEventFromRequest,
+  shouldSkipReplayTest,
+  waitForReplayRequest,
+} from '../../../../utils/replayHelpers';
+
+sentryTest('slow click that triggers error is captured', async ({ getLocalTestUrl, page }) => {
+  if (shouldSkipReplayTest()) {
+    sentryTest.skip();
+  }
+
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+
+  await page.goto(url);
+
+  const [req0] = await Promise.all([
+    waitForReplayRequest(page, (_event, res) => {
+      const { breadcrumbs } = getCustomRecordingEvents(res);
+
+      return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.slowClickDetected');
+    }),
+    page.click('#buttonError'),
+  ]);
+
+  const { breadcrumbs } = getCustomRecordingEvents(req0);
+
+  const slowClickBreadcrumbs = breadcrumbs.filter(breadcrumb => breadcrumb.category === 'ui.slowClickDetected');
+
+  expect(slowClickBreadcrumbs).toEqual([
+    {
+      category: 'ui.slowClickDetected',
+      type: 'default',
+      data: {
+        endReason: 'timeout',
+        clickCount: 1,
+        node: {
+          attributes: {
+            id: 'buttonError',
+          },
+          id: expect.any(Number),
+          tagName: 'button',
+          textContent: '******* *****',
+        },
+        nodeId: expect.any(Number),
+        timeAfterClickMs: 3500,
+        url: 'http://sentry-test.io/index.html',
+      },
+      message: 'body > button#buttonError',
+      timestamp: expect.any(Number),
+    },
+  ]);
+});
+
+sentryTest(
+  'click that triggers error & mutation is not captured',
+  async ({ getLocalTestUrl, page, forceFlushReplay }) => {
+    if (shouldSkipReplayTest()) {
+      sentryTest.skip();
+    }
+
+    await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 'test-id' }),
+      });
+    });
+
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    await page.goto(url);
+
+    let slowClickCount = 0;
+
+    page.on('response', res => {
+      const req = res.request();
+
+      const event = getReplayEventFromRequest(req);
+
+      if (!event) {
+        return;
+      }
+
+      const { breadcrumbs } = getCustomRecordingEvents(res);
+
+      const slowClicks = breadcrumbs.filter(breadcrumb => breadcrumb.category === 'ui.slowClickDetected');
+      slowClickCount += slowClicks.length;
+    });
+
+    const [req1] = await Promise.all([
+      waitForReplayRequest(page, (_event, res) => {
+        const { breadcrumbs } = getCustomRecordingEvents(res);
+
+        return breadcrumbs.some(breadcrumb => breadcrumb.category === 'ui.click');
+      }),
+      page.click('#buttonErrorMutation'),
+    ]);
+
+    const { breadcrumbs } = getCustomRecordingEvents(req1);
+
+    expect(breadcrumbs).toEqual([
+      {
+        category: 'ui.click',
+        data: {
+          node: {
+            attributes: {
+              id: 'buttonErrorMutation',
+            },
+            id: expect.any(Number),
+            tagName: 'button',
+            textContent: '******* *****',
+          },
+          nodeId: expect.any(Number),
+        },
+        message: 'body > button#buttonErrorMutation',
+        timestamp: expect.any(Number),
+        type: 'default',
+      },
+    ]);
+
+    // Ensure we wait for timeout, to make sure no slow click is created
+    // Waiting for 3500 + 1s rounding room
+    await new Promise(resolve => setTimeout(resolve, 4500));
+    await forceFlushReplay();
+
+    expect(slowClickCount).toBe(0);
+  },
+);

--- a/packages/replay/src/coreHandlers/util/domUtils.ts
+++ b/packages/replay/src/coreHandlers/util/domUtils.ts
@@ -7,6 +7,12 @@ export interface DomHandlerData {
 
 const INTERACTIVE_SELECTOR = 'button,a';
 
+/** Get the closest interactive parent element, or else return the given element. */
+export function getClosestInteractive(element: Element): Element {
+  const closestInteractive = element.closest(INTERACTIVE_SELECTOR);
+  return closestInteractive || element;
+}
+
 /**
  * For clicks, we check if the target is inside of a button or link
  * If so, we use this as the target instead
@@ -20,8 +26,7 @@ export function getClickTargetNode(event: DomHandlerData['event'] | MouseEvent):
     return target;
   }
 
-  const closestInteractive = target.closest(INTERACTIVE_SELECTOR);
-  return closestInteractive || target;
+  return getClosestInteractive(target);
 }
 
 /** Get the event target node. */

--- a/packages/replay/src/types/replay.ts
+++ b/packages/replay/src/types/replay.ts
@@ -441,7 +441,15 @@ export interface SendBufferedReplayOptions {
 export interface ReplayClickDetector {
   addListeners(): void;
   removeListeners(): void;
+
+  /** Handle a click breadcrumb. */
   handleClick(breadcrumb: Breadcrumb, node: HTMLElement): void;
+  /** Register a mutation that happened at a given time. */
+  registerMutation(timestamp?: number): void;
+  /** Register a scroll that happened at a given time. */
+  registerScroll(timestamp?: number): void;
+  /** Register that a click on an element happened. */
+  registerClick(element: HTMLElement): void;
 }
 
 export interface ReplayContainer {

--- a/packages/replay/src/util/handleRecordingEmit.ts
+++ b/packages/replay/src/util/handleRecordingEmit.ts
@@ -1,6 +1,7 @@
 import { EventType } from '@sentry-internal/rrweb';
 import { logger } from '@sentry/utils';
 
+import { updateClickDetectorForRecordingEvent } from '../coreHandlers/handleClick';
 import { saveSession } from '../session/saveSession';
 import type { RecordingEvent, ReplayContainer, ReplayOptionFrameEvent } from '../types';
 import { addEventSync } from './addEvent';
@@ -28,6 +29,10 @@ export function getHandleRecordingEmit(replay: ReplayContainer): RecordingEmitCa
     // We also want to treat the first event as a checkout, so we handle this specifically here
     const isCheckout = _isCheckout || !hadFirstEvent;
     hadFirstEvent = true;
+
+    if (replay.clickDetector) {
+      updateClickDetectorForRecordingEvent(replay.clickDetector, event);
+    }
 
     // The handler returns `true` if we do not want to trigger debounced flush, `false` if we want to debounce flush.
     replay.addUpdate(() => {


### PR DESCRIPTION
This refactors the slow/rage click detection to use rrweb events instead of adding our own event listeners.

* We look for incremental snapshot events, and update the `_lastMutation` and `_lastScroll` properties based on them.
* If a full snapshot happens, we interpret it as a mutation. this is not necessarily correct, but we don't know any different. also this shouldn't matter much because a full snapshot only happens in error mode, in which case things that happened before the full checkout should be discarded anyhow, so 🤷 

Integration tests for this are still passing, so it seems to me to be a good change. Hopefully this:

1. Decreases perf overhead by only using a single instrumentation instead of multiple overlapping ones
2. Increases consistency by ensuring that whatever we see changing in the replay will also be considered the same way for slow/rage click detection.