### PR TITLE
fix(utils): Fix `isPlainObject()` check for classes

### DIFF
--- a/packages/utils/src/is.ts
+++ b/packages/utils/src/is.ts
@@ -113,7 +113,16 @@ export function isPrimitive(wat: unknown): wat is Primitive {
  * @returns A boolean representing the result.
  */
 export function isPlainObject(wat: unknown): wat is Record<string, unknown> {
-  return isBuiltin(wat, 'Object');
+  if (!isBuiltin(wat, 'Object')) {
+    return false;
+  }
+
+  try {
+    const name = (Object.getPrototypeOf(wat) as { constructor: { name: string } }).constructor.name;
+    return !name || name === 'Object';
+  } catch {
+    return true;
+  }
 }
 
 /**

--- a/packages/utils/test/is.test.ts
+++ b/packages/utils/test/is.test.ts
@@ -5,6 +5,7 @@ import {
   isErrorEvent,
   isInstanceOf,
   isNaN,
+  isPlainObject,
   isPrimitive,
   isThenable,
   isVueViewModel,
@@ -142,5 +143,29 @@ describe('isVueViewModel()', () => {
     expect(isVueViewModel({ __isVue: true })).toEqual(true);
 
     expect(isVueViewModel({ foo: true })).toEqual(false);
+  });
+});
+
+describe('isPlainObject', () => {
+  class MyClass {
+    public foo: string = 'bar';
+  }
+
+  it.each([
+    [{}, true],
+    [true, false],
+    [false, false],
+    [undefined, false],
+    [null, false],
+    ['', false],
+    [1, false],
+    [0, false],
+    [{ aha: 'yes' }, true],
+    [new Object({ aha: 'yes' }), true],
+    [new String('aa'), false],
+    [new MyClass(), false],
+    [{ ...new MyClass() }, true],
+  ])('%s is %s', (value, expected) => {
+    expect(isPlainObject(value)).toBe(expected);
   });
 });


### PR DESCRIPTION
Turns it this was just wrong, it incorrectly returned `true` for class instances 😬 not sure if this used to work at some point, but it's very easy to reproduce this... and there were no tests 😬 😿 