### PR TITLE
feat(integrations): Deprecate `Transaction` integration

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,6 +10,11 @@ npx @sentry/migr8@latest
 This will let you select which updates to run, and automatically update your code. Make sure to still review all code
 changes!
 
+## Deprecated `Transaction` integration
+
+This pluggable integration from `@sentry/integrations` will be removed in v8. It was already undocumented and is not
+necessary for the SDK to work as expected.
+
 ## Changed integration interface
 
 In v8, integrations passed to a client will have an optional `setupOnce()` hook. Currently, this hook is always present,

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -7,6 +7,7 @@ export { Offline } from './offline';
 export { ReportingObserver } from './reportingobserver';
 export { RewriteFrames } from './rewriteframes';
 export { SessionTiming } from './sessiontiming';
+// eslint-disable-next-line deprecation/deprecation
 export { Transaction } from './transaction';
 export { HttpClient } from './httpclient';
 export { ContextLines } from './contextlines';

--- a/packages/integrations/src/transaction.ts
+++ b/packages/integrations/src/transaction.ts
@@ -26,7 +26,10 @@ const transactionIntegration = (() => {
   };
 }) satisfies IntegrationFn;
 
-/** Add node transaction to the event */
+/**
+ * Add node transaction to the event.
+ * @deprecated This integration will be removed in v8.
+ */
 // eslint-disable-next-line deprecation/deprecation
 export const Transaction = convertIntegrationFnToClass(INTEGRATION_NAME, transactionIntegration);
 

--- a/packages/integrations/test/transaction.test.ts
+++ b/packages/integrations/test/transaction.test.ts
@@ -1,5 +1,6 @@
 import { Transaction } from '../src/transaction';
 
+// eslint-disable-next-line deprecation/deprecation
 const transaction = new Transaction();
 
 describe('Transaction', () => {


### PR DESCRIPTION
This was not really documented anywhere anymore, and it's not clear what/when/why you would be using this, so we will remove this in v8.