### PR TITLE
feat(core): Ensure `startSpan()` can handle spans that require parent

### DIFF
--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-no-active-span/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-no-active-span/init.js
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  // disable pageload transaction
+  integrations: [Sentry.BrowserTracing({ tracingOrigins: ['http://example.com'], startTransactionOnPageLoad: false })],
+  tracesSampleRate: 1,
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-no-active-span/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-no-active-span/subject.js
@@ -1,0 +1,1 @@
+fetch('http://example.com/0').then(fetch('http://example.com/1').then(fetch('http://example.com/2')));

--- a/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-no-active-span/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/fetch-with-no-active-span/test.ts
@@ -1,0 +1,35 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { envelopeUrlRegex, shouldSkipTracingTest } from '../../../../utils/helpers';
+
+sentryTest(
+  'there should be no span created for fetch requests with no active span',
+  async ({ getLocalTestPath, page }) => {
+    if (shouldSkipTracingTest()) {
+      sentryTest.skip();
+    }
+
+    const url = await getLocalTestPath({ testDir: __dirname });
+
+    let requestCount = 0;
+    page.on('request', request => {
+      expect(envelopeUrlRegex.test(request.url())).toBe(false);
+      requestCount++;
+    });
+
+    await page.goto(url);
+
+    // Here are the requests that should exist:
+    // 1. HTML page
+    // 2. Init JS bundle
+    // 3. Subject JS bundle
+    // 4 [OPTIONAl] CDN JS bundle
+    // and then 3 fetch requests
+    if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_')) {
+      expect(requestCount).toBe(7);
+    } else {
+      expect(requestCount).toBe(6);
+    }
+  },
+);

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-with-no-active-span/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-with-no-active-span/init.js
@@ -1,0 +1,10 @@
+import * as Sentry from '@sentry/browser';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  // disable pageload transaction
+  integrations: [Sentry.BrowserTracing({ tracingOrigins: ['http://example.com'], startTransactionOnPageLoad: false })],
+  tracesSampleRate: 1,
+});

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-with-no-active-span/subject.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-with-no-active-span/subject.js
@@ -1,0 +1,11 @@
+const xhr_1 = new XMLHttpRequest();
+xhr_1.open('GET', 'http://example.com/0');
+xhr_1.send();
+
+const xhr_2 = new XMLHttpRequest();
+xhr_2.open('GET', 'http://example.com/1');
+xhr_2.send();
+
+const xhr_3 = new XMLHttpRequest();
+xhr_3.open('GET', 'http://example.com/2');
+xhr_3.send();

--- a/dev-packages/browser-integration-tests/suites/tracing/request/xhr-with-no-active-span/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/request/xhr-with-no-active-span/test.ts
@@ -1,0 +1,35 @@
+import { expect } from '@playwright/test';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { envelopeUrlRegex, shouldSkipTracingTest } from '../../../../utils/helpers';
+
+sentryTest(
+  'there should be no span created for xhr requests with no active span',
+  async ({ getLocalTestPath, page }) => {
+    if (shouldSkipTracingTest()) {
+      sentryTest.skip();
+    }
+
+    const url = await getLocalTestPath({ testDir: __dirname });
+
+    let requestCount = 0;
+    page.on('request', request => {
+      expect(envelopeUrlRegex.test(request.url())).toBe(false);
+      requestCount++;
+    });
+
+    await page.goto(url);
+
+    // Here are the requests that should exist:
+    // 1. HTML page
+    // 2. Init JS bundle
+    // 3. Subject JS bundle
+    // 4 [OPTIONAl] CDN JS bundle
+    // and then 3 fetch requests
+    if (process.env.PW_BUNDLE && process.env.PW_BUNDLE.startsWith('bundle_')) {
+      expect(requestCount).toBe(7);
+    } else {
+      expect(requestCount).toBe(6);
+    }
+  },
+);

--- a/dev-packages/browser-integration-tests/utils/helpers.ts
+++ b/dev-packages/browser-integration-tests/utils/helpers.ts
@@ -1,7 +1,7 @@
 import type { Page, Request } from '@playwright/test';
 import type { EnvelopeItemType, Event, EventEnvelopeHeaders } from '@sentry/types';
 
-const envelopeUrlRegex = /\.sentry\.io\/api\/\d+\/envelope\//;
+export const envelopeUrlRegex = /\.sentry\.io\/api\/\d+\/envelope\//;
 
 export const envelopeParser = (request: Request | null): unknown[] => {
   // https://develop.sentry.dev/sdk/envelopes/

--- a/packages/core/src/tracing/trace.ts
+++ b/packages/core/src/tracing/trace.ts
@@ -80,7 +80,9 @@ export function startSpan<T>(context: StartSpanOptions, callback: (span: Span | 
     // eslint-disable-next-line deprecation/deprecation
     const parentSpan = scope.getSpan();
 
-    const activeSpan = createChildSpanOrTransaction(hub, parentSpan, ctx);
+    const shouldSkipSpan = context.onlyIfParent && !parentSpan;
+    const activeSpan = shouldSkipSpan ? undefined : createChildSpanOrTransaction(hub, parentSpan, ctx);
+
     // eslint-disable-next-line deprecation/deprecation
     scope.setSpan(activeSpan);
 
@@ -128,7 +130,9 @@ export function startSpanManual<T>(
     // eslint-disable-next-line deprecation/deprecation
     const parentSpan = scope.getSpan();
 
-    const activeSpan = createChildSpanOrTransaction(hub, parentSpan, ctx);
+    const shouldSkipSpan = context.onlyIfParent && !parentSpan;
+    const activeSpan = shouldSkipSpan ? undefined : createChildSpanOrTransaction(hub, parentSpan, ctx);
+
     // eslint-disable-next-line deprecation/deprecation
     scope.setSpan(activeSpan);
 
@@ -173,6 +177,12 @@ export function startInactiveSpan(context: StartSpanOptions): Span | undefined {
     ? // eslint-disable-next-line deprecation/deprecation
       context.scope.getSpan()
     : getActiveSpan();
+
+  const shouldSkipSpan = context.onlyIfParent && !parentSpan;
+
+  if (shouldSkipSpan) {
+    return undefined;
+  }
 
   if (parentSpan) {
     // eslint-disable-next-line deprecation/deprecation

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -335,6 +335,28 @@ describe('startSpan', () => {
       });
     });
   });
+
+  describe('onlyIfParent', () => {
+    it('does not create a span if there is no parent', () => {
+      const span = startSpan({ name: 'test span', onlyIfParent: true }, span => {
+        return span;
+      });
+
+      expect(span).toBeUndefined();
+    });
+
+    it('creates a span if there is a parent', () => {
+      const span = startSpan({ name: 'parent span' }, () => {
+        const span = startSpan({ name: 'test span', onlyIfParent: true }, span => {
+          return span;
+        });
+
+        return span;
+      });
+
+      expect(span).toBeDefined();
+    });
+  });
 });
 
 describe('startSpanManual', () => {
@@ -415,6 +437,28 @@ describe('startSpanManual', () => {
       });
     });
   });
+
+  describe('onlyIfParent', () => {
+    it('does not create a span if there is no parent', () => {
+      const span = startSpanManual({ name: 'test span', onlyIfParent: true }, span => {
+        return span;
+      });
+
+      expect(span).toBeUndefined();
+    });
+
+    it('creates a span if there is a parent', () => {
+      const span = startSpan({ name: 'parent span' }, () => {
+        const span = startSpanManual({ name: 'test span', onlyIfParent: true }, span => {
+          return span;
+        });
+
+        return span;
+      });
+
+      expect(span).toBeDefined();
+    });
+  });
 });
 
 describe('startInactiveSpan', () => {
@@ -477,6 +521,24 @@ describe('startInactiveSpan', () => {
       const span = startInactiveSpan({ name: 'span' });
       expect(span?.spanContext().traceId).toBe('99999999999999999999999999999991');
       span?.end();
+    });
+  });
+
+  describe('onlyIfParent', () => {
+    it('does not create a span if there is no parent', () => {
+      const span = startInactiveSpan({ name: 'test span', onlyIfParent: true });
+
+      expect(span).toBeUndefined();
+    });
+
+    it('creates a span if there is a parent', () => {
+      const span = startSpan({ name: 'parent span' }, () => {
+        const span = startInactiveSpan({ name: 'test span', onlyIfParent: true });
+
+        return span;
+      });
+
+      expect(span).toBeDefined();
     });
   });
 });

--- a/packages/opentelemetry/src/types.ts
+++ b/packages/opentelemetry/src/types.ts
@@ -14,6 +14,7 @@ export interface OpenTelemetrySpanContext {
   origin?: SpanOrigin;
   source?: TransactionSource;
   scope?: Scope;
+  onlyIfParent?: boolean;
 
   // Base SpanOptions we support
   attributes?: Attributes;

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -2,6 +2,7 @@ import type { Span } from '@opentelemetry/api';
 import { SpanKind } from '@opentelemetry/api';
 import { TraceFlags, context, trace } from '@opentelemetry/api';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
+import { Span as SpanClass } from '@opentelemetry/sdk-trace-base';
 import type { PropagationContext } from '@sentry/types';
 
 import { getClient } from '../src/custom/hub';
@@ -260,6 +261,28 @@ describe('trace', () => {
         },
       );
     });
+
+    describe('onlyIfParent', () => {
+      it('does not create a span if there is no parent', () => {
+        const span = startSpan({ name: 'test span', onlyIfParent: true }, span => {
+          return span;
+        });
+
+        expect(span).not.toBeInstanceOf(SpanClass);
+      });
+
+      it('creates a span if there is a parent', () => {
+        const span = startSpan({ name: 'parent span' }, () => {
+          const span = startSpan({ name: 'test span', onlyIfParent: true }, span => {
+            return span;
+          });
+
+          return span;
+        });
+
+        expect(span).toBeInstanceOf(SpanClass);
+      });
+    });
   });
 
   describe('startInactiveSpan', () => {
@@ -349,6 +372,24 @@ describe('trace', () => {
       });
       expect(getSpanKind(span)).toEqual(SpanKind.CLIENT);
     });
+
+    describe('onlyIfParent', () => {
+      it('does not create a span if there is no parent', () => {
+        const span = startInactiveSpan({ name: 'test span', onlyIfParent: true });
+
+        expect(span).not.toBeInstanceOf(SpanClass);
+      });
+
+      it('creates a span if there is a parent', () => {
+        const span = startSpan({ name: 'parent span' }, () => {
+          const span = startInactiveSpan({ name: 'test span', onlyIfParent: true });
+
+          return span;
+        });
+
+        expect(span).toBeInstanceOf(SpanClass);
+      });
+    });
   });
 
   describe('startSpanManual', () => {
@@ -417,6 +458,28 @@ describe('trace', () => {
           expect(getSpanKind(span)).toEqual(SpanKind.CLIENT);
         },
       );
+    });
+  });
+
+  describe('onlyIfParent', () => {
+    it('does not create a span if there is no parent', () => {
+      const span = startSpanManual({ name: 'test span', onlyIfParent: true }, span => {
+        return span;
+      });
+
+      expect(span).not.toBeInstanceOf(SpanClass);
+    });
+
+    it('creates a span if there is a parent', () => {
+      const span = startSpan({ name: 'parent span' }, () => {
+        const span = startSpanManual({ name: 'test span', onlyIfParent: true }, span => {
+          return span;
+        });
+
+        return span;
+      });
+
+      expect(span).toBeInstanceOf(SpanClass);
     });
   });
 });

--- a/packages/react/src/profiler.tsx
+++ b/packages/react/src/profiler.tsx
@@ -57,6 +57,7 @@ class Profiler extends React.Component<ProfilerProps> {
 
     this._mountSpan = startInactiveSpan({
       name: `<${name}>`,
+      onlyIfParent: true,
       op: REACT_MOUNT_OP,
       origin: 'auto.ui.react.profiler',
       attributes: { 'ui.component_name': name },
@@ -83,6 +84,7 @@ class Profiler extends React.Component<ProfilerProps> {
         this._updateSpan = withActiveSpan(this._mountSpan, () => {
           return startInactiveSpan({
             name: `<${this.props.name}>`,
+            onlyIfParent: true,
             op: REACT_UPDATE_OP,
             origin: 'auto.ui.react.profiler',
             startTimestamp: now,
@@ -115,6 +117,7 @@ class Profiler extends React.Component<ProfilerProps> {
       const startTimestamp = spanToJSON(this._mountSpan).timestamp;
       withActiveSpan(this._mountSpan, () => {
         const renderSpan = startInactiveSpan({
+          onlyIfParent: true,
           name: `<${name}>`,
           op: REACT_RENDER_OP,
           origin: 'auto.ui.react.profiler',
@@ -187,6 +190,7 @@ function useProfiler(
 
     return startInactiveSpan({
       name: `<${name}>`,
+      onlyIfParent: true,
       op: REACT_MOUNT_OP,
       origin: 'auto.ui.react.profiler',
       attributes: { 'ui.component_name': name },
@@ -205,6 +209,7 @@ function useProfiler(
 
         const renderSpan = startInactiveSpan({
           name: `<${name}>`,
+          onlyIfParent: true,
           op: REACT_RENDER_OP,
           origin: 'auto.ui.react.profiler',
           startTimestamp,

--- a/packages/react/test/profiler.test.tsx
+++ b/packages/react/test/profiler.test.tsx
@@ -74,6 +74,7 @@ describe('withProfiler', () => {
       expect(mockStartInactiveSpan).toHaveBeenCalledTimes(1);
       expect(mockStartInactiveSpan).toHaveBeenLastCalledWith({
         name: `<${UNKNOWN_COMPONENT}>`,
+        onlyIfParent: true,
         op: REACT_MOUNT_OP,
         origin: 'auto.ui.react.profiler',
         attributes: { 'ui.component_name': 'unknown' },
@@ -92,6 +93,7 @@ describe('withProfiler', () => {
       expect(mockStartInactiveSpan).toHaveBeenCalledTimes(2);
       expect(mockStartInactiveSpan).toHaveBeenLastCalledWith({
         name: `<${UNKNOWN_COMPONENT}>`,
+        onlyIfParent: true,
         op: REACT_RENDER_OP,
         origin: 'auto.ui.react.profiler',
         startTimestamp: undefined,
@@ -125,6 +127,7 @@ describe('withProfiler', () => {
       expect(mockStartInactiveSpan).toHaveBeenLastCalledWith({
         attributes: { 'ui.react.changed_props': ['num'], 'ui.component_name': 'unknown' },
         name: `<${UNKNOWN_COMPONENT}>`,
+        onlyIfParent: true,
         op: REACT_UPDATE_OP,
         origin: 'auto.ui.react.profiler',
         startTimestamp: expect.any(Number),
@@ -136,6 +139,7 @@ describe('withProfiler', () => {
       expect(mockStartInactiveSpan).toHaveBeenLastCalledWith({
         attributes: { 'ui.react.changed_props': ['num'], 'ui.component_name': 'unknown' },
         name: `<${UNKNOWN_COMPONENT}>`,
+        onlyIfParent: true,
         op: REACT_UPDATE_OP,
         origin: 'auto.ui.react.profiler',
         startTimestamp: expect.any(Number),
@@ -175,6 +179,7 @@ describe('useProfiler()', () => {
       expect(mockStartInactiveSpan).toHaveBeenCalledTimes(1);
       expect(mockStartInactiveSpan).toHaveBeenLastCalledWith({
         name: '<Example>',
+        onlyIfParent: true,
         op: REACT_MOUNT_OP,
         origin: 'auto.ui.react.profiler',
         attributes: { 'ui.component_name': 'Example' },
@@ -199,6 +204,7 @@ describe('useProfiler()', () => {
       expect(mockStartInactiveSpan).toHaveBeenLastCalledWith(
         expect.objectContaining({
           name: '<Example>',
+          onlyIfParent: true,
           op: REACT_RENDER_OP,
           origin: 'auto.ui.react.profiler',
           attributes: { 'ui.component_name': 'Example' },

--- a/packages/serverless/src/awsservices.ts
+++ b/packages/serverless/src/awsservices.ts
@@ -71,7 +71,7 @@ function wrapMakeRequest<TService extends AWSService, TResult>(
       req.on('afterBuild', () => {
         span = startInactiveSpan({
           name: describe(this, operation, params),
-        onlyIfParent: true,
+          onlyIfParent: true,
           op: 'http.client',
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',

--- a/packages/serverless/src/awsservices.ts
+++ b/packages/serverless/src/awsservices.ts
@@ -71,6 +71,7 @@ function wrapMakeRequest<TService extends AWSService, TResult>(
       req.on('afterBuild', () => {
         span = startInactiveSpan({
           name: describe(this, operation, params),
+        onlyIfParent: true,
           op: 'http.client',
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',

--- a/packages/serverless/src/google-cloud-grpc.ts
+++ b/packages/serverless/src/google-cloud-grpc.ts
@@ -122,6 +122,7 @@ function fillGrpcFunction(stub: Stub, serviceIdentifier: string, methodName: str
         }
         const span = startInactiveSpan({
           name: `${callType} ${methodName}`,
+          onlyIfParent: true,
           op: `grpc.${serviceIdentifier}`,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.grpc.serverless',

--- a/packages/serverless/src/google-cloud-http.ts
+++ b/packages/serverless/src/google-cloud-http.ts
@@ -64,6 +64,7 @@ function wrapRequestFunction(orig: RequestFunction): RequestFunction {
     const span = SETUP_CLIENTS.has(getClient() as Client)
       ? startInactiveSpan({
           name: `${httpMethod} ${reqOpts.uri}`,
+      onlyIfParent: true,
           op: `http.client.${identifyService(this.apiEndpoint)}`,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',

--- a/packages/serverless/src/google-cloud-http.ts
+++ b/packages/serverless/src/google-cloud-http.ts
@@ -64,7 +64,7 @@ function wrapRequestFunction(orig: RequestFunction): RequestFunction {
     const span = SETUP_CLIENTS.has(getClient() as Client)
       ? startInactiveSpan({
           name: `${httpMethod} ${reqOpts.uri}`,
-      onlyIfParent: true,
+          onlyIfParent: true,
           op: `http.client.${identifyService(this.apiEndpoint)}`,
           attributes: {
             [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',

--- a/packages/serverless/test/awsservices.test.ts
+++ b/packages/serverless/test/awsservices.test.ts
@@ -61,6 +61,7 @@ describe('awsServicesIntegration', () => {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
         },
         name: 'aws.s3.getObject foo',
+        onlyIfParent: true,
       });
 
       expect(mockSpanEnd).toHaveBeenCalledTimes(1);
@@ -84,6 +85,7 @@ describe('awsServicesIntegration', () => {
       expect(mockStartInactiveSpan).toBeCalledWith({
         op: 'http.client',
         name: 'aws.s3.getObject foo',
+        onlyIfParent: true,
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
         },
@@ -114,6 +116,7 @@ describe('awsServicesIntegration', () => {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
         },
         name: 'aws.lambda.invoke foo',
+        onlyIfParent: true,
       });
       expect(mockSpanEnd).toHaveBeenCalledTimes(1);
     });

--- a/packages/serverless/test/google-cloud-grpc.test.ts
+++ b/packages/serverless/test/google-cloud-grpc.test.ts
@@ -149,6 +149,7 @@ describe('GoogleCloudGrpc tracing', () => {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.grpc.serverless',
         },
         name: 'unary call publish',
+        onlyIfParent: true,
       });
     });
   });

--- a/packages/serverless/test/google-cloud-http.test.ts
+++ b/packages/serverless/test/google-cloud-http.test.ts
@@ -75,6 +75,7 @@ describe('GoogleCloudHttp tracing', () => {
       expect(mockStartInactiveSpan).toBeCalledWith({
         op: 'http.client.bigquery',
         name: 'POST /jobs',
+        onlyIfParent: true,
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
         },
@@ -82,6 +83,7 @@ describe('GoogleCloudHttp tracing', () => {
       expect(mockStartInactiveSpan).toBeCalledWith({
         op: 'http.client.bigquery',
         name: expect.stringMatching(/^GET \/queries\/.+/),
+        onlyIfParent: true,
         attributes: {
           [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.serverless',
         },

--- a/packages/tracing-internal/src/browser/request.ts
+++ b/packages/tracing-internal/src/browser/request.ts
@@ -280,21 +280,19 @@ export function xhrCallback(
   const scope = getCurrentScope();
   const isolationScope = getIsolationScope();
 
-  // only create a child span if there is an active span. This is because
-  // `startInactiveSpan` can still create a transaction under the hood
-  const span =
-    shouldCreateSpanResult && getActiveSpan()
-      ? startInactiveSpan({
-          attributes: {
-            type: 'xhr',
-            'http.method': sentryXhrData.method,
-            url: sentryXhrData.url,
-            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.browser',
-          },
-          name: `${sentryXhrData.method} ${sentryXhrData.url}`,
-          op: 'http.client',
-        })
-      : undefined;
+  const span = shouldCreateSpanResult
+    ? startInactiveSpan({
+        name: `${sentryXhrData.method} ${sentryXhrData.url}`,
+        onlyIfParent: true,
+        attributes: {
+          type: 'xhr',
+          'http.method': sentryXhrData.method,
+          url: sentryXhrData.url,
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.browser',
+        },
+        op: 'http.client',
+      })
+    : undefined;
 
   if (span) {
     xhr.__sentry_xhr_span_id__ = span.spanContext().spanId;

--- a/packages/tracing-internal/src/browser/request.ts
+++ b/packages/tracing-internal/src/browser/request.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-lines */
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  getActiveSpan,
   getClient,
   getCurrentScope,
   getDynamicSamplingContextFromClient,

--- a/packages/tracing-internal/src/common/fetch.ts
+++ b/packages/tracing-internal/src/common/fetch.ts
@@ -82,21 +82,19 @@ export function instrumentFetchRequest(
 
   const { method, url } = handlerData.fetchData;
 
-  // only create a child span if there is an active span. This is because
-  // `startInactiveSpan` can still create a transaction under the hood
-  const span =
-    shouldCreateSpanResult && getActiveSpan()
-      ? startInactiveSpan({
-          attributes: {
-            url,
-            type: 'fetch',
-            'http.method': method,
-            [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: spanOrigin,
-          },
-          name: `${method} ${url}`,
-          op: 'http.client',
-        })
-      : undefined;
+  const span = shouldCreateSpanResult
+    ? startInactiveSpan({
+        name: `${method} ${url}`,
+        onlyIfParent: true,
+        attributes: {
+          url,
+          type: 'fetch',
+          'http.method': method,
+          [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: spanOrigin,
+        },
+        op: 'http.client',
+      })
+    : undefined;
 
   if (span) {
     handlerData.fetchData.__span = span.spanContext().spanId;

--- a/packages/tracing-internal/src/common/fetch.ts
+++ b/packages/tracing-internal/src/common/fetch.ts
@@ -1,6 +1,5 @@
 import {
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  getActiveSpan,
   getClient,
   getCurrentScope,
   getDynamicSamplingContextFromClient,

--- a/packages/tracing-internal/src/node/integrations/prisma.ts
+++ b/packages/tracing-internal/src/node/integrations/prisma.ts
@@ -103,6 +103,7 @@ export class Prisma implements Integration {
         return startSpan(
           {
             name: model ? `${model} ${action}` : action,
+            onlyIfParent: true,
             op: 'db.prisma',
             attributes: {
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.db.prisma',

--- a/packages/tracing/test/integrations/node/prisma.test.ts
+++ b/packages/tracing/test/integrations/node/prisma.test.ts
@@ -58,6 +58,7 @@ describe('setupOnce', function () {
             'sentry.origin': 'auto.db.prisma',
           },
           name: 'user create',
+          onlyIfParent: true,
           op: 'db.prisma',
           data: { 'db.system': 'postgresql', 'db.prisma.version': '3.1.2', 'db.operation': 'create' },
         },

--- a/packages/types/src/startSpanOptions.ts
+++ b/packages/types/src/startSpanOptions.ts
@@ -14,6 +14,9 @@ export interface StartSpanOptions extends TransactionContext {
   /** The name of the span. */
   name: string;
 
+  /** If set to true, only start a span if a parent span exists. */
+  onlyIfParent?: boolean;
+
   /** An op for the span. This is a categorization for spans. */
   op?: string;
 


### PR DESCRIPTION
This introduces a new `onlyIfParent` option to the start-span APIs, which, if set, will ensure to not create a span if there is no parent. I've added this also for otel to demonstrate this works there as well.

This PR also uses this option in a few places, esp. for http.client spans, to ensure we do not capture these if there is no ongoing transaction.

This replaces https://github.com/getsentry/sentry-javascript/pull/10375/files with a more generic solution, and includes the test from https://github.com/getsentry/sentry-javascript/pull/10376 (which passes here as well).