### PR TITLE
feat(utils): Add `propagationContextFromHeaders`

### DIFF
--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -1,5 +1,6 @@
 import type { Span, SpanTimeInput, StartSpanOptions, TransactionContext } from '@sentry/types';
 
+import type { propagationContextFromHeaders } from '@sentry/utils';
 import { dropUndefinedKeys, logger, tracingContextFromHeaders } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../debug-build';
@@ -213,16 +214,16 @@ export function continueTrace({
   sentryTrace,
   baggage,
 }: {
-  sentryTrace: Parameters<typeof tracingContextFromHeaders>[0];
-  baggage: Parameters<typeof tracingContextFromHeaders>[1];
+  sentryTrace: Parameters<typeof propagationContextFromHeaders>[0];
+  baggage: Parameters<typeof propagationContextFromHeaders>[1];
 }): Partial<TransactionContext>;
 export function continueTrace<V>(
   {
     sentryTrace,
     baggage,
   }: {
-    sentryTrace: Parameters<typeof tracingContextFromHeaders>[0];
-    baggage: Parameters<typeof tracingContextFromHeaders>[1];
+    sentryTrace: Parameters<typeof propagationContextFromHeaders>[0];
+    baggage: Parameters<typeof propagationContextFromHeaders>[1];
   },
   callback: (transactionContext: Partial<TransactionContext>) => V,
 ): V;
@@ -238,7 +239,9 @@ export function continueTrace<V>(
     sentryTrace,
     baggage,
   }: {
+    // eslint-disable-next-line deprecation/deprecation
     sentryTrace: Parameters<typeof tracingContextFromHeaders>[0];
+    // eslint-disable-next-line deprecation/deprecation
     baggage: Parameters<typeof tracingContextFromHeaders>[1];
   },
   callback?: (transactionContext: Partial<TransactionContext>) => V,
@@ -252,6 +255,7 @@ export function continueTrace<V>(
 
   const currentScope = getCurrentScope();
 
+  // eslint-disable-next-line deprecation/deprecation
   const { traceparentData, dynamicSamplingContext, propagationContext } = tracingContextFromHeaders(
     sentryTrace,
     baggage,

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -243,6 +243,13 @@ export function continueTrace<V>(
   },
   callback?: (transactionContext: Partial<TransactionContext>) => V,
 ): V | Partial<TransactionContext> {
+  // TODO(v8): Change this function so it doesn't do anything besides setting the propagation context on the current scope:
+  /*
+    const propagationContext = propagationContextFromHeaders(sentryTrace, baggage);
+    getCurrentScope().setPropagationContext(propagationContext);
+    return;
+  */
+
   const currentScope = getCurrentScope();
 
   const { traceparentData, dynamicSamplingContext, propagationContext } = tracingContextFromHeaders(

--- a/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
+++ b/packages/nextjs/src/client/routing/pagesRouterRoutingInstrumentation.ts
@@ -119,6 +119,7 @@ export function pagesRouterInstrumentation(
   startTransactionOnLocationChange: boolean = true,
 ): void {
   const { route, params, sentryTrace, baggage } = extractNextDataTagInformation();
+  // eslint-disable-next-line deprecation/deprecation
   const { traceparentData, dynamicSamplingContext, propagationContext } = tracingContextFromHeaders(
     sentryTrace,
     baggage,

--- a/packages/nextjs/src/common/utils/wrapperUtils.ts
+++ b/packages/nextjs/src/common/utils/wrapperUtils.ts
@@ -93,6 +93,7 @@ export function withTracedServerSideDataFetcher<F extends (...args: any[]) => Pr
       const sentryTrace =
         req.headers && isString(req.headers['sentry-trace']) ? req.headers['sentry-trace'] : undefined;
       const baggage = req.headers?.baggage;
+      // eslint-disable-next-line deprecation/deprecation
       const { traceparentData, dynamicSamplingContext, propagationContext } = tracingContextFromHeaders(
         sentryTrace,
         baggage,

--- a/packages/nextjs/src/common/withServerActionInstrumentation.ts
+++ b/packages/nextjs/src/common/withServerActionInstrumentation.ts
@@ -76,6 +76,7 @@ async function withServerActionInstrumentationImplementation<A extends (...args:
     }
 
     const currentScope = getCurrentScope();
+    // eslint-disable-next-line deprecation/deprecation
     const { traceparentData, dynamicSamplingContext, propagationContext } = tracingContextFromHeaders(
       sentryTraceHeader,
       baggageHeader,

--- a/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapRouteHandlerWithSentry.ts
@@ -28,6 +28,7 @@ export function wrapRouteHandlerWithSentry<F extends (...args: any[]) => any>(
   return new Proxy(routeHandler, {
     apply: (originalFunction, thisArg, args) => {
       return runWithAsyncContext(async () => {
+        // eslint-disable-next-line deprecation/deprecation
         const { traceparentData, dynamicSamplingContext, propagationContext } = tracingContextFromHeaders(
           sentryTraceHeader ?? headers?.get('sentry-trace') ?? undefined,
           baggageHeader ?? headers?.get('baggage'),

--- a/packages/node-experimental/src/sdk/init.ts
+++ b/packages/node-experimental/src/sdk/init.ts
@@ -12,8 +12,8 @@ import {
   consoleSandbox,
   dropUndefinedKeys,
   logger,
+  propagationContextFromHeaders,
   stackParserFromStackParserOptions,
-  tracingContextFromHeaders,
 } from '@sentry/utils';
 import { DEBUG_BUILD } from '../debug-build';
 
@@ -190,7 +190,7 @@ function updateScopeFromEnvVariables(): void {
   if (!['false', 'n', 'no', 'off', '0'].includes(sentryUseEnvironment)) {
     const sentryTraceEnv = process.env.SENTRY_TRACE;
     const baggageEnv = process.env.SENTRY_BAGGAGE;
-    const { propagationContext } = tracingContextFromHeaders(sentryTraceEnv, baggageEnv);
+    const propagationContext = propagationContextFromHeaders(sentryTraceEnv, baggageEnv);
     getCurrentScope().setPropagationContext(propagationContext);
   }
 }

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -17,8 +17,8 @@ import {
   GLOBAL_OBJ,
   createStackParser,
   nodeStackLineParser,
+  propagationContextFromHeaders,
   stackParserFromStackParserOptions,
-  tracingContextFromHeaders,
 } from '@sentry/utils';
 
 import { setNodeAsyncContextStrategy } from './async';
@@ -291,7 +291,7 @@ function updateScopeFromEnvVariables(): void {
   if (!['false', 'n', 'no', 'off', '0'].includes(sentryUseEnvironment)) {
     const sentryTraceEnv = process.env.SENTRY_TRACE;
     const baggageEnv = process.env.SENTRY_BAGGAGE;
-    const { propagationContext } = tracingContextFromHeaders(sentryTraceEnv, baggageEnv);
+    const propagationContext = propagationContextFromHeaders(sentryTraceEnv, baggageEnv);
     getCurrentScope().setPropagationContext(propagationContext);
   }
 }

--- a/packages/opentelemetry/src/propagator.ts
+++ b/packages/opentelemetry/src/propagator.ts
@@ -3,7 +3,7 @@ import { TraceFlags, propagation, trace } from '@opentelemetry/api';
 import { W3CBaggagePropagator, isTracingSuppressed } from '@opentelemetry/core';
 import { getDynamicSamplingContextFromClient } from '@sentry/core';
 import type { DynamicSamplingContext, PropagationContext } from '@sentry/types';
-import { SENTRY_BAGGAGE_KEY_PREFIX, generateSentryTraceHeader, tracingContextFromHeaders } from '@sentry/utils';
+import { SENTRY_BAGGAGE_KEY_PREFIX, generateSentryTraceHeader, propagationContextFromHeaders } from '@sentry/utils';
 
 import { SENTRY_BAGGAGE_HEADER, SENTRY_TRACE_HEADER } from './constants';
 import { getClient } from './custom/hub';
@@ -55,7 +55,7 @@ export class SentryPropagator extends W3CBaggagePropagator {
         : maybeSentryTraceHeader
       : undefined;
 
-    const { propagationContext } = tracingContextFromHeaders(sentryTraceHeader, maybeBaggageHeader);
+    const propagationContext = propagationContextFromHeaders(sentryTraceHeader, maybeBaggageHeader);
 
     // Add propagation context to context
     const contextWithPropagationContext = setPropagationContextOnContext(context, propagationContext);

--- a/packages/remix/src/utils/instrumentServer.ts
+++ b/packages/remix/src/utils/instrumentServer.ts
@@ -401,6 +401,7 @@ export function startRequestHandlerTransaction(
     method: string;
   },
 ): Transaction {
+  // eslint-disable-next-line deprecation/deprecation
   const { traceparentData, dynamicSamplingContext, propagationContext } = tracingContextFromHeaders(
     request.headers['sentry-trace'],
     request.headers.baggage,

--- a/packages/sveltekit/src/server/utils.ts
+++ b/packages/sveltekit/src/server/utils.ts
@@ -10,9 +10,11 @@ import { DEBUG_BUILD } from '../common/debug-build';
  *
  * Sets propagation context as a side effect.
  */
+// eslint-disable-next-line deprecation/deprecation
 export function getTracePropagationData(event: RequestEvent): ReturnType<typeof tracingContextFromHeaders> {
   const sentryTraceHeader = event.request.headers.get('sentry-trace') || '';
   const baggageHeader = event.request.headers.get('baggage');
+  // eslint-disable-next-line deprecation/deprecation
   return tracingContextFromHeaders(sentryTraceHeader, baggageHeader);
 }
 

--- a/packages/tracing-internal/src/browser/browserTracingIntegration.ts
+++ b/packages/tracing-internal/src/browser/browserTracingIntegration.ts
@@ -23,7 +23,7 @@ import {
   browserPerformanceTimeOrigin,
   getDomElement,
   logger,
-  tracingContextFromHeaders,
+  propagationContextFromHeaders,
 } from '@sentry/utils';
 
 import { DEBUG_BUILD } from '../common/debug-build';
@@ -201,21 +201,23 @@ export const _browserTracingIntegration = ((_options: Partial<BrowserTracingOpti
     if (isPageloadTransaction) {
       const sentryTrace = isPageloadTransaction ? getMetaContent('sentry-trace') : '';
       const baggage = isPageloadTransaction ? getMetaContent('baggage') : undefined;
-      const { traceparentData, dynamicSamplingContext } = tracingContextFromHeaders(sentryTrace, baggage);
+      const { traceId, dsc, parentSpanId, sampled } = propagationContextFromHeaders(sentryTrace, baggage);
       expandedContext = {
+        traceId,
+        parentSpanId,
+        parentSampled: sampled,
         ...context,
-        ...traceparentData,
         metadata: {
           // eslint-disable-next-line deprecation/deprecation
           ...context.metadata,
-          dynamicSamplingContext: traceparentData && !dynamicSamplingContext ? {} : dynamicSamplingContext,
+          dynamicSamplingContext: dsc,
         },
         trimEnd: true,
       };
     } else {
       expandedContext = {
-        ...context,
         trimEnd: true,
+        ...context,
       };
     }
 

--- a/packages/utils/src/tracing.ts
+++ b/packages/utils/src/tracing.ts
@@ -48,6 +48,7 @@ export function extractTraceparentData(traceparent?: string): TraceparentData | 
  *
  * @deprecated Use `propagationContextFromHeaders` instead.
  */
+// TODO(v8): Remove this function
 export function tracingContextFromHeaders(
   sentryTrace: Parameters<typeof extractTraceparentData>[0],
   baggage: Parameters<typeof baggageHeaderToDynamicSamplingContext>[0],

--- a/packages/utils/test/tracing.test.ts
+++ b/packages/utils/test/tracing.test.ts
@@ -1,9 +1,66 @@
-import { tracingContextFromHeaders } from '../src/tracing';
+import { propagationContextFromHeaders, tracingContextFromHeaders } from '../src/tracing';
+
+const EXAMPLE_SENTRY_TRACE = '12312012123120121231201212312012-1121201211212012-1';
+const EXAMPLE_BAGGAGE = 'sentry-release=1.2.3,sentry-foo=bar,other=baz';
 
 describe('tracingContextFromHeaders()', () => {
   it('should produce a frozen baggage (empty object) when there is an incoming trace but no baggage header', () => {
+    // eslint-disable-next-line deprecation/deprecation
     const tracingContext = tracingContextFromHeaders('12312012123120121231201212312012-1121201211212012-1', undefined);
     expect(tracingContext.dynamicSamplingContext).toEqual({});
     expect(tracingContext.propagationContext.dsc).toEqual({});
+  });
+});
+
+describe('propagationContextFromHeaders()', () => {
+  it('returns a completely new propagation context when no sentry-trace data is given but baggage data is given', () => {
+    const result = propagationContextFromHeaders(undefined, undefined);
+    expect(result).toEqual({
+      traceId: expect.any(String),
+      spanId: expect.any(String),
+    });
+  });
+
+  it('returns a completely new propagation context when no sentry-trace data is given', () => {
+    const result = propagationContextFromHeaders(undefined, EXAMPLE_BAGGAGE);
+    expect(result).toEqual({
+      traceId: expect.any(String),
+      spanId: expect.any(String),
+    });
+  });
+
+  it('returns the correct traceparent data within the propagation context when sentry trace data is given', () => {
+    const result = propagationContextFromHeaders(EXAMPLE_SENTRY_TRACE, undefined);
+    expect(result).toEqual(
+      expect.objectContaining({
+        traceId: '12312012123120121231201212312012',
+        parentSpanId: '1121201211212012',
+        spanId: expect.any(String),
+        sampled: true,
+      }),
+    );
+  });
+
+  it('returns a frozen dynamic sampling context (empty object) when there is an incoming trace but no baggage header', () => {
+    const result = propagationContextFromHeaders(EXAMPLE_SENTRY_TRACE, undefined);
+    expect(result).toEqual(
+      expect.objectContaining({
+        dsc: {},
+      }),
+    );
+  });
+
+  it('returns the correct trace parent data when both sentry-trace and baggage are given', () => {
+    const result = propagationContextFromHeaders(EXAMPLE_SENTRY_TRACE, EXAMPLE_BAGGAGE);
+    expect(result).toEqual({
+      traceId: '12312012123120121231201212312012',
+      parentSpanId: '1121201211212012',
+      spanId: expect.any(String),
+      sampled: true,
+      dsc: {
+        release: '1.2.3',
+        foo: 'bar',
+      },
+    });
   });
 });


### PR DESCRIPTION
Adds a simpler alternative to `tracingContextFromHeaders` which is deprecated with this PR. `tracingContextFromHeadrs` is returning duplicate data, and the value it returns is gonna be useless in a world where spans do not take traceparent data and dynamic sampling contexts directly.

I replaced the deprecated instances in places where it was easy and just added an eslint ignore in places where we will need to refactor in any case.