### PR TITLE
ref(sveltekit): Explicitly set `peerDependencies` for `svelte`

### DIFF
--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -34,7 +34,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@sveltejs/kit": "1.x || 2.x"
+    "@sveltejs/kit": "1.x || 2.x",
+    "svelte": "3.x || 4.x"
   },
   "dependencies": {
     "@sentry/core": "8.0.0-beta.5",


### PR DESCRIPTION
This PR explicitly sets Svelte 3 and 4 as peer dependencies for SvelteKit.

We already require these versions in `@sentry/svelte` but this peer dep conflict goes unnoticed when installing 
`@sentry/sveltekit`. This should make it more clear on installation that we don't support Svelte 5 yet (Svelte 
5 is not yet stable).

Fwiw, we do the same in NextJS with React (I assume for the same reasons)

ref #10275 
ref #10318 
