### PR TITLE
github: add replay to bug template in sdk options

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -31,7 +31,7 @@ body:
         setup.
       options:
         - '@sentry/browser'
-        - '@sentry/astro'        
+        - '@sentry/astro'
         - '@sentry/angular'
         - '@sentry/angular-ivy'
         - '@sentry/bun'
@@ -42,6 +42,7 @@ body:
         - '@sentry/opentelemetry-node'
         - '@sentry/react'
         - '@sentry/remix'
+        - '@sentry/replay'
         - '@sentry/serverless'
         - '@sentry/svelte'
         - '@sentry/sveltekit'


### PR DESCRIPTION
Was about to open a bug report and noticed that the option was missing?