### PR TITLE
chore(core): Mark `Span.getSpanJSON` method as internal

### DIFF
--- a/packages/core/src/tracing/span.ts
+++ b/packages/core/src/tracing/span.ts
@@ -508,6 +508,11 @@ export class Span implements SpanInterface {
 
   /**
    * Get JSON representation of this span.
+   *
+   * @hidden
+   * @internal This method is purely for internal purposes and should not be used outside
+   * of SDK code. If you need to get a JSON representation of a span,
+   * use `spanToJSON(span)` instead.
    */
   public getSpanJSON(): SpanJSON {
     return dropUndefinedKeys({


### PR DESCRIPTION
This small PR just clarifies the API status of the `Span.getSpanJSON` method. This method is purely purposed for internal usage and users should not rely on it but instead on `spanToJSON`.

Why should it stay on the `Span` _class_ anyway?
- The alternative would be to access private properties of `Span` class instances externally, which isn't clean or particularly safe either.
- Given above, we'd need to exclude all private property names from being mangled by Terser when we build our CDN bundles. Which also opens us up to potential errors in the future where we'd add private fields but forget to add the mangling exclusion.

I originally intended to deprecate this method but after discussing this, we decided to just clarify the internal purpose instead. The way we use this function right now is pretty safe, compared to the alternative mentioned above.

ref #10184 