### PR TITLE
ref: Remove `startTransaction` call from `withEdgeWrapping`

### DIFF
--- a/packages/nextjs/src/common/utils/edgeWrapperUtils.ts
+++ b/packages/nextjs/src/common/utils/edgeWrapperUtils.ts
@@ -13,7 +13,7 @@ export function withEdgeWrapping<H extends EdgeRouteHandler>(
 ): (...params: Parameters<H>) => Promise<ReturnType<H>> {
   return async function (this: unknown, ...args) {
     addTracingExtensions();
-    const req = args[0];
+    const req: unknown = args[0];
 
     let sentryTrace;
     let baggage;
@@ -36,7 +36,7 @@ export function withEdgeWrapping<H extends EdgeRouteHandler>(
         origin: 'auto.function.nextjs.withEdgeWrapping',
         metadata: {
           ...transactionContext.metadata,
-          request: winterCGRequestToRequestData(req),
+          request: req instanceof Request ? winterCGRequestToRequestData(req) : undefined,
           source: 'route',
         },
       },

--- a/packages/nextjs/test/edge/withSentryAPI.test.ts
+++ b/packages/nextjs/test/edge/withSentryAPI.test.ts
@@ -2,10 +2,6 @@ import * as coreSdk from '@sentry/core';
 
 import { wrapApiHandlerWithSentry } from '../../src/edge';
 
-// The wrap* functions require the hub to have tracing extensions. This is normally called by the EdgeClient
-// constructor but the client isn't used in these tests.
-coreSdk.addTracingExtensions();
-
 // @ts-expect-error Request does not exist on type Global
 const origRequest = global.Request;
 // @ts-expect-error Response does not exist on type Global
@@ -13,17 +9,23 @@ const origResponse = global.Response;
 
 // @ts-expect-error Request does not exist on type Global
 global.Request = class Request {
-  headers = {
+  public url: string;
+
+  public headers = {
     get() {
       return null;
     },
   };
 
-  method = 'POST';
+  public method = 'POST';
+
+  public constructor(input: string) {
+    this.url = input;
+  }
 };
 
 // @ts-expect-error Response does not exist on type Global
-global.Response = class Request {};
+global.Response = class Response {};
 
 afterAll(() => {
   // @ts-expect-error Request does not exist on type Global
@@ -32,66 +34,51 @@ afterAll(() => {
   global.Response = origResponse;
 });
 
-beforeEach(() => {
-  jest.resetAllMocks();
-  jest.restoreAllMocks();
-  jest.spyOn(coreSdk, 'hasTracingEnabled').mockImplementation(() => true);
+const traceSpy = jest.spyOn(coreSdk, 'trace');
+
+afterEach(() => {
+  jest.clearAllMocks();
 });
 
 describe('wrapApiHandlerWithSentry', () => {
-  it('should return a function that starts a transaction with the correct name when there is no active transaction and a request is being passed', async () => {
-    const startTransactionSpy = jest.spyOn(coreSdk, 'startTransaction');
-
-    const origFunctionReturnValue = new Response();
-    const origFunction = jest.fn(_req => origFunctionReturnValue);
+  it('should return a function that calls trace', async () => {
+    const request = new Request('https://sentry.io/');
+    const origFunction = jest.fn(_req => new Response());
 
     const wrappedFunction = wrapApiHandlerWithSentry(origFunction, '/user/[userId]/post/[postId]');
 
-    const request = new Request('https://sentry.io/');
     await wrappedFunction(request);
-    expect(startTransactionSpy).toHaveBeenCalledTimes(1);
-    expect(startTransactionSpy).toHaveBeenCalledWith(
+
+    expect(traceSpy).toHaveBeenCalledTimes(1);
+    expect(traceSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        metadata: expect.objectContaining({ source: 'route' }),
+        metadata: { request: { headers: {}, method: 'POST', url: 'https://sentry.io/' }, source: 'route' },
         name: 'POST /user/[userId]/post/[postId]',
         op: 'http.server',
+        origin: 'auto.function.nextjs.withEdgeWrapping',
       }),
+      expect.any(Function),
+      expect.any(Function),
     );
   });
 
-  it('should return a function that should not start a transaction when there is no active span and no request is being passed', async () => {
-    const startTransactionSpy = jest.spyOn(coreSdk, 'startTransaction');
-
-    const origFunctionReturnValue = new Response();
-    const origFunction = jest.fn(() => origFunctionReturnValue);
+  it('should return a function that calls trace without throwing when no request is passed', async () => {
+    const origFunction = jest.fn(() => new Response());
 
     const wrappedFunction = wrapApiHandlerWithSentry(origFunction, '/user/[userId]/post/[postId]');
 
     await wrappedFunction();
-    expect(startTransactionSpy).not.toHaveBeenCalled();
-  });
 
-  it('should return a function that starts a span on the current transaction with the correct description when there is an active transaction and no request is being passed', async () => {
-    const testTransaction = coreSdk.startTransaction({ name: 'testTransaction' });
-    coreSdk.getCurrentHub().getScope().setSpan(testTransaction);
-
-    const startChildSpy = jest.spyOn(testTransaction, 'startChild');
-
-    const origFunctionReturnValue = new Response();
-    const origFunction = jest.fn(() => origFunctionReturnValue);
-
-    const wrappedFunction = wrapApiHandlerWithSentry(origFunction, '/user/[userId]/post/[postId]');
-
-    await wrappedFunction();
-    expect(startChildSpy).toHaveBeenCalledTimes(1);
-    expect(startChildSpy).toHaveBeenCalledWith(
+    expect(traceSpy).toHaveBeenCalledTimes(1);
+    expect(traceSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        description: 'handler (/user/[userId]/post/[postId])',
-        op: 'function',
+        metadata: { source: 'route' },
+        name: 'handler (/user/[userId]/post/[postId])',
+        op: 'http.server',
+        origin: 'auto.function.nextjs.withEdgeWrapping',
       }),
+      expect.any(Function),
+      expect.any(Function),
     );
-
-    testTransaction.end();
-    coreSdk.getCurrentHub().getScope().setSpan(undefined);
   });
 });

--- a/packages/utils/src/requestdata.ts
+++ b/packages/utils/src/requestdata.ts
@@ -374,6 +374,7 @@ function extractQueryParams(
  * Transforms a `Headers` object that implements the `Web Fetch API` (https://developer.mozilla.org/en-US/docs/Web/API/Headers) into a simple key-value dict.
  * The header keys will be lower case: e.g. A "Content-Type" header will be stored as "content-type".
  */
+// TODO(v8): Make this function return undefined when the extraction fails.
 export function winterCGHeadersToDict(winterCGHeaders: WebFetchHeaders): Record<string, string> {
   const headers: Record<string, string> = {};
   try {


### PR DESCRIPTION
Continuing work to eliminate `startTransaction` from the codebase. 