### PR TITLE
ref(node-experimental): Deprecate `lastEventId` on scope

### DIFF
--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -59,6 +59,7 @@ export function withIsolationScope<T>(callback: (isolationScope: Scope) => T): T
  * @deprecated This function will be removed in the next major version of the Sentry SDK.
  */
 export function lastEventId(): string | undefined {
+  // eslint-disable-next-line deprecation/deprecation
   return getCurrentScope().lastEventId();
 }
 

--- a/packages/node-experimental/src/sdk/types.ts
+++ b/packages/node-experimental/src/sdk/types.ts
@@ -43,6 +43,9 @@ export interface Scope extends BaseScope {
     hint?: EventHint,
   ): string;
   captureEvent(event: Event, hint?: EventHint): string;
+  /**
+   * @deprecated This function will be removed in the next major version of the Sentry SDK.
+   */
   lastEventId(): string | undefined;
   getScopeData(): ScopeData;
 }


### PR DESCRIPTION
I forgot this deprecation in https://github.com/getsentry/sentry-javascript/pull/10043