### PR TITLE
test: Re-enable Remix client-side e2e tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1042,7 +1042,6 @@ jobs:
             'node-express-app',
             'create-react-app',
             'create-next-app',
-            # disabling remix e2e tests because of flakes
             'create-remix-app',
             'create-remix-app-v2',
             'debug-id-sourcemaps',

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1043,8 +1043,8 @@ jobs:
             'create-react-app',
             'create-next-app',
             # disabling remix e2e tests because of flakes
-            # 'create-remix-app',
-            # 'create-remix-app-v2',
+            'create-remix-app',
+            'create-remix-app-v2',
             'debug-id-sourcemaps',
             'nextjs-app-dir',
             'nextjs-14',

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.client.tsx
@@ -22,7 +22,6 @@ Sentry.init({
   // Session Replay
   replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
   replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
-  debug: true,
 });
 
 Sentry.addEventProcessor(event => {

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.client.tsx
@@ -22,6 +22,7 @@ Sentry.init({
   // Session Replay
   replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
   replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+  debug: true,
 });
 
 Sentry.addEventProcessor(event => {

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.client.tsx
@@ -10,6 +10,7 @@ import { StrictMode, startTransition, useEffect } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 
 Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: window.ENV.SENTRY_DSN,
   integrations: [
     new Sentry.BrowserTracing({

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.server.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.server.tsx
@@ -22,6 +22,7 @@ Sentry.init({
   dsn: process.env.E2E_TEST_DSN,
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
+  debug: true,
 });
 
 export const handleError = Sentry.wrapRemixHandleError;

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.server.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.server.tsx
@@ -22,7 +22,6 @@ Sentry.init({
   dsn: process.env.E2E_TEST_DSN,
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
-  debug: true,
 });
 
 export const handleError = Sentry.wrapRemixHandleError;

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.server.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/app/entry.server.tsx
@@ -19,6 +19,7 @@ installGlobals();
 const ABORT_DELAY = 5_000;
 
 Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/remix.config.js
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/remix.config.js
@@ -6,5 +6,4 @@ module.exports = {
   // serverBuildPath: 'build/index.js',
   // publicPath: '/build/',
   serverModuleFormat: 'cjs',
-  entry,
 };

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/tests/behaviour-client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/tests/behaviour-client.test.ts
@@ -47,8 +47,7 @@ test('Sends a client-side exception to Sentry', async ({ page }) => {
     .toBe(200);
 });
 
-// Skipping test because of flake
-test.skip('Sends a pageload transaction to Sentry', async ({ page }) => {
+test('Sends a pageload transaction to Sentry', async ({ page }) => {
   await page.goto('/');
 
   const recordedTransactionsHandle = await page.waitForFunction(() => {
@@ -107,8 +106,7 @@ test.skip('Sends a pageload transaction to Sentry', async ({ page }) => {
   expect(hadPageLoadTransaction).toBe(true);
 });
 
-// Skipped because of test flake
-test.skip('Sends a navigation transaction to Sentry', async ({ page }) => {
+test('Sends a navigation transaction to Sentry', async ({ page }) => {
   await page.goto('/');
 
   // Give pageload transaction time to finish

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/tests/behaviour-client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/tests/behaviour-client.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import axios, { AxiosError } from 'axios';
 
-const EVENT_POLLING_TIMEOUT = 90_000;
+const EVENT_POLLING_TIMEOUT = 120_000;
 
 const authToken = process.env.E2E_TEST_AUTH_TOKEN;
 const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/tests/behaviour-client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/tests/behaviour-client.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import axios, { AxiosError } from 'axios';
 
-const EVENT_POLLING_TIMEOUT = 120_000;
+const EVENT_POLLING_TIMEOUT = 90_000;
 
 const authToken = process.env.E2E_TEST_AUTH_TOKEN;
 const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;

--- a/dev-packages/e2e-tests/test-applications/create-remix-app/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app/app/entry.client.tsx
@@ -22,7 +22,6 @@ Sentry.init({
   // Session Replay
   replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
   replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
-  debug: true,
 });
 
 Sentry.addEventProcessor(event => {

--- a/dev-packages/e2e-tests/test-applications/create-remix-app/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app/app/entry.client.tsx
@@ -22,6 +22,7 @@ Sentry.init({
   // Session Replay
   replaysSessionSampleRate: 0.1, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
   replaysOnErrorSampleRate: 1.0, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+  debug: true,
 });
 
 Sentry.addEventProcessor(event => {

--- a/dev-packages/e2e-tests/test-applications/create-remix-app/app/entry.client.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app/app/entry.client.tsx
@@ -10,6 +10,7 @@ import { StrictMode, startTransition, useEffect } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 
 Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: window.ENV.SENTRY_DSN,
   integrations: [
     new Sentry.BrowserTracing({

--- a/dev-packages/e2e-tests/test-applications/create-remix-app/app/entry.server.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app/app/entry.server.tsx
@@ -19,7 +19,6 @@ Sentry.init({
   dsn: process.env.E2E_TEST_DSN,
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
-  debug: true,
 });
 
 export const handleError = Sentry.wrapRemixHandleError;

--- a/dev-packages/e2e-tests/test-applications/create-remix-app/app/entry.server.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app/app/entry.server.tsx
@@ -19,6 +19,7 @@ Sentry.init({
   dsn: process.env.E2E_TEST_DSN,
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!
+  debug: true,
 });
 
 export const handleError = Sentry.wrapRemixHandleError;

--- a/dev-packages/e2e-tests/test-applications/create-remix-app/app/entry.server.tsx
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app/app/entry.server.tsx
@@ -16,6 +16,7 @@ import { renderToPipeableStream } from 'react-dom/server';
 const ABORT_DELAY = 5_000;
 
 Sentry.init({
+  environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   // Performance Monitoring
   tracesSampleRate: 1.0, // Capture 100% of the transactions, reduce in production!

--- a/dev-packages/e2e-tests/test-applications/create-remix-app/tests/behaviour-client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app/tests/behaviour-client.test.ts
@@ -7,8 +7,7 @@ const authToken = process.env.E2E_TEST_AUTH_TOKEN;
 const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;
 const sentryTestProject = process.env.E2E_TEST_SENTRY_TEST_PROJECT;
 
-// skipping flaky test
-test.skip('Sends a client-side exception to Sentry', async ({ page }) => {
+test('Sends a client-side exception to Sentry', async ({ page }) => {
   await page.goto('/');
 
   const exceptionButton = page.locator('id=exception-button');
@@ -48,8 +47,7 @@ test.skip('Sends a client-side exception to Sentry', async ({ page }) => {
     .toBe(200);
 });
 
-// skipping flaky test
-test.skip('Sends a pageload transaction to Sentry', async ({ page }) => {
+test('Sends a pageload transaction to Sentry', async ({ page }) => {
   await page.goto('/');
 
   const recordedTransactionsHandle = await page.waitForFunction(() => {

--- a/dev-packages/e2e-tests/test-applications/create-remix-app/tests/behaviour-client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app/tests/behaviour-client.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import axios, { AxiosError } from 'axios';
 
-const EVENT_POLLING_TIMEOUT = 90_000;
+const EVENT_POLLING_TIMEOUT = 120_000;
 
 const authToken = process.env.E2E_TEST_AUTH_TOKEN;
 const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;

--- a/dev-packages/e2e-tests/test-applications/create-remix-app/tests/behaviour-client.test.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app/tests/behaviour-client.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import axios, { AxiosError } from 'axios';
 
-const EVENT_POLLING_TIMEOUT = 120_000;
+const EVENT_POLLING_TIMEOUT = 90_000;
 
 const authToken = process.env.E2E_TEST_AUTH_TOKEN;
 const sentryTestOrgSlug = process.env.E2E_TEST_SENTRY_ORG_SLUG;


### PR DESCRIPTION
**Update**: Added `environment: 'qa'` to Remix e2e tests.

~Could not find anything that may cause this to fail, I suppose it was slow ingestion.~

~It's still weird that it only happens in Remix client-side tests. (They take slightly longer to finish, so they may be more prone to timeout when there's slow ingestion)~

~Ran CI many times, and they're not timing out anymore as far as I see.~