### PR TITLE
ci: Add sentry cli and vite plugin to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,14 @@ updates:
       prefix: ci
       prefix-development: ci
       include: scope
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    allow:
+      - dependency-name: "@sentry/cli"
+      - dependency-name: "@sentry/vite-plugin"
+    commit-message:
+      prefix: feat
+      prefix-development: feat
+      include: scope


### PR DESCRIPTION
To make sure we keep up to date with sentry-cli and vite plugin deps, add dependabot reminders for them.

This is based on us forgetting to bump sentry-cli, causing issues like https://github.com/getsentry/sentry-javascript/pull/9740