### PR TITLE
feat(react): Add `reactRouterV3BrowserTracingIntegration` for react router v3

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -8,7 +8,7 @@ export { createReduxEnhancer } from './redux';
 export {
   // eslint-disable-next-line deprecation/deprecation
   reactRouterV3Instrumentation,
-  browserTracingReactRouterV3Integration,
+  reactRouterV3BrowserTracingIntegration,
 } from './reactrouterv3';
 export {
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -5,7 +5,11 @@ export { Profiler, withProfiler, useProfiler } from './profiler';
 export type { ErrorBoundaryProps, FallbackRender } from './errorboundary';
 export { ErrorBoundary, withErrorBoundary } from './errorboundary';
 export { createReduxEnhancer } from './redux';
-export { reactRouterV3Instrumentation } from './reactrouterv3';
+export {
+  // eslint-disable-next-line deprecation/deprecation
+  reactRouterV3Instrumentation,
+  browserTracingReactRouterV3Integration,
+} from './reactrouterv3';
 export {
   // eslint-disable-next-line deprecation/deprecation
   reactRouterV4Instrumentation,

--- a/packages/react/src/reactrouterv3.ts
+++ b/packages/react/src/reactrouterv3.ts
@@ -1,5 +1,22 @@
-import { WINDOW } from '@sentry/browser';
-import type { Primitive, Transaction, TransactionContext, TransactionSource } from '@sentry/types';
+import {
+  WINDOW,
+  browserTracingIntegration,
+  startBrowserTracingNavigationSpan,
+  startBrowserTracingPageLoadSpan,
+} from '@sentry/browser';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+} from '@sentry/core';
+import type {
+  Integration,
+  SpanAttributes,
+  StartSpanOptions,
+  Transaction,
+  TransactionContext,
+  TransactionSource,
+} from '@sentry/types';
 
 import type { Location, ReactRouterInstrumentation } from './types';
 
@@ -21,6 +38,52 @@ export type Match = (
 
 type ReactRouterV3TransactionSource = Extract<TransactionSource, 'url' | 'route'>;
 
+interface ReactRouterOptions {
+  history: HistoryV3;
+  routes: Route[];
+  match: Match;
+}
+
+/**
+ * A browser tracing integration that uses React Router v3 to instrument navigations.
+ * Expects `history` (and optionally `routes` and `matchPath`) to be passed as options.
+ */
+export function browserTracingReactRouterV3Integration(
+  options: Parameters<typeof browserTracingIntegration>[0] & ReactRouterOptions,
+): Integration {
+  const integration = browserTracingIntegration({
+    ...options,
+    instrumentPageLoad: false,
+    instrumentNavigation: false,
+  });
+
+  const { history, routes, match, instrumentPageLoad = true, instrumentNavigation = true } = options;
+
+  return {
+    ...integration,
+    afterAllSetup(client) {
+      integration.afterAllSetup(client);
+
+      const startPageloadCallback = (startSpanOptions: StartSpanOptions): undefined => {
+        startBrowserTracingPageLoadSpan(client, startSpanOptions);
+        return undefined;
+      };
+
+      const startNavigationCallback = (startSpanOptions: StartSpanOptions): undefined => {
+        startBrowserTracingNavigationSpan(client, startSpanOptions);
+        return undefined;
+      };
+
+      // eslint-disable-next-line deprecation/deprecation
+      const instrumentation = reactRouterV3Instrumentation(history, routes, match);
+
+      // Now instrument page load & navigation with correct settings
+      instrumentation(startPageloadCallback, instrumentPageLoad, false);
+      instrumentation(startNavigationCallback, false, instrumentNavigation);
+    },
+  };
+}
+
 /**
  * Creates routing instrumentation for React Router v3
  * Works for React Router >= 3.2.0 and < 4.0.0
@@ -28,6 +91,8 @@ type ReactRouterV3TransactionSource = Extract<TransactionSource, 'url' | 'route'
  * @param history object from the `history` library
  * @param routes a list of all routes, should be
  * @param match `Router.match` utility
+ *
+ * @deprecated Use `browserTracingReactRouterV3Integration()` instead
  */
 export function reactRouterV3Instrumentation(
   history: HistoryV3,
@@ -52,13 +117,10 @@ export function reactRouterV3Instrumentation(
           prevName = localName;
           activeTransaction = startTransaction({
             name: prevName,
-            op: 'pageload',
-            origin: 'auto.pageload.react.reactrouterv3',
-            tags: {
-              'routing.instrumentation': 'react-router-v3',
-            },
-            metadata: {
-              source,
+            attributes: {
+              [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
+              [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.react.reactrouter_v3',
+              [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: source,
             },
           });
         },
@@ -71,22 +133,23 @@ export function reactRouterV3Instrumentation(
           if (activeTransaction) {
             activeTransaction.end();
           }
-          const tags: Record<string, Primitive> = {
-            'routing.instrumentation': 'react-router-v3',
-          };
-          if (prevName) {
-            tags.from = prevName;
-          }
+          const from = prevName;
           normalizeTransactionName(routes, location, match, (localName: string, source: TransactionSource = 'url') => {
             prevName = localName;
+
+            const attributes: SpanAttributes = {
+              [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+              [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
+              [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: source,
+            };
+
+            if (from) {
+              attributes.from = from;
+            }
+
             activeTransaction = startTransaction({
               name: prevName,
-              op: 'navigation',
-              origin: 'auto.navigation.react.reactrouterv3',
-              tags,
-              metadata: {
-                source,
-              },
+              attributes,
             });
           });
         }

--- a/packages/react/src/reactrouterv3.ts
+++ b/packages/react/src/reactrouterv3.ts
@@ -48,7 +48,7 @@ interface ReactRouterOptions {
  * A browser tracing integration that uses React Router v3 to instrument navigations.
  * Expects `history` (and optionally `routes` and `matchPath`) to be passed as options.
  */
-export function browserTracingReactRouterV3Integration(
+export function reactRouterV3BrowserTracingIntegration(
   options: Parameters<typeof browserTracingIntegration>[0] & ReactRouterOptions,
 ): Integration {
   const integration = browserTracingIntegration({
@@ -92,7 +92,7 @@ export function browserTracingReactRouterV3Integration(
  * @param routes a list of all routes, should be
  * @param match `Router.match` utility
  *
- * @deprecated Use `browserTracingReactRouterV3Integration()` instead
+ * @deprecated Use `reactRouterV3BrowserTracingIntegration()` instead
  */
 export function reactRouterV3Instrumentation(
   history: HistoryV3,

--- a/packages/react/src/reactrouterv3.ts
+++ b/packages/react/src/reactrouterv3.ts
@@ -133,7 +133,6 @@ export function reactRouterV3Instrumentation(
           if (activeTransaction) {
             activeTransaction.end();
           }
-          const from = prevName;
           normalizeTransactionName(routes, location, match, (localName: string, source: TransactionSource = 'url') => {
             prevName = localName;
 
@@ -142,10 +141,6 @@ export function reactRouterV3Instrumentation(
               [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
               [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: source,
             };
-
-            if (from) {
-              attributes.from = from;
-            }
 
             activeTransaction = startTransaction({
               name: prevName,

--- a/packages/react/test/reactrouterv3.test.tsx
+++ b/packages/react/test/reactrouterv3.test.tsx
@@ -12,7 +12,7 @@ import * as React from 'react';
 import { IndexRoute, Route, Router, createMemoryHistory, createRoutes, match } from 'react-router-3';
 
 import type { Match, Route as RouteType } from '../src/reactrouterv3';
-import { browserTracingReactRouterV3Integration } from '../src/reactrouterv3';
+import { reactRouterV3BrowserTracingIntegration } from '../src/reactrouterv3';
 import { reactRouterV3Instrumentation } from '../src/reactrouterv3';
 
 // Have to manually set types because we are using package-alias
@@ -319,7 +319,7 @@ describe('browserTracingReactRouterV3', () => {
     const client = createMockBrowserClient();
     setCurrentClient(client);
 
-    client.addIntegration(browserTracingReactRouterV3Integration({ history, routes: instrumentationRoutes, match }));
+    client.addIntegration(reactRouterV3BrowserTracingIntegration({ history, routes: instrumentationRoutes, match }));
 
     client.init();
     render(<Router history={history}>{routes}</Router>);
@@ -340,7 +340,7 @@ describe('browserTracingReactRouterV3', () => {
     setCurrentClient(client);
 
     const history = createMemoryHistory();
-    client.addIntegration(browserTracingReactRouterV3Integration({ history, routes: instrumentationRoutes, match }));
+    client.addIntegration(reactRouterV3BrowserTracingIntegration({ history, routes: instrumentationRoutes, match }));
 
     client.init();
     render(<Router history={history}>{routes}</Router>);
@@ -378,7 +378,7 @@ describe('browserTracingReactRouterV3', () => {
     setCurrentClient(client);
 
     const history = createMemoryHistory();
-    client.addIntegration(browserTracingReactRouterV3Integration({ history, routes: instrumentationRoutes, match }));
+    client.addIntegration(reactRouterV3BrowserTracingIntegration({ history, routes: instrumentationRoutes, match }));
 
     client.init();
     render(<Router history={history}>{routes}</Router>);
@@ -393,7 +393,7 @@ describe('browserTracingReactRouterV3', () => {
     const client = createMockBrowserClient();
 
     const history = createMemoryHistory();
-    client.addIntegration(browserTracingReactRouterV3Integration({ history, routes: instrumentationRoutes, match }));
+    client.addIntegration(reactRouterV3BrowserTracingIntegration({ history, routes: instrumentationRoutes, match }));
 
     client.init();
     const { container } = render(<Router history={history}>{routes}</Router>);

--- a/packages/react/test/reactrouterv3.test.tsx
+++ b/packages/react/test/reactrouterv3.test.tsx
@@ -91,7 +91,6 @@ describe('reactRouterV3Instrumentation', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
-        from: '/',
       },
     });
 
@@ -105,7 +104,6 @@ describe('reactRouterV3Instrumentation', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
-        from: '/about',
       },
     });
   });
@@ -159,7 +157,6 @@ describe('reactRouterV3Instrumentation', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
-        from: '/',
       },
     });
   });
@@ -181,7 +178,6 @@ describe('reactRouterV3Instrumentation', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
-        from: '/',
       },
     });
 
@@ -197,7 +193,6 @@ describe('reactRouterV3Instrumentation', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
-        from: '/organizations/:orgid/v1/:teamid',
       },
     });
   });
@@ -218,7 +213,6 @@ describe('reactRouterV3Instrumentation', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
-        from: '/',
       },
     });
   });
@@ -368,7 +362,6 @@ describe('browserTracingReactRouterV3', () => {
         [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
         [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
-        from: '/about',
       },
     });
   });

--- a/packages/react/test/reactrouterv3.test.tsx
+++ b/packages/react/test/reactrouterv3.test.tsx
@@ -1,8 +1,18 @@
+import { BrowserClient } from '@sentry/browser';
+import {
+  SEMANTIC_ATTRIBUTE_SENTRY_OP,
+  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SOURCE,
+  createTransport,
+  getCurrentScope,
+  setCurrentClient,
+} from '@sentry/core';
 import { act, render } from '@testing-library/react';
 import * as React from 'react';
 import { IndexRoute, Route, Router, createMemoryHistory, createRoutes, match } from 'react-router-3';
 
 import type { Match, Route as RouteType } from '../src/reactrouterv3';
+import { browserTracingReactRouterV3Integration } from '../src/reactrouterv3';
 import { reactRouterV3Instrumentation } from '../src/reactrouterv3';
 
 // Have to manually set types because we are using package-alias
@@ -24,7 +34,7 @@ function createMockStartTransaction(opts: { finish?: jest.FunctionLike; setMetad
   });
 }
 
-describe('React Router V3', () => {
+describe('reactRouterV3Instrumentation', () => {
   const routes = (
     <Route path="/" component={({ children }: { children: JSX.Element }) => <div>{children}</div>}>
       <IndexRoute component={() => <div>Home</div>} />
@@ -43,6 +53,7 @@ describe('React Router V3', () => {
   const history = createMemoryHistory();
 
   const instrumentationRoutes = createRoutes(routes);
+  // eslint-disable-next-line deprecation/deprecation
   const instrumentation = reactRouterV3Instrumentation(history, instrumentationRoutes, match);
 
   it('starts a pageload transaction when instrumentation is started', () => {
@@ -51,11 +62,10 @@ describe('React Router V3', () => {
     expect(mockStartTransaction).toHaveBeenCalledTimes(1);
     expect(mockStartTransaction).toHaveBeenLastCalledWith({
       name: '/',
-      op: 'pageload',
-      origin: 'auto.pageload.react.reactrouterv3',
-      tags: { 'routing.instrumentation': 'react-router-v3' },
-      metadata: {
-        source: 'route',
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.react.reactrouter_v3',
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
       },
     });
   });
@@ -77,11 +87,11 @@ describe('React Router V3', () => {
     expect(mockStartTransaction).toHaveBeenCalledTimes(2);
     expect(mockStartTransaction).toHaveBeenLastCalledWith({
       name: '/about',
-      op: 'navigation',
-      origin: 'auto.navigation.react.reactrouterv3',
-      tags: { from: '/', 'routing.instrumentation': 'react-router-v3' },
-      metadata: {
-        source: 'route',
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+        from: '/',
       },
     });
 
@@ -91,11 +101,11 @@ describe('React Router V3', () => {
     expect(mockStartTransaction).toHaveBeenCalledTimes(3);
     expect(mockStartTransaction).toHaveBeenLastCalledWith({
       name: '/features',
-      op: 'navigation',
-      origin: 'auto.navigation.react.reactrouterv3',
-      tags: { from: '/about', 'routing.instrumentation': 'react-router-v3' },
-      metadata: {
-        source: 'route',
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+        from: '/about',
       },
     });
   });
@@ -145,11 +155,11 @@ describe('React Router V3', () => {
     expect(mockStartTransaction).toHaveBeenCalledTimes(2);
     expect(mockStartTransaction).toHaveBeenLastCalledWith({
       name: '/users/:userid',
-      op: 'navigation',
-      origin: 'auto.navigation.react.reactrouterv3',
-      tags: { from: '/', 'routing.instrumentation': 'react-router-v3' },
-      metadata: {
-        source: 'route',
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+        from: '/',
       },
     });
   });
@@ -167,11 +177,11 @@ describe('React Router V3', () => {
     expect(mockStartTransaction).toHaveBeenCalledTimes(2);
     expect(mockStartTransaction).toHaveBeenLastCalledWith({
       name: '/organizations/:orgid/v1/:teamid',
-      op: 'navigation',
-      origin: 'auto.navigation.react.reactrouterv3',
-      tags: { from: '/', 'routing.instrumentation': 'react-router-v3' },
-      metadata: {
-        source: 'route',
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+        from: '/',
       },
     });
 
@@ -183,11 +193,11 @@ describe('React Router V3', () => {
     expect(mockStartTransaction).toHaveBeenCalledTimes(3);
     expect(mockStartTransaction).toHaveBeenLastCalledWith({
       name: '/organizations/:orgid',
-      op: 'navigation',
-      origin: 'auto.navigation.react.reactrouterv3',
-      tags: { from: '/organizations/:orgid/v1/:teamid', 'routing.instrumentation': 'react-router-v3' },
-      metadata: {
-        source: 'route',
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+        from: '/organizations/:orgid/v1/:teamid',
       },
     });
   });
@@ -204,11 +214,11 @@ describe('React Router V3', () => {
     expect(mockStartTransaction).toHaveBeenCalledTimes(2);
     expect(mockStartTransaction).toHaveBeenLastCalledWith({
       name: '/organizations/1234/some/other/route',
-      op: 'navigation',
-      origin: 'auto.navigation.react.reactrouterv3',
-      tags: { from: '/', 'routing.instrumentation': 'react-router-v3' },
-      metadata: {
-        source: 'url',
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+        from: '/',
       },
     });
   });
@@ -216,6 +226,7 @@ describe('React Router V3', () => {
   it('sets metadata to url if no routes are provided', () => {
     const fakeRoutes = <div>hello</div>;
     const mockStartTransaction = createMockStartTransaction();
+    // eslint-disable-next-line deprecation/deprecation
     const mockInstrumentation = reactRouterV3Instrumentation(history, createRoutes(fakeRoutes), match);
     mockInstrumentation(mockStartTransaction);
     // We render here with `routes` instead of `fakeRoutes` from above to validate the case
@@ -225,11 +236,180 @@ describe('React Router V3', () => {
     expect(mockStartTransaction).toHaveBeenCalledTimes(1);
     expect(mockStartTransaction).toHaveBeenLastCalledWith({
       name: '/',
-      op: 'pageload',
-      origin: 'auto.pageload.react.reactrouterv3',
-      tags: { 'routing.instrumentation': 'react-router-v3' },
-      metadata: {
-        source: 'url',
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'url',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.react.reactrouter_v3',
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
+      },
+    });
+  });
+});
+
+const mockStartBrowserTracingPageLoadSpan = jest.fn();
+const mockStartBrowserTracingNavigationSpan = jest.fn();
+
+const mockRootSpan = {
+  updateName: jest.fn(),
+  setAttribute: jest.fn(),
+  getSpanJSON() {
+    return { op: 'pageload' };
+  },
+};
+
+jest.mock('@sentry/browser', () => {
+  const actual = jest.requireActual('@sentry/browser');
+  return {
+    ...actual,
+    startBrowserTracingNavigationSpan: (...args: unknown[]) => {
+      mockStartBrowserTracingNavigationSpan(...args);
+      return actual.startBrowserTracingNavigationSpan(...args);
+    },
+    startBrowserTracingPageLoadSpan: (...args: unknown[]) => {
+      mockStartBrowserTracingPageLoadSpan(...args);
+      return actual.startBrowserTracingPageLoadSpan(...args);
+    },
+  };
+});
+
+jest.mock('@sentry/core', () => {
+  const actual = jest.requireActual('@sentry/core');
+  return {
+    ...actual,
+    getRootSpan: () => {
+      return mockRootSpan;
+    },
+  };
+});
+
+describe('browserTracingReactRouterV3', () => {
+  const routes = (
+    <Route path="/" component={({ children }: { children: JSX.Element }) => <div>{children}</div>}>
+      <IndexRoute component={() => <div>Home</div>} />
+      <Route path="about" component={() => <div>About</div>} />
+      <Route path="features" component={() => <div>Features</div>} />
+      <Route
+        path="users/:userid"
+        component={({ params }: { params: Record<string, string> }) => <div>{params.userid}</div>}
+      />
+      <Route path="organizations/">
+        <Route path=":orgid" component={() => <div>OrgId</div>} />
+        <Route path=":orgid/v1/:teamid" component={() => <div>Team</div>} />
+      </Route>
+    </Route>
+  );
+  const history = createMemoryHistory();
+
+  const instrumentationRoutes = createRoutes(routes);
+
+  function createMockBrowserClient(): BrowserClient {
+    return new BrowserClient({
+      integrations: [],
+      transport: () => createTransport({ recordDroppedEvent: () => undefined }, _ => Promise.resolve({})),
+      stackParser: () => [],
+      debug: true,
+    });
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getCurrentScope().setClient(undefined);
+  });
+
+  it('starts a pageload transaction when instrumentation is started', () => {
+    const client = createMockBrowserClient();
+    setCurrentClient(client);
+
+    client.addIntegration(browserTracingReactRouterV3Integration({ history, routes: instrumentationRoutes, match }));
+
+    client.init();
+    render(<Router history={history}>{routes}</Router>);
+
+    expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenCalledTimes(1);
+    expect(mockStartBrowserTracingPageLoadSpan).toHaveBeenLastCalledWith(expect.any(BrowserClient), {
+      name: '/',
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.pageload.react.reactrouter_v3',
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'pageload',
+      },
+    });
+  });
+
+  it('starts a navigation transaction', () => {
+    const client = createMockBrowserClient();
+    setCurrentClient(client);
+
+    const history = createMemoryHistory();
+    client.addIntegration(browserTracingReactRouterV3Integration({ history, routes: instrumentationRoutes, match }));
+
+    client.init();
+    render(<Router history={history}>{routes}</Router>);
+
+    act(() => {
+      history.push('/about');
+    });
+    expect(mockStartBrowserTracingNavigationSpan).toHaveBeenCalledTimes(1);
+    expect(mockStartBrowserTracingNavigationSpan).toHaveBeenLastCalledWith(expect.any(BrowserClient), {
+      name: '/about',
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+      },
+    });
+
+    act(() => {
+      history.push('/features');
+    });
+    expect(mockStartBrowserTracingNavigationSpan).toHaveBeenCalledTimes(2);
+    expect(mockStartBrowserTracingNavigationSpan).toHaveBeenLastCalledWith(expect.any(BrowserClient), {
+      name: '/features',
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
+        from: '/about',
+      },
+    });
+  });
+
+  it('only starts a navigation transaction on push', () => {
+    const client = createMockBrowserClient();
+    setCurrentClient(client);
+
+    const history = createMemoryHistory();
+    client.addIntegration(browserTracingReactRouterV3Integration({ history, routes: instrumentationRoutes, match }));
+
+    client.init();
+    render(<Router history={history}>{routes}</Router>);
+
+    act(() => {
+      history.replace('hello');
+    });
+    expect(mockStartBrowserTracingNavigationSpan).toHaveBeenCalledTimes(0);
+  });
+
+  it('normalizes transaction name ', () => {
+    const client = createMockBrowserClient();
+
+    const history = createMemoryHistory();
+    client.addIntegration(browserTracingReactRouterV3Integration({ history, routes: instrumentationRoutes, match }));
+
+    client.init();
+    const { container } = render(<Router history={history}>{routes}</Router>);
+
+    act(() => {
+      history.push('/users/123');
+    });
+    expect(container.innerHTML).toContain('123');
+
+    expect(mockStartBrowserTracingNavigationSpan).toHaveBeenCalledTimes(1);
+    expect(mockStartBrowserTracingNavigationSpan).toHaveBeenLastCalledWith(expect.any(BrowserClient), {
+      name: '/users/:userid',
+      attributes: {
+        [SEMANTIC_ATTRIBUTE_SENTRY_SOURCE]: 'route',
+        [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.navigation.react.reactrouter_v3',
+        [SEMANTIC_ATTRIBUTE_SENTRY_OP]: 'navigation',
       },
     });
   });


### PR DESCRIPTION
To replace the routing instrumentation.

There is a _small_ issue here, which is that we do not set the `from` attribute for the first navigation after the pageload (as technically we are calling instrument twice there...) - IMHO that's acceptable, we don't really have a `from` field anyhow in other instrumentations, so we may even think about removing this I'd say...