### PR TITLE
test(node): otel Express integration tests

### DIFF
--- a/dev-packages/node-integration-tests/suites/anr/test.ts
+++ b/dev-packages/node-integration-tests/suites/anr/test.ts
@@ -1,5 +1,5 @@
 import { conditionalTest } from '../../utils';
-import { createRunner } from '../../utils/runner';
+import { cleanupChildProcesses, createRunner } from '../../utils/runner';
 
 const EXPECTED_ANR_EVENT = {
   // Ensure we have context
@@ -52,6 +52,10 @@ const EXPECTED_ANR_EVENT = {
 };
 
 conditionalTest({ min: 16 })('should report ANR when event loop blocked', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
   // TODO (v8): Remove this old API and this test
   test('Legacy API', done => {
     createRunner(__dirname, 'legacy.js').expect({ event: EXPECTED_ANR_EVENT }).start(done);

--- a/dev-packages/node-integration-tests/suites/express/handle-error/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/handle-error/server.ts
@@ -1,3 +1,4 @@
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
 import express from 'express';
 
@@ -6,6 +7,7 @@ const app = express();
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
+  transport: loggingTransport,
 });
 
 app.use(Sentry.Handlers.requestHandler());
@@ -16,4 +18,4 @@ app.get('/test/express', () => {
 
 app.use(Sentry.Handlers.errorHandler());
 
-export default app;
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/handle-error/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/handle-error/test.ts
@@ -1,23 +1,38 @@
-import { TestEnv, assertSentryEvent } from '../../../utils/index';
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
-test('should capture and send Express controller error.', async () => {
-  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
-  const event = await env.getEnvelopeRequest({ url: `${env.url}/express` });
+afterAll(() => {
+  cleanupChildProcesses();
+});
 
-  expect((event[2] as any).exception.values[0].stacktrace.frames.length).toBeGreaterThan(0);
-
-  assertSentryEvent(event[2] as any, {
-    exception: {
-      values: [
-        {
-          mechanism: {
-            type: 'middleware',
-            handled: false,
-          },
-          type: 'Error',
-          value: 'test_error',
+test('should capture and send Express controller error.', done => {
+  const runner = createRunner(__dirname, 'server.ts')
+    .ignore('session', 'sessions')
+    .expect({
+      event: {
+        exception: {
+          values: [
+            {
+              mechanism: {
+                type: 'middleware',
+                handled: false,
+              },
+              type: 'Error',
+              value: 'test_error',
+              stacktrace: {
+                frames: expect.arrayContaining([
+                  expect.objectContaining({
+                    function: expect.any(String),
+                    lineno: expect.any(Number),
+                    colno: expect.any(Number),
+                  }),
+                ]),
+              },
+            },
+          ],
         },
-      ],
-    },
-  });
+      },
+    })
+    .start(done);
+
+  expect(() => runner.makeRequest('get', '/test/express')).rejects.toThrow();
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix-parameterized/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix-parameterized/server.ts
@@ -1,3 +1,4 @@
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
@@ -11,6 +12,7 @@ Sentry.init({
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
+  transport: loggingTransport,
 });
 
 app.use(Sentry.Handlers.requestHandler());
@@ -32,4 +34,4 @@ app.use('/api/v1', APIv1);
 
 app.use(Sentry.Handlers.errorHandler());
 
-export default app;
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix-parameterized/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix-parameterized/test.ts
@@ -1,11 +1,13 @@
-import { TestEnv, assertSentryEvent } from '../../../../utils/index';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
-test('should construct correct url with common infixes with multiple parameterized routers.', async () => {
-  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
-  const event = await env.getEnvelopeRequest({ url: env.url.replace('test', 'api/v1/user/3212') });
+afterAll(() => {
+  cleanupChildProcesses();
+});
 
-  assertSentryEvent(event[2] as any, {
-    message: 'Custom Message',
-    transaction: 'GET /api/v1/user/:userId',
-  });
+test('should construct correct url with common infixes with multiple parameterized routers.', done => {
+  createRunner(__dirname, 'server.ts')
+    .ignore('transaction', 'session', 'sessions')
+    .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/user/:userId' } })
+    .start(done)
+    .makeRequest('get', '/api/v1/user/3212');
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix/server.ts
@@ -1,3 +1,4 @@
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
@@ -11,6 +12,7 @@ Sentry.init({
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
+  transport: loggingTransport,
 });
 
 app.use(Sentry.Handlers.requestHandler());
@@ -32,4 +34,4 @@ app.use('/api2/v1', APIv1);
 
 app.use(Sentry.Handlers.errorHandler());
 
-export default app;
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix/test.ts
@@ -1,11 +1,13 @@
-import { TestEnv, assertSentryEvent } from '../../../../utils/index';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
-test('should construct correct url with common infixes with multiple routers.', async () => {
-  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
-  const event = await env.getEnvelopeRequest({ url: env.url.replace('test', 'api2/v1/test/') });
+afterAll(() => {
+  cleanupChildProcesses();
+});
 
-  assertSentryEvent(event[2] as any, {
-    message: 'Custom Message',
-    transaction: 'GET /api2/v1/test',
-  });
+test('should construct correct url with common infixes with multiple routers.', done => {
+  createRunner(__dirname, 'server.ts')
+    .ignore('transaction', 'session', 'sessions')
+    .expect({ event: { message: 'Custom Message', transaction: 'GET /api2/v1/test' } })
+    .start(done)
+    .makeRequest('get', '/api2/v1/test');
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized-reverse/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized-reverse/server.ts
@@ -1,3 +1,4 @@
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
@@ -11,6 +12,7 @@ Sentry.init({
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
+  transport: loggingTransport,
 });
 
 app.use(Sentry.Handlers.requestHandler());
@@ -32,4 +34,4 @@ app.use('/api', root);
 
 app.use(Sentry.Handlers.errorHandler());
 
-export default app;
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized-reverse/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized-reverse/test.ts
@@ -1,11 +1,13 @@
-import { TestEnv, assertSentryEvent } from '../../../../utils/index';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
-test('should construct correct urls with multiple parameterized routers (use order reversed).', async () => {
-  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
-  const event = await env.getEnvelopeRequest({ url: env.url.replace('test', 'api/v1/user/1234/') });
+afterAll(() => {
+  cleanupChildProcesses();
+});
 
-  assertSentryEvent(event[2] as any, {
-    message: 'Custom Message',
-    transaction: 'GET /api/v1/user/:userId',
-  });
+test('should construct correct urls with multiple parameterized routers (use order reversed).', done => {
+  createRunner(__dirname, 'server.ts')
+    .ignore('transaction', 'session', 'sessions')
+    .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/user/:userId' } })
+    .start(done)
+    .makeRequest('get', '/api/v1/user/1234/');
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized/server.ts
@@ -1,3 +1,4 @@
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
@@ -11,6 +12,7 @@ Sentry.init({
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
+  transport: loggingTransport,
 });
 
 app.use(Sentry.Handlers.requestHandler());
@@ -32,4 +34,4 @@ app.use('/api/v1', APIv1);
 
 app.use(Sentry.Handlers.errorHandler());
 
-export default app;
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized/test.ts
@@ -1,11 +1,13 @@
-import { TestEnv, assertSentryEvent } from '../../../../utils/index';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
-test('should construct correct urls with multiple parameterized routers.', async () => {
-  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
-  const event = await env.getEnvelopeRequest({ url: env.url.replace('test', 'api/v1/user/1234/') });
+afterAll(() => {
+  cleanupChildProcesses();
+});
 
-  assertSentryEvent(event[2] as any, {
-    message: 'Custom Message',
-    transaction: 'GET /api/v1/user/:userId',
-  });
+test('should construct correct urls with multiple parameterized routers.', done => {
+  createRunner(__dirname, 'server.ts')
+    .ignore('transaction', 'session', 'sessions')
+    .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/user/:userId' } })
+    .start(done)
+    .makeRequest('get', '/api/v1/user/1234/');
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized copy/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized copy/server.ts
@@ -1,3 +1,4 @@
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
@@ -11,6 +12,7 @@ Sentry.init({
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
+  transport: loggingTransport,
 });
 
 app.use(Sentry.Handlers.requestHandler());
@@ -32,4 +34,4 @@ app.use('/api', root);
 
 app.use(Sentry.Handlers.errorHandler());
 
-export default app;
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized copy/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized copy/test.ts
@@ -1,11 +1,13 @@
-import { TestEnv, assertSentryEvent } from '../../../../utils/index';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
-test('should construct correct url with multiple parameterized routers of the same length (use order reversed).', async () => {
-  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
-  const event = await env.getEnvelopeRequest({ url: env.url.replace('test', 'api/v1/1234/') });
+afterAll(() => {
+  cleanupChildProcesses();
+});
 
-  assertSentryEvent(event[2] as any, {
-    message: 'Custom Message',
-    transaction: 'GET /api/v1/:userId',
-  });
+test('should construct correct url with multiple parameterized routers of the same length (use order reversed).', done => {
+  createRunner(__dirname, 'server.ts')
+    .ignore('transaction', 'session', 'sessions')
+    .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/:userId' } })
+    .start(done)
+    .makeRequest('get', '/api/v1/1234/');
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized/server.ts
@@ -1,3 +1,4 @@
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
@@ -11,6 +12,7 @@ Sentry.init({
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
+  transport: loggingTransport,
 });
 
 app.use(Sentry.Handlers.requestHandler());
@@ -32,4 +34,4 @@ app.use('/api/v1', APIv1);
 
 app.use(Sentry.Handlers.errorHandler());
 
-export default app;
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized/test.ts
@@ -1,11 +1,13 @@
-import { TestEnv, assertSentryEvent } from '../../../../utils/index';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
-test('should construct correct url with multiple parameterized routers of the same length.', async () => {
-  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
-  const event = await env.getEnvelopeRequest({ url: env.url.replace('test', 'api/v1/1234/') });
+afterAll(() => {
+  cleanupChildProcesses();
+});
 
-  assertSentryEvent(event[2] as any, {
-    message: 'Custom Message',
-    transaction: 'GET /api/v1/:userId',
-  });
+test('should construct correct url with multiple parameterized routers of the same length.', done => {
+  createRunner(__dirname, 'server.ts')
+    .ignore('transaction', 'session', 'sessions')
+    .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/:userId' } })
+    .start(done)
+    .makeRequest('get', '/api/v1/1234/');
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix/server.ts
@@ -1,3 +1,4 @@
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
@@ -11,6 +12,7 @@ Sentry.init({
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
+  transport: loggingTransport,
 });
 
 app.use(Sentry.Handlers.requestHandler());
@@ -32,4 +34,4 @@ app.use('/api/v1', APIv1);
 
 app.use(Sentry.Handlers.errorHandler());
 
-export default app;
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix/test.ts
@@ -1,11 +1,13 @@
-import { TestEnv, assertSentryEvent } from '../../../../utils/index';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
-test('should construct correct urls with multiple routers.', async () => {
-  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
-  const event = await env.getEnvelopeRequest({ url: env.url.replace('test', 'api/v1/test/') });
+afterAll(() => {
+  cleanupChildProcesses();
+});
 
-  assertSentryEvent(event[2] as any, {
-    message: 'Custom Message',
-    transaction: 'GET /api/v1/test',
-  });
+test('should construct correct urls with multiple routers.', done => {
+  createRunner(__dirname, 'server.ts')
+    .ignore('transaction', 'session', 'sessions')
+    .expect({ event: { message: 'Custom Message', transaction: 'GET /api/v1/test' } })
+    .start(done)
+    .makeRequest('get', '/api/v1/test');
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/complex-router/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/complex-router/server.ts
@@ -1,3 +1,4 @@
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import express from 'express';
@@ -10,6 +11,7 @@ Sentry.init({
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
+  transport: loggingTransport,
 });
 
 app.use(Sentry.Handlers.requestHandler());
@@ -32,4 +34,4 @@ app.use('/api/api/v1', APIv1.use('/sub-router', APIv1));
 
 app.use(Sentry.Handlers.errorHandler());
 
-export default app;
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/complex-router/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/complex-router/test.ts
@@ -1,79 +1,84 @@
-import { TestEnv, assertSentryEvent } from '../../../../utils/index';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
-test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route', async () => {
-  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
-  const event = await env.getEnvelopeRequest({
-    url: env.url.replace('test', 'api/api/v1/sub-router/users/123/posts/456'),
-    envelopeType: 'transaction',
-  });
-  // parse node.js major version
-  const [major] = process.versions.node.split('.').map(Number);
-  // Split test result base on major node version because regex d flag is support from node 16+
-  if (major >= 16) {
-    assertSentryEvent(event[2] as any, {
-      transaction: 'GET /api/api/v1/sub-router/users/:userId/posts/:postId',
-      transaction_info: {
-        source: 'route',
-      },
-    });
-  } else {
-    assertSentryEvent(event[2] as any, {
-      transaction: 'GET /api/api/v1/sub-router/users/123/posts/:postId',
-      transaction_info: {
-        source: 'route',
-      },
-    });
-  }
+afterAll(() => {
+  cleanupChildProcesses();
 });
 
-test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route and original url has query params', async () => {
-  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
-  const event = await env.getEnvelopeRequest({
-    url: env.url.replace('test', 'api/api/v1/sub-router/users/123/posts/456?param=1'),
-    envelopeType: 'transaction',
-  });
+test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route', done => {
   // parse node.js major version
   const [major] = process.versions.node.split('.').map(Number);
   // Split test result base on major node version because regex d flag is support from node 16+
-  if (major >= 16) {
-    assertSentryEvent(event[2] as any, {
-      transaction: 'GET /api/api/v1/sub-router/users/:userId/posts/:postId',
-      transaction_info: {
-        source: 'route',
-      },
-    });
-  } else {
-    assertSentryEvent(event[2] as any, {
-      transaction: 'GET /api/api/v1/sub-router/users/123/posts/:postId',
-      transaction_info: {
-        source: 'route',
-      },
-    });
-  }
+
+  const EXPECTED_TRANSACTION =
+    major >= 16
+      ? {
+          transaction: 'GET /api/api/v1/sub-router/users/:userId/posts/:postId',
+          transaction_info: {
+            source: 'route',
+          },
+        }
+      : {
+          transaction: 'GET /api/api/v1/sub-router/users/123/posts/:postId',
+          transaction_info: {
+            source: 'route',
+          },
+        };
+
+  createRunner(__dirname, 'server.ts')
+    .ignore('event', 'session', 'sessions')
+    .expect({ transaction: EXPECTED_TRANSACTION as any })
+    .start(done)
+    .makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456');
 });
 
-test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route and original url ends with trailing slash and has query params', async () => {
-  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
-  const event = await env.getEnvelopeRequest({
-    url: env.url.replace('test', 'api/api/v1/sub-router/users/123/posts/456/?param=1'),
-    envelopeType: 'transaction',
-  });
+test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route and original url has query params', done => {
   // parse node.js major version
   const [major] = process.versions.node.split('.').map(Number);
   // Split test result base on major node version because regex d flag is support from node 16+
-  if (major >= 16) {
-    assertSentryEvent(event[2] as any, {
-      transaction: 'GET /api/api/v1/sub-router/users/:userId/posts/:postId',
-      transaction_info: {
-        source: 'route',
-      },
-    });
-  } else {
-    assertSentryEvent(event[2] as any, {
-      transaction: 'GET /api/api/v1/sub-router/users/123/posts/:postId',
-      transaction_info: {
-        source: 'route',
-      },
-    });
-  }
+  const EXPECTED_TRANSACTION =
+    major >= 16
+      ? {
+          transaction: 'GET /api/api/v1/sub-router/users/:userId/posts/:postId',
+          transaction_info: {
+            source: 'route',
+          },
+        }
+      : {
+          transaction: 'GET /api/api/v1/sub-router/users/123/posts/:postId',
+          transaction_info: {
+            source: 'route',
+          },
+        };
+
+  createRunner(__dirname, 'server.ts')
+    .ignore('event', 'session', 'sessions')
+    .expect({ transaction: EXPECTED_TRANSACTION as any })
+    .start(done)
+    .makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456?param=1');
+});
+
+test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route and express used multiple middlewares with route and original url ends with trailing slash and has query params', done => {
+  // parse node.js major version
+  const [major] = process.versions.node.split('.').map(Number);
+  // Split test result base on major node version because regex d flag is support from node 16+
+  const EXPECTED_TRANSACTION =
+    major >= 16
+      ? {
+          transaction: 'GET /api/api/v1/sub-router/users/:userId/posts/:postId',
+          transaction_info: {
+            source: 'route',
+          },
+        }
+      : {
+          transaction: 'GET /api/api/v1/sub-router/users/123/posts/:postId',
+          transaction_info: {
+            source: 'route',
+          },
+        };
+
+  createRunner(__dirname, 'server.ts')
+    .ignore('event', 'session', 'sessions')
+    .expect({ transaction: EXPECTED_TRANSACTION as any })
+    .start(done)
+    .makeRequest('get', '/api/api/v1/sub-router/users/123/posts/456/?param=1');
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/middle-layer-parameterized/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/middle-layer-parameterized/server.ts
@@ -1,3 +1,4 @@
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import express from 'express';
@@ -10,6 +11,7 @@ Sentry.init({
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
+  transport: loggingTransport,
 });
 
 app.use(Sentry.Handlers.requestHandler());
@@ -32,4 +34,4 @@ app.use('/api', root);
 
 app.use(Sentry.Handlers.errorHandler());
 
-export default app;
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/middle-layer-parameterized/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/middle-layer-parameterized/test.ts
@@ -1,28 +1,31 @@
-import { TestEnv, assertSentryEvent } from '../../../../utils/index';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 
-test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route', async () => {
-  const env = await TestEnv.init(__dirname, `${__dirname}/server.ts`);
-  const event = await env.getEnvelopeRequest({
-    url: env.url.replace('test', 'api/v1/users/123/posts/456'),
-    envelopeType: 'transaction',
-  });
+afterAll(() => {
+  cleanupChildProcesses();
+});
 
+test('should construct correct url with multiple parameterized routers, when param is also contain in middle layer route', done => {
   // parse node.js major version
   const [major] = process.versions.node.split('.').map(Number);
   // Split test result base on major node version because regex d flag is support from node 16+
-  if (major >= 16) {
-    assertSentryEvent(event[2] as any, {
-      transaction: 'GET /api/v1/users/:userId/posts/:postId',
-      transaction_info: {
-        source: 'route',
-      },
-    });
-  } else {
-    assertSentryEvent(event[2] as any, {
-      transaction: 'GET /api/v1/users/123/posts/:postId',
-      transaction_info: {
-        source: 'route',
-      },
-    });
-  }
+  const EXPECTED_TRANSACTION =
+    major >= 16
+      ? {
+          transaction: 'GET /api/v1/users/:userId/posts/:postId',
+          transaction_info: {
+            source: 'route',
+          },
+        }
+      : {
+          transaction: 'GET /api/v1/users/123/posts/:postId',
+          transaction_info: {
+            source: 'route',
+          },
+        };
+
+  createRunner(__dirname, 'server.ts')
+    .ignore('event', 'session', 'sessions')
+    .expect({ transaction: EXPECTED_TRANSACTION as any })
+    .start(done)
+    .makeRequest('get', '/api/v1/users/123/posts/456');
 });

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/server.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
@@ -16,6 +17,7 @@ Sentry.init({
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
+  transport: loggingTransport,
 });
 
 Sentry.setUser({ id: 'user123', segment: 'SegmentA' });
@@ -40,4 +42,4 @@ app.get('/test/express', (_req, res) => {
 
 app.use(Sentry.Handlers.errorHandler());
 
-export default app;
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/test.ts
@@ -1,12 +1,14 @@
-import * as path from 'path';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
+import type { TestAPIResponse } from './server';
 
-import { TestEnv } from '../../../../utils/index';
-import type { TestAPIResponse } from '../server';
+afterAll(() => {
+  cleanupChildProcesses();
+});
 
-test('should attach a `baggage` header to an outgoing request.', async () => {
-  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+test('should attach a baggage header to an outgoing request.', async () => {
+  const runner = createRunner(__dirname, 'server.ts').start();
 
-  const response = (await env.getAPIResponse(`${env.url}/express`)) as TestAPIResponse;
+  const response = await runner.makeRequest<TestAPIResponse>('get', '/test/express');
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/server.ts
@@ -1,4 +1,5 @@
-import http from 'http';
+import * as http from 'http';
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
@@ -17,6 +18,7 @@ Sentry.init({
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
+  transport: loggingTransport,
 });
 
 app.use(Sentry.Handlers.requestHandler());
@@ -42,4 +44,4 @@ app.get('/test/express', (_req, res) => {
 
 app.use(Sentry.Handlers.errorHandler());
 
-export default app;
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/test.ts
@@ -1,15 +1,17 @@
-import * as path from 'path';
-
-import { TestEnv } from '../../../../utils/index';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from '../server';
 
-test('should ignore sentry-values in `baggage` header of a third party vendor and overwrite them with incoming DSC', async () => {
-  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+afterAll(() => {
+  cleanupChildProcesses();
+});
 
-  const response = (await env.getAPIResponse(`${env.url}/express`, {
+test('should ignore sentry-values in `baggage` header of a third party vendor and overwrite them with incoming DSC', async () => {
+  const runner = createRunner(__dirname, 'server.ts').start();
+
+  const response = await runner.makeRequest<TestAPIResponse>('get', '/test/express', {
     'sentry-trace': '',
     baggage: 'sentry-release=2.1.0,sentry-environment=myEnv',
-  })) as TestAPIResponse;
+  });
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
@@ -24,9 +26,9 @@ test('should ignore sentry-values in `baggage` header of a third party vendor an
 });
 
 test('should ignore sentry-values in `baggage` header of a third party vendor and overwrite them with new DSC', async () => {
-  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const runner = createRunner(__dirname, 'server.ts').start();
 
-  const response = (await env.getAPIResponse(`${env.url}/express`, {})) as TestAPIResponse;
+  const response = await runner.makeRequest<TestAPIResponse>('get', '/test/express');
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/server.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
@@ -17,6 +18,7 @@ Sentry.init({
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
+  transport: loggingTransport,
 });
 
 app.use(Sentry.Handlers.requestHandler());
@@ -36,4 +38,4 @@ app.get('/test/express', (_req, res) => {
 
 app.use(Sentry.Handlers.errorHandler());
 
-export default app;
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/test.ts
@@ -1,15 +1,17 @@
-import * as path from 'path';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
+import type { TestAPIResponse } from './server';
 
-import { TestEnv } from '../../../../utils/index';
-import type { TestAPIResponse } from '../server';
+afterAll(() => {
+  cleanupChildProcesses();
+});
 
 test('should merge `baggage` header of a third party vendor with the Sentry DSC baggage items', async () => {
-  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+  const runner = createRunner(__dirname, 'server.ts').start();
 
-  const response = (await env.getAPIResponse(`${env.url}/express`, {
+  const response = await runner.makeRequest<TestAPIResponse>('get', '/test/express', {
     'sentry-trace': '',
     baggage: 'sentry-release=2.0.0,sentry-environment=myEnv',
-  })) as TestAPIResponse;
+  });
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/server.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
@@ -20,6 +21,7 @@ Sentry.init({
   tracesSampleRate: 1.0,
   // TODO: We're rethinking the mechanism for including Pii data in DSC, hence commenting out sendDefaultPii for now
   // sendDefaultPii: true,
+  transport: loggingTransport,
 });
 
 Sentry.setUser({ id: 'user123', segment: 'SegmentA' });
@@ -45,4 +47,4 @@ app.get('/test/express', (_req, res) => {
 
 app.use(Sentry.Handlers.errorHandler());
 
-export default app;
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/test.ts
@@ -1,12 +1,14 @@
-import * as path from 'path';
-
-import { TestEnv } from '../../../../utils/index';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from '../server';
 
-test('Includes transaction in baggage if the transaction name is parameterized', async () => {
-  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '.')}/server.ts`);
+afterAll(() => {
+  cleanupChildProcesses();
+});
 
-  const response = (await env.getAPIResponse(`${env.url}/express`)) as TestAPIResponse;
+test('Includes transaction in baggage if the transaction name is parameterized', async () => {
+  const runner = createRunner(__dirname, 'server.ts').start();
+
+  const response = await runner.makeRequest<TestAPIResponse>('get', '/test/express');
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/server.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
@@ -16,6 +17,7 @@ Sentry.init({
   // eslint-disable-next-line deprecation/deprecation
   integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
+  transport: loggingTransport,
 });
 
 app.use(Sentry.Handlers.requestHandler());
@@ -32,4 +34,4 @@ app.get('/test/express', (_req, res) => {
 
 app.use(Sentry.Handlers.errorHandler());
 
-export default app;
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/trace-header-assign/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/trace-header-assign/test.ts
@@ -1,15 +1,17 @@
-import * as path from 'path';
 import { TRACEPARENT_REGEXP } from '@sentry/utils';
-
-import { TestEnv } from '../../../../utils/index';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from '../server';
 
-test('Should assign `sentry-trace` header which sets parent trace id of an outgoing request.', async () => {
-  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+afterAll(() => {
+  cleanupChildProcesses();
+});
 
-  const response = (await env.getAPIResponse(`${env.url}/express`, {
+test('Should assign `sentry-trace` header which sets parent trace id of an outgoing request.', async () => {
+  const runner = createRunner(__dirname, '..', 'server.ts').start();
+
+  const response = await runner.makeRequest<TestAPIResponse>('get', '/test/express', {
     'sentry-trace': '12312012123120121231201212312012-1121201211212012-0',
-  })) as TestAPIResponse;
+  });
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
@@ -19,5 +21,5 @@ test('Should assign `sentry-trace` header which sets parent trace id of an outgo
     },
   });
 
-  expect(TRACEPARENT_REGEXP.test(response.test_data['sentry-trace'])).toBe(true);
+  expect(TRACEPARENT_REGEXP.test(response?.test_data['sentry-trace'] || '')).toBe(true);
 });

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/trace-header-out/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/trace-header-out/test.ts
@@ -1,13 +1,15 @@
-import * as path from 'path';
 import { TRACEPARENT_REGEXP } from '@sentry/utils';
-
-import { TestEnv } from '../../../../utils/index';
+import { cleanupChildProcesses, createRunner } from '../../../../utils/runner';
 import type { TestAPIResponse } from '../server';
 
-test('should attach a `sentry-trace` header to an outgoing request.', async () => {
-  const env = await TestEnv.init(__dirname, `${path.resolve(__dirname, '..')}/server.ts`);
+afterAll(() => {
+  cleanupChildProcesses();
+});
 
-  const response = (await env.getAPIResponse(`${env.url}/express`)) as TestAPIResponse;
+test('should attach a `sentry-trace` header to an outgoing request.', async () => {
+  const runner = createRunner(__dirname, '..', 'server.ts').start();
+
+  const response = await runner.makeRequest<TestAPIResponse>('get', '/test/express');
 
   expect(response).toBeDefined();
   expect(response).toMatchObject({
@@ -17,5 +19,5 @@ test('should attach a `sentry-trace` header to an outgoing request.', async () =
     },
   });
 
-  expect(TRACEPARENT_REGEXP.test(response.test_data['sentry-trace'])).toBe(true);
+  expect(TRACEPARENT_REGEXP.test(response?.test_data['sentry-trace'] || '')).toBe(true);
 });

--- a/dev-packages/node-integration-tests/suites/express/tracing-experimental/server.js
+++ b/dev-packages/node-integration-tests/suites/express/tracing-experimental/server.js
@@ -1,0 +1,41 @@
+const { loggingTransport, startExpressServerAndSendPortToRunner } = require('@sentry-internal/node-integration-tests');
+const Sentry = require('@sentry/node-experimental');
+const cors = require('cors');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  // disable attaching headers to /test/* endpoints
+  tracePropagationTargets: [/^(?!.*test).*$/],
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+});
+
+// express must be required after Sentry is initialized
+const express = require('express');
+
+const app = express();
+
+app.use(Sentry.Handlers.requestHandler());
+
+app.use(cors());
+
+app.get('/test/express', (_req, res) => {
+  res.send({ response: 'response 1' });
+});
+
+app.get(/\/test\/regex/, (_req, res) => {
+  res.send({ response: 'response 2' });
+});
+
+app.get(['/test/array1', /\/test\/array[2-9]/], (_req, res) => {
+  res.send({ response: 'response 3' });
+});
+
+app.get(['/test/arr/:id', /\/test\/arr[0-9]*\/required(path)?(\/optionalPath)?\/(lastParam)?/], (_req, res) => {
+  res.send({ response: 'response 4' });
+});
+
+app.use(Sentry.Handlers.errorHandler());
+
+startExpressServerAndSendPortToRunner(app);

--- a/dev-packages/node-integration-tests/suites/express/tracing-experimental/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing-experimental/test.ts
@@ -1,0 +1,147 @@
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+
+describe('express tracing experimental', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
+  describe('CJS', () => {
+    test('should create and send transactions for Express routes and spans for middlewares.', done => {
+      createRunner(__dirname, 'server.js')
+        .ignore('session', 'sessions')
+        .expect({
+          transaction: {
+            contexts: {
+              trace: {
+                span_id: expect.any(String),
+                trace_id: expect.any(String),
+                data: {
+                  url: expect.stringMatching(/\/test\/express$/),
+                  'http.response.status_code': 200,
+                },
+                op: 'http.server',
+                status: 'ok',
+                tags: {
+                  'http.status_code': 200,
+                },
+              },
+            },
+            spans: expect.arrayContaining([
+              expect.objectContaining({
+                data: expect.objectContaining({
+                  'express.name': 'corsMiddleware',
+                  'express.type': 'middleware',
+                }),
+                description: 'middleware - corsMiddleware',
+                origin: 'auto.http.otel.express',
+              }),
+            ]),
+          },
+        })
+        .start(done)
+        .makeRequest('get', '/test/express');
+    });
+
+    test('should set a correct transaction name for routes specified in RegEx', done => {
+      createRunner(__dirname, 'server.js')
+        .ignore('session', 'sessions')
+        .expect({
+          transaction: {
+            transaction: 'GET /',
+            transaction_info: {
+              source: 'route',
+            },
+            contexts: {
+              trace: {
+                trace_id: expect.any(String),
+                span_id: expect.any(String),
+                data: {
+                  url: expect.stringMatching(/\/test\/regex$/),
+                  'http.response.status_code': 200,
+                },
+                op: 'http.server',
+                status: 'ok',
+                tags: {
+                  'http.status_code': 200,
+                },
+              },
+            },
+          },
+        })
+        .start(done)
+        .makeRequest('get', '/test/regex');
+    });
+
+    test.each([['array1'], ['array5']])(
+      'should set a correct transaction name for routes consisting of arrays of routes',
+      ((segment: string, done: () => void) => {
+        createRunner(__dirname, 'server.js')
+          .ignore('session', 'sessions')
+          .expect({
+            transaction: {
+              transaction: 'GET /',
+              transaction_info: {
+                source: 'route',
+              },
+              contexts: {
+                trace: {
+                  trace_id: expect.any(String),
+                  span_id: expect.any(String),
+                  data: {
+                    url: expect.stringMatching(`/test/${segment}$`),
+                    'http.response.status_code': 200,
+                  },
+                  op: 'http.server',
+                  status: 'ok',
+                  tags: {
+                    'http.status_code': 200,
+                  },
+                },
+              },
+            },
+          })
+          .start(done)
+          .makeRequest('get', `/test/${segment}`);
+      }) as any,
+    );
+
+    test.each([
+      ['arr/545'],
+      ['arr/required'],
+      ['arr/required'],
+      ['arr/requiredPath'],
+      ['arr/required/lastParam'],
+      ['arr55/required/lastParam'],
+      ['arr/requiredPath/optionalPath/'],
+      ['arr/requiredPath/optionalPath/lastParam'],
+    ])('should handle more complex regexes in route arrays correctly', ((segment: string, done: () => void) => {
+      createRunner(__dirname, 'server.js')
+        .ignore('session', 'sessions')
+        .expect({
+          transaction: {
+            transaction: 'GET /',
+            transaction_info: {
+              source: 'route',
+            },
+            contexts: {
+              trace: {
+                trace_id: expect.any(String),
+                span_id: expect.any(String),
+                data: {
+                  url: expect.stringMatching(`/test/${segment}$`),
+                  'http.response.status_code': 200,
+                },
+                op: 'http.server',
+                status: 'ok',
+                tags: {
+                  'http.status_code': 200,
+                },
+              },
+            },
+          },
+        })
+        .start(done)
+        .makeRequest('get', `/test/${segment}`);
+    }) as any);
+  });
+});

--- a/dev-packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/test.ts
@@ -1,7 +1,12 @@
-import { createRunner } from '../../../utils/runner';
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+
+afterAll(() => {
+  cleanupChildProcesses();
+});
 
 test('should create and send transactions for Express routes and spans for middlewares.', done => {
   createRunner(__dirname, 'server.ts')
+    .ignore('session', 'sessions')
     .expect({
       transaction: {
         contexts: {
@@ -33,6 +38,7 @@ test('should create and send transactions for Express routes and spans for middl
 
 test('should set a correct transaction name for routes specified in RegEx', done => {
   createRunner(__dirname, 'server.ts')
+    .ignore('session', 'sessions')
     .expect({
       transaction: {
         transaction: 'GET /\\/test\\/regex/',
@@ -64,6 +70,7 @@ test.each([['array1'], ['array5']])(
   'should set a correct transaction name for routes consisting of arrays of routes',
   ((segment: string, done: () => void) => {
     createRunner(__dirname, 'server.ts')
+      .ignore('session', 'sessions')
       .expect({
         transaction: {
           transaction: 'GET /test/array1,/\\/test\\/array[2-9]',
@@ -103,6 +110,7 @@ test.each([
   ['arr/requiredPath/optionalPath/lastParam'],
 ])('should handle more complex regexes in route arrays correctly', ((segment: string, done: () => void) => {
   createRunner(__dirname, 'server.ts')
+    .ignore('session', 'sessions')
     .expect({
       transaction: {
         transaction: 'GET /test/arr/:id,/\\/test\\/arr[0-9]*\\/required(path)?(\\/optionalPath)?\\/(lastParam)?',

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/test.ts
@@ -1,7 +1,7 @@
 import * as childProcess from 'child_process';
 import * as path from 'path';
 import { conditionalTest } from '../../../utils';
-import { createRunner } from '../../../utils/runner';
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
 
 const EXPECTED_LOCAL_VARIABLES_EVENT = {
   exception: {
@@ -30,6 +30,10 @@ const EXPECTED_LOCAL_VARIABLES_EVENT = {
 };
 
 conditionalTest({ min: 18 })('LocalVariables integration', () => {
+  afterAll(() => {
+    cleanupChildProcesses();
+  });
+
   test('Should not include local variables by default', done => {
     createRunner(__dirname, 'no-local-variables.js')
       .ignore('session')


### PR DESCRIPTION
- Adds CJS integration tests for express for `@sentry/node-experimental`
  - I found some differences with the transactions vs the Sentry instrumentation (#10168)
- Converts all the existing express tests to use the new runner 
  - These are the only tests that dont appear to like the jest runner
- Added a `cleanupChildProcesses()` method to the runner than should be called in the `afterAll` hook to ensure no processes are left open/leaked 

I haven't managed to get otel ESM express auto instrumentation to work yet...