### PR TITLE
fix(cron): Make name required for instrumentNodeCron option

### DIFF
--- a/packages/node/src/cron/node-cron.ts
+++ b/packages/node/src/cron/node-cron.ts
@@ -2,12 +2,12 @@ import { withMonitor } from '@sentry/core';
 import { replaceCronNames } from './common';
 
 export interface NodeCronOptions {
-  name?: string;
+  name: string;
   timezone?: string;
 }
 
 export interface NodeCron {
-  schedule: (cronExpression: string, callback: () => void, options?: NodeCronOptions) => unknown;
+  schedule: (cronExpression: string, callback: () => void, options: NodeCronOptions) => unknown;
 }
 
 /**

--- a/packages/node/test/cron.test.ts
+++ b/packages/node/test/cron.test.ts
@@ -118,6 +118,7 @@ describe('cron check-ins', () => {
       const cronWithCheckIn = cron.instrumentNodeCron(nodeCron);
 
       expect(() => {
+        // @ts-expect-error Initially missing name
         cronWithCheckIn.schedule('* * * * *', () => {
           //
         });


### PR DESCRIPTION
This should enforce via TypeScript that users pass in a name, but we can keep the runtime check just in case.