### PR TITLE
chore(astro): Allow Astro 4.0 in peer dependencies

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -40,7 +40,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "astro": "3.x"
+    "astro": ">=3.x"
   },
   "dependencies": {
     "@sentry/browser": "7.82.0",


### PR DESCRIPTION
Astro 4.0.0 beta is out so let's adjust our peer deps!
I opted for an open max version for now. THere's a risk of this being problematic with future major versions but I'd argue we'd get support requests either way. The important part IMO is the lower bound. 