### PR TITLE
ref(feedback): Do not import window from browser pkg to avoid circular import

### DIFF
--- a/packages/feedback/package.json
+++ b/packages/feedback/package.json
@@ -23,7 +23,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@sentry/browser": "7.81.0",
     "@sentry/core": "7.81.0",
     "@sentry/types": "7.81.0",
     "@sentry/utils": "7.81.0"

--- a/packages/feedback/src/constants.ts
+++ b/packages/feedback/src/constants.ts
@@ -1,4 +1,4 @@
-import { GLOBAL_OBJ } from "@sentry/utils";
+import { GLOBAL_OBJ } from '@sentry/utils';
 
 // exporting a separate copy of `WINDOW` rather than exporting the one from `@sentry/browser`
 // prevents the browser package from being bundled in the CDN bundle, and avoids a

--- a/packages/feedback/src/constants.ts
+++ b/packages/feedback/src/constants.ts
@@ -2,7 +2,7 @@ import { GLOBAL_OBJ } from "@sentry/utils";
 
 // exporting a separate copy of `WINDOW` rather than exporting the one from `@sentry/browser`
 // prevents the browser package from being bundled in the CDN bundle, and avoids a
-// circular dependency between the browser and replay packages
+// circular dependency between the browser and feedback packages
 export const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
 
 const LIGHT_BACKGROUND = '#ffffff';

--- a/packages/feedback/src/constants.ts
+++ b/packages/feedback/src/constants.ts
@@ -1,3 +1,10 @@
+import { GLOBAL_OBJ } from "@sentry/utils";
+
+// exporting a separate copy of `WINDOW` rather than exporting the one from `@sentry/browser`
+// prevents the browser package from being bundled in the CDN bundle, and avoids a
+// circular dependency between the browser and replay packages
+export const WINDOW = GLOBAL_OBJ as typeof GLOBAL_OBJ & Window;
+
 const LIGHT_BACKGROUND = '#ffffff';
 const INHERIT = 'inherit';
 const SUBMIT_COLOR = 'rgba(108, 95, 199, 1)';

--- a/packages/feedback/src/integration.ts
+++ b/packages/feedback/src/integration.ts
@@ -1,4 +1,4 @@
-import { WINDOW } from '@sentry/browser';
+import { WINDOW } from './constants';
 import type { Integration } from '@sentry/types';
 import { isBrowser, logger } from '@sentry/utils';
 

--- a/packages/feedback/src/integration.ts
+++ b/packages/feedback/src/integration.ts
@@ -1,4 +1,3 @@
-import { WINDOW } from './constants';
 import type { Integration } from '@sentry/types';
 import { isBrowser, logger } from '@sentry/utils';
 
@@ -15,6 +14,7 @@ import {
   NAME_PLACEHOLDER,
   SUBMIT_BUTTON_LABEL,
   SUCCESS_MESSAGE_TEXT,
+  WINDOW,
 } from './constants';
 import type { FeedbackInternalOptions, FeedbackWidget, OptionalFeedbackConfiguration } from './types';
 import { mergeOptions } from './util/mergeOptions';

--- a/packages/feedback/src/widget/Icon.ts
+++ b/packages/feedback/src/widget/Icon.ts
@@ -1,4 +1,4 @@
-import { WINDOW } from '@sentry/browser';
+import { WINDOW } from '../constants';
 
 import { setAttributesNS } from '../util/setAttributesNS';
 

--- a/packages/feedback/src/widget/Icon.ts
+++ b/packages/feedback/src/widget/Icon.ts
@@ -1,5 +1,4 @@
 import { WINDOW } from '../constants';
-
 import { setAttributesNS } from '../util/setAttributesNS';
 
 const SIZE = 20;

--- a/packages/feedback/src/widget/Logo.ts
+++ b/packages/feedback/src/widget/Logo.ts
@@ -1,4 +1,4 @@
-import { WINDOW } from '@sentry/browser';
+import { WINDOW } from '../constants';
 
 import type { FeedbackInternalOptions } from '../types';
 import { setAttributesNS } from '../util/setAttributesNS';

--- a/packages/feedback/src/widget/Logo.ts
+++ b/packages/feedback/src/widget/Logo.ts
@@ -1,5 +1,4 @@
 import { WINDOW } from '../constants';
-
 import type { FeedbackInternalOptions } from '../types';
 import { setAttributesNS } from '../util/setAttributesNS';
 

--- a/packages/feedback/src/widget/SuccessIcon.ts
+++ b/packages/feedback/src/widget/SuccessIcon.ts
@@ -1,4 +1,4 @@
-import { WINDOW } from '@sentry/browser';
+import { WINDOW } from '../constants';
 
 import { setAttributesNS } from '../util/setAttributesNS';
 

--- a/packages/feedback/src/widget/SuccessIcon.ts
+++ b/packages/feedback/src/widget/SuccessIcon.ts
@@ -1,5 +1,4 @@
 import { WINDOW } from '../constants';
-
 import { setAttributesNS } from '../util/setAttributesNS';
 
 const WIDTH = 16;

--- a/packages/feedback/src/widget/createShadowHost.ts
+++ b/packages/feedback/src/widget/createShadowHost.ts
@@ -1,4 +1,4 @@
-import { WINDOW } from '@sentry/browser';
+import { WINDOW } from '../constants';
 import { logger } from '@sentry/utils';
 
 import type { FeedbackInternalOptions } from '../types';

--- a/packages/feedback/src/widget/createShadowHost.ts
+++ b/packages/feedback/src/widget/createShadowHost.ts
@@ -1,6 +1,6 @@
-import { WINDOW } from '../constants';
 import { logger } from '@sentry/utils';
 
+import { WINDOW } from '../constants';
 import type { FeedbackInternalOptions } from '../types';
 import { createDialogStyles } from './Dialog.css';
 import { createMainStyles } from './Main.css';

--- a/packages/feedback/src/widget/util/createElement.ts
+++ b/packages/feedback/src/widget/util/createElement.ts
@@ -1,4 +1,4 @@
-import { WINDOW } from '@sentry/browser';
+import { WINDOW } from '../../constants';
 
 /**
  * Helper function to create an element. Could be used as a JSX factory


### PR DESCRIPTION
We will be exporting the Feedback package from the `@sentry/browser` package, so to avoid circular imports when we do, we should remove imports from `@sentry/browser`

(this is what we did in Replay)