### PR TITLE
feat(sveltekit): Add more missing `@sentry/node` re-exports

### DIFF
--- a/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
+++ b/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
@@ -70,8 +70,11 @@ const DEPENDENTS: Dependent[] = [
   {
     package: '@sentry/sveltekit',
     exports: Object.keys(SentrySvelteKit),
-    // TODO: Fix exports in sveltekit
-    skip: true,
+    ignoreExports: [
+      // Deprecated, no need to add this now to sveltekit
+      'enableAnrDetection',
+      'getModuleFromFilename',
+    ],
   },
 ];
 

--- a/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
+++ b/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
@@ -22,8 +22,6 @@ const NODE_EXPORTS_IGNORE = [
   'DebugSession',
   'AnrIntegrationOptions',
   'LocalVariablesIntegrationOptions',
-  // deprecated
-  'spanStatusfromHttpCode',
 ];
 
 type Dependent = {
@@ -70,11 +68,6 @@ const DEPENDENTS: Dependent[] = [
   {
     package: '@sentry/sveltekit',
     exports: Object.keys(SentrySvelteKit),
-    ignoreExports: [
-      // Deprecated, no need to add this now to sveltekit
-      'enableAnrDetection',
-      'getModuleFromFilename',
-    ],
   },
 ];
 

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -79,6 +79,8 @@ export {
   continueTrace,
   cron,
   parameterize,
+  // eslint-disable-next-line deprecation/deprecation
+  getModuleFromFilename,
   createGetModuleFromFilename,
   functionToStringIntegration,
   hapiErrorPlugin,
@@ -87,6 +89,8 @@ export {
   requestDataIntegration,
   metrics,
   runWithAsyncContext,
+  // eslint-disable-next-line deprecation/deprecation
+  enableAnrDetection,
 } from '@sentry/node';
 
 // We can still leave this for the carrier init and type exports

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -30,6 +30,7 @@ export {
   getGlobalScope,
   getIsolationScope,
   Hub,
+  NodeClient,
   // eslint-disable-next-line deprecation/deprecation
   makeMain,
   setCurrentClient,
@@ -78,6 +79,14 @@ export {
   continueTrace,
   cron,
   parameterize,
+  createGetModuleFromFilename,
+  functionToStringIntegration,
+  hapiErrorPlugin,
+  inboundFiltersIntegration,
+  linkedErrorsIntegration,
+  requestDataIntegration,
+  metrics,
+  runWithAsyncContext,
 } from '@sentry/node';
 
 // We can still leave this for the carrier init and type exports


### PR DESCRIPTION
Adds missing re-exports from `@sentry/node` in the sveltekit server SDK and enables the re-export test for @sentry/sveltekit

builds on top of https://github.com/getsentry/sentry-javascript/pull/10389