### PR TITLE
fix(core): Ensure we copy passed in span data/tags/attributes

### DIFF
--- a/packages/core/src/tracing/span.ts
+++ b/packages/core/src/tracing/span.ts
@@ -139,9 +139,9 @@ export class Span implements SpanInterface {
     this._traceId = spanContext.traceId || uuid4();
     this._spanId = spanContext.spanId || uuid4().substring(16);
     this.startTimestamp = spanContext.startTimestamp || timestampInSeconds();
-    this.tags = spanContext.tags || {};
-    this.data = spanContext.data || {};
-    this.attributes = spanContext.attributes || {};
+    this.tags = spanContext.tags ? { ...spanContext.tags } : {};
+    this.data = spanContext.data ? { ...spanContext.data } : {};
+    this.attributes = spanContext.attributes ? { ...spanContext.attributes } : {};
     this.instrumenter = spanContext.instrumenter || 'sentry';
     this.origin = spanContext.origin || 'manual';
     // eslint-disable-next-line deprecation/deprecation


### PR DESCRIPTION
So we do not mutate this if we update data there.

Noticed this here: https://github.com/getsentry/sentry-javascript/pull/10097