### PR TITLE
fix(test): Clean up docker containers with script

### DIFF
--- a/dev-packages/node-integration-tests/package.json
+++ b/dev-packages/node-integration-tests/package.json
@@ -14,8 +14,8 @@
     "build:dev": "yarn build",
     "build:transpile": "rollup -c rollup.npm.config.mjs",
     "build:types": "tsc -p tsconfig.types.json",
-    "clean": "rimraf -g **/node_modules && run-p clean:docker:*",
-    "clean:docker:mysql2": "cd suites/tracing-experimental/mysql2 && docker-compose down --volumes",
+    "clean": "rimraf -g **/node_modules && run-p clean:docker",
+    "clean:docker": "node scripts/clean.js",
     "prisma:init": "(cd suites/tracing/prisma-orm && ts-node ./setup.ts)",
     "prisma:init:new": "(cd suites/tracing-new/prisma-orm && ts-node ./setup.ts)",
     "lint": "eslint . --format stylish",
@@ -51,6 +51,9 @@
     "pg": "^8.7.3",
     "proxy": "^2.1.1",
     "yargs": "^16.2.0"
+  },
+  "devDependencies": {
+    "globby": "11"
   },
   "config": {
     "mongodbMemoryServer": {

--- a/dev-packages/node-integration-tests/scripts/clean.js
+++ b/dev-packages/node-integration-tests/scripts/clean.js
@@ -1,0 +1,19 @@
+const { execSync } = require('child_process');
+const globby = require('globby');
+const { dirname, join } = require('path');
+
+const cwd = join(__dirname, '..');
+const paths = globby.sync(['suites/**/docker-compose.yml'], { cwd }).map(path => join(cwd, dirname(path)));
+
+// eslint-disable-next-line no-console
+console.log('Cleaning up docker containers and volumes...');
+
+for (const path of paths) {
+  try {
+    // eslint-disable-next-line no-console
+    console.log(`docker compose down @ ${path}`);
+    execSync('docker compose down --volumes', { stdio: 'inherit', cwd: path });
+  } catch (_) {
+    //
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16753,7 +16753,7 @@ globby@10.0.0:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
-globby@11.1.0, globby@^11.0.1, globby@^11.0.3, globby@^11.1.0:
+globby@11, globby@11.1.0, globby@^11.0.1, globby@^11.0.3, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==


### PR DESCRIPTION
This PR adds a script to cleanup any docker containers left over from the node integration tests.

- It uses `globby@11` since that is already installed for a couple of our dependencies. 
- It finds all the `docker-compose.yml` files and runs `docker compose down --volumes` in those directories.
- It catches all errors for when docker is not running
