### PR TITLE
feat(types): Add profile envelope types

### DIFF
--- a/packages/browser/src/profiling/integration.ts
+++ b/packages/browser/src/profiling/integration.ts
@@ -1,4 +1,4 @@
-import type { EventProcessor, Hub, Integration, Transaction } from '@sentry/types';
+import type { EventEnvelope, EventProcessor, Hub, Integration, Transaction } from '@sentry/types';
 import type { Profile } from '@sentry/types/src/profiling';
 import { logger } from '@sentry/utils';
 
@@ -110,7 +110,7 @@ export class BrowserProfilingIntegration implements Integration {
           }
         }
 
-        addProfilesToEnvelope(envelope, profilesToAddToEnvelope);
+        addProfilesToEnvelope(envelope as EventEnvelope, profilesToAddToEnvelope);
       });
     } else {
       logger.warn('[Profiling] Client does not support hooks, profiling will be disabled');

--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -3,7 +3,14 @@
 import { DEFAULT_ENVIRONMENT, getClient, getCurrentHub } from '@sentry/core';
 import type { DebugImage, Envelope, Event, StackFrame, StackParser, Transaction } from '@sentry/types';
 import type { Profile, ThreadCpuProfile } from '@sentry/types/src/profiling';
-import { GLOBAL_OBJ, browserPerformanceTimeOrigin, forEachEnvelopeItem, logger, uuid4 } from '@sentry/utils';
+import {
+  GLOBAL_OBJ,
+  addItemToEnvelope,
+  browserPerformanceTimeOrigin,
+  forEachEnvelopeItem,
+  logger,
+  uuid4,
+} from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
 import { WINDOW } from '../helpers';
@@ -306,8 +313,7 @@ export function addProfilesToEnvelope(envelope: Envelope, profiles: Profile[]): 
   }
 
   for (const profile of profiles) {
-    // @ts-expect-error untyped envelope
-    envelope[1].push([{ type: 'profile' }, profile]);
+    addItemToEnvelope(envelope, [{ type: 'profile' }, profile]);
   }
   return envelope;
 }

--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -1,16 +1,9 @@
 /* eslint-disable max-lines */
 
 import { DEFAULT_ENVIRONMENT, getClient, getCurrentHub } from '@sentry/core';
-import type { DebugImage, Envelope, Event, StackFrame, StackParser, Transaction } from '@sentry/types';
+import type { DebugImage, Envelope, Event, EventEnvelope, StackFrame, StackParser, Transaction } from '@sentry/types';
 import type { Profile, ThreadCpuProfile } from '@sentry/types/src/profiling';
-import {
-  GLOBAL_OBJ,
-  addItemToEnvelope,
-  browserPerformanceTimeOrigin,
-  forEachEnvelopeItem,
-  logger,
-  uuid4,
-} from '@sentry/utils';
+import { GLOBAL_OBJ, browserPerformanceTimeOrigin, forEachEnvelopeItem, logger, uuid4 } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
 import { WINDOW } from '../helpers';
@@ -307,13 +300,13 @@ export function convertJSSelfProfileToSampledFormat(input: JSSelfProfile): Profi
  * Adds items to envelope if they are not already present - mutates the envelope.
  * @param envelope
  */
-export function addProfilesToEnvelope(envelope: Envelope, profiles: Profile[]): Envelope {
+export function addProfilesToEnvelope(envelope: EventEnvelope, profiles: Profile[]): Envelope {
   if (!profiles.length) {
     return envelope;
   }
 
   for (const profile of profiles) {
-    addItemToEnvelope(envelope, [{ type: 'profile' }, profile]);
+    envelope[1].push([{ type: 'profile' }, profile]);
   }
   return envelope;
 }

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -104,14 +104,13 @@ type StatsdEnvelopeHeaders = BaseEnvelopeHeaders;
 
 export type EventEnvelope = BaseEnvelope<
   EventEnvelopeHeaders,
-  EventItem | AttachmentItem | UserFeedbackItem | FeedbackItem
+  EventItem | AttachmentItem | UserFeedbackItem | FeedbackItem | ProfileItem
 >;
 export type SessionEnvelope = BaseEnvelope<SessionEnvelopeHeaders, SessionItem>;
 export type ClientReportEnvelope = BaseEnvelope<ClientReportEnvelopeHeaders, ClientReportItem>;
 export type ReplayEnvelope = [ReplayEnvelopeHeaders, [ReplayEventItem, ReplayRecordingItem]];
 export type CheckInEnvelope = BaseEnvelope<CheckInEnvelopeHeaders, CheckInItem>;
 export type StatsdEnvelope = BaseEnvelope<StatsdEnvelopeHeaders, StatsdItem>;
-export type ProfiledEventEnvelope = [EventEnvelopeHeaders, [EventItem, ProfileItem]];
 
 export type Envelope =
   | EventEnvelope
@@ -119,6 +118,5 @@ export type Envelope =
   | ClientReportEnvelope
   | ReplayEnvelope
   | CheckInEnvelope
-  | StatsdEnvelope
-  | ProfiledEventEnvelope;
+  | StatsdEnvelope;
 export type EnvelopeItem = Envelope[1][number];

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -3,6 +3,7 @@ import type { ClientReport } from './clientreport';
 import type { DsnComponents } from './dsn';
 import type { Event } from './event';
 import type { FeedbackEvent } from './feedback';
+import type { Profile } from './profiling';
 import type { ReplayEvent, ReplayRecordingData } from './replay';
 import type { SdkInfo } from './sdkinfo';
 import type { SerializedSession, Session, SessionAggregates } from './session';
@@ -77,6 +78,7 @@ type ReplayEventItemHeaders = { type: 'replay_event' };
 type ReplayRecordingItemHeaders = { type: 'replay_recording'; length: number };
 type CheckInItemHeaders = { type: 'check_in' };
 type StatsdItemHeaders = { type: 'statsd' };
+type ProfileItemHeaders = { type: 'profile' };
 
 export type EventItem = BaseEnvelopeItem<EventItemHeaders, Event>;
 export type AttachmentItem = BaseEnvelopeItem<AttachmentItemHeaders, string | Uint8Array>;
@@ -91,6 +93,7 @@ type ReplayEventItem = BaseEnvelopeItem<ReplayEventItemHeaders, ReplayEvent>;
 type ReplayRecordingItem = BaseEnvelopeItem<ReplayRecordingItemHeaders, ReplayRecordingData>;
 export type StatsdItem = BaseEnvelopeItem<StatsdItemHeaders, string>;
 export type FeedbackItem = BaseEnvelopeItem<FeedbackItemHeaders, FeedbackEvent>;
+export type ProfileItem = BaseEnvelopeItem<ProfileItemHeaders, Profile>;
 
 export type EventEnvelopeHeaders = { event_id: string; sent_at: string; trace?: DynamicSamplingContext };
 type SessionEnvelopeHeaders = { sent_at: string };
@@ -108,6 +111,7 @@ export type ClientReportEnvelope = BaseEnvelope<ClientReportEnvelopeHeaders, Cli
 export type ReplayEnvelope = [ReplayEnvelopeHeaders, [ReplayEventItem, ReplayRecordingItem]];
 export type CheckInEnvelope = BaseEnvelope<CheckInEnvelopeHeaders, CheckInItem>;
 export type StatsdEnvelope = BaseEnvelope<StatsdEnvelopeHeaders, StatsdItem>;
+export type ProfiledEventEnvelope = [EventEnvelopeHeaders, [EventItem, ProfileItem]];
 
 export type Envelope =
   | EventEnvelope
@@ -115,5 +119,6 @@ export type Envelope =
   | ClientReportEnvelope
   | ReplayEnvelope
   | CheckInEnvelope
-  | StatsdEnvelope;
+  | StatsdEnvelope
+  | ProfiledEventEnvelope;
 export type EnvelopeItem = Envelope[1][number];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -44,6 +44,7 @@ export type {
   CheckInEnvelope,
   StatsdItem,
   StatsdEnvelope,
+  ProfileItem,
 } from './envelope';
 export type { ExtendedError } from './error';
 export type { Event, EventHint, EventType, ErrorEvent, TransactionEvent } from './event';


### PR DESCRIPTION
As suggested [here](https://github.com/getsentry/sentry-electron/pull/799#discussion_r1423316213) by @AbhiPrasad, this PR adds types for profile envelopes.
