### PR TITLE
build: Fix nx-config for lint

### DIFF
--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -45,6 +45,9 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
     "@playwright/test": "^1.31.1",
+    "@sentry/browser": "7.91.0",
+    "@sentry/tracing": "7.91.0",
+    "@sentry-internal/rrweb": "2.6.0",
     "axios": "1.6.0",
     "babel-loader": "^8.2.2",
     "html-webpack-plugin": "^5.5.0",

--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -18,6 +18,8 @@
     "test:watch": "yarn test --watch"
   },
   "dependencies": {
+    "@sentry/node": "7.91.0",
+    "@sentry/tracing": "7.91.0",
     "@prisma/client": "3.15.2",
     "@types/mongodb": "^3.6.20",
     "@types/mysql": "^2.15.21",

--- a/nx.json
+++ b/nx.json
@@ -3,14 +3,7 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": [
-          "build:bundle",
-          "build:transpile",
-          "build:types",
-          "lint:eslint",
-          "test:unit",
-          "build:tarball"
-        ],
+        "cacheableOperations": ["build:bundle", "build:transpile", "build:types", "lint", "test:unit", "build:tarball"],
         "cacheDirectory": ".nxcache"
       }
     }
@@ -41,7 +34,7 @@
       "dependsOn": ["^build:types"],
       "outputs": ["{projectRoot}/build/**/*.d.ts"]
     },
-    "lint:eslint": {
+    "lint": {
       "inputs": ["default"],
       "outputs": []
     },

--- a/nx.json
+++ b/nx.json
@@ -27,7 +27,7 @@
     "build:transpile": {
       "inputs": ["production", "^production"],
       "dependsOn": ["^build:transpile"],
-      "outputs": ["{projectRoot}/build/npm", "{projectRoot}/build/esm", "{projectRoot}/build/cjs"]
+      "outputs": ["{projectRoot}/build"]
     },
     "build:types": {
       "inputs": ["production", "^production"],

--- a/nx.json
+++ b/nx.json
@@ -36,6 +36,7 @@
     },
     "lint": {
       "inputs": ["default"],
+      "dependsOn": ["^build:types", "build:types"],
       "outputs": []
     },
     "test:unit": {


### PR DESCRIPTION
I ran into some funky behaviour where I had to run the `lint` script multiple times in order for all lint errors to be printed to me in the terminal.

Then I realized this mistake in our Nx config that we hadn't referenced the `lint` script but the `lint:eslint` script which doesn't exist.

I think this got introduced in https://github.com/getsentry/sentry-javascript/commit/5658aff81776c52c9219d9c02342c8a59d197a4a

Additionally, lint technically depends on `build:types` of the parent package, and in some cases even in the own package (Next.js), so I added that to the nx config.

Also, we were not marking the right outputs of build, so we're fixing that.