### PR TITLE
build(ci): Make dependabot actually update the sentry-cli versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
     allow:
       - dependency-name: "@sentry/cli"
       - dependency-name: "@sentry/vite-plugin"
+    versioning-strategy: increase
     commit-message:
       prefix: feat
       prefix-development: feat


### PR DESCRIPTION
Currently, it is only updating the yarn.lock, which is not really what we want, we want the version in the package.json to be raised, which is what this does (I believe).

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy

See https://github.com/getsentry/sentry-javascript/pull/10496 for how that does not correctly bump right now.