### PR TITLE
fix(astro): Isolate request instrumentation middleware on server side

### DIFF
--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -1,4 +1,4 @@
-import { captureException, configureScope, getCurrentHub, startSpan } from '@sentry/node';
+import { captureException, configureScope, getCurrentHub, runWithAsyncContext, startSpan } from '@sentry/node';
 import type { Hub, Span } from '@sentry/types';
 import {
   addNonEnumerableProperty,
@@ -56,107 +56,123 @@ type AstroLocalsWithSentry = Record<string, unknown> & {
   __sentry_wrapped__?: boolean;
 };
 
-export const handleRequest: (options?: MiddlewareOptions) => MiddlewareResponseHandler = (
-  options = { trackClientIp: false, trackHeaders: false },
-) => {
+export const handleRequest: (options?: MiddlewareOptions) => MiddlewareResponseHandler = options => {
+  const handlerOptions = { trackClientIp: false, trackHeaders: false, ...options };
+
   return async (ctx, next) => {
-    // Make sure we don't accidentally double wrap (e.g. user added middleware and integration auto added it)
-    const locals = ctx.locals as AstroLocalsWithSentry;
-    if (locals && locals.__sentry_wrapped__) {
-      return next();
+    // if there is an active span, we know that this handle call is nested and hence
+    // we don't create a new domain for it. If we created one, nested server calls would
+    // create new transactions instead of adding a child span to the currently active span.
+    if (getCurrentHub().getScope().getSpan()) {
+      return instrumentRequest(ctx, next, handlerOptions);
     }
-    addNonEnumerableProperty(locals, '__sentry_wrapped__', true);
-
-    const method = ctx.request.method;
-    const headers = ctx.request.headers;
-
-    const { dynamicSamplingContext, traceparentData, propagationContext } = tracingContextFromHeaders(
-      headers.get('sentry-trace') || undefined,
-      headers.get('baggage'),
-    );
-
-    const allHeaders: Record<string, string> = {};
-    headers.forEach((value, key) => {
-      allHeaders[key] = value;
+    return runWithAsyncContext(() => {
+      return instrumentRequest(ctx, next, handlerOptions);
     });
-
-    configureScope(scope => {
-      scope.setPropagationContext(propagationContext);
-
-      if (options.trackClientIp) {
-        scope.setUser({ ip_address: ctx.clientAddress });
-      }
-    });
-
-    try {
-      // storing res in a variable instead of directly returning is necessary to
-      // invoke the catch block if next() throws
-      const res = await startSpan(
-        {
-          name: `${method} ${interpolateRouteFromUrlAndParams(ctx.url.pathname, ctx.params)}`,
-          op: 'http.server',
-          origin: 'auto.http.astro',
-          status: 'ok',
-          ...traceparentData,
-          metadata: {
-            source: 'route',
-            dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,
-          },
-          data: {
-            method,
-            url: stripUrlQueryAndFragment(ctx.url.href),
-            ...(ctx.url.search && { 'http.query': ctx.url.search }),
-            ...(ctx.url.hash && { 'http.fragment': ctx.url.hash }),
-            ...(options.trackHeaders && { headers: allHeaders }),
-          },
-        },
-        async span => {
-          const originalResponse = await next();
-
-          if (span && originalResponse.status) {
-            span.setHttpStatus(originalResponse.status);
-          }
-
-          const hub = getCurrentHub();
-          const client = hub.getClient();
-          const contentType = originalResponse.headers.get('content-type');
-
-          const isPageloadRequest = contentType && contentType.startsWith('text/html');
-          if (!isPageloadRequest || !client) {
-            return originalResponse;
-          }
-
-          // Type case necessary b/c the body's ReadableStream type doesn't include
-          // the async iterator that is actually available in Node
-          // We later on use the async iterator to read the body chunks
-          // see https://github.com/microsoft/TypeScript/issues/39051
-          const originalBody = originalResponse.body as NodeJS.ReadableStream | null;
-          if (!originalBody) {
-            return originalResponse;
-          }
-
-          const newResponseStream = new ReadableStream({
-            start: async controller => {
-              for await (const chunk of originalBody) {
-                const html = typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
-                const modifiedHtml = addMetaTagToHead(html, hub, span);
-                controller.enqueue(new TextEncoder().encode(modifiedHtml));
-              }
-              controller.close();
-            },
-          });
-
-          return new Response(newResponseStream, originalResponse);
-        },
-      );
-      return res;
-    } catch (e) {
-      sendErrorToSentry(e);
-      throw e;
-    }
-    // TODO: flush if serveless (first extract function)
   };
 };
+
+async function instrumentRequest(
+  ctx: Parameters<MiddlewareResponseHandler>[0],
+  next: Parameters<MiddlewareResponseHandler>[1],
+  options: MiddlewareOptions,
+): Promise<Response> {
+  // Make sure we don't accidentally double wrap (e.g. user added middleware and integration auto added it)
+  const locals = ctx.locals as AstroLocalsWithSentry;
+  if (locals && locals.__sentry_wrapped__) {
+    return next();
+  }
+  addNonEnumerableProperty(locals, '__sentry_wrapped__', true);
+
+  const method = ctx.request.method;
+  const headers = ctx.request.headers;
+
+  const { dynamicSamplingContext, traceparentData, propagationContext } = tracingContextFromHeaders(
+    headers.get('sentry-trace') || undefined,
+    headers.get('baggage'),
+  );
+
+  const allHeaders: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    allHeaders[key] = value;
+  });
+
+  configureScope(scope => {
+    scope.setPropagationContext(propagationContext);
+
+    if (options.trackClientIp) {
+      scope.setUser({ ip_address: ctx.clientAddress });
+    }
+  });
+
+  try {
+    // storing res in a variable instead of directly returning is necessary to
+    // invoke the catch block if next() throws
+    const res = await startSpan(
+      {
+        name: `${method} ${interpolateRouteFromUrlAndParams(ctx.url.pathname, ctx.params)}`,
+        op: 'http.server',
+        origin: 'auto.http.astro',
+        status: 'ok',
+        ...traceparentData,
+        metadata: {
+          source: 'route',
+          dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,
+        },
+        data: {
+          method,
+          url: stripUrlQueryAndFragment(ctx.url.href),
+          ...(ctx.url.search && { 'http.query': ctx.url.search }),
+          ...(ctx.url.hash && { 'http.fragment': ctx.url.hash }),
+          ...(options.trackHeaders && { headers: allHeaders }),
+        },
+      },
+      async span => {
+        const originalResponse = await next();
+
+        if (span && originalResponse.status) {
+          span.setHttpStatus(originalResponse.status);
+        }
+
+        const hub = getCurrentHub();
+        const client = hub.getClient();
+        const contentType = originalResponse.headers.get('content-type');
+
+        const isPageloadRequest = contentType && contentType.startsWith('text/html');
+        if (!isPageloadRequest || !client) {
+          return originalResponse;
+        }
+
+        // Type case necessary b/c the body's ReadableStream type doesn't include
+        // the async iterator that is actually available in Node
+        // We later on use the async iterator to read the body chunks
+        // see https://github.com/microsoft/TypeScript/issues/39051
+        const originalBody = originalResponse.body as NodeJS.ReadableStream | null;
+        if (!originalBody) {
+          return originalResponse;
+        }
+
+        const newResponseStream = new ReadableStream({
+          start: async controller => {
+            for await (const chunk of originalBody) {
+              const html = typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
+              const modifiedHtml = addMetaTagToHead(html, hub, span);
+              controller.enqueue(new TextEncoder().encode(modifiedHtml));
+            }
+            controller.close();
+          },
+        });
+
+        return new Response(newResponseStream, originalResponse);
+      },
+    );
+    return res;
+  } catch (e) {
+    sendErrorToSentry(e);
+    throw e;
+  }
+  // TODO: flush if serveless (first extract function)
+}
 
 /**
  * This function optimistically assumes that the HTML coming in chunks will not be split

--- a/packages/astro/test/server/middleware.test.ts
+++ b/packages/astro/test/server/middleware.test.ts
@@ -15,7 +15,7 @@ describe('sentryMiddleware', () => {
 
   const getSpanMock = vi.fn(() => {});
   // @ts-expect-error only returning a partial hub here
-  const getCurrentHubSpy = vi.spyOn(SentryNode, 'getCurrentHub').mockImplementation(() => {
+  vi.spyOn(SentryNode, 'getCurrentHub').mockImplementation(() => {
     return {
       getScope: () => ({
         getSpan: getSpanMock,

--- a/packages/astro/test/server/middleware.test.ts
+++ b/packages/astro/test/server/middleware.test.ts
@@ -98,10 +98,6 @@ describe('sentryMiddleware', () => {
   });
 
   it('attaches tracing headers', async () => {
-    const scope = { setUser: vi.fn(), setPropagationContext: vi.fn() };
-    // @ts-expect-error, only passing a partial Scope object
-    const configureScopeSpy = vi.spyOn(SentryNode, 'configureScope').mockImplementation(cb => cb(scope));
-
     const middleware = handleRequest();
     const ctx = {
       request: {
@@ -119,17 +115,6 @@ describe('sentryMiddleware', () => {
 
     // @ts-expect-error, a partial ctx object is fine here
     await middleware(ctx, next);
-
-    expect(configureScopeSpy).toHaveBeenCalledTimes(1);
-    expect(scope.setPropagationContext).toHaveBeenCalledWith({
-      dsc: {
-        release: '1.0.0',
-      },
-      parentSpanId: '1234567890123456',
-      sampled: true,
-      spanId: expect.any(String),
-      traceId: '12345678901234567890123456789012',
-    });
 
     expect(startSpanSpy).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -211,6 +211,7 @@ export function continueTrace({
   sentryTrace: Parameters<typeof tracingContextFromHeaders>[0];
   baggage: Parameters<typeof tracingContextFromHeaders>[1];
 }): Partial<TransactionContext>;
+
 export function continueTrace<V>(
   {
     sentryTrace,

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -211,7 +211,6 @@ export function continueTrace({
   sentryTrace: Parameters<typeof tracingContextFromHeaders>[0];
   baggage: Parameters<typeof tracingContextFromHeaders>[1];
 }): Partial<TransactionContext>;
-
 export function continueTrace<V>(
   {
     sentryTrace,
@@ -227,7 +226,6 @@ export function continueTrace<V>(
  * These values can be obtained from incoming request headers,
  * or in the browser from `<meta name="sentry-trace">` and `<meta name="baggage">` HTML tags.
  *
- * It also takes an optional `request` option, which if provided will also be added to the scope & transaction metadata.
  * The callback receives a transactionContext that may be used for `startTransaction` or `startSpan`.
  */
 export function continueTrace<V>(


### PR DESCRIPTION
This PR adds isolation to our sever-side request instrumentation, similarly to the request handler in 
Sveltekit.

Note for reviewers: The changes look more drastic than they are. The gist is, we run the previous instrumentation in a new async context if there's no ongoing span. Otherwise we just call the instrumentation.
