### PR TITLE
fix(node): Correctly resolve module name

### DIFF
--- a/packages/node/test/module.test.ts
+++ b/packages/node/test/module.test.ts
@@ -1,42 +1,40 @@
 import { getModuleFromFilename } from '../src/module';
 
-function withFilename(fn: () => void, filename: string) {
-  const prevFilename = require.main?.filename;
-  if (require.main?.filename) {
-    require.main.filename = filename;
-  }
-
-  try {
-    fn();
-  } finally {
-    if (require.main && prevFilename) {
-      require.main.filename = prevFilename;
-    }
-  }
-}
-
 describe('getModuleFromFilename', () => {
   test('Windows', () => {
-    withFilename(() => {
-      expect(getModuleFromFilename('C:\\Users\\users\\Tim\\Desktop\\node_modules\\module.js', true)).toEqual('module');
-    }, 'C:\\Users\\Tim\\app.js');
+    expect(
+      getModuleFromFilename('C:\\Users\\Tim\\node_modules\\some-dep\\module.js', 'C:\\Users\\Tim\\', true),
+    ).toEqual('some-dep:module');
+
+    expect(getModuleFromFilename('C:\\Users\\Tim\\some\\more\\feature.js', 'C:\\Users\\Tim\\', true)).toEqual(
+      'some.more:feature',
+    );
   });
 
   test('POSIX', () => {
-    withFilename(() => {
-      expect(getModuleFromFilename('/Users/users/Tim/Desktop/node_modules/module.js')).toEqual('module');
-    }, '/Users/Tim/app.js');
+    expect(getModuleFromFilename('/Users/Tim/node_modules/some-dep/module.js', '/Users/Tim/')).toEqual(
+      'some-dep:module',
+    );
+
+    expect(getModuleFromFilename('/Users/Tim/some/more/feature.js', '/Users/Tim/')).toEqual('some.more:feature');
+    expect(getModuleFromFilename('/Users/Tim/main.js', '/Users/Tim/')).toEqual('main');
   });
 
-  test('POSIX .mjs', () => {
-    withFilename(() => {
-      expect(getModuleFromFilename('/Users/users/Tim/Desktop/node_modules/module.mjs')).toEqual('module');
-    }, '/Users/Tim/app.js');
+  test('.mjs', () => {
+    expect(getModuleFromFilename('/Users/Tim/node_modules/some-dep/module.mjs', '/Users/Tim/')).toEqual(
+      'some-dep:module',
+    );
   });
 
-  test('POSIX .cjs', () => {
-    withFilename(() => {
-      expect(getModuleFromFilename('/Users/users/Tim/Desktop/node_modules/module.cjs')).toEqual('module');
-    }, '/Users/Tim/app.js');
+  test('.cjs', () => {
+    expect(getModuleFromFilename('/Users/Tim/node_modules/some-dep/module.cjs', '/Users/Tim/')).toEqual(
+      'some-dep:module',
+    );
+  });
+
+  test('node internal', () => {
+    expect(getModuleFromFilename('node.js', '/Users/Tim/')).toEqual('node');
+    expect(getModuleFromFilename('node:internal/process/task_queues', '/Users/Tim/')).toEqual('task_queues');
+    expect(getModuleFromFilename('node:internal/timers', '/Users/Tim/')).toEqual('timers');
   });
 });


### PR DESCRIPTION
Closes #10000 

- Caches the `basePath` so `dirname(require.main.filename)` only gets called once
- Now uses full path for module name
- Now correctly handles inside `node_modules`
- Add more tests

