### PR TITLE
feat(core): Deprecate remaining `setName` declarations on `Transaction` and `Span`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -151,15 +151,16 @@ In v8, the Span class is heavily reworked. The following properties & methods ar
 - `span.name`: Use `spanToJSON(span).description` instead.
 - `span.description`: Use `spanToJSON(span).description` instead.
 - `span.getDynamicSamplingContext`: Use `getDynamicSamplingContextFromSpan` utility function instead.
-- `transaction.setMetadata()`: Use attributes instead, or set data on the scope.
-- `transaction.metadata`: Use attributes instead, or set data on the scope.
 - `span.tags`: Set tags on the surrounding scope instead, or use attributes.
 - `span.data`: Use `spanToJSON(span).data` instead.
 - `span.setTag()`: Use `span.setAttribute()` instead or set tags on the surrounding scope.
 - `span.setData()`: Use `span.setAttribute()` instead.
 - `span.instrumenter` This field was removed and will be replaced internally.
 - `span.transaction`: Use `getRootSpan` utility function instead.
+- `transaction.setMetadata()`: Use attributes instead, or set data on the scope.
+- `transaction.metadata`: Use attributes instead, or set data on the scope.
 - `transaction.setContext()`: Set context on the surrounding scope instead.
+- `transaction.setName()`: Set the name with `.updateName()` and the source with `.setAttribute()` instead.
 
 ## Deprecate `pushScope` & `popScope` in favor of `withScope`
 

--- a/packages/core/src/tracing/span.ts
+++ b/packages/core/src/tracing/span.ts
@@ -391,7 +391,11 @@ export class Span implements SpanInterface {
     return this;
   }
 
-  /** @inheritdoc */
+  /**
+   * @inheritdoc
+   *
+   * @deprecated Use `.updateName()` instead.
+   */
   public setName(name: string): void {
     this.updateName(name);
   }

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -137,7 +137,7 @@ export class Transaction extends SpanClass implements TransactionInterface {
   /**
    * Setter for `name` property, which also sets `source` on the metadata.
    *
-   * @deprecated Use `updateName()` and `setMetadata()` instead.
+   * @deprecated Use `.updateName()` and `.setAttribute()` instead.
    */
   public setName(name: string, source: TransactionMetadata['source'] = 'custom'): void {
     this._name = name;

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -104,6 +104,8 @@ export interface Transaction extends TransactionContext, Omit<Span, 'setName' | 
 
   /**
    * Set the name of the transaction
+   *
+   * @deprecated Use `.updateName()` and `.setAttribute()` instead.
    */
   setName(name: string, source?: TransactionMetadata['source']): void;
 


### PR DESCRIPTION
Seems like we didn't fully deprecate the `setName` API in #10018  as some deprecation annotations were still missing on 
* `Span` class
* `Transaction` class
* `Transaction` interface
