### PR TITLE
feat(core): Deprecate span `toContext()` and `updateWithContext()`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,6 +8,13 @@ npx @sentry/migr8@latest
 
 This will let you select which updates to run, and automatically update your code. Make sure to still review all code changes!
 
+## Deprecated fields on `Span` and `Transaction`
+
+In v8, the Span class is heavily reworked. The following properties & methods are thus deprecated:
+
+* `span.toContext()`: Access the fields directly instead.
+* `span.updateWithContext(newSpanContext)`: Update the fields directly instead.
+
 ## Deprecate `pushScope` & `popScope` in favor of `withScope`
 
 Instead of manually pushing/popping a scope, you should use `Sentry.withScope(callback: (scope: Scope))` instead.

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -149,6 +149,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
    * @inheritDoc
    */
   public toContext(): TransactionContext {
+    // eslint-disable-next-line deprecation/deprecation
     const spanContext = super.toContext();
 
     return dropUndefinedKeys({
@@ -162,6 +163,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
    * @inheritDoc
    */
   public updateWithContext(transactionContext: TransactionContext): this {
+     // eslint-disable-next-line deprecation/deprecation
     super.updateWithContext(transactionContext);
 
     this.name = transactionContext.name || '';

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -163,7 +163,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
    * @inheritDoc
    */
   public updateWithContext(transactionContext: TransactionContext): this {
-     // eslint-disable-next-line deprecation/deprecation
+    // eslint-disable-next-line deprecation/deprecation
     super.updateWithContext(transactionContext);
 
     this.name = transactionContext.name || '';

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -471,7 +471,6 @@ describe('Span', () => {
     });
   });
 
-  /* eslint-disable deprecation/deprecation */
   describe('toContext and updateWithContext', () => {
     test('toContext should return correct context', () => {
       const originalContext = { traceId: 'a', spanId: 'b', sampled: false, description: 'test', op: 'op' };
@@ -552,7 +551,6 @@ describe('Span', () => {
       expect(span.data).toStrictEqual({ data0: 'foo', data1: 'bar' });
     });
   });
-  /* eslint-enable deprecation/deprecation */
 
   describe('getDynamicSamplingContext', () => {
     beforeEach(() => {

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -471,6 +471,7 @@ describe('Span', () => {
     });
   });
 
+  /* eslint-disable deprecation/deprecation */
   describe('toContext and updateWithContext', () => {
     test('toContext should return correct context', () => {
       const originalContext = { traceId: 'a', spanId: 'b', sampled: false, description: 'test', op: 'op' };
@@ -551,6 +552,7 @@ describe('Span', () => {
       expect(span.data).toStrictEqual({ data0: 'foo', data1: 'bar' });
     });
   });
+  /* eslint-enable deprecation/deprecation */
 
   describe('getDynamicSamplingContext', () => {
     beforeEach(() => {

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -221,10 +221,16 @@ export interface Span extends SpanContext {
   /** Return a traceparent compatible header string */
   toTraceparent(): string;
 
-  /** Returns the current span properties as a `SpanContext` */
+  /**
+   * Returns the current span properties as a `SpanContext`.
+   * @deprecated Use `toJSON()` or access the fields directly instead.
+   */
   toContext(): SpanContext;
 
-  /** Updates the current span with a new `SpanContext` */
+  /**
+   * Updates the current span with a new `SpanContext`.
+   * @deprecated Update the fields directly instead.
+   */
   updateWithContext(spanContext: SpanContext): this;
 
   /** Convert the object to JSON for w. spans array info only */

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -102,10 +102,16 @@ export interface Transaction extends TransactionContext, Omit<Span, 'setName' | 
    */
   setMeasurement(name: string, value: number, unit: MeasurementUnit): void;
 
-  /** Returns the current transaction properties as a `TransactionContext` */
+  /**
+   * Returns the current transaction properties as a `TransactionContext`.
+   * @deprecated Use `toJSON()` or access the fields directly instead.
+   */
   toContext(): TransactionContext;
 
-  /** Updates the current transaction with a new `TransactionContext` */
+  /**
+   * Updates the current transaction with a new `TransactionContext`.
+   * @deprecated Update the fields directly instead.
+   */
   updateWithContext(transactionContext: TransactionContext): this;
 
   /**


### PR DESCRIPTION
These APIs are not really used, and are not compatible with OpenTelemetry. So let's deprecate them for removal in v8.

Unless somebody knows a reason why we still need something like this?
