### PR TITLE
feat(replay): Add `ReplayCanvas` integration

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -15,6 +15,13 @@ module.exports = [
     limit: '75 KB',
   },
   {
+    name: '@sentry/browser (incl. Tracing, Replay with Canvas) - Webpack (gzipped)',
+    path: 'packages/browser/build/npm/esm/index.js',
+    import: '{ init, Replay, BrowserTracing, ReplayCanvas }',
+    gzip: true,
+    limit: '90 KB',
+  },
+  {
     name: '@sentry/browser (incl. Tracing, Replay) - Webpack with treeshaking flags (gzipped)',
     path: 'packages/browser/build/npm/esm/index.js',
     import: '{ init, Replay, BrowserTracing }',

--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
     "@playwright/test": "^1.31.1",
-    "@sentry-internal/rrweb": "2.6.0",
+    "@sentry-internal/rrweb": "2.7.3",
     "@sentry/browser": "7.92.0",
     "@sentry/tracing": "7.92.0",
     "axios": "1.6.0",

--- a/dev-packages/browser-integration-tests/utils/replayHelpers.ts
+++ b/dev-packages/browser-integration-tests/utils/replayHelpers.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import type { fullSnapshotEvent, incrementalSnapshotEvent } from '@sentry-internal/rrweb';
 import { EventType } from '@sentry-internal/rrweb';
 import type { ReplayEventWithTime } from '@sentry/browser';
@@ -5,6 +6,7 @@ import type {
   InternalEventContext,
   RecordingEvent,
   ReplayContainer,
+  ReplayPluginOptions,
   Session,
 } from '@sentry/replay/build/npm/types/types';
 import type { Breadcrumb, Event, ReplayEvent, ReplayRecordingMode } from '@sentry/types';
@@ -171,6 +173,8 @@ export function getReplaySnapshot(page: Page): Promise<{
   _isPaused: boolean;
   _isEnabled: boolean;
   _context: InternalEventContext;
+  _options: ReplayPluginOptions;
+  _hasCanvas: boolean;
   session: Session | undefined;
   recordingMode: ReplayRecordingMode;
 }> {
@@ -182,6 +186,9 @@ export function getReplaySnapshot(page: Page): Promise<{
       _isPaused: replay.isPaused(),
       _isEnabled: replay.isEnabled(),
       _context: replay.getContext(),
+      _options: replay.getOptions(),
+      // We cannot pass the function through as this is serialized
+      _hasCanvas: typeof replay.getOptions()._experiments.canvas?.manager === 'function',
       session: replay.session,
       recordingMode: replay.recordingMode,
     };

--- a/packages/browser-integration-tests/suites/replay/canvas/template.html
+++ b/packages/browser-integration-tests/suites/replay/canvas/template.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <button onclick="console.log('Test log')">Click me</button>
+  </body>
+</html>

--- a/packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationFirst/init.js
+++ b/packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationFirst/init.js
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+window.Replay = new Sentry.Replay({
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
+  minReplayDuration: 0,
+});
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  sampleRate: 0,
+  replaysSessionSampleRate: 1.0,
+  replaysOnErrorSampleRate: 0.0,
+  debug: true,
+
+  integrations: [new Sentry.ReplayCanvas(), window.Replay],
+});

--- a/packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationFirst/test.ts
+++ b/packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationFirst/test.ts
@@ -1,0 +1,28 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { getReplaySnapshot, shouldSkipReplayTest } from '../../../../utils/replayHelpers';
+
+sentryTest('sets up canvas when adding ReplayCanvas integration first', async ({ getLocalTestUrl, page }) => {
+  if (shouldSkipReplayTest()) {
+    sentryTest.skip();
+  }
+
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+
+  await page.goto(url);
+
+  const replay = await getReplaySnapshot(page);
+  const canvasOptions = replay._options._experiments?.canvas;
+  expect(canvasOptions.fps).toBe(4);
+  expect(canvasOptions.quality).toBe(0.6);
+  expect(replay._hasCanvas).toBe(true);
+});

--- a/packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationSecond/init.js
+++ b/packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationSecond/init.js
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+window.Replay = new Sentry.Replay({
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
+  minReplayDuration: 0,
+});
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  sampleRate: 0,
+  replaysSessionSampleRate: 1.0,
+  replaysOnErrorSampleRate: 0.0,
+  debug: true,
+
+  integrations: [window.Replay, new Sentry.ReplayCanvas()],
+});

--- a/packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationSecond/test.ts
+++ b/packages/browser-integration-tests/suites/replay/canvas/withCanvasIntegrationSecond/test.ts
@@ -1,0 +1,28 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { getReplaySnapshot, shouldSkipReplayTest } from '../../../../utils/replayHelpers';
+
+sentryTest('sets up canvas when adding ReplayCanvas integration after Replay', async ({ getLocalTestUrl, page }) => {
+  if (shouldSkipReplayTest()) {
+    sentryTest.skip();
+  }
+
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+
+  await page.goto(url);
+
+  const replay = await getReplaySnapshot(page);
+  const canvasOptions = replay._options._experiments?.canvas;
+  expect(canvasOptions.fps).toBe(4);
+  expect(canvasOptions.quality).toBe(0.6);
+  expect(replay._hasCanvas).toBe(true);
+});

--- a/packages/browser-integration-tests/suites/replay/canvas/withoutCanvasIntegration/init.js
+++ b/packages/browser-integration-tests/suites/replay/canvas/withoutCanvasIntegration/init.js
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+window.Replay = new Sentry.Replay({
+  flushMinDelay: 200,
+  flushMaxDelay: 200,
+  minReplayDuration: 0,
+});
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  sampleRate: 0,
+  replaysSessionSampleRate: 1.0,
+  replaysOnErrorSampleRate: 0.0,
+  debug: true,
+
+  integrations: [window.Replay],
+});

--- a/packages/browser-integration-tests/suites/replay/canvas/withoutCanvasIntegration/test.ts
+++ b/packages/browser-integration-tests/suites/replay/canvas/withoutCanvasIntegration/test.ts
@@ -1,0 +1,27 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { getReplaySnapshot, shouldSkipReplayTest } from '../../../../utils/replayHelpers';
+
+sentryTest('does not setup up canvas without ReplayCanvas integration', async ({ getLocalTestUrl, page }) => {
+  if (shouldSkipReplayTest()) {
+    sentryTest.skip();
+  }
+
+  await page.route('https://dsn.ingest.sentry.io/**/*', route => {
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-id' }),
+    });
+  });
+
+  const url = await getLocalTestUrl({ testDir: __dirname });
+
+  await page.goto(url);
+
+  const replay = await getReplaySnapshot(page);
+  const canvasOptions = replay._options._experiments?.canvas;
+  expect(canvasOptions).toBe(undefined);
+  expect(replay._hasCanvas).toBe(false);
+});

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -20,7 +20,7 @@ const INTEGRATIONS = {
 
 export { INTEGRATIONS as Integrations };
 
-export { Replay } from '@sentry/replay';
+export { Replay, ReplayCanvas } from '@sentry/replay';
 export type {
   ReplayEventType,
   ReplayEventWithTime,

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -54,8 +54,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@sentry-internal/replay-worker": "7.92.0",
-    "@sentry-internal/rrweb": "2.6.0",
-    "@sentry-internal/rrweb-snapshot": "2.6.0",
+    "@sentry-internal/rrweb": "2.7.3",
+    "@sentry-internal/rrweb-snapshot": "2.7.3",
     "fflate": "^0.8.1",
     "jsdom-worker": "^0.2.1"
   },

--- a/packages/replay/rollup.bundle.config.mjs
+++ b/packages/replay/rollup.bundle.config.mjs
@@ -2,12 +2,20 @@ import { makeBaseBundleConfig, makeBundleConfigVariants } from '@sentry-internal
 
 const baseBundleConfig = makeBaseBundleConfig({
   bundleType: 'addon',
-  entrypoints: ['src/index.ts'],
+  entrypoints: ['src/integration.ts'],
   jsVersion: 'es6',
   licenseTitle: '@sentry/replay',
   outputFileBase: () => 'bundles/replay',
 });
 
-const builds = makeBundleConfigVariants(baseBundleConfig);
+const baseCanvasBundleConfig = makeBaseBundleConfig({
+  bundleType: 'addon',
+  entrypoints: ['src/canvas.ts'],
+  jsVersion: 'es6',
+  licenseTitle: '@sentry/replaycanvas',
+  outputFileBase: () => 'bundles/replaycanvas',
+});
+
+const builds = [...makeBundleConfigVariants(baseBundleConfig), ...makeBundleConfigVariants(baseCanvasBundleConfig)];
 
 export default builds;

--- a/packages/replay/src/canvas.ts
+++ b/packages/replay/src/canvas.ts
@@ -23,7 +23,7 @@ export class ReplayCanvas implements Integration {
   public constructor(options?: Partial<ReplayCanvasOptions>) {
     this.name = ReplayCanvas.id;
     this._canvasOptions = {
-      quality: options && options.quality || 'medium',
+      quality: (options && options.quality) || 'medium',
     };
   }
 

--- a/packages/replay/src/canvas.ts
+++ b/packages/replay/src/canvas.ts
@@ -1,0 +1,54 @@
+import { getCanvasManager } from '@sentry-internal/rrweb';
+import type { Integration } from '@sentry/types';
+import type { ReplayConfiguration } from './types';
+
+interface ReplayCanvasOptions {
+  fps: number;
+  quality: number;
+}
+
+/** An integration to add canvas recording to replay. */
+export class ReplayCanvas implements Integration {
+  /**
+   * @inheritDoc
+   */
+  public static id: string = 'ReplayCanvas';
+
+  /**
+   * @inheritDoc
+   */
+  public name: string;
+
+  private _canvasOptions: ReplayCanvasOptions;
+
+  public constructor() {
+    this.name = ReplayCanvas.id;
+    // TODO FN: Allow to configure this
+    // But since we haven't finalized how to configure this, this is predefined for now
+    // to avoid breaking changes
+    this._canvasOptions = {
+      fps: 4,
+      quality: 0.6,
+    };
+  }
+
+  /** @inheritdoc */
+  public setupOnce(): void {
+    // noop
+  }
+
+  /**
+   * Get the options that should be merged into replay options.
+   * This is what is actually called by the Replay integration to setup canvas.
+   */
+  public getOptions(): Partial<ReplayConfiguration> {
+    return {
+      _experiments: {
+        canvas: {
+          ...this._canvasOptions,
+          manager: getCanvasManager,
+        },
+      },
+    };
+  }
+}

--- a/packages/replay/src/canvas.ts
+++ b/packages/replay/src/canvas.ts
@@ -3,8 +3,7 @@ import type { Integration } from '@sentry/types';
 import type { ReplayConfiguration } from './types';
 
 interface ReplayCanvasOptions {
-  fps: number;
-  quality: number;
+  quality: 'low' | 'medium' | 'high';
 }
 
 /** An integration to add canvas recording to replay. */
@@ -21,14 +20,10 @@ export class ReplayCanvas implements Integration {
 
   private _canvasOptions: ReplayCanvasOptions;
 
-  public constructor() {
+  public constructor(options?: Partial<ReplayCanvasOptions>) {
     this.name = ReplayCanvas.id;
-    // TODO FN: Allow to configure this
-    // But since we haven't finalized how to configure this, this is predefined for now
-    // to avoid breaking changes
     this._canvasOptions = {
-      fps: 4,
-      quality: 0.6,
+      quality: options && options.quality || 'medium',
     };
   }
 
@@ -47,6 +42,7 @@ export class ReplayCanvas implements Integration {
         canvas: {
           ...this._canvasOptions,
           manager: getCanvasManager,
+          quality: this._canvasOptions.quality,
         },
       },
     };

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -1,4 +1,5 @@
 export { Replay } from './integration';
+export { ReplayCanvas } from './canvas';
 
 export type {
   ReplayEventType,

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -138,8 +138,11 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    */
   getEventProcessors?(): EventProcessor[];
 
-  /** Returns the client's instance of the given integration class, it any. */
+  /** Returns the client's instance of the given integration class, if it exists. */
   getIntegration<T extends Integration>(integration: IntegrationClass<T>): T | null;
+
+  /** Returns the client's instance of the given integration name, if it exists. */
+  getIntegrationById?(integrationId: string): Integration | undefined;
 
   /**
    * Add an integration to the client.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5231,33 +5231,33 @@
     semver "7.3.2"
     semver-intersect "1.4.0"
 
-"@sentry-internal/rrdom@2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.6.0.tgz#19b5ab7a01ad5031be2d4bcedd4afedb44ee2bed"
-  integrity sha512-XqxOhLk/CdrKh0toOKeQ6mOcjLDK3B1KY/UVqM9VwhdVhiHeMwPj6GjJUoNkEXh0MwkDM0pzIMv95oSq7hGhPg==
+"@sentry-internal/rrdom@2.7.3":
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.7.3.tgz#2efe68a9cf23de9a8970acf4303748cdd7866b20"
+  integrity sha512-XD14G4Lv3ppvJlR7VkkCgHTKu1ylh7yvXdSsN5/FyGTH+IAXQIKL5nINIgWZTN3noNBWV9R0vcHDufXG/WktWA==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.6.0"
+    "@sentry-internal/rrweb-snapshot" "2.7.3"
 
-"@sentry-internal/rrweb-snapshot@2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.6.0.tgz#1b214c9ab4645138a02ef255c95d811bd852f996"
-  integrity sha512-dlduO37avs5HBP8zRxFHlhRb7ZP6p3SrgMSztPCCnfYr/XAB/rn5yeVn9U2FDYdrgyUzPjFWfYWFvm1eJuEMSg==
+"@sentry-internal/rrweb-snapshot@2.7.3":
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.7.3.tgz#9a7173825a31c07ccf27a5956f154400e11fdd97"
+  integrity sha512-mSZuBPmWia3x9wCuaJiZMD9ZVDnFv7TSG1Nz9X4ZqWb3DdaxB2MogGUU/2aTVqmRj6F91nl+GHb5NpmNYojUsw==
 
-"@sentry-internal/rrweb-types@2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.6.0.tgz#e526994125db6684ce9402d96f64318f062bebb0"
-  integrity sha512-mPPumdbyNHF24zShvZqzqgkZRsJHhlNpglGTS0cR/PkX2QdG0CtsPVFpaYj6UQAFGpfb2Aj7VdkKuuzX4RX69w==
+"@sentry-internal/rrweb-types@2.7.3":
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.7.3.tgz#e38737bc5c31aa9dfb8ce8faf46af374c2aa7cbb"
+  integrity sha512-EqALxhZtvH0rimYfj7J48DRC+fj+AGsZ/VDdOPKh3MQXptTyHncoWBj4ZtB1AaH7foYUr+2wkyxl3HqMVwe+6g==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.6.0"
+    "@sentry-internal/rrweb-snapshot" "2.7.3"
 
-"@sentry-internal/rrweb@2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.6.0.tgz#0976e0d021c965b491a5193546a735f78dad9107"
-  integrity sha512-N+v0cgft/mikwIH5MPIspWNEqHa3E/01rA+IwozTs/TUp2e8sJmF3qxR0+OeBGZU0ln4soG1o18FjsCmadqbeQ==
+"@sentry-internal/rrweb@2.7.3":
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.7.3.tgz#900ce7b1bd8ec43b5557d73698cc1b4dc9f47f72"
+  integrity sha512-K2pksQ1FgDumv54r1o0+RAKB3Qx3Zgx6OrQAkU/SI6/7HcBIxe7b4zepg80NyvnfohUs/relw2EoD3K3kqd8tg==
   dependencies:
-    "@sentry-internal/rrdom" "2.6.0"
-    "@sentry-internal/rrweb-snapshot" "2.6.0"
-    "@sentry-internal/rrweb-types" "2.6.0"
+    "@sentry-internal/rrdom" "2.7.3"
+    "@sentry-internal/rrweb-snapshot" "2.7.3"
+    "@sentry-internal/rrweb-types" "2.7.3"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"


### PR DESCRIPTION
Adding this integration in addition to `Replay` will set up canvas recording.

This is _a bit_ hacky because interacting between multiple integrations is not really great/easy. But I think it is the best user experience we can provide there, AND it also provides a direct way to use this with CDN bundles as well - users just have to add the `replaycanvas` integration bundle in addition to the regular browser+replay bundle and it should just work.
