### PR TITLE
feat(core): Deprecate `finish` on `Span` interface in favour of `end`

### DIFF
--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -235,7 +235,10 @@ export interface Span extends SpanContext {
 
   /**
    * Sets the finish timestamp on the current span.
+   *
    * @param endTimestamp Takes an endTimestamp if the end should not be the time when you call this function.
+   *
+   * @deprecated Use `end()` instead.
    */
   finish(endTimestamp?: number): void;
 


### PR DESCRIPTION
This is more a fix than a feat but considering it's user facing I went with the latter.
Looks like we forgot to deprecate the method in the interface (it's already deprecated on the class).
