### PR TITLE
fix(nextjs): Use `globalThis` instead of `global` in edge runtime

### DIFF
--- a/packages/nextjs/src/config/loaders/valueInjectionLoader.ts
+++ b/packages/nextjs/src/config/loaders/valueInjectionLoader.ts
@@ -19,7 +19,7 @@ export default function valueInjectionLoader(this: LoaderThis<LoaderOptions>, us
   this.cacheable(false);
 
   // Define some global proxy that works on server and on the browser.
-  let injectedCode = 'var _sentryCollisionFreeGlobalObject = typeof window === "undefined" ? global : window;\n';
+  let injectedCode = 'var _sentryCollisionFreeGlobalObject = typeof window === "undefined" ? globalThis : window;\n';
 
   Object.entries(values).forEach(([key, value]) => {
     injectedCode += `_sentryCollisionFreeGlobalObject["${key}"] = ${JSON.stringify(value)};\n`;

--- a/packages/nextjs/src/config/loaders/valueInjectionLoader.ts
+++ b/packages/nextjs/src/config/loaders/valueInjectionLoader.ts
@@ -19,7 +19,8 @@ export default function valueInjectionLoader(this: LoaderThis<LoaderOptions>, us
   this.cacheable(false);
 
   // Define some global proxy that works on server and on the browser.
-  let injectedCode = 'var _sentryCollisionFreeGlobalObject = typeof window === "undefined" ? globalThis : window;\n';
+  let injectedCode =
+    'var _sentryCollisionFreeGlobalObject = typeof window != "undefined" ? window : typeof global != "undefined" ? global : typeof self != "undefined" ? self : {};\n';
 
   Object.entries(values).forEach(([key, value]) => {
     injectedCode += `_sentryCollisionFreeGlobalObject["${key}"] = ${JSON.stringify(value)};\n`;


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

> https://github.com/getsentry/sentry-javascript/commit/9f32c618cf91b5e6091deacd8801a7b28660c7d5#diff-55396f0a8f12ba2eb7ce27f3cf886f946c29c2aa93b5d2f993dadbd5a9f3cc75L979

Due to this commit, `sentry.edge.config.js` is added. But `global` doesn't exist in edge runtime, so we should use `globalThis`.

Error Msg:
<img width="749" alt="image" src="https://github.com/getsentry/sentry-javascript/assets/21997724/f63a1e95-46d2-4007-8b83-96873209bce8">

 