### PR TITLE
fix: Make `startSpan`, `startSpanManual` and `startInactiveSpan` pick up the scopes at time of creation instead of termination

### DIFF
--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -222,8 +222,11 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
 
     let eventId: string | undefined = hint && hint.event_id;
 
+    const sdkProcessingMetadata = event.sdkProcessingMetadata || {};
+    const capturedSpanScope: Scope | undefined = sdkProcessingMetadata.capturedSpanScope;
+
     this._process(
-      this._captureEvent(event, hint, scope).then(result => {
+      this._captureEvent(event, hint, capturedSpanScope || scope).then(result => {
         eventId = result;
       }),
     );
@@ -753,7 +756,10 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
 
     const dataCategory: DataCategory = eventType === 'replay_event' ? 'replay' : eventType;
 
-    return this._prepareEvent(event, hint, scope)
+    const sdkProcessingMetadata = event.sdkProcessingMetadata || {};
+    const capturedSpanIsolationScope: Scope | undefined = sdkProcessingMetadata.capturedSpanIsolationScope;
+
+    return this._prepareEvent(event, hint, scope, capturedSpanIsolationScope)
       .then(prepared => {
         if (prepared === null) {
           this.recordDroppedEvent('event_processor', dataCategory, event);

--- a/packages/core/src/tracing/transaction.ts
+++ b/packages/core/src/tracing/transaction.ts
@@ -19,6 +19,7 @@ import { SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE, SEMANTIC_ATTRIBUTE_SENTRY_SOURCE
 import { spanTimeInputToSeconds, spanToJSON, spanToTraceContext } from '../utils/spanUtils';
 import { getDynamicSamplingContextFromSpan } from './dynamicSamplingContext';
 import { Span as SpanClass, SpanRecorder } from './span';
+import { getCapturedScopesOnSpan } from './trace';
 
 /** JSDoc */
 export class Transaction extends SpanClass implements TransactionInterface {
@@ -303,6 +304,8 @@ export class Transaction extends SpanClass implements TransactionInterface {
       });
     }
 
+    const { scope: capturedSpanScope, isolationScope: capturedSpanIsolationScope } = getCapturedScopesOnSpan(this);
+
     // eslint-disable-next-line deprecation/deprecation
     const { metadata } = this;
     // eslint-disable-next-line deprecation/deprecation
@@ -324,6 +327,8 @@ export class Transaction extends SpanClass implements TransactionInterface {
       type: 'transaction',
       sdkProcessingMetadata: {
         ...metadata,
+        capturedSpanScope,
+        capturedSpanIsolationScope,
         dynamicSamplingContext: getDynamicSamplingContextFromSpan(this),
       },
       ...(source && {

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -7,7 +7,6 @@ import {
   makeMain,
   setCurrentClient,
   spanToJSON,
-  withIsolationScope,
   withScope,
 } from '../../../src';
 import { Scope } from '../../../src/scope';


### PR DESCRIPTION
Makes spans/transactions created with `startSpan`, `startSpanManual` and `startInactiveSpan` use data from the scopes that were active at the time these functions were called instead of using the scopes that are active when the span was `.end()`ed.

We already do this in the otel compatible SDK and we deem this behaviour more intuitive than using the scopes on span finish.