### PR TITLE
feat(types): Add support for new monitor config thresholds

### DIFF
--- a/packages/types/src/checkin.ts
+++ b/packages/types/src/checkin.ts
@@ -83,4 +83,8 @@ export interface MonitorConfig {
   // A tz database string representing the timezone which the monitor's execution schedule is in.
   // See: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
   timezone?: SerializedMonitorConfig['timezone'];
+  // How many consecutive failed check-ins it takes to create an issue.
+  failure_issue_threshold?: number;
+  // How many consecutive OK check-ins it takes to resolve an issue.
+  recovery_threshold?: number;
 }


### PR DESCRIPTION
ref https://github.com/getsentry/team-sdks/issues/43
relay PR: https://github.com/getsentry/relay/pull/2842

Update `MonitorConfig` to add support for `failure_issue_threshold` and  `recovery_threshold`.