### PR TITLE
build(ci): Use github reporter for playwright on CI

### DIFF
--- a/dev-packages/browser-integration-tests/package.json
+++ b/dev-packages/browser-integration-tests/package.json
@@ -38,7 +38,7 @@
     "test:loader:replay": "PW_BUNDLE=loader_replay yarn test:loader",
     "test:loader:full": "PW_BUNDLE=loader_tracing_replay yarn test:loader",
     "test:loader:debug": "PW_BUNDLE=loader_debug yarn test:loader",
-    "test:ci": "yarn test:all --reporter='line'",
+    "test:ci": "yarn test:all",
     "test:update-snapshots": "yarn test:all --update-snapshots",
     "test:detect-flaky": "ts-node scripts/detectFlakyTests.ts",
     "validate:es5": "es-check es5 'fixtures/loader.js'"

--- a/dev-packages/browser-integration-tests/playwright.config.ts
+++ b/dev-packages/browser-integration-tests/playwright.config.ts
@@ -3,6 +3,7 @@ import { devices } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   retries: 0,
+  reporter: process.env.CI ? 'github' : 'list',
   // Run tests inside of a single file in parallel
   fullyParallel: true,
   // Use 3 workers on CI, else use defaults (based on available CPU cores)

--- a/dev-packages/browser-integration-tests/playwright.config.ts
+++ b/dev-packages/browser-integration-tests/playwright.config.ts
@@ -3,7 +3,9 @@ import { devices } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   retries: 0,
-  reporter: process.env.CI ? 'github' : 'list',
+  // We always use the 'list' reporter here, expect for the esm environment on CI
+  // otherwise, a failed test will report to github for each env/bundle we run it in, leading to a messy UI
+  reporter: process.env.CI && process.env.PW_BUNDLE === 'esm' ? 'github' : 'list',
   // Run tests inside of a single file in parallel
   fullyParallel: true,
   // Use 3 workers on CI, else use defaults (based on available CPU cores)

--- a/dev-packages/browser-integration-tests/scripts/detectFlakyTests.ts
+++ b/dev-packages/browser-integration-tests/scripts/detectFlakyTests.ts
@@ -43,9 +43,7 @@ ${changedPaths.join('\n')}
   try {
     await new Promise<void>((resolve, reject) => {
       const cp = childProcess.spawn(
-        `npx playwright test ${
-          testPaths.length ? testPaths.join(' ') : './suites'
-        } --reporter='line' --repeat-each ${runCount}`,
+        `npx playwright test ${testPaths.length ? testPaths.join(' ') : './suites'} --repeat-each ${runCount}`,
         { shell: true, cwd },
       );
 

--- a/dev-packages/browser-integration-tests/suites/tracing/browsertracing/pageloadDelayed/test.ts
+++ b/dev-packages/browser-integration-tests/suites/tracing/browsertracing/pageloadDelayed/test.ts
@@ -23,4 +23,7 @@ sentryTest('should create a pageload transaction when initialized delayed', asyn
   expect(eventData.contexts?.trace?.op).toBe('pageload');
   expect(eventData.spans?.length).toBeGreaterThan(0);
   expect(eventData.transaction_info?.source).toEqual('url');
+
+  // TODO: Provoke an error to test this...
+  expect({}).toBe(false);
 });

--- a/dev-packages/e2e-tests/test-applications/create-next-app/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/create-next-app/playwright.config.ts
@@ -37,7 +37,7 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
+  reporter: process.env.CI ? 'github' : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/dev-packages/e2e-tests/test-applications/create-remix-app-v2/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app-v2/playwright.config.ts
@@ -26,7 +26,7 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
+  reporter: process.env.CI ? 'github' : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/dev-packages/e2e-tests/test-applications/create-remix-app/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/create-remix-app/playwright.config.ts
@@ -26,7 +26,7 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
+  reporter: process.env.CI ? 'github' : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/dev-packages/e2e-tests/test-applications/nextjs-14/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-14/playwright.config.ts
@@ -36,7 +36,7 @@ const config: PlaywrightTestConfig = {
   /* `next dev` is incredibly buggy with the app dir */
   retries: testEnv === 'development' ? 3 : 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
+  reporter: process.env.CI ? 'github' : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/playwright.config.ts
@@ -36,7 +36,7 @@ const config: PlaywrightTestConfig = {
   /* `next dev` is incredibly buggy with the app dir */
   retries: testEnv === 'development' ? 3 : 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
+  reporter: process.env.CI ? 'github' : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/dev-packages/e2e-tests/test-applications/node-experimental-fastify-app/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/node-experimental-fastify-app/playwright.config.ts
@@ -24,7 +24,7 @@ const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   retries: 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
+  reporter: process.env.CI ? 'github' : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/dev-packages/e2e-tests/test-applications/node-express-app/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/node-express-app/playwright.config.ts
@@ -30,7 +30,7 @@ const config: PlaywrightTestConfig = {
   /* Retry on CI only */
   retries: 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
+  reporter: process.env.CI ? 'github' : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/dev-packages/e2e-tests/test-applications/node-hapi-app/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/node-hapi-app/playwright.config.ts
@@ -25,7 +25,7 @@ const config: PlaywrightTestConfig = {
   /* Retry on CI only */
   retries: 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
+  reporter: process.env.CI ? 'github' : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/dev-packages/e2e-tests/test-applications/react-create-hash-router/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/react-create-hash-router/playwright.config.ts
@@ -24,7 +24,7 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
+  reporter: process.env.CI ? 'github' : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/react-router-6-use-routes/playwright.config.ts
@@ -24,7 +24,7 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
+  reporter: process.env.CI ? 'github' : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/dev-packages/e2e-tests/test-applications/standard-frontend-react-tracing-import/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/standard-frontend-react-tracing-import/playwright.config.ts
@@ -24,7 +24,7 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
+  reporter: process.env.CI ? 'github' : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/dev-packages/e2e-tests/test-applications/standard-frontend-react/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/standard-frontend-react/playwright.config.ts
@@ -24,7 +24,7 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
+  reporter: process.env.CI ? 'github' : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/dev-packages/e2e-tests/test-applications/sveltekit-2/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit-2/playwright.config.ts
@@ -30,7 +30,7 @@ const config: PlaywrightTestConfig = {
   /* `next dev` is incredibly buggy with the app dir */
   retries: testEnv === 'development' ? 3 : 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
+  reporter: process.env.CI ? 'github' : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/dev-packages/e2e-tests/test-applications/sveltekit/playwright.config.ts
+++ b/dev-packages/e2e-tests/test-applications/sveltekit/playwright.config.ts
@@ -30,7 +30,7 @@ const config: PlaywrightTestConfig = {
   /* `next dev` is incredibly buggy with the app dir */
   retries: testEnv === 'development' ? 3 : 0,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'list',
+  reporter: process.env.CI ? 'github' : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/packages/nextjs/playwright.config.ts
+++ b/packages/nextjs/playwright.config.ts
@@ -3,6 +3,7 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   retries: 0, // We do not accept flakes.
+  reporter: process.env.CI ? 'github' : 'list',
   use: {
     baseURL: 'http://localhost:3000',
   },

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -77,7 +77,7 @@
     "test:integration:prepare": "(cd test/integration && yarn)",
     "test:integration:clean": "(cd test/integration && rimraf .cache node_modules build)",
     "test:integration:client": "yarn playwright install-deps && yarn playwright test test/integration/test/client/ --project='chromium'",
-    "test:integration:client:ci": "yarn test:integration:client --reporter='line'",
+    "test:integration:client:ci": "yarn test:integration:client",
     "test:integration:server": "export NODE_OPTIONS='--stack-trace-limit=25' && jest --config=test/integration/jest.config.js test/integration/test/server/",
     "test:unit": "jest",
     "test:watch": "jest --watch",

--- a/packages/remix/playwright.config.ts
+++ b/packages/remix/playwright.config.ts
@@ -3,6 +3,7 @@ import { devices } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   retries: 0,
+  reporter: process.env.CI ? 'github' : 'list',
   use: {
     baseURL: 'http://localhost:3000',
   },


### PR DESCRIPTION
Based on https://playwright.dev/docs/test-reporters#github-actions-annotations, this should (hopefully) give us better annotations for playwright errors on CI.