### PR TITLE
fix(core): Ensure `withScope` sets current scope correctly with async callbacks

### DIFF
--- a/packages/core/test/lib/exports.test.ts
+++ b/packages/core/test/lib/exports.test.ts
@@ -90,4 +90,38 @@ describe('withScope', () => {
 
     expect(getCurrentScope()).toBe(scope1);
   });
+
+  it('correctly sets & resets the current scope when an error happens', () => {
+    const scope1 = getCurrentScope();
+
+    const error = new Error('foo');
+
+    expect(() =>
+      withScope(scope2 => {
+        expect(scope2).not.toBe(scope1);
+        expect(getCurrentScope()).toBe(scope2);
+
+        throw error;
+      }),
+    ).toThrow(error);
+
+    expect(getCurrentScope()).toBe(scope1);
+  });
+
+  it('correctly sets & resets the current scope with async functions & errors', async () => {
+    const scope1 = getCurrentScope();
+
+    const error = new Error('foo');
+
+    await expect(
+      withScope(async scope2 => {
+        expect(scope2).not.toBe(scope1);
+        expect(getCurrentScope()).toBe(scope2);
+
+        throw error;
+      }),
+    ).rejects.toBe(error);
+
+    expect(getCurrentScope()).toBe(scope1);
+  });
 });

--- a/packages/core/test/lib/exports.test.ts
+++ b/packages/core/test/lib/exports.test.ts
@@ -42,12 +42,52 @@ describe('withScope', () => {
     expect(res).toBe('foo');
   });
 
-  it('works with an async function', async () => {
+  it('works with an async function return value', async () => {
     const res = withScope(async scope => {
       return 'foo';
     });
 
     expect(res).toBeInstanceOf(Promise);
     expect(await res).toBe('foo');
+  });
+
+  it('correctly sets & resets the current scope', () => {
+    const scope1 = getCurrentScope();
+
+    withScope(scope2 => {
+      expect(scope2).not.toBe(scope1);
+      expect(getCurrentScope()).toBe(scope2);
+    });
+
+    withScope(scope3 => {
+      expect(scope3).not.toBe(scope1);
+      expect(getCurrentScope()).toBe(scope3);
+    });
+
+    expect(getCurrentScope()).toBe(scope1);
+  });
+
+  it('correctly sets & resets the current scope with async functions', async () => {
+    const scope1 = getCurrentScope();
+
+    await withScope(async scope2 => {
+      expect(scope2).not.toBe(scope1);
+      expect(getCurrentScope()).toBe(scope2);
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(getCurrentScope()).toBe(scope2);
+    });
+
+    await withScope(async scope3 => {
+      expect(scope3).not.toBe(scope1);
+      expect(getCurrentScope()).toBe(scope3);
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(getCurrentScope()).toBe(scope3);
+    });
+
+    expect(getCurrentScope()).toBe(scope1);
   });
 });


### PR DESCRIPTION
Oops, I noticed that our current `withScope` implementation does not actually wait for async callbacks for setting the current scope 😬 Related to https://github.com/getsentry/sentry-javascript/pull/9958, which I copied there now!