### PR TITLE
ci: Use larger runner for build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,7 @@ jobs:
   job_build:
     name: Build
     needs: [job_get_metadata, job_install_deps]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-large-js
     timeout-minutes: 30
     if: |
       (needs.job_get_metadata.outputs.changed_any_code == 'true' || github.event_name != 'pull_request')


### PR DESCRIPTION
I guess this will make CI much faster since it is a hot path?