### PR TITLE
fix(feedback): Replay breadcrumb for feedback events was incorrect

### DIFF
--- a/packages/replay/src/coreHandlers/util/addFeedbackBreadcrumb.ts
+++ b/packages/replay/src/coreHandlers/util/addFeedbackBreadcrumb.ts
@@ -1,7 +1,7 @@
 import { EventType } from '@sentry-internal/rrweb';
 import type { FeedbackEvent } from '@sentry/types';
 
-import type { ReplayContainer } from '../../types';
+import type { ReplayBreadcrumbFrameEvent, ReplayContainer } from '../../types';
 
 /**
  * Add a feedback breadcrumb event to replay.
@@ -21,16 +21,17 @@ export function addFeedbackBreadcrumb(replay: ReplayContainer, event: FeedbackEv
       type: EventType.Custom,
       timestamp: event.timestamp * 1000,
       data: {
-        timestamp: event.timestamp,
         tag: 'breadcrumb',
         payload: {
+          timestamp: event.timestamp,
+          type: 'default',
           category: 'sentry.feedback',
           data: {
             feedbackId: event.event_id,
           },
         },
       },
-    });
+    } as ReplayBreadcrumbFrameEvent);
 
     return false;
   });

--- a/packages/replay/src/types/replayFrame.ts
+++ b/packages/replay/src/types/replayFrame.ts
@@ -128,7 +128,7 @@ interface ReplayOptionFrame {
 }
 
 interface ReplayFeedbackFrameData {
-  feedback_id: string;
+  feedbackId: string;
 }
 
 interface ReplayFeedbackFrame extends ReplayBaseBreadcrumbFrame {


### PR DESCRIPTION
We are creating a replay breadcrumb when user feedback was submitted, however, the it was not typed correctly, which the timestamp not being included in the proper location.
