### PR TITLE
ref: Remove deprecated `continueTrace` variants

### DIFF
--- a/dev-packages/node-integration-tests/suites/express/tracing-experimental/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing-experimental/test.ts
@@ -133,9 +133,6 @@ describe('express tracing experimental', () => {
                 },
                 op: 'http.server',
                 status: 'ok',
-                tags: {
-                  'http.status_code': '200',
-                },
               },
             },
           },

--- a/dev-packages/node-integration-tests/suites/express/tracing/test.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/test.ts
@@ -87,9 +87,6 @@ test.each([['array1'], ['array5']])(
               },
               op: 'http.server',
               status: 'ok',
-              tags: {
-                'http.status_code': '200',
-              },
             },
           },
         },
@@ -127,9 +124,6 @@ test.each([
             },
             op: 'http.server',
             status: 'ok',
-            tags: {
-              'http.status_code': '200',
-            },
           },
         },
       },

--- a/packages/bun/src/integrations/bunserver.ts
+++ b/packages/bun/src/integrations/bunserver.ts
@@ -72,8 +72,8 @@ function instrumentBunServeOptions(serveOptions: Parameters<typeof Bun.serve>[0]
         const url = getSanitizedUrlString(parsedUrl);
 
         return continueTrace(
-          { sentryTrace: request.headers.get('sentry-trace') || '', baggage: request.headers.get('baggage') },
-          ctx => {
+          { sentryTrace: request.headers.get('sentry-trace'), baggage: request.headers.get('baggage') },
+          () => {
             return startSpan(
               {
                 attributes: {
@@ -81,11 +81,8 @@ function instrumentBunServeOptions(serveOptions: Parameters<typeof Bun.serve>[0]
                 },
                 op: 'http.server',
                 name: `${request.method} ${parsedUrl.path || '/'}`,
-                ...ctx,
                 data,
                 metadata: {
-                  // eslint-disable-next-line deprecation/deprecation
-                  ...ctx.metadata,
                   request: {
                     url,
                     method: request.method,

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -668,93 +668,49 @@ describe('continueTrace', () => {
   });
 
   it('works without trace & baggage data', () => {
-    const expectedContext = {
-      metadata: {},
-    };
-
-    const result = continueTrace({ sentryTrace: undefined, baggage: undefined }, ctx => {
-      expect(ctx).toEqual(expectedContext);
-      return ctx;
+    const propagationContext = continueTrace({ sentryTrace: undefined, baggage: undefined }, () => {
+      return getCurrentScope().getPropagationContext();
     });
 
-    expect(result).toEqual(expectedContext);
-
-    const scope = getCurrentScope();
-
-    expect(scope.getPropagationContext()).toEqual({
+    expect(propagationContext).toEqual({
       sampled: undefined,
       spanId: expect.any(String),
       traceId: expect.any(String),
     });
-
-    expect(scope['_sdkProcessingMetadata']).toEqual({});
   });
 
   it('works with trace data', () => {
-    const expectedContext = {
-      metadata: {
-        dynamicSamplingContext: {},
-      },
-      parentSampled: false,
-      parentSpanId: '1121201211212012',
-      traceId: '12312012123120121231201212312012',
-    };
-
-    const result = continueTrace(
+    const propagationContext = continueTrace(
       {
         sentryTrace: '12312012123120121231201212312012-1121201211212012-0',
         baggage: undefined,
       },
-      ctx => {
-        expect(ctx).toEqual(expectedContext);
-        return ctx;
+      () => {
+        return getCurrentScope().getPropagationContext();
       },
     );
 
-    expect(result).toEqual(expectedContext);
-
-    const scope = getCurrentScope();
-
-    expect(scope.getPropagationContext()).toEqual({
+    expect(propagationContext).toEqual({
       dsc: {}, // DSC should be an empty object (frozen), because there was an incoming trace
       sampled: false,
       parentSpanId: '1121201211212012',
       spanId: expect.any(String),
       traceId: '12312012123120121231201212312012',
     });
-
-    expect(scope['_sdkProcessingMetadata']).toEqual({});
   });
 
   it('works with trace & baggage data', () => {
-    const expectedContext = {
-      metadata: {
-        dynamicSamplingContext: {
-          environment: 'production',
-          version: '1.0',
-        },
-      },
-      parentSampled: true,
-      parentSpanId: '1121201211212012',
-      traceId: '12312012123120121231201212312012',
-    };
-
-    const result = continueTrace(
+    const propagationContext = continueTrace(
       {
         sentryTrace: '12312012123120121231201212312012-1121201211212012-1',
         baggage: 'sentry-version=1.0,sentry-environment=production',
       },
-      ctx => {
-        expect(ctx).toEqual(expectedContext);
-        return ctx;
+      () => {
+        return getCurrentScope().getPropagationContext();
       },
     );
 
-    expect(result).toEqual(expectedContext);
-
-    const scope = getCurrentScope();
-
-    expect(scope.getPropagationContext()).toEqual({
+    expect(propagationContext).toEqual({
       dsc: {
         environment: 'production',
         version: '1.0',
@@ -764,39 +720,20 @@ describe('continueTrace', () => {
       spanId: expect.any(String),
       traceId: '12312012123120121231201212312012',
     });
-
-    expect(scope['_sdkProcessingMetadata']).toEqual({});
   });
 
   it('works with trace & 3rd party baggage data', () => {
-    const expectedContext = {
-      metadata: {
-        dynamicSamplingContext: {
-          environment: 'production',
-          version: '1.0',
-        },
-      },
-      parentSampled: true,
-      parentSpanId: '1121201211212012',
-      traceId: '12312012123120121231201212312012',
-    };
-
-    const result = continueTrace(
+    const propagationContext = continueTrace(
       {
         sentryTrace: '12312012123120121231201212312012-1121201211212012-1',
         baggage: 'sentry-version=1.0,sentry-environment=production,dogs=great,cats=boring',
       },
-      ctx => {
-        expect(ctx).toEqual(expectedContext);
-        return ctx;
+      () => {
+        return getCurrentScope().getPropagationContext();
       },
     );
 
-    expect(result).toEqual(expectedContext);
-
-    const scope = getCurrentScope();
-
-    expect(scope.getPropagationContext()).toEqual({
+    expect(propagationContext).toEqual({
       dsc: {
         environment: 'production',
         version: '1.0',
@@ -806,49 +743,5 @@ describe('continueTrace', () => {
       spanId: expect.any(String),
       traceId: '12312012123120121231201212312012',
     });
-
-    expect(scope['_sdkProcessingMetadata']).toEqual({});
-  });
-
-  it('returns response of callback', () => {
-    const expectedContext = {
-      metadata: {
-        dynamicSamplingContext: {},
-      },
-      parentSampled: false,
-      parentSpanId: '1121201211212012',
-      traceId: '12312012123120121231201212312012',
-    };
-
-    const result = continueTrace(
-      {
-        sentryTrace: '12312012123120121231201212312012-1121201211212012-0',
-        baggage: undefined,
-      },
-      ctx => {
-        return { ctx };
-      },
-    );
-
-    expect(result).toEqual({ ctx: expectedContext });
-  });
-
-  it('works without a callback', () => {
-    const expectedContext = {
-      metadata: {
-        dynamicSamplingContext: {},
-      },
-      parentSampled: false,
-      parentSpanId: '1121201211212012',
-      traceId: '12312012123120121231201212312012',
-    };
-
-    // eslint-disable-next-line deprecation/deprecation
-    const ctx = continueTrace({
-      sentryTrace: '12312012123120121231201212312012-1121201211212012-0',
-      baggage: undefined,
-    });
-
-    expect(ctx).toEqual(expectedContext);
   });
 });

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -76,7 +76,7 @@ export function tracingHandler(): (
               // Push `span.end` to the next event loop so open spans have a chance to finish before the transaction
               // closes
               setImmediate(() => {
-                span?.setAttribute('http.status_code', `${res.statusCode}`);
+                span?.setAttribute('http.response.status_code', `${res.statusCode}`);
                 span?.setStatus(getSpanStatusFromHttpCode(res.statusCode));
                 span?.end();
               });

--- a/packages/node/src/handlers.ts
+++ b/packages/node/src/handlers.ts
@@ -76,6 +76,7 @@ export function tracingHandler(): (
               // Push `span.end` to the next event loop so open spans have a chance to finish before the transaction
               // closes
               setImmediate(() => {
+                span?.setAttribute('http.status_code', `${res.statusCode}`);
                 span?.setStatus(getSpanStatusFromHttpCode(res.statusCode));
                 span?.end();
               });

--- a/packages/node/src/integrations/hapi/index.ts
+++ b/packages/node/src/integrations/hapi/index.ts
@@ -1,7 +1,6 @@
 import {
   SDK_VERSION,
   captureException,
-  continueTrace,
   convertIntegrationFnToClass,
   defineIntegration,
   getActiveTransaction,

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -331,7 +331,7 @@ describe('tracingHandler', () => {
             trace: expect.objectContaining({
               status: 'ok',
               data: expect.objectContaining({
-                'http.status_code': '200',
+                'http.response.status_code': '200',
               }),
             }),
           }),

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -331,7 +331,7 @@ describe('tracingHandler', () => {
             trace: expect.objectContaining({
               status: 'ok',
               data: expect.objectContaining({
-                'http.response.status_code': '200',
+                'http.response.status_code': 200,
               }),
             }),
           }),

--- a/packages/utils/src/tracing.ts
+++ b/packages/utils/src/tracing.ts
@@ -19,7 +19,7 @@ export const TRACEPARENT_REGEXP = new RegExp(
  *
  * @returns Object containing data from the header, or undefined if traceparent string is malformed
  */
-export function extractTraceparentData(traceparent?: string): TraceparentData | undefined {
+export function extractTraceparentData(traceparent?: string | null): TraceparentData | undefined {
   if (!traceparent) {
     return undefined;
   }
@@ -90,7 +90,7 @@ export function tracingContextFromHeaders(
  * Create a propagation context from incoming headers.
  */
 export function propagationContextFromHeaders(
-  sentryTrace: string | undefined,
+  sentryTrace: string | undefined | null,
   baggage: string | number | boolean | string[] | null | undefined,
 ): PropagationContext {
   const traceparentData = extractTraceparentData(sentryTrace);


### PR DESCRIPTION
Probably needs to wait until we have migrated the otel express stuff.