### PR TITLE
fix(node): Module name resolution

### DIFF
--- a/packages/node/src/module.ts
+++ b/packages/node/src/module.ts
@@ -34,16 +34,15 @@ export function createGetModuleFromFilename(
       dir = '.';
     }
 
-    let n = dir.lastIndexOf('/node_modules');
+    const n = dir.lastIndexOf('/node_modules');
     if (n > -1) {
       return `${dir.slice(n + 14).replace(/\//g, '.')}:${file}`;
     }
 
     // Let's see if it's a part of the main module
     // To be a part of main module, it has to share the same base
-    n = `${dir}/`.lastIndexOf(normalizedBase, 0);
-    if (n === 0) {
-      let moduleName = dir.slice(normalizedBase.length).replace(/\//g, '.');
+    if (dir.startsWith(normalizedBase)) {
+      let moduleName = dir.slice(normalizedBase.length + 1).replace(/\//g, '.');
 
       if (moduleName) {
         moduleName += ':';

--- a/packages/node/test/module.test.ts
+++ b/packages/node/test/module.test.ts
@@ -1,7 +1,7 @@
 import { createGetModuleFromFilename } from '../src/module';
 
-const getModuleFromFilenameWindows = createGetModuleFromFilename('C:\\Users\\Tim\\', true);
-const getModuleFromFilenamePosix = createGetModuleFromFilename('/Users/Tim/');
+const getModuleFromFilenameWindows = createGetModuleFromFilename('C:\\Users\\Tim', true);
+const getModuleFromFilenamePosix = createGetModuleFromFilename('/Users/Tim');
 
 describe('createGetModuleFromFilename', () => {
   test('Windows', () => {


### PR DESCRIPTION
The default `basePath` for `createGetModuleFromFilename` is `dirname(process.argv[1])`:

```ts
/** Creates a function that gets the module name from a filename */
export function createGetModuleFromFilename(
  basePath: string = dirname(process.argv[1]),
```
But the tests used a trailing slash for the base path:
https://github.com/getsentry/sentry-javascript/blob/84791bf8f83fc637e02a7071bbe70a0d22e20666/packages/node/test/module.test.ts#L3-L4

Which means in some situations the module name can include a leading `.`.

The tests need to pass without a trailing slash on the `basePath`!