### PR TITLE
ref: Deprecate `deepReadDirSync`

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -54,6 +54,7 @@ export {
   addRequestDataToEvent,
   DEFAULT_USER_INCLUDES,
   extractRequestData,
+  // eslint-disable-next-line deprecation/deprecation
   deepReadDirSync,
   Integrations,
   Handlers,

--- a/packages/nextjs/test/buildProcess/tests/nft.test.ts
+++ b/packages/nextjs/test/buildProcess/tests/nft.test.ts
@@ -33,6 +33,7 @@ it('excludes build-time SDK dependencies from nft files', () => {
   expect(rollupEntries.length).toEqual(0);
 
   // We don't want to accidentally remove the wrappers
+  // eslint-disable-next-line deprecation/deprecation
   const wrapperFiles = deepReadDirSync('src/config/wrappers/').filter(filename => filename !== 'types.ts');
   expect(sentryWrapperEntries.length).toEqual(wrapperFiles.length);
 });

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -49,6 +49,7 @@ export {
   addRequestDataToEvent,
   DEFAULT_USER_INCLUDES,
   extractRequestData,
+  // eslint-disable-next-line deprecation/deprecation
   deepReadDirSync,
   getModuleFromFilename,
   close,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -80,6 +80,7 @@ export { NodeClient } from './client';
 export { makeNodeTransport } from './transports';
 export { defaultIntegrations, init, defaultStackParser, getSentryRelease } from './sdk';
 export { addRequestDataToEvent, DEFAULT_USER_INCLUDES, extractRequestData } from '@sentry/utils';
+// eslint-disable-next-line deprecation/deprecation
 export { deepReadDirSync } from './utils';
 export { getModuleFromFilename } from './module';
 // eslint-disable-next-line deprecation/deprecation

--- a/packages/node/src/utils.ts
+++ b/packages/node/src/utils.ts
@@ -7,6 +7,7 @@ import * as path from 'path';
  * @param targetDir Absolute or relative path of the directory to scan. All returned paths will be relative to this
  * directory.
  * @returns Array holding all relative paths
+ * @deprecated This function will be removed in the next major version.
  */
 export function deepReadDirSync(targetDir: string): string[] {
   const targetDirAbsPath = path.resolve(targetDir);

--- a/packages/node/test/utils.test.ts
+++ b/packages/node/test/utils.test.ts
@@ -25,6 +25,7 @@ describe('deepReadDirSync', () => {
     ].map(p => (process.platform === 'win32' ? p.replace(/\//g, '\\') : p));
 
     // compare sets so that order doesn't matter
+    // eslint-disable-next-line deprecation/deprecation
     expect(new Set(deepReadDirSync('./test/fixtures/testDeepReadDirSync'))).toEqual(new Set(expected));
   });
 
@@ -35,6 +36,7 @@ describe('deepReadDirSync', () => {
     fs.mkdtemp(`${tmpDir}${path.sep}`, (err, dirPath) => {
       if (err) throw err;
       try {
+        // eslint-disable-next-line deprecation/deprecation
         expect(deepReadDirSync(dirPath)).toEqual([]);
         done();
       } catch (error) {
@@ -44,10 +46,12 @@ describe('deepReadDirSync', () => {
   });
 
   it('errors if directory does not exist', () => {
+    // eslint-disable-next-line deprecation/deprecation
     expect(() => deepReadDirSync('./IDontExist')).toThrowError('Directory does not exist.');
   });
 
   it('errors if given path is not a directory', () => {
+    // eslint-disable-next-line deprecation/deprecation
     expect(() => deepReadDirSync('package.json')).toThrowError('it is not a directory');
   });
 });

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -53,6 +53,7 @@ export {
   addRequestDataToEvent,
   DEFAULT_USER_INCLUDES,
   extractRequestData,
+  // eslint-disable-next-line deprecation/deprecation
   deepReadDirSync,
   Integrations,
   Handlers,

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -55,6 +55,7 @@ export {
   DEFAULT_USER_INCLUDES,
   addRequestDataToEvent,
   extractRequestData,
+  // eslint-disable-next-line deprecation/deprecation
   deepReadDirSync,
   Handlers,
   Integrations,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -51,6 +51,7 @@ export {
   addRequestDataToEvent,
   DEFAULT_USER_INCLUDES,
   extractRequestData,
+  // eslint-disable-next-line deprecation/deprecation
   deepReadDirSync,
   Integrations,
   Handlers,


### PR DESCRIPTION
This function has absolutely nothing to do with SDK functionality and isn't used anywhere except for our Next.js tests (?).