### PR TITLE
fix(nextjs): Do not report redirects and notFound calls as errors in server actions

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/app/server-action/page.tsx
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/app/server-action/page.tsx
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/nextjs';
 import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
 
 export default function ServerComponent() {
   async function myServerAction(formData: FormData) {
@@ -14,11 +15,29 @@ export default function ServerComponent() {
     );
   }
 
+  async function notFoundServerAction(formData: FormData) {
+    'use server';
+    return await Sentry.withServerActionInstrumentation(
+      'notFoundServerAction',
+      { formData, headers: headers(), recordResponse: true },
+      () => {
+        notFound();
+      },
+    );
+  }
+
   return (
-    // @ts-ignore
-    <form action={myServerAction}>
-      <input type="text" defaultValue={'some-default-value'} name="some-text-value" />
-      <button type="submit">Run Action</button>
-    </form>
+    <>
+      {/* @ts-ignore */}
+      <form action={myServerAction}>
+        <input type="text" defaultValue={'some-default-value'} name="some-text-value" />
+        <button type="submit">Run Action</button>
+      </form>
+      {/* @ts-ignore */}
+      <form action={notFoundServerAction}>
+        <input type="text" defaultValue={'some-default-value'} name="some-text-value" />
+        <button type="submit">Run NotFound Action</button>
+      </form>
+    </>
   );
 }


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-javascript/issues/10466