### PR TITLE
feat(node-experimental): Replace `getCurrentHub` with `getCurrentScope`

### DIFF
--- a/packages/node-experimental/README.md
+++ b/packages/node-experimental/README.md
@@ -50,7 +50,39 @@ Currently, this SDK:
 * Will capture errors (same as @sentry/node)
 * Auto-instrument for performance - see below for which performance integrations are available.
 * Provide _some_ manual instrumentation APIs
-* Sync OpenTelemetry Context with our Sentry Hub/Scope
+* Sync OpenTelemetry Context with our Sentry Scope
+
+### Hub, Scope & Context
+
+node-experimental has no public concept of a Hub anymore.
+Instead, you always interact with a Scope, which maps to an OpenTelemetry Context.
+This means that the following common API is _not_ available:
+
+```js
+const hub = Sentry.getCurrentHub();
+```
+
+Instead, you can directly get the current scope:
+
+```js
+const scope = Sentry.getCurrentScope();
+```
+
+Additionally, there are some more utilities to work with:
+
+```js
+// Get the currently active scope
+const scope = Sentry.getCurrentScope();
+// Get the currently active root scope
+// A root scope is either the global scope, OR the first forked scope, OR the scope of the root span
+const rootScope = Sentry.getCurrentRootScope();
+// Create a new execution context - basically a wrapper for `context.with()` in OpenTelemetry
+Sentry.withScope(scope => {});
+// Create a new execution context, which should be a root scope. This overwrites any previously set root scope
+Sentry.withRootScope(rootScope => {});
+// Get the client of the SDK
+const client = Sentry.getClient();
+```
 
 ### Manual Instrumentation
 

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -12,8 +12,17 @@ export { INTEGRATIONS as Integrations };
 export { getAutoPerformanceIntegrations } from './integrations/getAutoPerformanceIntegrations';
 export * as Handlers from './sdk/handlers';
 export type { Span } from './types';
+export { getClient } from './sdk/client';
 
-export { startSpan, startInactiveSpan, getCurrentHub, getActiveSpan } from '@sentry/opentelemetry';
+export {
+  startSpan,
+  startInactiveSpan,
+  getActiveSpan,
+  getCurrentScope,
+  getCurrentRootScope,
+  withScope,
+  withRootScope,
+} from '@sentry/opentelemetry';
 
 export {
   makeNodeTransport,
@@ -30,12 +39,10 @@ export {
   captureEvent,
   captureMessage,
   close,
-  configureScope,
   createTransport,
   extractTraceparentData,
   flush,
   getActiveTransaction,
-  Hub,
   lastEventId,
   makeMain,
   runWithAsyncContext,
@@ -49,7 +56,6 @@ export {
   setUser,
   spanStatusfromHttpCode,
   trace,
-  withScope,
   captureCheckIn,
   withMonitor,
 } from '@sentry/node';

--- a/packages/node-experimental/src/sdk/client.ts
+++ b/packages/node-experimental/src/sdk/client.ts
@@ -1,5 +1,7 @@
 import { NodeClient, SDK_VERSION } from '@sentry/node';
-import { wrapClientClass } from '@sentry/opentelemetry';
+import { getCurrentHub, wrapClientClass } from '@sentry/opentelemetry';
+
+import type { NodeExperimentalClient as NodeExperimentalClientInterface } from '../types';
 
 class NodeExperimentalBaseClient extends NodeClient {
   public constructor(options: ConstructorParameters<typeof NodeClient>[0]) {
@@ -20,3 +22,10 @@ class NodeExperimentalBaseClient extends NodeClient {
 }
 
 export const NodeExperimentalClient = wrapClientClass(NodeExperimentalBaseClient);
+
+/**
+ * Get the currently active client (or undefined, if the SDK is not initialized).
+ */
+export function getClient(): NodeExperimentalClientInterface | undefined {
+  return getCurrentHub().getClient<NodeExperimentalClientInterface>();
+}

--- a/packages/node-experimental/test/integration/client.test.ts
+++ b/packages/node-experimental/test/integration/client.test.ts
@@ -1,0 +1,32 @@
+import { GLOBAL_OBJ } from '@sentry/utils';
+
+import * as Sentry from '../../src';
+import { NodeExperimentalClient } from '../../src/sdk/client';
+import { cleanupOtel, mockSdkInit } from '../helpers/mockSdkInit';
+
+describe('Integration | Client', () => {
+  describe('getClient', () => {
+    beforeEach(() => {
+      GLOBAL_OBJ.__SENTRY__ = {
+        extensions: {},
+        hub: undefined,
+        globalEventProcessors: [],
+        logger: undefined,
+      };
+    });
+
+    afterEach(() => {
+      cleanupOtel();
+    });
+
+    test('it works with no client', () => {
+      expect(Sentry.getClient()).toBeUndefined();
+    });
+
+    test('it works with a client', () => {
+      mockSdkInit();
+      expect(Sentry.getClient()).toBeDefined();
+      expect(Sentry.getClient()).toBeInstanceOf(NodeExperimentalClient);
+    });
+  });
+});

--- a/packages/opentelemetry/src/constants.ts
+++ b/packages/opentelemetry/src/constants.ts
@@ -8,3 +8,9 @@ export const SENTRY_PROPAGATION_CONTEXT_CONTEXT_KEY = createContextKey('SENTRY_P
 
 /** Context Key to hold a Hub. */
 export const SENTRY_HUB_CONTEXT_KEY = createContextKey('sentry_hub');
+
+/** Context Key to hold a root scope. */
+export const SENTRY_ROOT_SCOPE_CONTEXT_KEY = createContextKey('sentry_root_scope');
+
+/** Context Key to force setting of the root scope, even if one already exists. */
+export const SENTRY_FORCE_ROOT_SCOPE_CONTEXT_KEY = createContextKey('sentry_force_root_scope');

--- a/packages/opentelemetry/src/custom/hub.ts
+++ b/packages/opentelemetry/src/custom/hub.ts
@@ -73,6 +73,13 @@ export function getCurrentHub(): Hub {
 }
 
 /**
+ * Check if a given hub is the global hub.
+ */
+export function isGlobalHub(hub: Hub): boolean {
+  return hub === getGlobalHub();
+}
+
+/**
  * Ensure the global hub is an OpenTelemetryHub.
  */
 export function setupGlobalHub(): void {
@@ -112,7 +119,10 @@ export function ensureHubOnCarrier(carrier: Carrier, parent: Hub = getGlobalHub(
   }
 }
 
-function getGlobalHub(registry: Carrier = getMainCarrier()): Hub {
+/**
+ * Get the global hub.
+ */
+export function getGlobalHub(registry: Carrier = getMainCarrier()): Hub {
   // If there's no hub, or its an old API, assign a new one
   if (!hasHubOnCarrier(registry) || getHubFromCarrier(registry).isOlderThan(API_VERSION)) {
     setHubOnCarrier(registry, new OpenTelemetryHub());

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -19,6 +19,8 @@ export {
   spanHasStatus,
 } from './utils/spanTypes';
 
+export { getCurrentScope, getCurrentRootScope, getGlobalScope, withScope, withRootScope } from './utils/scope';
+
 export { isSentryRequestSpan } from './utils/isSentryRequest';
 
 export { getActiveSpan, getRootSpan } from './utils/getActiveSpan';

--- a/packages/opentelemetry/src/utils/contextData.ts
+++ b/packages/opentelemetry/src/utils/contextData.ts
@@ -1,7 +1,12 @@
 import type { Context } from '@opentelemetry/api';
-import type { Hub, PropagationContext } from '@sentry/types';
+import type { Hub, PropagationContext, Scope } from '@sentry/types';
 
-import { SENTRY_HUB_CONTEXT_KEY, SENTRY_PROPAGATION_CONTEXT_CONTEXT_KEY } from '../constants';
+import {
+  SENTRY_FORCE_ROOT_SCOPE_CONTEXT_KEY,
+  SENTRY_HUB_CONTEXT_KEY,
+  SENTRY_PROPAGATION_CONTEXT_CONTEXT_KEY,
+  SENTRY_ROOT_SCOPE_CONTEXT_KEY,
+} from '../constants';
 
 /**
  * Try to get the Propagation Context from the given OTEL context.
@@ -20,7 +25,7 @@ export function setPropagationContextOnContext(context: Context, propagationCont
 }
 
 /**
- * Try to get the Hub from the given OTEL context.
+ * Try to get the hub from the given OTEL context.
  * This requires a Context Manager that was wrapped with getWrappedContextManager.
  */
 export function getHubFromContext(context: Context): Hub | undefined {
@@ -28,9 +33,49 @@ export function getHubFromContext(context: Context): Hub | undefined {
 }
 
 /**
- * Set a Hub on an OTEL context..
+ * Set a hub on an OTEL context.
  * This will return a forked context with the Propagation Context set.
  */
 export function setHubOnContext(context: Context, hub: Hub): Context {
   return context.setValue(SENTRY_HUB_CONTEXT_KEY, hub);
+}
+
+/**
+ * Try to get the root scope from the given OTEL context.
+ * This requires a Context Manager that was wrapped with getWrappedContextManager.
+ */
+export function getRootScopeFromContext(context: Context): Scope | undefined {
+  return context.getValue(SENTRY_ROOT_SCOPE_CONTEXT_KEY) as Scope | undefined;
+}
+
+/**
+ * Set a root scope on an OTEL context.
+ * This will return a forked context with the Propagation Context set.
+ */
+export function setRootScopeOnContext(context: Context, scope: Scope): Context {
+  return context.setValue(SENTRY_ROOT_SCOPE_CONTEXT_KEY, scope);
+}
+
+/**
+ * If this context should be forced to generate a new root scope.
+ * This requires a Context Manager that was wrapped with getWrappedContextManager.
+ */
+export function getForceRootScopeFromContext(context: Context): boolean {
+  return !!context.getValue(SENTRY_FORCE_ROOT_SCOPE_CONTEXT_KEY);
+}
+
+/**
+ * Set a flag on the context to ensure we set the new scope as root scope.
+ * This will return a forked context with the Propagation Context set.
+ */
+export function setForceRootScopeOnContext(context: Context, force = true): Context {
+  return context.setValue(SENTRY_FORCE_ROOT_SCOPE_CONTEXT_KEY, force);
+}
+
+/**
+ * Clear the force root scope flag on the context.
+ * This will return a forked context with the Propagation Context set.
+ */
+export function clearForceRootScopeOnContext(context: Context): Context {
+  return context.deleteValue(SENTRY_FORCE_ROOT_SCOPE_CONTEXT_KEY);
 }

--- a/packages/opentelemetry/src/utils/scope.ts
+++ b/packages/opentelemetry/src/utils/scope.ts
@@ -1,0 +1,53 @@
+import { context } from '@opentelemetry/api';
+import type { Scope } from '@sentry/types';
+
+import { getCurrentHub, getGlobalHub } from '../custom/hub';
+import { getRootScopeFromContext, setForceRootScopeOnContext } from './contextData';
+
+/**
+ * Get the currently active scope.
+ */
+export function getCurrentScope(): Scope {
+  return getCurrentHub().getScope();
+}
+
+/**
+ * Get the currently active root scope,
+ * or fall back to the active scope if none is available.
+ */
+export function getCurrentRootScope(): Scope {
+  const rootScope = getRootScopeFromContext(context.active());
+
+  return rootScope || getCurrentScope();
+}
+
+/**
+ * Get the global scope.
+ */
+export function getGlobalScope(): Scope {
+  return getGlobalHub().getScope();
+}
+
+/**
+ * Creates a new scope with and executes the given operation within.
+ * The scope is automatically removed once the operation
+ * finishes or throws.
+ */
+export function withScope(callback: (scope: Scope) => void): void {
+  context.with(context.active(), () => {
+    const scope = getCurrentScope();
+    callback(scope);
+  });
+}
+
+/**
+ * Creates a new root scope with and executes the given operation within.
+ * The scope is automatically removed once the operation
+ * finishes or throws.
+ */
+export function withRootScope(callback: (scope: Scope) => void): void {
+  context.with(setForceRootScopeOnContext(context.active()), () => {
+    const scope = getCurrentScope();
+    callback(scope);
+  });
+}


### PR DESCRIPTION
This removes `getCurrentHub()` & `configureScope()` from node-experimental, and instead exposes a few new APIs:

* `getCurrentScope()`
* `getCurrentRootScope()`
* `withScope()` - has the same API as before, uses OTEL under the hood
* `withRootScope()`
* `getClient()`

## `getClient()`

IMHO this API we can/should add to all SDKs, it's annoying to have to do `getCurrentHub().getClient()` anyhow. This is just a short cut and a nicer API.

## What is a root scope

This PR introduces the (tentative) concept of a _root scope_. A root scope is supposed to be the scope attached to an execution context, e.g. to a route handler:

```js
const globalScope = Sentry.getCurrentRootScope();

app.get('/route1', () => {
  const scope = Sentry.getCurrentRootScope();
  Sentry.withScope(() => {
    Sentry.getCurrentRootScope() === scope;
  });
});

app.get('/route2', () => {
  const scope = Sentry.getCurrentRootScope();
  Sentry.withScope(() => {
    Sentry.getCurrentRootScope() === scope;
  });
});
```

The goal of the root scope is to make reasoning about scopes with the heavily nested scopes/contexts we have in otel easier. Since every change on the context creates a new hub & scope, you can quickly get into a scenario where it's impossible to actually get the correct scope to add stuff to.

Eventually, the idea is that the root scope is always applied to events _in addition_ the the actual current scope. This is not yet implemented in this PR but will be done in a follow up PR. This will also streamline the breadcrumbs handling we have, as we'll be able to simply put the breadcrumbs on the root scope instead of on the root span.

The scenario we are solving is things like this:

```js
fastify.addHook('preValidation', () => {
  Sentry.getCurrentRootScope().addEventProcessor(...);
});
```

Without this, it is basically impossible to add execution-context specific things, because the fastify otel instrumentation creates a span for each hook, which in turn creates a new context (and scope), which means that if you do this:

```js
fastify.addHook('preValidation', () => {
  Sentry.getCurrentScope().addEventProcessor(...);
});
```

You'll only add this to the scope valid inside of this hook, not to the request.

For most user-land scenarios, this should not be necessary - you can still do e.g.:

```js
app.get('/route', () => {
  const scope = Sentry.getCurrentScope();
  scope.setUser(user);
});
```

To mutate the current scope. But it gives more flexibility to integrations/plugins etc.

### How do we detect/set the root scope

Here is where it gets tricky. Conceptually, in most cases it is relatively clear what we _want_ the root scope to be - the scope for the `http.server` request. However, it is not necessarily easy to find this, nor to generalize this for _all_ environments, as some may not have requests at all.

This PR takes the following approach:

1. The first scope that is forked from the global scope is considered a root scope:

```js
const globalScope = getCurrentScope(); 
// globalScope is a root scope

withScope(scope1 => {
  // scope1 is a root scope!
});

withScope(scope2 => {
  // scope2 is a root scope!
  withScope(scope3 => {
    // scope3 is _not_  a root scope!
  });
});
```

2. A scope that has a root span is considered a root scope:

```js
withScope(scope1 => {
  // scope1 is a root scope!
  startSpan({ name: 'root span' }, () => {
    const scope2 = getCurrentScope();
    // scope2 is a root scope!
    startSpan({ name: 'span' }, () => {
      const scope3 = getCurrentScope();
      // scope3 is _not_ a root scope!
    });
  });
});
```

3. You can also manually fork a root scope, no matter where you are:

```js
withScope(scope1 => {
  // scope1 is a root scope!
  withRootScope(scope2 => {
    // scope2 is a root scope!
  });
});
```

4. We fall back to the current scope if we can't find anything else.