### PR TITLE
fix(replay-canvas): Add missing dependency on @sentry/utils

### DIFF
--- a/packages/replay-canvas/package.json
+++ b/packages/replay-canvas/package.json
@@ -61,7 +61,8 @@
   "dependencies": {
     "@sentry/core": "7.94.1",
     "@sentry/replay": "7.94.1",
-    "@sentry/types": "7.94.1"
+    "@sentry/types": "7.94.1",
+    "@sentry/utils": "7.94.1"
   },
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

~- [ ] If you've added code that should be tested, please add tests.~ N/A
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

Fixes #10266

The built version of `@sentry-internal/replay-canvas` imports from `@sentry/utils`, and should therefore list `@sentry/utils` as one of its dependencies.

![image](https://github.com/getsentry/sentry-javascript/assets/693755/31b1d529-2b97-41ca-bcda-fc6fa2d7ada3)
