### PR TITLE
ref(integrations): Refactor pluggable integrations to avoid `setupOnce`

### DIFF
--- a/packages/integrations/src/captureconsole.ts
+++ b/packages/integrations/src/captureconsole.ts
@@ -42,7 +42,7 @@ export class CaptureConsole implements Integration {
   }
 
   /** @inheritdoc */
-  public client(client: Client): void {
+  public setup(client: Client): void {
     if (!('console' in GLOBAL_OBJ)) {
       return;
     }

--- a/packages/integrations/src/httpclient.ts
+++ b/packages/integrations/src/httpclient.ts
@@ -1,5 +1,6 @@
-import { getClient, isSentryRequestUrl } from '@sentry/core';
+import { captureEvent, getClient, isSentryRequestUrl } from '@sentry/core';
 import type {
+  Client,
   Event as SentryEvent,
   EventProcessor,
   Hub,
@@ -20,6 +21,7 @@ import { DEBUG_BUILD } from './debug-build';
 
 export type HttpStatusCodeRange = [number, number] | number;
 export type HttpRequestTarget = string | RegExp;
+
 interface HttpClientOptions {
   /**
    * HTTP status codes that should be considered failed.
@@ -56,11 +58,6 @@ export class HttpClient implements Integration {
   private readonly _options: HttpClientOptions;
 
   /**
-   * Returns current hub.
-   */
-  private _getCurrentHub?: () => Hub;
-
-  /**
    * @inheritDoc
    *
    * @param options
@@ -79,10 +76,14 @@ export class HttpClient implements Integration {
    *
    * @param options
    */
-  public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
-    this._getCurrentHub = getCurrentHub;
-    this._wrapFetch();
-    this._wrapXHR();
+  public setupOnce(_: (callback: EventProcessor) => void, _getCurrentHub: () => Hub): void {
+    // noop
+  }
+
+  /** @inheritdoc */
+  public setup(client: Client): void {
+    this._wrapFetch(client);
+    this._wrapXHR(client);
   }
 
   /**
@@ -93,13 +94,12 @@ export class HttpClient implements Integration {
    * @param requestInit The request init object
    */
   private _fetchResponseHandler(requestInfo: RequestInfo, response: Response, requestInit?: RequestInit): void {
-    if (this._getCurrentHub && this._shouldCaptureResponse(response.status, response.url)) {
+    if (this._shouldCaptureResponse(response.status, response.url)) {
       const request = _getRequest(requestInfo, requestInit);
-      const hub = this._getCurrentHub();
 
       let requestHeaders, responseHeaders, requestCookies, responseCookies;
 
-      if (hub.shouldSendDefaultPii()) {
+      if (_shouldSendDefaultPii()) {
         [{ headers: requestHeaders, cookies: requestCookies }, { headers: responseHeaders, cookies: responseCookies }] =
           [
             { cookieHeader: 'Cookie', obj: request },
@@ -135,7 +135,7 @@ export class HttpClient implements Integration {
         responseCookies,
       });
 
-      hub.captureEvent(event);
+      captureEvent(event);
     }
   }
 
@@ -147,11 +147,10 @@ export class HttpClient implements Integration {
    * @param headers The HTTP headers
    */
   private _xhrResponseHandler(xhr: XMLHttpRequest, method: string, headers: Record<string, string>): void {
-    if (this._getCurrentHub && this._shouldCaptureResponse(xhr.status, xhr.responseURL)) {
+    if (this._shouldCaptureResponse(xhr.status, xhr.responseURL)) {
       let requestHeaders, responseCookies, responseHeaders;
-      const hub = this._getCurrentHub();
 
-      if (hub.shouldSendDefaultPii()) {
+      if (_shouldSendDefaultPii()) {
         try {
           const cookieString = xhr.getResponseHeader('Set-Cookie') || xhr.getResponseHeader('set-cookie') || undefined;
 
@@ -181,7 +180,7 @@ export class HttpClient implements Integration {
         responseCookies,
       });
 
-      hub.captureEvent(event);
+      captureEvent(event);
     }
   }
 
@@ -296,12 +295,16 @@ export class HttpClient implements Integration {
   /**
    * Wraps `fetch` function to capture request and response data
    */
-  private _wrapFetch(): void {
+  private _wrapFetch(client: Client): void {
     if (!supportsNativeFetch()) {
       return;
     }
 
     addFetchInstrumentationHandler(handlerData => {
+      if (getClient() !== client) {
+        return;
+      }
+
       const { response, args } = handlerData;
       const [requestInfo, requestInit] = args as [RequestInfo, RequestInit | undefined];
 
@@ -316,12 +319,16 @@ export class HttpClient implements Integration {
   /**
    * Wraps XMLHttpRequest to capture request and response data
    */
-  private _wrapXHR(): void {
+  private _wrapXHR(client: Client): void {
     if (!('XMLHttpRequest' in GLOBAL_OBJ)) {
       return;
     }
 
     addXhrInstrumentationHandler(handlerData => {
+      if (getClient() !== client) {
+        return;
+      }
+
       const xhr = handlerData.xhr as SentryWrappedXMLHttpRequest & XMLHttpRequest;
 
       const sentryXhrData = xhr[SENTRY_XHR_DATA_KEY];
@@ -417,4 +424,9 @@ function _getRequest(requestInfo: RequestInfo, requestInit?: RequestInit): Reque
   }
 
   return new Request(requestInfo, requestInit);
+}
+
+function _shouldSendDefaultPii(): boolean {
+  const client = getClient();
+  return client ? Boolean(client.getOptions().sendDefaultPii) : false;
 }

--- a/packages/integrations/test/debug.test.ts
+++ b/packages/integrations/test/debug.test.ts
@@ -2,7 +2,7 @@ import type { Client, Event, EventHint, Hub, Integration } from '@sentry/types';
 
 import { Debug } from '../src/debug';
 
-function testEventLogged(integration: Integration, testEvent?: Event, testEventHint?: EventHint) {
+function testEventLogged(integration: Debug, testEvent?: Event, testEventHint?: EventHint) {
   const callbacks: ((event: Event, hint?: EventHint) => void)[] = [];
 
   const client: Client = {
@@ -12,15 +12,7 @@ function testEventLogged(integration: Integration, testEvent?: Event, testEventH
     },
   } as Client;
 
-  function getCurrentHub() {
-    return {
-      getClient: jest.fn(() => {
-        return client;
-      }),
-    } as unknown as Hub;
-  }
-
-  integration.setupOnce(() => {}, getCurrentHub);
+  integration.setup(client);
 
   expect(callbacks.length).toEqual(1);
 


### PR DESCRIPTION
Slowly getting rid of `getCurrentHub()`...