### PR TITLE
feat(vue): Deprecate `new VueIntegration()`

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -4,4 +4,8 @@ export { init } from './sdk';
 export { vueRouterInstrumentation } from './router';
 export { attachErrorHandler } from './errorhandler';
 export { createTracingMixins } from './tracing';
-export { vueIntegration, VueIntegration } from './integration';
+export {
+  vueIntegration,
+  // eslint-disable-next-line deprecation/deprecation
+  VueIntegration,
+} from './integration';

--- a/packages/vue/src/integration.ts
+++ b/packages/vue/src/integration.ts
@@ -35,6 +35,8 @@ export const vueIntegration = defineIntegration(_vueIntegration);
 
 /**
  * Initialize Vue error & performance tracking.
+ *
+ * @deprecated Use `vueIntegration()` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export const VueIntegration = convertIntegrationFnToClass(

--- a/packages/vue/test/integration/VueIntegration.test.ts
+++ b/packages/vue/test/integration/VueIntegration.test.ts
@@ -36,7 +36,7 @@ describe('Sentry.VueIntegration', () => {
     });
 
     // This would normally happen through client.addIntegration()
-    const integration = new Sentry.VueIntegration({ app });
+    const integration = Sentry.vueIntegration({ app });
     integration['setup']?.(Sentry.getClient() as Client);
 
     app.mount(el);
@@ -58,7 +58,7 @@ describe('Sentry.VueIntegration', () => {
     app.mount(el);
 
     // This would normally happen through client.addIntegration()
-    const integration = new Sentry.VueIntegration({ app });
+    const integration = Sentry.vueIntegration({ app });
     integration['setup']?.(Sentry.getClient() as Client);
 
     expect(warnings).toEqual([

--- a/packages/vue/test/integration/init.test.ts
+++ b/packages/vue/test/integration/init.test.ts
@@ -1,6 +1,5 @@
 import { createApp } from 'vue';
 
-import { VueIntegration } from '../../src/integration';
 import type { Options } from '../../src/types';
 import * as Sentry from './../../src';
 
@@ -104,7 +103,7 @@ Update your \`Sentry.init\` call with an appropriate config option:
 });
 
 function runInit(options: Partial<Options>): void {
-  const integration = new VueIntegration();
+  const integration = Sentry.vueIntegration();
 
   Sentry.init({
     dsn: PUBLIC_DSN,


### PR DESCRIPTION
`vueIntegration()` is already exported, but we didn't deprecate the class yet.
