### PR TITLE
test(node): Add Mongo otel integration test

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing-experimental/mongodb/scenario.js
+++ b/dev-packages/node-integration-tests/suites/tracing-experimental/mongodb/scenario.js
@@ -1,0 +1,48 @@
+const { loggingTransport } = require('@sentry-internal/node-integration-tests');
+const Sentry = require('@sentry/node-experimental');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  debug: true,
+  transport: loggingTransport,
+});
+
+// Must be required after Sentry is initialized
+const { MongoClient } = require('mongodb');
+
+const client = new MongoClient(process.env.MONGO_URL || '', {
+  useUnifiedTopology: true,
+});
+
+async function run() {
+  await Sentry.startSpan(
+    {
+      name: 'Test Transaction',
+      op: 'transaction',
+    },
+    async () => {
+      try {
+        await client.connect();
+
+        const database = client.db('admin');
+        const collection = database.collection('movies');
+
+        await collection.insertOne({ title: 'Rick and Morty' });
+        await collection.findOne({ title: 'Back to the Future' });
+        await collection.updateOne({ title: 'Back to the Future' }, { $set: { title: 'South Park' } });
+        await collection.findOne({ title: 'South Park' });
+
+        await collection.find({ title: 'South Park' }).toArray();
+      } finally {
+        await client.close();
+      }
+    },
+  );
+
+  Sentry.flush(2000);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+run();

--- a/dev-packages/node-integration-tests/suites/tracing-experimental/mongodb/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-experimental/mongodb/test.ts
@@ -1,0 +1,87 @@
+import { MongoMemoryServer } from 'mongodb-memory-server-global';
+
+import { conditionalTest } from '../../../utils';
+import { cleanupChildProcesses, createRunner } from '../../../utils/runner';
+
+jest.setTimeout(20000);
+
+conditionalTest({ min: 14 })('MongoDB experimental Test', () => {
+  let mongoServer: MongoMemoryServer;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    process.env.MONGO_URL = mongoServer.getUri();
+  }, 10000);
+
+  afterAll(async () => {
+    if (mongoServer) {
+      await mongoServer.stop();
+    }
+    cleanupChildProcesses();
+  });
+
+  const EXPECTED_TRANSACTION = {
+    transaction: 'Test Transaction',
+    spans: expect.arrayContaining([
+      expect.objectContaining({
+        data: expect.objectContaining({
+          'db.system': 'mongodb',
+          'db.name': 'admin',
+          'db.operation': 'insert',
+          'db.mongodb.collection': 'movies',
+        }),
+        description: '{"title":"?","_id":"?"}',
+        op: 'db',
+        origin: 'auto.db.otel.mongo',
+      }),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          'db.system': 'mongodb',
+          'db.name': 'admin',
+          'db.operation': 'find',
+          'db.mongodb.collection': 'movies',
+        }),
+        description: '{"title":"?"}',
+        op: 'db',
+        origin: 'auto.db.otel.mongo',
+      }),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          'db.system': 'mongodb',
+          'db.name': 'admin',
+          'db.operation': 'update',
+          'db.mongodb.collection': 'movies',
+        }),
+        description: '{"title":"?"}',
+        op: 'db',
+        origin: 'auto.db.otel.mongo',
+      }),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          'db.system': 'mongodb',
+          'db.name': 'admin',
+          'db.operation': 'find',
+          'db.mongodb.collection': 'movies',
+        }),
+        description: '{"title":"?"}',
+        op: 'db',
+        origin: 'auto.db.otel.mongo',
+      }),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          'db.system': 'mongodb',
+          'db.name': 'admin',
+          'db.operation': 'find',
+          'db.mongodb.collection': 'movies',
+        }),
+        description: '{"title":"?"}',
+        op: 'db',
+        origin: 'auto.db.otel.mongo',
+      }),
+    ]),
+  };
+
+  test('CJS - should auto-instrument `mongodb` package.', done => {
+    createRunner(__dirname, 'scenario.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
+  });
+});


### PR DESCRIPTION
This PR adds a `@sentry/node-experimental` test for Mongo auto-instrumentation.

There is no ESM test because `mongodb` doesn't support support ESM.
