### PR TITLE
feat(core): Deprecate `Transaction.instrumenter`

### DIFF
--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -99,6 +99,8 @@ export interface Transaction extends TransactionContext, Omit<Span, 'setName' | 
 
   /**
    * The instrumenter that created this transaction.
+   *
+   * @deprecated This field will be removed in v8.
    */
   instrumenter: Instrumenter;
 


### PR DESCRIPTION
I didn't see that `instrumenter` was redeclared on the `Transcation` interface in #10139 - this PR now also deprecates it on `Transaction`.