### PR TITLE
fix(astro): Remove method from span op

### DIFF
--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -83,7 +83,7 @@ export const handleRequest: (options?: MiddlewareOptions) => MiddlewareResponseH
       const res = await startSpan(
         {
           name: `${method} ${interpolateRouteFromUrlAndParams(ctx.url.pathname, ctx.params)}`,
-          op: `http.server.${method.toLowerCase()}`,
+          op: 'http.server',
           origin: 'auto.http.astro',
           status: 'ok',
           ...traceparentData,

--- a/packages/astro/test/server/middleware.test.ts
+++ b/packages/astro/test/server/middleware.test.ts
@@ -47,7 +47,7 @@ describe('sentryMiddleware', () => {
           source: 'route',
         },
         name: 'GET /users/[id]/details',
-        op: 'http.server.get',
+        op: 'http.server',
         origin: 'auto.http.astro',
         status: 'ok',
       },


### PR DESCRIPTION
Although adding method is nice to span op, it duplicates information that is already in span description.

In addition, we want to reduce the total list of span ops as much as possible for cardinality reasons, `http.server` + span data about method is good enough to understand intent here.