### PR TITLE
feat(core): Replace idle transaction with idle span

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -25,6 +25,7 @@ import type {
   SessionAggregates,
   Severity,
   SeverityLevel,
+  Span,
   Transaction,
   TransactionEvent,
   Transport,
@@ -430,6 +431,12 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
   public on(hook: 'finishTransaction', callback: (transaction: Transaction) => void): void;
 
   /** @inheritdoc */
+  public on(hook: 'spanStart', callback: (span: Span) => void): void;
+
+  /** @inheritdoc */
+  public on(hook: 'spanEnd', callback: (span: Span) => void): void;
+
+  /** @inheritdoc */
   public on(hook: 'beforeEnvelope', callback: (envelope: Envelope) => void): void;
 
   /** @inheritdoc */
@@ -474,6 +481,12 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
 
   /** @inheritdoc */
   public emit(hook: 'finishTransaction', transaction: Transaction): void;
+
+  /** @inheritdoc */
+  public emit(hook: 'spanStart', span: Span): void;
+
+  /** @inheritdoc */
+  public emit(hook: 'spanEnd', span: Span): void;
 
   /** @inheritdoc */
   public emit(hook: 'beforeEnvelope', envelope: Envelope): void;

--- a/packages/core/src/tracing/hubextensions.ts
+++ b/packages/core/src/tracing/hubextensions.ts
@@ -74,6 +74,7 @@ The transaction will not be sampled. Please use the ${configInstrumenter} instru
 
 /**
  * Create new idle transaction.
+ * @deprecated Use `startIdleSpan` instead.
  */
 export function startIdleTransaction(
   hub: Hub,
@@ -83,10 +84,12 @@ export function startIdleTransaction(
   onScope?: boolean,
   customSamplingContext?: CustomSamplingContext,
   heartbeatInterval?: number,
+  // eslint-disable-next-line deprecation/deprecation
 ): IdleTransaction {
   const client = hub.getClient();
   const options: Partial<ClientOptions> = (client && client.getOptions()) || {};
 
+  // eslint-disable-next-line deprecation/deprecation
   let transaction = new IdleTransaction(transactionContext, hub, idleTimeout, finalTimeout, heartbeatInterval, onScope);
   transaction = sampleTransaction(transaction, options, {
     parentSampled: transactionContext.parentSampled,

--- a/packages/core/src/tracing/idlespan.ts
+++ b/packages/core/src/tracing/idlespan.ts
@@ -1,0 +1,318 @@
+/* eslint-disable max-lines */
+import type { TransactionContext } from '@sentry/types';
+import { logger, timestampInSeconds } from '@sentry/utils';
+
+import { DEBUG_BUILD } from '../debug-build';
+import { getClient } from '../exports';
+import type { Span } from './span';
+import { startSpanManual } from './trace';
+
+export const TRACING_DEFAULTS = {
+  idleTimeout: 1000,
+  finalTimeout: 30000,
+  heartbeatInterval: 5000,
+};
+
+const FINISH_REASON_TAG = 'finishReason';
+
+const FINISH_REASON_HEARTBEAT_FAILED = 'heartbeatFailed';
+const FINISH_REASON_IDLE_TIMEOUT = 'idleTimeout';
+const FINISH_REASON_FINAL_TIMEOUT = 'finalTimeout';
+const FINISH_REASON_EXTERNAL_FINISH = 'externalFinish';
+const FINISH_REASON_CANCELLED = 'cancelled';
+
+// unused
+const FINISH_REASON_DOCUMENT_HIDDEN = 'documentHidden';
+
+// unusued in this file, but used in BrowserTracing
+const FINISH_REASON_INTERRUPTED = 'interactionInterrupted';
+
+type IdleSpanFinishReason =
+  | typeof FINISH_REASON_CANCELLED
+  | typeof FINISH_REASON_DOCUMENT_HIDDEN
+  | typeof FINISH_REASON_EXTERNAL_FINISH
+  | typeof FINISH_REASON_FINAL_TIMEOUT
+  | typeof FINISH_REASON_HEARTBEAT_FAILED
+  | typeof FINISH_REASON_IDLE_TIMEOUT
+  | typeof FINISH_REASON_INTERRUPTED;
+
+interface IdleSpanOptions {
+  transactionContext: TransactionContext;
+  idleTimeout: number;
+  finalTimeout: number;
+  // TODO FN: Do we need this??
+  // customSamplingContext?: CustomSamplingContext;
+  heartbeatInterval?: number;
+}
+
+/**
+ * An idle span is a span that automatically finishes. It does this by tracking child spans as activities.
+ * An idle span is always the active span.
+ */
+export function startIdleSpan(options: IdleSpanOptions): Span | undefined {
+  // Activities store a list of active spans
+  const activities = new Map<string, boolean>();
+
+  // Track state of activities in previous heartbeat
+  let _prevHeartbeatString: string | undefined;
+
+  // Amount of times heartbeat has counted. Will cause span to finish after 3 beats.
+  let _heartbeatCounter = 0;
+
+  // We should not use heartbeat if we finished a span
+  let _finished = false;
+
+  // Idle timeout was canceled and we should finish the span with the last span end.
+  let _idleTimeoutCanceledPermanently = false;
+
+  // Timer that tracks span idleTimeout
+  let _idleTimeoutID: ReturnType<typeof setTimeout> | undefined;
+
+  // The reason why the span was finished
+  let _finishReason: IdleSpanFinishReason = FINISH_REASON_EXTERNAL_FINISH;
+
+  const {
+    transactionContext,
+    idleTimeout,
+    finalTimeout,
+    heartbeatInterval = TRACING_DEFAULTS.heartbeatInterval,
+  } = options;
+
+  const client = getClient();
+
+  if (!client || !client.on) {
+    return;
+  }
+
+  const _span = _startIdleSpan(transactionContext);
+
+  // Span _should_ always be defined here, but TS does not know that...
+  if (!_span) {
+    return;
+  }
+
+  // For TS, so that we know everything below here has a span
+  const span = _span;
+  const spanId = span.spanId;
+
+  // We keep all child spans (and children of children) here,
+  // so we can force end them when we end the idle span
+  const childSpans: Span[] = [];
+
+  /**
+   * Cancels the existing idle timeout, if there is one.
+   * @param restartOnChildSpanChange If set to false the transaction will end with the last child span.
+   */
+  function cancelIdleTimeout(
+    endTimestamp?: number,
+    { restartOnChildSpanChange } = {
+      restartOnChildSpanChange: true,
+    },
+  ): void {
+    _idleTimeoutCanceledPermanently = restartOnChildSpanChange === false;
+    if (_idleTimeoutID) {
+      clearTimeout(_idleTimeoutID);
+      _idleTimeoutID = undefined;
+
+      if (activities.size === 0 && _idleTimeoutCanceledPermanently) {
+        _finishReason = FINISH_REASON_CANCELLED;
+        span.end(endTimestamp);
+      }
+    }
+  }
+
+  /**
+   * Restarts idle timeout, if there is no running idle timeout it will start one.
+   */
+  function _restartIdleTimeout(endTimestamp?: number): void {
+    cancelIdleTimeout();
+    _idleTimeoutID = setTimeout(() => {
+      if (!_finished && activities.size === 0) {
+        _finishReason = FINISH_REASON_IDLE_TIMEOUT;
+        span.end(endTimestamp);
+      }
+    }, idleTimeout);
+  }
+
+  /**
+   * Start tracking a specific activity.
+   * @param spanId The span id that represents the activity
+   */
+  function _pushActivity(spanId: string): void {
+    cancelIdleTimeout(undefined, { restartOnChildSpanChange: !_idleTimeoutCanceledPermanently });
+    activities.set(spanId, true);
+    DEBUG_BUILD && logger.log(`[Tracing] pushActivity: ${spanId}`);
+    DEBUG_BUILD && logger.log('[Tracing] new activities count', activities.size);
+  }
+
+  /**
+   * Remove an activity from usage
+   * @param spanId The span id that represents the activity
+   */
+  function _popActivity(spanId: string): void {
+    if (activities.has(spanId)) {
+      DEBUG_BUILD && logger.log(`[Tracing] popActivity ${spanId}`);
+      activities.delete(spanId);
+      DEBUG_BUILD && logger.log('[Tracing] new activities count', activities.size);
+    }
+
+    if (activities.size === 0) {
+      const endTimestamp = timestampInSeconds();
+      if (_idleTimeoutCanceledPermanently) {
+        _finishReason = FINISH_REASON_CANCELLED;
+        span.end(endTimestamp);
+      } else {
+        // We need to add the timeout here to have the real endtimestamp of the transaction
+        // Remember timestampInSeconds is in seconds, timeout is in ms
+        _restartIdleTimeout(endTimestamp + idleTimeout / 1000);
+      }
+    }
+  }
+
+  /**
+   * Checks when entries of activities are not changing for 3 beats.
+   * If this occurs we finish the transaction.
+   */
+  function _beat(): void {
+    // We should not be running heartbeat if the idle transaction is finished.
+    if (_finished) {
+      return;
+    }
+
+    const heartbeatString = Array.from(activities.keys()).join('');
+
+    if (heartbeatString === _prevHeartbeatString) {
+      _heartbeatCounter++;
+    } else {
+      _heartbeatCounter = 1;
+    }
+
+    _prevHeartbeatString = heartbeatString;
+
+    if (_heartbeatCounter >= 3) {
+      DEBUG_BUILD && logger.log('[Tracing] Transaction finished because of no change for 3 heart beats');
+      span.setStatus('deadline_exceeded');
+      _finishReason = FINISH_REASON_HEARTBEAT_FAILED;
+      span.end();
+    } else {
+      _pingHeartbeat();
+    }
+  }
+
+  /**
+   * Pings the heartbeat
+   */
+  function _pingHeartbeat(): void {
+    DEBUG_BUILD && logger.log(`pinging Heartbeat -> current counter: ${_heartbeatCounter}`);
+    setTimeout(() => {
+      _beat();
+    }, heartbeatInterval);
+  }
+
+  function endIdleSpan(): void {
+    const endTimestamp = span.endTimestamp;
+
+    // This should never happen, but to make TS happy...
+    if (!endTimestamp) {
+      return;
+    }
+
+    _finished = true;
+    activities.clear();
+
+    if (span.op === 'ui.action.click' && !span.tags[FINISH_REASON_TAG]) {
+      span.setTag(FINISH_REASON_TAG, _finishReason);
+    }
+
+    DEBUG_BUILD && logger.log('[Tracing] finishing idle span', new Date(endTimestamp * 1000).toISOString(), span.op);
+
+    childSpans.forEach(childSpan => {
+      // We cancel all pending spans with status "cancelled" to indicate the idle span was finished early
+      if (!childSpan.endTimestamp) {
+        childSpan.endTimestamp = endTimestamp;
+        childSpan.setStatus('cancelled');
+        DEBUG_BUILD &&
+          logger.log('[Tracing] cancelling span since span ended early', JSON.stringify(childSpan, undefined, 2));
+      }
+
+      const spanStartedBeforeIdleSpanEnd = childSpan.startTimestamp < endTimestamp;
+
+      // Add a delta with idle timeout so that we prevent false positives
+      const timeoutWithMarginOfError = (finalTimeout + idleTimeout) / 1000;
+      const spanEndedBeforeFinalTimeout = childSpan.endTimestamp - span.startTimestamp < timeoutWithMarginOfError;
+
+      if (DEBUG_BUILD) {
+        const stringifiedSpan = JSON.stringify(childSpan, undefined, 2);
+        if (!spanStartedBeforeIdleSpanEnd) {
+          logger.log('[Tracing] discarding Span since it happened after idle span was finished', stringifiedSpan);
+        } else if (!spanEndedBeforeFinalTimeout) {
+          logger.log('[Tracing] discarding Span since it finished after idle span final timeout', stringifiedSpan);
+        }
+      }
+    });
+
+    DEBUG_BUILD && logger.log('[Tracing] flushing idle span');
+
+    // Clear array of child spans
+    childSpans.splice(0, childSpans.length);
+  }
+
+  client.on('spanStart', span => {
+    if (_finished) {
+      return;
+    }
+
+    const { parentSpanId } = span;
+    // We only care about spans that are direct children of the idle span or its children
+    // and about spans that are not immediately closed
+    if (parentSpanId && (activities.has(parentSpanId) || parentSpanId === spanId) && span.endTimestamp === undefined) {
+      _pushActivity(span.spanId);
+      childSpans.push(span);
+    }
+  });
+
+  client.on('spanEnd', span => {
+    if (_finished) {
+      return;
+    }
+
+    _popActivity(span.spanId);
+
+    if (span.spanId === spanId) {
+      endIdleSpan();
+    }
+  });
+
+  _restartIdleTimeout();
+
+  setTimeout(() => {
+    if (!_finished) {
+      span.setStatus('deadline_exceeded');
+      _finishReason = FINISH_REASON_FINAL_TIMEOUT;
+      span.end();
+    }
+  }, finalTimeout);
+
+  // Start heartbeat so that spans do not run forever.
+  DEBUG_BUILD && logger.log('Starting heartbeat');
+  _pingHeartbeat();
+
+  return span;
+}
+
+function _startIdleSpan(transactionContext: TransactionContext): Span | undefined {
+  // Note: This is a bit hacky, and ONLY works in the browser
+  // because we do not actually have an execution context here anyhow, so the scope is not really forked
+  // Technically, this is incorrect, because the span is only active (spec-wise) inside of the `startSpanManual` callback
+  // But we rely on the incorrect browser behavior here that this is not actually the case
+  let span: Span | undefined;
+  startSpanManual(transactionContext, _span => {
+    span = _span;
+  });
+
+  if (span) {
+    DEBUG_BUILD && logger.log(`Setting idle span on scope. Span ID: ${span.spanId}`);
+  }
+
+  return span;
+}

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -1,5 +1,12 @@
-export { startIdleTransaction, addTracingExtensions } from './hubextensions';
-export { IdleTransaction, TRACING_DEFAULTS } from './idletransaction';
+export {
+  // eslint-disable-next-line deprecation/deprecation
+  startIdleTransaction,
+  addTracingExtensions,
+} from './hubextensions';
+export { startIdleSpan, TRACING_DEFAULTS } from './idlespan';
+// eslint-disable-next-line deprecation/deprecation
+export { IdleTransaction } from './idletransaction';
+// eslint-disable-next-line deprecation/deprecation
 export type { BeforeFinishCallback } from './idletransaction';
 export { Span, spanStatusfromHttpCode } from './span';
 export { Transaction } from './transaction';

--- a/packages/core/src/tracing/span.ts
+++ b/packages/core/src/tracing/span.ts
@@ -11,6 +11,7 @@ import type {
 import { dropUndefinedKeys, generateSentryTraceHeader, logger, timestampInSeconds, uuid4 } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
+import { getClient } from '../exports';
 import { ensureTimestampInSeconds } from './utils';
 
 /**
@@ -162,6 +163,11 @@ export class Span implements SpanInterface {
     if (spanContext.endTimestamp) {
       this.endTimestamp = spanContext.endTimestamp;
     }
+
+    const client = getClient();
+    if (client && client.emit) {
+      client.emit('spanStart', this);
+    }
   }
 
   /** An alias for `description` of the Span. */
@@ -283,6 +289,11 @@ export class Span implements SpanInterface {
 
     this.endTimestamp =
       typeof endTimestamp === 'number' ? ensureTimestampInSeconds(endTimestamp) : timestampInSeconds();
+
+    const client = getClient();
+    if (client && client.emit) {
+      client.emit('spanEnd', this);
+    }
   }
 
   /**

--- a/packages/tracing-internal/src/browser/backgroundtab.ts
+++ b/packages/tracing-internal/src/browser/backgroundtab.ts
@@ -1,4 +1,4 @@
-import type { IdleTransaction, SpanStatusType } from '@sentry/core';
+import type { SpanStatusType } from '@sentry/core';
 import { getActiveTransaction } from '@sentry/core';
 import { logger } from '@sentry/utils';
 
@@ -12,7 +12,7 @@ import { WINDOW } from './types';
 export function registerBackgroundTabDetection(): void {
   if (WINDOW && WINDOW.document) {
     WINDOW.document.addEventListener('visibilitychange', () => {
-      const activeTransaction = getActiveTransaction() as IdleTransaction;
+      const activeTransaction = getActiveTransaction();
       if (WINDOW.document.hidden && activeTransaction) {
         const statusType: SpanStatusType = 'cancelled';
 

--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import type { IdleTransaction, Transaction } from '@sentry/core';
+import type { Transaction } from '@sentry/core';
 import { getActiveTransaction } from '@sentry/core';
 import type { Measurements, SpanContext } from '@sentry/types';
 import { browserPerformanceTimeOrigin, getComponentName, htmlTreeAsString, logger } from '@sentry/utils';
@@ -69,7 +69,7 @@ export function startTrackingWebVitals(): () => void {
 export function startTrackingLongTasks(): void {
   addPerformanceInstrumentationHandler('longtask', ({ entries }) => {
     for (const entry of entries) {
-      const transaction = getActiveTransaction() as IdleTransaction | undefined;
+      const transaction = getActiveTransaction();
       if (!transaction) {
         return;
       }
@@ -93,7 +93,7 @@ export function startTrackingLongTasks(): void {
 export function startTrackingInteractions(): void {
   addPerformanceInstrumentationHandler('event', ({ entries }) => {
     for (const entry of entries) {
-      const transaction = getActiveTransaction() as IdleTransaction | undefined;
+      const transaction = getActiveTransaction();
       if (!transaction) {
         return;
       }

--- a/packages/tracing-internal/src/exports/index.ts
+++ b/packages/tracing-internal/src/exports/index.ts
@@ -3,11 +3,13 @@ export {
   extractTraceparentData,
   getActiveTransaction,
   hasTracingEnabled,
+  // eslint-disable-next-line deprecation/deprecation
   IdleTransaction,
   Span,
   // eslint-disable-next-line deprecation/deprecation
   SpanStatus,
   spanStatusfromHttpCode,
+  // eslint-disable-next-line deprecation/deprecation
   startIdleTransaction,
   Transaction,
 } from '@sentry/core';

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -150,11 +150,13 @@ export const TRACEPARENT_REGEXP = TRACEPARENT_REGEXP_T;
 /**
  * @deprecated `@sentry/tracing` has been deprecated and will be moved to to `@sentry/node`, `@sentry/browser`, or your framework SDK in the next major version.
  */
+// eslint-disable-next-line deprecation/deprecation
 export const IdleTransaction = IdleTransactionT;
 
 /**
  * @deprecated `@sentry/tracing` has been deprecated and will be moved to to `@sentry/node`, `@sentry/browser`, or your framework SDK in the next major version.
  */
+// eslint-disable-next-line deprecation/deprecation
 export type IdleTransaction = IdleTransactionT;
 
 /**
@@ -165,6 +167,7 @@ export const instrumentOutgoingRequests = instrumentOutgoingRequestsT;
 /**
  * @deprecated `@sentry/tracing` has been deprecated and will be moved to to `@sentry/node`, `@sentry/browser`, or your framework SDK in the next major version.
  */
+// eslint-disable-next-line deprecation/deprecation
 export const startIdleTransaction = startIdleTransactionT;
 
 /**

--- a/packages/tracing/test/idletransaction.test.ts
+++ b/packages/tracing/test/idletransaction.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import { BrowserClient } from '@sentry/browser';
 import { TRACING_DEFAULTS, Transaction } from '@sentry/core';
 

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -14,6 +14,7 @@ import type { Scope } from './scope';
 import type { SdkMetadata } from './sdkmetadata';
 import type { Session, SessionAggregates } from './session';
 import type { Severity, SeverityLevel } from './severity';
+import type { Span } from './span';
 import type { Transaction } from './transaction';
 import type { Transport, TransportMakeRequestResponse } from './transport';
 
@@ -204,6 +205,18 @@ export interface Client<O extends ClientOptions = ClientOptions> {
   on?(hook: 'finishTransaction', callback: (transaction: Transaction) => void): void;
 
   /**
+   * Register a callback when a span (or transaction) starts.
+   * Receives the span as argument.
+   */
+  on?(hook: 'spanStart', callback: (span: Span) => void): void;
+
+  /**
+   * Register a callback when a span (or transaction) ends.
+   * Receives the span as argument.
+   */
+  on?(hook: 'spanEnd', callback: (span: Span) => void): void;
+
+  /**
    * Register a callback for transaction start and finish.
    */
   on?(hook: 'beforeEnvelope', callback: (envelope: Envelope) => void): void;
@@ -267,6 +280,18 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    * Expects to be given a transaction as the second argument.
    */
   emit?(hook: 'finishTransaction', transaction: Transaction): void;
+
+  /**
+   * Fire a hook for span (or transaction) start.
+   * Expects to be given a span as the second argument.
+   */
+  emit?(hook: 'spanStart', span: Span): void;
+
+  /**
+   * Fire a hook for span (or transaction) ends.
+   * Expects to be given a span as the second argument.
+   */
+  emit?(hook: 'spanEnd', span: Span): void;
 
   /*
    * Fire a hook event for envelope creation and sending. Expects to be given an envelope as the


### PR DESCRIPTION
This is a draft, replacing `startIdleTransaction` with `startIdleSpan`.

Missing for this is adding tests for this, but wanted to check first if the approach seems good to everyone.

Some notes:

* I got rid of the `onScope` option, as we always put it on the scope right now. So no need to expose this for now.
* ~~This currently depends on "buggy" behavior of `startSpanManual` in regards to scope forking in Browser. But that's OK I guess~~ This for now still uses `scope.setSpan()`, we may need to revisit this in v8, but should be OK for now
* There are some things that still kind of expect a Transaction, API wise. For now I just guard there for this, which _should_ generally be OK as we would still be created transactions under the hood if this is a root span. But it may be a subtle change...