### PR TITLE
test(ci): Do not run browser integration tests for CJS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -555,7 +555,6 @@ jobs:
       matrix:
         bundle:
           - esm
-          - cjs
           - bundle_es5
           - bundle_es5_min
           - bundle_es6


### PR DESCRIPTION
This does not really tell us anything the ESM tests do not already tell us. We can save some CI time there...
