### PR TITLE
ci: Always run code formatting CI job (even for *.md only PRs)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,8 +165,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 15
     if: |
-      (needs.job_get_metadata.outputs.is_gitflow_sync == 'false' && needs.job_get_metadata.outputs.has_gitflow_label == 'false') &&
-      (needs.job_get_metadata.outputs.changed_any_code == 'true' || github.event_name != 'pull_request')
+      (needs.job_get_metadata.outputs.is_gitflow_sync == 'false' && needs.job_get_metadata.outputs.has_gitflow_label == 'false')
     steps:
       - name: 'Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})'
         uses: actions/checkout@v4
@@ -215,6 +214,8 @@ jobs:
     needs: [job_get_metadata, job_install_deps]
     runs-on: ubuntu-20.04
     timeout-minutes: 30
+    if: |
+      (needs.job_get_metadata.outputs.changed_any_code == 'true' || github.event_name != 'pull_request')
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v4
@@ -322,6 +323,28 @@ jobs:
         run: yarn lint
       - name: Validate ES5 builds
         run: yarn validate:es5
+
+  job_lint_md:
+    name: Lint Markdown
+    needs: [job_get_metadata, job_install_deps]
+    timeout-minutes: 10
+    runs-on: ubuntu-20.04
+    if: needs.job_get_metadata.outputs.changed_any_code != 'true' && github.event_name == 'pull_request'
+    steps:
+      - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.HEAD_COMMIT }}
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+      - name: Restore caches
+        uses: ./.github/actions/restore-cache
+        env:
+          DEPENDENCY_CACHE_KEY: ${{ needs.job_build.outputs.dependency_cache_key }}
+      - name: Lint .md files
+        run: yarn lint:prettier
 
   job_circular_dep_check:
     name: Circular Dependency Check
@@ -1015,6 +1038,7 @@ jobs:
         job_e2e_tests,
         job_artifacts,
         job_lint,
+        job_lint_md,
         job_circular_dep_check,
       ]
     # Always run this, even if a dependent job failed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,16 +320,15 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_build.outputs.dependency_cache_key }}
       - name: Lint source files
-        run: yarn lint
+        run: lint:lerna
       - name: Validate ES5 builds
         run: yarn validate:es5
 
-  job_lint_md:
-    name: Lint Markdown
+  job_check_format:
+    name: Check file formatting
     needs: [job_get_metadata, job_install_deps]
     timeout-minutes: 10
     runs-on: ubuntu-20.04
-    if: needs.job_get_metadata.outputs.changed_any_code != 'true' && github.event_name == 'pull_request'
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v4
@@ -339,8 +338,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
-      - name: Lint .md files
-        run: yarn lint:prettier
+      - name: Check dependency cache
+        uses: actions/cache/restore@v3
+        with:
+          path: ${{ env.CACHED_DEPENDENCY_PATHS }}
+          key: ${{ needs.job_install_deps.outputs.dependency_cache_key }}
+          fail-on-cache-miss: true
+      - name: Check file formatting
+        run: yarn lint:prettier && yarn lint:biome
 
   job_circular_dep_check:
     name: Circular Dependency Check
@@ -1034,7 +1039,7 @@ jobs:
         job_e2e_tests,
         job_artifacts,
         job_lint,
-        job_lint_md,
+        job_check_format,
         job_circular_dep_check,
       ]
     # Always run this, even if a dependent job failed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,10 +339,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
-      - name: Restore caches
-        uses: ./.github/actions/restore-cache
-        env:
-          DEPENDENCY_CACHE_KEY: ${{ needs.job_build.outputs.dependency_cache_key }}
       - name: Lint .md files
         run: yarn lint:prettier
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -320,7 +320,7 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_build.outputs.dependency_cache_key }}
       - name: Lint source files
-        run: lint:lerna
+        run: yarn lint:lerna
       - name: Validate ES5 builds
         run: yarn validate:es5
 


### PR DESCRIPTION
This runs a separate, streamlined lint step for prettier only, if only markdown files are changed.