### PR TITLE
fix(astro): Configure sourcemap assets directory for Vercel adapter

### DIFF
--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -100,6 +100,16 @@ function findDefaultSdkInitFile(type: 'server' | 'client'): string | undefined {
 }
 
 function getSourcemapsAssetsGlob(config: AstroConfig): string {
+  // The vercel adapter puts the output into its .vercel directory
+  // However, the way this adapter is written, the config.outDir value is update too late for
+  // us to reliably detect it. Also, server files are first temporarily written to <root>/dist and then
+  // only copied over to <root>/.vercel. This seems to happen too late though.
+  // So we glob on both of these directories.
+  // Another case of "it ain't pretty but it works":(
+  if (config.adapter && config.adapter.name?.startsWith('@astrojs/vercel')) {
+    return '{.vercel,dist}/**/*';
+  }
+
   // paths are stored as "file://" URLs
   const outDirPathname = config.outDir && path.resolve(config.outDir.pathname);
   const rootDirName = path.resolve((config.root && config.root.pathname) || process.cwd());

--- a/packages/astro/test/integration/index.test.ts
+++ b/packages/astro/test/integration/index.test.ts
@@ -83,6 +83,33 @@ describe('sentryAstro integration', () => {
     });
   });
 
+  it('sets the correct assets glob for vercel if the Vercel adapter is used', async () => {
+    const integration = sentryAstro({
+      sourceMapsUploadOptions: { enabled: true, org: 'my-org', project: 'my-project', telemetry: false },
+    });
+    // @ts-expect-error - the hook exists and we only need to pass what we actually use
+    await integration.hooks['astro:config:setup']({
+      updateConfig,
+      injectScript,
+      config: {
+        // @ts-expect-error - we only need to pass what we actually use
+        adapter: { name: '@astrojs/vercel/serverless' },
+      },
+    });
+
+    expect(sentryVitePluginSpy).toHaveBeenCalledTimes(1);
+    expect(sentryVitePluginSpy).toHaveBeenCalledWith({
+      authToken: 'my-token',
+      org: 'my-org',
+      project: 'my-project',
+      telemetry: false,
+      debug: false,
+      sourcemaps: {
+        assets: ['{.vercel,dist}/**/*'],
+      },
+    });
+  });
+
   it("doesn't enable source maps if `sourceMapsUploadOptions.enabled` is `false`", async () => {
     const integration = sentryAstro({
       sourceMapsUploadOptions: { enabled: false },


### PR DESCRIPTION
This PR adds support for uploading sourcemaps when using the `@astrojs/vercel/*` adapters. 

It seems that the adapter updates the config.outdir value too late for our previous detection logic to 
correctly detect the .vercel output directory. Furthermore, the adapter for some reason first saves server 
files to <root>/dist only to copy it later to <root>/.vercel/functions. This copy command seems to happen too 
late for when our sourcemaps plugin runs.

For these two reasons, we try to detect the used adapter (love that this is much simpler in Astro than 
Sveltekit) and adjust the assets glob to search for files in both, `dist` and `.vercel`. 

Tested this for client side (island) and server-side errors with a test app deployed to vercel (serverless, not 
edge) and it seems to work well.  

Note: I'll open a separate PR for users to specify a custom assets glob for more advanced setups.

closes https://github.com/getsentry/sentry-javascript/issues/9591