### PR TITLE
build: bump sucrase to 3.34.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -29365,10 +29365,11 @@ stylus@0.54.8, stylus@^0.54.7, stylus@^0.54.8:
     source-map "^0.7.3"
 
 sucrase@^3.20.0:
-  version "3.21.0"
-  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.21.0.tgz#6a5affdbe716b22e4dc99c57d366ad0d216444b9"
-  integrity sha512-FjAhMJjDcifARI7bZej0Bi1yekjWQHoEvWIXhLPwDhC6O4iZ5PtGb86WV56riW87hzpgB13wwBKO9vKAiWu5VQ==
+  version "3.34.0"
+  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.34.0.tgz#1e0e2d8fcf07f8b9c3569067d92fbd8690fb576f"
+  integrity sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==
   dependencies:
+    "@jridgewell/gen-mapping" "^0.3.2"
     commander "^4.0.0"
     glob "7.1.6"
     lines-and-columns "^1.1.6"


### PR DESCRIPTION
To ensure we have up-to-date TS support, e.g. `satisfies` cannot be transpiled previously.

See https://github.com/alangpierce/sucrase/blob/main/CHANGELOG.md
