### PR TITLE
fix(node): Fix downleveled types entry point

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -20,8 +20,8 @@
   "types": "build/types/index.d.ts",
   "typesVersions": {
     "<4.9": {
-      "build/npm/types/index.d.ts": [
-        "build/npm/types-ts3.8/index.d.ts"
+      "build/types/index.d.ts": [
+        "build/types-ts3.8/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
Just noticed that this entry point was broken. `build/npm` doesn't exist because the node package is not a package with CDN bundles. Hence all NPM tarball contents are directly in `build`.