### PR TITLE
feat(core): Add `addEventProcessor` method

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,6 +8,14 @@ npx @sentry/migr8@latest
 
 This will let you select which updates to run, and automatically update your code. Make sure to still review all code changes!
 
+## Deprecate `addGlobalEventProcessor` in favor of `addEventProcessor`
+
+Instead of using `addGlobalEventProcessor`, you should use `addEventProcessor` which does not add the event processor globally, but to the current client.
+
+For the vast majority of cases, the behavior of these should be the same. Only in the case where you have multiple clients will this differ - but you'll likely want to add event processors per-client then anyhow, not globally.
+
+In v8, we will remove the global event processors overall, as that allows us to avoid keeping global state that is not necessary.
+
 ## Deprecate `extractTraceParentData` export from `@sentry/core` & downstream packages
 
 Instead, import this directly from `@sentry/utils`.

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -8,7 +8,9 @@ import { handleRequest } from './server/middleware';
 
 // Hence, we export everything from the Node SDK explicitly:
 export {
+  // eslint-disable-next-line deprecation/deprecation
   addGlobalEventProcessor,
+  addEventProcessor,
   addBreadcrumb,
   captureException,
   captureEvent,

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -21,7 +21,9 @@ export type { BrowserOptions } from './client';
 export type { ReportDialogOptions } from './helpers';
 
 export {
+  // eslint-disable-next-line deprecation/deprecation
   addGlobalEventProcessor,
+  addEventProcessor,
   addBreadcrumb,
   addIntegration,
   captureException,

--- a/packages/browser/src/integrations/dedupe.ts
+++ b/packages/browser/src/integrations/dedupe.ts
@@ -25,7 +25,7 @@ export class Dedupe implements Integration {
   }
 
   /** @inheritDoc */
-  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+  public setupOnce(_addGlobalEventProcessor: unknown, _getCurrentHub: unknown): void {
     // noop
   }
 

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -24,7 +24,9 @@ export type { TransactionNamingScheme } from '@sentry/node';
 export type { BunOptions } from './types';
 
 export {
+  // eslint-disable-next-line deprecation/deprecation
   addGlobalEventProcessor,
+  addEventProcessor,
   addBreadcrumb,
   addIntegration,
   captureException,

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -46,6 +46,7 @@ import {
 import { getEnvelopeEndpointWithUrlEncodedAuth } from './api';
 import { DEBUG_BUILD } from './debug-build';
 import { createEventEnvelope, createSessionEnvelope } from './envelope';
+import { getCurrentHub } from './hub';
 import type { IntegrationIndex } from './integration';
 import { setupIntegration, setupIntegrations } from './integration';
 import type { Scope } from './scope';
@@ -833,4 +834,18 @@ function isErrorEvent(event: Event): event is ErrorEvent {
 
 function isTransactionEvent(event: Event): event is TransactionEvent {
   return event.type === 'transaction';
+}
+
+/**
+ * Add an event processor to the current client.
+ * This event processor will run for all events processed by this client.
+ */
+export function addEventProcessor(callback: EventProcessor): void {
+  const client = getCurrentHub().getClient();
+
+  if (!client || !client.addEventProcessor) {
+    return;
+  }
+
+  client.addEventProcessor(callback);
 }

--- a/packages/core/src/eventProcessors.ts
+++ b/packages/core/src/eventProcessors.ts
@@ -3,8 +3,6 @@ import { SyncPromise, getGlobalSingleton, isThenable, logger } from '@sentry/uti
 
 import { DEBUG_BUILD } from './debug-build';
 
-import { getCurrentHub } from './hub';
-
 /**
  * Returns the global event processors.
  * @deprecated Global event processors will be removed in v8.
@@ -20,20 +18,6 @@ export function getGlobalEventProcessors(): EventProcessor[] {
 export function addGlobalEventProcessor(callback: EventProcessor): void {
   // eslint-disable-next-line deprecation/deprecation
   getGlobalEventProcessors().push(callback);
-}
-
-/**
- * Add an event processor to the current client.
- * This event processor will run for all events processed by this client.
- */
-export function addEventProcessor(callback: EventProcessor): void {
-  const client = getCurrentHub().getClient();
-
-  if (!client || !client.addEventProcessor) {
-    return;
-  }
-
-  client.addEventProcessor(callback);
 }
 
 /**

--- a/packages/core/src/eventProcessors.ts
+++ b/packages/core/src/eventProcessors.ts
@@ -3,8 +3,11 @@ import { SyncPromise, getGlobalSingleton, isThenable, logger } from '@sentry/uti
 
 import { DEBUG_BUILD } from './debug-build';
 
+import { getCurrentHub } from './hub';
+
 /**
  * Returns the global event processors.
+ * @deprecated Global event processors will be removed in v8.
  */
 export function getGlobalEventProcessors(): EventProcessor[] {
   return getGlobalSingleton<EventProcessor[]>('globalEventProcessors', () => []);
@@ -12,10 +15,25 @@ export function getGlobalEventProcessors(): EventProcessor[] {
 
 /**
  * Add a EventProcessor to be kept globally.
- * @param callback EventProcessor to add
+ * @deprecated Use `addEventProcessor` instead. Global event processors will be removed in v8.
  */
 export function addGlobalEventProcessor(callback: EventProcessor): void {
+  // eslint-disable-next-line deprecation/deprecation
   getGlobalEventProcessors().push(callback);
+}
+
+/**
+ * Add an event processor to the current client.
+ * This event processor will run for all events processed by this client.
+ */
+export function addEventProcessor(callback: EventProcessor): void {
+  const client = getCurrentHub().getClient();
+
+  if (!client || !client.addEventProcessor) {
+    return;
+  }
+
+  client.addEventProcessor(callback);
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,7 +41,11 @@ export {
 export { makeSession, closeSession, updateSession } from './session';
 export { SessionFlusher } from './sessionflusher';
 export { Scope } from './scope';
-export { addGlobalEventProcessor } from './eventProcessors';
+export {
+  // eslint-disable-next-line deprecation/deprecation
+  addGlobalEventProcessor,
+  addEventProcessor,
+} from './eventProcessors';
 export { getEnvelopeEndpointWithUrlEncodedAuth, getReportDialogEndpoint } from './api';
 export { BaseClient } from './baseclient';
 export { ServerRuntimeClient } from './server-runtime-client';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,10 +44,9 @@ export { Scope } from './scope';
 export {
   // eslint-disable-next-line deprecation/deprecation
   addGlobalEventProcessor,
-  addEventProcessor,
 } from './eventProcessors';
 export { getEnvelopeEndpointWithUrlEncodedAuth, getReportDialogEndpoint } from './api';
-export { BaseClient } from './baseclient';
+export { BaseClient, addEventProcessor } from './baseclient';
 export { ServerRuntimeClient } from './server-runtime-client';
 export { initAndBind } from './sdk';
 export { createTransport } from './transports/base';

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -105,6 +105,7 @@ export function setupIntegration(client: Client, integration: Integration, integ
 
   // `setupOnce` is only called the first time
   if (installedIntegrations.indexOf(integration.name) === -1) {
+    // eslint-disable-next-line deprecation/deprecation
     integration.setupOnce(addGlobalEventProcessor, getCurrentHub);
     installedIntegrations.push(integration.name);
   }

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -50,7 +50,7 @@ export class InboundFilters implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+  public setupOnce(_addGlobalEventProcessor: unknown, _getCurrentHub: unknown): void {
     // noop
   }
 

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -523,7 +523,12 @@ export class Scope implements ScopeInterface {
 
     // TODO (v8): Update this order to be: Global > Client > Scope
     return notifyEventProcessors(
-      [...(additionalEventProcessors || []), ...getGlobalEventProcessors(), ...this._eventProcessors],
+      [
+        ...(additionalEventProcessors || []),
+        // eslint-disable-next-line deprecation/deprecation
+        ...getGlobalEventProcessors(),
+        ...this._eventProcessors,
+      ],
       event,
       hint,
     );

--- a/packages/core/src/utils/prepareEvent.ts
+++ b/packages/core/src/utils/prepareEvent.ts
@@ -110,7 +110,15 @@ export function prepareEvent(
   } else {
     // Apply client & global event processors even if there is no scope
     // TODO (v8): Update the order to be Global > Client
-    result = notifyEventProcessors([...clientEventProcessors, ...getGlobalEventProcessors()], prepared, hint);
+    result = notifyEventProcessors(
+      [
+        ...clientEventProcessors,
+        // eslint-disable-next-line deprecation/deprecation
+        ...getGlobalEventProcessors(),
+      ],
+      prepared,
+      hint,
+    );
   }
 
   return result.then(evt => {

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -23,7 +23,9 @@ export type { AddRequestDataToEventOptions } from '@sentry/utils';
 export type { DenoOptions } from './types';
 
 export {
+  // eslint-disable-next-line deprecation/deprecation
   addGlobalEventProcessor,
+  addEventProcessor,
   addBreadcrumb,
   captureException,
   captureEvent,

--- a/packages/e2e-tests/README.md
+++ b/packages/e2e-tests/README.md
@@ -107,7 +107,7 @@ A standardized frontend test application has the following features:
   be done with an event processor:
 
   ```ts
-  Sentry.addGlobalEventProcessor(event => {
+  Sentry.addEventProcessor(event => {
     if (
       event.type === 'transaction' &&
       (event.contexts?.trace?.op === 'pageload' || event.contexts?.trace?.op === 'navigation')

--- a/packages/e2e-tests/test-applications/create-next-app/sentry.client.config.ts
+++ b/packages/e2e-tests/test-applications/create-next-app/sentry.client.config.ts
@@ -16,7 +16,7 @@ Sentry.init({
   // that it will also get attached to your source maps
 });
 
-Sentry.addGlobalEventProcessor(event => {
+Sentry.addEventProcessor(event => {
   if (
     event.type === 'transaction' &&
     (event.contexts?.trace?.op === 'pageload' || event.contexts?.trace?.op === 'navigation')

--- a/packages/e2e-tests/test-applications/create-next-app/sentry.server.config.ts
+++ b/packages/e2e-tests/test-applications/create-next-app/sentry.server.config.ts
@@ -23,7 +23,7 @@ Sentry.init({
   integrations: [new Sentry.Integrations.LocalVariables()],
 });
 
-Sentry.addGlobalEventProcessor(event => {
+Sentry.addEventProcessor(event => {
   global.transactionIds = global.transactionIds || [];
 
   if (event.type === 'transaction') {

--- a/packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.client.tsx
+++ b/packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.client.tsx
@@ -24,7 +24,7 @@ Sentry.init({
   replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
 });
 
-Sentry.addGlobalEventProcessor(event => {
+Sentry.addEventProcessor(event => {
   if (
     event.type === 'transaction' &&
     (event.contexts?.trace?.op === 'pageload' || event.contexts?.trace?.op === 'navigation')

--- a/packages/e2e-tests/test-applications/create-remix-app/app/entry.client.tsx
+++ b/packages/e2e-tests/test-applications/create-remix-app/app/entry.client.tsx
@@ -24,7 +24,7 @@ Sentry.init({
   replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
 });
 
-Sentry.addGlobalEventProcessor(event => {
+Sentry.addEventProcessor(event => {
   if (
     event.type === 'transaction' &&
     (event.contexts?.trace?.op === 'pageload' || event.contexts?.trace?.op === 'navigation')

--- a/packages/e2e-tests/test-applications/node-express-app/src/app.ts
+++ b/packages/e2e-tests/test-applications/node-express-app/src/app.ts
@@ -89,7 +89,7 @@ app.listen(port, () => {
   console.log(`Example app listening on port ${port}`);
 });
 
-Sentry.addGlobalEventProcessor(event => {
+Sentry.addEventProcessor(event => {
   global.transactionIds = global.transactionIds || [];
 
   if (event.type === 'transaction') {

--- a/packages/e2e-tests/test-applications/react-create-hash-router/src/index.tsx
+++ b/packages/e2e-tests/test-applications/react-create-hash-router/src/index.tsx
@@ -47,7 +47,7 @@ Object.defineProperty(window, 'sentryReplayId', {
   },
 });
 
-Sentry.addGlobalEventProcessor(event => {
+Sentry.addEventProcessor(event => {
   if (
     event.type === 'transaction' &&
     (event.contexts?.trace?.op === 'pageload' || event.contexts?.trace?.op === 'navigation')

--- a/packages/e2e-tests/test-applications/react-router-6-use-routes/src/index.tsx
+++ b/packages/e2e-tests/test-applications/react-router-6-use-routes/src/index.tsx
@@ -45,7 +45,7 @@ Object.defineProperty(window, 'sentryReplayId', {
   },
 });
 
-Sentry.addGlobalEventProcessor(event => {
+Sentry.addEventProcessor(event => {
   if (
     event.type === 'transaction' &&
     (event.contexts?.trace?.op === 'pageload' || event.contexts?.trace?.op === 'navigation')

--- a/packages/e2e-tests/test-applications/standard-frontend-react-tracing-import/src/index.tsx
+++ b/packages/e2e-tests/test-applications/standard-frontend-react-tracing-import/src/index.tsx
@@ -34,7 +34,7 @@ Sentry.init({
   release: 'e2e-test',
 });
 
-Sentry.addGlobalEventProcessor(event => {
+Sentry.addEventProcessor(event => {
   if (
     event.type === 'transaction' &&
     (event.contexts?.trace?.op === 'pageload' || event.contexts?.trace?.op === 'navigation')

--- a/packages/e2e-tests/test-applications/standard-frontend-react/src/index.tsx
+++ b/packages/e2e-tests/test-applications/standard-frontend-react/src/index.tsx
@@ -46,7 +46,7 @@ Object.defineProperty(window, 'sentryReplayId', {
   },
 });
 
-Sentry.addGlobalEventProcessor(event => {
+Sentry.addEventProcessor(event => {
   if (
     event.type === 'transaction' &&
     (event.contexts?.trace?.op === 'pageload' || event.contexts?.trace?.op === 'navigation')

--- a/packages/ember/tests/test-helper.ts
+++ b/packages/ember/tests/test-helper.ts
@@ -13,7 +13,7 @@ declare global {
   }
 }
 
-Sentry.addGlobalEventProcessor(event => {
+Sentry.addEventProcessor(event => {
   if (isTesting()) {
     if (!window._sentryTestEvents) {
       window._sentryTestEvents = [];

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -46,7 +46,8 @@ export const getCurrentHub = getCurrentHubCore;
 /**
  * @deprecated This export has moved to @sentry/core. The @sentry/hub package will be removed in v8.
  */
-export const addGlobalEventProcessor = addGlobalEventProcessorCore;
+
+export const addGlobalEventProcessor = addGlobalEventProcessorCore; // eslint-disable-line deprecation/deprecation
 
 /**
  * @deprecated This export has moved to @sentry/core. The @sentry/hub package will be removed in v8.

--- a/packages/hub/test/scope.test.ts
+++ b/packages/hub/test/scope.test.ts
@@ -644,6 +644,7 @@ describe('Scope', () => {
       const localScope = new Scope();
       localScope.setExtra('a', 'b');
 
+      // eslint-disable-next-line deprecation/deprecation
       addGlobalEventProcessor((processedEvent: Event) => {
         processedEvent.dist = '1';
         return processedEvent;

--- a/packages/integrations/src/contextlines.ts
+++ b/packages/integrations/src/contextlines.ts
@@ -44,7 +44,7 @@ export class ContextLines implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+  public setupOnce(_addGlobalEventProcessor: unknown, _getCurrentHub: unknown): void {
     // noop
   }
 

--- a/packages/integrations/src/dedupe.ts
+++ b/packages/integrations/src/dedupe.ts
@@ -25,7 +25,7 @@ export class Dedupe implements Integration {
   }
 
   /** @inheritDoc */
-  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+  public setupOnce(_addGlobalEventProcessor: unknown, _getCurrentHub: unknown): void {
     // noop
   }
 

--- a/packages/integrations/src/extraerrordata.ts
+++ b/packages/integrations/src/extraerrordata.ts
@@ -38,7 +38,7 @@ export class ExtraErrorData implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+  public setupOnce(_addGlobalEventProcessor: unknown, _getCurrentHub: unknown): void {
     // noop
   }
 

--- a/packages/integrations/src/rewriteframes.ts
+++ b/packages/integrations/src/rewriteframes.ts
@@ -43,7 +43,7 @@ export class RewriteFrames implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+  public setupOnce(_addGlobalEventProcessor: unknown, _getCurrentHub: unknown): void {
     // noop
   }
 

--- a/packages/integrations/src/sessiontiming.ts
+++ b/packages/integrations/src/sessiontiming.ts
@@ -23,7 +23,7 @@ export class SessionTiming implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+  public setupOnce(_addGlobalEventProcessor: unknown, _getCurrentHub: unknown): void {
     // noop
   }
 

--- a/packages/integrations/src/transaction.ts
+++ b/packages/integrations/src/transaction.ts
@@ -19,7 +19,7 @@ export class Transaction implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+  public setupOnce(_addGlobalEventProcessor: unknown, _getCurrentHub: unknown): void {
     // noop
   }
 

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -24,7 +24,9 @@ export {
   extractRequestData,
   deepReadDirSync,
   getModuleFromFilename,
+  // eslint-disable-next-line deprecation/deprecation
   addGlobalEventProcessor,
+  addEventProcessor,
   addBreadcrumb,
   captureException,
   captureEvent,

--- a/packages/node/src/anr/index.ts
+++ b/packages/node/src/anr/index.ts
@@ -3,7 +3,7 @@ import { getClient, makeSession, updateSession } from '@sentry/core';
 import type { Event, Session, StackFrame } from '@sentry/types';
 import { logger, watchdogTimer } from '@sentry/utils';
 
-import { addGlobalEventProcessor, captureEvent, flush, getCurrentHub } from '..';
+import { addEventProcessor, captureEvent, flush, getCurrentHub } from '..';
 import { captureStackTrace } from './debugger';
 
 const DEFAULT_INTERVAL = 50;
@@ -191,7 +191,7 @@ function handleChildProcess(options: Options): void {
     });
   }
 
-  addGlobalEventProcessor(event => {
+  addEventProcessor(event => {
     // Strip sdkProcessingMetadata from all child process events to remove trace info
     delete event.sdkProcessingMetadata;
     event.tags = {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -23,7 +23,9 @@ export type { AddRequestDataToEventOptions, TransactionNamingScheme } from '@sen
 export type { NodeOptions } from './types';
 
 export {
+  // eslint-disable-next-line deprecation/deprecation
   addGlobalEventProcessor,
+  addEventProcessor,
   addBreadcrumb,
   addIntegration,
   captureException,

--- a/packages/opentelemetry-node/src/spanprocessor.ts
+++ b/packages/opentelemetry-node/src/spanprocessor.ts
@@ -2,7 +2,7 @@ import type { Context } from '@opentelemetry/api';
 import { SpanKind, context, trace } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
 import type { Span as OtelSpan, SpanProcessor as OtelSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { Transaction, addGlobalEventProcessor, addTracingExtensions, getClient, getCurrentHub } from '@sentry/core';
+import { addEventProcessor, addTracingExtensions, getClient, getCurrentHub, Transaction } from '@sentry/core';
 import type { DynamicSamplingContext, Span as SentrySpan, TraceparentData, TransactionContext } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
@@ -22,7 +22,7 @@ export class SentrySpanProcessor implements OtelSpanProcessor {
   public constructor() {
     addTracingExtensions();
 
-    addGlobalEventProcessor(event => {
+    addEventProcessor(event => {
       const otelSpan = trace && trace.getActiveSpan && (trace.getActiveSpan() as OtelSpan | undefined);
       if (!otelSpan) {
         return event;

--- a/packages/opentelemetry-node/src/spanprocessor.ts
+++ b/packages/opentelemetry-node/src/spanprocessor.ts
@@ -2,7 +2,7 @@ import type { Context } from '@opentelemetry/api';
 import { SpanKind, context, trace } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
 import type { Span as OtelSpan, SpanProcessor as OtelSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { addEventProcessor, addTracingExtensions, getClient, getCurrentHub, Transaction } from '@sentry/core';
+import { Transaction, addEventProcessor, addTracingExtensions, getClient, getCurrentHub } from '@sentry/core';
 import type { DynamicSamplingContext, Span as SentrySpan, TraceparentData, TransactionContext } from '@sentry/types';
 import { logger } from '@sentry/utils';
 

--- a/packages/react/src/redux.ts
+++ b/packages/react/src/redux.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { addGlobalEventProcessor, configureScope, getClient } from '@sentry/browser';
+import { addEventProcessor, configureScope, getClient } from '@sentry/browser';
 import type { Scope } from '@sentry/types';
 import { addNonEnumerableProperty } from '@sentry/utils';
 
@@ -97,7 +97,7 @@ function createReduxEnhancer(enhancerOptions?: Partial<SentryEnhancerOptions>): 
   return (next: StoreEnhancerStoreCreator): StoreEnhancerStoreCreator =>
     <S = any, A extends Action = AnyAction>(reducer: Reducer<S, A>, initialState?: PreloadedState<S>) => {
       options.attachReduxState &&
-        addGlobalEventProcessor((event, hint) => {
+        addEventProcessor((event, hint) => {
           try {
             // @ts-expect-error try catch to reduce bundle size
             if (event.type === undefined && event.contexts.state.state.type === 'redux') {

--- a/packages/react/test/redux.test.ts
+++ b/packages/react/test/redux.test.ts
@@ -14,15 +14,15 @@ jest.mock('@sentry/browser', () => ({
       addBreadcrumb: mockAddBreadcrumb,
       setContext: mockSetContext,
     }),
-  addGlobalEventProcessor: jest.fn(),
+  addEventProcessor: jest.fn(),
 }));
 
-const mockAddGlobalEventProcessor = Sentry.addGlobalEventProcessor as jest.Mock;
+const mockAddEventProcessor = Sentry.addEventProcessor as jest.Mock;
 
 afterEach(() => {
   mockAddBreadcrumb.mockReset();
   mockSetContext.mockReset();
-  mockAddGlobalEventProcessor.mockReset();
+  mockAddEventProcessor.mockReset();
 });
 
 describe('createReduxEnhancer', () => {
@@ -258,9 +258,9 @@ describe('createReduxEnhancer', () => {
 
       Redux.createStore((state = initialState) => state, enhancer);
 
-      expect(mockAddGlobalEventProcessor).toHaveBeenCalledTimes(1);
+      expect(mockAddEventProcessor).toHaveBeenCalledTimes(1);
 
-      const callbackFunction = mockAddGlobalEventProcessor.mock.calls[0][0];
+      const callbackFunction = mockAddEventProcessor.mock.calls[0][0];
 
       const mockEvent = {
         contexts: {
@@ -307,7 +307,7 @@ describe('createReduxEnhancer', () => {
 
       Redux.createStore((state = initialState) => state, enhancer);
 
-      expect(mockAddGlobalEventProcessor).toHaveBeenCalledTimes(0);
+      expect(mockAddEventProcessor).toHaveBeenCalledTimes(0);
     });
 
     it('does not attach when state.type is not redux', () => {
@@ -319,9 +319,9 @@ describe('createReduxEnhancer', () => {
 
       Redux.createStore((state = initialState) => state, enhancer);
 
-      expect(mockAddGlobalEventProcessor).toHaveBeenCalledTimes(1);
+      expect(mockAddEventProcessor).toHaveBeenCalledTimes(1);
 
-      const callbackFunction = mockAddGlobalEventProcessor.mock.calls[0][0];
+      const callbackFunction = mockAddEventProcessor.mock.calls[0][0];
 
       const mockEvent = {
         contexts: {
@@ -354,9 +354,9 @@ describe('createReduxEnhancer', () => {
 
       Redux.createStore((state = initialState) => state, enhancer);
 
-      expect(mockAddGlobalEventProcessor).toHaveBeenCalledTimes(1);
+      expect(mockAddEventProcessor).toHaveBeenCalledTimes(1);
 
-      const callbackFunction = mockAddGlobalEventProcessor.mock.calls[0][0];
+      const callbackFunction = mockAddEventProcessor.mock.calls[0][0];
 
       const mockEvent = {
         contexts: {
@@ -386,9 +386,9 @@ describe('createReduxEnhancer', () => {
 
       Redux.createStore((state = initialState) => state, enhancer);
 
-      expect(mockAddGlobalEventProcessor).toHaveBeenCalledTimes(1);
+      expect(mockAddEventProcessor).toHaveBeenCalledTimes(1);
 
-      const callbackFunction = mockAddGlobalEventProcessor.mock.calls[0][0];
+      const callbackFunction = mockAddEventProcessor.mock.calls[0][0];
 
       const mockEvent = {
         type: 'not_redux',

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -10,7 +10,9 @@ import type { RemixOptions } from './utils/remixOptions';
 // We need to explicitly export @sentry/node as they end up under `default` in ESM builds
 // See: https://github.com/getsentry/sentry-javascript/issues/8474
 export {
+  // eslint-disable-next-line deprecation/deprecation
   addGlobalEventProcessor,
+  addEventProcessor,
   addBreadcrumb,
   captureCheckIn,
   withMonitor,

--- a/packages/replay/src/coreHandlers/handleGlobalEvent.ts
+++ b/packages/replay/src/coreHandlers/handleGlobalEvent.ts
@@ -10,7 +10,7 @@ import { addFeedbackBreadcrumb } from './util/addFeedbackBreadcrumb';
 import { shouldSampleForBufferEvent } from './util/shouldSampleForBufferEvent';
 
 /**
- * Returns a listener to be added to `addGlobalEventProcessor(listener)`.
+ * Returns a listener to be added to `addEventProcessor(listener)`.
  */
 export function handleGlobalEventListener(
   replay: ReplayContainer,

--- a/packages/replay/src/util/addGlobalListeners.ts
+++ b/packages/replay/src/util/addGlobalListeners.ts
@@ -1,5 +1,5 @@
 import type { BaseClient } from '@sentry/core';
-import { addGlobalEventProcessor, getClient, getCurrentHub } from '@sentry/core';
+import { addEventProcessor, getClient, getCurrentHub } from '@sentry/core';
 import type { Client, DynamicSamplingContext } from '@sentry/types';
 import { addClickKeypressInstrumentationHandler, addHistoryInstrumentationHandler } from '@sentry/utils';
 
@@ -30,7 +30,7 @@ export function addGlobalListeners(replay: ReplayContainer): void {
   if (client && client.addEventProcessor) {
     client.addEventProcessor(eventProcessor);
   } else {
-    addGlobalEventProcessor(eventProcessor);
+    addEventProcessor(eventProcessor);
   }
 
   // If a custom client has no hooks yet, we continue to use the "old" implementation

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -14,7 +14,9 @@ export {
   SDK_VERSION,
   Scope,
   addBreadcrumb,
+  // eslint-disable-next-line deprecation/deprecation
   addGlobalEventProcessor,
+  addEventProcessor,
   addIntegration,
   autoDiscoverNodePerformanceMonitoringIntegrations,
   captureEvent,

--- a/packages/svelte/src/sdk.ts
+++ b/packages/svelte/src/sdk.ts
@@ -1,5 +1,5 @@
 import type { BrowserOptions } from '@sentry/browser';
-import { SDK_VERSION, addGlobalEventProcessor, init as browserInit } from '@sentry/browser';
+import { SDK_VERSION, addEventProcessor, init as browserInit } from '@sentry/browser';
 import type { EventProcessor, SdkMetadata } from '@sentry/types';
 import { getDomElement } from '@sentry/utils';
 /**
@@ -50,7 +50,7 @@ export function detectAndReportSvelteKit(): void {
   };
   svelteKitProcessor.id = 'svelteKitProcessor';
 
-  addGlobalEventProcessor(svelteKitProcessor);
+  addEventProcessor(svelteKitProcessor);
 }
 
 /**

--- a/packages/svelte/test/sdk.test.ts
+++ b/packages/svelte/test/sdk.test.ts
@@ -7,8 +7,8 @@ import { detectAndReportSvelteKit, init as svelteInit, isSvelteKitApp } from '..
 let passedEventProcessor: EventProcessor | undefined;
 
 const browserInit = jest.spyOn(SentryBrowser, 'init');
-const addGlobalEventProcessor = jest
-  .spyOn(SentryBrowser, 'addGlobalEventProcessor')
+const addEventProcessor = jest
+  .spyOn(SentryBrowser, 'addEventProcessor')
   .mockImplementation((eventProcessor: EventProcessor) => {
     passedEventProcessor = eventProcessor;
     return () => {};
@@ -79,10 +79,10 @@ describe('detectAndReportSvelteKit()', () => {
     passedEventProcessor = undefined;
   });
 
-  it('registers a global event processor', async () => {
+  it('registers an event processor', async () => {
     detectAndReportSvelteKit();
 
-    expect(addGlobalEventProcessor).toHaveBeenCalledTimes(1);
+    expect(addEventProcessor).toHaveBeenCalledTimes(1);
     expect(passedEventProcessor?.id).toEqual('svelteKitProcessor');
   });
 

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -4,7 +4,9 @@
 // on the top - level namespace.
 // Hence, we export everything from the Node SDK explicitly:
 export {
+  // eslint-disable-next-line deprecation/deprecation
   addGlobalEventProcessor,
+  addEventProcessor,
   addBreadcrumb,
   addIntegration,
   captureException,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -23,7 +23,9 @@ export type { AddRequestDataToEventOptions } from '@sentry/utils';
 export type { VercelEdgeOptions } from './types';
 
 export {
+  // eslint-disable-next-line deprecation/deprecation
   addGlobalEventProcessor,
+  addEventProcessor,
   addBreadcrumb,
   addIntegration,
   captureException,

--- a/packages/vue/src/integration.ts
+++ b/packages/vue/src/integration.ts
@@ -40,7 +40,7 @@ export class VueIntegration implements Integration {
   }
 
   /** @inheritDoc */
-  public setupOnce(_addGlobaleventProcessor: unknown, getCurrentHub: () => Hub): void {
+  public setupOnce(_addGlobalEventProcessor: unknown, getCurrentHub: () => Hub): void {
     this._setupIntegration(getCurrentHub());
   }
 

--- a/packages/wasm/src/index.ts
+++ b/packages/wasm/src/index.ts
@@ -49,7 +49,7 @@ export class Wasm implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(_addGlobaleventProcessor: unknown, _getCurrentHub: unknown): void {
+  public setupOnce(_addGlobalEventProcessor: unknown, _getCurrentHub: unknown): void {
     patchWebAssembly();
   }
 


### PR DESCRIPTION
And deprecate `addGlobalEventProcessor()` and `getGlobalEventProcessors()`.

In v8, all event processors will be on the client only, streamlining this a bit and preventing global "pollution".

Closes https://github.com/getsentry/sentry-javascript/issues/9082