### PR TITLE
feat(astro): Add `assets` option to source maps upload options

### DIFF
--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -42,7 +42,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
                   authToken: uploadOptions.authToken ?? env.SENTRY_AUTH_TOKEN,
                   telemetry: uploadOptions.telemetry ?? true,
                   sourcemaps: {
-                    assets: [getSourcemapsAssetsGlob(config)],
+                    assets: uploadOptions.assets ?? [getSourcemapsAssetsGlob(config)],
                   },
                   debug: options.debug ?? false,
                 }),

--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -106,13 +106,13 @@ function getSourcemapsAssetsGlob(config: AstroConfig): string {
   // only copied over to <root>/.vercel. This seems to happen too late though.
   // So we glob on both of these directories.
   // Another case of "it ain't pretty but it works":(
-  if (config.adapter && config.adapter.name?.startsWith('@astrojs/vercel')) {
+  if (config.adapter?.name?.startsWith('@astrojs/vercel')) {
     return '{.vercel,dist}/**/*';
   }
 
   // paths are stored as "file://" URLs
   const outDirPathname = config.outDir && path.resolve(config.outDir.pathname);
-  const rootDirName = path.resolve((config.root && config.root.pathname) || process.cwd());
+  const rootDirName = path.resolve(config.root?.pathname || process.cwd());
 
   if (outDirPathname) {
     const relativePath = path.relative(rootDirName, outDirPathname);

--- a/packages/astro/src/integration/types.ts
+++ b/packages/astro/src/integration/types.ts
@@ -68,6 +68,18 @@ type SourceMapsOptions = {
      * @default true
      */
     telemetry?: boolean;
+
+    /**
+     * A glob or an array of globs that specify the build artifacts and source maps that will uploaded to Sentry.
+     *
+     * If this option is not specified, sensible defaults based on your `outDir`, `rootDir` and `adapter`
+     * config will be used. Use this option to override these defaults, for instance if you have a
+     * customized build setup that diverges from Astro's defaults.
+     *
+     * The globbing patterns must follow the implementation of the `glob` package.
+     * @see https://www.npmjs.com/package/glob#glob-primer
+     */
+    assets?: string | Array<string>;
   };
 };
 

--- a/packages/astro/test/integration/index.test.ts
+++ b/packages/astro/test/integration/index.test.ts
@@ -110,6 +110,38 @@ describe('sentryAstro integration', () => {
     });
   });
 
+  it('prefers user-specified assets-globs over the default values', async () => {
+    const integration = sentryAstro({
+      sourceMapsUploadOptions: {
+        enabled: true,
+        org: 'my-org',
+        project: 'my-project',
+        assets: ['dist/server/**/*, dist/client/**/*'],
+      },
+    });
+    // @ts-expect-error - the hook exists and we only need to pass what we actually use
+    await integration.hooks['astro:config:setup']({
+      updateConfig,
+      injectScript,
+      // @ts-expect-error - only passing in partial config
+      config: {
+        outDir: new URL('file://path/to/project/build'),
+      },
+    });
+
+    expect(sentryVitePluginSpy).toHaveBeenCalledTimes(1);
+    expect(sentryVitePluginSpy).toHaveBeenCalledWith({
+      authToken: 'my-token',
+      org: 'my-org',
+      project: 'my-project',
+      telemetry: true,
+      debug: false,
+      sourcemaps: {
+        assets: ['dist/server/**/*, dist/client/**/*'],
+      },
+    });
+  });
+
   it("doesn't enable source maps if `sourceMapsUploadOptions.enabled` is `false`", async () => {
     const integration = sentryAstro({
       sourceMapsUploadOptions: { enabled: false },


### PR DESCRIPTION
This PR adds the `assets` option to the Astro integration source maps upload options.

It behaves just like the `assets` option of the Vite plugin, taking a (array of) glob(s) and overriding the 
default values. 
This came up in #9591 and I think it makes sense to give users with more advanced/custom setups the ability to 
override our defaults.

Docs PR: https://github.com/getsentry/sentry-docs/pull/8586
