### PR TITLE
fix(node-experimental): Ensure `http.status_code` is always a string

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-experimental-fastify-app/tests/propagation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-experimental-fastify-app/tests/propagation.test.ts
@@ -68,7 +68,7 @@ test('Propagates trace for outgoing http requests', async ({ baseURL }) => {
           span_id: expect.any(String),
           status: 'ok',
           tags: {
-            'http.status_code': 200,
+            'http.status_code': '200',
           },
           trace_id: traceId,
           origin: 'auto.http.otel.http',
@@ -91,7 +91,7 @@ test('Propagates trace for outgoing http requests', async ({ baseURL }) => {
           span_id: expect.any(String),
           status: 'ok',
           tags: {
-            'http.status_code': 200,
+            'http.status_code': '200',
           },
           trace_id: traceId,
           origin: 'auto.http.otel.http',
@@ -161,7 +161,7 @@ test('Propagates trace for outgoing fetch requests', async ({ baseURL }) => {
           span_id: expect.any(String),
           status: 'ok',
           tags: {
-            'http.status_code': 200,
+            'http.status_code': '200',
           },
           trace_id: traceId,
           origin: 'auto.http.otel.http',
@@ -184,7 +184,7 @@ test('Propagates trace for outgoing fetch requests', async ({ baseURL }) => {
           span_id: expect.any(String),
           status: 'ok',
           tags: {
-            'http.status_code': 200,
+            'http.status_code': '200',
           },
           trace_id: traceId,
           origin: 'auto.http.otel.http',

--- a/dev-packages/e2e-tests/test-applications/node-experimental-fastify-app/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/node-experimental-fastify-app/tests/transactions.test.ts
@@ -33,7 +33,7 @@ test('Sends an API route transaction', async ({ baseURL }) => {
           span_id: expect.any(String),
           status: 'ok',
           tags: {
-            'http.status_code': 200,
+            'http.status_code': '200',
           },
           trace_id: expect.any(String),
           origin: 'auto.http.otel.http',
@@ -85,7 +85,7 @@ test('Sends an API route transaction', async ({ baseURL }) => {
         },
       ],
       tags: {
-        'http.status_code': 200,
+        'http.status_code': '200',
       },
       transaction: 'GET /test-transaction',
       type: 'transaction',

--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -280,9 +280,8 @@ function getTags(span: ReadableSpan): Record<string, string> {
   const tags: Record<string, string> = {};
 
   if (attributes[SemanticAttributes.HTTP_STATUS_CODE]) {
-    const statusCode = attributes[SemanticAttributes.HTTP_STATUS_CODE] as string;
-
-    tags['http.status_code'] = statusCode;
+    const statusCode = attributes[SemanticAttributes.HTTP_STATUS_CODE] as string | number;
+    tags['http.status_code'] = `${statusCode}`;
   }
 
   return tags;


### PR DESCRIPTION
Noticed here: https://github.com/getsentry/sentry-javascript/issues/10168, tags should always be strings.