### PR TITLE
ref(deno): Update deno integrations to avoid `setupOnce`

### DIFF
--- a/packages/deno/src/integrations/context.ts
+++ b/packages/deno/src/integrations/context.ts
@@ -58,7 +58,12 @@ export class DenoContext implements Integration {
   public name: string = DenoContext.id;
 
   /** @inheritDoc */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void): void {
-    addGlobalEventProcessor(async (event: Event) => denoRuntime(event));
+  public setupOnce(_addGlobalEventProcessor: (callback: EventProcessor) => void): void {
+    // noop
+  }
+
+  /** @inheritDoc */
+  public processEvent(event: Event): Promise<Event> {
+    return denoRuntime(event);
   }
 }

--- a/packages/deno/src/integrations/contextlines.ts
+++ b/packages/deno/src/integrations/contextlines.ts
@@ -67,8 +67,13 @@ export class ContextLines implements Integration {
   /**
    * @inheritDoc
    */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void): void {
-    addGlobalEventProcessor(event => this.addSourceContext(event));
+  public setupOnce(_addGlobalEventProcessor: (callback: EventProcessor) => void): void {
+    // noop
+  }
+
+  /** @inheritDoc */
+  public processEvent(event: Event): Promise<Event> {
+    return this.addSourceContext(event);
   }
 
   /** Processes an event and adds context lines */

--- a/packages/deno/src/integrations/normalizepaths.ts
+++ b/packages/deno/src/integrations/normalizepaths.ts
@@ -72,29 +72,32 @@ export class NormalizePaths implements Integration {
   public name: string = NormalizePaths.id;
 
   /** @inheritDoc */
-  public setupOnce(addGlobalEventProcessor: (callback: EventProcessor) => void): void {
+  public setupOnce(_addGlobalEventProcessor: (callback: EventProcessor) => void): void {
+    // noop
+  }
+
+  /** @inheritDoc */
+  public processEvent(event: Event): Event | null {
     // This error.stack hopefully contains paths that traverse the app cwd
     const error = new Error();
 
-    addGlobalEventProcessor((event: Event): Event | null => {
-      const appRoot = getAppRoot(error);
+    const appRoot = getAppRoot(error);
 
-      if (appRoot) {
-        for (const exception of event.exception?.values || []) {
-          for (const frame of exception.stacktrace?.frames || []) {
-            if (frame.filename && frame.in_app) {
-              const startIndex = frame.filename.indexOf(appRoot);
+    if (appRoot) {
+      for (const exception of event.exception?.values || []) {
+        for (const frame of exception.stacktrace?.frames || []) {
+          if (frame.filename && frame.in_app) {
+            const startIndex = frame.filename.indexOf(appRoot);
 
-              if (startIndex > -1) {
-                const endIndex = startIndex + appRoot.length;
-                frame.filename = `app://${frame.filename.substring(endIndex)}`;
-              }
+            if (startIndex > -1) {
+              const endIndex = startIndex + appRoot.length;
+              frame.filename = `app://${frame.filename.substring(endIndex)}`;
             }
           }
         }
       }
+    }
 
-      return event;
-    });
+    return event;
   }
 }


### PR DESCRIPTION
Where possible, we should use the new `processEvent` and/or `setup` hooks of the integrations, instead of `setupOnce`. This updates this for the deno integrations.