### PR TITLE
chore(feedback): Adjust package resolutions for `@sentry-internal/feedback` in Remix and NextJS Integration tests

### DIFF
--- a/docs/new-sdk-release-checklist.md
+++ b/docs/new-sdk-release-checklist.md
@@ -49,6 +49,8 @@ This page serves as a checklist of what to do when releasing a new SDK for the f
 
 - [ ] Make sure it is added to the [Verdaccio config](https://github.com/getsentry/sentry-javascript/blob/develop/packages/e2e-tests/verdaccio-config/config.yaml) for the E2E tests
 
+- [ ] If the package you're adding is a dependency of fullstack frameworks (e.g. Remix or NextJS), make sure that your package is added to the integration test apps' `"resolutions"` field in their `package.json`s.
+
 ## Cutting the Release
 
 When you’re ready to make the first release, there are a couple of steps that need to be performed in the **correct order**. Note that you can prepare the PRs at any time but the **merging oder** is important:

--- a/packages/nextjs/test/integration/package.json
+++ b/packages/nextjs/test/integration/package.json
@@ -33,6 +33,7 @@
     "@sentry/replay": "file:../../../replay",
     "@sentry/tracing": "file:../../../tracing",
     "@sentry-internal/tracing": "file:../../../tracing-internal",
+    "@sentry-internal/feedback": "file:../../../feedback",
     "@sentry/types": "file:../../../types",
     "@sentry/utils": "file:../../../utils",
     "@sentry/vercel-edge": "file:../../../vercel-edge"

--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -31,6 +31,7 @@
     "@sentry/replay": "file:../../../replay",
     "@sentry/tracing": "file:../../../tracing",
     "@sentry-internal/tracing": "file:../../../tracing-internal",
+    "@sentry-internal/feedback": "file:../../../feedback",
     "@sentry/types": "file:../../../types",
     "@sentry/utils": "file:../../../utils",
     "@vanilla-extract/css": "1.13.0"


### PR DESCRIPTION
Exporting user feedback via @sentry/browser (https://github.com/getsentry/sentry-javascript/pull/9586) broke Remix and NextJS integration tests because they rely on local package resolutions. I'm not sure why CI didn't catch this but it's currently [blocking](https://github.com/getsentry/sentry-javascript/actions/runs/7089739847) the 7.85.0 release.

This PR adds the missing entries and updates the "New SDK/Package Release Checklist". Adding a package that's. a dependency of these framework SDKs happens so rarely that we probably didn't come across this yet.  

Once this is merged we need to sync develop into master and then we can try publishing again