### PR TITLE
feat(core): Allow to use `continueTrace` without callback

### DIFF
--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -203,6 +203,23 @@ export function getActiveSpan(): Span | undefined {
   return getCurrentHub().getScope().getSpan();
 }
 
+export function continueTrace({
+  sentryTrace,
+  baggage,
+}: {
+  sentryTrace: Parameters<typeof tracingContextFromHeaders>[0];
+  baggage: Parameters<typeof tracingContextFromHeaders>[1];
+}): Partial<TransactionContext>;
+export function continueTrace<V>(
+  {
+    sentryTrace,
+    baggage,
+  }: {
+    sentryTrace: Parameters<typeof tracingContextFromHeaders>[0];
+    baggage: Parameters<typeof tracingContextFromHeaders>[1];
+  },
+  callback: (transactionContext: Partial<TransactionContext>) => V,
+): V;
 /**
  * Continue a trace from `sentry-trace` and `baggage` values.
  * These values can be obtained from incoming request headers,
@@ -219,8 +236,8 @@ export function continueTrace<V>(
     sentryTrace: Parameters<typeof tracingContextFromHeaders>[0];
     baggage: Parameters<typeof tracingContextFromHeaders>[1];
   },
-  callback: (transactionContext: Partial<TransactionContext>) => V,
-): V {
+  callback?: (transactionContext: Partial<TransactionContext>) => V,
+): V | Partial<TransactionContext> {
   const hub = getCurrentHub();
   const currentScope = hub.getScope();
 
@@ -241,6 +258,10 @@ export function continueTrace<V>(
       dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,
     }),
   };
+
+  if (!callback) {
+    return transactionContext;
+  }
 
   return callback(transactionContext);
 }

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -320,4 +320,45 @@ describe('continueTrace', () => {
 
     expect(scope['_sdkProcessingMetadata']).toEqual({});
   });
+
+  it('returns response of callback', () => {
+    const expectedContext = {
+      metadata: {
+        dynamicSamplingContext: {},
+      },
+      parentSampled: false,
+      parentSpanId: '1121201211212012',
+      traceId: '12312012123120121231201212312012',
+    };
+
+    const result = continueTrace(
+      {
+        sentryTrace: '12312012123120121231201212312012-1121201211212012-0',
+        baggage: undefined,
+      },
+      ctx => {
+        return { ctx };
+      },
+    );
+
+    expect(result).toEqual({ ctx: expectedContext });
+  });
+
+  it('works without a callback', () => {
+    const expectedContext = {
+      metadata: {
+        dynamicSamplingContext: {},
+      },
+      parentSampled: false,
+      parentSpanId: '1121201211212012',
+      traceId: '12312012123120121231201212312012',
+    };
+
+    const ctx = continueTrace({
+      sentryTrace: '12312012123120121231201212312012-1121201211212012-0',
+      baggage: undefined,
+    });
+
+    expect(ctx).toEqual(expectedContext);
+  });
 });


### PR DESCRIPTION
Inspired by recent comments about the continueTrace method, I figured we can actually update this in a backwards-compatible way to _also_ allow to use it without a callback.