### PR TITLE
feat(browser): Deprecate `BrowserTracing` integration

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -10,6 +10,122 @@ npx @sentry/migr8@latest
 This will let you select which updates to run, and automatically update your code. Make sure to still review all code
 changes!
 
+## Depreacted `BrowserTracing` integration
+
+The `BrowserTracing` integration, together with the custom routing instrumentations passed to it, are deprecated in v8.
+Instead, you should use `Sentry.browserTracingIntegration()`.
+
+Package-specific browser tracing integrations are available directly. In most cases, there is a single integration
+provided for each package, which will make sure to set up performance tracing correctly for the given SDK. For react, we
+provide multiple integrations to cover different router integrations:
+
+### `@sentry/browser`, `@sentry/svelte`, `@sentry/gatsby`
+
+```js
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  integrations: [Sentry.browserTracingIntegration()],
+});
+```
+
+### `@sentry/react`
+
+```js
+import * as Sentry from '@sentry/react';
+
+Sentry.init({
+  integrations: [
+    // No react router
+    Sentry.browserTracingIntegration(),
+    // OR, if you are using react router, instead use one of the following:
+    Sentry.reactRouterV6BrowserTracingIntegration({
+      useEffect,
+      useLocation,
+      useNavigationType,
+      createRoutesFromChildren,
+      matchRoutes,
+      stripBasename,
+    }),
+    Sentry.reactRouterV5BrowserTracingIntegration({
+      history,
+    }),
+    Sentry.reactRouterV4BrowserTracingIntegration({
+      history,
+    }),
+    Sentry.reactRouterV3BrowserTracingIntegration({
+      history,
+      routes,
+      match,
+    }),
+  ],
+});
+```
+
+### `@sentry/vue`
+
+```js
+import * as Sentry from '@sentry/vue';
+
+Sentry.init({
+  integrations: [
+    Sentry.browserTracingIntegration({
+      // pass router in, if applicable
+      router,
+    }),
+  ],
+});
+```
+
+### `@sentry/angular` & `@sentry/angular-ivy`
+
+```js
+import * as Sentry from '@sentry/angular';
+
+Sentry.init({
+  integrations: [Sentry.browserTracingIntegration()],
+});
+
+// You still need to add the Trace Service like before!
+```
+
+### `@sentry/remix`
+
+```js
+import * as Sentry from '@sentry/remix';
+
+Sentry.init({
+  integrations: [
+    Sentry.browserTracingIntegration({
+      useEffect,
+      useLocation,
+      useMatches,
+    }),
+  ],
+});
+```
+
+### `@sentry/nextjs`, `@sentry/astro`, `@sentry/sveltekit`
+
+Browser tracing is automatically set up for you in these packages. If you need to customize the options, you can do it
+like this:
+
+```js
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  integrations: [
+    Sentry.browserTracingIntegration({
+      // add custom options here
+    }),
+  ],
+});
+```
+
+### `@sentry/ember`
+
+Browser tracing is automatically set up for you. You can configure it as before through configuration.
+
 ## Deprecated `transactionContext` passed to `tracesSampler`
 
 Instead of an `transactionContext` being passed to the `tracesSampler` callback, the callback will directly receive
@@ -43,6 +159,7 @@ The following list shows how integrations should be migrated:
 
 | Old                          | New                                 | Packages                                                                                                |
 | ---------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `new BrowserTracing()`       | `browserTracingIntegration()`       | `@sentry/browser`                                                                                       |
 | `new InboundFilters()`       | `inboundFiltersIntegration()`       | `@sentry/core`, `@sentry/browser`, `@sentry/node`, `@sentry/deno`, `@sentry/bun`, `@sentry/vercel-edge` |
 | `new FunctionToString()`     | `functionToStringIntegration()`     | `@sentry/core`, `@sentry/browser`, `@sentry/node`, `@sentry/deno`, `@sentry/bun`, `@sentry/vercel-edge` |
 | `new LinkedErrors()`         | `linkedErrorsIntegration()`         | `@sentry/core`, `@sentry/browser`, `@sentry/node`, `@sentry/deno`, `@sentry/bun`, `@sentry/vercel-edge` |

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -192,8 +192,8 @@ The following list shows how integrations should be migrated:
 | `new OnUncaughtException()`  | `onUncaughtExceptionIntegration()`  | `@sentry/node`                                                                                          |
 | `new OnUnhandledRejection()` | `onUnhandledRejectionIntegration()` | `@sentry/node`                                                                                          |
 | `new LocalVariables()`       | `localVariablesIntegration()`       | `@sentry/node`                                                                                          |
-| `new Spotlight()`            | `spotlightIntergation()`            | `@sentry/node`                                                                                          |
-| `new Anr()`                  | `anrIntergation()`                  | `@sentry/node`                                                                                          |
+| `new Spotlight()`            | `spotlightIntegration()`            | `@sentry/node`                                                                                          |
+| `new Anr()`                  | `anrIntegration()`                  | `@sentry/node`                                                                                          |
 | `new Hapi()`                 | `hapiIntegration()`                 | `@sentry/node`                                                                                          |
 | `new Undici()`               | `nativeNodeFetchIntegration()`      | `@sentry/node`                                                                                          |
 | `new Http()`                 | `httpIntegration()`                 | `@sentry/node`                                                                                          |

--- a/packages/astro/src/client/sdk.ts
+++ b/packages/astro/src/client/sdk.ts
@@ -1,6 +1,6 @@
 import type { BrowserOptions } from '@sentry/browser';
 import {
-  BrowserTracing,
+  browserTracingIntegration,
   getDefaultIntegrations as getBrowserDefaultIntegrations,
   init as initBrowserSdk,
   setTag,
@@ -34,7 +34,7 @@ function getDefaultIntegrations(options: BrowserOptions): Integration[] | undefi
   // in which case everything inside will get treeshaken away
   if (typeof __SENTRY_TRACING__ === 'undefined' || __SENTRY_TRACING__) {
     if (hasTracingEnabled(options)) {
-      return [...getBrowserDefaultIntegrations(options), new BrowserTracing()];
+      return [...getBrowserDefaultIntegrations(options), browserTracingIntegration()];
     }
   }
 

--- a/packages/astro/test/client/sdk.test.ts
+++ b/packages/astro/test/client/sdk.test.ts
@@ -122,7 +122,7 @@ describe('Sentry client SDK', () => {
         expect(options.finalTimeout).toEqual(10);
       });
 
-      it('Overrides the automatically default BrowserTracing instance with a a user-provided browserTracingIntergation instance', () => {
+      it('Overrides the automatically default BrowserTracing instance with a a user-provided browserTracingIntegration instance', () => {
         init({
           dsn: 'https://public@dsn.ingest.sentry.io/1337',
           integrations: [

--- a/packages/astro/test/client/sdk.test.ts
+++ b/packages/astro/test/client/sdk.test.ts
@@ -104,12 +104,14 @@ describe('Sentry client SDK', () => {
       it('Overrides the automatically default BrowserTracing instance with a a user-provided BrowserTracing instance', () => {
         init({
           dsn: 'https://public@dsn.ingest.sentry.io/1337',
+          // eslint-disable-next-line deprecation/deprecation
           integrations: [new BrowserTracing({ finalTimeout: 10, startTransactionOnLocationChange: false })],
           enableTracing: true,
         });
 
         const integrationsToInit = browserInit.mock.calls[0][0]?.defaultIntegrations;
 
+        // eslint-disable-next-line deprecation/deprecation
         const browserTracing = getClient<BrowserClient>()?.getIntegrationByName('BrowserTracing') as BrowserTracing;
         const options = browserTracing.options;
 

--- a/packages/browser/src/helpers.ts
+++ b/packages/browser/src/helpers.ts
@@ -201,6 +201,7 @@ export function bundleBrowserTracingIntegration(
   options: Parameters<typeof browserTracingIntegration>[0] = {},
 ): Integration {
   // Migrate some options from the old integration to the new one
+  // eslint-disable-next-line deprecation/deprecation
   const opts: ConstructorParameters<typeof BrowserTracing>[0] = options;
 
   if (typeof options.markBackgroundSpan === 'boolean') {
@@ -215,5 +216,6 @@ export function bundleBrowserTracingIntegration(
     opts.startTransactionOnLocationChange = options.instrumentNavigation;
   }
 
+  // eslint-disable-next-line deprecation/deprecation
   return new BrowserTracing(opts);
 }

--- a/packages/browser/src/index.bundle.feedback.ts
+++ b/packages/browser/src/index.bundle.feedback.ts
@@ -14,10 +14,12 @@ import * as Sentry from './index.bundle.base';
 // eslint-disable-next-line deprecation/deprecation
 Sentry.Integrations.Replay = Replay;
 
+// eslint-disable-next-line deprecation/deprecation
 Sentry.Integrations.BrowserTracing = BrowserTracing;
 
 export * from './index.bundle.base';
 export {
+  // eslint-disable-next-line deprecation/deprecation
   BrowserTracing,
   browserTracingIntegration,
   addTracingExtensions,

--- a/packages/browser/src/index.bundle.replay.ts
+++ b/packages/browser/src/index.bundle.replay.ts
@@ -14,10 +14,12 @@ import * as Sentry from './index.bundle.base';
 // eslint-disable-next-line deprecation/deprecation
 Sentry.Integrations.Replay = Replay;
 
+// eslint-disable-next-line deprecation/deprecation
 Sentry.Integrations.BrowserTracing = BrowserTracing;
 
 export * from './index.bundle.base';
 export {
+  // eslint-disable-next-line deprecation/deprecation
   BrowserTracing,
   browserTracingIntegration,
   addTracingExtensions,

--- a/packages/browser/src/index.bundle.tracing.replay.feedback.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.feedback.ts
@@ -11,6 +11,7 @@ import * as Sentry from './index.bundle.base';
 // eslint-disable-next-line deprecation/deprecation
 Sentry.Integrations.Replay = Replay;
 
+// eslint-disable-next-line deprecation/deprecation
 Sentry.Integrations.BrowserTracing = BrowserTracing;
 
 // We are patching the global object with our hub extension methods
@@ -23,6 +24,7 @@ export {
   Replay,
   feedbackIntegration,
   replayIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   BrowserTracing,
   browserTracingIntegration,
   Span,

--- a/packages/browser/src/index.bundle.tracing.replay.ts
+++ b/packages/browser/src/index.bundle.tracing.replay.ts
@@ -11,6 +11,7 @@ import * as Sentry from './index.bundle.base';
 // eslint-disable-next-line deprecation/deprecation
 Sentry.Integrations.Replay = Replay;
 
+// eslint-disable-next-line deprecation/deprecation
 Sentry.Integrations.BrowserTracing = BrowserTracing;
 
 // We are patching the global object with our hub extension methods
@@ -23,6 +24,7 @@ export {
   Replay,
   replayIntegration,
   feedbackIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   BrowserTracing,
   browserTracingIntegration,
   Span,

--- a/packages/browser/src/index.bundle.tracing.ts
+++ b/packages/browser/src/index.bundle.tracing.ts
@@ -11,6 +11,7 @@ import * as Sentry from './index.bundle.base';
 // eslint-disable-next-line deprecation/deprecation
 Sentry.Integrations.Replay = Replay;
 
+// eslint-disable-next-line deprecation/deprecation
 Sentry.Integrations.BrowserTracing = BrowserTracing;
 
 // We are patching the global object with our hub extension methods
@@ -23,6 +24,7 @@ export {
   Replay,
   feedbackIntegration,
   replayIntegration,
+  // eslint-disable-next-line deprecation/deprecation
   BrowserTracing,
   browserTracingIntegration,
   Span,

--- a/packages/browser/src/index.bundle.ts
+++ b/packages/browser/src/index.bundle.ts
@@ -15,10 +15,12 @@ import * as Sentry from './index.bundle.base';
 // eslint-disable-next-line deprecation/deprecation
 Sentry.Integrations.Replay = Replay;
 
+// eslint-disable-next-line deprecation/deprecation
 Sentry.Integrations.BrowserTracing = BrowserTracing;
 
 export * from './index.bundle.base';
 export {
+  // eslint-disable-next-line deprecation/deprecation
   BrowserTracing,
   addTracingExtensions,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -54,6 +54,7 @@ export {
 } from '@sentry-internal/feedback';
 
 export {
+  // eslint-disable-next-line deprecation/deprecation
   BrowserTracing,
   defaultRequestInstrumentationOptions,
   instrumentOutgoingRequests,

--- a/packages/deno/src/integrations/globalhandlers.ts
+++ b/packages/deno/src/integrations/globalhandlers.ts
@@ -48,7 +48,7 @@ export const globalHandlersIntegration = defineIntegration(_globalHandlersIntegr
 
 /**
  * Global handlers.
- * @deprecated Use `globalHandlersIntergation()` instead.
+ * @deprecated Use `globalHandlersIntegration()` instead.
  */
 // eslint-disable-next-line deprecation/deprecation
 export const GlobalHandlers = convertIntegrationFnToClass(

--- a/packages/ember/addon/instance-initializers/sentry-performance.ts
+++ b/packages/ember/addon/instance-initializers/sentry-performance.ts
@@ -109,7 +109,11 @@ export function _instrumentEmberRouter(
     return;
   }
 
-  if (url && browserTracingOptions.startTransactionOnPageLoad !== false) {
+  if (
+    url &&
+    browserTracingOptions.startTransactionOnPageLoad !== false &&
+    browserTracingOptions.instrumentPageLoad !== false
+  ) {
     const routeInfo = routerService.recognize(url);
     Sentry.startBrowserTracingPageLoadSpan(client, {
       name: `route:${routeInfo.name}`,
@@ -132,7 +136,10 @@ export function _instrumentEmberRouter(
     getBackburner().off('end', finishActiveTransaction);
   };
 
-  if (browserTracingOptions.startTransactionOnLocationChange === false) {
+  if (
+    browserTracingOptions.startTransactionOnLocationChange === false &&
+    browserTracingOptions.instrumentNavigation === false
+  ) {
     return;
   }
 

--- a/packages/ember/addon/types.ts
+++ b/packages/ember/addon/types.ts
@@ -1,7 +1,9 @@
-import type { BrowserOptions, BrowserTracing } from '@sentry/browser';
+import type { BrowserOptions, BrowserTracing, browserTracingIntegration } from '@sentry/browser';
 import type { Transaction, TransactionContext } from '@sentry/types';
 
-type BrowserTracingOptions = ConstructorParameters<typeof BrowserTracing>[0];
+type BrowserTracingOptions = Parameters<typeof browserTracingIntegration>[0] &
+  // eslint-disable-next-line deprecation/deprecation
+  ConstructorParameters<typeof BrowserTracing>[0];
 
 export type EmberSentryConfig = {
   sentry: BrowserOptions & { browserTracingOptions?: BrowserTracingOptions };

--- a/packages/gatsby/src/utils/integrations.ts
+++ b/packages/gatsby/src/utils/integrations.ts
@@ -1,5 +1,5 @@
 import { hasTracingEnabled } from '@sentry/core';
-import { BrowserTracing } from '@sentry/react';
+import { browserTracingIntegration } from '@sentry/react';
 import type { Integration } from '@sentry/types';
 
 import type { GatsbyOptions } from './types';
@@ -31,8 +31,8 @@ export function getIntegrationsFromOptions(options: GatsbyOptions): UserIntegrat
  * @param isTracingEnabled Whether the user has enabled tracing.
  */
 function getIntegrationsFromArray(userIntegrations: Integration[], isTracingEnabled: boolean): Integration[] {
-  if (isTracingEnabled && !userIntegrations.some(integration => integration.name === BrowserTracing.name)) {
-    userIntegrations.push(new BrowserTracing());
+  if (isTracingEnabled && !userIntegrations.some(integration => integration.name === 'BrowserTracing')) {
+    userIntegrations.push(browserTracingIntegration());
   }
   return userIntegrations;
 }

--- a/packages/gatsby/test/gatsby-browser.test.ts
+++ b/packages/gatsby/test/gatsby-browser.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { onClientEntry } from '../gatsby-browser';
-import { BrowserTracing } from '../src/index';
+import { browserTracingIntegration } from '../src/index';
 
 (global as any).__SENTRY_RELEASE__ = '683f3a6ab819d47d23abfca9a914c81f0524d35b';
 (global as any).__SENTRY_DSN__ = 'https://examplePublicKey@o0.ingest.sentry.io/0';
@@ -141,7 +141,7 @@ describe('onClientEntry', () => {
   });
 
   it('only defines a single `BrowserTracing` integration', () => {
-    const integrations = [new BrowserTracing()];
+    const integrations = [browserTracingIntegration()];
     onClientEntry(undefined, { tracesSampleRate: 0.5, integrations });
 
     expect(sentryInit).toHaveBeenLastCalledWith(

--- a/packages/gatsby/test/sdk.test.ts
+++ b/packages/gatsby/test/sdk.test.ts
@@ -1,4 +1,4 @@
-import { BrowserTracing, SDK_VERSION, init } from '@sentry/react';
+import { SDK_VERSION, browserTracingIntegration, init } from '@sentry/react';
 import type { Integration } from '@sentry/types';
 
 import { init as gatsbyInit } from '../src/sdk';
@@ -68,27 +68,27 @@ describe('Integrations from options', () => {
     [
       'tracing disabled, with BrowserTracing as an array',
       [],
-      { integrations: [new BrowserTracing()] },
+      { integrations: [browserTracingIntegration()] },
       ['BrowserTracing'],
     ],
     [
       'tracing disabled, with BrowserTracing as a function',
       [],
       {
-        integrations: () => [new BrowserTracing()],
+        integrations: () => [browserTracingIntegration()],
       },
       ['BrowserTracing'],
     ],
     [
       'tracing enabled, with BrowserTracing as an array',
       [],
-      { tracesSampleRate: 1, integrations: [new BrowserTracing()] },
+      { tracesSampleRate: 1, integrations: [browserTracingIntegration()] },
       ['BrowserTracing'],
     ],
     [
       'tracing enabled, with BrowserTracing as a function',
       [],
-      { tracesSampleRate: 1, integrations: () => [new BrowserTracing()] },
+      { tracesSampleRate: 1, integrations: () => [browserTracingIntegration()] },
       ['BrowserTracing'],
     ],
   ] as TestArgs[])(

--- a/packages/integration-shims/src/BrowserTracing.ts
+++ b/packages/integration-shims/src/BrowserTracing.ts
@@ -5,6 +5,8 @@ import { consoleSandbox } from '@sentry/utils';
  * This is a shim for the BrowserTracing integration.
  * It is needed in order for the CDN bundles to continue working when users add/remove tracing
  * from it, without changing their config. This is necessary for the loader mechanism.
+ *
+ * @deprecated Use `browserTracingIntegration()` instead.
  */
 class BrowserTracingShim implements Integration {
   /**
@@ -19,6 +21,7 @@ class BrowserTracingShim implements Integration {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public constructor(_options: any) {
+    // eslint-disable-next-line deprecation/deprecation
     this.name = BrowserTracingShim.id;
 
     consoleSandbox(() => {
@@ -39,10 +42,15 @@ class BrowserTracingShim implements Integration {
  * from it, without changing their config. This is necessary for the loader mechanism.
  */
 function browserTracingIntegrationShim(_options: unknown): Integration {
+  // eslint-disable-next-line deprecation/deprecation
   return new BrowserTracingShim({});
 }
 
-export { BrowserTracingShim as BrowserTracing, browserTracingIntegrationShim as browserTracingIntegration };
+export {
+  // eslint-disable-next-line deprecation/deprecation
+  BrowserTracingShim as BrowserTracing,
+  browserTracingIntegrationShim as browserTracingIntegration,
+};
 
 /** Shim function */
 export function addTracingExtensions(): void {

--- a/packages/integration-shims/src/Feedback.ts
+++ b/packages/integration-shims/src/Feedback.ts
@@ -6,7 +6,7 @@ import { consoleSandbox } from '@sentry/utils';
  * It is needed in order for the CDN bundles to continue working when users add/remove feedback
  * from it, without changing their config. This is necessary for the loader mechanism.
  *
- * @deprecated Use `feedbackIntergation()` instead.
+ * @deprecated Use `feedbackIntegration()` instead.
  */
 class FeedbackShim implements Integration {
   /**

--- a/packages/nextjs/src/client/browserTracingIntegration.ts
+++ b/packages/nextjs/src/client/browserTracingIntegration.ts
@@ -13,7 +13,9 @@ import { nextRouterInstrumentation } from '../index.client';
  *
  * @deprecated Use `browserTracingIntegration` instead.
  */
+// eslint-disable-next-line deprecation/deprecation
 export class BrowserTracing extends OriginalBrowserTracing {
+  // eslint-disable-next-line deprecation/deprecation
   public constructor(options?: ConstructorParameters<typeof OriginalBrowserTracing>[0]) {
     super({
       // eslint-disable-next-line deprecation/deprecation

--- a/packages/sveltekit/src/client/browserTracingIntegration.ts
+++ b/packages/sveltekit/src/client/browserTracingIntegration.ts
@@ -19,7 +19,9 @@ import { svelteKitRoutingInstrumentation } from './router';
  * includes SvelteKit-specific routing instrumentation out of the box. Therefore there's no need
  * to pass in `svelteKitRoutingInstrumentation` anymore.
  */
+// eslint-disable-next-line deprecation/deprecation
 export class BrowserTracing extends OriginalBrowserTracing {
+  // eslint-disable-next-line deprecation/deprecation
   public constructor(options?: ConstructorParameters<typeof OriginalBrowserTracing>[0]) {
     super({
       // eslint-disable-next-line deprecation/deprecation

--- a/packages/sveltekit/test/client/sdk.test.ts
+++ b/packages/sveltekit/test/client/sdk.test.ts
@@ -98,10 +98,12 @@ describe('Sentry client SDK', () => {
       it('Merges a user-provided BrowserTracing integration with the automatically added one', () => {
         init({
           dsn: 'https://public@dsn.ingest.sentry.io/1337',
+          // eslint-disable-next-line deprecation/deprecation
           integrations: [new BrowserTracing({ finalTimeout: 10 })],
           enableTracing: true,
         });
 
+        // eslint-disable-next-line deprecation/deprecation
         const browserTracing = getClient<BrowserClient>()?.getIntegrationByName('BrowserTracing') as BrowserTracing;
         const options = browserTracing.options;
 
@@ -122,6 +124,7 @@ describe('Sentry client SDK', () => {
           enableTracing: true,
         });
 
+        // eslint-disable-next-line deprecation/deprecation
         const browserTracing = getClient<BrowserClient>()?.getIntegrationByName('BrowserTracing') as BrowserTracing;
         const options = browserTracing.options;
 

--- a/packages/tracing-internal/src/browser/browsertracing.ts
+++ b/packages/tracing-internal/src/browser/browsertracing.ts
@@ -156,6 +156,8 @@ const DEFAULT_BROWSER_TRACING_OPTIONS: BrowserTracingOptions = {
  *
  * The integration can be configured with a variety of options, and can be extended to use
  * any routing library. This integration uses {@see IdleTransaction} to create transactions.
+ *
+ * @deprecated Use `browserTracingIntegration()` instead.
  */
 export class BrowserTracing implements Integration {
   // This class currently doesn't have a static `id` field like the other integration classes, because it prevented

--- a/packages/tracing-internal/src/browser/index.ts
+++ b/packages/tracing-internal/src/browser/index.ts
@@ -2,7 +2,11 @@ export * from '../exports';
 
 export type { RequestInstrumentationOptions } from './request';
 
-export { BrowserTracing, BROWSER_TRACING_INTEGRATION_ID } from './browsertracing';
+export {
+  // eslint-disable-next-line deprecation/deprecation
+  BrowserTracing,
+  BROWSER_TRACING_INTEGRATION_ID,
+} from './browsertracing';
 export {
   browserTracingIntegration,
   startBrowserTracingNavigationSpan,

--- a/packages/tracing-internal/src/index.ts
+++ b/packages/tracing-internal/src/index.ts
@@ -13,6 +13,7 @@ export {
 export type { LazyLoadedIntegration } from './node';
 
 export {
+  // eslint-disable-next-line deprecation/deprecation
   BrowserTracing,
   browserTracingIntegration,
   startBrowserTracingNavigationSpan,

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -38,6 +38,7 @@ import {
  * import { BrowserTracing } from '@sentry/browser';
  * new BrowserTracing()
  */
+// eslint-disable-next-line deprecation/deprecation
 export const BrowserTracing = BrowserTracingT;
 
 // BrowserTracing is already exported as part of `Integrations` below (and for the moment will remain so for
@@ -50,6 +51,7 @@ export const BrowserTracing = BrowserTracingT;
  * import { BrowserTracing } from '@sentry/browser';
  * new BrowserTracing()
  */
+// eslint-disable-next-line deprecation/deprecation
 export type BrowserTracing = BrowserTracingT;
 
 /**


### PR DESCRIPTION
There is a proper replacement for all of them now.

Depends on:

* https://github.com/getsentry/sentry-javascript/pull/10491
* https://github.com/getsentry/sentry-javascript/pull/10489
* https://github.com/getsentry/sentry-javascript/pull/10488