### PR TITLE
chore(biome): Ignore SvelteKit and NextJS build output directories

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -48,7 +48,9 @@
       "dev-packages/browser-integration-tests/loader-suites/**/*.js",
       "dev-packages/browser-integration-tests/suites/stacktraces/**/*.js",
       "**/fixtures/*/*.json",
-      "**/*.min.js"
+      "**/*.min.js",
+      ".next/**",
+      ".svelte-kit/**"
     ]
   },
   "javascript": {


### PR DESCRIPTION
added ignoring of build output folders because otherwise testing and linting locally is annoying
