### PR TITLE
feat(remix): Add more missing `@sentry/node` re-exports

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
+++ b/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
@@ -48,8 +48,11 @@ const DEPENDENTS: Dependent[] = [
   {
     package: '@sentry/remix',
     exports: Object.keys(SentryRemix),
-    // TODO: Fix exports in remix
-    skip: true,
+    ignoreExports: [
+      // Deprecated, no need to add this now to remix
+      'getModuleFromFilename',
+      'enableAnrDetection',
+    ],
   },
   {
     package: '@sentry/serverless',
@@ -58,9 +61,9 @@ const DEPENDENTS: Dependent[] = [
       // Deprecated, no need to add this now to serverless
       'extractTraceparentData',
       'getModuleFromFilename',
+      'enableAnrDetection',
       // TODO: Should these be exported from serverless?
       'cron',
-      'enableAnrDetection',
       'runWithAsyncContext',
       'hapiErrorPlugin',
     ],

--- a/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
+++ b/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
@@ -22,8 +22,6 @@ const NODE_EXPORTS_IGNORE = [
   'DebugSession',
   'AnrIntegrationOptions',
   'LocalVariablesIntegrationOptions',
-  // deprecated
-  'spanStatusfromHttpCode',
 ];
 
 type Dependent = {
@@ -43,16 +41,10 @@ const DEPENDENTS: Dependent[] = [
     // Next.js doesn't require explicit exports, so we can just merge top level and `default` exports:
     // @ts-expect-error: `default` is not in the type definition but it's defined
     exports: Object.keys({ ...SentryNextJs, ...SentryNextJs.default }),
-    ignoreExports: ['withSentryConfig'],
   },
   {
     package: '@sentry/remix',
     exports: Object.keys(SentryRemix),
-    ignoreExports: [
-      // Deprecated, no need to add this now to remix
-      'getModuleFromFilename',
-      'enableAnrDetection',
-    ],
   },
   {
     package: '@sentry/serverless',

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -85,6 +85,8 @@ export {
   cron,
   parameterize,
   metrics,
+  // eslint-disable-next-line deprecation/deprecation
+  getModuleFromFilename,
   createGetModuleFromFilename,
   functionToStringIntegration,
   hapiErrorPlugin,
@@ -92,6 +94,8 @@ export {
   linkedErrorsIntegration,
   requestDataIntegration,
   runWithAsyncContext,
+  // eslint-disable-next-line deprecation/deprecation
+  enableAnrDetection,
 } from '@sentry/node';
 
 // Keeping the `*` exports for backwards compatibility and types

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -39,6 +39,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   makeMain,
   setCurrentClient,
+  NodeClient,
   Scope,
   // eslint-disable-next-line deprecation/deprecation
   startTransaction,
@@ -83,6 +84,14 @@ export {
   isInitialized,
   cron,
   parameterize,
+  metrics,
+  createGetModuleFromFilename,
+  functionToStringIntegration,
+  hapiErrorPlugin,
+  inboundFiltersIntegration,
+  linkedErrorsIntegration,
+  requestDataIntegration,
+  runWithAsyncContext,
 } from '@sentry/node';
 
 // Keeping the `*` exports for backwards compatibility and types


### PR DESCRIPTION
Missed some exports in my manual pass in #10385. Test in #10389 discovered more missing exports which this PR adds or marks as unnecessary in the re-export test.
 
