### PR TITLE
fix(wasm): Add `@sentry/core` as a dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,7 @@ jobs:
               - 'packages/replay/**'
               - 'packages/replay-canvas/**'
               - 'packages/feedback/**'
+              - 'packages/wasm/**'
             browser_integration:
               - *shared
               - *browser

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "@sentry/browser": "7.94.1",
     "@sentry/types": "7.94.1",
-    "@sentry/utils": "7.94.1"
+    "@sentry/utils": "7.94.1",
+    "@sentry/core": "7.94.1"
   },
   "scripts": {
     "build": "run-p build:transpile build:bundle build:types",


### PR DESCRIPTION
By using functional integrations in #10230, we started importing from `@sentry/core` in the WASM integration. However, we didn't register `@sentry/core` as a dependency, making rollup bundle core into the package output. This changed the `build/npm` directory structure, making our entry points in `package.json` invalid.

This PR fixes things by simply registering core as a dependency of wasm. If we move WASM to core (which I strongly think we should do), we'll be able to get rid of this again.