### PR TITLE
feat(feedback): use custom prepare/send, re-use createEventEnvelope from core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,7 @@ export type { OfflineStore, OfflineTransportOptions } from './transports/offline
 export type { ServerRuntimeClientOptions } from './server-runtime-client';
 
 export * from './tracing';
-export {createEventEnvelope} from './envelope';
+export { createEventEnvelope } from './envelope';
 export {
   addBreadcrumb,
   captureCheckIn,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export type { OfflineStore, OfflineTransportOptions } from './transports/offline
 export type { ServerRuntimeClientOptions } from './server-runtime-client';
 
 export * from './tracing';
+export {createEventEnvelope} from './envelope';
 export {
   addBreadcrumb,
   captureCheckIn,

--- a/packages/feedback/src/index.ts
+++ b/packages/feedback/src/index.ts
@@ -1,2 +1,2 @@
-export { sendFeedbackRequest } from './util/sendFeedbackRequest';
+export { sendFeedback } from './sendFeedback';
 export { Feedback } from './integration';

--- a/packages/feedback/src/types/index.ts
+++ b/packages/feedback/src/types/index.ts
@@ -1,25 +1,9 @@
-import type { Event, Primitive } from '@sentry/types';
+import type { Primitive } from '@sentry/types';
 
 import type { ActorComponent } from '../widget/Actor';
 import type { DialogComponent } from '../widget/Dialog';
 
 export type SentryTags = { [key: string]: Primitive } | undefined;
-
-/**
- * NOTE: These types are still considered Beta and subject to change.
- * @hidden
- */
-export interface FeedbackEvent extends Event {
-  feedback: {
-    message: string;
-    url: string;
-    contact_email?: string;
-    name?: string;
-    replay_id?: string;
-  };
-  // TODO: Add this event type to Event
-  // type: 'feedback_event';
-}
 
 export interface SendFeedbackData {
   feedback: {

--- a/packages/feedback/src/util/handleFeedbackSubmit.ts
+++ b/packages/feedback/src/util/handleFeedbackSubmit.ts
@@ -5,38 +5,34 @@ import type { DialogComponent } from '../widget/Dialog';
 /**
  * Calls `sendFeedback` to send feedback, handles UI behavior of dialog.
  */
-export async function handleFeedbackSubmit(
+export function handleFeedbackSubmit(
   dialog: DialogComponent | null,
   feedback: FeedbackFormData,
   options?: SendFeedbackOptions,
-): Promise<Response | false> {
+): string | undefined {
   if (!dialog) {
     // Not sure when this would happen
-    return false;
+    return;
   }
 
-  const showFetchError = (): void => {
-    if (!dialog) {
-      return;
-    }
-    dialog.showError('There was a problem submitting feedback, please wait and try again.');
-  };
+  // const showFetchError = (): void => {
+  //   if (!dialog) {
+  //     return;
+  //   }
+  //   dialog.showError('There was a problem submitting feedback, please wait and try again.');
+  // };
 
-  try {
-    dialog.hideError();
-    const resp = await sendFeedback(feedback, options);
+  dialog.hideError();
 
-    if (!resp) {
-      // Errored... re-enable submit button
-      showFetchError();
-      return false;
-    }
-
-    // Success!
-    return resp;
-  } catch {
-    // Errored... re-enable submit button
-    showFetchError();
-    return false;
-  }
+  // TODO: Error handling?
+  return sendFeedback(feedback, options);
+  // try {
+  //   const resp = await sendFeedback(feedback, options);
+  //
+  //   // Success!
+  //   return resp;
+  // } catch {
+  //   // Errored... re-enable submit button
+  //   showFetchError();
+  // }
 }

--- a/packages/feedback/src/util/handleFeedbackSubmit.ts
+++ b/packages/feedback/src/util/handleFeedbackSubmit.ts
@@ -1,3 +1,5 @@
+import type { TransportMakeRequestResponse } from '@sentry/types';
+
 import { sendFeedback } from '../sendFeedback';
 import type { FeedbackFormData, SendFeedbackOptions } from '../types';
 import type { DialogComponent } from '../widget/Dialog';
@@ -5,34 +7,33 @@ import type { DialogComponent } from '../widget/Dialog';
 /**
  * Calls `sendFeedback` to send feedback, handles UI behavior of dialog.
  */
-export function handleFeedbackSubmit(
+export async function handleFeedbackSubmit(
   dialog: DialogComponent | null,
   feedback: FeedbackFormData,
   options?: SendFeedbackOptions,
-): string | undefined {
+): Promise<TransportMakeRequestResponse | void> {
   if (!dialog) {
     // Not sure when this would happen
     return;
   }
 
-  // const showFetchError = (): void => {
-  //   if (!dialog) {
-  //     return;
-  //   }
-  //   dialog.showError('There was a problem submitting feedback, please wait and try again.');
-  // };
+  const showFetchError = (): void => {
+    if (!dialog) {
+      return;
+    }
+    dialog.showError('There was a problem submitting feedback, please wait and try again.');
+  };
 
   dialog.hideError();
 
-  // TODO: Error handling?
-  return sendFeedback(feedback, options);
-  // try {
-  //   const resp = await sendFeedback(feedback, options);
-  //
-  //   // Success!
-  //   return resp;
-  // } catch {
-  //   // Errored... re-enable submit button
-  //   showFetchError();
-  // }
+  try {
+    const resp = await sendFeedback(feedback, options);
+
+    // Success!
+    return resp;
+  } catch (err) {
+    console.error(err);
+    // Errored... re-enable submit button
+    showFetchError();
+  }
 }

--- a/packages/feedback/src/util/handleFeedbackSubmit.ts
+++ b/packages/feedback/src/util/handleFeedbackSubmit.ts
@@ -6,7 +6,8 @@ import type { FeedbackFormData, SendFeedbackOptions } from '../types';
 import type { DialogComponent } from '../widget/Dialog';
 
 /**
- * Calls `sendFeedback` to send feedback, handles UI behavior of dialog.
+ * Handles UI behavior of dialog when feedback is submitted, calls
+ * `sendFeedback` to send feedback.
  */
 export async function handleFeedbackSubmit(
   dialog: DialogComponent | null,
@@ -33,7 +34,7 @@ export async function handleFeedbackSubmit(
     // Success!
     return resp;
   } catch (err) {
-    logger.error(err);
+    __DEBUG_BUILD__ && logger.error(err);
     showFetchError();
   }
 }

--- a/packages/feedback/src/util/handleFeedbackSubmit.ts
+++ b/packages/feedback/src/util/handleFeedbackSubmit.ts
@@ -1,4 +1,5 @@
 import type { TransportMakeRequestResponse } from '@sentry/types';
+import { logger } from '@sentry/utils';
 
 import { sendFeedback } from '../sendFeedback';
 import type { FeedbackFormData, SendFeedbackOptions } from '../types';
@@ -32,8 +33,7 @@ export async function handleFeedbackSubmit(
     // Success!
     return resp;
   } catch (err) {
-    console.error(err);
-    // Errored... re-enable submit button
+    logger.error(err);
     showFetchError();
   }
 }

--- a/packages/feedback/src/util/prepareFeedbackEvent.ts
+++ b/packages/feedback/src/util/prepareFeedbackEvent.ts
@@ -23,7 +23,7 @@ export async function prepareFeedbackEvent({
   const preparedEvent = (await prepareEvent(
     client.getOptions(),
     event,
-    { integrations: undefined },
+    eventHint,
     scope,
     client,
   )) as FeedbackEvent | null;

--- a/packages/feedback/src/util/prepareFeedbackEvent.ts
+++ b/packages/feedback/src/util/prepareFeedbackEvent.ts
@@ -1,8 +1,6 @@
 import type { Scope } from '@sentry/core';
 import { prepareEvent } from '@sentry/core';
-import type { Client } from '@sentry/types';
-
-import type { FeedbackEvent } from '../types';
+import type { Client, FeedbackEvent } from '@sentry/types';
 
 interface PrepareFeedbackEventParams {
   client: Client;
@@ -11,13 +9,15 @@ interface PrepareFeedbackEventParams {
 }
 /**
  * Prepare a feedback event & enrich it with the SDK metadata.
+ *
+ * TODO: Refactor this with the replay version
  */
 export async function prepareFeedbackEvent({
   client,
   scope,
   event,
 }: PrepareFeedbackEventParams): Promise<FeedbackEvent | null> {
-  const eventHint = { integrations: undefined };
+  const eventHint = {};
   if (client.emit) {
     client.emit('preprocessEvent', event, eventHint);
   }
@@ -44,9 +44,9 @@ export async function prepareFeedbackEvent({
   const { name, version } = (metadata && metadata.sdk) || {};
 
   preparedEvent.sdk = {
-    ...preparedEvent.sdk,
     name: name || 'sentry.javascript.unknown',
     version: version || '0.0.0',
   };
+
   return preparedEvent;
 }

--- a/packages/feedback/src/util/sendFeedbackRequest.ts
+++ b/packages/feedback/src/util/sendFeedbackRequest.ts
@@ -10,7 +10,6 @@ import { prepareFeedbackEvent } from './prepareFeedbackEvent';
 export async function sendFeedbackRequest({
   feedback: { message, email, name, replay_id, url },
 }: SendFeedbackData): Promise<void | TransportMakeRequestResponse> {
-  debugger;
   const hub = getCurrentHub();
   const client = hub.getClient();
   const scope = hub.getScope();

--- a/packages/feedback/src/util/sendFeedbackRequest.ts
+++ b/packages/feedback/src/util/sendFeedbackRequest.ts
@@ -109,7 +109,7 @@ export async function sendFeedbackRequest({
     return response;
   }
 
-  // If the status code is invalid, we want to immediately stop & not retry
+  // Require valid status codes, otherwise can assume feedback was not sent successfully
   if (typeof response.statusCode === 'number' && (response.statusCode < 200 || response.statusCode >= 300)) {
     throw new Error('Unable to send Feedback');
   }

--- a/packages/feedback/src/util/sendFeedbackRequest.ts
+++ b/packages/feedback/src/util/sendFeedbackRequest.ts
@@ -90,7 +90,6 @@ export async function sendFeedbackRequest({
   let response: void | TransportMakeRequestResponse;
 
   try {
-    console.log(envelope);
     response = await transport.send(envelope);
   } catch (err) {
     const error = new Error('Unable to send Feedback');

--- a/packages/feedback/src/util/sendFeedbackRequest.ts
+++ b/packages/feedback/src/util/sendFeedbackRequest.ts
@@ -1,20 +1,23 @@
-import { getCurrentHub } from '@sentry/core';
-import type { FeedbackEvent } from '@sentry/types';
-import { uuid4 } from '@sentry/utils';
+import { createEventEnvelope, getCurrentHub } from '@sentry/core';
+import type { FeedbackEvent, TransportMakeRequestResponse } from '@sentry/types';
 
 import type { SendFeedbackData } from '../types';
+import { prepareFeedbackEvent } from './prepareFeedbackEvent';
 
 /**
- * Send feedback using `fetch()`
+ * Send feedback using transport
  */
-export function sendFeedbackRequest({
+export async function sendFeedbackRequest({
   feedback: { message, email, name, replay_id, url },
-}: SendFeedbackData): string | undefined {
+}: SendFeedbackData): Promise<void | TransportMakeRequestResponse> {
+  debugger;
   const hub = getCurrentHub();
   const client = hub.getClient();
   const scope = hub.getScope();
+  const transport = client && client.getTransport();
+  const dsn = client && client.getDsn();
 
-  if (!client) {
+  if (!client || !transport || !dsn) {
     return;
   }
 
@@ -31,11 +34,87 @@ export function sendFeedbackRequest({
     type: 'feedback',
   };
 
-  return client.captureEvent(
-    baseEvent,
-    {
-      event_id: uuid4(),
-    },
+  const feedbackEvent = await prepareFeedbackEvent({
     scope,
-  );
+    client,
+    event: baseEvent,
+  });
+
+  if (feedbackEvent === null) {
+    return;
+  }
+
+  /*
+  For reference, the fully built event looks something like this:
+  {
+      "type": "feedback",
+      "event_id": "d2132d31b39445f1938d7e21b6bf0ec4",
+      "timestamp": 1597977777.6189718,
+      "dist": "1.12",
+      "platform": "javascript",
+      "environment": "production",
+      "release": 42,
+      "tags": {"transaction": "/organizations/:orgId/performance/:eventSlug/"},
+      "sdk": {"name": "name", "version": "version"},
+      "user": {
+          "id": "123",
+          "username": "user",
+          "email": "user@site.com",
+          "ip_address": "192.168.11.12",
+      },
+      "request": {
+          "url": None,
+          "headers": {
+              "user-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.5 Safari/605.1.15"
+          },
+      },
+      "contexts": {
+          "feedback": {
+              "message": "test message",
+              "contact_email": "test@example.com",
+              "type": "feedback",
+          },
+          "trace": {
+              "trace_id": "4C79F60C11214EB38604F4AE0781BFB2",
+              "span_id": "FA90FDEAD5F74052",
+              "type": "trace",
+          },
+          "replay": {
+              "replay_id": "e2d42047b1c5431c8cba85ee2a8ab25d",
+          },
+      },
+    }
+  */
+
+  const envelope = createEventEnvelope(feedbackEvent, dsn, client.getOptions()._metadata, client.getOptions().tunnel);
+
+  let response: void | TransportMakeRequestResponse;
+
+  try {
+    console.log(envelope);
+    response = await transport.send(envelope);
+  } catch (err) {
+    const error = new Error('Unable to send Feedback');
+
+    try {
+      // In case browsers don't allow this property to be writable
+      // @ts-expect-error This needs lib es2022 and newer
+      error.cause = err;
+    } catch {
+      // nothing to do
+    }
+    throw error;
+  }
+
+  // TODO (v8): we can remove this guard once transport.send's type signature doesn't include void anymore
+  if (!response) {
+    return response;
+  }
+
+  // If the status code is invalid, we want to immediately stop & not retry
+  if (typeof response.statusCode === 'number' && (response.statusCode < 200 || response.statusCode >= 300)) {
+    throw new Error('Unable to send Feedback');
+  }
+
+  return response;
 }

--- a/packages/feedback/src/util/sendFeedbackRequest.ts
+++ b/packages/feedback/src/util/sendFeedbackRequest.ts
@@ -1,113 +1,41 @@
 import { getCurrentHub } from '@sentry/core';
-import { dsnToString } from '@sentry/utils';
+import type { FeedbackEvent } from '@sentry/types';
+import { uuid4 } from '@sentry/utils';
 
 import type { SendFeedbackData } from '../types';
-import { prepareFeedbackEvent } from './prepareFeedbackEvent';
 
 /**
  * Send feedback using `fetch()`
  */
-export async function sendFeedbackRequest({
+export function sendFeedbackRequest({
   feedback: { message, email, name, replay_id, url },
-}: SendFeedbackData): Promise<Response | null> {
+}: SendFeedbackData): string | undefined {
   const hub = getCurrentHub();
-
-  if (!hub) {
-    return null;
-  }
-
   const client = hub.getClient();
   const scope = hub.getScope();
-  const transport = client && client.getTransport();
-  const dsn = client && client.getDsn();
 
-  if (!client || !transport || !dsn) {
-    return null;
+  if (!client) {
+    return;
   }
 
-  const baseEvent = {
-    feedback: {
-      contact_email: email,
-      name,
-      message,
-      replay_id,
-      url,
+  const baseEvent: FeedbackEvent = {
+    contexts: {
+      feedback: {
+        contact_email: email,
+        name,
+        message,
+        replay_id,
+        url,
+      },
     },
-    // type: 'feedback_event',
+    type: 'feedback',
   };
 
-  const feedbackEvent = await prepareFeedbackEvent({
+  return client.captureEvent(
+    baseEvent,
+    {
+      event_id: uuid4(),
+    },
     scope,
-    client,
-    event: baseEvent,
-  });
-
-  if (!feedbackEvent) {
-    // Taken from baseclient's `_processEvent` method, where this is handled for errors/transactions
-    // client.recordDroppedEvent('event_processor', 'feedback', baseEvent);
-    return null;
-  }
-
-  /*
-  For reference, the fully built event looks something like this:
-  {
-    "data": {
-      "dist": "abc123",
-      "environment": "production",
-      "feedback": {
-        "contact_email": "colton.allen@sentry.io",
-        "message": "I really like this user-feedback feature!",
-        "replay_id": "ec3b4dc8b79f417596f7a1aa4fcca5d2",
-        "url": "https://docs.sentry.io/platforms/javascript/"
-      },
-      "id": "1ffe0775ac0f4417aed9de36d9f6f8dc",
-      "platform": "javascript",
-      "release": "version@1.3",
-      "request": {
-        "headers": {
-          "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"
-        }
-      },
-      "sdk": {
-        "name": "sentry.javascript.react",
-        "version": "6.18.1"
-      },
-      "tags": {
-        "key": "value"
-      },
-      "timestamp": "2023-08-31T14:10:34.954048",
-      "user": {
-        "email": "username@example.com",
-        "id": "123",
-        "ip_address": "127.0.0.1",
-        "name": "user",
-        "username": "user2270129"
-      }
-    }
-  }
-  */
-
-  // Prevent this data (which, if it exists, was used in earlier steps in the processing pipeline) from being sent to
-  // sentry. (Note: Our use of this property comes and goes with whatever we might be debugging, whatever hacks we may
-  // have temporarily added, etc. Even if we don't happen to be using it at some point in the future, let's not get rid
-  // of this `delete`, lest we miss putting it back in the next time the property is in use.)
-  delete feedbackEvent.sdkProcessingMetadata;
-
-  try {
-    const path = 'https://sentry.io/api/0/feedback/';
-    const response = await fetch(path, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `DSN ${dsnToString(dsn)}`,
-      },
-      body: JSON.stringify(feedbackEvent),
-    });
-    if (!response.ok) {
-      return null;
-    }
-    return response;
-  } catch (err) {
-    return null;
-  }
+  );
 }

--- a/packages/feedback/src/widget/createWidget.ts
+++ b/packages/feedback/src/widget/createWidget.ts
@@ -94,10 +94,10 @@ export function createWidget({
       return;
     }
 
-    const eventId = handleFeedbackSubmit(dialog, feedback);
+    const result = await handleFeedbackSubmit(dialog, feedback);
 
     // Error submitting feedback
-    if (!eventId) {
+    if (!result) {
       if (options.onSubmitError) {
         options.onSubmitError();
       }

--- a/packages/feedback/src/widget/createWidget.ts
+++ b/packages/feedback/src/widget/createWidget.ts
@@ -94,10 +94,10 @@ export function createWidget({
       return;
     }
 
-    const result = await handleFeedbackSubmit(dialog, feedback);
+    const eventId = handleFeedbackSubmit(dialog, feedback);
 
     // Error submitting feedback
-    if (!result) {
+    if (!eventId) {
       if (options.onSubmitError) {
         options.onSubmitError();
       }

--- a/packages/feedback/test/unit/util/prepareFeedbackEvent.test.ts
+++ b/packages/feedback/test/unit/util/prepareFeedbackEvent.test.ts
@@ -1,8 +1,7 @@
 import type { Hub, Scope } from '@sentry/core';
 import { getCurrentHub } from '@sentry/core';
-import type { Client } from '@sentry/types';
+import type { Client, FeedbackEvent } from '@sentry/types';
 
-import type { FeedbackEvent } from '../../../src/types';
 import { prepareFeedbackEvent } from '../../../src/util/prepareFeedbackEvent';
 import { getDefaultClientOptions, TestClient } from '../../utils/TestClient';
 
@@ -18,15 +17,6 @@ describe('Unit | util | prepareFeedbackEvent', () => {
 
     client = hub.getClient()!;
     scope = hub.getScope()!;
-
-    jest.spyOn(client, 'getSdkMetadata').mockImplementation(() => {
-      return {
-        sdk: {
-          name: 'sentry.javascript.testSdk',
-          version: '1.0.0',
-        },
-      };
-    });
   });
 
   afterEach(() => {
@@ -41,13 +31,14 @@ describe('Unit | util | prepareFeedbackEvent', () => {
     const event: FeedbackEvent = {
       timestamp: 1670837008.634,
       event_id: 'feedback-ID',
-      feedback: {
-        contact_email: 'test@test.com',
-        message: 'looks great!',
-        replay_id: replayId,
-        url: 'https://sentry.io/',
-      },
+      type: 'feedback',
       contexts: {
+        feedback: {
+          contact_email: 'test@test.com',
+          message: 'looks great!',
+          replay_id: replayId,
+          url: 'https://sentry.io/',
+        },
         replay: {
           error_sample_rate: 1.0,
           session_sample_rate: 0.1,
@@ -57,31 +48,26 @@ describe('Unit | util | prepareFeedbackEvent', () => {
 
     const feedbackEvent = await prepareFeedbackEvent({ scope, client, event });
 
-    expect(client.getSdkMetadata).toHaveBeenCalledTimes(1);
-
     expect(feedbackEvent).toEqual({
       timestamp: 1670837008.634,
       event_id: 'feedback-ID',
-      feedback: {
-        contact_email: 'test@test.com',
-        message: 'looks great!',
-        replay_id: replayId,
-        url: 'https://sentry.io/',
-      },
       platform: 'javascript',
       environment: 'production',
       contexts: {
+        feedback: {
+          contact_email: 'test@test.com',
+          message: 'looks great!',
+          replay_id: replayId,
+          url: 'https://sentry.io/',
+        },
         replay: {
           error_sample_rate: 1.0,
           session_sample_rate: 0.1,
         },
       },
-      sdk: {
-        name: 'sentry.javascript.testSdk',
-        version: '1.0.0',
-      },
       sdkProcessingMetadata: expect.any(Object),
       breadcrumbs: undefined,
+      type: 'feedback',
     });
   });
 });

--- a/packages/feedback/test/widget/createWidget.test.ts
+++ b/packages/feedback/test/widget/createWidget.test.ts
@@ -177,7 +177,7 @@ describe('createWidget', () => {
     });
 
     (sendFeedbackRequest as jest.Mock).mockImplementation(() => {
-      return false;
+      throw new Error('Unable to send feedback');
     });
     widget.actor?.el?.dispatchEvent(new Event('click'));
 

--- a/packages/types/src/datacategory.ts
+++ b/packages/types/src/datacategory.ts
@@ -24,5 +24,7 @@ export type DataCategory =
   | 'profile'
   // Check-in event (monitor)
   | 'monitor'
+  // Feedback type event (v2)
+  | 'feedback'
   // Unknown data category
   | 'unknown';

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -2,6 +2,7 @@ import type { SerializedCheckIn } from './checkin';
 import type { ClientReport } from './clientreport';
 import type { DsnComponents } from './dsn';
 import type { Event } from './event';
+import type { FeedbackEvent } from './feedback';
 import type { ReplayEvent, ReplayRecordingData } from './replay';
 import type { SdkInfo } from './sdkinfo';
 import type { SerializedSession, Session, SessionAggregates } from './session';
@@ -26,6 +27,7 @@ export type DynamicSamplingContext = {
 export type EnvelopeItemType =
   | 'client_report'
   | 'user_report'
+  | 'feedback'
   | 'session'
   | 'sessions'
   | 'transaction'
@@ -57,7 +59,7 @@ type BaseEnvelope<EnvelopeHeader, Item> = [
 ];
 
 type EventItemHeaders = {
-  type: 'event' | 'transaction' | 'profile';
+  type: 'event' | 'transaction' | 'profile' | 'feedback';
 };
 type AttachmentItemHeaders = {
   type: 'attachment';
@@ -67,6 +69,7 @@ type AttachmentItemHeaders = {
   attachment_type?: string;
 };
 type UserFeedbackItemHeaders = { type: 'user_report' };
+type FeedbackItemHeaders = { type: 'feedback' };
 type SessionItemHeaders = { type: 'session' };
 type SessionAggregatesItemHeaders = { type: 'sessions' };
 type ClientReportItemHeaders = { type: 'client_report' };
@@ -87,6 +90,7 @@ export type CheckInItem = BaseEnvelopeItem<CheckInItemHeaders, SerializedCheckIn
 type ReplayEventItem = BaseEnvelopeItem<ReplayEventItemHeaders, ReplayEvent>;
 type ReplayRecordingItem = BaseEnvelopeItem<ReplayRecordingItemHeaders, ReplayRecordingData>;
 export type StatsdItem = BaseEnvelopeItem<StatsdItemHeaders, string>;
+export type FeedbackItem = BaseEnvelopeItem<FeedbackItemHeaders, FeedbackEvent>;
 
 export type EventEnvelopeHeaders = { event_id: string; sent_at: string; trace?: DynamicSamplingContext };
 type SessionEnvelopeHeaders = { sent_at: string };
@@ -95,7 +99,10 @@ type ClientReportEnvelopeHeaders = BaseEnvelopeHeaders;
 type ReplayEnvelopeHeaders = BaseEnvelopeHeaders;
 type StatsdEnvelopeHeaders = BaseEnvelopeHeaders;
 
-export type EventEnvelope = BaseEnvelope<EventEnvelopeHeaders, EventItem | AttachmentItem | UserFeedbackItem>;
+export type EventEnvelope = BaseEnvelope<
+  EventEnvelopeHeaders,
+  EventItem | AttachmentItem | UserFeedbackItem | FeedbackItem
+>;
 export type SessionEnvelope = BaseEnvelope<SessionEnvelopeHeaders, SessionItem>;
 export type ClientReportEnvelope = BaseEnvelope<ClientReportEnvelopeHeaders, ClientReportItem>;
 export type ReplayEnvelope = [ReplayEnvelopeHeaders, [ReplayEventItem, ReplayRecordingItem]];

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -61,7 +61,7 @@ export interface Event {
  * Note that `ErrorEvent`s do not have a type (hence its undefined),
  * while all other events are required to have one.
  */
-export type EventType = 'transaction' | 'profile' | 'replay_event' | undefined;
+export type EventType = 'transaction' | 'profile' | 'replay_event' | 'feedback' | undefined;
 
 export interface ErrorEvent extends Event {
   type: undefined;

--- a/packages/types/src/feedback.ts
+++ b/packages/types/src/feedback.ts
@@ -1,0 +1,20 @@
+import type { Event } from './event';
+
+export interface FeedbackContext extends Record<string, unknown> {
+  message: string;
+  contact_email?: string;
+  name?: string;
+  replay_id?: string;
+  url?: string;
+}
+
+/**
+ * NOTE: These types are still considered Alpha and subject to change.
+ * @hidden
+ */
+export interface FeedbackEvent extends Event {
+  type: 'feedback';
+  contexts: Event['contexts'] & {
+    feedback: FeedbackContext;
+  };
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -36,6 +36,7 @@ export type {
   EventEnvelopeHeaders,
   EventItem,
   ReplayEnvelope,
+  FeedbackItem,
   SessionEnvelope,
   SessionItem,
   UserFeedbackItem,
@@ -69,6 +70,7 @@ export type {
   Profile,
 } from './profiling';
 export type { ReplayEvent, ReplayRecordingData, ReplayRecordingMode } from './replay';
+export type {FeedbackEvent} from './feedback';
 export type { QueryParams, Request, SanitizedRequestData } from './request';
 export type { Runtime } from './runtime';
 export type { CaptureContext, Scope, ScopeContext } from './scope';

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -70,7 +70,7 @@ export type {
   Profile,
 } from './profiling';
 export type { ReplayEvent, ReplayRecordingData, ReplayRecordingMode } from './replay';
-export type {FeedbackEvent} from './feedback';
+export type { FeedbackEvent } from './feedback';
 export type { QueryParams, Request, SanitizedRequestData } from './request';
 export type { Runtime } from './runtime';
 export type { CaptureContext, Scope, ScopeContext } from './scope';

--- a/packages/utils/src/envelope.ts
+++ b/packages/utils/src/envelope.ts
@@ -208,6 +208,7 @@ const ITEM_TYPE_TO_DATA_CATEGORY_MAP: Record<EnvelopeItemType, DataCategory> = {
   replay_event: 'replay',
   replay_recording: 'replay',
   check_in: 'monitor',
+  feedback: 'feedback',
   // TODO: This is a temporary workaround until we have a proper data category for metrics
   statsd: 'unknown',
 };


### PR DESCRIPTION
Remove the use of our temporary ingest endpoint, and use our normal ingestion instead.