### PR TITLE
fix(node): Guard `process.env.NODE_ENV` access in Spotlight integration

### DIFF
--- a/packages/node/src/integrations/spotlight.ts
+++ b/packages/node/src/integrations/spotlight.ts
@@ -41,8 +41,8 @@ export class Spotlight implements Integration {
    * Sets up forwarding envelopes to the Spotlight Sidecar
    */
   public setup(client: Client): void {
-    if (process.env.NODE_ENV !== 'development') {
-      logger.warn("[Spotlight] It seems you're not in dev mode. Do you really want to have Spoltight enabled?");
+    if (typeof process === 'object' && process.env && process.env.NODE_ENV !== 'development') {
+      logger.warn("[Spotlight] It seems you're not in dev mode. Do you really want to have Spotlight enabled?");
     }
     connectToSpotlight(client, this._options);
   }

--- a/packages/node/test/integrations/spotlight.test.ts
+++ b/packages/node/test/integrations/spotlight.test.ts
@@ -138,7 +138,7 @@ describe('Spotlight', () => {
     integration.setup(client);
 
     expect(loggerSpy).toHaveBeenCalledWith(
-      expect.stringContaining("It seems you're not in dev mode. Do you really want to have Spoltight enabled?"),
+      expect.stringContaining("It seems you're not in dev mode. Do you really want to have Spotlight enabled?"),
     );
 
     process.env.NODE_ENV = oldEnvValue;
@@ -152,9 +152,41 @@ describe('Spotlight', () => {
     integration.setup(client);
 
     expect(loggerSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining("It seems you're not in dev mode. Do you really want to have Spoltight enabled?"),
+      expect.stringContaining("It seems you're not in dev mode. Do you really want to have Spotlight enabled?"),
     );
 
     process.env.NODE_ENV = oldEnvValue;
+  });
+
+  it('handles `process` not being available', () => {
+    const originalProcess = process;
+
+    // @ts-expect-error - TS complains but we explicitly wanna test this
+    delete globalThis.process;
+
+    const integration = new Spotlight({ sidecarUrl: 'http://localhost:8969' });
+    integration.setup(client);
+
+    expect(loggerSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("It seems you're not in dev mode. Do you really want to have Spotlight enabled?"),
+    );
+
+    globalThis.process = originalProcess;
+  });
+
+  it('handles `process.env` not being available', () => {
+    const originalEnv = process.env;
+
+    // @ts-expect-error - TS complains but we explicitly wanna test this
+    delete process.env;
+
+    const integration = new Spotlight({ sidecarUrl: 'http://localhost:8969' });
+    integration.setup(client);
+
+    expect(loggerSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("It seems you're not in dev mode. Do you really want to have Spotlight enabled?"),
+    );
+
+    process.env = originalEnv;
   });
 });

--- a/packages/node/test/integrations/spotlight.test.ts
+++ b/packages/node/test/integrations/spotlight.test.ts
@@ -162,7 +162,7 @@ describe('Spotlight', () => {
     const originalProcess = process;
 
     // @ts-expect-error - TS complains but we explicitly wanna test this
-    delete globalThis.process;
+    delete global.process;
 
     const integration = new Spotlight({ sidecarUrl: 'http://localhost:8969' });
     integration.setup(client);
@@ -171,7 +171,7 @@ describe('Spotlight', () => {
       expect.stringContaining("It seems you're not in dev mode. Do you really want to have Spotlight enabled?"),
     );
 
-    globalThis.process = originalProcess;
+    global.process = originalProcess;
   });
 
   it('handles `process.env` not being available', () => {


### PR DESCRIPTION
Seems like the spotlight integration code is possibly ending up in places it shouldn't. 
While this PR doesn't adress this, it guards accessing `process.env.NODE_ENV` which we should do anyway.

Maybe addresses https://github.com/getsentry/sentry-javascript/issues/8377#issuecomment-1839948743
