### PR TITLE
fix(angular-ivy): Adjust package entry points to support Angular 17 with SSR config

### DIFF
--- a/packages/angular-ivy/package.json
+++ b/packages/angular-ivy/package.json
@@ -46,7 +46,7 @@
     "build:watch": "yarn build:syncSymlinks && yarn build:transpile:watch",
     "build:dev:watch": "yarn build:watch",
     "build:transpile:watch": "ng build --watch",
-    "build:tarball": "npm pack ./build",
+    "build:tarball": "ts-node ./scripts/prepack.ts && npm pack ./build",
     "build:syncSymlinks": "ts-node ./scripts/syncSourceFiles.ts",
     "circularDepCheck": "madge --circular src/index.ts",
     "clean": "rimraf build coverage sentry-angular-ivy-*.tgz",
@@ -56,7 +56,7 @@
     "lint": "run-s lint:prettier lint:eslint",
     "lint:eslint": "eslint . --format stylish",
     "lint:prettier": "prettier --check \"{src,test,scripts}/**/**.ts\"",
-    "yalc:publish": "yalc publish build --push --sig"
+    "yalc:publish": "ts-node ./scripts/prepack.ts && yalc publish build --push --sig"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/angular-ivy/scripts/prepack.ts
+++ b/packages/angular-ivy/scripts/prepack.ts
@@ -1,0 +1,27 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+type PackageJson = {
+  main?: string;
+  type?: string;
+  nx?: string;
+  volta?: any;
+};
+
+const buildDir = path.join(process.cwd(), 'build');
+const pkjJsonPath = path.join(buildDir, 'package.json');
+const pkgJson: PackageJson = JSON.parse(fs.readFileSync(pkjJsonPath).toString());
+
+// This is necessary for Angular 17+ compatibility when SSR is configured which switches dev mode to using Vite.
+// Deleting "main" and adding "type": "module" will direct Vite to
+// use the fesm2015 bundle instead of the UMD bundle.
+delete pkgJson.main;
+pkgJson.type = 'module';
+
+// no need to keep around other properties that are only relevant for our reop:
+delete pkgJson.nx;
+delete pkgJson.volta;
+
+fs.writeFileSync(pkjJsonPath, JSON.stringify(pkgJson, null, 2));
+
+console.log('Adjusted package.json for Angular 17+ compatibility.');


### PR DESCRIPTION
This PR adjusts the entry points of `@sentry/angular-ivy`'s `package.json` to point directly to FESM2015 bundles (= bundled ESM2015 code) instead of the UMD bundles. This fixes an error when the old (no longer supported) UMD bundles were picked up by Vite in Angular apps with SSR config (#9376).   

This workaround was [suggested](https://github.com/angular/angular-cli/issues/26135#issuecomment-1782904827) by an Angular Team member and after experimenting with it, I found out that in addition to removing the `main` entry point, we also need to add `"type": "module"`.

Tested this with Angular 17 + Node 18 as well as Angular 12 with Node 12. Both seem to work in my test apps. I'm not 100% confident that this always works because we're no longer [APF12](https://docs.google.com/document/d/1CZC2rcpxffTDfRDs6p1cfbmKNLA6x5O-NtkJglDaBVs/preview#heading=h.k0mh3o8u5hx)-compliant. However we'll go with this for now and revisit if we get reports. 

A proper long term fix to this is to bump to Angular 15 in this package which we can only do in a new major. 

closes #9376 