### PR TITLE
chore: update node.js to v20

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "yalc:publish": "lerna run yalc:publish"
   },
   "volta": {
-    "node": "18.17.0",
+    "node": "20.10.0",
     "yarn": "1.22.19"
   },
   "workspaces": [


### PR DESCRIPTION
The LTS release is now Node v20. I propose using v20 on our local machines. 