### PR TITLE
feat(core): Add `span.updateName()` and deprecate `span.setName()`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -14,6 +14,7 @@ In v8, the Span class is heavily reworked. The following properties & methods ar
 
 * `span.toContext()`: Access the fields directly instead.
 * `span.updateWithContext(newSpanContext)`: Update the fields directly instead.
+* `span.setName(newName)`: Use `span.updateName(newName)` instead.
 
 ## Deprecate `pushScope` & `popScope` in favor of `withScope`
 

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -118,7 +118,8 @@ export class TraceService implements OnDestroy {
       const transaction = getActiveTransaction();
       // TODO (v8 / #5416): revisit the source condition. Do we want to make the parameterized route the default?
       if (transaction && transaction.metadata.source === 'url') {
-        transaction.setName(route, 'route');
+        transaction.updateName(route);
+        transaction.setMetadata({ source: 'route' });
       }
     }),
   );

--- a/packages/angular/test/tracing.test.ts
+++ b/packages/angular/test/tracing.test.ts
@@ -10,7 +10,8 @@ let transaction: any;
 const defaultStartTransaction = (ctx: any) => {
   transaction = {
     ...ctx,
-    setName: jest.fn(name => (transaction.name = name)),
+    updateName: jest.fn(name => (transaction.name = name)),
+    setMetadata: jest.fn(),
   };
 
   return transaction;
@@ -110,7 +111,7 @@ describe('Angular Tracing', () => {
             ...ctx.metadata,
             source: 'custom',
           },
-          setName: jest.fn(name => (transaction.name = name)),
+          updateName: jest.fn(name => (transaction.name = name)),
         };
 
         return transaction;
@@ -137,7 +138,7 @@ describe('Angular Tracing', () => {
         metadata: { source: 'url' },
       });
 
-      expect(transaction.setName).toHaveBeenCalledTimes(0);
+      expect(transaction.updateName).toHaveBeenCalledTimes(0);
       expect(transaction.name).toEqual(url);
       expect(transaction.metadata.source).toBe('custom');
 
@@ -327,7 +328,8 @@ describe('Angular Tracing', () => {
           origin: 'auto.navigation.angular',
           metadata: { source: 'url' },
         });
-        expect(transaction.setName).toHaveBeenCalledWith(result, 'route');
+        expect(transaction.updateName).toHaveBeenCalledWith(result);
+        expect(transaction.setMetadata).toHaveBeenCalledWith({ source: 'route' });
 
         env.destroy();
       });

--- a/packages/core/src/tracing/span.ts
+++ b/packages/core/src/tracing/span.ts
@@ -277,8 +277,9 @@ export class Span implements SpanInterface {
   /**
    * @inheritDoc
    */
-  public updateName(name: string): void {
+  public updateName(name: string): this {
     this.description = name;
+    return this;
   }
 
   /**

--- a/packages/core/src/tracing/span.ts
+++ b/packages/core/src/tracing/span.ts
@@ -176,9 +176,11 @@ export class Span implements SpanInterface {
   public get name(): string {
     return this.description || '';
   }
-  /** Update the name of the span. */
+  /**
+   * Update the name of the span.
+   */
   public set name(name: string) {
-    this.setName(name);
+    this.updateName(name);
   }
 
   /**
@@ -267,10 +269,15 @@ export class Span implements SpanInterface {
     return this;
   }
 
+  /** @inheritdoc */
+  public setName(name: string): void {
+    this.updateName(name);
+  }
+
   /**
    * @inheritDoc
    */
-  public setName(name: string): void {
+  public updateName(name: string): void {
     this.description = name;
   }
 

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -101,8 +101,9 @@ export class Transaction extends SpanClass implements TransactionInterface {
   }
 
   /** @inheritdoc */
-  public updateName(name: string): void {
+  public updateName(name: string): this {
     this._name = name;
+    return this;
   }
 
   /**

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -82,17 +82,27 @@ export class Transaction extends SpanClass implements TransactionInterface {
     return this._name;
   }
 
-  /** Setter for `name` property, which also sets `source` as custom */
+  /**
+   * Setter for `name` property, which also sets `source` as custom.
+   */
   public set name(newName: string) {
+    // eslint-disable-next-line deprecation/deprecation
     this.setName(newName);
   }
 
   /**
-   * JSDoc
+   * Setter for `name` property, which also sets `source` on the metadata.
+   *
+   * @deprecated Use `updateName()` and `setMetadata()` instead.
    */
   public setName(name: string, source: TransactionMetadata['source'] = 'custom'): void {
     this._name = name;
     this.metadata.source = source;
+  }
+
+  /** @inheritdoc */
+  public updateName(name: string): void {
+    this._name = name;
   }
 
   /**

--- a/packages/core/test/lib/tracing/span.test.ts
+++ b/packages/core/test/lib/tracing/span.test.ts
@@ -19,12 +19,35 @@ describe('span', () => {
     expect(span.description).toEqual(undefined);
   });
 
-  it('allows to update the name', () => {
+  it('allows to update the name via setter', () => {
     const span = new Span({ name: 'span name' });
     expect(span.name).toEqual('span name');
     expect(span.description).toEqual('span name');
 
     span.name = 'new name';
+
+    expect(span.name).toEqual('new name');
+    expect(span.description).toEqual('new name');
+  });
+
+  it('allows to update the name via setName', () => {
+    const span = new Span({ name: 'span name' });
+    expect(span.name).toEqual('span name');
+    expect(span.description).toEqual('span name');
+
+    // eslint-disable-next-line deprecation/deprecation
+    span.setName('new name');
+
+    expect(span.name).toEqual('new name');
+    expect(span.description).toEqual('new name');
+  });
+
+  it('allows to update the name via updateName', () => {
+    const span = new Span({ name: 'span name' });
+    expect(span.name).toEqual('span name');
+    expect(span.description).toEqual('span name');
+
+    span.updateName('new name');
 
     expect(span.name).toEqual('new name');
     expect(span.description).toEqual('new name');

--- a/packages/core/test/lib/tracing/transaction.test.ts
+++ b/packages/core/test/lib/tracing/transaction.test.ts
@@ -6,12 +6,39 @@ describe('transaction', () => {
     expect(transaction.name).toEqual('span name');
   });
 
-  it('allows to update the name', () => {
+  it('allows to update the name via setter', () => {
     const transaction = new Transaction({ name: 'span name' });
+    transaction.setMetadata({ source: 'route' });
     expect(transaction.name).toEqual('span name');
 
     transaction.name = 'new name';
 
     expect(transaction.name).toEqual('new name');
+    expect(transaction.metadata.source).toEqual('custom');
+  });
+
+  it('allows to update the name via setName', () => {
+    const transaction = new Transaction({ name: 'span name' });
+    transaction.setMetadata({ source: 'route' });
+    expect(transaction.name).toEqual('span name');
+
+    transaction.setMetadata({ source: 'route' });
+
+    // eslint-disable-next-line deprecation/deprecation
+    transaction.setName('new name');
+
+    expect(transaction.name).toEqual('new name');
+    expect(transaction.metadata.source).toEqual('custom');
+  });
+
+  it('allows to update the name via updateName', () => {
+    const transaction = new Transaction({ name: 'span name' });
+    transaction.setMetadata({ source: 'route' });
+    expect(transaction.name).toEqual('span name');
+
+    transaction.updateName('new name');
+
+    expect(transaction.name).toEqual('new name');
+    expect(transaction.metadata.source).toEqual('route');
   });
 });

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -329,7 +329,8 @@ export function trpcMiddleware(options: SentryTrpcMiddlewareOptions = {}) {
     const sentryTransaction = getCurrentScope().getTransaction();
 
     if (sentryTransaction) {
-      sentryTransaction.setName(`trpc/${path}`, 'route');
+      sentryTransaction.updateName(`trpc/${path}`);
+      sentryTransaction.setMetadata({ source: 'route' });
       sentryTransaction.op = 'rpc.server';
 
       const trpcContext: Record<string, unknown> = {

--- a/packages/opentelemetry-node/src/spanprocessor.ts
+++ b/packages/opentelemetry-node/src/spanprocessor.ts
@@ -216,7 +216,8 @@ function updateTransactionWithOtelData(transaction: Transaction, otelSpan: OtelS
   transaction.setStatus(mapOtelStatus(otelSpan));
 
   transaction.op = op;
-  transaction.setName(description, source);
+  transaction.updateName(description);
+  transaction.setMetadata({ source });
 }
 
 function convertOtelTimeToSeconds([seconds, nano]: [number, number]): number {

--- a/packages/react/src/reactrouter.tsx
+++ b/packages/react/src/reactrouter.tsx
@@ -165,7 +165,8 @@ export function withSentryRouting<P extends Record<string, any>, R extends React
 
   const WrappedRoute: React.FC<P> = (props: P) => {
     if (activeTransaction && props && props.computedMatch && props.computedMatch.isExact) {
-      activeTransaction.setName(props.computedMatch.path, 'route');
+      activeTransaction.updateName(props.computedMatch.path);
+      activeTransaction.setMetadata({ source: 'route' });
     }
 
     // @ts-expect-error Setting more specific React Component typing for `R` generic above

--- a/packages/react/src/reactrouterv6.tsx
+++ b/packages/react/src/reactrouterv6.tsx
@@ -134,7 +134,9 @@ function updatePageloadTransaction(
     : (_matchRoutes(routes, location, basename) as unknown as RouteMatch[]);
 
   if (activeTransaction && branches) {
-    activeTransaction.setName(...getNormalizedName(routes, location, branches, basename));
+    const [name, source] = getNormalizedName(routes, location, branches, basename);
+    activeTransaction.updateName(name);
+    activeTransaction.setMetadata({ source });
   }
 }
 

--- a/packages/react/test/reactrouterv5.test.tsx
+++ b/packages/react/test/reactrouterv5.test.tsx
@@ -12,7 +12,7 @@ describe('React Router v5', () => {
     startTransactionOnPageLoad?: boolean;
     startTransactionOnLocationChange?: boolean;
     routes?: RouteConfig[];
-  }): [jest.Mock, any, { mockSetName: jest.Mock; mockFinish: jest.Mock }] {
+  }): [jest.Mock, any, { mockUpdateName: jest.Mock; mockFinish: jest.Mock; mockSetMetadata: jest.Mock }] {
     const options = {
       matchPath: _opts && _opts.routes !== undefined ? matchPath : undefined,
       routes: undefined,
@@ -22,14 +22,17 @@ describe('React Router v5', () => {
     };
     const history = createMemoryHistory();
     const mockFinish = jest.fn();
-    const mockSetName = jest.fn();
-    const mockStartTransaction = jest.fn().mockReturnValue({ setName: mockSetName, end: mockFinish });
+    const mockUpdateName = jest.fn();
+    const mockSetMetadata = jest.fn();
+    const mockStartTransaction = jest
+      .fn()
+      .mockReturnValue({ updateName: mockUpdateName, end: mockFinish, setMetadata: mockSetMetadata });
     reactRouterV5Instrumentation(history, options.routes, options.matchPath)(
       mockStartTransaction,
       options.startTransactionOnPageLoad,
       options.startTransactionOnLocationChange,
     );
-    return [mockStartTransaction, history, { mockSetName, mockFinish }];
+    return [mockStartTransaction, history, { mockUpdateName, mockFinish, mockSetMetadata }];
   }
 
   it('starts a pageload transaction when instrumentation is started', () => {
@@ -166,7 +169,7 @@ describe('React Router v5', () => {
   });
 
   it('normalizes transaction name with custom Route', () => {
-    const [mockStartTransaction, history, { mockSetName }] = createInstrumentation();
+    const [mockStartTransaction, history, { mockUpdateName, mockSetMetadata }] = createInstrumentation();
     const SentryRoute = withSentryRouting(Route);
 
     const { getByText } = render(
@@ -191,12 +194,13 @@ describe('React Router v5', () => {
       tags: { 'routing.instrumentation': 'react-router-v5' },
       metadata: { source: 'url' },
     });
-    expect(mockSetName).toHaveBeenCalledTimes(2);
-    expect(mockSetName).toHaveBeenLastCalledWith('/users/:userid', 'route');
+    expect(mockUpdateName).toHaveBeenCalledTimes(2);
+    expect(mockUpdateName).toHaveBeenLastCalledWith('/users/:userid');
+    expect(mockSetMetadata).toHaveBeenLastCalledWith({ source: 'route' });
   });
 
   it('normalizes nested transaction names with custom Route', () => {
-    const [mockStartTransaction, history, { mockSetName }] = createInstrumentation();
+    const [mockStartTransaction, history, { mockUpdateName, mockSetMetadata }] = createInstrumentation();
     const SentryRoute = withSentryRouting(Route);
 
     const { getByText } = render(
@@ -222,8 +226,9 @@ describe('React Router v5', () => {
       tags: { 'routing.instrumentation': 'react-router-v5' },
       metadata: { source: 'url' },
     });
-    expect(mockSetName).toHaveBeenCalledTimes(2);
-    expect(mockSetName).toHaveBeenLastCalledWith('/organizations/:orgid/v1/:teamid', 'route');
+    expect(mockUpdateName).toHaveBeenCalledTimes(2);
+    expect(mockUpdateName).toHaveBeenLastCalledWith('/organizations/:orgid/v1/:teamid');
+    expect(mockSetMetadata).toHaveBeenLastCalledWith({ source: 'route' });
 
     act(() => {
       history.push('/organizations/543');
@@ -238,8 +243,8 @@ describe('React Router v5', () => {
       tags: { 'routing.instrumentation': 'react-router-v5' },
       metadata: { source: 'url' },
     });
-    expect(mockSetName).toHaveBeenCalledTimes(3);
-    expect(mockSetName).toHaveBeenLastCalledWith('/organizations/:orgid', 'route');
+    expect(mockUpdateName).toHaveBeenCalledTimes(3);
+    expect(mockUpdateName).toHaveBeenLastCalledWith('/organizations/:orgid');
   });
 
   it('matches with route object', () => {

--- a/packages/remix/src/client/performance.tsx
+++ b/packages/remix/src/client/performance.tsx
@@ -125,7 +125,8 @@ export function withSentry<P extends Record<string, unknown>, R extends React.Co
 
     _useEffect(() => {
       if (activeTransaction && matches && matches.length) {
-        activeTransaction.setName(matches[matches.length - 1].id, 'route');
+        activeTransaction.updateName(matches[matches.length - 1].id);
+        activeTransaction.setMetadata({ source: 'route' });
       }
 
       isBaseLocation = true;

--- a/packages/sveltekit/src/client/router.ts
+++ b/packages/sveltekit/src/client/router.ts
@@ -56,7 +56,8 @@ function instrumentPageload(startTransactionFn: (context: TransactionContext) =>
     const routeId = page.route && page.route.id;
 
     if (pageloadTransaction && routeId) {
-      pageloadTransaction.setName(routeId, 'route');
+      pageloadTransaction.updateName(routeId);
+      pageloadTransaction.setMetadata({ source: 'route' });
     }
   });
 }

--- a/packages/sveltekit/test/client/router.test.ts
+++ b/packages/sveltekit/test/client/router.test.ts
@@ -27,6 +27,7 @@ describe('sveltekitRoutingInstrumentation', () => {
     returnedTransaction = {
       ...txnCtx,
       updateName: vi.fn(),
+      setMetadata: vi.fn(),
       startChild: vi.fn().mockImplementation(ctx => {
         return { ...mockedRoutingSpan, ...ctx };
       }),

--- a/packages/sveltekit/test/client/router.test.ts
+++ b/packages/sveltekit/test/client/router.test.ts
@@ -26,7 +26,7 @@ describe('sveltekitRoutingInstrumentation', () => {
   const mockedStartTransaction = vi.fn().mockImplementation(txnCtx => {
     returnedTransaction = {
       ...txnCtx,
-      setName: vi.fn(),
+      updateName: vi.fn(),
       startChild: vi.fn().mockImplementation(ctx => {
         return { ...mockedRoutingSpan, ...ctx };
       }),
@@ -68,8 +68,9 @@ describe('sveltekitRoutingInstrumentation', () => {
     page.set({ route: { id: 'testRoute' } });
 
     // This should update the transaction name with the parameterized route:
-    expect(returnedTransaction?.setName).toHaveBeenCalledTimes(1);
-    expect(returnedTransaction?.setName).toHaveBeenCalledWith('testRoute', 'route');
+    expect(returnedTransaction?.updateName).toHaveBeenCalledTimes(1);
+    expect(returnedTransaction?.updateName).toHaveBeenCalledWith('testRoute');
+    expect(returnedTransaction?.setMetadata).toHaveBeenCalledWith({ source: 'route' });
   });
 
   it("doesn't start a pageload transaction if `startTransactionOnPageLoad` is false", () => {

--- a/packages/tracing-internal/src/node/integrations/express.ts
+++ b/packages/tracing-internal/src/node/integrations/express.ts
@@ -376,7 +376,9 @@ function instrumentRouter(appOrRouter: ExpressRouter): void {
         // Therefore, we fall back to setting the final route to '/' in this case.
         const finalRoute = req._reconstructedRoute || '/';
 
-        transaction.setName(...extractPathForTransaction(req, { path: true, method: true, customRoute: finalRoute }));
+        const [name, source] = extractPathForTransaction(req, { path: true, method: true, customRoute: finalRoute });
+        transaction.updateName(name);
+        transaction.setMetadata({ source });
       }
     }
 

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -86,7 +86,7 @@ describe('Span', () => {
     test('setName', () => {
       const span = new Span({});
       expect(span.description).toBeUndefined();
-      span.setName('foo');
+      span.updateName('foo');
       expect(span.description).toBe('foo');
     });
   });

--- a/packages/tracing/test/transaction.test.ts
+++ b/packages/tracing/test/transaction.test.ts
@@ -63,17 +63,10 @@ describe('`Transaction` class', () => {
     });
 
     describe('`updateName` method', () => {
-      it("sets source to `'custom'` if no source provided", () => {
+      it('does not change the source', () => {
         const transaction = new Transaction({ name: 'dogpark' });
+        transaction.setMetadata({ source: 'route' });
         transaction.updateName('ballpit');
-
-        expect(transaction.name).toEqual('ballpit');
-        expect(transaction.metadata.source).toEqual('custom');
-      });
-
-      it('uses given `source` value', () => {
-        const transaction = new Transaction({ name: 'dogpark' });
-        transaction.updateName('ballpit', 'route');
 
         expect(transaction.name).toEqual('ballpit');
         expect(transaction.metadata.source).toEqual('route');

--- a/packages/tracing/test/transaction.test.ts
+++ b/packages/tracing/test/transaction.test.ts
@@ -61,6 +61,24 @@ describe('`Transaction` class', () => {
         expect(transaction.metadata.source).toEqual('route');
       });
     });
+
+    describe('`updateName` method', () => {
+      it("sets source to `'custom'` if no source provided", () => {
+        const transaction = new Transaction({ name: 'dogpark' });
+        transaction.updateName('ballpit');
+
+        expect(transaction.name).toEqual('ballpit');
+        expect(transaction.metadata.source).toEqual('custom');
+      });
+
+      it('uses given `source` value', () => {
+        const transaction = new Transaction({ name: 'dogpark' });
+        transaction.updateName('ballpit', 'route');
+
+        expect(transaction.name).toEqual('ballpit');
+        expect(transaction.metadata.source).toEqual('route');
+      });
+    });
   });
 
   describe('setContext', () => {

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -212,7 +212,7 @@ export interface Span extends SpanContext {
   /**
    * Update the name of the span.
    */
-  updateName(name: string): void;
+  updateName(name: string): this;
 
   /**
    * Creates a new `Span` while setting the current `Span.id` as `parentSpanId`.

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -204,8 +204,15 @@ export interface Span extends SpanContext {
 
   /**
    * Set the name of the span.
+   *
+   * @deprecated Use `updateName()` instead.
    */
   setName(name: string): void;
+
+  /**
+   * Update the name of the span.
+   */
+  updateName(name: string): void;
 
   /**
    * Creates a new `Span` while setting the current `Span.id` as `parentSpanId`.

--- a/packages/utils/src/requestdata.ts
+++ b/packages/utils/src/requestdata.ts
@@ -74,7 +74,9 @@ export function addRequestDataToTransaction(
   if (!transaction) return;
   if (!transaction.metadata.source || transaction.metadata.source === 'url') {
     // Attempt to grab a parameterized route off of the request
-    transaction.setName(...extractPathForTransaction(req, { path: true, method: true }));
+    const [name, source] = extractPathForTransaction(req, { path: true, method: true });
+    transaction.updateName(name);
+    transaction.setMetadata({ source });
   }
   transaction.setData('url', req.originalUrl || req.url);
   if (req.baseUrl) {

--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -111,7 +111,8 @@ export function vueRouterInstrumentation(
         const pageloadTransaction = getActiveTransaction();
         if (pageloadTransaction) {
           if (pageloadTransaction.metadata.source !== 'custom') {
-            pageloadTransaction.setName(transactionName, transactionSource);
+            pageloadTransaction.updateName(transactionName);
+            pageloadTransaction.setMetadata({ source: transactionSource });
           }
           pageloadTransaction.setData('params', data.params);
           pageloadTransaction.setData('query', data.query);

--- a/packages/vue/test/router.test.ts
+++ b/packages/vue/test/router.test.ts
@@ -126,8 +126,9 @@ describe('vueRouterInstrumentation()', () => {
     'should return instrumentation that instruments VueRouter.beforeEach(%s, %s) for pageloads',
     (fromKey, toKey, transactionName, transactionSource) => {
       const mockedTxn = {
-        setName: jest.fn(),
+        updateName: jest.fn(),
         setData: jest.fn(),
+        setMetadata: jest.fn(),
         metadata: {},
       };
       const customMockStartTxn = { ...mockStartTransaction }.mockImplementation(_ => {
@@ -163,7 +164,8 @@ describe('vueRouterInstrumentation()', () => {
       beforeEachCallback(to, from, mockNext);
       expect(mockVueRouter.beforeEach).toHaveBeenCalledTimes(1);
 
-      expect(mockedTxn.setName).toHaveBeenCalledWith(transactionName, transactionSource);
+      expect(mockedTxn.updateName).toHaveBeenCalledWith(transactionName);
+      expect(mockedTxn.setMetadata).toHaveBeenCalledWith({ source: transactionSource });
       expect(mockedTxn.setData).toHaveBeenNthCalledWith(1, 'params', to.params);
       expect(mockedTxn.setData).toHaveBeenNthCalledWith(2, 'query', to.query);
 
@@ -237,7 +239,7 @@ describe('vueRouterInstrumentation()', () => {
 
   it("doesn't overwrite a pageload transaction name it was set to custom before the router resolved the route", () => {
     const mockedTxn = {
-      setName: jest.fn(),
+      updateName: jest.fn(),
       setData: jest.fn(),
       name: '',
       metadata: {
@@ -279,7 +281,7 @@ describe('vueRouterInstrumentation()', () => {
 
     expect(mockVueRouter.beforeEach).toHaveBeenCalledTimes(1);
 
-    expect(mockedTxn.setName).not.toHaveBeenCalled();
+    expect(mockedTxn.updateName).not.toHaveBeenCalled();
     expect(mockedTxn.metadata.source).toEqual('custom');
     expect(mockedTxn.name).toEqual('customTxnName');
   });


### PR DESCRIPTION
You can call `span.setMetadata()` if you need to update the source.

This aligns with the OTEL API for spans.