### PR TITLE
ref(types): Add known attribute keys to `SpanAttributes` type

### DIFF
--- a/packages/types/src/span.ts
+++ b/packages/types/src/span.ts
@@ -23,7 +23,13 @@ export type SpanAttributeValue =
   | Array<null | undefined | number>
   | Array<null | undefined | boolean>;
 
-export type SpanAttributes = Record<string, SpanAttributeValue | undefined>;
+export type SpanAttributes = Partial<{
+  'sentry.origin': string;
+  'sentry.op': string;
+  'sentry.source': string;
+  'sentry.sample_rate': number;
+}> &
+  Record<string, SpanAttributeValue | undefined>;
 
 /** This type is aligned with the OpenTelemetry TimeInput type. */
 export type SpanTimeInput = HrTime | number | Date;


### PR DESCRIPTION
(extracted from #10274 to discuss in isolation)

I propose we add known attribute keys to the `SpanAttributes` type because this way we can 
1. enforce a concrete type for some known keys
2. give users (and us) auto suggestions when setting attributes

WDYT, is this an improvement to the pure `Record` type?  