### PR TITLE
fix(utils): Update `eventFromUnknownInput` to avoid scope pollution & `getCurrentHub`

### DIFF
--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -16,7 +16,7 @@ import { eventFromMessage, eventFromUnknownInput, logger, resolvedSyncPromise, u
 import { BaseClient } from './baseclient';
 import { createCheckInEnvelope } from './checkin';
 import { DEBUG_BUILD } from './debug-build';
-import { getCurrentHub } from './hub';
+import { getClient } from './exports';
 import type { Scope } from './scope';
 import { SessionFlusher } from './sessionflusher';
 import { addTracingExtensions, getDynamicSamplingContextFromClient } from './tracing';
@@ -50,7 +50,7 @@ export class ServerRuntimeClient<
    * @inheritDoc
    */
   public eventFromException(exception: unknown, hint?: EventHint): PromiseLike<Event> {
-    return resolvedSyncPromise(eventFromUnknownInput(getCurrentHub, this._options.stackParser, exception, hint));
+    return resolvedSyncPromise(eventFromUnknownInput(getClient(), this._options.stackParser, exception, hint));
   }
 
   /**

--- a/packages/deno/src/integrations/globalhandlers.ts
+++ b/packages/deno/src/integrations/globalhandlers.ts
@@ -1,5 +1,6 @@
 import type { ServerRuntimeClient } from '@sentry/core';
-import { flush, getCurrentHub } from '@sentry/core';
+import { getClient, getCurrentHub, getCurrentScope } from '@sentry/core';
+import { flush } from '@sentry/core';
 import type { Event, Hub, Integration, Primitive, StackParser } from '@sentry/types';
 import { eventFromUnknownInput, isPrimitive } from '@sentry/utils';
 
@@ -70,7 +71,7 @@ function installGlobalErrorHandler(): void {
     const [hub, stackParser] = getHubAndOptions();
     const { message, error } = data;
 
-    const event = eventFromUnknownInput(getCurrentHub, stackParser, error || message);
+    const event = eventFromUnknownInput(getClient(), stackParser, error || message);
 
     event.level = 'fatal';
 
@@ -113,7 +114,7 @@ function installGlobalUnhandledRejectionHandler(): void {
 
     const event = isPrimitive(error)
       ? eventFromRejectionWithPrimitive(error)
-      : eventFromUnknownInput(getCurrentHub, stackParser, error, undefined);
+      : eventFromUnknownInput(getClient(), stackParser, error, undefined);
 
     event.level = 'fatal';
 

--- a/packages/utils/src/eventbuilder.ts
+++ b/packages/utils/src/eventbuilder.ts
@@ -63,6 +63,8 @@ function getMessageForObject(exception: object): string {
 
 /**
  * Builds and Event from a Exception
+ *
+ * TODO(v8): Remove getHub fallback
  * @hidden
  */
 export function eventFromUnknownInput(

--- a/packages/utils/src/eventbuilder.ts
+++ b/packages/utils/src/eventbuilder.ts
@@ -83,12 +83,12 @@ export function eventFromUnknownInput(
     type: 'generic',
   };
 
-  const extras: Extras = {};
+  let extras: Extras | undefined;
 
   if (!isError(exception)) {
     if (isPlainObject(exception)) {
       const normalizeDepth = client && client.getOptions().normalizeDepth;
-      extras['__serialized__'] = normalizeToSize(exception as Record<string, unknown>, normalizeDepth);
+      extras = { ['__serialized__']: normalizeToSize(exception as Record<string, unknown>, normalizeDepth) };
 
       const message = getMessageForObject(exception);
       ex = (hint && hint.syntheticException) || new Error(message);
@@ -106,8 +106,11 @@ export function eventFromUnknownInput(
     exception: {
       values: [exceptionFromError(stackParser, ex as Error)],
     },
-    extra: extras,
   };
+
+  if (extras) {
+    event.extra = extras;
+  }
 
   addExceptionTypeValue(event, undefined, undefined);
   addExceptionMechanism(event, mechanism);

--- a/packages/utils/test/eventbuilder.test.ts
+++ b/packages/utils/test/eventbuilder.test.ts
@@ -36,4 +36,9 @@ describe('eventFromUnknownInput', () => {
     const event = eventFromUnknownInput(getCurrentHub, stackParser, { foo: { bar: 'baz' }, message: 'Some message' });
     expect(event.exception?.values?.[0].value).toBe('Some message');
   });
+
+  test('passing client directly', () => {
+    const event = eventFromUnknownInput(undefined, stackParser, { foo: { bar: 'baz' }, prop: 1 });
+    expect(event.exception?.values?.[0].value).toBe('Object captured as exception with keys: foo, prop');
+  });
 });


### PR DESCRIPTION
Instead we can pass a client directly, and I refactored the method to avoid setting extra on the scope, and just set it on the event directly - as this is also kind of leaking right now, because the extra may also be applied to other events using the same scope.