### PR TITLE
fix(nextjs): Fix devserver CORS blockage when `assetPrefix` is defined

### DIFF
--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -122,7 +122,8 @@ function addClientIntegrations(options: BrowserOptions): void {
                 /^(?=.*localhost)(?!.*webpack\.hot-update\.json).*/,
                 /^\/(?!\/)/,
               ]
-            : [...defaultRequestInstrumentationOptions.tracingOrigins, /^(api\/)/],
+            : // eslint-disable-next-line deprecation/deprecation
+              [...defaultRequestInstrumentationOptions.tracingOrigins, /^(api\/)/],
         routingInstrumentation: nextRouterInstrumentation,
       });
 

--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -113,7 +113,16 @@ function addClientIntegrations(options: BrowserOptions): void {
     if (hasTracingEnabled(options)) {
       const defaultBrowserTracingIntegration = new BrowserTracing({
         // eslint-disable-next-line deprecation/deprecation
-        tracingOrigins: [...defaultRequestInstrumentationOptions.tracingOrigins, /^(api\/)/],
+        tracingOrigins:
+          process.env.NODE_ENV === 'development'
+            ? [
+                // Will match any URL that contains "localhost" but not "webpack.hot-update.json" - The webpack dev-server
+                // has cors and it doesn't like extra headers when it's accessed from a different URL.
+                // TODO(v8): Ideally we rework our tracePropagationTargets logic so this hack won't be necessary anymore (see issue #9764)
+                /^(?=.*localhost)(?!.*webpack\.hot-update\.json).*/,
+                /^\/(?!\/)/,
+              ]
+            : [...defaultRequestInstrumentationOptions.tracingOrigins, /^(api\/)/],
         routingInstrumentation: nextRouterInstrumentation,
       });
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/8727

When `assetPrefix` is defined the webpack dev server will live on that prefixed domain.

The SDK may attach tracing headers to the HMR server when the asset prefix is something like `http://cdn.localhost:3000` because we match on "localhost". Because this is then a different origin we run into CORS issues with the dev server.

This PR resolves that by special casing the `tracePropagationTargets` when Next.js is in dev mode. This is a bit of a hack for now.

Once we get to https://github.com/getsentry/sentry-javascript/issues/9764 we can remove the hack again.