### PR TITLE
feat(feedback): Add onClose callback to showReportDialog (#9433)

### DIFF
--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -180,4 +180,6 @@ export interface ReportDialogOptions {
   successMessage?: string;
   /** Callback after reportDialog showed up */
   onLoad?(this: void): void;
+  /** Callback after reportDialog closed */
+  onClose?(this: void): void;
 }

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -168,7 +168,7 @@ export function showReportDialog(options: ReportDialogOptions = {}, hub: Hub = g
   const { onClose } = options;
   if (onClose) {
     const reportDialogClosedMessageHandler = (event: MessageEvent): void => {
-      if (event.data === 'reportdialog_closed') {
+      if (event.data === '__sentry_reportdialog_closed__') {
         try {
           onClose();
         } finally {

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -165,6 +165,20 @@ export function showReportDialog(options: ReportDialogOptions = {}, hub: Hub = g
     script.onload = options.onLoad;
   }
 
+  const { onClose } = options;
+  if (onClose) {
+    const reportDialogClosedMessageHandler = (event: MessageEvent): void => {
+      if (event.data === 'reportdialog_closed') {
+        try {
+          onClose();
+        } finally {
+          WINDOW.removeEventListener('message', reportDialogClosedMessageHandler);
+        }
+      }
+    };
+    WINDOW.addEventListener('message', reportDialogClosedMessageHandler);
+  }
+
   const injectionPoint = WINDOW.document.head || WINDOW.document.body;
   if (injectionPoint) {
     injectionPoint.appendChild(script);

--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -146,15 +146,15 @@ describe('SentryBrowser', () => {
         await flush(10);
       };
 
-      it('should call `onClose` when receiving `reportdialog_closed` MessageEvent', async () => {
+      it('should call `onClose` when receiving `__sentry_reportdialog_closed__` MessageEvent', async () => {
         const onClose = jest.fn();
         showReportDialog({ onClose });
 
-        await waitForPostMessage('reportdialog_closed');
+        await waitForPostMessage('__sentry_reportdialog_closed__');
         expect(onClose).toHaveBeenCalledTimes(1);
 
         // ensure the event handler has been removed so onClose is not called again
-        await waitForPostMessage('reportdialog_closed');
+        await waitForPostMessage('__sentry_reportdialog_closed__');
         expect(onClose).toHaveBeenCalledTimes(1);
       });
 
@@ -164,11 +164,11 @@ describe('SentryBrowser', () => {
         });
         showReportDialog({ onClose });
 
-        await waitForPostMessage('reportdialog_closed');
+        await waitForPostMessage('__sentry_reportdialog_closed__');
         expect(onClose).toHaveBeenCalledTimes(1);
 
         // ensure the event handler has been removed so onClose is not called again
-        await waitForPostMessage('reportdialog_closed');
+        await waitForPostMessage('__sentry_reportdialog_closed__');
         expect(onClose).toHaveBeenCalledTimes(1);
       });
 
@@ -179,7 +179,7 @@ describe('SentryBrowser', () => {
         await waitForPostMessage('some_message');
         expect(onClose).not.toHaveBeenCalled();
 
-        await waitForPostMessage('reportdialog_closed');
+        await waitForPostMessage('__sentry_reportdialog_closed__');
         expect(onClose).toHaveBeenCalledTimes(1);
       });
     });

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -70,6 +70,10 @@ export function getReportDialogEndpoint(
       continue;
     }
 
+    if (key === 'onClose') {
+      continue;
+    }
+
     if (key === 'user') {
       const user = dialogOptions.user;
       if (!user) {

--- a/packages/core/test/lib/api.test.ts
+++ b/packages/core/test/lib/api.test.ts
@@ -119,6 +119,12 @@ describe('API', () => {
         { user: undefined },
         'https://sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@sentry.io:1234/subpath/123',
       ],
+      [
+        'with Public DSN and onClose callback',
+        dsnPublic,
+        { onClose: () => {} },
+        'https://sentry.io:1234/subpath/api/embed/error-page/?dsn=https://abc@sentry.io:1234/subpath/123',
+      ],
     ])(
       '%s',
       (


### PR DESCRIPTION
Adds an `onClose` callback to `showReportDialog`.

The callback is invoked when a `__sentry_reportdialog_closed__` MessageEvent is received. This is sent from the error page embed via `window.postMessage` and listened to in the sdk.

Please have a look at the accompanying PRs
* for the backend: https://github.com/getsentry/sentry/pull/59885
* for the docs: https://github.com/getsentry/sentry-docs/pull/8484

And here is a sample project that uses `onClose` to color the background green again after closing the widget:
https://github.com/arya-s/sentry-onclose-report-dialog

### Caveats 
* Any `__sentry_reportdialog_closed__` message will call `onClose`, so if users use more than one widget per page it could wrongly trigger `onClose`. I figured the widget takes over the entire page and having more than one wouldn't make much sense, but if this is an issue I could generate a key in the sdk and pass it along to the backend and specifically listen for it back, please advise.
* The jest test for when `onClose` throws, prevents jest from failing when encountering the uncaught exception when firing off the `MessageEvent`. This seems a bit hackish, and I had to dig into `jest-environment-jsdom`'s source to figure out how to prevent the test from failing.
Curiously, I couldn't reproduce this on codesandbox: https://codesandbox.io/s/distracted-dubinsky-7x59dy?file=/src/index.test.js


Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [X] If you've added code that should be tested, please add tests.
- [X] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

