### PR TITLE
chore(biome): Add `useRegexLiterals` rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -31,7 +31,7 @@
         "noDelete": "off"
       }
     },
-    "ignore": [".vscode/*", "**/*.json"]
+    "ignore": [".vscode/*", "**/*.json", ".next/**/*", ".svelte-kit/**/*"]
   },
   "files": {
     "ignoreUnknown": true

--- a/biome.json
+++ b/biome.json
@@ -22,7 +22,8 @@
         "noControlCharactersInRegex": "error"
       },
       "nursery": {
-        "noUnusedImports": "error"
+        "noUnusedImports": "error",
+        "useRegexLiterals": "error"
       },
       "performance": {
         "all": true,

--- a/packages/serverless/test/google-cloud-http.test.ts
+++ b/packages/serverless/test/google-cloud-http.test.ts
@@ -49,7 +49,7 @@ describe('GoogleCloudHttp tracing', () => {
           '{"kind":"bigquery#job","configuration":{"query":{"query":"SELECT true AS foo","destinationTable":{"projectId":"project-id","datasetId":"_7b1eed9bef45ab5fb7345c3d6f662cd767e5ab3e","tableId":"anon101ee25adad33d4f09179679ae9144ad436a210e"},"writeDisposition":"WRITE_TRUNCATE","priority":"INTERACTIVE","useLegacySql":false},"jobType":"QUERY"},"jobReference":{"projectId":"project-id","jobId":"8874c5d5-9cfe-4daa-8390-b0504b97b429","location":"US"},"statistics":{"creationTime":"1603072686488","startTime":"1603072686756","query":{"statementType":"SELECT"}},"status":{"state":"RUNNING"}}',
         );
       nock('https://bigquery.googleapis.com')
-        .get(new RegExp('^/bigquery/v2/projects/project-id/queries/.+$'))
+        .get(/^\/bigquery\/v2\/projects\/project-id\/queries\/.+$/)
         .query(true)
         .reply(
           200,
@@ -67,7 +67,7 @@ describe('GoogleCloudHttp tracing', () => {
       expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
         op: 'http.client.bigquery',
         origin: 'auto.http.serverless',
-        description: expect.stringMatching(new RegExp('^GET /queries/.+')),
+        description: expect.stringMatching(/^GET \/queries\/.+/),
       });
     });
   });


### PR DESCRIPTION
This PR adds the [useRegexLiterals](https://biomejs.dev/linter/rules/use-regex-literals/) rule to our biome config which will  flag unnecessary usage of the `RegExp` constructor where a static regex could be used instead.

The fix codemod seems to be still quite buggy, as it e.g. can't correctly convert slashes `new RegExp('/my/path')` becomes `//my/path/` instead of `/\/my\/path/`. However, an incorrect conversion will trigger other warnings, so I'm okay with that for the moment. 

ref #9960 (in contrast to #10009, this PR doesn't address the RegExp usage problem but it's a nice addition IMO)