### PR TITLE
ref(serverless): Avoid using `pushScope`

### DIFF
--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -95,8 +95,6 @@ describe('AWSLambda', () => {
     });
 
     test('captureTimeoutWarning enabled (default)', async () => {
-      expect.assertions(2);
-
       const handler: Handler = (_event, _context, callback) => {
         setTimeout(() => {
           callback(null, 42);
@@ -105,14 +103,13 @@ describe('AWSLambda', () => {
       const wrappedHandler = wrapHandler(handler);
       await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
 
+      expect(Sentry.withScope).toBeCalledTimes(2);
       expect(Sentry.captureMessage).toBeCalled();
       // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setTag).toBeCalledWith('timeout', '1s');
     });
 
     test('captureTimeoutWarning disabled', async () => {
-      expect.assertions(2);
-
       const handler: Handler = (_event, _context, callback) => {
         setTimeout(() => {
           callback(null, 42);
@@ -123,8 +120,10 @@ describe('AWSLambda', () => {
       });
       await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
 
-      expect(Sentry.withScope).not.toBeCalled();
+      expect(Sentry.withScope).toBeCalledTimes(1);
       expect(Sentry.captureMessage).not.toBeCalled();
+      // @ts-expect-error see "Why @ts-expect-error" note
+      expect(SentryNode.fakeScope.setTag).not.toBeCalledWith('timeout', '1s');
     });
 
     test('captureTimeoutWarning with configured timeoutWarningLimit', async () => {


### PR DESCRIPTION
This is the only place I've found where we use `pushScope`, and since we updated the `withScope` signature we can rewrite this.