### PR TITLE
feat(core): Deprecate `Transaction.getDynamicSamplingContext` in favour of `getDynamicSamplingContextFromSpan`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -98,6 +98,7 @@ In v8, the Span class is heavily reworked. The following properties & methods ar
 * `span.traceId`: Use `span.spanContext().traceId` instead.
 * `span.name`: Use `spanToJSON(span).description` instead.
 * `span.description`: Use `spanToJSON(span).description` instead.
+* `span.getDynamicSamplingContext`: Use `getDynamicSamplingContextFromSpan` utility function instead.
 * `transaction.setMetadata()`: Use attributes instead, or set data on the scope.
 * `transaction.metadata`: Use attributes instead, or set data on the scope.
 

--- a/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
+++ b/dev-packages/rollup-utils/plugins/bundlePlugins.mjs
@@ -135,6 +135,9 @@ export function makeTerserPlugin() {
           // These are used by instrument.ts in utils for identifying HTML elements & events
           '_sentryCaptured',
           '_sentryId',
+          // For v7 backwards-compatibility we need to access txn._frozenDynamicSamplingContext
+          // TODO (v8): Remove this reserved word
+          '_frozenDynamicSamplingContext',
         ],
       },
     },

--- a/packages/astro/src/server/meta.ts
+++ b/packages/astro/src/server/meta.ts
@@ -1,5 +1,8 @@
-import { getDynamicSamplingContextFromClient, spanToTraceHeader } from '@sentry/core';
-import { getDynamicSamplingContextFromSpan } from '@sentry/core/src/tracing/dynamicSamplingContext';
+import {
+  getDynamicSamplingContextFromClient,
+  getDynamicSamplingContextFromSpan,
+  spanToTraceHeader,
+} from '@sentry/core';
 import type { Client, Scope, Span } from '@sentry/types';
 import {
   TRACEPARENT_REGEXP,

--- a/packages/astro/src/server/meta.ts
+++ b/packages/astro/src/server/meta.ts
@@ -1,4 +1,5 @@
 import { getDynamicSamplingContextFromClient, spanToTraceHeader } from '@sentry/core';
+import { getDynamicSamplingContextFromSpan } from '@sentry/core/src/tracing/dynamicSamplingContext';
 import type { Client, Scope, Span } from '@sentry/types';
 import {
   TRACEPARENT_REGEXP,
@@ -33,7 +34,7 @@ export function getTracingMetaTags(
   const sentryTrace = span ? spanToTraceHeader(span) : generateSentryTraceHeader(traceId, undefined, sampled);
 
   const dynamicSamplingContext = transaction
-    ? transaction.getDynamicSamplingContext()
+    ? getDynamicSamplingContextFromSpan(transaction)
     : dsc
       ? dsc
       : client

--- a/packages/astro/test/server/meta.test.ts
+++ b/packages/astro/test/server/meta.test.ts
@@ -32,6 +32,10 @@ const mockedScope = {
 describe('getTracingMetaTags', () => {
   it('returns the tracing tags from the span, if it is provided', () => {
     {
+      vi.spyOn(SentryCore, 'getDynamicSamplingContextFromSpan').mockReturnValueOnce({
+        environment: 'production',
+      });
+
       const tags = getTracingMetaTags(mockedSpan, mockedScope, mockedClient);
 
       expect(tags).toEqual({

--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -21,7 +21,11 @@ import { getClient } from './exports';
 import { MetricsAggregator } from './metrics/aggregator';
 import type { Scope } from './scope';
 import { SessionFlusher } from './sessionflusher';
-import { addTracingExtensions, getDynamicSamplingContextFromClient } from './tracing';
+import {
+  addTracingExtensions,
+  getDynamicSamplingContextFromClient,
+  getDynamicSamplingContextFromSpan,
+} from './tracing';
 import { spanToTraceContext } from './utils/spanUtils';
 
 export interface ServerRuntimeClientOptions extends ClientOptions<BaseTransportOptions> {
@@ -258,7 +262,7 @@ export class ServerRuntimeClient<
     // eslint-disable-next-line deprecation/deprecation
     const span = scope.getSpan();
     if (span) {
-      const samplingContext = span.transaction ? span.transaction.getDynamicSamplingContext() : undefined;
+      const samplingContext = span.transaction ? getDynamicSamplingContextFromSpan(span) : undefined;
       return [samplingContext, spanToTraceContext(span)];
     }
 

--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -1,17 +1,19 @@
-import type { Client, DynamicSamplingContext, Scope } from '@sentry/types';
+import type { Client, DynamicSamplingContext, Scope, Span } from '@sentry/types';
 import { dropUndefinedKeys } from '@sentry/utils';
 
 import { DEFAULT_ENVIRONMENT } from '../constants';
+import { getClient, getCurrentScope } from '../exports';
 
 /**
  * Creates a dynamic sampling context from a client.
  *
- * Dispatchs the `createDsc` lifecycle hook as a side effect.
+ * Dispatches the `createDsc` lifecycle hook as a side effect.
  */
 export function getDynamicSamplingContextFromClient(
   trace_id: string,
   client: Client,
   scope?: Scope,
+  emitHook: boolean = true,
 ): DynamicSamplingContext {
   const options = client.getOptions();
 
@@ -25,6 +27,64 @@ export function getDynamicSamplingContextFromClient(
     public_key,
     trace_id,
   }) as DynamicSamplingContext;
+
+  if (emitHook) {
+    client.emit && client.emit('createDsc', dsc);
+  }
+
+  return dsc;
+}
+
+/**
+ * A Span with a frozen dynamic sampling context.
+ */
+type TransactionWithV7FrozenDsc = Span & { _frozenDynamicSamplingContext?: DynamicSamplingContext };
+
+/**
+ * Creates a dynamic sampling context from a span (and client and scope)
+ *
+ * @param span the span from which a few values like the root span name and sample rate are extracted.
+ *
+ * @returns a dynamic sampling context
+ */
+export function getDynamicSamplingContextFromSpan(span: Span): Readonly<Partial<DynamicSamplingContext>> {
+  // TODO (v8): Remove v7FrozenDsc as a Transaction will no longer have _frozenDynamicSamplingContext
+  // For now we need to avoid breaking users who directly created a txn with a DSC, where this field is still set.
+  // @see Transaction class constructor
+  const v7FrozenDsc = (span as TransactionWithV7FrozenDsc)._frozenDynamicSamplingContext;
+  if (v7FrozenDsc) {
+    return v7FrozenDsc;
+  }
+
+  const client = getClient();
+  if (!client) {
+    return {};
+  }
+
+  // passing emit=false here to only emit later once the DSC is actually populated
+  const dsc = getDynamicSamplingContextFromClient(span.traceId, client, getCurrentScope(), false);
+  const txn = span.transaction;
+  if (!txn) {
+    return dsc;
+  }
+
+  const maybeSampleRate = txn.metadata.sampleRate;
+  if (maybeSampleRate !== undefined) {
+    dsc.sample_rate = `${maybeSampleRate}`;
+  }
+
+  // We don't want to have a transaction name in the DSC if the source is "url" because URLs might contain PII
+  const source = txn.metadata.source;
+  if (source && source !== 'url') {
+    dsc.transaction = txn.name;
+  }
+
+  // TODO: Switch to `spanIsSampled` once we have it
+  // eslint-disable-next-line deprecation/deprecation
+  if (txn.sampled !== undefined) {
+    // eslint-disable-next-line deprecation/deprecation
+    dsc.sampled = String(txn.sampled);
+  }
 
   client.emit && client.emit('createDsc', dsc);
 

--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -1,8 +1,9 @@
-import type { Client, DynamicSamplingContext, Scope, Span, Transaction } from '@sentry/types';
+import type { Client, DynamicSamplingContext, Scope, Span, Transaction, TransactionSource } from '@sentry/types';
 import { dropUndefinedKeys } from '@sentry/utils';
 
 import { DEFAULT_ENVIRONMENT } from '../constants';
 import { getClient, getCurrentScope } from '../exports';
+import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '../semanticAttributes';
 import { spanIsSampled, spanToJSON } from '../utils/spanUtils';
 
 /**
@@ -78,7 +79,7 @@ export function getDynamicSamplingContextFromSpan(span: Span): Readonly<Partial<
   }
 
   // We don't want to have a transaction name in the DSC if the source is "url" because URLs might contain PII
-  const source = txn.metadata.source;
+  const source = txn.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] as TransactionSource | undefined;
   const jsonSpan = spanToJSON(txn);
 
   // after JSON conversion, txn.name becomes jsonSpan.description

--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -70,13 +70,15 @@ export function getDynamicSamplingContextFromSpan(span: Span): Readonly<Partial<
     return v7FrozenDsc;
   }
 
-  const maybeSampleRate = txn.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE] as number | undefined;
+  // TODO (v8): Replace txn.metadata with txn.attributes[]
+  // We can't do this yet because attributes aren't always set yet.
+  // eslint-disable-next-line deprecation/deprecation
+  const { sampleRate: maybeSampleRate, source } = txn.metadata;
   if (maybeSampleRate != null) {
     dsc.sample_rate = `${maybeSampleRate}`;
   }
 
   // We don't want to have a transaction name in the DSC if the source is "url" because URLs might contain PII
-  const source = txn.attributes[SEMANTIC_ATTRIBUTE_SENTRY_SOURCE] as TransactionSource | undefined;
   const jsonSpan = spanToJSON(txn);
 
   // after JSON conversion, txn.name becomes jsonSpan.description

--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -1,9 +1,8 @@
-import type { Client, DynamicSamplingContext, Scope, Span, Transaction, TransactionSource } from '@sentry/types';
+import type { Client, DynamicSamplingContext, Scope, Span, Transaction } from '@sentry/types';
 import { dropUndefinedKeys } from '@sentry/utils';
 
 import { DEFAULT_ENVIRONMENT } from '../constants';
 import { getClient, getCurrentScope } from '../exports';
-import { SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '../semanticAttributes';
 import { spanIsSampled, spanToJSON } from '../utils/spanUtils';
 
 /**

--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -48,10 +48,14 @@ type TransactionWithV7FrozenDsc = Span & { _frozenDynamicSamplingContext?: Dynam
  * @returns a dynamic sampling context
  */
 export function getDynamicSamplingContextFromSpan(span: Span): Readonly<Partial<DynamicSamplingContext>> {
+  // As long as we use `Transaction`s internally, this should be fine.
+  // TODO: We need to replace this with a `getRootSpan(span)` function though
+  const txn = span.transaction;
+
   // TODO (v8): Remove v7FrozenDsc as a Transaction will no longer have _frozenDynamicSamplingContext
   // For now we need to avoid breaking users who directly created a txn with a DSC, where this field is still set.
   // @see Transaction class constructor
-  const v7FrozenDsc = (span as TransactionWithV7FrozenDsc)._frozenDynamicSamplingContext;
+  const v7FrozenDsc = (txn as TransactionWithV7FrozenDsc)._frozenDynamicSamplingContext;
   if (v7FrozenDsc) {
     return v7FrozenDsc;
   }
@@ -63,7 +67,6 @@ export function getDynamicSamplingContextFromSpan(span: Span): Readonly<Partial<
 
   // passing emit=false here to only emit later once the DSC is actually populated
   const dsc = getDynamicSamplingContextFromClient(span.traceId, client, getCurrentScope(), false);
-  const txn = span.transaction;
   if (!txn) {
     return dsc;
   }

--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -1,4 +1,4 @@
-import type { Client, DynamicSamplingContext, Scope, Span } from '@sentry/types';
+import type { Client, DynamicSamplingContext, Scope, Span, Transaction } from '@sentry/types';
 import { dropUndefinedKeys } from '@sentry/utils';
 
 import { DEFAULT_ENVIRONMENT } from '../constants';
@@ -38,7 +38,7 @@ export function getDynamicSamplingContextFromClient(
 /**
  * A Span with a frozen dynamic sampling context.
  */
-type TransactionWithV7FrozenDsc = Span & { _frozenDynamicSamplingContext?: DynamicSamplingContext };
+type TransactionWithV7FrozenDsc = Transaction & { _frozenDynamicSamplingContext?: DynamicSamplingContext };
 
 /**
  * Creates a dynamic sampling context from a span (and client and scope)
@@ -48,18 +48,6 @@ type TransactionWithV7FrozenDsc = Span & { _frozenDynamicSamplingContext?: Dynam
  * @returns a dynamic sampling context
  */
 export function getDynamicSamplingContextFromSpan(span: Span): Readonly<Partial<DynamicSamplingContext>> {
-  // As long as we use `Transaction`s internally, this should be fine.
-  // TODO: We need to replace this with a `getRootSpan(span)` function though
-  const txn = span.transaction;
-
-  // TODO (v8): Remove v7FrozenDsc as a Transaction will no longer have _frozenDynamicSamplingContext
-  // For now we need to avoid breaking users who directly created a txn with a DSC, where this field is still set.
-  // @see Transaction class constructor
-  const v7FrozenDsc = (txn as TransactionWithV7FrozenDsc)._frozenDynamicSamplingContext;
-  if (v7FrozenDsc) {
-    return v7FrozenDsc;
-  }
-
   const client = getClient();
   if (!client) {
     return {};
@@ -67,8 +55,21 @@ export function getDynamicSamplingContextFromSpan(span: Span): Readonly<Partial<
 
   // passing emit=false here to only emit later once the DSC is actually populated
   const dsc = getDynamicSamplingContextFromClient(span.traceId, client, getCurrentScope(), false);
+
+  const txn = span.transaction as TransactionWithV7FrozenDsc | undefined;
   if (!txn) {
     return dsc;
+  }
+
+  // As long as we use `Transaction`s internally, this should be fine.
+  // TODO: We need to replace this with a `getRootSpan(span)` function though
+
+  // TODO (v8): Remove v7FrozenDsc as a Transaction will no longer have _frozenDynamicSamplingContext
+  // For now we need to avoid breaking users who directly created a txn with a DSC, where this field is still set.
+  // @see Transaction class constructor
+  const v7FrozenDsc = txn && txn._frozenDynamicSamplingContext;
+  if (v7FrozenDsc) {
+    return v7FrozenDsc;
   }
 
   const maybeSampleRate = txn.metadata.sampleRate;

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -19,5 +19,5 @@ export {
   startSpanManual,
   continueTrace,
 } from './trace';
-export { getDynamicSamplingContextFromClient } from './dynamicSamplingContext';
+export { getDynamicSamplingContextFromClient, getDynamicSamplingContextFromSpan } from './dynamicSamplingContext';
 export { setMeasurement } from './measurement';

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -35,6 +35,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
 
   private _trimEnd?: boolean;
 
+  // DO NOT yet remove this property, it is used in a hack for v7 backwards compatibility.
   private _frozenDynamicSamplingContext: Readonly<Partial<DynamicSamplingContext>> | undefined;
 
   private _metadata: Partial<TransactionMetadata>;

--- a/packages/core/src/utils/applyScopeDataToEvent.ts
+++ b/packages/core/src/utils/applyScopeDataToEvent.ts
@@ -1,5 +1,6 @@
 import type { Breadcrumb, Event, PropagationContext, ScopeData, Span } from '@sentry/types';
 import { arrayify } from '@sentry/utils';
+import { getDynamicSamplingContextFromSpan } from '../tracing/dynamicSamplingContext';
 import { spanToJSON, spanToTraceContext } from './spanUtils';
 
 /**
@@ -176,7 +177,7 @@ function applySpanToEvent(event: Event, span: Span): void {
   const transaction = span.transaction;
   if (transaction) {
     event.sdkProcessingMetadata = {
-      dynamicSamplingContext: transaction.getDynamicSamplingContext(),
+      dynamicSamplingContext: getDynamicSamplingContextFromSpan(span),
       ...event.sdkProcessingMetadata,
     };
     const transactionName = spanToJSON(transaction).description;

--- a/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
+++ b/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
@@ -29,6 +29,7 @@ describe('getDynamicSamplingContextFromSpan', () => {
   test('returns a new DSC, if no DSC was provided during transaction creation', () => {
     const transaction = new Transaction({
       name: 'tx',
+      sampled: true,
       metadata: {
         sampleRate: 0.56,
       },
@@ -39,6 +40,7 @@ describe('getDynamicSamplingContextFromSpan', () => {
     expect(dynamicSamplingContext).toStrictEqual({
       release: '1.0.1',
       environment: 'production',
+      sampled: 'true',
       sample_rate: '0.56',
       trace_id: expect.any(String),
       transaction: 'tx',

--- a/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
+++ b/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
@@ -1,0 +1,77 @@
+import type { TransactionSource } from '@sentry/types';
+import { Hub, makeMain } from '../../../src';
+import { Transaction, getDynamicSamplingContextFromSpan } from '../../../src/tracing';
+import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
+
+describe('getDynamicSamplingContextFromSpan', () => {
+  beforeEach(() => {
+    const options = getDefaultTestClientOptions({ tracesSampleRate: 0.0, release: '1.0.1' });
+    const client = new TestClient(options);
+    const hub = new Hub(client);
+    makeMain(hub);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('returns the DSC provided during transaction creation', () => {
+    const transaction = new Transaction({
+      name: 'tx',
+      metadata: { dynamicSamplingContext: { environment: 'myEnv' } },
+    });
+
+    const dynamicSamplingContext = getDynamicSamplingContextFromSpan(transaction);
+
+    expect(dynamicSamplingContext).toStrictEqual({ environment: 'myEnv' });
+  });
+
+  test('returns a new DSC, if no DSC was provided during transaction creation', () => {
+    const transaction = new Transaction({
+      name: 'tx',
+      metadata: {
+        sampleRate: 0.56,
+      },
+    });
+
+    const dynamicSamplingContext = getDynamicSamplingContextFromSpan(transaction);
+
+    expect(dynamicSamplingContext).toStrictEqual({
+      release: '1.0.1',
+      environment: 'production',
+      sample_rate: '0.56',
+      trace_id: expect.any(String),
+      transaction: 'tx',
+    });
+  });
+
+  describe('Including transaction name in DSC', () => {
+    test('is not included if transaction source is url', () => {
+      const transaction = new Transaction({
+        name: 'tx',
+        metadata: {
+          source: 'url',
+        },
+      });
+
+      const dsc = getDynamicSamplingContextFromSpan(transaction);
+      expect(dsc.transaction).toBeUndefined();
+    });
+
+    test.each([
+      ['is included if transaction source is parameterized route/url', 'route'],
+      ['is included if transaction source is a custom name', 'custom'],
+    ])('%s', (_: string, source) => {
+      const transaction = new Transaction({
+        name: 'tx',
+        metadata: {
+          ...(source && { source: source as TransactionSource }),
+        },
+      });
+
+      const dsc = getDynamicSamplingContextFromSpan(transaction);
+
+      expect(dsc.transaction).toEqual('tx');
+    });
+  });
+});

--- a/packages/nextjs/src/common/wrapAppGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapAppGetInitialPropsWithSentry.ts
@@ -1,4 +1,10 @@
-import { addTracingExtensions, getClient, getCurrentScope, spanToTraceHeader } from '@sentry/core';
+import {
+  addTracingExtensions,
+  getClient,
+  getCurrentScope,
+  getDynamicSamplingContextFromSpan,
+  spanToTraceHeader,
+} from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type App from 'next/app';
 
@@ -66,7 +72,7 @@ export function wrapAppGetInitialPropsWithSentry(origAppGetInitialProps: AppGetI
         if (requestTransaction) {
           appGetInitialProps.pageProps._sentryTraceData = spanToTraceHeader(requestTransaction);
 
-          const dynamicSamplingContext = requestTransaction.getDynamicSamplingContext();
+          const dynamicSamplingContext = getDynamicSamplingContextFromSpan(requestTransaction);
           appGetInitialProps.pageProps._sentryBaggage =
             dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
         }

--- a/packages/nextjs/src/common/wrapErrorGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapErrorGetInitialPropsWithSentry.ts
@@ -1,4 +1,10 @@
-import { addTracingExtensions, getClient, getCurrentScope, spanToTraceHeader } from '@sentry/core';
+import {
+  addTracingExtensions,
+  getClient,
+  getCurrentScope,
+  getDynamicSamplingContextFromSpan,
+  spanToTraceHeader,
+} from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { NextPageContext } from 'next';
 import type { ErrorProps } from 'next/error';
@@ -58,7 +64,7 @@ export function wrapErrorGetInitialPropsWithSentry(
         if (requestTransaction) {
           errorGetInitialProps._sentryTraceData = spanToTraceHeader(requestTransaction);
 
-          const dynamicSamplingContext = requestTransaction.getDynamicSamplingContext();
+          const dynamicSamplingContext = getDynamicSamplingContextFromSpan(requestTransaction);
           errorGetInitialProps._sentryBaggage = dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
         }
 

--- a/packages/nextjs/src/common/wrapGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGetInitialPropsWithSentry.ts
@@ -1,4 +1,10 @@
-import { addTracingExtensions, getClient, getCurrentScope, spanToTraceHeader } from '@sentry/core';
+import {
+  addTracingExtensions,
+  getClient,
+  getCurrentScope,
+  getDynamicSamplingContextFromSpan,
+  spanToTraceHeader,
+} from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { NextPage } from 'next';
 
@@ -54,7 +60,7 @@ export function wrapGetInitialPropsWithSentry(origGetInitialProps: GetInitialPro
         if (requestTransaction) {
           initialProps._sentryTraceData = spanToTraceHeader(requestTransaction);
 
-          const dynamicSamplingContext = requestTransaction.getDynamicSamplingContext();
+          const dynamicSamplingContext = getDynamicSamplingContextFromSpan(requestTransaction);
           initialProps._sentryBaggage = dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
         }
 

--- a/packages/nextjs/src/common/wrapGetServerSidePropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGetServerSidePropsWithSentry.ts
@@ -1,4 +1,10 @@
-import { addTracingExtensions, getClient, getCurrentScope, spanToTraceHeader } from '@sentry/core';
+import {
+  addTracingExtensions,
+  getClient,
+  getCurrentScope,
+  getDynamicSamplingContextFromSpan,
+  spanToTraceHeader,
+} from '@sentry/core';
 import { dynamicSamplingContextToSentryBaggageHeader } from '@sentry/utils';
 import type { GetServerSideProps } from 'next';
 
@@ -51,7 +57,7 @@ export function wrapGetServerSidePropsWithSentry(
           if (requestTransaction) {
             serverSideProps.props._sentryTraceData = spanToTraceHeader(requestTransaction);
 
-            const dynamicSamplingContext = requestTransaction.getDynamicSamplingContext();
+            const dynamicSamplingContext = getDynamicSamplingContextFromSpan(requestTransaction);
             serverSideProps.props._sentryBaggage = dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
           }
         }

--- a/packages/node/src/integrations/hapi/index.ts
+++ b/packages/node/src/integrations/hapi/index.ts
@@ -5,6 +5,7 @@ import {
   convertIntegrationFnToClass,
   getActiveTransaction,
   getCurrentScope,
+  getDynamicSamplingContextFromSpan,
   spanToTraceHeader,
   startTransaction,
 } from '@sentry/core';
@@ -101,7 +102,7 @@ export const hapiTracingPlugin = {
         response.header('sentry-trace', spanToTraceHeader(transaction));
 
         const dynamicSamplingContext = dynamicSamplingContextToSentryBaggageHeader(
-          transaction.getDynamicSamplingContext(),
+          getDynamicSamplingContextFromSpan(transaction),
         );
 
         if (dynamicSamplingContext) {

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -8,6 +8,7 @@ import {
   getCurrentHub,
   getCurrentScope,
   getDynamicSamplingContextFromClient,
+  getDynamicSamplingContextFromSpan,
   isSentryRequestUrl,
   spanToJSON,
   spanToTraceHeader,
@@ -271,7 +272,7 @@ function _createWrappedRequestMethodFactory(
       if (shouldAttachTraceData(rawRequestUrl)) {
         if (requestSpan) {
           const sentryTraceHeader = spanToTraceHeader(requestSpan);
-          const dynamicSamplingContext = requestSpan?.transaction?.getDynamicSamplingContext();
+          const dynamicSamplingContext = getDynamicSamplingContextFromSpan(requestSpan);
           addHeadersToRequestOptions(requestOptions, requestUrl, sentryTraceHeader, dynamicSamplingContext);
         } else {
           const client = getClient();

--- a/packages/node/src/integrations/undici/index.ts
+++ b/packages/node/src/integrations/undici/index.ts
@@ -5,6 +5,7 @@ import {
   getCurrentHub,
   getCurrentScope,
   getDynamicSamplingContextFromClient,
+  getDynamicSamplingContextFromSpan,
   isSentryRequestUrl,
   spanToTraceHeader,
 } from '@sentry/core';
@@ -181,7 +182,7 @@ export class Undici implements Integration {
 
     if (shouldAttachTraceData(stringUrl)) {
       if (span) {
-        const dynamicSamplingContext = span?.transaction?.getDynamicSamplingContext();
+        const dynamicSamplingContext = getDynamicSamplingContextFromSpan(span);
         const sentryBaggageHeader = dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
 
         setHeadersOnRequest(request, spanToTraceHeader(span), sentryBaggageHeader);

--- a/packages/opentelemetry-node/src/propagator.ts
+++ b/packages/opentelemetry-node/src/propagator.ts
@@ -1,7 +1,7 @@
 import type { Baggage, Context, TextMapGetter, TextMapSetter } from '@opentelemetry/api';
 import { TraceFlags, isSpanContextValid, propagation, trace } from '@opentelemetry/api';
 import { W3CBaggagePropagator, isTracingSuppressed } from '@opentelemetry/core';
-import { spanToTraceHeader } from '@sentry/core';
+import { getDynamicSamplingContextFromSpan, spanToTraceHeader } from '@sentry/core';
 import {
   SENTRY_BAGGAGE_KEY_PREFIX,
   baggageHeaderToDynamicSamplingContext,
@@ -36,7 +36,7 @@ export class SentryPropagator extends W3CBaggagePropagator {
       setter.set(carrier, SENTRY_TRACE_HEADER, spanToTraceHeader(span));
 
       if (span.transaction) {
-        const dynamicSamplingContext = span.transaction.getDynamicSamplingContext();
+        const dynamicSamplingContext = getDynamicSamplingContextFromSpan(span);
         baggage = Object.entries(dynamicSamplingContext).reduce<Baggage>((b, [dscKey, dscValue]) => {
           if (dscValue) {
             return b.setEntry(`${SENTRY_BAGGAGE_KEY_PREFIX}${dscKey}`, { value: dscValue });

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -4,6 +4,7 @@ import {
   getActiveTransaction,
   getClient,
   getCurrentScope,
+  getDynamicSamplingContextFromSpan,
   hasTracingEnabled,
   runWithAsyncContext,
   spanToJSON,
@@ -307,7 +308,7 @@ function getTraceAndBaggage(): {
     const span = getActiveSpan();
 
     if (span && transaction) {
-      const dynamicSamplingContext = transaction.getDynamicSamplingContext();
+      const dynamicSamplingContext = getDynamicSamplingContextFromSpan(transaction);
 
       return {
         sentryTrace: spanToTraceHeader(span),

--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -1,4 +1,4 @@
-import { getActiveSpan, getCurrentScope, spanToTraceHeader } from '@sentry/core';
+import { getActiveSpan, getCurrentScope, getDynamicSamplingContextFromSpan, spanToTraceHeader } from '@sentry/core';
 import { getActiveTransaction, runWithAsyncContext, startSpan } from '@sentry/core';
 import { captureException } from '@sentry/node';
 /* eslint-disable @sentry-internal/sdk/no-optional-chaining */
@@ -100,7 +100,7 @@ export function addSentryCodeToPage(options: SentryHandleOptions): NonNullable<R
     if (transaction) {
       const traceparentData = spanToTraceHeader(transaction);
       const dynamicSamplingContext = dynamicSamplingContextToSentryBaggageHeader(
-        transaction.getDynamicSamplingContext(),
+        getDynamicSamplingContextFromSpan(transaction),
       );
       const contentMeta = `<head>
     <meta name="sentry-trace" content="${traceparentData}"/>

--- a/packages/tracing-internal/src/browser/request.ts
+++ b/packages/tracing-internal/src/browser/request.ts
@@ -4,6 +4,7 @@ import {
   getClient,
   getCurrentScope,
   getDynamicSamplingContextFromClient,
+  getDynamicSamplingContextFromSpan,
   hasTracingEnabled,
   spanToTraceHeader,
 } from '@sentry/core';
@@ -297,7 +298,7 @@ export function xhrCallback(
   if (xhr.setRequestHeader && shouldAttachHeaders(sentryXhrData.url)) {
     if (span) {
       const transaction = span && span.transaction;
-      const dynamicSamplingContext = transaction && transaction.getDynamicSamplingContext();
+      const dynamicSamplingContext = transaction && getDynamicSamplingContextFromSpan(transaction);
       const sentryBaggageHeader = dynamicSamplingContextToSentryBaggageHeader(dynamicSamplingContext);
       setHeaderOnXhr(xhr, spanToTraceHeader(span), sentryBaggageHeader);
     } else {

--- a/packages/tracing-internal/src/common/fetch.ts
+++ b/packages/tracing-internal/src/common/fetch.ts
@@ -3,6 +3,7 @@ import {
   getClient,
   getCurrentScope,
   getDynamicSamplingContextFromClient,
+  getDynamicSamplingContextFromSpan,
   hasTracingEnabled,
   spanToTraceHeader,
 } from '@sentry/core';
@@ -139,7 +140,7 @@ export function addTracingHeadersToFetchRequest(
 
   const sentryTraceHeader = span ? spanToTraceHeader(span) : generateSentryTraceHeader(traceId, undefined, sampled);
   const dynamicSamplingContext = transaction
-    ? transaction.getDynamicSamplingContext()
+    ? getDynamicSamplingContextFromSpan(transaction)
     : dsc
       ? dsc
       : getDynamicSamplingContextFromClient(traceId, client, scope);

--- a/packages/tracing/test/span.test.ts
+++ b/packages/tracing/test/span.test.ts
@@ -571,24 +571,19 @@ describe('Span', () => {
         hub,
       );
 
-      const hubSpy = jest.spyOn(hub.getClient()!, 'getOptions');
-
       const dynamicSamplingContext = transaction.getDynamicSamplingContext();
 
-      expect(hubSpy).not.toHaveBeenCalled();
       expect(dynamicSamplingContext).toStrictEqual({ environment: 'myEnv' });
     });
 
     test('should return new DSC, if no DSC was provided during transaction creation', () => {
-      const transaction = new Transaction(
-        {
-          name: 'tx',
-          metadata: {
-            sampleRate: 0.56,
-          },
+      const transaction = new Transaction({
+        name: 'tx',
+        metadata: {
+          sampleRate: 0.56,
         },
-        hub,
-      );
+        sampled: true,
+      });
 
       const getOptionsSpy = jest.spyOn(hub.getClient()!, 'getOptions');
 
@@ -598,6 +593,7 @@ describe('Span', () => {
       expect(dynamicSamplingContext).toStrictEqual({
         release: '1.0.1',
         environment: 'production',
+        sampled: 'true',
         sample_rate: '0.56',
         trace_id: expect.any(String),
         transaction: 'tx',

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -136,7 +136,11 @@ export interface Transaction extends TransactionContext, Omit<Span, 'setName' | 
    */
   setMetadata(newMetadata: Partial<TransactionMetadata>): void;
 
-  /** Return the current Dynamic Sampling Context of this transaction */
+  /**
+   * Return the current Dynamic Sampling Context of this transaction
+   *
+   * @deprecated Use top-level `getDynamicSamplingContextFromSpan` instead.
+   */
   getDynamicSamplingContext(): Partial<DynamicSamplingContext>;
 }
 


### PR DESCRIPTION
This PR deprecates `Transaction.getDynamicSamplingContext` and introduces its direct replacement, a top-level utility function. Note that IMO this only is an intermediate step we should take to rework how we generate and handle the DSC creation. More details in #10095 

Used various new APIs like `spanToJSON` and `spanIsSampled`. Observed that a slight behavioural change is, that `isSpanSampled` always returns a boolean while `span.sampled` could also be undefined. Considering integration tests still pass, I'd say this is fine.

Added new tests for the top level helper and left the older ones in place to still cover `transaction.getDSC`.

