### PR TITLE
feat(core): Deprecate `trace` in favor of `startSpan`

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -41,6 +41,7 @@ export {
   setTags,
   setUser,
   spanStatusfromHttpCode,
+  // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,
   autoDiscoverNodePerformanceMonitoringIntegrations,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -48,6 +48,7 @@ export {
   extractTraceparentData,
   getActiveTransaction,
   spanStatusfromHttpCode,
+  // eslint-disable-next-line deprecation/deprecation
   trace,
   makeMultiplexedTransport,
   ModuleMetadata,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -60,6 +60,7 @@ export {
   setTags,
   setUser,
   spanStatusfromHttpCode,
+  // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,
   captureCheckIn,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,6 +69,7 @@ export { prepareEvent } from './utils/prepareEvent';
 export { createCheckInEnvelope } from './checkin';
 export { hasTracingEnabled } from './utils/hasTracingEnabled';
 export { isSentryRequestUrl } from './utils/isSentryRequestUrl';
+export { handleCallbackErrors } from './utils/handleCallbackErrors';
 export { spanToTraceHeader } from './utils/spanUtils';
 export { DEFAULT_ENVIRONMENT } from './constants';
 export { ModuleMetadata } from './integrations/metadata';

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -9,6 +9,7 @@ export { extractTraceparentData, getActiveTransaction } from './utils';
 export { SpanStatus } from './spanstatus';
 export type { SpanStatusType } from './span';
 export {
+  // eslint-disable-next-line deprecation/deprecation
   trace,
   getActiveSpan,
   startSpan,

--- a/packages/core/src/utils/handleCallbackErrors.ts
+++ b/packages/core/src/utils/handleCallbackErrors.ts
@@ -1,0 +1,63 @@
+import { isThenable } from '@sentry/utils';
+
+/**
+ * Wrap a callback function with error handling.
+ * If an error is thrown, it will be passed to the `onError` callback and re-thrown.
+ *
+ * If the return value of the function is a promise, it will be handled with `maybeHandlePromiseRejection`.
+ *
+ * If an `onFinally` callback is provided, this will be called when the callback has finished
+ * - so if it returns a promise, once the promise resolved/rejected,
+ * else once the callback has finished executing.
+ * The `onFinally` callback will _always_ be called, no matter if an error was thrown or not.
+ */
+export function handleCallbackErrors<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Fn extends () => any,
+>(
+  fn: Fn,
+  onError: (error: unknown) => void,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  onFinally: () => void = () => {},
+): ReturnType<Fn> {
+  let maybePromiseResult: ReturnType<Fn>;
+  try {
+    maybePromiseResult = fn();
+  } catch (e) {
+    onError(e);
+    onFinally();
+    throw e;
+  }
+
+  return maybeHandlePromiseRejection(maybePromiseResult, onError, onFinally);
+}
+
+/**
+ * Maybe handle a promise rejection.
+ * This expects to be given a value that _may_ be a promise, or any other value.
+ * If it is a promise, and it rejects, it will call the `onError` callback.
+ * Other than this, it will generally return the given value as-is.
+ */
+function maybeHandlePromiseRejection<MaybePromise>(
+  value: MaybePromise,
+  onError: (error: unknown) => void,
+  onFinally: () => void,
+): MaybePromise {
+  if (isThenable(value)) {
+    // @ts-expect-error - the isThenable check returns the "wrong" type here
+    return value.then(
+      res => {
+        onFinally();
+        return res;
+      },
+      e => {
+        onError(e);
+        onFinally();
+        throw e;
+      },
+    );
+  }
+
+  onFinally();
+  return value;
+}

--- a/packages/core/test/lib/utils/handleCallbackErrors.test.ts
+++ b/packages/core/test/lib/utils/handleCallbackErrors.test.ts
@@ -1,0 +1,150 @@
+import { handleCallbackErrors } from '../../../src/utils/handleCallbackErrors';
+
+describe('handleCallbackErrors', () => {
+  it('works with a simple callback', () => {
+    const onError = jest.fn();
+
+    const fn = jest.fn(() => 'aa');
+
+    const res = handleCallbackErrors(fn, onError);
+
+    expect(res).toBe('aa');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('triggers onError when callback has sync error', () => {
+    const error = new Error('test error');
+
+    const onError = jest.fn();
+
+    const fn = jest.fn(() => {
+      throw error;
+    });
+
+    expect(() => handleCallbackErrors(fn, onError)).toThrow(error);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(error);
+  });
+
+  it('works with an async callback', async () => {
+    const onError = jest.fn();
+
+    const fn = jest.fn(async () => 'aa');
+
+    const res = handleCallbackErrors(fn, onError);
+
+    expect(res).toBeInstanceOf(Promise);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+
+    const value = await res;
+    expect(value).toBe('aa');
+  });
+
+  it('triggers onError when callback returns promise that rejects', async () => {
+    const onError = jest.fn();
+
+    const error = new Error('test error');
+
+    const fn = jest.fn(async () => {
+      await new Promise(resolve => setTimeout(resolve, 10));
+      throw error;
+    });
+
+    const res = handleCallbackErrors(fn, onError);
+
+    expect(res).toBeInstanceOf(Promise);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+
+    await expect(res).rejects.toThrow(error);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(error);
+  });
+
+  describe('onFinally', () => {
+    it('triggers after successfuly sync callback', () => {
+      const onError = jest.fn();
+      const onFinally = jest.fn();
+
+      const fn = jest.fn(() => 'aa');
+
+      const res = handleCallbackErrors(fn, onError, onFinally);
+
+      expect(res).toBe('aa');
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(onError).not.toHaveBeenCalled();
+      expect(onFinally).toHaveBeenCalledTimes(1);
+    });
+
+    it('triggers after error in sync callback', () => {
+      const error = new Error('test error');
+
+      const onError = jest.fn();
+      const onFinally = jest.fn();
+
+      const fn = jest.fn(() => {
+        throw error;
+      });
+
+      expect(() => handleCallbackErrors(fn, onError, onFinally)).toThrow(error);
+
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(error);
+      expect(onFinally).toHaveBeenCalledTimes(1);
+    });
+
+    it('triggers after successful async callback', async () => {
+      const onError = jest.fn();
+      const onFinally = jest.fn();
+
+      const fn = jest.fn(async () => 'aa');
+
+      const res = handleCallbackErrors(fn, onError, onFinally);
+
+      expect(res).toBeInstanceOf(Promise);
+
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(onError).not.toHaveBeenCalled();
+      expect(onFinally).not.toHaveBeenCalled();
+
+      const value = await res;
+      expect(value).toBe('aa');
+
+      expect(onFinally).toHaveBeenCalledTimes(1);
+    });
+
+    it('triggers after error in async callback', async () => {
+      const onError = jest.fn();
+      const onFinally = jest.fn();
+
+      const error = new Error('test error');
+
+      const fn = jest.fn(async () => {
+        await new Promise(resolve => setTimeout(resolve, 10));
+        throw error;
+      });
+
+      const res = handleCallbackErrors(fn, onError, onFinally);
+
+      expect(res).toBeInstanceOf(Promise);
+
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(onError).not.toHaveBeenCalled();
+      expect(onFinally).not.toHaveBeenCalled();
+
+      await expect(res).rejects.toThrow(error);
+
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledWith(error);
+      expect(onFinally).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -59,6 +59,7 @@ export {
   setTags,
   setUser,
   spanStatusfromHttpCode,
+  // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,
   captureCheckIn,

--- a/packages/nextjs/src/common/wrapServerComponentWithSentry.ts
+++ b/packages/nextjs/src/common/wrapServerComponentWithSentry.ts
@@ -99,6 +99,8 @@ export function wrapServerComponentWithSentry<F extends (...args: any[]) => any>
             );
           },
         );
+
+        return res;
       });
     },
   });

--- a/packages/nextjs/test/edge/edgeWrapperUtils.test.ts
+++ b/packages/nextjs/test/edge/edgeWrapperUtils.test.ts
@@ -65,7 +65,7 @@ describe('withEdgeWrapping', () => {
   });
 
   it('should return a function that calls trace', async () => {
-    const traceSpy = jest.spyOn(coreSdk, 'trace');
+    const startSpanSpy = jest.spyOn(coreSdk, 'startSpan');
 
     const request = new Request('https://sentry.io/');
     const origFunction = jest.fn(_req => new Response());
@@ -78,15 +78,14 @@ describe('withEdgeWrapping', () => {
 
     await wrappedFunction(request);
 
-    expect(traceSpy).toHaveBeenCalledTimes(1);
-    expect(traceSpy).toHaveBeenCalledWith(
+    expect(startSpanSpy).toHaveBeenCalledTimes(1);
+    expect(startSpanSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         metadata: { request: { headers: {} }, source: 'route' },
         name: 'some label',
         op: 'some op',
         origin: 'auto.function.nextjs.withEdgeWrapping',
       }),
-      expect.any(Function),
       expect.any(Function),
     );
   });

--- a/packages/nextjs/test/edge/withSentryAPI.test.ts
+++ b/packages/nextjs/test/edge/withSentryAPI.test.ts
@@ -34,7 +34,7 @@ afterAll(() => {
   global.Response = origResponse;
 });
 
-const traceSpy = jest.spyOn(coreSdk, 'trace');
+const startSpanSpy = jest.spyOn(coreSdk, 'startSpan');
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -49,15 +49,14 @@ describe('wrapApiHandlerWithSentry', () => {
 
     await wrappedFunction(request);
 
-    expect(traceSpy).toHaveBeenCalledTimes(1);
-    expect(traceSpy).toHaveBeenCalledWith(
+    expect(startSpanSpy).toHaveBeenCalledTimes(1);
+    expect(startSpanSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         metadata: { request: { headers: {}, method: 'POST', url: 'https://sentry.io/' }, source: 'route' },
         name: 'POST /user/[userId]/post/[postId]',
         op: 'http.server',
         origin: 'auto.function.nextjs.withEdgeWrapping',
       }),
-      expect.any(Function),
       expect.any(Function),
     );
   });
@@ -69,15 +68,14 @@ describe('wrapApiHandlerWithSentry', () => {
 
     await wrappedFunction();
 
-    expect(traceSpy).toHaveBeenCalledTimes(1);
-    expect(traceSpy).toHaveBeenCalledWith(
+    expect(startSpanSpy).toHaveBeenCalledTimes(1);
+    expect(startSpanSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         metadata: { source: 'route' },
         name: 'handler (/user/[userId]/post/[postId])',
         op: 'http.server',
         origin: 'auto.function.nextjs.withEdgeWrapping',
       }),
-      expect.any(Function),
       expect.any(Function),
     );
   });

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -60,6 +60,7 @@ export {
   runWithAsyncContext,
   SDK_VERSION,
   spanStatusfromHttpCode,
+  // eslint-disable-next-line deprecation/deprecation
   trace,
   captureCheckIn,
   withMonitor,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -59,6 +59,7 @@ export {
   setTags,
   setUser,
   spanStatusfromHttpCode,
+  // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,
   captureCheckIn,

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -40,6 +40,7 @@ export {
   setTags,
   setUser,
   spanStatusfromHttpCode,
+  // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,
   autoDiscoverNodePerformanceMonitoringIntegrations,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -38,6 +38,7 @@ export {
   setTags,
   setUser,
   spanStatusfromHttpCode,
+  // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,
   autoDiscoverNodePerformanceMonitoringIntegrations,

--- a/packages/sveltekit/test/client/load.test.ts
+++ b/packages/sveltekit/test/client/load.test.ts
@@ -7,15 +7,15 @@ import { wrapLoadWithSentry } from '../../src/client/load';
 
 const mockCaptureException = vi.spyOn(SentrySvelte, 'captureException').mockImplementation(() => 'xx');
 
-const mockTrace = vi.fn();
+const mockStartSpan = vi.fn();
 
 vi.mock('@sentry/core', async () => {
   const original = (await vi.importActual('@sentry/core')) as any;
   return {
     ...original,
-    trace: (...args: unknown[]) => {
-      mockTrace(...args);
-      return original.trace(...args);
+    startSpan: (...args: unknown[]) => {
+      mockStartSpan(...args);
+      return original.startSpan(...args);
     },
   };
 });
@@ -39,7 +39,7 @@ beforeAll(() => {
 describe('wrapLoadWithSentry', () => {
   beforeEach(() => {
     mockCaptureException.mockClear();
-    mockTrace.mockClear();
+    mockStartSpan.mockClear();
   });
 
   it('calls captureException', async () => {
@@ -79,8 +79,8 @@ describe('wrapLoadWithSentry', () => {
       const wrappedLoad = wrapLoadWithSentry(load);
       await wrappedLoad(MOCK_LOAD_ARGS);
 
-      expect(mockTrace).toHaveBeenCalledTimes(1);
-      expect(mockTrace).toHaveBeenCalledWith(
+      expect(mockStartSpan).toHaveBeenCalledTimes(1);
+      expect(mockStartSpan).toHaveBeenCalledWith(
         {
           op: 'function.sveltekit.load',
           origin: 'auto.function.sveltekit',
@@ -90,7 +90,6 @@ describe('wrapLoadWithSentry', () => {
             source: 'route',
           },
         },
-        expect.any(Function),
         expect.any(Function),
       );
     });
@@ -108,8 +107,8 @@ describe('wrapLoadWithSentry', () => {
 
       await wrappedLoad(MOCK_LOAD_ARGS);
 
-      expect(mockTrace).toHaveBeenCalledTimes(1);
-      expect(mockTrace).toHaveBeenCalledWith(
+      expect(mockStartSpan).toHaveBeenCalledTimes(1);
+      expect(mockStartSpan).toHaveBeenCalledWith(
         {
           op: 'function.sveltekit.load',
           origin: 'auto.function.sveltekit',
@@ -119,7 +118,6 @@ describe('wrapLoadWithSentry', () => {
             source: 'url',
           },
         },
-        expect.any(Function),
         expect.any(Function),
       );
     });
@@ -152,6 +150,6 @@ describe('wrapLoadWithSentry', () => {
     const wrappedLoad = wrapLoadWithSentry(wrapLoadWithSentry(load));
     await wrappedLoad(MOCK_LOAD_ARGS);
 
-    expect(mockTrace).toHaveBeenCalledTimes(1);
+    expect(mockStartSpan).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/tracing-internal/src/node/integrations/prisma.ts
+++ b/packages/tracing-internal/src/node/integrations/prisma.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub, trace } from '@sentry/core';
+import { getCurrentHub, startSpan } from '@sentry/core';
 import type { Integration } from '@sentry/types';
 import { addNonEnumerableProperty, logger } from '@sentry/utils';
 
@@ -99,7 +99,7 @@ export class Prisma implements Integration {
         const action = params.action;
         const model = params.model;
 
-        return trace(
+        return startSpan(
           {
             name: model ? `${model} ${action}` : action,
             op: 'db.prisma',

--- a/packages/tracing/test/integrations/node/prisma.test.ts
+++ b/packages/tracing/test/integrations/node/prisma.test.ts
@@ -5,15 +5,15 @@ import { Hub } from '@sentry/core';
 import { Integrations } from '../../../src';
 import { getTestClient } from '../../testutils';
 
-const mockTrace = jest.fn();
+const mockStartSpan = jest.fn();
 
 jest.mock('@sentry/core', () => {
   const original = jest.requireActual('@sentry/core');
   return {
     ...original,
-    trace: (...args: unknown[]) => {
-      mockTrace(...args);
-      return original.trace(...args);
+    startSpan: (...args: unknown[]) => {
+      mockStartSpan(...args);
+      return original.startSpan(...args);
     },
   };
 });
@@ -43,16 +43,16 @@ class PrismaClient {
 
 describe('setupOnce', function () {
   beforeEach(() => {
-    mockTrace.mockClear();
-    mockTrace.mockReset();
+    mockStartSpan.mockClear();
+    mockStartSpan.mockReset();
   });
 
   it('should add middleware with $use method correctly', done => {
     const prismaClient = new PrismaClient();
     new Integrations.Prisma({ client: prismaClient });
     void prismaClient.user.create()?.then(() => {
-      expect(mockTrace).toHaveBeenCalledTimes(1);
-      expect(mockTrace).toHaveBeenLastCalledWith(
+      expect(mockStartSpan).toHaveBeenCalledTimes(1);
+      expect(mockStartSpan).toHaveBeenLastCalledWith(
         {
           name: 'user create',
           op: 'db.prisma',
@@ -75,7 +75,7 @@ describe('setupOnce', function () {
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
 
     void prismaClient.user.create()?.then(() => {
-      expect(mockTrace).not.toHaveBeenCalled();
+      expect(mockStartSpan).not.toHaveBeenCalled();
       done();
     });
   });

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -59,6 +59,7 @@ export {
   setTags,
   setUser,
   spanStatusfromHttpCode,
+  // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,
   captureCheckIn,


### PR DESCRIPTION
Also add a `handleCallbackErrors` utility to replace this.

We've been using this in a few places, and since it has a bit of a different usage than `startSpan` I had to add a new utility to properly make this work. The upside is that we now can ensure to use the same implementation for this "maybe promise" handling everywhere!