### PR TITLE
build: Stop running overhead metrics in develop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -976,8 +976,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 30
     if: |
-      contains(github.event.pull_request.labels.*.name, 'ci-overhead-measurements') ||
-      needs.job_get_metadata.outputs.is_develop == 'true'
+      contains(github.event.pull_request.labels.*.name, 'ci-overhead-measurements')
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v4


### PR DESCRIPTION
<img width="990" alt="image" src="https://github.com/getsentry/sentry-javascript/assets/18689448/78214fb1-2eb4-4c0c-b6f1-0423583d03a5">
