### PR TITLE
build: Fix size limit

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -101,7 +101,7 @@ module.exports = [
     path: 'packages/browser/build/bundles/bundle.min.js',
     gzip: false,
     brotli: false,
-    limit: '70 KB',
+    limit: '80 KB',
   },
 
   // Browser CDN bundles (ES5)
@@ -110,7 +110,7 @@ module.exports = [
     name: '@sentry/browser (incl. Tracing) - ES5 CDN Bundle (gzipped)',
     path: 'packages/browser/build/bundles/bundle.tracing.es5.min.js',
     gzip: true,
-    limit: '35 KB',
+    limit: '40 KB',
   },
 
   // React

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -60,7 +60,7 @@ module.exports = [
     name: '@sentry/browser (incl. Tracing, Replay, Feedback) - ES6 CDN Bundle (gzipped)',
     path: 'packages/browser/build/bundles/bundle.tracing.replay.feedback.min.js',
     gzip: true,
-    limit: '75 KB',
+    limit: '90 KB',
   },
   {
     name: '@sentry/browser (incl. Tracing, Replay) - ES6 CDN Bundle (gzipped)',


### PR DESCRIPTION
I think this was just not updated... I aligned it with the webpack size limit for the "full" bundle.