### PR TITLE
meta: Disable biome quickfix in vscode config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,7 +37,6 @@
   "deno.enablePaths": ["packages/deno/test"],
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "explicit",
-    "quickfix.biome": "explicit"
   },
   "editor.defaultFormatter": "biomejs.biome"
 }


### PR DESCRIPTION
This setting is incredibly buggy. It deletes a bunch of whitespace when I type "// TODO (" for example.