### PR TITLE
fix(astro): Handle non-utf8 encoded streams in middleware

### DIFF
--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -162,7 +162,7 @@ async function instrumentRequest(
         const newResponseStream = new ReadableStream({
           start: async controller => {
             for await (const chunk of originalBody) {
-              const html = typeof chunk === 'string' ? chunk : decoder.decode(chunk);
+              const html = typeof chunk === 'string' ? chunk : decoder.decode(chunk, { stream: true });
               const modifiedHtml = addMetaTagToHead(html, scope, client, span);
               controller.enqueue(new TextEncoder().encode(modifiedHtml));
             }


### PR DESCRIPTION
Ref https://github.com/getsentry/sentry-javascript/issues/9985

Some context on the proposed change: https://github.com/whatwg/encoding/issues/184