### PR TITLE
fix(sveltekit): Add conditional exports

### DIFF
--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -14,8 +14,14 @@
   "browser": "build/esm/index.client.js",
   "types": "build/types/index.types.d.ts",
   "exports": {
-    "browser": "./build/esm/index.client.js",
-    "node": "./build/cjs/index.server.js"
+    "./package.json": "./package.json",
+    ".": {
+      "browser": {
+        "import": "./build/esm/index.client.js",
+        "require": "./build/cjs/index.client.js"
+      },
+      "node": "./build/cjs/index.server.js"
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -13,6 +13,10 @@
   "module": "build/esm/index.server.js",
   "browser": "build/esm/index.client.js",
   "types": "build/types/index.types.d.ts",
+  "exports": {
+    "browser": "./build/esm/index.client.js",
+    "node": "./build/cjs/index.server.js"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Looks like Vite 5 module resolution for `@sentry/sveltekit` only works with defining conditional exports. Tested this locally with a Sverdle kit@1, kit@2 and the syntax website. 

It'd be nice to get confirmation that this fixes https://github.com/syntaxfm/website/pull/1458 but based on my tests it should be fine 🤞 

Added an e2e test for Kit 2.0 in #9873 

ref #9851 
