### PR TITLE
chore: Update .git-blame-ignore-revs for dev-package changes

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,6 @@ ef6b3c7877d5fc8031c08bb28b0ffafaeb01f501
 
 # chore: Enforce formatting of MD files in repository root #10127
 aecf26f22dbf65ce2c0caadc4ce71b46266c9f45
+
+# chore: Create dev-packages folder #9997 
+35205b4cc5783237e69452c39ea001e461d9c84d


### PR DESCRIPTION
Trying to do a git blame to investigate some stuff, figured would be nice to ignore these changes