### PR TITLE
fix(replay): Add `BODY_PARSE_ERROR` warning & time out fetch response load

### DIFF
--- a/packages/replay/src/coreHandlers/util/networkUtils.ts
+++ b/packages/replay/src/coreHandlers/util/networkUtils.ts
@@ -84,16 +84,27 @@ export function getBodyString(body: unknown): [string | undefined, NetworkMetaWa
   return [undefined];
 }
 
-/** Merge warnings into an possibly existing meta. */
-export function mergeWarningsIntoMeta(
-  meta: ReplayNetworkRequestOrResponse['_meta'],
-  warnings: NetworkMetaWarning[],
-): ReplayNetworkRequestOrResponse['_meta'] {
-  const newMeta = { ...meta };
-  const existingWarnings = newMeta.warnings || [];
-  newMeta.warnings = [...existingWarnings, ...warnings];
+/** Merge a warning into an existing network request/response. */
+export function mergeWarning(
+  info: ReplayNetworkRequestOrResponse | undefined,
+  warning: NetworkMetaWarning,
+): ReplayNetworkRequestOrResponse {
+  if (!info) {
+    return {
+      headers: {},
+      size: undefined,
+      _meta: {
+        warnings: [warning],
+      },
+    };
+  }
 
-  return newMeta;
+  const newMeta = { ...info._meta };
+  const existingWarnings = newMeta.warnings || [];
+  newMeta.warnings = [...existingWarnings, warning];
+
+  info._meta = newMeta;
+  return info;
 }
 
 /** Convert ReplayNetworkRequestData to a PerformanceEntry. */

--- a/packages/replay/src/coreHandlers/util/xhrUtils.ts
+++ b/packages/replay/src/coreHandlers/util/xhrUtils.ts
@@ -16,7 +16,7 @@ import {
   getBodySize,
   getBodyString,
   makeNetworkReplayBreadcrumb,
-  mergeWarningsIntoMeta,
+  mergeWarning,
   parseContentLengthHeader,
   urlMatches,
 } from './networkUtils';
@@ -116,22 +116,14 @@ function _prepareXhrData(
   const request = buildNetworkRequestOrResponse(networkRequestHeaders, requestBodySize, requestBody);
   const response = buildNetworkRequestOrResponse(networkResponseHeaders, responseBodySize, responseBody);
 
-  if (request && requestWarning) {
-    request._meta = mergeWarningsIntoMeta(request._meta, [requestWarning]);
-  }
-
-  if (response && responseWarning) {
-    response._meta = mergeWarningsIntoMeta(response._meta, [responseWarning]);
-  }
-
   return {
     startTimestamp,
     endTimestamp,
     url,
     method,
     statusCode,
-    request,
-    response,
+    request: requestWarning ? mergeWarning(request, requestWarning) : request,
+    response: responseWarning ? mergeWarning(response, responseWarning) : response,
   };
 }
 

--- a/packages/replay/src/coreHandlers/util/xhrUtils.ts
+++ b/packages/replay/src/coreHandlers/util/xhrUtils.ts
@@ -1,7 +1,13 @@
 import type { Breadcrumb, TextEncoderInternal, XhrBreadcrumbData } from '@sentry/types';
 import { logger, SENTRY_XHR_DATA_KEY } from '@sentry/utils';
 
-import type { ReplayContainer, ReplayNetworkOptions, ReplayNetworkRequestData, XhrHint } from '../../types';
+import type {
+  NetworkMetaWarning,
+  ReplayContainer,
+  ReplayNetworkOptions,
+  ReplayNetworkRequestData,
+  XhrHint,
+} from '../../types';
 import { addNetworkBreadcrumb } from './addNetworkBreadcrumb';
 import {
   buildNetworkRequestOrResponse,
@@ -10,6 +16,7 @@ import {
   getBodySize,
   getBodyString,
   makeNetworkReplayBreadcrumb,
+  mergeWarningsIntoMeta,
   parseContentLengthHeader,
   urlMatches,
 } from './networkUtils';
@@ -103,11 +110,19 @@ function _prepareXhrData(
     : {};
   const networkResponseHeaders = getAllowedHeaders(getResponseHeaders(xhr), options.networkResponseHeaders);
 
-  const requestBody = options.networkCaptureBodies ? getBodyString(input) : undefined;
-  const responseBody = options.networkCaptureBodies ? _getXhrResponseBody(xhr) : undefined;
+  const [requestBody, requestWarning] = options.networkCaptureBodies ? getBodyString(input) : [undefined];
+  const [responseBody, responseWarning] = options.networkCaptureBodies ? _getXhrResponseBody(xhr) : [undefined];
 
   const request = buildNetworkRequestOrResponse(networkRequestHeaders, requestBodySize, requestBody);
   const response = buildNetworkRequestOrResponse(networkResponseHeaders, responseBodySize, responseBody);
+
+  if (request && requestWarning) {
+    request._meta = mergeWarningsIntoMeta(request._meta, [requestWarning]);
+  }
+
+  if (response && responseWarning) {
+    response._meta = mergeWarningsIntoMeta(response._meta, [responseWarning]);
+  }
 
   return {
     startTimestamp,
@@ -134,12 +149,12 @@ function getResponseHeaders(xhr: XMLHttpRequest): Record<string, string> {
   }, {});
 }
 
-function _getXhrResponseBody(xhr: XMLHttpRequest): string | undefined {
+function _getXhrResponseBody(xhr: XMLHttpRequest): [string | undefined, NetworkMetaWarning?] {
   // We collect errors that happen, but only log them if we can't get any response body
   const errors: unknown[] = [];
 
   try {
-    return xhr.responseText;
+    return [xhr.responseText];
   } catch (e) {
     errors.push(e);
   }
@@ -154,5 +169,5 @@ function _getXhrResponseBody(xhr: XMLHttpRequest): string | undefined {
 
   __DEBUG_BUILD__ && logger.warn('[Replay] Failed to get xhr response body', ...errors);
 
-  return undefined;
+  return [undefined];
 }

--- a/packages/replay/src/types/request.ts
+++ b/packages/replay/src/types/request.ts
@@ -3,7 +3,7 @@ type JsonArray = unknown[];
 
 export type NetworkBody = JsonObject | JsonArray | string;
 
-export type NetworkMetaWarning = 'MAYBE_JSON_TRUNCATED' | 'TEXT_TRUNCATED' | 'URL_SKIPPED';
+export type NetworkMetaWarning = 'MAYBE_JSON_TRUNCATED' | 'TEXT_TRUNCATED' | 'URL_SKIPPED' | 'BODY_PARSE_ERROR';
 
 interface NetworkMeta {
   warnings?: NetworkMetaWarning[];

--- a/packages/replay/test/unit/coreHandlers/handleNetworkBreadcrumbs.test.ts
+++ b/packages/replay/test/unit/coreHandlers/handleNetworkBreadcrumbs.test.ts
@@ -23,6 +23,8 @@ async function waitForReplayEventBuffer() {
   await Promise.resolve();
   await Promise.resolve();
   await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 const LARGE_BODY = 'a'.repeat(NETWORK_BODY_MAX_SIZE + 1);

--- a/packages/replay/test/unit/coreHandlers/util/fetchUtils.test.ts
+++ b/packages/replay/test/unit/coreHandlers/util/fetchUtils.test.ts
@@ -1,0 +1,137 @@
+import { TextEncoder } from 'util';
+
+import { _getResponseInfo } from '../../../../src/coreHandlers/util/fetchUtils';
+
+describe('_getResponseInfo', () => {
+  it('works with captureDetails: false', async () => {
+    const res = await _getResponseInfo(
+      false,
+      {
+        networkCaptureBodies: true,
+        textEncoder: new TextEncoder(),
+        networkResponseHeaders: [],
+      },
+      undefined,
+      undefined,
+    );
+
+    expect(res).toEqual(undefined);
+  });
+
+  it('works with captureDetails: false & responseBodySize', async () => {
+    const res = await _getResponseInfo(
+      false,
+      {
+        networkCaptureBodies: true,
+        textEncoder: new TextEncoder(),
+        networkResponseHeaders: [],
+      },
+      undefined,
+      123,
+    );
+
+    expect(res).toEqual({
+      headers: {},
+      size: 123,
+      _meta: {
+        warnings: ['URL_SKIPPED'],
+      },
+    });
+  });
+
+  it('works with text body', async () => {
+    const response = {
+      headers: {
+        has: () => {
+          return false;
+        },
+        get: () => {
+          return undefined;
+        },
+      },
+      clone: () => response,
+      text: () => Promise.resolve('text body'),
+    } as unknown as Response;
+
+    const res = await _getResponseInfo(
+      true,
+      {
+        networkCaptureBodies: true,
+        textEncoder: new TextEncoder(),
+        networkResponseHeaders: [],
+      },
+      response,
+      undefined,
+    );
+
+    expect(res).toEqual({
+      headers: {},
+      size: 9,
+      body: 'text body',
+    });
+  });
+
+  it('works with body that fails', async () => {
+    const response = {
+      headers: {
+        has: () => {
+          return false;
+        },
+        get: () => {
+          return undefined;
+        },
+      },
+      clone: () => response,
+      text: () => Promise.reject('cannot read'),
+    } as unknown as Response;
+
+    const res = await _getResponseInfo(
+      true,
+      {
+        networkCaptureBodies: true,
+        textEncoder: new TextEncoder(),
+        networkResponseHeaders: [],
+      },
+      response,
+      undefined,
+    );
+
+    expect(res).toEqual({
+      _meta: { warnings: ['BODY_PARSE_ERROR'] },
+      headers: {},
+      size: undefined,
+    });
+  });
+
+  it('works with body that times out', async () => {
+    const response = {
+      headers: {
+        has: () => {
+          return false;
+        },
+        get: () => {
+          return undefined;
+        },
+      },
+      clone: () => response,
+      text: () => new Promise(resolve => setTimeout(() => resolve('text body'), 1000)),
+    } as unknown as Response;
+
+    const res = await _getResponseInfo(
+      true,
+      {
+        networkCaptureBodies: true,
+        textEncoder: new TextEncoder(),
+        networkResponseHeaders: [],
+      },
+      response,
+      undefined,
+    );
+
+    expect(res).toEqual({
+      _meta: { warnings: ['BODY_PARSE_ERROR'] },
+      headers: {},
+      size: undefined,
+    });
+  });
+});


### PR DESCRIPTION
This is a tricky one 😬 Basically, it is possible that fetch returns a readable stream that is ongoing. So if we do `await response.text()` this will be pending forever, if a stream is ongoing.

I haven't found a way to really check that is the case and avoid parsing this at all 🤔 So the best I could come up with was to instead add a timeout of 500ms when we stop waiting for the fetch body.

This should at least unblock waiting on this, but it will still mean that the response continues to be parsed client-side - I don't think there is a way to abort this 🤔 

Additionally, this also refactors this a bit so we add a new `BODY_PARSE_ERROR` meta warning if the parsing of the body fails, for whatever reason. we may also use this in the replay UI cc @ryan953 somehow?

"fixes" https://github.com/getsentry/sentry-javascript/issues/9616