### PR TITLE
feat(astro): Add `enabled` option to Astro integration options

### DIFF
--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -28,11 +28,10 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
           client: typeof options.enabled === 'boolean' ? options.enabled : options.enabled?.client ?? true,
           server: typeof options.enabled === 'boolean' ? options.enabled : options.enabled?.server ?? true,
         };
-        const partiallyEnabled = sdkEnabled.client || sdkEnabled.server;
 
+        const sourceMapsNeeded = sdkEnabled.client || sdkEnabled.server;
         const uploadOptions = options.sourceMapsUploadOptions || {};
-
-        const shouldUploadSourcemaps = (partiallyEnabled && uploadOptions?.enabled) ?? true;
+        const shouldUploadSourcemaps = (sourceMapsNeeded && uploadOptions?.enabled) ?? true;
 
         // We don't need to check for AUTH_TOKEN here, because the plugin will pick it up from the env
         if (shouldUploadSourcemaps && command !== 'dev') {

--- a/packages/astro/src/integration/index.ts
+++ b/packages/astro/src/integration/index.ts
@@ -24,9 +24,15 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
         // Will revisit this later.
         const env = process.env;
 
+        const sdkEnabled = {
+          client: typeof options.enabled === 'boolean' ? options.enabled : options.enabled?.client ?? true,
+          server: typeof options.enabled === 'boolean' ? options.enabled : options.enabled?.server ?? true,
+        };
+        const partiallyEnabled = sdkEnabled.client || sdkEnabled.server;
+
         const uploadOptions = options.sourceMapsUploadOptions || {};
 
-        const shouldUploadSourcemaps = uploadOptions?.enabled ?? true;
+        const shouldUploadSourcemaps = (partiallyEnabled && uploadOptions?.enabled) ?? true;
 
         // We don't need to check for AUTH_TOKEN here, because the plugin will pick it up from the env
         if (shouldUploadSourcemaps && command !== 'dev') {
@@ -51,31 +57,35 @@ export const sentryAstro = (options: SentryOptions = {}): AstroIntegration => {
           });
         }
 
-        const pathToClientInit = options.clientInitPath
-          ? path.resolve(options.clientInitPath)
-          : findDefaultSdkInitFile('client');
-        const pathToServerInit = options.serverInitPath
-          ? path.resolve(options.serverInitPath)
-          : findDefaultSdkInitFile('server');
+        if (sdkEnabled.client) {
+          const pathToClientInit = options.clientInitPath
+            ? path.resolve(options.clientInitPath)
+            : findDefaultSdkInitFile('client');
 
-        if (pathToClientInit) {
-          options.debug && console.log(`[sentry-astro] Using ${pathToClientInit} for client init.`);
-          injectScript('page', buildSdkInitFileImportSnippet(pathToClientInit));
-        } else {
-          options.debug && console.log('[sentry-astro] Using default client init.');
-          injectScript('page', buildClientSnippet(options || {}));
+          if (pathToClientInit) {
+            options.debug && console.log(`[sentry-astro] Using ${pathToClientInit} for client init.`);
+            injectScript('page', buildSdkInitFileImportSnippet(pathToClientInit));
+          } else {
+            options.debug && console.log('[sentry-astro] Using default client init.');
+            injectScript('page', buildClientSnippet(options || {}));
+          }
         }
 
-        if (pathToServerInit) {
-          options.debug && console.log(`[sentry-astro] Using ${pathToServerInit} for server init.`);
-          injectScript('page-ssr', buildSdkInitFileImportSnippet(pathToServerInit));
-        } else {
-          options.debug && console.log('[sentry-astro] Using default server init.');
-          injectScript('page-ssr', buildServerSnippet(options || {}));
+        if (sdkEnabled.server) {
+          const pathToServerInit = options.serverInitPath
+            ? path.resolve(options.serverInitPath)
+            : findDefaultSdkInitFile('server');
+          if (pathToServerInit) {
+            options.debug && console.log(`[sentry-astro] Using ${pathToServerInit} for server init.`);
+            injectScript('page-ssr', buildSdkInitFileImportSnippet(pathToServerInit));
+          } else {
+            options.debug && console.log('[sentry-astro] Using default server init.');
+            injectScript('page-ssr', buildServerSnippet(options || {}));
+          }
         }
 
         const isSSR = config && (config.output === 'server' || config.output === 'hybrid');
-        const shouldAddMiddleware = options.autoInstrumentation?.requestHandler !== false;
+        const shouldAddMiddleware = sdkEnabled.server && options.autoInstrumentation?.requestHandler !== false;
 
         // Guarding calling the addMiddleware function because it was only introduced in astro@3.5.0
         // Users on older versions of astro will need to add the middleware manually.

--- a/packages/astro/src/integration/types.ts
+++ b/packages/astro/src/integration/types.ts
@@ -106,6 +106,26 @@ type InstrumentationOptions = {
   };
 };
 
+type SdkEnabledOptions = {
+  /**
+   * Controls if the Sentry SDK is enabled or not.
+   *
+   * You can either set a boolean value to enable/disable the SDK for both client and server,
+   * or pass an object with `client` and `server` properties to enable/disable the SDK.
+   *
+   * If the SDK is disabled, no data will be caught or sent to Sentry. In this case, also no
+   * Sentry code will be added to your bundle.
+   *
+   * @default true - the SDK is enabled by default for both, client and server.
+   */
+  enabled?:
+    | boolean
+    | {
+        client?: boolean;
+        server?: boolean;
+      };
+};
+
 /**
  * A subset of Sentry SDK options that can be set via the `sentryAstro` integration.
  * Some options (e.g. integrations) are set by default and cannot be changed here.
@@ -119,4 +139,5 @@ export type SentryOptions = SdkInitPaths &
   Pick<Options, 'dsn' | 'release' | 'environment' | 'sampleRate' | 'tracesSampleRate' | 'debug'> &
   Pick<BrowserOptions, 'replaysSessionSampleRate' | 'replaysOnErrorSampleRate'> &
   SourceMapsOptions &
-  InstrumentationOptions;
+  InstrumentationOptions &
+  SdkEnabledOptions;


### PR DESCRIPTION
This PR adds a top level `enabled` option to the Astro integration options. This option can be used to globally enable/disable all Sentry features, either for client or server separately or for both sides simultaneously. 

* Disabeling either side will avoid the respective SDK code being injected into the bundles. 
* If both sides are disabled, source maps will not be generated and uploaded.
* If both or just the server side is disabled, the Sentry middleware won't be added.
* Obviously, this options defaults to `true`

### API:

```js
// astro.config.mjs

export default defineConfig({
  integrations: [
    sentry({
      // disable entirely
      enabled: false,
      // or just one side
      enabled: {
        client: true, // <-- can also be omitted
        server: false,
      }
    }),
  ],
});
```

closes #9783 
ref #9777 

