### PR TITLE
ref(node): Use Sentry.continueTrace in node

### DIFF
--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -68,6 +68,7 @@ export function tracingHandler(): (
           name,
           op: 'http.server',
           origin: 'auto.http.node.tracingHandler',
+          ...ctx,
           metadata: {
             ...ctx.metadata,
             // The request should already have been stored in `scope.sdkProcessingMetadata` (which will become


### PR DESCRIPTION
Carrying on work from https://github.com/getsentry/sentry-javascript/pull/9606

I thought about doing more w/ removing `startTransaction`, but given this is going away soon in v8/otel, not touching it.