### PR TITLE
feat(core): Add optional `setup` hook to integrations

### DIFF
--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -101,9 +101,15 @@ export function setupIntegrations(client: Client, integrations: Integration[]): 
 export function setupIntegration(client: Client, integration: Integration, integrationIndex: IntegrationIndex): void {
   integrationIndex[integration.name] = integration;
 
+  // `setupOnce` is only called the first time
   if (installedIntegrations.indexOf(integration.name) === -1) {
     integration.setupOnce(addGlobalEventProcessor, getCurrentHub);
     installedIntegrations.push(integration.name);
+  }
+
+  // `setup` is run for each client
+  if (integration.setup && typeof integration.setup === 'function') {
+    integration.setup(client);
   }
 
   if (client.on && typeof integration.preprocessEvent === 'function') {

--- a/packages/core/test/lib/integration.test.ts
+++ b/packages/core/test/lib/integration.test.ts
@@ -378,6 +378,44 @@ describe('setupIntegration', () => {
     expect(integration4.setupOnce).not.toHaveBeenCalled();
   });
 
+  it('calls setup for each client', () => {
+    class CustomIntegration implements Integration {
+      name = 'test';
+      setupOnce = jest.fn();
+      setup = jest.fn();
+    }
+
+    const client1 = getTestClient();
+    const client2 = getTestClient();
+
+    const integrationIndex = {};
+    const integration1 = new CustomIntegration();
+    const integration2 = new CustomIntegration();
+    const integration3 = new CustomIntegration();
+    const integration4 = new CustomIntegration();
+
+    setupIntegration(client1, integration1, integrationIndex);
+    setupIntegration(client1, integration2, integrationIndex);
+    setupIntegration(client2, integration3, integrationIndex);
+    setupIntegration(client2, integration4, integrationIndex);
+
+    expect(integrationIndex).toEqual({ test: integration4 });
+    expect(integration1.setupOnce).toHaveBeenCalledTimes(1);
+    expect(integration2.setupOnce).not.toHaveBeenCalled();
+    expect(integration3.setupOnce).not.toHaveBeenCalled();
+    expect(integration4.setupOnce).not.toHaveBeenCalled();
+
+    expect(integration1.setup).toHaveBeenCalledTimes(1);
+    expect(integration2.setup).toHaveBeenCalledTimes(1);
+    expect(integration3.setup).toHaveBeenCalledTimes(1);
+    expect(integration4.setup).toHaveBeenCalledTimes(1);
+
+    expect(integration1.setup).toHaveBeenCalledWith(client1);
+    expect(integration2.setup).toHaveBeenCalledWith(client1);
+    expect(integration3.setup).toHaveBeenCalledWith(client2);
+    expect(integration4.setup).toHaveBeenCalledWith(client2);
+  });
+
   it('binds preprocessEvent for each client', () => {
     class CustomIntegration implements Integration {
       name = 'test';

--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -27,6 +27,16 @@ export interface Integration {
   setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void;
 
   /**
+   * Set up an integration for the given client.
+   * Receives the client as argument.
+   *
+   * Whenever possible, prefer this over `setupOnce`, as that is only run for the first client,
+   * whereas `setup` runs for each client. Only truly global things (e.g. registering global handlers)
+   * should be done in `setupOnce`.
+   */
+  setup?(client: Client): void;
+
+  /**
    * An optional hook that allows to preprocess an event _before_ it is passed to all other event processors.
    */
   preprocessEvent?(event: Event, hint: EventHint | undefined, client: Client): void;


### PR DESCRIPTION
This can be used to replace some of our `setupOnce` hooks, and does not rely on global state.

I think with this, we are mostly done with the minimal integration API changes for v8. After this, we can:

1. update `setupOnce` to not get any arguments (you can just import and use `getCurrentHub` or whatever if you need it) - this we'll probably do only in v8 itself
2. Add  a new functional form for the integrations. We can support both in v7 and then drop the class form in v8. So integrations would look like this:

```ts
export class Console implements Integration {
  public static id = 'Console';
  public name Console.id;
  public constructor(options) {}
  public setupOnce() {}
}
```

becomes

```ts
export const consoleIntegration: IntegrationFn = (options) => {
  return {
    setupOnce() {}
  }
}
```

And usage becomes:

```ts
Sentry.init({
  integrations: [
    // old
    new Sentry.Integrations.Console(options),
    // new
    Sentry.consoleIntegration(options)
   ]
})
```