### PR TITLE
feat(v8/serverless): Remove deprecated exports

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,6 +11,22 @@ enum. If you were using the `Severity` enum, you should replace it with the `Sev
 The `Offline` integration has been removed in favor of the offline transport wrapper:
 http://docs.sentry.io/platforms/javascript/configuration/transports/#offline-caching
 
+## Updating `@sentry/serverless` exports
+
+The `AWSServices`, `GoogleCloudGrpc`, and `GoogleCloudHttp`. integrations have been removed from `@sentry/serverless` package. See the [table below](#deprecate-class-based-integrations) to find what to upgrade to.
+
+Using the `Sentry.AWSLambda` export has also changed. It no longer re-exports all of methods of the Node SDK, you'll have to import them directly from `@sentry/serverless`, instead it only exports `init`, `wrapHandler` and `tryPatchHandler`.
+
+```js
+import * as Sentry from '@sentry/serverless';
+
+// before
+Sentry.AWSLambda.captureException(...);
+
+// after
+Sentry.captureException(...);
+```
+
 # Deprecations in 7.x
 
 You can use the **Experimental** [@sentry/migr8](https://www.npmjs.com/package/@sentry/migr8) to automatically update
@@ -210,6 +226,9 @@ The following list shows how integrations should be migrated:
 | `new Hapi()`                 | `hapiIntegration()`                 | `@sentry/node`                                                                                          |
 | `new Undici()`               | `nativeNodeFetchIntegration()`      | `@sentry/node`                                                                                          |
 | `new Http()`                 | `httpIntegration()`                 | `@sentry/node`                                                                                          |
+| `new AWSServices()`          | `awsServicesIntegration()`          | `@sentry/serverless`                                                                                    |
+| `new GoogleCloudGrpc()`      | `googleCloudGrpcIntegration()`      | `@sentry/serverless`                                                                                    |
+| `new GoogleCloudHttp()`      | `googleCloudHttpIntegration()`      | `@sentry/serverless`                                                                                    |
 
 ## Deprecate `hub.bindClient()` and `makeMain()`
 

--- a/packages/serverless/src/awslambda-auto.ts
+++ b/packages/serverless/src/awslambda-auto.ts
@@ -1,4 +1,4 @@
-import * as Sentry from './index';
+import { init, tryPatchHandler } from './awslambda';
 
 const lambdaTaskRoot = process.env.LAMBDA_TASK_ROOT;
 if (lambdaTaskRoot) {
@@ -7,11 +7,11 @@ if (lambdaTaskRoot) {
     throw Error(`LAMBDA_TASK_ROOT is non-empty(${lambdaTaskRoot}) but _HANDLER is not set`);
   }
 
-  Sentry.AWSLambda.init({
+  init({
     _invokedByLambdaLayer: true,
   });
 
-  Sentry.AWSLambda.tryPatchHandler(lambdaTaskRoot, handlerString);
+  tryPatchHandler(lambdaTaskRoot, handlerString);
 } else {
   throw Error('LAMBDA_TASK_ROOT environment variable is not set');
 }

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -26,8 +26,6 @@ import { awsServicesIntegration } from './awsservices';
 import { DEBUG_BUILD } from './debug-build';
 import { markEventUnhandled } from './utils';
 
-export * from '@sentry/node';
-
 const { isPromise } = types;
 
 // https://www.npmjs.com/package/aws-lambda-consumer
@@ -37,7 +35,7 @@ type SyncHandler<T extends Handler> = (
   callback: Parameters<T>[2],
 ) => void;
 
-export type AsyncHandler<T extends Handler> = (
+type AsyncHandler<T extends Handler> = (
   event: Parameters<T>[0],
   context: Parameters<T>[1],
 ) => Promise<NonNullable<Parameters<Parameters<T>[2]>[1]>>;

--- a/packages/serverless/src/awslambda.ts
+++ b/packages/serverless/src/awslambda.ts
@@ -8,7 +8,6 @@ import {
   captureException,
   captureMessage,
   continueTrace,
-  defaultIntegrations as nodeDefaultIntegrations,
   flush,
   getCurrentScope,
   getDefaultIntegrations as getNodeDefaultIntegrations,
@@ -65,13 +64,6 @@ export interface WrapperOptions {
    */
   startTrace: boolean;
 }
-
-/** @deprecated Use `getDefaultIntegrations(options)` instead. */
-export const defaultIntegrations: Integration[] = [
-  // eslint-disable-next-line deprecation/deprecation
-  ...nodeDefaultIntegrations,
-  awsServicesIntegration({ optional: true }),
-];
 
 /** Get the default integrations for the AWSLambda SDK. */
 export function getDefaultIntegrations(options: Options): Integration[] {

--- a/packages/serverless/src/awsservices.ts
+++ b/packages/serverless/src/awsservices.ts
@@ -1,6 +1,6 @@
-import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, convertIntegrationFnToClass, defineIntegration } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, defineIntegration } from '@sentry/core';
 import { getClient, startInactiveSpan } from '@sentry/node';
-import type { Client, Integration, IntegrationClass, IntegrationFn, Span } from '@sentry/types';
+import type { Client, IntegrationFn, Span } from '@sentry/types';
 import { fill } from '@sentry/utils';
 // 'aws-sdk/global' import is expected to be type-only so it's erased in the final .js file.
 // When TypeScript compiler is upgraded, use `import type` syntax to explicitly assert that we don't want to load a module here.
@@ -41,21 +41,10 @@ const _awsServicesIntegration = ((options: { optional?: boolean } = {}) => {
   };
 }) satisfies IntegrationFn;
 
-export const awsServicesIntegration = defineIntegration(_awsServicesIntegration);
-
 /**
  * AWS Service Request Tracking.
- *
- * @deprecated Use `awsServicesIntegration()` instead.
  */
-// eslint-disable-next-line deprecation/deprecation
-export const AWSServices = convertIntegrationFnToClass(
-  INTEGRATION_NAME,
-  awsServicesIntegration,
-) as IntegrationClass<Integration>;
-
-// eslint-disable-next-line deprecation/deprecation
-export type AWSServices = typeof AWSServices;
+export const awsServicesIntegration = defineIntegration(_awsServicesIntegration);
 
 /**
  * Patches AWS SDK request to create `http.client` spans.

--- a/packages/serverless/src/gcpfunction/index.ts
+++ b/packages/serverless/src/gcpfunction/index.ts
@@ -1,10 +1,5 @@
 import type { NodeOptions } from '@sentry/node';
-import {
-  SDK_VERSION,
-  defaultIntegrations as defaultNodeIntegrations,
-  getDefaultIntegrations as getDefaultNodeIntegrations,
-  init as initNode,
-} from '@sentry/node';
+import { SDK_VERSION, getDefaultIntegrations as getDefaultNodeIntegrations, init as initNode } from '@sentry/node';
 import type { Integration, Options, SdkMetadata } from '@sentry/types';
 
 import { googleCloudGrpcIntegration } from '../google-cloud-grpc';
@@ -13,14 +8,6 @@ import { googleCloudHttpIntegration } from '../google-cloud-http';
 export * from './http';
 export * from './events';
 export * from './cloud_events';
-
-/** @deprecated Use `getDefaultIntegrations(options)` instead. */
-export const defaultIntegrations: Integration[] = [
-  // eslint-disable-next-line deprecation/deprecation
-  ...defaultNodeIntegrations,
-  googleCloudHttpIntegration({ optional: true }), // We mark this integration optional since '@google-cloud/common' module could be missing.
-  googleCloudGrpcIntegration({ optional: true }), // We mark this integration optional since 'google-gax' module could be missing.
-];
 
 /** Get the default integrations for the GCP SDK. */
 export function getDefaultIntegrations(options: Options): Integration[] {

--- a/packages/serverless/src/google-cloud-grpc.ts
+++ b/packages/serverless/src/google-cloud-grpc.ts
@@ -1,12 +1,7 @@
 import type { EventEmitter } from 'events';
-import {
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  convertIntegrationFnToClass,
-  defineIntegration,
-  getClient,
-} from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, defineIntegration, getClient } from '@sentry/core';
 import { startInactiveSpan } from '@sentry/node';
-import type { Client, Integration, IntegrationClass, IntegrationFn } from '@sentry/types';
+import type { Client, IntegrationFn } from '@sentry/types';
 import { fill } from '@sentry/utils';
 
 interface GrpcFunction extends CallableFunction {
@@ -62,21 +57,10 @@ const _googleCloudGrpcIntegration = ((options: { optional?: boolean } = {}) => {
   };
 }) satisfies IntegrationFn;
 
-export const googleCloudGrpcIntegration = defineIntegration(_googleCloudGrpcIntegration);
-
 /**
  * Google Cloud Platform service requests tracking for GRPC APIs.
- *
- * @deprecated Use `googleCloudGrpcIntegration()` instead.
  */
-// eslint-disable-next-line deprecation/deprecation
-export const GoogleCloudGrpc = convertIntegrationFnToClass(
-  INTEGRATION_NAME,
-  googleCloudGrpcIntegration,
-) as IntegrationClass<Integration>;
-
-// eslint-disable-next-line deprecation/deprecation
-export type GoogleCloudGrpc = typeof GoogleCloudGrpc;
+export const googleCloudGrpcIntegration = defineIntegration(_googleCloudGrpcIntegration);
 
 /** Returns a wrapped function that returns a stub with tracing enabled */
 function wrapCreateStub(origCreate: CreateStubFunc): CreateStubFunc {

--- a/packages/serverless/src/google-cloud-http.ts
+++ b/packages/serverless/src/google-cloud-http.ts
@@ -1,12 +1,7 @@
 import type * as common from '@google-cloud/common';
-import {
-  SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
-  convertIntegrationFnToClass,
-  defineIntegration,
-  getClient,
-} from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN, defineIntegration, getClient } from '@sentry/core';
 import { startInactiveSpan } from '@sentry/node';
-import type { Client, Integration, IntegrationClass, IntegrationFn } from '@sentry/types';
+import type { Client, IntegrationFn } from '@sentry/types';
 import { fill } from '@sentry/utils';
 
 type RequestOptions = common.DecorateRequestOptions;
@@ -41,21 +36,10 @@ const _googleCloudHttpIntegration = ((options: { optional?: boolean } = {}) => {
   };
 }) satisfies IntegrationFn;
 
-export const googleCloudHttpIntegration = defineIntegration(_googleCloudHttpIntegration);
-
 /**
  * Google Cloud Platform service requests tracking for RESTful APIs.
- *
- * @deprecated Use `googleCloudHttpIntegration()` instead.
  */
-// eslint-disable-next-line deprecation/deprecation
-export const GoogleCloudHttp = convertIntegrationFnToClass(
-  INTEGRATION_NAME,
-  googleCloudHttpIntegration,
-) as IntegrationClass<Integration>;
-
-// eslint-disable-next-line deprecation/deprecation
-export type GoogleCloudHttp = typeof GoogleCloudHttp;
+export const googleCloudHttpIntegration = defineIntegration(_googleCloudHttpIntegration);
 
 /** Returns a wrapped function that makes a request with tracing enabled */
 function wrapRequestFunction(orig: RequestFunction): RequestFunction {

--- a/packages/serverless/src/index.awslambda.ts
+++ b/packages/serverless/src/index.awslambda.ts
@@ -1,8 +1,12 @@
 /** This file is used as the entrypoint for the lambda layer bundle, and is not included in the npm package. */
 
-// https://medium.com/unsplash/named-namespace-imports-7345212bbffb
-import * as AWSLambda from './awslambda';
-export { AWSLambda };
+import { init as awsLambdaInit, tryPatchHandler, wrapHandler } from './awslambda';
+
+export const AWSLambda = {
+  init: awsLambdaInit,
+  wrapHandler,
+  tryPatchHandler,
+};
 
 export * from './awsservices';
 export * from '@sentry/node';

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -2,17 +2,15 @@ export { awsServicesIntegration } from './awsservices';
 import { init as awsLambdaInit, tryPatchHandler, wrapHandler } from './awslambda';
 import { init as gcpFunctionInit } from './gcpfunction';
 
-const AWSLambda = {
+export const AWSLambda = {
   init: awsLambdaInit,
   wrapHandler,
   tryPatchHandler,
 };
 
-const GCPFunction = {
+export const GCPFunction = {
   init: gcpFunctionInit,
 };
-
-export { AWSLambda, GCPFunction };
 
 import type { WrapperOptions as AWSWrapperOptions } from './awslambda';
 export type { AWSWrapperOptions };

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -1,10 +1,18 @@
-// https://medium.com/unsplash/named-namespace-imports-7345212bbffb
-import * as AWSLambda from './awslambda';
-import * as GCPFunction from './gcpfunction';
-export { AWSLambda, GCPFunction };
+export { awsServicesIntegration } from './awsservices';
 
-// eslint-disable-next-line deprecation/deprecation
-export { AWSServices, awsServicesIntegration } from './awsservices';
+import { init as awsLambdaInit, wrapHandler } from './awslambda';
+import { init as gcpFunctionInit } from './gcpfunction';
+
+const AWSLambda = {
+  init: awsLambdaInit,
+  wrapHandler,
+};
+
+const GCPFunction = {
+  init: gcpFunctionInit,
+};
+
+export { AWSLambda, GCPFunction };
 
 // TODO(v8): We have to explicitly export these because of the namespace exports
 // above. This is because just doing `export * from '@sentry/node'` will not
@@ -15,8 +23,6 @@ export {
   SDK_VERSION,
   Scope,
   addBreadcrumb,
-  // eslint-disable-next-line deprecation/deprecation
-  addGlobalEventProcessor,
   addEventProcessor,
   addIntegration,
   autoDiscoverNodePerformanceMonitoringIntegrations,
@@ -25,25 +31,15 @@ export {
   captureMessage,
   captureCheckIn,
   withMonitor,
-  // eslint-disable-next-line deprecation/deprecation
-  configureScope,
   createTransport,
-  // eslint-disable-next-line deprecation/deprecation
-  getActiveTransaction,
-  // eslint-disable-next-line deprecation/deprecation
-  getCurrentHub,
   getClient,
   isInitialized,
   getCurrentScope,
   getGlobalScope,
   getIsolationScope,
   getHubFromCarrier,
-  // eslint-disable-next-line deprecation/deprecation
-  spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
   setHttpStatus,
-  // eslint-disable-next-line deprecation/deprecation
-  makeMain,
   setCurrentClient,
   setContext,
   setExtra,
@@ -51,35 +47,23 @@ export {
   setTag,
   setTags,
   setUser,
-  // eslint-disable-next-line deprecation/deprecation
-  startTransaction,
   withScope,
   withIsolationScope,
   NodeClient,
   makeNodeTransport,
   close,
-  // eslint-disable-next-line deprecation/deprecation
-  defaultIntegrations,
   getDefaultIntegrations,
   defaultStackParser,
   flush,
   getSentryRelease,
   init,
-  // eslint-disable-next-line deprecation/deprecation
-  lastEventId,
   DEFAULT_USER_INCLUDES,
   addRequestDataToEvent,
   extractRequestData,
-  // eslint-disable-next-line deprecation/deprecation
-  deepReadDirSync,
   Handlers,
-  // eslint-disable-next-line deprecation/deprecation
-  Integrations,
   setMeasurement,
   getActiveSpan,
   startSpan,
-  // eslint-disable-next-line deprecation/deprecation
-  startActiveSpan,
   startInactiveSpan,
   startSpanManual,
   continueTrace,
@@ -88,12 +72,8 @@ export {
   linkedErrorsIntegration,
   inboundFiltersIntegration,
   functionToStringIntegration,
-  // eslint-disable-next-line deprecation/deprecation
-  getModuleFromFilename,
   createGetModuleFromFilename,
   metrics,
-  // eslint-disable-next-line deprecation/deprecation
-  extractTraceparentData,
   runWithAsyncContext,
   consoleIntegration,
   onUncaughtExceptionIntegration,

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -1,11 +1,11 @@
 export { awsServicesIntegration } from './awsservices';
-
-import { init as awsLambdaInit, wrapHandler } from './awslambda';
+import { init as awsLambdaInit, tryPatchHandler, wrapHandler } from './awslambda';
 import { init as gcpFunctionInit } from './gcpfunction';
 
 const AWSLambda = {
   init: awsLambdaInit,
   wrapHandler,
+  tryPatchHandler,
 };
 
 const GCPFunction = {
@@ -13,6 +13,9 @@ const GCPFunction = {
 };
 
 export { AWSLambda, GCPFunction };
+
+import type { WrapperOptions as AWSWrapperOptions } from './awslambda';
+export type { AWSWrapperOptions };
 
 // TODO(v8): We have to explicitly export these because of the namespace exports
 // above. This is because just doing `export * from '@sentry/node'` will not


### PR DESCRIPTION
ref https://github.com/getsentry/sentry-javascript/issues/10100

This removes all deprecated exports from the serverless package.

it also removes the namespace exports used (for ex. `import * as AWSLambda from './awslambda';`) because that causes esm issues. These are replaced with plain object exports.

Once we start looking more actively at the new esm structure, we could use subpath exports for these (`export { init } from "@sentry/serverless/awslambda"`)