### PR TITLE
feat(core): Allow to pass `scope` to `startSpan` APIs

### DIFF
--- a/packages/core/test/lib/exports.test.ts
+++ b/packages/core/test/lib/exports.test.ts
@@ -134,6 +134,30 @@ describe('withScope', () => {
 
     expect(getCurrentScope()).toBe(scope1);
   });
+
+  it('allows to pass a custom scope', () => {
+    const scope1 = getCurrentScope();
+    scope1.setExtra('x1', 'x1');
+
+    const customScope = new Scope();
+    customScope.setExtra('x2', 'x2');
+
+    withScope(customScope, scope2 => {
+      expect(scope2).not.toBe(scope1);
+      expect(scope2).toBe(customScope);
+      expect(getCurrentScope()).toBe(scope2);
+      expect(scope2['_extra']).toEqual({ x2: 'x2' });
+    });
+
+    withScope(customScope, scope3 => {
+      expect(scope3).not.toBe(scope1);
+      expect(scope3).toBe(customScope);
+      expect(getCurrentScope()).toBe(scope3);
+      expect(scope3['_extra']).toEqual({ x2: 'x2' });
+    });
+
+    expect(getCurrentScope()).toBe(scope1);
+  });
 });
 
 describe('session APIs', () => {

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -1,6 +1,6 @@
-import type { Span } from '@sentry/types';
 import { Hub, addTracingExtensions, getCurrentScope, makeMain } from '../../../src';
-import { continueTrace, startInactiveSpan, startSpan, startSpanManual } from '../../../src/tracing';
+import { Scope } from '../../../src/scope';
+import { Span, continueTrace, startInactiveSpan, startSpan, startSpanManual } from '../../../src/tracing';
 import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
 beforeAll(() => {
@@ -81,18 +81,6 @@ describe('startSpan', () => {
       expect(ref.status).toEqual(isError ? 'internal_error' : undefined);
     });
 
-    it('creates & finishes span', async () => {
-      let _span: Span | undefined;
-      startSpan({ name: 'GET users/[id]' }, span => {
-        expect(span).toBeDefined();
-        expect(span?.endTimestamp).toBeUndefined();
-        _span = span;
-      });
-
-      expect(_span).toBeDefined();
-      expect(_span?.endTimestamp).toBeDefined();
-    });
-
     it('allows traceparent information to be overriden', async () => {
       let ref: any = undefined;
       client.on('finishTransaction', transaction => {
@@ -160,14 +148,6 @@ describe('startSpan', () => {
       expect(ref.spanRecorder.spans[1].status).toEqual(isError ? 'internal_error' : undefined);
     });
 
-    it('allows to pass a `startTime`', () => {
-      const start = startSpan({ name: 'outer', startTime: [1234, 0] }, span => {
-        return span?.startTimestamp;
-      });
-
-      expect(start).toEqual(1234);
-    });
-
     it('allows for span to be mutated', async () => {
       let ref: any = undefined;
       client.on('finishTransaction', transaction => {
@@ -189,18 +169,57 @@ describe('startSpan', () => {
       expect(ref.spanRecorder.spans).toHaveLength(2);
       expect(ref.spanRecorder.spans[1].op).toEqual('db.query');
     });
+  });
 
-    it('forks the scope', () => {
-      const initialScope = getCurrentScope();
-
-      startSpan({ name: 'GET users/[id]' }, span => {
-        expect(getCurrentScope()).not.toBe(initialScope);
-        expect(getCurrentScope().getSpan()).toBe(span);
-      });
-
-      expect(getCurrentScope()).toBe(initialScope);
-      expect(initialScope.getSpan()).toBe(undefined);
+  it('creates & finishes span', async () => {
+    let _span: Span | undefined;
+    startSpan({ name: 'GET users/[id]' }, span => {
+      expect(span).toBeDefined();
+      expect(span?.endTimestamp).toBeUndefined();
+      _span = span as Span;
     });
+
+    expect(_span).toBeDefined();
+    expect(_span?.endTimestamp).toBeDefined();
+  });
+
+  it('allows to pass a `startTime`', () => {
+    const start = startSpan({ name: 'outer', startTime: [1234, 0] }, span => {
+      return span?.startTimestamp;
+    });
+
+    expect(start).toEqual(1234);
+  });
+
+  it('forks the scope', () => {
+    const initialScope = getCurrentScope();
+
+    startSpan({ name: 'GET users/[id]' }, span => {
+      expect(getCurrentScope()).not.toBe(initialScope);
+      expect(getCurrentScope().getSpan()).toBe(span);
+    });
+
+    expect(getCurrentScope()).toBe(initialScope);
+    expect(initialScope.getSpan()).toBe(undefined);
+  });
+
+  it('allows to pass a scope', () => {
+    const initialScope = getCurrentScope();
+
+    const manualScope = new Scope();
+    const parentSpan = new Span({ spanId: 'parent-span-id' });
+    manualScope.setSpan(parentSpan);
+
+    startSpan({ name: 'GET users/[id]', scope: manualScope }, span => {
+      expect(getCurrentScope()).not.toBe(initialScope);
+      expect(getCurrentScope()).toBe(manualScope);
+      expect(getCurrentScope().getSpan()).toBe(span);
+
+      expect(span?.parentSpanId).toBe('parent-span-id');
+    });
+
+    expect(getCurrentScope()).toBe(initialScope);
+    expect(initialScope.getSpan()).toBe(undefined);
   });
 });
 
@@ -220,6 +239,29 @@ describe('startSpanManual', () => {
     startSpanManual({ name: 'GET users/[id]' }, (span, finish) => {
       expect(getCurrentScope()).not.toBe(initialScope);
       expect(getCurrentScope().getSpan()).toBe(span);
+
+      finish();
+
+      // Is still the active span
+      expect(getCurrentScope().getSpan()).toBe(span);
+    });
+
+    expect(getCurrentScope()).toBe(initialScope);
+    expect(initialScope.getSpan()).toBe(undefined);
+  });
+
+  it('allows to pass a scope', () => {
+    const initialScope = getCurrentScope();
+
+    const manualScope = new Scope();
+    const parentSpan = new Span({ spanId: 'parent-span-id' });
+    manualScope.setSpan(parentSpan);
+
+    startSpanManual({ name: 'GET users/[id]', scope: manualScope }, (span, finish) => {
+      expect(getCurrentScope()).not.toBe(initialScope);
+      expect(getCurrentScope()).toBe(manualScope);
+      expect(getCurrentScope().getSpan()).toBe(span);
+      expect(span?.parentSpanId).toBe('parent-span-id');
 
       finish();
 
@@ -259,6 +301,24 @@ describe('startInactiveSpan', () => {
     const span = startInactiveSpan({ name: 'GET users/[id]' });
 
     expect(span).toBeDefined();
+    expect(initialScope.getSpan()).toBeUndefined();
+
+    span?.end();
+
+    expect(initialScope.getSpan()).toBeUndefined();
+  });
+
+  it('allows to pass a scope', () => {
+    const initialScope = getCurrentScope();
+
+    const manualScope = new Scope();
+    const parentSpan = new Span({ spanId: 'parent-span-id' });
+    manualScope.setSpan(parentSpan);
+
+    const span = startInactiveSpan({ name: 'GET users/[id]', scope: manualScope });
+
+    expect(span).toBeDefined();
+    expect(span?.parentSpanId).toBe('parent-span-id');
     expect(initialScope.getSpan()).toBeUndefined();
 
     span?.end();

--- a/packages/node-experimental/src/utils/contextData.ts
+++ b/packages/node-experimental/src/utils/contextData.ts
@@ -1,9 +1,12 @@
 import type { Context } from '@opentelemetry/api';
 import { createContextKey } from '@opentelemetry/api';
+import type { Scope } from '@sentry/types';
 
 import type { CurrentScopes } from '../sdk/types';
 
 export const SENTRY_SCOPES_CONTEXT_KEY = createContextKey('sentry_scopes');
+
+const SCOPE_CONTEXT_MAP = new WeakMap<Scope, Context>();
 
 /**
  * Try to get the current scopes from the given OTEL context.
@@ -18,5 +21,17 @@ export function getScopesFromContext(context: Context): CurrentScopes | undefine
  * This will return a forked context with the Propagation Context set.
  */
 export function setScopesOnContext(context: Context, scopes: CurrentScopes): Context {
+  // So we can look up the context from the scope later
+  SCOPE_CONTEXT_MAP.set(scopes.scope, context);
+  SCOPE_CONTEXT_MAP.set(scopes.isolationScope, context);
+
   return context.setValue(SENTRY_SCOPES_CONTEXT_KEY, scopes);
+}
+
+/**
+ * Get the context related to a scope.
+ * TODO v8: Use this for the `trace` functions.
+ * */
+export function getContextFromScope(scope: Scope): Context | undefined {
+  return SCOPE_CONTEXT_MAP.get(scope);
 }

--- a/packages/opentelemetry/src/types.ts
+++ b/packages/opentelemetry/src/types.ts
@@ -1,6 +1,6 @@
 import type { Attributes, Span as WriteableSpan, SpanKind, TimeInput, Tracer } from '@opentelemetry/api';
 import type { BasicTracerProvider, ReadableSpan, Span } from '@opentelemetry/sdk-trace-base';
-import type { SpanOrigin, TransactionMetadata, TransactionSource } from '@sentry/types';
+import type { Scope, SpanOrigin, TransactionMetadata, TransactionSource } from '@sentry/types';
 
 export interface OpenTelemetryClient {
   tracer: Tracer;
@@ -13,6 +13,7 @@ export interface OpenTelemetrySpanContext {
   metadata?: Partial<TransactionMetadata>;
   origin?: SpanOrigin;
   source?: TransactionSource;
+  scope?: Scope;
 
   // Base SpanOptions we support
   attributes?: Attributes;


### PR DESCRIPTION
Also allow to pass this to `withScope()`, which actually aligns with OTEL as well, where you can also do that. If you pass a scope there, it will use this instead of forking a new one.

This should be the last thing needed to refactor some `span.startChild()` occurrences - you can now store the scope you want to fork off, and pass this into `startSpan` as needed.