### PR TITLE
feat(replays): Add an SDK _experiments configuration flag to enable canvas recording

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -339,6 +339,8 @@ export class ReplayContainer implements ReplayContainerInterface {
         ...(this.recordingMode === 'buffer' && { checkoutEveryNms: BUFFER_CHECKOUT_TIME }),
         emit: getHandleRecordingEmit(this),
         onMutation: this._onMutationHandler,
+        recordCanvas: this._options._experiments.enableCanvas,
+        ...(this._options._experiments.enableCanvas && { sampling: { canvas: 4, }, dataURLOptions: { quality: 0.6, } }),
       });
     } catch (err) {
       this._handleException(err);

--- a/packages/replay/src/types/replay.ts
+++ b/packages/replay/src/types/replay.ts
@@ -232,6 +232,7 @@ export interface ReplayPluginOptions extends ReplayNetworkOptions {
   _experiments: Partial<{
     captureExceptions: boolean;
     traceInternals: boolean;
+    enableCanvas: boolean;
   }>;
 }
 


### PR DESCRIPTION
SDK _experiments configuration flag to enable canvas recording. It allows snapshot canvas recording at 4fps.

Closes https://github.com/getsentry/team-replay/issues/306
