### PR TITLE
fix(astro): Mark SDK package as Astro-external

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -74,5 +74,8 @@
   },
   "volta": {
     "extends": "../../package.json"
+  },
+  "astro": {
+    "external": true
   }
 }


### PR DESCRIPTION
Astro's Vite plugin tries to detect if a package is an "astro component package" (i.e. contains `.astro`) files by checking for a bunch of heuristics in the project's `package.json`. These packages will be run through the Astro compiler. 

https://github.com/withastro/astro/blob/7c458514c06c95158245bba4fa3c254abd333f5a/packages/astro/src/core/create-vite.ts#L74-L89

Because our SDK package matches multiple of the used heuristics, it is added to the compiler build which causes errors because some of our packages make the build fail (not sure why/how). Apparently, this is only problematic when the project is managed by `pnpm` which results in a build error. Other package managers don't seem to have a problem.

This PR adds the `astro.external: true` flag to the `package.json` which short-circuits the heuristics checks and excludes the package from being added to the compiler run.

Fixes https://github.com/pnpm/pnpm/issues/7279 for us

Big thanks to @matthewp for helping us debug this!