### PR TITLE
feat(remix): Add dynamic loading of `@remix-run/router` module.

### DIFF
--- a/packages/remix/src/utils/routerLoader.ts
+++ b/packages/remix/src/utils/routerLoader.ts
@@ -1,0 +1,51 @@
+import { loadModule, logger } from '@sentry/utils';
+import { cwd } from 'process';
+import { DEBUG_BUILD } from './debug-build';
+import type { ReactRouterDomPkg } from './vendor/types';
+
+function hasMatchRoutes(pkg: ReactRouterDomPkg | undefined): boolean {
+  return !!pkg && typeof pkg.matchRoutes === 'function';
+}
+
+/**
+ * Loads the router package that provides matchRoutes.
+ * Tries loading @remix-run/router first, then falls back to react-router-dom.
+ */
+export async function loadRemixRouterModule(): Promise<ReactRouterDomPkg | undefined> {
+  // Try loading @remix-run/router first, then fall back to react-router-dom
+  for (const moduleName of ['@remix-run/router', 'react-router-dom']) {
+    const pkg = await tryLoadRouterModule(moduleName);
+
+    if (pkg) {
+      return pkg;
+    }
+  }
+
+  DEBUG_BUILD && logger.warn('Could not find a router package that provides `matchRoutes`.');
+
+  return;
+}
+
+async function tryLoadRouterModule(moduleName: string): Promise<ReactRouterDomPkg | undefined> {
+  let pkg: ReactRouterDomPkg | undefined;
+
+  pkg = loadModule<ReactRouterDomPkg>(moduleName);
+
+  if (hasMatchRoutes(pkg)) {
+    return pkg;
+  }
+
+  try {
+    pkg = await import(moduleName);
+  } catch (e) {
+    pkg = await import(`${cwd()}/node_modules/${moduleName}`);
+  }
+
+  if (hasMatchRoutes(pkg)) {
+    return pkg;
+  } else {
+    DEBUG_BUILD && logger.warn(`Could not find ${moduleName} package.`);
+  }
+
+  return;
+}

--- a/packages/remix/test/integration/package.json
+++ b/packages/remix/test/integration/package.json
@@ -7,16 +7,16 @@
     "start": "remix-serve build"
   },
   "dependencies": {
-    "@remix-run/express": "1.17.0",
-    "@remix-run/node": "1.17.0",
-    "@remix-run/react": "1.17.0",
-    "@remix-run/serve": "1.17.0",
+    "@remix-run/express": "1.19.3",
+    "@remix-run/node": "1.19.3",
+    "@remix-run/react": "1.19.3",
+    "@remix-run/serve": "1.19.3",
     "@sentry/remix": "file:../..",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@remix-run/dev": "1.17.0",
+    "@remix-run/dev": "1.19.3",
     "@types/react": "^17.0.47",
     "@types/react-dom": "^17.0.17",
     "nock": "^13.1.0",


### PR DESCRIPTION
Potentially fixes: https://github.com/getsentry/sentry-javascript/issues/10349

Added dynamic loading support for `@remix-run/router` package as a provider of `matchRoutes`. `matchRoutes` from `react-router-dom` and `@remix-run/router` can be used interchangeably for our use case.

Also updated integration tests' Remix version to `1.19.3` which is the latest `1.x` version.

Don't have the reproduction of the original issue, but I expect this PR to resolve that problem.