### PR TITLE
chore(vscode): Use new code action values `"explicit"`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,8 +30,8 @@
   ],
   "deno.enablePaths": ["packages/deno/test"],
   "editor.codeActionsOnSave": {
-    "source.organizeImports.biome": true,
-    "quickfix.biome": true
+    "source.organizeImports.biome": "explicit",
+    "quickfix.biome": "explicit"
   },
   "editor.defaultFormatter": "biomejs.biome"
 }


### PR DESCRIPTION
latest vscode will attempt to correct these values every time you open the project.

**The new options are:**
explicit - Triggers Code Actions when explicitly saved. Same as true. 
always - Triggers Code Actions when explicitly saved and on Auto Saves from window or focus changes. 
never - Never triggers Code Actions on save. Same as false.

https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto
