### PR TITLE
build(ci): Bump action dependencies for node profiling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -555,7 +555,7 @@ jobs:
           node-version: 20
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8.10'
+          python-version: '3.11.7'
       - name: Restore caches
         uses: ./.github/actions/restore-cache
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -554,6 +554,8 @@ jobs:
         with:
           node-version: 20
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8.10'
       - name: Restore caches
         uses: ./.github/actions/restore-cache
         env:
@@ -1316,12 +1318,12 @@ jobs:
           ln -sf python3 /usr/bin/python
 
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.HEAD_COMMIT }}
 
       - name: Restore dependency cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: restore-dependencies
         with:
           path: ${{ env.CACHED_DEPENDENCY_PATHS }}
@@ -1329,7 +1331,7 @@ jobs:
           enableCrossOsArchive: true
 
       - name: Restore build cache
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: restore-build
         with:
           path: ${{ env.CACHED_BUILD_PATHS }}
@@ -1348,14 +1350,14 @@ jobs:
         run: yarn config set network-timeout 600000 -g
 
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         if: ${{ !contains(matrix.container, 'alpine') }}
         id: python-setup
         with:
           python-version: '3.8.10'
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 


### PR DESCRIPTION
Noticed warnings in GH for these, so bumping all of these to latest.