### PR TITLE
feat(core): Deprecate `getActiveTransaction()` & `scope.getTransaction()`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,6 +8,10 @@ npx @sentry/migr8@latest
 
 This will let you select which updates to run, and automatically update your code. Make sure to still review all code changes!
 
+## Deprecate `scope.getTransaction()` and `getActiveTransaction()`
+
+Instead, you should not rely on the active transaction, but just use `startSpan()` APIs, which handle this for you.
+
 ## Deprecate arguments for `startSpan()` APIs
 
 In v8, the API to start a new span will be reduced from the currently available options.

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/server.ts
@@ -26,6 +26,7 @@ app.use(Sentry.Handlers.tracingHandler());
 app.use(cors());
 
 app.get('/test/express', (_req, res) => {
+  // eslint-disable-next-line deprecation/deprecation
   const transaction = Sentry.getCurrentHub().getScope().getTransaction();
   if (transaction) {
     // eslint-disable-next-line deprecation/deprecation

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/server.ts
@@ -29,6 +29,7 @@ app.use(Sentry.Handlers.tracingHandler());
 app.use(cors());
 
 app.get('/test/express', (_req, res) => {
+  // eslint-disable-next-line deprecation/deprecation
   const transaction = Sentry.getCurrentHub().getScope().getTransaction();
   if (transaction) {
     // eslint-disable-next-line deprecation/deprecation

--- a/packages/angular-ivy/README.md
+++ b/packages/angular-ivy/README.md
@@ -215,33 +215,22 @@ export class FooterComponent implements OnInit {
 }
 ```
 
-You can also add your own custom spans by attaching them to the current active transaction using `getActiveTransaction`
-helper. For example, if you'd like to track the duration of Angular boostraping process, you can do it as follows:
+You can also add your own custom spans via `startSpan()`. For example, if you'd like to track the duration of Angular boostraping process, you can do it as follows:
 
 ```javascript
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { init, getActiveTransaction } from '@sentry/angular-ivy';
+import { init, startSpan } from '@sentry/angular';
 
 import { AppModule } from './app/app.module';
 
 // ...
-
-const activeTransaction = getActiveTransaction();
-const boostrapSpan =
-  activeTransaction &&
-  activeTransaction.startChild({
-    description: 'platform-browser-dynamic',
-    op: 'ui.angular.bootstrap',
-  });
-
-platformBrowserDynamic()
-  .bootstrapModule(AppModule)
-  .then(() => console.log(`Bootstrap success`))
-  .catch(err => console.error(err));
-  .finally(() => {
-    if (bootstrapSpan) {
-      boostrapSpan.finish();
-    }
-  })
+startSpan({
+  name: 'platform-browser-dynamic',
+  op: 'ui.angular.bootstrap'
+  },
+  async () => {
+    await platformBrowserDynamic().bootstrapModule(AppModule);
+  }
+);
 ```

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -215,33 +215,22 @@ export class FooterComponent implements OnInit {
 }
 ```
 
-You can also add your own custom spans by attaching them to the current active transaction using `getActiveTransaction`
-helper. For example, if you'd like to track the duration of Angular boostraping process, you can do it as follows:
+You can also add your own custom spans via `startSpan()`. For example, if you'd like to track the duration of Angular boostraping process, you can do it as follows:
 
 ```javascript
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { init, getActiveTransaction } from '@sentry/angular';
+import { init, startSpan } from '@sentry/angular';
 
 import { AppModule } from './app/app.module';
 
 // ...
-
-const activeTransaction = getActiveTransaction();
-const boostrapSpan =
-  activeTransaction &&
-  activeTransaction.startChild({
-    description: 'platform-browser-dynamic',
-    op: 'ui.angular.bootstrap',
-  });
-
-platformBrowserDynamic()
-  .bootstrapModule(AppModule)
-  .then(() => console.log(`Bootstrap success`))
-  .catch(err => console.error(err));
-  .finally(() => {
-    if (bootstrapSpan) {
-      boostrapSpan.finish();
-    }
-  })
+startSpan({
+  name: 'platform-browser-dynamic',
+  op: 'ui.angular.bootstrap'
+  },
+  async () => {
+    await platformBrowserDynamic().bootstrapModule(AppModule);
+  }
+);
 ```

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -5,6 +5,7 @@ export * from '@sentry/browser';
 export { init } from './sdk';
 export { createErrorHandler, SentryErrorHandler } from './errorhandler';
 export {
+  // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
   // TODO `instrumentAngularRouting` is just an alias for `routingInstrumentation`; deprecate the latter at some point
   instrumentAngularRouting, // new name

--- a/packages/angular/src/tracing.ts
+++ b/packages/angular/src/tracing.ts
@@ -47,9 +47,12 @@ export function routingInstrumentation(
 export const instrumentAngularRouting = routingInstrumentation;
 
 /**
- * Grabs active transaction off scope
+ * Grabs active transaction off scope.
+ *
+ * @deprecated You should not rely on the transaction, but just use `startSpan()` APIs instead.
  */
 export function getActiveTransaction(): Transaction | undefined {
+  // eslint-disable-next-line deprecation/deprecation
   return getCurrentScope().getTransaction();
 }
 
@@ -69,6 +72,7 @@ export class TraceService implements OnDestroy {
       }
 
       const strippedUrl = stripUrlQueryAndFragment(navigationEvent.url);
+      // eslint-disable-next-line deprecation/deprecation
       let activeTransaction = getActiveTransaction();
 
       if (!activeTransaction && stashedStartTransactionOnLocationChange) {
@@ -116,6 +120,7 @@ export class TraceService implements OnDestroy {
         (event.state as unknown as RouterState & { root: ActivatedRouteSnapshot }).root,
       );
 
+      // eslint-disable-next-line deprecation/deprecation
       const transaction = getActiveTransaction();
       // TODO (v8 / #5416): revisit the source condition. Do we want to make the parameterized route the default?
       if (transaction && transaction.metadata.source === 'url') {
@@ -182,6 +187,7 @@ export class TraceDirective implements OnInit, AfterViewInit {
       this.componentName = UNKNOWN_COMPONENT;
     }
 
+    // eslint-disable-next-line deprecation/deprecation
     const activeTransaction = getActiveTransaction();
     if (activeTransaction) {
       // eslint-disable-next-line deprecation/deprecation
@@ -225,6 +231,7 @@ export function TraceClassDecorator(): ClassDecorator {
     const originalOnInit = target.prototype.ngOnInit;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     target.prototype.ngOnInit = function (...args: any[]): ReturnType<typeof originalOnInit> {
+      // eslint-disable-next-line deprecation/deprecation
       const activeTransaction = getActiveTransaction();
       if (activeTransaction) {
         // eslint-disable-next-line deprecation/deprecation
@@ -263,6 +270,7 @@ export function TraceMethodDecorator(): MethodDecorator {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     descriptor.value = function (...args: any[]): ReturnType<typeof originalMethod> {
       const now = timestampInSeconds();
+      // eslint-disable-next-line deprecation/deprecation
       const activeTransaction = getActiveTransaction();
       if (activeTransaction) {
         // eslint-disable-next-line deprecation/deprecation

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -22,6 +22,7 @@ export {
   createTransport,
   // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
+  // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
   getHubFromCarrier,
   getCurrentHub,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -46,6 +46,7 @@ export {
   setMeasurement,
   // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
+  // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
   spanStatusfromHttpCode,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/browser/src/profiling/integration.ts
+++ b/packages/browser/src/profiling/integration.ts
@@ -24,6 +24,7 @@ const browserProfilingIntegration: IntegrationFn = () => {
     setup(client) {
       const scope = getCurrentScope();
 
+      // eslint-disable-next-line deprecation/deprecation
       const transaction = scope.getTransaction();
 
       if (transaction && isAutomatedPageLoadTransaction(transaction)) {

--- a/packages/browser/test/unit/profiling/integration.test.ts
+++ b/packages/browser/test/unit/profiling/integration.test.ts
@@ -50,6 +50,7 @@ describe('BrowserProfilingIntegration', () => {
 
     const client = Sentry.getClient<BrowserClient>();
 
+    // eslint-disable-next-line deprecation/deprecation
     const currentTransaction = Sentry.getCurrentHub().getScope().getTransaction();
     expect(currentTransaction?.op).toBe('pageload');
     currentTransaction?.end();

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -39,6 +39,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
   flush,
+  // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
   getHubFromCarrier,
   getCurrentHub,

--- a/packages/core/src/metrics/exports.ts
+++ b/packages/core/src/metrics/exports.ts
@@ -30,6 +30,7 @@ function addToMetricsAggregator(
     }
     const { unit, tags, timestamp } = data;
     const { release, environment } = client.getOptions();
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = scope.getTransaction();
     const metricTags: Record<string, string> = {};
     if (release) {

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -321,7 +321,8 @@ export class Scope implements ScopeInterface {
   }
 
   /**
-   * @inheritDoc
+   * Returns the `Transaction` attached to the scope (if there is one).
+   * @deprecated You should not rely on the transaction, but just use `startSpan()` APIs instead.
    */
   public getTransaction(): Transaction | undefined {
     // Often, this span (if it exists at all) will be a transaction, but it's not guaranteed to be. Regardless, it will

--- a/packages/core/src/tracing/errors.ts
+++ b/packages/core/src/tracing/errors.ts
@@ -27,6 +27,7 @@ export function registerErrorInstrumentation(): void {
  * If an error or unhandled promise occurs, we mark the active transaction as failed
  */
 function errorCallback(): void {
+  // eslint-disable-next-line deprecation/deprecation
   const activeTransaction = getActiveTransaction();
   if (activeTransaction) {
     const status: SpanStatusType = 'internal_error';

--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -196,6 +196,7 @@ export class IdleTransaction extends Transaction {
     // if `this._onScope` is `true`, the transaction put itself on the scope when it started
     if (this._onScope) {
       const scope = this._idleHub.getScope();
+      // eslint-disable-next-line deprecation/deprecation
       if (scope.getTransaction() === this) {
         scope.setSpan(undefined);
       }

--- a/packages/core/src/tracing/measurement.ts
+++ b/packages/core/src/tracing/measurement.ts
@@ -6,6 +6,7 @@ import { getActiveTransaction } from './utils';
  * Adds a measurement to the current active transaction.
  */
 export function setMeasurement(name: string, value: number, unit: MeasurementUnit): void {
+  // eslint-disable-next-line deprecation/deprecation
   const transaction = getActiveTransaction();
   if (transaction) {
     transaction.setMeasurement(name, value, unit);

--- a/packages/core/src/tracing/utils.ts
+++ b/packages/core/src/tracing/utils.ts
@@ -4,10 +4,15 @@ import { extractTraceparentData as _extractTraceparentData } from '@sentry/utils
 import type { Hub } from '../hub';
 import { getCurrentHub } from '../hub';
 
-/** Grabs active transaction off scope, if any */
+/**
+ * Grabs active transaction off scope.
+ *
+ * @deprecated You should not rely on the transaction, but just use `startSpan()` APIs instead.
+ */
 export function getActiveTransaction<T extends Transaction>(maybeHub?: Hub): T | undefined {
   const hub = maybeHub || getCurrentHub();
   const scope = hub.getScope();
+  // eslint-disable-next-line deprecation/deprecation
   return scope.getTransaction() as T | undefined;
 }
 

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -38,6 +38,7 @@ export {
   extractTraceparentData,
   continueTrace,
   flush,
+  // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
   getHubFromCarrier,
   getCurrentHub,

--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -196,6 +196,7 @@ function _instrumentEmberRunloop(config: EmberSentryConfig): void {
     if (previousInstance) {
       return;
     }
+    // eslint-disable-next-line deprecation/deprecation
     const activeTransaction = getActiveTransaction();
     if (!activeTransaction) {
       return;
@@ -227,6 +228,7 @@ function _instrumentEmberRunloop(config: EmberSentryConfig): void {
 
       // Setup for next queue
 
+      // eslint-disable-next-line deprecation/deprecation
       const stillActiveTransaction = getActiveTransaction();
       if (!stillActiveTransaction) {
         return;
@@ -288,6 +290,7 @@ function processComponentRenderAfter(
   const componentRenderDuration = now - begin.now;
 
   if (componentRenderDuration * 1000 >= minComponentDuration) {
+    // eslint-disable-next-line deprecation/deprecation
     const activeTransaction = getActiveTransaction();
     // eslint-disable-next-line deprecation/deprecation
     activeTransaction?.startChild({
@@ -374,6 +377,7 @@ function _instrumentInitialLoad(config: EmberSentryConfig): void {
   const startTimestamp = (measure.startTime + browserPerformanceTimeOrigin) / 1000;
   const endTimestamp = startTimestamp + measure.duration / 1000;
 
+  // eslint-disable-next-line deprecation/deprecation
   const transaction = getActiveTransaction();
   // eslint-disable-next-line deprecation/deprecation
   const span = transaction?.startChild({

--- a/packages/nextjs/src/common/utils/wrapperUtils.ts
+++ b/packages/nextjs/src/common/utils/wrapperUtils.ts
@@ -194,6 +194,7 @@ export async function callDataFetcherTraced<F extends (...args: any[]) => Promis
 ): Promise<ReturnType<F>> {
   const { parameterizedRoute, dataFetchingMethodName } = options;
 
+  // eslint-disable-next-line deprecation/deprecation
   const transaction = getActiveTransaction();
 
   if (!transaction) {

--- a/packages/nextjs/src/common/wrapAppGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapAppGetInitialPropsWithSentry.ts
@@ -52,6 +52,7 @@ export function wrapAppGetInitialPropsWithSentry(origAppGetInitialProps: AppGetI
           };
         } = await tracedGetInitialProps.apply(thisArg, args);
 
+        // eslint-disable-next-line deprecation/deprecation
         const requestTransaction = getTransactionFromRequest(req) ?? getCurrentScope().getTransaction();
 
         // Per definition, `pageProps` is not optional, however an increased amount of users doesn't seem to call

--- a/packages/nextjs/src/common/wrapErrorGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapErrorGetInitialPropsWithSentry.ts
@@ -53,6 +53,7 @@ export function wrapErrorGetInitialPropsWithSentry(
           _sentryBaggage?: string;
         } = await tracedGetInitialProps.apply(thisArg, args);
 
+        // eslint-disable-next-line deprecation/deprecation
         const requestTransaction = getTransactionFromRequest(req) ?? getCurrentScope().getTransaction();
         if (requestTransaction) {
           errorGetInitialProps._sentryTraceData = spanToTraceHeader(requestTransaction);

--- a/packages/nextjs/src/common/wrapGetInitialPropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGetInitialPropsWithSentry.ts
@@ -49,6 +49,7 @@ export function wrapGetInitialPropsWithSentry(origGetInitialProps: GetInitialPro
           _sentryBaggage?: string;
         } = (await tracedGetInitialProps.apply(thisArg, args)) ?? {}; // Next.js allows undefined to be returned from a getInitialPropsFunction.
 
+        // eslint-disable-next-line deprecation/deprecation
         const requestTransaction = getTransactionFromRequest(req) ?? getCurrentScope().getTransaction();
         if (requestTransaction) {
           initialProps._sentryTraceData = spanToTraceHeader(requestTransaction);

--- a/packages/nextjs/src/common/wrapGetServerSidePropsWithSentry.ts
+++ b/packages/nextjs/src/common/wrapGetServerSidePropsWithSentry.ts
@@ -46,6 +46,7 @@ export function wrapGetServerSidePropsWithSentry(
         >);
 
         if (serverSideProps && 'props' in serverSideProps) {
+          // eslint-disable-next-line deprecation/deprecation
           const requestTransaction = getTransactionFromRequest(req) ?? getCurrentScope().getTransaction();
           if (requestTransaction) {
             serverSideProps.props._sentryTraceData = spanToTraceHeader(requestTransaction);

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -328,6 +328,7 @@ interface TrpcMiddlewareArguments<T> {
 export function trpcMiddleware(options: SentryTrpcMiddlewareOptions = {}) {
   return function <T>({ path, type, next, rawInput }: TrpcMiddlewareArguments<T>): T {
     const clientOptions = getClient()?.getOptions();
+    // eslint-disable-next-line deprecation/deprecation
     const sentryTransaction = getCurrentScope().getTransaction();
 
     if (sentryTransaction) {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -38,6 +38,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
   flush,
+  // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
   getHubFromCarrier,
   getCurrentHub,

--- a/packages/node/src/integrations/hapi/index.ts
+++ b/packages/node/src/integrations/hapi/index.ts
@@ -45,6 +45,7 @@ export const hapiErrorPlugin = {
     const server = serverArg as unknown as Server;
 
     server.events.on('request', (request, event) => {
+      // eslint-disable-next-line deprecation/deprecation
       const transaction = getActiveTransaction();
 
       if (request.response && isBoomObject(request.response)) {
@@ -91,6 +92,7 @@ export const hapiTracingPlugin = {
     });
 
     server.ext('onPreResponse', (request, h) => {
+      // eslint-disable-next-line deprecation/deprecation
       const transaction = getActiveTransaction();
 
       if (request.response && isResponseObject(request.response) && transaction) {
@@ -110,6 +112,7 @@ export const hapiTracingPlugin = {
     });
 
     server.ext('onPostHandler', (request, h) => {
+      // eslint-disable-next-line deprecation/deprecation
       const transaction = getActiveTransaction();
 
       if (request.response && isResponseObject(request.response) && transaction) {

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -340,6 +340,7 @@ describe('tracingHandler', () => {
 
     sentryTracingMiddleware(req, res, next);
 
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = sentryCore.getCurrentHub().getScope().getTransaction();
 
     expect(transaction).toBeDefined();
@@ -463,6 +464,7 @@ describe('tracingHandler', () => {
 
     sentryTracingMiddleware(req, res, next);
 
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = sentryCore.getCurrentScope().getTransaction();
 
     expect(transaction?.metadata.request).toEqual(req);

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -227,6 +227,7 @@ export { withProfiler, Profiler, useProfiler };
 export function getActiveTransaction<T extends Transaction>(hub: Hub = getCurrentHub()): T | undefined {
   if (hub) {
     const scope = hub.getScope();
+    // eslint-disable-next-line deprecation/deprecation
     return scope.getTransaction() as T | undefined;
   }
 

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -25,6 +25,7 @@ export {
   createTransport,
   // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
+  // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
   getHubFromCarrier,
   getCurrentHub,

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -141,6 +141,7 @@ export async function captureRemixServerException(err: unknown, name: string, re
   const objectifiedErr = objectify(err);
 
   captureException(isResponse(objectifiedErr) ? await extractResponseError(objectifiedErr) : objectifiedErr, scope => {
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = getActiveTransaction();
     const activeTransactionName = transaction ? spanToJSON(transaction) : undefined;
 
@@ -183,6 +184,7 @@ function makeWrappedDocumentRequestFunction(remixVersion?: number) {
       loadContext?: Record<string, unknown>,
     ): Promise<Response> {
       let res: Response;
+      // eslint-disable-next-line deprecation/deprecation
       const activeTransaction = getActiveTransaction();
 
       try {
@@ -238,6 +240,7 @@ function makeWrappedDataFunction(
     }
 
     let res: Response | AppData;
+    // eslint-disable-next-line deprecation/deprecation
     const activeTransaction = getActiveTransaction();
     const currentScope = getCurrentScope();
 
@@ -294,6 +297,7 @@ function getTraceAndBaggage(): {
   sentryTrace?: string;
   sentryBaggage?: string;
 } {
+  // eslint-disable-next-line deprecation/deprecation
   const transaction = getActiveTransaction();
   const currentScope = getCurrentScope();
 

--- a/packages/replay/src/replay.ts
+++ b/packages/replay/src/replay.ts
@@ -699,6 +699,7 @@ export class ReplayContainer implements ReplayContainerInterface {
    * This is only available if performance is enabled, and if an instrumented router is used.
    */
   public getCurrentRoute(): string | undefined {
+    // eslint-disable-next-line deprecation/deprecation
     const lastTransaction = this.lastTransaction || getCurrentScope().getTransaction();
     if (!lastTransaction || !['route', 'custom'].includes(lastTransaction.metadata.source)) {
       return undefined;

--- a/packages/serverless/src/awsservices.ts
+++ b/packages/serverless/src/awsservices.ts
@@ -58,6 +58,7 @@ function wrapMakeRequest<TService extends AWSService, TResult>(
   return function (this: TService, operation: string, params?: GenericParams, callback?: MakeRequestCallback<TResult>) {
     let span: Span | undefined;
     const scope = getCurrentScope();
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = scope.getTransaction();
     const req = orig.call(this, operation, params);
     req.on('afterBuild', () => {

--- a/packages/serverless/src/google-cloud-grpc.ts
+++ b/packages/serverless/src/google-cloud-grpc.ts
@@ -109,6 +109,7 @@ function fillGrpcFunction(stub: Stub, serviceIdentifier: string, methodName: str
         }
         let span: Span | undefined;
         const scope = getCurrentScope();
+        // eslint-disable-next-line deprecation/deprecation
         const transaction = scope.getTransaction();
         if (transaction) {
           // eslint-disable-next-line deprecation/deprecation

--- a/packages/serverless/src/google-cloud-http.ts
+++ b/packages/serverless/src/google-cloud-http.ts
@@ -53,6 +53,7 @@ function wrapRequestFunction(orig: RequestFunction): RequestFunction {
   return function (this: common.Service, reqOpts: RequestOptions, callback: ResponseCallback): void {
     let span: Span | undefined;
     const scope = getCurrentScope();
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = scope.getTransaction();
     if (transaction) {
       const httpMethod = reqOpts.method || 'GET';

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -27,6 +27,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   configureScope,
   createTransport,
+  // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
   getCurrentHub,
   getClient,

--- a/packages/svelte/src/performance.ts
+++ b/packages/svelte/src/performance.ts
@@ -94,5 +94,6 @@ function recordUpdateSpans(componentName: string, initSpan?: Span): void {
 }
 
 function getActiveTransaction(): Transaction | undefined {
+  // eslint-disable-next-line deprecation/deprecation
   return getCurrentScope().getTransaction();
 }

--- a/packages/sveltekit/src/client/router.ts
+++ b/packages/sveltekit/src/client/router.ts
@@ -98,6 +98,7 @@ function instrumentNavigations(startTransactionFn: (context: TransactionContext)
     const parameterizedRouteOrigin = from && from.route.id;
     const parameterizedRouteDestination = to && to.route.id;
 
+    // eslint-disable-next-line deprecation/deprecation
     activeTransaction = getActiveTransaction();
 
     if (!activeTransaction) {

--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -95,6 +95,7 @@ export function addSentryCodeToPage(options: SentryHandleOptions): NonNullable<R
   const nonce = fetchProxyScriptNonce ? `nonce="${fetchProxyScriptNonce}"` : '';
 
   return ({ html }) => {
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = getActiveTransaction();
     if (transaction) {
       const traceparentData = spanToTraceHeader(transaction);

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -19,6 +19,7 @@ export {
   createTransport,
   // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
+  // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
   getHubFromCarrier,
   getCurrentHub,

--- a/packages/tracing-internal/src/browser/backgroundtab.ts
+++ b/packages/tracing-internal/src/browser/backgroundtab.ts
@@ -12,6 +12,7 @@ import { WINDOW } from './types';
 export function registerBackgroundTabDetection(): void {
   if (WINDOW && WINDOW.document) {
     WINDOW.document.addEventListener('visibilitychange', () => {
+      // eslint-disable-next-line deprecation/deprecation
       const activeTransaction = getActiveTransaction() as IdleTransaction;
       if (WINDOW.document.hidden && activeTransaction) {
         const statusType: SpanStatusType = 'cancelled';

--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -390,6 +390,7 @@ export class BrowserTracing implements Integration {
       const { idleTimeout, finalTimeout, heartbeatInterval } = this.options;
       const op = 'ui.action.click';
 
+      // eslint-disable-next-line deprecation/deprecation
       const currentTransaction = getActiveTransaction();
       if (currentTransaction && currentTransaction.op && ['navigation', 'pageload'].includes(currentTransaction.op)) {
         DEBUG_BUILD &&

--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -69,6 +69,7 @@ export function startTrackingWebVitals(): () => void {
 export function startTrackingLongTasks(): void {
   addPerformanceInstrumentationHandler('longtask', ({ entries }) => {
     for (const entry of entries) {
+      // eslint-disable-next-line deprecation/deprecation
       const transaction = getActiveTransaction() as IdleTransaction | undefined;
       if (!transaction) {
         return;
@@ -94,6 +95,7 @@ export function startTrackingLongTasks(): void {
 export function startTrackingInteractions(): void {
   addPerformanceInstrumentationHandler('event', ({ entries }) => {
     for (const entry of entries) {
+      // eslint-disable-next-line deprecation/deprecation
       const transaction = getActiveTransaction() as IdleTransaction | undefined;
       if (!transaction) {
         return;

--- a/packages/tracing-internal/src/exports/index.ts
+++ b/packages/tracing-internal/src/exports/index.ts
@@ -1,6 +1,7 @@
 export {
   // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
+  // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
   hasTracingEnabled,
   IdleTransaction,

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -62,6 +62,7 @@ export const addExtensionMethods = addExtensionMethodsT;
  *
  * `getActiveTransaction` can be imported from `@sentry/node`, `@sentry/browser`, or your framework SDK
  */
+// eslint-disable-next-line deprecation/deprecation
 export const getActiveTransaction = getActiveTransactionT;
 
 /**

--- a/packages/tracing/test/idletransaction.test.ts
+++ b/packages/tracing/test/idletransaction.test.ts
@@ -34,6 +34,7 @@ describe('IdleTransaction', () => {
       transaction.initSpanRecorder(10);
 
       const scope = hub.getScope();
+      // eslint-disable-next-line deprecation/deprecation
       expect(scope.getTransaction()).toBe(transaction);
     });
 
@@ -42,6 +43,7 @@ describe('IdleTransaction', () => {
       transaction.initSpanRecorder(10);
 
       const scope = hub.getScope();
+      // eslint-disable-next-line deprecation/deprecation
       expect(scope.getTransaction()).toBe(undefined);
     });
 
@@ -60,6 +62,7 @@ describe('IdleTransaction', () => {
       jest.runAllTimers();
 
       const scope = hub.getScope();
+      // eslint-disable-next-line deprecation/deprecation
       expect(scope.getTransaction()).toBe(undefined);
     });
 
@@ -77,6 +80,7 @@ describe('IdleTransaction', () => {
       jest.runAllTimers();
 
       const scope = hub.getScope();
+      // eslint-disable-next-line deprecation/deprecation
       expect(scope.getTransaction()).toBe(undefined);
     });
 
@@ -99,6 +103,7 @@ describe('IdleTransaction', () => {
       jest.runAllTimers();
 
       const scope = hub.getScope();
+      // eslint-disable-next-line deprecation/deprecation
       expect(scope.getTransaction()).toBe(otherTransaction);
     });
   });

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -147,7 +147,8 @@ export interface Scope {
   getSpan(): Span | undefined;
 
   /**
-   * Returns the `Transaction` attached to the scope (if there is one)
+   * Returns the `Transaction` attached to the scope (if there is one).
+   * @deprecated You should not rely on the transaction, but just use `startSpan()` APIs instead.
    */
   getTransaction(): Transaction | undefined;
 

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -38,6 +38,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   extractTraceparentData,
   flush,
+  // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
   getHubFromCarrier,
   getCurrentHub,

--- a/packages/vue/src/router.ts
+++ b/packages/vue/src/router.ts
@@ -108,6 +108,7 @@ export function vueRouterInstrumentation(
       }
 
       if (startTransactionOnPageLoad && isPageLoadNavigation) {
+        // eslint-disable-next-line deprecation/deprecation
         const pageloadTransaction = getActiveTransaction();
         if (pageloadTransaction) {
           if (pageloadTransaction.metadata.source !== 'custom') {

--- a/packages/vue/src/tracing.ts
+++ b/packages/vue/src/tracing.ts
@@ -32,8 +32,13 @@ const HOOKS: { [key in Operation]: Hook[] } = {
   update: ['beforeUpdate', 'updated'],
 };
 
-/** Grabs active transaction off scope, if any */
+/**
+ * Grabs active transaction off scope.
+ *
+ * @deprecated You should not rely on the transaction, but just use `startSpan()` APIs instead.
+ */
 export function getActiveTransaction(): Transaction | undefined {
+  // eslint-disable-next-line deprecation/deprecation
   return getCurrentScope().getTransaction();
 }
 
@@ -73,6 +78,7 @@ export const createTracingMixins = (options: TracingOptions): Mixins => {
         const isRoot = this.$root === this;
 
         if (isRoot) {
+          // eslint-disable-next-line deprecation/deprecation
           const activeTransaction = getActiveTransaction();
           if (activeTransaction) {
             this.$_sentryRootSpan =
@@ -102,6 +108,7 @@ export const createTracingMixins = (options: TracingOptions): Mixins => {
         // Start a new span if current hook is a 'before' hook.
         // Otherwise, retrieve the current span and finish it.
         if (internalHook == internalHooks[0]) {
+          // eslint-disable-next-line deprecation/deprecation
           const activeTransaction = (this.$root && this.$root.$_sentryRootSpan) || getActiveTransaction();
           if (activeTransaction) {
             // Cancel old span for this hook operation in case it didn't get cleaned up. We're not actually sure if it


### PR DESCRIPTION
A lot to refactor for us... but for now, let's deprecate this.