### PR TITLE
feat(feedback): Change `message` to `comments` [BREAKING]

### DIFF
--- a/packages/feedback/src/sendFeedback.ts
+++ b/packages/feedback/src/sendFeedback.ts
@@ -6,7 +6,7 @@ import type { SendFeedbackOptions } from './types';
 import { sendFeedbackRequest } from './util/sendFeedbackRequest';
 
 interface SendFeedbackParams {
-  message: string;
+  comments: string;
   name?: string;
   email?: string;
   url?: string;
@@ -17,7 +17,7 @@ interface SendFeedbackParams {
  * Public API to send a Feedback item to Sentry
  */
 export function sendFeedback(
-  { name, email, message, source = 'api', url = getLocationHref() }: SendFeedbackParams,
+  { name, email, comments, source = 'api', url = getLocationHref() }: SendFeedbackParams,
   { includeReplay = true }: SendFeedbackOptions = {},
 ): ReturnType<typeof sendFeedbackRequest> {
   const client = getCurrentHub().getClient<BrowserClient>();
@@ -27,7 +27,7 @@ export function sendFeedback(
   replay && replay.flush();
   const replayId = replay && replay.getReplayId();
 
-  if (!message) {
+  if (!comments) {
     throw new Error('Unable to submit feedback with empty message');
   }
 
@@ -35,7 +35,7 @@ export function sendFeedback(
     feedback: {
       name,
       email,
-      message,
+      comments,
       url,
       replay_id: replayId,
       source,

--- a/packages/feedback/src/types/index.ts
+++ b/packages/feedback/src/types/index.ts
@@ -7,7 +7,7 @@ export type SentryTags = { [key: string]: Primitive } | undefined;
 
 export interface SendFeedbackData {
   feedback: {
-    message: string;
+    comments: string;
     url: string;
     email?: string;
     replay_id?: string;
@@ -27,7 +27,7 @@ export interface SendFeedbackOptions {
  * Feedback data expected from UI/form
  */
 export interface FeedbackFormData {
-  message: string;
+  comments: string;
   email?: string;
   name?: string;
 }

--- a/packages/feedback/src/util/sendFeedbackRequest.ts
+++ b/packages/feedback/src/util/sendFeedbackRequest.ts
@@ -8,7 +8,7 @@ import { prepareFeedbackEvent } from './prepareFeedbackEvent';
  * Send feedback using transport
  */
 export async function sendFeedbackRequest({
-  feedback: { message, email, name, source, replay_id, url },
+  feedback: { comments, email, name, source, replay_id, url },
 }: SendFeedbackData): Promise<void | TransportMakeRequestResponse> {
   const hub = getCurrentHub();
   const client = hub.getClient();
@@ -25,7 +25,7 @@ export async function sendFeedbackRequest({
       feedback: {
         contact_email: email,
         name,
-        message,
+        message: comments,
         replay_id,
         url,
         source,
@@ -70,7 +70,7 @@ export async function sendFeedbackRequest({
       },
       "contexts": {
           "feedback": {
-              "message": "test message",
+              "comments": "test message",
               "contact_email": "test@example.com",
               "type": "feedback",
           },

--- a/packages/feedback/src/widget/Form.ts
+++ b/packages/feedback/src/widget/Form.ts
@@ -81,7 +81,7 @@ export function Form({
         const feedback = {
           name: retrieveStringValue(formData, 'name'),
           email: retrieveStringValue(formData, 'email'),
-          message: retrieveStringValue(formData, 'message'),
+          comments: retrieveStringValue(formData, 'comments'),
         };
 
         onSubmit(feedback);
@@ -129,10 +129,10 @@ export function Form({
   });
 
   const messageEl = createElement('textarea', {
-    id: 'message',
+    id: 'comments',
     autoFocus: 'true',
     rows: '5',
-    name: 'message',
+    name: 'comments',
     required: true,
     className: 'form__input form__input--textarea',
     placeholder: messagePlaceholder,
@@ -187,7 +187,7 @@ export function Form({
       createElement(
         'label',
         {
-          htmlFor: 'message',
+          htmlFor: 'comments',
           className: 'form__label',
         },
         [

--- a/packages/feedback/src/widget/createWidget.ts
+++ b/packages/feedback/src/widget/createWidget.ts
@@ -89,7 +89,7 @@ export function createWidget({
     }
 
     // Simple validation for now, just check for non-empty message
-    if (!feedback.message) {
+    if (!feedback.comments) {
       dialog.showError('Please enter in some feedback before submitting!');
       return;
     }

--- a/packages/feedback/test/sendFeedback.test.ts
+++ b/packages/feedback/test/sendFeedback.test.ts
@@ -11,7 +11,7 @@ describe('sendFeedback', () => {
     await sendFeedback({
       name: 'doe',
       email: 're@example.org',
-      message: 'mi',
+      comments: 'mi',
     });
     expect(mockTransport).toHaveBeenCalledWith([
       { event_id: expect.any(String), sent_at: expect.any(String) },

--- a/packages/feedback/test/widget/Form.test.ts
+++ b/packages/feedback/test/widget/Form.test.ts
@@ -50,7 +50,7 @@ describe('Form', () => {
     expect(emailInput).not.toBeNull();
     expect(nameInput.value).toBe('Foo Bar');
     expect(emailInput.value).toBe('foo@example.com');
-    expect(formComponent.el.querySelector('[name="message"]')).not.toBeNull();
+    expect(formComponent.el.querySelector('[name="comments"]')).not.toBeNull();
 
     const button = formComponent.el.querySelector('button[type="submit"]') as HTMLButtonElement | null;
     expect(button?.textContent).toBe('Submit!');
@@ -69,7 +69,7 @@ describe('Form', () => {
     expect(emailInput).not.toBeNull();
     expect(nameInput.value).toBe('Foo Bar');
     expect(emailInput.value).toBe('foo@example.com');
-    expect(formComponent.el.querySelector('[name="message"]')).not.toBeNull();
+    expect(formComponent.el.querySelector('[name="comments"]')).not.toBeNull();
   });
 
   it('can change text labels', () => {
@@ -84,14 +84,14 @@ describe('Form', () => {
 
     const nameLabel = formComponent.el.querySelector('label[htmlFor="name"]') as HTMLLabelElement;
     const emailLabel = formComponent.el.querySelector('label[htmlFor="email"]') as HTMLLabelElement;
-    const messageLabel = formComponent.el.querySelector('label[htmlFor="message"]') as HTMLLabelElement;
+    const messageLabel = formComponent.el.querySelector('label[htmlFor="comments"]') as HTMLLabelElement;
     expect(nameLabel.textContent).toBe('Name!');
     expect(emailLabel.textContent).toBe('Email!');
     expect(messageLabel.textContent).toBe('Description! (required)');
 
     const nameInput = formComponent.el.querySelector('[name="name"]') as HTMLInputElement;
     const emailInput = formComponent.el.querySelector('[name="email"]') as HTMLInputElement;
-    const messageInput = formComponent.el.querySelector('[name="message"]') as HTMLTextAreaElement;
+    const messageInput = formComponent.el.querySelector('[name="comments"]') as HTMLTextAreaElement;
 
     expect(nameInput.placeholder).toBe('Your full name!');
     expect(emailInput.placeholder).toBe('foo@example.org!');
@@ -101,7 +101,7 @@ describe('Form', () => {
   it('submit is enabled if message is not empty', () => {
     const formComponent = renderForm();
 
-    const message = formComponent.el.querySelector('[name="message"]') as HTMLTextAreaElement;
+    const message = formComponent.el.querySelector('[name="comments"]') as HTMLTextAreaElement;
 
     message.value = 'Foo (message)';
     message.dispatchEvent(new KeyboardEvent('keyup'));
@@ -140,7 +140,7 @@ describe('Form', () => {
 
     expect(onSubmit).toHaveBeenCalledWith({
       email: 'foo@example.com',
-      message: '',
+      comments: '',
       name: 'Foo Bar',
     });
   });
@@ -158,16 +158,16 @@ describe('Form', () => {
     const emailInput = formComponent.el.querySelector('[name="email"][type="text"]') as HTMLInputElement;
     expect(nameInput).toBeNull();
     expect(emailInput).toBeNull();
-    expect(formComponent.el.querySelector('[name="message"]')).not.toBeNull();
+    expect(formComponent.el.querySelector('[name="comments"]')).not.toBeNull();
 
-    const message = formComponent.el.querySelector('[name="message"]') as HTMLTextAreaElement;
+    const message = formComponent.el.querySelector('[name="comments"]') as HTMLTextAreaElement;
     message.value = 'Foo (message)';
     message.dispatchEvent(new KeyboardEvent('keyup'));
 
     formComponent.el.dispatchEvent(submitEvent);
     expect(onSubmit).toHaveBeenCalledWith({
       email: '',
-      message: 'Foo (message)',
+      comments: 'Foo (message)',
       name: '',
     });
   });

--- a/packages/feedback/test/widget/createWidget.test.ts
+++ b/packages/feedback/test/widget/createWidget.test.ts
@@ -140,7 +140,7 @@ describe('createWidget', () => {
     nameEl.value = 'Jane Doe';
     const emailEl = widget.dialog?.el?.querySelector('[name="email"]') as HTMLInputElement;
     emailEl.value = 'jane@example.com';
-    const messageEl = widget.dialog?.el?.querySelector('[name="message"]') as HTMLTextAreaElement;
+    const messageEl = widget.dialog?.el?.querySelector('[name="comments"]') as HTMLTextAreaElement;
     messageEl.value = 'My feedback';
 
     nameEl.dispatchEvent(new Event('change'));
@@ -152,7 +152,7 @@ describe('createWidget', () => {
       feedback: {
         name: 'Jane Doe',
         email: 'jane@example.com',
-        message: 'My feedback',
+        comments: 'My feedback',
         url: 'http://localhost/',
         replay_id: undefined,
         source: 'widget',
@@ -182,7 +182,7 @@ describe('createWidget', () => {
     });
     widget.actor?.el?.dispatchEvent(new Event('click'));
 
-    const messageEl = widget.dialog?.el?.querySelector('[name="message"]') as HTMLTextAreaElement;
+    const messageEl = widget.dialog?.el?.querySelector('[name="comments"]') as HTMLTextAreaElement;
     messageEl.value = 'My feedback';
 
     messageEl.dispatchEvent(new Event('change'));
@@ -192,7 +192,7 @@ describe('createWidget', () => {
       feedback: {
         name: '',
         email: '',
-        message: 'My feedback',
+        comments: 'My feedback',
         url: 'http://localhost/',
         replay_id: undefined,
         source: 'widget',


### PR DESCRIPTION
This is a breaking change that changes the Feedback object `message` property to `comments` to match the old `captureUserFeedback`. This will make it easier to fold the new API into the old one.
