### PR TITLE
build(test): Skip codecov upload for bun & deno

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -477,10 +477,6 @@ jobs:
       - name: Run tests
         run: |
           yarn test-ci-bun
-      - name: Compute test coverage
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   job_deno_unit_tests:
     name: Deno Unit Tests
@@ -512,10 +508,6 @@ jobs:
           cd packages/deno
           yarn build
           yarn test
-      - name: Compute test coverage
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   job_node_unit_tests:
     name: Node (${{ matrix.node }}) Unit Tests

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -47,7 +47,7 @@
     "test": "run-s install:deno test:types test:unit",
     "test:build": "tsc -p tsconfig.test.types.json && rollup -c rollup.test.config.mjs",
     "test:types": "deno check ./build/index.mjs",
-    "test:unit": "deno test --allow-read --allow-run",
+    "test:unit": "deno test --allow-read --allow-run --coverage=coverage",
     "test:unit:update": "deno test --allow-read --allow-write --allow-run -- --update",
     "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push --sig"
   },

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -47,7 +47,7 @@
     "test": "run-s install:deno test:types test:unit",
     "test:build": "tsc -p tsconfig.test.types.json && rollup -c rollup.test.config.mjs",
     "test:types": "deno check ./build/index.mjs",
-    "test:unit": "deno test --allow-read --allow-run --coverage=coverage",
+    "test:unit": "deno test --allow-read --allow-run",
     "test:unit:update": "deno test --allow-read --allow-write --allow-run -- --update",
     "yalc:publish": "ts-node ../../scripts/prepack.ts && yalc publish build --push --sig"
   },


### PR DESCRIPTION
We don't generate coverage report for these, so we should not try to upload them to codecov, as the action warns about this.