### PR TITLE
ref(feedback): Refactor attaching replay id to feedback event to use hooks

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -27,6 +27,7 @@ import type {
   Transport,
   TransportMakeRequestResponse,
 } from '@sentry/types';
+import type { FeedbackEvent } from '@sentry/types';
 import {
   addItemToEnvelope,
   checkOrSetAlreadyCaught,
@@ -414,6 +415,12 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   public on(hook: 'otelSpanEnd', callback: (otelSpan: unknown, mutableOptions: { drop: boolean }) => void): void;
 
   /** @inheritdoc */
+  public on(
+    hook: 'afterPrepareFeedback',
+    callback: (feedback: FeedbackEvent, options?: { includeReplay: boolean }) => void,
+  ): void;
+
+  /** @inheritdoc */
   public on(hook: string, callback: unknown): void {
     if (!this._hooks[hook]) {
       this._hooks[hook] = [];
@@ -449,6 +456,9 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
 
   /** @inheritdoc */
   public emit(hook: 'otelSpanEnd', otelSpan: unknown, mutableOptions: { drop: boolean }): void;
+
+  /** @inheritdoc */
+  public emit(hook: 'afterPrepareFeedback', feedback: FeedbackEvent, options?: { includeReplay: boolean }): void;
 
   /** @inheritdoc */
   public emit(hook: string, ...rest: unknown[]): void {

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -416,7 +416,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
 
   /** @inheritdoc */
   public on(
-    hook: 'afterPrepareFeedback',
+    hook: 'beforeSendFeedback',
     callback: (feedback: FeedbackEvent, options?: { includeReplay: boolean }) => void,
   ): void;
 
@@ -458,7 +458,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   public emit(hook: 'otelSpanEnd', otelSpan: unknown, mutableOptions: { drop: boolean }): void;
 
   /** @inheritdoc */
-  public emit(hook: 'afterPrepareFeedback', feedback: FeedbackEvent, options?: { includeReplay: boolean }): void;
+  public emit(hook: 'beforeSendFeedback', feedback: FeedbackEvent, options?: { includeReplay: boolean }): void;
 
   /** @inheritdoc */
   public emit(hook: string, ...rest: unknown[]): void {

--- a/packages/feedback/src/sendFeedback.ts
+++ b/packages/feedback/src/sendFeedback.ts
@@ -1,5 +1,3 @@
-import type { BrowserClient, Replay } from '@sentry/browser';
-import { getCurrentHub } from '@sentry/core';
 import { getLocationHref } from '@sentry/utils';
 
 import { FEEDBACK_API_SOURCE } from './constants';
@@ -19,27 +17,22 @@ interface SendFeedbackParams {
  */
 export function sendFeedback(
   { name, email, message, source = FEEDBACK_API_SOURCE, url = getLocationHref() }: SendFeedbackParams,
-  { includeReplay = true }: SendFeedbackOptions = {},
+  options: SendFeedbackOptions = {},
 ): ReturnType<typeof sendFeedbackRequest> {
-  const client = getCurrentHub().getClient<BrowserClient>();
-  const replay = includeReplay && client ? (client.getIntegrationById('Replay') as Replay | undefined) : undefined;
-
-  // Prepare session replay
-  replay && replay.flush();
-  const replayId = replay && replay.getReplayId();
-
   if (!message) {
     throw new Error('Unable to submit feedback with empty message');
   }
 
-  return sendFeedbackRequest({
-    feedback: {
-      name,
-      email,
-      message,
-      url,
-      replay_id: replayId,
-      source,
+  return sendFeedbackRequest(
+    {
+      feedback: {
+        name,
+        email,
+        message,
+        url,
+        source,
+      },
     },
-  });
+    options,
+  );
 }

--- a/packages/feedback/src/util/prepareFeedbackEvent.ts
+++ b/packages/feedback/src/util/prepareFeedbackEvent.ts
@@ -27,6 +27,7 @@ export async function prepareFeedbackEvent({
     scope,
     client,
   )) as FeedbackEvent | null;
+
   if (preparedEvent === null) {
     // Taken from baseclient's `_processEvent` method, where this is handled for errors/transactions
     client.recordDroppedEvent('event_processor', 'feedback', event);

--- a/packages/feedback/src/util/sendFeedbackRequest.ts
+++ b/packages/feedback/src/util/sendFeedbackRequest.ts
@@ -55,7 +55,7 @@ export async function sendFeedbackRequest(
       }
 
       if (client && client.emit) {
-        client.emit('afterPrepareFeedback', feedbackEvent, { includeReplay: Boolean(includeReplay) });
+        client.emit('beforeSendFeedback', feedbackEvent, { includeReplay: Boolean(includeReplay) });
       }
 
       const envelope = createEventEnvelope(

--- a/packages/feedback/test/widget/createWidget.test.ts
+++ b/packages/feedback/test/widget/createWidget.test.ts
@@ -132,7 +132,7 @@ describe('createWidget', () => {
     });
 
     (sendFeedbackRequest as jest.Mock).mockImplementation(() => {
-      return true;
+      return Promise.resolve(true);
     });
     widget.actor?.el?.dispatchEvent(new Event('click'));
 
@@ -154,10 +154,9 @@ describe('createWidget', () => {
         email: 'jane@example.com',
         message: 'My feedback',
         url: 'http://localhost/',
-        replay_id: undefined,
         source: 'widget',
       },
-    });
+    }, {})
 
     // sendFeedbackRequest is async
     await flushPromises();
@@ -221,10 +220,9 @@ describe('createWidget', () => {
         email: 'jane@example.com',
         message: 'My feedback',
         url: 'http://localhost/',
-        replay_id: undefined,
         source: 'widget',
       },
-    });
+    }, {});
 
     // sendFeedbackRequest is async
     await flushPromises();
@@ -260,10 +258,9 @@ describe('createWidget', () => {
         email: '',
         message: 'My feedback',
         url: 'http://localhost/',
-        replay_id: undefined,
         source: 'widget',
       },
-    });
+    }, {});
 
     // sendFeedbackRequest is async
     await flushPromises();

--- a/packages/feedback/test/widget/createWidget.test.ts
+++ b/packages/feedback/test/widget/createWidget.test.ts
@@ -148,15 +148,18 @@ describe('createWidget', () => {
     messageEl.dispatchEvent(new Event('change'));
 
     widget.dialog?.el?.querySelector('form')?.dispatchEvent(new Event('submit'));
-    expect(sendFeedbackRequest).toHaveBeenCalledWith({
-      feedback: {
-        name: 'Jane Doe',
-        email: 'jane@example.com',
-        message: 'My feedback',
-        url: 'http://localhost/',
-        source: 'widget',
+    expect(sendFeedbackRequest).toHaveBeenCalledWith(
+      {
+        feedback: {
+          name: 'Jane Doe',
+          email: 'jane@example.com',
+          message: 'My feedback',
+          url: 'http://localhost/',
+          source: 'widget',
+        },
       },
-    }, {})
+      {},
+    );
 
     // sendFeedbackRequest is async
     await flushPromises();
@@ -214,15 +217,18 @@ describe('createWidget', () => {
     messageEl.value = 'My feedback';
 
     widget.dialog?.el?.querySelector('form')?.dispatchEvent(new Event('submit'));
-    expect(sendFeedbackRequest).toHaveBeenCalledWith({
-      feedback: {
-        name: 'Jane Doe',
-        email: 'jane@example.com',
-        message: 'My feedback',
-        url: 'http://localhost/',
-        source: 'widget',
+    expect(sendFeedbackRequest).toHaveBeenCalledWith(
+      {
+        feedback: {
+          name: 'Jane Doe',
+          email: 'jane@example.com',
+          message: 'My feedback',
+          url: 'http://localhost/',
+          source: 'widget',
+        },
       },
-    }, {});
+      {},
+    );
 
     // sendFeedbackRequest is async
     await flushPromises();
@@ -252,15 +258,18 @@ describe('createWidget', () => {
     messageEl.dispatchEvent(new Event('change'));
 
     widget.dialog?.el?.querySelector('form')?.dispatchEvent(new Event('submit'));
-    expect(sendFeedbackRequest).toHaveBeenCalledWith({
-      feedback: {
-        name: '',
-        email: '',
-        message: 'My feedback',
-        url: 'http://localhost/',
-        source: 'widget',
+    expect(sendFeedbackRequest).toHaveBeenCalledWith(
+      {
+        feedback: {
+          name: '',
+          email: '',
+          message: 'My feedback',
+          url: 'http://localhost/',
+          source: 'widget',
+        },
       },
-    }, {});
+      {},
+    );
 
     // sendFeedbackRequest is async
     await flushPromises();

--- a/packages/replay/src/util/addGlobalListeners.ts
+++ b/packages/replay/src/util/addGlobalListeners.ts
@@ -59,7 +59,7 @@ export function addGlobalListeners(replay: ReplayContainer): void {
     });
 
     // We want to flush replay
-    client.on('afterPrepareFeedback', (feedbackEvent, options) => {
+    client.on('beforeSendFeedback', (feedbackEvent, options) => {
       const replayId = replay.getSessionId();
       if (options && options.includeReplay && replay.isEnabled() && replayId) {
         void replay.flush();

--- a/packages/replay/src/util/addGlobalListeners.ts
+++ b/packages/replay/src/util/addGlobalListeners.ts
@@ -57,6 +57,17 @@ export function addGlobalListeners(replay: ReplayContainer): void {
     client.on('finishTransaction', transaction => {
       replay.lastTransaction = transaction;
     });
+
+    // We want to flush replay
+    client.on('afterPrepareFeedback', (feedbackEvent, options) => {
+      const replayId = replay.getSessionId();
+      if (options && options.includeReplay && replay.isEnabled() && replayId) {
+        void replay.flush();
+        if (feedbackEvent.contexts && feedbackEvent.contexts.feedback) {
+          feedbackEvent.contexts.feedback.replay_id = replayId;
+        }
+      }
+    });
   }
 }
 

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -6,6 +6,7 @@ import type { DsnComponents } from './dsn';
 import type { DynamicSamplingContext, Envelope } from './envelope';
 import type { Event, EventHint } from './event';
 import type { EventProcessor } from './eventprocessor';
+import type { FeedbackEvent } from './feedback';
 import type { Integration, IntegrationClass } from './integration';
 import type { ClientOptions } from './options';
 import type { Scope } from './scope';
@@ -238,6 +239,16 @@ export interface Client<O extends ClientOptions = ClientOptions> {
   on?(hook: 'otelSpanEnd', callback: (otelSpan: unknown, mutableOptions: { drop: boolean }) => void): void;
 
   /**
+   * Register a callback when a Feedback event has been prepared.
+   * This should be used to mutate the event. The options argument can hint
+   * about what kind of mutation it expects.
+   */
+  on?(
+    hook: 'afterPrepareFeedback',
+    callback: (feedback: FeedbackEvent, options?: { includeReplay?: boolean }) => void,
+  ): void;
+
+  /**
    * Fire a hook event for transaction start.
    * Expects to be given a transaction as the second argument.
    */
@@ -290,6 +301,13 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    * The option argument may be mutated to drop the span.
    */
   emit?(hook: 'otelSpanEnd', otelSpan: unknown, mutableOptions: { drop: boolean }): void;
+
+  /**
+   * Fire a hook event for after preparing a feedback event. Events to be given
+   * a feedback event as the second argument, and an optional options object as
+   * third argument.
+   */
+  emit?(hook: 'afterPrepareFeedback', feedback: FeedbackEvent, options?: { includeReplay?: boolean }): void;
 
   /* eslint-enable @typescript-eslint/unified-signatures */
 }

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -244,7 +244,7 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    * about what kind of mutation it expects.
    */
   on?(
-    hook: 'afterPrepareFeedback',
+    hook: 'beforeSendFeedback',
     callback: (feedback: FeedbackEvent, options?: { includeReplay?: boolean }) => void,
   ): void;
 
@@ -307,7 +307,7 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    * a feedback event as the second argument, and an optional options object as
    * third argument.
    */
-  emit?(hook: 'afterPrepareFeedback', feedback: FeedbackEvent, options?: { includeReplay?: boolean }): void;
+  emit?(hook: 'beforeSendFeedback', feedback: FeedbackEvent, options?: { includeReplay?: boolean }): void;
 
   /* eslint-enable @typescript-eslint/unified-signatures */
 }


### PR DESCRIPTION
Add a `beforeSendFeedback` hook that replay listens to, to attach replayId to the feedback event.
