### PR TITLE
ref(core): Refactor core integrations to functional style

### DIFF
--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -1,4 +1,14 @@
-import type { Client, Event, EventHint, Integration, IntegrationClass, IntegrationFn, Options } from '@sentry/types';
+import type {
+  Client,
+  Event,
+  EventHint,
+  EventProcessor,
+  Hub,
+  Integration,
+  IntegrationClass,
+  IntegrationFn,
+  Options,
+} from '@sentry/types';
 import { arrayify, logger } from '@sentry/utils';
 
 import { DEBUG_BUILD } from './debug-build';
@@ -165,7 +175,11 @@ function findIndex<T>(arr: T[], callback: (item: T) => boolean): number {
 export function convertIntegrationFnToClass<Fn extends IntegrationFn>(
   name: string,
   fn: Fn,
-): IntegrationClass<Integration> {
+): IntegrationClass<
+  Integration & {
+    setupOnce: (addGlobalEventProcessor?: (callback: EventProcessor) => void, getCurrentHub?: () => Hub) => void;
+  }
+> {
   return Object.assign(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     function ConvertedIntegration(...rest: any[]) {
@@ -176,5 +190,9 @@ export function convertIntegrationFnToClass<Fn extends IntegrationFn>(
       };
     },
     { id: name },
-  ) as unknown as IntegrationClass<Integration>;
+  ) as unknown as IntegrationClass<
+    Integration & {
+      setupOnce: (addGlobalEventProcessor?: (callback: EventProcessor) => void, getCurrentHub?: () => Hub) => void;
+    }
+  >;
 }

--- a/packages/core/src/integrations/functiontostring.ts
+++ b/packages/core/src/integrations/functiontostring.ts
@@ -1,41 +1,33 @@
-import type { Integration, WrappedFunction } from '@sentry/types';
+import type { IntegrationFn, WrappedFunction } from '@sentry/types';
 import { getOriginalFunction } from '@sentry/utils';
+import { convertIntegrationFnToClass } from '../integration';
 
 let originalFunctionToString: () => void;
 
+const INTEGRATION_NAME = 'FunctionToString';
+
+const functionToStringIntegration: IntegrationFn = () => {
+  return {
+    name: INTEGRATION_NAME,
+    setupOnce() {
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      originalFunctionToString = Function.prototype.toString;
+
+      // intrinsics (like Function.prototype) might be immutable in some environments
+      // e.g. Node with --frozen-intrinsics, XS (an embedded JavaScript engine) or SES (a JavaScript proposal)
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        Function.prototype.toString = function (this: WrappedFunction, ...args: any[]): string {
+          const context = getOriginalFunction(this) || this;
+          return originalFunctionToString.apply(context, args);
+        };
+      } catch {
+        // ignore errors here, just don't patch this
+      }
+    },
+  };
+};
+
 /** Patch toString calls to return proper name for wrapped functions */
-export class FunctionToString implements Integration {
-  /**
-   * @inheritDoc
-   */
-  public static id: string = 'FunctionToString';
-
-  /**
-   * @inheritDoc
-   */
-  public name: string;
-
-  public constructor() {
-    this.name = FunctionToString.id;
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public setupOnce(): void {
-    // eslint-disable-next-line @typescript-eslint/unbound-method
-    originalFunctionToString = Function.prototype.toString;
-
-    // intrinsics (like Function.prototype) might be immutable in some environments
-    // e.g. Node with --frozen-intrinsics, XS (an embedded JavaScript engine) or SES (a JavaScript proposal)
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      Function.prototype.toString = function (this: WrappedFunction, ...args: any[]): string {
-        const context = getOriginalFunction(this) || this;
-        return originalFunctionToString.apply(context, args);
-      };
-    } catch {
-      // ignore errors here, just don't patch this
-    }
-  }
-}
+// eslint-disable-next-line deprecation/deprecation
+export const FunctionToString = convertIntegrationFnToClass(INTEGRATION_NAME, functionToStringIntegration);

--- a/packages/core/src/integrations/metadata.ts
+++ b/packages/core/src/integrations/metadata.ts
@@ -1,7 +1,41 @@
-import type { Client, Event, EventItem, EventProcessor, Hub, Integration } from '@sentry/types';
+import type { Event, EventItem, IntegrationFn } from '@sentry/types';
 import { forEachEnvelopeItem } from '@sentry/utils';
+import { convertIntegrationFnToClass } from '../integration';
 
 import { addMetadataToStackFrames, stripMetadataFromStackFrames } from '../metadata';
+
+const INTEGRATION_NAME = 'ModuleMetadata';
+
+const moduleMetadataIntegration: IntegrationFn = () => {
+  return {
+    name: INTEGRATION_NAME,
+    setup(client) {
+      if (typeof client.on !== 'function') {
+        return;
+      }
+
+      // We need to strip metadata from stack frames before sending them to Sentry since these are client side only.
+      client.on('beforeEnvelope', envelope => {
+        forEachEnvelopeItem(envelope, (item, type) => {
+          if (type === 'event') {
+            const event = Array.isArray(item) ? (item as EventItem)[1] : undefined;
+
+            if (event) {
+              stripMetadataFromStackFrames(event);
+              item[1] = event;
+            }
+          }
+        });
+      });
+    },
+
+    processEvent(event, _hint, client) {
+      const stackParser = client.getOptions().stackParser;
+      addMetadataToStackFrames(stackParser, event);
+      return event;
+    },
+  };
+};
 
 /**
  * Adds module metadata to stack frames.
@@ -12,53 +46,5 @@ import { addMetadataToStackFrames, stripMetadataFromStackFrames } from '../metad
  * under the `module_metadata` property. This can be used to help in tagging or routing of events from different teams
  * our sources
  */
-export class ModuleMetadata implements Integration {
-  /*
-   * @inheritDoc
-   */
-  public static id: string = 'ModuleMetadata';
-
-  /**
-   * @inheritDoc
-   */
-  public name: string;
-
-  public constructor() {
-    this.name = ModuleMetadata.id;
-  }
-
-  /**
-   * @inheritDoc
-   */
-  public setupOnce(_addGlobalEventProcessor: (processor: EventProcessor) => void, _getCurrentHub: () => Hub): void {
-    // noop
-  }
-
-  /** @inheritDoc */
-  public setup(client: Client): void {
-    if (typeof client.on !== 'function') {
-      return;
-    }
-
-    // We need to strip metadata from stack frames before sending them to Sentry since these are client side only.
-    client.on('beforeEnvelope', envelope => {
-      forEachEnvelopeItem(envelope, (item, type) => {
-        if (type === 'event') {
-          const event = Array.isArray(item) ? (item as EventItem)[1] : undefined;
-
-          if (event) {
-            stripMetadataFromStackFrames(event);
-            item[1] = event;
-          }
-        }
-      });
-    });
-  }
-
-  /** @inheritDoc */
-  public processEvent(event: Event, _hint: unknown, client: Client): Event {
-    const stackParser = client.getOptions().stackParser;
-    addMetadataToStackFrames(stackParser, event);
-    return event;
-  }
-}
+// eslint-disable-next-line deprecation/deprecation
+export const ModuleMetadata = convertIntegrationFnToClass(INTEGRATION_NAME, moduleMetadataIntegration);

--- a/packages/serverless/test/__mocks__/@sentry/node.ts
+++ b/packages/serverless/test/__mocks__/@sentry/node.ts
@@ -41,6 +41,7 @@ export const captureException = jest.fn();
 export const captureMessage = jest.fn();
 export const withScope = jest.fn(cb => cb(fakeScope));
 export const flush = jest.fn(() => Promise.resolve());
+export const getClient = jest.fn(() => ({}));
 
 export const resetMocks = (): void => {
   fakeTransaction.setHttpStatus.mockClear();
@@ -68,4 +69,5 @@ export const resetMocks = (): void => {
   captureMessage.mockClear();
   withScope.mockClear();
   flush.mockClear();
+  getClient.mockClear();
 };


### PR DESCRIPTION
Also make a small adjustment to the legacy converter util to ensure `setupOnce()` is callable with or without arguments, to remain stable.