### PR TITLE
test(browser): Replace flakey integration test

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/eventBreadcrumbs/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/eventBreadcrumbs/subject.js
@@ -1,0 +1,3 @@
+Sentry.captureMessage('a');
+
+Sentry.captureException(new Error('test_simple_breadcrumb_error'));

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/eventBreadcrumbs/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/eventBreadcrumbs/test.ts
@@ -1,0 +1,23 @@
+import { expect } from '@playwright/test';
+import type { Event } from '@sentry/types';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
+
+sentryTest(
+  'should capture recorded transactions as breadcrumbs for the following event sent',
+  async ({ getLocalTestPath, page }) => {
+    const url = await getLocalTestPath({ testDir: __dirname });
+
+    const events = await getMultipleSentryEnvelopeRequests<Event>(page, 2, { url });
+
+    const errorEvent = events.find(event => event.exception?.values?.[0].value === 'test_simple_breadcrumb_error')!;
+
+    expect(errorEvent.breadcrumbs).toHaveLength(1);
+    expect(errorEvent.breadcrumbs?.[0]).toMatchObject({
+      category: 'sentry.event',
+      event_id: expect.any(String),
+      level: expect.any(String),
+    });
+  },
+);

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/transactionBreadcrumbs/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/transactionBreadcrumbs/subject.js
@@ -1,0 +1,8 @@
+Sentry.captureEvent({
+  event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2',
+  message: 'someMessage',
+  transaction: 'wat',
+  type: 'transaction',
+});
+
+Sentry.captureException(new Error('test_simple_breadcrumb_error'));

--- a/dev-packages/browser-integration-tests/suites/public-api/captureException/transactionBreadcrumbs/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureException/transactionBreadcrumbs/test.ts
@@ -1,0 +1,22 @@
+import { expect } from '@playwright/test';
+import type { Event } from '@sentry/types';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
+
+sentryTest(
+  'should capture recorded transactions as breadcrumbs for the following event sent',
+  async ({ getLocalTestPath, page }) => {
+    const url = await getLocalTestPath({ testDir: __dirname });
+
+    const events = await getMultipleSentryEnvelopeRequests<Event>(page, 2, { url });
+
+    const errorEvent = events.find(event => event.exception?.values?.[0].value === 'test_simple_breadcrumb_error')!;
+
+    expect(errorEvent.breadcrumbs).toHaveLength(1);
+    expect(errorEvent.breadcrumbs?.[0]).toMatchObject({
+      category: 'sentry.transaction',
+      message: expect.any(String),
+    });
+  },
+);

--- a/packages/browser/test/integration/suites/api.js
+++ b/packages/browser/test/integration/suites/api.js
@@ -20,23 +20,6 @@ describe('API', function () {
     });
   });
 
-  it('should capture Sentry internal event as breadcrumbs for the following event sent', function () {
-    return runInSandbox(sandbox, { manual: true }, function () {
-      window.allowSentryBreadcrumbs = true;
-      Sentry.captureMessage('a');
-      Sentry.captureMessage('b');
-      // For the loader
-      Sentry.flush && Sentry.flush(2000);
-      window.finalizeManualTest();
-    }).then(function (summary) {
-      assert.equal(summary.events.length, 2);
-      assert.equal(summary.breadcrumbs.length, 2);
-      assert.equal(summary.events[1].breadcrumbs[0].category, 'sentry.event');
-      assert.equal(summary.events[1].breadcrumbs[0].event_id, summary.events[0].event_id);
-      assert.equal(summary.events[1].breadcrumbs[0].level, summary.events[0].level);
-    });
-  });
-
   it('should generate a synthetic trace for captureException w/ non-errors', function () {
     return runInSandbox(sandbox, function () {
       throwNonError();

--- a/packages/browser/test/integration/suites/api.js
+++ b/packages/browser/test/integration/suites/api.js
@@ -37,31 +37,6 @@ describe('API', function () {
     });
   });
 
-  // This test is flakey on firefox
-  it.skip('should capture Sentry internal transaction as breadcrumbs for the following event sent', function () {
-    return runInSandbox(sandbox, { manual: true }, function () {
-      window.allowSentryBreadcrumbs = true;
-      Sentry.captureEvent({
-        event_id: 'aa3ff046696b4bc6b609ce6d28fde9e2',
-        message: 'someMessage',
-        transaction: 'wat',
-        type: 'transaction',
-      });
-      Sentry.captureMessage('c');
-      // For the loader
-      Sentry.flush && Sentry.flush(2000);
-      window.finalizeManualTest();
-    }).then(function (summary) {
-      // We have a length of one here since transactions don't go through beforeSend
-      // and we add events to summary in beforeSend
-      assert.equal(summary.events.length, 1);
-      assert.equal(summary.breadcrumbs.length, 2);
-      assert.equal(summary.events[0].breadcrumbs[0].category, 'sentry.transaction');
-      assert.isNotEmpty(summary.events[0].breadcrumbs[0].event_id);
-      assert.isUndefined(summary.events[0].breadcrumbs[0].level);
-    });
-  });
-
   it('should generate a synthetic trace for captureException w/ non-errors', function () {
     return runInSandbox(sandbox, function () {
       throwNonError();

--- a/packages/browser/test/integration/suites/api.js
+++ b/packages/browser/test/integration/suites/api.js
@@ -37,7 +37,8 @@ describe('API', function () {
     });
   });
 
-  it('should capture Sentry internal transaction as breadcrumbs for the following event sent', function () {
+  // This test is flakey on firefox
+  it.skip('should capture Sentry internal transaction as breadcrumbs for the following event sent', function () {
     return runInSandbox(sandbox, { manual: true }, function () {
       window.allowSentryBreadcrumbs = true;
       Sentry.captureEvent({


### PR DESCRIPTION
This test regularly but inconsitently fails so let's try to run it in the newer browser integration tests and hope it is more consistent.

https://github.com/getsentry/sentry-javascript/actions/runs/7420119902/job/20191060365

EDIT: So it's actually 2 flakey tests https://github.com/getsentry/sentry-javascript/actions/runs/7421372038/job/20194632050?pr=10075#step:5:985