### PR TITLE
fix(nextjs): Catch rejecting flushes

### DIFF
--- a/packages/nextjs/src/common/_error.ts
+++ b/packages/nextjs/src/common/_error.ts
@@ -1,5 +1,6 @@
 import { captureException, getClient, withScope } from '@sentry/core';
 import type { NextPageContext } from 'next';
+import { flushQueue } from './utils/responseEnd';
 
 type ContextOrProps = {
   req?: NextPageContext['req'];
@@ -8,12 +9,6 @@ type ContextOrProps = {
   pathname?: string;
   statusCode?: number;
 };
-
-/** Platform-agnostic version of `flush` */
-function flush(timeout?: number): PromiseLike<boolean> {
-  const client = getClient();
-  return client ? client.flush(timeout) : Promise.resolve(false);
-}
 
 /**
  * Capture the exception passed by nextjs to the `_error` page, adding context data as appropriate.
@@ -60,5 +55,5 @@ export async function captureUnderscoreErrorException(contextOrProps: ContextOrP
 
   // In case this is being run as part of a serverless function (as is the case with the server half of nextjs apps
   // deployed to vercel), make sure the error gets sent to Sentry before the lambda exits.
-  await flush(2000);
+  await flushQueue();
 }

--- a/packages/nextjs/src/common/utils/edgeWrapperUtils.ts
+++ b/packages/nextjs/src/common/utils/edgeWrapperUtils.ts
@@ -10,6 +10,7 @@ import {
 
 import type { EdgeRouteHandler } from '../../edge/types';
 import { DEBUG_BUILD } from '../debug-build';
+import { flushQueue } from './responseEnd';
 
 /**
  * Wraps a function on the edge runtime with error and performance monitoring.
@@ -97,7 +98,7 @@ export function withEdgeWrapping<H extends EdgeRouteHandler>(
     } finally {
       span?.finish();
       currentScope?.setSpan(prevSpan);
-      await flush(2000);
+      await flushQueue();
     }
   };
 }

--- a/packages/nextjs/src/common/withServerActionInstrumentation.ts
+++ b/packages/nextjs/src/common/withServerActionInstrumentation.ts
@@ -3,6 +3,7 @@ import { logger, tracingContextFromHeaders } from '@sentry/utils';
 
 import { DEBUG_BUILD } from './debug-build';
 import { platformSupportsStreaming } from './utils/platformSupportsStreaming';
+import { flushQueue } from './utils/responseEnd';
 
 interface Options {
   formData?: FormData;
@@ -118,11 +119,11 @@ async function withServerActionInstrumentationImplementation<A extends (...args:
     } finally {
       if (!platformSupportsStreaming()) {
         // Lambdas require manual flushing to prevent execution freeze before the event is sent
-        await flush(1000);
+        await flushQueue();
       }
 
       if (process.env.NEXT_RUNTIME === 'edge') {
-        void flush();
+        void flushQueue();
       }
     }
 

--- a/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
@@ -4,6 +4,7 @@ import { tracingContextFromHeaders, winterCGHeadersToDict } from '@sentry/utils'
 import { isRedirectNavigationError } from './nextNavigationErrorUtils';
 import type { RouteHandlerContext } from './types';
 import { platformSupportsStreaming } from './utils/platformSupportsStreaming';
+import { flushQueue } from './utils/responseEnd';
 
 /**
  * Wraps a Next.js route handler with performance and error instrumentation.
@@ -70,7 +71,7 @@ export function wrapRouteHandlerWithSentry<F extends (...args: any[]) => any>(
           if (!platformSupportsStreaming() || process.env.NEXT_RUNTIME === 'edge') {
             // 1. Edge tranpsort requires manual flushing
             // 2. Lambdas require manual flushing to prevent execution freeze before the event is sent
-            await flush(1000);
+            await flushQueue();
           }
         }
 


### PR DESCRIPTION
We missed catching flushes in a few places which could cause problems if there are issues when sending events.