### PR TITLE
fix(nextjs): Apply server action data to correct isolation scope

### DIFF
--- a/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/transactions.test.ts
+++ b/dev-packages/e2e-tests/test-applications/nextjs-app-dir/tests/transactions.test.ts
@@ -130,11 +130,11 @@ test('Should send a transaction for instrumented server actions', async ({ page 
   await page.getByText('Run Action').click();
 
   expect(await serverComponentTransactionPromise).toBeDefined();
-  expect(
-    (await serverComponentTransactionPromise).contexts?.trace?.data?.['server_action_form_data.some-text-value'],
-  ).toEqual('some-default-value');
-  expect((await serverComponentTransactionPromise).contexts?.trace?.data?.['server_action_result']).toEqual({
-    city: 'Vienna',
+  expect((await serverComponentTransactionPromise).extra).toMatchObject({
+    'server_action_form_data.some-text-value': 'some-default-value',
+    server_action_result: {
+      city: 'Vienna',
+    },
   });
 
   expect(Object.keys((await serverComponentTransactionPromise).request?.headers || {}).length).toBeGreaterThan(0);

--- a/packages/nextjs/src/common/withServerActionInstrumentation.ts
+++ b/packages/nextjs/src/common/withServerActionInstrumentation.ts
@@ -1,3 +1,4 @@
+import { getIsolationScope } from '@sentry/core';
 import {
   addTracingExtensions,
   captureException,
@@ -115,12 +116,12 @@ async function withServerActionInstrumentationImplementation<A extends (...args:
               });
 
               if (options.recordResponse !== undefined ? options.recordResponse : sendDefaultPii) {
-                isolationScope.setExtra('server_action_result', result);
+                getIsolationScope().setExtra('server_action_result', result);
               }
 
               if (options.formData) {
                 options.formData.forEach((value, key) => {
-                  isolationScope.setExtra(
+                  getIsolationScope().setExtra(
                     `server_action_form_data.${key}`,
                     typeof value === 'string' ? value : '[non-string value]',
                   );


### PR DESCRIPTION
We were setting data on the wrong isolation scope for server actions.