### PR TITLE
feat(core): Update `withScope` to return callback return value

### DIFF
--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -163,8 +163,8 @@ export function setUser(user: User | null): ReturnType<Hub['setUser']> {
  *
  * @param callback that will be enclosed into push/popScope.
  */
-export function withScope(callback: (scope: Scope) => void): ReturnType<Hub['withScope']> {
-  getCurrentHub().withScope(callback);
+export function withScope<T>(callback: (scope: Scope) => T): T {
+  return getCurrentHub().withScope(callback);
 }
 
 /**

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -161,10 +161,10 @@ export class Hub implements HubInterface {
   /**
    * @inheritDoc
    */
-  public withScope(callback: (scope: Scope) => void): void {
+  public withScope<T>(callback: (scope: Scope) => T): T {
     const scope = this.pushScope();
     try {
-      callback(scope);
+      return callback(scope);
     } finally {
       this.popScope();
     }

--- a/packages/core/test/lib/exports.test.ts
+++ b/packages/core/test/lib/exports.test.ts
@@ -1,4 +1,4 @@
-import { Hub, Scope, makeMain, withScope, getCurrentScope } from '../../src';
+import { Hub, Scope, getCurrentScope, makeMain, withScope } from '../../src';
 import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
 
 function getTestClient(): TestClient {
@@ -42,12 +42,12 @@ describe('withScope', () => {
     expect(res).toBe('foo');
   });
 
-  it('works with an async function',async  () => {
+  it('works with an async function', async () => {
     const res = withScope(async scope => {
       return 'foo';
     });
 
     expect(res).toBeInstanceOf(Promise);
-    expect(await res).toBe('foo')
+    expect(await res).toBe('foo');
   });
 });

--- a/packages/core/test/lib/exports.test.ts
+++ b/packages/core/test/lib/exports.test.ts
@@ -1,0 +1,53 @@
+import { Hub, Scope, makeMain, withScope, getCurrentScope } from '../../src';
+import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
+
+function getTestClient(): TestClient {
+  return new TestClient(
+    getDefaultTestClientOptions({
+      dsn: 'https://username@domain/123',
+    }),
+  );
+}
+
+describe('withScope', () => {
+  beforeEach(() => {
+    const client = getTestClient();
+    const hub = new Hub(client);
+    makeMain(hub);
+  });
+
+  it('works without a return value', () => {
+    const scope1 = getCurrentScope();
+    expect(scope1).toBeInstanceOf(Scope);
+
+    scope1.setTag('foo', 'bar');
+
+    const res = withScope(scope => {
+      expect(scope).toBeInstanceOf(Scope);
+      expect(scope).not.toBe(scope1);
+      expect(scope['_tags']).toEqual({ foo: 'bar' });
+
+      expect(getCurrentScope()).toBe(scope);
+    });
+
+    expect(getCurrentScope()).toBe(scope1);
+    expect(res).toBe(undefined);
+  });
+
+  it('works with a return value', () => {
+    const res = withScope(scope => {
+      return 'foo';
+    });
+
+    expect(res).toBe('foo');
+  });
+
+  it('works with an async function',async  () => {
+    const res = withScope(async scope => {
+      return 'foo';
+    });
+
+    expect(res).toBeInstanceOf(Promise);
+    expect(await res).toBe('foo')
+  });
+});

--- a/packages/feedback/src/util/sendFeedbackRequest.ts
+++ b/packages/feedback/src/util/sendFeedbackRequest.ts
@@ -33,67 +33,58 @@ export async function sendFeedbackRequest(
     type: 'feedback',
   };
 
-  return new Promise((resolve, reject) => {
-    withScope(async scope => {
-      // No use for breadcrumbs in feedback
-      scope.clearBreadcrumbs();
+  return withScope(async scope => {
+    // No use for breadcrumbs in feedback
+    scope.clearBreadcrumbs();
 
-      if ([FEEDBACK_API_SOURCE, FEEDBACK_WIDGET_SOURCE].includes(String(source))) {
-        scope.setLevel('info');
-      }
+    if ([FEEDBACK_API_SOURCE, FEEDBACK_WIDGET_SOURCE].includes(String(source))) {
+      scope.setLevel('info');
+    }
 
-      const feedbackEvent = await prepareFeedbackEvent({
-        scope,
-        client,
-        event: baseEvent,
-      });
+    const feedbackEvent = await prepareFeedbackEvent({
+      scope,
+      client,
+      event: baseEvent,
+    });
 
-      if (!feedbackEvent) {
-        resolve();
-        return;
-      }
+    if (!feedbackEvent) {
+      return;
+    }
 
-      if (client.emit) {
-        client.emit('beforeSendFeedback', feedbackEvent, { includeReplay: Boolean(includeReplay) });
-      }
+    if (client.emit) {
+      client.emit('beforeSendFeedback', feedbackEvent, { includeReplay: Boolean(includeReplay) });
+    }
 
-      const envelope = createEventEnvelope(
-        feedbackEvent,
-        dsn,
-        client.getOptions()._metadata,
-        client.getOptions().tunnel,
-      );
+    const envelope = createEventEnvelope(feedbackEvent, dsn, client.getOptions()._metadata, client.getOptions().tunnel);
 
-      let response: void | TransportMakeRequestResponse;
+    let response: void | TransportMakeRequestResponse;
+
+    try {
+      response = await transport.send(envelope);
+    } catch (err) {
+      const error = new Error('Unable to send Feedback');
 
       try {
-        response = await transport.send(envelope);
-      } catch (err) {
-        const error = new Error('Unable to send Feedback');
-
-        try {
-          // In case browsers don't allow this property to be writable
-          // @ts-expect-error This needs lib es2022 and newer
-          error.cause = err;
-        } catch {
-          // nothing to do
-        }
-        reject(error);
+        // In case browsers don't allow this property to be writable
+        // @ts-expect-error This needs lib es2022 and newer
+        error.cause = err;
+      } catch {
+        // nothing to do
       }
+      throw error;
+    }
 
-      // TODO (v8): we can remove this guard once transport.send's type signature doesn't include void anymore
-      if (!response) {
-        resolve(response);
-        return;
-      }
+    // TODO (v8): we can remove this guard once transport.send's type signature doesn't include void anymore
+    if (!response) {
+      return;
+    }
 
-      // Require valid status codes, otherwise can assume feedback was not sent successfully
-      if (typeof response.statusCode === 'number' && (response.statusCode < 200 || response.statusCode >= 300)) {
-        reject(new Error('Unable to send Feedback'));
-      }
+    // Require valid status codes, otherwise can assume feedback was not sent successfully
+    if (typeof response.statusCode === 'number' && (response.statusCode < 200 || response.statusCode >= 300)) {
+      throw new Error('Unable to send Feedback');
+    }
 
-      resolve(response);
-    });
+    return response;
   });
 }
 

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -65,7 +65,7 @@ export interface Hub {
    *
    * @param callback that will be enclosed into push/popScope.
    */
-  withScope(callback: (scope: Scope) => void): void;
+  withScope<T>(callback: (scope: Scope) => T): T;
 
   /** Returns the client of the top stack. */
   getClient(): Client | undefined;


### PR DESCRIPTION
To align this with OpenTelemetry and make some things possible that are currently not easily doable without `pushScope` / `popScope`.

Noticed this because currently it's not easily possible to e.g. use `withScope` in places like [this](https://github.com/getsentry/sentry-javascript/pull/9862#discussion_r1427826506).



This should be backwards compatible because any code that previously relied on this returning `void` should still work.
