### PR TITLE
feat(core): Deprecate `Hub.shouldSendDefaultPii`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,7 +10,7 @@ This will let you select which updates to run, and automatically update your cod
 
 ## Deprecate `Sentry.lastEventId()` and `hub.lastEventId()`
 
-`Sentry.lastEventId()` sometimes causes race conditons, so we are deprecating it in favour of the `beforeSend` callback.
+`Sentry.lastEventId()` sometimes causes race conditions, so we are deprecating it in favour of the `beforeSend` callback.
 
 ```js
 // Before
@@ -36,6 +36,12 @@ Sentry.init({
   },
 });
 ```
+
+## Deprecated fields on `Hub`
+
+In v8, the Hub class will be removed. The following methods are therefore deprecated:
+
+- `hub.shouldSendDefaultPii()`: Access Sentry client option via `Sentry.getClient().getOptions().sendDefaultPii` instead
 
 ## Deprecated fields on `Span` and `Transaction`
 

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -532,6 +532,9 @@ Sentry.init({...});
   /**
    * Returns if default PII should be sent to Sentry and propagated in ourgoing requests
    * when Tracing is used.
+   *
+   * @deprecated Use top-level `getClient().getOptions().sendDefaultPii` instead. This function
+   * only unnecessarily increased API surface but only wrapped accessing the option.
    */
   public shouldSendDefaultPii(): boolean {
     const client = this.getClient();

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -245,6 +245,9 @@ export interface Hub {
   /**
    * Returns if default PII should be sent to Sentry and propagated in ourgoing requests
    * when Tracing is used.
+   *
+   * @deprecated Use top-level `getClient().getOptions().sendDefaultPii` instead. This function
+   * only unnecessarily increased API surface but only wrapped accessing the option.
    */
   shouldSendDefaultPii(): boolean;
 }


### PR DESCRIPTION
Quick one for a change...

This PR only deprecates the unnecessary `Hub. shouldSendDefaultPii` method which can be easily replaced by accessing client options directly. Replacement of usages was already done in #9899, hence, only the deprecation is left.