### PR TITLE
ref: Pass client instead of hub to `isSentryRequestUrl`

### DIFF
--- a/packages/core/src/utils/isSentryRequestUrl.ts
+++ b/packages/core/src/utils/isSentryRequestUrl.ts
@@ -1,11 +1,13 @@
-import type { DsnComponents, Hub } from '@sentry/types';
+import type { Client, DsnComponents, Hub } from '@sentry/types';
 
 /**
  * Checks whether given url points to Sentry server
  * @param url url to verify
+ *
+ * TODO(v8): Remove Hub fallback type
  */
-export function isSentryRequestUrl(url: string, hub: Hub): boolean {
-  const client = hub.getClient();
+export function isSentryRequestUrl(url: string, hubOrClient: Hub | Client | undefined): boolean {
+  const client = hubOrClient && isHub(hubOrClient) ? hubOrClient.getClient() : hubOrClient;
   const dsn = client && client.getDsn();
   const tunnel = client && client.getOptions().tunnel;
 
@@ -26,4 +28,8 @@ function checkDsn(url: string, dsn: DsnComponents | undefined): boolean {
 
 function removeTrailingSlash(str: string): string {
   return str[str.length - 1] === '/' ? str.slice(0, -1) : str;
+}
+
+function isHub(hubOrClient: Hub | Client | undefined): hubOrClient is Hub {
+  return (hubOrClient as Hub).getClient !== undefined;
 }

--- a/packages/core/test/lib/utils/isSentryRequestUrl.test.ts
+++ b/packages/core/test/lib/utils/isSentryRequestUrl.test.ts
@@ -1,4 +1,4 @@
-import type { Hub } from '@sentry/types';
+import type { Client, Hub } from '@sentry/types';
 
 import { isSentryRequestUrl } from '../../../src';
 
@@ -12,15 +12,21 @@ describe('isSentryRequestUrl', () => {
     ['http://tunnel:4200/', 'sentry-dsn.com', 'http://tunnel:4200', true],
     ['http://tunnel:4200/a', 'sentry-dsn.com', 'http://tunnel:4200', false],
   ])('works with url=%s, dsn=%s, tunnel=%s', (url: string, dsn: string, tunnel: string, expected: boolean) => {
+    const client = {
+      getOptions: () => ({ tunnel }),
+      getDsn: () => ({ host: dsn }),
+    } as unknown as Client;
+
     const hub = {
       getClient: () => {
-        return {
-          getOptions: () => ({ tunnel }),
-          getDsn: () => ({ host: dsn }),
-        };
+        return client;
       },
     } as unknown as Hub;
 
+    // Works with hub passed
     expect(isSentryRequestUrl(url, hub)).toBe(expected);
+
+    // Works with client passed
+    expect(isSentryRequestUrl(url, client)).toBe(expected);
   });
 });

--- a/packages/integrations/src/httpclient.ts
+++ b/packages/integrations/src/httpclient.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub, isSentryRequestUrl } from '@sentry/core';
+import { getClient, isSentryRequestUrl } from '@sentry/core';
 import type {
   Event as SentryEvent,
   EventProcessor,
@@ -348,9 +348,7 @@ export class HttpClient implements Integration {
    */
   private _shouldCaptureResponse(status: number, url: string): boolean {
     return (
-      this._isInGivenStatusRanges(status) &&
-      this._isInGivenRequestTargets(url) &&
-      !isSentryRequestUrl(url, getCurrentHub())
+      this._isInGivenStatusRanges(status) && this._isInGivenRequestTargets(url) && !isSentryRequestUrl(url, getClient())
     );
   }
 

--- a/packages/node-experimental/src/integrations/http.ts
+++ b/packages/node-experimental/src/integrations/http.ts
@@ -102,7 +102,7 @@ export class Http implements Integration {
               return false;
             }
 
-            if (isSentryRequestUrl(url, getCurrentHub())) {
+            if (isSentryRequestUrl(url, getClient())) {
               return true;
             }
 

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -240,7 +240,7 @@ function _createWrappedRequestMethodFactory(
       const requestUrl = extractUrl(requestOptions);
 
       // we don't want to record requests to Sentry as either breadcrumbs or spans, so just use the original method
-      if (isSentryRequestUrl(requestUrl, getCurrentHub())) {
+      if (isSentryRequestUrl(requestUrl, getClient())) {
         return originalRequestMethod.apply(httpModule, requestArgs);
       }
 

--- a/packages/node/src/integrations/undici/index.ts
+++ b/packages/node/src/integrations/undici/index.ts
@@ -1,4 +1,10 @@
-import { getCurrentHub, getCurrentScope, getDynamicSamplingContextFromClient, isSentryRequestUrl } from '@sentry/core';
+import {
+  getClient,
+  getCurrentHub,
+  getCurrentScope,
+  getDynamicSamplingContextFromClient,
+  isSentryRequestUrl,
+} from '@sentry/core';
 import type { EventProcessor, Integration, Span } from '@sentry/types';
 import {
   LRUMap,
@@ -137,12 +143,12 @@ export class Undici implements Integration {
 
     const stringUrl = request.origin ? request.origin.toString() + request.path : request.path;
 
-    if (isSentryRequestUrl(stringUrl, hub) || request.__sentry_span__ !== undefined) {
+    const client = getClient<NodeClient>();
+    if (!client) {
       return;
     }
 
-    const client = hub.getClient<NodeClient>();
-    if (!client) {
+    if (isSentryRequestUrl(stringUrl, client) || request.__sentry_span__ !== undefined) {
       return;
     }
 
@@ -197,7 +203,7 @@ export class Undici implements Integration {
 
     const stringUrl = request.origin ? request.origin.toString() + request.path : request.path;
 
-    if (isSentryRequestUrl(stringUrl, hub)) {
+    if (isSentryRequestUrl(stringUrl, getClient())) {
       return;
     }
 
@@ -237,7 +243,7 @@ export class Undici implements Integration {
 
     const stringUrl = request.origin ? request.origin.toString() + request.path : request.path;
 
-    if (isSentryRequestUrl(stringUrl, hub)) {
+    if (isSentryRequestUrl(stringUrl, getClient())) {
       return;
     }
 

--- a/packages/opentelemetry-node/src/utils/isSentryRequest.ts
+++ b/packages/opentelemetry-node/src/utils/isSentryRequest.ts
@@ -1,6 +1,6 @@
 import type { Span as OtelSpan } from '@opentelemetry/sdk-trace-base';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import { getCurrentHub, isSentryRequestUrl } from '@sentry/core';
+import { getClient, isSentryRequestUrl } from '@sentry/core';
 
 /**
  *
@@ -16,5 +16,5 @@ export function isSentryRequestSpan(otelSpan: OtelSpan): boolean {
     return false;
   }
 
-  return isSentryRequestUrl(httpUrl.toString(), getCurrentHub());
+  return isSentryRequestUrl(httpUrl.toString(), getClient());
 }

--- a/packages/opentelemetry/src/utils/isSentryRequest.ts
+++ b/packages/opentelemetry/src/utils/isSentryRequest.ts
@@ -1,5 +1,5 @@
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import { getCurrentHub, isSentryRequestUrl } from '@sentry/core';
+import { getClient, isSentryRequestUrl } from '@sentry/core';
 
 import type { AbstractSpan } from '../types';
 import { spanHasAttributes } from './spanTypes';
@@ -22,5 +22,5 @@ export function isSentryRequestSpan(span: AbstractSpan): boolean {
     return false;
   }
 
-  return isSentryRequestUrl(httpUrl.toString(), getCurrentHub());
+  return isSentryRequestUrl(httpUrl.toString(), getClient());
 }

--- a/packages/replay/src/util/shouldFilterRequest.ts
+++ b/packages/replay/src/util/shouldFilterRequest.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub, isSentryRequestUrl } from '@sentry/core';
+import { getClient, isSentryRequestUrl } from '@sentry/core';
 
 import { DEBUG_BUILD } from '../debug-build';
 import type { ReplayContainer } from '../types';
@@ -13,5 +13,5 @@ export function shouldFilterRequest(replay: ReplayContainer, url: string): boole
     return false;
   }
 
-  return isSentryRequestUrl(url, getCurrentHub());
+  return isSentryRequestUrl(url, getClient());
 }

--- a/packages/vercel-edge/src/integrations/wintercg-fetch.ts
+++ b/packages/vercel-edge/src/integrations/wintercg-fetch.ts
@@ -54,7 +54,7 @@ export class WinterCGFetch implements Integration {
         return;
       }
 
-      if (isSentryRequestUrl(handlerData.fetchData.url, hub)) {
+      if (isSentryRequestUrl(handlerData.fetchData.url, getClient())) {
         return;
       }
 


### PR DESCRIPTION
Step by step, eradicating the hub...

Note: I haven't found a way to mark an attribute type of a function as deprecated 😬 I think it's OK here, but generally a bit annoying/tricky...