### PR TITLE
feat(integrations): Deprecate pluggable integration classes

### DIFF
--- a/packages/integrations/src/captureconsole.ts
+++ b/packages/integrations/src/captureconsole.ts
@@ -1,4 +1,11 @@
-import { captureException, captureMessage, convertIntegrationFnToClass, getClient, withScope } from '@sentry/core';
+import {
+  captureException,
+  captureMessage,
+  convertIntegrationFnToClass,
+  defineIntegration,
+  getClient,
+  withScope,
+} from '@sentry/core';
 import type { CaptureContext, Client, Integration, IntegrationClass, IntegrationFn } from '@sentry/types';
 import {
   CONSOLE_LEVELS,
@@ -15,7 +22,7 @@ interface CaptureConsoleOptions {
 
 const INTEGRATION_NAME = 'CaptureConsole';
 
-const captureConsoleIntegration = ((options: CaptureConsoleOptions = {}) => {
+const _captureConsoleIntegration = ((options: CaptureConsoleOptions = {}) => {
   const levels = options.levels || CONSOLE_LEVELS;
 
   return {
@@ -38,7 +45,12 @@ const captureConsoleIntegration = ((options: CaptureConsoleOptions = {}) => {
   };
 }) satisfies IntegrationFn;
 
-/** Send Console API calls as Sentry Events */
+export const captureConsoleIntegration = defineIntegration(_captureConsoleIntegration);
+
+/**
+ * Send Console API calls as Sentry Events.
+ * @deprecated Use `captureConsoleIntegration()` instead.
+ */
 // eslint-disable-next-line deprecation/deprecation
 export const CaptureConsole = convertIntegrationFnToClass(
   INTEGRATION_NAME,

--- a/packages/integrations/src/contextlines.ts
+++ b/packages/integrations/src/contextlines.ts
@@ -1,4 +1,4 @@
-import { convertIntegrationFnToClass } from '@sentry/core';
+import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
 import type { Event, Integration, IntegrationClass, IntegrationFn, StackFrame } from '@sentry/types';
 import { GLOBAL_OBJ, addContextToFrame, stripUrlQueryAndFragment } from '@sentry/utils';
 
@@ -18,7 +18,7 @@ interface ContextLinesOptions {
   frameContextLines?: number;
 }
 
-const contextLinesIntegration = ((options: ContextLinesOptions = {}) => {
+const _contextLinesIntegration = ((options: ContextLinesOptions = {}) => {
   const contextLines = options.frameContextLines != null ? options.frameContextLines : DEFAULT_LINES_OF_CONTEXT;
 
   return {
@@ -31,6 +31,8 @@ const contextLinesIntegration = ((options: ContextLinesOptions = {}) => {
   };
 }) satisfies IntegrationFn;
 
+export const contextLinesIntegration = defineIntegration(_contextLinesIntegration);
+
 /**
  * Collects source context lines around the lines of stackframes pointing to JS embedded in
  * the current page's HTML.
@@ -41,6 +43,8 @@ const contextLinesIntegration = ((options: ContextLinesOptions = {}) => {
  *
  * Use this integration if you have inline JS code in HTML pages that can't be accessed
  * by our backend (e.g. due to a login-protected page).
+ *
+ * @deprecated Use `contextLinesIntegration()` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export const ContextLines = convertIntegrationFnToClass(INTEGRATION_NAME, contextLinesIntegration) as IntegrationClass<

--- a/packages/integrations/src/debug.ts
+++ b/packages/integrations/src/debug.ts
@@ -1,4 +1,4 @@
-import { convertIntegrationFnToClass } from '@sentry/core';
+import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
 import type { Client, Event, EventHint, Integration, IntegrationClass, IntegrationFn } from '@sentry/types';
 import { consoleSandbox } from '@sentry/utils';
 
@@ -11,7 +11,7 @@ interface DebugOptions {
   debugger?: boolean;
 }
 
-const debugIntegration = ((options: DebugOptions = {}) => {
+const _debugIntegration = ((options: DebugOptions = {}) => {
   const _options = {
     debugger: false,
     stringify: false,
@@ -53,9 +53,13 @@ const debugIntegration = ((options: DebugOptions = {}) => {
   };
 }) satisfies IntegrationFn;
 
+export const debugIntegration = defineIntegration(_debugIntegration);
+
 /**
  * Integration to debug sent Sentry events.
- * This integration should not be used in production
+ * This integration should not be used in production.
+ *
+ * @deprecated Use `debugIntegration()` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export const Debug = convertIntegrationFnToClass(INTEGRATION_NAME, debugIntegration) as IntegrationClass<

--- a/packages/integrations/src/dedupe.ts
+++ b/packages/integrations/src/dedupe.ts
@@ -1,4 +1,4 @@
-import { convertIntegrationFnToClass } from '@sentry/core';
+import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
 import type { Event, Exception, Integration, IntegrationClass, IntegrationFn, StackFrame } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
@@ -6,7 +6,7 @@ import { DEBUG_BUILD } from './debug-build';
 
 const INTEGRATION_NAME = 'Dedupe';
 
-const dedupeIntegration = (() => {
+const _dedupeIntegration = (() => {
   let previousEvent: Event | undefined;
 
   return {
@@ -33,7 +33,12 @@ const dedupeIntegration = (() => {
   };
 }) satisfies IntegrationFn;
 
-/** Deduplication filter */
+export const dedupeIntegration = defineIntegration(_dedupeIntegration);
+
+/**
+ * Deduplication filter.
+ * @deprecated Use `dedupeIntegration()` instead.
+ */
 // eslint-disable-next-line deprecation/deprecation
 export const Dedupe = convertIntegrationFnToClass(INTEGRATION_NAME, dedupeIntegration) as IntegrationClass<
   Integration & { processEvent: (event: Event) => Event }

--- a/packages/integrations/src/extraerrordata.ts
+++ b/packages/integrations/src/extraerrordata.ts
@@ -1,4 +1,4 @@
-import { convertIntegrationFnToClass } from '@sentry/core';
+import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
 import type {
   Contexts,
   Event,
@@ -28,7 +28,7 @@ interface ExtraErrorDataOptions {
   captureErrorCause: boolean;
 }
 
-const extraErrorDataIntegration = ((options: Partial<ExtraErrorDataOptions> = {}) => {
+const _extraErrorDataIntegration = ((options: Partial<ExtraErrorDataOptions> = {}) => {
   const depth = options.depth || 3;
 
   // TODO(v8): Flip the default for this option to true
@@ -44,7 +44,12 @@ const extraErrorDataIntegration = ((options: Partial<ExtraErrorDataOptions> = {}
   };
 }) satisfies IntegrationFn;
 
-/** Extract additional data for from original exceptions. */
+export const extraErrorDataIntegration = defineIntegration(_extraErrorDataIntegration);
+
+/**
+ * Extract additional data for from original exceptions.
+ * @deprecated Use `extraErrorDataIntegration()` instead.
+ */
 // eslint-disable-next-line deprecation/deprecation
 export const ExtraErrorData = convertIntegrationFnToClass(
   INTEGRATION_NAME,

--- a/packages/integrations/src/httpclient.ts
+++ b/packages/integrations/src/httpclient.ts
@@ -1,4 +1,10 @@
-import { captureEvent, convertIntegrationFnToClass, getClient, isSentryRequestUrl } from '@sentry/core';
+import {
+  captureEvent,
+  convertIntegrationFnToClass,
+  defineIntegration,
+  getClient,
+  isSentryRequestUrl,
+} from '@sentry/core';
 import type {
   Client,
   Event as SentryEvent,
@@ -45,7 +51,7 @@ interface HttpClientOptions {
   failedRequestTargets: HttpRequestTarget[];
 }
 
-const httpClientIntegration = ((options: Partial<HttpClientOptions> = {}) => {
+const _httpClientIntegration = ((options: Partial<HttpClientOptions> = {}) => {
   const _options: HttpClientOptions = {
     failedRequestStatusCodes: [[500, 599]],
     failedRequestTargets: [/.*/],
@@ -63,7 +69,12 @@ const httpClientIntegration = ((options: Partial<HttpClientOptions> = {}) => {
   };
 }) satisfies IntegrationFn;
 
-/** HTTPClient integration creates events for failed client side HTTP requests. */
+export const httpClientIntegration = defineIntegration(_httpClientIntegration);
+
+/**
+ * Create events for failed client side HTTP requests.
+ * @deprecated Use `httpClientIntegration()` instead.
+ */
 // eslint-disable-next-line deprecation/deprecation
 export const HttpClient = convertIntegrationFnToClass(INTEGRATION_NAME, httpClientIntegration) as IntegrationClass<
   Integration & { setup: (client: Client) => void }

--- a/packages/integrations/src/index.ts
+++ b/packages/integrations/src/index.ts
@@ -1,13 +1,12 @@
-export { CaptureConsole } from './captureconsole';
-export { Debug } from './debug';
-export { Dedupe } from './dedupe';
-export { ExtraErrorData } from './extraerrordata';
-// eslint-disable-next-line deprecation/deprecation
+/* eslint-disable deprecation/deprecation */
+export { CaptureConsole, captureConsoleIntegration } from './captureconsole';
+export { Debug, debugIntegration } from './debug';
+export { Dedupe, dedupeIntegration } from './dedupe';
+export { ExtraErrorData, extraErrorDataIntegration } from './extraerrordata';
 export { Offline } from './offline';
-export { ReportingObserver } from './reportingobserver';
-export { RewriteFrames } from './rewriteframes';
-export { SessionTiming } from './sessiontiming';
-// eslint-disable-next-line deprecation/deprecation
+export { ReportingObserver, reportingObserverIntegration } from './reportingobserver';
+export { RewriteFrames, rewriteFramesIntegration } from './rewriteframes';
+export { SessionTiming, sessionTimingIntegration } from './sessiontiming';
 export { Transaction } from './transaction';
-export { HttpClient } from './httpclient';
-export { ContextLines } from './contextlines';
+export { HttpClient, httpClientIntegration } from './httpclient';
+export { ContextLines, contextLinesIntegration } from './contextlines';

--- a/packages/integrations/src/reportingobserver.ts
+++ b/packages/integrations/src/reportingobserver.ts
@@ -1,4 +1,4 @@
-import { captureMessage, convertIntegrationFnToClass, getClient, withScope } from '@sentry/core';
+import { captureMessage, convertIntegrationFnToClass, defineIntegration, getClient, withScope } from '@sentry/core';
 import type { Client, Integration, IntegrationClass, IntegrationFn } from '@sentry/types';
 import { GLOBAL_OBJ, supportsReportingObserver } from '@sentry/utils';
 
@@ -48,7 +48,7 @@ interface ReportingObserverOptions {
 
 const SETUP_CLIENTS = new WeakMap<Client, boolean>();
 
-const reportingObserverIntegration = ((options: ReportingObserverOptions = {}) => {
+const _reportingObserverIntegration = ((options: ReportingObserverOptions = {}) => {
   const types = options.types || ['crash', 'deprecation', 'intervention'];
 
   /** Handler for the reporting observer. */
@@ -115,7 +115,12 @@ const reportingObserverIntegration = ((options: ReportingObserverOptions = {}) =
   };
 }) satisfies IntegrationFn;
 
-/** Reporting API integration - https://w3c.github.io/reporting/ */
+export const reportingObserverIntegration = defineIntegration(_reportingObserverIntegration);
+
+/**
+ * Reporting API integration - https://w3c.github.io/reporting/
+ * @deprecated Use `reportingObserverIntegration()` instead.
+ */
 // eslint-disable-next-line deprecation/deprecation
 export const ReportingObserver = convertIntegrationFnToClass(
   INTEGRATION_NAME,

--- a/packages/integrations/src/rewriteframes.ts
+++ b/packages/integrations/src/rewriteframes.ts
@@ -1,4 +1,4 @@
-import { convertIntegrationFnToClass } from '@sentry/core';
+import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
 import type { Event, Integration, IntegrationClass, IntegrationFn, StackFrame, Stacktrace } from '@sentry/types';
 import { basename, relative } from '@sentry/utils';
 
@@ -12,7 +12,7 @@ interface RewriteFramesOptions {
   iteratee?: StackFrameIteratee;
 }
 
-const rewriteFramesIntegration = ((options: RewriteFramesOptions = {}) => {
+const _rewriteFramesIntegration = ((options: RewriteFramesOptions = {}) => {
   const root = options.root;
   const prefix = options.prefix || 'app:///';
 
@@ -85,7 +85,12 @@ const rewriteFramesIntegration = ((options: RewriteFramesOptions = {}) => {
   };
 }) satisfies IntegrationFn;
 
-/** Rewrite event frames paths */
+export const rewriteFramesIntegration = defineIntegration(_rewriteFramesIntegration);
+
+/**
+ * Rewrite event frames paths.
+ * @deprecated Use `rewriteFramesIntegration()` instead.
+ */
 // eslint-disable-next-line deprecation/deprecation
 export const RewriteFrames = convertIntegrationFnToClass(
   INTEGRATION_NAME,

--- a/packages/integrations/src/sessiontiming.ts
+++ b/packages/integrations/src/sessiontiming.ts
@@ -1,9 +1,9 @@
-import { convertIntegrationFnToClass } from '@sentry/core';
+import { convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
 import type { Event, Integration, IntegrationClass, IntegrationFn } from '@sentry/types';
 
 const INTEGRATION_NAME = 'SessionTiming';
 
-const sessionTimingIntegration = (() => {
+const _sessionTimingIntegration = (() => {
   const startTime = Date.now();
 
   return {
@@ -26,7 +26,12 @@ const sessionTimingIntegration = (() => {
   };
 }) satisfies IntegrationFn;
 
-/** This function adds duration since Sentry was initialized till the time event was sent */
+export const sessionTimingIntegration = defineIntegration(_sessionTimingIntegration);
+
+/**
+ * This function adds duration since Sentry was initialized till the time event was sent.
+ * @deprecated Use `sessionTimingIntegration()` instead.
+ */
 // eslint-disable-next-line deprecation/deprecation
 export const SessionTiming = convertIntegrationFnToClass(
   INTEGRATION_NAME,

--- a/packages/integrations/test/debug.test.ts
+++ b/packages/integrations/test/debug.test.ts
@@ -1,9 +1,15 @@
 import type { Client, Event, EventHint, Integration } from '@sentry/types';
 
+import type { debugIntegration } from '../src/debug';
 import { Debug } from '../src/debug';
 
 interface IntegrationWithSetup extends Integration {
   setup: (client: Client) => void;
+}
+
+function getIntegration(...args: Parameters<typeof debugIntegration>) {
+  // eslint-disable-next-line deprecation/deprecation
+  return new Debug(...args);
 }
 
 function testEventLogged(integration: IntegrationWithSetup, testEvent?: Event, testEventHint?: EventHint) {
@@ -42,7 +48,7 @@ describe('Debug integration setup should register an event processor that', () =
   });
 
   it('logs an event', () => {
-    const debugIntegration = new Debug();
+    const debugIntegration = getIntegration();
     const testEvent = { event_id: 'some event' };
 
     testEventLogged(debugIntegration, testEvent);
@@ -52,7 +58,7 @@ describe('Debug integration setup should register an event processor that', () =
   });
 
   it('logs an event hint if available', () => {
-    const debugIntegration = new Debug();
+    const debugIntegration = getIntegration();
 
     const testEvent = { event_id: 'some event' };
     const testEventHint = { event_id: 'some event hint' };
@@ -65,7 +71,7 @@ describe('Debug integration setup should register an event processor that', () =
   });
 
   it('logs events in stringified format when `stringify` option was set', () => {
-    const debugIntegration = new Debug({ stringify: true });
+    const debugIntegration = getIntegration({ stringify: true });
     const testEvent = { event_id: 'some event' };
 
     testEventLogged(debugIntegration, testEvent);
@@ -75,7 +81,7 @@ describe('Debug integration setup should register an event processor that', () =
   });
 
   it('logs event hints in stringified format when `stringify` option was set', () => {
-    const debugIntegration = new Debug({ stringify: true });
+    const debugIntegration = getIntegration({ stringify: true });
 
     const testEvent = { event_id: 'some event' };
     const testEventHint = { event_id: 'some event hint' };

--- a/packages/integrations/test/dedupe.test.ts
+++ b/packages/integrations/test/dedupe.test.ts
@@ -1,5 +1,6 @@
 import type { Event as SentryEvent, Exception, StackFrame, Stacktrace } from '@sentry/types';
 
+import type { dedupeIntegration } from '../src/dedupe';
 import { Dedupe, _shouldDropEvent } from '../src/dedupe';
 
 type EventWithException = SentryEvent & {
@@ -12,6 +13,11 @@ type StacktraceWithFrames = Stacktrace & { frames: StackFrame[] };
 
 function clone<T>(data: T): T {
   return JSON.parse(JSON.stringify(data));
+}
+
+function getIntegration(...args: Parameters<typeof dedupeIntegration>) {
+  // eslint-disable-next-line deprecation/deprecation
+  return new Dedupe(...args);
 }
 
 const messageEvent: EventWithException = {
@@ -177,7 +183,7 @@ describe('Dedupe', () => {
 
   describe('processEvent', () => {
     it('ignores consecutive errors', () => {
-      const integration = new Dedupe();
+      const integration = getIntegration();
 
       expect(integration.processEvent(clone(exceptionEvent))).not.toBeNull();
       expect(integration.processEvent(clone(exceptionEvent))).toBeNull();
@@ -185,7 +191,7 @@ describe('Dedupe', () => {
     });
 
     it('ignores transactions between errors', () => {
-      const integration = new Dedupe();
+      const integration = getIntegration();
 
       expect(integration.processEvent(clone(exceptionEvent))).not.toBeNull();
       expect(

--- a/packages/integrations/test/extraerrordata.test.ts
+++ b/packages/integrations/test/extraerrordata.test.ts
@@ -1,8 +1,14 @@
 import type { Event as SentryEvent, ExtendedError } from '@sentry/types';
 
+import type { extraErrorDataIntegration } from '../src/extraerrordata';
 import { ExtraErrorData } from '../src/extraerrordata';
 
-const extraErrorData = new ExtraErrorData();
+function getIntegration(...args: Parameters<typeof extraErrorDataIntegration>) {
+  // eslint-disable-next-line deprecation/deprecation
+  return new ExtraErrorData(...args);
+}
+
+const extraErrorData = getIntegration();
 let event: SentryEvent;
 
 describe('ExtraErrorData()', () => {
@@ -186,7 +192,7 @@ describe('ExtraErrorData()', () => {
       return;
     }
 
-    const extraErrorDataWithCauseCapture = new ExtraErrorData({ captureErrorCause: true });
+    const extraErrorDataWithCauseCapture = getIntegration({ captureErrorCause: true });
 
     // @ts-expect-error The typing .d.ts library we have installed isn't aware of Error.cause yet
     const error = new Error('foo', { cause: { woot: 'foo' } }) as ExtendedError;
@@ -211,7 +217,7 @@ describe('ExtraErrorData()', () => {
       return;
     }
 
-    const extraErrorDataWithoutCauseCapture = new ExtraErrorData();
+    const extraErrorDataWithoutCauseCapture = getIntegration();
 
     // @ts-expect-error The typing .d.ts library we have installed isn't aware of Error.cause yet
     const error = new Error('foo', { cause: { woot: 'foo' } }) as ExtendedError;

--- a/packages/integrations/test/reportingobserver.test.ts
+++ b/packages/integrations/test/reportingobserver.test.ts
@@ -1,6 +1,7 @@
 import * as SentryCore from '@sentry/core';
 import type { Client, Hub } from '@sentry/types';
 
+import type { reportingObserverIntegration } from '../src/reportingobserver';
 import { ReportingObserver } from '../src/reportingobserver';
 
 const mockScope = {
@@ -26,6 +27,11 @@ class MockReportingObserver {
   }
 }
 
+function getIntegration(...args: Parameters<typeof reportingObserverIntegration>) {
+  // eslint-disable-next-line deprecation/deprecation
+  return new ReportingObserver(...args);
+}
+
 describe('ReportingObserver', () => {
   let mockClient: Client;
 
@@ -49,7 +55,7 @@ describe('ReportingObserver', () => {
       // Act like ReportingObserver is unavailable
       delete (global as any).ReportingObserver;
 
-      const reportingObserverIntegration = new ReportingObserver();
+      const reportingObserverIntegration = getIntegration();
 
       expect(() => {
         reportingObserverIntegration.setupOnce(
@@ -63,7 +69,7 @@ describe('ReportingObserver', () => {
     });
 
     it('should use default report types', () => {
-      const reportingObserverIntegration = new ReportingObserver();
+      const reportingObserverIntegration = getIntegration();
       reportingObserverIntegration.setupOnce(
         () => undefined,
         () => mockHub,
@@ -78,7 +84,7 @@ describe('ReportingObserver', () => {
     });
 
     it('should use user-provided report types', () => {
-      const reportingObserverIntegration = new ReportingObserver({ types: ['crash'] });
+      const reportingObserverIntegration = getIntegration({ types: ['crash'] });
       reportingObserverIntegration.setupOnce(
         () => undefined,
         () => mockHub,
@@ -93,7 +99,7 @@ describe('ReportingObserver', () => {
     });
 
     it('should use `buffered` option', () => {
-      const reportingObserverIntegration = new ReportingObserver();
+      const reportingObserverIntegration = getIntegration();
       reportingObserverIntegration.setupOnce(
         () => undefined,
         () => mockHub,
@@ -108,7 +114,7 @@ describe('ReportingObserver', () => {
     });
 
     it('should call `observe` function', () => {
-      const reportingObserverIntegration = new ReportingObserver();
+      const reportingObserverIntegration = getIntegration();
       reportingObserverIntegration.setupOnce(
         () => undefined,
         () => mockHub,
@@ -121,7 +127,7 @@ describe('ReportingObserver', () => {
 
   describe('handler', () => {
     it('should abort gracefully and not do anything when integration is not installed', () => {
-      const reportingObserverIntegration = new ReportingObserver();
+      const reportingObserverIntegration = getIntegration();
       reportingObserverIntegration.setupOnce(
         () => undefined,
         () => mockHub,
@@ -138,7 +144,7 @@ describe('ReportingObserver', () => {
     });
 
     it('should capture messages', () => {
-      const reportingObserverIntegration = new ReportingObserver();
+      const reportingObserverIntegration = getIntegration();
       reportingObserverIntegration.setupOnce(
         () => undefined,
         () => mockHub,
@@ -155,7 +161,7 @@ describe('ReportingObserver', () => {
     });
 
     it('should set extra including the url of a report', () => {
-      const reportingObserverIntegration = new ReportingObserver();
+      const reportingObserverIntegration = getIntegration();
       reportingObserverIntegration.setupOnce(
         () => undefined,
         () => mockHub,
@@ -173,7 +179,7 @@ describe('ReportingObserver', () => {
     });
 
     it('should set extra including the report body if available', () => {
-      const reportingObserverIntegration = new ReportingObserver();
+      const reportingObserverIntegration = getIntegration();
       reportingObserverIntegration.setupOnce(
         () => undefined,
         () => mockHub,
@@ -191,7 +197,7 @@ describe('ReportingObserver', () => {
     });
 
     it('should not set extra report body extra when no body is set', () => {
-      const reportingObserverIntegration = new ReportingObserver();
+      const reportingObserverIntegration = getIntegration();
       reportingObserverIntegration.setupOnce(
         () => undefined,
         () => mockHub,
@@ -205,7 +211,7 @@ describe('ReportingObserver', () => {
     });
 
     it('should capture report details from body on crash report', () => {
-      const reportingObserverIntegration = new ReportingObserver();
+      const reportingObserverIntegration = getIntegration();
       reportingObserverIntegration.setupOnce(
         () => undefined,
         () => mockHub,
@@ -226,7 +232,7 @@ describe('ReportingObserver', () => {
     });
 
     it('should capture report message from body on deprecation report', () => {
-      const reportingObserverIntegration = new ReportingObserver();
+      const reportingObserverIntegration = getIntegration();
       reportingObserverIntegration.setupOnce(
         () => undefined,
         () => mockHub,
@@ -246,7 +252,7 @@ describe('ReportingObserver', () => {
     });
 
     it('should capture report message from body on intervention report', () => {
-      const reportingObserverIntegration = new ReportingObserver();
+      const reportingObserverIntegration = getIntegration();
       reportingObserverIntegration.setupOnce(
         () => undefined,
         () => mockHub,
@@ -266,7 +272,7 @@ describe('ReportingObserver', () => {
     });
 
     it('should use fallback message when no body is available', () => {
-      const reportingObserverIntegration = new ReportingObserver();
+      const reportingObserverIntegration = getIntegration();
       reportingObserverIntegration.setupOnce(
         () => undefined,
         () => mockHub,
@@ -285,7 +291,7 @@ describe('ReportingObserver', () => {
     });
 
     it('should use fallback message when no body details are available for crash report', () => {
-      const reportingObserverIntegration = new ReportingObserver();
+      const reportingObserverIntegration = getIntegration();
       reportingObserverIntegration.setupOnce(
         () => undefined,
         () => mockHub,
@@ -301,7 +307,7 @@ describe('ReportingObserver', () => {
     });
 
     it('should use fallback message when no body message is available for deprecation report', () => {
-      const reportingObserverIntegration = new ReportingObserver();
+      const reportingObserverIntegration = getIntegration();
       reportingObserverIntegration.setupOnce(
         () => undefined,
         () => mockHub,
@@ -321,7 +327,7 @@ describe('ReportingObserver', () => {
     });
 
     it('should use fallback message when no body message is available for intervention report', () => {
-      const reportingObserverIntegration = new ReportingObserver();
+      const reportingObserverIntegration = getIntegration();
       reportingObserverIntegration.setupOnce(
         () => undefined,
         () => mockHub,

--- a/packages/integrations/test/sessiontiming.test.ts
+++ b/packages/integrations/test/sessiontiming.test.ts
@@ -1,5 +1,6 @@
 import { SessionTiming } from '../src/sessiontiming';
 
+// eslint-disable-next-line deprecation/deprecation
 const sessionTiming = new SessionTiming();
 
 describe('SessionTiming', () => {

--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -75,6 +75,7 @@ function addClientIntegrations(options: BrowserOptions): void {
   // is set there, we set it here as well, just in case something has gone wrong with the injection.
   const assetPrefixPath = globalWithInjectedValues.__rewriteFramesAssetPrefixPath__ || '';
 
+  // eslint-disable-next-line deprecation/deprecation
   const defaultRewriteFramesIntegration = new RewriteFrames({
     // Turn `<origin>/<path>/_next/static/...` into `app:///_next/static/...`
     iteratee: frame => {

--- a/packages/nextjs/src/edge/index.ts
+++ b/packages/nextjs/src/edge/index.ts
@@ -51,6 +51,7 @@ export function init(options: VercelEdgeOptions = {}): void {
     // eslint-disable-next-line @sentry-internal/sdk/no-regexp-constructor -- user input is escaped
     const SOURCEMAP_FILENAME_REGEX = new RegExp(`.*${escapeStringForRegex(distDirAbsPath)}`);
 
+    // eslint-disable-next-line deprecation/deprecation
     const defaultRewriteFramesIntegration = new RewriteFrames({
       iteratee: frame => {
         frame.filename = frame.filename?.replace(SOURCEMAP_FILENAME_REGEX, 'app:///_next');

--- a/packages/nextjs/src/server/index.ts
+++ b/packages/nextjs/src/server/index.ts
@@ -134,6 +134,7 @@ function addServerIntegrations(options: NodeOptions): void {
     // eslint-disable-next-line @sentry-internal/sdk/no-regexp-constructor -- user input is escaped
     const SOURCEMAP_FILENAME_REGEX = new RegExp(escapeStringForRegex(distDirAbsPath));
 
+    // eslint-disable-next-line deprecation/deprecation
     const defaultRewriteFramesIntegration = new RewriteFrames({
       iteratee: frame => {
         frame.filename = frame.filename?.replace(SOURCEMAP_FILENAME_REGEX, 'app:///_next');

--- a/packages/sveltekit/src/server/sdk.ts
+++ b/packages/sveltekit/src/server/sdk.ts
@@ -23,6 +23,7 @@ export function init(options: NodeOptions): void {
 
 function addServerIntegrations(options: NodeOptions): void {
   options.integrations = addOrUpdateIntegration(
+    // eslint-disable-next-line deprecation/deprecation
     new RewriteFrames({ iteratee: rewriteFramesIteratee }),
     options.integrations || [],
   );

--- a/packages/sveltekit/test/server/utils.test.ts
+++ b/packages/sveltekit/test/server/utils.test.ts
@@ -79,7 +79,9 @@ describe('rewriteFramesIteratee', () => {
       module: '3-ab34d22f.js',
     };
 
+    // eslint-disable-next-line deprecation/deprecation
     const originalRewriteFrames = new RewriteFrames();
+    // eslint-disable-next-line deprecation/deprecation
     const rewriteFrames = new RewriteFrames({ iteratee: rewriteFramesIteratee });
 
     const event: Event = {


### PR DESCRIPTION
Instead, users should import & use the integration functions.