### PR TITLE
feat(core): Add `withActiveSpan`

### DIFF
--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -17,6 +17,7 @@ import type {
   SessionContext,
   Severity,
   SeverityLevel,
+  Span,
   TransactionContext,
   User,
 } from '@sentry/types';
@@ -226,6 +227,21 @@ export function withScope<T>(
 export function withIsolationScope<T>(callback: (isolationScope: Scope) => T): T {
   return runWithAsyncContext(() => {
     return callback(getIsolationScope());
+  });
+}
+
+/**
+ * Forks the current scope and sets the provided span as active span in the context of the provided callback.
+ *
+ * @param span Spans started in the context of the provided callback will be children of this span.
+ * @param callback Execution context in which the provided span will be active. Is passed the newly forked scope.
+ * @returns the value returned from the provided callback function.
+ */
+export function withActiveSpan<T>(span: Span, callback: (scope: Scope) => T): T {
+  return withScope(scope => {
+    // eslint-disable-next-line deprecation/deprecation
+    scope.setSpan(span);
+    return callback(scope);
   });
 }
 

--- a/packages/core/test/lib/scope.test.ts
+++ b/packages/core/test/lib/scope.test.ts
@@ -1,6 +1,20 @@
 import type { Attachment, Breadcrumb, Client, Event } from '@sentry/types';
-import { applyScopeDataToEvent, getCurrentScope, getIsolationScope, withIsolationScope } from '../../src';
+import {
+  Hub,
+  addTracingExtensions,
+  applyScopeDataToEvent,
+  getActiveSpan,
+  getCurrentScope,
+  getIsolationScope,
+  makeMain,
+  startInactiveSpan,
+  startSpan,
+  withIsolationScope,
+} from '../../src';
+
+import { withActiveSpan } from '../../src/exports';
 import { Scope, getGlobalScope, setGlobalScope } from '../../src/scope';
+import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
 
 describe('Scope', () => {
   beforeEach(() => {
@@ -499,6 +513,43 @@ describe('isolation scope', () => {
           expect(getIsolationScope()).toBe(scope2);
           done();
         });
+      });
+    });
+  });
+});
+
+describe('withActiveSpan()', () => {
+  beforeAll(() => {
+    addTracingExtensions();
+  });
+
+  beforeEach(() => {
+    const options = getDefaultTestClientOptions({ enableTracing: true });
+    const client = new TestClient(options);
+    const scope = new Scope();
+    const hub = new Hub(client, scope);
+    makeMain(hub);
+  });
+
+  it('should set the active span within the callback', () => {
+    expect.assertions(2);
+    const inactiveSpan = startInactiveSpan({ name: 'inactive-span' });
+
+    expect(getActiveSpan()).not.toBe(inactiveSpan);
+
+    withActiveSpan(inactiveSpan!, () => {
+      expect(getActiveSpan()).toBe(inactiveSpan);
+    });
+  });
+
+  it('should create child spans when calling startSpan within the callback', done => {
+    expect.assertions(1);
+    const inactiveSpan = startInactiveSpan({ name: 'inactive-span' });
+
+    withActiveSpan(inactiveSpan!, () => {
+      startSpan({ name: 'child-span' }, childSpan => {
+        expect(childSpan?.parentSpanId).toBe(inactiveSpan?.spanContext().spanId);
+        done();
       });
     });
   });


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry-javascript/pull/10194

Adds withActiveSpan to the core package that will fork the current scope and set the provided span as active within the provided callback. Any startSpan calls within the callback will have the provided span as a child span.

We need this in situations where we need to pick up and create children for spans from a different execution context.