### PR TITLE
fix(node): Anr events should have an `event_id`

### DIFF
--- a/packages/node/src/integrations/anr/worker.ts
+++ b/packages/node/src/integrations/anr/worker.ts
@@ -6,7 +6,13 @@ import {
   updateSession,
 } from '@sentry/core';
 import type { Event, Session, StackFrame, TraceContext } from '@sentry/types';
-import { callFrameToStackFrame, normalizeUrlToBase, stripSentryFramesAndReverse, watchdogTimer } from '@sentry/utils';
+import {
+  callFrameToStackFrame,
+  normalizeUrlToBase,
+  stripSentryFramesAndReverse,
+  uuid4,
+  watchdogTimer,
+} from '@sentry/utils';
 import { Session as InspectorSession } from 'inspector';
 import { parentPort, workerData } from 'worker_threads';
 import { makeNodeTransport } from '../../transports';
@@ -90,6 +96,7 @@ async function sendAnrEvent(frames?: StackFrame[], traceContext?: TraceContext):
   log('Sending event');
 
   const event: Event = {
+    event_id: uuid4(),
     contexts: { ...options.contexts, trace: traceContext },
     release: options.release,
     environment: options.environment,


### PR DESCRIPTION
I didn't notice this was missing since events still end up in Sentry. 

It was only when I ran it through the Electron e2e tests that I realised it was missing vs the previous incarnation!
