### PR TITLE
chore(sveltekit): Add SvelteKit 2.0 to peer dependency range

### DIFF
--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@sveltejs/kit": "1.x"
+    "@sveltejs/kit": ">=1.x"
   },
   "dependencies": {
     "@sentry-internal/tracing": "7.88.0",


### PR DESCRIPTION
Setting the range to `>=1.x` to include kit 2.0 and higher
