### PR TITLE
build(replay): Ensure we can publish replay-canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
 
+## 7.94.1
+
+This release fixes a publishing issue.
+
 ## 7.94.0
 
 ### Important Changes

--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -41,6 +41,9 @@
     "test:watch": "jest --watch",
     "yalc:publish": "ts-node ../../scripts/prepack.ts --bundles && yalc publish ./build/npm --push --sig"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/getsentry/sentry-javascript.git"


### PR DESCRIPTION
This is a hotfix on master so we can fix the partial release 7.94.0...

Since we publish in order we published these as 7.94.0:

* `@sentry/types`
* `@sentry/utils`
* `@sentry/core`
* `@sentry-internal/tracing`
* `@sentry/replay`
* `@sentry/opentelemetry`
* `@sentry-internal/feedback`

So nothing should be broken, technically.

Replaces https://github.com/getsentry/sentry-javascript/pull/10261