### PR TITLE
feat(core): Add top level `getClient()` method

### DIFF
--- a/packages/angular/src/errorhandler.ts
+++ b/packages/angular/src/errorhandler.ts
@@ -115,7 +115,7 @@ class SentryErrorHandler implements AngularErrorHandler {
 
     // Optionally show user dialog to provide details on what happened.
     if (this._options.showDialog) {
-      const client = Sentry.getCurrentHub().getClient();
+      const client = Sentry.getClient();
 
       if (client && client.on && !this._registeredAfterSendEventHandler) {
         client.on('afterSendEvent', (event: Event) => {

--- a/packages/angular/test/errorhandler.test.ts
+++ b/packages/angular/test/errorhandler.test.ts
@@ -1,6 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import * as SentryBrowser from '@sentry/browser';
-import type { Event } from '@sentry/types';
+import type { Client, Event } from '@sentry/types';
 
 import { createErrorHandler, SentryErrorHandler } from '../src/errorhandler';
 
@@ -505,10 +505,7 @@ describe('SentryErrorHandler', () => {
           }),
         };
 
-        // @ts-expect-error this is a minmal hub, we're missing a few props but that's ok
-        jest.spyOn(SentryBrowser, 'getCurrentHub').mockImplementationOnce(() => {
-          return { getClient: () => client };
-        });
+        jest.spyOn(SentryBrowser, 'getClient').mockImplementationOnce(() => client as unknown as Client);
 
         const showReportDialogSpy = jest.spyOn(SentryBrowser, 'showReportDialog');
 

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -21,6 +21,7 @@ export {
   getActiveTransaction,
   getHubFromCarrier,
   getCurrentHub,
+  getClient,
   Hub,
   makeMain,
   Scope,

--- a/packages/astro/test/client/sdk.test.ts
+++ b/packages/astro/test/client/sdk.test.ts
@@ -1,6 +1,6 @@
 import type { BrowserClient } from '@sentry/browser';
 import * as SentryBrowser from '@sentry/browser';
-import { BrowserTracing, getCurrentHub, SDK_VERSION, WINDOW } from '@sentry/browser';
+import { BrowserTracing, getClient, getCurrentHub, SDK_VERSION, WINDOW } from '@sentry/browser';
 import { vi } from 'vitest';
 
 import { init } from '../../../astro/src/client/sdk';
@@ -60,7 +60,7 @@ describe('Sentry client SDK', () => {
         });
 
         const integrationsToInit = browserInit.mock.calls[0][0]?.integrations;
-        const browserTracing = (getCurrentHub().getClient() as BrowserClient)?.getIntegrationById('BrowserTracing');
+        const browserTracing = getClient<BrowserClient>()?.getIntegrationById('BrowserTracing');
 
         expect(integrationsToInit).toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
         expect(browserTracing).toBeDefined();
@@ -76,7 +76,7 @@ describe('Sentry client SDK', () => {
         });
 
         const integrationsToInit = browserInit.mock.calls[0][0]?.integrations;
-        const browserTracing = (getCurrentHub().getClient() as BrowserClient)?.getIntegrationById('BrowserTracing');
+        const browserTracing = getClient<BrowserClient>()?.getIntegrationById('BrowserTracing');
 
         expect(integrationsToInit).not.toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
         expect(browserTracing).toBeUndefined();
@@ -91,7 +91,7 @@ describe('Sentry client SDK', () => {
         });
 
         const integrationsToInit = browserInit.mock.calls[0][0]?.integrations;
-        const browserTracing = (getCurrentHub().getClient() as BrowserClient)?.getIntegrationById('BrowserTracing');
+        const browserTracing = getClient<BrowserClient>()?.getIntegrationById('BrowserTracing');
 
         expect(integrationsToInit).not.toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
         expect(browserTracing).toBeUndefined();
@@ -108,9 +108,7 @@ describe('Sentry client SDK', () => {
 
         const integrationsToInit = browserInit.mock.calls[0][0]?.integrations;
 
-        const browserTracing = (getCurrentHub().getClient() as BrowserClient)?.getIntegrationById(
-          'BrowserTracing',
-        ) as BrowserTracing;
+        const browserTracing = getClient<BrowserClient>()?.getIntegrationById('BrowserTracing') as BrowserTracing;
         const options = browserTracing.options;
 
         expect(integrationsToInit).toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -33,6 +33,7 @@ export {
   flush,
   getHubFromCarrier,
   getCurrentHub,
+  getClient,
   Hub,
   lastEventId,
   makeMain,

--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -19,6 +19,7 @@ import {
   severityLevelFromString,
 } from '@sentry/utils';
 
+import { getClient } from '../exports';
 import { WINDOW } from '../helpers';
 
 type HandlerData = Record<string, unknown>;
@@ -103,7 +104,7 @@ export class Breadcrumbs implements Integration {
       addInstrumentationHandler('history', _historyBreadcrumb);
     }
     if (this.options.sentry) {
-      const client = getCurrentHub().getClient();
+      const client = getClient();
       client && client.on && client.on('beforeSendEvent', addSentryBreadcrumb);
     }
   }

--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -5,6 +5,7 @@ import type { DebugImage, Envelope, Event, StackFrame, StackParser, Transaction 
 import type { Profile, ThreadCpuProfile } from '@sentry/types/src/profiling';
 import { browserPerformanceTimeOrigin, forEachEnvelopeItem, GLOBAL_OBJ, logger, uuid4 } from '@sentry/utils';
 
+import { getClient } from '../exports';
 import { WINDOW } from '../helpers';
 import type { JSSelfProfile, JSSelfProfiler, JSSelfProfilerConstructor, JSSelfProfileStack } from './jsSelfProfiling';
 
@@ -532,7 +533,7 @@ export function shouldProfileTransaction(transaction: Transaction): boolean {
     return false;
   }
 
-  const client = getCurrentHub().getClient();
+  const client = getClient();
   const options = client && client.getOptions();
   if (!options) {
     __DEBUG_BUILD__ && logger.log('[Profiling] Profiling disabled, no options found.');

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -1,5 +1,6 @@
 import type { Hub } from '@sentry/core';
 import {
+  getClient,
   getCurrentHub,
   getIntegrationsToSetup,
   getReportDialogEndpoint,
@@ -252,7 +253,7 @@ function startSessionTracking(): void {
  * Captures user feedback and sends it to Sentry.
  */
 export function captureUserFeedback(feedback: UserFeedback): void {
-  const client = getCurrentHub().getClient<BrowserClient>();
+  const client = getClient<BrowserClient>();
   if (client) {
     client.captureUserFeedback(feedback);
   }

--- a/packages/browser/test/unit/eventbuilder.test.ts
+++ b/packages/browser/test/unit/eventbuilder.test.ts
@@ -1,5 +1,3 @@
-import type { Client } from '@sentry/types';
-
 import { defaultStackParser } from '../../src';
 import { eventFromPlainObject } from '../../src/eventbuilder';
 
@@ -7,9 +5,14 @@ jest.mock('@sentry/core', () => {
   const original = jest.requireActual('@sentry/core');
   return {
     ...original,
-    getCurrentHub(): {
-      getClient(): Client;
-    } {
+    getClient() {
+      return {
+        getOptions(): any {
+          return { normalizeDepth: 6 };
+        },
+      };
+    },
+    getCurrentHub() {
       return {
         getClient(): any {
           return {

--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -11,6 +11,7 @@ import {
   captureMessage,
   configureScope,
   flush,
+  getClient,
   getCurrentHub,
   init,
   Integrations,
@@ -271,11 +272,11 @@ describe('SentryBrowser initialization', () => {
     it('should set SDK data when Sentry.init() is called', () => {
       init({ dsn });
 
-      const sdkData = (getCurrentHub().getClient() as any).getOptions()._metadata.sdk;
+      const sdkData = getClient()?.getOptions()._metadata?.sdk || {};
 
       expect(sdkData?.name).toBe('sentry.javascript.browser');
-      expect(sdkData?.packages[0].name).toBe('npm:@sentry/browser');
-      expect(sdkData?.packages[0].version).toBe(SDK_VERSION);
+      expect(sdkData?.packages?.[0].name).toBe('npm:@sentry/browser');
+      expect(sdkData?.packages?.[0].version).toBe(SDK_VERSION);
       expect(sdkData?.version).toBe(SDK_VERSION);
     });
 
@@ -283,9 +284,9 @@ describe('SentryBrowser initialization', () => {
       global.SENTRY_SDK_SOURCE = 'loader';
       init({ dsn });
 
-      const sdkData = (getCurrentHub().getClient() as any).getOptions()._metadata.sdk;
+      const sdkData = getClient()?.getOptions()._metadata?.sdk || {};
 
-      expect(sdkData?.packages[0].name).toBe('loader:@sentry/browser');
+      expect(sdkData.packages?.[0].name).toBe('loader:@sentry/browser');
       delete global.SENTRY_SDK_SOURCE;
     });
 
@@ -293,9 +294,9 @@ describe('SentryBrowser initialization', () => {
       const spy = jest.spyOn(utils, 'getSDKSource').mockReturnValue('cdn');
       init({ dsn });
 
-      const sdkData = (getCurrentHub().getClient() as any).getOptions()._metadata.sdk;
+      const sdkData = getClient()?.getOptions()._metadata?.sdk || {};
 
-      expect(sdkData?.packages[0].name).toBe('cdn:@sentry/browser');
+      expect(sdkData.packages?.[0].name).toBe('cdn:@sentry/browser');
       expect(utils.getSDKSource).toBeCalledTimes(1);
       spy.mockRestore();
     });
@@ -332,11 +333,11 @@ describe('SentryBrowser initialization', () => {
         },
       });
 
-      const sdkData = (getCurrentHub().getClient() as any).getOptions()._metadata?.sdk;
+      const sdkData = getClient()?.getOptions()._metadata?.sdk || {};
 
       expect(sdkData.name).toBe('sentry.javascript.angular');
-      expect(sdkData.packages[0].name).toBe('npm:@sentry/angular');
-      expect(sdkData.packages[0].version).toBe(SDK_VERSION);
+      expect(sdkData.packages?.[0].name).toBe('npm:@sentry/angular');
+      expect(sdkData.packages?.[0].version).toBe(SDK_VERSION);
       expect(sdkData.version).toBe(SDK_VERSION);
     });
   });

--- a/packages/browser/test/unit/integrations/breadcrumbs.test.ts
+++ b/packages/browser/test/unit/integrations/breadcrumbs.test.ts
@@ -1,15 +1,18 @@
 import { getCurrentHub } from '@sentry/core';
+import type { Client } from '@sentry/types';
 
 import { Breadcrumbs, BrowserClient, flush, Hub } from '../../../src';
 import { getDefaultBrowserClientOptions } from '../helper/browser-client-options';
 
 const hub = new Hub();
+let client: Client | undefined;
 
 jest.mock('@sentry/core', () => {
   const original = jest.requireActual('@sentry/core');
   return {
     ...original,
     getCurrentHub: () => hub,
+    getClient: () => client,
   };
 });
 
@@ -18,7 +21,7 @@ describe('Breadcrumbs', () => {
     const addBreadcrumb = jest.fn();
     hub.addBreadcrumb = addBreadcrumb;
 
-    const client = new BrowserClient({
+    client = new BrowserClient({
       ...getDefaultBrowserClientOptions(),
       dsn: 'https://username@domain/123',
       integrations: [new Breadcrumbs()],

--- a/packages/browser/test/unit/profiling/integration.test.ts
+++ b/packages/browser/test/unit/profiling/integration.test.ts
@@ -48,12 +48,12 @@ describe('BrowserProfilingIntegration', () => {
       integrations: [new Sentry.BrowserTracing(), new BrowserProfilingIntegration()],
     });
 
-    const client = Sentry.getCurrentHub().getClient() as BrowserClient;
+    const client = Sentry.getClient<BrowserClient>();
 
     const currentTransaction = Sentry.getCurrentHub().getScope().getTransaction();
     expect(currentTransaction?.op).toBe('pageload');
     currentTransaction?.finish();
-    await client.flush(1000);
+    await client?.flush(1000);
 
     expect(send).toHaveBeenCalledTimes(1);
 

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -39,6 +39,7 @@ export {
   getActiveTransaction,
   getHubFromCarrier,
   getCurrentHub,
+  getClient,
   Hub,
   lastEventId,
   makeMain,

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -13,6 +13,7 @@ import type {
   EventDropReason,
   EventHint,
   EventProcessor,
+  FeedbackEvent,
   Integration,
   IntegrationClass,
   Outcome,
@@ -27,7 +28,6 @@ import type {
   Transport,
   TransportMakeRequestResponse,
 } from '@sentry/types';
-import type { FeedbackEvent } from '@sentry/types';
 import {
   addItemToEnvelope,
   checkOrSetAlreadyCaught,

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -2,6 +2,7 @@ import type {
   Breadcrumb,
   CaptureContext,
   CheckIn,
+  Client,
   CustomSamplingContext,
   Event,
   EventHint,
@@ -266,7 +267,7 @@ export function withMonitor<T>(
  * doesn't (or if there's no client defined).
  */
 export async function flush(timeout?: number): Promise<boolean> {
-  const client = getCurrentHub().getClient();
+  const client = getClient();
   if (client) {
     return client.flush(timeout);
   }
@@ -283,7 +284,7 @@ export async function flush(timeout?: number): Promise<boolean> {
  * doesn't (or if there's no client defined).
  */
 export async function close(timeout?: number): Promise<boolean> {
-  const client = getCurrentHub().getClient();
+  const client = getClient();
   if (client) {
     return client.close(timeout);
   }
@@ -298,4 +299,11 @@ export async function close(timeout?: number): Promise<boolean> {
  */
 export function lastEventId(): string | undefined {
   return getCurrentHub().lastEventId();
+}
+
+/**
+ * Get the currently active client.
+ */
+export function getClient<C extends Client>(): C | undefined {
+  return getCurrentHub().getClient<C>();
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ export {
   setTags,
   setUser,
   withScope,
+  getClient,
 } from './exports';
 export {
   getCurrentHub,

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -2,6 +2,7 @@ import type { Client, Event, EventHint, Integration, Options } from '@sentry/typ
 import { arrayify, logger } from '@sentry/utils';
 
 import { addGlobalEventProcessor } from './eventProcessors';
+import { getClient } from './exports';
 import { getCurrentHub } from './hub';
 
 declare module '@sentry/types' {
@@ -132,7 +133,7 @@ export function setupIntegration(client: Client, integration: Integration, integ
 
 /** Add an integration to the current hub's client. */
 export function addIntegration(integration: Integration): void {
-  const client = getCurrentHub().getClient();
+  const client = getClient();
 
   if (!client || !client.addIntegration) {
     __DEBUG_BUILD__ && logger.warn(`Cannot add integration "${integration.name}" because no SDK Client is available.`);

--- a/packages/core/src/utils/hasTracingEnabled.ts
+++ b/packages/core/src/utils/hasTracingEnabled.ts
@@ -1,6 +1,6 @@
 import type { Options } from '@sentry/types';
 
-import { getCurrentHub } from '../hub';
+import { getClient } from '../exports';
 
 // Treeshakable guard to remove all code related to tracing
 declare const __SENTRY_TRACING__: boolean | undefined;
@@ -17,7 +17,7 @@ export function hasTracingEnabled(
     return false;
   }
 
-  const client = getCurrentHub().getClient();
+  const client = getClient();
   const options = maybeOptions || (client && client.getOptions());
   return !!options && (options.enableTracing || 'tracesSampleRate' in options || 'tracesSampler' in options);
 }

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -38,6 +38,7 @@ export {
   getActiveTransaction,
   getHubFromCarrier,
   getCurrentHub,
+  getClient,
   Hub,
   lastEventId,
   makeMain,

--- a/packages/feedback/test/sendFeedback.test.ts
+++ b/packages/feedback/test/sendFeedback.test.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getClient } from '@sentry/core';
 
 import { sendFeedback } from '../src/sendFeedback';
 import { mockSdk } from './utils/mockSdk';
@@ -6,7 +6,7 @@ import { mockSdk } from './utils/mockSdk';
 describe('sendFeedback', () => {
   it('sends feedback', async () => {
     mockSdk();
-    const mockTransport = jest.spyOn(getCurrentHub().getClient()!.getTransport()!, 'send');
+    const mockTransport = jest.spyOn(getClient()!.getTransport()!, 'send');
 
     await sendFeedback({
       name: 'doe',

--- a/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
+++ b/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getClient, getCurrentHub } from '@sentry/core';
 import { WINDOW } from '@sentry/react';
 import type { Primitive, Transaction, TransactionContext, TransactionSource } from '@sentry/types';
 import {
@@ -101,7 +101,7 @@ let activeTransaction: Transaction | undefined = undefined;
 // This is either a route or a pathname.
 let prevLocationName: string | undefined = undefined;
 
-const client = getCurrentHub().getClient();
+const client = getClient();
 
 /**
  * Instruments the Next.js pages router. Only supported for

--- a/packages/nextjs/src/common/_error.ts
+++ b/packages/nextjs/src/common/_error.ts
@@ -1,4 +1,4 @@
-import { captureException, getCurrentHub, withScope } from '@sentry/core';
+import { captureException, getClient, withScope } from '@sentry/core';
 import type { NextPageContext } from 'next';
 
 type ContextOrProps = {
@@ -11,7 +11,7 @@ type ContextOrProps = {
 
 /** Platform-agnostic version of `flush` */
 function flush(timeout?: number): PromiseLike<boolean> {
-  const client = getCurrentHub().getClient();
+  const client = getClient();
   return client ? client.flush(timeout) : Promise.resolve(false);
 }
 

--- a/packages/nextjs/src/common/wrapDocumentGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapDocumentGetInitialPropsWithSentry.ts
@@ -1,4 +1,4 @@
-import { addTracingExtensions, getCurrentHub } from '@sentry/core';
+import { addTracingExtensions, getClient } from '@sentry/core';
 import type Document from 'next/document';
 
 import { isBuild } from './utils/isBuild';
@@ -29,7 +29,7 @@ export function wrapDocumentGetInitialPropsWithSentry(
       const { req, res } = context;
 
       const errorWrappedGetInitialProps = withErrorInstrumentation(wrappingTarget);
-      const options = getCurrentHub().getClient()?.getOptions();
+      const options = getClient()?.getOptions();
 
       // Generally we can assume that `req` and `res` are always defined on the server:
       // https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#context-object

--- a/packages/nextjs/src/common/wrapGetStaticPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGetStaticPropsWithSentry.ts
@@ -1,4 +1,4 @@
-import { addTracingExtensions, getCurrentHub } from '@sentry/core';
+import { addTracingExtensions, getClient } from '@sentry/core';
 import type { GetStaticProps } from 'next';
 
 import { isBuild } from './utils/isBuild';
@@ -26,7 +26,7 @@ export function wrapGetStaticPropsWithSentry(
       addTracingExtensions();
 
       const errorWrappedGetStaticProps = withErrorInstrumentation(wrappingTarget);
-      const options = getCurrentHub().getClient()?.getOptions();
+      const options = getClient()?.getOptions();
 
       if (options?.instrumenter === 'sentry') {
         return callDataFetcherTraced(errorWrappedGetStaticProps, args, {

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -13,7 +13,7 @@ export { getAutoPerformanceIntegrations } from './integrations/getAutoPerformanc
 export * as Handlers from './sdk/handlers';
 export type { Span } from './types';
 
-export { startSpan, startInactiveSpan, getCurrentHub, getActiveSpan } from '@sentry/opentelemetry';
+export { startSpan, startInactiveSpan, getCurrentHub, getClient, getActiveSpan } from '@sentry/opentelemetry';
 
 export {
   makeNodeTransport,

--- a/packages/node-experimental/src/integrations/http.ts
+++ b/packages/node-experimental/src/integrations/http.ts
@@ -3,7 +3,7 @@ import { SpanKind } from '@opentelemetry/api';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { hasTracingEnabled, isSentryRequestUrl } from '@sentry/core';
-import { _INTERNAL, getClient, getSpanKind, setSpanMetadata, getCurrentHub } from '@sentry/opentelemetry';
+import { _INTERNAL, getClient, getCurrentHub, getSpanKind, setSpanMetadata } from '@sentry/opentelemetry';
 import type { EventProcessor, Hub, Integration } from '@sentry/types';
 import { stringMatchesSomePattern } from '@sentry/utils';
 import type { ClientRequest, IncomingMessage, ServerResponse } from 'http';

--- a/packages/node-experimental/src/integrations/http.ts
+++ b/packages/node-experimental/src/integrations/http.ts
@@ -3,7 +3,7 @@ import { SpanKind } from '@opentelemetry/api';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { hasTracingEnabled, isSentryRequestUrl } from '@sentry/core';
-import { _INTERNAL, getCurrentHub, getSpanKind, setSpanMetadata } from '@sentry/opentelemetry';
+import { _INTERNAL, getClient, getSpanKind, setSpanMetadata, getCurrentHub } from '@sentry/opentelemetry';
 import type { EventProcessor, Hub, Integration } from '@sentry/types';
 import { stringMatchesSomePattern } from '@sentry/utils';
 import type { ClientRequest, IncomingMessage, ServerResponse } from 'http';
@@ -84,7 +84,7 @@ export class Http implements Integration {
       return;
     }
 
-    const client = getCurrentHub().getClient<NodeExperimentalClient>();
+    const client = getClient<NodeExperimentalClient>();
     const clientOptions = client?.getOptions();
 
     // This is used in the sampler function

--- a/packages/node-experimental/src/integrations/node-fetch.ts
+++ b/packages/node-experimental/src/integrations/node-fetch.ts
@@ -2,7 +2,7 @@ import type { Span } from '@opentelemetry/api';
 import { SpanKind } from '@opentelemetry/api';
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { hasTracingEnabled } from '@sentry/core';
-import { _INTERNAL, getCurrentHub, getSpanKind } from '@sentry/opentelemetry';
+import { _INTERNAL, getCurrentHub, getSpanKind, getClient } from '@sentry/opentelemetry';
 import type { Integration } from '@sentry/types';
 
 import type { NodeExperimentalClient } from '../types';
@@ -87,7 +87,7 @@ export class NodeFetch extends NodePerformanceIntegration<NodeFetchOptions> impl
   public setupOnce(): void {
     super.setupOnce();
 
-    const client = getCurrentHub().getClient<NodeExperimentalClient>();
+    const client = getClient<NodeExperimentalClient>();
     const clientOptions = client?.getOptions();
 
     // This is used in the sampler function

--- a/packages/node-experimental/src/integrations/node-fetch.ts
+++ b/packages/node-experimental/src/integrations/node-fetch.ts
@@ -2,7 +2,7 @@ import type { Span } from '@opentelemetry/api';
 import { SpanKind } from '@opentelemetry/api';
 import type { Instrumentation } from '@opentelemetry/instrumentation';
 import { hasTracingEnabled } from '@sentry/core';
-import { _INTERNAL, getCurrentHub, getSpanKind, getClient } from '@sentry/opentelemetry';
+import { _INTERNAL, getClient, getCurrentHub, getSpanKind } from '@sentry/opentelemetry';
 import type { Integration } from '@sentry/types';
 
 import type { NodeExperimentalClient } from '../types';

--- a/packages/node-experimental/src/sdk/initOtel.ts
+++ b/packages/node-experimental/src/sdk/initOtel.ts
@@ -5,7 +5,7 @@ import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { SDK_VERSION } from '@sentry/core';
 import {
-  getCurrentHub,
+  getClient,
   SentryPropagator,
   SentrySampler,
   setupEventContextTrace,
@@ -20,7 +20,7 @@ import { NodeExperimentalSentrySpanProcessor } from './spanProcessor';
  * Initialize OpenTelemetry for Node.
  */
 export function initOtel(): void {
-  const client = getCurrentHub().getClient<NodeExperimentalClient>();
+  const client = getClient<NodeExperimentalClient>();
 
   if (!client) {
     __DEBUG_BUILD__ &&

--- a/packages/node-experimental/src/sdk/spanProcessor.ts
+++ b/packages/node-experimental/src/sdk/spanProcessor.ts
@@ -1,7 +1,7 @@
 import { SpanKind } from '@opentelemetry/api';
 import type { Span } from '@opentelemetry/sdk-trace-base';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import { getCurrentHub, SentrySpanProcessor } from '@sentry/opentelemetry';
+import { getClient, SentrySpanProcessor } from '@sentry/opentelemetry';
 
 import { Http } from '../integrations/http';
 import { NodeFetch } from '../integrations/node-fetch';
@@ -13,7 +13,7 @@ import type { NodeExperimentalClient } from '../types';
 export class NodeExperimentalSentrySpanProcessor extends SentrySpanProcessor {
   /** @inheritDoc */
   protected _shouldSendSpanToSentry(span: Span): boolean {
-    const client = getCurrentHub().getClient<NodeExperimentalClient>();
+    const client = getClient<NodeExperimentalClient>();
     const httpIntegration = client ? client.getIntegration(Http) : undefined;
     const fetchIntegration = client ? client.getIntegration(NodeFetch) : undefined;
 

--- a/packages/node/src/anr/index.ts
+++ b/packages/node/src/anr/index.ts
@@ -1,4 +1,4 @@
-import { makeSession, updateSession } from '@sentry/core';
+import { getClient, makeSession, updateSession } from '@sentry/core';
 import type { Event, Session, StackFrame } from '@sentry/types';
 import { logger, watchdogTimer } from '@sentry/utils';
 import { spawn } from 'child_process';
@@ -173,7 +173,7 @@ function handleChildProcess(options: Options): void {
     if (session) {
       log('Sending abnormal session');
       updateSession(session, { status: 'abnormal', abnormal_mechanism: 'anr_foreground' });
-      getCurrentHub().getClient()?.sendSession(session);
+      getClient()?.sendSession(session);
 
       try {
         // Notify the main process that the session has ended so the session can be cleared from the scope

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -3,6 +3,7 @@ import {
   captureException,
   continueTrace,
   flush,
+  getClient,
   getCurrentHub,
   hasTracingEnabled,
   runWithAsyncContext,
@@ -278,7 +279,7 @@ export function errorHandler(options?: {
           _scope.setSpan(transaction);
         }
 
-        const client = getCurrentHub().getClient<NodeClient>();
+        const client = getClient<NodeClient>();
         if (client && isAutoSessionTrackingEnabled(client)) {
           // Check if the `SessionFlusher` is instantiated on the client to go into this branch that marks the
           // `requestSession.status` as `Crashed`, and this check is necessary because the `SessionFlusher` is only

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -39,6 +39,7 @@ export {
   getActiveTransaction,
   getHubFromCarrier,
   getCurrentHub,
+  getClient,
   Hub,
   lastEventId,
   makeMain,

--- a/packages/node/src/integrations/onuncaughtexception.ts
+++ b/packages/node/src/integrations/onuncaughtexception.ts
@@ -1,5 +1,5 @@
 import type { Scope } from '@sentry/core';
-import { getCurrentHub } from '@sentry/core';
+import { getClient, getCurrentHub } from '@sentry/core';
 import type { Integration } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
@@ -86,7 +86,7 @@ export class OnUncaughtException implements Integration {
 
     return (error: Error): void => {
       let onFatalError: OnFatalErrorHandler = logAndExitProcess;
-      const client = getCurrentHub().getClient<NodeClient>();
+      const client = getClient<NodeClient>();
 
       if (this._options.onFatalError) {
         onFatalError = this._options.onFatalError;

--- a/packages/node/src/integrations/utils/errorhandling.ts
+++ b/packages/node/src/integrations/utils/errorhandling.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getClient } from '@sentry/core';
 import { logger } from '@sentry/utils';
 
 import type { NodeClient } from '../../client';
@@ -12,7 +12,7 @@ export function logAndExitProcess(error: Error): void {
   // eslint-disable-next-line no-console
   console.error(error);
 
-  const client = getCurrentHub().getClient<NodeClient>();
+  const client = getClient<NodeClient>();
 
   if (client === undefined) {
     __DEBUG_BUILD__ && logger.warn('No NodeClient was defined, we are exiting the process now.');

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -8,6 +8,7 @@ import {
   captureException,
   captureMessage,
   configureScope,
+  getClient,
   getCurrentHub,
   init,
   NodeClient,
@@ -296,6 +297,7 @@ describe('SentryNode', () => {
         const hub = getCurrentHub();
         hub.bindClient(client);
         expect(getCurrentHub().getClient()).toBe(client);
+        expect(getClient()).toBe(client);
         hub.captureEvent({ message: 'test domain' });
       });
     });
@@ -366,12 +368,11 @@ describe('SentryNode initialization', () => {
     it('should set SDK data when `Sentry.init()` is called', () => {
       init({ dsn });
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const sdkData = (getCurrentHub().getClient() as any).getOptions()._metadata.sdk;
+      const sdkData = getClient()?.getOptions()._metadata?.sdk || {};
 
       expect(sdkData.name).toEqual('sentry.javascript.node');
-      expect(sdkData.packages[0].name).toEqual('npm:@sentry/node');
-      expect(sdkData.packages[0].version).toEqual(SDK_VERSION);
+      expect(sdkData.packages?.[0].name).toEqual('npm:@sentry/node');
+      expect(sdkData.packages?.[0].version).toEqual(SDK_VERSION);
       expect(sdkData.version).toEqual(SDK_VERSION);
     });
 
@@ -408,12 +409,11 @@ describe('SentryNode initialization', () => {
         },
       });
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const sdkData = (getCurrentHub().getClient() as any).getOptions()._metadata.sdk;
+      const sdkData = getClient()?.getOptions()._metadata?.sdk || {};
 
       expect(sdkData.name).toEqual('sentry.javascript.serverless');
-      expect(sdkData.packages[0].name).toEqual('npm:@sentry/serverless');
-      expect(sdkData.packages[0].version).toEqual(SDK_VERSION);
+      expect(sdkData.packages?.[0].name).toEqual('npm:@sentry/serverless');
+      expect(sdkData.packages?.[0].version).toEqual(SDK_VERSION);
       expect(sdkData.version).toEqual(SDK_VERSION);
     });
   });

--- a/packages/node/test/manual/release-health/session-aggregates/aggregates-disable-single-session.js
+++ b/packages/node/test/manual/release-health/session-aggregates/aggregates-disable-single-session.js
@@ -65,7 +65,7 @@ Sentry.init({
 app.use(Sentry.Handlers.requestHandler());
 
 // Hack that resets the 60s default flush interval, and replaces it with just a one second interval
-const flusher = Sentry.getCurrentHub().getClient()._sessionFlusher;
+const flusher = Sentry.getClient()._sessionFlusher;
 clearInterval(flusher._intervalId);
 flusher._intervalId = setInterval(() => flusher.flush(), 1000);
 

--- a/packages/opentelemetry-node/src/spanprocessor.ts
+++ b/packages/opentelemetry-node/src/spanprocessor.ts
@@ -2,7 +2,7 @@ import type { Context } from '@opentelemetry/api';
 import { context, SpanKind, trace } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
 import type { Span as OtelSpan, SpanProcessor as OtelSpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { addGlobalEventProcessor, addTracingExtensions, getCurrentHub, Transaction } from '@sentry/core';
+import { addGlobalEventProcessor, addTracingExtensions, getClient, getCurrentHub, Transaction } from '@sentry/core';
 import type { DynamicSamplingContext, Span as SentrySpan, TraceparentData, TransactionContext } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
@@ -100,7 +100,7 @@ export class SentrySpanProcessor implements OtelSpanProcessor {
       return;
     }
 
-    const client = getCurrentHub().getClient();
+    const client = getClient();
 
     const mutableOptions = { drop: false };
     client && client.emit && client?.emit('otelSpanEnd', otelSpan, mutableOptions);
@@ -141,7 +141,7 @@ export class SentrySpanProcessor implements OtelSpanProcessor {
    * @inheritDoc
    */
   public async forceFlush(): Promise<void> {
-    const client = getCurrentHub().getClient();
+    const client = getClient();
     if (client) {
       return client.flush().then();
     }

--- a/packages/opentelemetry/src/custom/hub.ts
+++ b/packages/opentelemetry/src/custom/hub.ts
@@ -28,6 +28,11 @@ export class OpenTelemetryHub extends Hub {
   }
 }
 
+/** Custom getClient method that uses the custom hub. */
+export function getClient<C extends Client>(): C | undefined {
+  return getCurrentHub().getClient<C>();
+}
+
 /**
  * *******************************************************************************
  * Everything below here is a copy of the stuff from core's hub.ts,

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -24,7 +24,7 @@ export { isSentryRequestSpan } from './utils/isSentryRequest';
 export { getActiveSpan, getRootSpan } from './utils/getActiveSpan';
 export { startSpan, startInactiveSpan } from './trace';
 
-export { getCurrentHub, setupGlobalHub } from './custom/hub';
+export { getCurrentHub, setupGlobalHub, getClient } from './custom/hub';
 export { addTracingExtensions } from './custom/hubextensions';
 export { setupEventContextTrace } from './setupEventContextTrace';
 

--- a/packages/opentelemetry/src/propagator.ts
+++ b/packages/opentelemetry/src/propagator.ts
@@ -6,7 +6,7 @@ import type { DynamicSamplingContext, PropagationContext } from '@sentry/types';
 import { generateSentryTraceHeader, SENTRY_BAGGAGE_KEY_PREFIX, tracingContextFromHeaders } from '@sentry/utils';
 
 import { SENTRY_BAGGAGE_HEADER, SENTRY_TRACE_HEADER } from './constants';
-import { getCurrentHub } from './custom/hub';
+import { getClient } from './custom/hub';
 import { getPropagationContextFromContext, setPropagationContextOnContext } from './utils/contextData';
 import { getSpanScope } from './utils/spanData';
 
@@ -90,7 +90,7 @@ function getDsc(
   }
 
   // Else, we try to generate a new one
-  const client = getCurrentHub().getClient();
+  const client = getClient();
   const activeSpan = trace.getSpan(context);
   const scope = activeSpan ? getSpanScope(activeSpan) : undefined;
 

--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -4,7 +4,7 @@ import { SDK_VERSION } from '@sentry/core';
 import type { Client } from '@sentry/types';
 import { isThenable } from '@sentry/utils';
 
-import { getCurrentHub } from './custom/hub';
+import { getClient } from './custom/hub';
 import { InternalSentrySemanticAttributes } from './semanticAttributes';
 import type { OpenTelemetryClient, OpenTelemetrySpanContext } from './types';
 import { setSpanMetadata } from './utils/spanData';
@@ -85,7 +85,7 @@ export function startInactiveSpan(spanContext: OpenTelemetrySpanContext): Span {
 }
 
 function getTracer(): Tracer {
-  const client = getCurrentHub().getClient<Client & OpenTelemetryClient>();
+  const client = getClient<Client & OpenTelemetryClient>();
   return (client && client.tracer) || trace.getTracer('@sentry/opentelemetry', SDK_VERSION);
 }
 

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -1,5 +1,5 @@
 import type { ReportDialogOptions, Scope } from '@sentry/browser';
-import { captureException, getCurrentHub, showReportDialog, withScope } from '@sentry/browser';
+import { captureException, getClient, showReportDialog, withScope } from '@sentry/browser';
 import { isError, logger } from '@sentry/utils';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import * as React from 'react';
@@ -104,7 +104,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
     this.state = INITIAL_STATE;
     this._openFallbackReportDialog = true;
 
-    const client = getCurrentHub().getClient();
+    const client = getClient();
     if (client && client.on && props.showDialog) {
       this._openFallbackReportDialog = false;
       client.on('afterSendEvent', event => {

--- a/packages/react/src/redux.ts
+++ b/packages/react/src/redux.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { addGlobalEventProcessor, configureScope, getCurrentHub } from '@sentry/browser';
+import { addGlobalEventProcessor, configureScope, getClient } from '@sentry/browser';
 import type { Scope } from '@sentry/types';
 import { addNonEnumerableProperty } from '@sentry/utils';
 
@@ -130,7 +130,7 @@ function createReduxEnhancer(enhancerOptions?: Partial<SentryEnhancerOptions>): 
           /* Set latest state to scope */
           const transformedState = options.stateTransformer(newState);
           if (typeof transformedState !== 'undefined' && transformedState !== null) {
-            const client = getCurrentHub().getClient();
+            const client = getClient();
             const options = client && client.getOptions();
             const normalizationDepth = (options && options.normalizeDepth) || 3; // default state normalization depth to 3
 

--- a/packages/react/test/errorboundary.test.tsx
+++ b/packages/react/test/errorboundary.test.tsx
@@ -1,4 +1,4 @@
-import { getCurrentHub, Scope } from '@sentry/browser';
+import { getClient, getCurrentHub, Scope } from '@sentry/browser';
 import { fireEvent, render, screen } from '@testing-library/react';
 import * as React from 'react';
 import { useState } from 'react';
@@ -422,7 +422,7 @@ describe('ErrorBoundary', () => {
     });
 
     it('shows a Sentry Report Dialog with correct options if client does not have hooks', () => {
-      expect(getCurrentHub().getClient()).toBeUndefined();
+      expect(getClient()).toBeUndefined();
 
       const options = { title: 'custom title' };
       render(

--- a/packages/replay/src/coreHandlers/handleAfterSendEvent.ts
+++ b/packages/replay/src/coreHandlers/handleAfterSendEvent.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getClient } from '@sentry/core';
 import type { ErrorEvent, Event, TransactionEvent, Transport, TransportMakeRequestResponse } from '@sentry/types';
 
 import type { ReplayContainer } from '../types';
@@ -79,7 +79,7 @@ function handleErrorEvent(replay: ReplayContainer, event: ErrorEvent): void {
 }
 
 function isBaseTransportSend(): boolean {
-  const client = getCurrentHub().getClient();
+  const client = getClient();
   if (!client) {
     return false;
   }

--- a/packages/replay/src/coreHandlers/handleNetworkBreadcrumbs.ts
+++ b/packages/replay/src/coreHandlers/handleNetworkBreadcrumbs.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getClient } from '@sentry/core';
 import type {
   Breadcrumb,
   BreadcrumbHint,
@@ -26,7 +26,7 @@ interface ExtendedNetworkBreadcrumbsOptions extends ReplayNetworkOptions {
  *   (enriching it with further data that is _not_ added to the regular breadcrumbs)
  */
 export function handleNetworkBreadcrumbs(replay: ReplayContainer): void {
-  const client = getCurrentHub().getClient();
+  const client = getClient();
 
   try {
     const textEncoder = new TextEncoder();

--- a/packages/replay/src/integration.ts
+++ b/packages/replay/src/integration.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getClient } from '@sentry/core';
 import type { BrowserClientReplayOptions, Integration } from '@sentry/types';
 import { dropUndefinedKeys, isBrowser } from '@sentry/utils';
 
@@ -343,7 +343,7 @@ Sentry.init({ replaysOnErrorSampleRate: ${errorSampleRate} })`,
 
 /** Parse Replay-related options from SDK options */
 function loadReplayOptionsFromClient(initialOptions: InitialReplayPluginOptions): ReplayPluginOptions {
-  const client = getCurrentHub().getClient();
+  const client = getClient();
   const opt = client && (client.getOptions() as BrowserClientReplayOptions);
 
   const finalOptions = { sessionSampleRate: 0, errorSampleRate: 0, ...dropUndefinedKeys(initialOptions) };

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */ // TODO: We might want to split this file up
 import { EventType, record } from '@sentry-internal/rrweb';
-import { captureException, getCurrentHub } from '@sentry/core';
+import { captureException, getClient, getCurrentHub } from '@sentry/core';
 import type { ReplayRecordingMode, Transaction } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
@@ -1107,7 +1107,7 @@ export class ReplayContainer implements ReplayContainerInterface {
       // In this case, we want to completely stop the replay - otherwise, we may get inconsistent segments
       void this.stop({ reason: 'sendReplay' });
 
-      const client = getCurrentHub().getClient();
+      const client = getClient();
 
       if (client) {
         client.recordDroppedEvent('send_error', 'replay');

--- a/packages/replay/src/util/addEvent.ts
+++ b/packages/replay/src/util/addEvent.ts
@@ -1,5 +1,5 @@
 import { EventType } from '@sentry-internal/rrweb';
-import { getCurrentHub } from '@sentry/core';
+import { getClient } from '@sentry/core';
 import { logger } from '@sentry/utils';
 
 import { EventBufferSizeExceededError } from '../eventBuffer/error';
@@ -80,7 +80,7 @@ async function _addEvent(
     __DEBUG_BUILD__ && logger.error(error);
     await replay.stop({ reason });
 
-    const client = getCurrentHub().getClient();
+    const client = getClient();
 
     if (client) {
       client.recordDroppedEvent('internal_sdk_error', 'replay');

--- a/packages/replay/src/util/addGlobalListeners.ts
+++ b/packages/replay/src/util/addGlobalListeners.ts
@@ -1,5 +1,5 @@
 import type { BaseClient } from '@sentry/core';
-import { addGlobalEventProcessor, getCurrentHub } from '@sentry/core';
+import { addGlobalEventProcessor, getClient, getCurrentHub } from '@sentry/core';
 import type { Client, DynamicSamplingContext } from '@sentry/types';
 import { addInstrumentationHandler } from '@sentry/utils';
 
@@ -17,7 +17,7 @@ import type { ReplayContainer } from '../types';
 export function addGlobalListeners(replay: ReplayContainer): void {
   // Listeners from core SDK //
   const scope = getCurrentHub().getScope();
-  const client = getCurrentHub().getClient();
+  const client = getClient();
 
   scope.addScopeListener(handleScopeListener(replay));
   addInstrumentationHandler('dom', handleDomListener(replay));

--- a/packages/replay/test/integration/coreHandlers/handleAfterSendEvent.test.ts
+++ b/packages/replay/test/integration/coreHandlers/handleAfterSendEvent.test.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getClient } from '@sentry/core';
 import type { ErrorEvent, Event } from '@sentry/types';
 
 import { UNABLE_TO_SEND_REPLAY } from '../../../src/constants';
@@ -152,7 +152,7 @@ describe('Integration | coreHandlers | handleAfterSendEvent', () => {
       },
     }));
 
-    const client = getCurrentHub().getClient()!;
+    const client = getClient()!;
     // @ts-expect-error make sure to remove this
     delete client.getTransport()!.send.__sentry__baseTransport__;
 
@@ -186,7 +186,7 @@ describe('Integration | coreHandlers | handleAfterSendEvent', () => {
       },
     }));
 
-    const mockSend = getCurrentHub().getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>;
+    const mockSend = getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>;
 
     const error1 = Error({ event_id: 'err1', tags: { replayId: 'replayid1' } });
 
@@ -225,7 +225,7 @@ describe('Integration | coreHandlers | handleAfterSendEvent', () => {
       },
     }));
 
-    const mockSend = getCurrentHub().getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>;
+    const mockSend = getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>;
 
     const error1 = Error({ event_id: 'err1' });
 
@@ -259,7 +259,7 @@ describe('Integration | coreHandlers | handleAfterSendEvent', () => {
       },
     }));
 
-    const mockSend = getCurrentHub().getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>;
+    const mockSend = getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>;
 
     const profileEvent: Event = { type: 'profile' };
     const replayEvent: Event = { type: 'replay_event' };
@@ -294,7 +294,7 @@ describe('Integration | coreHandlers | handleAfterSendEvent', () => {
       },
     }));
 
-    const mockSend = getCurrentHub().getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>;
+    const mockSend = getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>;
 
     const error1 = Error({ event_id: 'err1' });
 
@@ -328,7 +328,7 @@ describe('Integration | coreHandlers | handleAfterSendEvent', () => {
       },
     }));
 
-    const mockSend = getCurrentHub().getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>;
+    const mockSend = getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>;
 
     const error1: ErrorEvent = { event_id: 'err1', type: undefined };
 
@@ -362,7 +362,7 @@ describe('Integration | coreHandlers | handleAfterSendEvent', () => {
       },
     }));
 
-    const mockSend = getCurrentHub().getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>;
+    const mockSend = getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>;
 
     const error1 = Error({ event_id: 'err1', message: UNABLE_TO_SEND_REPLAY });
 
@@ -396,7 +396,7 @@ describe('Integration | coreHandlers | handleAfterSendEvent', () => {
       },
     }));
 
-    const mockSend = getCurrentHub().getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>;
+    const mockSend = getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>;
 
     const error1 = Error({ event_id: 'err1', tags: { replayId: 'replayid1' } });
 
@@ -429,7 +429,7 @@ describe('Integration | coreHandlers | handleAfterSendEvent', () => {
       },
     }));
 
-    const mockSend = getCurrentHub().getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>;
+    const mockSend = getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>;
 
     const handler = handleAfterSendEvent(replay);
 

--- a/packages/replay/test/integration/errorSampleRate.test.ts
+++ b/packages/replay/test/integration/errorSampleRate.test.ts
@@ -1,4 +1,4 @@
-import { captureException, getCurrentHub } from '@sentry/core';
+import { captureException, getClient } from '@sentry/core';
 
 import {
   BUFFER_CHECKOUT_TIME,
@@ -718,7 +718,7 @@ describe('Integration | errorSampleRate', () => {
 
       // Now wait after session expires - should stop recording
       mockRecord.takeFullSnapshot.mockClear();
-      (getCurrentHub().getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>).mockClear();
+      (getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>).mockClear();
 
       expect(replay).not.toHaveLastSentReplay();
 
@@ -786,7 +786,7 @@ describe('Integration | errorSampleRate', () => {
 
       // Now wait after session expires - should stop recording
       mockRecord.takeFullSnapshot.mockClear();
-      (getCurrentHub().getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>).mockClear();
+      (getClient()!.getTransport()!.send as unknown as jest.SpyInstance<any>).mockClear();
 
       jest.advanceTimersByTime(MAX_REPLAY_DURATION);
       await new Promise(process.nextTick);

--- a/packages/replay/test/integration/events.test.ts
+++ b/packages/replay/test/integration/events.test.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getClient } from '@sentry/core';
 
 import { WINDOW } from '../../src/constants';
 import type { ReplayContainer } from '../../src/replay';
@@ -36,7 +36,7 @@ describe('Integration | events', () => {
       },
     }));
 
-    mockTransportSend = jest.spyOn(getCurrentHub().getClient()!.getTransport()!, 'send');
+    mockTransportSend = jest.spyOn(getClient()!.getTransport()!, 'send');
 
     // Create a new session and clear mocks because a segment (from initial
     // checkout) will have already been uploaded by the time the tests run

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -26,6 +26,7 @@ export {
   createTransport,
   getActiveTransaction,
   getCurrentHub,
+  getClient,
   getHubFromCarrier,
   makeMain,
   setContext,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -19,6 +19,7 @@ export {
   getActiveTransaction,
   getHubFromCarrier,
   getCurrentHub,
+  getClient,
   Hub,
   makeMain,
   Scope,

--- a/packages/sveltekit/test/client/sdk.test.ts
+++ b/packages/sveltekit/test/client/sdk.test.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getClient, getCurrentHub } from '@sentry/core';
 import type { BrowserClient } from '@sentry/svelte';
 import * as SentrySvelte from '@sentry/svelte';
 import { SDK_VERSION, WINDOW } from '@sentry/svelte';
@@ -62,7 +62,7 @@ describe('Sentry client SDK', () => {
         });
 
         const integrationsToInit = svelteInit.mock.calls[0][0].integrations;
-        const browserTracing = (getCurrentHub().getClient() as BrowserClient)?.getIntegrationById('BrowserTracing');
+        const browserTracing = getClient<BrowserClient>()?.getIntegrationById('BrowserTracing');
 
         expect(integrationsToInit).toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
         expect(browserTracing).toBeDefined();
@@ -78,7 +78,7 @@ describe('Sentry client SDK', () => {
         });
 
         const integrationsToInit = svelteInit.mock.calls[0][0].integrations;
-        const browserTracing = (getCurrentHub().getClient() as BrowserClient)?.getIntegrationById('BrowserTracing');
+        const browserTracing = getClient<BrowserClient>()?.getIntegrationById('BrowserTracing');
 
         expect(integrationsToInit).not.toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
         expect(browserTracing).toBeUndefined();
@@ -97,7 +97,7 @@ describe('Sentry client SDK', () => {
         });
 
         const integrationsToInit = svelteInit.mock.calls[0][0].integrations;
-        const browserTracing = (getCurrentHub().getClient() as BrowserClient)?.getIntegrationById('BrowserTracing');
+        const browserTracing = getClient<BrowserClient>()?.getIntegrationById('BrowserTracing');
 
         expect(integrationsToInit).not.toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
         expect(browserTracing).toBeUndefined();
@@ -115,9 +115,7 @@ describe('Sentry client SDK', () => {
 
         const integrationsToInit = svelteInit.mock.calls[0][0].integrations;
 
-        const browserTracing = (getCurrentHub().getClient() as BrowserClient)?.getIntegrationById(
-          'BrowserTracing',
-        ) as BrowserTracing;
+        const browserTracing = getClient<BrowserClient>()?.getIntegrationById('BrowserTracing') as BrowserTracing;
         const options = browserTracing.options;
 
         expect(integrationsToInit).toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -38,6 +38,7 @@ export {
   getActiveTransaction,
   getHubFromCarrier,
   getCurrentHub,
+  getClient,
   Hub,
   lastEventId,
   makeMain,


### PR DESCRIPTION
This can be used instead of `getCurrentHub().getClient()`.

This prepares us also for a post-hub time, but makes sense generally IMHO, also simplifies user-facing interaction with the client (e.g. to lazy-add integrations etc).

This is a 1-1 replacement, so should be pretty straightforward.
