### PR TITLE
build(nx): Improve Nx setup

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -21,7 +21,7 @@
     },
     "build:tarball": {
       "inputs": ["production", "^production"],
-      "dependsOn": ["build:transpile", "build:types"],
+      "dependsOn": ["build:transpile", "^build:transpile", "build:types", "^build:types"],
       "outputs": []
     },
     "build:transpile": {
@@ -33,10 +33,7 @@
       "inputs": ["production", "^production"],
       "dependsOn": ["^build:types"],
       "outputs": [
-        "{projectRoot}/build/types",
-        "{projectRoot}/build/types-ts3.8",
-        "{projectRoot}/build/npm/types",
-        "{projectRoot}/build/npm/types-ts3.8"
+        "{projectRoot}/build/**/*.d.ts"
       ]
     },
     "lint:eslint": {

--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,14 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["build:bundle", "build:transpile", "build:types", "lint:eslint", "test:unit", "build:tarball"],
+        "cacheableOperations": [
+          "build:bundle",
+          "build:transpile",
+          "build:types",
+          "lint:eslint",
+          "test:unit",
+          "build:tarball"
+        ],
         "cacheDirectory": ".nxcache"
       }
     }
@@ -11,7 +18,12 @@
   "namedInputs": {
     "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "sharedGlobals": ["{workspaceRoot}/*.js", "{workspaceRoot}/*.json"],
-    "production": ["default", "!{projectRoot}/test/**/*", "!{projectRoot}/**/*.md", "!{projectRoot}/*.tgz"]
+    "production": [
+      "default",
+      "!{projectRoot}/test/**/*",
+      "!{projectRoot}/**/*.md",
+      "!{projectRoot}/*.tgz"
+    ]
   },
   "targetDefaults": {
     "build:bundle": {
@@ -21,27 +33,39 @@
     },
     "build:tarball": {
       "inputs": ["production", "^production"],
-      "dependsOn": ["build:transpile", "^build:transpile", "build:types", "^build:types"],
+      "dependsOn": [
+        "build:transpile",
+        "^build:transpile",
+        "build:types",
+        "^build:types"
+      ],
       "outputs": ["{projectRoot}/*.tgz"]
     },
     "build:transpile": {
       "inputs": ["production", "^production"],
       "dependsOn": ["^build:transpile"],
-      "outputs": ["{projectRoot}/build/npm", "{projectRoot}/build/esm", "{projectRoot}/build/cjs"]
+      "outputs": [
+        "{projectRoot}/build/npm",
+        "{projectRoot}/build/esm",
+        "{projectRoot}/build/cjs"
+      ]
     },
     "build:types": {
       "inputs": ["production", "^production"],
       "dependsOn": ["^build:types"],
-      "outputs": [
-        "{projectRoot}/build/**/*.d.ts"
-      ]
+      "outputs": ["{projectRoot}/build/**/*.d.ts"]
     },
     "lint:eslint": {
       "inputs": ["default"],
       "outputs": []
     },
     "test:unit": {
-      "dependsOn": ["build:types", "^build:types", "build:transpile", "^build:transpile"],
+      "dependsOn": [
+        "build:types",
+        "^build:types",
+        "build:transpile",
+        "^build:transpile"
+      ],
       "inputs": ["default"],
       "outputs": ["{projectRoot}/coverage"]
     }

--- a/nx.json
+++ b/nx.json
@@ -3,7 +3,7 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["build:bundle", "build:transpile", "build:types", "lint:eslint", "test:unit"],
+        "cacheableOperations": ["build:bundle", "build:transpile", "build:types", "lint:eslint", "test:unit", "build:tarball"],
         "cacheDirectory": ".nxcache"
       }
     }
@@ -11,7 +11,7 @@
   "namedInputs": {
     "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "sharedGlobals": ["{workspaceRoot}/*.js", "{workspaceRoot}/*.json"],
-    "production": ["default", "!{projectRoot}/test/**/*", "!{projectRoot}/**/*.md"]
+    "production": ["default", "!{projectRoot}/test/**/*", "!{projectRoot}/**/*.md", "!{projectRoot}/*.tgz"]
   },
   "targetDefaults": {
     "build:bundle": {
@@ -22,7 +22,7 @@
     "build:tarball": {
       "inputs": ["production", "^production"],
       "dependsOn": ["build:transpile", "^build:transpile", "build:types", "^build:types"],
-      "outputs": []
+      "outputs": ["{projectRoot}/*.tgz"]
     },
     "build:transpile": {
       "inputs": ["production", "^production"],

--- a/nx.json
+++ b/nx.json
@@ -18,12 +18,7 @@
   "namedInputs": {
     "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "sharedGlobals": ["{workspaceRoot}/*.js", "{workspaceRoot}/*.json"],
-    "production": [
-      "default",
-      "!{projectRoot}/test/**/*",
-      "!{projectRoot}/**/*.md",
-      "!{projectRoot}/*.tgz"
-    ]
+    "production": ["default", "!{projectRoot}/test/**/*", "!{projectRoot}/**/*.md", "!{projectRoot}/*.tgz"]
   },
   "targetDefaults": {
     "build:bundle": {
@@ -33,22 +28,13 @@
     },
     "build:tarball": {
       "inputs": ["production", "^production"],
-      "dependsOn": [
-        "build:transpile",
-        "^build:transpile",
-        "build:types",
-        "^build:types"
-      ],
+      "dependsOn": ["build:transpile", "^build:transpile", "build:types", "^build:types"],
       "outputs": ["{projectRoot}/*.tgz"]
     },
     "build:transpile": {
       "inputs": ["production", "^production"],
       "dependsOn": ["^build:transpile"],
-      "outputs": [
-        "{projectRoot}/build/npm",
-        "{projectRoot}/build/esm",
-        "{projectRoot}/build/cjs"
-      ]
+      "outputs": ["{projectRoot}/build/npm", "{projectRoot}/build/esm", "{projectRoot}/build/cjs"]
     },
     "build:types": {
       "inputs": ["production", "^production"],
@@ -60,12 +46,7 @@
       "outputs": []
     },
     "test:unit": {
-      "dependsOn": [
-        "build:types",
-        "^build:types",
-        "build:transpile",
-        "^build:transpile"
-      ],
+      "dependsOn": ["build:types", "^build:types", "build:transpile", "^build:transpile"],
       "inputs": ["default"],
       "outputs": ["{projectRoot}/coverage"]
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "build": "node ./scripts/verify-packages-versions.js && run-s build:transpile build:types build:bundle",
+    "build": "node ./scripts/verify-packages-versions.js && lerna run build:transpile,build:types,build:bundle",
     "build:bundle": "lerna run build:bundle",
     "build:dev": "lerna run build:types,build:transpile",
     "build:dev:filter": "lerna run build:dev --include-filtered-dependencies --include-filtered-dependents --scope",


### PR DESCRIPTION
We're doing a few thnings here:
1. Use lerna run for the workspace `build` script instead of run-s for a pretty straightforward scheduling optimization I guess.
2. We have weird CI flakes: [example](https://github.com/getsentry/sentry-javascript/actions/runs/7342967303/job/19992925304#step:7:322) and I hope we are solving this by differently caching the `build:types` ouptut. It seems like doing this solves the issue but I am not 100% sure about this...
3. We cache `build:tarball`