### PR TITLE
ref: Deprecate `lastEventId()`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -44,6 +44,25 @@ Instead, import this directly from `@sentry/utils`.
 
 Generally, in most cases you should probably use `continueTrace` instead, which abstracts this away from you and handles scope propagation for you.
 
+## Deprecate `lastEventId()`
+
+Instead, if you need the ID of a recently captured event, we recommend using `beforeSend` instead:
+
+```ts
+import * as Sentry from "@sentry/browser";
+
+Sentry.init({
+  dsn: "__DSN__",
+  beforeSend(event, hint) {
+    const lastCapturedEventId = event.event_id;
+
+    // Do something with `lastCapturedEventId` here
+    
+    return event;
+  },
+});
+```
+
 ## Deprecate `timestampWithMs` export - #7878
 
 The `timestampWithMs` util is deprecated in favor of using `timestampInSeconds`.

--- a/packages/angular/src/errorhandler.ts
+++ b/packages/angular/src/errorhandler.ts
@@ -13,7 +13,8 @@ import { runOutsideAngular } from './zone';
 export interface ErrorHandlerOptions {
   logErrors?: boolean;
   showDialog?: boolean;
-  dialogOptions?: Sentry.ReportDialogOptions;
+  // eslint-disable-next-line deprecation/deprecation
+  dialogOptions?: Omit<Sentry.ReportDialogOptions, 'eventId'>;
   /**
    * Custom implementation of error extraction from the raw value captured by the Angular.
    * @param error Value captured by Angular's ErrorHandler provider
@@ -120,6 +121,7 @@ class SentryErrorHandler implements AngularErrorHandler {
       if (client && client.on && !this._registeredAfterSendEventHandler) {
         client.on('afterSendEvent', (event: Event) => {
           if (!event.type) {
+            // eslint-disable-next-line deprecation/deprecation
             Sentry.showReportDialog({ ...this._options.dialogOptions, eventId: event.event_id });
           }
         });

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -47,6 +47,7 @@ export {
   makeNodeTransport,
   defaultIntegrations,
   defaultStackParser,
+  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   flush,
   close,

--- a/packages/astro/src/index.types.ts
+++ b/packages/astro/src/index.types.ts
@@ -21,6 +21,10 @@ export declare const defaultStackParser: StackParser;
 
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
+
+/**
+ * @deprecated This function will be removed in the next major version of the Sentry SDK.
+ */
 export declare function lastEventId(): string | undefined;
 
 export default sentryAstro;

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -18,6 +18,8 @@ export type {
 } from '@sentry/types';
 
 export type { BrowserOptions } from './client';
+
+// eslint-disable-next-line deprecation/deprecation
 export type { ReportDialogOptions } from './helpers';
 
 export {
@@ -39,6 +41,7 @@ export {
   getClient,
   getCurrentScope,
   Hub,
+  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   makeMain,
   Scope,

--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -156,6 +156,8 @@ export function wrap(
 
 /**
  * All properties the report dialog supports
+ *
+ * @deprecated This type will be removed in the next major version of the Sentry SDK. `showReportDialog` will still be around, however the `eventId` option will now be required.
  */
 export interface ReportDialogOptions {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -133,12 +133,32 @@ export function init(options: BrowserOptions = {}): void {
   }
 }
 
-/**
- * Present the user with a report dialog.
- *
- * @param options Everything is optional, we try to fetch all info need from the global scope.
- */
-export function showReportDialog(options: ReportDialogOptions = {}, hub: Hub = getCurrentHub()): void {
+type NewReportDialogOptions = ReportDialogOptions & { eventId: string }; // eslint-disable-line
+
+interface ShowReportDialogFunction {
+  /**
+   * Present the user with a report dialog.
+   *
+   * @param options Everything is optional, we try to fetch all info need from the global scope.
+   */
+  (options: NewReportDialogOptions): void;
+
+  /**
+   * Present the user with a report dialog.
+   *
+   * @param options Everything is optional, we try to fetch all info need from the global scope.
+   *
+   * @deprecated Please always pass an `options` argument with `eventId`. The `hub` argument will not be used in the next version of the SDK.
+   */
+  // eslint-disable-next-line deprecation/deprecation
+  (options?: ReportDialogOptions, hub?: Hub): void;
+}
+
+export const showReportDialog: ShowReportDialogFunction = (
+  // eslint-disable-next-line deprecation/deprecation
+  options: ReportDialogOptions = {},
+  hub: Hub = getCurrentHub(),
+) => {
   // doesn't work without a document (React Native)
   if (!WINDOW.document) {
     DEBUG_BUILD && logger.error('Global document not defined in showReportDialog call');
@@ -159,7 +179,10 @@ export function showReportDialog(options: ReportDialogOptions = {}, hub: Hub = g
     };
   }
 
+  // TODO(v8): Remove this entire if statement. `eventId` will be a required option.
+  // eslint-disable-next-line deprecation/deprecation
   if (!options.eventId) {
+    // eslint-disable-next-line deprecation/deprecation
     options.eventId = hub.lastEventId();
   }
 
@@ -192,7 +215,7 @@ export function showReportDialog(options: ReportDialogOptions = {}, hub: Hub = g
   } else {
     DEBUG_BUILD && logger.error('Not injecting report dialog. No injection point found in HTML');
   }
-}
+};
 
 /**
  * This function is here to be API compatible with the loader.

--- a/packages/browser/test/unit/index.test.ts
+++ b/packages/browser/test/unit/index.test.ts
@@ -88,6 +88,7 @@ describe('SentryBrowser', () => {
         getCurrentScope().setUser(EX_USER);
         getCurrentHub().bindClient(client);
 
+        // eslint-disable-next-line deprecation/deprecation
         showReportDialog();
 
         expect(getReportDialogEndpoint).toHaveBeenCalledTimes(1);
@@ -102,6 +103,7 @@ describe('SentryBrowser', () => {
         getCurrentHub().bindClient(client);
 
         const DIALOG_OPTION_USER = { email: 'option@example.com' };
+        // eslint-disable-next-line deprecation/deprecation
         showReportDialog({ user: DIALOG_OPTION_USER });
 
         expect(getReportDialogEndpoint).toHaveBeenCalledTimes(1);
@@ -135,6 +137,7 @@ describe('SentryBrowser', () => {
 
       it('should call `onClose` when receiving `__sentry_reportdialog_closed__` MessageEvent', async () => {
         const onClose = jest.fn();
+        // eslint-disable-next-line deprecation/deprecation
         showReportDialog({ onClose });
 
         await waitForPostMessage('__sentry_reportdialog_closed__');
@@ -149,6 +152,7 @@ describe('SentryBrowser', () => {
         const onClose = jest.fn(() => {
           throw new Error();
         });
+        // eslint-disable-next-line deprecation/deprecation
         showReportDialog({ onClose });
 
         await waitForPostMessage('__sentry_reportdialog_closed__');
@@ -161,6 +165,7 @@ describe('SentryBrowser', () => {
 
       it('should not call `onClose` for other MessageEvents', async () => {
         const onClose = jest.fn();
+        // eslint-disable-next-line deprecation/deprecation
         showReportDialog({ onClose });
 
         await waitForPostMessage('some_message');

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -47,6 +47,7 @@ export {
   getGlobalScope,
   getIsolationScope,
   Hub,
+  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   makeMain,
   runWithAsyncContext,

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -300,6 +300,7 @@ export async function close(timeout?: number): Promise<boolean> {
  * This is the getter for lastEventId.
  *
  * @returns The last event id of a captured event.
+ * @deprecated This function will be removed in the next major version of the Sentry SDK.
  */
 export function lastEventId(): string | undefined {
   return getCurrentHub().lastEventId();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   configureScope,
   flush,
+  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   startTransaction,
   setContext,

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -46,6 +46,7 @@ export {
   getGlobalScope,
   getIsolationScope,
   Hub,
+  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   makeMain,
   runWithAsyncContext,

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -22,6 +22,7 @@ export {
   captureMessage,
   addGlobalEventProcessor,
   addEventProcessor,
+  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   setContext,
   setExtra,

--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -56,7 +56,10 @@ export function withIsolationScope<T>(callback: (isolationScope: Scope) => T): T
   });
 }
 
-/** Get the ID of the last sent error event. */
+/**
+ * Get the ID of the last sent error event.
+ * @deprecated This function will be removed in the next major version of the Sentry SDK.
+ */
 export function lastEventId(): string | undefined {
   return getCurrentScope().lastEventId();
 }

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -46,6 +46,7 @@ export {
   getGlobalScope,
   getIsolationScope,
   Hub,
+  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   makeMain,
   runWithAsyncContext,

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -28,7 +28,8 @@ export type ErrorBoundaryProps = {
    * Options to be passed into the Sentry report dialog.
    * No-op if {@link showDialog} is false.
    */
-  dialogOptions?: ReportDialogOptions | undefined;
+  // eslint-disable-next-line deprecation/deprecation
+  dialogOptions?: Omit<ReportDialogOptions, 'eventId'> | undefined;
   /**
    * A fallback component that gets rendered when the error boundary encounters an error.
    *
@@ -111,6 +112,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
       this._openFallbackReportDialog = false;
       client.on('afterSendEvent', event => {
         if (!event.type && event.event_id === this._lastEventId) {
+          // eslint-disable-next-line deprecation/deprecation
           showReportDialog({ ...props.dialogOptions, eventId: this._lastEventId });
         }
       });

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -46,6 +46,7 @@ export {
   makeNodeTransport,
   defaultIntegrations,
   defaultStackParser,
+  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   flush,
   close,

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -25,4 +25,9 @@ declare const runtime: 'client' | 'server';
 
 export const close = runtime === 'client' ? clientSdk.close : serverSdk.close;
 export const flush = runtime === 'client' ? clientSdk.flush : serverSdk.flush;
+
+/**
+ * @deprecated This function will be removed in the next major version of the Sentry SDK.
+ */
+// eslint-disable-next-line deprecation/deprecation
 export const lastEventId = runtime === 'client' ? clientSdk.lastEventId : serverSdk.lastEventId;

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -51,6 +51,7 @@ export {
   flush,
   getSentryRelease,
   init,
+  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   DEFAULT_USER_INCLUDES,
   addRequestDataToEvent,

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -44,4 +44,8 @@ export declare const defaultStackParser: StackParser;
 
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
+
+/**
+ * @deprecated This function will be removed in the next major version of the Sentry SDK.
+ */
 export declare function lastEventId(): string | undefined;

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -44,6 +44,7 @@ export {
   makeNodeTransport,
   defaultIntegrations,
   defaultStackParser,
+  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   flush,
   close,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -46,6 +46,7 @@ export {
   getGlobalScope,
   getIsolationScope,
   Hub,
+  // eslint-disable-next-line deprecation/deprecation
   lastEventId,
   makeMain,
   runWithAsyncContext,


### PR DESCRIPTION
Deprecates `lastEventID()`.

Reasoning:
- It is only used in `showReportDialog` and we recommend everywhere to explicitly pass in an event id to that function.
- It has race-condition-like behaviour.