### PR TITLE
fix(svelte): Make component tracking compatible with Svelte 5

### DIFF
--- a/packages/svelte/src/performance.ts
+++ b/packages/svelte/src/performance.ts
@@ -52,7 +52,6 @@ function recordInitSpan(componentName: string): Span | undefined {
   });
 
   onMount(() => {
-    console.log('END SPAN', componentName);
     initSpan.end();
   });
 

--- a/packages/svelte/src/performance.ts
+++ b/packages/svelte/src/performance.ts
@@ -1,7 +1,6 @@
 import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, getActiveSpan } from '@sentry/browser';
 import type { Span } from '@sentry/types';
 import { afterUpdate, beforeUpdate, onMount } from 'svelte';
-import { current_component } from 'svelte/internal';
 
 import { getRootSpan, startInactiveSpan, withActiveSpan } from '@sentry/core';
 import { DEFAULT_COMPONENT_NAME, UI_SVELTE_INIT, UI_SVELTE_UPDATE } from './constants';
@@ -32,7 +31,7 @@ export function trackComponent(options?: TrackComponentOptions): void {
 
   // current_component.ctor.name is likely to give us the component's name automatically
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  const componentName = `<${customComponentName || current_component.constructor.name || DEFAULT_COMPONENT_NAME}>`;
+  const componentName = `<${customComponentName || DEFAULT_COMPONENT_NAME}>`;
 
   let initSpan: Span | undefined = undefined;
   if (mergedOptions.trackInit) {
@@ -53,6 +52,7 @@ function recordInitSpan(componentName: string): Span | undefined {
   });
 
   onMount(() => {
+    console.log('END SPAN', componentName);
     initSpan.end();
   });
 

--- a/packages/svelte/src/preprocessors.ts
+++ b/packages/svelte/src/preprocessors.ts
@@ -18,6 +18,8 @@ export const FIRST_PASS_COMPONENT_TRACKING_PREPROC_ID = 'FIRST_PASS_COMPONENT_TR
 export function componentTrackingPreprocessor(options?: ComponentTrackingInitOptions): PreprocessorGroup {
   const mergedOptions = { ...defaultComponentTrackingOptions, ...options };
 
+  console.log('mergedOptions', mergedOptions);
+
   const visitedFiles = new Set<string>();
   const visitedFilesMarkup = new Set<string>();
 

--- a/packages/svelte/src/preprocessors.ts
+++ b/packages/svelte/src/preprocessors.ts
@@ -18,8 +18,6 @@ export const FIRST_PASS_COMPONENT_TRACKING_PREPROC_ID = 'FIRST_PASS_COMPONENT_TR
 export function componentTrackingPreprocessor(options?: ComponentTrackingInitOptions): PreprocessorGroup {
   const mergedOptions = { ...defaultComponentTrackingOptions, ...options };
 
-  console.log('mergedOptions', mergedOptions);
-
   const visitedFiles = new Set<string>();
   const visitedFilesMarkup = new Set<string>();
 


### PR DESCRIPTION
depends on #10311 

This PR adds compatibility for Svelte 5 by adjusting our component tracking functionality to work with Svelte 5.

TLDR: This change entails a minor behaviour "breaking" change for a subset of Svelte component tracking users. 

Our previous implementation relied on an exported internal API (`current_component`) to automatically detect the name of the component name for the respective spans. This API was removed in Svelte 5, so we can no longer use it. Importing it causes a build error. This means that going forward, calls to `trackComponent` need to set the `componentName` option or the span will get the fallback `<Svelte Component>` name. However, this only applies if the function is called manually.

In case users use our `withSentryConfig` wrapper in their `svelte.config.js`, we inject a preprocessor that already creates passes the component name from the component file name to the injected `trackComponent` call.  So nothing changes in this use case - component spans will still automatically get the correct name. We recommend this approach [in our docs](https://docs.sentry.io/platforms/javascript/guides/svelte/features/component-tracking/#usage).

ref #10275 