### PR TITLE
test(e2e): Add request instrumentation tests for Next.js 14

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-14/app/request-instrumentation/page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/app/request-instrumentation/page.tsx
@@ -1,0 +1,13 @@
+import http from 'http';
+
+export const dynamic = 'force-dynamic';
+
+export default async function Page() {
+  await fetch('http://example.com/');
+  await new Promise<void>(resolve => {
+    http.get('http://example.com/', () => {
+      resolve();
+    });
+  });
+  return <p>Hello World!</p>;
+}

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/tests/request-instrumentation.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/tests/request-instrumentation.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+import { waitForTransaction } from '../event-proxy-server';
+
+test('Should send a transaction with a fetch span', async ({ page }) => {
+  const transactionPromise = waitForTransaction('nextjs-14', async transactionEvent => {
+    return transactionEvent?.transaction === 'Page Server Component (/request-instrumentation)';
+  });
+
+  await page.goto(`/request-instrumentation`);
+
+  expect((await transactionPromise).spans).toContainEqual(
+    expect.objectContaining({
+      data: expect.objectContaining({
+        'http.method': 'GET',
+        'sentry.op': 'http.client',
+        'sentry.origin': 'auto.http.node.undici',
+      }),
+      description: 'GET http://example.com/',
+    }),
+  );
+
+  expect((await transactionPromise).spans).toContainEqual(
+    expect.objectContaining({
+      data: expect.objectContaining({
+        'http.method': 'GET',
+        'sentry.op': 'http.client',
+        'sentry.origin': 'auto.http.node.http',
+      }),
+      description: 'GET http://example.com/',
+    }),
+  );
+});


### PR DESCRIPTION
We are running some experiments with Vercel to exlude the SDK from externalized packages and during that I noticed we have a test gap for patching request instrumentation.

In our experiments it broke due to funky compilation.