### PR TITLE
fix(cdn): Emit console warning instead of error for integration shims

### DIFF
--- a/packages/integration-shims/src/BrowserTracing.ts
+++ b/packages/integration-shims/src/BrowserTracing.ts
@@ -23,7 +23,7 @@ class BrowserTracingShim implements Integration {
 
     consoleSandbox(() => {
       // eslint-disable-next-line no-console
-      console.error('You are using new BrowserTracing() even though this bundle does not include tracing.');
+      console.warn('You are using new BrowserTracing() even though this bundle does not include tracing.');
     });
   }
 

--- a/packages/integration-shims/src/Feedback.ts
+++ b/packages/integration-shims/src/Feedback.ts
@@ -23,7 +23,7 @@ class FeedbackShim implements Integration {
 
     consoleSandbox(() => {
       // eslint-disable-next-line no-console
-      console.error('You are using new Feedback() even though this bundle does not include Feedback.');
+      console.warn('You are using new Feedback() even though this bundle does not include Feedback.');
     });
   }
 

--- a/packages/integration-shims/src/Replay.ts
+++ b/packages/integration-shims/src/Replay.ts
@@ -23,7 +23,7 @@ class ReplayShim implements Integration {
 
     consoleSandbox(() => {
       // eslint-disable-next-line no-console
-      console.error('You are using new Replay() even though this bundle does not include replay.');
+      console.warn('You are using new Replay() even though this bundle does not include replay.');
     });
   }
 


### PR DESCRIPTION
This is a bit less "in your face" which is probably more appropriate here - it is not really an error, we just want to let the user know that the integration is not doing anything.

fixes https://github.com/getsentry/sentry/issues/63085