### PR TITLE
ref: Clean up new integrations API and pave migration path

### DIFF
--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -184,3 +184,11 @@ export function convertIntegrationFnToClass<Fn extends IntegrationFn>(
     new (...args: Parameters<Fn>): Integration & ReturnType<Fn>;
   };
 }
+
+/**
+ * Utility function to aid with creating Sentry SDK integrations.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function defineSentryIntegration<F extends (...args: any[]) => Integration>(integrationFactory: F): F {
+  return integrationFactory;
+}

--- a/packages/core/src/integrations/functiontostring.ts
+++ b/packages/core/src/integrations/functiontostring.ts
@@ -7,7 +7,7 @@ let originalFunctionToString: () => void;
 const INTEGRATION_NAME = 'FunctionToString';
 
 /**
- * Patch toString calls to return proper name for wrapped functions
+ * Patch toString calls to return proper name for wrapped functions.
  */
 export const functionToStringIntegration = defineSentryIntegration(() => {
   // eslint-disable-next-line deprecation/deprecation
@@ -15,9 +15,7 @@ export const functionToStringIntegration = defineSentryIntegration(() => {
 });
 
 /**
- * Patch toString calls to return proper name for wrapped functions
- *
- * @deprecated Use `functionToStringIntegration()` instead.
+ * Patch toString calls to return proper name for wrapped functions.
  */
 export class FunctionToString implements Integration {
   public static id = INTEGRATION_NAME;

--- a/packages/core/src/integrations/functiontostring.ts
+++ b/packages/core/src/integrations/functiontostring.ts
@@ -1,33 +1,48 @@
-import type { IntegrationFn, WrappedFunction } from '@sentry/types';
+import type { Integration, WrappedFunction } from '@sentry/types';
 import { getOriginalFunction } from '@sentry/utils';
-import { convertIntegrationFnToClass } from '../integration';
+import { defineSentryIntegration } from '../integration';
 
 let originalFunctionToString: () => void;
 
 const INTEGRATION_NAME = 'FunctionToString';
 
-const functionToStringIntegration: IntegrationFn = () => {
-  return {
-    name: INTEGRATION_NAME,
-    setupOnce() {
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      originalFunctionToString = Function.prototype.toString;
+/**
+ * Patch toString calls to return proper name for wrapped functions
+ */
+export const functionToStringIntegration = defineSentryIntegration(() => {
+  // eslint-disable-next-line deprecation/deprecation
+  return new FunctionToString();
+});
 
-      // intrinsics (like Function.prototype) might be immutable in some environments
-      // e.g. Node with --frozen-intrinsics, XS (an embedded JavaScript engine) or SES (a JavaScript proposal)
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        Function.prototype.toString = function (this: WrappedFunction, ...args: any[]): string {
-          const context = getOriginalFunction(this) || this;
-          return originalFunctionToString.apply(context, args);
-        };
-      } catch {
-        // ignore errors here, just don't patch this
-      }
-    },
-  };
-};
+/**
+ * Patch toString calls to return proper name for wrapped functions
+ *
+ * @deprecated Use `functionToStringIntegration()` instead.
+ */
+export class FunctionToString implements Integration {
+  public static id = INTEGRATION_NAME;
 
-/** Patch toString calls to return proper name for wrapped functions */
-// eslint-disable-next-line deprecation/deprecation
-export const FunctionToString = convertIntegrationFnToClass(INTEGRATION_NAME, functionToStringIntegration);
+  public name: typeof INTEGRATION_NAME;
+
+  public constructor() {
+    this.name = INTEGRATION_NAME;
+  }
+
+  // eslint-disable-next-line jsdoc/require-jsdoc
+  public setupOnce(): void {
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    originalFunctionToString = Function.prototype.toString;
+
+    // intrinsics (like Function.prototype) might be immutable in some environments
+    // e.g. Node with --frozen-intrinsics, XS (an embedded JavaScript engine) or SES (a JavaScript proposal)
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      Function.prototype.toString = function (this: WrappedFunction, ...args: any[]): string {
+        const context = getOriginalFunction(this) || this;
+        return originalFunctionToString.apply(context, args);
+      };
+    } catch {
+      // ignore errors here, just don't patch this
+    }
+  }
+}

--- a/packages/core/src/integrations/inboundfilters.ts
+++ b/packages/core/src/integrations/inboundfilters.ts
@@ -38,9 +38,7 @@ export const inboundFiltersIntegration = defineSentryIntegration((options?: Part
 });
 
 /**
- * Inbound filters configurable by the user
- *
- * @deprecated Use `inboundFiltersIntegration()` instead.
+ * Inbound filters configurable by the user.
  */
 export class InboundFilters implements Integration {
   public static id = INTEGRATION_NAME;

--- a/packages/vercel-edge/src/sdk.ts
+++ b/packages/vercel-edge/src/sdk.ts
@@ -16,7 +16,9 @@ declare const process: {
 const nodeStackParser = createStackParser(nodeStackLineParser());
 
 export const defaultIntegrations = [
+  // eslint-disable-next-line deprecation/deprecation
   new CoreIntegrations.InboundFilters(),
+  // eslint-disable-next-line deprecation/deprecation
   new CoreIntegrations.FunctionToString(),
   new CoreIntegrations.LinkedErrors(),
   new WinterCGFetch(),


### PR DESCRIPTION
This PR intends to supersede this PR and our current migration path because it is very convoluted and leads to potential typing issues. https://github.com/getsentry/sentry-javascript/pull/10143

### What is different?

- We keep all the integration classes as we had them before (they need to stick around for v7 in any case - we can remove them in v8). This sadly involves reverting all of our class-removal work, however, the work wasn't entirely in-vain, as all the refactoring to reduce state will help us when we completely move the logic from classes to functions.
- We introduce a helper function similar to rollup and vite's `defineConfig()` function that let's us and users create integration factories in a type-safe manner.
- We expose functional-alternatives for all of our integrations that do nothing else than simply instantiating the class equivalent. For this, we can also use the helper function.

### What will this do?

- Will keep the typings for our class-based integrations.
- The return types of the functional integrations will not be widened to `Integration` but will exactly represent the return value as it is. We can evaluate whether this is beneficial for us because it, in theory and counter-intuitively, widens our API. We could also decide on an integration-by-integration basis whether an integration should be of the type `Integration` or it's actual shape.

### Are there any drawbacks?

No.