### PR TITLE
feat(replay): Bump `rrweb` to 2.5.0

### DIFF
--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -48,8 +48,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@sentry-internal/replay-worker": "7.86.0",
-    "@sentry-internal/rrweb": "2.2.0",
-    "@sentry-internal/rrweb-snapshot": "2.2.0",
+    "@sentry-internal/rrweb": "2.5.0",
+    "@sentry-internal/rrweb-snapshot": "2.5.0",
     "fflate": "^0.8.1",
     "jsdom-worker": "^0.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5048,33 +5048,33 @@
     semver "7.3.2"
     semver-intersect "1.4.0"
 
-"@sentry-internal/rrdom@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.2.0.tgz#edc292e55263e1e2541a9ed282ff998aae272a0a"
-  integrity sha512-pX2YxpZfKxfbeEKG+sc0WzlSMUsG9mgwK3IioeVulNovUmus6UhLLQHYeZEsQg0WehClCgBRZakk8qEFXbmwdg==
+"@sentry-internal/rrdom@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.5.0.tgz#5571b9791f1efc79141237bf8d4faaf7b872b7bb"
+  integrity sha512-1wGVQXoC7wnk6/T8BdHd6fK9F4fGn6huQGtss77uCvX9gJaXpfwUDV7Rbj8bOhTMn8bXsIIhpuBg7OMMgXYTzA==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.2.0"
+    "@sentry-internal/rrweb-snapshot" "2.5.0"
 
-"@sentry-internal/rrweb-snapshot@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.2.0.tgz#23a231ffd8ef734c2665690e8040a4ffc2faaf9f"
-  integrity sha512-txHynfjaJHLJvS+Kf9DOJyL7ur/nIBSJsF7OVKoJYJr43uRJzOyJ/SdliIrGz71IpVOCkuBa/ufRRVEVneRDDg==
+"@sentry-internal/rrweb-snapshot@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.5.0.tgz#c13faa437cf703568a5dae4ba67e4e0adc356a23"
+  integrity sha512-7UMeAPLzXCDmB6CnuGUSHQ4TZ1YJc7a4u8HHoQhbL4gYhi2kgsmE5KMkulV5IKOUqZLlwFkzcXTqf37BXcEMUQ==
 
-"@sentry-internal/rrweb-types@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.2.0.tgz#79a76a8d5c436cf18cdee604ab95a9e3049d1949"
-  integrity sha512-0x7gL9cEF/rrdx1feIORD8+pHihJVA2t1wMRnT+PyiEJZToNJO08Mpbe2rlWgovfK3kGDj5GVFVXsPKGTj8c3A==
+"@sentry-internal/rrweb-types@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.5.0.tgz#5ecd52f83b561ae011f2db1f9e3d0ea3273f1b32"
+  integrity sha512-m9X9F3rOqEDUPaNxlhs6NNDB6GPJf4jbdNqFrKa9Qj567S5iInQTj5yplEUuD84ydpXFgoOTm2Kp2sLhP8SEwg==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.2.0"
+    "@sentry-internal/rrweb-snapshot" "2.5.0"
 
-"@sentry-internal/rrweb@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.2.0.tgz#f9b538f16718b88f6ca99b3393c5fbebc274bc06"
-  integrity sha512-gcdC9uuw6b5WZp1wsqC8p8yBN8bmiZN7X7UaxMrhBwH9TifbYxK1gNbgeKOI/GzZF9OVbduXYm3UDt9ZS1njGg==
+"@sentry-internal/rrweb@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.5.0.tgz#32c8496bd113bc93bef6d8f11100e8b5193e4225"
+  integrity sha512-kl6Tyk77j+zREgZVg0YH8YOn7xQxYB+1RRzqRL8rMrKou64uRSGVLMjhb4MR3i4hizkp4ILV3TinaondSx6v8w==
   dependencies:
-    "@sentry-internal/rrdom" "2.2.0"
-    "@sentry-internal/rrweb-snapshot" "2.2.0"
-    "@sentry-internal/rrweb-types" "2.2.0"
+    "@sentry-internal/rrdom" "2.5.0"
+    "@sentry-internal/rrweb-snapshot" "2.5.0"
+    "@sentry-internal/rrweb-types" "2.5.0"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"


### PR DESCRIPTION
> * Revert "fix: isCheckout is not included in fullsnapshot event (rrweb-io#1141)"

Fixes an issue where Meta event is being lost in buffered replays.

> revert: feat: Remove plugins related code, which is not used #123
> feat: Export additional canvas-related types and functions (#134)

Changes needed for canvas playback

> feat: Skip addHoverClass when stylesheet is >= 1MB #130

Affects playback only
