### PR TITLE
feat(nextjs): Add automatic sourcemapping for edge part of the SDK

### DIFF
--- a/packages/bun/src/client.ts
+++ b/packages/bun/src/client.ts
@@ -30,7 +30,7 @@ export class BunClient extends ServerRuntimeClient<BunClientOptions> {
 
     const clientOptions: ServerRuntimeClientOptions = {
       ...options,
-      platform: 'bun',
+      platform: 'javascript',
       runtime: { name: 'bun', version: Bun.version },
       serverName: options.serverName || global.process.env.SENTRY_NAME || os.hostname(),
     };

--- a/packages/core/test/lib/serverruntimeclient.test.ts
+++ b/packages/core/test/lib/serverruntimeclient.test.ts
@@ -22,13 +22,13 @@ describe('ServerRuntimeClient', () => {
   describe('_prepareEvent', () => {
     test('adds platform to event', () => {
       const options = getDefaultClientOptions({ dsn: PUBLIC_DSN });
-      const client = new ServerRuntimeClient({ ...options, platform: 'edge' });
+      const client = new ServerRuntimeClient({ ...options, platform: 'blargh' });
 
       const event: Event = {};
       const hint: EventHint = {};
       (client as any)._prepareEvent(event, hint);
 
-      expect(event.platform).toEqual('edge');
+      expect(event.platform).toEqual('blargh');
     });
 
     test('adds server_name to event', () => {

--- a/packages/deno/src/client.ts
+++ b/packages/deno/src/client.ts
@@ -34,7 +34,7 @@ export class DenoClient extends ServerRuntimeClient<DenoClientOptions> {
 
     const clientOptions: ServerRuntimeClientOptions = {
       ...options,
-      platform: 'deno',
+      platform: 'javascript',
       runtime: { name: 'deno', version: Deno.version.deno },
       serverName: options.serverName || getHostName(),
     };

--- a/packages/deno/test/__snapshots__/mod.test.ts.snap
+++ b/packages/deno/test/__snapshots__/mod.test.ts.snap
@@ -135,7 +135,7 @@ snapshot[`captureException 1`] = `
       },
     ],
   },
-  platform: "deno",
+  platform: "javascript",
   sdk: {
     integrations: [
       "InboundFilters",
@@ -195,7 +195,7 @@ snapshot[`captureMessage 1`] = `
   event_id: "{{id}}",
   level: "info",
   message: "Some error message",
-  platform: "deno",
+  platform: "javascript",
   sdk: {
     integrations: [
       "InboundFilters",

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -958,7 +958,7 @@ function addValueInjectionLoader(
     ...isomorphicValues,
     // Make sure that if we have a windows path, the backslashes are interpreted as such (rather than as escape
     // characters)
-    __rewriteFramesDistDir__: path.resolve(userNextConfig.distDir?.replace(/\\/g, '\\\\') || '.next'),
+    __rewriteFramesDistDir__: userNextConfig.distDir?.replace(/\\/g, '\\\\') || '.next',
   };
 
   const clientValues = {

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -3,8 +3,7 @@ import type { NodeOptions } from '@sentry/node';
 import { configureScope, getCurrentHub, init as nodeInit, Integrations } from '@sentry/node';
 import type { EventProcessor } from '@sentry/types';
 import type { IntegrationWithExclusionOption } from '@sentry/utils';
-import { addOrUpdateIntegration, escapeStringForRegex, logger } from '@sentry/utils';
-import * as path from 'path';
+import { addOrUpdateIntegration, logger } from '@sentry/utils';
 
 import { devErrorSymbolicationEventProcessor } from '../common/devErrorSymbolicationEventProcessor';
 import { getVercelEnv } from '../common/getVercelEnv';

--- a/packages/nextjs/test/config/loaders.test.ts
+++ b/packages/nextjs/test/config/loaders.test.ts
@@ -72,7 +72,7 @@ describe('webpack loaders', () => {
       });
 
       expect(finalWebpackConfig.module.rules).toContainEqual({
-        test: /sentry\.server\.config\.(jsx?|tsx?)/,
+        test: /sentry\.(server|edge)\.config\.(jsx?|tsx?)/,
         use: [
           {
             loader: expect.stringEndingWith('valueInjectionLoader.js'),

--- a/packages/nextjs/test/config/webpack/sentryWebpackPlugin.test.ts
+++ b/packages/nextjs/test/config/webpack/sentryWebpackPlugin.test.ts
@@ -141,8 +141,7 @@ describe('Sentry webpack plugin config', () => {
       ) as SentryWebpackPlugin;
 
       expect(sentryWebpackPluginInstance.options.include).toEqual([
-        { paths: [`${serverBuildContextWebpack4.dir}/.next/server/pages/`], urlPrefix: '~/_next/server/pages' },
-        { paths: [`${serverBuildContextWebpack4.dir}/.next/server/app/`], urlPrefix: '~/_next/server/app' },
+        { paths: [`${serverBuildContextWebpack4.dir}/.next/server/`], urlPrefix: '~/_next/server' },
       ]);
     });
 
@@ -159,9 +158,7 @@ describe('Sentry webpack plugin config', () => {
       ) as SentryWebpackPlugin;
 
       expect(sentryWebpackPluginInstance.options.include).toEqual([
-        { paths: [`${serverBuildContext.dir}/.next/server/pages/`], urlPrefix: '~/_next/server/pages' },
-        { paths: [`${serverBuildContext.dir}/.next/server/app/`], urlPrefix: '~/_next/server/app' },
-        { paths: [`${serverBuildContext.dir}/.next/server/chunks/`], urlPrefix: '~/_next/server/chunks' },
+        { paths: [`${serverBuildContext.dir}/.next/server/`], urlPrefix: '~/_next/server' },
       ]);
     });
   });

--- a/packages/vercel-edge/src/client.ts
+++ b/packages/vercel-edge/src/client.ts
@@ -33,7 +33,7 @@ export class VercelEdgeClient extends ServerRuntimeClient<VercelEdgeClientOption
 
     const clientOptions: ServerRuntimeClientOptions = {
       ...options,
-      platform: 'vercel-edge',
+      platform: 'javascript',
       // TODO: Grab version information
       runtime: { name: 'vercel-edge' },
       serverName: options.serverName || process.env.SENTRY_NAME,


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/8646
Fixes https://github.com/getsentry/sentry-javascript/pull/9454

- Fixes bug where we set the platform to something other than `"node"` or `"javascript"`. Doing so will cause symbolicator not to do anything.
- Generally widens the upload scope for Next.js server files for sourcemaps. I believe this should not be harmful. Let's see.
- Adds rewriting logic to the edge part of the SDK to match the paths of stackframes to the uploaded artifacts properly.