### PR TITLE
feat: Deprecate user segment field

### DIFF
--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -19,6 +19,7 @@ export function getDynamicSamplingContextFromClient(
   const options = client.getOptions();
 
   const { publicKey: public_key } = client.getDsn() || {};
+  // TODO(v8): Remove segment from User
   const { segment: user_segment } = (scope && scope.getUser()) || {};
 
   const dsc = dropUndefinedKeys({

--- a/packages/core/src/tracing/dynamicSamplingContext.ts
+++ b/packages/core/src/tracing/dynamicSamplingContext.ts
@@ -20,6 +20,7 @@ export function getDynamicSamplingContextFromClient(
 
   const { publicKey: public_key } = client.getDsn() || {};
   // TODO(v8): Remove segment from User
+  // eslint-disable-next-line deprecation/deprecation
   const { segment: user_segment } = (scope && scope.getUser()) || {};
 
   const dsc = dropUndefinedKeys({

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -20,6 +20,9 @@ export type DynamicSamplingContext = {
   release?: string;
   environment?: string;
   transaction?: string;
+  /**
+   * @deprecated Functonality for segment has been removed.
+   */
   user_segment?: string;
   replay_id?: string;
   sampled?: string;

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -1,10 +1,15 @@
-/** JSDoc */
+/**
+ * An interface describing a user of an application or a handled request.
+ */
 export interface User {
   [key: string]: any;
   id?: string | number;
   ip_address?: string;
   email?: string;
   username?: string;
+  /**
+   * @deprecated Functonality for segment has been removed. Use a custom tag or context instead to capture this information.
+   */
   segment?: string;
 }
 


### PR DESCRIPTION
See https://github.com/getsentry/sentry/issues/58767#issuecomment-1808116241

Segment is no longer supported by the product, so we can remove it in v8.