### PR TITLE
feat(core): Deprecate `spanStatusfromHttpCode` in favour of `getSpanStatusFromHttpCode`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,6 +38,5 @@
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "explicit",
   },
-  "editor.defaultFormatter": "biomejs.biome",
-  "cSpell.words": ["Statusfrom"]
+  "editor.defaultFormatter": "biomejs.biome"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -38,5 +38,6 @@
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "explicit",
   },
-  "editor.defaultFormatter": "biomejs.biome"
+  "editor.defaultFormatter": "biomejs.biome",
+  "cSpell.words": ["Statusfrom"]
 }

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -46,7 +46,9 @@ export {
   setTag,
   setTags,
   setUser,
+  // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
+  getSpanStatusFromHttpCode,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -71,7 +71,9 @@ export {
   extractTraceparentData,
   // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
+  // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
+  getSpanStatusFromHttpCode,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   makeMultiplexedTransport,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -66,7 +66,9 @@ export {
   setTag,
   setTags,
   setUser,
+  // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
+  getSpanStatusFromHttpCode,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -7,7 +7,12 @@ export { Transaction } from './transaction';
 export { extractTraceparentData, getActiveTransaction } from './utils';
 // eslint-disable-next-line deprecation/deprecation
 export { SpanStatus } from './spanstatus';
-export { setHttpStatus, spanStatusfromHttpCode } from './spanstatus';
+export {
+  setHttpStatus,
+  // eslint-disable-next-line deprecation/deprecation
+  spanStatusfromHttpCode,
+  getSpanStatusFromHttpCode,
+} from './spanstatus';
 export type { SpanStatusType } from './spanstatus';
 export {
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/core/src/tracing/spanstatus.ts
+++ b/packages/core/src/tracing/spanstatus.ts
@@ -83,7 +83,7 @@ export type SpanStatusType =
  * @param httpStatus The HTTP response status code.
  * @returns The span status or unknown_error.
  */
-export function spanStatusfromHttpCode(httpStatus: number): SpanStatusType {
+export function getSpanStatusFromHttpCode(httpStatus: number): SpanStatusType {
   if (httpStatus < 400 && httpStatus >= 100) {
     return 'ok';
   }
@@ -124,6 +124,17 @@ export function spanStatusfromHttpCode(httpStatus: number): SpanStatusType {
 }
 
 /**
+ * Converts a HTTP status code into a {@link SpanStatusType}.
+ *
+ * @deprecated Use {@link spanStatusFromHttpCode} instead.
+ * This export will be removed in v8 as the signature contains a typo.
+ *
+ * @param httpStatus The HTTP response status code.
+ * @returns The span status or unknown_error.
+ */
+export const spanStatusfromHttpCode = getSpanStatusFromHttpCode;
+
+/**
  * Sets the Http status attributes on the current span based on the http code.
  * Additionally, the span's status is updated, depending on the http code.
  */
@@ -140,7 +151,7 @@ export function setHttpStatus(span: Span, httpStatus: number): void {
   // eslint-disable-next-line deprecation/deprecation
   span.setData('http.response.status_code', httpStatus);
 
-  const spanStatus = spanStatusfromHttpCode(httpStatus);
+  const spanStatus = getSpanStatusFromHttpCode(httpStatus);
   if (spanStatus !== 'unknown_error') {
     span.setStatus(spanStatus);
   }

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -65,7 +65,9 @@ export {
   setTag,
   setTags,
   setUser,
+  // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
+  getSpanStatusFromHttpCode,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -66,7 +66,9 @@ export {
   Hub,
   runWithAsyncContext,
   SDK_VERSION,
+  // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
+  getSpanStatusFromHttpCode,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   captureCheckIn,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -65,7 +65,9 @@ export {
   setTag,
   setTags,
   setUser,
+  // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
+  getSpanStatusFromHttpCode,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -49,7 +49,9 @@ export {
   setTag,
   setTags,
   setUser,
+  // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
+  getSpanStatusFromHttpCode,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -43,7 +43,9 @@ export {
   setTag,
   setTags,
   setUser,
+  // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
+  getSpanStatusFromHttpCode,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,

--- a/packages/tracing-internal/src/exports/index.ts
+++ b/packages/tracing-internal/src/exports/index.ts
@@ -8,6 +8,7 @@ export {
   Span,
   // eslint-disable-next-line deprecation/deprecation
   SpanStatus,
+  // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
   startIdleTransaction,
   Transaction,

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -78,6 +78,7 @@ export const extractTraceparentData = extractTraceparentDataT;
  *
  * `spanStatusfromHttpCode` can be imported from `@sentry/node`, `@sentry/browser`, or your framework SDK
  */
+// eslint-disable-next-line deprecation/deprecation
 export const spanStatusfromHttpCode = spanStatusfromHttpCodeT;
 
 /**

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -65,7 +65,9 @@ export {
   setTag,
   setTags,
   setUser,
+  // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
+  getSpanStatusFromHttpCode,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,


### PR DESCRIPTION
The old export contained a typo/camel-case inconsistency which I fixed in the new export and I opted to prepend the `get` verb. Came across this while working on #10268 and thought since we can, we should fix it in v8.

Also, this finally:

closes #10184  
