### PR TITLE
fix(astro): Avoid adding the Sentry Vite plugin in dev mode

### DIFF
--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -14,7 +14,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
     name: PKG_NAME,
     hooks: {
       // eslint-disable-next-line complexity
-      'astro:config:setup': async ({ updateConfig, injectScript, addMiddleware, config }) => {
+      'astro:config:setup': async ({ updateConfig, injectScript, addMiddleware, config, command }) => {
         // The third param here enables loading of all env vars, regardless of prefix
         // see: https://main.vitejs.dev/config/#using-environment-variables-in-config
 
@@ -29,7 +29,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
         const shouldUploadSourcemaps = uploadOptions?.enabled ?? true;
 
         // We don't need to check for AUTH_TOKEN here, because the plugin will pick it up from the env
-        if (shouldUploadSourcemaps) {
+        if (shouldUploadSourcemaps && command !== 'dev') {
           updateConfig({
             vite: {
               build: {

--- a/packages/astro/src/integration/types.ts
+++ b/packages/astro/src/integration/types.ts
@@ -1,5 +1,4 @@
 import type { BrowserOptions } from '@sentry/browser';
-import { NodeOptions } from '@sentry/node';
 import type { Options } from '@sentry/types';
 
 type SdkInitPaths = {

--- a/packages/astro/src/integration/types.ts
+++ b/packages/astro/src/integration/types.ts
@@ -1,4 +1,5 @@
 import type { BrowserOptions } from '@sentry/browser';
+import { NodeOptions } from '@sentry/node';
 import type { Options } from '@sentry/types';
 
 type SdkInitPaths = {

--- a/packages/astro/test/integration/index.test.ts
+++ b/packages/astro/test/integration/index.test.ts
@@ -155,6 +155,19 @@ describe('sentryAstro integration', () => {
     expect(sentryVitePluginSpy).toHaveBeenCalledTimes(0);
   });
 
+  it("doesn't add the Vite plugin in dev mode", async () => {
+    const integration = sentryAstro({
+      sourceMapsUploadOptions: { enabled: true },
+    });
+
+    expect(integration.hooks['astro:config:setup']).toBeDefined();
+    // @ts-expect-error - the hook exists and we only need to pass what we actually use
+    await integration.hooks['astro:config:setup']({ updateConfig, injectScript, config, command: 'dev' });
+
+    expect(updateConfig).toHaveBeenCalledTimes(0);
+    expect(sentryVitePluginSpy).toHaveBeenCalledTimes(0);
+  });
+
   it('injects client and server init scripts', async () => {
     const integration = sentryAstro({});
 


### PR DESCRIPTION
This PR adds a guard to avoid adding the Sentry Vite plugin for source maps upload in dev mode. 
Reason: The vite plugin ships with a Sentry SDK. This SDK conflicts with the Astro server-side SDK. For example for some reason, it skews up the line numbers of stack frames. Not exactly sure why that's happening but my best guess is that the plugin SDK somehow changes code (maybe we even inject debugIds or release values or something like this) that mixes up line numbers. 

Anyway, I think it's generally more correct to not use the plugin in dev mode. 