### PR TITLE
feat(replay): Update rrweb to 2.7.3

### DIFF
--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
     "@playwright/test": "^1.31.1",
-    "@sentry-internal/rrweb": "2.6.0",
+    "@sentry-internal/rrweb": "2.7.3",
     "@sentry/browser": "7.92.0",
     "@sentry/tracing": "7.92.0",
     "axios": "1.6.0",

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -54,8 +54,8 @@
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@sentry-internal/replay-worker": "7.92.0",
-    "@sentry-internal/rrweb": "2.6.0",
-    "@sentry-internal/rrweb-snapshot": "2.6.0",
+    "@sentry-internal/rrweb": "2.7.3",
+    "@sentry-internal/rrweb-snapshot": "2.7.3",
     "fflate": "^0.8.1",
     "jsdom-worker": "^0.2.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5231,33 +5231,33 @@
     semver "7.3.2"
     semver-intersect "1.4.0"
 
-"@sentry-internal/rrdom@2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.6.0.tgz#19b5ab7a01ad5031be2d4bcedd4afedb44ee2bed"
-  integrity sha512-XqxOhLk/CdrKh0toOKeQ6mOcjLDK3B1KY/UVqM9VwhdVhiHeMwPj6GjJUoNkEXh0MwkDM0pzIMv95oSq7hGhPg==
+"@sentry-internal/rrdom@2.7.3":
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrdom/-/rrdom-2.7.3.tgz#2efe68a9cf23de9a8970acf4303748cdd7866b20"
+  integrity sha512-XD14G4Lv3ppvJlR7VkkCgHTKu1ylh7yvXdSsN5/FyGTH+IAXQIKL5nINIgWZTN3noNBWV9R0vcHDufXG/WktWA==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.6.0"
+    "@sentry-internal/rrweb-snapshot" "2.7.3"
 
-"@sentry-internal/rrweb-snapshot@2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.6.0.tgz#1b214c9ab4645138a02ef255c95d811bd852f996"
-  integrity sha512-dlduO37avs5HBP8zRxFHlhRb7ZP6p3SrgMSztPCCnfYr/XAB/rn5yeVn9U2FDYdrgyUzPjFWfYWFvm1eJuEMSg==
+"@sentry-internal/rrweb-snapshot@2.7.3":
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-snapshot/-/rrweb-snapshot-2.7.3.tgz#9a7173825a31c07ccf27a5956f154400e11fdd97"
+  integrity sha512-mSZuBPmWia3x9wCuaJiZMD9ZVDnFv7TSG1Nz9X4ZqWb3DdaxB2MogGUU/2aTVqmRj6F91nl+GHb5NpmNYojUsw==
 
-"@sentry-internal/rrweb-types@2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.6.0.tgz#e526994125db6684ce9402d96f64318f062bebb0"
-  integrity sha512-mPPumdbyNHF24zShvZqzqgkZRsJHhlNpglGTS0cR/PkX2QdG0CtsPVFpaYj6UQAFGpfb2Aj7VdkKuuzX4RX69w==
+"@sentry-internal/rrweb-types@2.7.3":
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb-types/-/rrweb-types-2.7.3.tgz#e38737bc5c31aa9dfb8ce8faf46af374c2aa7cbb"
+  integrity sha512-EqALxhZtvH0rimYfj7J48DRC+fj+AGsZ/VDdOPKh3MQXptTyHncoWBj4ZtB1AaH7foYUr+2wkyxl3HqMVwe+6g==
   dependencies:
-    "@sentry-internal/rrweb-snapshot" "2.6.0"
+    "@sentry-internal/rrweb-snapshot" "2.7.3"
 
-"@sentry-internal/rrweb@2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.6.0.tgz#0976e0d021c965b491a5193546a735f78dad9107"
-  integrity sha512-N+v0cgft/mikwIH5MPIspWNEqHa3E/01rA+IwozTs/TUp2e8sJmF3qxR0+OeBGZU0ln4soG1o18FjsCmadqbeQ==
+"@sentry-internal/rrweb@2.7.3":
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/@sentry-internal/rrweb/-/rrweb-2.7.3.tgz#900ce7b1bd8ec43b5557d73698cc1b4dc9f47f72"
+  integrity sha512-K2pksQ1FgDumv54r1o0+RAKB3Qx3Zgx6OrQAkU/SI6/7HcBIxe7b4zepg80NyvnfohUs/relw2EoD3K3kqd8tg==
   dependencies:
-    "@sentry-internal/rrdom" "2.6.0"
-    "@sentry-internal/rrweb-snapshot" "2.6.0"
-    "@sentry-internal/rrweb-types" "2.6.0"
+    "@sentry-internal/rrdom" "2.7.3"
+    "@sentry-internal/rrweb-snapshot" "2.7.3"
+    "@sentry-internal/rrweb-types" "2.7.3"
     "@types/css-font-loading-module" "0.0.7"
     "@xstate/fsm" "^1.4.0"
     base64-arraybuffer "^1.0.1"


### PR DESCRIPTION
This bump contains the following changes:

- fix(rrweb): Use unpatched requestAnimationFrame when possible [#150](https://github.com/getsentry/rrweb/pull/150)
- ref: Avoid async in canvas [#143](https://github.com/getsentry/rrweb/pull/143)
- feat: Bundle canvas worker manually [#144](https://github.com/getsentry/rrweb/pull/144)
- build: Build for ES2020 [#142](https://github.com/getsentry/rrweb/pull/142)

Extracted out from https://github.com/getsentry/sentry-javascript/pull/9826

Closes https://github.com/getsentry/sentry-javascript/issues/6946