### PR TITLE
feat(core): Add type & utility for function-based integrations

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,7 +59,6 @@ export {
   addIntegration,
   // eslint-disable-next-line deprecation/deprecation
   convertIntegrationFnToClass,
-  makeIntegrationFn,
 } from './integration';
 export { FunctionToString, InboundFilters, LinkedErrors } from './integrations';
 export { prepareEvent } from './utils/prepareEvent';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,7 +54,13 @@ export { createTransport } from './transports/base';
 export { makeOfflineTransport } from './transports/offline';
 export { makeMultiplexedTransport } from './transports/multiplexed';
 export { SDK_VERSION } from './version';
-export { getIntegrationsToSetup, addIntegration } from './integration';
+export {
+  getIntegrationsToSetup,
+  addIntegration,
+  // eslint-disable-next-line deprecation/deprecation
+  convertIntegrationFnToClass,
+  makeIntegrationFn,
+} from './integration';
 export { FunctionToString, InboundFilters, LinkedErrors } from './integrations';
 export { prepareEvent } from './utils/prepareEvent';
 export { createCheckInEnvelope } from './checkin';

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -1,12 +1,4 @@
-import type {
-  Client,
-  Event,
-  EventHint,
-  Integration,
-  IntegrationClass,
-  IntegrationFn,
-  Options,
-} from '@sentry/types';
+import type { Client, Event, EventHint, Integration, IntegrationClass, IntegrationFn, Options } from '@sentry/types';
 import { arrayify, logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from './debug-build';

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -174,7 +174,7 @@ export function makeIntegrationFn<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Fn extends (...rest: any[]) => Partial<IntegrationFnResult>,
 >(name: string, fn: Fn): ((...rest: Parameters<Fn>) => ReturnType<Fn> & { name: string }) & { id: string } {
-  const patchedFn = addIdToIntegrationFnResult(name, fn);
+  const patchedFn = addNameToIntegrationFnResult(name, fn);
 
   return Object.assign(patchedFn, { id: name });
 }
@@ -205,7 +205,7 @@ export function convertIntegrationFnToClass<
   ) as unknown as IntegrationClass<Integration>;
 }
 
-function addIdToIntegrationFnResult<
+function addNameToIntegrationFnResult<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Fn extends (...rest: any[]) => Partial<IntegrationFnResult>,
 >(name: string, fn: Fn): (...rest: Parameters<Fn>) => ReturnType<Fn> & { name: string } {

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -5,7 +5,6 @@ import type {
   Integration,
   IntegrationClass,
   IntegrationFn,
-  IntegrationFnResult,
   Options,
 } from '@sentry/types';
 import { arrayify, logger } from '@sentry/utils';
@@ -163,15 +162,6 @@ function findIndex<T>(arr: T[], callback: (item: T) => boolean): number {
   }
 
   return -1;
-}
-
-/**
- * Generate a full integration function from a simple function.
- * This will ensure to add the given name both to the function definition (as id),
- * as well as to the integration return value.
- */
-export function makeIntegrationFn<Fn extends IntegrationFn>(fn: Fn): Fn {
-  return fn;
 }
 
 /**

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -169,10 +169,10 @@ function findIndex<T>(arr: T[], callback: (item: T) => boolean): number {
  * Generate a full integration function from a simple function.
  * This will ensure to add the given name both to the function definition, as well as to the integration return value.
  */
-export function makeIntegrationFn<Fn extends (...rest: any[]) => Partial<IntegrationFnResult>>(
-  name: string,
-  fn: Fn,
-): ((...rest: Parameters<Fn>) => ReturnType<Fn> & { name: string }) & { id: string } {
+export function makeIntegrationFn<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Fn extends (...rest: any[]) => Partial<IntegrationFnResult>,
+>(name: string, fn: Fn): ((...rest: Parameters<Fn>) => ReturnType<Fn> & { name: string }) & { id: string } {
   const patchedFn = addIdToIntegrationFnResult(name, fn);
 
   return Object.assign(patchedFn, { id: name });
@@ -181,11 +181,15 @@ export function makeIntegrationFn<Fn extends (...rest: any[]) => Partial<Integra
 /**
  * Convert a new integration function to the legacy class syntax.
  * In v8, we can remove this and instead export the integration functions directly.
+ *
+ * @deprecated This will be removed in v8!
  */
-export function convertIntegrationFnToClass<Fn extends IntegrationFn<(...rest: any[]) => IntegrationFnResult>>(
-  fn: Fn,
-): IntegrationClass<Integration> {
+export function convertIntegrationFnToClass<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Fn extends IntegrationFn<(...rest: any[]) => IntegrationFnResult>,
+>(fn: Fn): IntegrationClass<Integration> {
   return Object.assign(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     function ConvertedIntegration(...rest: any[]) {
       const res = {
         // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -200,10 +204,10 @@ export function convertIntegrationFnToClass<Fn extends IntegrationFn<(...rest: a
   ) as unknown as IntegrationClass<Integration>;
 }
 
-function addIdToIntegrationFnResult<Fn extends (...rest: any[]) => Partial<IntegrationFnResult>>(
-  name: string,
-  fn: Fn,
-): (...rest: Parameters<Fn>) => ReturnType<Fn> & { name: string } {
+function addIdToIntegrationFnResult<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Fn extends (...rest: any[]) => Partial<IntegrationFnResult>,
+>(name: string, fn: Fn): (...rest: Parameters<Fn>) => ReturnType<Fn> & { name: string } {
   const patchedFn = (...rest: Parameters<Fn>): ReturnType<Fn> & { name: string } => {
     return { ...fn(...rest), name } as ReturnType<Fn> & { name: string };
   };

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -167,7 +167,8 @@ function findIndex<T>(arr: T[], callback: (item: T) => boolean): number {
 
 /**
  * Generate a full integration function from a simple function.
- * This will ensure to add the given name both to the function definition, as well as to the integration return value.
+ * This will ensure to add the given name both to the function definition (as id),
+ * as well as to the integration return value.
  */
 export function makeIntegrationFn<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -170,16 +170,8 @@ function findIndex<T>(arr: T[], callback: (item: T) => boolean): number {
  * This will ensure to add the given name both to the function definition (as id),
  * as well as to the integration return value.
  */
-export function makeIntegrationFn<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Fn extends (...rest: any[]) => Partial<IntegrationFnResult>,
->(name: string, fn: Fn): ((...rest: Parameters<Fn>) => ReturnType<Fn> & { name: string }) & { id: string } {
-  const patchedFn = addNameToIntegrationFnResult(name, fn) as ((
-    ...rest: Parameters<Fn>
-  ) => ReturnType<Fn> & { name: string }) & { id: string };
-
-  patchedFn.id = name;
-  return patchedFn;
+export function makeIntegrationFn<Fn extends IntegrationFn>(fn: Fn): Fn {
+  return fn;
 }
 
 /**
@@ -188,10 +180,10 @@ export function makeIntegrationFn<
  *
  * @deprecated This will be removed in v8!
  */
-export function convertIntegrationFnToClass<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Fn extends IntegrationFn<(...rest: any[]) => IntegrationFnResult>,
->(fn: Fn): IntegrationClass<Integration> {
+export function convertIntegrationFnToClass<Fn extends IntegrationFn>(
+  name: string,
+  fn: Fn,
+): IntegrationClass<Integration> {
   return Object.assign(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     function ConvertedIntegration(...rest: any[]) {
@@ -199,22 +191,8 @@ export function convertIntegrationFnToClass<
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         setupOnce: () => {},
         ...fn(...rest),
-        name: fn.id,
       };
     },
-    { id: fn.id },
+    { id: name },
   ) as unknown as IntegrationClass<Integration>;
-}
-
-function addNameToIntegrationFnResult<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Fn extends (...rest: any[]) => Partial<IntegrationFnResult>,
->(name: string, fn: Fn): (...rest: Parameters<Fn>) => ReturnType<Fn> & { name: string } {
-  const patchedFn = (...rest: Parameters<Fn>): ReturnType<Fn> & { name: string } => {
-    const result = fn(...rest);
-    result.name = name;
-    return result as ReturnType<Fn> & { name: string };
-  };
-
-  return patchedFn;
 }

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -1,8 +1,8 @@
-import type { Client, Event, EventHint, Integration, StackFrame } from '@sentry/types';
+import type {  Event, IntegrationFn, StackFrame } from '@sentry/types';
 import { getEventDescription, logger, stringMatchesSomePattern } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
-import { convertIntegrationFnToClass, makeIntegrationFn } from '../integration';
+import { convertIntegrationFnToClass } from '../integration';
 
 // "Script error." is hard coded into browsers for errors that it can't read.
 // this is the result of a script being pulled in from an external domain and CORS.
@@ -30,7 +30,7 @@ export interface InboundFiltersOptions {
 }
 
 const INTEGRATION_NAME = 'InboundFilters';
-const inboundFiltersIntegration = makeIntegrationFn((options: Partial<InboundFiltersOptions>) => {
+const inboundFiltersIntegration: IntegrationFn = (options: Partial<InboundFiltersOptions>) => {
   return {
     name: INTEGRATION_NAME,
     processEvent(event, _hint, client) {
@@ -39,7 +39,7 @@ const inboundFiltersIntegration = makeIntegrationFn((options: Partial<InboundFil
       return _shouldDropEvent(event, mergedOptions) ? null : event;
     },
   };
-});
+}
 
 /** Inbound filters configurable by the user */
 // eslint-disable-next-line deprecation/deprecation

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -1,4 +1,4 @@
-import type {  Event, IntegrationFn, StackFrame } from '@sentry/types';
+import type { Event, IntegrationFn, StackFrame } from '@sentry/types';
 import { getEventDescription, logger, stringMatchesSomePattern } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
@@ -39,7 +39,7 @@ const inboundFiltersIntegration: IntegrationFn = (options: Partial<InboundFilter
       return _shouldDropEvent(event, mergedOptions) ? null : event;
     },
   };
-}
+};
 
 /** Inbound filters configurable by the user */
 // eslint-disable-next-line deprecation/deprecation

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -35,8 +35,8 @@ const inboundFiltersIntegration = makeIntegrationFn('InboundFilters', (options: 
       const clientOptions = client.getOptions();
       const mergedOptions = _mergeOptions(options, clientOptions);
       return _shouldDropEvent(event, mergedOptions) ? null : event;
-    }
-  }
+    },
+  };
 });
 
 /** Inbound filters configurable by the user */

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -29,8 +29,10 @@ export interface InboundFiltersOptions {
   disableTransactionDefaults: boolean;
 }
 
-const inboundFiltersIntegration = makeIntegrationFn('InboundFilters', (options: Partial<InboundFiltersOptions>) => {
+const INTEGRATION_NAME = 'InboundFilters';
+const inboundFiltersIntegration = makeIntegrationFn((options: Partial<InboundFiltersOptions>) => {
   return {
+    name: INTEGRATION_NAME,
     processEvent(event, _hint, client) {
       const clientOptions = client.getOptions();
       const mergedOptions = _mergeOptions(options, clientOptions);
@@ -41,7 +43,7 @@ const inboundFiltersIntegration = makeIntegrationFn('InboundFilters', (options: 
 
 /** Inbound filters configurable by the user */
 // eslint-disable-next-line deprecation/deprecation
-export const InboundFilters = convertIntegrationFnToClass(inboundFiltersIntegration);
+export const InboundFilters = convertIntegrationFnToClass(INTEGRATION_NAME, inboundFiltersIntegration);
 
 function _mergeOptions(
   internalOptions: Partial<InboundFiltersOptions> = {},

--- a/packages/core/test/lib/integration.test.ts
+++ b/packages/core/test/lib/integration.test.ts
@@ -657,11 +657,11 @@ describe('addIntegration', () => {
 
 describe('makeIntegrationFn', () => {
   it('works with a minimal integration', () => {
-    const myIntegration = makeIntegrationFn('testName', () => {
-      return {};
+    const myIntegration = makeIntegrationFn(() => {
+      return {
+        name: 'testName'
+      };
     });
-
-    expect(myIntegration.id).toBe('testName');
 
     const integration = myIntegration();
     expect(integration).toEqual({
@@ -673,11 +673,11 @@ describe('makeIntegrationFn', () => {
   });
 
   it('works with integration options', () => {
-    const myIntegration = makeIntegrationFn('testName', (_options: { xxx: string }) => {
-      return {};
+    const myIntegration = makeIntegrationFn((_options: { xxx: string }) => {
+      return {
+        name: 'testName'
+      };
     });
-
-    expect(myIntegration.id).toBe('testName');
 
     const integration = myIntegration({ xxx: 'aa' });
     expect(integration).toEqual({
@@ -696,16 +696,15 @@ describe('makeIntegrationFn', () => {
     const processEvent = jest.fn();
     const preprocessEvent = jest.fn();
 
-    const myIntegration = makeIntegrationFn('testName', () => {
+    const myIntegration = makeIntegrationFn(() => {
       return {
+        name: 'testName',
         setup,
         setupOnce,
         processEvent,
         preprocessEvent,
       };
     });
-
-    expect(myIntegration.id).toBe('testName');
 
     const integration = myIntegration();
     expect(integration).toEqual({
@@ -724,9 +723,9 @@ describe('makeIntegrationFn', () => {
 describe('convertIntegrationFnToClass', () => {
   /* eslint-disable deprecation/deprecation */
   it('works with a minimal integration', () => {
-    const integrationFn = makeIntegrationFn('testName', () => ({}));
+    const integrationFn = makeIntegrationFn(() => ({ name: 'testName'}));
 
-    const IntegrationClass = convertIntegrationFnToClass(integrationFn);
+    const IntegrationClass = convertIntegrationFnToClass('testName', integrationFn);
 
     expect(IntegrationClass.id).toBe('testName');
 
@@ -743,8 +742,9 @@ describe('convertIntegrationFnToClass', () => {
     const processEvent = jest.fn();
     const preprocessEvent = jest.fn();
 
-    const integrationFn = makeIntegrationFn('testName', () => {
+    const integrationFn = makeIntegrationFn( () => {
       return {
+        name: 'testName',
         setup,
         setupOnce,
         processEvent,
@@ -752,7 +752,7 @@ describe('convertIntegrationFnToClass', () => {
       };
     });
 
-    const IntegrationClass = convertIntegrationFnToClass(integrationFn);
+    const IntegrationClass = convertIntegrationFnToClass('testName', integrationFn);
 
     expect(IntegrationClass.id).toBe('testName');
 

--- a/packages/core/test/lib/integration.test.ts
+++ b/packages/core/test/lib/integration.test.ts
@@ -7,7 +7,6 @@ import {
   convertIntegrationFnToClass,
   getIntegrationsToSetup,
   installedIntegrations,
-  makeIntegrationFn,
   setupIntegration,
 } from '../../src/integration';
 import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
@@ -655,75 +654,12 @@ describe('addIntegration', () => {
   });
 });
 
-describe('makeIntegrationFn', () => {
-  it('works with a minimal integration', () => {
-    const myIntegration = makeIntegrationFn(() => {
-      return {
-        name: 'testName'
-      };
-    });
 
-    const integration = myIntegration();
-    expect(integration).toEqual({
-      name: 'testName',
-    });
-
-    // @ts-expect-error This SHOULD error
-    myIntegration({});
-  });
-
-  it('works with integration options', () => {
-    const myIntegration = makeIntegrationFn((_options: { xxx: string }) => {
-      return {
-        name: 'testName'
-      };
-    });
-
-    const integration = myIntegration({ xxx: 'aa' });
-    expect(integration).toEqual({
-      name: 'testName',
-    });
-
-    // @ts-expect-error This SHOULD error
-    myIntegration();
-    // @ts-expect-error This SHOULD error
-    myIntegration({});
-  });
-
-  it('works with integration hooks', () => {
-    const setup = jest.fn();
-    const setupOnce = jest.fn();
-    const processEvent = jest.fn();
-    const preprocessEvent = jest.fn();
-
-    const myIntegration = makeIntegrationFn(() => {
-      return {
-        name: 'testName',
-        setup,
-        setupOnce,
-        processEvent,
-        preprocessEvent,
-      };
-    });
-
-    const integration = myIntegration();
-    expect(integration).toEqual({
-      name: 'testName',
-      setup,
-      setupOnce,
-      processEvent,
-      preprocessEvent,
-    });
-
-    // @ts-expect-error This SHOULD error
-    makeIntegrationFn('testName', () => ({ other: 'aha' }));
-  });
-});
 
 describe('convertIntegrationFnToClass', () => {
   /* eslint-disable deprecation/deprecation */
   it('works with a minimal integration', () => {
-    const integrationFn = makeIntegrationFn(() => ({ name: 'testName'}));
+    const integrationFn = () => ({ name: 'testName'});
 
     const IntegrationClass = convertIntegrationFnToClass('testName', integrationFn);
 
@@ -742,7 +678,7 @@ describe('convertIntegrationFnToClass', () => {
     const processEvent = jest.fn();
     const preprocessEvent = jest.fn();
 
-    const integrationFn = makeIntegrationFn( () => {
+    const integrationFn = () => {
       return {
         name: 'testName',
         setup,
@@ -750,7 +686,7 @@ describe('convertIntegrationFnToClass', () => {
         processEvent,
         preprocessEvent,
       };
-    });
+    };
 
     const IntegrationClass = convertIntegrationFnToClass('testName', integrationFn);
 

--- a/packages/core/test/lib/integration.test.ts
+++ b/packages/core/test/lib/integration.test.ts
@@ -722,6 +722,7 @@ describe('makeIntegrationFn', () => {
 });
 
 describe('convertIntegrationFnToClass', () => {
+  /* eslint-disable deprecation/deprecation */
   it('works with a minimal integration', () => {
     const integrationFn = makeIntegrationFn('testName', () => ({}));
 
@@ -764,4 +765,5 @@ describe('convertIntegrationFnToClass', () => {
       preprocessEvent,
     });
   });
+  /* eslint-enable deprecation/deprecation */
 });

--- a/packages/core/test/lib/integration.test.ts
+++ b/packages/core/test/lib/integration.test.ts
@@ -654,12 +654,10 @@ describe('addIntegration', () => {
   });
 });
 
-
-
 describe('convertIntegrationFnToClass', () => {
   /* eslint-disable deprecation/deprecation */
   it('works with a minimal integration', () => {
-    const integrationFn = () => ({ name: 'testName'});
+    const integrationFn = () => ({ name: 'testName' });
 
     const IntegrationClass = convertIntegrationFnToClass('testName', integrationFn);
 

--- a/packages/integrations/src/contextlines.ts
+++ b/packages/integrations/src/contextlines.ts
@@ -49,8 +49,8 @@ export class ContextLines implements Integration {
   }
 
   /** @inheritDoc */
-  public processEvent(event: Event): Event {
-    return this.addSourceContext(event);
+  public preprocessEvent(event: Event): void {
+    this.addSourceContext(event);
   }
 
   /**

--- a/packages/integrations/src/contextlines.ts
+++ b/packages/integrations/src/contextlines.ts
@@ -49,8 +49,8 @@ export class ContextLines implements Integration {
   }
 
   /** @inheritDoc */
-  public preprocessEvent(event: Event): void {
-    this.addSourceContext(event);
+  public processEvent(event: Event): Event {
+    return this.addSourceContext(event);
   }
 
   /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -52,7 +52,7 @@ export type { EventProcessor } from './eventprocessor';
 export type { Exception } from './exception';
 export type { Extra, Extras } from './extra';
 export type { Hub } from './hub';
-export type { Integration, IntegrationClass } from './integration';
+export type { Integration, IntegrationClass, IntegrationFn, IntegrationFnResult } from './integration';
 export type { Mechanism } from './mechanism';
 export type { ExtractedNodeRequestData, HttpHeaderValue, Primitive, WorkerLocation } from './misc';
 export type { ClientOptions, Options } from './options';

--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -10,7 +10,49 @@ export interface IntegrationClass<T> {
    */
   id: string;
 
-  new (...args: any[]): T;
+  new(...args: any[]): T;
+}
+
+/**
+ * An integration in function form.
+ * This is expected to return an integration result,
+ * and also have a `name` property that holds the integration name (so we can e.g. filter these before actually calling them).
+ */
+export type IntegrationFn<Fn extends ((...rest: any[]) => IntegrationFnResult)> = { id: string } & Fn;
+
+export interface IntegrationFnResult {
+  /**
+   * The name of the integration.
+   */
+  name: string;
+
+  /**
+   * This hook is only called once, even if multiple clients are created.
+   * It does not receives any arguments, and should only use for e.g. global monkey patching and similar things.
+   */
+  setupOnce?(): void;
+
+  /**
+   * Set up an integration for the given client.
+   * Receives the client as argument.
+   *
+   * Whenever possible, prefer this over `setupOnce`, as that is only run for the first client,
+   * whereas `setup` runs for each client. Only truly global things (e.g. registering global handlers)
+   * should be done in `setupOnce`.
+   */
+  setup?(client: Client): void;
+
+  /**
+   * An optional hook that allows to preprocess an event _before_ it is passed to all other event processors.
+   */
+  preprocessEvent?(event: Event, hint: EventHint | undefined, client: Client): void;
+
+  /**
+   * An optional hook that allows to process an event.
+   * Return `null` to drop the event, or mutate the event & return it.
+   * This receives the client that the integration was installed for as third argument.
+   */
+  processEvent?(event: Event, hint: EventHint, client: Client): Event | null | PromiseLike<Event | null>;
 }
 
 /** Integration interface */

--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -16,9 +16,8 @@ export interface IntegrationClass<T> {
 /**
  * An integration in function form.
  * This is expected to return an integration result,
- * and also have a `name` property that holds the integration name (so we can e.g. filter these before actually calling them).
  */
-export type IntegrationFn<Fn extends (...rest: any[]) => IntegrationFnResult> = { id: string } & Fn;
+export type IntegrationFn = (...rest: any[]) => IntegrationFnResult;
 
 export interface IntegrationFnResult {
   /**

--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -10,7 +10,7 @@ export interface IntegrationClass<T> {
    */
   id: string;
 
-  new(...args: any[]): T;
+  new (...args: any[]): T;
 }
 
 /**
@@ -18,7 +18,7 @@ export interface IntegrationClass<T> {
  * This is expected to return an integration result,
  * and also have a `name` property that holds the integration name (so we can e.g. filter these before actually calling them).
  */
-export type IntegrationFn<Fn extends ((...rest: any[]) => IntegrationFnResult)> = { id: string } & Fn;
+export type IntegrationFn<Fn extends (...rest: any[]) => IntegrationFnResult> = { id: string } & Fn;
 
 export interface IntegrationFnResult {
   /**


### PR DESCRIPTION
This PR adds new types for function-based integrations, that eventually (in v8) should fully replace the class-based functions.

This also introduces a small helper function to make writing such integrations easier (as we need to set an id/name etc. on the integration). With this, you can write an integration like this:

```ts
const inboundFiltersIntegration = makeIntegrationFn(
  'InboundFilters', 
  (options: Partial<InboundFiltersOptions>) => {
  return {
    processEvent(event, _hint, client) {
      const clientOptions = client.getOptions();
      const mergedOptions = _mergeOptions(options, clientOptions);
      return _shouldDropEvent(event, mergedOptions) ? null : event;
    }
  }
});
```

And you get a fully typed integration ready to go!

For backwards compatibility, and so that we can actually start converting integrations in v7 already, this PR also adds a small utility `convertIntegrationFnToClass()` to convert such an integration to the "current" integration class syntax.

So we can actually already start porting integrations over like this:

```js
/** Inbound filters configurable by the user */
// eslint-disable-next-line deprecation/deprecation
export const InboundFilters = convertIntegrationFnToClass(inboundFiltersIntegration);
```

Then, in v8 we only have to remove all the `convertIntegrationFnToClass` calls, export the integration functions directly, and update the overall integration types which can be passed to `init()` etc.