### PR TITLE
build(ci): Update paths-filter action to v3.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
           echo "COMMIT_MESSAGE=$(git log -n 1 --pretty=format:%s $COMMIT_SHA)" >> $GITHUB_ENV
 
       - name: Determine changed packages
-        uses: getsentry/paths-filter@v2.11.1
+        uses: dorny/paths-filter@v3.0.0
         id: changed
         with:
           filters: |

--- a/.github/workflows/flaky-test-detector.yml
+++ b/.github/workflows/flaky-test-detector.yml
@@ -71,7 +71,7 @@ jobs:
         run: npx playwright install-deps
 
       - name: Determine changed tests
-        uses: getsentry/paths-filter@v2.11.1
+        uses: dorny/paths-filter@v3.0.0
         id: changed
         with:
           list-files: json


### PR DESCRIPTION
Also move off our custom fork as that is no longer needed.

This mainly fixes the node16 deprecation warning for the action: https://github.com/dorny/paths-filter/releases/tag/v3.0.0