### PR TITLE
fix(astro): Adjust Vite plugin config to upload server source maps

### DIFF
--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -86,11 +86,11 @@ function findDefaultSdkInitFile(type: 'server' | 'client'): string | undefined {
 }
 
 function getSourcemapsAssetsGlob(config: AstroConfig): string {
-  // outDir is stored as a `file://` URL
-  const outDirPathname = config.outDir && config.outDir.pathname;
-  const rootDirName = config.root && config.root.pathname;
+  // paths are stored as "file://" URLs
+  const outDirPathname = config.outDir && path.resolve(config.outDir.pathname);
+  const rootDirName = path.resolve((config.root && config.root.pathname) || process.cwd());
 
-  if (outDirPathname && rootDirName) {
+  if (outDirPathname) {
     const relativePath = path.relative(rootDirName, outDirPathname);
     return `${relativePath}/**/*`;
   }

--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -90,8 +90,6 @@ function getSourcemapsAssetsGlob(config: AstroConfig): string {
   const outDirPathname = config.outDir && config.outDir.pathname;
   const rootDirName = config.root && config.root.pathname;
 
-  console.log({ outDirPathname, rootDirName });
-
   if (outDirPathname && rootDirName) {
     const relativePath = path.relative(rootDirName, outDirPathname);
     return `${relativePath}/**/*`;


### PR DESCRIPTION
For some reason our automatic assets detection in the Vite plugin doesn't work well in Astro builds. While client files were picked up and uploaded correctly, server-side source and map files were not uploaded.

This PR ensures we search for files to be uploaded in the entire output directory by building an `assets` glob from the output directory stored in the `config` object. Once again Astro's integrations API comes in super handy here as this already gives us a custom output directory if users overwrote the default (`/dist`) one. 