### PR TITLE
build(ci): Ensure we run E2E tests when profiling node is skipped

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -952,7 +952,13 @@ jobs:
 
   job_e2e_prepare:
     name: Prepare E2E tests
-    if:
+    # We want to run this if:
+    # - The build job was successful, not skipped
+    # - AND if the profiling node bindings were either successful or skipped
+    # AND if this is not a PR from a fork or dependabot
+    if: |
+      always() && needs.job_build.result == 'success' &&
+      (needs.job_compile_bindings_profiling_node.result == 'success' || needs.job_compile_bindings_profiling_node.result == 'skipped') &&
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       github.actor != 'dependabot[bot]'
     needs: [job_get_metadata, job_build, job_compile_bindings_profiling_node]
@@ -1014,7 +1020,10 @@ jobs:
     name: E2E ${{ matrix.label || matrix.test-application }} Test
     # We only run E2E tests for non-fork PRs because the E2E tests require secrets to work and they can't be accessed from forks
     # Dependabot PRs sadly also don't have access to secrets, so we skip them as well
+    # We need to add the `always()` check here because the previous step has this as well :(
+    # See: https://github.com/actions/runner/issues/2205
     if:
+      always() && needs.job_e2e_prepare.result == 'success' &&
       (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
       github.actor != 'dependabot[bot]'
     needs: [job_get_metadata, job_build, job_e2e_prepare]

--- a/dev-packages/e2e-tests/test-applications/vue-3/tests/performance.test.ts
+++ b/dev-packages/e2e-tests/test-applications/vue-3/tests/performance.test.ts
@@ -53,7 +53,7 @@ test('sends a navigation transaction with a parameterized URL', async ({ page })
           'sentry.source': 'route',
           'sentry.origin': 'auto.navigation.vue',
           'sentry.op': 'navigation',
-          'params.id': '456',
+          'params.id': '123',
         },
         op: 'navigation',
         origin: 'auto.navigation.vue',


### PR DESCRIPTION
With the recent change to skip the node profiling compile step when it was not changed, we implicitly also skipped the "Prepare E2E tests" job - as that is by default skipped if the dependent job is skipped.

This PR changes this so that we should be running this even if that was skipped. We have to make sure to check that `build` itself was not skipped though (as then we want to _actually_ skip this).