### PR TITLE
build(remix): Fix version for remix build on node 14

### DIFF
--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -32,7 +32,8 @@
     "@sentry/tracing": "file:../../../tracing",
     "@sentry-internal/tracing": "file:../../../tracing-internal",
     "@sentry/types": "file:../../../types",
-    "@sentry/utils": "file:../../../utils"
+    "@sentry/utils": "file:../../../utils",
+    "@vanilla-extract/css": "1.13.0"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
This should fix integration tests for remix.

It seems this version: https://github.com/vanilla-extract-css/vanilla-extract/releases/tag/%40vanilla-extract%2Fcss%401.14.0 switched a dependency which fails on Node 14. so pinning on the previous version here...