### PR TITLE
ref(core): Add missing class field deprecations

### DIFF
--- a/packages/core/src/tracing/span.ts
+++ b/packages/core/src/tracing/span.ts
@@ -454,7 +454,7 @@ export class Span implements SpanInterface {
   /**
    * @inheritDoc
    *
-   * @deprecated Use `toJSON()` or access the fields directly instead.
+   * @deprecated Use `spanToJSON()` or access the fields directly instead.
    */
   public toContext(): SpanContext {
     return dropUndefinedKeys({

--- a/packages/core/src/tracing/span.ts
+++ b/packages/core/src/tracing/span.ts
@@ -444,6 +444,8 @@ export class Span implements SpanInterface {
 
   /**
    * @inheritDoc
+   *
+   * @deprecated Use `spanToTraceHeader()` instead.
    */
   public toTraceparent(): string {
     return spanToTraceHeader(this);
@@ -451,6 +453,8 @@ export class Span implements SpanInterface {
 
   /**
    * @inheritDoc
+   *
+   * @deprecated Use `toJSON()` or access the fields directly instead.
    */
   public toContext(): SpanContext {
     return dropUndefinedKeys({
@@ -471,6 +475,8 @@ export class Span implements SpanInterface {
 
   /**
    * @inheritDoc
+   *
+   * @deprecated Update the fields directly instead.
    */
   public updateWithContext(spanContext: SpanContext): this {
     // eslint-disable-next-line deprecation/deprecation
@@ -493,6 +499,8 @@ export class Span implements SpanInterface {
 
   /**
    * @inheritDoc
+   *
+   * @deprecated Use `spanToTraceContext()` util function instead.
    */
   public getTraceContext(): TraceContext {
     return spanToTraceContext(this);


### PR DESCRIPTION
This PR adds some `@deprecated` annotations to already deprecated Span APIs:

* `Span.toTraceParent()`
* `Span.toContext()`
* `Span.updateWithContext()`
* `Span.getTraceContext()`

These fields were already deprecated on the interface, this patch only adds the deprecation annotation to the JSDoc of the class fields.
When testing with eslint, it will correctly infer the deprecation status from the interface. VSCode also shows the fields as deprecated in the JSDoc but doesn't apply the strikethrough. So for extra clarity, let's also deprecate the class fields here.

ref #10184 
