### PR TITLE
feat(core): Deprecate `Transaction.setMeasurement` in favor of `setMeasurement`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -160,6 +160,8 @@ In v8, the Span class is heavily reworked. The following properties & methods ar
 - `transaction.setMetadata()`: Use attributes instead, or set data on the scope.
 - `transaction.metadata`: Use attributes instead, or set data on the scope.
 - `transaction.setContext()`: Set context on the surrounding scope instead.
+- `transaction.setMeasurement()`: Use `Sentry.setMeasurement()` instead. In v8, setting measurements will be limited to
+  the currently active root span.
 - `transaction.setName()`: Set the name with `.updateName()` and the source with `.setAttribute()` instead.
 
 ## Deprecate `pushScope` & `popScope` in favor of `withScope`

--- a/packages/core/src/tracing/measurement.ts
+++ b/packages/core/src/tracing/measurement.ts
@@ -9,6 +9,7 @@ export function setMeasurement(name: string, value: number, unit: MeasurementUni
   // eslint-disable-next-line deprecation/deprecation
   const transaction = getActiveTransaction();
   if (transaction) {
+    // eslint-disable-next-line deprecation/deprecation
     transaction.setMeasurement(name, value, unit);
   }
 }

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -176,6 +176,8 @@ export class Transaction extends SpanClass implements TransactionInterface {
 
   /**
    * @inheritDoc
+   *
+   * @deprecated Use top-level `setMeasurement()` instead.
    */
   public setMeasurement(name: string, value: number, unit: MeasurementUnit = ''): void {
     this._measurements[name] = { value, unit };

--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import type { IdleTransaction, Transaction } from '@sentry/core';
-import { getActiveTransaction } from '@sentry/core';
+import { getActiveTransaction, setMeasurement } from '@sentry/core';
 import type { Measurements, SpanContext } from '@sentry/types';
 import { browserPerformanceTimeOrigin, getComponentName, htmlTreeAsString, logger } from '@sentry/utils';
 
@@ -296,11 +296,7 @@ export function addPerformanceEntries(transaction: Transaction): void {
     }
 
     Object.keys(_measurements).forEach(measurementName => {
-      transaction.setMeasurement(
-        measurementName,
-        _measurements[measurementName].value,
-        _measurements[measurementName].unit,
-      );
+      setMeasurement(measurementName, _measurements[measurementName].value, _measurements[measurementName].unit);
     });
 
     _tagMetricInfo(transaction);

--- a/packages/types/src/transaction.ts
+++ b/packages/types/src/transaction.ts
@@ -123,6 +123,8 @@ export interface Transaction extends TransactionContext, Omit<Span, 'setName' | 
    * @param name Name of the measurement
    * @param value Value of the measurement
    * @param unit Unit of the measurement. (Defaults to an empty string)
+   *
+   * @deprecated Use top-level `setMeasurement()` instead.
    */
   setMeasurement(name: string, value: number, unit: MeasurementUnit): void;
 


### PR DESCRIPTION
This PR deprecates the `setMeasurement` API on the transaction interface and class. It's replaced by an already existing top level `setMeasurement` function. 

The actual replacement behaviour is TBD for v8 but for now we need to deprecate this method as it's not part of the Otel API. 