### PR TITLE
ref(serverless): Use new span APIs for serverless

### DIFF
--- a/packages/serverless/test/__mocks__/@sentry/node.ts
+++ b/packages/serverless/test/__mocks__/@sentry/node.ts
@@ -14,18 +14,12 @@ export const fakeScope = {
   setTag: jest.fn(),
   setContext: jest.fn(),
   setSpan: jest.fn(),
-  getTransaction: jest.fn(() => fakeTransaction),
   setSDKProcessingMetadata: jest.fn(),
   setPropagationContext: jest.fn(),
 };
 export const fakeSpan = {
   end: jest.fn(),
   setHttpStatus: jest.fn(),
-};
-export const fakeTransaction = {
-  end: jest.fn(),
-  setHttpStatus: jest.fn(),
-  startChild: jest.fn(() => fakeSpan),
 };
 export const init = jest.fn();
 export const addGlobalEventProcessor = jest.fn();
@@ -36,11 +30,9 @@ export const withScope = jest.fn(cb => cb(fakeScope));
 export const flush = jest.fn(() => Promise.resolve());
 export const getClient = jest.fn(() => ({}));
 export const startSpanManual = jest.fn((ctx, callback: (span: any) => any) => callback(fakeSpan));
+export const startInactiveSpan = jest.fn(() => fakeSpan);
 
 export const resetMocks = (): void => {
-  fakeTransaction.setHttpStatus.mockClear();
-  fakeTransaction.end.mockClear();
-  fakeTransaction.startChild.mockClear();
   fakeSpan.end.mockClear();
   fakeSpan.setHttpStatus.mockClear();
 
@@ -48,7 +40,6 @@ export const resetMocks = (): void => {
   fakeScope.setTag.mockClear();
   fakeScope.setContext.mockClear();
   fakeScope.setSpan.mockClear();
-  fakeScope.getTransaction.mockClear();
 
   init.mockClear();
   addGlobalEventProcessor.mockClear();

--- a/packages/serverless/test/awslambda.test.ts
+++ b/packages/serverless/test/awslambda.test.ts
@@ -8,13 +8,6 @@ import * as Sentry from '../src';
 
 const { wrapHandler } = Sentry.AWSLambda;
 
-/**
- * Why @ts-expect-error some Sentry.X calls
- *
- * A hack-ish way to contain everything related to mocks in the same __mocks__ file.
- * Thanks to this, we don't have to do more magic than necessary. Just add and export desired method and assert on it.
- */
-
 // Default `timeoutWarningLimit` is 500ms so leaving some space for it to trigger when necessary
 const DEFAULT_EXECUTION_TIME = 100;
 let fakeEvent: { [key: string]: unknown };

--- a/packages/serverless/test/awsservices.test.ts
+++ b/packages/serverless/test/awsservices.test.ts
@@ -4,13 +4,6 @@ import * as nock from 'nock';
 
 import { AWSServices } from '../src/awsservices';
 
-/**
- * Why @ts-expect-error some Sentry.X calls
- *
- * A hack-ish way to contain everything related to mocks in the same __mocks__ file.
- * Thanks to this, we don't have to do more magic than necessary. Just add and export desired method and assert on it.
- */
-
 describe('AWSServices', () => {
   beforeAll(() => {
     new AWSServices().setupOnce();
@@ -30,11 +23,10 @@ describe('AWSServices', () => {
       nock('https://foo.s3.amazonaws.com').get('/bar').reply(200, 'contents');
       const data = await s3.getObject({ Bucket: 'foo', Key: 'bar' }).promise();
       expect(data.Body?.toString('utf-8')).toEqual('contents');
-      // @ts-expect-error see "Why @ts-expect-error" note
-      expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
+      expect(SentryNode.startInactiveSpan).toBeCalledWith({
         op: 'http.client',
         origin: 'auto.http.serverless',
-        description: 'aws.s3.getObject foo',
+        name: 'aws.s3.getObject foo',
       });
       // @ts-expect-error see "Why @ts-expect-error" note
       expect(SentryNode.fakeSpan.end).toBeCalled();
@@ -48,11 +40,10 @@ describe('AWSServices', () => {
         expect(data.Body?.toString('utf-8')).toEqual('contents');
         done();
       });
-      // @ts-expect-error see "Why @ts-expect-error" note
-      expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
+      expect(SentryNode.startInactiveSpan).toBeCalledWith({
         op: 'http.client',
         origin: 'auto.http.serverless',
-        description: 'aws.s3.getObject foo',
+        name: 'aws.s3.getObject foo',
       });
     });
   });
@@ -64,11 +55,10 @@ describe('AWSServices', () => {
       nock('https://lambda.eu-north-1.amazonaws.com').post('/2015-03-31/functions/foo/invocations').reply(201, 'reply');
       const data = await lambda.invoke({ FunctionName: 'foo' }).promise();
       expect(data.Payload?.toString('utf-8')).toEqual('reply');
-      // @ts-expect-error see "Why @ts-expect-error" note
-      expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
+      expect(SentryNode.startInactiveSpan).toBeCalledWith({
         op: 'http.client',
         origin: 'auto.http.serverless',
-        description: 'aws.lambda.invoke foo',
+        name: 'aws.lambda.invoke foo',
       });
     });
   });

--- a/packages/serverless/test/gcpfunction.test.ts
+++ b/packages/serverless/test/gcpfunction.test.ts
@@ -14,12 +14,6 @@ import type {
   Request,
   Response,
 } from '../src/gcpfunction/general';
-/**
- * Why @ts-expect-error some Sentry.X calls
- *
- * A hack-ish way to contain everything related to mocks in the same __mocks__ file.
- * Thanks to this, we don't have to do more magic than necessary. Just add and export desired method and assert on it.
- */
 
 describe('GCPFunction', () => {
   afterEach(() => {

--- a/packages/serverless/test/google-cloud-grpc.test.ts
+++ b/packages/serverless/test/google-cloud-grpc.test.ts
@@ -11,13 +11,6 @@ import * as nock from 'nock';
 
 import { GoogleCloudGrpc } from '../src/google-cloud-grpc';
 
-/**
- * Why @ts-expect-error some Sentry.X calls
- *
- * A hack-ish way to contain everything related to mocks in the same __mocks__ file.
- * Thanks to this, we don't have to do more magic than necessary. Just add and export desired method and assert on it.
- */
-
 const spyConnect = jest.spyOn(http2, 'connect');
 
 /** Fake HTTP2 stream */
@@ -126,11 +119,10 @@ describe('GoogleCloudGrpc tracing', () => {
       mockHttp2Session().mockUnaryRequest(Buffer.from('00000000120a1031363337303834313536363233383630', 'hex'));
       const resp = await pubsub.topic('nicetopic').publish(Buffer.from('data'));
       expect(resp).toEqual('1637084156623860');
-      // @ts-expect-error see "Why @ts-expect-error" note
-      expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
+      expect(SentryNode.startInactiveSpan).toBeCalledWith({
         op: 'grpc.pubsub',
         origin: 'auto.grpc.serverless',
-        description: 'unary call publish',
+        name: 'unary call publish',
       });
       await pubsub.close();
     });

--- a/packages/serverless/test/google-cloud-http.test.ts
+++ b/packages/serverless/test/google-cloud-http.test.ts
@@ -6,13 +6,6 @@ import * as nock from 'nock';
 
 import { GoogleCloudHttp } from '../src/google-cloud-http';
 
-/**
- * Why @ts-expect-error some Sentry.X calls
- *
- * A hack-ish way to contain everything related to mocks in the same __mocks__ file.
- * Thanks to this, we don't have to do more magic than necessary. Just add and export desired method and assert on it.
- */
-
 describe('GoogleCloudHttp tracing', () => {
   beforeAll(() => {
     new GoogleCloudHttp().setupOnce();
@@ -57,17 +50,15 @@ describe('GoogleCloudHttp tracing', () => {
         );
       const resp = await bigquery.query('SELECT true AS foo');
       expect(resp).toEqual([[{ foo: true }]]);
-      // @ts-expect-error see "Why @ts-expect-error" note
-      expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
+      expect(SentryNode.startInactiveSpan).toBeCalledWith({
         op: 'http.client.bigquery',
         origin: 'auto.http.serverless',
-        description: 'POST /jobs',
+        name: 'POST /jobs',
       });
-      // @ts-expect-error see "Why @ts-expect-error" note
-      expect(SentryNode.fakeTransaction.startChild).toBeCalledWith({
+      expect(SentryNode.startInactiveSpan).toBeCalledWith({
         op: 'http.client.bigquery',
         origin: 'auto.http.serverless',
-        description: expect.stringMatching(/^GET \/queries\/.+/),
+        name: expect.stringMatching(/^GET \/queries\/.+/),
       });
     });
   });


### PR DESCRIPTION
Most of the changes here are with tests, otherwise we swap to use `startInactiveSpan` everywhere.

IMO it might be more correct to refactor to use `startSpanManual`, but that can come later, I want to keep same behavior for now.