### PR TITLE
fix(node): `LocalVariables` integration should have correct name

### DIFF
--- a/packages/node/src/integrations/local-variables/local-variables-sync.ts
+++ b/packages/node/src/integrations/local-variables/local-variables-sync.ts
@@ -208,7 +208,7 @@ function tryNewAsyncSession(): AsyncSession | undefined {
   }
 }
 
-const INTEGRATION_NAME = 'LocalVariablesSync';
+const INTEGRATION_NAME = 'LocalVariables';
 
 /**
  * Adds local variables to exception frames

--- a/packages/node/test/integrations/localvariables.test.ts
+++ b/packages/node/test/integrations/localvariables.test.ts
@@ -169,7 +169,7 @@ describeIf(NODE_VERSION.major >= 18)('LocalVariables', () => {
     client.setupIntegrations(true);
 
     const eventProcessors = client['_eventProcessors'];
-    const eventProcessor = eventProcessors.find(processor => processor.id === 'LocalVariablesSync');
+    const eventProcessor = eventProcessors.find(processor => processor.id === 'LocalVariables');
 
     expect(eventProcessor).toBeDefined();
 
@@ -306,7 +306,7 @@ describeIf(NODE_VERSION.major >= 18)('LocalVariables', () => {
     client.setupIntegrations(true);
 
     const eventProcessors = client['_eventProcessors'];
-    const eventProcessor = eventProcessors.find(processor => processor.id === 'LocalVariablesSync');
+    const eventProcessor = eventProcessors.find(processor => processor.id === 'LocalVariables');
 
     expect(eventProcessor).toBeDefined();
   });
@@ -322,7 +322,7 @@ describeIf(NODE_VERSION.major >= 18)('LocalVariables', () => {
     client.setupIntegrations(true);
 
     const eventProcessors = client['_eventProcessors'];
-    const eventProcessor = eventProcessors.find(processor => processor.id === 'LocalVariablesSync');
+    const eventProcessor = eventProcessors.find(processor => processor.id === 'LocalVariables');
 
     expect(eventProcessor).toBeDefined();
   });


### PR DESCRIPTION
In #10077, I disabled the async `LocalVariables` integration but forgot to change the name of sync integration to match. Users might be filtering on this!
