### PR TITLE
feat(tracing): Deprecate transaction-related options for `BrowserTracing`

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,6 +10,16 @@ npx @sentry/migr8@latest
 This will let you select which updates to run, and automatically update your code. Make sure to still review all code
 changes!
 
+## Deprecate transaction-related options to `BrowserTracing`
+
+When configuring the `BrowserTracing` integration, some options have been renamed:
+
+- `startTransactionOnPageLoad` --> `spanOnPageLoad`
+- `startTransactionOnLocationChange` --> `spanOnLocationChange`
+- `markBackgroundTransactions` --> `markBackgroundSpan`
+
+Also, `beforeNavigate` is replaced with a `beforeStartSpan` callback, which receives `StartSpanOptions`.
+
 ## Deprecate using `getClient()` to check if the SDK was initialized
 
 In v8, `getClient()` will stop returning `undefined` if `Sentry.init()` was not called. For cases where this may be used

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -1,15 +1,5 @@
-import type {
-  Instrumenter,
-  Primitive,
-  Scope,
-  Span,
-  SpanTimeInput,
-  TransactionContext,
-  TransactionMetadata,
-} from '@sentry/types';
-import type { SpanAttributes } from '@sentry/types';
-import type { SpanOrigin } from '@sentry/types';
-import type { TransactionSource } from '@sentry/types';
+import type { Span, SpanTimeInput, StartSpanOptions, TransactionContext } from '@sentry/types';
+
 import { dropUndefinedKeys, logger, tracingContextFromHeaders } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
@@ -19,105 +9,6 @@ import { getCurrentHub } from '../hub';
 import { handleCallbackErrors } from '../utils/handleCallbackErrors';
 import { hasTracingEnabled } from '../utils/hasTracingEnabled';
 import { spanTimeInputToSeconds, spanToJSON } from '../utils/spanUtils';
-
-interface StartSpanOptions extends TransactionContext {
-  /** A manually specified start time for the created `Span` object. */
-  startTime?: SpanTimeInput;
-
-  /** If defined, start this span off this scope instead off the current scope. */
-  scope?: Scope;
-
-  /** The name of the span. */
-  name: string;
-
-  /** An op for the span. This is a categorization for spans. */
-  op?: string;
-
-  /** The origin of the span - if it comes from auto instrumenation or manual instrumentation. */
-  origin?: SpanOrigin;
-
-  /** Attributes for the span. */
-  attributes?: SpanAttributes;
-
-  // All remaining fields are deprecated
-
-  /**
-   * @deprecated Manually set the end timestamp instead.
-   */
-  trimEnd?: boolean;
-
-  /**
-   * @deprecated This cannot be set manually anymore.
-   */
-  parentSampled?: boolean;
-
-  /**
-   * @deprecated Use attributes or set data on scopes instead.
-   */
-  metadata?: Partial<TransactionMetadata>;
-
-  /**
-   * The name thingy.
-   * @deprecated Use `name` instead.
-   */
-  description?: string;
-
-  /**
-   * @deprecated Use `span.setStatus()` instead.
-   */
-  status?: string;
-
-  /**
-   * @deprecated Use `scope` instead.
-   */
-  parentSpanId?: string;
-
-  /**
-   * @deprecated You cannot manually set the span to sampled anymore.
-   */
-  sampled?: boolean;
-
-  /**
-   * @deprecated You cannot manually set the spanId anymore.
-   */
-  spanId?: string;
-
-  /**
-   * @deprecated You cannot manually set the traceId anymore.
-   */
-  traceId?: string;
-
-  /**
-   * @deprecated Use an attribute instead.
-   */
-  source?: TransactionSource;
-
-  /**
-   * @deprecated Use attributes or set tags on the scope instead.
-   */
-  tags?: { [key: string]: Primitive };
-
-  /**
-   * @deprecated Use attributes instead.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data?: { [key: string]: any };
-
-  /**
-   * @deprecated Use `startTime` instead.
-   */
-  startTimestamp?: number;
-
-  /**
-   * @deprecated Use `span.end()` instead.
-   */
-  endTimestamp?: number;
-
-  /**
-   * @deprecated You cannot set the instrumenter manually anymore.
-   */
-  instrumenter?: Instrumenter;
-}
 
 /**
  * Wraps a function with a transaction/span and finishes the span after the function is done.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -100,6 +100,7 @@ export type {
   SpanContextData,
   TraceFlag,
 } from './span';
+export type { StartSpanOptions } from './startSpanOptions';
 export type { StackFrame } from './stackframe';
 export type { Stacktrace, StackParser, StackLineParser, StackLineParserFn } from './stacktrace';
 export type { TextEncoderInternal } from './textencoder';

--- a/packages/types/src/startSpanOptions.ts
+++ b/packages/types/src/startSpanOptions.ts
@@ -1,0 +1,104 @@
+import type { Instrumenter } from './instrumenter';
+import type { Primitive } from './misc';
+import type { Scope } from './scope';
+import type { SpanAttributes, SpanOrigin, SpanTimeInput } from './span';
+import type { TransactionContext, TransactionMetadata, TransactionSource } from './transaction';
+
+export interface StartSpanOptions extends TransactionContext {
+  /** A manually specified start time for the created `Span` object. */
+  startTime?: SpanTimeInput;
+
+  /** If defined, start this span off this scope instead off the current scope. */
+  scope?: Scope;
+
+  /** The name of the span. */
+  name: string;
+
+  /** An op for the span. This is a categorization for spans. */
+  op?: string;
+
+  /** The origin of the span - if it comes from auto instrumenation or manual instrumentation. */
+  origin?: SpanOrigin;
+
+  /** Attributes for the span. */
+  attributes?: SpanAttributes;
+
+  // All remaining fields are deprecated
+
+  /**
+   * @deprecated Manually set the end timestamp instead.
+   */
+  trimEnd?: boolean;
+
+  /**
+   * @deprecated This cannot be set manually anymore.
+   */
+  parentSampled?: boolean;
+
+  /**
+   * @deprecated Use attributes or set data on scopes instead.
+   */
+  metadata?: Partial<TransactionMetadata>;
+
+  /**
+   * The name thingy.
+   * @deprecated Use `name` instead.
+   */
+  description?: string;
+
+  /**
+   * @deprecated Use `span.setStatus()` instead.
+   */
+  status?: string;
+
+  /**
+   * @deprecated Use `scope` instead.
+   */
+  parentSpanId?: string;
+
+  /**
+   * @deprecated You cannot manually set the span to sampled anymore.
+   */
+  sampled?: boolean;
+
+  /**
+   * @deprecated You cannot manually set the spanId anymore.
+   */
+  spanId?: string;
+
+  /**
+   * @deprecated You cannot manually set the traceId anymore.
+   */
+  traceId?: string;
+
+  /**
+   * @deprecated Use an attribute instead.
+   */
+  source?: TransactionSource;
+
+  /**
+   * @deprecated Use attributes or set tags on the scope instead.
+   */
+  tags?: { [key: string]: Primitive };
+
+  /**
+   * @deprecated Use attributes instead.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data?: { [key: string]: any };
+
+  /**
+   * @deprecated Use `startTime` instead.
+   */
+  startTimestamp?: number;
+
+  /**
+   * @deprecated Use `span.end()` instead.
+   */
+  endTimestamp?: number;
+
+  /**
+   * @deprecated You cannot set the instrumenter manually anymore.
+   */
+  instrumenter?: Instrumenter;
+}


### PR DESCRIPTION
These are mostly naming changes to use `span` instead of `transaction` for options.

Missing is a new handling for `routingInstrumentation`, which I will tackle in a separate PR.