### PR TITLE
fix(node): Anr should not block exit

### DIFF
--- a/dev-packages/node-integration-tests/suites/anr/should-exit.js
+++ b/dev-packages/node-integration-tests/suites/anr/should-exit.js
@@ -1,0 +1,19 @@
+const Sentry = require('@sentry/node');
+
+function configureSentry() {
+  Sentry.init({
+    dsn: 'https://public@dsn.ingest.sentry.io/1337',
+    release: '1.0',
+    debug: true,
+    autoSessionTracking: false,
+    integrations: [new Sentry.Integrations.Anr({ captureStackTrace: true })],
+  });
+}
+
+async function main() {
+  configureSentry();
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  process.exit(0);
+}
+
+main();

--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -115,6 +115,21 @@ conditionalTest({ min: 16 })('should report ANR when event loop blocked', () => 
     });
   });
 
+  test('can exit', done => {
+    const testScriptPath = path.resolve(__dirname, 'should-exit.js');
+    let hasClosed = false;
+
+    setTimeout(() => {
+      if (!hasClosed) {
+        done();
+      }
+    }, 5_000);
+
+    childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (_, stdout) => {
+      hasClosed = true;
+    });
+  });
+
   test('With session', done => {
     expect.assertions(9);
 

--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -120,9 +120,8 @@ conditionalTest({ min: 16 })('should report ANR when event loop blocked', () => 
     let hasClosed = false;
 
     setTimeout(() => {
-      if (!hasClosed) {
-        done();
-      }
+      expect(hasClosed).toBe(true);
+      done();
     }, 5_000);
 
     childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (_, stdout) => {

--- a/packages/node/src/integrations/anr/index.ts
+++ b/packages/node/src/integrations/anr/index.ts
@@ -123,6 +123,10 @@ async function _startWorker(client: NodeClient, _options: Partial<Options>): Pro
   // Ensure this thread can't block app exit
   worker.unref();
 
+  process.on('exit', () => {
+    worker.terminate();
+  });
+
   const timer = setInterval(() => {
     try {
       const currentSession = getCurrentScope().getSession();
@@ -135,6 +139,8 @@ async function _startWorker(client: NodeClient, _options: Partial<Options>): Pro
       //
     }
   }, options.pollInterval);
+  // Timer should not block exit
+  timer.unref();
 
   worker.on('message', (msg: string) => {
     if (msg === 'session-ended') {


### PR DESCRIPTION
Closes #10022

This could have also been fixed by notifying the worker to disconnect the debugger but this seems simpler.
