### PR TITLE
ref(astro): Streamline how we add browser tracing

### DIFF
--- a/packages/astro/src/client/sdk.ts
+++ b/packages/astro/src/client/sdk.ts
@@ -1,7 +1,12 @@
 import type { BrowserOptions } from '@sentry/browser';
-import { BrowserTracing, init as initBrowserSdk } from '@sentry/browser';
-import { getCurrentScope, hasTracingEnabled } from '@sentry/core';
-import { addOrUpdateIntegration } from '@sentry/utils';
+import {
+  BrowserTracing,
+  getDefaultIntegrations as getBrowserDefaultIntegrations,
+  init as initBrowserSdk,
+  setTag,
+} from '@sentry/browser';
+import { hasTracingEnabled } from '@sentry/core';
+import type { Integration } from '@sentry/types';
 
 import { applySdkMetadata } from '../common/metadata';
 
@@ -14,27 +19,26 @@ declare const __SENTRY_TRACING__: boolean;
  * @param options Configuration options for the SDK.
  */
 export function init(options: BrowserOptions): void {
-  applySdkMetadata(options, ['astro', 'browser']);
+  const opts = {
+    defaultIntegrations: getDefaultIntegrations(options),
+    ...options,
+  };
 
-  addClientIntegrations(options);
+  applySdkMetadata(opts, ['astro', 'browser']);
 
-  initBrowserSdk(options);
+  initBrowserSdk(opts);
 
-  getCurrentScope().setTag('runtime', 'browser');
+  setTag('runtime', 'browser');
 }
 
-function addClientIntegrations(options: BrowserOptions): void {
-  let integrations = options.integrations || [];
-
+function getDefaultIntegrations(options: BrowserOptions): Integration[] | undefined {
   // This evaluates to true unless __SENTRY_TRACING__ is text-replaced with "false",
   // in which case everything inside will get treeshaken away
   if (typeof __SENTRY_TRACING__ === 'undefined' || __SENTRY_TRACING__) {
     if (hasTracingEnabled(options)) {
-      const defaultBrowserTracingIntegration = new BrowserTracing({});
-
-      integrations = addOrUpdateIntegration(defaultBrowserTracingIntegration, integrations);
+      return [...getBrowserDefaultIntegrations(options), new BrowserTracing()];
     }
   }
 
-  options.integrations = integrations;
+  return undefined;
 }

--- a/packages/astro/src/server/sdk.ts
+++ b/packages/astro/src/server/sdk.ts
@@ -1,6 +1,5 @@
-import { getCurrentScope } from '@sentry/core';
 import type { NodeOptions } from '@sentry/node';
-import { init as initNodeSdk } from '@sentry/node';
+import { init as initNodeSdk, setTag } from '@sentry/node';
 
 import { applySdkMetadata } from '../common/metadata';
 
@@ -13,5 +12,5 @@ export function init(options: NodeOptions): void {
 
   initNodeSdk(options);
 
-  getCurrentScope().setTag('runtime', 'node');
+  setTag('runtime', 'node');
 }

--- a/packages/astro/test/client/sdk.test.ts
+++ b/packages/astro/test/client/sdk.test.ts
@@ -60,7 +60,7 @@ describe('Sentry client SDK', () => {
           ...tracingOptions,
         });
 
-        const integrationsToInit = browserInit.mock.calls[0][0]?.integrations;
+        const integrationsToInit = browserInit.mock.calls[0][0]?.defaultIntegrations;
         const browserTracing = getClient<BrowserClient>()?.getIntegrationByName('BrowserTracing');
 
         expect(integrationsToInit).toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
@@ -76,7 +76,7 @@ describe('Sentry client SDK', () => {
           ...tracingOptions,
         });
 
-        const integrationsToInit = browserInit.mock.calls[0][0]?.integrations;
+        const integrationsToInit = browserInit.mock.calls[0][0]?.defaultIntegrations;
         const browserTracing = getClient<BrowserClient>()?.getIntegrationByName('BrowserTracing');
 
         expect(integrationsToInit).not.toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
@@ -91,7 +91,7 @@ describe('Sentry client SDK', () => {
           enableTracing: true,
         });
 
-        const integrationsToInit = browserInit.mock.calls[0][0]?.integrations;
+        const integrationsToInit = browserInit.mock.calls[0][0]?.defaultIntegrations;
         const browserTracing = getClient<BrowserClient>()?.getIntegrationByName('BrowserTracing');
 
         expect(integrationsToInit).not.toContainEqual(expect.objectContaining({ name: 'BrowserTracing' }));
@@ -107,7 +107,7 @@ describe('Sentry client SDK', () => {
           enableTracing: true,
         });
 
-        const integrationsToInit = browserInit.mock.calls[0][0]?.integrations;
+        const integrationsToInit = browserInit.mock.calls[0][0]?.defaultIntegrations;
 
         const browserTracing = getClient<BrowserClient>()?.getIntegrationByName('BrowserTracing') as BrowserTracing;
         const options = browserTracing.options;


### PR DESCRIPTION
We should wait for https://github.com/getsentry/sentry-javascript/pull/10243 to merge this, as otherwise we'll get a deprecation/eslint error there.