### PR TITLE
meta: Ignore `Transaction` deprecation lint warnings in DSC tests

### DIFF
--- a/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
+++ b/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
@@ -20,6 +20,7 @@ describe('getDynamicSamplingContextFromSpan', () => {
   });
 
   test('returns the DSC provided during transaction creation', () => {
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = new Transaction({
       name: 'tx',
       metadata: { dynamicSamplingContext: { environment: 'myEnv' } },
@@ -67,6 +68,7 @@ describe('getDynamicSamplingContextFromSpan', () => {
   });
 
   test('returns a new DSC, if no DSC was provided during transaction creation (via new Txn and deprecated metadata)', () => {
+    // eslint-disable-next-line deprecation/deprecation
     const transaction = new Transaction({
       name: 'tx',
       metadata: {
@@ -90,6 +92,7 @@ describe('getDynamicSamplingContextFromSpan', () => {
 
   describe('Including transaction name in DSC', () => {
     test('is not included if transaction source is url', () => {
+      // eslint-disable-next-line deprecation/deprecation
       const transaction = new Transaction({
         name: 'tx',
         metadata: {
@@ -106,6 +109,7 @@ describe('getDynamicSamplingContextFromSpan', () => {
       ['is included if transaction source is parameterized route/url', 'route'],
       ['is included if transaction source is a custom name', 'custom'],
     ])('%s', (_: string, source) => {
+      // eslint-disable-next-line deprecation/deprecation
       const transaction = new Transaction({
         name: 'tx',
         metadata: {


### PR DESCRIPTION
Currently fails develop.