### PR TITLE
fix(core): Make `FunctionToString` integration use SETUP_CLIENTS weakmap

### DIFF
--- a/packages/core/src/integrations/functiontostring.ts
+++ b/packages/core/src/integrations/functiontostring.ts
@@ -4,7 +4,6 @@ import { getClient } from '../exports';
 import { convertIntegrationFnToClass, defineIntegration } from '../integration';
 
 let originalFunctionToString: () => void;
-let hasSetup = false;
 
 const INTEGRATION_NAME = 'FunctionToString';
 
@@ -14,10 +13,6 @@ const _functionToStringIntegration = (() => {
   return {
     name: INTEGRATION_NAME,
     setupOnce() {
-      if (hasSetup) {
-        return;
-      }
-
       // eslint-disable-next-line @typescript-eslint/unbound-method
       originalFunctionToString = Function.prototype.toString;
 
@@ -31,8 +26,6 @@ const _functionToStringIntegration = (() => {
             SETUP_CLIENTS.has(getClient() as Client) && originalFunction !== undefined ? originalFunction : this;
           return originalFunctionToString.apply(context, args);
         };
-
-        hasSetup = true;
       } catch {
         // ignore errors here, just don't patch this
       }

--- a/packages/core/test/lib/integrations/functiontostring.test.ts
+++ b/packages/core/test/lib/integrations/functiontostring.test.ts
@@ -1,7 +1,18 @@
-import { fill } from '../../../../utils/src/object';
-import { FunctionToString } from '../../../src/integrations/functiontostring';
+import { fill } from '@sentry/utils';
+import { getClient, getCurrentScope, setCurrentClient } from '../../../src';
+import { functionToStringIntegration } from '../../../src/integrations/functiontostring';
+import { TestClient, getDefaultTestClientOptions } from '../../mocks/client';
 
 describe('FunctionToString', () => {
+  beforeEach(() => {
+    const testClient = new TestClient(getDefaultTestClientOptions({}));
+    setCurrentClient(testClient);
+  });
+
+  afterAll(() => {
+    getCurrentScope().setClient(undefined);
+  });
+
   it('it works as expected', () => {
     const foo = {
       bar(wat: boolean): boolean {
@@ -17,10 +28,31 @@ describe('FunctionToString', () => {
 
     expect(foo.bar.toString()).not.toBe(originalFunction);
 
-    // eslint-disable-next-line deprecation/deprecation
-    const fts = new FunctionToString();
-    fts.setupOnce();
+    const fts = functionToStringIntegration();
+    getClient()?.addIntegration?.(fts);
 
     expect(foo.bar.toString()).toBe(originalFunction);
+  });
+
+  it('does not activate when client is not active', () => {
+    const foo = {
+      bar(wat: boolean): boolean {
+        return wat;
+      },
+    };
+    const originalFunction = foo.bar.toString();
+    fill(foo, 'bar', function wat(whatever: boolean): () => void {
+      return function watwat(): boolean {
+        return whatever;
+      };
+    });
+
+    expect(foo.bar.toString()).not.toBe(originalFunction);
+
+    const testClient = new TestClient(getDefaultTestClientOptions({}));
+    const fts = functionToStringIntegration();
+    testClient.addIntegration(fts);
+
+    expect(foo.bar.toString()).not.toBe(originalFunction);
   });
 });


### PR DESCRIPTION
Auditing our integrations to make sure they work with the new client paradigm, also adding `export type` where appropriate.