### PR TITLE
fix(nextjs): Guard against injecting multiple times

### DIFF
--- a/packages/nextjs/src/config/webpack.ts
+++ b/packages/nextjs/src/config/webpack.ts
@@ -625,6 +625,9 @@ function addFilesToExistingEntryPoint(
 
   if (typeof currentEntryPoint === 'string' || Array.isArray(currentEntryPoint)) {
     newEntryPoint = arrayify(currentEntryPoint);
+    if (newEntryPoint.some(entry => filesToInsert.includes(entry))) {
+      return;
+    }
 
     if (isDevMode) {
       // Inserting at beginning breaks dev mode so we insert at the end
@@ -638,6 +641,9 @@ function addFilesToExistingEntryPoint(
   else if (typeof currentEntryPoint === 'object' && 'import' in currentEntryPoint) {
     const currentImportValue = currentEntryPoint.import;
     const newImportValue = arrayify(currentImportValue);
+    if (newImportValue.some(entry => filesToInsert.includes(entry))) {
+      return;
+    }
 
     if (isDevMode) {
       // Inserting at beginning breaks dev mode so we insert at the end


### PR DESCRIPTION
Pointed out by @samijaber - in dev mode we have the possibility to add files to an entry point multiple times. This feels problematic, so fixing it here.  