### PR TITLE
docs: Add docs on building the SDK

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,11 @@ able to use it. From the top level of the repo, there are three commands availab
   dependencies (`utils`, `core`, `browser`, etc), and all packages which depend on it (currently `gatsby` and `nextjs`))
 - `yarn build:dev:watch`, which runs `yarn build:dev` in watch mode (recommended)
 
+You can also run a production build via `yarn build`, which will build everything except for the tarballs for publishing to NPM.
+You can use this if you want to bundle Sentry yourself. The build output can be found in the packages `build/` folder, e.g. `packages/browser/build`.
+Bundled files can be found in `packages/browser/build/bundles`.
+Note that there are no guarantees about the produced file names etc., so make sure to double check which files are generated after upgrading.
+
 ## Testing SDK Packages Locally
 
 To test local versions of SDK packages, for instance in test projects, you have a couple of options:


### PR DESCRIPTION
As this comes up every now and then (e.g. https://github.com/getsentry/sentry-javascript/issues/5108), I gather it makes sense to document how to build the SDK youself. I added a note to explicitly state that there are no guarantees there.