### PR TITLE
feat(node): Instrumentation for `node-schedule` library

### DIFF
--- a/packages/node/src/cron/cron.ts
+++ b/packages/node/src/cron/cron.ts
@@ -56,6 +56,8 @@ const ERROR_TEXT = 'Automatic instrumentation of CronJob only supports crontab s
  * ```
  */
 export function instrumentCron<T>(lib: T & CronJobConstructor, monitorSlug: string): T {
+  let jobScheduled = false;
+
   return new Proxy(lib, {
     construct(target, args: ConstructorParameters<CronJobConstructor>) {
       const [cronTime, onTick, onComplete, start, timeZone, ...rest] = args;
@@ -63,6 +65,12 @@ export function instrumentCron<T>(lib: T & CronJobConstructor, monitorSlug: stri
       if (typeof cronTime !== 'string') {
         throw new Error(ERROR_TEXT);
       }
+
+      if (jobScheduled) {
+        throw new Error(`A job named '${monitorSlug}' has already been scheduled`);
+      }
+
+      jobScheduled = true;
 
       const cronString = replaceCronNames(cronTime);
 
@@ -89,6 +97,12 @@ export function instrumentCron<T>(lib: T & CronJobConstructor, monitorSlug: stri
           if (typeof cronTime !== 'string') {
             throw new Error(ERROR_TEXT);
           }
+
+          if (jobScheduled) {
+            throw new Error(`A job named '${monitorSlug}' has already been scheduled`);
+          }
+
+          jobScheduled = true;
 
           const cronString = replaceCronNames(cronTime);
 

--- a/packages/node/src/cron/node-schedule.ts
+++ b/packages/node/src/cron/node-schedule.ts
@@ -1,0 +1,59 @@
+import { withMonitor } from '@sentry/core';
+import { replaceCronNames } from './common';
+
+export interface NodeSchedule {
+  scheduleJob(expression: string | Date | object, callback: () => void): unknown;
+}
+
+/**
+ * Instruments the `node-schedule` library to send a check-in event to Sentry for each job execution.
+ *
+ * ```ts
+ * import * as Sentry from '@sentry/node';
+ * import * as schedule from 'node-schedule';
+ *
+ * const scheduleWithCheckIn = Sentry.cron.instrumentNodeSchedule(schedule, 'my-cron-job');
+ *
+ * const job = scheduleWithCheckIn.scheduleJob('* * * * *', () => {
+ *  console.log('You will see this message every minute');
+ * });
+ * ```
+ */
+export function instrumentNodeSchedule<T>(lib: T & NodeSchedule, monitorSlug: string): T {
+  let jobScheduled = false;
+
+  return new Proxy(lib, {
+    get(target, prop: keyof NodeSchedule) {
+      if (prop === 'scheduleJob') {
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        return new Proxy(target.scheduleJob, {
+          apply(target, thisArg, argArray: Parameters<NodeSchedule['scheduleJob']>) {
+            const [expression] = argArray;
+
+            if (typeof expression !== 'string') {
+              throw new Error('Automatic instrumentation of "node-schedule" only supports crontab string');
+            }
+
+            if (jobScheduled) {
+              throw new Error(`A job named '${monitorSlug}' has already been scheduled`);
+            }
+
+            jobScheduled = true;
+
+            return withMonitor(
+              monitorSlug,
+              () => {
+                return target.apply(thisArg, argArray);
+              },
+              {
+                schedule: { type: 'crontab', value: replaceCronNames(expression) },
+              },
+            );
+          },
+        });
+      }
+
+      return target[prop];
+    },
+  });
+}

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -124,9 +124,11 @@ export { hapiErrorPlugin } from './integrations/hapi';
 
 import { instrumentCron } from './cron/cron';
 import { instrumentNodeCron } from './cron/node-cron';
+import { instrumentNodeSchedule } from './cron/node-schedule';
 
 /** Methods to instrument cron libraries for Sentry check-ins */
 export const cron = {
   instrumentCron,
   instrumentNodeCron,
+  instrumentNodeSchedule,
 };


### PR DESCRIPTION
Closes #9893

This PR adds auto instrumented check-ins for the `node-schedule` library.

It's not shown in the readme, but `scheduleJob` can be passed a job name as the first parameter:
https://github.com/node-schedule/node-schedule/blob/c5a4d9a0dbcd5bda4996e089817e5669b5acd95f/lib/schedule.js#L28

```ts
import * as Sentry from '@sentry/node';
import * as schedule from 'node-schedule';

const scheduleWithCheckIn = Sentry.cron.instrumentNodeSchedule(schedule);

const job = scheduleWithCheckIn.scheduleJob('my-cron-job', '* * * * *', () => {
  console.log('You will see this message every minute');
});
```

This PR also adds a check to the `cron` instrumentation that ensures that you can't create multiple schedules with the same monitor slug. 