### PR TITLE
feat: Export `setHttpStatus` from all packages

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -49,6 +49,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
+  setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -72,6 +72,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
+  setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   makeMultiplexedTransport,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -69,6 +69,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
+  setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -68,6 +68,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
+  setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -81,6 +81,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
+  setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   captureCheckIn,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -68,6 +68,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
+  setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -53,6 +53,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
+  setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -41,6 +41,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
+  setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation
   makeMain,
   setCurrentClient,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -47,6 +47,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
+  setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -68,6 +68,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
+  setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation
   trace,
   withScope,


### PR DESCRIPTION
This replaces an old API but was not exported anywhere.

We introduced this here: https://github.com/getsentry/sentry-javascript/pull/10268/files
