### PR TITLE
fix(tracing): Don't attach resource size if null

### DIFF
--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -497,7 +497,7 @@ function setResourceEntrySizeData(
   dataKey: 'http.response_transfer_size' | 'http.response_content_length' | 'http.decoded_response_content_length',
 ): void {
   const entryVal = entry[key];
-  if (entryVal !== undefined && entryVal < MAX_INT_AS_BYTES) {
+  if (entryVal != null && entryVal < MAX_INT_AS_BYTES) {
     data[dataKey] = entryVal;
   }
 }

--- a/packages/tracing-internal/test/browser/metrics/index.test.ts
+++ b/packages/tracing-internal/test/browser/metrics/index.test.ts
@@ -189,4 +189,26 @@ describe('_addResourceSpans', () => {
       }),
     );
   });
+
+  // resource sizes can be set as null on some browsers
+  // https://github.com/getsentry/sentry/pull/60601
+  it('does not attach null resource sizes', () => {
+    const entry = {
+      initiatorType: 'css',
+      transferSize: null,
+      encodedBodySize: null,
+      decodedBodySize: null,
+    } as unknown as ResourceEntry;
+
+    _addResourceSpans(transaction, entry, '/assets/to/css', 100, 23, 345);
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(transaction.startChild).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(transaction.startChild).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: {},
+      }),
+    );
+  });
 });


### PR DESCRIPTION
Resource size can be null in some browsers, so don't set it if it's null (only set integers).