### PR TITLE
fix(browser): Avoid importing from `./exports`

### DIFF
--- a/packages/browser/src/integrations/breadcrumbs.ts
+++ b/packages/browser/src/integrations/breadcrumbs.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { getCurrentHub } from '@sentry/core';
+import { getClient, getCurrentHub } from '@sentry/core';
 import type {
   Event as SentryEvent,
   HandlerDataConsole,
@@ -31,7 +31,6 @@ import {
 } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
-import { getClient } from '../exports';
 import { WINDOW } from '../helpers';
 
 /** JSDoc */

--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -1,12 +1,11 @@
 /* eslint-disable max-lines */
 
-import { DEFAULT_ENVIRONMENT, getCurrentHub } from '@sentry/core';
+import { DEFAULT_ENVIRONMENT, getClient, getCurrentHub } from '@sentry/core';
 import type { DebugImage, Envelope, Event, StackFrame, StackParser, Transaction } from '@sentry/types';
 import type { Profile, ThreadCpuProfile } from '@sentry/types/src/profiling';
 import { GLOBAL_OBJ, browserPerformanceTimeOrigin, forEachEnvelopeItem, logger, uuid4 } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
-import { getClient } from '../exports';
 import { WINDOW } from '../helpers';
 import type { JSSelfProfile, JSSelfProfileStack, JSSelfProfiler, JSSelfProfilerConstructor } from './jsSelfProfiling';
 


### PR DESCRIPTION
This has a side effect in `@sentry/browser`, so importing from there is not safe. Instead just directly import this from core.
