### PR TITLE
feat(core): Deprecate `span.startChild()`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,9 +8,9 @@ npx @sentry/migr8@latest
 
 This will let you select which updates to run, and automatically update your code. Make sure to still review all code changes!
 
-## Deprecate `startTransaction()`
+## Deprecate `startTransaction()` & `span.startChild()`
 
-In v8, the old performance API `startTransaction()` (as well as `hub.startTransaction()`) will be removed.
+In v8, the old performance API `startTransaction()` (and `hub.startTransaction()`), as well as `span.startChild()`, will be removed.
 Instead, use the new performance APIs:
 
 * `startSpan()`

--- a/dev-packages/e2e-tests/test-applications/create-next-app/pages/api/success.ts
+++ b/dev-packages/e2e-tests/test-applications/create-next-app/pages/api/success.ts
@@ -7,6 +7,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const transaction = Sentry.startTransaction({ name: 'test-transaction', op: 'e2e-test' });
   Sentry.getCurrentHub().getScope().setSpan(transaction);
 
+  // eslint-disable-next-line deprecation/deprecation
   const span = transaction.startChild();
 
   span.end();

--- a/dev-packages/e2e-tests/test-applications/node-express-app/src/app.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-app/src/app.ts
@@ -38,6 +38,7 @@ app.get('/test-transaction', async function (req, res) {
   const transaction = Sentry.startTransaction({ name: 'test-transaction', op: 'e2e-test' });
   Sentry.getCurrentScope().setSpan(transaction);
 
+  // eslint-disable-next-line deprecation/deprecation
   const span = transaction.startChild();
 
   span.end();

--- a/dev-packages/node-integration-tests/suites/public-api/startTransaction/with-nested-spans/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/startTransaction/with-nested-spans/scenario.ts
@@ -10,6 +10,7 @@ Sentry.init({
 
 // eslint-disable-next-line deprecation/deprecation
 const transaction = Sentry.startTransaction({ name: 'test_transaction_1' });
+// eslint-disable-next-line deprecation/deprecation
 const span_1 = transaction.startChild({
   op: 'span_1',
   data: {
@@ -23,16 +24,20 @@ for (let i = 0; i < 2000; i++);
 span_1.end();
 
 // span_2 doesn't finish
+// eslint-disable-next-line deprecation/deprecation
 transaction.startChild({ op: 'span_2' });
 for (let i = 0; i < 4000; i++);
 
+// eslint-disable-next-line deprecation/deprecation
 const span_3 = transaction.startChild({ op: 'span_3' });
 for (let i = 0; i < 4000; i++);
 
 // span_4 is the child of span_3 but doesn't finish.
+// eslint-disable-next-line deprecation/deprecation
 span_3.startChild({ op: 'span_4', data: { qux: 'quux' } });
 
 // span_5 is another child of span_3 but finishes.
+// eslint-disable-next-line deprecation/deprecation
 span_3.startChild({ op: 'span_5' }).end();
 
 // span_3 also finishes

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -84,6 +84,7 @@ export class TraceService implements OnDestroy {
         if (this._routingSpan) {
           this._routingSpan.end();
         }
+        // eslint-disable-next-line deprecation/deprecation
         this._routingSpan = activeTransaction.startChild({
           description: `${navigationEvent.url}`,
           op: ANGULAR_ROUTING_OP,
@@ -183,6 +184,7 @@ export class TraceDirective implements OnInit, AfterViewInit {
 
     const activeTransaction = getActiveTransaction();
     if (activeTransaction) {
+      // eslint-disable-next-line deprecation/deprecation
       this._tracingSpan = activeTransaction.startChild({
         description: `<${this.componentName}>`,
         op: ANGULAR_INIT_OP,
@@ -225,6 +227,7 @@ export function TraceClassDecorator(): ClassDecorator {
     target.prototype.ngOnInit = function (...args: any[]): ReturnType<typeof originalOnInit> {
       const activeTransaction = getActiveTransaction();
       if (activeTransaction) {
+        // eslint-disable-next-line deprecation/deprecation
         tracingSpan = activeTransaction.startChild({
           description: `<${target.name}>`,
           op: ANGULAR_INIT_OP,
@@ -262,6 +265,7 @@ export function TraceMethodDecorator(): MethodDecorator {
       const now = timestampInSeconds();
       const activeTransaction = getActiveTransaction();
       if (activeTransaction) {
+        // eslint-disable-next-line deprecation/deprecation
         activeTransaction.startChild({
           description: `<${target.constructor.name}>`,
           endTimestamp: now,

--- a/packages/core/src/tracing/span.ts
+++ b/packages/core/src/tracing/span.ts
@@ -187,7 +187,10 @@ export class Span implements SpanInterface {
   }
 
   /**
-   * @inheritDoc
+   * Creates a new `Span` while setting the current `Span.id` as `parentSpanId`.
+   * Also the `sampled` decision will be inherited.
+   *
+   * @deprecated Use `startSpan()`, `startSpanManual()` or `startInactiveSpan()` instead.
    */
   public startChild(
     spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'sampled' | 'traceId' | 'parentSpanId'>>,

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -158,7 +158,8 @@ export function startInactiveSpan(context: StartSpanOptions): Span | undefined {
   const hub = getCurrentHub();
   const parentSpan = getActiveSpan();
   return parentSpan
-    ? parentSpan.startChild(ctx)
+    ? // eslint-disable-next-line deprecation/deprecation
+      parentSpan.startChild(ctx)
     : // eslint-disable-next-line deprecation/deprecation
       hub.startTransaction(ctx);
 }
@@ -240,7 +241,8 @@ function createChildSpanOrTransaction(
     return undefined;
   }
   return parentSpan
-    ? parentSpan.startChild(ctx)
+    ? // eslint-disable-next-line deprecation/deprecation
+      parentSpan.startChild(ctx)
     : // eslint-disable-next-line deprecation/deprecation
       hub.startTransaction(ctx);
 }

--- a/packages/ember/addon/index.ts
+++ b/packages/ember/addon/index.ts
@@ -88,6 +88,7 @@ export const instrumentRoutePerformance = <T extends RouteConstructor>(BaseRoute
       return result;
     }
     currentTransaction
+      // eslint-disable-next-line deprecation/deprecation
       .startChild({
         op,
         description,

--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -149,6 +149,7 @@ export function _instrumentEmberRouter(
         'routing.instrumentation': '@sentry/ember',
       },
     });
+    // eslint-disable-next-line deprecation/deprecation
     transitionSpan = activeTransaction?.startChild({
       op: 'ui.ember.transition',
       description: `route:${fromRoute} -> route:${toRoute}`,
@@ -212,6 +213,7 @@ function _instrumentEmberRunloop(config: EmberSentryConfig): void {
 
         if ((now - currentQueueStart) * 1000 >= minQueueDuration) {
           activeTransaction
+            // eslint-disable-next-line deprecation/deprecation
             ?.startChild({
               op: `ui.ember.runloop.${queue}`,
               origin: 'auto.ui.ember',
@@ -287,7 +289,7 @@ function processComponentRenderAfter(
 
   if (componentRenderDuration * 1000 >= minComponentDuration) {
     const activeTransaction = getActiveTransaction();
-
+    // eslint-disable-next-line deprecation/deprecation
     activeTransaction?.startChild({
       op,
       description: payload.containerKey || payload.object,
@@ -373,6 +375,7 @@ function _instrumentInitialLoad(config: EmberSentryConfig): void {
   const endTimestamp = startTimestamp + measure.duration / 1000;
 
   const transaction = getActiveTransaction();
+  // eslint-disable-next-line deprecation/deprecation
   const span = transaction?.startChild({
     op: 'ui.ember.init',
     origin: 'auto.ui.ember',

--- a/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
+++ b/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
@@ -186,6 +186,7 @@ export function pagesRouterInstrumentation(
         // We don't want to finish the navigation transaction on `routeChangeComplete`, since users might want to attach
         // spans to that transaction even after `routeChangeComplete` is fired (eg. HTTP requests in some useEffect
         // hooks). Instead, we'll simply let the navigation transaction finish itself (it's an `IdleTransaction`).
+        // eslint-disable-next-line deprecation/deprecation
         const nextRouteChangeSpan = navigationTransaction.startChild({
           op: 'ui.nextjs.route-change',
           origin: 'auto.ui.nextjs.pages_router_instrumentation',

--- a/packages/nextjs/src/common/utils/wrapperUtils.ts
+++ b/packages/nextjs/src/common/utils/wrapperUtils.ts
@@ -131,6 +131,7 @@ export function withTracedServerSideDataFetcher<F extends (...args: any[]) => Pr
           spanToContinue = previousSpan;
         }
 
+        // eslint-disable-next-line deprecation/deprecation
         dataFetcherSpan = spanToContinue.startChild({
           op: 'function.nextjs',
           description: `${options.dataFetchingMethodName} (${options.dataFetcherRouteName})`,
@@ -209,6 +210,7 @@ export async function callDataFetcherTraced<F extends (...args: any[]) => Promis
 
   // Capture the route, since pre-loading, revalidation, etc might mean that this span may happen during another
   // route's transaction
+  // eslint-disable-next-line deprecation/deprecation
   const span = transaction.startChild({
     op: 'function.nextjs',
     origin: 'auto.function.nextjs',

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -251,7 +251,8 @@ function _createWrappedRequestMethodFactory(
       const data = getRequestSpanData(requestUrl, requestOptions);
 
       const requestSpan = shouldCreateSpan(rawRequestUrl)
-        ? parentSpan?.startChild({
+        ? // eslint-disable-next-line deprecation/deprecation
+          parentSpan?.startChild({
             op: 'http.client',
             origin: 'auto.http.node.http',
             description: `${data['http.method']} ${data.url}`,

--- a/packages/node/src/integrations/undici/index.ts
+++ b/packages/node/src/integrations/undici/index.ts
@@ -310,6 +310,7 @@ function createRequestSpan(
   if (url.hash) {
     data['http.fragment'] = url.hash;
   }
+  // eslint-disable-next-line deprecation/deprecation
   return activeSpan?.startChild({
     op: 'http.client',
     origin: 'auto.http.node.undici',

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -424,6 +424,7 @@ describe('tracingHandler', () => {
   it('waits to finish transaction until all spans are finished, even though `transaction.end()` is registered on `res.finish` event first', done => {
     const transaction = new Transaction({ name: 'mockTransaction', sampled: true });
     transaction.initSpanRecorder();
+    // eslint-disable-next-line deprecation/deprecation
     const span = transaction.startChild({
       description: 'reallyCoolHandler',
       op: 'middleware',

--- a/packages/opentelemetry-node/src/spanprocessor.ts
+++ b/packages/opentelemetry-node/src/spanprocessor.ts
@@ -56,6 +56,7 @@ export class SentrySpanProcessor implements OtelSpanProcessor {
     const sentryParentSpan = otelParentSpanId && getSentrySpan(otelParentSpanId);
 
     if (sentryParentSpan) {
+      // eslint-disable-next-line deprecation/deprecation
       const sentryChildSpan = sentryParentSpan.startChild({
         description: otelSpan.name,
         instrumenter: 'otel',

--- a/packages/opentelemetry-node/test/propagator.test.ts
+++ b/packages/opentelemetry-node/test/propagator.test.ts
@@ -65,6 +65,7 @@ describe('SentryPropagator', () => {
         if (type === PerfType.Span) {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const { spanId, ...ctx } = transactionContext;
+          // eslint-disable-next-line deprecation/deprecation
           const span = transaction.startChild({ ...ctx, description: transaction.name });
           setSentrySpan(span.spanId, span);
         }

--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -204,6 +204,7 @@ function createAndFinishSpanForOtelSpan(node: SpanNode, sentryParentSpan: Sentry
   const { op, description, tags, data, origin } = getSpanData(span);
   const allData = { ...removeSentryAttributes(attributes), ...data };
 
+  // eslint-disable-next-line deprecation/deprecation
   const sentrySpan = sentryParentSpan.startChild({
     description,
     op,

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -59,6 +59,7 @@ class Profiler extends React.Component<ProfilerProps> {
 
     const activeTransaction = getActiveTransaction();
     if (activeTransaction) {
+      // eslint-disable-next-line deprecation/deprecation
       this._mountSpan = activeTransaction.startChild({
         description: `<${name}>`,
         op: REACT_MOUNT_OP,
@@ -85,6 +86,7 @@ class Profiler extends React.Component<ProfilerProps> {
       const changedProps = Object.keys(updateProps).filter(k => updateProps[k] !== this.props.updateProps[k]);
       if (changedProps.length > 0) {
         const now = timestampInSeconds();
+        // eslint-disable-next-line deprecation/deprecation
         this._updateSpan = this._mountSpan.startChild({
           data: {
             changedProps,
@@ -116,6 +118,7 @@ class Profiler extends React.Component<ProfilerProps> {
     if (this._mountSpan && includeRender) {
       // If we were able to obtain the spanId of the mount activity, we should set the
       // next activity as a child to the component mount activity.
+      // eslint-disable-next-line deprecation/deprecation
       this._mountSpan.startChild({
         description: `<${name}>`,
         endTimestamp: timestampInSeconds(),
@@ -183,6 +186,7 @@ function useProfiler(
 
     const activeTransaction = getActiveTransaction();
     if (activeTransaction) {
+      // eslint-disable-next-line deprecation/deprecation
       return activeTransaction.startChild({
         description: `<${name}>`,
         op: REACT_MOUNT_OP,
@@ -201,6 +205,7 @@ function useProfiler(
 
     return (): void => {
       if (mountSpan && options.hasRenderSpan) {
+        // eslint-disable-next-line deprecation/deprecation
         mountSpan.startChild({
           description: `<${name}>`,
           endTimestamp: timestampInSeconds(),

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -184,6 +184,7 @@ function makeWrappedDocumentRequestFunction(remixVersion?: number) {
       const activeTransaction = getActiveTransaction();
 
       try {
+        // eslint-disable-next-line deprecation/deprecation
         const span = activeTransaction?.startChild({
           op: 'function.remix.document_request',
           origin: 'auto.function.remix',
@@ -239,6 +240,7 @@ function makeWrappedDataFunction(
     const currentScope = getCurrentScope();
 
     try {
+      // eslint-disable-next-line deprecation/deprecation
       const span = activeTransaction?.startChild({
         op: `function.remix.${name}`,
         origin: 'auto.ui.remix',

--- a/packages/serverless/src/awsservices.ts
+++ b/packages/serverless/src/awsservices.ts
@@ -62,6 +62,7 @@ function wrapMakeRequest<TService extends AWSService, TResult>(
     const req = orig.call(this, operation, params);
     req.on('afterBuild', () => {
       if (transaction) {
+        // eslint-disable-next-line deprecation/deprecation
         span = transaction.startChild({
           description: describe(this, operation, params),
           op: 'http.client',

--- a/packages/serverless/src/google-cloud-grpc.ts
+++ b/packages/serverless/src/google-cloud-grpc.ts
@@ -111,6 +111,7 @@ function fillGrpcFunction(stub: Stub, serviceIdentifier: string, methodName: str
         const scope = getCurrentScope();
         const transaction = scope.getTransaction();
         if (transaction) {
+          // eslint-disable-next-line deprecation/deprecation
           span = transaction.startChild({
             description: `${callType} ${methodName}`,
             op: `grpc.${serviceIdentifier}`,

--- a/packages/serverless/src/google-cloud-http.ts
+++ b/packages/serverless/src/google-cloud-http.ts
@@ -56,6 +56,7 @@ function wrapRequestFunction(orig: RequestFunction): RequestFunction {
     const transaction = scope.getTransaction();
     if (transaction) {
       const httpMethod = reqOpts.method || 'GET';
+      // eslint-disable-next-line deprecation/deprecation
       span = transaction.startChild({
         description: `${httpMethod} ${reqOpts.uri}`,
         op: `http.client.${identifyService(this.apiEndpoint)}`,

--- a/packages/svelte/src/performance.ts
+++ b/packages/svelte/src/performance.ts
@@ -47,6 +47,7 @@ export function trackComponent(options?: TrackComponentOptions): void {
 }
 
 function recordInitSpan(transaction: Transaction, componentName: string): Span {
+  // eslint-disable-next-line deprecation/deprecation
   const initSpan = transaction.startChild({
     op: UI_SVELTE_INIT,
     description: componentName,
@@ -75,6 +76,7 @@ function recordUpdateSpans(componentName: string, initSpan?: Span): void {
     const parentSpan =
       initSpan && !initSpan.endTimestamp && initSpan.transaction === transaction ? initSpan : transaction;
 
+    // eslint-disable-next-line deprecation/deprecation
     updateSpan = parentSpan.startChild({
       op: UI_SVELTE_UPDATE,
       description: componentName,

--- a/packages/sveltekit/src/client/router.ts
+++ b/packages/sveltekit/src/client/router.ts
@@ -117,6 +117,7 @@ function instrumentNavigations(startTransactionFn: (context: TransactionContext)
         // If a routing span is still open from a previous navigation, we finish it.
         routingSpan.end();
       }
+      // eslint-disable-next-line deprecation/deprecation
       routingSpan = activeTransaction.startChild({
         op: 'ui.sveltekit.routing',
         description: 'SvelteKit Route Change',

--- a/packages/sveltekit/test/client/router.test.ts
+++ b/packages/sveltekit/test/client/router.test.ts
@@ -117,6 +117,7 @@ describe('sveltekitRoutingInstrumentation', () => {
       },
     });
 
+    // eslint-disable-next-line deprecation/deprecation
     expect(returnedTransaction?.startChild).toHaveBeenCalledWith({
       op: 'ui.sveltekit.routing',
       origin: 'auto.ui.sveltekit',
@@ -168,6 +169,7 @@ describe('sveltekitRoutingInstrumentation', () => {
         },
       });
 
+      // eslint-disable-next-line deprecation/deprecation
       expect(returnedTransaction?.startChild).toHaveBeenCalledWith({
         op: 'ui.sveltekit.routing',
         origin: 'auto.ui.sveltekit',

--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -76,6 +76,7 @@ export function startTrackingLongTasks(): void {
       const startTime = msToSec((browserPerformanceTimeOrigin as number) + entry.startTime);
       const duration = msToSec(entry.duration);
 
+      // eslint-disable-next-line deprecation/deprecation
       transaction.startChild({
         description: 'Main UI thread blocked',
         op: 'ui.long-task',
@@ -115,6 +116,7 @@ export function startTrackingInteractions(): void {
           span.data = { 'ui.component_name': componentName };
         }
 
+        // eslint-disable-next-line deprecation/deprecation
         transaction.startChild(span);
       }
     }

--- a/packages/tracing-internal/src/browser/metrics/utils.ts
+++ b/packages/tracing-internal/src/browser/metrics/utils.ts
@@ -18,6 +18,7 @@ export function _startChild(transaction: Transaction, { startTimestamp, ...ctx }
     transaction.startTimestamp = startTimestamp;
   }
 
+  // eslint-disable-next-line deprecation/deprecation
   return transaction.startChild({
     startTimestamp,
     ...ctx,

--- a/packages/tracing-internal/src/browser/request.ts
+++ b/packages/tracing-internal/src/browser/request.ts
@@ -275,7 +275,8 @@ export function xhrCallback(
 
   const span =
     shouldCreateSpanResult && parentSpan
-      ? parentSpan.startChild({
+      ? // eslint-disable-next-line deprecation/deprecation
+        parentSpan.startChild({
           data: {
             type: 'xhr',
             'http.method': sentryXhrData.method,

--- a/packages/tracing-internal/src/common/fetch.ts
+++ b/packages/tracing-internal/src/common/fetch.ts
@@ -79,7 +79,8 @@ export function instrumentFetchRequest(
 
   const span =
     shouldCreateSpanResult && parentSpan
-      ? parentSpan.startChild({
+      ? // eslint-disable-next-line deprecation/deprecation
+        parentSpan.startChild({
           data: {
             url,
             type: 'fetch',

--- a/packages/tracing-internal/src/node/integrations/apollo.ts
+++ b/packages/tracing-internal/src/node/integrations/apollo.ts
@@ -190,6 +190,7 @@ function wrapResolver(
     return function (this: unknown, ...args: unknown[]) {
       const scope = getCurrentHub().getScope();
       const parentSpan = scope.getSpan();
+      // eslint-disable-next-line deprecation/deprecation
       const span = parentSpan?.startChild({
         description: `${resolverGroupName}.${resolverName}`,
         op: 'graphql.resolve',

--- a/packages/tracing-internal/src/node/integrations/express.ts
+++ b/packages/tracing-internal/src/node/integrations/express.ts
@@ -157,6 +157,7 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
       return function (this: NodeJS.Global, req: unknown, res: ExpressResponse & SentryTracingResponse): void {
         const transaction = res.__sentry_transaction;
         if (transaction) {
+          // eslint-disable-next-line deprecation/deprecation
           const span = transaction.startChild({
             description: fn.name,
             op: `middleware.express.${method}`,
@@ -177,6 +178,7 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
         next: () => void,
       ): void {
         const transaction = res.__sentry_transaction;
+        // eslint-disable-next-line deprecation/deprecation
         const span = transaction?.startChild({
           description: fn.name,
           op: `middleware.express.${method}`,
@@ -197,6 +199,7 @@ function wrap(fn: Function, method: Method): (...args: any[]) => void {
         next: () => void,
       ): void {
         const transaction = res.__sentry_transaction;
+        // eslint-disable-next-line deprecation/deprecation
         const span = transaction?.startChild({
           description: fn.name,
           op: `middleware.express.${method}`,

--- a/packages/tracing-internal/src/node/integrations/graphql.ts
+++ b/packages/tracing-internal/src/node/integrations/graphql.ts
@@ -54,6 +54,7 @@ export class GraphQL implements LazyLoadedIntegration<GraphQLModule> {
         const scope = getCurrentHub().getScope();
         const parentSpan = scope.getSpan();
 
+        // eslint-disable-next-line deprecation/deprecation
         const span = parentSpan?.startChild({
           description: 'execute',
           op: 'graphql.execute',

--- a/packages/tracing-internal/src/node/integrations/mongo.ts
+++ b/packages/tracing-internal/src/node/integrations/mongo.ts
@@ -180,6 +180,7 @@ export class Mongo implements LazyLoadedIntegration<MongoModule> {
         // Check if the operation was passed a callback. (mapReduce requires a different check, as
         // its (non-callback) arguments can also be functions.)
         if (typeof lastArg !== 'function' || (operation === 'mapReduce' && args.length === 2)) {
+          // eslint-disable-next-line deprecation/deprecation
           const span = parentSpan?.startChild(getSpanContext(this, operation, args));
           const maybePromiseOrCursor = orig.call(this, ...args);
 
@@ -211,6 +212,7 @@ export class Mongo implements LazyLoadedIntegration<MongoModule> {
           }
         }
 
+        // eslint-disable-next-line deprecation/deprecation
         const span = parentSpan?.startChild(getSpanContext(this, operation, args.slice(0, -1)));
 
         return orig.call(this, ...args.slice(0, -1), function (err: Error, result: unknown) {

--- a/packages/tracing-internal/src/node/integrations/mysql.ts
+++ b/packages/tracing-internal/src/node/integrations/mysql.ts
@@ -106,6 +106,7 @@ export class Mysql implements LazyLoadedIntegration<MysqlConnection> {
         const scope = getCurrentHub().getScope();
         const parentSpan = scope.getSpan();
 
+        // eslint-disable-next-line deprecation/deprecation
         const span = parentSpan?.startChild({
           description: typeof options === 'string' ? options : (options as { sql: string }).sql,
           op: 'db',

--- a/packages/tracing-internal/src/node/integrations/postgres.ts
+++ b/packages/tracing-internal/src/node/integrations/postgres.ts
@@ -128,6 +128,7 @@ export class Postgres implements LazyLoadedIntegration<PGModule> {
           // ignore
         }
 
+        // eslint-disable-next-line deprecation/deprecation
         const span = parentSpan?.startChild({
           description: typeof config === 'string' ? config : (config as { text: string }).text,
           op: 'db',

--- a/packages/tracing-internal/test/browser/metrics/index.test.ts
+++ b/packages/tracing-internal/test/browser/metrics/index.test.ts
@@ -5,6 +5,7 @@ import { _addMeasureSpans, _addResourceSpans } from '../../../src/browser/metric
 describe('_addMeasureSpans', () => {
   const transaction = new Transaction({ op: 'pageload', name: '/' });
   beforeEach(() => {
+    // eslint-disable-next-line deprecation/deprecation
     transaction.startChild = jest.fn();
   });
 
@@ -21,12 +22,12 @@ describe('_addMeasureSpans', () => {
     const startTime = 23;
     const duration = 356;
 
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // eslint-disable-next-line @typescript-eslint/unbound-method, deprecation/deprecation
     expect(transaction.startChild).toHaveBeenCalledTimes(0);
     _addMeasureSpans(transaction, entry, startTime, duration, timeOrigin);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // eslint-disable-next-line @typescript-eslint/unbound-method, deprecation/deprecation
     expect(transaction.startChild).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // eslint-disable-next-line @typescript-eslint/unbound-method, deprecation/deprecation
     expect(transaction.startChild).toHaveBeenLastCalledWith({
       description: 'measure-1',
       startTimestamp: timeOrigin + startTime,
@@ -40,6 +41,7 @@ describe('_addMeasureSpans', () => {
 describe('_addResourceSpans', () => {
   const transaction = new Transaction({ op: 'pageload', name: '/' });
   beforeEach(() => {
+    // eslint-disable-next-line deprecation/deprecation
     transaction.startChild = jest.fn();
   });
 
@@ -54,7 +56,7 @@ describe('_addResourceSpans', () => {
     };
     _addResourceSpans(transaction, entry, '/assets/to/me', 123, 456, 100);
 
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // eslint-disable-next-line @typescript-eslint/unbound-method, deprecation/deprecation
     expect(transaction.startChild).toHaveBeenCalledTimes(0);
   });
 
@@ -68,7 +70,7 @@ describe('_addResourceSpans', () => {
     };
     _addResourceSpans(transaction, entry, '/assets/to/me', 123, 456, 100);
 
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // eslint-disable-next-line @typescript-eslint/unbound-method, deprecation/deprecation
     expect(transaction.startChild).toHaveBeenCalledTimes(0);
   });
 
@@ -87,9 +89,9 @@ describe('_addResourceSpans', () => {
 
     _addResourceSpans(transaction, entry, '/assets/to/css', startTime, duration, timeOrigin);
 
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // eslint-disable-next-line @typescript-eslint/unbound-method, deprecation/deprecation
     expect(transaction.startChild).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // eslint-disable-next-line @typescript-eslint/unbound-method, deprecation/deprecation
     expect(transaction.startChild).toHaveBeenLastCalledWith({
       data: {
         ['http.decoded_response_content_length']: entry.decodedBodySize,
@@ -135,7 +137,7 @@ describe('_addResourceSpans', () => {
       };
       _addResourceSpans(transaction, entry, '/assets/to/me', 123, 234, 465);
 
-      // eslint-disable-next-line @typescript-eslint/unbound-method
+      // eslint-disable-next-line @typescript-eslint/unbound-method, deprecation/deprecation
       expect(transaction.startChild).toHaveBeenLastCalledWith(
         expect.objectContaining({
           op,
@@ -155,9 +157,9 @@ describe('_addResourceSpans', () => {
 
     _addResourceSpans(transaction, entry, '/assets/to/css', 100, 23, 345);
 
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // eslint-disable-next-line @typescript-eslint/unbound-method, deprecation/deprecation
     expect(transaction.startChild).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // eslint-disable-next-line @typescript-eslint/unbound-method, deprecation/deprecation
     expect(transaction.startChild).toHaveBeenLastCalledWith(
       expect.objectContaining({
         data: {
@@ -180,9 +182,9 @@ describe('_addResourceSpans', () => {
 
     _addResourceSpans(transaction, entry, '/assets/to/css', 100, 23, 345);
 
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // eslint-disable-next-line @typescript-eslint/unbound-method, deprecation/deprecation
     expect(transaction.startChild).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // eslint-disable-next-line @typescript-eslint/unbound-method, deprecation/deprecation
     expect(transaction.startChild).toHaveBeenLastCalledWith(
       expect.objectContaining({
         data: {},
@@ -202,9 +204,9 @@ describe('_addResourceSpans', () => {
 
     _addResourceSpans(transaction, entry, '/assets/to/css', 100, 23, 345);
 
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // eslint-disable-next-line @typescript-eslint/unbound-method, deprecation/deprecation
     expect(transaction.startChild).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line @typescript-eslint/unbound-method
+    // eslint-disable-next-line @typescript-eslint/unbound-method, deprecation/deprecation
     expect(transaction.startChild).toHaveBeenLastCalledWith(
       expect.objectContaining({
         data: {},

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -239,6 +239,8 @@ export interface Span extends SpanContext {
   /**
    * Creates a new `Span` while setting the current `Span.id` as `parentSpanId`.
    * Also the `sampled` decision will be inherited.
+   *
+   * @deprecated Use `startSpan()`, `startSpanManual()` or `startInactiveSpan()` instead.
    */
   startChild(spanContext?: Pick<SpanContext, Exclude<keyof SpanContext, 'sampled' | 'traceId' | 'parentSpanId'>>): Span;
 

--- a/packages/vue/src/tracing.ts
+++ b/packages/vue/src/tracing.ts
@@ -77,6 +77,7 @@ export const createTracingMixins = (options: TracingOptions): Mixins => {
           if (activeTransaction) {
             this.$_sentryRootSpan =
               this.$_sentryRootSpan ||
+              // eslint-disable-next-line deprecation/deprecation
               activeTransaction.startChild({
                 description: 'Application Render',
                 op: `${VUE_OP}.render`,
@@ -111,6 +112,7 @@ export const createTracingMixins = (options: TracingOptions): Mixins => {
               oldSpan.end();
             }
 
+            // eslint-disable-next-line deprecation/deprecation
             this.$_sentrySpans[operation] = activeTransaction.startChild({
               description: `Vue <${name}>`,
               op: `${VUE_OP}.${operation}`,


### PR DESCRIPTION
We still have quite a lot of these ourselves, but we can refactor them over time during the v8 preparation.

But with this, I think we have the most important deprecations mostly done!