### PR TITLE
ref(replay): Add further logging to network body parsing

### DIFF
--- a/packages/replay/src/coreHandlers/util/networkUtils.ts
+++ b/packages/replay/src/coreHandlers/util/networkUtils.ts
@@ -78,6 +78,8 @@ export function getBodyString(body: unknown): string | undefined {
     __DEBUG_BUILD__ && logger.warn('[Replay] Failed to serialize body', body);
   }
 
+  __DEBUG_BUILD__ && logger.info('[Replay] Skipping network body because of body type', body);
+
   return undefined;
 }
 

--- a/packages/replay/src/coreHandlers/util/xhrUtils.ts
+++ b/packages/replay/src/coreHandlers/util/xhrUtils.ts
@@ -135,15 +135,24 @@ function getResponseHeaders(xhr: XMLHttpRequest): Record<string, string> {
 }
 
 function _getXhrResponseBody(xhr: XMLHttpRequest): string | undefined {
+  // We collect errors that happen, but only log them if we can't get any response body
+  const errors: unknown[] = [];
+
   try {
     return xhr.responseText;
-  } catch {} // eslint-disable-line no-empty
+  } catch (e) {
+    errors.push(e);
+  }
 
   // Try to manually parse the response body, if responseText fails
   try {
     const response = xhr.response;
     return getBodyString(response);
-  } catch {} // eslint-disable-line no-empty
+  } catch (e) {
+    errors.push(e);
+  }
+
+  __DEBUG_BUILD__ && logger.warn('[Replay] Failed to get xhr response body', ...errors);
 
   return undefined;
 }


### PR DESCRIPTION
We got somewhat closer to figuring out the problem there. Based on this comment: https://github.com/getsentry/sentry-javascript/issues/9339#issuecomment-1811681894

> The requests are now showing with the request body, but the response body is "undefined"

It seems that the problem is with parsing the response body for a XHR request. I added some more logging there, to be able to debug this further.