### PR TITLE
test(node): Add tests for Apollo / GraphQL OpenTelemetry auto-instrumentation.

### DIFF
--- a/dev-packages/node-integration-tests/suites/tracing-experimental/apollo-graphql/scenario.js
+++ b/dev-packages/node-integration-tests/suites/tracing-experimental/apollo-graphql/scenario.js
@@ -1,0 +1,52 @@
+const Sentry = require('@sentry/node-experimental');
+const { loggingTransport } = require('@sentry-internal/node-integration-tests');
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  release: '1.0',
+  tracesSampleRate: 1.0,
+  transport: loggingTransport,
+});
+
+// Stop the process from exiting before the transaction is sent
+setInterval(() => {}, 1000);
+
+async function run() {
+  const { ApolloServer, gql } = require('apollo-server');
+
+  await Sentry.startSpan(
+    {
+      name: 'Test Transaction',
+      op: 'transaction',
+    },
+    async span => {
+      const typeDefs = gql`type Query { hello: String }`;
+
+      const resolvers = {
+        Query: {
+          hello: () => {
+            return 'Hello world!';
+          },
+        },
+      };
+
+      const server = new ApolloServer({
+        typeDefs,
+        resolvers,
+      });
+
+      // Ref: https://www.apollographql.com/docs/apollo-server/testing/testing/#testing-using-executeoperation
+      await server.executeOperation({
+        query: '{hello}',
+      });
+
+      setTimeout(() => {
+        span.end();
+        server.stop();
+      }, 500);
+    },
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-floating-promises
+run();

--- a/dev-packages/node-integration-tests/suites/tracing-experimental/apollo-graphql/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-experimental/apollo-graphql/test.ts
@@ -1,0 +1,42 @@
+import { conditionalTest } from '../../../utils';
+import { createRunner } from '../../../utils/runner';
+
+jest.setTimeout(10000);
+
+// Node 10 is not supported by `graphql-js`
+// Ref: https://github.com/graphql/graphql-js/blob/main/package.json
+conditionalTest({ min: 12 })('GraphQL/Apollo Tests', () => {
+  const EXPECTED_TRANSACTION = {
+    transaction: 'Test Transaction',
+    spans: expect.arrayContaining([
+      expect.objectContaining({
+        data: {
+          'graphql.operation.type': 'query',
+          'graphql.source': '{hello}',
+          'otel.kind': 'INTERNAL',
+          'sentry.origin': 'auto.graphql.otel.graphql',
+        },
+        description: 'query',
+        status: 'ok',
+        origin: 'auto.graphql.otel.graphql',
+      }),
+      expect.objectContaining({
+        data: {
+          'graphql.field.name': 'hello',
+          'graphql.field.path': 'hello',
+          'graphql.field.type': 'String',
+          'graphql.source': 'hello',
+          'otel.kind': 'INTERNAL',
+          'sentry.origin': 'manual',
+        },
+        description: 'graphql.resolve',
+        status: 'ok',
+        origin: 'manual',
+      }),
+    ]),
+  };
+
+  test('CJS - should instrument GraphQL queries used from Apollo Server.', done => {
+    createRunner(__dirname, 'scenario.js').expect({ transaction: EXPECTED_TRANSACTION }).start(done);
+  });
+});

--- a/dev-packages/node-integration-tests/suites/tracing-experimental/apollo-graphql/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-experimental/apollo-graphql/test.ts
@@ -1,9 +1,7 @@
 import { conditionalTest } from '../../../utils';
 import { createRunner } from '../../../utils/runner';
 
-// Node 10 is not supported by `graphql-js`
-// Ref: https://github.com/graphql/graphql-js/blob/main/package.json
-conditionalTest({ min: 12 })('GraphQL/Apollo Tests', () => {
+conditionalTest({ min: 14 })('GraphQL/Apollo Tests', () => {
   const EXPECTED_TRANSACTION = {
     transaction: 'Test Transaction',
     spans: expect.arrayContaining([

--- a/dev-packages/node-integration-tests/suites/tracing-experimental/apollo-graphql/test.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-experimental/apollo-graphql/test.ts
@@ -1,8 +1,6 @@
 import { conditionalTest } from '../../../utils';
 import { createRunner } from '../../../utils/runner';
 
-jest.setTimeout(10000);
-
 // Node 10 is not supported by `graphql-js`
 // Ref: https://github.com/graphql/graphql-js/blob/main/package.json
 conditionalTest({ min: 12 })('GraphQL/Apollo Tests', () => {


### PR DESCRIPTION
Part of: #9907

Tests only CJS usage.