### PR TITLE
build: Re-enable eslint `no-unused-vars`, `no-control-regex` and `no-loss-of-precision`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,21 +24,9 @@ module.exports = {
   ],
   overrides: [
     {
-      files: ['*'],
-      rules: {
-        // Disabled because it's included with Biome's linter
-        'no-control-regex': 'off',
-      },
-    },
-    {
       files: ['*.ts', '*.tsx', '*.d.ts'],
       parserOptions: {
         project: ['tsconfig.json'],
-      },
-      rules: {
-        // Disabled because it's included with Biome's linter
-        '@typescript-eslint/no-unused-vars': 'off',
-        '@typescript-eslint/no-loss-of-precision': 'off',
       },
     },
     {

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/error-sync/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/error-sync/test.ts
@@ -13,7 +13,7 @@ sentryTest('should capture an error within a sync startSpan callback', async ({ 
   const gotoPromise = page.goto(url);
   const envelopePromise = getMultipleSentryEnvelopeRequests<Event>(page, 2);
 
-  const [_, events] = await Promise.all([gotoPromise, envelopePromise]);
+  const [, events] = await Promise.all([gotoPromise, envelopePromise]);
   const txn = events.find(event => event.type === 'transaction');
   const err = events.find(event => !event.type);
 

--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -124,7 +124,7 @@ conditionalTest({ min: 16 })('should report ANR when event loop blocked', () => 
       done();
     }, 5_000);
 
-    childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, (_, stdout) => {
+    childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, () => {
       hasClosed = true;
     });
   });

--- a/packages/core/test/lib/exports.test.ts
+++ b/packages/core/test/lib/exports.test.ts
@@ -35,7 +35,7 @@ describe('withScope', () => {
   });
 
   it('works with a return value', () => {
-    const res = withScope(scope => {
+    const res = withScope(() => {
       return 'foo';
     });
 
@@ -43,7 +43,7 @@ describe('withScope', () => {
   });
 
   it('works with an async function return value', async () => {
-    const res = withScope(async scope => {
+    const res = withScope(async () => {
       return 'foo';
     });
 

--- a/packages/core/test/lib/utils/applyScopeDataToEvent.test.ts
+++ b/packages/core/test/lib/utils/applyScopeDataToEvent.test.ts
@@ -156,9 +156,9 @@ describe('mergeScopeData', () => {
     const breadcrumb2 = { message: '2' } as Breadcrumb;
     const breadcrumb3 = { message: '3' } as Breadcrumb;
 
-    const eventProcessor1 = ((a: unknown) => null) as EventProcessor;
-    const eventProcessor2 = ((b: unknown) => null) as EventProcessor;
-    const eventProcessor3 = ((c: unknown) => null) as EventProcessor;
+    const eventProcessor1 = (() => null) as EventProcessor;
+    const eventProcessor2 = (() => null) as EventProcessor;
+    const eventProcessor3 = (() => null) as EventProcessor;
 
     const data1: ScopeData = {
       eventProcessors: [eventProcessor1],

--- a/packages/node/src/cron/node-cron.ts
+++ b/packages/node/src/cron/node-cron.ts
@@ -35,7 +35,7 @@ export function instrumentNodeCron<T>(lib: Partial<NodeCron> & T): T {
         // When 'get' is called for schedule, return a proxied version of the schedule function
         return new Proxy(target.schedule, {
           apply(target, thisArg, argArray: Parameters<NodeCron['schedule']>) {
-            const [expression, _, options] = argArray;
+            const [expression, , options] = argArray;
 
             if (!options?.name) {
               throw new Error('Missing "name" for scheduled job. A name is required for Sentry check-in monitoring.');

--- a/packages/node/test/cron.test.ts
+++ b/packages/node/test/cron.test.ts
@@ -53,7 +53,7 @@ describe('cron check-ins', () => {
 
       const CronJobWithCheckIn = cron.instrumentCron(CronJobMock, 'my-cron-job');
 
-      const _ = new CronJobWithCheckIn('* * * Jan,Sep Sun', () => {
+      new CronJobWithCheckIn('* * * Jan,Sep Sun', () => {
         expect(withMonitorSpy).toHaveBeenCalledTimes(1);
         expect(withMonitorSpy).toHaveBeenLastCalledWith('my-cron-job', expect.anything(), {
           schedule: { type: 'crontab', value: '* * * 1,9 0' },
@@ -67,7 +67,7 @@ describe('cron check-ins', () => {
 
       const CronJobWithCheckIn = cron.instrumentCron(CronJobMock, 'my-cron-job');
 
-      const _ = CronJobWithCheckIn.from({
+      CronJobWithCheckIn.from({
         cronTime: '* * * Jan,Sep Sun',
         onTick: () => {
           expect(withMonitorSpy).toHaveBeenCalledTimes(1);

--- a/packages/opentelemetry/src/custom/client.ts
+++ b/packages/opentelemetry/src/custom/client.ts
@@ -71,7 +71,7 @@ export function wrapClientClass<
       event: Event,
       hint: EventHint,
       scope?: Scope,
-      isolationScope?: Scope,
+      _isolationScope?: Scope,
     ): PromiseLike<Event | null> {
       let actualScope = scope;
 

--- a/packages/opentelemetry/src/spanProcessor.ts
+++ b/packages/opentelemetry/src/spanProcessor.ts
@@ -12,7 +12,7 @@ import { maybeCaptureExceptionForTimedEvent } from './utils/captureExceptionForT
 import { getHubFromContext } from './utils/contextData';
 import { getSpanHub, setSpanFinishScope, setSpanHub, setSpanParent, setSpanScope } from './utils/spanData';
 
-function onSpanStart(span: Span, parentContext: Context, ScopeClass: typeof OpenTelemetryScope): void {
+function onSpanStart(span: Span, parentContext: Context, _ScopeClass: typeof OpenTelemetryScope): void {
   // This is a reliable way to get the parent span - because this is exactly how the parent is identified in the OTEL SDK
   const parentSpan = trace.getSpan(parentContext);
   const hub = getHubFromContext(parentContext);

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -39,9 +39,7 @@ const fakeCallback: Callback = (err, result) => {
   return err;
 };
 
-function expectScopeSettings(fakeTransactionContext: any) {
-  // @ts-expect-error see "Why @ts-expect-error" note
-  const fakeSpan = { ...SentryNode.fakeSpan, ...fakeTransactionContext };
+function expectScopeSettings() {
   // @ts-expect-error see "Why @ts-expect-error" note
   expect(SentryNode.fakeScope.setTransactionName).toBeCalledWith('functionName');
   // @ts-expect-error see "Why @ts-expect-error" note
@@ -213,7 +211,7 @@ describe('AWSLambda', () => {
 
       expect(rv).toStrictEqual(42);
       expect(SentryNode.startSpanManual).toBeCalledWith(fakeTransactionContext, expect.any(Function));
-      expectScopeSettings(fakeTransactionContext);
+      expectScopeSettings();
       // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeSpan.end).toBeCalled();
       expect(SentryNode.flush).toBeCalledWith(2000);
@@ -239,7 +237,7 @@ describe('AWSLambda', () => {
         };
 
         expect(SentryNode.startSpanManual).toBeCalledWith(fakeTransactionContext, expect.any(Function));
-        expectScopeSettings(fakeTransactionContext);
+        expectScopeSettings();
         expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
         // @ts-expect-error see "Why @ts-expect-error" note
         expect(SentryNode.fakeSpan.end).toBeCalled();
@@ -317,7 +315,7 @@ describe('AWSLambda', () => {
         };
 
         expect(SentryNode.startSpanManual).toBeCalledWith(fakeTransactionContext, expect.any(Function));
-        expectScopeSettings(fakeTransactionContext);
+        expectScopeSettings();
         expect(SentryNode.captureException).toBeCalledWith(e, expect.any(Function));
         // @ts-expect-error see "Why @ts-expect-error" note
         expect(SentryNode.fakeSpan.end).toBeCalled();
@@ -345,7 +343,7 @@ describe('AWSLambda', () => {
 
       expect(rv).toStrictEqual(42);
       expect(SentryNode.startSpanManual).toBeCalledWith(fakeTransactionContext, expect.any(Function));
-      expectScopeSettings(fakeTransactionContext);
+      expectScopeSettings();
       // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeSpan.end).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
@@ -382,7 +380,7 @@ describe('AWSLambda', () => {
         };
 
         expect(SentryNode.startSpanManual).toBeCalledWith(fakeTransactionContext, expect.any(Function));
-        expectScopeSettings(fakeTransactionContext);
+        expectScopeSettings();
         expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
         // @ts-expect-error see "Why @ts-expect-error" note
         expect(SentryNode.fakeSpan.end).toBeCalled();
@@ -425,7 +423,7 @@ describe('AWSLambda', () => {
 
       expect(rv).toStrictEqual(42);
       expect(SentryNode.startSpanManual).toBeCalledWith(fakeTransactionContext, expect.any(Function));
-      expectScopeSettings(fakeTransactionContext);
+      expectScopeSettings();
       // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeSpan.end).toBeCalled();
       expect(SentryNode.flush).toBeCalled();
@@ -462,7 +460,7 @@ describe('AWSLambda', () => {
         };
 
         expect(SentryNode.startSpanManual).toBeCalledWith(fakeTransactionContext, expect.any(Function));
-        expectScopeSettings(fakeTransactionContext);
+        expectScopeSettings();
         expect(SentryNode.captureException).toBeCalledWith(error, expect.any(Function));
         // @ts-expect-error see "Why @ts-expect-error" note
         expect(SentryNode.fakeSpan.end).toBeCalled();

--- a/packages/types/src/metrics.ts
+++ b/packages/types/src/metrics.ts
@@ -16,7 +16,7 @@ export abstract class MetricInstance {
   /**
    * Adds a value to a metric.
    */
-  public add(value: number | string): void {
+  public add(): void {
     // Override this.
   }
 

--- a/packages/types/src/metrics.ts
+++ b/packages/types/src/metrics.ts
@@ -5,27 +5,21 @@ import type { Primitive } from './misc';
  * An abstract definition of the minimum required API
  * for a metric instance.
  */
-export abstract class MetricInstance {
+export interface MetricInstance {
   /**
    * Returns the weight of the metric.
    */
-  public get weight(): number {
-    return 1;
-  }
+  weight: number;
 
   /**
    * Adds a value to a metric.
    */
-  public add(): void {
-    // Override this.
-  }
+  add(value: number | string): void;
 
   /**
    * Serializes the metric into a statsd format string.
    */
-  public toString(): string {
-    return '';
-  }
+  toString(): string;
 }
 
 export interface MetricBucketItem {


### PR DESCRIPTION
This effectively undoes changes done in https://github.com/getsentry/sentry-javascript/pull/9692

Our lint job passes even though we clearly have unused variables in our code base. Example: https://github.com/getsentry/sentry-javascript/pull/10012#discussion_r1440651940

This makes me not trust biome so I am adding back the eslint rules.