### PR TITLE
chore: Add migration docs for `Hub`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,6 +8,50 @@ npx @sentry/migr8@latest
 
 This will let you select which updates to run, and automatically update your code. Make sure to still review all code changes!
 
+## Deprecate `Hub`
+
+The `Hub` has been a very important part of the Sentry SDK API up until now.
+Hubs were the SDKs "unit of concurrency" to keep track of data across threads and to scope data to certain parts of your code.
+Because it is overly complicated and confusing to power users, it is going to be replaced by a set of new APIs: the "new Scope API".
+
+`Scope`s have existed before in the SDK but we are now expanding on them because we have found them powerful enough to fully cover the `Hub` API.
+
+If you are using the `Hub` right now, see the following table on how to migrate to the new API:
+
+| Old `Hub` API | New `Scope` API |
+| --- | --- |
+| `new Hub()` | `withScope()`, `withIsolationScope()` or `new Scope()` |
+| hub.isOlderThan() | REMOVED - Was used to compare `Hub` instances, which are gonna be removed. |
+| hub.bindClient() | A combination of `scope.setClient()` and `client.setupIntegrations()` |
+| hub.pushScope() | Best replaced with `withScope()` |
+| hub.popScope() | When used in combination with `hub.pushScope()` best replaced with `withScope()` |
+| hub.withScope() | `withScope()` |
+| getClient() | `scope.getClient` |
+| getScope() | REMOVED - Scopes are used directly now. |
+| getIsolationScope() | `Sentry.getIsolationScope()` |
+| getStack() | REMOVED - The stack used to hold scopes. Scopes are used directly now. |
+| getStackTop() | REMOVED - The stack used to hold scopes. Scopes are used directly now. |
+| captureException() | `scope.captureException()` |
+| captureMessage() | `scope.captureMessage()` |
+| captureEvent() | `scope.captureEvent()` |
+| lastEventId() | REMOVED - Use event processors or beforeSend instead. |
+| addBreadcrumb() | `scope.addBreadcrumb()` |
+| setUser() | `scope.setUser()` |
+| setTags() | `scope.setTags()` |
+| setExtras() | `scope.setExtras()` |
+| setTag() | `scope.setTag()` |
+| setExtra() | `scope.setExtra()` |
+| setContext() | `scope.setContext()` |
+| configureScope() | REMOVED - Scopes are now the unit of concurrency.  |
+| run() | `withScope()` or `withIsolationScope()` |
+| getIntegration() | `client.getIntegration()` |
+| startTransaction() | `startSpan()`, `startInactiveSpan()` or `startSpanManual()` |
+| traceHeaders() | REMOVED - The closest equivalent is now `spanToTraceHeader(getActiveSpan())`  |
+| captureSession() | Use top level `Sentry.captureSession()` |
+| startSession() | Top level `Sentry.startSession()` |
+| endSession() | Top level `Sentry.endSession()` |
+| shouldSendDefaultPii() | REMOVED - The closest equivalent is `scope.getClient().getOptions().sendDefaultPii` |
+
 ## Deprecate `scope.getSpan()` and `scope.setSpan()`
 
 Instead, you can get the currently active span via `Sentry.getActiveSpan()`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -21,36 +21,36 @@ If you are using the `Hub` right now, see the following table on how to migrate 
 | Old `Hub` API | New `Scope` API |
 | --- | --- |
 | `new Hub()` | `withScope()`, `withIsolationScope()` or `new Scope()` |
-| hub.isOlderThan() | REMOVED - Was used to compare `Hub` instances, which are gonna be removed. |
+| hub.isOlderThan() | REMOVED - Was used to compare `Hub` instances, which are gonna be removed |
 | hub.bindClient() | A combination of `scope.setClient()` and `client.setupIntegrations()` |
-| hub.pushScope() | Best replaced with `withScope()` |
-| hub.popScope() | When used in combination with `hub.pushScope()` best replaced with `withScope()` |
-| hub.withScope() | `withScope()` |
-| getClient() | `scope.getClient` |
-| getScope() | REMOVED - Scopes are used directly now. |
+| hub.pushScope() | `Sentry.withScope()` |
+| hub.popScope() | `Sentry.withScope()` |
+| hub.withScope() | `Sentry.withScope()` |
+| getClient() | `Sentry.getClient()` |
+| getScope() | `Sentry.getCurrentScope()` to get the currently active scope |
 | getIsolationScope() | `Sentry.getIsolationScope()` |
-| getStack() | REMOVED - The stack used to hold scopes. Scopes are used directly now. |
-| getStackTop() | REMOVED - The stack used to hold scopes. Scopes are used directly now. |
-| captureException() | `scope.captureException()` |
-| captureMessage() | `scope.captureMessage()` |
-| captureEvent() | `scope.captureEvent()` |
-| lastEventId() | REMOVED - Use event processors or beforeSend instead. |
-| addBreadcrumb() | `scope.addBreadcrumb()` |
-| setUser() | `scope.setUser()` |
-| setTags() | `scope.setTags()` |
-| setExtras() | `scope.setExtras()` |
-| setTag() | `scope.setTag()` |
-| setExtra() | `scope.setExtra()` |
-| setContext() | `scope.setContext()` |
-| configureScope() | REMOVED - Scopes are now the unit of concurrency.  |
-| run() | `withScope()` or `withIsolationScope()` |
+| getStack() | REMOVED - The stack used to hold scopes. Scopes are used directly now |
+| getStackTop() | REMOVED - The stack used to hold scopes. Scopes are used directly now |
+| captureException() | `Sentry.captureException()` |
+| captureMessage() | `Sentry.captureMessage()` |
+| captureEvent() | `Sentry.captureEvent()` |
+| lastEventId() | REMOVED - Use event processors or beforeSend instead |
+| addBreadcrumb() | `Sentry.addBreadcrumb()` |
+| setUser() | `Sentry.setUser()` |
+| setTags() | `Sentry.setTags()` |
+| setExtras() | `Sentry.setExtras()` |
+| setTag() | `Sentry.setTag()` |
+| setExtra() | `Sentry.setExtra()` |
+| setContext() | `Sentry.setContext()` |
+| configureScope() | REMOVED - Scopes are now the unit of concurrency  |
+| run() | `Sentry.withScope()` or `Sentry.withIsolationScope()` |
 | getIntegration() | `client.getIntegration()` |
-| startTransaction() | `startSpan()`, `startInactiveSpan()` or `startSpanManual()` |
+| startTransaction() | `Sentry.startSpan()`, `Sentry.startInactiveSpan()` or `Sentry.startSpanManual()` |
 | traceHeaders() | REMOVED - The closest equivalent is now `spanToTraceHeader(getActiveSpan())`  |
-| captureSession() | Use top level `Sentry.captureSession()` |
-| startSession() | Top level `Sentry.startSession()` |
-| endSession() | Top level `Sentry.endSession()` |
-| shouldSendDefaultPii() | REMOVED - The closest equivalent is `scope.getClient().getOptions().sendDefaultPii` |
+| captureSession() | `Sentry.captureSession()` |
+| startSession() | `Sentry.startSession()` |
+| endSession() | `Sentry.endSession()` |
+| shouldSendDefaultPii() | REMOVED - The closest equivalent is `Sentry.getClient().getOptions().sendDefaultPii` |
 
 ## Deprecate `scope.getSpan()` and `scope.setSpan()`
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,7 +11,7 @@ This will let you select which updates to run, and automatically update your cod
 ## Deprecate `Hub`
 
 The `Hub` has been a very important part of the Sentry SDK API up until now.
-Hubs were the SDKs "unit of concurrency" to keep track of data across threads and to scope data to certain parts of your code.
+Hubs were the SDK's "unit of concurrency" to keep track of data across threads and to scope data to certain parts of your code.
 Because it is overly complicated and confusing to power users, it is going to be replaced by a set of new APIs: the "new Scope API".
 
 `Scope`s have existed before in the SDK but we are now expanding on them because we have found them powerful enough to fully cover the `Hub` API.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -117,17 +117,6 @@ Sentry.init({
 });
 ```
 
-## Deprecated fields on `Hub`
-
-In v8, the Hub class will be removed. The following methods are therefore deprecated:
-
-* `hub.startTransaction()`: See [Deprecation of `startTransaction`](#deprecate-starttransaction)
-* `hub.lastEventId()`: See [Deprecation of `lastEventId`](#deprecate-sentrylasteventid-and-hublasteventid)
-* `hub.startSession()`: Use top-level `Sentry.startSession()` instead
-* `hub.endSession()`: Use top-level `Sentry.endSession()` instead
-* `hub.captureSession()`: Use top-level `Sentry.captureSession()` instead
-* `hub.shouldSendDefaultPii()`: Access Sentry client option via `Sentry.getClient().getOptions().sendDefaultPii` instead
-
 ## Deprecated fields on `Span` and `Transaction`
 
 In v8, the Span class is heavily reworked. The following properties & methods are thus deprecated:


### PR DESCRIPTION
Adds documentation on how to migrate off the hub API to the MIGRATION guide. This is still a bit basic - we will expand on this once we have figured out all of our migration paths and are finalizing v8.