### PR TITLE
ref(nextjs): Set `automaticVercelMonitors` to be `false` by default

### DIFF
--- a/packages/nextjs/src/config/types.ts
+++ b/packages/nextjs/src/config/types.ts
@@ -139,7 +139,7 @@ export type UserSentryOptions = {
   /**
    * Automatically create cron monitors in Sentry for your Vercel Cron Jobs if configured via `vercel.json`.
    *
-   * Defaults to `true`.
+   * Defaults to `false`.
    */
   automaticVercelMonitors?: boolean;
 };

--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -220,7 +220,7 @@ export function constructWebpackConfigFunction(
 
       let vercelCronsConfig: VercelCronsConfig = undefined;
       try {
-        if (process.env.VERCEL && userSentryOptions.automaticVercelMonitors !== false) {
+        if (process.env.VERCEL && userSentryOptions.automaticVercelMonitors) {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           vercelCronsConfig = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'vercel.json'), 'utf8')).crons;
           if (vercelCronsConfig) {


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-javascript/issues/8701