### PR TITLE
fix(remix): Don't capture error responses that are not 5xx on Remix v2.

### DIFF
--- a/packages/remix/src/client/errors.tsx
+++ b/packages/remix/src/client/errors.tsx
@@ -13,7 +13,8 @@ import type { ErrorResponse } from '../utils/vendor/types';
 export function captureRemixErrorBoundaryError(error: unknown): string | undefined {
   let eventId: string | undefined;
   const isClientSideRuntimeError = !isNodeEnv() && error instanceof Error;
-  const isRemixErrorResponse = isRouteErrorResponse(error);
+  // We only capture `ErrorResponse`s that are 5xx errors.
+  const isRemixErrorResponse = isRouteErrorResponse(error) && error.status >= 500;
   // Server-side errors apart from `ErrorResponse`s also appear here without their stacktraces.
   // So, we only capture:
   //    1. `ErrorResponse`s


### PR DESCRIPTION
Resolves: #9489

Manually tested. Could not figure a way to e2e or integration test this, with our current test setup.

Note: Server-side transactions are still reported regardless they are 404 or not.

