### PR TITLE
fix(nextjs): Only inject basepath in dev mode

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -952,7 +952,7 @@ function addValueInjectionLoader(
     SENTRY_RELEASE: buildContext.dev
       ? undefined
       : { id: sentryWebpackPluginOptions.release ?? getSentryRelease(buildContext.buildId) },
-    __sentryBasePath: userNextConfig.basePath,
+    __sentryBasePath: buildContext.dev ? userNextConfig.basePath : undefined,
   };
 
   const serverValues = {


### PR DESCRIPTION
I forgot to push this change to https://github.com/getsentry/sentry-javascript/pull/9457.

This is not technically required but we should avoid exposing any kind of information if it isn't necessary.