### PR TITLE
feat(core): Deprecate `Span.instrumenter`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -151,6 +151,7 @@ In v8, the Span class is heavily reworked. The following properties & methods ar
 - `span.data`: Use `spanToJSON(span).data` instead.
 - `span.setTag()`: Use `span.setAttribute()` instead or set tags on the surrounding scope.
 - `span.setData()`: Use `span.setAttribute()` instead.
+- `span.instrumenter` This field was removed and will be replaced internally.
 - `transaction.setContext()`: Set context on the surrounding scope instead.
 
 ## Deprecate `pushScope` & `popScope` in favor of `withScope`

--- a/packages/core/src/tracing/span.ts
+++ b/packages/core/src/tracing/span.ts
@@ -110,6 +110,12 @@ export class Span implements SpanInterface {
 
   /**
    * The instrumenter that created this span.
+   *
+   * TODO (v8): This can probably be replaced by an `instanceOf` check of the span class.
+   *            the instrumenter can only be sentry or otel so we can check the span instance
+   *            to verify which one it is and remove this field entirely.
+   *
+   * @deprecated This field will be removed.
    */
   public instrumenter: Instrumenter;
 
@@ -142,6 +148,7 @@ export class Span implements SpanInterface {
     // eslint-disable-next-line deprecation/deprecation
     this.data = spanContext.data ? { ...spanContext.data } : {};
     this._attributes = spanContext.attributes ? { ...spanContext.attributes } : {};
+    // eslint-disable-next-line deprecation/deprecation
     this.instrumenter = spanContext.instrumenter || 'sentry';
     this.origin = spanContext.origin || 'manual';
     // eslint-disable-next-line deprecation/deprecation

--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -221,6 +221,8 @@ export interface Span extends SpanContext {
 
   /**
    * The instrumenter that created this span.
+   *
+   * @deprecated this field will be removed.
    */
   instrumenter: Instrumenter;
 


### PR DESCRIPTION
This PR deprecates the `instrumenter` field on the `Span` interface and class. The field is not part of the Otel Span API and hence it can't exist publicly on our spans either. After talking with @mydea about the replacement, we can probably replace this with an `instanceof` check when setting `instrumenter` on the event in v8. This is breaking though, so for now, we only deprecate it. Users shouldn't need to worry about this field anyway.   