### PR TITLE
fix(replay): Add additional safeguards for capturing network bodies

### DIFF
--- a/packages/replay/src/coreHandlers/util/fetchUtils.ts
+++ b/packages/replay/src/coreHandlers/util/fetchUtils.ts
@@ -164,7 +164,8 @@ async function _getResponseInfo(
     }
 
     return buildNetworkRequestOrResponse(headers, size, undefined);
-  } catch {
+  } catch (error) {
+    __DEBUG_BUILD__ && logger.warn('[Replay] Failed to serialize response body', error);
     // fallback
     return buildNetworkRequestOrResponse(headers, responseBodySize, undefined);
   }

--- a/packages/replay/src/coreHandlers/util/networkUtils.ts
+++ b/packages/replay/src/coreHandlers/util/networkUtils.ts
@@ -1,5 +1,5 @@
 import type { TextEncoderInternal } from '@sentry/types';
-import { dropUndefinedKeys, stringMatchesSomePattern } from '@sentry/utils';
+import { dropUndefinedKeys, logger, stringMatchesSomePattern } from '@sentry/utils';
 
 import { NETWORK_BODY_MAX_SIZE, WINDOW } from '../../constants';
 import type {
@@ -74,7 +74,9 @@ export function getBodyString(body: unknown): string | undefined {
     if (body instanceof FormData) {
       return _serializeFormData(body);
     }
-  } catch {} // eslint-disable-line no-empty
+  } catch {
+    __DEBUG_BUILD__ && logger.warn('[Replay] Failed to serialize body', body);
+  }
 
   return undefined;
 }

--- a/packages/replay/src/coreHandlers/util/networkUtils.ts
+++ b/packages/replay/src/coreHandlers/util/networkUtils.ts
@@ -62,17 +62,19 @@ export function parseContentLengthHeader(header: string | null | undefined): num
 
 /** Get the string representation of a body. */
 export function getBodyString(body: unknown): string | undefined {
-  if (typeof body === 'string') {
-    return body;
-  }
+  try {
+    if (typeof body === 'string') {
+      return body;
+    }
 
-  if (body instanceof URLSearchParams) {
-    return body.toString();
-  }
+    if (body instanceof URLSearchParams) {
+      return body.toString();
+    }
 
-  if (body instanceof FormData) {
-    return _serializeFormData(body);
-  }
+    if (body instanceof FormData) {
+      return _serializeFormData(body);
+    }
+  } catch {} // eslint-disable-line no-empty
 
   return undefined;
 }
@@ -199,7 +201,6 @@ function normalizeNetworkBody(body: string | undefined): {
   }
 
   const exceedsSizeLimit = body.length > NETWORK_BODY_MAX_SIZE;
-
   const isProbablyJson = _strIsProbablyJson(body);
 
   if (exceedsSizeLimit) {


### PR DESCRIPTION
This adds additional safeguards around fetch/xhr body capturing for replay.
I added additional try-catch in all places that depend on `networkCaptureBodies`.

This also types the fetch/xhr hints as `Partial` to ensure we guard against any of the things not actually being defined, to be on the safe side.

Hopefully fixes https://github.com/getsentry/sentry-javascript/issues/9339