### PR TITLE
feat(core): Deprecate `scope.getSpan()` & `scope.setSpan()`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,6 +8,11 @@ npx @sentry/migr8@latest
 
 This will let you select which updates to run, and automatically update your code. Make sure to still review all code changes!
 
+## Deprecate `scope.getSpan()` and `scope.setSpan()`
+
+Instead, you can get the currently active span via `Sentry.getActiveSpan()`.
+Setting a span on the scope happens automatically when you use the new performance APIs `startSpan()` and `startSpanManual()`.
+
 ## Deprecate `scope.setTransactionName()`
 
 Instead, either set this as attributes or tags, or use an event processor to set `event.transaction`.

--- a/dev-packages/e2e-tests/test-applications/create-next-app/pages/api/success.ts
+++ b/dev-packages/e2e-tests/test-applications/create-next-app/pages/api/success.ts
@@ -5,6 +5,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   // eslint-disable-next-line deprecation/deprecation
   const transaction = Sentry.startTransaction({ name: 'test-transaction', op: 'e2e-test' });
+  // eslint-disable-next-line deprecation/deprecation
   Sentry.getCurrentHub().getScope().setSpan(transaction);
 
   // eslint-disable-next-line deprecation/deprecation

--- a/dev-packages/node-integration-tests/suites/tracing-new/apollo-graphql/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-new/apollo-graphql/scenario.ts
@@ -30,6 +30,7 @@ const server = new ApolloServer({
 // eslint-disable-next-line deprecation/deprecation
 const transaction = Sentry.startTransaction({ name: 'test_transaction', op: 'transaction' });
 
+// eslint-disable-next-line deprecation/deprecation
 Sentry.getCurrentScope().setSpan(transaction);
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/dev-packages/node-integration-tests/suites/tracing-new/auto-instrument/mongodb/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-new/auto-instrument/mongodb/scenario.ts
@@ -22,6 +22,7 @@ async function run(): Promise<void> {
     op: 'transaction',
   });
 
+  // eslint-disable-next-line deprecation/deprecation
   Sentry.getCurrentScope().setSpan(transaction);
 
   try {

--- a/dev-packages/node-integration-tests/suites/tracing-new/auto-instrument/mysql/withConnect/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-new/auto-instrument/mysql/withConnect/scenario.ts
@@ -25,6 +25,7 @@ const transaction = Sentry.startTransaction({
   name: 'Test Transaction',
 });
 
+// eslint-disable-next-line deprecation/deprecation
 Sentry.getCurrentScope().setSpan(transaction);
 
 connection.query('SELECT 1 + 1 AS solution', function () {

--- a/dev-packages/node-integration-tests/suites/tracing-new/auto-instrument/mysql/withoutCallback/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-new/auto-instrument/mysql/withoutCallback/scenario.ts
@@ -25,6 +25,7 @@ const transaction = Sentry.startTransaction({
   name: 'Test Transaction',
 });
 
+// eslint-disable-next-line deprecation/deprecation
 Sentry.getCurrentScope().setSpan(transaction);
 
 const query = connection.query('SELECT 1 + 1 AS solution');

--- a/dev-packages/node-integration-tests/suites/tracing-new/auto-instrument/mysql/withoutConnect/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-new/auto-instrument/mysql/withoutConnect/scenario.ts
@@ -19,6 +19,7 @@ const transaction = Sentry.startTransaction({
   name: 'Test Transaction',
 });
 
+// eslint-disable-next-line deprecation/deprecation
 Sentry.getCurrentScope().setSpan(transaction);
 
 connection.query('SELECT 1 + 1 AS solution', function () {

--- a/dev-packages/node-integration-tests/suites/tracing-new/auto-instrument/pg/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-new/auto-instrument/pg/scenario.ts
@@ -14,6 +14,7 @@ const transaction = Sentry.startTransaction({
   name: 'Test Transaction',
 });
 
+// eslint-disable-next-line deprecation/deprecation
 Sentry.getCurrentScope().setSpan(transaction);
 
 const client = new pg.Client();

--- a/dev-packages/node-integration-tests/suites/tracing-new/prisma-orm/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-new/prisma-orm/scenario.ts
@@ -19,6 +19,7 @@ async function run(): Promise<void> {
     op: 'transaction',
   });
 
+  // eslint-disable-next-line deprecation/deprecation
   Sentry.getCurrentScope().setSpan(transaction);
 
   try {

--- a/dev-packages/node-integration-tests/suites/tracing-new/tracePropagationTargets/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-new/tracePropagationTargets/scenario.ts
@@ -13,6 +13,7 @@ Sentry.init({
 // eslint-disable-next-line deprecation/deprecation
 const transaction = Sentry.startTransaction({ name: 'test_transaction' });
 
+// eslint-disable-next-line deprecation/deprecation
 Sentry.getCurrentScope().setSpan(transaction);
 
 http.get('http://match-this-url.com/api/v0');

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/scenario.ts
@@ -32,6 +32,7 @@ const server = new ApolloServer({
 // eslint-disable-next-line deprecation/deprecation
 const transaction = Sentry.startTransaction({ name: 'test_transaction', op: 'transaction' });
 
+// eslint-disable-next-line deprecation/deprecation
 Sentry.getCurrentScope().setSpan(transaction);
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/dev-packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/auto-instrument/mongodb/scenario.ts
@@ -23,6 +23,7 @@ async function run(): Promise<void> {
     op: 'transaction',
   });
 
+  // eslint-disable-next-line deprecation/deprecation
   Sentry.getCurrentScope().setSpan(transaction);
 
   try {

--- a/dev-packages/node-integration-tests/suites/tracing/auto-instrument/mysql/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/auto-instrument/mysql/scenario.ts
@@ -26,6 +26,7 @@ const transaction = Sentry.startTransaction({
   name: 'Test Transaction',
 });
 
+// eslint-disable-next-line deprecation/deprecation
 Sentry.getCurrentScope().setSpan(transaction);
 
 connection.query('SELECT 1 + 1 AS solution', function () {

--- a/dev-packages/node-integration-tests/suites/tracing/auto-instrument/pg/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/auto-instrument/pg/scenario.ts
@@ -15,6 +15,7 @@ const transaction = Sentry.startTransaction({
   name: 'Test Transaction',
 });
 
+// eslint-disable-next-line deprecation/deprecation
 Sentry.getCurrentScope().setSpan(transaction);
 
 const client = new pg.Client();

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm/scenario.ts
@@ -21,6 +21,7 @@ async function run(): Promise<void> {
     op: 'transaction',
   });
 
+  // eslint-disable-next-line deprecation/deprecation
   Sentry.getCurrentScope().setSpan(transaction);
 
   try {

--- a/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/scenario.ts
@@ -15,6 +15,7 @@ Sentry.init({
 // eslint-disable-next-line deprecation/deprecation
 const transaction = Sentry.startTransaction({ name: 'test_transaction' });
 
+// eslint-disable-next-line deprecation/deprecation
 Sentry.getCurrentScope().setSpan(transaction);
 
 http.get('http://match-this-url.com/api/v0');

--- a/packages/astro/src/server/middleware.ts
+++ b/packages/astro/src/server/middleware.ts
@@ -2,6 +2,7 @@ import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import {
   captureException,
   continueTrace,
+  getActiveSpan,
   getClient,
   getCurrentScope,
   runWithAsyncContext,
@@ -70,7 +71,7 @@ export const handleRequest: (options?: MiddlewareOptions) => MiddlewareResponseH
     // if there is an active span, we know that this handle call is nested and hence
     // we don't create a new domain for it. If we created one, nested server calls would
     // create new transactions instead of adding a child span to the currently active span.
-    if (getCurrentScope().getSpan()) {
+    if (getActiveSpan()) {
       return instrumentRequest(ctx, next, handlerOptions);
     }
     return runWithAsyncContext(() => {

--- a/packages/astro/test/server/middleware.test.ts
+++ b/packages/astro/test/server/middleware.test.ts
@@ -1,6 +1,6 @@
 import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import * as SentryNode from '@sentry/node';
-import type { Client } from '@sentry/types';
+import type { Client, Span } from '@sentry/types';
 import { vi } from 'vitest';
 
 import { handleRequest, interpolateRouteFromUrlAndParams } from '../../src/server/middleware';
@@ -15,7 +15,9 @@ vi.mock('../../src/server/meta', () => ({
 describe('sentryMiddleware', () => {
   const startSpanSpy = vi.spyOn(SentryNode, 'startSpan');
 
-  const getSpanMock = vi.fn(() => {});
+  const getSpanMock = vi.fn(() => {
+    return {} as Span | undefined;
+  });
   const setUserMock = vi.fn();
 
   beforeEach(() => {
@@ -26,6 +28,7 @@ describe('sentryMiddleware', () => {
         getSpan: getSpanMock,
       } as any;
     });
+    vi.spyOn(SentryNode, 'getActiveSpan').mockImplementation(getSpanMock);
     vi.spyOn(SentryNode, 'getClient').mockImplementation(() => ({}) as Client);
   });
 

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -308,7 +308,9 @@ export class Scope implements ScopeInterface {
   }
 
   /**
-   * @inheritDoc
+   * Sets the Span on the scope.
+   * @param span Span
+   * @deprecated Instead of setting a span on a scope, use `startSpan()`/`startSpanManual()` instead.
    */
   public setSpan(span?: Span): this {
     this._span = span;
@@ -317,7 +319,8 @@ export class Scope implements ScopeInterface {
   }
 
   /**
-   * @inheritDoc
+   * Returns the `Span` if there is one.
+   * @deprecated Use `getActiveSpan()` instead.
    */
   public getSpan(): Span | undefined {
     return this._span;
@@ -330,7 +333,7 @@ export class Scope implements ScopeInterface {
   public getTransaction(): Transaction | undefined {
     // Often, this span (if it exists at all) will be a transaction, but it's not guaranteed to be. Regardless, it will
     // have a pointer to the currently-active transaction.
-    const span = this.getSpan();
+    const span = this._span;
     return span && span.transaction;
   }
 

--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -255,6 +255,7 @@ export class ServerRuntimeClient<
       return [undefined, undefined];
     }
 
+    // eslint-disable-next-line deprecation/deprecation
     const span = scope.getSpan();
     if (span) {
       const samplingContext = span.transaction ? span.transaction.getDynamicSamplingContext() : undefined;

--- a/packages/core/src/tracing/hubextensions.ts
+++ b/packages/core/src/tracing/hubextensions.ts
@@ -13,6 +13,7 @@ import { Transaction } from './transaction';
 /** Returns all trace headers that are currently on the top scope. */
 function traceHeaders(this: Hub): { [key: string]: string } {
   const scope = this.getScope();
+  // eslint-disable-next-line deprecation/deprecation
   const span = scope.getSpan();
 
   return span

--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -124,6 +124,7 @@ export class IdleTransaction extends Transaction {
       // We set the transaction here on the scope so error events pick up the trace
       // context and attach it to the error.
       DEBUG_BUILD && logger.log(`Setting idle transaction on scope. Span ID: ${this.spanContext().spanId}`);
+      // eslint-disable-next-line deprecation/deprecation
       _idleHub.getScope().setSpan(this);
     }
 
@@ -198,6 +199,7 @@ export class IdleTransaction extends Transaction {
       const scope = this._idleHub.getScope();
       // eslint-disable-next-line deprecation/deprecation
       if (scope.getTransaction() === this) {
+        // eslint-disable-next-line deprecation/deprecation
         scope.setSpan(undefined);
       }
     }

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -143,11 +143,13 @@ export function trace<T>(
 ): T {
   const hub = getCurrentHub();
   const scope = getCurrentScope();
+  // eslint-disable-next-line deprecation/deprecation
   const parentSpan = scope.getSpan();
 
   const ctx = normalizeContext(context);
   const activeSpan = createChildSpanOrTransaction(hub, parentSpan, ctx);
 
+  // eslint-disable-next-line deprecation/deprecation
   scope.setSpan(activeSpan);
 
   return handleCallbackErrors(
@@ -158,6 +160,7 @@ export function trace<T>(
     },
     () => {
       activeSpan && activeSpan.end();
+      // eslint-disable-next-line deprecation/deprecation
       scope.setSpan(parentSpan);
       afterFinish();
     },
@@ -180,10 +183,11 @@ export function startSpan<T>(context: StartSpanOptions, callback: (span: Span | 
 
   return withScope(context.scope, scope => {
     const hub = getCurrentHub();
-    const scopeForSpan = context.scope || scope;
-    const parentSpan = scopeForSpan.getSpan();
+    // eslint-disable-next-line deprecation/deprecation
+    const parentSpan = scope.getSpan();
 
     const activeSpan = createChildSpanOrTransaction(hub, parentSpan, ctx);
+    // eslint-disable-next-line deprecation/deprecation
     scope.setSpan(activeSpan);
 
     return handleCallbackErrors(
@@ -223,9 +227,11 @@ export function startSpanManual<T>(
 
   return withScope(context.scope, scope => {
     const hub = getCurrentHub();
+    // eslint-disable-next-line deprecation/deprecation
     const parentSpan = scope.getSpan();
 
     const activeSpan = createChildSpanOrTransaction(hub, parentSpan, ctx);
+    // eslint-disable-next-line deprecation/deprecation
     scope.setSpan(activeSpan);
 
     function finishAndSetSpan(): void {
@@ -261,7 +267,10 @@ export function startInactiveSpan(context: StartSpanOptions): Span | undefined {
 
   const ctx = normalizeContext(context);
   const hub = getCurrentHub();
-  const parentSpan = context.scope ? context.scope.getSpan() : getActiveSpan();
+  const parentSpan = context.scope
+    ? // eslint-disable-next-line deprecation/deprecation
+      context.scope.getSpan()
+    : getActiveSpan();
   return parentSpan
     ? // eslint-disable-next-line deprecation/deprecation
       parentSpan.startChild(ctx)
@@ -273,6 +282,7 @@ export function startInactiveSpan(context: StartSpanOptions): Span | undefined {
  * Returns the currently active span.
  */
 export function getActiveSpan(): Span | undefined {
+  // eslint-disable-next-line deprecation/deprecation
   return getCurrentScope().getSpan();
 }
 

--- a/packages/nextjs/src/edge/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/edge/wrapApiHandlerWithSentry.ts
@@ -1,4 +1,4 @@
-import { getCurrentScope } from '@sentry/core';
+import { getActiveSpan } from '@sentry/core';
 
 import { withEdgeWrapping } from '../common/utils/edgeWrapperUtils';
 import type { EdgeRouteHandler } from './types';
@@ -14,7 +14,7 @@ export function wrapApiHandlerWithSentry<H extends EdgeRouteHandler>(
     apply: (wrappingTarget, thisArg, args: Parameters<H>) => {
       const req = args[0];
 
-      const activeSpan = getCurrentScope().getSpan();
+      const activeSpan = getActiveSpan();
 
       const wrappedHandler = withEdgeWrapping(wrappingTarget, {
         spanDescription:

--- a/packages/nextjs/test/clientSdk.test.ts
+++ b/packages/nextjs/test/clientSdk.test.ts
@@ -90,6 +90,7 @@ describe('Client init()', () => {
     const transportSend = jest.spyOn(hub.getClient()!.getTransport()!, 'send');
 
     // Ensure we have no current span, so our next span is a transaction
+    // eslint-disable-next-line deprecation/deprecation
     getCurrentScope().setSpan(undefined);
 
     SentryReact.startSpan({ name: '/404' }, () => {

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -5,6 +5,7 @@ import {
   captureException,
   continueTrace,
   flush,
+  getActiveSpan,
   getClient,
   getCurrentScope,
   hasTracingEnabled,
@@ -91,6 +92,7 @@ export function tracingHandler(): (
     );
 
     // We put the transaction on the scope so users can attach children to it
+    // eslint-disable-next-line deprecation/deprecation
     getCurrentScope().setSpan(transaction);
 
     // We also set __sentry_transaction on the response so people can grab the transaction there to add
@@ -275,7 +277,8 @@ export function errorHandler(options?: {
         // For some reason we need to set the transaction on the scope again
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         const transaction = (res as any).__sentry_transaction as Span;
-        if (transaction && _scope.getSpan() === undefined) {
+        if (transaction && !getActiveSpan()) {
+          // eslint-disable-next-line deprecation/deprecation
           _scope.setSpan(transaction);
         }
 

--- a/packages/node/src/integrations/hapi/index.ts
+++ b/packages/node/src/integrations/hapi/index.ts
@@ -86,6 +86,7 @@ export const hapiTracingPlugin = {
         },
       );
 
+      // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
 
       return h.continue;

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -3,6 +3,7 @@ import type * as https from 'https';
 import type { Hub } from '@sentry/core';
 import {
   addBreadcrumb,
+  getActiveSpan,
   getClient,
   getCurrentHub,
   getCurrentScope,
@@ -253,7 +254,7 @@ function _createWrappedRequestMethodFactory(
       }
 
       const scope = getCurrentScope();
-      const parentSpan = scope.getSpan();
+      const parentSpan = getActiveSpan();
 
       const data = getRequestSpanData(requestUrl, requestOptions);
 

--- a/packages/node/src/integrations/undici/index.ts
+++ b/packages/node/src/integrations/undici/index.ts
@@ -1,5 +1,6 @@
 import {
   addBreadcrumb,
+  getActiveSpan,
   getClient,
   getCurrentHub,
   getCurrentScope,
@@ -156,8 +157,7 @@ export class Undici implements Integration {
 
     const clientOptions = client.getOptions();
     const scope = getCurrentScope();
-
-    const parentSpan = scope.getSpan();
+    const parentSpan = getActiveSpan();
 
     const span = this._shouldCreateSpan(stringUrl) ? createRequestSpan(parentSpan, request, stringUrl) : undefined;
     if (span) {

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -22,6 +22,7 @@ const originalHttpRequest = http.request;
 
 describe('tracing', () => {
   afterEach(() => {
+    // eslint-disable-next-line deprecation/deprecation
     sentryCore.getCurrentHub().getScope().setSpan(undefined);
   });
 
@@ -48,6 +49,8 @@ describe('tracing', () => {
 
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
     jest.spyOn(sentryCore, 'getCurrentScope').mockImplementation(() => hub.getScope());
+    // eslint-disable-next-line deprecation/deprecation
+    jest.spyOn(sentryCore, 'getActiveSpan').mockImplementation(() => hub.getScope().getSpan());
     jest.spyOn(sentryCore, 'getClient').mockReturnValue(hub.getClient());
 
     const transaction = startInactiveSpan({
@@ -58,6 +61,7 @@ describe('tracing', () => {
 
     expect(transaction).toBeInstanceOf(Transaction);
 
+    // eslint-disable-next-line deprecation/deprecation
     hub.getScope().setSpan(transaction);
 
     return transaction;
@@ -75,6 +79,8 @@ describe('tracing', () => {
     const hub = new Hub(new NodeClient(options));
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
     jest.spyOn(sentryCore, 'getCurrentScope').mockImplementation(() => hub.getScope());
+    // eslint-disable-next-line deprecation/deprecation
+    jest.spyOn(sentryCore, 'getActiveSpan').mockImplementation(() => hub.getScope().getSpan());
     jest.spyOn(sentryCore, 'getClient').mockReturnValue(hub.getClient());
     return hub;
   }
@@ -361,6 +367,8 @@ describe('tracing', () => {
 
       jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
       jest.spyOn(sentryCore, 'getCurrentScope').mockImplementation(() => hub.getScope());
+      // eslint-disable-next-line deprecation/deprecation
+      jest.spyOn(sentryCore, 'getActiveSpan').mockImplementation(() => hub.getScope().getSpan());
       jest.spyOn(sentryCore, 'getClient').mockReturnValue(hub.getClient());
 
       const client = new NodeClient(options);
@@ -373,6 +381,7 @@ describe('tracing', () => {
     function createTransactionAndPutOnScope(hub: Hub) {
       addTracingExtensions();
       const transaction = startInactiveSpan({ name: 'dogpark' });
+      // eslint-disable-next-line deprecation/deprecation
       hub.getScope().setSpan(transaction);
       return transaction;
     }
@@ -388,6 +397,8 @@ describe('tracing', () => {
 
         jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
         jest.spyOn(sentryCore, 'getCurrentScope').mockImplementation(() => hub.getScope());
+        // eslint-disable-next-line deprecation/deprecation
+        jest.spyOn(sentryCore, 'getActiveSpan').mockImplementation(() => hub.getScope().getSpan());
         jest.spyOn(sentryCore, 'getClient').mockReturnValue(hub.getClient());
 
         httpIntegration.setupOnce(
@@ -497,6 +508,8 @@ describe('tracing', () => {
 
         jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
         jest.spyOn(sentryCore, 'getCurrentScope').mockImplementation(() => hub.getScope());
+        // eslint-disable-next-line deprecation/deprecation
+        jest.spyOn(sentryCore, 'getActiveSpan').mockImplementation(() => hub.getScope().getSpan());
         jest.spyOn(sentryCore, 'getClient').mockReturnValue(hub.getClient());
 
         httpIntegration.setupOnce(

--- a/packages/node/test/integrations/undici.test.ts
+++ b/packages/node/test/integrations/undici.test.ts
@@ -1,5 +1,5 @@
 import * as http from 'http';
-import { Transaction, startSpan } from '@sentry/core';
+import { Transaction, getActiveSpan, startSpan } from '@sentry/core';
 import { spanToTraceHeader } from '@sentry/core';
 import { Hub, makeMain, runWithAsyncContext } from '@sentry/core';
 import type { fetch as FetchType } from 'undici';
@@ -182,7 +182,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
       // ignore
     }
 
-    expect(hub.getScope().getSpan()).toBeUndefined();
+    expect(getActiveSpan()).toBeUndefined();
   });
 
   it('does create a span if `shouldCreateSpanForRequest` is defined', async () => {

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -122,6 +122,7 @@ describe('SentrySpanProcessor', () => {
         expect(sentrySpan?.spanContext().spanId).toEqual(childOtelSpan.spanContext().spanId);
         expect(sentrySpan?.parentSpanId).toEqual(sentrySpanTransaction?.spanContext().spanId);
 
+        // eslint-disable-next-line deprecation/deprecation
         expect(hub.getScope().getSpan()).toBeUndefined();
 
         child.end(endTime);
@@ -162,6 +163,7 @@ describe('SentrySpanProcessor', () => {
         expect(sentrySpan?.spanContext().spanId).toEqual(childOtelSpan.spanContext().spanId);
         expect(sentrySpan?.parentSpanId).toEqual(parentOtelSpan.spanContext().spanId);
 
+        // eslint-disable-next-line deprecation/deprecation
         expect(hub.getScope().getSpan()).toBeUndefined();
 
         child.end(endTime);

--- a/packages/opentelemetry/test/custom/scope.test.ts
+++ b/packages/opentelemetry/test/custom/scope.test.ts
@@ -81,12 +81,14 @@ describe('NodeExperimentalScope', () => {
     // Pretend we have a _span set
     scope['_span'] = {} as any;
 
+    // eslint-disable-next-line deprecation/deprecation
     expect(scope.getSpan()).toBeUndefined();
   });
 
   it('setSpan is a noop', () => {
     const scope = new OpenTelemetryScope();
 
+    // eslint-disable-next-line deprecation/deprecation
     scope.setSpan({} as any);
 
     expect(scope['_span']).toBeUndefined();

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
 import {
+  getActiveSpan,
   getActiveTransaction,
   getClient,
   getCurrentScope,
@@ -257,11 +258,13 @@ function makeWrappedDataFunction(
 
       if (span) {
         // Assign data function to hub to be able to see `db` transactions (if any) as children.
+        // eslint-disable-next-line deprecation/deprecation
         currentScope.setSpan(span);
       }
 
       res = await origFn.call(this, args);
 
+      // eslint-disable-next-line deprecation/deprecation
       currentScope.setSpan(activeTransaction);
       span?.end();
     } catch (err) {
@@ -299,10 +302,9 @@ function getTraceAndBaggage(): {
 } {
   // eslint-disable-next-line deprecation/deprecation
   const transaction = getActiveTransaction();
-  const currentScope = getCurrentScope();
 
   if (isNodeEnv() && hasTracingEnabled()) {
-    const span = currentScope.getSpan();
+    const span = getActiveSpan();
 
     if (span && transaction) {
       const dynamicSamplingContext = transaction.getDynamicSamplingContext();
@@ -418,6 +420,7 @@ export function startRequestHandlerTransaction(
     },
   });
 
+  // eslint-disable-next-line deprecation/deprecation
   hub.getScope().setSpan(transaction);
   return transaction;
 }

--- a/packages/sveltekit/src/server/handle.ts
+++ b/packages/sveltekit/src/server/handle.ts
@@ -1,4 +1,4 @@
-import { getCurrentScope, spanToTraceHeader } from '@sentry/core';
+import { getActiveSpan, getCurrentScope, spanToTraceHeader } from '@sentry/core';
 import { getActiveTransaction, runWithAsyncContext, startSpan } from '@sentry/core';
 import { captureException } from '@sentry/node';
 /* eslint-disable @sentry-internal/sdk/no-optional-chaining */
@@ -143,7 +143,7 @@ export function sentryHandle(handlerOptions?: SentryHandleOptions): Handle {
     // if there is an active transaction, we know that this handle call is nested and hence
     // we don't create a new domain for it. If we created one, nested server calls would
     // create new transactions instead of adding a child span to the currently active span.
-    if (getCurrentScope().getSpan()) {
+    if (getActiveSpan()) {
       return instrumentHandle(input, options);
     }
     return runWithAsyncContext(() => {

--- a/packages/tracing-internal/src/browser/request.ts
+++ b/packages/tracing-internal/src/browser/request.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines */
 import {
+  getActiveSpan,
   getClient,
   getCurrentScope,
   getDynamicSamplingContextFromClient,
@@ -271,7 +272,7 @@ export function xhrCallback(
   }
 
   const scope = getCurrentScope();
-  const parentSpan = scope.getSpan();
+  const parentSpan = getActiveSpan();
 
   const span =
     shouldCreateSpanResult && parentSpan

--- a/packages/tracing-internal/src/common/fetch.ts
+++ b/packages/tracing-internal/src/common/fetch.ts
@@ -1,4 +1,5 @@
 import {
+  getActiveSpan,
   getClient,
   getCurrentScope,
   getDynamicSamplingContextFromClient,
@@ -73,7 +74,7 @@ export function instrumentFetchRequest(
 
   const scope = getCurrentScope();
   const client = getClient();
-  const parentSpan = scope.getSpan();
+  const parentSpan = getActiveSpan();
 
   const { method, url } = handlerData.fetchData;
 
@@ -129,6 +130,7 @@ export function addTracingHeadersToFetchRequest(
   },
   requestSpan?: Span,
 ): PolymorphicRequestHeaders | undefined {
+  // eslint-disable-next-line deprecation/deprecation
   const span = requestSpan || scope.getSpan();
 
   const transaction = span && span.transaction;

--- a/packages/tracing-internal/src/node/integrations/apollo.ts
+++ b/packages/tracing-internal/src/node/integrations/apollo.ts
@@ -189,6 +189,7 @@ function wrapResolver(
   fill(model[resolverGroupName], resolverName, function (orig: () => unknown | Promise<unknown>) {
     return function (this: unknown, ...args: unknown[]) {
       const scope = getCurrentHub().getScope();
+      // eslint-disable-next-line deprecation/deprecation
       const parentSpan = scope.getSpan();
       // eslint-disable-next-line deprecation/deprecation
       const span = parentSpan?.startChild({

--- a/packages/tracing-internal/src/node/integrations/graphql.ts
+++ b/packages/tracing-internal/src/node/integrations/graphql.ts
@@ -52,6 +52,7 @@ export class GraphQL implements LazyLoadedIntegration<GraphQLModule> {
     fill(pkg, 'execute', function (orig: () => void | Promise<unknown>) {
       return function (this: unknown, ...args: unknown[]) {
         const scope = getCurrentHub().getScope();
+        // eslint-disable-next-line deprecation/deprecation
         const parentSpan = scope.getSpan();
 
         // eslint-disable-next-line deprecation/deprecation
@@ -61,6 +62,7 @@ export class GraphQL implements LazyLoadedIntegration<GraphQLModule> {
           origin: 'auto.graphql.graphql',
         });
 
+        // eslint-disable-next-line deprecation/deprecation
         scope?.setSpan(span);
 
         const rv = orig.call(this, ...args);
@@ -68,6 +70,7 @@ export class GraphQL implements LazyLoadedIntegration<GraphQLModule> {
         if (isThenable(rv)) {
           return rv.then((res: unknown) => {
             span?.end();
+            // eslint-disable-next-line deprecation/deprecation
             scope?.setSpan(parentSpan);
 
             return res;
@@ -75,6 +78,7 @@ export class GraphQL implements LazyLoadedIntegration<GraphQLModule> {
         }
 
         span?.end();
+        // eslint-disable-next-line deprecation/deprecation
         scope?.setSpan(parentSpan);
         return rv;
       };

--- a/packages/tracing-internal/src/node/integrations/mongo.ts
+++ b/packages/tracing-internal/src/node/integrations/mongo.ts
@@ -175,6 +175,7 @@ export class Mongo implements LazyLoadedIntegration<MongoModule> {
       return function (this: unknown, ...args: unknown[]) {
         const lastArg = args[args.length - 1];
         const scope = getCurrentHub().getScope();
+        // eslint-disable-next-line deprecation/deprecation
         const parentSpan = scope.getSpan();
 
         // Check if the operation was passed a callback. (mapReduce requires a different check, as

--- a/packages/tracing-internal/src/node/integrations/mysql.ts
+++ b/packages/tracing-internal/src/node/integrations/mysql.ts
@@ -104,6 +104,7 @@ export class Mysql implements LazyLoadedIntegration<MysqlConnection> {
     fill(pkg, 'createQuery', function (orig: () => void) {
       return function (this: unknown, options: unknown, values: unknown, callback: unknown) {
         const scope = getCurrentHub().getScope();
+        // eslint-disable-next-line deprecation/deprecation
         const parentSpan = scope.getSpan();
 
         // eslint-disable-next-line deprecation/deprecation

--- a/packages/tracing-internal/src/node/integrations/postgres.ts
+++ b/packages/tracing-internal/src/node/integrations/postgres.ts
@@ -105,6 +105,7 @@ export class Postgres implements LazyLoadedIntegration<PGModule> {
     fill(Client.prototype, 'query', function (orig: PgClientQuery) {
       return function (this: PgClientThis, config: unknown, values: unknown, callback: unknown) {
         const scope = getCurrentHub().getScope();
+        // eslint-disable-next-line deprecation/deprecation
         const parentSpan = scope.getSpan();
 
         const data: Record<string, string | number> = {

--- a/packages/tracing-internal/test/browser/backgroundtab.test.ts
+++ b/packages/tracing-internal/test/browser/backgroundtab.test.ts
@@ -30,6 +30,7 @@ conditionalTest({ min: 10 })('registerBackgroundTabDetection', () => {
 
   afterEach(() => {
     events = {};
+    // eslint-disable-next-line deprecation/deprecation
     hub.getScope().setSpan(undefined);
   });
 

--- a/packages/tracing/test/idletransaction.test.ts
+++ b/packages/tracing/test/idletransaction.test.ts
@@ -97,6 +97,7 @@ describe('IdleTransaction', () => {
 
       // @ts-expect-error need to pass in hub
       const otherTransaction = new Transaction({ name: 'bar' }, hub);
+      // eslint-disable-next-line deprecation/deprecation
       hub.getScope().setSpan(otherTransaction);
 
       transaction.end();
@@ -117,6 +118,7 @@ describe('IdleTransaction', () => {
     const mockFinish = jest.spyOn(transaction, 'end');
     transaction.initSpanRecorder(10);
     expect(transaction.activities).toMatchObject({});
+    // eslint-disable-next-line deprecation/deprecation
     getCurrentScope().setSpan(transaction);
 
     const span = startInactiveSpan({ name: 'inner' })!;
@@ -135,6 +137,7 @@ describe('IdleTransaction', () => {
     const transaction = new IdleTransaction({ name: 'foo' }, hub);
     transaction.initSpanRecorder(10);
     expect(transaction.activities).toMatchObject({});
+    // eslint-disable-next-line deprecation/deprecation
     getCurrentScope().setSpan(transaction);
 
     startInactiveSpan({ name: 'inner', startTimestamp: 1234, endTimestamp: 5678 });
@@ -146,6 +149,7 @@ describe('IdleTransaction', () => {
     const mockFinish = jest.spyOn(transaction, 'end');
     transaction.initSpanRecorder(10);
     expect(transaction.activities).toMatchObject({});
+    // eslint-disable-next-line deprecation/deprecation
     getCurrentScope().setSpan(transaction);
 
     startSpanManual({ name: 'inner1' }, span => {
@@ -169,6 +173,7 @@ describe('IdleTransaction', () => {
     transaction.initSpanRecorder(10);
     transaction.registerBeforeFinishCallback(mockCallback1);
     transaction.registerBeforeFinishCallback(mockCallback2);
+    // eslint-disable-next-line deprecation/deprecation
     getCurrentScope().setSpan(transaction);
 
     expect(mockCallback1).toHaveBeenCalledTimes(0);
@@ -186,6 +191,7 @@ describe('IdleTransaction', () => {
   it('filters spans on finish', () => {
     const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub);
     transaction.initSpanRecorder(10);
+    // eslint-disable-next-line deprecation/deprecation
     getCurrentScope().setSpan(transaction);
 
     // regular child - should be kept
@@ -220,6 +226,7 @@ describe('IdleTransaction', () => {
   it('filters out spans that exceed final timeout', () => {
     const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub, 1000, 3000);
     transaction.initSpanRecorder(10);
+    // eslint-disable-next-line deprecation/deprecation
     getCurrentScope().setSpan(transaction);
 
     const span = startInactiveSpan({ name: 'span', startTimestamp: transaction.startTimestamp + 2 })!;
@@ -256,6 +263,7 @@ describe('IdleTransaction', () => {
     it('does not finish if a activity is started', () => {
       const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub);
       transaction.initSpanRecorder(10);
+      // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
 
       startInactiveSpan({ name: 'span' });
@@ -268,6 +276,7 @@ describe('IdleTransaction', () => {
       const idleTimeout = 10;
       const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub, idleTimeout);
       transaction.initSpanRecorder(10);
+      // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
 
       startSpan({ name: 'span1' }, () => {});
@@ -285,6 +294,7 @@ describe('IdleTransaction', () => {
       const idleTimeout = 10;
       const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub, idleTimeout);
       transaction.initSpanRecorder(10);
+      // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
 
       startSpan({ name: 'span1' }, () => {});
@@ -304,6 +314,7 @@ describe('IdleTransaction', () => {
       const idleTimeout = 10;
       const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub, idleTimeout);
       transaction.initSpanRecorder(10);
+      // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
 
       const firstSpan = startInactiveSpan({ name: 'span1' })!;
@@ -319,6 +330,7 @@ describe('IdleTransaction', () => {
       const idleTimeout = 10;
       const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub, idleTimeout);
       transaction.initSpanRecorder(10);
+      // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
 
       const firstSpan = startInactiveSpan({ name: 'span1' })!;
@@ -340,6 +352,7 @@ describe('IdleTransaction', () => {
       const idleTimeout = 10;
       const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub, idleTimeout);
       transaction.initSpanRecorder(10);
+      // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
 
       startSpan({ name: 'span' }, () => {});
@@ -355,6 +368,7 @@ describe('IdleTransaction', () => {
       const idleTimeout = 10;
       const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234 }, hub, idleTimeout);
       transaction.initSpanRecorder(10);
+      // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
 
       startSpan({ name: 'span' }, () => {});
@@ -402,6 +416,7 @@ describe('IdleTransaction', () => {
       const transaction = new IdleTransaction({ name: 'foo' }, hub, TRACING_DEFAULTS.idleTimeout);
       const mockFinish = jest.spyOn(transaction, 'end');
       transaction.initSpanRecorder(10);
+      // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
 
       expect(mockFinish).toHaveBeenCalledTimes(0);
@@ -424,6 +439,7 @@ describe('IdleTransaction', () => {
       const transaction = new IdleTransaction({ name: 'foo' }, hub, TRACING_DEFAULTS.idleTimeout, 50000);
       const mockFinish = jest.spyOn(transaction, 'end');
       transaction.initSpanRecorder(10);
+      // eslint-disable-next-line deprecation/deprecation
       getCurrentScope().setSpan(transaction);
 
       expect(mockFinish).toHaveBeenCalledTimes(0);

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -140,11 +140,13 @@ export interface Scope {
   /**
    * Sets the Span on the scope.
    * @param span Span
+   * @deprecated Instead of setting a span on a scope, use `startSpan()`/`startSpanManual()` instead.
    */
   setSpan(span?: Span): this;
 
   /**
-   * Returns the `Span` if there is one
+   * Returns the `Span` if there is one.
+   * @deprecated Use `getActiveSpan()` instead.
    */
   getSpan(): Span | undefined;
 


### PR DESCRIPTION
These APIs are not compatible with OTEL tracing, and thus will not be public API anymore in v8.

In v8, we'll add new (?) methods to the scope that are "internal", as for non-node based SDKs we'll still need to keep the active span on the scope. But these should not be reflected publicly, and not in types' Scope.

Note that we'll also need to make sure to use types' `Scope` for all callbacks etc., which we currently don't do.