### PR TITLE
fix(nextjs): Fix sourcemaps resolving for local dev when basePath is set

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -955,6 +955,7 @@ function addValueInjectionLoader(
     SENTRY_RELEASE: buildContext.dev
       ? undefined
       : { id: sentryWebpackPluginOptions.release ?? getSentryRelease(buildContext.buildId) },
+    __sentryBasePath: userNextConfig.basePath,
   };
 
   const serverValues = {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/9057

We inject the base path into the bundles in dev mode and use it for the requests to the resolving server.