### PR TITLE
feat(remix): Export missing functions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,11 @@ able to use it. From the top level of the repo, there are three commands availab
   dependencies (`utils`, `core`, `browser`, etc), and all packages which depend on it (currently `gatsby` and `nextjs`))
 - `yarn build:dev:watch`, which runs `yarn build:dev` in watch mode (recommended)
 
-You can also run a production build via `yarn build`, which will build everything except for the tarballs for publishing to NPM.
-You can use this if you want to bundle Sentry yourself. The build output can be found in the packages `build/` folder, e.g. `packages/browser/build`.
-Bundled files can be found in `packages/browser/build/bundles`.
-Note that there are no guarantees about the produced file names etc., so make sure to double check which files are generated after upgrading.
+You can also run a production build via `yarn build`, which will build everything except for the tarballs for publishing
+to NPM. You can use this if you want to bundle Sentry yourself. The build output can be found in the packages `build/`
+folder, e.g. `packages/browser/build`. Bundled files can be found in `packages/browser/build/bundles`. Note that there
+are no guarantees about the produced file names etc., so make sure to double check which files are generated after
+upgrading.
 
 ## Testing SDK Packages Locally
 

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -15,6 +15,7 @@ export {
   addGlobalEventProcessor,
   addEventProcessor,
   addBreadcrumb,
+  addIntegration,
   captureCheckIn,
   withMonitor,
   captureException,
@@ -30,6 +31,10 @@ export {
   getHubFromCarrier,
   // eslint-disable-next-line deprecation/deprecation
   getCurrentHub,
+  getClient,
+  getCurrentScope,
+  getGlobalScope,
+  getIsolationScope,
   Hub,
   // eslint-disable-next-line deprecation/deprecation
   makeMain,
@@ -67,6 +72,13 @@ export {
   deepReadDirSync,
   Integrations,
   Handlers,
+  setMeasurement,
+  getActiveSpan,
+  startSpan,
+  startSpanManual,
+  startInactiveSpan,
+  continueTrace,
+  isInitialized,
   cron,
   parameterize,
 } from '@sentry/node';


### PR DESCRIPTION
Looks like we missed re-exporting a couple of recently added functions in the Remix SDK. This PR adds the missing exports:

* `addIntegration`
* `getClient`
* `getCurrentScope`, `getIsolationScope`, `getGlobalScope`
* `setMeasurement`
* `getActiveSpan`
* `startSpan`, `startSpanManual`, `startInactiveSpan`
* `continueTrace`
* `isInitialized`

closes #10384 