### PR TITLE
test(browser-integration-tests): Skip flakey test on chrome

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/dom/click/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/dom/click/test.ts
@@ -4,57 +4,62 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
-sentryTest('captures Breadcrumb for clicks & debounces them for a second', async ({ getLocalTestUrl, page }) => {
-  const url = await getLocalTestUrl({ testDir: __dirname });
+sentryTest(
+  'captures Breadcrumb for clicks & debounces them for a second',
+  async ({ getLocalTestUrl, page, browserName }) => {
+    sentryTest.skip(browserName === 'firefox', 'This consistently flakes on firefox.');
 
-  await page.route('**/foo', route => {
-    return route.fulfill({
-      status: 200,
-      body: JSON.stringify({
-        userNames: ['John', 'Jane'],
-      }),
-      headers: {
-        'Content-Type': 'application/json',
-      },
+    const url = await getLocalTestUrl({ testDir: __dirname });
+
+    await page.route('**/foo', route => {
+      return route.fulfill({
+        status: 200,
+        body: JSON.stringify({
+          userNames: ['John', 'Jane'],
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
     });
-  });
 
-  const promise = getFirstSentryEnvelopeRequest<Event>(page);
+    const promise = getFirstSentryEnvelopeRequest<Event>(page);
 
-  await page.goto(url);
+    await page.goto(url);
 
-  await page.click('#button1');
-  // not debounced because other target
-  await page.click('#button2');
-  // This should be debounced
-  await page.click('#button2');
+    await page.click('#button1');
+    // not debounced because other target
+    await page.click('#button2');
+    // This should be debounced
+    await page.click('#button2');
 
-  // Wait a second for the debounce to finish
-  await page.waitForTimeout(1000);
-  await page.click('#button2');
+    // Wait a second for the debounce to finish
+    await page.waitForTimeout(1000);
+    await page.click('#button2');
 
-  const [eventData] = await Promise.all([promise, page.evaluate('Sentry.captureException("test exception")')]);
+    const [eventData] = await Promise.all([promise, page.evaluate('Sentry.captureException("test exception")')]);
 
-  expect(eventData.exception?.values).toHaveLength(1);
+    expect(eventData.exception?.values).toHaveLength(1);
 
-  expect(eventData.breadcrumbs).toEqual([
-    {
-      timestamp: expect.any(Number),
-      category: 'ui.click',
-      message: 'body > button#button1[type="button"]',
-    },
-    {
-      timestamp: expect.any(Number),
-      category: 'ui.click',
-      message: 'body > button#button2[type="button"]',
-    },
-    {
-      timestamp: expect.any(Number),
-      category: 'ui.click',
-      message: 'body > button#button2[type="button"]',
-    },
-  ]);
-});
+    expect(eventData.breadcrumbs).toEqual([
+      {
+        timestamp: expect.any(Number),
+        category: 'ui.click',
+        message: 'body > button#button1[type="button"]',
+      },
+      {
+        timestamp: expect.any(Number),
+        category: 'ui.click',
+        message: 'body > button#button2[type="button"]',
+      },
+      {
+        timestamp: expect.any(Number),
+        category: 'ui.click',
+        message: 'body > button#button2[type="button"]',
+      },
+    ]);
+  },
+);
 
 sentryTest(
   'uses the annotated component name in the breadcrumb messages and adds it to the data object',

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/dom/click/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/dom/click/test.ts
@@ -7,7 +7,7 @@ import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 sentryTest(
   'captures Breadcrumb for clicks & debounces them for a second',
   async ({ getLocalTestUrl, page, browserName }) => {
-    sentryTest.skip(browserName === 'firefox', 'This consistently flakes on firefox.');
+    sentryTest.skip(browserName === 'chromium', 'This consistently flakes on chrome.');
 
     const url = await getLocalTestUrl({ testDir: __dirname });
 


### PR DESCRIPTION
This test consistently flakes on chrome: 

- https://github.com/getsentry/sentry-javascript/actions/runs/7422426777/job/20197877425
- https://github.com/getsentry/sentry-javascript/actions/runs/7422956761/job/20199398886?pr=10039#step:10:578