### PR TITLE
feat(astro): Add distributed tracing via `<meta>` tags

### DIFF
--- a/packages/astro/src/server/meta.ts
+++ b/packages/astro/src/server/meta.ts
@@ -1,0 +1,43 @@
+import type { Hub } from '@sentry/core';
+import { getDynamicSamplingContextFromClient } from '@sentry/core';
+import type { Span } from '@sentry/types';
+import { dynamicSamplingContextToSentryBaggageHeader, generateSentryTraceHeader } from '@sentry/utils';
+
+/**
+ * Extracts the tracing data from the current span or from the client's scope
+ * (via transaction or propagation context) and renders the data to <meta> tags.
+ *
+ * This function creates two serialized <meta> tags:
+ * - `<meta name="sentry-trace" content="..."/>`
+ * - `<meta name="baggage" content="..."/>`
+ *
+ * TODO: Extract this later on and export it from the Core or Node SDK
+ *
+ * @param span the currently active span
+ * @param client the SDK's client
+ *
+ * @returns an object with the two serialized <meta> tags
+ */
+export function getTracingMetaTags(span: Span | undefined, hub: Hub): { sentryTrace: string; baggage?: string } {
+  const scope = hub.getScope();
+  const client = hub.getClient();
+  const { dsc, sampled, traceId } = scope.getPropagationContext();
+  const transaction = span?.transaction;
+
+  const sentryTrace = span ? span.toTraceparent() : generateSentryTraceHeader(traceId, undefined, sampled);
+
+  const dynamicSamplingContext = transaction
+    ? transaction.getDynamicSamplingContext()
+    : dsc
+    ? dsc
+    : client
+    ? getDynamicSamplingContextFromClient(traceId, client, scope)
+    : undefined;
+
+  const baggage = dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
+
+  return {
+    sentryTrace: `<meta name="sentry-trace" content="${sentryTrace}"/>`,
+    baggage: baggage ? `<meta name="baggage" content="${baggage}"/>` : undefined,
+  };
+}

--- a/packages/astro/src/server/meta.ts
+++ b/packages/astro/src/server/meta.ts
@@ -1,6 +1,5 @@
-import type { Hub } from '@sentry/core';
 import { getDynamicSamplingContextFromClient } from '@sentry/core';
-import type { Span } from '@sentry/types';
+import type { Hub, Span } from '@sentry/types';
 import {
   dynamicSamplingContextToSentryBaggageHeader,
   generateSentryTraceHeader,

--- a/packages/astro/src/server/meta.ts
+++ b/packages/astro/src/server/meta.ts
@@ -1,7 +1,12 @@
 import type { Hub } from '@sentry/core';
 import { getDynamicSamplingContextFromClient } from '@sentry/core';
 import type { Span } from '@sentry/types';
-import { dynamicSamplingContextToSentryBaggageHeader, generateSentryTraceHeader } from '@sentry/utils';
+import {
+  dynamicSamplingContextToSentryBaggageHeader,
+  generateSentryTraceHeader,
+  logger,
+  TRACEPARENT_REGEXP,
+} from '@sentry/utils';
 
 /**
  * Extracts the tracing data from the current span or from the client's scope
@@ -36,8 +41,39 @@ export function getTracingMetaTags(span: Span | undefined, hub: Hub): { sentryTr
 
   const baggage = dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
 
+  const isValidSentryTraceHeader = TRACEPARENT_REGEXP.test(sentryTrace);
+  if (!isValidSentryTraceHeader) {
+    logger.warn('Invalid sentry-trace data. Returning empty <meta name="sentry-trace"/> tag');
+  }
+
+  const validBaggage = isValidBaggageString(baggage);
+  if (!validBaggage) {
+    logger.warn('Invalid baggage data. Returning empty <meta name="baggage"/> tag');
+  }
+
   return {
-    sentryTrace: `<meta name="sentry-trace" content="${sentryTrace}"/>`,
-    baggage: baggage ? `<meta name="baggage" content="${baggage}"/>` : undefined,
+    sentryTrace: `<meta name="sentry-trace" content="${isValidSentryTraceHeader ? sentryTrace : ''}"/>`,
+    baggage: baggage && `<meta name="baggage" content="${validBaggage ? baggage : ''}"/>`,
   };
+}
+
+/**
+ * Tests string against baggage spec as defined in:
+ *
+ * - W3C Baggage grammar: https://www.w3.org/TR/baggage/#definition
+ * - RFC7230 token definition: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6
+ *
+ * exported for testing
+ */
+export function isValidBaggageString(baggage?: string): boolean {
+  if (!baggage || !baggage.length) {
+    return false;
+  }
+  const keyRegex = "[-!#$%&'*+.^_`|~A-Za-z0-9]+";
+  const valueRegex = '[!#-+-./0-9:<=>?@A-Z\\[\\]a-z{-}]+';
+  const spaces = '\\s*';
+  const baggageRegex = new RegExp(
+    `^${keyRegex}${spaces}=${spaces}${valueRegex}(${spaces},${spaces}${keyRegex}${spaces}=${spaces}${valueRegex})*$`,
+  );
+  return baggageRegex.test(baggage);
 }

--- a/packages/astro/test/server/meta.test.ts
+++ b/packages/astro/test/server/meta.test.ts
@@ -1,10 +1,10 @@
 import * as SentryCore from '@sentry/core';
 import { vi } from 'vitest';
 
-import { getTracingMetaTags } from '../../src/server/meta';
+import { getTracingMetaTags, isValidBaggageString } from '../../src/server/meta';
 
 const mockedSpan = {
-  toTraceparent: () => '123',
+  toTraceparent: () => '12345678901234567890123456789012-1234567890123456-1',
   transaction: {
     getDynamicSamplingContext: () => ({
       environment: 'production',
@@ -28,7 +28,7 @@ describe('getTracingMetaTags', () => {
       const tags = getTracingMetaTags(mockedSpan, mockedHub);
 
       expect(tags).toEqual({
-        sentryTrace: '<meta name="sentry-trace" content="123"/>',
+        sentryTrace: '<meta name="sentry-trace" content="12345678901234567890123456789012-1234567890123456-1"/>',
         baggage: '<meta name="baggage" content="sentry-environment=production"/>',
       });
     }
@@ -40,21 +40,24 @@ describe('getTracingMetaTags', () => {
       // @ts-expect-error - only passing a partial scope object
       getScope: () => ({
         getPropagationContext: () => ({
-          traceId: 'abc',
+          traceId: '12345678901234567890123456789012',
           sampled: true,
-          spanId: '456',
+          spanId: '1234567890123456',
           dsc: {
             environment: 'staging',
             public_key: 'key',
-            trace_id: 'abc',
+            trace_id: '12345678901234567890123456789012',
           },
         }),
       }),
     });
 
     expect(tags).toEqual({
-      sentryTrace: expect.stringMatching(/<meta name="sentry-trace" content="abc-.+-1"/),
-      baggage: '<meta name="baggage" content="sentry-environment=staging,sentry-public_key=key,sentry-trace_id=abc"/>',
+      sentryTrace: expect.stringMatching(
+        /<meta name="sentry-trace" content="12345678901234567890123456789012-(.{16})-1"\/>/,
+      ),
+      baggage:
+        '<meta name="baggage" content="sentry-environment=staging,sentry-public_key=key,sentry-trace_id=12345678901234567890123456789012"/>',
     });
   });
 
@@ -67,14 +70,14 @@ describe('getTracingMetaTags', () => {
     const tags = getTracingMetaTags(
       // @ts-expect-error - only passing a partial span object
       {
-        toTraceparent: () => '123',
+        toTraceparent: () => '12345678901234567890123456789012-1234567890123456-1',
         transaction: undefined,
       },
       mockedHub,
     );
 
     expect(tags).toEqual({
-      sentryTrace: '<meta name="sentry-trace" content="123"/>',
+      sentryTrace: '<meta name="sentry-trace" content="12345678901234567890123456789012-1234567890123456-1"/>',
     });
   });
 
@@ -87,7 +90,7 @@ describe('getTracingMetaTags', () => {
     const tags = getTracingMetaTags(
       // @ts-expect-error - only passing a partial span object
       {
-        toTraceparent: () => '123',
+        toTraceparent: () => '12345678901234567890123456789012-1234567890123456-1',
         transaction: undefined,
       },
       {
@@ -97,7 +100,79 @@ describe('getTracingMetaTags', () => {
     );
 
     expect(tags).toEqual({
-      sentryTrace: '<meta name="sentry-trace" content="123"/>',
+      sentryTrace: '<meta name="sentry-trace" content="12345678901234567890123456789012-1234567890123456-1"/>',
     });
+  });
+});
+
+describe('isValidBaggageString', () => {
+  it.each([
+    'sentry-environment=production',
+    'sentry-environment=staging,sentry-public_key=key,sentry-trace_id=abc',
+    // @ is allowed in values
+    'sentry-release=project@1.0.0',
+    // spaces are allowed around the delimiters
+    'sentry-environment=staging ,   sentry-public_key=key  ,sentry-release=myproject@1.0.0',
+    'sentry-environment=staging ,   thirdparty=value  ,sentry-release=myproject@1.0.0',
+    // these characters are explicitly allowed for keys in the baggage spec:
+    "!#$%&'*+-.^_`|~1234567890abcxyzABCXYZ=true",
+    // special characters in values are fine (except for ",;\ - see other test)
+    'key=(value)',
+    'key=[{(value)}]',
+    'key=some$value',
+    'key=more#value',
+    'key=max&value',
+    'key=max:value',
+    'key=x=value',
+  ])('returns true if the baggage string is valid (%s)', baggageString => {
+    expect(isValidBaggageString(baggageString)).toBe(true);
+  });
+
+  it.each([
+    // baggage spec doesn't permit leading spaces
+    ' sentry-environment=production,sentry-publickey=key,sentry-trace_id=abc',
+    // no spaces in keys or values
+    'sentry-public key=key',
+    'sentry-publickey=my key',
+    // no delimiters ("(),/:;<=>?@[\]{}") in keys
+    'asdf(x=value',
+    'asdf)x=value',
+    'asdf,x=value',
+    'asdf/x=value',
+    'asdf:x=value',
+    'asdf;x=value',
+    'asdf<x=value',
+    'asdf>x=value',
+    'asdf?x=value',
+    'asdf@x=value',
+    'asdf[x=value',
+    'asdf]x=value',
+    'asdf\\x=value',
+    'asdf{x=value',
+    'asdf}x=value',
+    // no ,;\" in values
+    'key=va,lue',
+    'key=va;lue',
+    'key=va\\lue',
+    'key=va"lue"',
+    // baggage headers can have properties but we currently don't support them
+    'sentry-environment=production;prop1=foo;prop2=bar,nextkey=value',
+    // no fishy stuff
+    'absolutely not a valid baggage string',
+    'val"/><script>alert("xss")</script>',
+    'something"/>',
+    '<script>alert("xss")</script>',
+    '/>',
+    '" onblur="alert("xss")',
+  ])('returns false if the baggage string is invalid (%s)', baggageString => {
+    expect(isValidBaggageString(baggageString)).toBe(false);
+  });
+
+  it('returns false if the baggage string is empty', () => {
+    expect(isValidBaggageString('')).toBe(false);
+  });
+
+  it('returns false if the baggage string is empty', () => {
+    expect(isValidBaggageString(undefined)).toBe(false);
   });
 });

--- a/packages/astro/test/server/meta.test.ts
+++ b/packages/astro/test/server/meta.test.ts
@@ -1,0 +1,103 @@
+import * as SentryCore from '@sentry/core';
+import { vi } from 'vitest';
+
+import { getTracingMetaTags } from '../../src/server/meta';
+
+const mockedSpan = {
+  toTraceparent: () => '123',
+  transaction: {
+    getDynamicSamplingContext: () => ({
+      environment: 'production',
+    }),
+  },
+};
+
+const mockedHub = {
+  getScope: () => ({
+    getPropagationContext: () => ({
+      traceId: '123',
+    }),
+  }),
+  getClient: () => ({}),
+};
+
+describe('getTracingMetaTags', () => {
+  it('returns the tracing tags from the span, if it is provided', () => {
+    {
+      // @ts-expect-error - only passing a partial span object
+      const tags = getTracingMetaTags(mockedSpan, mockedHub);
+
+      expect(tags).toEqual({
+        sentryTrace: '<meta name="sentry-trace" content="123"/>',
+        baggage: '<meta name="baggage" content="sentry-environment=production"/>',
+      });
+    }
+  });
+
+  it('returns propagationContext DSC data if no span is available', () => {
+    const tags = getTracingMetaTags(undefined, {
+      ...mockedHub,
+      // @ts-expect-error - only passing a partial scope object
+      getScope: () => ({
+        getPropagationContext: () => ({
+          traceId: 'abc',
+          sampled: true,
+          spanId: '456',
+          dsc: {
+            environment: 'staging',
+            public_key: 'key',
+            trace_id: 'abc',
+          },
+        }),
+      }),
+    });
+
+    expect(tags).toEqual({
+      sentryTrace: expect.stringMatching(/<meta name="sentry-trace" content="abc-.+-1"/),
+      baggage: '<meta name="baggage" content="sentry-environment=staging,sentry-public_key=key,sentry-trace_id=abc"/>',
+    });
+  });
+
+  it('returns only the `sentry-trace` tag if no DSC is available', () => {
+    vi.spyOn(SentryCore, 'getDynamicSamplingContextFromClient').mockReturnValueOnce({
+      trace_id: '',
+      public_key: undefined,
+    });
+
+    const tags = getTracingMetaTags(
+      // @ts-expect-error - only passing a partial span object
+      {
+        toTraceparent: () => '123',
+        transaction: undefined,
+      },
+      mockedHub,
+    );
+
+    expect(tags).toEqual({
+      sentryTrace: '<meta name="sentry-trace" content="123"/>',
+    });
+  });
+
+  it('returns only the `sentry-trace` tag if no DSC is available', () => {
+    vi.spyOn(SentryCore, 'getDynamicSamplingContextFromClient').mockReturnValueOnce({
+      trace_id: '',
+      public_key: undefined,
+    });
+
+    const tags = getTracingMetaTags(
+      // @ts-expect-error - only passing a partial span object
+      {
+        toTraceparent: () => '123',
+        transaction: undefined,
+      },
+      {
+        ...mockedHub,
+        getClient: () => undefined,
+      },
+    );
+
+    expect(tags).toEqual({
+      sentryTrace: '<meta name="sentry-trace" content="123"/>',
+    });
+  });
+});

--- a/packages/astro/test/server/middleware.test.ts
+++ b/packages/astro/test/server/middleware.test.ts
@@ -259,7 +259,8 @@ describe('sentryMiddleware', () => {
       url: new URL('https://myDomain.io/users/'),
     };
 
-    const originalResponse = new Response('<p>no head</p>', {
+    const originalHtml = '<p>no head</p>';
+    const originalResponse = new Response(originalHtml, {
       headers: new Headers({ 'content-type': 'text/html' }),
     });
     const next = vi.fn(() => Promise.resolve(originalResponse));
@@ -267,7 +268,11 @@ describe('sentryMiddleware', () => {
     // @ts-expect-error, a partial ctx object is fine here
     const resultFromNext = await middleware(ctx, next);
 
-    expect(resultFromNext).toBe(originalResponse);
+    expect(resultFromNext?.headers.get('content-type')).toEqual('text/html');
+
+    const html = await resultFromNext?.text();
+
+    expect(html).toBe(originalHtml);
   });
 });
 


### PR DESCRIPTION
This PR adds `<meta>` tag injection in our new `handleRequest` Astro middleware to enable distributed traces between BE and FE transactions. 

This is also the first step towards exporting a `<meta>` tag helper function (tracked in #8438). In a future PR I'll extract the function to the core or utils package and export it in our server-side SDKs.

![image](https://github.com/getsentry/sentry-javascript/assets/8420481/0e0a6129-c4a7-48f6-822e-fbb9ec7a1f94)

As with all our connected traces via <meta> tags, the trace ordering is wrong in the sense that the FE transaction is the child of the BE transaction. We should fix this but this is out of scope for this PR


ref #9444 
ref #8438 