### PR TITLE
feat(replay): Add `getReplay` utility function

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -27,6 +27,7 @@ export {
   // eslint-disable-next-line deprecation/deprecation
   Replay,
   replayIntegration,
+  getReplay,
 } from '@sentry/replay';
 export type {
   ReplayEventType,

--- a/packages/replay/src/index.ts
+++ b/packages/replay/src/index.ts
@@ -19,5 +19,7 @@ export type {
   CanvasManagerOptions,
 } from './types';
 
+export { getReplay } from './util/getReplay';
+
 // TODO (v8): Remove deprecated types
 export * from './types/deprecated';

--- a/packages/replay/src/util/getReplay.ts
+++ b/packages/replay/src/util/getReplay.ts
@@ -1,0 +1,13 @@
+import { getClient } from '@sentry/core';
+import type { replayIntegration } from '../integration';
+
+/**
+ * This is a small utility to get a type-safe instance of the Replay integration.
+ */
+// eslint-disable-next-line deprecation/deprecation
+export function getReplay(): ReturnType<typeof replayIntegration> | undefined {
+  const client = getClient();
+  return (
+    client && client.getIntegrationByName && client.getIntegrationByName<ReturnType<typeof replayIntegration>>('Replay')
+  );
+}

--- a/packages/replay/test/unit/util/getReplay.test.ts
+++ b/packages/replay/test/unit/util/getReplay.test.ts
@@ -1,7 +1,7 @@
 import { getCurrentScope } from '@sentry/core';
 import { replayIntegration } from '../../../src/integration';
 import { getReplay } from '../../../src/util/getReplay';
-import { TestClient, getDefaultClientOptions } from '../../utils/TestClient';
+import { getDefaultClientOptions, init } from '../../utils/TestClient';
 
 describe('getReplay', () => {
   beforeEach(() => {
@@ -14,27 +14,29 @@ describe('getReplay', () => {
   });
 
   it('works with a client without Replay', () => {
-    const client = new TestClient(getDefaultClientOptions());
-    getCurrentScope().setClient(client);
+    init(
+      getDefaultClientOptions({
+        dsn: 'https://dsn@ingest.f00.f00/1',
+      }),
+    );
 
     const actual = getReplay();
     expect(actual).toBeUndefined();
   });
 
-  it('works with a client with Replay', () => {
+  it('works with a client with Replay xxx', () => {
     const replay = replayIntegration();
-    const client = new TestClient(
+    init(
       getDefaultClientOptions({
         integrations: [replay],
         replaysOnErrorSampleRate: 0,
         replaysSessionSampleRate: 0,
       }),
     );
-    getCurrentScope().setClient(client);
-    client.init();
 
     const actual = getReplay();
-    expect(actual).toBe(replay);
+    expect(actual).toBeDefined();
+    expect(actual === replay).toBe(true);
     expect(replay.getReplayId()).toBe(undefined);
   });
 });

--- a/packages/replay/test/unit/util/getReplay.test.ts
+++ b/packages/replay/test/unit/util/getReplay.test.ts
@@ -1,0 +1,40 @@
+import { getCurrentScope } from '@sentry/core';
+import { replayIntegration } from '../../../src/integration';
+import { getReplay } from '../../../src/util/getReplay';
+import { TestClient, getDefaultClientOptions } from '../../utils/TestClient';
+
+describe('getReplay', () => {
+  beforeEach(() => {
+    getCurrentScope().setClient(undefined);
+  });
+
+  it('works without a client', () => {
+    const actual = getReplay();
+    expect(actual).toBeUndefined();
+  });
+
+  it('works with a client without Replay', () => {
+    const client = new TestClient(getDefaultClientOptions());
+    getCurrentScope().setClient(client);
+
+    const actual = getReplay();
+    expect(actual).toBeUndefined();
+  });
+
+  it('works with a client with Replay', () => {
+    const replay = replayIntegration();
+    const client = new TestClient(
+      getDefaultClientOptions({
+        integrations: [replay],
+        replaysOnErrorSampleRate: 0,
+        replaysSessionSampleRate: 0,
+      }),
+    );
+    getCurrentScope().setClient(client);
+    client.init();
+
+    const actual = getReplay();
+    expect(actual).toBe(replay);
+    expect(replay.getReplayId()).toBe(undefined);
+  });
+});

--- a/packages/replay/test/utils/TestClient.ts
+++ b/packages/replay/test/utils/TestClient.ts
@@ -39,7 +39,7 @@ export function init(options: TestClientOptions): void {
   initAndBind(TestClient, options);
 }
 
-export function getDefaultClientOptions(options: Partial<ClientOptions> = {}): ClientOptions {
+export function getDefaultClientOptions(options: Partial<TestClientOptions> = {}): ClientOptions {
   return {
     integrations: [],
     dsn: 'https://username@domain/123',


### PR DESCRIPTION
As pointed out here, and I also did notice that myself, it is not super nice - as you need to provide a generic integration to `getIntegrationByName`, which is annoying to do in a type safe way, esp. if you want to avoid deprecations:

```ts
const client = getClient();
const replay = client && client.getIntegrationByName && client.getIntegrationByName<ReturnType<typeof replayIntegration>>('Replay');
```

So IMHO a small utility `Sentry.getReplay()` is not unreasonable for this 🤔 
 