### PR TITLE
ref: Use `getCurrentScope()` / `getClient` instead of  `hub.xxx`

### DIFF
--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -7,7 +7,7 @@ import type { ActivatedRouteSnapshot, Event, RouterState } from '@angular/router
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import { NavigationCancel, NavigationError, Router } from '@angular/router';
 import { NavigationEnd, NavigationStart, ResolveEnd } from '@angular/router';
-import { WINDOW, getCurrentHub } from '@sentry/browser';
+import { WINDOW, getCurrentScope } from '@sentry/browser';
 import type { Span, Transaction, TransactionContext } from '@sentry/types';
 import { logger, stripUrlQueryAndFragment, timestampInSeconds } from '@sentry/utils';
 import type { Observable } from 'rxjs';
@@ -50,14 +50,7 @@ export const instrumentAngularRouting = routingInstrumentation;
  * Grabs active transaction off scope
  */
 export function getActiveTransaction(): Transaction | undefined {
-  const currentHub = getCurrentHub();
-
-  if (currentHub) {
-    const scope = currentHub.getScope();
-    return scope.getTransaction();
-  }
-
-  return undefined;
+  return getCurrentScope().getTransaction();
 }
 
 /**

--- a/packages/angular/test/tracing.test.ts
+++ b/packages/angular/test/tracing.test.ts
@@ -21,16 +21,12 @@ jest.mock('@sentry/browser', () => {
   const original = jest.requireActual('@sentry/browser');
   return {
     ...original,
-    getCurrentHub: () => {
+    getCurrentScope() {
       return {
-        getScope: () => {
-          return {
-            getTransaction: () => {
-              return transaction;
-            },
-          };
+        getTransaction: () => {
+          return transaction;
         },
-      } as unknown as Hub;
+      };
     },
   };
 });

--- a/packages/astro/src/server/meta.ts
+++ b/packages/astro/src/server/meta.ts
@@ -1,5 +1,5 @@
 import { getDynamicSamplingContextFromClient } from '@sentry/core';
-import type { Hub, Span } from '@sentry/types';
+import type { Client, Scope, Span } from '@sentry/types';
 import {
   TRACEPARENT_REGEXP,
   dynamicSamplingContextToSentryBaggageHeader,
@@ -22,9 +22,11 @@ import {
  *
  * @returns an object with the two serialized <meta> tags
  */
-export function getTracingMetaTags(span: Span | undefined, hub: Hub): { sentryTrace: string; baggage?: string } {
-  const scope = hub.getScope();
-  const client = hub.getClient();
+export function getTracingMetaTags(
+  span: Span | undefined,
+  scope: Scope,
+  client: Client | undefined,
+): { sentryTrace: string; baggage?: string } {
   const { dsc, sampled, traceId } = scope.getPropagationContext();
   const transaction = span?.transaction;
 

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getClient } from '@sentry/core';
 import type { Event, EventHint, Exception, Severity, SeverityLevel, StackFrame, StackParser } from '@sentry/types';
 import {
   addExceptionMechanism,
@@ -48,8 +48,7 @@ export function eventFromPlainObject(
   syntheticException?: Error,
   isUnhandledRejection?: boolean,
 ): Event {
-  const hub = getCurrentHub();
-  const client = hub.getClient();
+  const client = getClient();
   const normalizeDepth = client && client.getOptions().normalizeDepth;
 
   const event: Event = {

--- a/packages/browser/src/profiling/utils.ts
+++ b/packages/browser/src/profiling/utils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 
-import { DEFAULT_ENVIRONMENT, getClient, getCurrentHub } from '@sentry/core';
+import { DEFAULT_ENVIRONMENT, getClient } from '@sentry/core';
 import type { DebugImage, Envelope, Event, EventEnvelope, StackFrame, StackParser, Transaction } from '@sentry/types';
 import type { Profile, ThreadCpuProfile } from '@sentry/types/src/profiling';
 import { GLOBAL_OBJ, browserPerformanceTimeOrigin, forEachEnvelopeItem, logger, uuid4 } from '@sentry/utils';
@@ -347,19 +347,10 @@ export function applyDebugMetadata(resource_paths: ReadonlyArray<string>): Debug
     return [];
   }
 
-  const hub = getCurrentHub();
-  if (!hub) {
-    return [];
-  }
-  const client = hub.getClient();
-  if (!client) {
-    return [];
-  }
-  const options = client.getOptions();
-  if (!options) {
-    return [];
-  }
-  const stackParser = options.stackParser;
+  const client = getClient();
+  const options = client && client.getOptions();
+  const stackParser = options && options.stackParser;
+
   if (!stackParser) {
     return [];
   }

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -48,7 +48,7 @@ import {
 import { getEnvelopeEndpointWithUrlEncodedAuth } from './api';
 import { DEBUG_BUILD } from './debug-build';
 import { createEventEnvelope, createSessionEnvelope } from './envelope';
-import { getCurrentHub } from './hub';
+import { getClient } from './exports';
 import type { IntegrationIndex } from './integration';
 import { setupIntegration, setupIntegrations } from './integration';
 import { createMetricEnvelope } from './metrics/envelope';
@@ -870,7 +870,7 @@ function isTransactionEvent(event: Event): event is TransactionEvent {
  * This event processor will run for all events processed by this client.
  */
 export function addEventProcessor(callback: EventProcessor): void {
-  const client = getCurrentHub().getClient();
+  const client = getClient();
 
   if (!client || !client.addEventProcessor) {
     return;

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -202,9 +202,8 @@ export function startTransaction(
  * to create a monitor automatically when sending a check in.
  */
 export function captureCheckIn(checkIn: CheckIn, upsertMonitorConfig?: MonitorConfig): string {
-  const hub = getCurrentHub();
-  const scope = hub.getScope();
-  const client = hub.getClient();
+  const scope = getCurrentScope();
+  const client = getClient();
   if (!client) {
     DEBUG_BUILD && logger.warn('Cannot capture check-in. No client defined.');
   } else if (!client.captureCheckIn) {

--- a/packages/core/src/metrics/exports.ts
+++ b/packages/core/src/metrics/exports.ts
@@ -2,7 +2,7 @@ import type { ClientOptions, MeasurementUnit, Primitive } from '@sentry/types';
 import { logger } from '@sentry/utils';
 import type { BaseClient } from '../baseclient';
 import { DEBUG_BUILD } from '../debug-build';
-import { getCurrentHub } from '../hub';
+import { getClient, getCurrentScope } from '../exports';
 import { COUNTER_METRIC_TYPE, DISTRIBUTION_METRIC_TYPE, GAUGE_METRIC_TYPE, SET_METRIC_TYPE } from './constants';
 import { MetricsAggregator } from './integration';
 import type { MetricType } from './types';
@@ -19,9 +19,8 @@ function addToMetricsAggregator(
   value: number | string,
   data: MetricData = {},
 ): void {
-  const hub = getCurrentHub();
-  const client = hub.getClient() as BaseClient<ClientOptions>;
-  const scope = hub.getScope();
+  const client = getClient<BaseClient<ClientOptions>>();
+  const scope = getCurrentScope();
   if (client) {
     if (!client.metricsAggregator) {
       DEBUG_BUILD &&

--- a/packages/core/src/sessionflusher.ts
+++ b/packages/core/src/sessionflusher.ts
@@ -6,8 +6,7 @@ import type {
   SessionFlusherLike,
 } from '@sentry/types';
 import { dropUndefinedKeys } from '@sentry/utils';
-
-import { getCurrentHub } from './hub';
+import { getCurrentScope } from './exports';
 
 type ReleaseHealthAttributes = {
   environment?: string;
@@ -75,7 +74,7 @@ export class SessionFlusher implements SessionFlusherLike {
     if (!this._isEnabled) {
       return;
     }
-    const scope = getCurrentHub().getScope();
+    const scope = getCurrentScope();
     const requestSession = scope.getRequestSession();
 
     if (requestSession && requestSession.status) {

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -2,6 +2,7 @@ import type { TransactionContext } from '@sentry/types';
 import { dropUndefinedKeys, isThenable, logger, tracingContextFromHeaders } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
+import { getCurrentScope } from '../exports';
 import type { Hub } from '../hub';
 import { getCurrentHub } from '../hub';
 import { hasTracingEnabled } from '../utils/hasTracingEnabled';
@@ -28,7 +29,7 @@ export function trace<T>(
   const ctx = normalizeContext(context);
 
   const hub = getCurrentHub();
-  const scope = hub.getScope();
+  const scope = getCurrentScope();
   const parentSpan = scope.getSpan();
 
   const activeSpan = createChildSpanOrTransaction(hub, parentSpan, ctx);
@@ -37,7 +38,7 @@ export function trace<T>(
 
   function finishAndSetSpan(): void {
     activeSpan && activeSpan.finish();
-    hub.getScope().setSpan(parentSpan);
+    scope.setSpan(parentSpan);
   }
 
   let maybePromiseResult: T;
@@ -83,7 +84,7 @@ export function startSpan<T>(context: TransactionContext, callback: (span: Span 
   const ctx = normalizeContext(context);
 
   const hub = getCurrentHub();
-  const scope = hub.getScope();
+  const scope = getCurrentScope();
   const parentSpan = scope.getSpan();
 
   const activeSpan = createChildSpanOrTransaction(hub, parentSpan, ctx);
@@ -91,7 +92,7 @@ export function startSpan<T>(context: TransactionContext, callback: (span: Span 
 
   function finishAndSetSpan(): void {
     activeSpan && activeSpan.finish();
-    hub.getScope().setSpan(parentSpan);
+    scope.setSpan(parentSpan);
   }
 
   let maybePromiseResult: T;
@@ -143,7 +144,7 @@ export function startSpanManual<T>(
   const ctx = normalizeContext(context);
 
   const hub = getCurrentHub();
-  const scope = hub.getScope();
+  const scope = getCurrentScope();
   const parentSpan = scope.getSpan();
 
   const activeSpan = createChildSpanOrTransaction(hub, parentSpan, ctx);
@@ -151,7 +152,7 @@ export function startSpanManual<T>(
 
   function finishAndSetSpan(): void {
     activeSpan && activeSpan.finish();
-    hub.getScope().setSpan(parentSpan);
+    scope.setSpan(parentSpan);
   }
 
   let maybePromiseResult: T;
@@ -201,7 +202,7 @@ export function startInactiveSpan(context: TransactionContext): Span | undefined
  * Returns the currently active span.
  */
 export function getActiveSpan(): Span | undefined {
-  return getCurrentHub().getScope().getSpan();
+  return getCurrentScope().getSpan();
 }
 
 export function continueTrace({
@@ -238,8 +239,7 @@ export function continueTrace<V>(
   },
   callback?: (transactionContext: Partial<TransactionContext>) => V,
 ): V | Partial<TransactionContext> {
-  const hub = getCurrentHub();
-  const currentScope = hub.getScope();
+  const currentScope = getCurrentScope();
 
   const { traceparentData, dynamicSamplingContext, propagationContext } = tracingContextFromHeaders(
     sentryTrace,

--- a/packages/e2e-tests/test-applications/node-express-app/src/app.ts
+++ b/packages/e2e-tests/test-applications/node-express-app/src/app.ts
@@ -35,7 +35,7 @@ app.get('/test-param/:param', function (req, res) {
 
 app.get('/test-transaction', async function (req, res) {
   const transaction = Sentry.startTransaction({ name: 'test-transaction', op: 'e2e-test' });
-  Sentry.getCurrentHub().getScope().setSpan(transaction);
+  Sentry.getCurrentScope().setSpan(transaction);
 
   const span = transaction.startChild();
 

--- a/packages/feedback/src/widget/createWidget.ts
+++ b/packages/feedback/src/widget/createWidget.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getCurrentScope } from '@sentry/core';
 import { logger } from '@sentry/utils';
 
 import type { FeedbackFormData, FeedbackInternalOptions, FeedbackWidget } from '../types';
@@ -160,7 +160,7 @@ export function createWidget({
       }
 
       const userKey = options.useSentryUser;
-      const scope = getCurrentHub().getScope();
+      const scope = getCurrentScope();
       const user = scope && scope.getUser();
 
       dialog = Dialog({

--- a/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
+++ b/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
@@ -1,5 +1,5 @@
 import type { ParsedUrlQuery } from 'querystring';
-import { getClient, getCurrentHub } from '@sentry/core';
+import { getClient, getCurrentScope } from '@sentry/core';
 import { WINDOW } from '@sentry/react';
 import type { Primitive, Transaction, TransactionContext, TransactionSource } from '@sentry/types';
 import {
@@ -124,7 +124,7 @@ export function pagesRouterInstrumentation(
     baggage,
   );
 
-  getCurrentHub().getScope().setPropagationContext(propagationContext);
+  getCurrentScope().setPropagationContext(propagationContext);
   prevLocationName = route || globalObject.location.pathname;
 
   if (startTransactionOnPageLoad) {

--- a/packages/nextjs/src/common/utils/edgeWrapperUtils.ts
+++ b/packages/nextjs/src/common/utils/edgeWrapperUtils.ts
@@ -1,4 +1,4 @@
-import { addTracingExtensions, captureException, flush, getCurrentHub, startTransaction } from '@sentry/core';
+import { addTracingExtensions, captureException, getCurrentScope, startTransaction } from '@sentry/core';
 import type { Span } from '@sentry/types';
 import {
   addExceptionMechanism,
@@ -23,7 +23,7 @@ export function withEdgeWrapping<H extends EdgeRouteHandler>(
     addTracingExtensions();
 
     const req = args[0];
-    const currentScope = getCurrentHub().getScope();
+    const currentScope = getCurrentScope();
     const prevSpan = currentScope.getSpan();
 
     let span: Span | undefined;

--- a/packages/nextjs/src/common/utils/wrapperUtils.ts
+++ b/packages/nextjs/src/common/utils/wrapperUtils.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import {
   captureException,
   getActiveTransaction,
-  getCurrentHub,
+  getCurrentScope,
   runWithAsyncContext,
   startTransaction,
 } from '@sentry/core';
@@ -84,8 +84,7 @@ export function withTracedServerSideDataFetcher<F extends (...args: any[]) => Pr
 ): (...params: Parameters<F>) => Promise<ReturnType<F>> {
   return async function (this: unknown, ...args: Parameters<F>): Promise<ReturnType<F>> {
     return runWithAsyncContext(async () => {
-      const hub = getCurrentHub();
-      const scope = hub.getScope();
+      const scope = getCurrentScope();
       const previousSpan: Span | undefined = getTransactionFromRequest(req) ?? scope.getSpan();
       let dataFetcherSpan;
 

--- a/packages/nextjs/src/common/withServerActionInstrumentation.ts
+++ b/packages/nextjs/src/common/withServerActionInstrumentation.ts
@@ -1,4 +1,11 @@
-import { addTracingExtensions, captureException, flush, getCurrentHub, runWithAsyncContext, trace } from '@sentry/core';
+import {
+  addTracingExtensions,
+  captureException,
+  getClient,
+  getCurrentScope,
+  runWithAsyncContext,
+  trace,
+} from '@sentry/core';
 import { logger, tracingContextFromHeaders } from '@sentry/utils';
 
 import { DEBUG_BUILD } from './debug-build';
@@ -49,8 +56,7 @@ async function withServerActionInstrumentationImplementation<A extends (...args:
 ): Promise<ReturnType<A>> {
   addTracingExtensions();
   return runWithAsyncContext(async () => {
-    const hub = getCurrentHub();
-    const sendDefaultPii = hub.getClient()?.getOptions().sendDefaultPii;
+    const sendDefaultPii = getClient()?.getOptions().sendDefaultPii;
 
     let sentryTraceHeader;
     let baggageHeader;
@@ -68,7 +74,7 @@ async function withServerActionInstrumentationImplementation<A extends (...args:
         );
     }
 
-    const currentScope = hub.getScope();
+    const currentScope = getCurrentScope();
     const { traceparentData, dynamicSamplingContext, propagationContext } = tracingContextFromHeaders(
       sentryTraceHeader,
       baggageHeader,

--- a/packages/nextjs/src/common/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapApiHandlerWithSentry.ts
@@ -1,7 +1,8 @@
 import {
   addTracingExtensions,
   captureException,
-  getCurrentHub,
+  getClient,
+  getCurrentScope,
   runWithAsyncContext,
   startTransaction,
 } from '@sentry/core';
@@ -87,10 +88,9 @@ export function withSentry(apiHandler: NextApiHandler, parameterizedRoute?: stri
       const boundHandler = runWithAsyncContext(
         // eslint-disable-next-line complexity
         async () => {
-          const hub = getCurrentHub();
           let transaction: Transaction | undefined;
-          const currentScope = hub.getScope();
-          const options = hub.getClient()?.getOptions();
+          const currentScope = getCurrentScope();
+          const options = getClient()?.getOptions();
 
           currentScope.setSDKProcessingMetadata({ request: req });
 

--- a/packages/nextjs/src/common/wrapAppGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapAppGetInitialPropsWithSentry.ts
@@ -1,4 +1,4 @@
-import { addTracingExtensions, getCurrentHub } from '@sentry/core';
+import { addTracingExtensions, getClient, getCurrentScope } from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type App from 'next/app';
 
@@ -32,8 +32,7 @@ export function wrapAppGetInitialPropsWithSentry(origAppGetInitialProps: AppGetI
       const { req, res } = context.ctx;
 
       const errorWrappedAppGetInitialProps = withErrorInstrumentation(wrappingTarget);
-      const hub = getCurrentHub();
-      const options = hub.getClient()?.getOptions();
+      const options = getClient()?.getOptions();
 
       // Generally we can assume that `req` and `res` are always defined on the server:
       // https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#context-object
@@ -53,7 +52,7 @@ export function wrapAppGetInitialPropsWithSentry(origAppGetInitialProps: AppGetI
           };
         } = await tracedGetInitialProps.apply(thisArg, args);
 
-        const requestTransaction = getTransactionFromRequest(req) ?? hub.getScope().getTransaction();
+        const requestTransaction = getTransactionFromRequest(req) ?? getCurrentScope().getTransaction();
 
         // Per definition, `pageProps` is not optional, however an increased amount of users doesn't seem to call
         // `App.getInitialProps(appContext)` in their custom `_app` pages which is required as per

--- a/packages/nextjs/src/common/wrapErrorGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapErrorGetInitialPropsWithSentry.ts
@@ -1,4 +1,4 @@
-import { addTracingExtensions, getCurrentHub } from '@sentry/core';
+import { addTracingExtensions, getClient, getCurrentScope } from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { NextPageContext } from 'next';
 import type { ErrorProps } from 'next/error';
@@ -35,8 +35,7 @@ export function wrapErrorGetInitialPropsWithSentry(
       const { req, res } = context;
 
       const errorWrappedGetInitialProps = withErrorInstrumentation(wrappingTarget);
-      const hub = getCurrentHub();
-      const options = hub.getClient()?.getOptions();
+      const options = getClient()?.getOptions();
 
       // Generally we can assume that `req` and `res` are always defined on the server:
       // https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#context-object
@@ -54,7 +53,7 @@ export function wrapErrorGetInitialPropsWithSentry(
           _sentryBaggage?: string;
         } = await tracedGetInitialProps.apply(thisArg, args);
 
-        const requestTransaction = getTransactionFromRequest(req) ?? hub.getScope().getTransaction();
+        const requestTransaction = getTransactionFromRequest(req) ?? getCurrentScope().getTransaction();
         if (requestTransaction) {
           errorGetInitialProps._sentryTraceData = requestTransaction.toTraceparent();
 

--- a/packages/nextjs/src/common/wrapGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGetInitialPropsWithSentry.ts
@@ -1,4 +1,4 @@
-import { addTracingExtensions, getCurrentHub } from '@sentry/core';
+import { addTracingExtensions, getClient, getCurrentScope } from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { NextPage } from 'next';
 
@@ -31,8 +31,7 @@ export function wrapGetInitialPropsWithSentry(origGetInitialProps: GetInitialPro
       const { req, res } = context;
 
       const errorWrappedGetInitialProps = withErrorInstrumentation(wrappingTarget);
-      const hub = getCurrentHub();
-      const options = hub.getClient()?.getOptions();
+      const options = getClient()?.getOptions();
 
       // Generally we can assume that `req` and `res` are always defined on the server:
       // https://nextjs.org/docs/api-reference/data-fetching/get-initial-props#context-object
@@ -50,7 +49,7 @@ export function wrapGetInitialPropsWithSentry(origGetInitialProps: GetInitialPro
           _sentryBaggage?: string;
         } = (await tracedGetInitialProps.apply(thisArg, args)) ?? {}; // Next.js allows undefined to be returned from a getInitialPropsFunction.
 
-        const requestTransaction = getTransactionFromRequest(req) ?? hub.getScope().getTransaction();
+        const requestTransaction = getTransactionFromRequest(req) ?? getCurrentScope().getTransaction();
         if (requestTransaction) {
           initialProps._sentryTraceData = requestTransaction.toTraceparent();
 

--- a/packages/nextjs/src/common/wrapGetServerSidePropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGetServerSidePropsWithSentry.ts
@@ -1,4 +1,4 @@
-import { addTracingExtensions, getCurrentHub } from '@sentry/core';
+import { addTracingExtensions, getClient, getCurrentScope } from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { GetServerSideProps } from 'next';
 
@@ -32,8 +32,7 @@ export function wrapGetServerSidePropsWithSentry(
       const { req, res } = context;
 
       const errorWrappedGetServerSideProps = withErrorInstrumentation(wrappingTarget);
-      const hub = getCurrentHub();
-      const options = hub.getClient()?.getOptions();
+      const options = getClient()?.getOptions();
 
       if (options?.instrumenter === 'sentry') {
         const tracedGetServerSideProps = withTracedServerSideDataFetcher(errorWrappedGetServerSideProps, req, res, {
@@ -47,7 +46,7 @@ export function wrapGetServerSidePropsWithSentry(
         >);
 
         if (serverSideProps && 'props' in serverSideProps) {
-          const requestTransaction = getTransactionFromRequest(req) ?? hub.getScope().getTransaction();
+          const requestTransaction = getTransactionFromRequest(req) ?? getCurrentScope().getTransaction();
           if (requestTransaction) {
             serverSideProps.props._sentryTraceData = requestTransaction.toTraceparent();
 

--- a/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
@@ -1,4 +1,4 @@
-import { addTracingExtensions, captureException, flush, getCurrentHub, runWithAsyncContext, trace } from '@sentry/core';
+import { addTracingExtensions, captureException, getCurrentScope, runWithAsyncContext, trace } from '@sentry/core';
 import { tracingContextFromHeaders, winterCGHeadersToDict } from '@sentry/utils';
 
 import { isRedirectNavigationError } from './nextNavigationErrorUtils';
@@ -20,14 +20,11 @@ export function wrapRouteHandlerWithSentry<F extends (...args: any[]) => any>(
   return new Proxy(routeHandler, {
     apply: (originalFunction, thisArg, args) => {
       return runWithAsyncContext(async () => {
-        const hub = getCurrentHub();
-        const currentScope = hub.getScope();
-
         const { traceparentData, dynamicSamplingContext, propagationContext } = tracingContextFromHeaders(
           sentryTraceHeader ?? headers?.get('sentry-trace') ?? undefined,
           baggageHeader ?? headers?.get('baggage'),
         );
-        currentScope.setPropagationContext(propagationContext);
+        getCurrentScope().setPropagationContext(propagationContext);
 
         let res;
         try {

--- a/packages/nextjs/src/common/wrapServerComponentWithSentry.ts
+++ b/packages/nextjs/src/common/wrapServerComponentWithSentry.ts
@@ -1,7 +1,7 @@
 import {
   addTracingExtensions,
   captureException,
-  getCurrentHub,
+  getCurrentScope,
   runWithAsyncContext,
   startTransaction,
 } from '@sentry/core';
@@ -28,9 +28,7 @@ export function wrapServerComponentWithSentry<F extends (...args: any[]) => any>
   return new Proxy(appDirComponent, {
     apply: (originalFunction, thisArg, args) => {
       return runWithAsyncContext(() => {
-        const hub = getCurrentHub();
-        const currentScope = hub.getScope();
-
+        const currentScope = getCurrentScope();
         let maybePromiseResult;
 
         const completeHeadersDict: Record<string, string> = context.headers

--- a/packages/nextjs/src/edge/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/edge/wrapApiHandlerWithSentry.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getCurrentHub, getCurrentScope } from '@sentry/core';
 
 import { withEdgeWrapping } from '../common/utils/edgeWrapperUtils';
 import type { EdgeRouteHandler } from './types';
@@ -14,7 +14,7 @@ export function wrapApiHandlerWithSentry<H extends EdgeRouteHandler>(
     apply: (wrappingTarget, thisArg, args: Parameters<H>) => {
       const req = args[0];
 
-      const activeSpan = getCurrentHub().getScope().getSpan();
+      const activeSpan = getCurrentScope().getSpan();
 
       const wrappedHandler = withEdgeWrapping(wrappingTarget, {
         spanDescription:

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -1,8 +1,8 @@
 import * as path from 'path';
-import { addTracingExtensions } from '@sentry/core';
+import { addTracingExtensions, getClient } from '@sentry/core';
 import { RewriteFrames } from '@sentry/integrations';
 import type { NodeOptions } from '@sentry/node';
-import { Integrations, getCurrentHub, getCurrentScope, init as nodeInit } from '@sentry/node';
+import { Integrations, getCurrentScope, init as nodeInit } from '@sentry/node';
 import type { EventProcessor } from '@sentry/types';
 import type { IntegrationWithExclusionOption } from '@sentry/utils';
 import { addOrUpdateIntegration, escapeStringForRegex, logger } from '@sentry/utils';
@@ -117,8 +117,7 @@ export function init(options: NodeOptions): void {
 }
 
 function sdkAlreadyInitialized(): boolean {
-  const hub = getCurrentHub();
-  return !!hub.getClient();
+  return !!getClient();
 }
 
 function addServerIntegrations(options: NodeOptions): void {

--- a/packages/nextjs/test/config/wrappers.test.ts
+++ b/packages/nextjs/test/config/wrappers.test.ts
@@ -2,10 +2,10 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import * as SentryCore from '@sentry/core';
 import { addTracingExtensions } from '@sentry/core';
 
+import type { Client } from '@sentry/types';
 import { wrapGetInitialPropsWithSentry, wrapGetServerSidePropsWithSentry } from '../../src/common';
 
 const startTransactionSpy = jest.spyOn(SentryCore, 'startTransaction');
-const originalGetCurrentHub = jest.requireActual('@sentry/node').getCurrentHub;
 
 // The wrap* functions require the hub to have tracing extensions. This is normally called by the NodeClient
 // constructor but the client isn't used in these tests.
@@ -22,16 +22,11 @@ describe('data-fetching function wrappers', () => {
       res = { end: jest.fn() } as unknown as ServerResponse;
 
       jest.spyOn(SentryCore, 'hasTracingEnabled').mockReturnValue(true);
-      jest.spyOn(SentryCore, 'getCurrentHub').mockImplementation(() => {
-        const hub = originalGetCurrentHub();
-
-        hub.getClient = () =>
-          ({
-            getOptions: () => ({ instrumenter: 'sentry' }),
-            getDsn: () => {},
-          }) as any;
-
-        return hub;
+      jest.spyOn(SentryCore, 'getClient').mockImplementation(() => {
+        return {
+          getOptions: () => ({ instrumenter: 'sentry' }),
+          getDsn: () => {},
+        } as Client;
       });
     });
 

--- a/packages/node/src/anr/index.ts
+++ b/packages/node/src/anr/index.ts
@@ -1,9 +1,9 @@
 import { spawn } from 'child_process';
-import { getClient, makeSession, updateSession } from '@sentry/core';
+import { getClient, getCurrentScope, makeSession, updateSession } from '@sentry/core';
 import type { Event, Session, StackFrame } from '@sentry/types';
 import { logger, watchdogTimer } from '@sentry/utils';
 
-import { addEventProcessor, captureEvent, flush, getCurrentHub } from '..';
+import { addEventProcessor, captureEvent, flush } from '..';
 import { captureStackTrace } from './debugger';
 
 const DEFAULT_INTERVAL = 50;
@@ -91,8 +91,6 @@ function startChildProcess(options: Options): void {
     logger.log(`[ANR] ${message}`, ...args);
   }
 
-  const hub = getCurrentHub();
-
   try {
     const env = { ...process.env };
     env.SENTRY_ANR_CHILD_PROCESS = 'true';
@@ -112,7 +110,7 @@ function startChildProcess(options: Options): void {
 
     const timer = setInterval(() => {
       try {
-        const currentSession = hub.getScope()?.getSession();
+        const currentSession = getCurrentScope()?.getSession();
         // We need to copy the session object and remove the toJSON method so it can be sent to the child process
         // serialized without making it a SerializedSession
         const session = currentSession ? { ...currentSession, toJSON: undefined } : undefined;
@@ -126,7 +124,7 @@ function startChildProcess(options: Options): void {
     child.on('message', (msg: string) => {
       if (msg === 'session-ended') {
         log('ANR event sent from child process. Clearing session in this process.');
-        hub.getScope()?.setSession(undefined);
+        getCurrentScope()?.setSession(undefined);
       }
     });
 

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -1,6 +1,7 @@
 import type * as http from 'http';
 import type * as https from 'https';
 import type { Hub } from '@sentry/core';
+import { getClient, getCurrentScope } from '@sentry/core';
 import { getCurrentHub, getDynamicSamplingContextFromClient, isSentryRequestUrl } from '@sentry/core';
 import type {
   DynamicSamplingContext,
@@ -243,8 +244,7 @@ function _createWrappedRequestMethodFactory(
         return originalRequestMethod.apply(httpModule, requestArgs);
       }
 
-      const hub = getCurrentHub();
-      const scope = hub.getScope();
+      const scope = getCurrentScope();
       const parentSpan = scope.getSpan();
 
       const data = getRequestSpanData(requestUrl, requestOptions);
@@ -264,7 +264,7 @@ function _createWrappedRequestMethodFactory(
           const dynamicSamplingContext = requestSpan?.transaction?.getDynamicSamplingContext();
           addHeadersToRequestOptions(requestOptions, requestUrl, sentryTraceHeader, dynamicSamplingContext);
         } else {
-          const client = hub.getClient();
+          const client = getClient();
           const { traceId, sampled, dsc } = scope.getPropagationContext();
           const sentryTraceHeader = generateSentryTraceHeader(traceId, undefined, sampled);
           const dynamicSamplingContext =

--- a/packages/node/src/integrations/undici/index.ts
+++ b/packages/node/src/integrations/undici/index.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub, getDynamicSamplingContextFromClient, isSentryRequestUrl } from '@sentry/core';
+import { getCurrentHub, getCurrentScope, getDynamicSamplingContextFromClient, isSentryRequestUrl } from '@sentry/core';
 import type { EventProcessor, Integration, Span } from '@sentry/types';
 import {
   LRUMap,
@@ -147,7 +147,7 @@ export class Undici implements Integration {
     }
 
     const clientOptions = client.getOptions();
-    const scope = hub.getScope();
+    const scope = getCurrentScope();
 
     const parentSpan = scope.getSpan();
 

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -1,7 +1,9 @@
 /* eslint-disable max-lines */
 import {
   Integrations as CoreIntegrations,
+  getClient,
   getCurrentHub,
+  getCurrentScope,
   getIntegrationsToSetup,
   getMainCarrier,
   initAndBind,
@@ -182,7 +184,7 @@ export function init(options: NodeOptions = {}): void {
   updateScopeFromEnvVariables();
 
   if (options.spotlight) {
-    const client = getCurrentHub().getClient();
+    const client = getClient();
     if (client && client.addIntegration) {
       // force integrations to be setup even if no DSN was set
       client.setupIntegrations(true);
@@ -277,6 +279,6 @@ function updateScopeFromEnvVariables(): void {
     const sentryTraceEnv = process.env.SENTRY_TRACE;
     const baggageEnv = process.env.SENTRY_BAGGAGE;
     const { propagationContext } = tracingContextFromHeaders(sentryTraceEnv, baggageEnv);
-    getCurrentHub().getScope().setPropagationContext(propagationContext);
+    getCurrentScope().setPropagationContext(propagationContext);
   }
 }

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -458,10 +458,11 @@ describe('tracingHandler', () => {
     const hub = new sentryCore.Hub(new NodeClient(options));
 
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
+    jest.spyOn(sentryCore, 'getCurrentScope').mockImplementation(() => hub.getScope());
 
     sentryTracingMiddleware(req, res, next);
 
-    const transaction = sentryCore.getCurrentHub().getScope().getTransaction();
+    const transaction = sentryCore.getCurrentScope().getTransaction();
 
     expect(transaction?.metadata.request).toEqual(req);
   });

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -44,6 +44,8 @@ describe('tracing', () => {
     });
 
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
+    jest.spyOn(sentryCore, 'getCurrentScope').mockImplementation(() => hub.getScope());
+    jest.spyOn(sentryCore, 'getClient').mockReturnValue(hub.getClient());
 
     const transaction = hub.startTransaction({
       name: 'dogpark',
@@ -67,7 +69,8 @@ describe('tracing', () => {
     });
     const hub = new Hub(new NodeClient(options));
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
-
+    jest.spyOn(sentryCore, 'getCurrentScope').mockImplementation(() => hub.getScope());
+    jest.spyOn(sentryCore, 'getClient').mockReturnValue(hub.getClient());
     return hub;
   }
 
@@ -236,11 +239,7 @@ describe('tracing', () => {
     const baggageHeader = request.getHeader('baggage') as string;
 
     const parts = sentryTraceHeader.split('-');
-    expect(parts.length).toEqual(3);
-    expect(parts[0]).toEqual('86f39e84263a4de99c326acab3bfe3bd');
-    expect(parts[1]).toEqual(expect.any(String));
-    expect(parts[2]).toEqual('1');
-
+    expect(parts).toEqual(['86f39e84263a4de99c326acab3bfe3bd', expect.any(String), '1']);
     expect(baggageHeader).toEqual('sentry-trace_id=86f39e84263a4de99c326acab3bfe3bd,sentry-public_key=test-public-key');
   });
 
@@ -355,7 +354,9 @@ describe('tracing', () => {
 
       const hub = new Hub();
 
-      jest.spyOn(sentryCore, 'getCurrentHub').mockImplementation(() => hub);
+      jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
+      jest.spyOn(sentryCore, 'getCurrentScope').mockImplementation(() => hub.getScope());
+      jest.spyOn(sentryCore, 'getClient').mockReturnValue(hub.getClient());
 
       const client = new NodeClient(options);
       jest.spyOn(hub, 'getClient').mockImplementation(() => client);
@@ -379,6 +380,10 @@ describe('tracing', () => {
         const httpIntegration = new HttpIntegration({ tracing: true });
 
         const hub = createHub({ shouldCreateSpanForRequest: () => false });
+
+        jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
+        jest.spyOn(sentryCore, 'getCurrentScope').mockImplementation(() => hub.getScope());
+        jest.spyOn(sentryCore, 'getClient').mockReturnValue(hub.getClient());
 
         httpIntegration.setupOnce(
           () => undefined,
@@ -484,6 +489,10 @@ describe('tracing', () => {
         });
 
         const hub = createHub();
+
+        jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
+        jest.spyOn(sentryCore, 'getCurrentScope').mockImplementation(() => hub.getScope());
+        jest.spyOn(sentryCore, 'getClient').mockReturnValue(hub.getClient());
 
         httpIntegration.setupOnce(
           () => undefined,

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -1,5 +1,6 @@
 import type { NodeOptions } from '@sentry/node';
-import { getCurrentHub, getCurrentScope, init as nodeInit } from '@sentry/node';
+import { getClient } from '@sentry/node';
+import { getCurrentScope, init as nodeInit } from '@sentry/node';
 import { logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from './utils/debug-build';
@@ -68,8 +69,7 @@ export { wrapExpressCreateRequestHandler } from './utils/serverAdapters/express'
 export type { SentryMetaArgs } from './utils/types';
 
 function sdkAlreadyInitialized(): boolean {
-  const hub = getCurrentHub();
-  return !!hub.getClient();
+  return !!getClient();
 }
 
 /** Initializes Sentry Remix SDK on Node. */

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { getActiveTransaction, hasTracingEnabled, runWithAsyncContext } from '@sentry/core';
+import { getActiveTransaction, getClient, getCurrentScope, hasTracingEnabled, runWithAsyncContext } from '@sentry/core';
 import type { Hub } from '@sentry/node';
 import { captureException, getCurrentHub } from '@sentry/node';
 import type { Transaction, TransactionSource, WrappedFunction } from '@sentry/types';
@@ -225,7 +225,7 @@ function makeWrappedDataFunction(
   return async function (this: unknown, args: DataFunctionArgs): Promise<Response | AppData> {
     let res: Response | AppData;
     const activeTransaction = getActiveTransaction();
-    const currentScope = getCurrentHub().getScope();
+    const currentScope = getCurrentScope();
 
     try {
       const span = activeTransaction?.startChild({
@@ -280,7 +280,7 @@ function getTraceAndBaggage(): {
   sentryBaggage?: string;
 } {
   const transaction = getActiveTransaction();
-  const currentScope = getCurrentHub().getScope();
+  const currentScope = getCurrentScope();
 
   if (isNodeEnv() && hasTracingEnabled()) {
     const span = currentScope.getSpan();
@@ -421,8 +421,8 @@ function wrapRequestHandler(origRequestHandler: RequestHandler, build: ServerBui
   return async function (this: unknown, request: RemixRequest, loadContext?: unknown): Promise<Response> {
     return runWithAsyncContext(async () => {
       const hub = getCurrentHub();
-      const options = hub.getClient()?.getOptions();
-      const scope = hub.getScope();
+      const options = getClient()?.getOptions();
+      const scope = getCurrentScope();
 
       let normalizedRequest: Record<string, unknown> = request;
 

--- a/packages/remix/src/utils/serverAdapters/express.ts
+++ b/packages/remix/src/utils/serverAdapters/express.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub, hasTracingEnabled } from '@sentry/core';
+import { getClient, getCurrentHub, getCurrentScope, hasTracingEnabled } from '@sentry/core';
 import { flush } from '@sentry/node';
 import type { Transaction } from '@sentry/types';
 import { extractRequestData, isString, logger } from '@sentry/utils';
@@ -59,8 +59,8 @@ function wrapExpressRequestHandler(
 
     const request = extractRequestData(req);
     const hub = getCurrentHub();
-    const options = hub.getClient()?.getOptions();
-    const scope = hub.getScope();
+    const options = getClient()?.getOptions();
+    const scope = getCurrentScope();
 
     scope.setSDKProcessingMetadata({ request });
 

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines */ // TODO: We might want to split this file up
 import { EventType, record } from '@sentry-internal/rrweb';
-import { captureException, getClient, getCurrentHub } from '@sentry/core';
-import type { Event as SentryEvent, ReplayRecordingMode, Transaction } from '@sentry/types';
+import { captureException, getClient, getCurrentScope } from '@sentry/core';
+import type { ReplayRecordingMode, Transaction } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import {
@@ -698,7 +698,7 @@ export class ReplayContainer implements ReplayContainerInterface {
    * This is only available if performance is enabled, and if an instrumented router is used.
    */
   public getCurrentRoute(): string | undefined {
-    const lastTransaction = this.lastTransaction || getCurrentHub().getScope().getTransaction();
+    const lastTransaction = this.lastTransaction || getCurrentScope().getTransaction();
     if (!lastTransaction || !['route', 'custom'].includes(lastTransaction.metadata.source)) {
       return undefined;
     }

--- a/packages/replay/src/util/addGlobalListeners.ts
+++ b/packages/replay/src/util/addGlobalListeners.ts
@@ -1,5 +1,6 @@
 import type { BaseClient } from '@sentry/core';
-import { addEventProcessor, getClient, getCurrentHub } from '@sentry/core';
+import { getCurrentScope } from '@sentry/core';
+import { addEventProcessor, getClient } from '@sentry/core';
 import type { Client, DynamicSamplingContext } from '@sentry/types';
 import { addClickKeypressInstrumentationHandler, addHistoryInstrumentationHandler } from '@sentry/utils';
 
@@ -17,7 +18,7 @@ import type { ReplayContainer } from '../types';
  */
 export function addGlobalListeners(replay: ReplayContainer): void {
   // Listeners from core SDK //
-  const scope = getCurrentHub().getScope();
+  const scope = getCurrentScope();
   const client = getClient();
 
   scope.addScopeListener(handleScopeListener(replay));

--- a/packages/replay/src/util/sendReplayRequest.ts
+++ b/packages/replay/src/util/sendReplayRequest.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getClient, getCurrentScope } from '@sentry/core';
 import type { ReplayEvent, TransportMakeRequestResponse } from '@sentry/types';
 import type { RateLimits } from '@sentry/utils';
 import { isRateLimited, updateRateLimits } from '@sentry/utils';
@@ -30,9 +30,8 @@ export async function sendReplayRequest({
 
   const { urls, errorIds, traceIds, initialTimestamp } = eventContext;
 
-  const hub = getCurrentHub();
-  const client = hub.getClient();
-  const scope = hub.getScope();
+  const client = getClient();
+  const scope = getCurrentScope();
   const transport = client && client.getTransport();
   const dsn = client && client.getDsn();
 

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -305,7 +305,7 @@ export function wrapHandler<TEvent, TResult>(
         sentryTrace,
         baggage,
       );
-      hub.getScope().setPropagationContext(propagationContext);
+      Sentry.getCurrentScope().setPropagationContext(propagationContext);
 
       transaction = hub.startTransaction({
         name: context.functionName,

--- a/packages/serverless/src/awsservices.ts
+++ b/packages/serverless/src/awsservices.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/node';
+import { getCurrentScope } from '@sentry/node';
 import type { Integration, Span } from '@sentry/types';
 import { fill } from '@sentry/utils';
 // 'aws-sdk/global' import is expected to be type-only so it's erased in the final .js file.
@@ -57,7 +57,7 @@ function wrapMakeRequest<TService extends AWSService, TResult>(
 ): MakeRequestFunction<GenericParams, TResult> {
   return function (this: TService, operation: string, params?: GenericParams, callback?: MakeRequestCallback<TResult>) {
     let span: Span | undefined;
-    const scope = getCurrentHub().getScope();
+    const scope = getCurrentScope();
     const transaction = scope.getTransaction();
     const req = orig.call(this, operation, params);
     req.on('afterBuild', () => {

--- a/packages/serverless/src/google-cloud-grpc.ts
+++ b/packages/serverless/src/google-cloud-grpc.ts
@@ -1,5 +1,5 @@
 import type { EventEmitter } from 'events';
-import { getCurrentHub } from '@sentry/node';
+import { getCurrentScope } from '@sentry/node';
 import type { Integration, Span } from '@sentry/types';
 import { fill } from '@sentry/utils';
 
@@ -108,7 +108,7 @@ function fillGrpcFunction(stub: Stub, serviceIdentifier: string, methodName: str
           return ret;
         }
         let span: Span | undefined;
-        const scope = getCurrentHub().getScope();
+        const scope = getCurrentScope();
         const transaction = scope.getTransaction();
         if (transaction) {
           span = transaction.startChild({

--- a/packages/serverless/src/google-cloud-http.ts
+++ b/packages/serverless/src/google-cloud-http.ts
@@ -1,7 +1,7 @@
 // '@google-cloud/common' import is expected to be type-only so it's erased in the final .js file.
 // When TypeScript compiler is upgraded, use `import type` syntax to explicitly assert that we don't want to load a module here.
 import type * as common from '@google-cloud/common';
-import { getCurrentHub } from '@sentry/node';
+import { getCurrentScope } from '@sentry/node';
 import type { Integration, Span } from '@sentry/types';
 import { fill } from '@sentry/utils';
 
@@ -52,7 +52,7 @@ export class GoogleCloudHttp implements Integration {
 function wrapRequestFunction(orig: RequestFunction): RequestFunction {
   return function (this: common.Service, reqOpts: RequestOptions, callback: ResponseCallback): void {
     let span: Span | undefined;
-    const scope = getCurrentHub().getScope();
+    const scope = getCurrentScope();
     const transaction = scope.getTransaction();
     if (transaction) {
       const httpMethod = reqOpts.method || 'GET';

--- a/packages/svelte/src/performance.ts
+++ b/packages/svelte/src/performance.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/browser';
+import { getCurrentScope } from '@sentry/browser';
 import type { Span, Transaction } from '@sentry/types';
 import { afterUpdate, beforeUpdate, onMount } from 'svelte';
 import { current_component } from 'svelte/internal';
@@ -92,5 +92,5 @@ function recordUpdateSpans(componentName: string, initSpan?: Span): void {
 }
 
 function getActiveTransaction(): Transaction | undefined {
-  return getCurrentHub().getScope().getTransaction();
+  return getCurrentScope().getTransaction();
 }

--- a/packages/svelte/test/performance.test.ts
+++ b/packages/svelte/test/performance.test.ts
@@ -22,18 +22,12 @@ jest.mock('@sentry/core', () => {
   const original = jest.requireActual('@sentry/core');
   return {
     ...original,
-    getCurrentHub(): {
-      getScope(): Scope;
-    } {
+    getCurrentScope(): Scope {
       return {
-        getScope(): any {
-          return {
-            getTransaction: () => {
-              return returnUndefinedTransaction ? undefined : testTransaction;
-            },
-          };
+        getTransaction: () => {
+          return returnUndefinedTransaction ? undefined : testTransaction;
         },
-      };
+      } as Scope;
     },
   };
 });

--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @sentry-internal/sdk/no-optional-chaining */
 import type { Span } from '@sentry/core';
-import { getActiveTransaction, getCurrentHub, runWithAsyncContext, startSpan } from '@sentry/core';
+import { getCurrentScope } from '@sentry/core';
+import { getActiveTransaction, runWithAsyncContext, startSpan } from '@sentry/core';
 import { captureException } from '@sentry/node';
 import { dynamicSamplingContextToSentryBaggageHeader, objectify } from '@sentry/utils';
 import type { Handle, ResolveOptions } from '@sveltejs/kit';
@@ -102,7 +103,7 @@ export function sentryHandle(handlerOptions?: SentryHandleOptions): Handle {
     // if there is an active transaction, we know that this handle call is nested and hence
     // we don't create a new domain for it. If we created one, nested server calls would
     // create new transactions instead of adding a child span to the currently active span.
-    if (getCurrentHub().getScope().getSpan()) {
+    if (getCurrentScope().getSpan()) {
       return instrumentHandle(input, options);
     }
     return runWithAsyncContext(() => {
@@ -122,7 +123,7 @@ async function instrumentHandle(
   }
 
   const { dynamicSamplingContext, traceparentData, propagationContext } = getTracePropagationData(event);
-  getCurrentHub().getScope().setPropagationContext(propagationContext);
+  getCurrentScope().setPropagationContext(propagationContext);
 
   try {
     const resolveResult = await startSpan(

--- a/packages/sveltekit/src/server/load.ts
+++ b/packages/sveltekit/src/server/load.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @sentry-internal/sdk/no-optional-chaining */
-import { getCurrentHub, startSpan } from '@sentry/core';
+import { getCurrentScope, startSpan } from '@sentry/core';
 import { captureException } from '@sentry/node';
 import type { TransactionContext } from '@sentry/types';
 import { addNonEnumerableProperty, objectify } from '@sentry/utils';
@@ -130,7 +130,7 @@ export function wrapServerLoadWithSentry<T extends (...args: any) => any>(origSe
       const routeId = event.route && (Object.getOwnPropertyDescriptor(event.route, 'id')?.value as string | undefined);
 
       const { dynamicSamplingContext, traceparentData, propagationContext } = getTracePropagationData(event);
-      getCurrentHub().getScope().setPropagationContext(propagationContext);
+      getCurrentScope().setPropagationContext(propagationContext);
 
       const traceLoadContext: TransactionContext = {
         op: 'function.sveltekit.server.load',

--- a/packages/tracing-internal/src/browser/request.ts
+++ b/packages/tracing-internal/src/browser/request.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import { getCurrentHub, getDynamicSamplingContextFromClient, hasTracingEnabled } from '@sentry/core';
+import { getClient, getCurrentScope, getDynamicSamplingContextFromClient, hasTracingEnabled } from '@sentry/core';
 import type { HandlerDataXhr, SentryWrappedXMLHttpRequest, Span } from '@sentry/types';
 import {
   BAGGAGE_HEADER_NAME,
@@ -264,8 +264,7 @@ export function xhrCallback(
     return undefined;
   }
 
-  const hub = getCurrentHub();
-  const scope = hub.getScope();
+  const scope = getCurrentScope();
   const parentSpan = scope.getSpan();
 
   const span =
@@ -294,7 +293,7 @@ export function xhrCallback(
       const sentryBaggageHeader = dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
       setHeaderOnXhr(xhr, span.toTraceparent(), sentryBaggageHeader);
     } else {
-      const client = hub.getClient();
+      const client = getClient();
       const { traceId, sampled, dsc } = scope.getPropagationContext();
       const sentryTraceHeader = generateSentryTraceHeader(traceId, undefined, sampled);
       const dynamicSamplingContext =

--- a/packages/tracing-internal/src/common/fetch.ts
+++ b/packages/tracing-internal/src/common/fetch.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub, getDynamicSamplingContextFromClient, hasTracingEnabled } from '@sentry/core';
+import { getClient, getCurrentScope, getDynamicSamplingContextFromClient, hasTracingEnabled } from '@sentry/core';
 import type { Client, HandlerDataFetch, Scope, Span, SpanOrigin } from '@sentry/types';
 import {
   BAGGAGE_HEADER_NAME,
@@ -65,9 +65,8 @@ export function instrumentFetchRequest(
     return undefined;
   }
 
-  const hub = getCurrentHub();
-  const scope = hub.getScope();
-  const client = hub.getClient();
+  const scope = getCurrentScope();
+  const client = getClient();
   const parentSpan = scope.getSpan();
 
   const { method, url } = handlerData.fetchData;

--- a/packages/vercel-edge/src/integrations/wintercg-fetch.ts
+++ b/packages/vercel-edge/src/integrations/wintercg-fetch.ts
@@ -1,5 +1,5 @@
 import { instrumentFetchRequest } from '@sentry-internal/tracing';
-import { getCurrentHub, isSentryRequestUrl } from '@sentry/core';
+import { getClient, getCurrentHub, isSentryRequestUrl } from '@sentry/core';
 import type { FetchBreadcrumbData, FetchBreadcrumbHint, HandlerDataFetch, Integration, Span } from '@sentry/types';
 import { LRUMap, addFetchInstrumentationHandler, stringMatchesSomePattern } from '@sentry/utils';
 
@@ -74,8 +74,7 @@ export class WinterCGFetch implements Integration {
 
   /** Decides whether to attach trace data to the outgoing fetch request */
   private _shouldAttachTraceData(url: string): boolean {
-    const hub = getCurrentHub();
-    const client = hub.getClient();
+    const client = getClient();
 
     if (!client) {
       return false;

--- a/packages/vercel-edge/test/wintercg-fetch.test.ts
+++ b/packages/vercel-edge/test/wintercg-fetch.test.ts
@@ -29,6 +29,8 @@ const fakeHubInstance = new FakeHub(
 );
 
 jest.spyOn(sentryCore, 'getCurrentHub').mockImplementation(() => fakeHubInstance);
+jest.spyOn(sentryCore, 'getCurrentScope').mockImplementation(() => fakeHubInstance.getScope());
+jest.spyOn(sentryCore, 'getClient').mockImplementation(() => fakeHubInstance.getClient());
 
 const addFetchInstrumentationHandlerSpy = jest.spyOn(sentryUtils, 'addFetchInstrumentationHandler');
 const instrumentFetchRequestSpy = jest.spyOn(internalTracing, 'instrumentFetchRequest');

--- a/packages/vue/src/tracing.ts
+++ b/packages/vue/src/tracing.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/browser';
+import { getCurrentHub, getCurrentScope } from '@sentry/browser';
 import type { Span, Transaction } from '@sentry/types';
 import { logger, timestampInSeconds } from '@sentry/utils';
 
@@ -34,7 +34,7 @@ const HOOKS: { [key in Operation]: Hook[] } = {
 
 /** Grabs active transaction off scope, if any */
 export function getActiveTransaction(): Transaction | undefined {
-  return getCurrentHub().getScope().getTransaction();
+  return getCurrentScope().getTransaction();
 }
 
 /** Finish top-level span and activity with a debounce configured using `timeout` option */


### PR DESCRIPTION
Except for places where we are really passing a `hub` in, not using `getCurrentHub()`.