### PR TITLE
NIT: typo on types.ts

### DIFF
--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { BrowserOptions } from '@sentry/browser';
 
-// This is not great, but kinda necessary to make it woth with Vue@2 and Vue@3 at the same time.
+// This is not great, but kinda necessary to make it work with Vue@2 and Vue@3 at the same time.
 export interface Vue {
   config: {
     errorHandler?: any;


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [ ] If you've added code that should be tested, please add tests.
- [ ] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

I was reading the type.ts code and I found the `woth` typo that should be `work`

#skip-changelog