### PR TITLE
feat(core): Export `IntegrationIndex` type

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export type { AsyncContextStrategy, Carrier, Layer, RunWithAsyncContextOptions }
 export type { OfflineStore, OfflineTransportOptions } from './transports/offline';
 export type { ServerRuntimeClientOptions } from './server-runtime-client';
 export type { RequestDataIntegrationOptions } from './integrations/requestdata';
+export type { IntegrationIndex } from './integration';
 
 export * from './tracing';
 export * from './semanticAttributes';

--- a/packages/replay/src/util/prepareReplayEvent.ts
+++ b/packages/replay/src/util/prepareReplayEvent.ts
@@ -1,7 +1,6 @@
-import type { Scope } from '@sentry/core';
+import type { IntegrationIndex, Scope } from '@sentry/core';
 import { getIsolationScope } from '@sentry/core';
 import { prepareEvent } from '@sentry/core';
-import type { IntegrationIndex } from '@sentry/core/build/types/integration';
 import type { Client, EventHint, ReplayEvent } from '@sentry/types';
 
 /**


### PR DESCRIPTION
This type wasn't exported from core but used in Replay. This PR just adds the export and fixes the faulty import

(This is part of a couple of fixes we need to get out to fix currently broken type declarations)