### PR TITLE
ref(vue): use functional vue integration as default

### DIFF
--- a/packages/vue/src/sdk.ts
+++ b/packages/vue/src/sdk.ts
@@ -1,6 +1,6 @@
 import { SDK_VERSION, defaultIntegrations, init as browserInit } from '@sentry/browser';
 
-import { VueIntegration } from './integration';
+import { vueIntegration } from './integration';
 import type { Options, TracingOptions } from './types';
 
 /**
@@ -22,7 +22,7 @@ export function init(
         version: SDK_VERSION,
       },
     },
-    defaultIntegrations: [...defaultIntegrations, new VueIntegration()],
+    defaultIntegrations: [...defaultIntegrations, vueIntegration()],
     ...config,
   };
 


### PR DESCRIPTION
Following up on stuff that was missed with https://github.com/getsentry/sentry-javascript/pull/10218