### PR TITLE
test(node): Add memory leak test for `LocalVariables`

### DIFF
--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-memory-test.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-memory-test.js
@@ -1,0 +1,44 @@
+/* eslint-disable no-unused-vars */
+const Sentry = require('@sentry/node');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  includeLocalVariables: true,
+  beforeSend: _ => {
+    return null;
+  },
+  // Stop the rate limiting from kicking in
+  integrations: [new Sentry.Integrations.LocalVariables({ maxExceptionsPerSecond: 10000000 })],
+});
+
+class Some {
+  two(name) {
+    throw new Error('Enough!');
+  }
+}
+
+function one(name) {
+  const arr = [1, '2', null];
+  const obj = {
+    name,
+    num: 5,
+  };
+
+  const ty = new Some();
+
+  ty.two(name);
+}
+
+// Every millisecond cause a caught exception
+setInterval(() => {
+  try {
+    one('some name');
+  } catch (e) {
+    //
+  }
+}, 1);
+
+// Every second send a memory usage update to parent process
+setInterval(() => {
+  process.send({ memUsage: process.memoryUsage() });
+}, 1000);


### PR DESCRIPTION
This PR adds a test for the `LocalVariable` integration that causes 20k caught exceptions and checks that the memory usage does not go over 100MB.