### PR TITLE
fix(tracing): Filter out invalid resource sizes

### DIFF
--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -15,7 +15,7 @@ import { getVisibilityWatcher } from '../web-vitals/lib/getVisibilityWatcher';
 import type { NavigatorDeviceMemory, NavigatorNetworkInformation } from '../web-vitals/types';
 import { _startChild, isMeasurementValue } from './utils';
 
-const ONE_GB_IN_BYTES = 1000000000;
+const MAX_INT_AS_BYTES = 2147483647;
 
 /**
  * Converts from milliseconds to seconds
@@ -497,7 +497,7 @@ function setResourceEntrySizeData(
   dataKey: 'http.response_transfer_size' | 'http.response_content_length' | 'http.decoded_response_content_length',
 ): void {
   const entryVal = entry[key];
-  if (entryVal !== undefined && entryVal < ONE_GB_IN_BYTES) {
+  if (entryVal !== undefined && entryVal < MAX_INT_AS_BYTES) {
     data[dataKey] = entryVal;
   }
 }

--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -15,6 +15,8 @@ import { getVisibilityWatcher } from '../web-vitals/lib/getVisibilityWatcher';
 import type { NavigatorDeviceMemory, NavigatorNetworkInformation } from '../web-vitals/types';
 import { _startChild, isMeasurementValue } from './utils';
 
+const ONE_GB_IN_BYTES = 1000000000;
+
 /**
  * Converts from milliseconds to seconds
  * @param time time in ms
@@ -402,15 +404,9 @@ export function _addResourceSpans(
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const data: Record<string, any> = {};
-  if ('transferSize' in entry) {
-    data['http.response_transfer_size'] = entry.transferSize;
-  }
-  if ('encodedBodySize' in entry) {
-    data['http.response_content_length'] = entry.encodedBodySize;
-  }
-  if ('decodedBodySize' in entry) {
-    data['http.decoded_response_content_length'] = entry.decodedBodySize;
-  }
+  setResourceEntrySizeData(data, entry, 'transferSize', 'http.response_transfer_size');
+  setResourceEntrySizeData(data, entry, 'encodedBodySize', 'http.response_content_length');
+  setResourceEntrySizeData(data, entry, 'decodedBodySize', 'http.decoded_response_content_length');
   if ('renderBlockingStatus' in entry) {
     data['resource.render_blocking_status'] = entry.renderBlockingStatus;
   }
@@ -491,5 +487,17 @@ function _tagMetricInfo(transaction: Transaction): void {
     _clsEntry.sources.forEach((source, index) =>
       transaction.setTag(`cls.source.${index + 1}`, htmlTreeAsString(source.node)),
     );
+  }
+}
+
+function setResourceEntrySizeData(
+  data: Record<string, unknown>,
+  entry: ResourceEntry,
+  key: keyof Pick<ResourceEntry, 'transferSize' | 'encodedBodySize' | 'decodedBodySize'>,
+  dataKey: 'http.response_transfer_size' | 'http.response_content_length' | 'http.decoded_response_content_length',
+): void {
+  const entryVal = entry[key];
+  if (entryVal !== undefined && entryVal < ONE_GB_IN_BYTES) {
+    data[dataKey] = entryVal;
   }
 }

--- a/packages/tracing-internal/test/browser/metrics/index.test.ts
+++ b/packages/tracing-internal/test/browser/metrics/index.test.ts
@@ -169,4 +169,24 @@ describe('_addResourceSpans', () => {
       }),
     );
   });
+
+  it('does not attach resource sizes that exceed 1 GB', () => {
+    const entry: ResourceEntry = {
+      initiatorType: 'css',
+      transferSize: 1000000000,
+      encodedBodySize: 1000000000,
+      decodedBodySize: 1000000000,
+    };
+
+    _addResourceSpans(transaction, entry, '/assets/to/css', 100, 23, 345);
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(transaction.startChild).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(transaction.startChild).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: {},
+      }),
+    );
+  });
 });

--- a/packages/tracing-internal/test/browser/metrics/index.test.ts
+++ b/packages/tracing-internal/test/browser/metrics/index.test.ts
@@ -170,12 +170,12 @@ describe('_addResourceSpans', () => {
     );
   });
 
-  it('does not attach resource sizes that exceed 1 GB', () => {
+  it('does not attach resource sizes that exceed MAX_INT bytes', () => {
     const entry: ResourceEntry = {
       initiatorType: 'css',
-      transferSize: 1000000000,
-      encodedBodySize: 1000000000,
-      decodedBodySize: 1000000000,
+      transferSize: 2147483647,
+      encodedBodySize: 2147483647,
+      decodedBodySize: 2147483647,
     };
 
     _addResourceSpans(transaction, entry, '/assets/to/css', 100, 23, 345);


### PR DESCRIPTION
There's a bug in some browsers that attaches huge resource sizes that are completely unrealistic. Here's an example in chromium: https://bugs.chromium.org/p/chromium/issues/detail?id=1324812#c25

To get around this, we add a filter to enforce that resource sizes should only be attached if the size is < 2147483647 bytes (size of maximum value of integer in c/c++).

@mydea should we add this to replay as well? Maybe a good time to unify the resource entry handling logic.