### PR TITLE
feat(core): Deprecate methods on `Hub`

### DIFF
--- a/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/sdkLoadedInMeanwhile/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/noOnLoad/sdkLoadedInMeanwhile/test.ts
@@ -54,7 +54,7 @@ sentryTest('it does not download the SDK if the SDK was loaded in the meanwhile'
   expect(sentryEventCount).toBe(1);
 
   // Ensure loader does not overwrite init/config
-  const options = await page.evaluate(() => (window as any).Sentry.getCurrentHub().getClient()?.getOptions());
+  const options = await page.evaluate(() => (window as any).Sentry.getClient()?.getOptions());
   expect(options?.replaysSessionSampleRate).toBe(0.42);
 
   expect(eventData.exception?.values?.length).toBe(1);

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customBrowserTracing/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customBrowserTracing/test.ts
@@ -27,7 +27,7 @@ sentryTest('should handle custom added BrowserTracing integration', async ({ get
   expect(eventData.transaction_info?.source).toEqual('url');
 
   const tracePropagationTargets = await page.evaluate(() => {
-    const browserTracing = (window as any).Sentry.getCurrentHub().getClient().getIntegrationById('BrowserTracing');
+    const browserTracing = (window as any).Sentry.getClient().getIntegrationById('BrowserTracing');
     return browserTracing.options.tracePropagationTargets;
   });
 

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customInit/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customInit/test.ts
@@ -30,5 +30,5 @@ sentryTest('always calls onLoad init correctly', async ({ getLocalTestUrl, page 
 
   expect(await page.evaluate('window.__hadSentry')).toEqual(false);
   expect(await page.evaluate('window.__sentryOnLoad')).toEqual(1);
-  expect(await page.evaluate('Sentry.getCurrentHub().getClient().getOptions().sampleRate')).toEqual(0.5);
+  expect(await page.evaluate('Sentry.getClient().getOptions().sampleRate')).toEqual(0.5);
 });

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customIntegrations/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customIntegrations/test.ts
@@ -24,14 +24,14 @@ sentryTest('should handle custom added integrations & default integrations', asy
   });
 
   const hasCustomIntegration = await page.evaluate(() => {
-    return !!(window as any).Sentry.getCurrentHub().getClient().getIntegrationById('CustomIntegration');
+    return !!(window as any).Sentry.getClient().getIntegrationById('CustomIntegration');
   });
 
   const hasReplay = await page.evaluate(() => {
-    return !!(window as any).Sentry.getCurrentHub().getClient().getIntegrationById('Replay');
+    return !!(window as any).Sentry.getClient().getIntegrationById('Replay');
   });
   const hasBrowserTracing = await page.evaluate(() => {
-    return !!(window as any).Sentry.getCurrentHub().getClient().getIntegrationById('BrowserTracing');
+    return !!(window as any).Sentry.getClient().getIntegrationById('BrowserTracing');
   });
 
   expect(hasCustomIntegration).toEqual(true);

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customIntegrationsFunction/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customIntegrationsFunction/test.ts
@@ -21,14 +21,14 @@ sentryTest(
     });
 
     const hasCustomIntegration = await page.evaluate(() => {
-      return !!(window as any).Sentry.getCurrentHub().getClient().getIntegrationById('CustomIntegration');
+      return !!(window as any).Sentry.getClient().getIntegrationById('CustomIntegration');
     });
 
     const hasReplay = await page.evaluate(() => {
-      return !!(window as any).Sentry.getCurrentHub().getClient().getIntegrationById('Replay');
+      return !!(window as any).Sentry.getClient().getIntegrationById('Replay');
     });
     const hasBrowserTracing = await page.evaluate(() => {
-      return !!(window as any).Sentry.getCurrentHub().getClient().getIntegrationById('BrowserTracing');
+      return !!(window as any).Sentry.getClient().getIntegrationById('BrowserTracing');
     });
 
     expect(hasCustomIntegration).toEqual(true);

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customReplay/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/customReplay/test.ts
@@ -27,7 +27,7 @@ sentryTest('should handle custom added Replay integration', async ({ getLocalTes
   expect(eventData.segment_id).toBe(0);
 
   const useCompression = await page.evaluate(() => {
-    const replay = (window as any).Sentry.getCurrentHub().getClient().getIntegrationById('Replay');
+    const replay = (window as any).Sentry.getClient().getIntegrationById('Replay');
     return replay._replay.getOptions().useCompression;
   });
 

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/sentryOnLoad/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/sentryOnLoad/test.ts
@@ -11,5 +11,5 @@ sentryTest('sentryOnLoad callback is called before Sentry.onLoad()', async ({ ge
 
   expect(eventData.message).toBe('Test exception');
 
-  expect(await page.evaluate('Sentry.getCurrentHub().getClient().getOptions().tracesSampleRate')).toEqual(0.123);
+  expect(await page.evaluate('Sentry.getClient().getOptions().tracesSampleRate')).toEqual(0.123);
 });

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/sentryOnLoadAndOnLoad/init.js
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/sentryOnLoadAndOnLoad/init.js
@@ -1,4 +1,4 @@
 Sentry.onLoad(function () {
   // this should be called _after_ window.sentryOnLoad
-  Sentry.captureException(`Test exception: ${Sentry.getCurrentHub().getClient().getOptions().tracesSampleRate}`);
+  Sentry.captureException(`Test exception: ${Sentry.getClient().getOptions().tracesSampleRate}`);
 });

--- a/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/sentryOnLoadAndOnLoad/test.ts
+++ b/dev-packages/browser-integration-tests/loader-suites/loader/onLoad/sentryOnLoadAndOnLoad/test.ts
@@ -11,5 +11,5 @@ sentryTest('sentryOnLoad callback is used', async ({ getLocalTestUrl, page }) =>
 
   expect(eventData.message).toBe('Test exception: 0.123');
 
-  expect(await page.evaluate('Sentry.getCurrentHub().getClient().getOptions().tracesSampleRate')).toEqual(0.123);
+  expect(await page.evaluate('Sentry.getClient().getOptions().tracesSampleRate')).toEqual(0.123);
 });

--- a/dev-packages/e2e-tests/test-applications/create-next-app/pages/api/success.ts
+++ b/dev-packages/e2e-tests/test-applications/create-next-app/pages/api/success.ts
@@ -6,7 +6,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   // eslint-disable-next-line deprecation/deprecation
   const transaction = Sentry.startTransaction({ name: 'test-transaction', op: 'e2e-test' });
   // eslint-disable-next-line deprecation/deprecation
-  Sentry.getCurrentHub().getScope().setSpan(transaction);
+  Sentry.getCurrentScope().setSpan(transaction);
 
   // eslint-disable-next-line deprecation/deprecation
   const span = transaction.startChild();

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/server.ts
@@ -27,7 +27,7 @@ app.use(cors());
 
 app.get('/test/express', (_req, res) => {
   // eslint-disable-next-line deprecation/deprecation
-  const transaction = Sentry.getCurrentHub().getScope().getTransaction();
+  const transaction = Sentry.getCurrentScope().getTransaction();
   if (transaction) {
     // eslint-disable-next-line deprecation/deprecation
     transaction.traceId = '86f39e84263a4de99c326acab3bfe3bd';

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/server.ts
@@ -31,7 +31,7 @@ app.use(cors());
 
 app.get('/test/express', (_req, res) => {
   // eslint-disable-next-line deprecation/deprecation
-  const transaction = Sentry.getCurrentHub().getScope().getTransaction();
+  const transaction = Sentry.getCurrentScope().getTransaction();
   if (transaction) {
     // eslint-disable-next-line deprecation/deprecation
     transaction.traceId = '86f39e84263a4de99c326acab3bfe3bd';

--- a/dev-packages/node-integration-tests/suites/sessions/server.ts
+++ b/dev-packages/node-integration-tests/suites/sessions/server.ts
@@ -14,7 +14,7 @@ app.use(Sentry.Handlers.requestHandler());
 
 // ### Taken from manual tests ###
 // Hack that resets the 60s default flush interval, and replaces it with just a one second interval
-const flusher = (Sentry.getCurrentHub()?.getClient() as Sentry.NodeClient)['_sessionFlusher'] as SessionFlusher;
+const flusher = (Sentry.getClient() as Sentry.NodeClient)['_sessionFlusher'] as SessionFlusher;
 
 let flusherIntervalId = flusher && flusher['_intervalId'];
 

--- a/packages/astro/test/client/sdk.test.ts
+++ b/packages/astro/test/client/sdk.test.ts
@@ -1,6 +1,7 @@
 import type { BrowserClient } from '@sentry/browser';
+import { getCurrentScope } from '@sentry/browser';
 import * as SentryBrowser from '@sentry/browser';
-import { BrowserTracing, SDK_VERSION, WINDOW, getClient, getCurrentHub } from '@sentry/browser';
+import { BrowserTracing, SDK_VERSION, WINDOW, getClient } from '@sentry/browser';
 import { vi } from 'vitest';
 
 import { init } from '../../../astro/src/client/sdk';
@@ -37,7 +38,7 @@ describe('Sentry client SDK', () => {
     });
 
     it('sets the runtime tag on the scope', () => {
-      const currentScope = getCurrentHub().getScope();
+      const currentScope = getCurrentScope();
 
       // @ts-expect-error need access to protected _tags attribute
       expect(currentScope._tags).toEqual({});

--- a/packages/astro/test/server/sdk.test.ts
+++ b/packages/astro/test/server/sdk.test.ts
@@ -1,4 +1,3 @@
-import { getCurrentHub } from '@sentry/core';
 import * as SentryNode from '@sentry/node';
 import { SDK_VERSION } from '@sentry/node';
 import { GLOBAL_OBJ } from '@sentry/utils';
@@ -38,7 +37,7 @@ describe('Sentry server SDK', () => {
     });
 
     it('sets the runtime tag on the scope', () => {
-      const currentScope = getCurrentHub().getScope();
+      const currentScope = SentryNode.getCurrentScope();
 
       // @ts-expect-error need access to protected _tags attribute
       expect(currentScope._tags).toEqual({});

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -167,6 +167,7 @@ export const showReportDialog: ShowReportDialogFunction = (
     return;
   }
 
+  // eslint-disable-next-line deprecation/deprecation
   const { client, scope } = hub.getStackTop();
   const dsn = options.dsn || (client && client.getDsn());
   if (!dsn) {

--- a/packages/browser/test/unit/profiling/integration.test.ts
+++ b/packages/browser/test/unit/profiling/integration.test.ts
@@ -51,7 +51,7 @@ describe('BrowserProfilingIntegration', () => {
     const client = Sentry.getClient<BrowserClient>();
 
     // eslint-disable-next-line deprecation/deprecation
-    const currentTransaction = Sentry.getCurrentHub().getScope().getTransaction();
+    const currentTransaction = Sentry.getCurrentScope().getTransaction();
     expect(currentTransaction?.op).toBe('pageload');
     currentTransaction?.end();
     await client?.flush(1000);

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -99,6 +99,7 @@ export function configureScope(callback: (scope: Scope) => void): ReturnType<Hub
  * @param breadcrumb The breadcrumb to record.
  */
 export function addBreadcrumb(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): ReturnType<Hub['addBreadcrumb']> {
+  // eslint-disable-next-line deprecation/deprecation
   getCurrentHub().addBreadcrumb(breadcrumb, hint);
 }
 
@@ -109,6 +110,7 @@ export function addBreadcrumb(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): Re
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function setContext(name: string, context: { [key: string]: any } | null): ReturnType<Hub['setContext']> {
+  // eslint-disable-next-line deprecation/deprecation
   getCurrentHub().setContext(name, context);
 }
 
@@ -117,6 +119,7 @@ export function setContext(name: string, context: { [key: string]: any } | null)
  * @param extras Extras object to merge into current context.
  */
 export function setExtras(extras: Extras): ReturnType<Hub['setExtras']> {
+  // eslint-disable-next-line deprecation/deprecation
   getCurrentHub().setExtras(extras);
 }
 
@@ -126,6 +129,7 @@ export function setExtras(extras: Extras): ReturnType<Hub['setExtras']> {
  * @param extra Any kind of data. This data will be normalized.
  */
 export function setExtra(key: string, extra: Extra): ReturnType<Hub['setExtra']> {
+  // eslint-disable-next-line deprecation/deprecation
   getCurrentHub().setExtra(key, extra);
 }
 
@@ -134,6 +138,7 @@ export function setExtra(key: string, extra: Extra): ReturnType<Hub['setExtra']>
  * @param tags Tags context object to merge into current context.
  */
 export function setTags(tags: { [key: string]: Primitive }): ReturnType<Hub['setTags']> {
+  // eslint-disable-next-line deprecation/deprecation
   getCurrentHub().setTags(tags);
 }
 
@@ -146,6 +151,7 @@ export function setTags(tags: { [key: string]: Primitive }): ReturnType<Hub['set
  * @param value Value of tag
  */
 export function setTag(key: string, value: Primitive): ReturnType<Hub['setTag']> {
+  // eslint-disable-next-line deprecation/deprecation
   getCurrentHub().setTag(key, value);
 }
 
@@ -155,6 +161,7 @@ export function setTag(key: string, value: Primitive): ReturnType<Hub['setTag']>
  * @param user User context object to be set in the current context. Pass `null` to unset the user.
  */
 export function setUser(user: User | null): ReturnType<Hub['setUser']> {
+  // eslint-disable-next-line deprecation/deprecation
   getCurrentHub().setUser(user);
 }
 
@@ -184,16 +191,20 @@ export function withScope<T>(
   if (rest.length === 2) {
     const [scope, callback] = rest;
     if (!scope) {
+      // eslint-disable-next-line deprecation/deprecation
       return getCurrentHub().withScope(callback);
     }
 
     const hub = getCurrentHub();
+    // eslint-disable-next-line deprecation/deprecation
     return hub.withScope(() => {
+      // eslint-disable-next-line deprecation/deprecation
       hub.getStackTop().scope = scope as Scope;
       return callback(scope as Scope);
     });
   }
 
+  // eslint-disable-next-line deprecation/deprecation
   return getCurrentHub().withScope(rest[0]);
 }
 
@@ -332,6 +343,7 @@ export async function close(timeout?: number): Promise<boolean> {
  * @deprecated This function will be removed in the next major version of the Sentry SDK.
  */
 export function lastEventId(): string | undefined {
+  // eslint-disable-next-line deprecation/deprecation
   return getCurrentHub().lastEventId();
 }
 
@@ -339,6 +351,7 @@ export function lastEventId(): string | undefined {
  * Get the currently active client.
  */
 export function getClient<C extends Client>(): C | undefined {
+  // eslint-disable-next-line deprecation/deprecation
   return getCurrentHub().getClient<C>();
 }
 
@@ -346,6 +359,7 @@ export function getClient<C extends Client>(): C | undefined {
  * Get the currently active scope.
  */
 export function getCurrentScope(): Scope {
+  // eslint-disable-next-line deprecation/deprecation
   return getCurrentHub().getScope();
 }
 

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -154,7 +154,12 @@ export class Hub implements HubInterface {
   }
 
   /**
-   * @inheritDoc
+   * Checks if this hub's version is older than the given version.
+   *
+   * @param version A version number to compare to.
+   * @return True if the given version is newer; otherwise false.
+   *
+   * @deprecated This will be removed in v8.
    */
   public isOlderThan(version: number): boolean {
     return this._version < version;
@@ -164,6 +169,7 @@ export class Hub implements HubInterface {
    * @inheritDoc
    */
   public bindClient(client?: Client): void {
+    // eslint-disable-next-line deprecation/deprecation
     const top = this.getStackTop();
     top.client = client;
     top.scope.setClient(client);
@@ -179,8 +185,11 @@ export class Hub implements HubInterface {
    */
   public pushScope(): Scope {
     // We want to clone the content of prev scope
+    // eslint-disable-next-line deprecation/deprecation
     const scope = this.getScope().clone();
+    // eslint-disable-next-line deprecation/deprecation
     this.getStack().push({
+      // eslint-disable-next-line deprecation/deprecation
       client: this.getClient(),
       scope,
     });
@@ -193,12 +202,16 @@ export class Hub implements HubInterface {
    * @deprecated Use `withScope` instead.
    */
   public popScope(): boolean {
+    // eslint-disable-next-line deprecation/deprecation
     if (this.getStack().length <= 1) return false;
+    // eslint-disable-next-line deprecation/deprecation
     return !!this.getStack().pop();
   }
 
   /**
    * @inheritDoc
+   *
+   * @deprecated Use `Sentry.withScope()` instead.
    */
   public withScope<T>(callback: (scope: Scope) => T): T {
     // eslint-disable-next-line deprecation/deprecation
@@ -236,27 +249,43 @@ export class Hub implements HubInterface {
 
   /**
    * @inheritDoc
+   *
+   * @deprecated Use `Sentry.getClient()` instead.
    */
   public getClient<C extends Client>(): C | undefined {
+    // eslint-disable-next-line deprecation/deprecation
     return this.getStackTop().client as C;
   }
 
-  /** Returns the scope of the top stack. */
+  /**
+   * Returns the scope of the top stack.
+   *
+   * @deprecated Use `Sentry.getCurrentScope()` instead.
+   */
   public getScope(): Scope {
+    // eslint-disable-next-line deprecation/deprecation
     return this.getStackTop().scope;
   }
 
-  /** @inheritdoc */
+  /**
+   * @deprecated Use `Sentry.getIsolationScope()` instead.
+   */
   public getIsolationScope(): Scope {
     return this._isolationScope;
   }
 
-  /** Returns the scope stack for domains or the process. */
+  /**
+   * Returns the scope stack for domains or the process.
+   * @deprecated This will be removed in v8.
+   */
   public getStack(): Layer[] {
     return this._stack;
   }
 
-  /** Returns the topmost scope layer in the order domain > local > process. */
+  /**
+   * Returns the topmost scope layer in the order domain > local > process.
+   * @deprecated This will be removed in v8.
+   */
   public getStackTop(): Layer {
     return this._stack[this._stack.length - 1];
   }
@@ -269,6 +298,7 @@ export class Hub implements HubInterface {
   public captureException(exception: unknown, hint?: EventHint): string {
     const eventId = (this._lastEventId = hint && hint.event_id ? hint.event_id : uuid4());
     const syntheticException = new Error('Sentry syntheticException');
+    // eslint-disable-next-line deprecation/deprecation
     this.getScope().captureException(exception, {
       originalException: exception,
       syntheticException,
@@ -292,6 +322,7 @@ export class Hub implements HubInterface {
   ): string {
     const eventId = (this._lastEventId = hint && hint.event_id ? hint.event_id : uuid4());
     const syntheticException = new Error(message);
+    // eslint-disable-next-line deprecation/deprecation
     this.getScope().captureMessage(message, level, {
       originalException: message,
       syntheticException,
@@ -312,13 +343,15 @@ export class Hub implements HubInterface {
     if (!event.type) {
       this._lastEventId = eventId;
     }
-
+    // eslint-disable-next-line deprecation/deprecation
     this.getScope().captureEvent(event, { ...hint, event_id: eventId });
     return eventId;
   }
 
   /**
    * @inheritDoc
+   *
+   * @deprecated This will be removed in v8.
    */
   public lastEventId(): string | undefined {
     return this._lastEventId;
@@ -326,8 +359,11 @@ export class Hub implements HubInterface {
 
   /**
    * @inheritDoc
+   *
+   * @deprecated Use `Sentry.addBreadcrumb()` instead.
    */
   public addBreadcrumb(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): void {
+    // eslint-disable-next-line deprecation/deprecation
     const { scope, client } = this.getStackTop();
 
     if (!client) return;
@@ -354,44 +390,56 @@ export class Hub implements HubInterface {
 
   /**
    * @inheritDoc
+   * @deprecated Use `Sentry.setUser()` instead.
    */
   public setUser(user: User | null): void {
+    // eslint-disable-next-line deprecation/deprecation
     this.getScope().setUser(user);
   }
 
   /**
    * @inheritDoc
+   * @deprecated Use `Sentry.setTags()` instead.
    */
   public setTags(tags: { [key: string]: Primitive }): void {
+    // eslint-disable-next-line deprecation/deprecation
     this.getScope().setTags(tags);
   }
 
   /**
    * @inheritDoc
+   * @deprecated Use `Sentry.setExtras()` instead.
    */
   public setExtras(extras: Extras): void {
+    // eslint-disable-next-line deprecation/deprecation
     this.getScope().setExtras(extras);
   }
 
   /**
    * @inheritDoc
+   * @deprecated Use `Sentry.setTag()` instead.
    */
   public setTag(key: string, value: Primitive): void {
+    // eslint-disable-next-line deprecation/deprecation
     this.getScope().setTag(key, value);
   }
 
   /**
    * @inheritDoc
+   * @deprecated Use `Sentry.setExtra()` instead.
    */
   public setExtra(key: string, extra: Extra): void {
+    // eslint-disable-next-line deprecation/deprecation
     this.getScope().setExtra(key, extra);
   }
 
   /**
    * @inheritDoc
+   * @deprecated Use `Sentry.setContext()` instead.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public setContext(name: string, context: { [key: string]: any } | null): void {
+    // eslint-disable-next-line deprecation/deprecation
     this.getScope().setContext(name, context);
   }
 
@@ -401,6 +449,7 @@ export class Hub implements HubInterface {
    * @deprecated Use `getScope()` directly.
    */
   public configureScope(callback: (scope: Scope) => void): void {
+    // eslint-disable-next-line deprecation/deprecation
     const { scope, client } = this.getStackTop();
     if (client) {
       callback(scope);
@@ -421,8 +470,10 @@ export class Hub implements HubInterface {
 
   /**
    * @inheritDoc
+   * @deprecated Use `Sentry.getClient().getIntegration()` instead.
    */
   public getIntegration<T extends Integration>(integration: IntegrationClass<T>): T | null {
+    // eslint-disable-next-line deprecation/deprecation
     const client = this.getClient();
     if (!client) return null;
     try {
@@ -456,6 +507,7 @@ export class Hub implements HubInterface {
     const result = this._callExtensionMethod<Transaction>('startTransaction', context, customSamplingContext);
 
     if (DEBUG_BUILD && !result) {
+      // eslint-disable-next-line deprecation/deprecation
       const client = this.getClient();
       if (!client) {
         logger.warn(
@@ -474,6 +526,7 @@ Sentry.init({...});
 
   /**
    * @inheritDoc
+   * @deprecated Use `spanToTraceHeader()` instead.
    */
   public traceHeaders(): { [key: string]: string } {
     return this._callExtensionMethod<{ [key: string]: string }>('traceHeaders');
@@ -500,6 +553,7 @@ Sentry.init({...});
    * @deprecated Use top level `endSession` instead.
    */
   public endSession(): void {
+    // eslint-disable-next-line deprecation/deprecation
     const layer = this.getStackTop();
     const scope = layer.scope;
     const session = scope.getSession();
@@ -517,6 +571,7 @@ Sentry.init({...});
    * @deprecated Use top level `startSession` instead.
    */
   public startSession(context?: SessionContext): Session {
+    // eslint-disable-next-line deprecation/deprecation
     const { scope, client } = this.getStackTop();
     const { release, environment = DEFAULT_ENVIRONMENT } = (client && client.getOptions()) || {};
 
@@ -553,6 +608,7 @@ Sentry.init({...});
    * only unnecessarily increased API surface but only wrapped accessing the option.
    */
   public shouldSendDefaultPii(): boolean {
+    // eslint-disable-next-line deprecation/deprecation
     const client = this.getClient();
     const options = client && client.getOptions();
     return Boolean(options && options.sendDefaultPii);
@@ -562,24 +618,12 @@ Sentry.init({...});
    * Sends the current Session on the scope
    */
   private _sendSessionUpdate(): void {
+    // eslint-disable-next-line deprecation/deprecation
     const { scope, client } = this.getStackTop();
 
     const session = scope.getSession();
     if (session && client && client.captureSession) {
       client.captureSession(session);
-    }
-  }
-
-  /**
-   * Internal helper function to call a method on the top client if it exists.
-   *
-   * @param method The method to call on the client.
-   * @param args Arguments to pass to the client function.
-   */
-  private _withClient(callback: (client: Client, scope: Scope) => void): void {
-    const { scope, client } = this.getStackTop();
-    if (client) {
-      callback(client, scope);
     }
   }
 
@@ -654,12 +698,18 @@ export function getCurrentHub(): Hub {
  * meaning that it will remain stable for the same Hub.
  */
 export function getIsolationScope(): Scope {
+  // eslint-disable-next-line deprecation/deprecation
   return getCurrentHub().getIsolationScope();
 }
 
 function getGlobalHub(registry: Carrier = getMainCarrier()): Hub {
   // If there's no hub, or its an old API, assign a new one
-  if (!hasHubOnCarrier(registry) || getHubFromCarrier(registry).isOlderThan(API_VERSION)) {
+
+  if (
+    !hasHubOnCarrier(registry) ||
+    // eslint-disable-next-line deprecation/deprecation
+    getHubFromCarrier(registry).isOlderThan(API_VERSION)
+  ) {
     setHubOnCarrier(registry, new Hub());
   }
 
@@ -674,9 +724,16 @@ function getGlobalHub(registry: Carrier = getMainCarrier()): Hub {
  */
 export function ensureHubOnCarrier(carrier: Carrier, parent: Hub = getGlobalHub()): void {
   // If there's no hub on current domain, or it's an old API, assign a new one
-  if (!hasHubOnCarrier(carrier) || getHubFromCarrier(carrier).isOlderThan(API_VERSION)) {
+  if (
+    !hasHubOnCarrier(carrier) ||
+    // eslint-disable-next-line deprecation/deprecation
+    getHubFromCarrier(carrier).isOlderThan(API_VERSION)
+  ) {
+    // eslint-disable-next-line deprecation/deprecation
     const client = parent.getClient();
+    // eslint-disable-next-line deprecation/deprecation
     const scope = parent.getScope();
+    // eslint-disable-next-line deprecation/deprecation
     const isolationScope = parent.getIsolationScope();
     setHubOnCarrier(carrier, new Hub(client, scope.clone(), isolationScope.clone()));
   }

--- a/packages/core/src/sdk.ts
+++ b/packages/core/src/sdk.ts
@@ -30,6 +30,7 @@ export function initAndBind<F extends Client, O extends ClientOptions>(
     }
   }
   const hub = getCurrentHub();
+  // eslint-disable-next-line deprecation/deprecation
   const scope = hub.getScope();
   scope.update(options.initialScope);
 

--- a/packages/core/src/tracing/hubextensions.ts
+++ b/packages/core/src/tracing/hubextensions.ts
@@ -12,6 +12,7 @@ import { Transaction } from './transaction';
 
 /** Returns all trace headers that are currently on the top scope. */
 function traceHeaders(this: Hub): { [key: string]: string } {
+  // eslint-disable-next-line deprecation/deprecation
   const scope = this.getScope();
   // eslint-disable-next-line deprecation/deprecation
   const span = scope.getSpan();
@@ -43,6 +44,7 @@ function _startTransaction(
   transactionContext: TransactionContext,
   customSamplingContext?: CustomSamplingContext,
 ): Transaction {
+  // eslint-disable-next-line deprecation/deprecation
   const client = this.getClient();
   const options: Partial<ClientOptions> = (client && client.getOptions()) || {};
 
@@ -88,6 +90,7 @@ export function startIdleTransaction(
   customSamplingContext?: CustomSamplingContext,
   heartbeatInterval?: number,
 ): IdleTransaction {
+  // eslint-disable-next-line deprecation/deprecation
   const client = hub.getClient();
   const options: Partial<ClientOptions> = (client && client.getOptions()) || {};
 

--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -199,6 +199,7 @@ export class IdleTransaction extends Transaction {
 
     // if `this._onScope` is `true`, the transaction put itself on the scope when it started
     if (this._onScope) {
+      // eslint-disable-next-line deprecation/deprecation
       const scope = this._idleHub.getScope();
       // eslint-disable-next-line deprecation/deprecation
       if (scope.getTransaction() === this) {

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -265,6 +265,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
     // just sets the end timestamp
     super.end(endTimestamp);
 
+    // eslint-disable-next-line deprecation/deprecation
     const client = this._hub.getClient();
     if (client && client.emit) {
       client.emit('finishTransaction', this);

--- a/packages/core/src/tracing/utils.ts
+++ b/packages/core/src/tracing/utils.ts
@@ -11,6 +11,7 @@ import { getCurrentHub } from '../hub';
  */
 export function getActiveTransaction<T extends Transaction>(maybeHub?: Hub): T | undefined {
   const hub = maybeHub || getCurrentHub();
+  // eslint-disable-next-line deprecation/deprecation
   const scope = hub.getScope();
   // eslint-disable-next-line deprecation/deprecation
   return scope.getTransaction() as T | undefined;

--- a/packages/core/src/utils/isSentryRequestUrl.ts
+++ b/packages/core/src/utils/isSentryRequestUrl.ts
@@ -7,7 +7,11 @@ import type { Client, DsnComponents, Hub } from '@sentry/types';
  * TODO(v8): Remove Hub fallback type
  */
 export function isSentryRequestUrl(url: string, hubOrClient: Hub | Client | undefined): boolean {
-  const client = hubOrClient && isHub(hubOrClient) ? hubOrClient.getClient() : hubOrClient;
+  const client =
+    hubOrClient && isHub(hubOrClient)
+      ? // eslint-disable-next-line deprecation/deprecation
+        hubOrClient.getClient()
+      : hubOrClient;
   const dsn = client && client.getDsn();
   const tunnel = client && client.getOptions().tunnel;
 
@@ -31,5 +35,6 @@ function removeTrailingSlash(str: string): string {
 }
 
 function isHub(hubOrClient: Hub | Client | undefined): hubOrClient is Hub {
+  // eslint-disable-next-line deprecation/deprecation
   return (hubOrClient as Hub).getClient !== undefined;
 }

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -122,6 +122,7 @@ describe('BaseClient', () => {
       const hub = new Hub(client, scope);
 
       scope.addBreadcrumb({ message: 'hello' }, 100);
+      // eslint-disable-next-line deprecation/deprecation
       hub.addBreadcrumb({ message: 'world' });
 
       expect((scope as any)._breadcrumbs[1].message).toEqual('world');
@@ -136,6 +137,7 @@ describe('BaseClient', () => {
       const hub = new Hub(client, scope);
 
       scope.addBreadcrumb({ message: 'hello' }, 100);
+      // eslint-disable-next-line deprecation/deprecation
       hub.addBreadcrumb({ message: 'world' });
 
       expect((scope as any)._breadcrumbs[1].timestamp).toBeGreaterThan(1);
@@ -150,6 +152,7 @@ describe('BaseClient', () => {
       const hub = new Hub(client, scope);
 
       scope.addBreadcrumb({ message: 'hello' }, 100);
+      // eslint-disable-next-line deprecation/deprecation
       hub.addBreadcrumb({ message: 'world' });
 
       expect((scope as any)._breadcrumbs.length).toEqual(1);
@@ -164,7 +167,8 @@ describe('BaseClient', () => {
       const scope = new Scope();
       const hub = new Hub(client, scope);
 
-      hub.addBreadcrumb({ message: 'hello' });
+      scope.addBreadcrumb({ message: 'hello' });
+      // eslint-disable-next-line deprecation/deprecation
       hub.addBreadcrumb({ message: 'world' });
 
       expect((scope as any)._breadcrumbs).toHaveLength(2);
@@ -179,6 +183,7 @@ describe('BaseClient', () => {
       const scope = new Scope();
       const hub = new Hub(client, scope);
 
+      // eslint-disable-next-line deprecation/deprecation
       hub.addBreadcrumb({ message: 'hello' });
 
       expect((scope as any)._breadcrumbs[0].message).toEqual('hello');
@@ -193,6 +198,7 @@ describe('BaseClient', () => {
       const scope = new Scope();
       const hub = new Hub(client, scope);
 
+      // eslint-disable-next-line deprecation/deprecation
       hub.addBreadcrumb({ message: 'hello' });
 
       expect((scope as any)._breadcrumbs[0].message).toEqual('changed');
@@ -207,6 +213,7 @@ describe('BaseClient', () => {
       const scope = new Scope();
       const hub = new Hub(client, scope);
 
+      // eslint-disable-next-line deprecation/deprecation
       hub.addBreadcrumb({ message: 'hello' });
 
       expect((scope as any)._breadcrumbs.length).toEqual(0);
@@ -221,6 +228,7 @@ describe('BaseClient', () => {
       const scope = new Scope();
       const hub = new Hub(client, scope);
 
+      // eslint-disable-next-line deprecation/deprecation
       hub.addBreadcrumb({ message: 'hello' }, { data: 'someRandomThing' });
 
       expect((scope as any)._breadcrumbs[0].message).toEqual('hello');
@@ -613,7 +621,9 @@ describe('BaseClient', () => {
       const client = new TestClient(options);
       const scope = new Scope();
       const hub = new Hub(client, scope);
+      // eslint-disable-next-line deprecation/deprecation
       hub.addBreadcrumb({ message: '1' });
+      // eslint-disable-next-line deprecation/deprecation
       hub.addBreadcrumb({ message: '2' });
 
       client.captureEvent({ message: 'message' }, undefined, scope);

--- a/packages/core/test/lib/prepareEvent.test.ts
+++ b/packages/core/test/lib/prepareEvent.test.ts
@@ -9,7 +9,7 @@ import type {
   ScopeContext,
 } from '@sentry/types';
 import { GLOBAL_OBJ, createStackParser } from '@sentry/utils';
-import { getCurrentHub, getIsolationScope, setGlobalScope } from '../../src';
+import { getIsolationScope, setGlobalScope } from '../../src';
 
 import { Scope, getGlobalScope } from '../../src/scope';
 import {
@@ -192,7 +192,7 @@ describe('parseEventHintOrCaptureContext', () => {
 describe('prepareEvent', () => {
   beforeEach(() => {
     setGlobalScope(undefined);
-    getCurrentHub().getIsolationScope().clear();
+    getIsolationScope().clear();
   });
 
   it('works without any scope data', async () => {

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -358,7 +358,7 @@ describe('continueTrace', () => {
 
     expect(result).toEqual(expectedContext);
 
-    const scope = hub.getScope();
+    const scope = getCurrentScope();
 
     expect(scope.getPropagationContext()).toEqual({
       sampled: undefined,
@@ -392,7 +392,7 @@ describe('continueTrace', () => {
 
     expect(result).toEqual(expectedContext);
 
-    const scope = hub.getScope();
+    const scope = getCurrentScope();
 
     expect(scope.getPropagationContext()).toEqual({
       sampled: false,
@@ -430,7 +430,7 @@ describe('continueTrace', () => {
 
     expect(result).toEqual(expectedContext);
 
-    const scope = hub.getScope();
+    const scope = getCurrentScope();
 
     expect(scope.getPropagationContext()).toEqual({
       dsc: {
@@ -472,7 +472,7 @@ describe('continueTrace', () => {
 
     expect(result).toEqual(expectedContext);
 
-    const scope = hub.getScope();
+    const scope = getCurrentScope();
 
     expect(scope.getPropagationContext()).toEqual({
       dsc: {

--- a/packages/core/test/mocks/integration.ts
+++ b/packages/core/test/mocks/integration.ts
@@ -1,6 +1,6 @@
 import type { Event, EventProcessor, Integration } from '@sentry/types';
 
-import { getCurrentHub, getCurrentScope } from '../../src';
+import { getClient, getCurrentScope } from '../../src';
 
 export class TestIntegration implements Integration {
   public static id: string = 'TestIntegration';
@@ -9,7 +9,7 @@ export class TestIntegration implements Integration {
 
   public setupOnce(): void {
     const eventProcessor: EventProcessor = (event: Event) => {
-      if (!getCurrentHub().getIntegration(TestIntegration)) {
+      if (!getClient()?.getIntegration(TestIntegration)) {
         return event;
       }
 

--- a/packages/ember/addon/index.ts
+++ b/packages/ember/addon/index.ts
@@ -74,7 +74,7 @@ export function InitSentryForEmber(_runtimeConfig?: BrowserOptions): void {
  */
 export const getActiveTransaction = (): Transaction | undefined => {
   // eslint-disable-next-line deprecation/deprecation
-  return Sentry.getCurrentHub().getScope().getTransaction();
+  return Sentry.getCurrentScope().getTransaction();
 };
 
 type RouteConstructor = new (...args: ConstructorParameters<typeof Route>) => Route;

--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -437,7 +437,7 @@ export async function instrumentForPerformance(appInstance: ApplicationInstance)
   });
 
   if (macroCondition(isTesting())) {
-    const client = Sentry.getCurrentHub().getClient();
+    const client = Sentry.getClient();
 
     if (
       client &&
@@ -449,7 +449,7 @@ export async function instrumentForPerformance(appInstance: ApplicationInstance)
     }
   }
 
-  const client = Sentry.getCurrentHub().getClient();
+  const client = Sentry.getClient();
   if (client && client.addIntegration) {
     client.addIntegration(browserTracing);
   }

--- a/packages/ember/tests/acceptance/sentry-replay-test.ts
+++ b/packages/ember/tests/acceptance/sentry-replay-test.ts
@@ -13,7 +13,7 @@ module('Acceptance | Sentry Session Replay', function (hooks) {
   test('Test replay', async function (assert) {
     await visit('/replay');
 
-    const integration = Sentry.getCurrentHub().getIntegration(Sentry.Replay);
+    const integration = Sentry.getClient()?.getIntegration(Sentry.Replay);
     assert.ok(integration);
 
     const replay = (integration as Sentry.Replay)['_replay'] as ReplayContainer;

--- a/packages/ember/tests/dummy/app/routes/replay.ts
+++ b/packages/ember/tests/dummy/app/routes/replay.ts
@@ -6,8 +6,8 @@ export default class ReplayRoute extends Route {
   public async beforeModel(): Promise<void> {
     const { Replay } = Sentry;
 
-    if (!Sentry.getCurrentHub().getIntegration(Replay)) {
-      const client = Sentry.getCurrentHub().getClient() as BrowserClient;
+    if (!Sentry.getClient()!.getIntegration(Replay)) {
+      const client = Sentry.getClient() as BrowserClient;
       client.addIntegration(new Replay());
     }
   }

--- a/packages/feedback/test/unit/util/prepareFeedbackEvent.test.ts
+++ b/packages/feedback/test/unit/util/prepareFeedbackEvent.test.ts
@@ -1,4 +1,5 @@
 import type { Hub, Scope } from '@sentry/core';
+import { getCurrentScope } from '@sentry/core';
 import { getCurrentHub } from '@sentry/core';
 import type { Client, FeedbackEvent } from '@sentry/types';
 
@@ -14,9 +15,7 @@ describe('Unit | util | prepareFeedbackEvent', () => {
     hub = getCurrentHub();
     client = new TestClient(getDefaultClientOptions());
     hub.bindClient(client);
-
-    client = hub.getClient()!;
-    scope = hub.getScope();
+    scope = getCurrentScope();
   });
 
   afterEach(() => {

--- a/packages/nextjs/test/clientSdk.test.ts
+++ b/packages/nextjs/test/clientSdk.test.ts
@@ -1,4 +1,4 @@
-import { BaseClient, getCurrentHub } from '@sentry/core';
+import { BaseClient, getClient } from '@sentry/core';
 import * as SentryReact from '@sentry/react';
 import { BrowserTracing, WINDOW, getCurrentScope } from '@sentry/react';
 import type { Integration } from '@sentry/types';
@@ -70,7 +70,7 @@ describe('Client init()', () => {
   });
 
   it('sets runtime on scope', () => {
-    const currentScope = getCurrentHub().getScope();
+    const currentScope = getCurrentScope();
 
     // @ts-expect-error need access to protected _tags attribute
     expect(currentScope._tags).toEqual({});
@@ -86,8 +86,7 @@ describe('Client init()', () => {
       dsn: 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012',
       tracesSampleRate: 1.0,
     });
-    const hub = getCurrentHub();
-    const transportSend = jest.spyOn(hub.getClient()!.getTransport()!, 'send');
+    const transportSend = jest.spyOn(getClient()!.getTransport()!, 'send');
 
     // Ensure we have no current span, so our next span is a transaction
     // eslint-disable-next-line deprecation/deprecation

--- a/packages/nextjs/test/serverSdk.test.ts
+++ b/packages/nextjs/test/serverSdk.test.ts
@@ -1,6 +1,6 @@
 import { runWithAsyncContext } from '@sentry/core';
 import * as SentryNode from '@sentry/node';
-import { NodeClient, getCurrentHub } from '@sentry/node';
+import { NodeClient, getClient, getCurrentHub, getCurrentScope } from '@sentry/node';
 import type { Integration } from '@sentry/types';
 import { GLOBAL_OBJ, logger } from '@sentry/utils';
 
@@ -71,7 +71,7 @@ describe('Server init()', () => {
   });
 
   it('sets runtime on scope', () => {
-    const currentScope = getCurrentHub().getScope();
+    const currentScope = getCurrentScope();
 
     // @ts-expect-error need access to protected _tags attribute
     expect(currentScope._tags).toEqual({});
@@ -87,7 +87,7 @@ describe('Server init()', () => {
   // is resolved when importing.
 
   it('does not apply `vercel` tag when not running on vercel', () => {
-    const currentScope = getCurrentHub().getScope();
+    const currentScope = getCurrentScope();
 
     expect(process.env.VERCEL).toBeUndefined();
 
@@ -102,8 +102,7 @@ describe('Server init()', () => {
       dsn: 'https://dogsarebadatkeepingsecrets@squirrelchasers.ingest.sentry.io/12312012',
       tracesSampleRate: 1.0,
     });
-    const hub = getCurrentHub();
-    const transportSend = jest.spyOn(hub.getClient()!.getTransport()!, 'send');
+    const transportSend = jest.spyOn(getClient()!.getTransport()!, 'send');
 
     SentryNode.startSpan({ name: '/404' }, () => {
       // noop
@@ -124,7 +123,9 @@ describe('Server init()', () => {
       // If we call runWithAsyncContext before init, it executes the callback in the same context as there is no
       // strategy yet
       expect(globalHub2).toBe(globalHub);
+      // eslint-disable-next-line deprecation/deprecation
       expect(globalHub.getClient()).toBeUndefined();
+      // eslint-disable-next-line deprecation/deprecation
       expect(globalHub2.getClient()).toBeUndefined();
 
       init({});
@@ -132,13 +133,18 @@ describe('Server init()', () => {
       runWithAsyncContext(() => {
         const domainHub = getCurrentHub();
         // this tag should end up only in the domain hub
+        // eslint-disable-next-line deprecation/deprecation
         domainHub.setTag('dogs', 'areGreat');
 
+        // eslint-disable-next-line deprecation/deprecation
         expect(globalHub.getClient()).toEqual(expect.any(NodeClient));
+        // eslint-disable-next-line deprecation/deprecation
         expect(domainHub.getClient()).toBe(globalHub.getClient());
         // @ts-expect-error need access to protected _tags attribute
+        // eslint-disable-next-line deprecation/deprecation
         expect(globalHub.getScope()._tags).toEqual({ runtime: 'node' });
         // @ts-expect-error need access to protected _tags attribute
+        // eslint-disable-next-line deprecation/deprecation
         expect(domainHub.getScope()._tags).toEqual({ runtime: 'node', dogs: 'areGreat' });
       });
     });

--- a/packages/node-experimental/test/integration/breadcrumbs.test.ts
+++ b/packages/node-experimental/test/integration/breadcrumbs.test.ts
@@ -1,5 +1,5 @@
 import { captureException, withScope } from '@sentry/core';
-import { getCurrentHub, startSpan } from '@sentry/opentelemetry';
+import { startSpan } from '@sentry/opentelemetry';
 import { addBreadcrumb, getClient, withIsolationScope } from '../../src/sdk/api';
 
 import type { NodeExperimentalClient } from '../../src/types';
@@ -19,16 +19,15 @@ describe('Integration | breadcrumbs', () => {
 
       mockSdkInit({ beforeSend, beforeBreadcrumb });
 
-      const hub = getCurrentHub();
-      const client = hub.getClient() as NodeExperimentalClient;
+      const client = getClient() as NodeExperimentalClient;
 
-      hub.addBreadcrumb({ timestamp: 123456, message: 'test1' });
-      hub.addBreadcrumb({ timestamp: 123457, message: 'test2', data: { nested: 'yes' } });
-      hub.addBreadcrumb({ timestamp: 123455, message: 'test3' });
+      addBreadcrumb({ timestamp: 123456, message: 'test1' });
+      addBreadcrumb({ timestamp: 123457, message: 'test2', data: { nested: 'yes' } });
+      addBreadcrumb({ timestamp: 123455, message: 'test3' });
 
       const error = new Error('test');
       // eslint-disable-next-line deprecation/deprecation
-      hub.captureException(error);
+      captureException(error);
 
       await client.flush();
 
@@ -103,24 +102,23 @@ describe('Integration | breadcrumbs', () => {
 
     mockSdkInit({ beforeSend, beforeBreadcrumb, beforeSendTransaction, enableTracing: true });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as NodeExperimentalClient;
+    const client = getClient() as NodeExperimentalClient;
 
     const error = new Error('test');
 
     startSpan({ name: 'test' }, () => {
-      hub.addBreadcrumb({ timestamp: 123456, message: 'test1' });
+      addBreadcrumb({ timestamp: 123456, message: 'test1' });
 
       startSpan({ name: 'inner1' }, () => {
-        hub.addBreadcrumb({ timestamp: 123457, message: 'test2', data: { nested: 'yes' } });
+        addBreadcrumb({ timestamp: 123457, message: 'test2', data: { nested: 'yes' } });
       });
 
       startSpan({ name: 'inner2' }, () => {
-        hub.addBreadcrumb({ timestamp: 123455, message: 'test3' });
+        addBreadcrumb({ timestamp: 123455, message: 'test3' });
       });
 
       // eslint-disable-next-line deprecation/deprecation
-      hub.captureException(error);
+      captureException(error);
     });
 
     await client.flush();
@@ -150,31 +148,30 @@ describe('Integration | breadcrumbs', () => {
 
     mockSdkInit({ beforeSend, beforeBreadcrumb, beforeSendTransaction, enableTracing: true });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as NodeExperimentalClient;
+    const client = getClient() as NodeExperimentalClient;
 
     const error = new Error('test');
 
     withIsolationScope(() => {
       startSpan({ name: 'test1' }, () => {
-        hub.addBreadcrumb({ timestamp: 123456, message: 'test1-a' });
+        addBreadcrumb({ timestamp: 123456, message: 'test1-a' });
 
         startSpan({ name: 'inner1' }, () => {
-          hub.addBreadcrumb({ timestamp: 123457, message: 'test1-b' });
+          addBreadcrumb({ timestamp: 123457, message: 'test1-b' });
         });
       });
     });
 
     withIsolationScope(() => {
       startSpan({ name: 'test2' }, () => {
-        hub.addBreadcrumb({ timestamp: 123456, message: 'test2-a' });
+        addBreadcrumb({ timestamp: 123456, message: 'test2-a' });
 
         startSpan({ name: 'inner2' }, () => {
-          hub.addBreadcrumb({ timestamp: 123457, message: 'test2-b' });
+          addBreadcrumb({ timestamp: 123457, message: 'test2-b' });
         });
 
         // eslint-disable-next-line deprecation/deprecation
-        hub.captureException(error);
+        captureException(error);
       });
     });
 
@@ -204,21 +201,20 @@ describe('Integration | breadcrumbs', () => {
 
     mockSdkInit({ beforeSend, beforeBreadcrumb, beforeSendTransaction, enableTracing: true });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as NodeExperimentalClient;
+    const client = getClient() as NodeExperimentalClient;
 
     const error = new Error('test');
 
     startSpan({ name: 'test1' }, () => {
       withScope(() => {
-        hub.addBreadcrumb({ timestamp: 123456, message: 'test1' });
+        addBreadcrumb({ timestamp: 123456, message: 'test1' });
       });
       startSpan({ name: 'inner1' }, () => {
-        hub.addBreadcrumb({ timestamp: 123457, message: 'test2' });
+        addBreadcrumb({ timestamp: 123457, message: 'test2' });
       });
 
       // eslint-disable-next-line deprecation/deprecation
-      hub.captureException(error);
+      captureException(error);
     });
 
     await client.flush();
@@ -247,37 +243,36 @@ describe('Integration | breadcrumbs', () => {
 
     mockSdkInit({ beforeSend, beforeBreadcrumb, beforeSendTransaction, enableTracing: true });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as NodeExperimentalClient;
+    const client = getClient() as NodeExperimentalClient;
 
     const error = new Error('test');
 
     startSpan({ name: 'test1' }, () => {
       withScope(() => {
-        hub.addBreadcrumb({ timestamp: 123456, message: 'test1' });
+        addBreadcrumb({ timestamp: 123456, message: 'test1' });
       });
       startSpan({ name: 'inner1' }, () => {
-        hub.addBreadcrumb({ timestamp: 123457, message: 'test2' });
+        addBreadcrumb({ timestamp: 123457, message: 'test2' });
 
         startSpan({ name: 'inner2' }, () => {
-          hub.addBreadcrumb({ timestamp: 123457, message: 'test3' });
+          addBreadcrumb({ timestamp: 123457, message: 'test3' });
 
           startSpan({ name: 'inner3' }, () => {
-            hub.addBreadcrumb({ timestamp: 123457, message: 'test4' });
+            addBreadcrumb({ timestamp: 123457, message: 'test4' });
 
             // eslint-disable-next-line deprecation/deprecation
-            hub.captureException(error);
+            captureException(error);
 
             startSpan({ name: 'inner4' }, () => {
-              hub.addBreadcrumb({ timestamp: 123457, message: 'test5' });
+              addBreadcrumb({ timestamp: 123457, message: 'test5' });
             });
 
-            hub.addBreadcrumb({ timestamp: 123457, message: 'test6' });
+            addBreadcrumb({ timestamp: 123457, message: 'test6' });
           });
         });
       });
 
-      hub.addBreadcrumb({ timestamp: 123456, message: 'test99' });
+      addBreadcrumb({ timestamp: 123456, message: 'test99' });
     });
 
     await client.flush();
@@ -307,40 +302,39 @@ describe('Integration | breadcrumbs', () => {
 
     mockSdkInit({ beforeSend, beforeBreadcrumb, beforeSendTransaction, enableTracing: true });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as NodeExperimentalClient;
+    const client = getClient() as NodeExperimentalClient;
 
     const error = new Error('test');
 
     const promise1 = withIsolationScope(async () => {
       await startSpan({ name: 'test' }, async () => {
-        hub.addBreadcrumb({ timestamp: 123456, message: 'test1' });
+        addBreadcrumb({ timestamp: 123456, message: 'test1' });
 
         await startSpan({ name: 'inner1' }, async () => {
-          hub.addBreadcrumb({ timestamp: 123457, message: 'test2' });
+          addBreadcrumb({ timestamp: 123457, message: 'test2' });
         });
 
         await startSpan({ name: 'inner2' }, async () => {
-          hub.addBreadcrumb({ timestamp: 123455, message: 'test3' });
+          addBreadcrumb({ timestamp: 123455, message: 'test3' });
         });
 
         await new Promise(resolve => setTimeout(resolve, 10));
 
         // eslint-disable-next-line deprecation/deprecation
-        hub.captureException(error);
+        captureException(error);
       });
     });
 
     const promise2 = withIsolationScope(async () => {
       await startSpan({ name: 'test-b' }, async () => {
-        hub.addBreadcrumb({ timestamp: 123456, message: 'test1-b' });
+        addBreadcrumb({ timestamp: 123456, message: 'test1-b' });
 
         await startSpan({ name: 'inner1b' }, async () => {
-          hub.addBreadcrumb({ timestamp: 123457, message: 'test2-b' });
+          addBreadcrumb({ timestamp: 123457, message: 'test2-b' });
         });
 
         await startSpan({ name: 'inner2b' }, async () => {
-          hub.addBreadcrumb({ timestamp: 123455, message: 'test3-b' });
+          addBreadcrumb({ timestamp: 123455, message: 'test3-b' });
         });
       });
     });

--- a/packages/node-experimental/test/integration/scope.test.ts
+++ b/packages/node-experimental/test/integration/scope.test.ts
@@ -1,5 +1,5 @@
-import { setGlobalScope } from '@sentry/core';
-import { getCurrentHub, getSpanScope } from '@sentry/opentelemetry';
+import { getCurrentScope, setGlobalScope } from '@sentry/core';
+import { getClient, getSpanScope } from '@sentry/opentelemetry';
 
 import * as Sentry from '../../src/';
 import type { NodeExperimentalClient } from '../../src/types';
@@ -20,10 +20,9 @@ describe('Integration | Scope', () => {
 
       mockSdkInit({ enableTracing, beforeSend, beforeSendTransaction });
 
-      const hub = getCurrentHub();
-      const client = hub.getClient() as NodeExperimentalClient;
+      const client = getClient() as NodeExperimentalClient;
 
-      const rootScope = hub.getScope();
+      const rootScope = getCurrentScope();
 
       const error = new Error('test error');
       let spanId: string | undefined;
@@ -122,10 +121,8 @@ describe('Integration | Scope', () => {
 
       mockSdkInit({ enableTracing, beforeSend, beforeSendTransaction });
 
-      const hub = getCurrentHub();
-      const client = hub.getClient() as NodeExperimentalClient;
-
-      const rootScope = hub.getScope();
+      const client = getClient() as NodeExperimentalClient;
+      const rootScope = getCurrentScope();
 
       const error1 = new Error('test error 1');
       const error2 = new Error('test error 2');

--- a/packages/node-experimental/test/integration/transactions.test.ts
+++ b/packages/node-experimental/test/integration/transactions.test.ts
@@ -2,7 +2,7 @@ import { SpanKind, TraceFlags, context, trace } from '@opentelemetry/api';
 import type { SpanProcessor } from '@opentelemetry/sdk-trace-base';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 import { spanToJSON } from '@sentry/core';
-import { SentrySpanProcessor, getCurrentHub, setPropagationContextOnContext } from '@sentry/opentelemetry';
+import { SentrySpanProcessor, getClient, setPropagationContextOnContext } from '@sentry/opentelemetry';
 import type { Integration, PropagationContext, TransactionEvent } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
@@ -338,8 +338,7 @@ describe('Integration | Transactions', () => {
 
     mockSdkInit({ enableTracing: true, beforeSendTransaction });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as NodeExperimentalClient;
+    const client = getClient() as NodeExperimentalClient;
 
     // We simulate the correct context we'd normally get from the SentryPropagator
     context.with(
@@ -438,8 +437,7 @@ describe('Integration | Transactions', () => {
 
     mockSdkInit({ enableTracing: true, beforeSendTransaction });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as NodeExperimentalClient;
+    const client = getClient() as NodeExperimentalClient;
     const provider = getProvider();
     const multiSpanProcessor = provider?.activeSpanProcessor as
       | (SpanProcessor & { _spanProcessors?: SpanProcessor[] })
@@ -512,8 +510,7 @@ describe('Integration | Transactions', () => {
 
     jest.useFakeTimers();
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as NodeExperimentalClient;
+    const client = getClient() as NodeExperimentalClient;
 
     jest.spyOn(client, 'getIntegration').mockImplementation(integrationClass => {
       if (integrationClass.name === 'Http') {
@@ -577,8 +574,7 @@ describe('Integration | Transactions', () => {
 
     jest.useFakeTimers();
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as NodeExperimentalClient;
+    const client = getClient() as NodeExperimentalClient;
 
     jest.spyOn(client, 'getIntegration').mockImplementation(integrationClass => {
       if (integrationClass.name === 'NodeFetch') {

--- a/packages/node/src/integrations/http.ts
+++ b/packages/node/src/integrations/http.ts
@@ -114,6 +114,7 @@ export class Http implements Integration {
       return;
     }
 
+    // eslint-disable-next-line deprecation/deprecation
     const clientOptions = setupOnceGetCurrentHub().getClient<NodeClient>()?.getOptions();
 
     // Do not auto-instrument for other instrumenter
@@ -220,6 +221,7 @@ function _createWrappedRequestMethodFactory(
     req: http.ClientRequest,
     res?: http.IncomingMessage,
   ): void {
+    // eslint-disable-next-line deprecation/deprecation
     if (!getCurrentHub().getIntegration(Http)) {
       return;
     }

--- a/packages/node/src/integrations/undici/index.ts
+++ b/packages/node/src/integrations/undici/index.ts
@@ -2,7 +2,6 @@ import {
   addBreadcrumb,
   getActiveSpan,
   getClient,
-  getCurrentHub,
   getCurrentScope,
   getDynamicSamplingContextFromClient,
   getDynamicSamplingContextFromSpan,
@@ -138,8 +137,7 @@ export class Undici implements Integration {
   }
 
   private _onRequestCreate = (message: unknown): void => {
-    const hub = getCurrentHub();
-    if (!hub.getIntegration(Undici)) {
+    if (!getClient()?.getIntegration(Undici)) {
       return;
     }
 
@@ -197,8 +195,7 @@ export class Undici implements Integration {
   };
 
   private _onRequestEnd = (message: unknown): void => {
-    const hub = getCurrentHub();
-    if (!hub.getIntegration(Undici)) {
+    if (!getClient()?.getIntegration(Undici)) {
       return;
     }
 
@@ -237,8 +234,7 @@ export class Undici implements Integration {
   };
 
   private _onRequestError = (message: unknown): void => {
-    const hub = getCurrentHub();
-    if (!hub.getIntegration(Undici)) {
+    if (!getClient()?.getIntegration(Undici)) {
       return;
     }
 

--- a/packages/node/test/async/domain.test.ts
+++ b/packages/node/test/async/domain.test.ts
@@ -13,12 +13,14 @@ describe('domains', () => {
     setDomainAsyncContextStrategy();
 
     const globalHub = getCurrentHub();
+    // eslint-disable-next-line deprecation/deprecation
     globalHub.setExtra('a', 'b');
 
     runWithAsyncContext(() => {
       const hub1 = getCurrentHub();
       expect(hub1).toEqual(globalHub);
 
+      // eslint-disable-next-line deprecation/deprecation
       hub1.setExtra('c', 'd');
       expect(hub1).not.toEqual(globalHub);
 
@@ -27,6 +29,7 @@ describe('domains', () => {
         expect(hub2).toEqual(hub1);
         expect(hub2).not.toEqual(globalHub);
 
+        // eslint-disable-next-line deprecation/deprecation
         hub2.setExtra('e', 'f');
         expect(hub2).not.toEqual(hub1);
       });
@@ -39,6 +42,7 @@ describe('domains', () => {
     async function addRandomExtra(hub: Hub, key: string): Promise<void> {
       return new Promise(resolve => {
         setTimeout(() => {
+          // eslint-disable-next-line deprecation/deprecation
           hub.setExtra(key, Math.random());
           resolve();
         }, 100);
@@ -110,7 +114,9 @@ describe('domains', () => {
 
     runWithAsyncContext(() => {
       const hub = getCurrentHub();
+      // eslint-disable-next-line deprecation/deprecation
       hub.getStack().push({ client: 'process' } as any);
+      // eslint-disable-next-line deprecation/deprecation
       expect(hub.getStack()[1]).toEqual({ client: 'process' });
       // Just in case so we don't have to worry which one finishes first
       // (although it always should be d2)
@@ -124,7 +130,9 @@ describe('domains', () => {
 
     runWithAsyncContext(() => {
       const hub = getCurrentHub();
+      // eslint-disable-next-line deprecation/deprecation
       hub.getStack().push({ client: 'local' } as any);
+      // eslint-disable-next-line deprecation/deprecation
       expect(hub.getStack()[1]).toEqual({ client: 'local' });
       setTimeout(() => {
         d2done = true;

--- a/packages/node/test/async/hooks.test.ts
+++ b/packages/node/test/async/hooks.test.ts
@@ -24,12 +24,14 @@ conditionalTest({ min: 12 })('async_hooks', () => {
     setHooksAsyncContextStrategy();
 
     const globalHub = getCurrentHub();
+    // eslint-disable-next-line deprecation/deprecation
     globalHub.setExtra('a', 'b');
 
     runWithAsyncContext(() => {
       const hub1 = getCurrentHub();
       expect(hub1).toEqual(globalHub);
 
+      // eslint-disable-next-line deprecation/deprecation
       hub1.setExtra('c', 'd');
       expect(hub1).not.toEqual(globalHub);
 
@@ -38,6 +40,7 @@ conditionalTest({ min: 12 })('async_hooks', () => {
         expect(hub2).toEqual(hub1);
         expect(hub2).not.toEqual(globalHub);
 
+        // eslint-disable-next-line deprecation/deprecation
         hub2.setExtra('e', 'f');
         expect(hub2).not.toEqual(hub1);
       });
@@ -50,6 +53,7 @@ conditionalTest({ min: 12 })('async_hooks', () => {
     async function addRandomExtra(hub: Hub, key: string): Promise<void> {
       return new Promise(resolve => {
         setTimeout(() => {
+          // eslint-disable-next-line deprecation/deprecation
           hub.setExtra(key, Math.random());
           resolve();
         }, 100);
@@ -121,7 +125,9 @@ conditionalTest({ min: 12 })('async_hooks', () => {
 
     runWithAsyncContext(() => {
       const hub = getCurrentHub();
+      // eslint-disable-next-line deprecation/deprecation
       hub.getStack().push({ client: 'process' } as any);
+      // eslint-disable-next-line deprecation/deprecation
       expect(hub.getStack()[1]).toEqual({ client: 'process' });
       // Just in case so we don't have to worry which one finishes first
       // (although it always should be d2)
@@ -135,7 +141,9 @@ conditionalTest({ min: 12 })('async_hooks', () => {
 
     runWithAsyncContext(() => {
       const hub = getCurrentHub();
+      // eslint-disable-next-line deprecation/deprecation
       hub.getStack().push({ client: 'local' } as any);
+      // eslint-disable-next-line deprecation/deprecation
       expect(hub.getStack()[1]).toEqual({ client: 'local' });
       setTimeout(() => {
         d2done = true;

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -1,7 +1,7 @@
 import * as http from 'http';
 import type { Hub } from '@sentry/core';
 import * as sentryCore from '@sentry/core';
-import { Transaction, setAsyncContextStrategy } from '@sentry/core';
+import { Transaction, getClient, getCurrentScope, setAsyncContextStrategy } from '@sentry/core';
 import type { Event, PropagationContext } from '@sentry/types';
 import { SentryError } from '@sentry/utils';
 
@@ -65,7 +65,7 @@ describe('requestHandler', () => {
 
     sentryRequestMiddleware(req, res, next);
 
-    const scope = sentryCore.getCurrentHub().getScope();
+    const scope = getCurrentScope();
     expect(scope?.getRequestSession()).toEqual({ status: 'ok' });
   });
 
@@ -79,7 +79,7 @@ describe('requestHandler', () => {
 
     sentryRequestMiddleware(req, res, next);
 
-    const scope = sentryCore.getCurrentHub().getScope();
+    const scope = getCurrentScope();
     expect(scope?.getRequestSession()).toBeUndefined();
   });
 
@@ -95,7 +95,7 @@ describe('requestHandler', () => {
 
     sentryRequestMiddleware(req, res, next);
 
-    const scope = sentryCore.getCurrentHub().getScope();
+    const scope = getCurrentScope();
     res.emit('finish');
 
     setImmediate(() => {
@@ -116,7 +116,7 @@ describe('requestHandler', () => {
     const captureRequestSession = jest.spyOn<any, any>(client, '_captureRequestSession');
 
     sentryRequestMiddleware(req, res, next);
-    const scope = sentryCore.getCurrentHub().getScope();
+    const scope = getCurrentScope();
     res.emit('finish');
 
     setImmediate(() => {
@@ -163,7 +163,7 @@ describe('requestHandler', () => {
 
     sentryRequestMiddleware(req, res, next);
 
-    const scope = sentryCore.getCurrentHub().getScope();
+    const scope = getCurrentScope();
     expect((scope as any)._sdkProcessingMetadata).toEqual({
       request: req,
       requestDataOptionsFromExpressHandler: requestHandlerOptions,
@@ -191,7 +191,8 @@ describe('tracingHandler', () => {
 
   beforeEach(() => {
     hub = new sentryCore.Hub(new NodeClient(getDefaultNodeClientOptions({ tracesSampleRate: 1.0 })));
-    jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
+    sentryCore.makeMain(hub);
+
     mockAsyncContextStrategy(() => hub);
     req = {
       headers,
@@ -210,7 +211,7 @@ describe('tracingHandler', () => {
 
   function getPropagationContext(): PropagationContext {
     // @ts-expect-error accesing private property for test
-    return hub.getScope()._propagationContext;
+    return getCurrentScope()._propagationContext;
   }
 
   it('creates a transaction when handling a request', () => {
@@ -240,7 +241,7 @@ describe('tracingHandler', () => {
   });
 
   it("doesn't create a transaction if tracing is disabled", () => {
-    delete hub.getClient()?.getOptions().tracesSampleRate;
+    delete getClient()?.getOptions().tracesSampleRate;
     const startTransaction = jest.spyOn(sentryCore, 'startTransaction');
 
     sentryTracingMiddleware(req, res, next);
@@ -341,7 +342,7 @@ describe('tracingHandler', () => {
     sentryTracingMiddleware(req, res, next);
 
     // eslint-disable-next-line deprecation/deprecation
-    const transaction = sentryCore.getCurrentHub().getScope().getTransaction();
+    const transaction = getCurrentScope().getTransaction();
 
     expect(transaction).toBeDefined();
     expect(transaction).toEqual(
@@ -466,6 +467,7 @@ describe('tracingHandler', () => {
     const hub = new sentryCore.Hub(new NodeClient(options));
 
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
+    // eslint-disable-next-line deprecation/deprecation
     jest.spyOn(sentryCore, 'getCurrentScope').mockImplementation(() => hub.getScope());
 
     sentryTracingMiddleware(req, res, next);
@@ -519,7 +521,7 @@ describe('errorHandler()', () => {
     // by the`requestHandler`)
     client.initSessionFlusher();
 
-    const scope = sentryCore.getCurrentHub().getScope();
+    const scope = getCurrentScope();
     const hub = new sentryCore.Hub(client);
 
     jest.spyOn<any, any>(client, '_captureRequestSession');
@@ -535,7 +537,7 @@ describe('errorHandler()', () => {
     const options = getDefaultNodeClientOptions({ autoSessionTracking: false, release: '3.3' });
     client = new NodeClient(options);
 
-    const scope = sentryCore.getCurrentHub().getScope();
+    const scope = getCurrentScope();
     const hub = new sentryCore.Hub(client);
 
     jest.spyOn<any, any>(client, '_captureRequestSession');
@@ -562,7 +564,7 @@ describe('errorHandler()', () => {
     hub.run(() => {
       scope?.setRequestSession({ status: 'ok' });
       sentryErrorMiddleware({ name: 'error', message: 'this is an error' }, req, res, () => {
-        const scope = sentryCore.getCurrentHub().getScope();
+        const scope = getCurrentScope();
         const requestSession = scope?.getRequestSession();
         expect(requestSession).toEqual({ status: 'crashed' });
       });
@@ -598,6 +600,7 @@ describe('errorHandler()', () => {
     // `captureException` in order to examine the scope as it exists inside the `withScope` callback
     // eslint-disable-next-line deprecation/deprecation
     hub.captureException = function (this: sentryCore.Hub, _exception: any) {
+      // eslint-disable-next-line deprecation/deprecation
       const scope = this.getScope();
       expect((scope as any)._sdkProcessingMetadata.request).toEqual(req);
     } as any;

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -286,6 +286,7 @@ describe('SentryNode', () => {
       runWithAsyncContext(() => {
         const hub = getCurrentHub();
         hub.bindClient(client);
+        // eslint-disable-next-line deprecation/deprecation
         expect(getCurrentHub().getClient()).toBe(client);
         expect(getClient()).toBe(client);
         // eslint-disable-next-line deprecation/deprecation
@@ -466,7 +467,7 @@ describe('SentryNode initialization', () => {
     it('defaults to sentry instrumenter', () => {
       init({ dsn });
 
-      const instrumenter = (getCurrentHub()?.getClient()?.getOptions() as NodeClientOptions).instrumenter;
+      const instrumenter = (getClient()?.getOptions() as NodeClientOptions).instrumenter;
 
       expect(instrumenter).toEqual('sentry');
     });
@@ -474,7 +475,7 @@ describe('SentryNode initialization', () => {
     it('allows to set instrumenter', () => {
       init({ dsn, instrumenter: 'otel' });
 
-      const instrumenter = (getCurrentHub()?.getClient()?.getOptions() as NodeClientOptions).instrumenter;
+      const instrumenter = (getClient()?.getOptions() as NodeClientOptions).instrumenter;
 
       expect(instrumenter).toEqual('otel');
     });
@@ -485,7 +486,7 @@ describe('SentryNode initialization', () => {
       process.env.SENTRY_TRACE = '12312012123120121231201212312012-1121201211212012-0';
       process.env.SENTRY_BAGGAGE = 'sentry-release=1.0.0,sentry-environment=production';
 
-      getCurrentHub().getScope().clear();
+      getCurrentScope().clear();
     });
 
     afterEach(() => {
@@ -497,7 +498,7 @@ describe('SentryNode initialization', () => {
       init({ dsn });
 
       // @ts-expect-error accessing private method for test
-      expect(getCurrentHub().getScope()._propagationContext).toEqual({
+      expect(getCurrentScope()._propagationContext).toEqual({
         traceId: '12312012123120121231201212312012',
         parentSpanId: '1121201211212012',
         spanId: expect.any(String),
@@ -516,7 +517,7 @@ describe('SentryNode initialization', () => {
         init({ dsn });
 
         // @ts-expect-error accessing private method for test
-        expect(getCurrentHub().getScope()._propagationContext.traceId).not.toEqual('12312012123120121231201212312012');
+        expect(getCurrentScope()._propagationContext.traceId).not.toEqual('12312012123120121231201212312012');
 
         delete process.env.SENTRY_USE_ENVIRONMENT;
       },

--- a/packages/node/test/integrations/undici.test.ts
+++ b/packages/node/test/integrations/undici.test.ts
@@ -1,5 +1,5 @@
 import * as http from 'http';
-import { Transaction, getActiveSpan, startSpan } from '@sentry/core';
+import { Transaction, getActiveSpan, getClient, getCurrentScope, startSpan } from '@sentry/core';
 import { spanToTraceHeader } from '@sentry/core';
 import { Hub, makeMain, runWithAsyncContext } from '@sentry/core';
 import type { fetch as FetchType } from 'undici';
@@ -232,7 +232,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
   // This flakes on CI for some reason: https://github.com/getsentry/sentry-javascript/pull/8449
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('attaches the sentry trace and baggage headers if there is no active span', async () => {
-    const scope = hub.getScope();
+    const scope = getCurrentScope();
 
     await fetch('http://localhost:18100', { method: 'POST' });
 
@@ -247,7 +247,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
   // This flakes on CI for some reason: https://github.com/getsentry/sentry-javascript/pull/8449
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('attaches headers if `shouldCreateSpanForRequest` does not create a span using propagation context', async () => {
-    const scope = hub.getScope();
+    const scope = getCurrentScope();
     const propagationContext = scope.getPropagationContext();
 
     await startSpan({ name: 'outer-span' }, async outerSpan => {
@@ -417,7 +417,7 @@ function setupTestServer() {
 
 function patchUndici(userOptions: Partial<UndiciOptions>): () => void {
   try {
-    const undici = hub.getClient()!.getIntegration(Undici);
+    const undici = getClient()!.getIntegration(Undici);
     // @ts-expect-error need to access private property
     options = { ...undici._options };
     // @ts-expect-error need to access private property
@@ -428,7 +428,7 @@ function patchUndici(userOptions: Partial<UndiciOptions>): () => void {
 
   return () => {
     try {
-      const undici = hub.getClient()!.getIntegration(Undici);
+      const undici = getClient()!.getIntegration(Undici);
       // @ts-expect-error Need to override readonly property
       undici!['_options'] = { ...options };
     } catch (_) {

--- a/packages/opentelemetry-node/src/utils/captureExceptionForTimedEvent.ts
+++ b/packages/opentelemetry-node/src/utils/captureExceptionForTimedEvent.ts
@@ -35,6 +35,7 @@ export function maybeCaptureExceptionForTimedEvent(hub: Hub, event: TimedEvent, 
     syntheticError.name = type;
   }
 
+  // eslint-disable-next-line deprecation/deprecation
   hub.captureException(syntheticError, {
     captureContext: otelSpan
       ? {

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -985,7 +985,9 @@ describe('SentrySpanProcessor', () => {
     hub = new Hub(client);
     makeMain(hub);
 
+    // eslint-disable-next-line deprecation/deprecation
     const newHub = new Hub(client, hub.getScope().clone());
+    // eslint-disable-next-line deprecation/deprecation
     newHub.getScope().setTag('foo', 'bar');
 
     const tracer = provider.getTracer('default');

--- a/packages/opentelemetry/src/custom/hub.ts
+++ b/packages/opentelemetry/src/custom/hub.ts
@@ -17,6 +17,7 @@ export class OpenTelemetryHub extends Hub {
 
 /** Custom getClient method that uses the custom hub. */
 export function getClient<C extends Client>(): C | undefined {
+  // eslint-disable-next-line deprecation/deprecation
   return getCurrentHub().getClient<C>();
 }
 
@@ -95,7 +96,12 @@ export function getHubFromCarrier(carrier: Carrier): Hub {
  */
 export function ensureHubOnCarrier(carrier: Carrier, parent: Hub = getGlobalHub()): void {
   // If there's no hub on current domain, or it's an old API, assign a new one
-  if (!hasHubOnCarrier(carrier) || getHubFromCarrier(carrier).isOlderThan(API_VERSION)) {
+  if (
+    !hasHubOnCarrier(carrier) ||
+    // eslint-disable-next-line deprecation/deprecation
+    getHubFromCarrier(carrier).isOlderThan(API_VERSION)
+  ) {
+    // eslint-disable-next-line deprecation/deprecation
     const globalHubTopStack = parent.getStackTop();
     setHubOnCarrier(carrier, new OpenTelemetryHub(globalHubTopStack.client, globalHubTopStack.scope.clone()));
   }
@@ -103,7 +109,11 @@ export function ensureHubOnCarrier(carrier: Carrier, parent: Hub = getGlobalHub(
 
 function getGlobalHub(registry: Carrier = getMainCarrier()): Hub {
   // If there's no hub, or its an old API, assign a new one
-  if (!hasHubOnCarrier(registry) || getHubFromCarrier(registry).isOlderThan(API_VERSION)) {
+  if (
+    !hasHubOnCarrier(registry) ||
+    // eslint-disable-next-line deprecation/deprecation
+    getHubFromCarrier(registry).isOlderThan(API_VERSION)
+  ) {
     setHubOnCarrier(registry, new OpenTelemetryHub());
   }
 

--- a/packages/opentelemetry/src/custom/transaction.ts
+++ b/packages/opentelemetry/src/custom/transaction.ts
@@ -8,6 +8,7 @@ import { uuid4 } from '@sentry/utils';
  * with some OTEL specifics.
  */
 export function startTransaction(hub: HubInterface, transactionContext: TransactionContext): Transaction {
+  // eslint-disable-next-line deprecation/deprecation
   const client = hub.getClient();
   const options: Partial<ClientOptions> = (client && client.getOptions()) || {};
 
@@ -37,6 +38,7 @@ export class OpenTelemetryTransaction extends Transaction {
       return undefined;
     }
 
+    // eslint-disable-next-line deprecation/deprecation
     const client = this._hub.getClient();
 
     if (!client) {

--- a/packages/opentelemetry/src/spanProcessor.ts
+++ b/packages/opentelemetry/src/spanProcessor.ts
@@ -31,8 +31,9 @@ function onSpanStart(span: Span, parentContext: Context, _ScopeClass: typeof Ope
 
   // We need the scope at time of span creation in order to apply it to the event when the span is finished
   if (actualHub) {
+    // eslint-disable-next-line deprecation/deprecation
     const scope = actualHub.getScope();
-    setSpanScope(span, actualHub.getScope());
+    setSpanScope(span, scope);
     setSpanHub(span, actualHub);
 
     // Use this scope for finishing the span

--- a/packages/opentelemetry/src/utils/captureExceptionForTimedEvent.ts
+++ b/packages/opentelemetry/src/utils/captureExceptionForTimedEvent.ts
@@ -35,6 +35,7 @@ export function maybeCaptureExceptionForTimedEvent(hub: Hub, event: TimedEvent, 
     syntheticError.name = type;
   }
 
+  // eslint-disable-next-line deprecation/deprecation
   hub.captureException(syntheticError, {
     captureContext: otelSpan
       ? {

--- a/packages/opentelemetry/test/asyncContextStrategy.test.ts
+++ b/packages/opentelemetry/test/asyncContextStrategy.test.ts
@@ -29,12 +29,14 @@ describe('asyncContextStrategy', () => {
 
   test('hub scope inheritance', () => {
     const globalHub = getCurrentHub();
+    // eslint-disable-next-line deprecation/deprecation
     globalHub.setExtra('a', 'b');
 
     runWithAsyncContext(() => {
       const hub1 = getCurrentHub();
       expect(hub1).toEqual(globalHub);
 
+      // eslint-disable-next-line deprecation/deprecation
       hub1.setExtra('c', 'd');
       expect(hub1).not.toEqual(globalHub);
 
@@ -43,6 +45,7 @@ describe('asyncContextStrategy', () => {
         expect(hub2).toEqual(hub1);
         expect(hub2).not.toEqual(globalHub);
 
+        // eslint-disable-next-line deprecation/deprecation
         hub2.setExtra('e', 'f');
         expect(hub2).not.toEqual(hub1);
       });
@@ -53,6 +56,7 @@ describe('asyncContextStrategy', () => {
     async function addRandomExtra(hub: Hub, key: string): Promise<void> {
       return new Promise(resolve => {
         setTimeout(() => {
+          // eslint-disable-next-line deprecation/deprecation
           hub.setExtra(key, Math.random());
           resolve();
         }, 100);
@@ -116,7 +120,9 @@ describe('asyncContextStrategy', () => {
 
     runWithAsyncContext(() => {
       const hub = getCurrentHub();
+      // eslint-disable-next-line deprecation/deprecation
       hub.getStack().push({ client: 'process' } as any);
+      // eslint-disable-next-line deprecation/deprecation
       expect(hub.getStack()[1]).toEqual({ client: 'process' });
       // Just in case so we don't have to worry which one finishes first
       // (although it always should be d2)
@@ -130,7 +136,9 @@ describe('asyncContextStrategy', () => {
 
     runWithAsyncContext(() => {
       const hub = getCurrentHub();
+      // eslint-disable-next-line deprecation/deprecation
       hub.getStack().push({ client: 'local' } as any);
+      // eslint-disable-next-line deprecation/deprecation
       expect(hub.getStack()[1]).toEqual({ client: 'local' });
       setTimeout(() => {
         d2done = true;

--- a/packages/opentelemetry/test/custom/hub.test.ts
+++ b/packages/opentelemetry/test/custom/hub.test.ts
@@ -10,6 +10,7 @@ describe('OpenTelemetryHub', () => {
     const hub2 = getCurrentHub();
     expect(hub2).toBe(hub);
 
+    // eslint-disable-next-line deprecation/deprecation
     const scope = hub.getScope();
     expect(scope).toBeDefined();
     expect(scope).toBeInstanceOf(OpenTelemetryScope);
@@ -18,6 +19,7 @@ describe('OpenTelemetryHub', () => {
   it('hub gets correct scope on initialization', () => {
     const hub = new OpenTelemetryHub();
 
+    // eslint-disable-next-line deprecation/deprecation
     const scope = hub.getScope();
     expect(scope).toBeDefined();
     expect(scope).toBeInstanceOf(OpenTelemetryScope);
@@ -30,6 +32,7 @@ describe('OpenTelemetryHub', () => {
     const scope = hub.pushScope();
     expect(scope).toBeInstanceOf(OpenTelemetryScope);
 
+    // eslint-disable-next-line deprecation/deprecation
     const scope2 = hub.getScope();
     expect(scope2).toBe(scope);
   });
@@ -37,6 +40,7 @@ describe('OpenTelemetryHub', () => {
   it('withScope() creates correct scope', () => {
     const hub = new OpenTelemetryHub();
 
+    // eslint-disable-next-line deprecation/deprecation
     hub.withScope(scope => {
       expect(scope).toBeInstanceOf(OpenTelemetryScope);
     });

--- a/packages/opentelemetry/test/helpers/initOtel.ts
+++ b/packages/opentelemetry/test/helpers/initOtel.ts
@@ -7,7 +7,7 @@ import { SDK_VERSION } from '@sentry/core';
 import { logger } from '@sentry/utils';
 
 import { wrapContextManagerClass } from '../../src/contextManager';
-import { getCurrentHub } from '../../src/custom/hub';
+import { getClient } from '../../src/custom/hub';
 import { DEBUG_BUILD } from '../../src/debug-build';
 import { SentryPropagator } from '../../src/propagator';
 import { SentrySampler } from '../../src/sampler';
@@ -19,7 +19,7 @@ import type { TestClientInterface } from './TestClient';
  * Initialize OpenTelemetry for Node.
  */
 export function initOtel(): void {
-  const client = getCurrentHub().getClient<TestClientInterface>();
+  const client = getClient<TestClientInterface>();
 
   if (!client) {
     DEBUG_BUILD &&

--- a/packages/opentelemetry/test/integration/breadcrumbs.test.ts
+++ b/packages/opentelemetry/test/integration/breadcrumbs.test.ts
@@ -1,6 +1,6 @@
-import { withScope } from '@sentry/core';
+import { addBreadcrumb, captureException, withScope } from '@sentry/core';
 
-import { OpenTelemetryHub, getCurrentHub } from '../../src/custom/hub';
+import { OpenTelemetryHub, getClient, getCurrentHub } from '../../src/custom/hub';
 import { startSpan } from '../../src/trace';
 import type { TestClientInterface } from '../helpers/TestClient';
 import { cleanupOtel, mockSdkInit } from '../helpers/mockSdkInit';
@@ -20,17 +20,17 @@ describe('Integration | breadcrumbs', () => {
       mockSdkInit({ beforeSend, beforeBreadcrumb });
 
       const hub = getCurrentHub();
-      const client = hub.getClient() as TestClientInterface;
+      const client = getClient() as TestClientInterface;
 
       expect(hub).toBeInstanceOf(OpenTelemetryHub);
 
-      hub.addBreadcrumb({ timestamp: 123456, message: 'test1' });
-      hub.addBreadcrumb({ timestamp: 123457, message: 'test2', data: { nested: 'yes' } });
-      hub.addBreadcrumb({ timestamp: 123455, message: 'test3' });
+      addBreadcrumb({ timestamp: 123456, message: 'test1' });
+      addBreadcrumb({ timestamp: 123457, message: 'test2', data: { nested: 'yes' } });
+      addBreadcrumb({ timestamp: 123455, message: 'test3' });
 
       const error = new Error('test');
       // eslint-disable-next-line deprecation/deprecation
-      hub.captureException(error);
+      captureException(error);
 
       await client.flush();
 
@@ -60,26 +60,26 @@ describe('Integration | breadcrumbs', () => {
       mockSdkInit({ beforeSend, beforeBreadcrumb });
 
       const hub = getCurrentHub();
-      const client = hub.getClient() as TestClientInterface;
+      const client = getClient() as TestClientInterface;
 
       expect(hub).toBeInstanceOf(OpenTelemetryHub);
 
       const error = new Error('test');
 
-      hub.addBreadcrumb({ timestamp: 123456, message: 'test0' });
+      addBreadcrumb({ timestamp: 123456, message: 'test0' });
 
       withScope(() => {
-        hub.addBreadcrumb({ timestamp: 123456, message: 'test1' });
+        addBreadcrumb({ timestamp: 123456, message: 'test1' });
       });
 
       withScope(() => {
-        hub.addBreadcrumb({ timestamp: 123456, message: 'test2' });
+        addBreadcrumb({ timestamp: 123456, message: 'test2' });
         // eslint-disable-next-line deprecation/deprecation
-        hub.captureException(error);
+        captureException(error);
       });
 
       withScope(() => {
-        hub.addBreadcrumb({ timestamp: 123456, message: 'test3' });
+        addBreadcrumb({ timestamp: 123456, message: 'test3' });
       });
 
       await client.flush();
@@ -109,24 +109,22 @@ describe('Integration | breadcrumbs', () => {
 
     mockSdkInit({ beforeSend, beforeBreadcrumb, beforeSendTransaction, enableTracing: true });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as TestClientInterface;
+    const client = getClient() as TestClientInterface;
 
     const error = new Error('test');
 
     startSpan({ name: 'test' }, () => {
-      hub.addBreadcrumb({ timestamp: 123456, message: 'test1' });
+      addBreadcrumb({ timestamp: 123456, message: 'test1' });
 
       startSpan({ name: 'inner1' }, () => {
-        hub.addBreadcrumb({ timestamp: 123457, message: 'test2', data: { nested: 'yes' } });
+        addBreadcrumb({ timestamp: 123457, message: 'test2', data: { nested: 'yes' } });
       });
 
       startSpan({ name: 'inner2' }, () => {
-        hub.addBreadcrumb({ timestamp: 123455, message: 'test3' });
+        addBreadcrumb({ timestamp: 123455, message: 'test3' });
       });
 
-      // eslint-disable-next-line deprecation/deprecation
-      hub.captureException(error);
+      captureException(error);
     });
 
     await client.flush();
@@ -156,28 +154,26 @@ describe('Integration | breadcrumbs', () => {
 
     mockSdkInit({ beforeSend, beforeBreadcrumb, beforeSendTransaction, enableTracing: true });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as TestClientInterface;
+    const client = getClient() as TestClientInterface;
 
     const error = new Error('test');
 
     startSpan({ name: 'test1' }, () => {
-      hub.addBreadcrumb({ timestamp: 123456, message: 'test1-a' });
+      addBreadcrumb({ timestamp: 123456, message: 'test1-a' });
 
       startSpan({ name: 'inner1' }, () => {
-        hub.addBreadcrumb({ timestamp: 123457, message: 'test1-b' });
+        addBreadcrumb({ timestamp: 123457, message: 'test1-b' });
       });
     });
 
     startSpan({ name: 'test2' }, () => {
-      hub.addBreadcrumb({ timestamp: 123456, message: 'test2-a' });
+      addBreadcrumb({ timestamp: 123456, message: 'test2-a' });
 
       startSpan({ name: 'inner2' }, () => {
-        hub.addBreadcrumb({ timestamp: 123457, message: 'test2-b' });
+        addBreadcrumb({ timestamp: 123457, message: 'test2-b' });
       });
 
-      // eslint-disable-next-line deprecation/deprecation
-      hub.captureException(error);
+      captureException(error);
     });
 
     await client.flush();
@@ -206,21 +202,19 @@ describe('Integration | breadcrumbs', () => {
 
     mockSdkInit({ beforeSend, beforeBreadcrumb, beforeSendTransaction, enableTracing: true });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as TestClientInterface;
+    const client = getClient() as TestClientInterface;
 
     const error = new Error('test');
 
     startSpan({ name: 'test1' }, () => {
       withScope(() => {
-        hub.addBreadcrumb({ timestamp: 123456, message: 'test1' });
+        addBreadcrumb({ timestamp: 123456, message: 'test1' });
       });
       startSpan({ name: 'inner1' }, () => {
-        hub.addBreadcrumb({ timestamp: 123457, message: 'test2' });
+        addBreadcrumb({ timestamp: 123457, message: 'test2' });
       });
 
-      // eslint-disable-next-line deprecation/deprecation
-      hub.captureException(error);
+      captureException(error);
     });
 
     await client.flush();
@@ -249,37 +243,35 @@ describe('Integration | breadcrumbs', () => {
 
     mockSdkInit({ beforeSend, beforeBreadcrumb, beforeSendTransaction, enableTracing: true });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as TestClientInterface;
+    const client = getClient() as TestClientInterface;
 
     const error = new Error('test');
 
     startSpan({ name: 'test1' }, () => {
       withScope(() => {
-        hub.addBreadcrumb({ timestamp: 123456, message: 'test1' });
+        addBreadcrumb({ timestamp: 123456, message: 'test1' });
       });
       startSpan({ name: 'inner1' }, () => {
-        hub.addBreadcrumb({ timestamp: 123457, message: 'test2' });
+        addBreadcrumb({ timestamp: 123457, message: 'test2' });
 
         startSpan({ name: 'inner2' }, () => {
-          hub.addBreadcrumb({ timestamp: 123457, message: 'test3' });
+          addBreadcrumb({ timestamp: 123457, message: 'test3' });
 
           startSpan({ name: 'inner3' }, () => {
-            hub.addBreadcrumb({ timestamp: 123457, message: 'test4' });
+            addBreadcrumb({ timestamp: 123457, message: 'test4' });
 
-            // eslint-disable-next-line deprecation/deprecation
-            hub.captureException(error);
+            captureException(error);
 
             startSpan({ name: 'inner4' }, () => {
-              hub.addBreadcrumb({ timestamp: 123457, message: 'test5' });
+              addBreadcrumb({ timestamp: 123457, message: 'test5' });
             });
 
-            hub.addBreadcrumb({ timestamp: 123457, message: 'test6' });
+            addBreadcrumb({ timestamp: 123457, message: 'test6' });
           });
         });
       });
 
-      hub.addBreadcrumb({ timestamp: 123456, message: 'test99' });
+      addBreadcrumb({ timestamp: 123456, message: 'test99' });
     });
 
     await client.flush();
@@ -309,37 +301,35 @@ describe('Integration | breadcrumbs', () => {
 
     mockSdkInit({ beforeSend, beforeBreadcrumb, beforeSendTransaction, enableTracing: true });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as TestClientInterface;
+    const client = getClient() as TestClientInterface;
 
     const error = new Error('test');
 
     const promise1 = startSpan({ name: 'test' }, async () => {
-      hub.addBreadcrumb({ timestamp: 123456, message: 'test1' });
+      addBreadcrumb({ timestamp: 123456, message: 'test1' });
 
       await startSpan({ name: 'inner1' }, async () => {
-        hub.addBreadcrumb({ timestamp: 123457, message: 'test2' });
+        addBreadcrumb({ timestamp: 123457, message: 'test2' });
       });
 
       await startSpan({ name: 'inner2' }, async () => {
-        hub.addBreadcrumb({ timestamp: 123455, message: 'test3' });
+        addBreadcrumb({ timestamp: 123455, message: 'test3' });
       });
 
       await new Promise(resolve => setTimeout(resolve, 10));
 
-      // eslint-disable-next-line deprecation/deprecation
-      hub.captureException(error);
+      captureException(error);
     });
 
     const promise2 = startSpan({ name: 'test-b' }, async () => {
-      hub.addBreadcrumb({ timestamp: 123456, message: 'test1-b' });
+      addBreadcrumb({ timestamp: 123456, message: 'test1-b' });
 
       await startSpan({ name: 'inner1' }, async () => {
-        hub.addBreadcrumb({ timestamp: 123457, message: 'test2-b' });
+        addBreadcrumb({ timestamp: 123457, message: 'test2-b' });
       });
 
       await startSpan({ name: 'inner2' }, async () => {
-        hub.addBreadcrumb({ timestamp: 123455, message: 'test3-b' });
+        addBreadcrumb({ timestamp: 123455, message: 'test3-b' });
       });
     });
 

--- a/packages/opentelemetry/test/integration/otelTimedEvents.test.ts
+++ b/packages/opentelemetry/test/integration/otelTimedEvents.test.ts
@@ -1,6 +1,6 @@
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 
-import { getCurrentHub } from '../../src/custom/hub';
+import { getClient } from '../../src/custom/hub';
 import { startSpan } from '../../src/trace';
 import type { TestClientInterface } from '../helpers/TestClient';
 import { cleanupOtel, mockSdkInit } from '../helpers/mockSdkInit';
@@ -16,8 +16,7 @@ describe('Integration | OTEL TimedEvents', () => {
 
     mockSdkInit({ beforeSend, beforeSendTransaction, enableTracing: true });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as TestClientInterface;
+    const client = getClient() as TestClientInterface;
 
     startSpan({ name: 'test' }, span => {
       span.addEvent('exception', {

--- a/packages/opentelemetry/test/integration/scope.test.ts
+++ b/packages/opentelemetry/test/integration/scope.test.ts
@@ -1,6 +1,6 @@
-import { captureException, setTag, withScope } from '@sentry/core';
+import { captureException, getCurrentScope, setTag, withScope } from '@sentry/core';
 
-import { OpenTelemetryHub, getCurrentHub } from '../../src/custom/hub';
+import { OpenTelemetryHub, getClient, getCurrentHub } from '../../src/custom/hub';
 import { OpenTelemetryScope } from '../../src/custom/scope';
 import { startSpan } from '../../src/trace';
 import { getSpanScope } from '../../src/utils/spanData';
@@ -23,9 +23,9 @@ describe('Integration | Scope', () => {
       mockSdkInit({ enableTracing, beforeSend, beforeSendTransaction });
 
       const hub = getCurrentHub();
-      const client = hub.getClient() as TestClientInterface;
+      const client = getClient() as TestClientInterface;
 
-      const rootScope = hub.getScope();
+      const rootScope = getCurrentScope();
 
       expect(hub).toBeInstanceOf(OpenTelemetryHub);
       expect(rootScope).toBeInstanceOf(OpenTelemetryScope);
@@ -128,9 +128,8 @@ describe('Integration | Scope', () => {
       mockSdkInit({ enableTracing, beforeSend, beforeSendTransaction });
 
       const hub = getCurrentHub();
-      const client = hub.getClient() as TestClientInterface;
-
-      const rootScope = hub.getScope();
+      const client = getClient() as TestClientInterface;
+      const rootScope = getCurrentScope();
 
       expect(hub).toBeInstanceOf(OpenTelemetryHub);
       expect(rootScope).toBeInstanceOf(OpenTelemetryScope);

--- a/packages/opentelemetry/test/integration/transactions.test.ts
+++ b/packages/opentelemetry/test/integration/transactions.test.ts
@@ -5,7 +5,7 @@ import type { PropagationContext, TransactionEvent } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import { spanToJSON } from '@sentry/core';
-import { getCurrentHub } from '../../src/custom/hub';
+import { getClient } from '../../src/custom/hub';
 import { SentrySpanProcessor } from '../../src/spanProcessor';
 import { startInactiveSpan, startSpan } from '../../src/trace';
 import { setPropagationContextOnContext } from '../../src/utils/contextData';
@@ -23,8 +23,7 @@ describe('Integration | Transactions', () => {
 
     mockSdkInit({ enableTracing: true, beforeSendTransaction });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as TestClientInterface;
+    const client = getClient() as TestClientInterface;
 
     addBreadcrumb({ message: 'test breadcrumb 1', timestamp: 123456 });
     setTag('outer.tag', 'test value');
@@ -174,8 +173,7 @@ describe('Integration | Transactions', () => {
 
     mockSdkInit({ enableTracing: true, beforeSendTransaction });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as TestClientInterface;
+    const client = getClient() as TestClientInterface;
 
     addBreadcrumb({ message: 'test breadcrumb 1', timestamp: 123456 });
 
@@ -332,8 +330,7 @@ describe('Integration | Transactions', () => {
 
     mockSdkInit({ enableTracing: true, beforeSendTransaction });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as TestClientInterface;
+    const client = getClient() as TestClientInterface;
 
     // We simulate the correct context we'd normally get from the SentryPropagator
     context.with(
@@ -432,8 +429,7 @@ describe('Integration | Transactions', () => {
 
     mockSdkInit({ enableTracing: true, beforeSendTransaction });
 
-    const hub = getCurrentHub();
-    const client = hub.getClient() as TestClientInterface;
+    const client = getClient() as TestClientInterface;
     const provider = getProvider();
     const multiSpanProcessor = provider?.activeSpanProcessor as
       | (SpanProcessor & { _spanProcessors?: SpanProcessor[] })

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -4,7 +4,7 @@ import { TraceFlags, context, trace } from '@opentelemetry/api';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import type { PropagationContext } from '@sentry/types';
 
-import { getCurrentHub } from '../src/custom/hub';
+import { getClient } from '../src/custom/hub';
 import { InternalSentrySemanticAttributes } from '../src/semanticAttributes';
 import { startInactiveSpan, startSpan, startSpanManual } from '../src/trace';
 import type { AbstractSpan } from '../src/types';
@@ -503,7 +503,7 @@ describe('trace (sampling)', () => {
 
       // Now let's mutate the tracesSampleRate so that the next entry _should_ not be sampled
       // but it will because of parent sampling
-      const client = getCurrentHub().getClient();
+      const client = getClient();
       client!.getOptions().tracesSampleRate = 0.5;
 
       startSpan({ name: 'inner' }, innerSpan => {
@@ -526,7 +526,7 @@ describe('trace (sampling)', () => {
 
       // Now let's mutate the tracesSampleRate so that the next entry _should_ be sampled
       // but it will remain unsampled because of parent sampling
-      const client = getCurrentHub().getClient();
+      const client = getClient();
       client!.getOptions().tracesSampleRate = 1;
 
       startSpan({ name: 'inner' }, innerSpan => {

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -226,6 +226,7 @@ export { withProfiler, Profiler, useProfiler };
 /** Grabs active transaction off scope */
 export function getActiveTransaction<T extends Transaction>(hub: Hub = getCurrentHub()): T | undefined {
   if (hub) {
+    // eslint-disable-next-line deprecation/deprecation
     const scope = hub.getScope();
     // eslint-disable-next-line deprecation/deprecation
     return scope.getTransaction() as T | undefined;

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -403,6 +403,7 @@ export function startRequestHandlerTransaction(
     request.headers['sentry-trace'],
     request.headers.baggage,
   );
+  // eslint-disable-next-line deprecation/deprecation
   hub.getScope().setPropagationContext(propagationContext);
 
   // TODO: Refactor this to `startSpan()`

--- a/packages/remix/test/index.client.test.ts
+++ b/packages/remix/test/index.client.test.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getCurrentScope } from '@sentry/core';
 import * as SentryReact from '@sentry/react';
 import { GLOBAL_OBJ } from '@sentry/utils';
 
@@ -39,7 +39,7 @@ describe('Client init()', () => {
   });
 
   it('sets runtime on scope', () => {
-    const currentScope = getCurrentHub().getScope();
+    const currentScope = getCurrentScope();
 
     // @ts-expect-error need access to protected _tags attribute
     expect(currentScope._tags).toEqual({});

--- a/packages/remix/test/index.server.test.ts
+++ b/packages/remix/test/index.server.test.ts
@@ -1,5 +1,4 @@
 import * as SentryNode from '@sentry/node';
-import { getCurrentHub } from '@sentry/node';
 import { GLOBAL_OBJ } from '@sentry/utils';
 
 import { Integrations, init } from '../src/index.server';
@@ -47,7 +46,7 @@ describe('Server init()', () => {
   });
 
   it('sets runtime on scope', () => {
-    const currentScope = getCurrentHub().getScope();
+    const currentScope = SentryNode.getCurrentScope();
 
     // @ts-expect-error need access to protected _tags attribute
     expect(currentScope._tags).toEqual({});

--- a/packages/replay/jest.setup.ts
+++ b/packages/replay/jest.setup.ts
@@ -1,6 +1,6 @@
 import { TextEncoder } from 'util';
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { getCurrentHub } from '@sentry/core';
+import { getClient } from '@sentry/core';
 import type { ReplayRecordingData, Transport } from '@sentry/types';
 import * as SentryUtils from '@sentry/utils';
 
@@ -155,7 +155,7 @@ const toHaveSentReplay = function (
   _received: jest.Mocked<ReplayContainer>,
   expected?: SentReplayExpected | { sample: SentReplayExpected; inverse: boolean },
 ) {
-  const { calls } = (getCurrentHub().getClient()?.getTransport()?.send as MockTransport).mock;
+  const { calls } = (getClient()?.getTransport()?.send as MockTransport).mock;
 
   let result: CheckCallForSentReplayResult;
 
@@ -214,7 +214,7 @@ const toHaveLastSentReplay = function (
   _received: jest.Mocked<ReplayContainer>,
   expected?: SentReplayExpected | { sample: SentReplayExpected; inverse: boolean },
 ) {
-  const { calls } = (getCurrentHub().getClient()?.getTransport()?.send as MockTransport).mock;
+  const { calls } = (getClient()?.getTransport()?.send as MockTransport).mock;
   const replayCalls = getReplayCalls(calls);
 
   const lastCall = replayCalls[calls.length - 1]?.[0];

--- a/packages/replay/test/integration/beforeAddRecordingEvent.test.ts
+++ b/packages/replay/test/integration/beforeAddRecordingEvent.test.ts
@@ -72,7 +72,7 @@ describe('Integration | beforeAddRecordingEvent', () => {
     mockSendReplayRequest = jest.spyOn(SendReplayRequest, 'sendReplayRequest');
 
     jest.runAllTimers();
-    mockTransportSend = SentryCore.getCurrentHub()?.getClient()?.getTransport()?.send as MockTransportSend;
+    mockTransportSend = SentryCore.getClient()?.getTransport()?.send as MockTransportSend;
   });
 
   beforeEach(() => {

--- a/packages/replay/test/integration/coreHandlers/handleScope.test.ts
+++ b/packages/replay/test/integration/coreHandlers/handleScope.test.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getCurrentScope } from '@sentry/core';
 
 import * as HandleScope from '../../../src/coreHandlers/handleScope';
 import { mockSdk } from './../../index';
@@ -22,7 +22,7 @@ describe('Integration | coreHandlers | handleScope', () => {
 
     expect(mockHandleScopeListener).toHaveBeenCalledTimes(1);
 
-    getCurrentHub().getScope().addBreadcrumb({ category: 'console', message: 'testing' });
+    getCurrentScope().addBreadcrumb({ category: 'console', message: 'testing' });
 
     expect(mockHandleScope).toHaveBeenCalledTimes(1);
     expect(mockHandleScope).toHaveReturnedWith(expect.objectContaining({ category: 'console', message: 'testing' }));
@@ -31,7 +31,7 @@ describe('Integration | coreHandlers | handleScope', () => {
 
     // This will trigger breadcrumb/scope listener, but handleScope should return
     // null because breadcrumbs has not changed
-    getCurrentHub().getScope().setUser({ email: 'foo@foo.com' });
+    getCurrentScope().setUser({ email: 'foo@foo.com' });
     expect(mockHandleScope).toHaveBeenCalledTimes(1);
     expect(mockHandleScope).toHaveReturnedWith(null);
   });

--- a/packages/replay/test/integration/rateLimiting.test.ts
+++ b/packages/replay/test/integration/rateLimiting.test.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getClient } from '@sentry/core';
 import type { Transport, TransportMakeRequestResponse } from '@sentry/types';
 
 import { DEFAULT_FLUSH_MIN_DELAY } from '../../src/constants';
@@ -30,7 +30,7 @@ describe('Integration | rate-limiting behaviour', () => {
       },
     }));
 
-    mockTransportSend = getCurrentHub()?.getClient()?.getTransport()?.send as MockTransportSend;
+    mockTransportSend = getClient()?.getTransport()?.send as MockTransportSend;
   });
 
   afterEach(async () => {

--- a/packages/replay/test/integration/sendReplayEvent.test.ts
+++ b/packages/replay/test/integration/sendReplayEvent.test.ts
@@ -48,7 +48,7 @@ describe('Integration | sendReplayEvent', () => {
     mockSendReplayRequest = jest.spyOn(SendReplayRequest, 'sendReplayRequest');
 
     jest.runAllTimers();
-    mockTransportSend = SentryCore.getCurrentHub()?.getClient()?.getTransport()?.send as MockTransportSend;
+    mockTransportSend = SentryCore.getClient()?.getTransport()?.send as MockTransportSend;
   });
 
   beforeEach(() => {

--- a/packages/replay/test/integration/session.test.ts
+++ b/packages/replay/test/integration/session.test.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/core';
+import { getClient } from '@sentry/core';
 import type { Transport } from '@sentry/types';
 
 import {
@@ -43,7 +43,7 @@ describe('Integration | session', () => {
       },
     }));
 
-    const mockTransport = getCurrentHub()?.getClient()?.getTransport()?.send as jest.MockedFunction<Transport['send']>;
+    const mockTransport = getClient()?.getTransport()?.send as jest.MockedFunction<Transport['send']>;
     mockTransport?.mockClear();
   });
 

--- a/packages/replay/test/unit/util/prepareReplayEvent.test.ts
+++ b/packages/replay/test/unit/util/prepareReplayEvent.test.ts
@@ -1,23 +1,16 @@
-import type { Hub, Scope } from '@sentry/core';
+import { getClient, getCurrentScope } from '@sentry/core';
 import { getCurrentHub } from '@sentry/core';
-import type { Client, ReplayEvent } from '@sentry/types';
+import type { ReplayEvent } from '@sentry/types';
 
 import { REPLAY_EVENT_NAME } from '../../../src/constants';
 import { prepareReplayEvent } from '../../../src/util/prepareReplayEvent';
 import { TestClient, getDefaultClientOptions } from '../../utils/TestClient';
 
 describe('Unit | util | prepareReplayEvent', () => {
-  let hub: Hub;
-  let client: Client;
-  let scope: Scope;
-
   beforeEach(() => {
-    hub = getCurrentHub();
-    client = new TestClient(getDefaultClientOptions());
+    const hub = getCurrentHub();
+    const client = new TestClient(getDefaultClientOptions());
     hub.bindClient(client);
-
-    client = hub.getClient()!;
-    scope = hub.getScope();
 
     jest.spyOn(client, 'getSdkMetadata').mockImplementation(() => {
       return {
@@ -34,6 +27,9 @@ describe('Unit | util | prepareReplayEvent', () => {
   });
 
   it('works', async () => {
+    const client = getClient()!;
+    const scope = getCurrentScope()!;
+
     expect(client).toBeDefined();
     expect(scope).toBeDefined();
 

--- a/packages/sveltekit/test/client/sdk.test.ts
+++ b/packages/sveltekit/test/client/sdk.test.ts
@@ -1,4 +1,4 @@
-import { getClient, getCurrentHub } from '@sentry/core';
+import { getClient, getCurrentScope } from '@sentry/core';
 import type { BrowserClient } from '@sentry/svelte';
 import * as SentrySvelte from '@sentry/svelte';
 import { SDK_VERSION, WINDOW } from '@sentry/svelte';
@@ -39,7 +39,7 @@ describe('Sentry client SDK', () => {
     });
 
     it('sets the runtime tag on the scope', () => {
-      const currentScope = getCurrentHub().getScope();
+      const currentScope = getCurrentScope();
 
       // @ts-expect-error need access to protected _tags attribute
       expect(currentScope._tags).toEqual({});

--- a/packages/sveltekit/test/server/sdk.test.ts
+++ b/packages/sveltekit/test/server/sdk.test.ts
@@ -1,4 +1,3 @@
-import { getCurrentHub } from '@sentry/core';
 import * as SentryNode from '@sentry/node';
 import { SDK_VERSION } from '@sentry/node';
 import { GLOBAL_OBJ } from '@sentry/utils';
@@ -37,7 +36,7 @@ describe('Sentry server SDK', () => {
     });
 
     it('sets the runtime tag on the scope', () => {
-      const currentScope = getCurrentHub().getScope();
+      const currentScope = SentryNode.getCurrentScope();
 
       // @ts-expect-error need access to protected _tags attribute
       expect(currentScope._tags).toEqual({});

--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -230,6 +230,7 @@ export class BrowserTracing implements Integration {
   public setupOnce(_: (callback: EventProcessor) => void, getCurrentHub: () => Hub): void {
     this._getCurrentHub = getCurrentHub;
     const hub = getCurrentHub();
+    // eslint-disable-next-line deprecation/deprecation
     const client = hub.getClient();
     const clientOptions = client && client.getOptions();
 
@@ -369,6 +370,7 @@ export class BrowserTracing implements Integration {
       heartbeatInterval,
     );
 
+    // eslint-disable-next-line deprecation/deprecation
     const scope = hub.getScope();
 
     // If it's a pageload and there is a meta tag set

--- a/packages/tracing-internal/src/node/integrations/apollo.ts
+++ b/packages/tracing-internal/src/node/integrations/apollo.ts
@@ -188,6 +188,7 @@ function wrapResolver(
 ): void {
   fill(model[resolverGroupName], resolverName, function (orig: () => unknown | Promise<unknown>) {
     return function (this: unknown, ...args: unknown[]) {
+      // eslint-disable-next-line deprecation/deprecation
       const scope = getCurrentHub().getScope();
       // eslint-disable-next-line deprecation/deprecation
       const parentSpan = scope.getSpan();

--- a/packages/tracing-internal/src/node/integrations/graphql.ts
+++ b/packages/tracing-internal/src/node/integrations/graphql.ts
@@ -51,6 +51,7 @@ export class GraphQL implements LazyLoadedIntegration<GraphQLModule> {
 
     fill(pkg, 'execute', function (orig: () => void | Promise<unknown>) {
       return function (this: unknown, ...args: unknown[]) {
+        // eslint-disable-next-line deprecation/deprecation
         const scope = getCurrentHub().getScope();
         // eslint-disable-next-line deprecation/deprecation
         const parentSpan = scope.getSpan();

--- a/packages/tracing-internal/src/node/integrations/mongo.ts
+++ b/packages/tracing-internal/src/node/integrations/mongo.ts
@@ -174,6 +174,7 @@ export class Mongo implements LazyLoadedIntegration<MongoModule> {
     fill(collection.prototype, operation, function (orig: () => void | Promise<unknown>) {
       return function (this: unknown, ...args: unknown[]) {
         const lastArg = args[args.length - 1];
+        // eslint-disable-next-line deprecation/deprecation
         const scope = getCurrentHub().getScope();
         // eslint-disable-next-line deprecation/deprecation
         const parentSpan = scope.getSpan();

--- a/packages/tracing-internal/src/node/integrations/mysql.ts
+++ b/packages/tracing-internal/src/node/integrations/mysql.ts
@@ -103,6 +103,7 @@ export class Mysql implements LazyLoadedIntegration<MysqlConnection> {
     //    function (options, values, callback) => void
     fill(pkg, 'createQuery', function (orig: () => void) {
       return function (this: unknown, options: unknown, values: unknown, callback: unknown) {
+        // eslint-disable-next-line deprecation/deprecation
         const scope = getCurrentHub().getScope();
         // eslint-disable-next-line deprecation/deprecation
         const parentSpan = scope.getSpan();

--- a/packages/tracing-internal/src/node/integrations/postgres.ts
+++ b/packages/tracing-internal/src/node/integrations/postgres.ts
@@ -104,6 +104,7 @@ export class Postgres implements LazyLoadedIntegration<PGModule> {
      */
     fill(Client.prototype, 'query', function (orig: PgClientQuery) {
       return function (this: PgClientThis, config: unknown, values: unknown, callback: unknown) {
+        // eslint-disable-next-line deprecation/deprecation
         const scope = getCurrentHub().getScope();
         // eslint-disable-next-line deprecation/deprecation
         const parentSpan = scope.getSpan();

--- a/packages/tracing-internal/src/node/integrations/utils/node-utils.ts
+++ b/packages/tracing-internal/src/node/integrations/utils/node-utils.ts
@@ -7,6 +7,7 @@ import type { Hub } from '@sentry/types';
  * @returns boolean
  */
 export function shouldDisableAutoInstrumentation(getCurrentHub: () => Hub): boolean {
+  // eslint-disable-next-line deprecation/deprecation
   const clientOptions = getCurrentHub().getClient()?.getOptions();
   const instrumenter = clientOptions?.instrumenter || 'sentry';
 

--- a/packages/tracing/test/idletransaction.test.ts
+++ b/packages/tracing/test/idletransaction.test.ts
@@ -9,7 +9,7 @@ import {
   startSpanManual,
 } from '@sentry/core';
 
-import { Hub, IdleTransaction, Span, makeMain } from '../../core/src';
+import { Hub, IdleTransaction, Span, getClient, makeMain } from '../../core/src';
 import { IdleTransactionSpanRecorder } from '../../core/src/tracing/idletransaction';
 import { getDefaultBrowserClientOptions } from './testutils';
 
@@ -34,7 +34,7 @@ describe('IdleTransaction', () => {
       );
       transaction.initSpanRecorder(10);
 
-      const scope = hub.getScope();
+      const scope = getCurrentScope();
       // eslint-disable-next-line deprecation/deprecation
       expect(scope.getTransaction()).toBe(transaction);
     });
@@ -43,7 +43,7 @@ describe('IdleTransaction', () => {
       const transaction = new IdleTransaction({ name: 'foo' }, hub);
       transaction.initSpanRecorder(10);
 
-      const scope = hub.getScope();
+      const scope = getCurrentScope();
       // eslint-disable-next-line deprecation/deprecation
       expect(scope.getTransaction()).toBe(undefined);
     });
@@ -62,7 +62,7 @@ describe('IdleTransaction', () => {
       transaction.end();
       jest.runAllTimers();
 
-      const scope = hub.getScope();
+      const scope = getCurrentScope();
       // eslint-disable-next-line deprecation/deprecation
       expect(scope.getTransaction()).toBe(undefined);
     });
@@ -80,7 +80,7 @@ describe('IdleTransaction', () => {
       transaction.end();
       jest.runAllTimers();
 
-      const scope = hub.getScope();
+      const scope = getCurrentScope();
       // eslint-disable-next-line deprecation/deprecation
       expect(scope.getTransaction()).toBe(undefined);
     });
@@ -100,12 +100,12 @@ describe('IdleTransaction', () => {
       // eslint-disable-next-line deprecation/deprecation
       const otherTransaction = new Transaction({ name: 'bar' }, hub);
       // eslint-disable-next-line deprecation/deprecation
-      hub.getScope().setSpan(otherTransaction);
+      getCurrentScope().setSpan(otherTransaction);
 
       transaction.end();
       jest.runAllTimers();
 
-      const scope = hub.getScope();
+      const scope = getCurrentScope();
       // eslint-disable-next-line deprecation/deprecation
       expect(scope.getTransaction()).toBe(otherTransaction);
     });
@@ -243,7 +243,7 @@ describe('IdleTransaction', () => {
   it('should record dropped transactions', async () => {
     const transaction = new IdleTransaction({ name: 'foo', startTimestamp: 1234, sampled: false }, hub, 1000);
 
-    const client = hub.getClient()!;
+    const client = getClient()!;
 
     const recordDroppedEventSpy = jest.spyOn(client, 'recordDroppedEvent');
 

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -21,7 +21,7 @@ export interface Hub {
    * @param version A version number to compare to.
    * @return True if the given version is newer; otherwise false.
    *
-   * @hidden
+   * @deprecated This will be removed in v8.
    */
   isOlderThan(version: number): boolean;
 
@@ -68,18 +68,28 @@ export interface Hub {
    *     popScope();
    *
    * @param callback that will be enclosed into push/popScope.
+   *
+   * @deprecated Use `Sentry.withScope()` instead.
    */
   withScope<T>(callback: (scope: Scope) => T): T;
 
-  /** Returns the client of the top stack. */
+  /**
+   * Returns the client of the top stack.
+   * @deprecated Use `Sentry.getClient()` instead.
+   */
   getClient(): Client | undefined;
 
-  /** Returns the scope of the top stack */
+  /**
+   * Returns the scope of the top stack.
+   * @deprecated Use `Sentry.getCurrentScope()` instead.
+   */
   getScope(): Scope;
 
   /**
    * Get the currently active isolation scope.
    * The isolation scope is used to isolate data between different hubs.
+   *
+   * @deprecated Use `Sentry.getIsolationScope()` instead.
    */
   getIsolationScope(): Scope;
 
@@ -89,6 +99,8 @@ export interface Hub {
    * @param exception An exception-like object.
    * @param hint May contain additional information about the original exception.
    * @returns The generated eventId.
+   *
+   * @deprecated Use `Sentry.captureException()` instead.
    */
   captureException(exception: any, hint?: EventHint): string;
 
@@ -99,6 +111,8 @@ export interface Hub {
    * @param level Define the level of the message.
    * @param hint May contain additional information about the original exception.
    * @returns The generated eventId.
+   *
+   * @deprecated Use `Sentry.captureMessage()` instead.
    */
   captureMessage(
     message: string,
@@ -112,6 +126,8 @@ export interface Hub {
    *
    * @param event The event to send to Sentry.
    * @param hint May contain additional information about the original exception.
+   *
+   * @deprecated Use `Sentry.captureEvent()` instead.
    */
   captureEvent(event: Event, hint?: EventHint): string;
 
@@ -119,6 +135,8 @@ export interface Hub {
    * This is the getter for lastEventId.
    *
    * @returns The last event id of a captured event.
+   *
+   * @deprecated This will be removed in v8.
    */
   lastEventId(): string | undefined;
 
@@ -130,6 +148,8 @@ export interface Hub {
    *
    * @param breadcrumb The breadcrumb to record.
    * @param hint May contain additional information about the original breadcrumb.
+   *
+   * @deprecated Use `Sentry.addBreadcrumb()` instead.
    */
   addBreadcrumb(breadcrumb: Breadcrumb, hint?: BreadcrumbHint): void;
 
@@ -137,6 +157,8 @@ export interface Hub {
    * Updates user context information for future events.
    *
    * @param user User context object to be set in the current context. Pass `null` to unset the user.
+   *
+   * @deprecated Use `Sentry.setUser()` instead.
    */
   setUser(user: User | null): void;
 
@@ -144,6 +166,8 @@ export interface Hub {
    * Set an object that will be merged sent as tags data with the event.
    *
    * @param tags Tags context object to merge into current context.
+   *
+   * @deprecated Use `Sentry.setTags()` instead.
    */
   setTags(tags: { [key: string]: Primitive }): void;
 
@@ -154,6 +178,8 @@ export interface Hub {
    *
    * @param key String key of tag
    * @param value Value of tag
+   *
+   * @deprecated Use `Sentry.setTag()` instead.
    */
   setTag(key: string, value: Primitive): void;
 
@@ -161,12 +187,16 @@ export interface Hub {
    * Set key:value that will be sent as extra data with the event.
    * @param key String of extra
    * @param extra Any kind of data. This data will be normalized.
+   *
+   * @deprecated Use `Sentry.setExtra()` instead.
    */
   setExtra(key: string, extra: Extra): void;
 
   /**
    * Set an object that will be merged sent as extra data with the event.
    * @param extras Extras object to merge into current context.
+   *
+   * @deprecated Use `Sentry.setExtras()` instead.
    */
   setExtras(extras: Extras): void;
 
@@ -174,6 +204,8 @@ export interface Hub {
    * Sets context data with the given name.
    * @param name of the context
    * @param context Any kind of data. This data will be normalized.
+   *
+   * @deprecated Use `Sentry.setContext()` instead.
    */
   setContext(name: string, context: { [key: string]: any } | null): void;
 
@@ -189,13 +221,23 @@ export interface Hub {
    * For the duration of the callback, this hub will be set as the global current Hub.
    * This function is useful if you want to run your own client and hook into an already initialized one
    * e.g.: Reporting issues to your own sentry when running in your component while still using the users configuration.
+   *
+   * TODO v8: This will be merged with `withScope()`
    */
   run(callback: (hub: Hub) => void): void;
 
-  /** Returns the integration if installed on the current client. */
+  /**
+   * Returns the integration if installed on the current client.
+   *
+   * @deprecated Use `Sentry.getClient().getIntegration()` instead.
+   */
   getIntegration<T extends Integration>(integration: IntegrationClass<T>): T | null;
 
-  /** Returns all trace headers that are currently on the top scope. */
+  /**
+   * Returns all trace headers that are currently on the top scope.
+   *
+   * @deprecated Use `spanToTraceHeader()` instead.
+   */
   traceHeaders(): { [key: string]: string };
 
   /**

--- a/packages/utils/src/eventbuilder.ts
+++ b/packages/utils/src/eventbuilder.ts
@@ -74,7 +74,11 @@ export function eventFromUnknownInput(
   exception: unknown,
   hint?: EventHint,
 ): Event {
-  const client = typeof getHubOrClient === 'function' ? getHubOrClient().getClient() : getHubOrClient;
+  const client =
+    typeof getHubOrClient === 'function'
+      ? // eslint-disable-next-line deprecation/deprecation
+        getHubOrClient().getClient()
+      : getHubOrClient;
 
   let ex: unknown = exception;
   const providedMechanism: Mechanism | undefined =

--- a/packages/vercel-edge/src/integrations/wintercg-fetch.ts
+++ b/packages/vercel-edge/src/integrations/wintercg-fetch.ts
@@ -1,5 +1,5 @@
 import { instrumentFetchRequest } from '@sentry-internal/tracing';
-import { addBreadcrumb, getClient, getCurrentHub, isSentryRequestUrl } from '@sentry/core';
+import { addBreadcrumb, getClient, isSentryRequestUrl } from '@sentry/core';
 import type { FetchBreadcrumbData, FetchBreadcrumbHint, HandlerDataFetch, Integration, Span } from '@sentry/types';
 import { LRUMap, addFetchInstrumentationHandler, stringMatchesSomePattern } from '@sentry/utils';
 
@@ -49,8 +49,7 @@ export class WinterCGFetch implements Integration {
     const spans: Record<string, Span> = {};
 
     addFetchInstrumentationHandler(handlerData => {
-      const hub = getCurrentHub();
-      if (!hub.getIntegration(WinterCGFetch)) {
+      if (!getClient()?.getIntegration(WinterCGFetch)) {
         return;
       }
 

--- a/packages/vercel-edge/test/wintercg-fetch.test.ts
+++ b/packages/vercel-edge/test/wintercg-fetch.test.ts
@@ -7,14 +7,20 @@ import { createStackParser } from '@sentry/utils';
 import { VercelEdgeClient } from '../src/index';
 import { WinterCGFetch } from '../src/integrations/wintercg-fetch';
 
-class FakeHub extends sentryCore.Hub {
+class FakeClient extends VercelEdgeClient {
   getIntegration<T extends Integration>(integration: IntegrationClass<T>): T | null {
     return new integration();
   }
 }
 
-const fakeHubInstance = new FakeHub(
-  new VercelEdgeClient({
+const addFetchInstrumentationHandlerSpy = jest.spyOn(sentryUtils, 'addFetchInstrumentationHandler');
+const instrumentFetchRequestSpy = jest.spyOn(internalTracing, 'instrumentFetchRequest');
+const addBreadcrumbSpy = jest.spyOn(sentryCore, 'addBreadcrumb');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  const client = new FakeClient({
     dsn: 'https://public@dsn.ingest.sentry.io/1337',
     enableTracing: true,
     tracesSampleRate: 1,
@@ -25,19 +31,9 @@ const fakeHubInstance = new FakeHub(
     }),
     tracePropagationTargets: ['http://my-website.com/'],
     stackParser: createStackParser(),
-  }),
-);
+  });
 
-jest.spyOn(sentryCore, 'getCurrentHub').mockImplementation(() => fakeHubInstance);
-jest.spyOn(sentryCore, 'getCurrentScope').mockImplementation(() => fakeHubInstance.getScope());
-jest.spyOn(sentryCore, 'getClient').mockImplementation(() => fakeHubInstance.getClient());
-
-const addFetchInstrumentationHandlerSpy = jest.spyOn(sentryUtils, 'addFetchInstrumentationHandler');
-const instrumentFetchRequestSpy = jest.spyOn(internalTracing, 'instrumentFetchRequest');
-const addBreadcrumbSpy = jest.spyOn(sentryCore, 'addBreadcrumb');
-
-beforeEach(() => {
-  jest.clearAllMocks();
+  jest.spyOn(sentryCore, 'getClient').mockImplementation(() => client);
 });
 
 describe('WinterCGFetch instrumentation', () => {

--- a/packages/vue/src/integration.ts
+++ b/packages/vue/src/integration.ts
@@ -46,6 +46,7 @@ export class VueIntegration implements Integration {
 
   /** Just here for easier testing */
   protected _setupIntegration(hub: Hub): void {
+    // eslint-disable-next-line deprecation/deprecation
     const client = hub.getClient();
     const options: Options = { ...DEFAULT_CONFIG, ...(client && client.getOptions()), ...this._options };
 

--- a/packages/vue/test/integration/init.test.ts
+++ b/packages/vue/test/integration/init.test.ts
@@ -104,7 +104,7 @@ Update your \`Sentry.init\` call with an appropriate config option:
 });
 
 function runInit(options: Partial<Options>): void {
-  const hasRunBefore = Sentry.getCurrentHub().getIntegration(VueIntegration);
+  const hasRunBefore = Sentry.getClient()?.getIntegration(VueIntegration);
 
   const integration = new VueIntegration();
 


### PR DESCRIPTION
Except for `bindClient()` which needs a separate replacement. For everything else we already have a replacement in place!

Then in a follow up we can deprecate `getCurrentHub()` itself.