### PR TITLE
fix(remix): Check the error data before spreading.

### DIFF
--- a/packages/remix/src/client/errors.tsx
+++ b/packages/remix/src/client/errors.tsx
@@ -23,13 +23,14 @@ export function captureRemixErrorBoundaryError(error: unknown): string | undefin
     const eventData = isRemixErrorResponse
       ? {
           function: 'ErrorResponse',
-          ...error.data,
+          ...getErrorData(error),
         }
       : {
           function: 'ReactError',
         };
 
     const actualError = isRemixErrorResponse ? getExceptionToCapture(error) : error;
+
     eventId = captureException(actualError, {
       mechanism: {
         type: 'instrument',
@@ -42,10 +43,21 @@ export function captureRemixErrorBoundaryError(error: unknown): string | undefin
   return eventId;
 }
 
+function getErrorData(error: ErrorResponse): object {
+  if (isString(error.data)) {
+    return {
+      error: error.data,
+    };
+  }
+
+  return error.data;
+}
+
 function getExceptionToCapture(error: ErrorResponse): string | ErrorResponse {
   if (isString(error.data)) {
     return error.data;
   }
+
   if (error.statusText) {
     return error.statusText;
   }

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -93,7 +93,7 @@ export async function captureRemixServerException(err: unknown, name: string, re
   // Skip capturing if the request is aborted as Remix docs suggest
   // Ref: https://remix.run/docs/en/main/file-conventions/entry.server#handleerror
   if (request.signal.aborted) {
-    __DEBUG_BUILD__ && logger.warn('Skipping capture of aborted request');
+    DEBUG_BUILD && logger.warn('Skipping capture of aborted request');
     return;
   }
 


### PR DESCRIPTION
Closes: #9279

Note: The original case mentioned in the issue (capturing 404 responses) is addressed by https://github.com/getsentry/sentry-javascript/pull/9655.
