### PR TITLE
ci(profiling): run compile only if bindings have changed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -979,7 +979,7 @@ jobs:
       - name: Build tarballs
         run: yarn build:tarball --ignore @sentry/profiling-node
 
-      # Rebuild profiling by compiling TS and pull the precompiled binary arficats
+      # Rebuild profiling by compiling TS and pull the precompiled binary artifacts
       - name: Build Profiling Node
         if: |
           (needs.job_get_metadata.outputs.changed_profiling_node_bindings == 'true') ||
@@ -1096,7 +1096,7 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_build.outputs.dependency_cache_key }}
 
-      # Rebuild profiling by compiling TS and pull the precompiled binary arficats
+      # Rebuild profiling by compiling TS and pull the precompiled binary artifacts
       - name: Build Profiling Node
         if: |
           (needs.job_get_metadata.outputs.changed_profiling_node_bindings == 'true') ||

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,8 @@ jobs:
               - *shared
               - 'packages/node/**'
               - 'packages/profiling-node/**'
+            profiling_node_bindings:
+              - 'packages/profiling-node/bindings/**'
             deno:
               - *shared
               - *browser
@@ -155,6 +157,7 @@ jobs:
       changed_remix: ${{ steps.changed.outputs.remix }}
       changed_node: ${{ steps.changed.outputs.node }}
       changed_profiling_node: ${{ steps.changed.outputs.profiling_node }}
+      changed_profiling_node_bindings: ${{ steps.changed.outputs.profiling_node_bindings }}
       changed_deno: ${{ steps.changed.outputs.deno }}
       changed_browser: ${{ steps.changed.outputs.browser }}
       changed_browser_integration: ${{ steps.changed.outputs.browser_integration }}
@@ -976,13 +979,20 @@ jobs:
       - name: Build tarballs
         run: yarn build:tarball --ignore @sentry/profiling-node
 
-      # Rebuild profiling by compiling TS and pulling the precompiled binaries
+      # Rebuild profiling by compiling TS and pull the precompiled binary arficats
       - name: Build Profiling Node
+        if: |
+          (needs.job_get_metadata.outputs.changed_profiling_node_bindings == 'true') ||
+          (needs.job_get_metadata.outputs.is_release == 'true') ||
+          (github.event_name != 'pull_request')
         run: yarn lerna run build:lib --scope @sentry/profiling-node
 
       - name: Extract Profiling Node Prebuilt Binaries
         # @TODO: v4 breaks convenient merging of same name artifacts
         # https://github.com/actions/upload-artifact/issues/478
+        if: |
+          (needs.job_get_metadata.outputs.changed_profiling_node_bindings == 'true') ||
+          (github.event_name != 'pull_request')
         uses: actions/download-artifact@v3
         with:
           name: profiling-node-binaries-${{ github.sha }}
@@ -1086,13 +1096,20 @@ jobs:
         env:
           DEPENDENCY_CACHE_KEY: ${{ needs.job_build.outputs.dependency_cache_key }}
 
-      # Rebuild profiling by compiling TS and pulling the precompiled binaries
+      # Rebuild profiling by compiling TS and pull the precompiled binary arficats
       - name: Build Profiling Node
+        if: |
+          (needs.job_get_metadata.outputs.changed_profiling_node_bindings == 'true') ||
+          (needs.job_get_metadata.outputs.is_release == 'true') ||
+          (github.event_name != 'pull_request')
         run: yarn lerna run build:lib --scope @sentry/profiling-node
 
       - name: Extract Profiling Node Prebuilt Binaries
         # @TODO: v4 breaks convenient merging of same name artifacts
         # https://github.com/actions/upload-artifact/issues/478
+        if: |
+          (needs.job_get_metadata.outputs.changed_profiling_node_bindings == 'true') ||
+          (github.event_name != 'pull_request')
         uses: actions/download-artifact@v3
         with:
           name: profiling-node-binaries-${{ github.sha }}
@@ -1226,9 +1243,9 @@ jobs:
     name: Compile & Test Profiling Bindings (v${{ matrix.node }}) ${{ matrix.target_platform || matrix.os }}, ${{ matrix.node || matrix.container }}, ${{ matrix.arch || matrix.container }}, ${{ contains(matrix.container, 'alpine') && 'musl' || 'glibc'  }}
     needs: [job_get_metadata, job_install_deps, job_build]
     # Compiling bindings can be very slow (especially on windows), so only run precompile
-    # if profiling or profiling node package had changed or if we are on a release branch.
+    # Skip precompile unless we are on a release branch as precompile slows down CI times.
     if: |
-      (needs.job_get_metadata.outputs.changed_profiling_node == 'true') ||
+      (needs.job_get_metadata.outputs.changed_profiling_node_bindings == 'true') ||
       (needs.job_get_metadata.outputs.is_release == 'true') ||
       (github.event_name != 'pull_request')
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Mitigates https://github.com/getsentry/sentry-javascript/issues/10486 by skipping compilation unless binaries have changed or we are on release branch