### PR TITLE
test(nextjs): Don't run Next.js integration tests for Node.js < 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -585,7 +585,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12, 14, 16, 18, 20, 21]
+        node: [14, 16, 18, 20, 21]
     steps:
       - name: Check out current commit (${{ needs.job_get_metadata.outputs.commit_label }})
         uses: actions/checkout@v4
@@ -612,12 +612,12 @@ jobs:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
           key: ${{ runner.os }}-Playwright-${{steps.playwright-version.outputs.version}}
       - name: Install Playwright browser if not cached
-        if: steps.playwright-cache.outputs.cache-hit != 'true' && matrix.node >= 14
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps
         env:
           PLAYWRIGHT_BROWSERS_PATH: ${{steps.npm-cache-dir.outputs.dir}}
       - name: Install OS dependencies of Playwright if cache hit
-        if: steps.playwright-cache.outputs.cache-hit == 'true' && matrix.node >= 14
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps
       - name: Run tests
         env:

--- a/packages/nextjs/test/run-integration-tests.sh
+++ b/packages/nextjs/test/run-integration-tests.sh
@@ -45,18 +45,6 @@ for NEXTJS_VERSION in 10 11 12 13; do
     export NODE_MAJOR=$NODE_MAJOR
     export USE_APPDIR=$USE_APPDIR
 
-    # Next 10 requires at least Node v10
-    if [ "$NODE_MAJOR" -lt "10" ]; then
-      echo "[nextjs] Next.js is not compatible with versions of Node older than v10. Current version $NODE_VERSION"
-      exit 0
-    fi
-
-    # Next.js v11 requires at least Node v12
-    if [ "$NODE_MAJOR" -lt "12" ] && [ "$NEXTJS_VERSION" -ge "11" ]; then
-      echo "[nextjs@$NEXTJS_VERSION] Not compatible with Node $NODE_MAJOR"
-      exit 0
-    fi
-
     # Next.js v13 requires at least Node v16
     if [ "$NODE_MAJOR" -lt "16" ] && [ "$NEXTJS_VERSION" -ge "13" ]; then
       echo "[nextjs@$NEXTJS_VERSION] Not compatible with Node $NODE_MAJOR"


### PR DESCRIPTION
We are dropping Node.js < 14 in v8.