### PR TITLE
fix(tracing-internal): Only collect request/response spans when browser performance timing is available

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/app/very-slow-component/page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/app/very-slow-component/page.tsx
@@ -1,0 +1,6 @@
+export const dynamic = 'force-dynamic';
+
+export default async function SuperSlowPage() {
+  await new Promise(resolve => setTimeout(resolve, 10000));
+  return null;
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/transactions.test.ts
@@ -139,3 +139,20 @@ test('Should send a transaction for instrumented server actions', async ({ page 
 
   expect(Object.keys((await serverComponentTransactionPromise).request?.headers || {}).length).toBeGreaterThan(0);
 });
+
+test('Will not include spans in pageload transaction with faulty timestamps for slow loading pages', async ({
+  page,
+}) => {
+  const pageloadTransactionEventPromise = waitForTransaction('nextjs-13-app-dir', transactionEvent => {
+    return (
+      transactionEvent?.contexts?.trace?.op === 'pageload' && transactionEvent?.transaction === '/very-slow-component'
+    );
+  });
+
+  await page.goto('/very-slow-component');
+
+  const pageLoadTransaction = await pageloadTransactionEventPromise;
+
+  // @ts-expect-error We are looking at the serialized span format here
+  expect(pageLoadTransaction.spans?.filter(span => span.timestamp < span.start_timestamp)).toHaveLength(0);
+});

--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -369,21 +369,27 @@ function _addPerformanceNavigationTiming(
 /** Create request and response related spans */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function _addRequest(transaction: Transaction, entry: Record<string, any>, timeOrigin: number): void {
-  _startChild(transaction, {
-    op: 'browser',
-    origin: 'auto.browser.browser.metrics',
-    description: 'request',
-    startTimestamp: timeOrigin + msToSec(entry.requestStart as number),
-    endTimestamp: timeOrigin + msToSec(entry.responseEnd as number),
-  });
+  // It is possible that we are collecting these metrics when the page hasn't finished loading yet, for example when the HTML slowly streams in.
+  // In this case, ie. when the document request hasn't finished yet, `entry.responseEnd` will be 0.
+  // In order not to produce faulty spans, where the end timestamp is before the start timestamp, we will only collect
+  // these spans when the responseEnd value is available. Relay would drop the entire transaction if it contained faulty spans.
+  if (entry.responseEnd !== 0) {
+    _startChild(transaction, {
+      op: 'browser',
+      origin: 'auto.browser.browser.metrics',
+      description: 'request',
+      startTimestamp: timeOrigin + msToSec(entry.requestStart as number),
+      endTimestamp: timeOrigin + msToSec(entry.responseEnd as number),
+    });
 
-  _startChild(transaction, {
-    op: 'browser',
-    origin: 'auto.browser.browser.metrics',
-    description: 'response',
-    startTimestamp: timeOrigin + msToSec(entry.responseStart as number),
-    endTimestamp: timeOrigin + msToSec(entry.responseEnd as number),
-  });
+    _startChild(transaction, {
+      op: 'browser',
+      origin: 'auto.browser.browser.metrics',
+      description: 'response',
+      startTimestamp: timeOrigin + msToSec(entry.responseStart as number),
+      endTimestamp: timeOrigin + msToSec(entry.responseEnd as number),
+    });
+  }
 }
 
 export interface ResourceEntry extends Record<string, unknown> {

--- a/packages/tracing-internal/src/browser/metrics/index.ts
+++ b/packages/tracing-internal/src/browser/metrics/index.ts
@@ -369,11 +369,11 @@ function _addPerformanceNavigationTiming(
 /** Create request and response related spans */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function _addRequest(transaction: Transaction, entry: Record<string, any>, timeOrigin: number): void {
-  // It is possible that we are collecting these metrics when the page hasn't finished loading yet, for example when the HTML slowly streams in.
-  // In this case, ie. when the document request hasn't finished yet, `entry.responseEnd` will be 0.
-  // In order not to produce faulty spans, where the end timestamp is before the start timestamp, we will only collect
-  // these spans when the responseEnd value is available. Relay would drop the entire transaction if it contained faulty spans.
-  if (entry.responseEnd !== 0) {
+  if (entry.responseEnd) {
+    // It is possible that we are collecting these metrics when the page hasn't finished loading yet, for example when the HTML slowly streams in.
+    // In this case, ie. when the document request hasn't finished yet, `entry.responseEnd` will be 0.
+    // In order not to produce faulty spans, where the end timestamp is before the start timestamp, we will only collect
+    // these spans when the responseEnd value is available. The backend (Relay) would drop the entire transaction if it contained faulty spans.
     _startChild(transaction, {
       op: 'browser',
       origin: 'auto.browser.browser.metrics',


### PR DESCRIPTION
I found that Relay was dropping pageload transactions from my Next.js test app pretty consistently so in my debugging journey I discovered that the reason was that we were sending spans with start timestamps larger than the end timestamps.

Root cause was that we assumed that the `responseEnd` property on the `navigation` performance entry is always present. It is, however, when the response hasn't finished yet, it is `0`.

As a fallback behaviour, this PR changes the logic so we will only collect these performance entry spans when the `responseEnd` logic is available.

We should probably delay finishing of the pageload transaction until domContentLoded fired or the timeout is reached...