### PR TITLE
ref(tracing): Implement changes to new `browserTracingIntegration`

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -60,8 +60,6 @@ export {
   browserTracingIntegration,
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
-  disableDefaultBrowserTracingNavigationSpan,
-  disableDefaultBrowserTracingPageLoadSpan,
 } from '@sentry-internal/tracing';
 export type { RequestInstrumentationOptions } from '@sentry-internal/tracing';
 export {

--- a/packages/tracing-internal/src/browser/index.ts
+++ b/packages/tracing-internal/src/browser/index.ts
@@ -7,8 +7,6 @@ export {
   browserTracingIntegration,
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
-  disableDefaultBrowserTracingNavigationSpan,
-  disableDefaultBrowserTracingPageLoadSpan,
 } from './browserTracingIntegration';
 
 export { instrumentOutgoingRequests, defaultRequestInstrumentationOptions } from './request';

--- a/packages/tracing-internal/src/index.ts
+++ b/packages/tracing-internal/src/index.ts
@@ -17,8 +17,6 @@ export {
   browserTracingIntegration,
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
-  disableDefaultBrowserTracingNavigationSpan,
-  disableDefaultBrowserTracingPageLoadSpan,
   BROWSER_TRACING_INTEGRATION_ID,
   instrumentOutgoingRequests,
   defaultRequestInstrumentationOptions,


### PR DESCRIPTION
This implements changes to the new integration, based on feedback from the team.

The main thing this addresses is the way we disable the default span creation. The original idea was to make this work with custom router instrumentations (e.g. for react router) that may be added as separate integrations. This required us to keep track of if another, non-default implementation has been added, to opt out of the defaults.

With this change, we do not do this anymore. Instead, the defaults should be configured by wrapping integrations. Some examples for how this should then work:

1. Angular:
```ts
export function browserTracingIntegration(
  options?: Parameters<typeof originalBrowserTracingIntegration>[0],
): Integration {
  // do not use default navigation, as we provide our own
  // actual code for this is in the angular service
  options.instrumentNavigation = false;
  return originalBrowserTracingIntegration(options);
}
```

2. Vue
```ts
export function browserTracingIntegration(
  options?: Parameters<typeof originalBrowserTracingIntegration>[0] & { router?: VueRouter },
): Integration {

  if (options.router) {
    options.instrumentNavigation = false;
    const integration = originalBrowserTracingIntegration(options);
    const originalSetupAfterAll = integration.setupAfterAll;
    integration.setupAfterAll = (client: Client) => {
      setupVueRoutingInstrumentation(client); // some method
      originalSetupAfterAll(client);
    }
  }

  return originalBrowserTracingIntegration(options);
}
```

3. React
```ts
export function browserTracingIntegration(
  options?: Parameters<typeof originalBrowserTracingIntegration>[0] & { router?: ReactRouterInstrumentation },
): Integration {

  if (options.router) {
    options.instrumentNavigation = false;
    options.instrumentPageLoad = false;
    const integration = originalBrowserTracingIntegration(options);
    const originalSetupAfterAll = integration.setupAfterAll;
    integration.setupAfterAll = (client: Client) => {
      // setup custom routing instrumentation
      options.router(client); // or whatever API we want there
      originalSetupAfterAll(client);
    }
  }

  return originalBrowserTracingIntegration(options);
}
```