### PR TITLE
feat(core): Add `afterAllSetup` hook for integrations

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -52,7 +52,7 @@ import { DEBUG_BUILD } from './debug-build';
 import { createEventEnvelope, createSessionEnvelope } from './envelope';
 import { getClient } from './exports';
 import { getIsolationScope } from './hub';
-import type { IntegrationIndex} from './integration';
+import type { IntegrationIndex } from './integration';
 import { afterSetupIntegrations } from './integration';
 import { setupIntegration, setupIntegrations } from './integration';
 import { createMetricEnvelope } from './metrics/envelope';

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -52,7 +52,8 @@ import { DEBUG_BUILD } from './debug-build';
 import { createEventEnvelope, createSessionEnvelope } from './envelope';
 import { getClient } from './exports';
 import { getIsolationScope } from './hub';
-import type { IntegrationIndex } from './integration';
+import type { IntegrationIndex} from './integration';
+import { afterSetupIntegrations } from './integration';
 import { setupIntegration, setupIntegrations } from './integration';
 import { createMetricEnvelope } from './metrics/envelope';
 import type { Scope } from './scope';
@@ -532,7 +533,10 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
 
   /** Setup integrations for this client. */
   protected _setupIntegrations(): void {
-    this._integrations = setupIntegrations(this, this._options.integrations);
+    const { integrations } = this._options;
+    this._integrations = setupIntegrations(this, integrations);
+    afterSetupIntegrations(this, integrations);
+
     // TODO v8: We don't need this flag anymore
     this._integrationsInitialized = true;
   }

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -109,13 +109,13 @@ export function setupIntegrations(client: Client, integrations: Integration[]): 
 }
 
 /**
- * Execute the `afterSetup` hooks of the given integrations.
+ * Execute the `afterAllSetup` hooks of the given integrations.
  */
 export function afterSetupIntegrations(client: Client, integrations: Integration[]): void {
   for (const integration of integrations) {
     // guard against empty provided integrations
-    if (integration && integration.afterSetup) {
-      integration.afterSetup(client);
+    if (integration && integration.afterAllSetup) {
+      integration.afterAllSetup(client);
     }
   }
 }

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -108,6 +108,18 @@ export function setupIntegrations(client: Client, integrations: Integration[]): 
   return integrationIndex;
 }
 
+/**
+ * Execute the `afterSetup` hooks of the given integrations.
+ */
+export function afterSetupIntegrations(client: Client, integrations: Integration[]): void {
+  for (const integration of integrations) {
+    // guard against empty provided integrations
+    if (integration && integration.afterSetup) {
+      integration.afterSetup(client);
+    }
+  }
+}
+
 /** Setup a single integration.  */
 export function setupIntegration(client: Client, integration: Integration, integrationIndex: IntegrationIndex): void {
   if (integrationIndex[integration.name]) {

--- a/packages/core/test/lib/sdk.test.ts
+++ b/packages/core/test/lib/sdk.test.ts
@@ -1,5 +1,5 @@
 import { Hub, captureCheckIn, makeMain, setCurrentClient } from '@sentry/core';
-import type { Client, Integration } from '@sentry/types';
+import type { Client, Integration, IntegrationFnResult } from '@sentry/types';
 
 import { installedIntegrations } from '../../src/integration';
 import { initAndBind } from '../../src/sdk';
@@ -34,6 +34,53 @@ describe('SDK', () => {
       initAndBind(TestClient, options);
       expect((integrations[0].setupOnce as jest.Mock).mock.calls.length).toBe(1);
       expect((integrations[1].setupOnce as jest.Mock).mock.calls.length).toBe(1);
+    });
+
+    test('calls hooks in the correct order', () => {
+      const list: string[] = [];
+
+      const integration1 = {
+        name: 'integration1',
+        setupOnce: jest.fn(() => list.push('setupOnce1')),
+        afterSetup: jest.fn(() => list.push('afterSetup1')),
+      } satisfies IntegrationFnResult;
+
+      const integration2 = {
+        name: 'integration2',
+        setupOnce: jest.fn(() => list.push('setupOnce2')),
+        setup: jest.fn(() => list.push('setup2')),
+        afterSetup: jest.fn(() => list.push('afterSetup2')),
+      } satisfies IntegrationFnResult;
+
+      const integration3 = {
+        name: 'integration3',
+        setupOnce: jest.fn(() => list.push('setupOnce3')),
+        setup: jest.fn(() => list.push('setup3')),
+      } satisfies IntegrationFnResult;
+
+      const integrations: Integration[] = [integration1, integration2, integration3];
+      const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, integrations });
+      initAndBind(TestClient, options);
+
+      expect(integration1.setupOnce).toHaveBeenCalledTimes(1);
+      expect(integration2.setupOnce).toHaveBeenCalledTimes(1);
+      expect(integration3.setupOnce).toHaveBeenCalledTimes(1);
+
+      expect(integration2.setup).toHaveBeenCalledTimes(1);
+      expect(integration3.setup).toHaveBeenCalledTimes(1);
+
+      expect(integration1.afterSetup).toHaveBeenCalledTimes(1);
+      expect(integration2.afterSetup).toHaveBeenCalledTimes(1);
+
+      expect(list).toEqual([
+        'setupOnce1',
+        'setupOnce2',
+        'setup2',
+        'setupOnce3',
+        'setup3',
+        'afterSetup1',
+        'afterSetup2',
+      ]);
     });
   });
 });

--- a/packages/core/test/lib/sdk.test.ts
+++ b/packages/core/test/lib/sdk.test.ts
@@ -42,14 +42,14 @@ describe('SDK', () => {
       const integration1 = {
         name: 'integration1',
         setupOnce: jest.fn(() => list.push('setupOnce1')),
-        afterSetup: jest.fn(() => list.push('afterSetup1')),
+        afterAllSetup: jest.fn(() => list.push('afterAllSetup1')),
       } satisfies IntegrationFnResult;
 
       const integration2 = {
         name: 'integration2',
         setupOnce: jest.fn(() => list.push('setupOnce2')),
         setup: jest.fn(() => list.push('setup2')),
-        afterSetup: jest.fn(() => list.push('afterSetup2')),
+        afterAllSetup: jest.fn(() => list.push('afterAllSetup2')),
       } satisfies IntegrationFnResult;
 
       const integration3 = {
@@ -69,8 +69,8 @@ describe('SDK', () => {
       expect(integration2.setup).toHaveBeenCalledTimes(1);
       expect(integration3.setup).toHaveBeenCalledTimes(1);
 
-      expect(integration1.afterSetup).toHaveBeenCalledTimes(1);
-      expect(integration2.afterSetup).toHaveBeenCalledTimes(1);
+      expect(integration1.afterAllSetup).toHaveBeenCalledTimes(1);
+      expect(integration2.afterAllSetup).toHaveBeenCalledTimes(1);
 
       expect(list).toEqual([
         'setupOnce1',
@@ -78,8 +78,8 @@ describe('SDK', () => {
         'setup2',
         'setupOnce3',
         'setup3',
-        'afterSetup1',
-        'afterSetup2',
+        'afterAllSetup1',
+        'afterAllSetup2',
       ]);
     });
   });

--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -40,6 +40,12 @@ export interface IntegrationFnResult {
   setup?(client: Client): void;
 
   /**
+   * This hook is triggered after `setupOnce()` and `setup()` have been called for all integrations.
+   * You can use it if it is important that all other integrations have been run before.
+   */
+  afterSetup?(client: Client): void;
+
+  /**
    * An optional hook that allows to preprocess an event _before_ it is passed to all other event processors.
    */
   preprocessEvent?(event: Event, hint: EventHint | undefined, client: Client): void;
@@ -82,6 +88,12 @@ export interface Integration {
    * should be done in `setupOnce`.
    */
   setup?(client: Client): void;
+
+  /**
+   * This hook is triggered after `setupOnce()` and `setup()` have been called for all integrations.
+   * You can use it if it is important that all other integrations have been run before.
+   */
+  afterSetup?(client: Client): void;
 
   /**
    * An optional hook that allows to preprocess an event _before_ it is passed to all other event processors.

--- a/packages/types/src/integration.ts
+++ b/packages/types/src/integration.ts
@@ -43,7 +43,7 @@ export interface IntegrationFnResult {
    * This hook is triggered after `setupOnce()` and `setup()` have been called for all integrations.
    * You can use it if it is important that all other integrations have been run before.
    */
-  afterSetup?(client: Client): void;
+  afterAllSetup?(client: Client): void;
 
   /**
    * An optional hook that allows to preprocess an event _before_ it is passed to all other event processors.
@@ -93,7 +93,7 @@ export interface Integration {
    * This hook is triggered after `setupOnce()` and `setup()` have been called for all integrations.
    * You can use it if it is important that all other integrations have been run before.
    */
-  afterSetup?(client: Client): void;
+  afterAllSetup?(client: Client): void;
 
   /**
    * An optional hook that allows to preprocess an event _before_ it is passed to all other event processors.


### PR DESCRIPTION
This adds a new hook to integrations which runs after all integrations have run their `setup` hooks.
This can be used to handle integrations that depend on each other. 

The only timing guarantee is that `afterAllSetup` will be called after every integration has run `setupOnce` and `setup`.