### PR TITLE
fix(replay): Capture JSON XHR response bodies

### DIFF
--- a/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseBody/test.ts
+++ b/packages/browser-integration-tests/suites/replay/extendNetworkBreadcrumbs/xhr/captureResponseBody/test.ts
@@ -178,6 +178,93 @@ sentryTest('captures JSON response body', async ({ getLocalTestPath, page, brows
   ]);
 });
 
+sentryTest('captures JSON response body when responseType=json', async ({ getLocalTestPath, page, browserName }) => {
+  // These are a bit flaky on non-chromium browsers
+  if (shouldSkipReplayTest() || browserName !== 'chromium') {
+    sentryTest.skip();
+  }
+
+  await page.route('**/foo', route => {
+    return route.fulfill({
+      status: 200,
+      body: JSON.stringify({ res: 'this' }),
+      headers: {
+        'Content-Length': '',
+      },
+    });
+  });
+
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const requestPromise = waitForErrorRequest(page);
+  const replayRequestPromise1 = waitForReplayRequest(page, 0);
+
+  const url = await getLocalTestPath({ testDir: __dirname });
+  await page.goto(url);
+
+  void page.evaluate(() => {
+    /* eslint-disable */
+    const xhr = new XMLHttpRequest();
+
+    xhr.open('POST', 'http://localhost:7654/foo');
+    // Setting this to json ensures that xhr.response returns a POJO
+    xhr.responseType = 'json';
+    xhr.send();
+
+    xhr.addEventListener('readystatechange', function () {
+      if (xhr.readyState === 4) {
+        // @ts-expect-error Sentry is a global
+        setTimeout(() => Sentry.captureException('test error', 0));
+      }
+    });
+    /* eslint-enable */
+  });
+
+  const request = await requestPromise;
+  const eventData = envelopeRequestParser(request);
+
+  expect(eventData.exception?.values).toHaveLength(1);
+
+  expect(eventData?.breadcrumbs?.length).toBe(1);
+  expect(eventData!.breadcrumbs![0]).toEqual({
+    timestamp: expect.any(Number),
+    category: 'xhr',
+    type: 'http',
+    data: {
+      method: 'POST',
+      response_body_size: 14,
+      status_code: 200,
+      url: 'http://localhost:7654/foo',
+    },
+  });
+
+  const replayReq1 = await replayRequestPromise1;
+  const { performanceSpans: performanceSpans1 } = getCustomRecordingEvents(replayReq1);
+  expect(performanceSpans1.filter(span => span.op === 'resource.xhr')).toEqual([
+    {
+      data: {
+        method: 'POST',
+        statusCode: 200,
+        response: {
+          size: 14,
+          headers: {},
+          body: { res: 'this' },
+        },
+      },
+      description: 'http://localhost:7654/foo',
+      endTimestamp: expect.any(Number),
+      op: 'resource.xhr',
+      startTimestamp: expect.any(Number),
+    },
+  ]);
+});
+
 sentryTest('captures non-text response body', async ({ getLocalTestPath, page, browserName }) => {
   // These are a bit flaky on non-chromium browsers
   if (shouldSkipReplayTest() || browserName !== 'chromium') {

--- a/packages/replay/src/coreHandlers/util/networkUtils.ts
+++ b/packages/replay/src/coreHandlers/util/networkUtils.ts
@@ -75,6 +75,10 @@ export function getBodyString(body: unknown): [string | undefined, NetworkMetaWa
     if (body instanceof FormData) {
       return [_serializeFormData(body)];
     }
+
+    if (!body) {
+      return [undefined];
+    }
   } catch {
     DEBUG_BUILD && logger.warn('[Replay] Failed to serialize body', body);
     return [undefined, 'BODY_PARSE_ERROR'];
@@ -82,7 +86,7 @@ export function getBodyString(body: unknown): [string | undefined, NetworkMetaWa
 
   DEBUG_BUILD && logger.info('[Replay] Skipping network body because of body type', body);
 
-  return [undefined];
+  return [undefined, 'UNPARSEABLE_BODY_TYPE'];
 }
 
 /** Merge a warning into an existing network request/response. */

--- a/packages/replay/src/coreHandlers/util/xhrUtils.ts
+++ b/packages/replay/src/coreHandlers/util/xhrUtils.ts
@@ -172,12 +172,13 @@ function _getXhrResponseBody(xhr: XMLHttpRequest): [string | undefined, NetworkM
  * Blob
  * Document
  * POJO
+ *
+ * Exported only for tests.
  */
 export function _parseXhrResponse(
   body: XMLHttpRequest['response'],
   responseType: XMLHttpRequest['responseType'],
 ): [string | undefined, NetworkMetaWarning?] {
-  logger.log(body, responseType, typeof body);
   try {
     if (typeof body === 'string') {
       return [body];
@@ -190,6 +191,10 @@ export function _parseXhrResponse(
     if (responseType === 'json' && body && typeof body === 'object') {
       return [JSON.stringify(body)];
     }
+
+    if (!body) {
+      return [undefined];
+    }
   } catch {
     __DEBUG_BUILD__ && logger.warn('[Replay] Failed to serialize body', body);
     return [undefined, 'BODY_PARSE_ERROR'];
@@ -197,7 +202,7 @@ export function _parseXhrResponse(
 
   __DEBUG_BUILD__ && logger.info('[Replay] Skipping network body because of body type', body);
 
-  return [undefined];
+  return [undefined, 'UNPARSEABLE_BODY_TYPE'];
 }
 
 function _getBodySize(

--- a/packages/replay/src/coreHandlers/util/xhrUtils.ts
+++ b/packages/replay/src/coreHandlers/util/xhrUtils.ts
@@ -196,11 +196,11 @@ export function _parseXhrResponse(
       return [undefined];
     }
   } catch {
-    __DEBUG_BUILD__ && logger.warn('[Replay] Failed to serialize body', body);
+    DEBUG_BUILD && logger.warn('[Replay] Failed to serialize body', body);
     return [undefined, 'BODY_PARSE_ERROR'];
   }
 
-  __DEBUG_BUILD__ && logger.info('[Replay] Skipping network body because of body type', body);
+  DEBUG_BUILD && logger.info('[Replay] Skipping network body because of body type', body);
 
   return [undefined, 'UNPARSEABLE_BODY_TYPE'];
 }

--- a/packages/replay/src/types/request.ts
+++ b/packages/replay/src/types/request.ts
@@ -3,7 +3,12 @@ type JsonArray = unknown[];
 
 export type NetworkBody = JsonObject | JsonArray | string;
 
-export type NetworkMetaWarning = 'MAYBE_JSON_TRUNCATED' | 'TEXT_TRUNCATED' | 'URL_SKIPPED' | 'BODY_PARSE_ERROR';
+export type NetworkMetaWarning =
+  | 'MAYBE_JSON_TRUNCATED'
+  | 'TEXT_TRUNCATED'
+  | 'URL_SKIPPED'
+  | 'BODY_PARSE_ERROR'
+  | 'UNPARSEABLE_BODY_TYPE';
 
 interface NetworkMeta {
   warnings?: NetworkMetaWarning[];

--- a/packages/replay/test/unit/coreHandlers/util/fetchUtils.test.ts
+++ b/packages/replay/test/unit/coreHandlers/util/fetchUtils.test.ts
@@ -2,136 +2,138 @@ import { TextEncoder } from 'util';
 
 import { _getResponseInfo } from '../../../../src/coreHandlers/util/fetchUtils';
 
-describe('_getResponseInfo', () => {
-  it('works with captureDetails: false', async () => {
-    const res = await _getResponseInfo(
-      false,
-      {
-        networkCaptureBodies: true,
-        textEncoder: new TextEncoder(),
-        networkResponseHeaders: [],
-      },
-      undefined,
-      undefined,
-    );
+describe('Unit | coreHandlers | util | fetchUtils', () => {
+  describe('_getResponseInfo', () => {
+    it('works with captureDetails: false', async () => {
+      const res = await _getResponseInfo(
+        false,
+        {
+          networkCaptureBodies: true,
+          textEncoder: new TextEncoder(),
+          networkResponseHeaders: [],
+        },
+        undefined,
+        undefined,
+      );
 
-    expect(res).toEqual(undefined);
-  });
-
-  it('works with captureDetails: false & responseBodySize', async () => {
-    const res = await _getResponseInfo(
-      false,
-      {
-        networkCaptureBodies: true,
-        textEncoder: new TextEncoder(),
-        networkResponseHeaders: [],
-      },
-      undefined,
-      123,
-    );
-
-    expect(res).toEqual({
-      headers: {},
-      size: 123,
-      _meta: {
-        warnings: ['URL_SKIPPED'],
-      },
+      expect(res).toEqual(undefined);
     });
-  });
 
-  it('works with text body', async () => {
-    const response = {
-      headers: {
-        has: () => {
-          return false;
+    it('works with captureDetails: false & responseBodySize', async () => {
+      const res = await _getResponseInfo(
+        false,
+        {
+          networkCaptureBodies: true,
+          textEncoder: new TextEncoder(),
+          networkResponseHeaders: [],
         },
-        get: () => {
-          return undefined;
+        undefined,
+        123,
+      );
+
+      expect(res).toEqual({
+        headers: {},
+        size: 123,
+        _meta: {
+          warnings: ['URL_SKIPPED'],
         },
-      },
-      clone: () => response,
-      text: () => Promise.resolve('text body'),
-    } as unknown as Response;
-
-    const res = await _getResponseInfo(
-      true,
-      {
-        networkCaptureBodies: true,
-        textEncoder: new TextEncoder(),
-        networkResponseHeaders: [],
-      },
-      response,
-      undefined,
-    );
-
-    expect(res).toEqual({
-      headers: {},
-      size: 9,
-      body: 'text body',
+      });
     });
-  });
 
-  it('works with body that fails', async () => {
-    const response = {
-      headers: {
-        has: () => {
-          return false;
+    it('works with text body', async () => {
+      const response = {
+        headers: {
+          has: () => {
+            return false;
+          },
+          get: () => {
+            return undefined;
+          },
         },
-        get: () => {
-          return undefined;
+        clone: () => response,
+        text: () => Promise.resolve('text body'),
+      } as unknown as Response;
+
+      const res = await _getResponseInfo(
+        true,
+        {
+          networkCaptureBodies: true,
+          textEncoder: new TextEncoder(),
+          networkResponseHeaders: [],
         },
-      },
-      clone: () => response,
-      text: () => Promise.reject('cannot read'),
-    } as unknown as Response;
+        response,
+        undefined,
+      );
 
-    const res = await _getResponseInfo(
-      true,
-      {
-        networkCaptureBodies: true,
-        textEncoder: new TextEncoder(),
-        networkResponseHeaders: [],
-      },
-      response,
-      undefined,
-    );
-
-    expect(res).toEqual({
-      _meta: { warnings: ['BODY_PARSE_ERROR'] },
-      headers: {},
-      size: undefined,
+      expect(res).toEqual({
+        headers: {},
+        size: 9,
+        body: 'text body',
+      });
     });
-  });
 
-  it('works with body that times out', async () => {
-    const response = {
-      headers: {
-        has: () => {
-          return false;
+    it('works with body that fails', async () => {
+      const response = {
+        headers: {
+          has: () => {
+            return false;
+          },
+          get: () => {
+            return undefined;
+          },
         },
-        get: () => {
-          return undefined;
+        clone: () => response,
+        text: () => Promise.reject('cannot read'),
+      } as unknown as Response;
+
+      const res = await _getResponseInfo(
+        true,
+        {
+          networkCaptureBodies: true,
+          textEncoder: new TextEncoder(),
+          networkResponseHeaders: [],
         },
-      },
-      clone: () => response,
-      text: () => new Promise(resolve => setTimeout(() => resolve('text body'), 1000)),
-    } as unknown as Response;
+        response,
+        undefined,
+      );
 
-    const res = await _getResponseInfo(
-      true,
-      {
-        networkCaptureBodies: true,
-        textEncoder: new TextEncoder(),
-        networkResponseHeaders: [],
-      },
-      response,
-      undefined,
-    );
+      expect(res).toEqual({
+        _meta: { warnings: ['BODY_PARSE_ERROR'] },
+        headers: {},
+        size: undefined,
+      });
+    });
 
-    expect(res).toEqual({
-      _meta: { warnings: ['BODY_PARSE_ERROR'] },
-      headers: {},
-      size: undefined,
+    it('works with body that times out', async () => {
+      const response = {
+        headers: {
+          has: () => {
+            return false;
+          },
+          get: () => {
+            return undefined;
+          },
+        },
+        clone: () => response,
+        text: () => new Promise(resolve => setTimeout(() => resolve('text body'), 1000)),
+      } as unknown as Response;
+
+      const res = await _getResponseInfo(
+        true,
+        {
+          networkCaptureBodies: true,
+          textEncoder: new TextEncoder(),
+          networkResponseHeaders: [],
+        },
+        response,
+        undefined,
+      );
+
+      expect(res).toEqual({
+        _meta: { warnings: ['BODY_PARSE_ERROR'] },
+        headers: {},
+        size: undefined,
+      });
     });
   });
 });

--- a/packages/replay/test/unit/coreHandlers/util/networkUtils.test.ts
+++ b/packages/replay/test/unit/coreHandlers/util/networkUtils.test.ts
@@ -4,6 +4,7 @@ import { NETWORK_BODY_MAX_SIZE } from '../../../../src/constants';
 import {
   buildNetworkRequestOrResponse,
   getBodySize,
+  getBodyString,
   getFullUrl,
   parseContentLengthHeader,
 } from '../../../../src/coreHandlers/util/networkUtils';
@@ -246,6 +247,41 @@ describe('Unit | coreHandlers | util | networkUtils', () => {
     ])('works with %s & baseURI %s', (url, baseURI, expected) => {
       const actual = getFullUrl(url, baseURI);
       expect(actual).toBe(expected);
+    });
+  });
+
+  describe('getBodyString', () => {
+    it('works with a string', () => {
+      const actual = getBodyString('abc');
+      expect(actual).toEqual(['abc']);
+    });
+
+    it('works with URLSearchParams', () => {
+      const body = new URLSearchParams();
+      body.append('name', 'Anne');
+      body.append('age', '32');
+      const actual = getBodyString(body);
+      expect(actual).toEqual(['name=Anne&age=32']);
+    });
+
+    it('works with FormData', () => {
+      const body = new FormData();
+      body.append('name', 'Anne');
+      body.append('age', '32');
+      const actual = getBodyString(body);
+      expect(actual).toEqual(['name=Anne&age=32']);
+    });
+
+    it('works with empty  data', () => {
+      const body = undefined;
+      const actual = getBodyString(body);
+      expect(actual).toEqual([undefined]);
+    });
+
+    it('works with other type of data', () => {
+      const body = {};
+      const actual = getBodyString(body);
+      expect(actual).toEqual([undefined, 'UNPARSEABLE_BODY_TYPE']);
     });
   });
 });

--- a/packages/replay/test/unit/coreHandlers/util/xhrUtils.test.ts
+++ b/packages/replay/test/unit/coreHandlers/util/xhrUtils.test.ts
@@ -1,0 +1,38 @@
+import { _parseXhrResponse } from '../../../../src/coreHandlers/util/xhrUtils';
+
+describe('Unit | coreHandlers | util | xhrUtils', () => {
+  describe('_parseXhrResponse', () => {
+    it('works with a string', () => {
+      const actual = _parseXhrResponse('abc', '');
+      expect(actual).toEqual(['abc']);
+    });
+
+    it('works with a Document', () => {
+      const body = document.implementation.createHTMLDocument();
+      const bodyEl = document.createElement('body');
+      bodyEl.innerHTML = '<div>abc</div>';
+      body.body = bodyEl;
+
+      const actual = _parseXhrResponse(body, '');
+      expect(actual).toEqual(['<body><div>abc</div></body>']);
+    });
+
+    it('works with empty  data', () => {
+      const body = undefined;
+      const actual = _parseXhrResponse(body, '');
+      expect(actual).toEqual([undefined]);
+    });
+
+    it('works with other type of data', () => {
+      const body = {};
+      const actual = _parseXhrResponse(body, '');
+      expect(actual).toEqual([undefined, 'UNPARSEABLE_BODY_TYPE']);
+    });
+
+    it('works with JSON data', () => {
+      const body = {};
+      const actual = _parseXhrResponse(body, 'json');
+      expect(actual).toEqual(['{}']);
+    });
+  });
+});


### PR DESCRIPTION
This is stupid, now that I figured it out. Basically, if you set `xhr.responseType = 'json'`, it will force `xhr.response` to be a POJO - which we can't parse right now.

We now handle this case specifically. 

This also adds a new `UNPARSEABLE_BODY_TYPE` meta warning if we are not getting a body because it is not matching any of the known/parsed types.

Closes https://github.com/getsentry/sentry-javascript/issues/9339