### PR TITLE
fix(test): Fix flaky browser integration tests.

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/dom/click/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/dom/click/test.ts
@@ -78,9 +78,8 @@ sentryTest(
 
     await page.goto(url);
     await page.locator('#annotated-button').click();
-    await page.evaluate('Sentry.captureException("test exception")');
 
-    const eventData = await promise;
+    const [eventData] = await Promise.all([promise, page.evaluate('Sentry.captureException("test exception")')]);
 
     expect(eventData.breadcrumbs).toEqual([
       {

--- a/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/simple/test.ts
+++ b/dev-packages/browser-integration-tests/suites/integrations/httpclient/fetch/simple/test.ts
@@ -4,6 +4,8 @@ import type { Event } from '@sentry/types';
 import { sentryTest } from '../../../../../utils/fixtures';
 import { getFirstSentryEnvelopeRequest } from '../../../../../utils/helpers';
 
+// This test rarely flakes with timeouts. The reason might be:
+// https://github.com/microsoft/playwright/issues/10376
 sentryTest(
   'should assign request and response context from a failed 500 fetch request',
   async ({ getLocalTestPath, page }) => {

--- a/dev-packages/browser-integration-tests/suites/public-api/startSpan/basic/subject.js
+++ b/dev-packages/browser-integration-tests/suites/public-api/startSpan/basic/subject.js
@@ -6,4 +6,6 @@ async function run() {
   });
 }
 
-run();
+(async () => {
+  await run();
+})();

--- a/dev-packages/browser-integration-tests/suites/replay/errorResponse/test.ts
+++ b/dev-packages/browser-integration-tests/suites/replay/errorResponse/test.ts
@@ -23,9 +23,8 @@ sentryTest('should stop recording after receiving an error response', async ({ g
   });
 
   const url = await getLocalTestPath({ testDir: __dirname });
-  await page.goto(url);
+  await Promise.all([page.goto(url), waitForReplayRequest(page)]);
 
-  await waitForReplayRequest(page);
   await page.locator('button').click();
 
   expect(called).toBe(1);


### PR DESCRIPTION
This is not a complete fix for all flaky integration tests, but it seems to resolve flakiness of a few tests that fail very frequently.