### PR TITLE
build(replay): Ensure we can publish replay-canvas

### DIFF
--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -41,6 +41,9 @@
     "test:watch": "jest --watch",
     "yalc:publish": "ts-node ../../scripts/prepack.ts --bundles && yalc publish ./build/npm --push --sig"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/getsentry/sentry-javascript.git"


### PR DESCRIPTION
See https://github.com/getsentry/publish/actions/runs/7581756645/job/20649976035, this fails without this apparently.