### PR TITLE
fix(utils): Fix XHR instrumentation early return

### DIFF
--- a/packages/utils/src/instrument/xhr.ts
+++ b/packages/utils/src/instrument/xhr.ts
@@ -46,7 +46,7 @@ export function instrumentXHR(): void {
       const url = parseUrl(args[1]);
 
       if (!method || !url) {
-        return;
+        return originalOpen.apply(this, args);
       }
 
       this[SENTRY_XHR_DATA_KEY] = {
@@ -124,7 +124,7 @@ export function instrumentXHR(): void {
       const sentryXhrData = this[SENTRY_XHR_DATA_KEY];
 
       if (!sentryXhrData) {
-        return;
+        return originalSend.apply(this, args);
       }
 
       if (args[0] !== undefined) {


### PR DESCRIPTION
This was introduced in https://github.com/getsentry/sentry-javascript/pull/9542 😬 

Ideally we could have a lint rule for this, but probably this is rather hard to do - so reminder to self to keep an eye out for this in the future!

Closes https://github.com/getsentry/sentry-javascript/issues/9747

Note to reviewer(s): could you double check the file to make sure I didn't miss anything again? Just being cautious there...