### PR TITLE
feat(feedback): Add `system-ui` to start of font family

### DIFF
--- a/packages/feedback/src/constants.ts
+++ b/packages/feedback/src/constants.ts
@@ -9,7 +9,7 @@ const LIGHT_BACKGROUND = '#ffffff';
 const INHERIT = 'inherit';
 const SUBMIT_COLOR = 'rgba(108, 95, 199, 1)';
 const LIGHT_THEME = {
-  fontFamily: "'Helvetica Neue', Arial, sans-serif",
+  fontFamily: "system-ui, 'Helvetica Neue', Arial, sans-serif",
   fontSize: '14px',
 
   background: LIGHT_BACKGROUND,


### PR DESCRIPTION
Requested by @Jesse-Box: "...fits better with the OS the user uses"
