### PR TITLE
test: Add test for manual client usage

### DIFF
--- a/packages/browser-integration-tests/suites/manual-client/browser-context/init.js
+++ b/packages/browser-integration-tests/suites/manual-client/browser-context/init.js
@@ -1,0 +1,37 @@
+import {
+  BrowserClient,
+  Breadcrumbs,
+  Dedupe,
+  FunctionToString,
+  HttpContext,
+  InboundFilters,
+  LinkedErrors,
+  defaultStackParser,
+  makeFetchTransport,
+  Hub,
+} from '@sentry/browser';
+
+const integrations = [
+  new Breadcrumbs(),
+  new FunctionToString(),
+  new Dedupe(),
+  new HttpContext(),
+  new InboundFilters(),
+  new LinkedErrors(),
+];
+
+const client = new BrowserClient({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '0.0.1',
+  environment: 'local',
+  sampleRate: 1.0,
+  tracesSampleRate: 0.0,
+  transport: makeFetchTransport,
+  stackParser: defaultStackParser,
+  integrations,
+  debug: true,
+});
+
+const hub = new Hub(client);
+
+hub.captureException(new Error('test client'));

--- a/packages/browser-integration-tests/suites/manual-client/browser-context/test.ts
+++ b/packages/browser-integration-tests/suites/manual-client/browser-context/test.ts
@@ -1,0 +1,48 @@
+import { expect } from '@playwright/test';
+import type { Event } from '@sentry/types';
+
+import { sentryTest } from '../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest } from '../../../utils/helpers';
+
+sentryTest('allows to setup a client manually & capture exceptions', async ({ getLocalTestUrl, page }) => {
+  const url = await getLocalTestUrl({ testDir: __dirname });
+
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
+
+  expect(eventData).toEqual({
+    exception: {
+      values: [
+        expect.objectContaining({
+          type: 'Error',
+          value: 'test client',
+          mechanism: {
+            type: 'generic',
+            handled: true,
+          },
+          stacktrace: {
+            frames: expect.any(Array),
+          },
+        }),
+      ],
+    },
+    level: 'error',
+    event_id: expect.any(String),
+    platform: 'javascript',
+    request: {
+      url,
+      headers: expect.objectContaining({
+        'User-Agent': expect.any(String),
+      }),
+    },
+    timestamp: expect.any(Number),
+    environment: 'local',
+    release: '0.0.1',
+    sdk: {
+      integrations: ['Breadcrumbs', 'FunctionToString', 'Dedupe', 'HttpContext', 'InboundFilters', 'LinkedErrors'],
+      name: 'sentry.javascript.browser',
+      version: expect.any(String),
+      packages: [{ name: expect.any(String), version: expect.any(String) }],
+    },
+    contexts: { trace: { trace_id: expect.any(String), span_id: expect.any(String) } },
+  });
+});


### PR DESCRIPTION
While debugging something, figured it is good to have a test covering that this works as expected!

See also: https://github.com/getsentry/sentry-docs/pull/8495