### PR TITLE
fix(utils): Do not use `Event` type in worldwide

### DIFF
--- a/packages/utils/src/instrument/globalError.ts
+++ b/packages/utils/src/instrument/globalError.ts
@@ -21,7 +21,7 @@ function instrumentError(): void {
   _oldOnErrorHandler = GLOBAL_OBJ.onerror;
 
   GLOBAL_OBJ.onerror = function (
-    msg: string | Event,
+    msg: string | object,
     url?: string,
     line?: number,
     column?: number,

--- a/packages/utils/src/worldwide.ts
+++ b/packages/utils/src/worldwide.ts
@@ -24,7 +24,7 @@ export interface InternalGlobal {
     Integrations?: Integration[];
   };
   onerror?: {
-    (event: Event | string, source?: string, lineno?: number, colno?: number, error?: Error): any;
+    (event: object | string, source?: string, lineno?: number, colno?: number, error?: Error): any;
     __SENTRY_INSTRUMENTED__?: true;
     __SENTRY_LOADER__?: true;
   };


### PR DESCRIPTION
As that is browser only.

Closes https://github.com/getsentry/sentry-javascript/issues/9860