### PR TITLE
test(core): Add integration test for `captureUserFeedback` on `captureException` and `captureMessage`

### DIFF
--- a/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/withCaptureException/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/withCaptureException/init.js
@@ -1,0 +1,16 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  beforeSend(event) {
+    Sentry.captureUserFeedback({
+      event_id: event.event_id,
+      name: 'John Doe',
+      email: 'john@doe.com',
+      comments: 'This feedback should be attached associated with the captured error',
+    });
+    return event;
+  },
+});

--- a/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/withCaptureException/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/withCaptureException/subject.js
@@ -1,0 +1,1 @@
+Sentry.captureException(new Error('Error with Feedback'));

--- a/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/withCaptureException/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/withCaptureException/test.ts
@@ -1,0 +1,23 @@
+import { expect } from '@playwright/test';
+import type { Event, UserFeedback } from '@sentry/types';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
+
+sentryTest('capture user feedback when captureException is called', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  const data = (await getMultipleSentryEnvelopeRequests(page, 2, { url })) as (Event | UserFeedback)[];
+
+  expect(data).toHaveLength(2);
+
+  const errorEvent = ('exception' in data[0] ? data[0] : data[1]) as Event;
+  const feedback = ('exception' in data[0] ? data[1] : data[0]) as UserFeedback;
+
+  expect(feedback).toEqual({
+    comments: 'This feedback should be attached associated with the captured error',
+    email: 'john@doe.com',
+    event_id: errorEvent.event_id,
+    name: 'John Doe',
+  });
+});

--- a/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/withCaptureMessage/init.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/withCaptureMessage/init.js
@@ -1,0 +1,16 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  beforeSend(event) {
+    Sentry.captureUserFeedback({
+      event_id: event.event_id,
+      name: 'John Doe',
+      email: 'john@doe.com',
+      comments: 'This feedback should be attached associated with the captured message',
+    });
+    return event;
+  },
+});

--- a/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/withCaptureMessage/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/withCaptureMessage/subject.js
@@ -1,0 +1,1 @@
+Sentry.captureMessage('Message with Feedback');

--- a/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/withCaptureMessage/test.ts
+++ b/dev-packages/browser-integration-tests/suites/public-api/captureUserFeedback/withCaptureMessage/test.ts
@@ -1,0 +1,23 @@
+import { expect } from '@playwright/test';
+import type { Event, UserFeedback } from '@sentry/types';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { getMultipleSentryEnvelopeRequests } from '../../../../utils/helpers';
+
+sentryTest('capture user feedback when captureMessage is called', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  const data = (await getMultipleSentryEnvelopeRequests(page, 2, { url })) as (Event | UserFeedback)[];
+
+  expect(data).toHaveLength(2);
+
+  const errorEvent = ('exception' in data[0] ? data[0] : data[1]) as Event;
+  const feedback = ('exception' in data[0] ? data[1] : data[0]) as UserFeedback;
+
+  expect(feedback).toEqual({
+    comments: 'This feedback should be attached associated with the captured message',
+    email: 'john@doe.com',
+    event_id: errorEvent.event_id,
+    name: 'John Doe',
+  });
+});


### PR DESCRIPTION
Added two tests to demonstrate correct behavior of `captureUserFeedback` when it's called in `beforeSend` as described in the docs.

Trying to rule out SDK issues for https://github.com/getsentry/sentry-javascript/issues/10229. Given the tests pass, I suspect something isn't working on the Sentry backend when ingesting the feedback.