### PR TITLE
fix(node): Update ANR min node version to v16.17.0

### DIFF
--- a/packages/node/src/integrations/anr/index.ts
+++ b/packages/node/src/integrations/anr/index.ts
@@ -56,8 +56,8 @@ const anrIntegration = ((options: Partial<Options> = {}) => {
   return {
     name: INTEGRATION_NAME,
     setup(client: NodeClient) {
-      if (NODE_VERSION.major < 16) {
-        throw new Error('ANR detection requires Node 16 or later');
+      if (NODE_VERSION.major < 16 || (NODE_VERSION.major === 16 && NODE_VERSION.minor < 17)) {
+        throw new Error('ANR detection requires Node 16.17.0 or later');
       }
 
       // setImmediate is used to ensure that all other integrations have been setup
@@ -68,6 +68,8 @@ const anrIntegration = ((options: Partial<Options> = {}) => {
 
 /**
  * Starts a thread to detect App Not Responding (ANR) events
+ *
+ * ANR detection requires Node 16.17.0 or later
  */
 // eslint-disable-next-line deprecation/deprecation
 export const Anr = convertIntegrationFnToClass(INTEGRATION_NAME, anrIntegration);


### PR DESCRIPTION
Upon testing the full range of Electron versions for release in CI, I found that starting a worker thread via a data uri requires at least node v16.17.0. 

This wasn't picked up by the tests in this repository because we only test the latest version of each major.
