### PR TITLE
fix(deno): Call function if client is not setup

### DIFF
--- a/packages/deno/src/integrations/deno-cron.ts
+++ b/packages/deno/src/integrations/deno-cron.ts
@@ -37,8 +37,8 @@ const denoCronIntegration = (() => {
           }
 
           async function cronCalled(): Promise<void> {
-            if (SETUP_CLIENTS.has(getClient() as Client)) {
-              return;
+            if (!SETUP_CLIENTS.has(getClient() as Client)) {
+              return fn();
             }
 
             await withMonitor(monitorSlug, async () => fn(), {


### PR DESCRIPTION
I think this conditional needs to still call the deno cron `fn()`, and that we should do an early return if the client is **not** on `SETUP_CLIENTS`