### PR TITLE
fix(nextjs): Don't match files called `middleware` in node_modules

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -172,12 +172,12 @@ export function constructWebpackConfigFunction(
       );
     };
 
+    const possibleMiddlewareLocations = ['js', 'jsx', 'ts', 'tsx'].map(middlewareFileEnding => {
+      return path.join(middlewareLocationFolder, `middleware.${middlewareFileEnding}`);
+    });
     const isMiddlewareResource = (resourcePath: string): boolean => {
       const normalizedAbsoluteResourcePath = normalizeLoaderResourcePath(resourcePath);
-      return (
-        normalizedAbsoluteResourcePath.startsWith(middlewareLocationFolder + path.sep) &&
-        !!normalizedAbsoluteResourcePath.match(/[\\/]middleware\.(js|jsx|ts|tsx)$/)
-      );
+      return possibleMiddlewareLocations.includes(normalizedAbsoluteResourcePath);
     };
 
     const isServerComponentResource = (resourcePath: string): boolean => {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/9681

With https://github.com/getsentry/sentry-javascript/pull/9637 we likely introduced a bug where we started matching any files called `middleware`, also inside node modules.

This PR limits the amount of files we match to a very strict list.