### PR TITLE
Use astro logger instead of console

### DIFF
--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as path from 'path';
-/* eslint-disable no-console */
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 import type { AstroConfig, AstroIntegration } from 'astro';
 
@@ -14,7 +13,7 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
     name: PKG_NAME,
     hooks: {
       // eslint-disable-next-line complexity
-      'astro:config:setup': async ({ updateConfig, injectScript, addMiddleware, config, command }) => {
+      'astro:config:setup': async ({ updateConfig, injectScript, addMiddleware, config, command, logger }) => {
         // The third param here enables loading of all env vars, regardless of prefix
         // see: https://main.vitejs.dev/config/#using-environment-variables-in-config
 
@@ -62,10 +61,10 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
             : findDefaultSdkInitFile('client');
 
           if (pathToClientInit) {
-            options.debug && console.log(`[sentry-astro] Using ${pathToClientInit} for client init.`);
+            options.debug && logger.info(`Using ${pathToClientInit} for client init.`);
             injectScript('page', buildSdkInitFileImportSnippet(pathToClientInit));
           } else {
-            options.debug && console.log('[sentry-astro] Using default client init.');
+            options.debug && logger.info('Using default client init.');
             injectScript('page', buildClientSnippet(options || {}));
           }
         }
@@ -75,10 +74,10 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
             ? path.resolve(options.serverInitPath)
             : findDefaultSdkInitFile('server');
           if (pathToServerInit) {
-            options.debug && console.log(`[sentry-astro] Using ${pathToServerInit} for server init.`);
+            options.debug && logger.info(`Using ${pathToServerInit} for server init.`);
             injectScript('page-ssr', buildSdkInitFileImportSnippet(pathToServerInit));
           } else {
-            options.debug && console.log('[sentry-astro] Using default server init.');
+            options.debug && logger.info('Using default server init.');
             injectScript('page-ssr', buildServerSnippet(options || {}));
           }
         }


### PR DESCRIPTION
We can simply use `AstroIntegrationLogger` instead of console. This might improve DX. https://docs.astro.build/en/reference/integrations-reference/#astrointegrationlogger