### PR TITLE
fix(nextjs): Fix Http integration type declaration

### DIFF
--- a/packages/nextjs/src/server/httpIntegration.ts
+++ b/packages/nextjs/src/server/httpIntegration.ts
@@ -1,11 +1,10 @@
 import { Integrations } from '@sentry/node';
-const { Http: OriginalHttp } = Integrations;
 
 /**
  * A custom HTTP integration where we always enable tracing.
  */
-export class Http extends OriginalHttp {
-  public constructor(options?: ConstructorParameters<typeof OriginalHttp>[0]) {
+export class Http extends Integrations.Http {
+  public constructor(options?: ConstructorParameters<typeof Integrations.Http>[0]) {
     super({
       ...options,
       tracing: true,

--- a/packages/nextjs/src/server/onUncaughtExceptionIntegration.ts
+++ b/packages/nextjs/src/server/onUncaughtExceptionIntegration.ts
@@ -1,11 +1,10 @@
 import { Integrations } from '@sentry/node';
-const { OnUncaughtException: OriginalOnUncaughtException } = Integrations;
 
 /**
  * A custom OnUncaughtException integration that does not exit by default.
  */
-export class OnUncaughtException extends OriginalOnUncaughtException {
-  public constructor(options?: ConstructorParameters<typeof OriginalOnUncaughtException>[0]) {
+export class OnUncaughtException extends Integrations.OnUncaughtException {
+  public constructor(options?: ConstructorParameters<typeof Integrations.OnUncaughtException>[0]) {
     super({
       exitEvenIfOtherHandlersAreRegistered: false,
       ...options,


### PR DESCRIPTION
For some reason `const { Http: OriginalHttp } = Integrations` caused weirdness around getting type imports from the local build structure instead of importing the type top-level. This PR removes the object destructuring in favour of directly referencing `Integrations.Http`.

ref https://github.com/getsentry/sentry-javascript/issues/10310#issuecomment-1909462471

(This is part of a couple of fixes we need to get out to fix currently broken type declarations)