### PR TITLE
ci: Use `package.json`s as additional dependency cache key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,7 +176,7 @@ jobs:
         # so no need to reinstall them
       - name: Compute dependency cache key
         id: compute_lockfile_hash
-        run: echo "hash=${{ hashFiles('yarn.lock') }}" >> "$GITHUB_OUTPUT"
+        run: echo "hash=${{ hashFiles('yarn.lock', '**/package.json') }}" >> "$GITHUB_OUTPUT"
 
       - name: Check dependency cache
         uses: actions/cache@v3


### PR DESCRIPTION
If a purely internal package is added, it is not added to the lockfile which will not invalidate the dependency cache and will not include the new internal package (symlink) in the cached deps. This PR fixes that.