### PR TITLE
feat(node-experimental): Update to new Scope APIs

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,6 +44,7 @@ export { makeSession, closeSession, updateSession } from './session';
 export { SessionFlusher } from './sessionflusher';
 export { Scope } from './scope';
 export {
+  notifyEventProcessors,
   // eslint-disable-next-line deprecation/deprecation
   addGlobalEventProcessor,
 } from './eventProcessors';

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -46,7 +46,7 @@ function filterDuplicates(integrations: Integration[]): Integration[] {
 }
 
 /** Gets integrations to install */
-export function getIntegrationsToSetup(options: Options): Integration[] {
+export function getIntegrationsToSetup(options: Pick<Options, 'defaultIntegrations' | 'integrations'>): Integration[] {
   const defaultIntegrations = options.defaultIntegrations || [];
   const userIntegrations = options.integrations;
 

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -13,7 +13,29 @@ export { getAutoPerformanceIntegrations } from './integrations/getAutoPerformanc
 export * as Handlers from './sdk/handlers';
 export type { Span } from './types';
 
-export { startSpan, startInactiveSpan, getCurrentHub, getClient, getActiveSpan } from '@sentry/opentelemetry';
+export { startSpan, startInactiveSpan, getActiveSpan } from '@sentry/opentelemetry';
+export {
+  getClient,
+  addBreadcrumb,
+  captureException,
+  captureEvent,
+  captureMessage,
+  addGlobalEventProcessor,
+  addEventProcessor,
+  lastEventId,
+  setContext,
+  setExtra,
+  setExtras,
+  setTag,
+  setTags,
+  setUser,
+  withScope,
+  withIsolationScope,
+  // eslint-disable-next-line deprecation/deprecation
+  configureScope,
+} from './sdk/api';
+export { getCurrentHub, makeMain } from './sdk/hub';
+export { Scope } from './sdk/scope';
 
 export {
   makeNodeTransport,
@@ -24,36 +46,16 @@ export {
   extractRequestData,
   deepReadDirSync,
   getModuleFromFilename,
-  // eslint-disable-next-line deprecation/deprecation
-  addGlobalEventProcessor,
-  addEventProcessor,
-  addBreadcrumb,
-  captureException,
-  captureEvent,
-  captureMessage,
   close,
-  // eslint-disable-next-line deprecation/deprecation
-  configureScope,
   createTransport,
   // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
   flush,
-  getActiveTransaction,
   Hub,
-  lastEventId,
-  makeMain,
   runWithAsyncContext,
-  Scope,
   SDK_VERSION,
-  setContext,
-  setExtra,
-  setExtras,
-  setTag,
-  setTags,
-  setUser,
   spanStatusfromHttpCode,
   trace,
-  withScope,
   captureCheckIn,
   withMonitor,
   hapiErrorPlugin,

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -33,6 +33,11 @@ export {
   withIsolationScope,
   // eslint-disable-next-line deprecation/deprecation
   configureScope,
+  getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
+  setIsolationScope,
+  setCurrentScope,
 } from './sdk/api';
 export { getCurrentHub, makeMain } from './sdk/hub';
 export { Scope } from './sdk/scope';

--- a/packages/node-experimental/src/integrations/http.ts
+++ b/packages/node-experimental/src/integrations/http.ts
@@ -4,16 +4,14 @@ import { SpanKind } from '@opentelemetry/api';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
 import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { addBreadcrumb, hasTracingEnabled, isSentryRequestUrl } from '@sentry/core';
-import { _INTERNAL, getClient, getCurrentHub, getSpanKind, getSpanScope, setSpanMetadata } from '@sentry/opentelemetry';
+import { _INTERNAL, getClient, getCurrentHub, getSpanKind, setSpanMetadata } from '@sentry/opentelemetry';
 import type { EventProcessor, Hub, Integration } from '@sentry/types';
 import { stringMatchesSomePattern } from '@sentry/utils';
 
-import { getSpanContext } from '@opentelemetry/api/build/src/trace/context-utils';
 import { getIsolationScope, setIsolationScope } from '../sdk/api';
 import { Scope } from '../sdk/scope';
 import type { NodeExperimentalClient } from '../types';
 import { addOriginToSpan } from '../utils/addOriginToSpan';
-import { getScopesFromContext } from '../utils/contextData';
 import { getRequestUrl } from '../utils/getRequestUrl';
 
 interface HttpOptions {

--- a/packages/node-experimental/src/integrations/http.ts
+++ b/packages/node-experimental/src/integrations/http.ts
@@ -132,7 +132,7 @@ export class Http implements Integration {
 
             // Update the isolation scope, isolation this request
             if (getSpanKind(span) === SpanKind.SERVER) {
-              setIsolationScope(Scope.clone(getIsolationScope()));
+              setIsolationScope(getIsolationScope().clone());
             }
           },
           responseHook: (span, res) => {

--- a/packages/node-experimental/src/integrations/http.ts
+++ b/packages/node-experimental/src/integrations/http.ts
@@ -130,7 +130,7 @@ export class Http implements Integration {
           requestHook: (span, req) => {
             this._updateSpan(span, req);
 
-            // Update the isolation scope, isolation this request
+            // Update the isolation scope, isolate this request
             if (getSpanKind(span) === SpanKind.SERVER) {
               setIsolationScope(getIsolationScope().clone());
             }

--- a/packages/node-experimental/src/otel/asyncContextStrategy.ts
+++ b/packages/node-experimental/src/otel/asyncContextStrategy.ts
@@ -1,0 +1,29 @@
+import * as api from '@opentelemetry/api';
+
+import { setAsyncContextStrategy } from './../sdk/globals';
+import { getCurrentHub } from './../sdk/hub';
+import type { CurrentScopes } from './../sdk/types';
+import { getScopesFromContext } from './../utils/contextData';
+
+/**
+ * Sets the async context strategy to use follow the OTEL context under the hood.
+ * We handle forking a hub inside of our custom OTEL Context Manager (./otelContextManager.ts)
+ */
+export function setOpenTelemetryContextAsyncContextStrategy(): void {
+  function getScopes(): CurrentScopes | undefined {
+    const ctx = api.context.active();
+    return getScopesFromContext(ctx);
+  }
+
+  /* This is more or less a NOOP - we rely on the OTEL context manager for this */
+  function runWithAsyncContext<T>(callback: () => T): T {
+    const ctx = api.context.active();
+
+    // We depend on the otelContextManager to handle the context/hub
+    return api.context.with(ctx, () => {
+      return callback();
+    });
+  }
+
+  setAsyncContextStrategy({ getScopes, getCurrentHub, runWithAsyncContext });
+}

--- a/packages/node-experimental/src/otel/contextManager.ts
+++ b/packages/node-experimental/src/otel/contextManager.ts
@@ -31,7 +31,7 @@ export class SentryContextManager extends AsyncLocalStorageContextManager {
     const currentScope = previousScopes ? previousScopes.scope : getCurrentScope();
     const isolationScope = previousScopes ? previousScopes.isolationScope : getIsolationScope();
 
-    const newCurrentScope = Scope.clone(currentScope);
+    const newCurrentScope = currentScope.clone();
     const scopes: CurrentScopes = { scope: newCurrentScope, isolationScope };
 
     // We also need to "mock" the hub on the context, as the original @sentry/opentelemetry uses that...

--- a/packages/node-experimental/src/otel/contextManager.ts
+++ b/packages/node-experimental/src/otel/contextManager.ts
@@ -1,0 +1,45 @@
+import type { Context } from '@opentelemetry/api';
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
+import { setHubOnContext } from '@sentry/opentelemetry';
+import { getCurrentHub } from '../sdk/hub';
+
+import { getCurrentScope, getIsolationScope } from './../sdk/api';
+import { Scope } from './../sdk/scope';
+import type { CurrentScopes } from './../sdk/types';
+import { getScopesFromContext, setScopesOnContext } from './../utils/contextData';
+
+/**
+ * This is a custom ContextManager for OpenTelemetry, which extends the default AsyncLocalStorageContextManager.
+ * It ensures that we create a new hub per context, so that the OTEL Context & the Sentry Hub are always in sync.
+ *
+ * Note that we currently only support AsyncHooks with this,
+ * but since this should work for Node 14+ anyhow that should be good enough.
+ */
+export class SentryContextManager extends AsyncLocalStorageContextManager {
+  /**
+   * Overwrite with() of the original AsyncLocalStorageContextManager
+   * to ensure we also create a new hub per context.
+   */
+  public with<A extends unknown[], F extends (...args: A) => ReturnType<F>>(
+    context: Context,
+    fn: F,
+    thisArg?: ThisParameterType<F>,
+    ...args: A
+  ): ReturnType<F> {
+    const previousScopes = getScopesFromContext(context);
+
+    const currentScope = previousScopes ? previousScopes.scope : getCurrentScope();
+    const isolationScope = previousScopes ? previousScopes.isolationScope : getIsolationScope();
+
+    const newCurrentScope = Scope.clone(currentScope);
+    const scopes: CurrentScopes = { scope: newCurrentScope, isolationScope };
+
+    // We also need to "mock" the hub on the context, as the original @sentry/opentelemetry uses that...
+    const mockHub = { ...getCurrentHub(), getScope: () => scopes.scope };
+
+    const ctx1 = setHubOnContext(context, mockHub);
+    const ctx2 = setScopesOnContext(ctx1, scopes);
+
+    return super.with(ctx2, fn, thisArg, ...args);
+  }
+}

--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -69,6 +69,14 @@ export function getIsolationScope(): Scope {
 }
 
 /**
+ * Set the currently active isolation scope.
+ * Use this with caution! As it updates the isolation scope for the current execution context.
+ */
+export function setIsolationScope(isolationScope: Scope): void {
+  getScopes().isolationScope = isolationScope;
+}
+
+/**
  * Fork a scope from the current scope, and make it the current scope in the given callback
  */
 export function withScope<T>(callback: (scope: Scope) => T): T {

--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -21,7 +21,8 @@ import type {
 import { GLOBAL_OBJ, consoleSandbox, dateTimestampInSeconds } from '@sentry/utils';
 
 import { getScopesFromContext, setScopesOnContext } from '../utils/contextData';
-import { ExclusiveEventHintOrCaptureContext, parseEventHintOrCaptureContext } from '../utils/prepareEvent';
+import type { ExclusiveEventHintOrCaptureContext} from '../utils/prepareEvent';
+import { parseEventHintOrCaptureContext } from '../utils/prepareEvent';
 import { getGlobalCarrier } from './globals';
 import { Scope } from './scope';
 import type { CurrentScopes, SentryCarrier } from './types';

--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -70,12 +70,12 @@ export function configureScope(callback: (scope: Scope) => void): void {
   callback(getCurrentScope());
 }
 
-/** Capture an exception to Sentry. */
+/** Record an exception and send it to Sentry. */
 export function captureException(exception: unknown, hint?: ExclusiveEventHintOrCaptureContext): string {
   return getCurrentScope().captureException(exception, parseEventHintOrCaptureContext(hint));
 }
 
-/** Capture a message to Sentry. */
+/** Record a message and send it to Sentry. */
 export function captureMessage(
   message: string,
   // eslint-disable-next-line deprecation/deprecation
@@ -89,13 +89,13 @@ export function captureMessage(
   return getCurrentScope().captureMessage(message, level, context);
 }
 
-/** Capture a generic event to Sentry. */
+/** Capture a generic event and send it to Sentry. */
 export function captureEvent(event: Event, hint?: EventHint): string {
   return getCurrentScope().captureEvent(event, hint);
 }
 
 /**
- * Add a breadcrumb.
+ * Add a breadcrumb to the current isolation scope.
  */
 export function addBreadcrumb(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): void {
   const client = getClient();
@@ -127,7 +127,7 @@ export function addGlobalEventProcessor(eventProcessor: EventProcessor): void {
 }
 
 /**
- * Add an event processor to the current isolation scope..
+ * Add an event processor to the current isolation scope.
  */
 export function addEventProcessor(eventProcessor: EventProcessor): void {
   getIsolationScope().addEventProcessor(eventProcessor);

--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -44,7 +44,7 @@ export function getClient<C extends Client>(): C {
 
 /** Get the current scope. */
 export function getCurrentScope(): Scope {
-  return getScopes().scope;
+  return getScopes().scope as Scope;
 }
 
 /**
@@ -63,12 +63,12 @@ export function getGlobalScope(): Scope {
     carrier.globalScope = new Scope();
   }
 
-  return carrier.globalScope;
+  return carrier.globalScope as Scope;
 }
 
 /** Get the currently active isolation scope. */
 export function getIsolationScope(): Scope {
-  return getScopes().isolationScope;
+  return getScopes().isolationScope as Scope;
 }
 
 /**

--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -100,7 +100,7 @@ export function withIsolationScope<T>(callback: (scope: Scope, isolationScope: S
         isolationScope: getIsolationScope(),
       };
 
-  scopes.isolationScope = Scope.clone(scopes.isolationScope);
+  scopes.isolationScope = scopes.isolationScope.clone();
 
   return context.with(setScopesOnContext(ctx, scopes), () => {
     return callback(getCurrentScope(), getIsolationScope());

--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -21,7 +21,7 @@ import type {
 import { GLOBAL_OBJ, consoleSandbox, dateTimestampInSeconds } from '@sentry/utils';
 
 import { getScopesFromContext, setScopesOnContext } from '../utils/contextData';
-import type { ExclusiveEventHintOrCaptureContext} from '../utils/prepareEvent';
+import type { ExclusiveEventHintOrCaptureContext } from '../utils/prepareEvent';
 import { parseEventHintOrCaptureContext } from '../utils/prepareEvent';
 import { getGlobalCarrier } from './globals';
 import { Scope } from './scope';

--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -1,0 +1,285 @@
+// PUBLIC APIS
+
+import { context } from '@opentelemetry/api';
+import { DEFAULT_ENVIRONMENT, closeSession, makeSession, updateSession } from '@sentry/core';
+import type {
+  Breadcrumb,
+  BreadcrumbHint,
+  Client,
+  Event,
+  EventHint,
+  EventProcessor,
+  Extra,
+  Extras,
+  Primitive,
+  Session,
+  Severity,
+  SeverityLevel,
+  User,
+} from '@sentry/types';
+import { GLOBAL_OBJ, consoleSandbox, dateTimestampInSeconds, logger } from '@sentry/utils';
+
+import { getScopesFromContext, setScopesOnContext } from '../utils/contextData';
+import { getGlobalCarrier } from './globals';
+import { Scope } from './scope';
+import type { CurrentScopes, SentryCarrier } from './types';
+
+/** Get the currently active client. */
+export function getClient<C extends Client>(): C {
+  const currentScope = getCurrentScope();
+  const isolationScope = getIsolationScope();
+  const globalScope = getGlobalScope();
+
+  const client = currentScope.getClient() || isolationScope.getClient() || globalScope.getClient();
+  if (client) {
+    return client as C;
+  }
+
+  // TODO otherwise ensure we use a noop client
+  return {} as C;
+}
+
+/** Get the current scope. */
+export function getCurrentScope(): Scope {
+  return getScopes().scope;
+}
+
+/**
+ * Set the current scope on the execution context.
+ * This should mostly only be called in Sentry.init()
+ */
+export function setCurrentScope(scope: Scope): void {
+  getScopes().scope = scope;
+}
+
+/** Get the global scope. */
+export function getGlobalScope(): Scope {
+  const carrier = getGlobalCarrier();
+
+  if (!carrier.globalScope) {
+    carrier.globalScope = new Scope();
+  }
+
+  return carrier.globalScope;
+}
+
+/** Get the currently active isolation scope. */
+export function getIsolationScope(): Scope {
+  return getScopes().isolationScope;
+}
+
+/**
+ * Fork a scope from the current scope, and make it the current scope in the given callback
+ */
+export function withScope<T>(callback: (scope: Scope) => T): T {
+  return context.with(context.active(), () => callback(getCurrentScope()));
+}
+
+/**
+ * Fork a scope from the current scope, and make it the current scope in the given callback.
+ * Additionally, also setup a new isolation scope for the callback.
+ */
+export function withIsolationScope<T>(callback: (scope: Scope, isolationScope: Scope) => T): T {
+  const ctx = context.active();
+  const currentScopes = getScopesFromContext(ctx);
+  const scopes = currentScopes
+    ? { ...currentScopes }
+    : {
+        scope: getCurrentScope(),
+        isolationScope: getIsolationScope(),
+      };
+
+  scopes.isolationScope = Scope.clone(scopes.isolationScope);
+
+  return context.with(setScopesOnContext(ctx, scopes), () => {
+    return callback(getCurrentScope(), getIsolationScope());
+  });
+}
+
+/** Get the ID of the last sent error event. */
+export function lastEventId(): string | undefined {
+  return getCurrentScope().lastEventId();
+}
+
+/**
+ * Configure the current scope.
+ * @deprecated Use `getCurrentScope()` instead.
+ */
+export function configureScope(callback: (scope: Scope) => void): void {
+  callback(getCurrentScope());
+}
+
+/** Capture an exception to Sentry. */
+export function captureException(exception: unknown, hint?: EventHint): string {
+  return getCurrentScope().captureException(exception, hint);
+}
+
+/** Capture a message to Sentry. */
+export function captureMessage(
+  message: string,
+  // eslint-disable-next-line deprecation/deprecation
+  level?: Severity | SeverityLevel,
+  hint?: EventHint,
+): string {
+  return getCurrentScope().captureMessage(message, level, hint);
+}
+
+/** Capture a generic event to Sentry. */
+export function captureEvent(event: Event, hint?: EventHint): string {
+  return getCurrentScope().captureEvent(event, hint);
+}
+
+/**
+ * Add a breadcrumb.
+ */
+export function addBreadcrumb(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): void {
+  const client = getClient();
+
+  const { beforeBreadcrumb, maxBreadcrumbs } = client.getOptions();
+
+  if (maxBreadcrumbs && maxBreadcrumbs <= 0) return;
+
+  const timestamp = dateTimestampInSeconds();
+  const mergedBreadcrumb = { timestamp, ...breadcrumb };
+  const finalBreadcrumb = beforeBreadcrumb
+    ? (consoleSandbox(() => beforeBreadcrumb(mergedBreadcrumb, hint)) as Breadcrumb | null)
+    : mergedBreadcrumb;
+
+  if (finalBreadcrumb === null) return;
+
+  if (client.emit) {
+    client.emit('beforeAddBreadcrumb', finalBreadcrumb, hint);
+  }
+
+  getIsolationScope().addBreadcrumb(finalBreadcrumb, maxBreadcrumbs);
+}
+
+/**
+ * Add a global event processor.
+ */
+export function addGlobalEventProcessor(eventProcessor: EventProcessor): void {
+  getGlobalScope().addEventProcessor(eventProcessor);
+}
+
+/**
+ * Add an event processor to the current isolation scope..
+ */
+export function addEventProcessor(eventProcessor: EventProcessor): void {
+  getIsolationScope().addEventProcessor(eventProcessor);
+}
+
+/** Set the user for the current isolation scope. */
+export function setUser(user: User | null): void {
+  getIsolationScope().setUser(user);
+}
+
+/** Set tags for the current isolation scope. */
+export function setTags(tags: { [key: string]: Primitive }): void {
+  getIsolationScope().setTags(tags);
+}
+
+/** Set a single tag user for the current isolation scope. */
+export function setTag(key: string, value: Primitive): void {
+  getIsolationScope().setTag(key, value);
+}
+
+/** Set extra data for the current isolation scope. */
+export function setExtra(key: string, extra: Extra): void {
+  getIsolationScope().setExtra(key, extra);
+}
+
+/** Set multiple extra data for the current isolation scope. */
+export function setExtras(extras: Extras): void {
+  getIsolationScope().setExtras(extras);
+}
+
+/** Set context data for the current isolation scope. */
+export function setContext(
+  name: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  context: { [key: string]: any } | null,
+): void {
+  getIsolationScope().setContext(name, context);
+}
+
+/** Start a session on the current isolation scope. */
+export function startSession(context?: Session): Session {
+  const client = getClient();
+  const scope = getIsolationScope();
+
+  const { release, environment = DEFAULT_ENVIRONMENT } = client.getOptions();
+
+  // Will fetch userAgent if called from browser sdk
+  const { userAgent } = GLOBAL_OBJ.navigator || {};
+
+  const session = makeSession({
+    release,
+    environment,
+    user: scope.getUser(),
+    ...(userAgent && { userAgent }),
+    ...context,
+  });
+
+  // End existing session if there's one
+  const currentSession = scope.getSession && scope.getSession();
+  if (currentSession && currentSession.status === 'ok') {
+    updateSession(currentSession, { status: 'exited' });
+  }
+  endSession();
+
+  // Afterwards we set the new session on the scope
+  scope.setSession(session);
+
+  return session;
+}
+
+/** End the session on the current isolation scope. */
+export function endSession(): void {
+  const scope = getIsolationScope();
+  const session = scope.getSession();
+  if (session) {
+    closeSession(session);
+  }
+  _sendSessionUpdate();
+
+  // the session is over; take it off of the scope
+  scope.setSession();
+}
+
+function getScopes(): CurrentScopes {
+  const carrier = getGlobalCarrier();
+
+  if (carrier.acs && carrier.acs.getScopes) {
+    const scopes = carrier.acs.getScopes();
+
+    if (scopes) {
+      return scopes;
+    }
+  }
+
+  return getGlobalCurrentScopes(carrier);
+}
+
+function getGlobalCurrentScopes(carrier: SentryCarrier): CurrentScopes {
+  if (!carrier.scopes) {
+    carrier.scopes = {
+      scope: new Scope(),
+      isolationScope: new Scope(),
+    };
+  }
+
+  return carrier.scopes;
+}
+
+/**
+ * Sends the current Session on the scope
+ */
+function _sendSessionUpdate(): void {
+  const scope = getCurrentScope();
+  const client = getClient();
+
+  const session = scope.getSession();
+  if (session && client.captureSession) {
+    client.captureSession(session);
+  }
+}

--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -37,10 +37,10 @@ export function withScope<T>(callback: (scope: Scope) => T): T {
 }
 
 /**
- * Fork a scope from the current scope, and make it the current scope in the given callback.
- * Additionally, also setup a new isolation scope for the callback.
+ * For a new isolation scope from the current isolation scope,
+ * and make it the current isolation scope in the given callback.
  */
-export function withIsolationScope<T>(callback: (scope: Scope, isolationScope: Scope) => T): T {
+export function withIsolationScope<T>(callback: (isolationScope: Scope) => T): T {
   const ctx = context.active();
   const currentScopes = getScopesFromContext(ctx);
   const scopes = currentScopes
@@ -53,7 +53,7 @@ export function withIsolationScope<T>(callback: (scope: Scope, isolationScope: S
   scopes.isolationScope = scopes.isolationScope.clone();
 
   return context.with(setScopesOnContext(ctx, scopes), () => {
-    return callback(getCurrentScope(), getIsolationScope());
+    return callback(getIsolationScope());
   });
 }
 

--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -170,7 +170,7 @@ export function setContext(
 /** Start a session on the current isolation scope. */
 export function startSession(context?: Session): Session {
   const client = getClient();
-  const scope = getIsolationScope();
+  const isolationScope = getIsolationScope();
 
   const { release, environment = DEFAULT_ENVIRONMENT } = client.getOptions();
 
@@ -180,35 +180,35 @@ export function startSession(context?: Session): Session {
   const session = makeSession({
     release,
     environment,
-    user: scope.getUser(),
+    user: isolationScope.getUser(),
     ...(userAgent && { userAgent }),
     ...context,
   });
 
   // End existing session if there's one
-  const currentSession = scope.getSession && scope.getSession();
+  const currentSession = isolationScope.getSession && isolationScope.getSession();
   if (currentSession && currentSession.status === 'ok') {
     updateSession(currentSession, { status: 'exited' });
   }
   endSession();
 
   // Afterwards we set the new session on the scope
-  scope.setSession(session);
+  isolationScope.setSession(session);
 
   return session;
 }
 
 /** End the session on the current isolation scope. */
 export function endSession(): void {
-  const scope = getIsolationScope();
-  const session = scope.getSession();
+  const isolationScope = getIsolationScope();
+  const session = isolationScope.getSession();
   if (session) {
     closeSession(session);
   }
   _sendSessionUpdate();
 
   // the session is over; take it off of the scope
-  scope.setSession();
+  isolationScope.setSession();
 }
 
 /**

--- a/packages/node-experimental/src/sdk/client.ts
+++ b/packages/node-experimental/src/sdk/client.ts
@@ -64,7 +64,7 @@ export class NodeExperimentalClient extends NodeClient {
 
     // Remove `captureContext` hint and instead clone already here
     if (hint && hint.captureContext) {
-      actualScope = getFinalScope(scope, hint.captureContext);
+      actualScope = getScopeForEvent(scope, hint.captureContext);
       delete hint.captureContext;
     }
 
@@ -72,7 +72,7 @@ export class NodeExperimentalClient extends NodeClient {
   }
 }
 
-function getFinalScope(scope: Scope | undefined, captureContext: CaptureContext): Scope | undefined {
+function getScopeForEvent(scope: Scope | undefined, captureContext: CaptureContext): Scope | undefined {
   const finalScope = scope ? scope.clone() : new Scope();
   finalScope.update(captureContext);
   return finalScope;

--- a/packages/node-experimental/src/sdk/globals.ts
+++ b/packages/node-experimental/src/sdk/globals.ts
@@ -1,0 +1,38 @@
+import type { Hub } from '@sentry/types';
+import { GLOBAL_OBJ, logger } from '@sentry/utils';
+import { DEBUG_BUILD } from '../debug-build';
+
+import type { AsyncContextStrategy, SentryCarrier } from './types';
+
+/** Update the async context strategy */
+export function setAsyncContextStrategy(strategy: AsyncContextStrategy | undefined): void {
+  const carrier = getGlobalCarrier();
+  carrier.acs = strategy;
+}
+
+/**
+ * Returns the global shim registry.
+ **/
+export function getGlobalCarrier(): SentryCarrier {
+  GLOBAL_OBJ.__SENTRY__ = GLOBAL_OBJ.__SENTRY__ || {
+    extensions: {},
+    // For legacy reasons...
+    globalEventProcessors: [],
+  };
+
+  return GLOBAL_OBJ.__SENTRY__;
+}
+
+/**
+ * Calls global extension method and binding current instance to the function call
+ */
+// @ts-expect-error Function lacks ending return statement and return type does not include 'undefined'. ts(2366)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function callExtensionMethod<T>(hub: Hub, method: string, ...args: any[]): T {
+  const carrier = getGlobalCarrier();
+
+  if (carrier.extensions && typeof carrier.extensions[method] === 'function') {
+    return carrier.extensions[method].apply(hub, args);
+  }
+  DEBUG_BUILD && logger.warn(`Extension method ${method} couldn't be found, doing nothing.`);
+}

--- a/packages/node-experimental/src/sdk/hub.ts
+++ b/packages/node-experimental/src/sdk/hub.ts
@@ -1,0 +1,158 @@
+import type {
+  Client,
+  CustomSamplingContext,
+  Hub,
+  Integration,
+  IntegrationClass,
+  Session,
+  TransactionContext,
+} from '@sentry/types';
+
+import {
+  addBreadcrumb,
+  captureEvent,
+  captureException,
+  captureMessage,
+  configureScope,
+  endSession,
+  getClient,
+  getCurrentScope,
+  lastEventId,
+  setContext,
+  setExtra,
+  setExtras,
+  setTag,
+  setTags,
+  setUser,
+  startSession,
+  withScope,
+} from './api';
+import { callExtensionMethod, getGlobalCarrier } from './globals';
+import type { Scope } from './scope';
+import type { SentryCarrier } from './types';
+
+/** Ensure the global hub is our proxied hub. */
+export function setupGlobalHub(): void {
+  const carrier = getGlobalCarrier();
+  carrier.hub = getCurrentHub();
+}
+
+/**
+ * This is for legacy reasons, and returns a proxy object instead of a hub to be used.
+ */
+export function getCurrentHub(): Hub {
+  return {
+    isOlderThan(_version: number): boolean {
+      return false;
+    },
+
+    bindClient(client: Client): void {
+      const scope = getCurrentScope();
+      scope.setClient(client);
+    },
+
+    pushScope(): Scope {
+      // TODO: This does not work and is actually deprecated
+      return getCurrentScope();
+    },
+
+    popScope(): boolean {
+      // TODO: This does not work and is actually deprecated
+      return false;
+    },
+
+    withScope,
+    getClient,
+    getScope: getCurrentScope,
+    captureException,
+    captureMessage,
+    captureEvent,
+    lastEventId,
+    addBreadcrumb,
+    setUser,
+    setTags,
+    setTag,
+    setExtra,
+    setExtras,
+    setContext,
+    // eslint-disable-next-line deprecation/deprecation
+    configureScope: configureScope,
+
+    run(callback: (hub: Hub) => void): void {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return withScope(() => callback(this as any));
+    },
+
+    getIntegration<T extends Integration>(integration: IntegrationClass<T>): T | null {
+      return getClient().getIntegration(integration);
+    },
+
+    traceHeaders(): { [key: string]: string } {
+      return callExtensionMethod<{ [key: string]: string }>(this, 'traceHeaders');
+    },
+
+    startTransaction(
+      _context: TransactionContext,
+      _customSamplingContext?: CustomSamplingContext,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ): any {
+      // eslint-disable-next-line no-console
+      console.warn('startTransaction is a noop in @sentry/node-experimental. Use `startSpan` instead.');
+      // We return an object here as hub.ts checks for the result of this
+      // and renders a different warning if this is empty
+      return {};
+    },
+
+    startSession,
+
+    endSession,
+
+    captureSession(endSession?: boolean): void {
+      // both send the update and pull the session from the scope
+      if (endSession) {
+        return this.endSession();
+      }
+
+      // only send the update
+      _sendSessionUpdate();
+    },
+
+    shouldSendDefaultPii(): boolean {
+      const client = getClient();
+      const options = client.getOptions();
+      return Boolean(options.sendDefaultPii);
+    },
+  };
+}
+
+/**
+ * Replaces the current main hub with the passed one on the global object
+ *
+ * @returns The old replaced hub
+ */
+export function makeMain(hub: Hub): Hub {
+  // eslint-disable-next-line no-console
+  console.warn('makeMain is a noop in @sentry/node-experimental. Use `setCurrentScope` instead.');
+  return hub;
+}
+
+/**
+ * Sends the current Session on the scope
+ */
+function _sendSessionUpdate(): void {
+  const scope = getCurrentScope();
+  const client = getClient();
+
+  const session = scope.getSession();
+  if (session && client.captureSession) {
+    client.captureSession(session);
+  }
+}
+
+/**
+ * Set a mocked hub on the current carrier.
+ */
+export function setLegacyHubOnCarrier(carrier: SentryCarrier): boolean {
+  carrier.hub = getCurrentHub();
+  return true;
+}

--- a/packages/node-experimental/src/sdk/hub.ts
+++ b/packages/node-experimental/src/sdk/hub.ts
@@ -1,10 +1,13 @@
 import type {
   Client,
   CustomSamplingContext,
+  EventHint,
   Hub,
   Integration,
   IntegrationClass,
   Session,
+  Severity,
+  SeverityLevel,
   TransactionContext,
 } from '@sentry/types';
 
@@ -64,8 +67,17 @@ export function getCurrentHub(): Hub {
     withScope,
     getClient,
     getScope: getCurrentScope,
-    captureException,
-    captureMessage,
+    captureException: (exception: unknown, hint?: EventHint) => {
+      return getCurrentScope().captureException(exception, hint);
+    },
+    captureMessage: (
+      message: string,
+      // eslint-disable-next-line deprecation/deprecation
+      level?: Severity | SeverityLevel,
+      hint?: EventHint,
+    ) => {
+      return getCurrentScope().captureMessage(message, level, hint);
+    },
     captureEvent,
     lastEventId,
     addBreadcrumb,

--- a/packages/node-experimental/src/sdk/init.ts
+++ b/packages/node-experimental/src/sdk/init.ts
@@ -1,15 +1,32 @@
-import { hasTracingEnabled } from '@sentry/core';
-import type { NodeClient } from '@sentry/node';
-import { defaultIntegrations as defaultNodeIntegrations, init as initNode } from '@sentry/node';
-import { setOpenTelemetryContextAsyncContextStrategy, setupGlobalHub } from '@sentry/opentelemetry';
+import { getIntegrationsToSetup, hasTracingEnabled } from '@sentry/core';
+import {
+  Integrations,
+  defaultIntegrations as defaultNodeIntegrations,
+  defaultStackParser,
+  getSentryRelease,
+  isAnrChildProcess,
+  makeNodeTransport,
+} from '@sentry/node';
 import type { Integration } from '@sentry/types';
-import { parseSemver } from '@sentry/utils';
+import {
+  consoleSandbox,
+  dropUndefinedKeys,
+  logger,
+  parseSemver,
+  stackParserFromStackParserOptions,
+  tracingContextFromHeaders,
+} from '@sentry/utils';
+import { DEBUG_BUILD } from '../debug-build';
 
 import { getAutoPerformanceIntegrations } from '../integrations/getAutoPerformanceIntegrations';
 import { Http } from '../integrations/http';
 import { NodeFetch } from '../integrations/node-fetch';
-import type { NodeExperimentalOptions } from '../types';
+import { setOpenTelemetryContextAsyncContextStrategy } from '../otel/asyncContextStrategy';
+import type { NodeExperimentalClientOptions, NodeExperimentalOptions } from '../types';
+import { endSession, getClient, getCurrentScope, getGlobalScope, getIsolationScope, startSession } from './api';
 import { NodeExperimentalClient } from './client';
+import { getGlobalCarrier } from './globals';
+import { setLegacyHubOnCarrier } from './hub';
 import { initOtel } from './initOtel';
 
 const NODE_VERSION: ReturnType<typeof parseSemver> = parseSemver(process.versions.node);
@@ -29,24 +46,172 @@ if (NODE_VERSION.major && NODE_VERSION.major >= 16) {
  * Initialize Sentry for Node.
  */
 export function init(options: NodeExperimentalOptions | undefined = {}): void {
-  setupGlobalHub();
+  const clientOptions = getClientOptions(options);
+
+  if (clientOptions.debug === true) {
+    if (DEBUG_BUILD) {
+      logger.enable();
+    } else {
+      // use `console.warn` rather than `logger.warn` since by non-debug bundles have all `logger.x` statements stripped
+      consoleSandbox(() => {
+        // eslint-disable-next-line no-console
+        console.warn('[Sentry] Cannot initialize SDK with `debug` option using a non-debug bundle.');
+      });
+    }
+  }
+
+  const scope = getCurrentScope();
+  scope.update(options.initialScope);
+
+  const client = new NodeExperimentalClient(clientOptions);
+  // The client is on the global scope, from where it generally is inherited
+  // unless somebody specifically sets a different one on a scope/isolations cope
+  getGlobalScope().setClient(client);
+
+  client.setupIntegrations();
+
+  if (options.autoSessionTracking) {
+    startSessionTracking();
+  }
+
+  updateScopeFromEnvVariables();
+
+  if (options.spotlight) {
+    const client = getClient();
+    if (client.addIntegration) {
+      // force integrations to be setup even if no DSN was set
+      client.setupIntegrations(true);
+      client.addIntegration(
+        new Integrations.Spotlight({
+          sidecarUrl: typeof options.spotlight === 'string' ? options.spotlight : undefined,
+        }),
+      );
+    }
+  }
+
+  // Always init Otel, even if tracing is disabled, because we need it for trace propagation & the HTTP integration
+  initOtel();
+  setOpenTelemetryContextAsyncContextStrategy();
+}
+
+function getClientOptions(options: NodeExperimentalOptions): NodeExperimentalClientOptions {
+  const carrier = getGlobalCarrier();
+  setLegacyHubOnCarrier(carrier);
 
   const isTracingEnabled = hasTracingEnabled(options);
 
-  options.defaultIntegrations =
+  const autoloadedIntegrations = carrier.integrations || [];
+
+  const fullDefaultIntegrations =
     options.defaultIntegrations === false
       ? []
       : [
           ...(Array.isArray(options.defaultIntegrations) ? options.defaultIntegrations : defaultIntegrations),
           ...(isTracingEnabled ? getAutoPerformanceIntegrations() : []),
+          ...autoloadedIntegrations,
         ];
 
-  options.instrumenter = 'otel';
-  options.clientClass = NodeExperimentalClient as unknown as typeof NodeClient;
+  const release = getRelease(options.release);
 
-  initNode(options);
+  // If there is no release, or we are in an ANR child process, we disable autoSessionTracking by default
+  const autoSessionTracking =
+    typeof release !== 'string' || isAnrChildProcess()
+      ? false
+      : options.autoSessionTracking === undefined
+        ? true
+        : options.autoSessionTracking;
+  // We enforce tracesSampleRate = 0 in ANR child processes
+  const tracesSampleRate = isAnrChildProcess() ? 0 : getTracesSampleRate(options.tracesSampleRate);
 
-  // Always init Otel, even if tracing is disabled, because we need it for trace propagation & the HTTP integration
-  initOtel();
-  setOpenTelemetryContextAsyncContextStrategy();
+  const baseOptions = dropUndefinedKeys({
+    transport: makeNodeTransport,
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.SENTRY_ENVIRONMENT,
+  });
+
+  const overwriteOptions = dropUndefinedKeys({
+    release,
+    autoSessionTracking,
+    tracesSampleRate,
+  });
+
+  const clientOptions: NodeExperimentalClientOptions = {
+    ...baseOptions,
+    ...options,
+    ...overwriteOptions,
+    instrumenter: 'otel',
+    stackParser: stackParserFromStackParserOptions(options.stackParser || defaultStackParser),
+    integrations: getIntegrationsToSetup({
+      defaultIntegrations: fullDefaultIntegrations,
+      integrations: options.integrations,
+    }),
+  };
+
+  return clientOptions;
+}
+
+function getRelease(release: NodeExperimentalOptions['release']): string | undefined {
+  if (release !== undefined) {
+    return release;
+  }
+
+  const detectedRelease = getSentryRelease();
+  if (detectedRelease !== undefined) {
+    return detectedRelease;
+  }
+
+  return undefined;
+}
+
+function getTracesSampleRate(tracesSampleRate: NodeExperimentalOptions['tracesSampleRate']): number | undefined {
+  if (tracesSampleRate !== undefined) {
+    return tracesSampleRate;
+  }
+
+  const sampleRateFromEnv = process.env.SENTRY_TRACES_SAMPLE_RATE;
+  if (!sampleRateFromEnv) {
+    return undefined;
+  }
+
+  const parsed = parseFloat(sampleRateFromEnv);
+  return isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * Update scope and propagation context based on environmental variables.
+ *
+ * See https://github.com/getsentry/rfcs/blob/main/text/0071-continue-trace-over-process-boundaries.md
+ * for more details.
+ */
+function updateScopeFromEnvVariables(): void {
+  const sentryUseEnvironment = (process.env.SENTRY_USE_ENVIRONMENT || '').toLowerCase();
+  if (!['false', 'n', 'no', 'off', '0'].includes(sentryUseEnvironment)) {
+    const sentryTraceEnv = process.env.SENTRY_TRACE;
+    const baggageEnv = process.env.SENTRY_BAGGAGE;
+    const { propagationContext } = tracingContextFromHeaders(sentryTraceEnv, baggageEnv);
+    getCurrentScope().setPropagationContext(propagationContext);
+  }
+}
+
+/**
+ * Enable automatic Session Tracking for the node process.
+ */
+function startSessionTracking(): void {
+  startSession();
+
+  // Emitted in the case of healthy sessions, error of `mechanism.handled: true` and unhandledrejections because
+  // The 'beforeExit' event is not emitted for conditions causing explicit termination,
+  // such as calling process.exit() or uncaught exceptions.
+  // Ref: https://nodejs.org/api/process.html#process_event_beforeexit
+  process.on('beforeExit', () => {
+    const session = getIsolationScope().getSession();
+
+    // Only call endSession, if the Session exists on Scope and SessionStatus is not a
+    // Terminal Status i.e. Exited or Crashed because
+    // "When a session is moved away from ok it must not be updated anymore."
+    // Ref: https://develop.sentry.dev/sdk/sessions/
+    if (session && session.status !== 'ok') {
+      endSession();
+    }
+  });
 }

--- a/packages/node-experimental/src/sdk/initOtel.ts
+++ b/packages/node-experimental/src/sdk/initOtel.ts
@@ -1,20 +1,15 @@
 import { DiagLogLevel, diag } from '@opentelemetry/api';
-import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
 import { Resource } from '@opentelemetry/resources';
 import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { SDK_VERSION } from '@sentry/core';
-import {
-  SentryPropagator,
-  SentrySampler,
-  getClient,
-  setupEventContextTrace,
-  wrapContextManagerClass,
-} from '@sentry/opentelemetry';
+import { SentryPropagator, SentrySampler, setupEventContextTrace } from '@sentry/opentelemetry';
 import { logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
+import { SentryContextManager } from '../otel/contextManager';
 import type { NodeExperimentalClient } from '../types';
+import { getClient } from './api';
 import { NodeExperimentalSentrySpanProcessor } from './spanProcessor';
 
 /**
@@ -61,8 +56,6 @@ export function setupOtel(client: NodeExperimentalClient): BasicTracerProvider {
     forceFlushTimeoutMillis: 500,
   });
   provider.addSpanProcessor(new NodeExperimentalSentrySpanProcessor());
-
-  const SentryContextManager = wrapContextManagerClass(AsyncLocalStorageContextManager);
 
   // Initialize the provider
   provider.register({

--- a/packages/node-experimental/src/sdk/scope.ts
+++ b/packages/node-experimental/src/sdk/scope.ts
@@ -1,41 +1,13 @@
 import { notifyEventProcessors } from '@sentry/core';
 import { OpenTelemetryScope } from '@sentry/opentelemetry';
-import type {
-  Attachment,
-  Breadcrumb,
-  Client,
-  Contexts,
-  Event,
-  EventHint,
-  EventProcessor,
-  Extras,
-  Primitive,
-  PropagationContext,
-  Severity,
-  SeverityLevel,
-  User,
-} from '@sentry/types';
+import type { Breadcrumb, Client, Event, EventHint, EventProcessor, Severity, SeverityLevel } from '@sentry/types';
 import { uuid4 } from '@sentry/utils';
 
 import { getClient, getGlobalScope, getIsolationScope } from './api';
-
-interface ScopeData {
-  eventProcessors: EventProcessor[];
-  breadcrumbs: Breadcrumb[];
-  user: User;
-  tags: { [key: string]: Primitive };
-  extra: Extras;
-  contexts: Contexts;
-  attachments: Attachment[];
-  propagationContext: PropagationContext;
-  sdkProcessingMetadata: { [key: string]: unknown };
-  fingerprint: string[];
-  // eslint-disable-next-line deprecation/deprecation
-  level?: Severity | SeverityLevel;
-}
+import type { Scope as ScopeInterface, ScopeData } from './types';
 
 /** A fork of the classic scope with some otel specific stuff. */
-export class Scope extends OpenTelemetryScope {
+export class Scope extends OpenTelemetryScope implements ScopeInterface {
   // Overwrite this if you want to use a specific isolation scope here
   public isolationScope: Scope | undefined;
 

--- a/packages/node-experimental/src/sdk/scope.ts
+++ b/packages/node-experimental/src/sdk/scope.ts
@@ -85,7 +85,7 @@ export class Scope extends OpenTelemetryScope implements ScopeInterface {
     newScope._tags = { ...this['_tags'] };
     newScope._extra = { ...this['_extra'] };
     newScope._contexts = { ...this['_contexts'] };
-    newScope._user = this['_user'];
+    newScope._user = { ...this['_user'] };
     newScope._level = this['_level'];
     newScope._span = this['_span'];
     newScope._session = this['_session'];

--- a/packages/node-experimental/src/sdk/scope.ts
+++ b/packages/node-experimental/src/sdk/scope.ts
@@ -1,0 +1,326 @@
+import { notifyEventProcessors } from '@sentry/core';
+import { OpenTelemetryScope } from '@sentry/opentelemetry';
+import type {
+  Attachment,
+  Breadcrumb,
+  Client,
+  Contexts,
+  Event,
+  EventHint,
+  EventProcessor,
+  Extras,
+  Primitive,
+  PropagationContext,
+  Severity,
+  SeverityLevel,
+  User,
+} from '@sentry/types';
+import { uuid4 } from '@sentry/utils';
+
+import { getClient, getGlobalScope, getIsolationScope } from './api';
+
+interface ScopeData {
+  eventProcessors: EventProcessor[];
+  breadcrumbs: Breadcrumb[];
+  user: User;
+  tags: { [key: string]: Primitive };
+  extra: Extras;
+  contexts: Contexts;
+  attachments: Attachment[];
+  propagationContext: PropagationContext;
+  sdkProcessingMetadata: { [key: string]: unknown };
+  fingerprint: string[];
+  // eslint-disable-next-line deprecation/deprecation
+  level?: Severity | SeverityLevel;
+}
+
+/** A fork of the classic scope with some otel specific stuff. */
+export class Scope extends OpenTelemetryScope {
+  // Overwrite this if you want to use a specific isolation scope here
+  public isolationScope: Scope | undefined;
+
+  protected _client: Client | undefined;
+
+  protected _lastEventId: string | undefined;
+
+  /**
+   * @inheritDoc
+   */
+  public static clone(scope?: Scope): Scope {
+    const newScope = new Scope();
+    if (scope) {
+      newScope._breadcrumbs = [...scope['_breadcrumbs']];
+      newScope._tags = { ...scope['_tags'] };
+      newScope._extra = { ...scope['_extra'] };
+      newScope._contexts = { ...scope['_contexts'] };
+      newScope._user = scope['_user'];
+      newScope._level = scope['_level'];
+      newScope._span = scope['_span'];
+      newScope._session = scope['_session'];
+      newScope._transactionName = scope['_transactionName'];
+      newScope._fingerprint = scope['_fingerprint'];
+      newScope._eventProcessors = [...scope['_eventProcessors']];
+      newScope._requestSession = scope['_requestSession'];
+      newScope._attachments = [...scope['_attachments']];
+      newScope._sdkProcessingMetadata = { ...scope['_sdkProcessingMetadata'] };
+      newScope._propagationContext = { ...scope['_propagationContext'] };
+      newScope._client = scope['_client'];
+      newScope._lastEventId = scope['_lastEventId'];
+    }
+    return newScope;
+  }
+
+  /** Update the client on the scope. */
+  public setClient(client: Client): void {
+    this._client = client;
+  }
+
+  /**
+   * Get the client assigned to this scope.
+   * Should generally not be used by users - use top-level `Sentry.getClient()` instead!
+   * @internal
+   */
+  public getClient(): Client | undefined {
+    return this._client;
+  }
+
+  /** Capture an exception for this scope. */
+  public captureException(exception: unknown, hint?: EventHint): string {
+    const eventId = hint && hint.event_id ? hint.event_id : uuid4();
+    const syntheticException = new Error('Sentry syntheticException');
+
+    getClient().captureException(
+      exception,
+      {
+        originalException: exception,
+        syntheticException,
+        ...hint,
+        event_id: eventId,
+      },
+      this,
+    );
+
+    this._lastEventId = eventId;
+
+    return eventId;
+  }
+
+  /** Capture a message for this scope. */
+  public captureMessage(
+    message: string,
+    // eslint-disable-next-line deprecation/deprecation
+    level?: Severity | SeverityLevel,
+    hint?: EventHint,
+  ): string {
+    const eventId = hint && hint.event_id ? hint.event_id : uuid4();
+    const syntheticException = new Error(message);
+
+    getClient().captureMessage(
+      message,
+      level,
+      {
+        originalException: message,
+        syntheticException,
+        ...hint,
+        event_id: eventId,
+      },
+      this,
+    );
+
+    this._lastEventId = eventId;
+
+    return eventId;
+  }
+
+  /** Capture a message for this scope. */
+  public captureEvent(event: Event, hint?: EventHint): string {
+    const eventId = hint && hint.event_id ? hint.event_id : uuid4();
+    if (!event.type) {
+      this._lastEventId = eventId;
+    }
+
+    getClient().captureEvent(event, { ...hint, event_id: eventId }, this);
+
+    return eventId;
+  }
+
+  /** Get the ID of the last sent error event. */
+  public lastEventId(): string | undefined {
+    return this._lastEventId;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public addBreadcrumb(breadcrumb: Breadcrumb, maxBreadcrumbs?: number): this {
+    return this._addBreadcrumb(breadcrumb, maxBreadcrumbs);
+  }
+
+  /** Get all relevant data for this scope. */
+  public getScopeData(): ScopeData {
+    const {
+      _breadcrumbs,
+      _attachments,
+      _contexts,
+      _tags,
+      _extra,
+      _user,
+      _level,
+      _fingerprint,
+      _eventProcessors,
+      _propagationContext,
+      _sdkProcessingMetadata,
+    } = this;
+
+    return {
+      breadcrumbs: _breadcrumbs,
+      attachments: _attachments,
+      contexts: _contexts,
+      tags: _tags,
+      extra: _extra,
+      user: _user,
+      level: _level,
+      fingerprint: _fingerprint || [],
+      eventProcessors: _eventProcessors,
+      propagationContext: _propagationContext,
+      sdkProcessingMetadata: _sdkProcessingMetadata,
+    };
+  }
+
+  /**
+   * Applies data from the scope to the event and runs all event processors on it.
+   *
+   * @param event Event
+   * @param hint Object containing additional information about the original exception, for use by the event processors.
+   * @hidden
+   */
+  public applyToEvent(
+    event: Event,
+    hint: EventHint = {},
+    additionalEventProcessors: EventProcessor[] = [],
+  ): PromiseLike<Event | null> {
+    const data = getGlobalScope().getScopeData();
+    const isolationScopeData = this._getIsolationScope().getScopeData();
+    const scopeData = this.getScopeData();
+
+    // Merge data together, in order
+    mergeData(data, isolationScopeData);
+    mergeData(data, scopeData);
+
+    // Apply the data
+    const { extra, tags, user, contexts, level, sdkProcessingMetadata, breadcrumbs, fingerprint, eventProcessors } =
+      data;
+
+    mergeProp(event, 'extra', extra);
+    mergeProp(event, 'tags', tags);
+    mergeProp(event, 'user', user);
+    mergeProp(event, 'contexts', contexts);
+    mergeProp(event, 'sdkProcessingMetadata', sdkProcessingMetadata);
+    event.sdkProcessingMetadata = {
+      ...event.sdkProcessingMetadata,
+      propagationContext: this._propagationContext,
+    };
+
+    mergeArray(event, 'breadcrumbs', breadcrumbs);
+    mergeArray(event, 'fingerprint', fingerprint);
+
+    if (level) {
+      event.level = level;
+    }
+
+    const allEventProcessors = [...additionalEventProcessors, ...eventProcessors];
+
+    // Apply additional things to the event
+    if (this._transactionName) {
+      event.transaction = this._transactionName;
+    }
+
+    return notifyEventProcessors(allEventProcessors, event, hint);
+  }
+
+  /**
+   * Get all breadcrumbs attached to this scope.
+   * @internal
+   */
+  public getBreadcrumbs(): Breadcrumb[] {
+    return this._breadcrumbs;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  protected _getBreadcrumbs(): Breadcrumb[] {
+    // breadcrumbs added directly to this scope, or to the active span
+    const breadcrumbs = super._getBreadcrumbs();
+
+    // add breadcrumbs from global scope and isolation scope
+    const globalBreadcrumbs = getGlobalScope().getBreadcrumbs();
+    const isolationBreadcrumbs = this._getIsolationScope().getBreadcrumbs();
+
+    return breadcrumbs.concat(globalBreadcrumbs, isolationBreadcrumbs);
+  }
+
+  /** Get the isolation scope for this scope. */
+  protected _getIsolationScope(): Scope {
+    return this.isolationScope || getIsolationScope();
+  }
+}
+
+function mergeData(data: ScopeData, mergeData: ScopeData): void {
+  const { extra, tags, user, contexts, level, sdkProcessingMetadata, breadcrumbs, fingerprint, eventProcessors } =
+    mergeData;
+
+  mergePropOverwrite(data, 'extra', extra);
+  mergePropOverwrite(data, 'tags', tags);
+  mergePropOverwrite(data, 'user', user);
+  mergePropOverwrite(data, 'contexts', contexts);
+  mergePropOverwrite(data, 'sdkProcessingMetadata', sdkProcessingMetadata);
+
+  if (level) {
+    data.level = level;
+  }
+
+  if (breadcrumbs.length) {
+    data.breadcrumbs = [...data.breadcrumbs, ...breadcrumbs];
+  }
+
+  if (fingerprint.length) {
+    data.fingerprint = [...data.fingerprint, ...fingerprint];
+  }
+
+  if (eventProcessors.length) {
+    data.eventProcessors = [...data.eventProcessors, ...eventProcessors];
+  }
+}
+
+function mergePropOverwrite<
+  Prop extends 'extra' | 'tags' | 'user' | 'contexts' | 'sdkProcessingMetadata',
+  Data extends ScopeData | Event,
+>(data: Data, prop: Prop, mergeVal: Data[Prop]): void {
+  if (mergeVal && Object.keys(mergeVal).length) {
+    data[prop] = { ...data[prop], ...mergeVal };
+  }
+}
+
+function mergeProp<
+  Prop extends 'extra' | 'tags' | 'user' | 'contexts' | 'sdkProcessingMetadata',
+  Data extends ScopeData | Event,
+>(data: Data, prop: Prop, mergeVal: Data[Prop]): void {
+  if (mergeVal && Object.keys(mergeVal).length) {
+    data[prop] = { ...mergeVal, ...data[prop] };
+  }
+}
+
+function mergeArray<Prop extends 'breadcrumbs' | 'fingerprint'>(
+  event: Event,
+  prop: Prop,
+  mergeVal: ScopeData[Prop],
+): void {
+  const prevVal = event[prop];
+  if (!prevVal && !mergeVal.length) {
+    return;
+  }
+
+  const merged = [...(prevVal || []), ...mergeVal] as ScopeData[Prop];
+  event[prop] = merged.length ? merged : undefined;
+}

--- a/packages/node-experimental/src/sdk/scope.ts
+++ b/packages/node-experimental/src/sdk/scope.ts
@@ -18,27 +18,24 @@ export class Scope extends OpenTelemetryScope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public static clone(scope?: Scope): Scope {
+  public clone(): Scope {
     const newScope = new Scope();
-    if (scope) {
-      newScope._breadcrumbs = [...scope['_breadcrumbs']];
-      newScope._tags = { ...scope['_tags'] };
-      newScope._extra = { ...scope['_extra'] };
-      newScope._contexts = { ...scope['_contexts'] };
-      newScope._user = scope['_user'];
-      newScope._level = scope['_level'];
-      newScope._span = scope['_span'];
-      newScope._session = scope['_session'];
-      newScope._transactionName = scope['_transactionName'];
-      newScope._fingerprint = scope['_fingerprint'];
-      newScope._eventProcessors = [...scope['_eventProcessors']];
-      newScope._requestSession = scope['_requestSession'];
-      newScope._attachments = [...scope['_attachments']];
-      newScope._sdkProcessingMetadata = { ...scope['_sdkProcessingMetadata'] };
-      newScope._propagationContext = { ...scope['_propagationContext'] };
-      newScope._client = scope['_client'];
-      newScope._lastEventId = scope['_lastEventId'];
-    }
+    newScope._breadcrumbs = [...this['_breadcrumbs']];
+    newScope._tags = { ...this['_tags'] };
+    newScope._extra = { ...this['_extra'] };
+    newScope._contexts = { ...this['_contexts'] };
+    newScope._user = this['_user'];
+    newScope._level = this['_level'];
+    newScope._span = this['_span'];
+    newScope._session = this['_session'];
+    newScope._transactionName = this['_transactionName'];
+    newScope._fingerprint = this['_fingerprint'];
+    newScope._eventProcessors = [...this['_eventProcessors']];
+    newScope._requestSession = this['_requestSession'];
+    newScope._attachments = [...this['_attachments']];
+    newScope._sdkProcessingMetadata = { ...this['_sdkProcessingMetadata'] };
+    newScope._propagationContext = { ...this['_propagationContext'] };
+
     return newScope;
   }
 

--- a/packages/node-experimental/src/sdk/scope.ts
+++ b/packages/node-experimental/src/sdk/scope.ts
@@ -3,8 +3,60 @@ import { OpenTelemetryScope } from '@sentry/opentelemetry';
 import type { Breadcrumb, Client, Event, EventHint, EventProcessor, Severity, SeverityLevel } from '@sentry/types';
 import { uuid4 } from '@sentry/utils';
 
-import { getClient, getGlobalScope, getIsolationScope } from './api';
-import type { Scope as ScopeInterface, ScopeData } from './types';
+import { getGlobalCarrier } from './globals';
+import type { CurrentScopes, Scope as ScopeInterface, ScopeData, SentryCarrier } from './types';
+
+/** Get the current scope. */
+export function getCurrentScope(): Scope {
+  return getScopes().scope as Scope;
+}
+
+/**
+ * Set the current scope on the execution context.
+ * This should mostly only be called in Sentry.init()
+ */
+export function setCurrentScope(scope: Scope): void {
+  getScopes().scope = scope;
+}
+
+/** Get the global scope. */
+export function getGlobalScope(): Scope {
+  const carrier = getGlobalCarrier();
+
+  if (!carrier.globalScope) {
+    carrier.globalScope = new Scope();
+  }
+
+  return carrier.globalScope as Scope;
+}
+
+/** Get the currently active isolation scope. */
+export function getIsolationScope(): Scope {
+  return getScopes().isolationScope as Scope;
+}
+
+/**
+ * Set the currently active isolation scope.
+ * Use this with caution! As it updates the isolation scope for the current execution context.
+ */
+export function setIsolationScope(isolationScope: Scope): void {
+  getScopes().isolationScope = isolationScope;
+}
+
+/** Get the currently active client. */
+export function getClient<C extends Client>(): C {
+  const currentScope = getCurrentScope();
+  const isolationScope = getIsolationScope();
+  const globalScope = getGlobalScope();
+
+  const client = currentScope.getClient() || isolationScope.getClient() || globalScope.getClient();
+  if (client) {
+    return client as C;
+  }
+
+  // TODO otherwise ensure we use a noop client
+  return {} as C;
+}
 
 /** A fork of the classic scope with some otel specific stuff. */
 export class Scope extends OpenTelemetryScope implements ScopeInterface {
@@ -292,4 +344,29 @@ function mergeArray<Prop extends 'breadcrumbs' | 'fingerprint'>(
 
   const merged = [...(prevVal || []), ...mergeVal] as ScopeData[Prop];
   event[prop] = merged.length ? merged : undefined;
+}
+
+function getScopes(): CurrentScopes {
+  const carrier = getGlobalCarrier();
+
+  if (carrier.acs && carrier.acs.getScopes) {
+    const scopes = carrier.acs.getScopes();
+
+    if (scopes) {
+      return scopes;
+    }
+  }
+
+  return getGlobalCurrentScopes(carrier);
+}
+
+function getGlobalCurrentScopes(carrier: SentryCarrier): CurrentScopes {
+  if (!carrier.scopes) {
+    carrier.scopes = {
+      scope: new Scope(),
+      isolationScope: new Scope(),
+    };
+  }
+
+  return carrier.scopes;
 }

--- a/packages/node-experimental/src/sdk/spanProcessor.ts
+++ b/packages/node-experimental/src/sdk/spanProcessor.ts
@@ -1,16 +1,35 @@
+import type { Context } from '@opentelemetry/api';
 import { SpanKind } from '@opentelemetry/api';
 import type { Span } from '@opentelemetry/sdk-trace-base';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import { SentrySpanProcessor, getClient } from '@sentry/opentelemetry';
+import { SentrySpanProcessor, getClient, getSpanFinishScope } from '@sentry/opentelemetry';
 
 import { Http } from '../integrations/http';
 import { NodeFetch } from '../integrations/node-fetch';
 import type { NodeExperimentalClient } from '../types';
+import { getIsolationScope } from './api';
+import { Scope } from './scope';
 
 /**
  * Implement custom code to avoid sending spans in certain cases.
  */
 export class NodeExperimentalSentrySpanProcessor extends SentrySpanProcessor {
+  public constructor() {
+    super({ scopeClass: Scope });
+  }
+
+  /** @inheritDoc */
+  public onStart(span: Span, parentContext: Context): void {
+    super.onStart(span, parentContext);
+
+    // We need to make sure that we use the correct isolation scope when finishing the span
+    // so we store it on the span finish scope for later use
+    const scope = getSpanFinishScope(span) as Scope | undefined;
+    if (scope) {
+      scope.isolationScope = getIsolationScope();
+    }
+  }
+
   /** @inheritDoc */
   protected _shouldSendSpanToSentry(span: Span): boolean {
     const client = getClient<NodeExperimentalClient>();

--- a/packages/node-experimental/src/sdk/types.ts
+++ b/packages/node-experimental/src/sdk/types.ts
@@ -1,0 +1,42 @@
+import type { Hub, Integration } from '@sentry/types';
+import type { Scope } from './scope';
+
+export interface CurrentScopes {
+  scope: Scope;
+  isolationScope: Scope;
+}
+
+/**
+ * Strategy used to track async context.
+ */
+export interface AsyncContextStrategy {
+  /**
+   * Gets the current async context. Returns undefined if there is no current async context.
+   */
+  getScopes: () => CurrentScopes | undefined;
+
+  /** This is here for legacy reasons. */
+  getCurrentHub: () => Hub;
+
+  /**
+   * Runs the supplied callback in its own async context.
+   */
+  runWithAsyncContext<T>(callback: () => T): T;
+}
+
+export interface SentryCarrier {
+  globalScope?: Scope;
+  scopes?: CurrentScopes;
+  acs?: AsyncContextStrategy;
+
+  // hub is here for legacy reasons
+  hub?: Hub;
+
+  extensions?: {
+    /** Extension methods for the hub, which are bound to the current Hub instance */
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    [key: string]: Function;
+  };
+
+  integrations?: Integration[];
+}

--- a/packages/node-experimental/src/sdk/types.ts
+++ b/packages/node-experimental/src/sdk/types.ts
@@ -1,5 +1,54 @@
-import type { Hub, Integration } from '@sentry/types';
-import type { Scope } from './scope';
+import type {
+  Attachment,
+  Breadcrumb,
+  Client,
+  Contexts,
+  Event,
+  EventHint,
+  EventProcessor,
+  Extras,
+  Hub,
+  Integration,
+  Primitive,
+  PropagationContext,
+  Scope as BaseScope,
+  Severity,
+  SeverityLevel,
+  User,
+} from '@sentry/types';
+
+export interface ScopeData {
+  eventProcessors: EventProcessor[];
+  breadcrumbs: Breadcrumb[];
+  user: User;
+  tags: { [key: string]: Primitive };
+  extra: Extras;
+  contexts: Contexts;
+  attachments: Attachment[];
+  propagationContext: PropagationContext;
+  sdkProcessingMetadata: { [key: string]: unknown };
+  fingerprint: string[];
+  level?: SeverityLevel;
+}
+
+export interface Scope extends BaseScope {
+  // @ts-expect-error typeof this is what we want here
+  isolationScope: typeof this | undefined;
+  // @ts-expect-error typeof this is what we want here
+  clone(scope?: Scope): typeof this;
+  setClient(client: Client): void;
+  getClient(): Client | undefined;
+  captureException(exception: unknown, hint?: EventHint): string;
+  captureMessage(
+    message: string,
+    // eslint-disable-next-line deprecation/deprecation
+    level?: Severity | SeverityLevel,
+    hint?: EventHint,
+  ): string;
+  captureEvent(event: Event, hint?: EventHint): string;
+  lastEventId(): string | undefined;
+  getScopeData(): ScopeData;
+}
 
 export interface CurrentScopes {
   scope: Scope;

--- a/packages/node-experimental/src/utils/contextData.ts
+++ b/packages/node-experimental/src/utils/contextData.ts
@@ -1,0 +1,22 @@
+import type { Context } from '@opentelemetry/api';
+import { createContextKey } from '@opentelemetry/api';
+
+import type { CurrentScopes } from '../sdk/types';
+
+export const SENTRY_SCOPES_CONTEXT_KEY = createContextKey('sentry_scopes');
+
+/**
+ * Try to get the current scopes from the given OTEL context.
+ * This requires a Context Manager that was wrapped with getWrappedContextManager.
+ */
+export function getScopesFromContext(context: Context): CurrentScopes | undefined {
+  return context.getValue(SENTRY_SCOPES_CONTEXT_KEY) as CurrentScopes | undefined;
+}
+
+/**
+ * Set the current scopes on an OTEL context..
+ * This will return a forked context with the Propagation Context set.
+ */
+export function setScopesOnContext(context: Context, scopes: CurrentScopes): Context {
+  return context.setValue(SENTRY_SCOPES_CONTEXT_KEY, scopes);
+}

--- a/packages/node-experimental/src/utils/contextData.ts
+++ b/packages/node-experimental/src/utils/contextData.ts
@@ -14,7 +14,7 @@ export function getScopesFromContext(context: Context): CurrentScopes | undefine
 }
 
 /**
- * Set the current scopes on an OTEL context..
+ * Set the current scopes on an OTEL context.
  * This will return a forked context with the Propagation Context set.
  */
 export function setScopesOnContext(context: Context, scopes: CurrentScopes): Context {

--- a/packages/node-experimental/src/utils/prepareEvent.ts
+++ b/packages/node-experimental/src/utils/prepareEvent.ts
@@ -1,0 +1,58 @@
+import { Scope } from '@sentry/core';
+import { CaptureContext, EventHint, Scope as ScopeInterface, ScopeContext } from '@sentry/types';
+
+/**
+ * This type makes sure that we get either a CaptureContext, OR an EventHint.
+ * It does not allow mixing them, which could lead to unexpected outcomes, e.g. this is disallowed:
+ * { user: { id: '123' }, mechanism: { handled: false } }
+ */
+export type ExclusiveEventHintOrCaptureContext =
+  | (CaptureContext & Partial<{ [key in keyof EventHint]: never }>)
+  | (EventHint & Partial<{ [key in keyof ScopeContext]: never }>);
+
+/**
+ * Parse either an `EventHint` directly, or convert a `CaptureContext` to an `EventHint`.
+ * This is used to allow to update method signatures that used to accept a `CaptureContext` but should now accept an `EventHint`.
+ */
+export function parseEventHintOrCaptureContext(
+  hint: ExclusiveEventHintOrCaptureContext | undefined,
+): EventHint | undefined {
+  if (!hint) {
+    return undefined;
+  }
+
+  // If you pass a Scope or `() => Scope` as CaptureContext, we just return this as captureContext
+  if (hintIsScopeOrFunction(hint)) {
+    return { captureContext: hint };
+  }
+
+  if (hintIsScopeContext(hint)) {
+    return {
+      captureContext: hint,
+    };
+  }
+
+  return hint;
+}
+
+function hintIsScopeOrFunction(
+  hint: CaptureContext | EventHint,
+): hint is ScopeInterface | ((scope: ScopeInterface) => ScopeInterface) {
+  return hint instanceof Scope || typeof hint === 'function';
+}
+
+type ScopeContextProperty = keyof ScopeContext;
+const captureContextKeys: readonly ScopeContextProperty[] = [
+  'user',
+  'level',
+  'extra',
+  'contexts',
+  'tags',
+  'fingerprint',
+  'requestSession',
+  'propagationContext',
+] as const;
+
+function hintIsScopeContext(hint: Partial<ScopeContext> | EventHint): hint is Partial<ScopeContext> {
+  return Object.keys(hint).some(key => captureContextKeys.includes(key as ScopeContextProperty));
+}

--- a/packages/node-experimental/src/utils/prepareEvent.ts
+++ b/packages/node-experimental/src/utils/prepareEvent.ts
@@ -1,5 +1,5 @@
 import { Scope } from '@sentry/core';
-import { CaptureContext, EventHint, Scope as ScopeInterface, ScopeContext } from '@sentry/types';
+import type { CaptureContext, EventHint, Scope as ScopeInterface, ScopeContext } from '@sentry/types';
 
 /**
  * This type makes sure that we get either a CaptureContext, OR an EventHint.

--- a/packages/node-experimental/test/helpers/mockSdkInit.ts
+++ b/packages/node-experimental/test/helpers/mockSdkInit.ts
@@ -7,14 +7,17 @@ import type { NodeExperimentalClientOptions } from '../../src/types';
 
 const PUBLIC_DSN = 'https://username@domain/123';
 
-export function mockSdkInit(options?: Partial<NodeExperimentalClientOptions>) {
+export function resetGlobals(): void {
   GLOBAL_OBJ.__SENTRY__ = {
     extensions: {},
     hub: undefined,
     globalEventProcessors: [],
     logger: undefined,
   };
+}
 
+export function mockSdkInit(options?: Partial<NodeExperimentalClientOptions>) {
+  resetGlobals();
   init({ dsn: PUBLIC_DSN, defaultIntegrations: false, ...options });
 }
 

--- a/packages/node-experimental/test/integration/breadcrumbs.test.ts
+++ b/packages/node-experimental/test/integration/breadcrumbs.test.ts
@@ -1,5 +1,6 @@
-import { withScope } from '@sentry/core';
+import { captureException, withScope } from '@sentry/core';
 import { getCurrentHub, startSpan } from '@sentry/opentelemetry';
+import { addBreadcrumb, getClient, withIsolationScope } from '../../src/sdk/api';
 
 import type { NodeExperimentalClient } from '../../src/types';
 import { cleanupOtel, mockSdkInit } from '../helpers/mockSdkInit';
@@ -55,24 +56,23 @@ describe('Integration | breadcrumbs', () => {
 
       mockSdkInit({ beforeSend, beforeBreadcrumb });
 
-      const hub = getCurrentHub();
-      const client = hub.getClient() as NodeExperimentalClient;
+      const client = getClient();
 
       const error = new Error('test');
 
-      hub.addBreadcrumb({ timestamp: 123456, message: 'test0' });
+      addBreadcrumb({ timestamp: 123456, message: 'test0' });
 
-      withScope(() => {
-        hub.addBreadcrumb({ timestamp: 123456, message: 'test1' });
+      withIsolationScope(() => {
+        addBreadcrumb({ timestamp: 123456, message: 'test1' });
       });
 
-      withScope(() => {
-        hub.addBreadcrumb({ timestamp: 123456, message: 'test2' });
-        hub.captureException(error);
+      withIsolationScope(() => {
+        addBreadcrumb({ timestamp: 123456, message: 'test2' });
+        captureException(error);
       });
 
-      withScope(() => {
-        hub.addBreadcrumb({ timestamp: 123456, message: 'test3' });
+      withIsolationScope(() => {
+        addBreadcrumb({ timestamp: 123456, message: 'test3' });
       });
 
       await client.flush();
@@ -142,7 +142,7 @@ describe('Integration | breadcrumbs', () => {
     );
   });
 
-  it('correctly adds & retrieves breadcrumbs for the current root span only', async () => {
+  it('correctly adds & retrieves breadcrumbs for the current isolation span only', async () => {
     const beforeSend = jest.fn(() => null);
     const beforeBreadcrumb = jest.fn(breadcrumb => breadcrumb);
 
@@ -153,22 +153,26 @@ describe('Integration | breadcrumbs', () => {
 
     const error = new Error('test');
 
-    startSpan({ name: 'test1' }, () => {
-      hub.addBreadcrumb({ timestamp: 123456, message: 'test1-a' });
+    withIsolationScope(() => {
+      startSpan({ name: 'test1' }, () => {
+        hub.addBreadcrumb({ timestamp: 123456, message: 'test1-a' });
 
-      startSpan({ name: 'inner1' }, () => {
-        hub.addBreadcrumb({ timestamp: 123457, message: 'test1-b' });
+        startSpan({ name: 'inner1' }, () => {
+          hub.addBreadcrumb({ timestamp: 123457, message: 'test1-b' });
+        });
       });
     });
 
-    startSpan({ name: 'test2' }, () => {
-      hub.addBreadcrumb({ timestamp: 123456, message: 'test2-a' });
+    withIsolationScope(() => {
+      startSpan({ name: 'test2' }, () => {
+        hub.addBreadcrumb({ timestamp: 123456, message: 'test2-a' });
 
-      startSpan({ name: 'inner2' }, () => {
-        hub.addBreadcrumb({ timestamp: 123457, message: 'test2-b' });
+        startSpan({ name: 'inner2' }, () => {
+          hub.addBreadcrumb({ timestamp: 123457, message: 'test2-b' });
+        });
+
+        hub.captureException(error);
       });
-
-      hub.captureException(error);
     });
 
     await client.flush();
@@ -303,31 +307,35 @@ describe('Integration | breadcrumbs', () => {
 
     const error = new Error('test');
 
-    const promise1 = startSpan({ name: 'test' }, async () => {
-      hub.addBreadcrumb({ timestamp: 123456, message: 'test1' });
+    const promise1 = withIsolationScope(async () => {
+      await startSpan({ name: 'test' }, async () => {
+        hub.addBreadcrumb({ timestamp: 123456, message: 'test1' });
 
-      await startSpan({ name: 'inner1' }, async () => {
-        hub.addBreadcrumb({ timestamp: 123457, message: 'test2' });
+        await startSpan({ name: 'inner1' }, async () => {
+          hub.addBreadcrumb({ timestamp: 123457, message: 'test2' });
+        });
+
+        await startSpan({ name: 'inner2' }, async () => {
+          hub.addBreadcrumb({ timestamp: 123455, message: 'test3' });
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        hub.captureException(error);
       });
-
-      await startSpan({ name: 'inner2' }, async () => {
-        hub.addBreadcrumb({ timestamp: 123455, message: 'test3' });
-      });
-
-      await new Promise(resolve => setTimeout(resolve, 10));
-
-      hub.captureException(error);
     });
 
-    const promise2 = startSpan({ name: 'test-b' }, async () => {
-      hub.addBreadcrumb({ timestamp: 123456, message: 'test1-b' });
+    const promise2 = withIsolationScope(async () => {
+      await startSpan({ name: 'test-b' }, async () => {
+        hub.addBreadcrumb({ timestamp: 123456, message: 'test1-b' });
 
-      await startSpan({ name: 'inner1b' }, async () => {
-        hub.addBreadcrumb({ timestamp: 123457, message: 'test2-b' });
-      });
+        await startSpan({ name: 'inner1b' }, async () => {
+          hub.addBreadcrumb({ timestamp: 123457, message: 'test2-b' });
+        });
 
-      await startSpan({ name: 'inner2b' }, async () => {
-        hub.addBreadcrumb({ timestamp: 123455, message: 'test3-b' });
+        await startSpan({ name: 'inner2b' }, async () => {
+          hub.addBreadcrumb({ timestamp: 123455, message: 'test3-b' });
+        });
       });
     });
 

--- a/packages/node-experimental/test/integration/scope.test.ts
+++ b/packages/node-experimental/test/integration/scope.test.ts
@@ -101,6 +101,7 @@ describe('Integration | Scope', () => {
               tag1: 'val1',
               tag2: 'val2',
               tag3: 'val3',
+              tag4: 'val4',
             },
             timestamp: expect.any(Number),
             transaction: 'outer',

--- a/packages/node-experimental/test/integration/scope.test.ts
+++ b/packages/node-experimental/test/integration/scope.test.ts
@@ -353,14 +353,16 @@ describe('Integration | Scope', () => {
       initialIsolationScope.setTag('tag1', 'val1');
       initialIsolationScope.setTag('tag2', 'val2');
 
+      const initialCurrentScope = Sentry.getCurrentScope();
+
       const error = new Error('test error');
 
-      Sentry.withIsolationScope((_currentScope, newIsolationScope) => {
+      Sentry.withIsolationScope(newIsolationScope => {
         newIsolationScope.setTag('tag4', 'val4');
       });
 
-      Sentry.withIsolationScope((currentScope, newIsolationScope) => {
-        expect(Sentry.getCurrentScope()).toBe(currentScope);
+      Sentry.withIsolationScope(newIsolationScope => {
+        expect(Sentry.getCurrentScope()).not.toBe(initialCurrentScope);
         expect(Sentry.getIsolationScope()).toBe(newIsolationScope);
         expect(newIsolationScope).not.toBe(initialIsolationScope);
 
@@ -402,13 +404,13 @@ describe('Integration | Scope', () => {
 
       const error = new Error('test error');
 
-      Sentry.withIsolationScope((_currentScope, newIsolationScope) => {
+      Sentry.withIsolationScope(newIsolationScope => {
         newIsolationScope.setTag('tag2', 'val2');
 
-        Sentry.withIsolationScope((_currentScope, newIsolationScope) => {
+        Sentry.withIsolationScope(newIsolationScope => {
           newIsolationScope.setTag('tag3', 'val3');
 
-          Sentry.withIsolationScope((_currentScope, newIsolationScope) => {
+          Sentry.withIsolationScope(newIsolationScope => {
             newIsolationScope.setTag('tag4', 'val4');
           });
 
@@ -648,8 +650,8 @@ describe('Integration | Scope', () => {
 
       const error = new Error('test error');
 
-      Sentry.withIsolationScope((currentScope, isolationScope) => {
-        currentScope.setTag('tag2', 'val2a');
+      Sentry.withIsolationScope(isolationScope => {
+        Sentry.getCurrentScope().setTag('tag2', 'val2a');
         isolationScope.setTag('tag2', 'val2b');
         isolationScope.setTag('tag3', 'val3');
 

--- a/packages/node-experimental/test/integration/transactions.test.ts
+++ b/packages/node-experimental/test/integration/transactions.test.ts
@@ -8,6 +8,7 @@ import { logger } from '@sentry/utils';
 import * as Sentry from '../../src';
 import { startSpan } from '../../src';
 import type { Http, NodeFetch } from '../../src/integrations';
+import { getIsolationScope } from '../../src/sdk/api';
 import type { NodeExperimentalClient } from '../../src/types';
 import { cleanupOtel, getProvider, mockSdkInit } from '../helpers/mockSdkInit';
 
@@ -22,8 +23,7 @@ describe('Integration | Transactions', () => {
 
     mockSdkInit({ enableTracing: true, beforeSendTransaction });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as NodeExperimentalClient;
+    const client = Sentry.getClient<NodeExperimentalClient>();
 
     Sentry.addBreadcrumb({ message: 'test breadcrumb 1', timestamp: 123456 });
     Sentry.setTag('outer.tag', 'test value');
@@ -128,6 +128,7 @@ describe('Integration | Transactions', () => {
         start_timestamp: expect.any(Number),
         tags: {
           'outer.tag': 'test value',
+          'test.tag': 'test value',
         },
         timestamp: expect.any(Number),
         transaction: 'test name',
@@ -176,49 +177,52 @@ describe('Integration | Transactions', () => {
 
     mockSdkInit({ enableTracing: true, beforeSendTransaction });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as NodeExperimentalClient;
+    const client = Sentry.getClient();
 
     Sentry.addBreadcrumb({ message: 'test breadcrumb 1', timestamp: 123456 });
 
-    Sentry.startSpan({ op: 'test op', name: 'test name', source: 'task', origin: 'auto.test' }, span => {
-      Sentry.addBreadcrumb({ message: 'test breadcrumb 2', timestamp: 123456 });
+    Sentry.withIsolationScope((scope, isolationScope) => {
+      Sentry.startSpan({ op: 'test op', name: 'test name', source: 'task', origin: 'auto.test' }, span => {
+        Sentry.addBreadcrumb({ message: 'test breadcrumb 2', timestamp: 123456 });
 
-      span.setAttributes({
-        'test.outer': 'test value',
-      });
+        span.setAttributes({
+          'test.outer': 'test value',
+        });
 
-      const subSpan = Sentry.startInactiveSpan({ name: 'inner span 1' });
-      subSpan.end();
+        const subSpan = Sentry.startInactiveSpan({ name: 'inner span 1' });
+        subSpan.end();
 
-      Sentry.setTag('test.tag', 'test value');
+        Sentry.setTag('test.tag', 'test value');
 
-      Sentry.startSpan({ name: 'inner span 2' }, innerSpan => {
-        Sentry.addBreadcrumb({ message: 'test breadcrumb 3', timestamp: 123456 });
+        Sentry.startSpan({ name: 'inner span 2' }, innerSpan => {
+          Sentry.addBreadcrumb({ message: 'test breadcrumb 3', timestamp: 123456 });
 
-        innerSpan.setAttributes({
-          'test.inner': 'test value',
+          innerSpan.setAttributes({
+            'test.inner': 'test value',
+          });
         });
       });
     });
 
-    Sentry.startSpan({ op: 'test op b', name: 'test name b' }, span => {
-      Sentry.addBreadcrumb({ message: 'test breadcrumb 2b', timestamp: 123456 });
+    Sentry.withIsolationScope(() => {
+      Sentry.startSpan({ op: 'test op b', name: 'test name b' }, span => {
+        Sentry.addBreadcrumb({ message: 'test breadcrumb 2b', timestamp: 123456 });
 
-      span.setAttributes({
-        'test.outer': 'test value b',
-      });
+        span.setAttributes({
+          'test.outer': 'test value b',
+        });
 
-      const subSpan = Sentry.startInactiveSpan({ name: 'inner span 1b' });
-      subSpan.end();
+        const subSpan = Sentry.startInactiveSpan({ name: 'inner span 1b' });
+        subSpan.end();
 
-      Sentry.setTag('test.tag', 'test value b');
+        Sentry.setTag('test.tag', 'test value b');
 
-      Sentry.startSpan({ name: 'inner span 2b' }, innerSpan => {
-        Sentry.addBreadcrumb({ message: 'test breadcrumb 3b', timestamp: 123456 });
+        Sentry.startSpan({ name: 'inner span 2b' }, innerSpan => {
+          Sentry.addBreadcrumb({ message: 'test breadcrumb 3b', timestamp: 123456 });
 
-        innerSpan.setAttributes({
-          'test.inner': 'test value b',
+          innerSpan.setAttributes({
+            'test.inner': 'test value b',
+          });
         });
       });
     });
@@ -257,7 +261,7 @@ describe('Integration | Transactions', () => {
           }),
         ],
         start_timestamp: expect.any(Number),
-        tags: {},
+        tags: { 'test.tag': 'test value' },
         timestamp: expect.any(Number),
         transaction: 'test name',
         transaction_info: { source: 'task' },
@@ -299,7 +303,7 @@ describe('Integration | Transactions', () => {
           }),
         ],
         start_timestamp: expect.any(Number),
-        tags: {},
+        tags: { 'test.tag': 'test value b' },
         timestamp: expect.any(Number),
         transaction: 'test name b',
         transaction_info: { source: 'custom' },

--- a/packages/node-experimental/test/integration/transactions.test.ts
+++ b/packages/node-experimental/test/integration/transactions.test.ts
@@ -181,7 +181,7 @@ describe('Integration | Transactions', () => {
 
     Sentry.addBreadcrumb({ message: 'test breadcrumb 1', timestamp: 123456 });
 
-    Sentry.withIsolationScope((scope, isolationScope) => {
+    Sentry.withIsolationScope(() => {
       Sentry.startSpan({ op: 'test op', name: 'test name', source: 'task', origin: 'auto.test' }, span => {
         Sentry.addBreadcrumb({ message: 'test breadcrumb 2', timestamp: 123456 });
 

--- a/packages/node-experimental/test/sdk/scope.test.ts
+++ b/packages/node-experimental/test/sdk/scope.test.ts
@@ -1,0 +1,416 @@
+import type { Attachment, Breadcrumb, Client, EventProcessor } from '@sentry/types';
+import { Scope, getIsolationScope } from '../../src';
+import { getGlobalScope, mergeArray, mergeData, mergePropKeep, mergePropOverwrite } from '../../src/sdk/scope';
+import type { ScopeData } from '../../src/sdk/types';
+import { mockSdkInit, resetGlobals } from '../helpers/mockSdkInit';
+
+describe('Unit | Scope', () => {
+  it('allows to create & update a scope', () => {
+    const scope = new Scope();
+
+    expect(scope.getScopeData()).toEqual({
+      breadcrumbs: [],
+      attachments: [],
+      contexts: {},
+      tags: {},
+      extra: {},
+      user: {},
+      level: undefined,
+      fingerprint: [],
+      eventProcessors: [],
+      propagationContext: {
+        traceId: expect.any(String),
+        spanId: expect.any(String),
+      },
+      sdkProcessingMetadata: {},
+    });
+
+    scope.update({
+      tags: { foo: 'bar' },
+      extra: { foo2: 'bar2' },
+    });
+
+    expect(scope.getScopeData()).toEqual({
+      breadcrumbs: [],
+      attachments: [],
+      contexts: {},
+      tags: {
+        foo: 'bar',
+      },
+      extra: {
+        foo2: 'bar2',
+      },
+      user: {},
+      level: undefined,
+      fingerprint: [],
+      eventProcessors: [],
+      propagationContext: {
+        traceId: expect.any(String),
+        spanId: expect.any(String),
+      },
+      sdkProcessingMetadata: {},
+    });
+  });
+
+  it('allows to clone a scope', () => {
+    const scope = new Scope();
+
+    scope.update({
+      tags: { foo: 'bar' },
+      extra: { foo2: 'bar2' },
+    });
+
+    const newScope = scope.clone();
+    expect(newScope).toBeInstanceOf(Scope);
+    expect(newScope).not.toBe(scope);
+
+    expect(newScope.getScopeData()).toEqual({
+      breadcrumbs: [],
+      attachments: [],
+      contexts: {},
+      tags: {
+        foo: 'bar',
+      },
+      extra: {
+        foo2: 'bar2',
+      },
+      user: {},
+      level: undefined,
+      fingerprint: [],
+      eventProcessors: [],
+      propagationContext: {
+        traceId: expect.any(String),
+        spanId: expect.any(String),
+      },
+      sdkProcessingMetadata: {},
+    });
+  });
+
+  it('allows to set & get a client', () => {
+    const scope = new Scope();
+    expect(scope.getClient()).toBeUndefined();
+    const client = {} as Client;
+    scope.setClient(client);
+    expect(scope.getClient()).toBe(client);
+  });
+
+  it('gets the correct isolationScope in _getIsolationScope', () => {
+    resetGlobals();
+
+    const scope = new Scope();
+    const globalIsolationScope = getIsolationScope();
+
+    expect(scope['_getIsolationScope']()).toBe(globalIsolationScope);
+
+    const customIsolationScope = new Scope();
+    scope.isolationScope = customIsolationScope;
+
+    expect(scope['_getIsolationScope']()).toBe(customIsolationScope);
+  });
+
+  describe('mergeArray', () => {
+    it.each([
+      [[], [], undefined],
+      [undefined, [], undefined],
+      [['a'], [], ['a']],
+      [['a'], ['b', 'c'], ['a', 'b', 'c']],
+      [[], ['b', 'c'], ['b', 'c']],
+      [undefined, ['b', 'c'], ['b', 'c']],
+    ])('works with %s and %s', (a, b, expected) => {
+      const data = { fingerprint: a };
+      mergeArray(data, 'fingerprint', b);
+      expect(data.fingerprint).toEqual(expected);
+    });
+
+    it('does not mutate the original array if no changes are made', () => {
+      const fingerprint = ['a'];
+      const data = { fingerprint };
+      mergeArray(data, 'fingerprint', []);
+      expect(data.fingerprint).toBe(fingerprint);
+    });
+  });
+
+  describe('mergePropKeep', () => {
+    it.each([
+      [{}, {}, {}],
+      [{ a: 'aa' }, {}, { a: 'aa' }],
+      [{ a: 'aa' }, { b: 'bb' }, { a: 'aa', b: 'bb' }],
+      // Does not overwrite existing keys
+      [{ a: 'aa' }, { b: 'bb', a: 'cc' }, { a: 'aa', b: 'bb' }],
+    ])('works with %s and %s', (a, b, expected) => {
+      const data = { tags: a } as unknown as ScopeData;
+      mergePropKeep(data, 'tags', b);
+      expect(data.tags).toEqual(expected);
+    });
+
+    it('does not deep merge', () => {
+      const data = {
+        contexts: {
+          app: { app_version: 'v1' },
+          culture: { display_name: 'name1' },
+        },
+      } as unknown as ScopeData;
+      mergePropKeep(data, 'contexts', {
+        os: { name: 'os1' },
+        app: { app_name: 'name1' },
+      });
+      expect(data.contexts).toEqual({
+        os: { name: 'os1' },
+        culture: { display_name: 'name1' },
+        app: { app_version: 'v1' },
+      });
+    });
+
+    it('does not mutate the original object if no changes are made', () => {
+      const tags = { a: 'aa' };
+      const data = { tags } as unknown as ScopeData;
+      mergePropKeep(data, 'tags', {});
+      expect(data.tags).toBe(tags);
+    });
+  });
+
+  describe('mergePropOverwrite', () => {
+    it.each([
+      [{}, {}, {}],
+      [{ a: 'aa' }, {}, { a: 'aa' }],
+      [{ a: 'aa' }, { b: 'bb' }, { a: 'aa', b: 'bb' }],
+      // overwrites existing keys
+      [{ a: 'aa' }, { b: 'bb', a: 'cc' }, { a: 'cc', b: 'bb' }],
+    ])('works with %s and %s', (a, b, expected) => {
+      const data = { tags: a } as unknown as ScopeData;
+      mergePropOverwrite(data, 'tags', b);
+      expect(data.tags).toEqual(expected);
+    });
+
+    it('does not deep merge', () => {
+      const data = {
+        contexts: {
+          app: { app_version: 'v1' },
+          culture: { display_name: 'name1' },
+        },
+      } as unknown as ScopeData;
+      mergePropOverwrite(data, 'contexts', {
+        os: { name: 'os1' },
+        app: { app_name: 'name1' },
+      });
+      expect(data.contexts).toEqual({
+        os: { name: 'os1' },
+        culture: { display_name: 'name1' },
+        app: { app_name: 'name1' },
+      });
+    });
+
+    it('does not mutate the original object if no changes are made', () => {
+      const tags = { a: 'aa' };
+      const data = { tags } as unknown as ScopeData;
+      mergePropOverwrite(data, 'tags', {});
+      expect(data.tags).toBe(tags);
+    });
+  });
+
+  describe('mergeData', () => {
+    it('works with empty data', () => {
+      const data1: ScopeData = {
+        eventProcessors: [],
+        breadcrumbs: [],
+        user: {},
+        tags: {},
+        extra: {},
+        contexts: {},
+        attachments: [],
+        propagationContext: { spanId: '1', traceId: '1' },
+        sdkProcessingMetadata: {},
+        fingerprint: [],
+      };
+      const data2: ScopeData = {
+        eventProcessors: [],
+        breadcrumbs: [],
+        user: {},
+        tags: {},
+        extra: {},
+        contexts: {},
+        attachments: [],
+        propagationContext: { spanId: '1', traceId: '1' },
+        sdkProcessingMetadata: {},
+        fingerprint: [],
+      };
+      mergeData(data1, data2);
+      expect(data1).toEqual({
+        eventProcessors: [],
+        breadcrumbs: [],
+        user: {},
+        tags: {},
+        extra: {},
+        contexts: {},
+        attachments: [],
+        propagationContext: { spanId: '1', traceId: '1' },
+        sdkProcessingMetadata: {},
+        fingerprint: [],
+      });
+    });
+
+    it('merges data correctly', () => {
+      const attachment1 = { filename: '1' } as Attachment;
+      const attachment2 = { filename: '2' } as Attachment;
+      const attachment3 = { filename: '3' } as Attachment;
+
+      const breadcrumb1 = { message: '1' } as Breadcrumb;
+      const breadcrumb2 = { message: '2' } as Breadcrumb;
+      const breadcrumb3 = { message: '3' } as Breadcrumb;
+
+      const eventProcessor1 = ((a: unknown) => null) as EventProcessor;
+      const eventProcessor2 = ((b: unknown) => null) as EventProcessor;
+      const eventProcessor3 = ((c: unknown) => null) as EventProcessor;
+
+      const data1: ScopeData = {
+        eventProcessors: [eventProcessor1],
+        breadcrumbs: [breadcrumb1],
+        user: { id: '1', email: 'test@example.com' },
+        tags: { tag1: 'aa', tag2: 'aa' },
+        extra: { extra1: 'aa', extra2: 'aa' },
+        contexts: { os: { name: 'os1' }, culture: { display_name: 'name1' } },
+        attachments: [attachment1],
+        propagationContext: { spanId: '1', traceId: '1' },
+        sdkProcessingMetadata: { aa: 'aa', bb: 'aa' },
+        fingerprint: ['aa', 'bb'],
+      };
+      const data2: ScopeData = {
+        eventProcessors: [eventProcessor2, eventProcessor3],
+        breadcrumbs: [breadcrumb2, breadcrumb3],
+        user: { id: '2', name: 'foo' },
+        tags: { tag2: 'bb', tag3: 'bb' },
+        extra: { extra2: 'bb', extra3: 'bb' },
+        contexts: { os: { name: 'os2' } },
+        attachments: [attachment2, attachment3],
+        propagationContext: { spanId: '2', traceId: '2' },
+        sdkProcessingMetadata: { bb: 'bb', cc: 'bb' },
+        fingerprint: ['cc'],
+      };
+      mergeData(data1, data2);
+      expect(data1).toEqual({
+        eventProcessors: [eventProcessor1, eventProcessor2, eventProcessor3],
+        breadcrumbs: [breadcrumb1, breadcrumb2, breadcrumb3],
+        user: { id: '2', name: 'foo', email: 'test@example.com' },
+        tags: { tag1: 'aa', tag2: 'bb', tag3: 'bb' },
+        extra: { extra1: 'aa', extra2: 'bb', extra3: 'bb' },
+        contexts: { os: { name: 'os2' }, culture: { display_name: 'name1' } },
+        attachments: [attachment1, attachment2, attachment3],
+        // This is not merged, we always use the one from the scope here anyhow
+        propagationContext: { spanId: '1', traceId: '1' },
+        sdkProcessingMetadata: { aa: 'aa', bb: 'bb', cc: 'bb' },
+        fingerprint: ['aa', 'bb', 'cc'],
+      });
+    });
+  });
+
+  describe('applyToEvent', () => {
+    it('works without any data', async () => {
+      mockSdkInit();
+
+      const scope = new Scope();
+
+      const event = await scope.applyToEvent({ message: 'foo' });
+
+      expect(event).toEqual({
+        message: 'foo',
+        sdkProcessingMetadata: {
+          propagationContext: {
+            spanId: expect.any(String),
+            traceId: expect.any(String),
+          },
+        },
+      });
+    });
+
+    it('merges scope data', async () => {
+      mockSdkInit();
+
+      const breadcrumb1 = { message: '1', timestamp: 111 } as Breadcrumb;
+      const breadcrumb2 = { message: '2', timestamp: 222 } as Breadcrumb;
+      const breadcrumb3 = { message: '3', timestamp: 123 } as Breadcrumb;
+      const breadcrumb4 = { message: '4', timestamp: 333 } as Breadcrumb;
+
+      const eventProcessor1 = jest.fn((a: unknown) => a) as EventProcessor;
+      const eventProcessor2 = jest.fn((b: unknown) => b) as EventProcessor;
+      const eventProcessor3 = jest.fn((c: unknown) => c) as EventProcessor;
+
+      const scope = new Scope();
+      scope.update({
+        user: { id: '1', email: 'test@example.com' },
+        tags: { tag1: 'aa', tag2: 'aa' },
+        extra: { extra1: 'aa', extra2: 'aa' },
+        contexts: { os: { name: 'os1' }, culture: { display_name: 'name1' } },
+        propagationContext: { spanId: '1', traceId: '1' },
+        fingerprint: ['aa'],
+      });
+      scope.addBreadcrumb(breadcrumb1);
+      scope.addEventProcessor(eventProcessor1);
+
+      const globalScope = getGlobalScope();
+      const isolationScope = getIsolationScope();
+
+      globalScope.addBreadcrumb(breadcrumb2);
+      globalScope.addEventProcessor(eventProcessor2);
+      globalScope.setSDKProcessingMetadata({ aa: 'aa' });
+
+      isolationScope.addBreadcrumb(breadcrumb3);
+      isolationScope.addEventProcessor(eventProcessor3);
+      globalScope.setSDKProcessingMetadata({ bb: 'bb' });
+
+      const event = await scope.applyToEvent({
+        message: 'foo',
+        breadcrumbs: [breadcrumb4],
+        fingerprint: ['dd'],
+      });
+
+      expect(event).toEqual({
+        message: 'foo',
+        user: { id: '1', email: 'test@example.com' },
+        tags: { tag1: 'aa', tag2: 'aa' },
+        extra: { extra1: 'aa', extra2: 'aa' },
+        contexts: { os: { name: 'os1' }, culture: { display_name: 'name1' } },
+        fingerprint: ['dd', 'aa'],
+        breadcrumbs: [breadcrumb4, breadcrumb2, breadcrumb3, breadcrumb1],
+        sdkProcessingMetadata: {
+          aa: 'aa',
+          bb: 'bb',
+          propagationContext: {
+            spanId: '1',
+            traceId: '1',
+          },
+        },
+      });
+    });
+  });
+
+  describe('getAttachments', () => {
+    it('works without any data', async () => {
+      mockSdkInit();
+
+      const scope = new Scope();
+
+      const actual = scope.getAttachments();
+      expect(actual).toEqual([]);
+    });
+
+    it('merges attachments data', async () => {
+      mockSdkInit();
+
+      const attachment1 = { filename: '1' } as Attachment;
+      const attachment2 = { filename: '2' } as Attachment;
+      const attachment3 = { filename: '3' } as Attachment;
+
+      const scope = new Scope();
+      scope.addAttachment(attachment1);
+
+      const globalScope = getGlobalScope();
+      const isolationScope = getIsolationScope();
+
+      globalScope.addAttachment(attachment2);
+      isolationScope.addAttachment(attachment3);
+
+      const actual = scope.getAttachments();
+      expect(actual).toEqual([attachment2, attachment3, attachment1]);
+    });
+  });
+});

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -79,7 +79,7 @@ export { defaultIntegrations, init, defaultStackParser, getSentryRelease } from 
 export { addRequestDataToEvent, DEFAULT_USER_INCLUDES, extractRequestData } from '@sentry/utils';
 export { deepReadDirSync } from './utils';
 export { getModuleFromFilename } from './module';
-export { enableAnrDetection } from './anr';
+export { enableAnrDetection, isAnrChildProcess } from './anr';
 
 import { Integrations as CoreIntegrations } from '@sentry/core';
 

--- a/packages/opentelemetry/src/custom/scope.ts
+++ b/packages/opentelemetry/src/custom/scope.ts
@@ -87,6 +87,11 @@ export class OpenTelemetryScope extends Scope {
       return this;
     }
 
+    return this._addBreadcrumb(breadcrumb, maxBreadcrumbs);
+  }
+
+  /** Add a breadcrumb to this scope. */
+  protected _addBreadcrumb(breadcrumb: Breadcrumb, maxBreadcrumbs?: number): this {
     return super.addBreadcrumb(breadcrumb, maxBreadcrumbs);
   }
 

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -6,9 +6,16 @@ export type { OpenTelemetryClient } from './types';
 export { wrapClientClass } from './custom/client';
 
 export { getSpanKind } from './utils/getSpanKind';
-export { getSpanHub, getSpanMetadata, getSpanParent, getSpanScope, setSpanMetadata } from './utils/spanData';
+export {
+  getSpanHub,
+  getSpanMetadata,
+  getSpanParent,
+  getSpanScope,
+  setSpanMetadata,
+  getSpanFinishScope,
+} from './utils/spanData';
 
-export { getPropagationContextFromContext, setPropagationContextOnContext } from './utils/contextData';
+export { getPropagationContextFromContext, setPropagationContextOnContext, setHubOnContext } from './utils/contextData';
 
 export {
   spanHasAttributes,
@@ -25,6 +32,7 @@ export { getActiveSpan, getRootSpan } from './utils/getActiveSpan';
 export { startSpan, startInactiveSpan } from './trace';
 
 export { getCurrentHub, setupGlobalHub, getClient } from './custom/hub';
+export { OpenTelemetryScope } from './custom/scope';
 export { addTracingExtensions } from './custom/hubextensions';
 export { setupEventContextTrace } from './setupEventContextTrace';
 

--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -20,7 +20,7 @@ import type { SpanNode } from './utils/groupSpansWithParents';
 import { groupSpansWithParents } from './utils/groupSpansWithParents';
 import { mapStatus } from './utils/mapStatus';
 import { parseSpanDescription } from './utils/parseSpanDescription';
-import { getSpanHub, getSpanMetadata, getSpanScope } from './utils/spanData';
+import { getSpanFinishScope, getSpanHub, getSpanMetadata, getSpanScope } from './utils/spanData';
 
 type SpanNodeCompleted = SpanNode & { span: ReadableSpan };
 
@@ -111,12 +111,9 @@ function maybeSend(spans: ReadableSpan[]): ReadableSpan[] {
     });
 
     // Now finish the transaction, which will send it together with all the spans
-    // We make sure to use the current span as the activeSpan for this transaction
-    const scope = getSpanScope(span) as OpenTelemetryScope | undefined;
-    const forkedScope = scope ? scope.clone() : new OpenTelemetryScope();
-    forkedScope.activeSpan = span as unknown as Span;
-
-    transaction.finishWithScope(convertOtelTimeToSeconds(span.endTime), forkedScope);
+    // We make sure to use the finish scope
+    const scope = getSpanFinishScope(span);
+    transaction.finishWithScope(convertOtelTimeToSeconds(span.endTime), scope);
   });
 
   return Array.from(remaining)

--- a/packages/opentelemetry/src/spanProcessor.ts
+++ b/packages/opentelemetry/src/spanProcessor.ts
@@ -36,7 +36,7 @@ function onSpanStart(span: Span, parentContext: Context, ScopeClass: typeof Open
     setSpanHub(span, actualHub);
 
     // Use this scope for finishing the span
-    const finishScope = ScopeClass.clone(scope as OpenTelemetryScope) as OpenTelemetryScope;
+    const finishScope = (scope as OpenTelemetryScope).clone();
     finishScope.activeSpan = span;
     setSpanFinishScope(span, finishScope);
   }

--- a/packages/opentelemetry/src/spanProcessor.ts
+++ b/packages/opentelemetry/src/spanProcessor.ts
@@ -5,13 +5,14 @@ import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { logger } from '@sentry/utils';
 
 import { getCurrentHub } from './custom/hub';
+import { OpenTelemetryScope } from './custom/scope';
 import { DEBUG_BUILD } from './debug-build';
 import { SentrySpanExporter } from './spanExporter';
 import { maybeCaptureExceptionForTimedEvent } from './utils/captureExceptionForTimedEvent';
 import { getHubFromContext } from './utils/contextData';
-import { getSpanHub, setSpanHub, setSpanParent, setSpanScope } from './utils/spanData';
+import { getSpanHub, setSpanFinishScope, setSpanHub, setSpanParent, setSpanScope } from './utils/spanData';
 
-function onSpanStart(span: Span, parentContext: Context): void {
+function onSpanStart(span: Span, parentContext: Context, ScopeClass: typeof OpenTelemetryScope): void {
   // This is a reliable way to get the parent span - because this is exactly how the parent is identified in the OTEL SDK
   const parentSpan = trace.getSpan(parentContext);
   const hub = getHubFromContext(parentContext);
@@ -30,8 +31,14 @@ function onSpanStart(span: Span, parentContext: Context): void {
 
   // We need the scope at time of span creation in order to apply it to the event when the span is finished
   if (actualHub) {
+    const scope = actualHub.getScope();
     setSpanScope(span, actualHub.getScope());
     setSpanHub(span, actualHub);
+
+    // Use this scope for finishing the span
+    const finishScope = ScopeClass.clone(scope as OpenTelemetryScope) as OpenTelemetryScope;
+    finishScope.activeSpan = span;
+    setSpanFinishScope(span, finishScope);
   }
 }
 
@@ -48,15 +55,19 @@ function onSpanEnd(span: Span): void {
  * the Sentry SDK.
  */
 export class SentrySpanProcessor extends BatchSpanProcessor implements SpanProcessorInterface {
-  public constructor() {
+  private _scopeClass: typeof OpenTelemetryScope;
+
+  public constructor(options: { scopeClass?: typeof OpenTelemetryScope } = {}) {
     super(new SentrySpanExporter());
+
+    this._scopeClass = options.scopeClass || OpenTelemetryScope;
   }
 
   /**
    * @inheritDoc
    */
   public onStart(span: Span, parentContext: Context): void {
-    onSpanStart(span, parentContext);
+    onSpanStart(span, parentContext, this._scopeClass);
 
     DEBUG_BUILD && logger.log(`[Tracing] Starting span "${span.name}" (${span.spanContext().spanId})`);
 

--- a/packages/opentelemetry/src/utils/spanData.ts
+++ b/packages/opentelemetry/src/utils/spanData.ts
@@ -7,6 +7,7 @@ import type { AbstractSpan } from '../types';
 // This way we can enhance the data that an OTEL Span natively gives us
 // and since we are using weakmaps, we do not need to clean up after ourselves
 const SpanScope = new WeakMap<AbstractSpan, Scope>();
+const SpanFinishScope = new WeakMap<AbstractSpan, Scope>();
 const SpanHub = new WeakMap<AbstractSpan, Hub>();
 const SpanParent = new WeakMap<AbstractSpan, Span>();
 const SpanMetadata = new WeakMap<AbstractSpan, Partial<TransactionMetadata>>();
@@ -49,4 +50,14 @@ export function setSpanMetadata(span: AbstractSpan, metadata: Partial<Transactio
 /** Get metadata for an OTEL span. */
 export function getSpanMetadata(span: AbstractSpan): Partial<TransactionMetadata> | undefined {
   return SpanMetadata.get(span);
+}
+
+/** Set the Sentry scope to be used for finishing a given OTEL span. */
+export function setSpanFinishScope(span: AbstractSpan, scope: Scope): void {
+  SpanFinishScope.set(span, scope);
+}
+
+/** Get the Sentry scope to use for finishing an OTEL span. */
+export function getSpanFinishScope(span: AbstractSpan): Scope | undefined {
+  return SpanFinishScope.get(span);
 }


### PR DESCRIPTION
This PR introduces the new scope APIs to node-experimental.

* `getCurrentHub()` is still around, but just a mock hub that uses other methods under the hood.
* Instead, there are the following new APIs:
  * `getCurrentScope()`
  * `getIsolationScope()`
  * `getGlobalScope()`  
  * `withIsolationScope()`

Mostly existing tests should cover this OK. The main change here is that for spans, since we use the isolation scope any tags etc. added while the span is running are _also_ added to the resulting event. 

For POTEL, we automatically set an isolation scope whenever a http.server span is generated.

Replaces https://github.com/getsentry/sentry-javascript/pull/9419