### PR TITLE
feat(core): Deprecate span `tags`, `data`, `context` & setters

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -100,6 +100,11 @@ In v8, the Span class is heavily reworked. The following properties & methods ar
 * `span.description`: Use `spanToJSON(span).description` instead.
 * `transaction.setMetadata()`: Use attributes instead, or set data on the scope.
 * `transaction.metadata`: Use attributes instead, or set data on the scope.
+* `span.tags`: Set tags on the surrounding scope instead, or use attributes.
+* `span.data`: Use `spanToJSON(span).data` instead.
+* `span.setTag()`: Use `span.setAttribute()` instead or set tags on the surrounding scope.
+* `span.setData()`: Use `span.setAttribute()` instead.
+* `transaction.setContext()`: Set context on the surrounding scope instead.
 
 ## Deprecate `pushScope` & `popScope` in favor of `withScope`
 

--- a/dev-packages/browser-integration-tests/suites/public-api/startTransaction/basic_usage/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/startTransaction/basic_usage/test.ts
@@ -31,6 +31,7 @@ sentryTest('should report finished spans as children of the root transaction', a
   const span_1 = transaction.spans?.[0];
   expect(span_1?.op).toBe('span_1');
   expect(span_1?.parentSpanId).toEqual(rootSpanId);
+  // eslint-disable-next-line deprecation/deprecation
   expect(span_1?.data).toMatchObject({ foo: 'bar', baz: [1, 2, 3] });
 
   const span_3 = transaction.spans?.[1];

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/transactions.test.ts
@@ -130,9 +130,9 @@ test('Should send a transaction for instrumented server actions', async ({ page 
   await page.getByText('Run Action').click();
 
   expect(await serverComponentTransactionPromise).toBeDefined();
-  expect((await serverComponentTransactionPromise).contexts?.trace?.data?.['server_action_form_data']).toEqual(
-    expect.objectContaining({ 'some-text-value': 'some-default-value' }),
-  );
+  expect(
+    (await serverComponentTransactionPromise).contexts?.trace?.data?.['server_action_form_data.some-text-value'],
+  ).toEqual('some-default-value');
   expect((await serverComponentTransactionPromise).contexts?.trace?.data?.['server_action_result']).toEqual({
     city: 'Vienna',
   });

--- a/dev-packages/node-integration-tests/suites/tracing-new/auto-instrument/mysql/withoutCallback/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-new/auto-instrument/mysql/withoutCallback/scenario.ts
@@ -32,10 +32,10 @@ const query = connection.query('SELECT 1 + 1 AS solution');
 const query2 = connection.query('SELECT NOW()', ['1', '2']);
 
 query.on('end', () => {
-  transaction.setTag('result_done', 'yes');
+  transaction.setAttribute('result_done', 'yes');
 
   query2.on('end', () => {
-    transaction.setTag('result_done2', 'yes');
+    transaction.setAttribute('result_done2', 'yes');
 
     // Wait a bit to ensure the queries completed
     setTimeout(() => {

--- a/dev-packages/node-integration-tests/suites/tracing-new/auto-instrument/mysql/withoutCallback/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-new/auto-instrument/mysql/withoutCallback/test.ts
@@ -7,11 +7,15 @@ test('should auto-instrument `mysql` package when using query without callback',
   expect(envelope).toHaveLength(3);
 
   assertSentryTransaction(envelope[2], {
-    transaction: 'Test Transaction',
-    tags: {
-      result_done: 'yes',
-      result_done2: 'yes',
+    contexts: {
+      trace: {
+        data: {
+          result_done: 'yes',
+          result_done2: 'yes',
+        },
+      },
     },
+    transaction: 'Test Transaction',
     spans: [
       {
         description: 'SELECT 1 + 1 AS solution',

--- a/docs/v8-new-performance-apis.md
+++ b/docs/v8-new-performance-apis.md
@@ -50,8 +50,8 @@ below to see which things used to exist, and how they can/should be mapped going
 | `status`              | use utility method TODO                              |
 | `sampled`             | `spanIsSampled(span)`                                |
 | `startTimestamp`      | `startTime` - note that this has a different format! |
-| `tags`                | `spanGetAttributes(span)`, or set tags on the scope  |
-| `data`                | `spanGetAttributes(span)`                            |
+| `tags`                | use attributes, or set tags on the scope             |
+| `data`                | `spanToJSON(span).data`                              |
 | `transaction`         | ??? Removed                                          |
 | `instrumenter`        | Removed                                              |
 | `finish()`            | `end()`                                              |
@@ -72,13 +72,13 @@ In addition, a transaction has this API:
 
 | Old name                    | Replace with                                     |
 | --------------------------- | ------------------------------------------------ |
-| `name`                      | `spanGetName(span)` (TODO)                       |
+| `name`                      | `spanToJSON(span).description`                   |
 | `trimEnd`                   | Removed                                          |
 | `parentSampled`             | `spanIsSampled(span)` & `spanContext().isRemote` |
-| `metadata`                  | `spanGetMetadata(span)`                          |
+| `metadata`                  | Use attributes instead or set on scope           |
 | `setContext()`              | Set context on scope instead                     |
 | `setMeasurement()`          | ??? TODO                                         |
-| `setMetadata()`             | `spanSetMetadata(span, metadata)`                |
+| `setMetadata()`             | Use attributes instead or set on scope           |
 | `getDynamicSamplingContext` | ??? TODO                                         |
 
 ### Attributes vs. Data vs. Tags vs. Context

--- a/packages/browser/src/profiling/hubextensions.ts
+++ b/packages/browser/src/profiling/hubextensions.ts
@@ -156,6 +156,8 @@ export function startProfileForTransaction(transaction: Transaction): Transactio
     // Always call onProfileHandler to ensure stopProfiling is called and the timeout is cleared.
     void onProfileHandler().then(
       () => {
+        // TODO: Can we rewrite this to use attributes?
+        // eslint-disable-next-line deprecation/deprecation
         transaction.setContext('profile', { profile_id: profileId, start_timestamp: startTimestamp });
         originalEnd();
       },

--- a/packages/bun/src/integrations/bunserver.ts
+++ b/packages/bun/src/integrations/bunserver.ts
@@ -4,6 +4,7 @@ import {
   captureException,
   continueTrace,
   convertIntegrationFnToClass,
+  getCurrentScope,
   runWithAsyncContext,
   startSpan,
 } from '@sentry/core';
@@ -90,9 +91,10 @@ function instrumentBunServeOptions(serveOptions: Parameters<typeof Bun.serve>[0]
                   >);
                   if (response && response.status) {
                     span?.setHttpStatus(response.status);
-                    span?.setData('http.response.status_code', response.status);
+                    span?.setAttribute('http.response.status_code', response.status);
                     if (span instanceof Transaction) {
-                      span.setContext('response', {
+                      const scope = getCurrentScope();
+                      scope.setContext('response', {
                         headers: response.headers.toJSON(),
                         status_code: response.status,
                       });

--- a/packages/bun/test/integrations/bunserver.test.ts
+++ b/packages/bun/test/integrations/bunserver.test.ts
@@ -26,6 +26,7 @@ describe('Bun Serve Integration', () => {
   test('generates a transaction around a request', async () => {
     client.on('finishTransaction', transaction => {
       expect(transaction.status).toBe('ok');
+      // eslint-disable-next-line deprecation/deprecation
       expect(transaction.tags).toEqual({
         'http.status_code': '200',
       });
@@ -48,6 +49,7 @@ describe('Bun Serve Integration', () => {
   test('generates a post transaction', async () => {
     client.on('finishTransaction', transaction => {
       expect(transaction.status).toBe('ok');
+      // eslint-disable-next-line deprecation/deprecation
       expect(transaction.tags).toEqual({
         'http.status_code': '200',
       });

--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -146,7 +146,7 @@ export class IdleTransaction extends Transaction {
     this.activities = {};
 
     if (this.op === 'ui.action.click') {
-      this.setTag(FINISH_REASON_TAG, this._finishReason);
+      this.setAttribute(FINISH_REASON_TAG, this._finishReason);
     }
 
     if (this.spanRecorder) {

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -110,11 +110,11 @@ export class Transaction extends SpanClass implements TransactionInterface {
       ...this._metadata,
 
       // From attributes
-      ...(this.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] && {
-        source: this.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] as TransactionMetadata['source'],
+      ...(this._attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] && {
+        source: this._attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] as TransactionMetadata['source'],
       }),
-      ...(this.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE] && {
-        sampleRate: this.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE] as TransactionMetadata['sampleRate'],
+      ...(this._attributes[SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE] && {
+        sampleRate: this._attributes[SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE] as TransactionMetadata['sampleRate'],
       }),
     };
   }
@@ -157,7 +157,8 @@ export class Transaction extends SpanClass implements TransactionInterface {
   }
 
   /**
-   * @inheritDoc
+   * Set the context of a transaction event.
+   * @deprecated Use either `.setAttribute()`, or set the context on the scope before creating the transaction.
    */
   public setContext(key: string, context: Context | null): void {
     if (context === null) {
@@ -334,6 +335,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
       // TODO: Pass spans serialized via `spanToJSON()` here instead in v8.
       spans: finishedSpans,
       start_timestamp: this.startTimestamp,
+      // eslint-disable-next-line deprecation/deprecation
       tags: this.tags,
       timestamp: this.endTimestamp,
       transaction: this._name,

--- a/packages/core/test/lib/tracing/span.test.ts
+++ b/packages/core/test/lib/tracing/span.test.ts
@@ -74,7 +74,7 @@ describe('span', () => {
       span.setAttribute('boolArray', [true, false]);
       span.setAttribute('arrayWithUndefined', [1, undefined, 2]);
 
-      expect(span.attributes).toEqual({
+      expect(span['_attributes']).toEqual({
         str: 'bar',
         num: 1,
         zero: 0,
@@ -92,11 +92,11 @@ describe('span', () => {
 
       span.setAttribute('str', 'bar');
 
-      expect(Object.keys(span.attributes).length).toEqual(1);
+      expect(Object.keys(span['_attributes']).length).toEqual(1);
 
       span.setAttribute('str', undefined);
 
-      expect(Object.keys(span.attributes).length).toEqual(0);
+      expect(Object.keys(span['_attributes']).length).toEqual(0);
     });
 
     it('disallows invalid attribute types', () => {
@@ -117,7 +117,7 @@ describe('span', () => {
     it('allows to set attributes', () => {
       const span = new Span();
 
-      const initialAttributes = span.attributes;
+      const initialAttributes = span['_attributes'];
 
       expect(initialAttributes).toEqual({});
 
@@ -135,7 +135,7 @@ describe('span', () => {
       };
       span.setAttributes(newAttributes);
 
-      expect(span.attributes).toEqual({
+      expect(span['_attributes']).toEqual({
         str: 'bar',
         num: 1,
         zero: 0,
@@ -147,14 +147,14 @@ describe('span', () => {
         arrayWithUndefined: [1, undefined, 2],
       });
 
-      expect(span.attributes).not.toBe(newAttributes);
+      expect(span['_attributes']).not.toBe(newAttributes);
 
       span.setAttributes({
         num: 2,
         numArray: [3, 4],
       });
 
-      expect(span.attributes).toEqual({
+      expect(span['_attributes']).toEqual({
         str: 'bar',
         num: 2,
         zero: 0,
@@ -172,11 +172,11 @@ describe('span', () => {
 
       span.setAttribute('str', 'bar');
 
-      expect(Object.keys(span.attributes).length).toEqual(1);
+      expect(Object.keys(span['_attributes']).length).toEqual(1);
 
       span.setAttributes({ str: undefined });
 
-      expect(Object.keys(span.attributes).length).toEqual(0);
+      expect(Object.keys(span['_attributes']).length).toEqual(0);
     });
   });
 
@@ -270,9 +270,11 @@ describe('span', () => {
 
     it('works with data only', () => {
       const span = new Span();
+      // eslint-disable-next-line deprecation/deprecation
       span.setData('foo', 'bar');
 
       expect(span['_getData']()).toEqual({ foo: 'bar' });
+      // eslint-disable-next-line deprecation/deprecation
       expect(span['_getData']()).toBe(span.data);
     });
 
@@ -281,6 +283,7 @@ describe('span', () => {
       span.setAttribute('foo', 'bar');
 
       expect(span['_getData']()).toEqual({ foo: 'bar' });
+      // eslint-disable-next-line deprecation/deprecation
       expect(span['_getData']()).toBe(span.attributes);
     });
 
@@ -288,11 +291,15 @@ describe('span', () => {
       const span = new Span();
       span.setAttribute('foo', 'foo');
       span.setAttribute('bar', 'bar');
+      // eslint-disable-next-line deprecation/deprecation
       span.setData('foo', 'foo2');
+      // eslint-disable-next-line deprecation/deprecation
       span.setData('baz', 'baz');
 
       expect(span['_getData']()).toEqual({ foo: 'foo', bar: 'bar', baz: 'baz' });
+      // eslint-disable-next-line deprecation/deprecation
       expect(span['_getData']()).not.toBe(span.attributes);
+      // eslint-disable-next-line deprecation/deprecation
       expect(span['_getData']()).not.toBe(span.data);
     });
   });

--- a/packages/nextjs/src/common/withServerActionInstrumentation.ts
+++ b/packages/nextjs/src/common/withServerActionInstrumentation.ts
@@ -104,19 +104,16 @@ async function withServerActionInstrumentationImplementation<A extends (...args:
           });
 
           if (options.recordResponse !== undefined ? options.recordResponse : sendDefaultPii) {
-            span?.setData('server_action_result', result);
+            span?.setAttribute('server_action_result', result);
           }
 
           if (options.formData) {
-            const formDataObject: Record<string, unknown> = {};
             options.formData.forEach((value, key) => {
-              if (typeof value === 'string') {
-                formDataObject[key] = value;
-              } else {
-                formDataObject[key] = '[non-string value]';
-              }
+              span?.setAttribute(
+                `server_action_form_data.${key}`,
+                typeof value === 'string' ? value : '[non-string value]',
+              );
             });
-            span?.setData('server_action_form_data', formDataObject);
           }
 
           return result;

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -351,6 +351,8 @@ export function trpcMiddleware(options: SentryTrpcMiddlewareOptions = {}) {
         trpcContext.input = normalize(rawInput);
       }
 
+      // TODO: Can we rewrite this to an attribute? Or set this on the scope?
+      // eslint-disable-next-line deprecation/deprecation
       sentryTransaction.setContext('trpc', trpcContext);
     }
 

--- a/packages/node/src/integrations/hapi/types.ts
+++ b/packages/node/src/integrations/hapi/types.ts
@@ -3,6 +3,7 @@
 /* eslint-disable @typescript-eslint/unified-signatures */
 /* eslint-disable @typescript-eslint/no-empty-interface */
 /* eslint-disable @typescript-eslint/no-namespace */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 // Vendored and simplified from:
 // - @types/hapi__hapi

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -372,8 +372,11 @@ describe('tracingHandler', () => {
     setImmediate(() => {
       expect(finishTransaction).toHaveBeenCalled();
       expect(transaction.status).toBe('ok');
+      // eslint-disable-next-line deprecation/deprecation
       expect(transaction.tags).toEqual(expect.objectContaining({ 'http.status_code': '200' }));
-      expect(transaction.data).toEqual(expect.objectContaining({ 'http.response.status_code': 200 }));
+      expect(sentryCore.spanToJSON(transaction).data).toEqual(
+        expect.objectContaining({ 'http.response.status_code': 200 }),
+      );
       done();
     });
   });

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -300,10 +300,13 @@ describe('tracing', () => {
     // our span is at index 1 because the transaction itself is at index 0
     expect(sentryCore.spanToJSON(spans[1]).description).toEqual('GET http://dogs.are.great/spaniel');
     expect(spans[1].op).toEqual('http.client');
-    expect(spans[1].data['http.method']).toEqual('GET');
-    expect(spans[1].data.url).toEqual('http://dogs.are.great/spaniel');
-    expect(spans[1].data['http.query']).toEqual('tail=wag&cute=true');
-    expect(spans[1].data['http.fragment']).toEqual('learn-more');
+
+    const spanAttributes = sentryCore.spanToJSON(spans[1]).data || {};
+
+    expect(spanAttributes['http.method']).toEqual('GET');
+    expect(spanAttributes.url).toEqual('http://dogs.are.great/spaniel');
+    expect(spanAttributes['http.query']).toEqual('tail=wag&cute=true');
+    expect(spanAttributes['http.fragment']).toEqual('learn-more');
   });
 
   it('fills in span data from http.RequestOptions object', () => {
@@ -316,13 +319,15 @@ describe('tracing', () => {
 
     expect(spans.length).toEqual(2);
 
+    const spanAttributes = sentryCore.spanToJSON(spans[1]).data || {};
+
     // our span is at index 1 because the transaction itself is at index 0
     expect(sentryCore.spanToJSON(spans[1]).description).toEqual('GET http://dogs.are.great/spaniel');
     expect(spans[1].op).toEqual('http.client');
-    expect(spans[1].data['http.method']).toEqual('GET');
-    expect(spans[1].data.url).toEqual('http://dogs.are.great/spaniel');
-    expect(spans[1].data['http.query']).toEqual('tail=wag&cute=true');
-    expect(spans[1].data['http.fragment']).toEqual('learn-more');
+    expect(spanAttributes['http.method']).toEqual('GET');
+    expect(spanAttributes.url).toEqual('http://dogs.are.great/spaniel');
+    expect(spanAttributes['http.query']).toEqual('tail=wag&cute=true');
+    expect(spanAttributes['http.fragment']).toEqual('learn-more');
   });
 
   it.each([

--- a/packages/opentelemetry-node/src/spanprocessor.ts
+++ b/packages/opentelemetry-node/src/spanprocessor.ts
@@ -194,14 +194,13 @@ function updateSpanWithOtelData(sentrySpan: SentrySpan, otelSpan: OtelSpan): voi
   const { op, description, data } = parseOtelSpanDescription(otelSpan);
 
   sentrySpan.setStatus(mapOtelStatus(otelSpan));
-  sentrySpan.setData('otel.kind', SpanKind[kind]);
 
-  const allData = { ...attributes, ...data };
-
-  Object.keys(allData).forEach(prop => {
-    const value = allData[prop];
-    sentrySpan.setData(prop, value);
-  });
+  const allData = {
+    ...attributes,
+    ...data,
+    'otel.kind': SpanKind[kind],
+  };
+  sentrySpan.setAttributes(allData);
 
   sentrySpan.op = op;
   sentrySpan.updateName(description);
@@ -210,17 +209,14 @@ function updateSpanWithOtelData(sentrySpan: SentrySpan, otelSpan: OtelSpan): voi
 function updateTransactionWithOtelData(transaction: Transaction, otelSpan: OtelSpan): void {
   const { op, description, source, data } = parseOtelSpanDescription(otelSpan);
 
+  // eslint-disable-next-line deprecation/deprecation
   transaction.setContext('otel', {
     attributes: otelSpan.attributes,
     resource: otelSpan.resource.attributes,
   });
 
   const allData = data || {};
-
-  Object.keys(allData).forEach(prop => {
-    const value = allData[prop];
-    transaction.setData(prop, value);
-  });
+  transaction.setAttributes(allData);
 
   transaction.setStatus(mapOtelStatus(otelSpan));
 

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -320,11 +320,11 @@ describe('SentrySpanProcessor', () => {
 
         const sentrySpan = getSpanForOtelSpan(child);
 
-        expect(sentrySpan?.data).toEqual({});
+        expect(spanToJSON(sentrySpan!).data).toEqual(undefined);
 
         child.end();
 
-        expect(sentrySpan?.data).toEqual({
+        expect(spanToJSON(sentrySpan!).data).toEqual({
           'otel.kind': 'INTERNAL',
           'test-attribute': 'test-value',
           'test-attribute-2': [1, 2, 3],
@@ -539,8 +539,10 @@ describe('SentrySpanProcessor', () => {
 
           child.end();
 
-          expect(sentrySpan ? spanToJSON(sentrySpan).description : undefined).toBe('GET /my/route/{id}');
-          expect(sentrySpan?.data).toEqual({
+          const { description, data } = spanToJSON(sentrySpan!);
+
+          expect(description).toBe('GET /my/route/{id}');
+          expect(data).toEqual({
             'http.method': 'GET',
             'http.route': '/my/route/{id}',
             'http.target': '/my/route/123',
@@ -567,10 +569,10 @@ describe('SentrySpanProcessor', () => {
 
           child.end();
 
-          expect(sentrySpan ? spanToJSON(sentrySpan).description : undefined).toBe(
-            'GET http://example.com/my/route/123',
-          );
-          expect(sentrySpan?.data).toEqual({
+          const { description, data } = spanToJSON(sentrySpan!);
+
+          expect(description).toBe('GET http://example.com/my/route/123');
+          expect(data).toEqual({
             'http.method': 'GET',
             'http.target': '/my/route/123',
             'http.url': 'http://example.com/my/route/123',
@@ -596,10 +598,10 @@ describe('SentrySpanProcessor', () => {
 
           child.end();
 
-          expect(sentrySpan ? spanToJSON(sentrySpan).description : undefined).toBe(
-            'GET http://example.com/my/route/123',
-          );
-          expect(sentrySpan?.data).toEqual({
+          const { description, data } = spanToJSON(sentrySpan!);
+
+          expect(description).toBe('GET http://example.com/my/route/123');
+          expect(data).toEqual({
             'http.method': 'GET',
             'http.target': '/my/route/123',
             'http.url': 'http://example.com/my/route/123?what=123#myHash',

--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -3,8 +3,8 @@ import type { ExportResult } from '@opentelemetry/core';
 import { ExportResultCode } from '@opentelemetry/core';
 import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import { flush } from '@sentry/core';
-import type { DynamicSamplingContext, Span as SentrySpan, SpanOrigin, TransactionSource } from '@sentry/types';
+import { flush, getCurrentScope } from '@sentry/core';
+import type { DynamicSamplingContext, Scope, Span as SentrySpan, SpanOrigin, TransactionSource } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import { getCurrentHub } from './custom/hub';
@@ -110,13 +110,24 @@ function maybeSend(spans: ReadableSpan[]): ReadableSpan[] {
 
     // Now finish the transaction, which will send it together with all the spans
     // We make sure to use the finish scope
-    const scope = getSpanFinishScope(span);
+    const scope = getScopeForTransactionFinish(span);
     transaction.finishWithScope(convertOtelTimeToSeconds(span.endTime), scope);
   });
 
   return Array.from(remaining)
     .map(node => node.span)
     .filter((span): span is ReadableSpan => !!span);
+}
+
+function getScopeForTransactionFinish(span: ReadableSpan): Scope {
+  // The finish scope should normally always be there (and it is already a clone),
+  // but for the sake of type safety we fall back to a clone of the current scope
+  const scope = getSpanFinishScope(span) || getCurrentScope().clone();
+  scope.setContext('otel', {
+    attributes: removeSentryAttributes(span.attributes),
+    resource: span.resource.attributes,
+  });
+  return scope;
 }
 
 function getCompletedRootNodes(nodes: SpanNode[]): SpanNodeCompleted[] {
@@ -175,11 +186,6 @@ function createTransactionForOtelSpan(span: ReadableSpan): OpenTelemetryTransact
     tags,
     sampled: true,
   }) as OpenTelemetryTransaction;
-
-  transaction.setContext('otel', {
-    attributes: removeSentryAttributes(span.attributes),
-    resource: span.resource.attributes,
-  });
 
   return transaction;
 }

--- a/packages/sveltekit/src/client/router.ts
+++ b/packages/sveltekit/src/client/router.ts
@@ -124,6 +124,7 @@ function instrumentNavigations(startTransactionFn: (context: TransactionContext)
         description: 'SvelteKit Route Change',
         origin: 'auto.ui.sveltekit',
       });
+      // eslint-disable-next-line deprecation/deprecation
       activeTransaction.setTag('from', parameterizedRouteOrigin);
     }
   });

--- a/packages/sveltekit/test/client/router.test.ts
+++ b/packages/sveltekit/test/client/router.test.ts
@@ -123,6 +123,7 @@ describe('sveltekitRoutingInstrumentation', () => {
       description: 'SvelteKit Route Change',
     });
 
+    // eslint-disable-next-line deprecation/deprecation
     expect(returnedTransaction?.setTag).toHaveBeenCalledWith('from', '/users');
 
     // We emit `null` here to simulate the end of the navigation lifecycle
@@ -173,6 +174,7 @@ describe('sveltekitRoutingInstrumentation', () => {
         description: 'SvelteKit Route Change',
       });
 
+      // eslint-disable-next-line deprecation/deprecation
       expect(returnedTransaction?.setTag).toHaveBeenCalledWith('from', '/users/[id]');
     });
 

--- a/packages/tracing-internal/src/browser/backgroundtab.ts
+++ b/packages/tracing-internal/src/browser/backgroundtab.ts
@@ -26,6 +26,8 @@ export function registerBackgroundTabDetection(): void {
         if (!activeTransaction.status) {
           activeTransaction.setStatus(statusType);
         }
+        // TODO: Can we rewrite this to an attribute?
+        // eslint-disable-next-line deprecation/deprecation
         activeTransaction.setTag('visibilitychange', 'document.hidden');
         activeTransaction.end();
       }

--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -343,6 +343,7 @@ export class BrowserTracing implements Integration {
 
     this._latestRouteName = finalContext.name;
 
+    // eslint-disable-next-line deprecation/deprecation
     const sourceFromData = context.data && context.data[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE];
     // eslint-disable-next-line deprecation/deprecation
     const sourceFromMetadata = finalContext.metadata && finalContext.metadata.source;

--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -115,7 +115,7 @@ export function startTrackingInteractions(): void {
 
         const componentName = getComponentName(entry.target);
         if (componentName) {
-          span.data = { 'ui.component_name': componentName };
+          span.attributes = { 'ui.component_name': componentName };
         }
 
         // eslint-disable-next-line deprecation/deprecation
@@ -448,10 +448,14 @@ function _trackNavigator(transaction: Transaction): void {
   const connection = navigator.connection;
   if (connection) {
     if (connection.effectiveType) {
+      // TODO: Can we rewrite this to an attribute?
+      // eslint-disable-next-line deprecation/deprecation
       transaction.setTag('effectiveConnectionType', connection.effectiveType);
     }
 
     if (connection.type) {
+      // TODO: Can we rewrite this to an attribute?
+      // eslint-disable-next-line deprecation/deprecation
       transaction.setTag('connectionType', connection.type);
     }
 
@@ -461,10 +465,14 @@ function _trackNavigator(transaction: Transaction): void {
   }
 
   if (isMeasurementValue(navigator.deviceMemory)) {
+    // TODO: Can we rewrite this to an attribute?
+    // eslint-disable-next-line deprecation/deprecation
     transaction.setTag('deviceMemory', `${navigator.deviceMemory} GB`);
   }
 
   if (isMeasurementValue(navigator.hardwareConcurrency)) {
+    // TODO: Can we rewrite this to an attribute?
+    // eslint-disable-next-line deprecation/deprecation
     transaction.setTag('hardwareConcurrency', String(navigator.hardwareConcurrency));
   }
 }
@@ -477,18 +485,26 @@ function _tagMetricInfo(transaction: Transaction): void {
     // Capture Properties of the LCP element that contributes to the LCP.
 
     if (_lcpEntry.element) {
+      // TODO: Can we rewrite this to an attribute?
+      // eslint-disable-next-line deprecation/deprecation
       transaction.setTag('lcp.element', htmlTreeAsString(_lcpEntry.element));
     }
 
     if (_lcpEntry.id) {
+      // TODO: Can we rewrite this to an attribute?
+      // eslint-disable-next-line deprecation/deprecation
       transaction.setTag('lcp.id', _lcpEntry.id);
     }
 
     if (_lcpEntry.url) {
       // Trim URL to the first 200 characters.
+      // TODO: Can we rewrite this to an attribute?
+      // eslint-disable-next-line deprecation/deprecation
       transaction.setTag('lcp.url', _lcpEntry.url.trim().slice(0, 200));
     }
 
+    // TODO: Can we rewrite this to an attribute?
+    // eslint-disable-next-line deprecation/deprecation
     transaction.setTag('lcp.size', _lcpEntry.size);
   }
 
@@ -496,6 +512,8 @@ function _tagMetricInfo(transaction: Transaction): void {
   if (_clsEntry && _clsEntry.sources) {
     DEBUG_BUILD && logger.log('[Measurements] Adding CLS Data');
     _clsEntry.sources.forEach((source, index) =>
+      // TODO: Can we rewrite this to an attribute?
+      // eslint-disable-next-line deprecation/deprecation
       transaction.setTag(`cls.source.${index + 1}`, htmlTreeAsString(source.node)),
     );
   }

--- a/packages/tracing-internal/src/common/fetch.ts
+++ b/packages/tracing-internal/src/common/fetch.ts
@@ -58,7 +58,7 @@ export function instrumentFetchRequest(
         if (contentLength) {
           const contentLengthNum = parseInt(contentLength);
           if (contentLengthNum > 0) {
-            span.setData('http.response_content_length', contentLengthNum);
+            span.setAttribute('http.response_content_length', contentLengthNum);
           }
         }
       } else if (handlerData.error) {

--- a/packages/tracing-internal/src/node/integrations/mysql.ts
+++ b/packages/tracing-internal/src/node/integrations/mysql.ts
@@ -73,7 +73,7 @@ export class Mysql implements LazyLoadedIntegration<MysqlConnection> {
       DEBUG_BUILD && logger.error('Mysql Integration was unable to instrument `mysql` config.');
     }
 
-    function spanDataFromConfig(): Record<string, unknown> {
+    function spanDataFromConfig(): Record<string, string | number | undefined> {
       if (!mySqlConfig) {
         return {};
       }
@@ -91,7 +91,7 @@ export class Mysql implements LazyLoadedIntegration<MysqlConnection> {
 
       const data = spanDataFromConfig();
       Object.keys(data).forEach(key => {
-        span.setData(key, data[key]);
+        span.setAttribute(key, data[key]);
       });
 
       span.end();

--- a/packages/tracing-internal/test/browser/backgroundtab.test.ts
+++ b/packages/tracing-internal/test/browser/backgroundtab.test.ts
@@ -55,6 +55,7 @@ conditionalTest({ min: 10 })('registerBackgroundTabDetection', () => {
       events.visibilitychange();
 
       expect(span?.status).toBe('cancelled');
+      // eslint-disable-next-line deprecation/deprecation
       expect(span?.tags.visibilitychange).toBe('document.hidden');
       expect(span?.endTimestamp).toBeDefined();
     });

--- a/packages/tracing-internal/test/browser/request.test.ts
+++ b/packages/tracing-internal/test/browser/request.test.ts
@@ -256,7 +256,7 @@ describe('callbacks', () => {
 
       expect(finishedSpan).toBeDefined();
       expect(finishedSpan).toBeInstanceOf(Span);
-      expect(finishedSpan.data).toEqual({
+      expect(sentryCore.spanToJSON(finishedSpan).data).toEqual({
         'http.response_content_length': 123,
         'http.method': 'GET',
         'http.response.status_code': 404,

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -129,11 +129,13 @@ export interface SpanContext {
 
   /**
    * Tags of the Span.
+   * @deprecated Pass `attributes` instead.
    */
   tags?: { [key: string]: Primitive };
 
   /**
    * Data of the Span.
+   * @deprecated Pass `attributes` instead.
    */
   data?: { [key: string]: any };
 
@@ -195,17 +197,20 @@ export interface Span extends SpanContext {
   startTimestamp: number;
 
   /**
-   * @inheritDoc
+   * Tags for the span.
+   * @deprecated Use `getSpanAttributes(span)` instead.
    */
   tags: { [key: string]: Primitive };
 
   /**
-   * @inheritDoc
+   * Data for the span.
+   * @deprecated Use `getSpanAttributes(span)` instead.
    */
   data: { [key: string]: any };
 
   /**
-   * @inheritDoc
+   * Attributes for the span.
+   * @deprecated Use `getSpanAttributes(span)` instead.
    */
   attributes: SpanAttributes;
 
@@ -243,6 +248,7 @@ export interface Span extends SpanContext {
    *
    * @param key Tag key
    * @param value Tag value
+   * @deprecated Use `setAttribute()` instead.
    */
   setTag(key: string, value: Primitive): this;
 
@@ -250,6 +256,7 @@ export interface Span extends SpanContext {
    * Sets the data attribute on the current span
    * @param key Data key
    * @param value Data value
+   * @deprecated Use `setAttribute()` instead.
    */
   setData(key: string, value: any): this;
 

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -74,17 +74,20 @@ export interface Transaction extends TransactionContext, Omit<Span, 'setName' | 
   startTimestamp: number;
 
   /**
-   * @inheritDoc
+   * Tags for the transaction.
+   * @deprecated Use `getSpanAttributes(transaction)` instead.
    */
   tags: { [key: string]: Primitive };
 
   /**
-   * @inheritDoc
+   * Data for the transaction.
+   * @deprecated Use `getSpanAttributes(transaction)` instead.
    */
   data: { [key: string]: any };
 
   /**
-   * @inheritDoc
+   * Attributes for the transaction.
+   * @deprecated Use `getSpanAttributes(transaction)` instead.
    */
   attributes: SpanAttributes;
 
@@ -105,7 +108,8 @@ export interface Transaction extends TransactionContext, Omit<Span, 'setName' | 
   setName(name: string, source?: TransactionMetadata['source']): void;
 
   /**
-   * Set the context of a transaction event
+   * Set the context of a transaction event.
+   * @deprecated Use either `.setAttribute()`, or set the context on the scope before creating the transaction.
    */
   setContext(key: string, context: Context): void;
 

--- a/packages/utils/src/requestdata.ts
+++ b/packages/utils/src/requestdata.ts
@@ -81,10 +81,12 @@ export function addRequestDataToTransaction(
     // eslint-disable-next-line deprecation/deprecation
     transaction.setMetadata({ source });
   }
-  transaction.setData('url', req.originalUrl || req.url);
+  transaction.setAttribute('url', req.originalUrl || req.url);
   if (req.baseUrl) {
-    transaction.setData('baseUrl', req.baseUrl);
+    transaction.setAttribute('baseUrl', req.baseUrl);
   }
+  // TODO: We need to rewrite this to a flat format?
+  // eslint-disable-next-line deprecation/deprecation
   transaction.setData('query', extractQueryParams(req, deps));
 }
 
@@ -190,6 +192,7 @@ export function extractRequestData(
   },
 ): ExtractedNodeRequestData {
   const { include = DEFAULT_REQUEST_INCLUDES, deps } = options || {};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const requestData: { [key: string]: any } = {};
 
   // headers:

--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -117,7 +117,10 @@ export function vueRouterInstrumentation(
             pageloadTransaction.updateName(transactionName);
             pageloadTransaction.setAttribute(SEMANTIC_ATTRIBUTE_SENTRY_SOURCE, transactionSource);
           }
+          // TODO: We need to flatten these to make them attributes
+          // eslint-disable-next-line deprecation/deprecation
           pageloadTransaction.setData('params', data.params);
+          // eslint-disable-next-line deprecation/deprecation
           pageloadTransaction.setData('query', data.query);
         }
       }


### PR DESCRIPTION
Also deprecate direct access to `span.attributes` (instead use `spanToJSON(span)`).

There are a few usages that we still need to figure out how we will replace them...!
