### PR TITLE
fix(react): Fix attachReduxState option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,11 @@ able to use it. From the top level of the repo, there are three commands availab
   dependencies (`utils`, `core`, `browser`, etc), and all packages which depend on it (currently `gatsby` and `nextjs`))
 - `yarn build:dev:watch`, which runs `yarn build:dev` in watch mode (recommended)
 
-You can also run a production build via `yarn build`, which will build everything except for the tarballs for publishing to NPM.
-You can use this if you want to bundle Sentry yourself. The build output can be found in the packages `build/` folder, e.g. `packages/browser/build`.
-Bundled files can be found in `packages/browser/build/bundles`.
-Note that there are no guarantees about the produced file names etc., so make sure to double check which files are generated after upgrading.
+You can also run a production build via `yarn build`, which will build everything except for the tarballs for publishing
+to NPM. You can use this if you want to bundle Sentry yourself. The build output can be found in the packages `build/`
+folder, e.g. `packages/browser/build`. Bundled files can be found in `packages/browser/build/bundles`. Note that there
+are no guarantees about the produced file names etc., so make sure to double check which files are generated after
+upgrading.
 
 ## Testing SDK Packages Locally
 

--- a/packages/react/src/redux.ts
+++ b/packages/react/src/redux.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { getClient, getCurrentScope } from '@sentry/browser';
-import { getGlobalScope } from '@sentry/core';
+import { getClient, getCurrentScope, getGlobalScope } from '@sentry/core';
 import type { Scope } from '@sentry/types';
 import { addNonEnumerableProperty } from '@sentry/utils';
 

--- a/packages/react/src/redux.ts
+++ b/packages/react/src/redux.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getClient, getCurrentScope } from '@sentry/browser';
+import { getGlobalScope } from '@sentry/core';
 import type { Scope } from '@sentry/types';
 import { addNonEnumerableProperty } from '@sentry/utils';
 
@@ -96,10 +97,8 @@ function createReduxEnhancer(enhancerOptions?: Partial<SentryEnhancerOptions>): 
 
   return (next: StoreEnhancerStoreCreator): StoreEnhancerStoreCreator =>
     <S = any, A extends Action = AnyAction>(reducer: Reducer<S, A>, initialState?: PreloadedState<S>) => {
-      const scope = getCurrentScope();
-
       options.attachReduxState &&
-        scope.addEventProcessor((event, hint) => {
+        getGlobalScope().addEventProcessor((event, hint) => {
           try {
             // @ts-expect-error try catch to reduce bundle size
             if (event.type === undefined && event.contexts.state.state.type === 'redux') {
@@ -117,6 +116,8 @@ function createReduxEnhancer(enhancerOptions?: Partial<SentryEnhancerOptions>): 
 
       const sentryReducer: Reducer<S, A> = (state, action): S => {
         const newState = reducer(state, action);
+
+        const scope = getCurrentScope();
 
         /* Action breadcrumbs */
         const transformedAction = options.actionTransformer(action);

--- a/packages/react/src/redux.ts
+++ b/packages/react/src/redux.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { addEventProcessor, getClient, getCurrentScope } from '@sentry/browser';
+import { getClient, getCurrentScope } from '@sentry/browser';
 import type { Scope } from '@sentry/types';
 import { addNonEnumerableProperty } from '@sentry/utils';
 
@@ -96,8 +96,10 @@ function createReduxEnhancer(enhancerOptions?: Partial<SentryEnhancerOptions>): 
 
   return (next: StoreEnhancerStoreCreator): StoreEnhancerStoreCreator =>
     <S = any, A extends Action = AnyAction>(reducer: Reducer<S, A>, initialState?: PreloadedState<S>) => {
+      const scope = getCurrentScope();
+
       options.attachReduxState &&
-        addEventProcessor((event, hint) => {
+        scope.addEventProcessor((event, hint) => {
           try {
             // @ts-expect-error try catch to reduce bundle size
             if (event.type === undefined && event.contexts.state.state.type === 'redux') {
@@ -116,7 +118,6 @@ function createReduxEnhancer(enhancerOptions?: Partial<SentryEnhancerOptions>): 
       const sentryReducer: Reducer<S, A> = (state, action): S => {
         const newState = reducer(state, action);
 
-        const scope = getCurrentScope();
         /* Action breadcrumbs */
         const transformedAction = options.actionTransformer(action);
         if (typeof transformedAction !== 'undefined' && transformedAction !== null) {

--- a/packages/react/test/redux.test.ts
+++ b/packages/react/test/redux.test.ts
@@ -5,6 +5,7 @@ import { createReduxEnhancer } from '../src/redux';
 
 const mockAddBreadcrumb = jest.fn();
 const mockSetContext = jest.fn();
+const mockAddEventProcessor = Sentry.addEventProcessor as jest.Mock;
 
 jest.mock('@sentry/browser', () => ({
   ...jest.requireActual('@sentry/browser'),
@@ -12,12 +13,11 @@ jest.mock('@sentry/browser', () => ({
     return {
       addBreadcrumb: mockAddBreadcrumb,
       setContext: mockSetContext,
+      addEventProcessor: mockAddEventProcessor,
     };
   },
   addEventProcessor: jest.fn(),
 }));
-
-const mockAddEventProcessor = Sentry.addEventProcessor as jest.Mock;
 
 afterEach(() => {
   mockAddBreadcrumb.mockReset();

--- a/packages/react/test/redux.test.ts
+++ b/packages/react/test/redux.test.ts
@@ -5,15 +5,19 @@ import { createReduxEnhancer } from '../src/redux';
 
 const mockAddBreadcrumb = jest.fn();
 const mockSetContext = jest.fn();
-const mockAddEventProcessor = Sentry.addEventProcessor as jest.Mock;
+const mockGlobalScopeAddEventProcessor = jest.fn();
 
-jest.mock('@sentry/browser', () => ({
-  ...jest.requireActual('@sentry/browser'),
+jest.mock('@sentry/core', () => ({
+  ...jest.requireActual('@sentry/core'),
   getCurrentScope() {
     return {
       addBreadcrumb: mockAddBreadcrumb,
       setContext: mockSetContext,
-      addEventProcessor: mockAddEventProcessor,
+    };
+  },
+  getGlobalScope() {
+    return {
+      addEventProcessor: mockGlobalScopeAddEventProcessor,
     };
   },
   addEventProcessor: jest.fn(),
@@ -22,7 +26,7 @@ jest.mock('@sentry/browser', () => ({
 afterEach(() => {
   mockAddBreadcrumb.mockReset();
   mockSetContext.mockReset();
-  mockAddEventProcessor.mockReset();
+  mockGlobalScopeAddEventProcessor.mockReset();
 });
 
 describe('createReduxEnhancer', () => {
@@ -257,9 +261,9 @@ describe('createReduxEnhancer', () => {
 
       Redux.createStore((state = initialState) => state, enhancer);
 
-      expect(mockAddEventProcessor).toHaveBeenCalledTimes(1);
+      expect(mockGlobalScopeAddEventProcessor).toHaveBeenCalledTimes(1);
 
-      const callbackFunction = mockAddEventProcessor.mock.calls[0][0];
+      const callbackFunction = mockGlobalScopeAddEventProcessor.mock.calls[0][0];
 
       const mockEvent = {
         contexts: {
@@ -306,7 +310,7 @@ describe('createReduxEnhancer', () => {
 
       Redux.createStore((state = initialState) => state, enhancer);
 
-      expect(mockAddEventProcessor).toHaveBeenCalledTimes(0);
+      expect(mockGlobalScopeAddEventProcessor).toHaveBeenCalledTimes(0);
     });
 
     it('does not attach when state.type is not redux', () => {
@@ -318,9 +322,9 @@ describe('createReduxEnhancer', () => {
 
       Redux.createStore((state = initialState) => state, enhancer);
 
-      expect(mockAddEventProcessor).toHaveBeenCalledTimes(1);
+      expect(mockGlobalScopeAddEventProcessor).toHaveBeenCalledTimes(1);
 
-      const callbackFunction = mockAddEventProcessor.mock.calls[0][0];
+      const callbackFunction = mockGlobalScopeAddEventProcessor.mock.calls[0][0];
 
       const mockEvent = {
         contexts: {
@@ -353,9 +357,9 @@ describe('createReduxEnhancer', () => {
 
       Redux.createStore((state = initialState) => state, enhancer);
 
-      expect(mockAddEventProcessor).toHaveBeenCalledTimes(1);
+      expect(mockGlobalScopeAddEventProcessor).toHaveBeenCalledTimes(1);
 
-      const callbackFunction = mockAddEventProcessor.mock.calls[0][0];
+      const callbackFunction = mockGlobalScopeAddEventProcessor.mock.calls[0][0];
 
       const mockEvent = {
         contexts: {
@@ -385,9 +389,9 @@ describe('createReduxEnhancer', () => {
 
       Redux.createStore((state = initialState) => state, enhancer);
 
-      expect(mockAddEventProcessor).toHaveBeenCalledTimes(1);
+      expect(mockGlobalScopeAddEventProcessor).toHaveBeenCalledTimes(1);
 
-      const callbackFunction = mockAddEventProcessor.mock.calls[0][0];
+      const callbackFunction = mockGlobalScopeAddEventProcessor.mock.calls[0][0];
 
       const mockEvent = {
         type: 'not_redux',


### PR DESCRIPTION
Before submitting a pull request, please take a look at our
[Contributing](https://github.com/getsentry/sentry-javascript/blob/master/CONTRIBUTING.md) guidelines and verify:

- [x] If you've added code that should be tested, please add tests.
- [x] Ensure your code lints and the test suite passes (`yarn lint`) & (`yarn test`).

While working on https://github.com/getsentry/sentry-javascript/issues/9220, I found that `attachReduxState` doesn't work anymore. This PR fixing it.
