### PR TITLE
fix(feedback): Fix logo color when colorScheme is "system"

### DIFF
--- a/packages/feedback/src/widget/Logo.ts
+++ b/packages/feedback/src/widget/Logo.ts
@@ -33,8 +33,13 @@ export function Logo({ colorScheme }: Props): IconReturn {
   const defs = createElementNS('defs');
   const style = createElementNS('style');
 
+  style.textContent = `
+    path {
+      fill: ${colorScheme === 'dark' ? '#fff' : '#362d59'};
+    }`;
+
   if (colorScheme === 'system') {
-    style.textContent = `
+    style.textContent += `
     @media (prefers-color-scheme: dark) {
       path: {
         fill: '#fff';
@@ -42,11 +47,6 @@ export function Logo({ colorScheme }: Props): IconReturn {
     }
     `;
   }
-
-  style.textContent = `
-    path {
-      fill: ${colorScheme === 'dark' ? '#fff' : '#362d59'};
-    }`;
 
   defs.append(style);
   svg.append(defs);


### PR DESCRIPTION
The CSS when colorScheme is "system" was always being overwritten so the logo color ends up being incorrect when OS is in dark mode.

![image](https://github.com/getsentry/sentry-javascript/assets/79684/062b3e1d-d310-470c-93f0-53105cfb89de)
