### PR TITLE
feat(types): Add `SerializedEvent` interface (pre v8)

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/browsertracing/http-timings/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browsertracing/http-timings/test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import type { Event } from '@sentry/types';
+import type { SerializedEvent } from '@sentry/types';
 
 import { sentryTest } from '../../../../utils/fixtures';
 import { getMultipleSentryEnvelopeRequests, shouldSkipTracingTest } from '../../../../utils/helpers';
@@ -23,7 +23,7 @@ sentryTest('should create fetch spans with http timing @firefox', async ({ brows
 
   const url = await getLocalTestPath({ testDir: __dirname });
 
-  const envelopes = await getMultipleSentryEnvelopeRequests<Event>(page, 2, { url, timeout: 10000 });
+  const envelopes = await getMultipleSentryEnvelopeRequests<SerializedEvent>(page, 2, { url, timeout: 10000 });
   const tracingEvent = envelopes[envelopes.length - 1]; // last envelope contains tracing data on all browsers
 
   const requestSpans = tracingEvent.spans?.filter(({ op }) => op === 'http.client');

--- a/packages/types/src/envelope.ts
+++ b/packages/types/src/envelope.ts
@@ -83,6 +83,7 @@ type CheckInItemHeaders = { type: 'check_in' };
 type StatsdItemHeaders = { type: 'statsd'; length: number };
 type ProfileItemHeaders = { type: 'profile' };
 
+// TODO (v8): Replace `Event` with `SerializedEvent`
 export type EventItem = BaseEnvelopeItem<EventItemHeaders, Event>;
 export type AttachmentItem = BaseEnvelopeItem<AttachmentItemHeaders, string | Uint8Array>;
 export type UserFeedbackItem = BaseEnvelopeItem<UserFeedbackItemHeaders, UserFeedback>;

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -11,7 +11,7 @@ import type { Request } from './request';
 import type { CaptureContext } from './scope';
 import type { SdkInfo } from './sdkinfo';
 import type { Severity, SeverityLevel } from './severity';
-import type { Span } from './span';
+import type { Span, SpanJSON } from './span';
 import type { Thread } from './thread';
 import type { TransactionSource } from './transaction';
 import type { User } from './user';
@@ -85,4 +85,15 @@ export interface EventHint {
   attachments?: Attachment[];
   data?: any;
   integrations?: string[];
+}
+
+/**
+ * Represents the event that's sent in an event envelope, omitting interfaces that are no longer representative after
+ * event serialization.
+ */
+export interface SerializedEvent extends Omit<Event, 'spans'> {
+  /**
+   * POJO objects of spans belonging to this event.
+   */
+  spans?: SpanJSON[];
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -47,7 +47,7 @@ export type {
   ProfileItem,
 } from './envelope';
 export type { ExtendedError } from './error';
-export type { Event, EventHint, EventType, ErrorEvent, TransactionEvent } from './event';
+export type { Event, EventHint, EventType, ErrorEvent, TransactionEvent, SerializedEvent } from './event';
 export type { EventProcessor } from './eventprocessor';
 export type { Exception } from './exception';
 export type { Extra, Extras } from './extra';


### PR DESCRIPTION
This PR adds a `SerializedEvent` interface which more accurately represents what an event envelope item contains (i.e. the JSON structure of a serialized `Event` object). Specifically, the `spans` field now correctly only contains the attributes the POJO span will continue to hold, i.e. without the deprecations and methods declared in the `Span` interface.

In v8, we should change the `EventItem` type for the event envelope but doing so now is a breaking change I believe (And arguably, not too important to do now anyway). 

However, we can already use this type in our browser integration tests to remove a lot of the unnecessary deprecation ignores. 

ref #10222 (rest of this has to happen in v8)  