### PR TITLE
feat(replay): Change to use preset quality values

### DIFF
--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -82,4 +82,4 @@ export const CANVAS_QUALITY = {
       quality: 0.5,
     },
   },
-}
+};

--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -53,3 +53,33 @@ export const MAX_REPLAY_DURATION = 3_600_000; // 60 minutes in ms;
 
 /** Default attributes to be ignored when `maskAllText` is enabled */
 export const DEFAULT_IGNORED_ATTRIBUTES = ['title', 'placeholder'];
+
+export const CANVAS_QUALITY = {
+  low: {
+    sampling: {
+      canvas: 1,
+    },
+    dataURLOptions: {
+      type: 'image/webp',
+      quality: 0.25,
+    },
+  },
+  normal: {
+    sampling: {
+      canvas: 2,
+    },
+    dataURLOptions: {
+      type: 'image/webp',
+      quality: 0.4,
+    },
+  },
+  high: {
+    sampling: {
+      canvas: 4,
+    },
+    dataURLOptions: {
+      type: 'image/webp',
+      quality: 0.5,
+    },
+  },
+}

--- a/packages/replay/src/constants.ts
+++ b/packages/replay/src/constants.ts
@@ -64,7 +64,7 @@ export const CANVAS_QUALITY = {
       quality: 0.25,
     },
   },
-  normal: {
+  medium: {
     sampling: {
       canvas: 2,
     },

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -6,6 +6,7 @@ import { logger } from '@sentry/utils';
 
 import {
   BUFFER_CHECKOUT_TIME,
+  CANVAS_QUALITY,
   SESSION_IDLE_EXPIRE_DURATION,
   SESSION_IDLE_PAUSE_DURATION,
   SLOW_CLICK_SCROLL_TIMEOUT,
@@ -340,14 +341,10 @@ export class ReplayContainer implements ReplayContainerInterface {
         ...(this.recordingMode === 'buffer' && { checkoutEveryNms: BUFFER_CHECKOUT_TIME }),
         emit: getHandleRecordingEmit(this),
         onMutation: this._onMutationHandler,
-        ...(canvas && {
+        ...(canvas && canvas.manager && {
           recordCanvas: true,
-          sampling: { canvas: canvas.fps || 4 },
-          dataURLOptions: {
-            type: canvas.type || 'image/webp',
-            quality: canvas.quality || 0.6,
-          },
           getCanvasManager: canvas.manager,
+          ...(CANVAS_QUALITY[canvas.quality || 'normal'] || CANVAS_QUALITY.normal)
         }),
       });
     } catch (err) {

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -341,11 +341,12 @@ export class ReplayContainer implements ReplayContainerInterface {
         ...(this.recordingMode === 'buffer' && { checkoutEveryNms: BUFFER_CHECKOUT_TIME }),
         emit: getHandleRecordingEmit(this),
         onMutation: this._onMutationHandler,
-        ...(canvas && canvas.manager && {
-          recordCanvas: true,
-          getCanvasManager: canvas.manager,
-          ...(CANVAS_QUALITY[canvas.quality || 'medium'] || CANVAS_QUALITY.medium)
-        }),
+        ...(canvas &&
+          canvas.manager && {
+            recordCanvas: true,
+            getCanvasManager: canvas.manager,
+            ...(CANVAS_QUALITY[canvas.quality || 'medium'] || CANVAS_QUALITY.medium),
+          }),
       });
     } catch (err) {
       this._handleException(err);

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -344,7 +344,7 @@ export class ReplayContainer implements ReplayContainerInterface {
         ...(canvas && canvas.manager && {
           recordCanvas: true,
           getCanvasManager: canvas.manager,
-          ...(CANVAS_QUALITY[canvas.quality || 'normal'] || CANVAS_QUALITY.normal)
+          ...(CANVAS_QUALITY[canvas.quality || 'medium'] || CANVAS_QUALITY.medium)
         }),
       });
     } catch (err) {

--- a/packages/replay/src/types/replay.ts
+++ b/packages/replay/src/types/replay.ts
@@ -233,9 +233,7 @@ export interface ReplayPluginOptions extends ReplayNetworkOptions {
     captureExceptions: boolean;
     traceInternals: boolean;
     canvas: {
-      fps?: number;
-      quality?: number;
-      type?: string;
+      quality?: 'low' | 'normal' | 'high';
       manager: (options: GetCanvasManagerOptions) => CanvasManagerInterface;
     };
   }>;

--- a/packages/replay/src/types/replay.ts
+++ b/packages/replay/src/types/replay.ts
@@ -233,7 +233,7 @@ export interface ReplayPluginOptions extends ReplayNetworkOptions {
     captureExceptions: boolean;
     traceInternals: boolean;
     canvas: {
-      quality?: 'low' | 'normal' | 'high';
+      quality?: 'low' | 'medium' | 'high';
       manager: (options: GetCanvasManagerOptions) => CanvasManagerInterface;
     };
   }>;

--- a/packages/replay/test/integration/rrweb.test.ts
+++ b/packages/replay/test/integration/rrweb.test.ts
@@ -1,3 +1,4 @@
+import type { CanvasManagerInterface, } from '../../src/types';
 import { resetSdkMock } from '../mocks/resetSdkMock';
 import { useFakeTimers } from '../utils/use-fake-timers';
 
@@ -39,5 +40,32 @@ describe('Integration | rrweb', () => {
         "unmaskTextSelector": ".sentry-unmask,[data-sentry-unmask]",
       }
     `);
+  });
+
+  it('calls rrweb.record with default canvas options', async () => {
+    const { mockRecord } = await resetSdkMock({
+      replayOptions: {
+        _experiments: {
+        canvas: {
+          // @ts-expect-error This should return
+          // CanvasManagerInterface, but we don't care about it
+          // for this test
+          manager: () => null,
+        }
+      },
+      }
+    });
+
+    expect(mockRecord).toHaveBeenLastCalledWith(expect.objectContaining({
+      recordCanvas: true,
+      getCanvasManager: expect.any(Function),
+      dataURLOptions: {
+        quality: 0.4,
+        type: 'image/webp',
+      },
+      sampling: {
+        canvas: 2,
+      }
+    }));
   });
 });

--- a/packages/replay/test/integration/rrweb.test.ts
+++ b/packages/replay/test/integration/rrweb.test.ts
@@ -1,4 +1,4 @@
-import type { CanvasManagerInterface, } from '../../src/types';
+import type { CanvasManagerInterface } from '../../src/types';
 import { resetSdkMock } from '../mocks/resetSdkMock';
 import { useFakeTimers } from '../utils/use-fake-timers';
 
@@ -46,26 +46,28 @@ describe('Integration | rrweb', () => {
     const { mockRecord } = await resetSdkMock({
       replayOptions: {
         _experiments: {
-        canvas: {
-          // @ts-expect-error This should return
-          // CanvasManagerInterface, but we don't care about it
-          // for this test
-          manager: () => null,
-        }
+          canvas: {
+            // @ts-expect-error This should return
+            // CanvasManagerInterface, but we don't care about it
+            // for this test
+            manager: () => null,
+          },
+        },
       },
-      }
     });
 
-    expect(mockRecord).toHaveBeenLastCalledWith(expect.objectContaining({
-      recordCanvas: true,
-      getCanvasManager: expect.any(Function),
-      dataURLOptions: {
-        quality: 0.4,
-        type: 'image/webp',
-      },
-      sampling: {
-        canvas: 2,
-      }
-    }));
+    expect(mockRecord).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        recordCanvas: true,
+        getCanvasManager: expect.any(Function),
+        dataURLOptions: {
+          quality: 0.4,
+          type: 'image/webp',
+        },
+        sampling: {
+          canvas: 2,
+        },
+      }),
+    );
   });
 });


### PR DESCRIPTION
Instead of using canvas recording quality values direct to rrweb, use presets to control image quality and fps.

Closes https://github.com/getsentry/team-replay/issues/325