### PR TITLE
feat(core): Add `getIsolationScope()` method

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -27,6 +27,8 @@ export {
   getCurrentHub,
   getClient,
   getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
   Hub,
   makeMain,
   Scope,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -44,6 +44,8 @@ export {
   getCurrentHub,
   getClient,
   getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
   Hub,
   lastEventId,
   makeMain,

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -49,6 +49,7 @@ import { getEnvelopeEndpointWithUrlEncodedAuth } from './api';
 import { DEBUG_BUILD } from './debug-build';
 import { createEventEnvelope, createSessionEnvelope } from './envelope';
 import { getClient } from './exports';
+import { getIsolationScope } from './hub';
 import type { IntegrationIndex } from './integration';
 import { setupIntegration, setupIntegrations } from './integration';
 import { createMetricEnvelope } from './metrics/envelope';
@@ -588,7 +589,12 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    * @param scope A scope containing event metadata.
    * @returns A new event with more information.
    */
-  protected _prepareEvent(event: Event, hint: EventHint, scope?: Scope): PromiseLike<Event | null> {
+  protected _prepareEvent(
+    event: Event,
+    hint: EventHint,
+    scope?: Scope,
+    isolationScope = getIsolationScope(),
+  ): PromiseLike<Event | null> {
     const options = this.getOptions();
     const integrations = Object.keys(this._integrations);
     if (!hint.integrations && integrations.length > 0) {
@@ -597,7 +603,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
 
     this.emit('preprocessEvent', event, hint);
 
-    return prepareEvent(options, event, hint, scope, this).then(evt => {
+    return prepareEvent(options, event, hint, scope, this, isolationScope).then(evt => {
       if (evt === null) {
         return evt;
       }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export {
 } from './exports';
 export {
   getCurrentHub,
+  getIsolationScope,
   getHubFromCarrier,
   Hub,
   makeMain,

--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -216,7 +216,12 @@ export class ServerRuntimeClient<
   /**
    * @inheritDoc
    */
-  protected _prepareEvent(event: Event, hint: EventHint, scope?: Scope): PromiseLike<Event | null> {
+  protected _prepareEvent(
+    event: Event,
+    hint: EventHint,
+    scope?: Scope,
+    isolationScope?: Scope,
+  ): PromiseLike<Event | null> {
     if (this._options.platform) {
       event.platform = event.platform || this._options.platform;
     }
@@ -232,7 +237,7 @@ export class ServerRuntimeClient<
       event.server_name = event.server_name || this._options.serverName;
     }
 
-    return super._prepareEvent(event, hint, scope);
+    return super._prepareEvent(event, hint, scope, isolationScope);
   }
 
   /** Extract trace information from scope */

--- a/packages/core/src/utils/prepareEvent.ts
+++ b/packages/core/src/utils/prepareEvent.ts
@@ -48,6 +48,7 @@ export function prepareEvent(
   hint: EventHint,
   scope?: Scope,
   client?: Client,
+  isolationScope?: Scope,
 ): PromiseLike<Event | null> {
   const { normalizeDepth = 3, normalizeMaxBreadth = 1_000 } = options;
   const prepared: Event = {
@@ -79,6 +80,11 @@ export function prepareEvent(
   // {@link Hub.addEventProcessor} gets the finished prepared event.
   // Merge scope data together
   const data = getGlobalScope().getScopeData();
+
+  if (isolationScope) {
+    const isolationData = isolationScope.getScopeData();
+    mergeScopeData(data, isolationData);
+  }
 
   if (finalScope) {
     const finalScopeData = finalScope.getScopeData();

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -43,6 +43,8 @@ export {
   getCurrentHub,
   getClient,
   getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
   Hub,
   lastEventId,
   makeMain,

--- a/packages/feedback/src/util/prepareFeedbackEvent.ts
+++ b/packages/feedback/src/util/prepareFeedbackEvent.ts
@@ -1,4 +1,4 @@
-import type { Scope } from '@sentry/core';
+import { Scope, getIsolationScope } from '@sentry/core';
 import { prepareEvent } from '@sentry/core';
 import type { Client, FeedbackEvent } from '@sentry/types';
 
@@ -26,6 +26,7 @@ export async function prepareFeedbackEvent({
     eventHint,
     scope,
     client,
+    getIsolationScope(),
   )) as FeedbackEvent | null;
 
   if (preparedEvent === null) {

--- a/packages/feedback/src/util/prepareFeedbackEvent.ts
+++ b/packages/feedback/src/util/prepareFeedbackEvent.ts
@@ -1,4 +1,5 @@
-import { Scope, getIsolationScope } from '@sentry/core';
+import type { Scope } from '@sentry/core';
+import { getIsolationScope } from '@sentry/core';
 import { prepareEvent } from '@sentry/core';
 import type { Client, FeedbackEvent } from '@sentry/types';
 

--- a/packages/hub/test/global.test.ts
+++ b/packages/hub/test/global.test.ts
@@ -19,13 +19,13 @@ describe('global', () => {
   });
 
   test('getGlobalHub', () => {
-    const newestHub = new Hub(undefined, undefined, 999999);
+    const newestHub = new Hub(undefined, undefined, undefined, 999999);
     GLOBAL_OBJ.__SENTRY__.hub = newestHub;
     expect(getCurrentHub()).toBe(newestHub);
   });
 
   test('hub extension methods receive correct hub instance', () => {
-    const newestHub = new Hub(undefined, undefined, 999999);
+    const newestHub = new Hub(undefined, undefined, undefined, 999999);
     GLOBAL_OBJ.__SENTRY__.hub = newestHub;
     const fn = jest.fn().mockImplementation(function (...args: []) {
       // @ts-expect-error typescript complains that this can be `any`

--- a/packages/node-experimental/src/sdk/hub.ts
+++ b/packages/node-experimental/src/sdk/hub.ts
@@ -5,7 +5,6 @@ import type {
   Hub,
   Integration,
   IntegrationClass,
-  Session,
   Severity,
   SeverityLevel,
   TransactionContext,
@@ -14,8 +13,6 @@ import type {
 import {
   addBreadcrumb,
   captureEvent,
-  captureException,
-  captureMessage,
   configureScope,
   endSession,
   getClient,
@@ -32,6 +29,7 @@ import {
 } from './api';
 import { callExtensionMethod, getGlobalCarrier } from './globals';
 import type { Scope } from './scope';
+import { getIsolationScope } from './scope';
 import type { SentryCarrier } from './types';
 
 /** Ensure the global hub is our proxied hub. */
@@ -67,6 +65,7 @@ export function getCurrentHub(): Hub {
     withScope,
     getClient,
     getScope: getCurrentScope,
+    getIsolationScope,
     captureException: (exception: unknown, hint?: EventHint) => {
       return getCurrentScope().captureException(exception, hint);
     },

--- a/packages/node-experimental/src/sdk/scope.ts
+++ b/packages/node-experimental/src/sdk/scope.ts
@@ -189,32 +189,6 @@ export class Scope extends OpenTelemetryScope implements ScopeInterface {
   public getOwnScopeData(): ScopeData {
     return super.getScopeData();
   }
-
-  /** @inheritdoc */
-  public getScopeData(): ScopeData {
-    const globalScope = getGlobalScope();
-    const isolationScope = this._getIsolationScope();
-
-    // Special case: If this is the global/isolation scope, no need to merge other data in here
-    if (this === globalScope || this === isolationScope) {
-      return this.getOwnScopeData();
-    }
-
-    // Global scope is applied anyhow in prepareEvent,
-    // but we need to merge the isolation scope in here
-    const data = isolationScope.getOwnScopeData();
-    const scopeData = this.getOwnScopeData();
-
-    // Merge data together, in order
-    mergeScopeData(data, scopeData);
-
-    return data;
-  }
-
-  /** Get the isolation scope for this scope. */
-  protected _getIsolationScope(): Scope {
-    return this.isolationScope || getIsolationScope();
-  }
 }
 
 function getScopes(): CurrentScopes {

--- a/packages/node-experimental/test/sdk/scope.test.ts
+++ b/packages/node-experimental/test/sdk/scope.test.ts
@@ -94,20 +94,6 @@ describe('Unit | Scope', () => {
     expect(scope.getClient()).toBe(client);
   });
 
-  it('gets the correct isolationScope in _getIsolationScope', () => {
-    resetGlobals();
-
-    const scope = new Scope();
-    const globalIsolationScope = getIsolationScope();
-
-    expect(scope['_getIsolationScope']()).toBe(globalIsolationScope);
-
-    const customIsolationScope = new Scope();
-    scope.isolationScope = customIsolationScope;
-
-    expect(scope['_getIsolationScope']()).toBe(customIsolationScope);
-  });
-
   describe('prepareEvent', () => {
     it('works without any scope data', async () => {
       mockSdkInit();
@@ -205,6 +191,8 @@ describe('Unit | Scope', () => {
           integrations: [],
         },
         scope,
+        undefined,
+        isolationScope,
       );
 
       expect(eventProcessor1).toHaveBeenCalledTimes(1);

--- a/packages/node-integration-tests/suites/public-api/scopes/initialScopes/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/scopes/initialScopes/scenario.ts
@@ -1,0 +1,23 @@
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+});
+
+const globalScope = Sentry.getGlobalScope();
+const isolationScope = Sentry.getIsolationScope();
+const currentScope = Sentry.getCurrentScope();
+
+globalScope.setExtra('aa', 'aa');
+isolationScope.setExtra('bb', 'bb');
+currentScope.setExtra('cc', 'cc');
+
+Sentry.captureMessage('outer_before');
+
+Sentry.withScope(scope => {
+  scope.setExtra('dd', 'dd');
+  Sentry.captureMessage('inner');
+});
+
+Sentry.captureMessage('outer_after');

--- a/packages/node-integration-tests/suites/public-api/scopes/initialScopes/test.ts
+++ b/packages/node-integration-tests/suites/public-api/scopes/initialScopes/test.ts
@@ -1,0 +1,31 @@
+import { TestEnv, assertSentryEvent } from '../../../../utils';
+
+test('should apply scopes correctly', async () => {
+  const env = await TestEnv.init(__dirname);
+  const events = await env.getMultipleEnvelopeRequest({ count: 3 });
+
+  assertSentryEvent(events[0][2], {
+    message: 'outer_before',
+    extra: {
+      aa: 'aa',
+      bb: 'bb',
+    },
+  });
+
+  assertSentryEvent(events[1][2], {
+    message: 'inner',
+    extra: {
+      aa: 'aa',
+      bb: 'bb',
+      cc: 'cc',
+    },
+  });
+
+  assertSentryEvent(events[2][2], {
+    message: 'outer_after',
+    extra: {
+      aa: 'aa',
+      bb: 'bb',
+    },
+  });
+});

--- a/packages/node-integration-tests/suites/public-api/scopes/isolationScope/scenario.ts
+++ b/packages/node-integration-tests/suites/public-api/scopes/isolationScope/scenario.ts
@@ -1,0 +1,30 @@
+import * as Sentry from '@sentry/node';
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+});
+
+const globalScope = Sentry.getGlobalScope();
+const isolationScope = Sentry.getIsolationScope();
+const currentScope = Sentry.getCurrentScope();
+
+globalScope.setExtra('aa', 'aa');
+isolationScope.setExtra('bb', 'bb');
+currentScope.setExtra('cc', 'cc');
+
+Sentry.captureMessage('outer_before');
+
+Sentry.withScope(scope => {
+  Sentry.getIsolationScope().setExtra('dd', 'dd');
+  scope.setExtra('ee', 'ee');
+  Sentry.captureMessage('inner');
+});
+
+Sentry.runWithAsyncContext(() => {
+  Sentry.getIsolationScope().setExtra('ff', 'ff');
+  Sentry.getCurrentScope().setExtra('gg', 'gg');
+  Sentry.captureMessage('inner_async_context');
+});
+
+Sentry.captureMessage('outer_after');

--- a/packages/node-integration-tests/suites/public-api/scopes/isolationScope/test.ts
+++ b/packages/node-integration-tests/suites/public-api/scopes/isolationScope/test.ts
@@ -1,0 +1,47 @@
+import { TestEnv, assertSentryEvent } from '../../../../utils';
+
+test('should apply scopes correctly', async () => {
+  const env = await TestEnv.init(__dirname);
+  const events = await env.getMultipleEnvelopeRequest({ count: 4 });
+
+  assertSentryEvent(events[0][2], {
+    message: 'outer_before',
+    extra: {
+      aa: 'aa',
+      bb: 'bb',
+    },
+  });
+
+  assertSentryEvent(events[1][2], {
+    message: 'inner',
+    extra: {
+      aa: 'aa',
+      bb: 'bb',
+      cc: 'cc',
+      dd: 'dd',
+      ee: 'ee',
+    },
+  });
+
+  assertSentryEvent(events[2][2], {
+    message: 'inner_async_context',
+    extra: {
+      aa: 'aa',
+      bb: 'bb',
+      cc: 'cc',
+      dd: 'dd',
+      ff: 'ff',
+      gg: 'gg',
+    },
+  });
+
+  assertSentryEvent(events[3][2], {
+    message: 'outer_after',
+    extra: {
+      aa: 'aa',
+      bb: 'bb',
+      cc: 'cc',
+      dd: 'dd',
+    },
+  });
+});

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -43,6 +43,8 @@ export {
   getCurrentHub,
   getClient,
   getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
   Hub,
   lastEventId,
   makeMain,

--- a/packages/opentelemetry/src/custom/client.ts
+++ b/packages/opentelemetry/src/custom/client.ts
@@ -67,7 +67,12 @@ export function wrapClientClass<
      * Extends the base `_prepareEvent` so that we can properly handle `captureContext`.
      * This uses `Scope.clone()`, which we need to replace with `OpenTelemetryScope.clone()` for this client.
      */
-    protected _prepareEvent(event: Event, hint: EventHint, scope?: Scope): PromiseLike<Event | null> {
+    protected _prepareEvent(
+      event: Event,
+      hint: EventHint,
+      scope?: Scope,
+      isolationScope?: Scope,
+    ): PromiseLike<Event | null> {
       let actualScope = scope;
 
       // Remove `captureContext` hint and instead clone already here

--- a/packages/replay/src/util/prepareReplayEvent.ts
+++ b/packages/replay/src/util/prepareReplayEvent.ts
@@ -1,4 +1,4 @@
-import type { Scope } from '@sentry/core';
+import { Scope, getIsolationScope } from '@sentry/core';
 import { prepareEvent } from '@sentry/core';
 import type { IntegrationIndex } from '@sentry/core/build/types/integration';
 import type { Client, EventHint, ReplayEvent } from '@sentry/types';
@@ -34,6 +34,7 @@ export async function prepareReplayEvent({
     eventHint,
     scope,
     client,
+    getIsolationScope(),
   )) as ReplayEvent | null;
 
   // If e.g. a global event processor returned null

--- a/packages/replay/src/util/prepareReplayEvent.ts
+++ b/packages/replay/src/util/prepareReplayEvent.ts
@@ -1,4 +1,5 @@
-import { Scope, getIsolationScope } from '@sentry/core';
+import type { Scope } from '@sentry/core';
+import { getIsolationScope } from '@sentry/core';
 import { prepareEvent } from '@sentry/core';
 import type { IntegrationIndex } from '@sentry/core/build/types/integration';
 import type { Client, EventHint, ReplayEvent } from '@sentry/types';

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -31,6 +31,8 @@ export {
   getCurrentHub,
   getClient,
   getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
   getHubFromCarrier,
   makeMain,
   setContext,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -24,6 +24,8 @@ export {
   getCurrentHub,
   getClient,
   getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
   Hub,
   makeMain,
   Scope,

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -78,6 +78,12 @@ export interface Hub {
   getScope(): Scope;
 
   /**
+   * Get the currently active isolation scope.
+   * The isolation scope is used to isolate data between different hubs.
+   */
+  getIsolationScope(): Scope;
+
+  /**
    * Captures an exception event and sends it to Sentry.
    *
    * @param exception An exception-like object.

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -43,6 +43,8 @@ export {
   getCurrentHub,
   getClient,
   getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
   Hub,
   lastEventId,
   makeMain,


### PR DESCRIPTION
Also ensure to actually export `getGlobalScope()` everywhere as well.

The isolation scope, currently, lies on the hub, and is applied to all events.