### PR TITLE
feat(core): Expose `isInitialized()` to replace checking via `getClient`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,6 +10,12 @@ npx @sentry/migr8@latest
 This will let you select which updates to run, and automatically update your code. Make sure to still review all code
 changes!
 
+## Deprecate using `getClient()` to check if the SDK was initialized
+
+In v8, `getClient()` will stop returning `undefined` if `Sentry.init()` was not called. For cases where this may be used
+to check if Sentry was actually initialized, using `getClient()` will thus not work anymore. Instead, you should use the
+new `Sentry.isInitialized()` utility to check this.
+
 ## Deprecate `getCurrentHub()`
 
 In v8, you will no longer have a Hub, only Scopes as a concept. This also means that `getCurrentHub()` will eventually

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -28,6 +28,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   getCurrentHub,
   getClient,
+  isInitialized,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -40,6 +40,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   getCurrentHub,
   getClient,
+  isInitialized,
   getCurrentScope,
   Hub,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -45,6 +45,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   getCurrentHub,
   getClient,
+  isInitialized,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -395,6 +395,13 @@ export function getClient<C extends Client>(): C | undefined {
 }
 
 /**
+ * Returns true if Sentry has been properly initialized.
+ */
+export function isInitialized(): boolean {
+  return !!getClient();
+}
+
+/**
  * Get the currently active scope.
  */
 export function getCurrentScope(): Scope {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,7 @@ export {
   withScope,
   withIsolationScope,
   getClient,
+  isInitialized,
   getCurrentScope,
   startSession,
   endSession,

--- a/packages/core/test/lib/exports.test.ts
+++ b/packages/core/test/lib/exports.test.ts
@@ -1,3 +1,4 @@
+import { GLOBAL_OBJ } from '@sentry/utils';
 import {
   Hub,
   Scope,
@@ -16,6 +17,7 @@ import {
   withIsolationScope,
   withScope,
 } from '../../src';
+import { isInitialized } from '../../src/exports';
 import { TestClient, getDefaultTestClientOptions } from '../mocks/client';
 
 function getTestClient(): TestClient {
@@ -313,5 +315,21 @@ describe('session APIs', () => {
         expect(isolationScope.getScopeData().contexts?.foo?.bar).toBe('baz');
       });
     });
+  });
+});
+
+describe('isInitialized', () => {
+  it('returns false if no client is setup', () => {
+    GLOBAL_OBJ.__SENTRY__.hub = undefined;
+    expect(isInitialized()).toBe(false);
+  });
+
+  it('returns true if client is setup', () => {
+    const client = getTestClient();
+    const hub = new Hub(client);
+    // eslint-disable-next-line deprecation/deprecation
+    makeMain(hub);
+
+    expect(isInitialized()).toBe(true);
   });
 });

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -44,6 +44,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   getCurrentHub,
   getClient,
+  isInitialized,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -17,6 +17,7 @@ export type { Span } from './types';
 export { startSpan, startSpanManual, startInactiveSpan, getActiveSpan } from '@sentry/opentelemetry';
 export {
   getClient,
+  isInitialized,
   addBreadcrumb,
   captureException,
   captureEvent,

--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -22,9 +22,9 @@ import { getContextFromScope, getScopesFromContext, setScopesOnContext } from '.
 import type { ExclusiveEventHintOrCaptureContext } from '../utils/prepareEvent';
 import { parseEventHintOrCaptureContext } from '../utils/prepareEvent';
 import type { Scope } from './scope';
-import { getClient, getCurrentScope, getGlobalScope, getIsolationScope } from './scope';
+import { getClient, getCurrentScope, getGlobalScope, getIsolationScope, isInitialized } from './scope';
 
-export { getCurrentScope, getGlobalScope, getIsolationScope, getClient };
+export { getCurrentScope, getGlobalScope, getIsolationScope, getClient, isInitialized };
 export { setCurrentScope, setIsolationScope } from './scope';
 
 /**

--- a/packages/node-experimental/src/sdk/scope.ts
+++ b/packages/node-experimental/src/sdk/scope.ts
@@ -65,6 +65,11 @@ export function getClient<C extends Client>(): C {
   return {} as C;
 }
 
+/** If the SDK was initialized. */
+export function isInitialized(): boolean {
+  return !!getClient().getDsn();
+}
+
 /** A fork of the classic scope with some otel specific stuff. */
 export class Scope extends OpenTelemetryScope implements ScopeInterface {
   // Overwrite this if you want to use a specific isolation scope here

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -44,6 +44,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   getCurrentHub,
   getClient,
+  isInitialized,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -32,6 +32,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   getCurrentHub,
   getClient,
+  isInitialized,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -25,6 +25,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   getCurrentHub,
   getClient,
+  isInitialized,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -44,6 +44,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   getCurrentHub,
   getClient,
+  isInitialized,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,


### PR DESCRIPTION
Currently, you can use `Sentry.getClient() !== undefined` to check if Sentry was initialized. In v8, we want to change this so that this _always_ returns a client (possibly a Noop client), so this check will not work anymore there. Instead, we can provide a new util that does this explicitly, where we can control what it checks under the hood.