### PR TITLE
feat(bundles): Add pluggable integrations on CDN to `Sentry` namespace

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/httpClientIntegration/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/httpClientIntegration/init.js
@@ -1,0 +1,11 @@
+import * as Sentry from '@sentry/browser';
+import { httpClientIntegration } from '@sentry/integrations';
+
+window.Sentry = Sentry;
+
+Sentry.init({
+  dsn: 'https://public@dsn.ingest.sentry.io/1337',
+  integrations: [httpClientIntegration()],
+  tracesSampleRate: 1,
+  sendDefaultPii: true,
+});

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/httpClientIntegration/subject.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/httpClientIntegration/subject.js
@@ -1,0 +1,8 @@
+const xhr = new XMLHttpRequest();
+
+xhr.open('GET', 'http://localhost:7654/foo', true);
+xhr.withCredentials = true;
+xhr.setRequestHeader('Accept', 'application/json');
+xhr.setRequestHeader('Content-Type', 'application/json');
+xhr.setRequestHeader('Cache', 'no-cache');
+xhr.send();

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/httpClientIntegration/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/httpClientIntegration/test.ts
@@ -1,0 +1,64 @@
+import { expect } from '@playwright/test';
+import type { Event } from '@sentry/types';
+
+import { sentryTest } from '../../../../utils/fixtures';
+import { getFirstSentryEnvelopeRequest } from '../../../../utils/helpers';
+
+sentryTest('works with httpClientIntegration', async ({ getLocalTestPath, page }) => {
+  const url = await getLocalTestPath({ testDir: __dirname });
+
+  await page.route('**/foo', route => {
+    return route.fulfill({
+      status: 500,
+      body: JSON.stringify({
+        error: {
+          message: 'Internal Server Error',
+        },
+      }),
+      headers: {
+        'Content-Type': 'text/html',
+      },
+    });
+  });
+
+  const eventData = await getFirstSentryEnvelopeRequest<Event>(page, url);
+
+  expect(eventData.exception?.values).toHaveLength(1);
+
+  // Not able to get the cookies from the request/response because of Playwright bug
+  // https://github.com/microsoft/playwright/issues/11035
+  expect(eventData).toMatchObject({
+    message: 'HTTP Client Error with status code: 500',
+    exception: {
+      values: [
+        {
+          type: 'Error',
+          value: 'HTTP Client Error with status code: 500',
+          mechanism: {
+            type: 'http.client',
+            handled: false,
+          },
+        },
+      ],
+    },
+    request: {
+      url: 'http://localhost:7654/foo',
+      method: 'GET',
+      headers: {
+        accept: 'application/json',
+        cache: 'no-cache',
+        'content-type': 'application/json',
+      },
+    },
+    contexts: {
+      response: {
+        status_code: 500,
+        body_size: 45,
+        headers: {
+          'content-type': 'text/html',
+          'content-length': '45',
+        },
+      },
+    },
+  });
+});

--- a/dev-packages/rollup-utils/bundleHelpers.mjs
+++ b/dev-packages/rollup-utils/bundleHelpers.mjs
@@ -82,6 +82,7 @@ export function makeBaseBundleConfig(options) {
           '  for (var key in exports) {',
           '    if (Object.prototype.hasOwnProperty.call(exports, key)) {',
           '      __window.Sentry.Integrations[key] = exports[key];',
+          '      __window.Sentry[key] = exports[key];',
           '    }',
           '  }',
         ].join('\n'),


### PR DESCRIPTION
Previously, they were only put on `Sentry.Integrations.XXX`, now you can do e.g. `Sentry.httpClientIntegration()`.

While at it, I also added a browser integration test for this. I also made the way we do this more future proof, as in v8 this will not be imported anymore from `@sentry/integrations` (which we rely on right now), plus the heuristic used to rely on integration name === filename. Now, there is a manual map of imported method names to a CDN bundle file name.