### PR TITLE
feat(core): Extract scope application to util

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,6 +63,7 @@ export {
   convertIntegrationFnToClass,
 } from './integration';
 export { FunctionToString, InboundFilters, LinkedErrors } from './integrations';
+export { applyScopeDataToEvent } from './utils/applyScopeDataToEvent';
 export { prepareEvent } from './utils/prepareEvent';
 export { createCheckInEnvelope } from './checkin';
 export { hasTracingEnabled } from './utils/hasTracingEnabled';

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -15,6 +15,7 @@ import type {
   RequestSession,
   Scope as ScopeInterface,
   ScopeContext,
+  ScopeData,
   Session,
   Severity,
   SeverityLevel,
@@ -26,6 +27,7 @@ import { arrayify, dateTimestampInSeconds, isPlainObject, uuid4 } from '@sentry/
 
 import { getGlobalEventProcessors, notifyEventProcessors } from './eventProcessors';
 import { updateSession } from './session';
+import { applyScopeDataToEvent } from './utils/applyScopeDataToEvent';
 
 /**
  * Default value for maximum number of breadcrumbs added to an event.
@@ -466,78 +468,65 @@ export class Scope implements ScopeInterface {
     return this;
   }
 
+  /** @inheritDoc */
+  public getScopeData(): ScopeData {
+    const {
+      _breadcrumbs,
+      _attachments,
+      _contexts,
+      _tags,
+      _extra,
+      _user,
+      _level,
+      _fingerprint,
+      _eventProcessors,
+      _propagationContext,
+      _sdkProcessingMetadata,
+      _transactionName,
+      _span,
+    } = this;
+
+    return {
+      breadcrumbs: _breadcrumbs,
+      attachments: _attachments,
+      contexts: _contexts,
+      tags: _tags,
+      extra: _extra,
+      user: _user,
+      level: _level,
+      fingerprint: _fingerprint || [],
+      eventProcessors: _eventProcessors,
+      propagationContext: _propagationContext,
+      sdkProcessingMetadata: _sdkProcessingMetadata,
+      transactionName: _transactionName,
+      span: _span,
+    };
+  }
+
   /**
    * Applies data from the scope to the event and runs all event processors on it.
    *
    * @param event Event
    * @param hint Object containing additional information about the original exception, for use by the event processors.
    * @hidden
+   * @deprecated Use `applyScopeDataToEvent()` directly
    */
   public applyToEvent(
     event: Event,
     hint: EventHint = {},
-    additionalEventProcessors?: EventProcessor[],
+    additionalEventProcessors: EventProcessor[] = [],
   ): PromiseLike<Event | null> {
-    if (this._extra && Object.keys(this._extra).length) {
-      event.extra = { ...this._extra, ...event.extra };
-    }
-    if (this._tags && Object.keys(this._tags).length) {
-      event.tags = { ...this._tags, ...event.tags };
-    }
-    if (this._user && Object.keys(this._user).length) {
-      event.user = { ...this._user, ...event.user };
-    }
-    if (this._contexts && Object.keys(this._contexts).length) {
-      event.contexts = { ...this._contexts, ...event.contexts };
-    }
-    if (this._level) {
-      event.level = this._level;
-    }
-    if (this._transactionName) {
-      event.transaction = this._transactionName;
-    }
-
-    // We want to set the trace context for normal events only if there isn't already
-    // a trace context on the event. There is a product feature in place where we link
-    // errors with transaction and it relies on that.
-    if (this._span) {
-      event.contexts = { trace: this._span.getTraceContext(), ...event.contexts };
-      const transaction = this._span.transaction;
-      if (transaction) {
-        event.sdkProcessingMetadata = {
-          dynamicSamplingContext: transaction.getDynamicSamplingContext(),
-          ...event.sdkProcessingMetadata,
-        };
-        const transactionName = transaction.name;
-        if (transactionName) {
-          event.tags = { transaction: transactionName, ...event.tags };
-        }
-      }
-    }
-
-    this._applyFingerprint(event);
-
-    const scopeBreadcrumbs = this._getBreadcrumbs();
-    const breadcrumbs = [...(event.breadcrumbs || []), ...scopeBreadcrumbs];
-    event.breadcrumbs = breadcrumbs.length > 0 ? breadcrumbs : undefined;
-
-    event.sdkProcessingMetadata = {
-      ...event.sdkProcessingMetadata,
-      ...this._sdkProcessingMetadata,
-      propagationContext: this._propagationContext,
-    };
+    applyScopeDataToEvent(event, this.getScopeData());
 
     // TODO (v8): Update this order to be: Global > Client > Scope
-    return notifyEventProcessors(
-      [
-        ...(additionalEventProcessors || []),
-        // eslint-disable-next-line deprecation/deprecation
-        ...getGlobalEventProcessors(),
-        ...this._eventProcessors,
-      ],
-      event,
-      hint,
-    );
+    const eventProcessors: EventProcessor[] = [
+      ...additionalEventProcessors,
+      // eslint-disable-next-line deprecation/deprecation
+      ...getGlobalEventProcessors(),
+      ...this._eventProcessors,
+    ];
+
+    return notifyEventProcessors(eventProcessors, event, hint);
   }
 
   /**
@@ -565,13 +554,6 @@ export class Scope implements ScopeInterface {
   }
 
   /**
-   * Get the breadcrumbs for this scope.
-   */
-  protected _getBreadcrumbs(): Breadcrumb[] {
-    return this._breadcrumbs;
-  }
-
-  /**
    * This will be called on every set call.
    */
   protected _notifyScopeListeners(): void {
@@ -584,25 +566,6 @@ export class Scope implements ScopeInterface {
         callback(this);
       });
       this._notifyingListeners = false;
-    }
-  }
-
-  /**
-   * Applies fingerprint from the scope to the event if there's one,
-   * uses message if there's one instead or get rid of empty fingerprint
-   */
-  private _applyFingerprint(event: Event): void {
-    // Make sure it's an array first and we actually have something in place
-    event.fingerprint = event.fingerprint ? arrayify(event.fingerprint) : [];
-
-    // If we have something on the scope, then merge it with event
-    if (this._fingerprint) {
-      event.fingerprint = event.fingerprint.concat(this._fingerprint);
-    }
-
-    // If we have no data at all, remove empty array default
-    if (event.fingerprint && !event.fingerprint.length) {
-      delete event.fingerprint;
     }
   }
 }

--- a/packages/core/src/utils/applyScopeDataToEvent.ts
+++ b/packages/core/src/utils/applyScopeDataToEvent.ts
@@ -1,0 +1,97 @@
+import type { Breadcrumb, Event, PropagationContext, ScopeData, Span } from '@sentry/types';
+import { arrayify } from '@sentry/utils';
+
+/**
+ * Applies data from the scope to the event and runs all event processors on it.
+ */
+export function applyScopeDataToEvent(event: Event, data: ScopeData): void {
+  const { fingerprint, span, breadcrumbs, sdkProcessingMetadata, propagationContext } = data;
+
+  // Apply general data
+  applyDataToEvent(event, data);
+
+  // We want to set the trace context for normal events only if there isn't already
+  // a trace context on the event. There is a product feature in place where we link
+  // errors with transaction and it relies on that.
+  if (span) {
+    applySpanToEvent(event, span);
+  }
+
+  applyFingerprintToEvent(event, fingerprint);
+  applyBreadcrumbsToEvent(event, breadcrumbs);
+  applySdkMetadataToEvent(event, sdkProcessingMetadata, propagationContext);
+}
+
+function applyDataToEvent(event: Event, data: ScopeData): void {
+  const { extra, tags, user, contexts, level, transactionName } = data;
+
+  if (extra && Object.keys(extra).length) {
+    event.extra = { ...extra, ...event.extra };
+  }
+  if (tags && Object.keys(tags).length) {
+    event.tags = { ...tags, ...event.tags };
+  }
+  if (user && Object.keys(user).length) {
+    event.user = { ...user, ...event.user };
+  }
+  if (contexts && Object.keys(contexts).length) {
+    event.contexts = { ...contexts, ...event.contexts };
+  }
+  if (level) {
+    event.level = level;
+  }
+  if (transactionName) {
+    event.transaction = transactionName;
+  }
+}
+
+function applyBreadcrumbsToEvent(event: Event, breadcrumbs: Breadcrumb[]): void {
+  const mergedBreadcrumbs = [...(event.breadcrumbs || []), ...breadcrumbs];
+  event.breadcrumbs = mergedBreadcrumbs.length ? mergedBreadcrumbs : undefined;
+}
+
+function applySdkMetadataToEvent(
+  event: Event,
+  sdkProcessingMetadata: ScopeData['sdkProcessingMetadata'],
+  propagationContext: PropagationContext,
+): void {
+  event.sdkProcessingMetadata = {
+    ...event.sdkProcessingMetadata,
+    ...sdkProcessingMetadata,
+    propagationContext: propagationContext,
+  };
+}
+
+function applySpanToEvent(event: Event, span: Span): void {
+  event.contexts = { trace: span.getTraceContext(), ...event.contexts };
+  const transaction = span.transaction;
+  if (transaction) {
+    event.sdkProcessingMetadata = {
+      dynamicSamplingContext: transaction.getDynamicSamplingContext(),
+      ...event.sdkProcessingMetadata,
+    };
+    const transactionName = transaction.name;
+    if (transactionName) {
+      event.tags = { transaction: transactionName, ...event.tags };
+    }
+  }
+}
+
+/**
+ * Applies fingerprint from the scope to the event if there's one,
+ * uses message if there's one instead or get rid of empty fingerprint
+ */
+function applyFingerprintToEvent(event: Event, fingerprint: ScopeData['fingerprint'] | undefined): void {
+  // Make sure it's an array first and we actually have something in place
+  event.fingerprint = event.fingerprint ? arrayify(event.fingerprint) : [];
+
+  // If we have something on the scope, then merge it with event
+  if (fingerprint) {
+    event.fingerprint = event.fingerprint.concat(fingerprint);
+  }
+
+  // If we have no data at all, remove empty array default
+  if (event.fingerprint && !event.fingerprint.length) {
+    delete event.fingerprint;
+  }
+}

--- a/packages/feedback/test/unit/util/prepareFeedbackEvent.test.ts
+++ b/packages/feedback/test/unit/util/prepareFeedbackEvent.test.ts
@@ -16,7 +16,7 @@ describe('Unit | util | prepareFeedbackEvent', () => {
     hub.bindClient(client);
 
     client = hub.getClient()!;
-    scope = hub.getScope()!;
+    scope = hub.getScope();
   });
 
   afterEach(() => {

--- a/packages/node-experimental/test/sdk/scope.test.ts
+++ b/packages/node-experimental/test/sdk/scope.test.ts
@@ -1,3 +1,4 @@
+import { applyScopeDataToEvent } from '@sentry/core';
 import type { Attachment, Breadcrumb, Client, EventProcessor } from '@sentry/types';
 import { Scope, getIsolationScope } from '../../src';
 import { getGlobalScope, mergeArray, mergeData, mergePropKeep, mergePropOverwrite } from '../../src/sdk/scope';
@@ -295,8 +296,7 @@ describe('Unit | Scope', () => {
         extra: { extra1: 'aa', extra2: 'bb', extra3: 'bb' },
         contexts: { os: { name: 'os2' }, culture: { display_name: 'name1' } },
         attachments: [attachment1, attachment2, attachment3],
-        // This is not merged, we always use the one from the scope here anyhow
-        propagationContext: { spanId: '1', traceId: '1' },
+        propagationContext: { spanId: '2', traceId: '2' },
         sdkProcessingMetadata: { aa: 'aa', bb: 'bb', cc: 'bb' },
         fingerprint: ['aa', 'bb', 'cc'],
       });
@@ -309,7 +309,8 @@ describe('Unit | Scope', () => {
 
       const scope = new Scope();
 
-      const event = await scope.applyToEvent({ message: 'foo' });
+      const event = { message: 'foo' };
+      applyScopeDataToEvent(event, scope.getScopeData());
 
       expect(event).toEqual({
         message: 'foo',
@@ -357,11 +358,9 @@ describe('Unit | Scope', () => {
       isolationScope.addEventProcessor(eventProcessor3);
       globalScope.setSDKProcessingMetadata({ bb: 'bb' });
 
-      const event = await scope.applyToEvent({
-        message: 'foo',
-        breadcrumbs: [breadcrumb4],
-        fingerprint: ['dd'],
-      });
+      const event = { message: 'foo', breadcrumbs: [breadcrumb4], fingerprint: ['dd'] };
+
+      applyScopeDataToEvent(event, scope.getScopeData());
 
       expect(event).toEqual({
         message: 'foo',

--- a/packages/node/src/integrations/hapi/index.ts
+++ b/packages/node/src/integrations/hapi/index.ts
@@ -38,6 +38,7 @@ function sendErrorToSentry(errorData: object): void {
 export const hapiErrorPlugin = {
   name: 'SentryHapiErrorPlugin',
   version: SDK_VERSION,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   register: async function (serverArg: Record<any, any>) {
     const server = serverArg as unknown as Server;
 
@@ -61,6 +62,7 @@ export const hapiErrorPlugin = {
 export const hapiTracingPlugin = {
   name: 'SentryHapiTracingPlugin',
   version: SDK_VERSION,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   register: async function (serverArg: Record<any, any>) {
     const server = serverArg as unknown as Server;
 
@@ -122,6 +124,7 @@ export const hapiTracingPlugin = {
 
 export type HapiOptions = {
   /** Hapi server instance */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   server?: Record<any, any>;
 };
 

--- a/packages/node/test/integrations/requestdata.test.ts
+++ b/packages/node/test/integrations/requestdata.test.ts
@@ -1,5 +1,6 @@
 import * as http from 'http';
-import type { RequestDataIntegrationOptions } from '@sentry/core';
+import type { RequestDataIntegrationOptions} from '@sentry/core';
+import { getCurrentScope } from '@sentry/core';
 import { RequestData, getCurrentHub } from '@sentry/core';
 import type { Event, EventProcessor, PolymorphicRequest } from '@sentry/types';
 import * as sentryUtils from '@sentry/utils';
@@ -67,7 +68,7 @@ describe('`RequestData` integration', () => {
 
       sentryRequestMiddleware(req, res, next);
 
-      await getCurrentHub().getScope()!.applyToEvent(event, {});
+      await getCurrentScope().applyToEvent(event, {});
       void requestDataEventProcessor(event, {});
 
       const passedOptions = addRequestDataToEventSpy.mock.calls[0][2];
@@ -80,7 +81,7 @@ describe('`RequestData` integration', () => {
       type GCPHandler = (req: PolymorphicRequest, res: http.ServerResponse) => void;
       const mockGCPWrapper = (origHandler: GCPHandler, options: Record<string, unknown>): GCPHandler => {
         const wrappedHandler: GCPHandler = (req, res) => {
-          getCurrentHub().getScope().setSDKProcessingMetadata({
+          getCurrentScope().setSDKProcessingMetadata({
             request: req,
             requestDataOptionsFromGCPWrapper: options,
           });
@@ -96,7 +97,7 @@ describe('`RequestData` integration', () => {
 
       wrappedGCPFunction(req, res);
 
-      await getCurrentHub().getScope()!.applyToEvent(event, {});
+      await getCurrentScope().applyToEvent(event, {});
       void requestDataEventProcessor(event, {});
 
       const passedOptions = addRequestDataToEventSpy.mock.calls[0][2];

--- a/packages/node/test/integrations/requestdata.test.ts
+++ b/packages/node/test/integrations/requestdata.test.ts
@@ -1,5 +1,6 @@
 import * as http from 'http';
-import type { RequestDataIntegrationOptions} from '@sentry/core';
+import type { RequestDataIntegrationOptions } from '@sentry/core';
+import { applyScopeDataToEvent } from '@sentry/core';
 import { getCurrentScope } from '@sentry/core';
 import { RequestData, getCurrentHub } from '@sentry/core';
 import type { Event, EventProcessor, PolymorphicRequest } from '@sentry/types';
@@ -68,7 +69,7 @@ describe('`RequestData` integration', () => {
 
       sentryRequestMiddleware(req, res, next);
 
-      await getCurrentScope().applyToEvent(event, {});
+      applyScopeDataToEvent(event, getCurrentScope().getScopeData());
       void requestDataEventProcessor(event, {});
 
       const passedOptions = addRequestDataToEventSpy.mock.calls[0][2];
@@ -97,7 +98,7 @@ describe('`RequestData` integration', () => {
 
       wrappedGCPFunction(req, res);
 
-      await getCurrentScope().applyToEvent(event, {});
+      applyScopeDataToEvent(event, getCurrentScope().getScopeData());
       void requestDataEventProcessor(event, {});
 
       const passedOptions = addRequestDataToEventSpy.mock.calls[0][2];

--- a/packages/opentelemetry/src/custom/scope.ts
+++ b/packages/opentelemetry/src/custom/scope.ts
@@ -90,11 +90,6 @@ export class OpenTelemetryScope extends Scope {
     return this._addBreadcrumb(breadcrumb, maxBreadcrumbs);
   }
 
-  /** Add a breadcrumb to this scope. */
-  protected _addBreadcrumb(breadcrumb: Breadcrumb, maxBreadcrumbs?: number): this {
-    return super.addBreadcrumb(breadcrumb, maxBreadcrumbs);
-  }
-
   /** @inheritDoc */
   public getScopeData(): ScopeData {
     const data = super.getScopeData();
@@ -102,6 +97,11 @@ export class OpenTelemetryScope extends Scope {
     data.breadcrumbs = this._getBreadcrumbs();
 
     return data;
+  }
+
+  /** Add a breadcrumb to this scope. */
+  protected _addBreadcrumb(breadcrumb: Breadcrumb, maxBreadcrumbs?: number): this {
+    return super.addBreadcrumb(breadcrumb, maxBreadcrumbs);
   }
 
   /**

--- a/packages/opentelemetry/src/custom/scope.ts
+++ b/packages/opentelemetry/src/custom/scope.ts
@@ -1,7 +1,7 @@
 import type { Span } from '@opentelemetry/api';
 import type { TimedEvent } from '@opentelemetry/sdk-trace-base';
 import { Scope } from '@sentry/core';
-import type { Breadcrumb, SeverityLevel, Span as SentrySpan } from '@sentry/types';
+import type { Breadcrumb, ScopeData, SeverityLevel, Span as SentrySpan } from '@sentry/types';
 import { dateTimestampInSeconds, dropUndefinedKeys, logger, normalize } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
@@ -93,6 +93,15 @@ export class OpenTelemetryScope extends Scope {
   /** Add a breadcrumb to this scope. */
   protected _addBreadcrumb(breadcrumb: Breadcrumb, maxBreadcrumbs?: number): this {
     return super.addBreadcrumb(breadcrumb, maxBreadcrumbs);
+  }
+
+  /** @inheritDoc */
+  public getScopeData(): ScopeData {
+    const data = super.getScopeData();
+
+    data.breadcrumbs = this._getBreadcrumbs();
+
+    return data;
   }
 
   /**

--- a/packages/replay/test/unit/util/prepareReplayEvent.test.ts
+++ b/packages/replay/test/unit/util/prepareReplayEvent.test.ts
@@ -17,7 +17,7 @@ describe('Unit | util | prepareReplayEvent', () => {
     hub.bindClient(client);
 
     client = hub.getClient()!;
-    scope = hub.getScope()!;
+    scope = hub.getScope();
 
     jest.spyOn(client, 'getSdkMetadata').mockImplementation(() => {
       return {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -72,7 +72,7 @@ export type { ReplayEvent, ReplayRecordingData, ReplayRecordingMode } from './re
 export type { FeedbackEvent } from './feedback';
 export type { QueryParams, Request, SanitizedRequestData } from './request';
 export type { Runtime } from './runtime';
-export type { CaptureContext, Scope, ScopeContext } from './scope';
+export type { CaptureContext, Scope, ScopeContext, ScopeData } from './scope';
 export type { SdkInfo } from './sdkinfo';
 export type { SdkMetadata } from './sdkmetadata';
 export type {

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -50,7 +50,7 @@ export interface Scope {
   /** Add new event processor that will be called after {@link applyToEvent}. */
   addEventProcessor(callback: EventProcessor): this;
 
-  /** Get the data of this scope, which should be applied to an event. */
+  /** Get the data of this scope, which is applied to an event during processing. */
   getScopeData(): ScopeData;
 
   /**

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -27,12 +27,31 @@ export interface ScopeContext {
   propagationContext: PropagationContext;
 }
 
+export interface ScopeData {
+  eventProcessors: EventProcessor[];
+  breadcrumbs: Breadcrumb[];
+  user: User;
+  tags: { [key: string]: Primitive };
+  extra: Extras;
+  contexts: Contexts;
+  attachments: Attachment[];
+  propagationContext: PropagationContext;
+  sdkProcessingMetadata: { [key: string]: unknown };
+  fingerprint: string[];
+  level?: SeverityLevel;
+  transactionName?: string;
+  span?: Span;
+}
+
 /**
  * Holds additional event information. {@link Scope.applyToEvent} will be called by the client before an event is sent.
  */
 export interface Scope {
   /** Add new event processor that will be called after {@link applyToEvent}. */
   addEventProcessor(callback: EventProcessor): this;
+
+  /** Get the data of this scope, which should be applied to an event. */
+  getScopeData(): ScopeData;
 
   /**
    * Updates user context information for future events.


### PR DESCRIPTION
This is a try to move the application of scope data to events out of the scope class into a util function.

This changes the flow to be:

1. The scope has a `getScopeData()` method that returns data that should be applied to events.
2. The `prepareEvent` method uses that to actually apply scope data to the event etc.
3. This also makes it much easier to do the experimentation in node-experimental (https://github.com/getsentry/sentry-javascript/pull/9799) because we only need to overwrite this, and can leave the rest of the event processing the same.

I _think_ this makes sense but would appreciate some more eyes on this as well. For me the separation makes also more sense, as e.g. the application of event processors etc. should not really be tied to the scope at all.

This is also is a first step to then allow us to add global scopes more easily.