### PR TITLE
build: Set Volta Node.js version to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "yalc:publish": "lerna run yalc:publish"
   },
   "volta": {
-    "node": "20.10.0",
+    "node": "18.17.0",
     "yarn": "1.22.19"
   },
   "workspaces": [


### PR DESCRIPTION
CI keeps flaking on us on what it seems like a node/v8 bug. Let's revert to 18 to fix.