### PR TITLE
fix(node): Handle inspector already open

### DIFF
--- a/packages/node/src/integrations/anr/index.ts
+++ b/packages/node/src/integrations/anr/index.ts
@@ -111,7 +111,9 @@ export class Anr implements Integration {
     if (options.captureStackTrace) {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const inspector: InspectorApi = require('inspector');
-      inspector.open(0);
+      if (!inspector.url()) {
+        inspector.open(0);
+      }
     }
 
     const { Worker } = getWorkerThreads();


### PR DESCRIPTION
If the inspector is already running, then ANR should be able to (re)use that, instead of opening it itself.

Fixes #10024

Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [X] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).
