### PR TITLE
meta: Deprecate `_addRequestData` in `RequestData` integration

### DIFF
--- a/packages/node/src/requestdata.ts
+++ b/packages/node/src/requestdata.ts
@@ -1,3 +1,5 @@
+// TODO(v8): Evaluate whether the exported functtions still make sense after we have a strictly typed `sdkProcessingMetadata.request` and related framework/instrumentation-specific mapping functions.
+
 import type {
   Event,
   ExtractedNodeRequestData,
@@ -32,6 +34,7 @@ export type AddRequestDataToEventOptions = {
   };
 };
 
+// TODO(v8): Decide whether we want to keep this and delete it in case we don't. The `RequestData` integration should most likely not set the `transaction` field
 export type TransactionNamingScheme = 'path' | 'methodPath' | 'handler';
 
 /**

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -47,6 +47,7 @@ export interface Event {
   measurements?: Measurements;
   debug_meta?: DebugMeta;
   // A place to stash data which is needed at some point in the SDK's event processing pipeline but which shouldn't get sent to Sentry
+  // TODO(v8): Properly type this out for the `request` key.
   sdkProcessingMetadata?: { [key: string]: any };
   transaction_info?: {
     source: TransactionSource;

--- a/packages/types/src/polymorphics.ts
+++ b/packages/types/src/polymorphics.ts
@@ -12,6 +12,11 @@ export interface PolymorphicEvent {
   readonly currentTarget?: unknown;
 }
 
+// TODO(v8): Instead of having this mess of a type we should simply stricly define *some* request interface for the
+// `sdkProcessingMetadata` and than have a variety of utility functions that map to this type to be used by the
+// RequestData integration.e.g. `normalizeExpressRequest`, or`normalizeKoaRequest`.
+// These utility functions are then used by the respective integrations to transform the Framework specific request
+// objects to a format that is compatible with the`RequestData` integration.
 /** A `Request` type compatible with Node, Express, browser, etc., because everything is optional */
 export type PolymorphicRequest = BaseRequest &
   BrowserRequest &


### PR DESCRIPTION
Just some v8 pre-work.

- Deprecating a method we will likely wanna get rid of.
- Mark a few places with todos where we will want to make changes.