### PR TITLE
feat: Add top level `getCurrentScope()` method

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -25,6 +25,7 @@ export {
   getHubFromCarrier,
   getCurrentHub,
   getClient,
+  getCurrentScope,
   Hub,
   makeMain,
   Scope,

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -36,6 +36,7 @@ export {
   getHubFromCarrier,
   getCurrentHub,
   getClient,
+  getCurrentScope,
   Hub,
   lastEventId,
   makeMain,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -42,6 +42,7 @@ export {
   getHubFromCarrier,
   getCurrentHub,
   getClient,
+  getCurrentScope,
   Hub,
   lastEventId,
   makeMain,

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -308,3 +308,10 @@ export function lastEventId(): string | undefined {
 export function getClient<C extends Client>(): C | undefined {
   return getCurrentHub().getClient<C>();
 }
+
+/**
+ * Get the currently active scope.
+ */
+export function getCurrentScope(): Scope {
+  return getCurrentHub().getScope();
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export {
   setUser,
   withScope,
   getClient,
+  getCurrentScope,
 } from './exports';
 export {
   getCurrentHub,

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -41,6 +41,7 @@ export {
   getHubFromCarrier,
   getCurrentHub,
   getClient,
+  getCurrentScope,
   Hub,
   lastEventId,
   makeMain,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -41,6 +41,7 @@ export {
   getHubFromCarrier,
   getCurrentHub,
   getClient,
+  getCurrentScope,
   Hub,
   lastEventId,
   makeMain,

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -29,6 +29,7 @@ export {
   getActiveTransaction,
   getCurrentHub,
   getClient,
+  getCurrentScope,
   getHubFromCarrier,
   makeMain,
   setContext,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -22,6 +22,7 @@ export {
   getHubFromCarrier,
   getCurrentHub,
   getClient,
+  getCurrentScope,
   Hub,
   makeMain,
   Scope,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -41,6 +41,7 @@ export {
   getHubFromCarrier,
   getCurrentHub,
   getClient,
+  getCurrentScope,
   Hub,
   lastEventId,
   makeMain,


### PR DESCRIPTION
This can be used instead of `getCurrentHub().getScope()`, and is a step towards getting rid of `getCurrentHub()` as a top level API.
