### PR TITLE
feat: Refactor exposed `defaultIntegrations` to `getDefaultIntegrations()`

### DIFF
--- a/packages/angular-ivy/src/sdk.ts
+++ b/packages/angular-ivy/src/sdk.ts
@@ -1,6 +1,7 @@
 import { VERSION } from '@angular/core';
 import type { BrowserOptions } from '@sentry/browser';
-import { SDK_VERSION, defaultIntegrations, init as browserInit, setContext } from '@sentry/browser';
+import { getDefaultIntegrations } from '@sentry/browser';
+import { SDK_VERSION, init as browserInit, setContext } from '@sentry/browser';
 import type { SdkMetadata } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
@@ -18,7 +19,7 @@ export function init(options: BrowserOptions): void {
     // see:
     //  - https://github.com/getsentry/sentry-javascript/issues/5417#issuecomment-1453407097
     //  - https://github.com/getsentry/sentry-javascript/issues/2744
-    defaultIntegrations: defaultIntegrations.filter(integration => {
+    defaultIntegrations: getDefaultIntegrations(options).filter(integration => {
       return integration.name !== 'TryCatch';
     }),
     ...options,

--- a/packages/angular/src/sdk.ts
+++ b/packages/angular/src/sdk.ts
@@ -1,6 +1,7 @@
 import { VERSION } from '@angular/core';
 import type { BrowserOptions } from '@sentry/browser';
-import { SDK_VERSION, defaultIntegrations, init as browserInit, setContext } from '@sentry/browser';
+import { getDefaultIntegrations } from '@sentry/browser';
+import { SDK_VERSION, init as browserInit, setContext } from '@sentry/browser';
 import type { SdkMetadata } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
@@ -18,7 +19,7 @@ export function init(options: BrowserOptions): void {
     // see:
     //  - https://github.com/getsentry/sentry-javascript/issues/5417#issuecomment-1453407097
     //  - https://github.com/getsentry/sentry-javascript/issues/2744
-    defaultIntegrations: defaultIntegrations.filter(integration => {
+    defaultIntegrations: getDefaultIntegrations(options).filter(integration => {
       return integration.name !== 'TryCatch';
     }),
     ...options,

--- a/packages/angular/test/sdk.test.ts
+++ b/packages/angular/test/sdk.test.ts
@@ -1,6 +1,6 @@
 import * as SentryBrowser from '@sentry/browser';
 
-import { defaultIntegrations, init } from '../src/index';
+import { getDefaultIntegrations, init } from '../src/index';
 
 describe('init', () => {
   it('sets the Angular version (if available) in the global scope', () => {
@@ -30,16 +30,23 @@ describe('init', () => {
       expect(options.defaultIntegrations).not.toContainEqual(expect.objectContaining({ name: 'TryCatch' }));
     });
 
-    it.each([false as const, defaultIntegrations])(
-      "doesn't filter if `defaultIntegrations` is set to %s",
-      defaultIntegrations => {
-        init({ defaultIntegrations });
+    it("doesn't filter if `defaultIntegrations` is set to `false`", () => {
+      init({ defaultIntegrations: false });
 
-        expect(browserInitSpy).toHaveBeenCalledTimes(1);
+      expect(browserInitSpy).toHaveBeenCalledTimes(1);
 
-        const options = browserInitSpy.mock.calls[0][0] || {};
-        expect(options.defaultIntegrations).toEqual(defaultIntegrations);
-      },
-    );
+      const options = browserInitSpy.mock.calls[0][0] || {};
+      expect(options.defaultIntegrations).toEqual(false);
+    });
+
+    it("doesn't filter if `defaultIntegrations` is overwritten", () => {
+      const defaultIntegrations = getDefaultIntegrations({});
+      init({ defaultIntegrations });
+
+      expect(browserInitSpy).toHaveBeenCalledTimes(1);
+
+      const options = browserInitSpy.mock.calls[0][0] || {};
+      expect(options.defaultIntegrations).toEqual(defaultIntegrations);
+    });
   });
 });

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -52,7 +52,9 @@ export {
   withIsolationScope,
   autoDiscoverNodePerformanceMonitoringIntegrations,
   makeNodeTransport,
+  // eslint-disable-next-line deprecation/deprecation
   defaultIntegrations,
+  getDefaultIntegrations,
   defaultStackParser,
   // eslint-disable-next-line deprecation/deprecation
   lastEventId,

--- a/packages/astro/src/index.types.ts
+++ b/packages/astro/src/index.types.ts
@@ -17,6 +17,7 @@ export declare function init(options: Options | clientSdk.BrowserOptions | serve
 export declare const Integrations: typeof clientSdk.Integrations & typeof serverSdk.Integrations;
 
 export declare const defaultIntegrations: Integration[];
+export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -89,7 +89,9 @@ export {
 export { eventFromException, eventFromMessage, exceptionFromError } from './eventbuilder';
 export { createUserFeedbackEnvelope } from './userfeedback';
 export {
+  // eslint-disable-next-line deprecation/deprecation
   defaultIntegrations,
+  getDefaultIntegrations,
   forceLoad,
   init,
   onLoad,

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -10,7 +10,7 @@ import {
   initAndBind,
   startSession,
 } from '@sentry/core';
-import type { UserFeedback } from '@sentry/types';
+import type { Integration, Options, UserFeedback } from '@sentry/types';
 import {
   addHistoryInstrumentationHandler,
   logger,
@@ -27,10 +27,12 @@ import { Breadcrumbs, Dedupe, GlobalHandlers, HttpContext, LinkedErrors, TryCatc
 import { defaultStackParser } from './stack-parsers';
 import { makeFetchTransport, makeXHRTransport } from './transports';
 
-/* eslint-disable deprecation/deprecation */
+/** @deprecated Use `getDefaultIntegrations(options)` instead. */
 export const defaultIntegrations = [
+  /* eslint-disable deprecation/deprecation */
   new InboundFilters(),
   new FunctionToString(),
+  /* eslint-enable deprecation/deprecation */
   new TryCatch(),
   new Breadcrumbs(),
   new GlobalHandlers(),
@@ -38,7 +40,15 @@ export const defaultIntegrations = [
   new Dedupe(),
   new HttpContext(),
 ];
-/* eslint-enable deprecation/deprecation */
+
+/** Get the default integrations for the browser SDK. */
+export function getDefaultIntegrations(_options: Options): Integration[] {
+  // We return a copy of the defaultIntegrations here to avoid mutating this
+  return [
+    // eslint-disable-next-line deprecation/deprecation
+    ...defaultIntegrations,
+  ];
+}
 
 /**
  * A magic string that build tooling can leverage in order to inject a release value into the SDK.
@@ -104,7 +114,7 @@ declare const __SENTRY_RELEASE__: string | undefined;
  */
 export function init(options: BrowserOptions = {}): void {
   if (options.defaultIntegrations === undefined) {
-    options.defaultIntegrations = defaultIntegrations;
+    options.defaultIntegrations = getDefaultIntegrations(options);
   }
   if (options.release === undefined) {
     // This allows build tooling to find-and-replace __SENTRY_RELEASE__ to inject a release value

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -88,7 +88,12 @@ export type { SpanStatusType } from '@sentry/core';
 export { autoDiscoverNodePerformanceMonitoringIntegrations, cron } from '@sentry/node';
 
 export { BunClient } from './client';
-export { defaultIntegrations, init } from './sdk';
+export {
+  // eslint-disable-next-line deprecation/deprecation
+  defaultIntegrations,
+  getDefaultIntegrations,
+  init,
+} from './sdk';
 
 import { Integrations as CoreIntegrations } from '@sentry/core';
 import { Integrations as NodeIntegrations } from '@sentry/node';

--- a/packages/bun/src/sdk.ts
+++ b/packages/bun/src/sdk.ts
@@ -1,18 +1,21 @@
 /* eslint-disable max-lines */
 import { FunctionToString, InboundFilters, LinkedErrors } from '@sentry/core';
 import { Integrations as NodeIntegrations, init as initNode } from '@sentry/node';
+import type { Integration, Options } from '@sentry/types';
 
 import { BunClient } from './client';
 import { BunServer } from './integrations';
 import { makeFetchTransport } from './transports';
 import type { BunOptions } from './types';
 
-/* eslint-disable deprecation/deprecation */
+/** @deprecated Use `getDefaultIntegrations(options)` instead. */
 export const defaultIntegrations = [
+  /* eslint-disable deprecation/deprecation */
   // Common
   new InboundFilters(),
   new FunctionToString(),
   new LinkedErrors(),
+  /* eslint-enable deprecation/deprecation */
   // Native Wrappers
   new NodeIntegrations.Console(),
   new NodeIntegrations.Http(),
@@ -29,7 +32,15 @@ export const defaultIntegrations = [
   // Bun Specific
   new BunServer(),
 ];
-/* eslint-enable deprecation/deprecation */
+
+/** Get the default integrations for the Bun SDK. */
+export function getDefaultIntegrations(_options: Options): Integration[] {
+  // We return a copy of the defaultIntegrations here to avoid mutating this
+  return [
+    // eslint-disable-next-line deprecation/deprecation
+    ...defaultIntegrations,
+  ];
+}
 
 /**
  * The Sentry Bun SDK Client.
@@ -90,9 +101,9 @@ export function init(options: BunOptions = {}): void {
   options.clientClass = BunClient;
   options.transport = options.transport || makeFetchTransport;
 
-  options.defaultIntegrations =
-    options.defaultIntegrations === false
-      ? []
-      : [...(Array.isArray(options.defaultIntegrations) ? options.defaultIntegrations : defaultIntegrations)];
+  if (options.defaultIntegrations === undefined) {
+    options.defaultIntegrations = getDefaultIntegrations(options);
+  }
+
   initNode(options);
 }

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -86,7 +86,12 @@ export type { SpanStatusType } from '@sentry/core';
 
 export { DenoClient } from './client';
 
-export { defaultIntegrations, init } from './sdk';
+export {
+  // eslint-disable-next-line deprecation/deprecation
+  defaultIntegrations,
+  getDefaultIntegrations,
+  init,
+} from './sdk';
 
 import { Integrations as CoreIntegrations } from '@sentry/core';
 

--- a/packages/deno/test/mod.test.ts
+++ b/packages/deno/test/mod.test.ts
@@ -3,7 +3,7 @@ import { assertSnapshot } from 'https://deno.land/std@0.202.0/testing/snapshot.t
 
 import type { sentryTypes } from '../build-test/index.js';
 import { sentryUtils } from '../build-test/index.js';
-import { DenoClient, Hub, Scope, defaultIntegrations } from '../build/index.mjs';
+import { DenoClient, Hub, Scope, getDefaultIntegrations } from '../build/index.mjs';
 import { getNormalizedEvent } from './normalize.ts';
 import { makeTestTransport } from './transport.ts';
 
@@ -14,7 +14,7 @@ function getTestClient(
   const client = new DenoClient({
     dsn: 'https://233a45e5efe34c47a3536797ce15dafa@nothing.here/5650507',
     debug: true,
-    integrations: [...defaultIntegrations, ...integrations],
+    integrations: [...getDefaultIntegrations({}), ...integrations],
     stackParser: sentryUtils.createStackParser(sentryUtils.nodeStackLineParser()),
     transport: makeTestTransport(envelope => {
       callback(getNormalizedEvent(envelope));

--- a/packages/nextjs/src/index.types.ts
+++ b/packages/nextjs/src/index.types.ts
@@ -25,6 +25,7 @@ export declare const Integrations: typeof clientSdk.Integrations &
   typeof edgeSdk.Integrations;
 
 export declare const defaultIntegrations: Integration[];
+export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 
 export declare function getSentryRelease(fallback?: string): string | undefined;

--- a/packages/nextjs/test/clientSdk.test.ts
+++ b/packages/nextjs/test/clientSdk.test.ts
@@ -184,7 +184,7 @@ describe('Client init()', () => {
         });
 
         const reactInitOptions = reactInit.mock.calls[0][0] as ModifiedInitOptionsIntegrationFunction;
-        const materializedIntegrations = reactInitOptions.integrations(SentryReact.defaultIntegrations);
+        const materializedIntegrations = reactInitOptions.integrations(SentryReact.getDefaultIntegrations({}));
         const browserTracingIntegration = findIntegrationByName(materializedIntegrations, 'BrowserTracing');
 
         expect(browserTracingIntegration).toEqual(

--- a/packages/node-experimental/src/sdk/spanProcessor.ts
+++ b/packages/node-experimental/src/sdk/spanProcessor.ts
@@ -40,7 +40,6 @@ export class NodeExperimentalSentrySpanProcessor extends SentrySpanProcessor {
     // In this case, if `shouldCreateSpansForRequests` is false, we want to _record_ the span but not _sample_ it,
     // So we can generate a breadcrumb for it but no span will be sent
     if (
-      httpIntegration &&
       (span.kind === SpanKind.CLIENT || span.kind === SpanKind.SERVER) &&
       span.attributes[SemanticAttributes.HTTP_URL] &&
       span.attributes[SemanticAttributes.HTTP_METHOD]

--- a/packages/node-experimental/test/sdk/init.test.ts
+++ b/packages/node-experimental/test/sdk/init.test.ts
@@ -1,8 +1,8 @@
 import type { Integration } from '@sentry/types';
 
 import * as auto from '../../src/integrations/getAutoPerformanceIntegrations';
-import * as sdk from '../../src/sdk/init';
 import { init } from '../../src/sdk/init';
+import { getClient } from '../../src/sdk/scope';
 import { cleanupOtel } from '../helpers/mockSdkInit';
 
 // eslint-disable-next-line no-var
@@ -18,8 +18,6 @@ class MockIntegration implements Integration {
   }
 }
 
-const defaultIntegrationsBackup = sdk.defaultIntegrations;
-
 describe('init()', () => {
   let mockAutoPerformanceIntegrations: jest.SpyInstance = jest.fn(() => []);
 
@@ -30,25 +28,21 @@ describe('init()', () => {
   });
 
   afterEach(() => {
-    // @ts-expect-error - Reset the default integrations of node sdk to original
-    sdk.defaultIntegrations = defaultIntegrationsBackup;
-
     cleanupOtel();
+
+    jest.clearAllMocks();
   });
 
   it("doesn't install default integrations if told not to", () => {
-    const mockDefaultIntegrations = [
-      new MockIntegration('Mock integration 1.1'),
-      new MockIntegration('Mock integration 1.2'),
-    ];
-
-    // @ts-expect-error - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
-    sdk.defaultIntegrations = mockDefaultIntegrations;
-
     init({ dsn: PUBLIC_DSN, defaultIntegrations: false });
 
-    expect(mockDefaultIntegrations[0].setupOnce as jest.Mock).toHaveBeenCalledTimes(0);
-    expect(mockDefaultIntegrations[1].setupOnce as jest.Mock).toHaveBeenCalledTimes(0);
+    const client = getClient();
+    expect(client.getOptions()).toEqual(
+      expect.objectContaining({
+        integrations: [],
+      }),
+    );
+
     expect(mockAutoPerformanceIntegrations).toHaveBeenCalledTimes(0);
   });
 
@@ -58,15 +52,12 @@ describe('init()', () => {
       new MockIntegration('Some mock integration 2.2'),
     ];
 
-    // @ts-expect-error - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
-    sdk.defaultIntegrations = mockDefaultIntegrations;
-
     const mockIntegrations = [
       new MockIntegration('Some mock integration 2.1'),
       new MockIntegration('Some mock integration 2.3'),
     ];
 
-    init({ dsn: PUBLIC_DSN, integrations: mockIntegrations });
+    init({ dsn: PUBLIC_DSN, integrations: mockIntegrations, defaultIntegrations: mockDefaultIntegrations });
 
     expect(mockDefaultIntegrations[0].setupOnce as jest.Mock).toHaveBeenCalledTimes(0);
     expect(mockDefaultIntegrations[1].setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
@@ -81,13 +72,11 @@ describe('init()', () => {
       new MockIntegration('Some mock integration 3.2'),
     ];
 
-    // @ts-expect-error - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
-    sdk.defaultIntegrations = mockDefaultIntegrations;
-
     const newIntegration = new MockIntegration('Some mock integration 3.3');
 
     init({
       dsn: PUBLIC_DSN,
+      defaultIntegrations: mockDefaultIntegrations,
       integrations: integrations => {
         const newIntegrations = [...integrations];
         newIntegrations[1] = newIntegration;
@@ -102,14 +91,6 @@ describe('init()', () => {
   });
 
   it('installs performance default instrumentations if tracing is enabled', () => {
-    const mockDefaultIntegrations = [
-      new MockIntegration('Some mock integration 4.1'),
-      new MockIntegration('Some mock integration 4.2'),
-    ];
-
-    // @ts-expect-error - Replace default integrations with mock integrations, needs ts-ignore because imports are readonly
-    sdk.defaultIntegrations = mockDefaultIntegrations;
-
     const autoPerformanceIntegration = new MockIntegration('Some mock integration 4.4');
 
     mockAutoPerformanceIntegrations.mockReset().mockImplementation(() => [autoPerformanceIntegration]);
@@ -119,13 +100,22 @@ describe('init()', () => {
       new MockIntegration('Some mock integration 4.3'),
     ];
 
-    init({ dsn: PUBLIC_DSN, integrations: mockIntegrations, enableTracing: true });
+    init({
+      dsn: PUBLIC_DSN,
+      integrations: mockIntegrations,
+      enableTracing: true,
+    });
 
-    expect(mockDefaultIntegrations[0].setupOnce as jest.Mock).toHaveBeenCalledTimes(0);
-    expect(mockDefaultIntegrations[1].setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
     expect(mockIntegrations[0].setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
     expect(mockIntegrations[1].setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
     expect(autoPerformanceIntegration.setupOnce as jest.Mock).toHaveBeenCalledTimes(1);
     expect(mockAutoPerformanceIntegrations).toHaveBeenCalledTimes(1);
+
+    const client = getClient();
+    expect(client.getOptions()).toEqual(
+      expect.objectContaining({
+        integrations: expect.arrayContaining([mockIntegrations[0], mockIntegrations[1], autoPerformanceIntegration]),
+      }),
+    );
   });
 });

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -90,7 +90,14 @@ export { autoDiscoverNodePerformanceMonitoringIntegrations } from './tracing';
 
 export { NodeClient } from './client';
 export { makeNodeTransport } from './transports';
-export { defaultIntegrations, init, defaultStackParser, getSentryRelease } from './sdk';
+export {
+  // eslint-disable-next-line deprecation/deprecation
+  defaultIntegrations,
+  getDefaultIntegrations,
+  init,
+  defaultStackParser,
+  getSentryRelease,
+} from './sdk';
 export { addRequestDataToEvent, DEFAULT_USER_INCLUDES, extractRequestData } from '@sentry/utils';
 // eslint-disable-next-line deprecation/deprecation
 export { deepReadDirSync } from './utils';

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -12,7 +12,7 @@ import {
   initAndBind,
   startSession,
 } from '@sentry/core';
-import type { SessionStatus, StackParser } from '@sentry/types';
+import type { Integration, Options, SessionStatus, StackParser } from '@sentry/types';
 import {
   GLOBAL_OBJ,
   createStackParser,
@@ -40,12 +40,15 @@ import { createGetModuleFromFilename } from './module';
 import { makeNodeTransport } from './transports';
 import type { NodeClientOptions, NodeOptions } from './types';
 
-/* eslint-disable deprecation/deprecation */
+/** @deprecated Use `getDefaultIntegrations(options)` instead. */
+
 export const defaultIntegrations = [
+  /* eslint-disable deprecation/deprecation */
   // Common
   new InboundFilters(),
   new FunctionToString(),
   new LinkedErrors(),
+  /* eslint-enable deprecation/deprecation */
   // Native Wrappers
   new Console(),
   new Http(),
@@ -58,9 +61,22 @@ export const defaultIntegrations = [
   new LocalVariables(),
   new Context(),
   new Modules(),
+  // eslint-disable-next-line deprecation/deprecation
   new RequestData(),
 ];
-/* eslint-enable deprecation/deprecation */
+
+/** Get the default integrations for the Node SDK. */
+export function getDefaultIntegrations(_options: Options): Integration[] {
+  const carrier = getMainCarrier();
+
+  const autoloadedIntegrations = carrier.__SENTRY__?.integrations || [];
+
+  return [
+    // eslint-disable-next-line deprecation/deprecation
+    ...defaultIntegrations,
+    ...autoloadedIntegrations,
+  ];
+}
 
 /**
  * The Sentry Node SDK Client.
@@ -119,19 +135,11 @@ export const defaultIntegrations = [
  */
 // eslint-disable-next-line complexity
 export function init(options: NodeOptions = {}): void {
-  const carrier = getMainCarrier();
-
   setNodeAsyncContextStrategy();
 
-  const autoloadedIntegrations = carrier.__SENTRY__?.integrations || [];
-
-  options.defaultIntegrations =
-    options.defaultIntegrations === false
-      ? []
-      : [
-          ...(Array.isArray(options.defaultIntegrations) ? options.defaultIntegrations : defaultIntegrations),
-          ...autoloadedIntegrations,
-        ];
+  if (options.defaultIntegrations === undefined) {
+    options.defaultIntegrations = getDefaultIntegrations(options);
+  }
 
   if (options.dsn === undefined && process.env.SENTRY_DSN) {
     options.dsn = process.env.SENTRY_DSN;

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -23,7 +23,7 @@ import {
 } from '../src';
 import { setNodeAsyncContextStrategy } from '../src/async';
 import { ContextLines } from '../src/integrations';
-import { defaultStackParser } from '../src/sdk';
+import { defaultStackParser, getDefaultIntegrations } from '../src/sdk';
 import type { NodeClientOptions } from '../src/types';
 import { getDefaultNodeClientOptions } from './helper/node-client-options';
 
@@ -436,23 +436,13 @@ describe('SentryNode initialization', () => {
   });
 
   describe('autoloaded integrations', () => {
-    it('should attach single integration to default integrations', () => {
+    it('should attach integrations to default integrations', () => {
       withAutoloadedIntegrations([new MockIntegration('foo')], () => {
         init({
-          defaultIntegrations: [new MockIntegration('bar')],
+          defaultIntegrations: [...getDefaultIntegrations({}), new MockIntegration('bar')],
         });
         const integrations = (initAndBind as jest.Mock).mock.calls[0][1].defaultIntegrations;
-        expect(integrations.map((i: { name: string }) => i.name)).toEqual(['bar', 'foo']);
-      });
-    });
-
-    it('should attach multiple integrations to default integrations', () => {
-      withAutoloadedIntegrations([new MockIntegration('foo'), new MockIntegration('bar')], () => {
-        init({
-          defaultIntegrations: [new MockIntegration('baz'), new MockIntegration('qux')],
-        });
-        const integrations = (initAndBind as jest.Mock).mock.calls[0][1].defaultIntegrations;
-        expect(integrations.map((i: { name: string }) => i.name)).toEqual(['baz', 'qux', 'foo', 'bar']);
+        expect(integrations.map((i: { name: string }) => i.name)).toEqual(expect.arrayContaining(['foo', 'bar']));
       });
     });
 
@@ -462,7 +452,7 @@ describe('SentryNode initialization', () => {
           defaultIntegrations: false,
         });
         const integrations = (initAndBind as jest.Mock).mock.calls[0][1].defaultIntegrations;
-        expect(integrations).toEqual([]);
+        expect(integrations).toEqual(false);
       });
     });
   });

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -51,7 +51,9 @@ export {
   withIsolationScope,
   autoDiscoverNodePerformanceMonitoringIntegrations,
   makeNodeTransport,
+  // eslint-disable-next-line deprecation/deprecation
   defaultIntegrations,
+  getDefaultIntegrations,
   defaultStackParser,
   // eslint-disable-next-line deprecation/deprecation
   lastEventId,

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -3,7 +3,7 @@
 export * from './index.client';
 export * from './index.server';
 
-import type { Integration, StackParser } from '@sentry/types';
+import type { Integration, Options, StackParser } from '@sentry/types';
 
 import * as clientSdk from './index.client';
 import * as serverSdk from './index.server';
@@ -16,6 +16,7 @@ export declare function init(options: RemixOptions): void;
 export declare const Integrations: typeof clientSdk.Integrations & typeof serverSdk.Integrations;
 
 export declare const defaultIntegrations: Integration[];
+export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 
 // This variable is not a runtime variable but just a type to tell typescript that the methods below can either come

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -12,11 +12,12 @@ import {
   defaultIntegrations as nodeDefaultIntegrations,
   flush,
   getCurrentScope,
+  getDefaultIntegrations as getNodeDefaultIntegrations,
   init as initNode,
   startSpanManual,
   withScope,
 } from '@sentry/node';
-import type { Integration, SdkMetadata, Span } from '@sentry/types';
+import type { Integration, Options, SdkMetadata, Span } from '@sentry/types';
 import { isString, logger } from '@sentry/utils';
 // NOTE: I have no idea how to fix this right now, and don't want to waste more time, as it builds just fine — Kamil
 import type { Context, Handler } from 'aws-lambda';
@@ -66,7 +67,17 @@ export interface WrapperOptions {
   startTrace: boolean;
 }
 
-export const defaultIntegrations: Integration[] = [...nodeDefaultIntegrations, new AWSServices({ optional: true })];
+/** @deprecated Use `getDefaultIntegrations(options)` instead. */
+export const defaultIntegrations: Integration[] = [
+  // eslint-disable-next-line deprecation/deprecation
+  ...nodeDefaultIntegrations,
+  new AWSServices({ optional: true }),
+];
+
+/** Get the default integrations for the AWSLambda SDK. */
+export function getDefaultIntegrations(options: Options): Integration[] {
+  return [...getNodeDefaultIntegrations(options), new AWSServices({ optional: true })];
+}
 
 interface AWSLambdaOptions extends NodeOptions {
   /**
@@ -84,7 +95,7 @@ interface AWSLambdaOptions extends NodeOptions {
 export function init(options: AWSLambdaOptions = {}): void {
   const opts = {
     _metadata: {} as SdkMetadata,
-    defaultIntegrations,
+    defaultIntegrations: getDefaultIntegrations(options),
     ...options,
   };
 

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -52,7 +52,9 @@ export {
   NodeClient,
   makeNodeTransport,
   close,
+  // eslint-disable-next-line deprecation/deprecation
   defaultIntegrations,
+  getDefaultIntegrations,
   defaultStackParser,
   flush,
   getSentryRelease,

--- a/packages/serverless/test/__mocks__/@sentry/node.ts
+++ b/packages/serverless/test/__mocks__/@sentry/node.ts
@@ -1,5 +1,6 @@
 const origSentry = jest.requireActual('@sentry/node');
 export const defaultIntegrations = origSentry.defaultIntegrations; // eslint-disable-line @typescript-eslint/no-unsafe-member-access
+export const getDefaultIntegrations = origSentry.getDefaultIntegrations; // eslint-disable-line @typescript-eslint/no-unsafe-member-access
 export const Handlers = origSentry.Handlers; // eslint-disable-line @typescript-eslint/no-unsafe-member-access
 export const Integrations = origSentry.Integrations;
 export const addRequestDataToEvent = origSentry.addRequestDataToEvent;

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -40,6 +40,7 @@ export declare function wrapLoadWithSentry<T extends (...args: any) => any>(orig
 export declare const Integrations: typeof clientSdk.Integrations & typeof serverSdk.Integrations;
 
 export declare const defaultIntegrations: Integration[];
+export declare const getDefaultIntegrations: (options: Options) => Integration[];
 export declare const defaultStackParser: StackParser;
 
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -49,7 +49,9 @@ export {
   withIsolationScope,
   autoDiscoverNodePerformanceMonitoringIntegrations,
   makeNodeTransport,
+  // eslint-disable-next-line deprecation/deprecation
   defaultIntegrations,
+  getDefaultIntegrations,
   defaultStackParser,
   // eslint-disable-next-line deprecation/deprecation
   lastEventId,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -86,7 +86,12 @@ export {
 export type { SpanStatusType } from '@sentry/core';
 
 export { VercelEdgeClient } from './client';
-export { defaultIntegrations, init } from './sdk';
+export {
+  // eslint-disable-next-line deprecation/deprecation
+  defaultIntegrations,
+  getDefaultIntegrations,
+  init,
+} from './sdk';
 
 import { Integrations as CoreIntegrations, RequestData } from '@sentry/core';
 

--- a/packages/vue/src/sdk.ts
+++ b/packages/vue/src/sdk.ts
@@ -1,4 +1,4 @@
-import { SDK_VERSION, defaultIntegrations, init as browserInit } from '@sentry/browser';
+import { SDK_VERSION, getDefaultIntegrations, init as browserInit } from '@sentry/browser';
 
 import { vueIntegration } from './integration';
 import type { Options, TracingOptions } from './types';
@@ -22,7 +22,7 @@ export function init(
         version: SDK_VERSION,
       },
     },
-    defaultIntegrations: [...defaultIntegrations, vueIntegration()],
+    defaultIntegrations: [...getDefaultIntegrations(config), vueIntegration()],
     ...config,
   };
 


### PR DESCRIPTION
The current implementation has two problems:

1. It is weird that you can accidentally mutate the default integrations of another package
2. We sometimes have logic-based default integrations - e.g. adding an integration only if tracing is enabled, or similar. This means that either we have to add some logic in the _upstream_ SDK to ensure this is still added even if downstream SDKs overwrite default integrations, or we need to duplicate the logic in the _downstream_ SDKs. With this new method, we can instead centralize this, and downstream SDKs simply need to call upstream `getDefaultIntegrations(options)`.