### PR TITLE
test(remix): Override `web-streams-polyfill` version to fix integration tests

### DIFF
--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -34,7 +34,8 @@
     "@sentry-internal/feedback": "file:../../../feedback",
     "@sentry/types": "file:../../../types",
     "@sentry/utils": "file:../../../utils",
-    "@vanilla-extract/css": "1.13.0"
+    "@vanilla-extract/css": "1.13.0",
+    "web-streams-polyfill": "3.2.1"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
temporarily fixes https://github.com/MattiasBuelens/web-streams-polyfill/issues/137 until the change is reverted.
