### PR TITLE
fix(replay): Ensure we stop for rate limit headers

### DIFF
--- a/packages/replay/src/util/sendReplay.ts
+++ b/packages/replay/src/util/sendReplay.ts
@@ -2,7 +2,7 @@ import { captureException, setContext } from '@sentry/core';
 
 import { RETRY_BASE_INTERVAL, RETRY_MAX_COUNT, UNABLE_TO_SEND_REPLAY } from '../constants';
 import type { SendReplayData } from '../types';
-import { sendReplayRequest, TransportStatusCodeError } from './sendReplayRequest';
+import { RateLimitError, sendReplayRequest, TransportStatusCodeError } from './sendReplayRequest';
 
 /**
  * Finalize and send the current replay event to Sentry
@@ -25,7 +25,7 @@ export async function sendReplay(
     await sendReplayRequest(replayData);
     return true;
   } catch (err) {
-    if (err instanceof TransportStatusCodeError) {
+    if (err instanceof TransportStatusCodeError || err instanceof RateLimitError) {
       throw err;
     }
 

--- a/packages/replay/src/util/sendReplayRequest.ts
+++ b/packages/replay/src/util/sendReplayRequest.ts
@@ -1,5 +1,7 @@
 import { getCurrentHub } from '@sentry/core';
 import type { ReplayEvent, TransportMakeRequestResponse } from '@sentry/types';
+import type { RateLimits } from '@sentry/utils';
+import { isRateLimited, updateRateLimits } from '@sentry/utils';
 
 import { REPLAY_EVENT_NAME, UNABLE_TO_SEND_REPLAY } from '../constants';
 import type { SendReplayData } from '../types';
@@ -128,6 +130,11 @@ export async function sendReplayRequest({
     throw new TransportStatusCodeError(response.statusCode);
   }
 
+  const rateLimits = updateRateLimits({}, response);
+  if (isRateLimited(rateLimits, 'replay')) {
+    throw new RateLimitError(rateLimits);
+  }
+
   return response;
 }
 
@@ -137,5 +144,17 @@ export async function sendReplayRequest({
 export class TransportStatusCodeError extends Error {
   public constructor(statusCode: number) {
     super(`Transport returned status code ${statusCode}`);
+  }
+}
+
+/**
+ * This error indicates that we hit a rate limit API error.
+ */
+export class RateLimitError extends Error {
+  public rateLimits: RateLimits;
+
+  public constructor(rateLimits: RateLimits) {
+    super('Rate limit hit');
+    this.rateLimits = rateLimits;
   }
 }


### PR DESCRIPTION
We changed this [here](https://github.com/getsentry/sentry-javascript/pull/7018), but apparently it is possible to have responses with a 200 status code but rate limit headers.

This PR updates our handling to stop either for a non-200 status code, _or_ for a rate limit header.

I also streamlined the tests for this a bit, we were testing a bunch of unrelated things, IMHO it's enough to test we stopped/didn't stop.

Resolves: https://github.com/getsentry/sentry/issues/49498