### PR TITLE
ref(remix): Rework Error Handling

### DIFF
--- a/packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.server.tsx
+++ b/packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.server.tsx
@@ -24,9 +24,7 @@ Sentry.init({
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
 });
 
-export function handleError(error: unknown, { request }: DataFunctionArgs): void {
-  Sentry.captureRemixServerException(error, 'remix.server', request);
-}
+export const handleError = Sentry.wrapRemixHandleError;
 
 export default function handleRequest(
   request: Request,

--- a/packages/e2e-tests/test-applications/create-remix-app/app/entry.server.tsx
+++ b/packages/e2e-tests/test-applications/create-remix-app/app/entry.server.tsx
@@ -21,9 +21,7 @@ Sentry.init({
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
 });
 
-export function handleError(error: unknown, { request }: DataFunctionArgs): void {
-  Sentry.captureRemixServerException(error, 'remix.server', request);
-}
+export const handleError = Sentry.wrapRemixHandleError;
 
 export default function handleRequest(
   request: Request,

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -59,7 +59,7 @@ export {
 // Keeping the `*` exports for backwards compatibility and types
 export * from '@sentry/node';
 
-export { captureRemixServerException } from './utils/instrumentServer';
+export { captureRemixServerException, wrapRemixHandleError } from './utils/instrumentServer';
 export { ErrorBoundary, withErrorBoundary } from '@sentry/react';
 export { remixRouterInstrumentation, withSentry } from './client/performance';
 export { captureRemixErrorBoundaryError } from './client/errors';

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -72,7 +72,12 @@ async function extractResponseError(response: Response): Promise<unknown> {
 }
 
 /**
+ * Sentry utility to be used in place of `handleError` function of Remix v2
+ * Remix Docs: https://remix.run/docs/en/main/file-conventions/entry.server#handleerror
  *
+ * Should be used in `entry.server` like:
+ *
+ * export const handleError = Sentry.wrapRemixHandleError
  */
 export function wrapRemixHandleError(err: unknown, { request }: DataFunctionArgs): void {
   // We are skipping thrown responses here as they are either handled:

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -75,7 +75,7 @@ async function extractResponseError(response: Response): Promise<unknown> {
 /**
  *
  */
-export function wrapRemixHandleError(this: unknown, err: unknown, { request }: DataFunctionArgs): void {
+export function wrapRemixHandleError(err: unknown, { request }: DataFunctionArgs): void {
   // We are skipping thrown responses here as they are either handled:
   // - Remix v1: by captureRemixServerException at loader / action
   // - Remix v2: by ErrorBoundary
@@ -85,29 +85,7 @@ export function wrapRemixHandleError(this: unknown, err: unknown, { request }: D
   if (isResponse(err) || isRouteErrorResponse(err)) {
     return;
   }
-
-  if (err && typeof err === 'object' && 'error' in err) {
-    // No need to await here as we're skipping the error responses
-    void captureRemixServerException(err, 'remix.server.handleError', request);
-  } else {
-    const objectifiedErr = objectify(err);
-
-    captureException(objectifiedErr, scope => {
-      scope.addEventProcessor(event => {
-        addExceptionMechanism(event, {
-          type: 'instrument',
-          handled: false,
-          data: {
-            function: 'remix.server.handleError',
-          },
-        });
-
-        return event;
-      });
-
-      return scope;
-    });
-  }
+  void captureRemixServerException(err, 'remix.server.handleError', request);
 }
 
 /**

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -33,7 +33,6 @@ import type {
   EntryContext,
   FutureConfig,
   HandleDocumentRequestFunction,
-  HandleErrorFunction,
   ReactRouterDomPkg,
   RemixRequest,
   RequestHandler,

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -190,38 +190,28 @@ function makeWrappedDocumentRequestFunction(remixVersion: number) {
       context: EntryContext,
       loadContext?: Record<string, unknown>,
     ): Promise<Response> {
-      let res: Response;
-
       const activeTransaction = getActiveTransaction();
 
-      try {
-        const span = activeTransaction?.startChild({
-          op: 'function.remix.document_request',
-          origin: 'auto.function.remix',
-          description: activeTransaction.name,
-          tags: {
-            method: request.method,
-            url: request.url,
-          },
-        });
+      const span = activeTransaction?.startChild({
+        op: 'function.remix.document_request',
+        origin: 'auto.function.remix',
+        description: activeTransaction.name,
+        tags: {
+          method: request.method,
+          url: request.url,
+        },
+      });
 
-        res = await origDocumentRequestFunction.call(
-          this,
-          request,
-          responseStatusCode,
-          responseHeaders,
-          context,
-          loadContext,
-        );
+      const res = await origDocumentRequestFunction.call(
+        this,
+        request,
+        responseStatusCode,
+        responseHeaders,
+        context,
+        loadContext,
+      );
 
-        span?.finish();
-      } catch (err) {
-        if (!FUTURE_FLAGS?.v2_errorBoundary && remixVersion !== 2) {
-          await captureRemixServerException(err, 'documentRequest', request);
-        }
-
-        throw err;
-      }
+      span?.finish();
 
       return res;
     };

--- a/packages/remix/src/utils/vendor/types.ts
+++ b/packages/remix/src/utils/vendor/types.ts
@@ -206,10 +206,6 @@ export interface DataFunctionArgs {
   params: Params;
 }
 
-export interface HandleErrorFunction {
-  (error: unknown, args: DataFunctionArgs): void;
-}
-
 export interface DataFunction {
   (args: DataFunctionArgs): Promise<Response> | Response | Promise<AppData> | AppData;
 }

--- a/packages/remix/src/utils/vendor/types.ts
+++ b/packages/remix/src/utils/vendor/types.ts
@@ -108,7 +108,12 @@ export type DeferredData = {
 };
 
 export interface MetaFunction {
-  (args: { data: AppData; parentsData: RouteData; params: Params; location: Location }): HtmlMetaDescriptor;
+  (args: {
+    data: AppData;
+    parentsData: RouteData;
+    params: Params;
+    location: Location;
+  }): HtmlMetaDescriptor;
 }
 
 export interface HtmlMetaDescriptor {
@@ -143,7 +148,11 @@ export interface LoaderFunction {
 }
 
 export interface HeadersFunction {
-  (args: { loaderHeaders: Headers; parentHeaders: Headers; actionHeaders: Headers }): Headers | HeadersInit;
+  (args: {
+    loaderHeaders: Headers;
+    parentHeaders: Headers;
+    actionHeaders: Headers;
+  }): Headers | HeadersInit;
 }
 
 export interface ServerRouteModule extends EntryRouteModule {
@@ -195,6 +204,10 @@ export interface DataFunctionArgs {
   request: RemixRequest;
   context: AppLoadContext;
   params: Params;
+}
+
+export interface HandleErrorFunction {
+  (error: unknown, args: DataFunctionArgs): void;
 }
 
 export interface DataFunction {

--- a/packages/remix/test/integration/app_v1/routes/server-side-unexpected-errors/$id.tsx
+++ b/packages/remix/test/integration/app_v1/routes/server-side-unexpected-errors/$id.tsx
@@ -1,0 +1,2 @@
+export * from '../../../common/routes/server-side-unexpected-errors.$id';
+export { default } from '../../../common/routes/server-side-unexpected-errors.$id';

--- a/packages/remix/test/integration/app_v1/routes/ssr-error.tsx
+++ b/packages/remix/test/integration/app_v1/routes/ssr-error.tsx
@@ -1,0 +1,2 @@
+export * from '../../common/routes/ssr-error';
+export { default } from '../../common/routes/ssr-error';

--- a/packages/remix/test/integration/app_v2/entry.server.tsx
+++ b/packages/remix/test/integration/app_v2/entry.server.tsx
@@ -11,9 +11,7 @@ Sentry.init({
   autoSessionTracking: false,
 });
 
-export function handleError(error: unknown, { request }: DataFunctionArgs): void {
-  Sentry.captureRemixServerException(error, 'remix.server', request);
-}
+export const handleError = Sentry.wrapRemixHandleError;
 
 export default function handleRequest(
   request: Request,

--- a/packages/remix/test/integration/app_v2/routes/server-side-unexpected-errors.$id.tsx
+++ b/packages/remix/test/integration/app_v2/routes/server-side-unexpected-errors.$id.tsx
@@ -1,0 +1,2 @@
+export * from '../../common/routes/server-side-unexpected-errors.$id';
+export { default } from '../../common/routes/server-side-unexpected-errors.$id';

--- a/packages/remix/test/integration/app_v2/routes/ssr-error.tsx
+++ b/packages/remix/test/integration/app_v2/routes/ssr-error.tsx
@@ -1,0 +1,2 @@
+export * from '../../common/routes/ssr-error';
+export { default } from '../../common/routes/ssr-error';

--- a/packages/remix/test/integration/common/routes/action-json-response.$id.tsx
+++ b/packages/remix/test/integration/common/routes/action-json-response.$id.tsx
@@ -2,7 +2,7 @@ import { ActionFunction, LoaderFunction, json, redirect } from '@remix-run/node'
 import { useActionData } from '@remix-run/react';
 
 export const loader: LoaderFunction = async ({ params: { id } }) => {
-  if (id === '-1') {
+  if (id === '-100') {
     throw new Error('Unexpected Server Error');
   }
 
@@ -16,7 +16,7 @@ export const action: ActionFunction = async ({ params: { id } }) => {
 
   if (id === '-2') {
     // Note: This GET request triggers the `Loader` of the URL, not the `Action`.
-    throw redirect('/action-json-response/-1');
+    throw redirect('/action-json-response/-100');
   }
 
   if (id === '-3') {

--- a/packages/remix/test/integration/common/routes/server-side-unexpected-errors.$id.tsx
+++ b/packages/remix/test/integration/common/routes/server-side-unexpected-errors.$id.tsx
@@ -1,0 +1,27 @@
+import { ActionFunction, LoaderFunction, json, redirect } from '@remix-run/node';
+import { useActionData } from '@remix-run/react';
+
+export const action: ActionFunction = async ({ params: { id } }) => {
+  // Throw string
+  if (id === '-1') {
+    throw 'Thrown String Error';
+  }
+
+  // Throw object
+  if (id === '-2') {
+    throw {
+      message: 'Thrown Object Error',
+      statusCode: 500,
+    };
+  }
+};
+
+export default function ActionJSONResponse() {
+  const data = useActionData();
+
+  return (
+    <div>
+      <h1>{data && data.test ? data.test : 'Not Found'}</h1>
+    </div>
+  );
+}

--- a/packages/remix/test/integration/common/routes/ssr-error.tsx
+++ b/packages/remix/test/integration/common/routes/ssr-error.tsx
@@ -1,0 +1,7 @@
+export default function SSRError() {
+  const data = ['err'].map(err => {
+    throw new Error('Sentry SSR Test Error');
+  });
+
+  return <div>{data}</div>;
+}

--- a/packages/remix/test/integration/test/client/ssr-error.test.ts
+++ b/packages/remix/test/integration/test/client/ssr-error.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@playwright/test';
+import { countEnvelopes } from './utils/helpers';
+
+test('should not report an SSR error on client side.', async ({ page }) => {
+  const count = await countEnvelopes(page, { url: '/ssr-error', envelopeType: 'event' });
+
+  expect(count).toBe(0);
+});

--- a/packages/remix/test/integration/test/server/action.test.ts
+++ b/packages/remix/test/integration/test/server/action.test.ts
@@ -140,7 +140,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
     });
   });
 
-  it('handles a thrown 500 response', async () => {
+  it('handles an error-throwing redirection target', async () => {
     const env = await RemixTestEnv.init(adapter);
     const url = `${env.url}/action-json-response/-2`;
 
@@ -254,7 +254,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
             stacktrace: expect.any(Object),
             mechanism: {
               data: {
-                function: useV2 ? 'ErrorResponse' : 'action',
+                function: 'action',
               },
               handled: false,
               type: 'instrument',
@@ -303,13 +303,11 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
         values: [
           {
             type: 'Error',
-            value: useV2
-              ? 'Object captured as exception with keys: data, internal, status, statusText'
-              : 'Object captured as exception with keys: data',
+            value: 'Object captured as exception with keys: data',
             stacktrace: expect.any(Object),
             mechanism: {
               data: {
-                function: useV2 ? 'ErrorResponse' : 'action',
+                function: 'action',
               },
               handled: false,
               type: 'instrument',
@@ -362,7 +360,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
             stacktrace: expect.any(Object),
             mechanism: {
               data: {
-                function: useV2 ? 'ErrorResponse' : 'action',
+                function: 'action',
               },
               handled: false,
               type: 'instrument',
@@ -411,13 +409,11 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
         values: [
           {
             type: 'Error',
-            value: useV2
-              ? 'Object captured as exception with keys: data, internal, status, statusText'
-              : 'Object captured as exception with keys: [object has no keys]',
+            value: 'Object captured as exception with keys: [object has no keys]',
             stacktrace: expect.any(Object),
             mechanism: {
               data: {
-                function: useV2 ? 'ErrorResponse' : 'action',
+                function: 'action',
               },
               handled: false,
               type: 'instrument',
@@ -428,7 +424,7 @@ describe.each(['builtin', 'express'])('Remix API Actions with adapter = %s', ada
     });
   });
 
-  it('handles thrown string from an action', async () => {
+  it('handles thrown string (primitive) from an action', async () => {
     const env = await RemixTestEnv.init(adapter);
     const url = `${env.url}/server-side-unexpected-errors/-1`;
 

--- a/packages/remix/test/integration/test/server/loader.test.ts
+++ b/packages/remix/test/integration/test/server/loader.test.ts
@@ -78,7 +78,7 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
     });
   });
 
-  it('handles a thrown 500 response', async () => {
+  it('handles an error-throwing redirection target', async () => {
     const env = await RemixTestEnv.init(adapter);
     const url = `${env.url}/loader-json-response/-1`;
 

--- a/packages/remix/test/integration/test/server/loader.test.ts
+++ b/packages/remix/test/integration/test/server/loader.test.ts
@@ -39,7 +39,7 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
             stacktrace: expect.any(Object),
             mechanism: {
               data: {
-                function: useV2 ? 'remix.server' : 'loader',
+                function: useV2 ? 'remix.server.handleError' : 'loader',
               },
               handled: false,
               type: 'instrument',
@@ -138,7 +138,7 @@ describe.each(['builtin', 'express'])('Remix API Loaders with adapter = %s', ada
             stacktrace: expect.any(Object),
             mechanism: {
               data: {
-                function: useV2 ? 'remix.server' : 'loader',
+                function: useV2 ? 'remix.server.handleError' : 'loader',
               },
               handled: false,
               type: 'instrument',

--- a/packages/remix/test/integration/test/server/ssr.test.ts
+++ b/packages/remix/test/integration/test/server/ssr.test.ts
@@ -1,0 +1,46 @@
+import { RemixTestEnv, assertSentryEvent, assertSentryTransaction } from './utils/helpers';
+
+const useV2 = process.env.REMIX_VERSION === '2';
+
+describe('Server Side Rendering', () => {
+  it('correctly reports a server side rendering error', async () => {
+    const env = await RemixTestEnv.init('builtin');
+    const url = `${env.url}/ssr-error`;
+    const envelopes = await env.getMultipleEnvelopeRequest({ url, count: 2, envelopeType: ['transaction', 'event'] });
+    const [transaction] = envelopes.filter(envelope => envelope[1].type === 'transaction');
+    const [event] = envelopes.filter(envelope => envelope[1].type === 'event');
+
+    assertSentryTransaction(transaction[2], {
+      contexts: {
+        trace: {
+          status: 'internal_error',
+          tags: {
+            'http.status_code': '500',
+          },
+          data: {
+            'http.response.status_code': 500,
+          },
+        },
+      },
+    });
+
+    assertSentryEvent(event[2], {
+      exception: {
+        values: [
+          {
+            type: 'Error',
+            value: 'Sentry SSR Test Error',
+            stacktrace: expect.any(Object),
+            mechanism: {
+              data: {
+                function: useV2 ? 'remix.server.handleError' : 'documentRequest',
+              },
+              handled: false,
+              type: 'instrument',
+            },
+          },
+        ],
+      },
+    });
+  });
+});


### PR DESCRIPTION
Resolves: #9695
Should also resolve: #9563

Rewrote the error reporting logic of Remix SDK to handle inconsistencies, missing stack traces and potential duplications.

There are 5 main error types that we are concerned.

- Runtime Browser errors
- SSR Rendering errors
- Errors thrown in `loader`s and `actions`
- Error Responses
- Unexpected server-side errors

And there are different points we can capture such as:
- `handleError`,
- `action / loader / documentRequest` instrumentation
- `ErrorBoundary`

An error is not guaranteed to end up only one of those utilities. Also the objects for the same error are not guaranteed to be the same in different places. That causes duplications.

So, with this patch, the new error handling / filtering logic for the instrumentation will be as below:

|                                    	| `handleError` 	| `loader`/`action` Instrumentation 	| `documentRequest` Instrumentation 	| Remix v2 `ErrorBoundary` 	| `@sentry/react` `ErrorBoundary` 	|
|------------------------------------	|:-------------:	|:---------------------------------:	|:---------------------------------:	|:------------------------:	|:-------------------------------:	|
| Runtime Browser Error              	|       -       	|                 -                 	|                 -                 	|            v2            	|                v1               	|
| SSR Rendering Error                	|       v2      	|                 -                 	|                 v1                	|             -            	|                -                	|
| `loader` / `action` Errors         	|       v2      	|                 v1                	|                 -                 	|             -            	|                -                	|
| Error Responses / Thrown Responses 	|       -       	|              v1 / v2              	|                 -                 	|             -            	|                -                	|
| Unexpected Server-side Errors      	|       v2      	|                 v1                	|                 -                 	|             -            	|                -                	|

This PR also adds:

- `Sentry.wrapRemixHandleError` to be assigned as `handleError` for `entry.server` (Needs docs / wizard support)
- New tests for SSR error capturing.
