### PR TITLE
fix(node): Anr doesn't block exit

### DIFF
--- a/dev-packages/node-integration-tests/suites/anr/should-exit-forced.js
+++ b/dev-packages/node-integration-tests/suites/anr/should-exit-forced.js
@@ -13,6 +13,7 @@ function configureSentry() {
 async function main() {
   configureSentry();
   await new Promise(resolve => setTimeout(resolve, 1000));
+  process.exit(0);
 }
 
 main();

--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -115,8 +115,22 @@ conditionalTest({ min: 16 })('should report ANR when event loop blocked', () => 
     });
   });
 
-  test('can exit', done => {
+  test('should exit', done => {
     const testScriptPath = path.resolve(__dirname, 'should-exit.js');
+    let hasClosed = false;
+
+    setTimeout(() => {
+      expect(hasClosed).toBe(true);
+      done();
+    }, 5_000);
+
+    childProcess.exec(`node ${testScriptPath}`, { encoding: 'utf8' }, () => {
+      hasClosed = true;
+    });
+  });
+
+  test('should exit forced', done => {
+    const testScriptPath = path.resolve(__dirname, 'should-exit-forced.js');
     let hasClosed = false;
 
     setTimeout(() => {

--- a/packages/node/src/integrations/anr/index.ts
+++ b/packages/node/src/integrations/anr/index.ts
@@ -122,8 +122,6 @@ async function _startWorker(client: NodeClient, _options: Partial<Options>): Pro
   const worker = new Worker(new URL(`data:application/javascript;base64,${base64WorkerScript}`), {
     workerData: options,
   });
-  // Ensure this thread can't block app exit
-  worker.unref();
 
   process.on('exit', () => {
     worker.terminate();
@@ -160,4 +158,7 @@ async function _startWorker(client: NodeClient, _options: Partial<Options>): Pro
     clearInterval(timer);
     log('ANR worker exit', code);
   });
+
+  // Ensure this thread can't block app exit
+  worker.unref();
 }


### PR DESCRIPTION
Closes #10023

`worker.on` actually calls `worker.ref()` internally so `worker.unref()` needs calling after!