### PR TITLE
feat(bun): Add missing `@sentry/node` re-exports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -947,6 +947,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: 'dev-packages/e2e-tests/package.json'
+      - name: Set up Bun
+        if: matrix.test-application == 'node-exports-test-app'
+        uses: oven-sh/setup-bun@v1
       - name: Restore caches
         uses: ./.github/actions/restore-cache
         env:

--- a/dev-packages/e2e-tests/test-applications/node-exports-test-app/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-exports-test-app/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "start": "pnpm build && node dist/consistentExports.js",
-    "test": " node dist/consistentExports.js",
+    "start": "pnpm build && bun run ./dist/consistentExports.js",
+    "test": " bun run ./dist/consistentExports.js",
     "clean": "npx rimraf node_modules,pnpm-lock.yaml,dist",
     "test:build": "pnpm install && pnpm build",
     "test:assert": "pnpm test"
@@ -20,6 +20,7 @@
     "@sentry/serverless": "latest || *",
     "@sentry/bun": "latest || *",
     "@sentry/types": "latest || *",
+    "@sentry/core": "latest || *",
     "@types/node": "18.15.1",
     "typescript": "4.9.5"
   },

--- a/dev-packages/e2e-tests/test-applications/node-exports-test-app/package.json
+++ b/dev-packages/e2e-tests/test-applications/node-exports-test-app/package.json
@@ -20,7 +20,6 @@
     "@sentry/serverless": "latest || *",
     "@sentry/bun": "latest || *",
     "@sentry/types": "latest || *",
-    "@sentry/core": "latest || *",
     "@types/node": "18.15.1",
     "typescript": "4.9.5"
   },

--- a/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
+++ b/dev-packages/e2e-tests/test-applications/node-exports-test-app/scripts/consistentExports.ts
@@ -1,5 +1,5 @@
 import * as SentryAstro from '@sentry/astro';
-// import * as SentryBun from '@sentry/bun';
+import * as SentryBun from '@sentry/bun';
 import * as SentryNextJs from '@sentry/nextjs';
 import * as SentryNode from '@sentry/node';
 import * as SentryRemix from '@sentry/remix';
@@ -37,6 +37,17 @@ const DEPENDENTS: Dependent[] = [
   {
     package: '@sentry/astro',
     exports: Object.keys(SentryAstro),
+  },
+  {
+    package: '@sentry/bun',
+    exports: Object.keys(SentryBun),
+    ignoreExports: [
+      // not supported in bun:
+      'Handlers',
+      'NodeClient',
+      'hapiErrorPlugin',
+      'makeNodeTransport',
+    ],
   },
   {
     package: '@sentry/nextjs',

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -89,7 +89,22 @@ export {
   parameterize,
 } from '@sentry/core';
 export type { SpanStatusType } from '@sentry/core';
-export { autoDiscoverNodePerformanceMonitoringIntegrations, cron } from '@sentry/node';
+export {
+  // eslint-disable-next-line deprecation/deprecation
+  deepReadDirSync,
+  // eslint-disable-next-line deprecation/deprecation
+  enableAnrDetection,
+  // eslint-disable-next-line deprecation/deprecation
+  getModuleFromFilename,
+  DEFAULT_USER_INCLUDES,
+  autoDiscoverNodePerformanceMonitoringIntegrations,
+  cron,
+  createGetModuleFromFilename,
+  defaultStackParser,
+  extractRequestData,
+  getSentryRelease,
+  addRequestDataToEvent,
+} from '@sentry/node';
 
 export { BunClient } from './client';
 export {


### PR DESCRIPTION
This PR adds missing exports from the Node to the Bun SDK. Ignored a couple of exports that I believe aren't compatible with Bun or for which we have dedicated Bun repalcements (e.g. client, transport).

Node would throw ESM/CJS errors when importing from `@sentry/bun`. So let's just use Bun for this test 🙃 

more details in https://github.com/getsentry/sentry-javascript/pull/10389