### PR TITLE
build(ci): Bump pr-labels-action to use node20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Get PR labels
         id: pr-labels
-        uses: mydea/pr-labels-action@bump-node20
+        uses: mydea/pr-labels-action@fn/bump-node20
 
     outputs:
       commit_label: '${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Get PR labels
         id: pr-labels
-        uses: mydea/pr-labels-action@update-core
+        uses: mydea/pr-labels-action@bump-node20
 
     outputs:
       commit_label: '${{ env.COMMIT_SHA }}: ${{ env.COMMIT_MESSAGE }}'


### PR DESCRIPTION
I also opened a PR upstream: https://github.com/joerick/pr-labels-action/pull/17 but merging speed is rather slow there, so I'd rather not wait for this.