### PR TITLE
feat(core): Deprecate `scope.setTransactionName()`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,6 +8,10 @@ npx @sentry/migr8@latest
 
 This will let you select which updates to run, and automatically update your code. Make sure to still review all code changes!
 
+## Deprecate `scope.setTransactionName()`
+
+Instead, either set this as attributes or tags, or use an event processor to set `event.transaction`.
+
 ## Deprecate `scope.getTransaction()` and `getActiveTransaction()`
 
 Instead, you should not rely on the active transaction, but just use `startSpan()` APIs, which handle this for you.

--- a/dev-packages/browser-integration-tests/suites/replay/dsc/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/dsc/test.ts
@@ -33,7 +33,10 @@ sentryTest(
     await page.evaluate(() => {
       const scope = (window as unknown as TestWindow).Sentry.getCurrentScope();
       scope.setUser({ id: 'user123', segment: 'segmentB' });
-      scope.setTransactionName('testTransactionDSC');
+      scope.addEventProcessor(event => {
+        event.transaction = 'testTransactionDSC';
+        return event;
+      });
     });
 
     const req0 = await transactionReq;
@@ -78,7 +81,10 @@ sentryTest(
     await page.evaluate(() => {
       const scope = (window as unknown as TestWindow).Sentry.getCurrentScope();
       scope.setUser({ id: 'user123', segment: 'segmentB' });
-      scope.setTransactionName('testTransactionDSC');
+      scope.addEventProcessor(event => {
+        event.transaction = 'testTransactionDSC';
+        return event;
+      });
     });
 
     const req0 = await transactionReq;
@@ -135,7 +141,10 @@ sentryTest(
     await page.evaluate(() => {
       const scope = (window as unknown as TestWindow).Sentry.getCurrentScope();
       scope.setUser({ id: 'user123', segment: 'segmentB' });
-      scope.setTransactionName('testTransactionDSC');
+      scope.addEventProcessor(event => {
+        event.transaction = 'testTransactionDSC';
+        return event;
+      });
     });
 
     const req0 = await transactionReq;
@@ -183,7 +192,10 @@ sentryTest(
     await page.evaluate(async () => {
       const scope = (window as unknown as TestWindow).Sentry.getCurrentScope();
       scope.setUser({ id: 'user123', segment: 'segmentB' });
-      scope.setTransactionName('testTransactionDSC');
+      scope.addEventProcessor(event => {
+        event.transaction = 'testTransactionDSC';
+        return event;
+      });
     });
 
     const req0 = await transactionReq;

--- a/dev-packages/browser-integration-tests/suites/tracing/envelope-header-transaction-name/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/envelope-header-transaction-name/init.js
@@ -13,5 +13,8 @@ Sentry.init({
 
 const scope = Sentry.getCurrentScope();
 scope.setUser({ id: 'user123', segment: 'segmentB' });
-scope.setTransactionName('testTransactionDSC');
+scope.addEventProcessor(event => {
+  event.transaction = 'testTransactionDSC';
+  return event;
+});
 scope.getTransaction().setMetadata({ source: 'custom' });

--- a/dev-packages/browser-integration-tests/suites/tracing/envelope-header/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/envelope-header/init.js
@@ -13,4 +13,7 @@ Sentry.init({
 
 const scope = Sentry.getCurrentScope();
 scope.setUser({ id: 'user123', segment: 'segmentB' });
-scope.setTransactionName('testTransactionDSC');
+scope.addEventProcessor(event => {
+  event.transaction = 'testTransactionDSC';
+  return event;
+});

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -89,7 +89,9 @@ export class Scope implements ScopeInterface {
   // eslint-disable-next-line deprecation/deprecation
   protected _level?: Severity | SeverityLevel;
 
-  /** Transaction Name */
+  /**
+   * Transaction Name
+   */
   protected _transactionName?: string;
 
   /** Span */
@@ -281,7 +283,8 @@ export class Scope implements ScopeInterface {
   }
 
   /**
-   * @inheritDoc
+   * Sets the transaction name on the scope for future events.
+   * @deprecated Use extra or tags instead.
    */
   public setTransactionName(name?: string): this {
     this._transactionName = name;

--- a/packages/core/src/utils/applyScopeDataToEvent.ts
+++ b/packages/core/src/utils/applyScopeDataToEvent.ts
@@ -37,6 +37,7 @@ export function mergeScopeData(data: ScopeData, mergeData: ScopeData): void {
     eventProcessors,
     attachments,
     propagationContext,
+    // eslint-disable-next-line deprecation/deprecation
     transactionName,
     span,
   } = mergeData;
@@ -52,6 +53,7 @@ export function mergeScopeData(data: ScopeData, mergeData: ScopeData): void {
   }
 
   if (transactionName) {
+    // eslint-disable-next-line deprecation/deprecation
     data.transactionName = transactionName;
   }
 
@@ -122,7 +124,15 @@ export function mergeArray<Prop extends 'breadcrumbs' | 'fingerprint'>(
 }
 
 function applyDataToEvent(event: Event, data: ScopeData): void {
-  const { extra, tags, user, contexts, level, transactionName } = data;
+  const {
+    extra,
+    tags,
+    user,
+    contexts,
+    level,
+    // eslint-disable-next-line deprecation/deprecation
+    transactionName,
+  } = data;
 
   if (extra && Object.keys(extra).length) {
     event.extra = { ...extra, ...event.extra };

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -224,7 +224,10 @@ function enhanceScopeWithEnvironmentData(scope: Scope, context: Context, startTi
  * @param context AWS Lambda context that will be used to extract some part of the data
  */
 function enhanceScopeWithTransactionData(scope: Scope, context: Context): void {
-  scope.setTransactionName(context.functionName);
+  scope.addEventProcessor(event => {
+    event.transaction = context.functionName;
+    return event;
+  });
   scope.setTag('server_name', process.env._AWS_XRAY_DAEMON_ADDRESS || process.env.SENTRY_NAME || hostname());
   scope.setTag('url', `awslambda:///${context.functionName}`);
 }

--- a/packages/serverless/test/__mocks__/@sentry/node.ts
+++ b/packages/serverless/test/__mocks__/@sentry/node.ts
@@ -11,7 +11,6 @@ export const continueTrace = origSentry.continueTrace;
 
 export const fakeScope = {
   addEventProcessor: jest.fn(),
-  setTransactionName: jest.fn(),
   setTag: jest.fn(),
   setContext: jest.fn(),
   setSpan: jest.fn(),
@@ -46,7 +45,6 @@ export const resetMocks = (): void => {
   fakeSpan.setHttpStatus.mockClear();
 
   fakeScope.addEventProcessor.mockClear();
-  fakeScope.setTransactionName.mockClear();
   fakeScope.setTag.mockClear();
   fakeScope.setContext.mockClear();
   fakeScope.setSpan.mockClear();

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -42,7 +42,14 @@ const fakeCallback: Callback = (err, result) => {
 
 function expectScopeSettings() {
   // @ts-expect-error see "Why @ts-expect-error" note
-  expect(SentryNode.fakeScope.setTransactionName).toBeCalledWith('functionName');
+  expect(SentryNode.fakeScope.addEventProcessor).toBeCalledTimes(1);
+  // Test than an event processor to add `transaction` is registered for the scope
+  // @ts-expect-error see "Why @ts-expect-error" note
+  const eventProcessor = SentryNode.fakeScope.addEventProcessor.mock.calls[0][0];
+  const event: Event = {};
+  eventProcessor(event);
+  expect(event).toEqual({ transaction: 'functionName' });
+
   // @ts-expect-error see "Why @ts-expect-error" note
   expect(SentryNode.fakeScope.setTag).toBeCalledWith('server_name', expect.anything());
   // @ts-expect-error see "Why @ts-expect-error" note
@@ -186,7 +193,7 @@ describe('AWSLambda', () => {
       await wrappedHandler(fakeEvent, fakeContext, fakeCallback);
 
       // @ts-expect-error see "Why @ts-expect-error" note
-      expect(SentryNode.fakeScope.setTransactionName).toBeCalledTimes(0);
+      expect(SentryNode.fakeScope.addEventProcessor).toBeCalledTimes(0);
       // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeScope.setTag).toBeCalledTimes(0);
       expect(SentryNode.startSpanManual).toBeCalledTimes(0);
@@ -195,7 +202,7 @@ describe('AWSLambda', () => {
 
   describe('wrapHandler() on sync handler', () => {
     test('successful execution', async () => {
-      expect.assertions(9);
+      expect.assertions(10);
 
       const handler: Handler = (_event, _context, callback) => {
         callback(null, 42);
@@ -222,7 +229,7 @@ describe('AWSLambda', () => {
     });
 
     test('unsuccessful execution', async () => {
-      expect.assertions(9);
+      expect.assertions(10);
 
       const error = new Error('sorry');
       const handler: Handler = (_event, _context, callback) => {
@@ -301,7 +308,7 @@ describe('AWSLambda', () => {
     });
 
     test('capture error', async () => {
-      expect.assertions(9);
+      expect.assertions(10);
 
       const error = new Error('wat');
       const handler: Handler = (_event, _context, _callback) => {
@@ -338,7 +345,7 @@ describe('AWSLambda', () => {
 
   describe('wrapHandler() on async handler', () => {
     test('successful execution', async () => {
-      expect.assertions(9);
+      expect.assertions(10);
 
       const handler: Handler = async (_event, _context) => {
         return 42;
@@ -376,7 +383,7 @@ describe('AWSLambda', () => {
     });
 
     test('capture error', async () => {
-      expect.assertions(9);
+      expect.assertions(10);
 
       const error = new Error('wat');
       const handler: Handler = async (_event, _context) => {
@@ -424,7 +431,7 @@ describe('AWSLambda', () => {
 
   describe('wrapHandler() on async handler with a callback method (aka incorrect usage)', () => {
     test('successful execution', async () => {
-      expect.assertions(9);
+      expect.assertions(10);
 
       const handler: Handler = async (_event, _context, _callback) => {
         return 42;
@@ -462,7 +469,7 @@ describe('AWSLambda', () => {
     });
 
     test('capture error', async () => {
-      expect.assertions(9);
+      expect.assertions(10);
 
       const error = new Error('wat');
       const handler: Handler = async (_event, _context, _callback) => {

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -41,6 +41,7 @@ export interface ScopeData {
   sdkProcessingMetadata: { [key: string]: unknown };
   fingerprint: string[];
   level?: SeverityLevel;
+  /** @deprecated This will be removed in v8. */
   transactionName?: string;
   span?: Span;
 }
@@ -125,6 +126,7 @@ export interface Scope {
 
   /**
    * Sets the transaction name on the scope for future events.
+   * @deprecated Use extra or tags instead.
    */
   setTransactionName(name?: string): this;
 


### PR DESCRIPTION
This can be replaced by an event processor. We only use this in a single place right now.

Closes https://github.com/getsentry/sentry-javascript/issues/5660
