### PR TITLE
feat(core): Add `setClient()` and `getClient()` to `Scope`

### DIFF
--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -124,16 +124,33 @@ export class Hub implements HubInterface {
    */
   public constructor(
     client?: Client,
-    scope: Scope = new Scope(),
-    isolationScope = new Scope(),
+    scope?: Scope,
+    isolationScope?: Scope,
     private readonly _version: number = API_VERSION,
   ) {
-    this._stack = [{ scope }];
+    let assignedScope;
+    if (!scope) {
+      assignedScope = new Scope();
+      assignedScope.setClient(client);
+    } else {
+      assignedScope = scope;
+    }
+
+    let assignedIsolationScope;
+    if (!isolationScope) {
+      assignedIsolationScope = new Scope();
+      assignedIsolationScope.setClient(client);
+    } else {
+      assignedIsolationScope = isolationScope;
+    }
+
+    this._stack = [{ scope: assignedScope }];
+
     if (client) {
       this.bindClient(client);
     }
 
-    this._isolationScope = isolationScope;
+    this._isolationScope = assignedIsolationScope;
   }
 
   /**

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -3,6 +3,7 @@ import type {
   Attachment,
   Breadcrumb,
   CaptureContext,
+  Client,
   Context,
   Contexts,
   Event,
@@ -100,6 +101,9 @@ export class Scope implements ScopeInterface {
   /** Request Mode Session Status */
   protected _requestSession?: RequestSession;
 
+  /** The client on this scope */
+  protected _client?: Client;
+
   // NOTE: Any field which gets added here should get added not only to the constructor but also to the `clone` method.
 
   public constructor() {
@@ -144,8 +148,23 @@ export class Scope implements ScopeInterface {
     newScope._attachments = [...this._attachments];
     newScope._sdkProcessingMetadata = { ...this._sdkProcessingMetadata };
     newScope._propagationContext = { ...this._propagationContext };
+    newScope._client = this._client;
 
     return newScope;
+  }
+
+  /** Update the client on the scope. */
+  public setClient(client: Client | undefined): void {
+    this._client = client;
+  }
+
+  /**
+   * Get the client assigned to this scope.
+   *
+   * It is generally recommended to use the global function `Sentry.getClient()` instead, unless you know what you are doing.
+   */
+  public getClient(): Client | undefined {
+    return this._client;
   }
 
   /**

--- a/packages/core/test/lib/scope.test.ts
+++ b/packages/core/test/lib/scope.test.ts
@@ -1,8 +1,8 @@
-import type { Attachment, Breadcrumb } from '@sentry/types';
+import type { Attachment, Breadcrumb, Client } from '@sentry/types';
 import { applyScopeDataToEvent } from '../../src';
 import { Scope, getGlobalScope, setGlobalScope } from '../../src/scope';
 
-describe('Unit | Scope', () => {
+describe('Scope', () => {
   beforeEach(() => {
     setGlobalScope(undefined);
   });
@@ -186,5 +186,30 @@ describe('Unit | Scope', () => {
       expect(actual).toEqual([attachment1, attachment2]);
     });
     /* eslint-enable deprecation/deprecation */
+  });
+
+  describe('setClient() and getClient()', () => {
+    it('allows storing and retrieving client objects', () => {
+      const fakeClient = {} as Client;
+      const scope = new Scope();
+      scope.setClient(fakeClient);
+      expect(scope.getClient()).toBe(fakeClient);
+    });
+
+    it('defaults to not having a client', () => {
+      const scope = new Scope();
+      expect(scope.getClient()).toBeUndefined();
+    });
+  });
+
+  describe('.clone()', () => {
+    it('will clone a client on the scope', () => {
+      const fakeClient = {} as Client;
+      const scope = new Scope();
+      scope.setClient(fakeClient);
+
+      const clonedScope = scope.clone();
+      expect(clonedScope.getClient()).toBe(fakeClient);
+    });
   });
 });

--- a/packages/node-experimental/src/sdk/types.ts
+++ b/packages/node-experimental/src/sdk/types.ts
@@ -1,7 +1,6 @@
 import type {
   Attachment,
   Breadcrumb,
-  Client,
   Contexts,
   Event,
   EventHint,

--- a/packages/node-experimental/src/sdk/types.ts
+++ b/packages/node-experimental/src/sdk/types.ts
@@ -36,8 +36,6 @@ export interface Scope extends BaseScope {
   isolationScope: typeof this | undefined;
   // @ts-expect-error typeof this is what we want here
   clone(scope?: Scope): typeof this;
-  setClient(client: Client): void;
-  getClient(): Client | undefined;
   captureException(exception: unknown, hint?: EventHint): string;
   captureMessage(
     message: string,

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -1,5 +1,6 @@
 import type { Attachment } from './attachment';
 import type { Breadcrumb } from './breadcrumb';
+import type { Client } from './client';
 import type { Context, Contexts } from './context';
 import type { EventProcessor } from './eventprocessor';
 import type { Extra, Extras } from './extra';
@@ -47,6 +48,18 @@ export interface ScopeData {
  * Holds additional event information. {@link Scope.applyToEvent} will be called by the client before an event is sent.
  */
 export interface Scope {
+  /**
+   * Update the client on the scope.
+   */
+  setClient(client: Client | undefined): void;
+
+  /**
+   * Get the client assigned to this scope.
+   *
+   * It is generally recommended to use the global function `Sentry.getClient()` instead, unless you know what you are doing.
+   */
+  getClient(): Client | undefined;
+
   /** Add new event processor that will be called after {@link applyToEvent}. */
   addEventProcessor(callback: EventProcessor): this;
 


### PR DESCRIPTION
Adds a getter and setter for client objects to the Scope to align with the new Scope API. We also adjust the logic in the Hub constructor to correctly set the client on newly instantiated scope objects residing on the hub.