### PR TITLE
feat(core): Deprecate `new Transaction()`

### DIFF
--- a/packages/core/src/tracing/hubextensions.ts
+++ b/packages/core/src/tracing/hubextensions.ts
@@ -60,6 +60,7 @@ The transaction will not be sampled. Please use the ${configInstrumenter} instru
     transactionContext.sampled = false;
   }
 
+  // eslint-disable-next-line deprecation/deprecation
   let transaction = new Transaction(transactionContext, this);
   transaction = sampleTransaction(transaction, options, {
     parentSampled: transactionContext.parentSampled,
@@ -90,6 +91,7 @@ export function startIdleTransaction(
   const client = hub.getClient();
   const options: Partial<ClientOptions> = (client && client.getOptions()) || {};
 
+  // eslint-disable-next-line deprecation/deprecation
   let transaction = new IdleTransaction(transactionContext, hub, idleTimeout, finalTimeout, heartbeatInterval, onScope);
   transaction = sampleTransaction(transaction, options, {
     parentSampled: transactionContext.parentSampled,

--- a/packages/core/src/tracing/idletransaction.ts
+++ b/packages/core/src/tracing/idletransaction.ts
@@ -95,6 +95,9 @@ export class IdleTransaction extends Transaction {
 
   private _finishReason: (typeof IDLE_TRANSACTION_FINISH_REASONS)[number];
 
+  /**
+   * @deprecated Transactions will be removed in v8. Use spans instead.
+   */
   public constructor(
     transactionContext: TransactionContext,
     private readonly _idleHub: Hub,

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -45,6 +45,8 @@ export class Transaction extends SpanClass implements TransactionInterface {
    * @internal
    * @hideconstructor
    * @hidden
+   *
+   * @deprecated Transactions will be removed in v8. Use spans instead.
    */
   public constructor(transactionContext: TransactionContext, hub?: Hub) {
     super(transactionContext);

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -361,6 +361,7 @@ describe('tracingHandler', () => {
   });
 
   it('pulls status code from the response', done => {
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = new Transaction({ name: 'mockTransaction' });
     jest.spyOn(sentryCore, 'startTransaction').mockReturnValue(transaction as Transaction);
     const finishTransaction = jest.spyOn(transaction, 'end');
@@ -412,6 +413,7 @@ describe('tracingHandler', () => {
   });
 
   it('closes the transaction when request processing is done', done => {
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = new Transaction({ name: 'mockTransaction' });
     jest.spyOn(sentryCore, 'startTransaction').mockReturnValue(transaction as Transaction);
     const finishTransaction = jest.spyOn(transaction, 'end');
@@ -426,6 +428,7 @@ describe('tracingHandler', () => {
   });
 
   it('waits to finish transaction until all spans are finished, even though `transaction.end()` is registered on `res.finish` event first', done => {
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = new Transaction({ name: 'mockTransaction', sampled: true });
     transaction.initSpanRecorder();
     // eslint-disable-next-line deprecation/deprecation

--- a/packages/opentelemetry-node/test/propagator.test.ts
+++ b/packages/opentelemetry-node/test/propagator.test.ts
@@ -60,6 +60,7 @@ describe('SentryPropagator', () => {
       }
 
       function createTransactionAndMaybeSpan(type: PerfType, transactionContext: TransactionContext) {
+        // eslint-disable-next-line deprecation/deprecation
         const transaction = new Transaction(transactionContext, hub);
         setSentrySpan(transaction.spanContext().spanId, transaction);
         if (type === PerfType.Span) {

--- a/packages/opentelemetry/src/custom/transaction.ts
+++ b/packages/opentelemetry/src/custom/transaction.ts
@@ -11,6 +11,7 @@ export function startTransaction(hub: HubInterface, transactionContext: Transact
   const client = hub.getClient();
   const options: Partial<ClientOptions> = (client && client.getOptions()) || {};
 
+  // eslint-disable-next-line deprecation/deprecation
   const transaction = new OpenTelemetryTransaction(transactionContext, hub as Hub);
   // Since we do not do sampling here, we assume that this is _always_ sampled
   // Any sampling decision happens in OpenTelemetry's sampler

--- a/packages/opentelemetry/test/custom/transaction.test.ts
+++ b/packages/opentelemetry/test/custom/transaction.test.ts
@@ -17,6 +17,7 @@ describe('NodeExperimentalTransaction', () => {
     const hub = getCurrentHub();
     hub.bindClient(client);
 
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = new OpenTelemetryTransaction({ name: 'test', sampled: true }, hub);
 
     const res = transaction.finishWithScope();
@@ -63,6 +64,7 @@ describe('NodeExperimentalTransaction', () => {
     const hub = getCurrentHub();
     hub.bindClient(client);
 
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = new OpenTelemetryTransaction({ name: 'test', startTimestamp: 123456, sampled: true }, hub);
 
     const res = transaction.finishWithScope(1234567);
@@ -87,6 +89,7 @@ describe('NodeExperimentalTransaction', () => {
     const hub = getCurrentHub();
     hub.bindClient(client);
 
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = new OpenTelemetryTransaction({ name: 'test', startTimestamp: 123456, sampled: true }, hub);
 
     const scope = new OpenTelemetryScope();

--- a/packages/tracing-internal/test/browser/metrics/index.test.ts
+++ b/packages/tracing-internal/test/browser/metrics/index.test.ts
@@ -3,6 +3,7 @@ import type { ResourceEntry } from '../../../src/browser/metrics';
 import { _addMeasureSpans, _addResourceSpans } from '../../../src/browser/metrics';
 
 describe('_addMeasureSpans', () => {
+  // eslint-disable-next-line deprecation/deprecation
   const transaction = new Transaction({ op: 'pageload', name: '/' });
   beforeEach(() => {
     // eslint-disable-next-line deprecation/deprecation
@@ -39,6 +40,7 @@ describe('_addMeasureSpans', () => {
 });
 
 describe('_addResourceSpans', () => {
+  // eslint-disable-next-line deprecation/deprecation
   const transaction = new Transaction({ op: 'pageload', name: '/' });
   beforeEach(() => {
     // eslint-disable-next-line deprecation/deprecation

--- a/packages/tracing-internal/test/browser/metrics/utils.test.ts
+++ b/packages/tracing-internal/test/browser/metrics/utils.test.ts
@@ -4,6 +4,7 @@ import { _startChild } from '../../../src/browser/metrics/utils';
 
 describe('_startChild()', () => {
   it('creates a span with given properties', () => {
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = new Transaction({ name: 'test' });
     const span = _startChild(transaction, {
       description: 'evaluation',
@@ -16,6 +17,7 @@ describe('_startChild()', () => {
   });
 
   it('adjusts the start timestamp if child span starts before transaction', () => {
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = new Transaction({ name: 'test', startTimestamp: 123 });
     const span = _startChild(transaction, {
       description: 'script.js',
@@ -28,6 +30,7 @@ describe('_startChild()', () => {
   });
 
   it('does not adjust start timestamp if child span starts after transaction', () => {
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = new Transaction({ name: 'test', startTimestamp: 123 });
     const span = _startChild(transaction, {
       description: 'script.js',

--- a/packages/tracing/test/idletransaction.test.ts
+++ b/packages/tracing/test/idletransaction.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import { BrowserClient } from '@sentry/browser';
 import {
   TRACING_DEFAULTS,
@@ -96,6 +97,7 @@ describe('IdleTransaction', () => {
       transaction.initSpanRecorder(10);
 
       // @ts-expect-error need to pass in hub
+      // eslint-disable-next-line deprecation/deprecation
       const otherTransaction = new Transaction({ name: 'bar' }, hub);
       // eslint-disable-next-line deprecation/deprecation
       hub.getScope().setSpan(otherTransaction);


### PR DESCRIPTION
No more transaction class!

This should not really affect users, as they should only use `startTransaction()` anyhow.