### PR TITLE
feat(replay): Update rrweb to 2.2.0

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -18,7 +18,6 @@ module.exports = [
       config.plugins.push(
         new webpack.DefinePlugin({
           __SENTRY_DEBUG__: false,
-          __RRWEB_EXCLUDE_CANVAS__: true,
           __RRWEB_EXCLUDE_SHADOW_DOM__: true,
           __RRWEB_EXCLUDE_IFRAME__: true,
           __SENTRY_EXCLUDE_REPLAY_WORKER__: true,

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -52,8 +52,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@sentry-internal/replay-worker": "7.77.0",
-    "@sentry-internal/rrweb": "2.1.0",
-    "@sentry-internal/rrweb-snapshot": "2.1.0",
+    "@sentry-internal/rrweb": "2.2.0",
+    "@sentry-internal/rrweb-snapshot": "2.2.0",
     "jsdom-worker": "^0.2.1"
   },
   "dependencies": {

--- a/rollup/bundleHelpers.js
+++ b/rollup/bundleHelpers.js
@@ -36,7 +36,6 @@ export function makeBaseBundleConfig(options) {
   const licensePlugin = makeLicensePlugin(licenseTitle);
   const tsPlugin = makeTSPlugin('es5');
   const rrwebBuildPlugin = makeRrwebBuildPlugin({
-    excludeCanvas: true,
     excludeIframe: false,
     excludeShadowDom: false,
   });

--- a/rollup/npmHelpers.js
+++ b/rollup/npmHelpers.js
@@ -36,7 +36,6 @@ export function makeBaseNPMConfig(options = {}) {
   const extractPolyfillsPlugin = makeExtractPolyfillsPlugin();
   const setSdkSourcePlugin = makeSetSDKSourcePlugin('npm');
   const rrwebBuildPlugin = makeRrwebBuildPlugin({
-    excludeCanvas: undefined,
     excludeShadowDom: undefined,
     excludeIframe: undefined,
   });

--- a/rollup/plugins/npmPlugins.js
+++ b/rollup/plugins/npmPlugins.js
@@ -111,14 +111,10 @@ export function makeDebugBuildStatementReplacePlugin() {
  * b) can easily be modified by our users' bundlers to evaluate to false, facilitating the treeshaking of logger code.
  *
  * When `undefined` is passed,
- * end users can define e.g. `__SENTRY_EXCLUDE_CANVAS__` in their bundler to shake out canvas specific rrweb code.
+ * end users can define e.g. `__RRWEB_EXCLUDE_SHADOW_DOM__` in their bundler to shake out shadow dom specific rrweb code.
  */
-export function makeRrwebBuildPlugin({ excludeCanvas, excludeShadowDom, excludeIframe } = {}) {
+export function makeRrwebBuildPlugin({ excludeShadowDom, excludeIframe } = {}) {
   const values = {};
-
-  if (typeof excludeCanvas === 'boolean') {
-    values['__RRWEB_EXCLUDE_CANVAS__'] = excludeCanvas;
-  }
 
   if (typeof excludeShadowDom === 'boolean') {
     values['__RRWEB_EXCLUDE_SHADOW_DOM__'] = excludeShadowDom;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4925,33 +4925,33 @@
     semver "7.3.2"
     semver-intersect "1.4.0"
 
-"@sentry-internal/rrdom@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.1.0.tgz#3e8822cd8f748de5c5a3c58121fac1eebbb767d5"
-  integrity sha512-99paancC1dkU9O1oUP9zAxfXupX+ha9Cglf9oINUsY/Ey8a6fOhFf5Z3wTzDne28OZ0KeivhBHc8yxeGzdCfGw==
+"@sentry-internal/rrdom@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.2.0.tgz#edc292e55263e1e2541a9ed282ff998aae272a0a"
+  integrity sha512-pX2YxpZfKxfbeEKG+sc0WzlSMUsG9mgwK3IioeVulNovUmus6UhLLQHYeZEsQg0WehClCgBRZakk8qEFXbmwdg==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.1.0"
+    "@sentry-internal/rrweb-snapshot" "2.2.0"
 
-"@sentry-internal/rrweb-snapshot@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.1.0.tgz#7ed2d51bc8f580496676460bcccf37e1f6da5902"
-  integrity sha512-nqzSIO25We6XIGDwmZ66zRZ7QHGZApck4gbgFYXA/lcCB/zcY0aPD0DTv85oIVUfEo2RCjLeNoWWKwlrrRWtUQ==
+"@sentry-internal/rrweb-snapshot@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.2.0.tgz#23a231ffd8ef734c2665690e8040a4ffc2faaf9f"
+  integrity sha512-txHynfjaJHLJvS+Kf9DOJyL7ur/nIBSJsF7OVKoJYJr43uRJzOyJ/SdliIrGz71IpVOCkuBa/ufRRVEVneRDDg==
 
-"@sentry-internal/rrweb-types@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.1.0.tgz#2888915faec726937db86b4bb9f56e958fdef5e9"
-  integrity sha512-h9pCw59SJYormxY/R2O/olcynp6xAMzhzZ6lnQy6ezzDfsjjf4G83oqXnAhs6hmqBmDn1QbdODFewMHK6uVxYw==
+"@sentry-internal/rrweb-types@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.2.0.tgz#79a76a8d5c436cf18cdee604ab95a9e3049d1949"
+  integrity sha512-0x7gL9cEF/rrdx1feIORD8+pHihJVA2t1wMRnT+PyiEJZToNJO08Mpbe2rlWgovfK3kGDj5GVFVXsPKGTj8c3A==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.1.0"
+    "@sentry-internal/rrweb-snapshot" "2.2.0"
 
-"@sentry-internal/rrweb@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.1.0.tgz#cc8166e9be4cdd2869d81bd65b4ba818063a491f"
-  integrity sha512-CXBZjl+TtRfPYjLtj5SX/ipqBtZLw5Z3MRIppODi/H7l7oQekOadUHu0+23lm82fl3CXK4jn9gMWcRRulUkn4Q==
+"@sentry-internal/rrweb@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.2.0.tgz#f9b538f16718b88f6ca99b3393c5fbebc274bc06"
+  integrity sha512-gcdC9uuw6b5WZp1wsqC8p8yBN8bmiZN7X7UaxMrhBwH9TifbYxK1gNbgeKOI/GzZF9OVbduXYm3UDt9ZS1njGg==
   dependencies:
-    "@sentry-internal/rrdom" "2.1.0"
-    "@sentry-internal/rrweb-snapshot" "2.1.0"
-    "@sentry-internal/rrweb-types" "2.1.0"
+    "@sentry-internal/rrdom" "2.2.0"
+    "@sentry-internal/rrweb-snapshot" "2.2.0"
+    "@sentry-internal/rrweb-types" "2.2.0"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"


### PR DESCRIPTION
- feat: Export getCanvasManager & allow passing it to record() [#122](https://github.com/getsentry/rrweb/pull/122)
- feat: Remove hooks related code, which is not used [#126](https://github.com/getsentry/rrweb/pull/126)
- feat: Remove plugins related code, which is not used [#123](https://github.com/getsentry/rrweb/pull/123)
- feat: Refactor module scope vars & export mirror & `takeFullSnapshot` directly [#113](https://github.com/getsentry/rrweb/pull/113)
- fix(rrweb): Fix rule.style being undefined [#121](https://github.com/getsentry/rrweb/pull/121)
- ref: Avoid unnecessary cloning of objects or arrays [#125](https://github.com/getsentry/rrweb/pull/125)
- ref: Avoid cloning events to add timestamp [#124](https://github.com/getsentry/rrweb/pull/124)


Note: With this update, canvas is _always_ excluded, unless we opt in by passing a `getCanvasManager` function to `record()`. We'll provide a way to do this once we have a fully formed canvas story. For now, this will reduce bundle size considerably for all SDK users.