### PR TITLE
build: enable biome performance rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,9 @@
         "noUnusedImports": "error"
       },
       "performance": {
-        "noAccumulatingSpread": "error"
+        "all": true,
+        "noAccumulatingSpread": "error",
+        "noDelete": "off"
       }
     },
     "ignore": [".vscode/*", "**/*.json"]


### PR DESCRIPTION
Disabled `noDelete` to avoid a huge change log. We can enable it gradually.