### PR TITLE
build: enable biome linter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,9 +24,21 @@ module.exports = {
   ],
   overrides: [
     {
+      files: ['*'],
+      rules: {
+        // Disabled because it's included with Biome's linter
+        'no-control-regex': 'off',
+      },
+    },
+    {
       files: ['*.ts', '*.tsx', '*.d.ts'],
       parserOptions: {
         project: ['tsconfig.json'],
+      },
+      rules: {
+        // Disabled because it's included with Biome's linter
+        '@typescript-eslint/no-unused-vars': 'off',
+        '@typescript-eslint/no-loss-of-precision': 'off',
       },
     },
     {

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ local.log
 ._*
 .Spotlight-V100
 .Trashes
+.nx
 
 .rpt2_cache
 

--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,20 @@
     "enabled": false
   },
   "linter": {
-    "enabled": false
+    "enabled": true,
+    "rules": {
+      "recommended": false,
+      "correctness": {
+        "all": false,
+        "noUnusedVariables": "error",
+        "noPrecisionLoss": "error"
+      },
+      "suspicious": {
+        "all": false,
+        "noControlCharactersInRegex": "error"
+      }
+    },
+    "ignore": [".vscode/*", "**/*.json"]
   },
   "files": {
     "ignoreUnknown": true
@@ -37,6 +50,9 @@
       "arrowParentheses": "asNeeded",
       "trailingComma": "all",
       "lineEnding": "lf"
+    },
+    "parser": {
+      "unsafeParameterDecoratorsEnabled": true
     }
   },
   "json": {

--- a/packages/bun/scripts/install-bun.js
+++ b/packages/bun/scripts/install-bun.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 if (process.env.CI) {
   // This script is not needed in CI we install bun via GH actions
-  return;
+  process.exit(0);
 }
 const { exec } = require('child_process');
 const https = require('https');

--- a/packages/node/test/manual/webpack-async-context/npm-build.js
+++ b/packages/node/test/manual/webpack-async-context/npm-build.js
@@ -4,7 +4,7 @@ const { execSync } = require('child_process');
 
 // Webpack test does not work in Node 18 and above.
 if (Number(process.versions.node.split('.')[0]) >= 18) {
-  return;
+  process.exit(0);
 }
 
 // biome-ignore format: Follow-up for prettier


### PR DESCRIPTION
Enables Biome linter and moves several rules to Biome.

Running `time yarn lint`

### Before

```
yarn lint  221.52s user 19.65s system 783% cpu 30.797 total
```

### After

```
yarn lint  212.49s user 19.99s system 772% cpu 30.756 total
```