### PR TITLE
feat(replay): Add `canvas.type` setting

### DIFF
--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -343,7 +343,10 @@ export class ReplayContainer implements ReplayContainerInterface {
         ...(canvas && {
           recordCanvas: true,
           sampling: { canvas: canvas.fps || 4 },
-          dataURLOptions: { quality: canvas.quality || 0.6 },
+          dataURLOptions: {
+            type: canvas.type || 'image/webp',
+            quality: canvas.quality || 0.6,
+          },
           getCanvasManager: canvas.manager,
         }),
       });

--- a/packages/replay/src/types/replay.ts
+++ b/packages/replay/src/types/replay.ts
@@ -235,6 +235,7 @@ export interface ReplayPluginOptions extends ReplayNetworkOptions {
     canvas: {
       fps?: number;
       quality?: number;
+      type?: string;
       manager: (options: GetCanvasManagerOptions) => CanvasManagerInterface;
     };
   }>;


### PR DESCRIPTION
Defaults to `webp` instead of `png`. This will also allow `quality` to work.

Closes https://github.com/getsentry/team-replay/issues/326
