### PR TITLE
feat(replay): Bump `rrweb` to 2.6.0

### DIFF
--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -48,8 +48,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@sentry-internal/replay-worker": "7.87.0",
-    "@sentry-internal/rrweb": "2.5.0",
-    "@sentry-internal/rrweb-snapshot": "2.5.0",
+    "@sentry-internal/rrweb": "2.6.0",
+    "@sentry-internal/rrweb-snapshot": "2.6.0",
     "fflate": "^0.8.1",
     "jsdom-worker": "^0.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5048,33 +5048,33 @@
     semver "7.3.2"
     semver-intersect "1.4.0"
 
-"@sentry-internal/rrdom@2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.5.0.tgz#5571b9791f1efc79141237bf8d4faaf7b872b7bb"
-  integrity sha512-1wGVQXoC7wnk6/T8BdHd6fK9F4fGn6huQGtss77uCvX9gJaXpfwUDV7Rbj8bOhTMn8bXsIIhpuBg7OMMgXYTzA==
+"@sentry-internal/rrdom@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.6.0.tgz#19b5ab7a01ad5031be2d4bcedd4afedb44ee2bed"
+  integrity sha512-XqxOhLk/CdrKh0toOKeQ6mOcjLDK3B1KY/UVqM9VwhdVhiHeMwPj6GjJUoNkEXh0MwkDM0pzIMv95oSq7hGhPg==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.5.0"
+    "@sentry-internal/rrweb-snapshot" "2.6.0"
 
-"@sentry-internal/rrweb-snapshot@2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.5.0.tgz#c13faa437cf703568a5dae4ba67e4e0adc356a23"
-  integrity sha512-7UMeAPLzXCDmB6CnuGUSHQ4TZ1YJc7a4u8HHoQhbL4gYhi2kgsmE5KMkulV5IKOUqZLlwFkzcXTqf37BXcEMUQ==
+"@sentry-internal/rrweb-snapshot@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.6.0.tgz#1b214c9ab4645138a02ef255c95d811bd852f996"
+  integrity sha512-dlduO37avs5HBP8zRxFHlhRb7ZP6p3SrgMSztPCCnfYr/XAB/rn5yeVn9U2FDYdrgyUzPjFWfYWFvm1eJuEMSg==
 
-"@sentry-internal/rrweb-types@2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.5.0.tgz#5ecd52f83b561ae011f2db1f9e3d0ea3273f1b32"
-  integrity sha512-m9X9F3rOqEDUPaNxlhs6NNDB6GPJf4jbdNqFrKa9Qj567S5iInQTj5yplEUuD84ydpXFgoOTm2Kp2sLhP8SEwg==
+"@sentry-internal/rrweb-types@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.6.0.tgz#e526994125db6684ce9402d96f64318f062bebb0"
+  integrity sha512-mPPumdbyNHF24zShvZqzqgkZRsJHhlNpglGTS0cR/PkX2QdG0CtsPVFpaYj6UQAFGpfb2Aj7VdkKuuzX4RX69w==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.5.0"
+    "@sentry-internal/rrweb-snapshot" "2.6.0"
 
-"@sentry-internal/rrweb@2.5.0":
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.5.0.tgz#32c8496bd113bc93bef6d8f11100e8b5193e4225"
-  integrity sha512-kl6Tyk77j+zREgZVg0YH8YOn7xQxYB+1RRzqRL8rMrKou64uRSGVLMjhb4MR3i4hizkp4ILV3TinaondSx6v8w==
+"@sentry-internal/rrweb@2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.6.0.tgz#0976e0d021c965b491a5193546a735f78dad9107"
+  integrity sha512-N+v0cgft/mikwIH5MPIspWNEqHa3E/01rA+IwozTs/TUp2e8sJmF3qxR0+OeBGZU0ln4soG1o18FjsCmadqbeQ==
   dependencies:
-    "@sentry-internal/rrdom" "2.5.0"
-    "@sentry-internal/rrweb-snapshot" "2.5.0"
-    "@sentry-internal/rrweb-types" "2.5.0"
+    "@sentry-internal/rrdom" "2.6.0"
+    "@sentry-internal/rrweb-snapshot" "2.6.0"
+    "@sentry-internal/rrweb-types" "2.6.0"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"


### PR DESCRIPTION
This should fix an issue where we were unable to record canvas because the canvas manager bundle was split from the main `record` bundle and was unable to emit mutations from the canvas manager.
