### PR TITLE
test(bun): Fix failing test after `span.isRecording` change

### DIFF
--- a/packages/bun/test/integrations/bunserver.test.ts
+++ b/packages/bun/test/integrations/bunserver.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, test } from 'bun:test';
-import { Hub, makeMain, spanToJSON } from '@sentry/core';
+import { Hub, getDynamicSamplingContextFromSpan, makeMain, spanIsSampled, spanToJSON } from '@sentry/core';
 
 import { BunClient } from '../../src/client';
 import { instrumentBunServe } from '../../src/integrations/bunserver';
@@ -82,10 +82,16 @@ describe('Bun Serve Integration', () => {
     client.on('finishTransaction', transaction => {
       expect(transaction.spanContext().traceId).toBe(TRACE_ID);
       expect(transaction.parentSpanId).toBe(PARENT_SPAN_ID);
-      expect(transaction.isRecording()).toBe(true);
+      expect(spanIsSampled(transaction)).toBe(true);
+      // span.endTimestamp is already set in `finishTransaction` hook
+      expect(transaction.isRecording()).toBe(false);
 
       // eslint-disable-next-line deprecation/deprecation
       expect(transaction.metadata?.dynamicSamplingContext).toStrictEqual({ version: '1.0', environment: 'production' });
+      expect(getDynamicSamplingContextFromSpan(transaction)).toStrictEqual({
+        version: '1.0',
+        environment: 'production',
+      });
     });
 
     const server = Bun.serve({


### PR DESCRIPTION
Not sure why our Bun Unit Tests were still passing but locally as well as in CI somehow 
else (weird) this test failed.

This failed in CI but I see no failed jobs 🤔 
![image](https://github.com/getsentry/sentry-javascript/assets/8420481/0e1f737d-bc06-4040-887d-8e288722a5d6)


cc @mydea I think the test fix should be correct - in the `finishTransaction` test, the 
span is already finished (hence, isRecording returns `false`) but `spanIsSampled` should 
still be true.
