### PR TITLE
fix(sveltekit): Add `types` field to package.json `exports`

### DIFF
--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -20,7 +20,8 @@
         "import": "./build/esm/index.client.js",
         "require": "./build/cjs/index.client.js"
       },
-      "node": "./build/cjs/index.server.js"
+      "node": "./build/cjs/index.server.js",
+      "types": "./build/types/index.types.d.ts"
     }
   },
   "publishConfig": {


### PR DESCRIPTION
Looks like we need to add a `types` field to the `"."` subpath in the `exports` object in package.json so that `svelte-check` type checking finds the type declarations of the SDK in Kit 2.0. 

fixes #9923