### PR TITLE
feat(v8): Remove Severity enum

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,3 +1,9 @@
+# Upgrading from 7.x to 8.x
+
+## Removal of Severity Enum
+
+In v7 we deprecated the `Severity` enum in favor of using the `SeverityLevel` type. In v8 we removed the `Severity` enum. If you were using the `Severity` enum, you should replace it with the `SeverityLevel` type. See [below](#severity-severitylevel-and-severitylevels) for code snippet examples
+
 # Deprecations in 7.x
 
 You can use the **Experimental** [@sentry/migr8](https://www.npmjs.com/package/@sentry/migr8) to automatically update

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -9,7 +9,6 @@ import type {
   EventHint,
   Options,
   ParameterizedString,
-  Severity,
   SeverityLevel,
   UserFeedback,
 } from '@sentry/types';
@@ -76,8 +75,7 @@ export class BrowserClient extends BaseClient<BrowserClientOptions> {
    */
   public eventFromMessage(
     message: ParameterizedString,
-    // eslint-disable-next-line deprecation/deprecation
-    level: Severity | SeverityLevel = 'info',
+    level: SeverityLevel = 'info',
     hint?: EventHint,
   ): PromiseLike<Event> {
     return eventFromMessage(this._options.stackParser, message, level, hint, this._options.attachStacktrace);

--- a/packages/browser/src/eventbuilder.ts
+++ b/packages/browser/src/eventbuilder.ts
@@ -4,7 +4,6 @@ import type {
   EventHint,
   Exception,
   ParameterizedString,
-  Severity,
   SeverityLevel,
   StackFrame,
   StackParser,
@@ -178,8 +177,7 @@ export function eventFromException(
 export function eventFromMessage(
   stackParser: StackParser,
   message: ParameterizedString,
-  // eslint-disable-next-line deprecation/deprecation
-  level: Severity | SeverityLevel = 'info',
+  level: SeverityLevel = 'info',
   hint?: EventHint,
   attachStacktrace?: boolean,
 ): PromiseLike<Event> {

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -6,8 +6,6 @@ export type {
   Event,
   EventHint,
   Exception,
-  // eslint-disable-next-line deprecation/deprecation
-  Severity,
   SeverityLevel,
   StackFrame,
   Stacktrace,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -8,8 +8,6 @@ export type {
   EventHint,
   Exception,
   Session,
-  // eslint-disable-next-line deprecation/deprecation
-  Severity,
   SeverityLevel,
   Span,
   StackFrame,

--- a/packages/core/src/baseclient.ts
+++ b/packages/core/src/baseclient.ts
@@ -23,7 +23,6 @@ import type {
   SdkMetadata,
   Session,
   SessionAggregates,
-  Severity,
   SeverityLevel,
   StartSpanOptions,
   Transaction,
@@ -186,8 +185,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    */
   public captureMessage(
     message: ParameterizedString,
-    // eslint-disable-next-line deprecation/deprecation
-    level?: Severity | SeverityLevel,
+    level?: SeverityLevel,
     hint?: EventHint,
     scope?: Scope,
   ): string | undefined {
@@ -876,8 +874,7 @@ export abstract class BaseClient<O extends ClientOptions> implements Client<O> {
    */
   public abstract eventFromMessage(
     _message: ParameterizedString,
-    // eslint-disable-next-line deprecation/deprecation
-    _level?: Severity | SeverityLevel,
+    _level?: SeverityLevel,
     _hint?: EventHint,
   ): PromiseLike<Event>;
 }

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -15,7 +15,6 @@ import type {
   Scope as ScopeInterface,
   Session,
   SessionContext,
-  Severity,
   SeverityLevel,
   Span,
   TransactionContext,
@@ -56,11 +55,7 @@ export function captureException(
  * @param captureContext Define the level of the message or pass in additional data to attach to the message.
  * @returns the id of the captured message.
  */
-export function captureMessage(
-  message: string,
-  // eslint-disable-next-line deprecation/deprecation
-  captureContext?: CaptureContext | Severity | SeverityLevel,
-): string {
+export function captureMessage(message: string, captureContext?: CaptureContext | SeverityLevel): string {
   // This is necessary to provide explicit scopes upgrade, without changing the original
   // arity of the `captureMessage(message, level)` method.
   const level = typeof captureContext === 'string' ? captureContext : undefined;

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -14,7 +14,6 @@ import type {
   Primitive,
   Session,
   SessionContext,
-  Severity,
   SeverityLevel,
   Transaction,
   TransactionContext,
@@ -320,12 +319,7 @@ export class Hub implements HubInterface {
    *
    * @deprecated Use  `Sentry.captureMessage()` instead.
    */
-  public captureMessage(
-    message: string,
-    // eslint-disable-next-line deprecation/deprecation
-    level?: Severity | SeverityLevel,
-    hint?: EventHint,
-  ): string {
+  public captureMessage(message: string, level?: SeverityLevel, hint?: EventHint): string {
     const eventId = (this._lastEventId = hint && hint.event_id ? hint.event_id : uuid4());
     const syntheticException = new Error(message);
     // eslint-disable-next-line deprecation/deprecation

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -18,7 +18,6 @@ import type {
   ScopeContext,
   ScopeData,
   Session,
-  Severity,
   SeverityLevel,
   Span,
   Transaction,
@@ -86,8 +85,7 @@ export class Scope implements ScopeInterface {
   protected _fingerprint?: string[];
 
   /** Severity */
-  // eslint-disable-next-line deprecation/deprecation
-  protected _level?: Severity | SeverityLevel;
+  protected _level?: SeverityLevel;
 
   /**
    * Transaction Name
@@ -283,10 +281,7 @@ export class Scope implements ScopeInterface {
   /**
    * @inheritDoc
    */
-  public setLevel(
-    // eslint-disable-next-line deprecation/deprecation
-    level: Severity | SeverityLevel,
-  ): this {
+  public setLevel(level: SeverityLevel): this {
     this._level = level;
     this._notifyScopeListeners();
     return this;

--- a/packages/core/src/server-runtime-client.ts
+++ b/packages/core/src/server-runtime-client.ts
@@ -8,7 +8,6 @@ import type {
   MonitorConfig,
   ParameterizedString,
   SerializedCheckIn,
-  Severity,
   SeverityLevel,
   TraceContext,
 } from '@sentry/types';
@@ -70,8 +69,7 @@ export class ServerRuntimeClient<
    */
   public eventFromMessage(
     message: ParameterizedString,
-    // eslint-disable-next-line deprecation/deprecation
-    level: Severity | SeverityLevel = 'info',
+    level: SeverityLevel = 'info',
     hint?: EventHint,
   ): PromiseLike<Event> {
     return resolvedSyncPromise(

--- a/packages/core/test/mocks/client.ts
+++ b/packages/core/test/mocks/client.ts
@@ -7,7 +7,6 @@ import type {
   Outcome,
   ParameterizedString,
   Session,
-  Severity,
   SeverityLevel,
 } from '@sentry/types';
 import { resolvedSyncPromise } from '@sentry/utils';
@@ -76,11 +75,7 @@ export class TestClient extends BaseClient<TestClientOptions> {
     return resolvedSyncPromise(event);
   }
 
-  public eventFromMessage(
-    message: ParameterizedString,
-    // eslint-disable-next-line deprecation/deprecation
-    level: Severity | SeverityLevel = 'info',
-  ): PromiseLike<Event> {
+  public eventFromMessage(message: ParameterizedString, level: SeverityLevel = 'info'): PromiseLike<Event> {
     return resolvedSyncPromise({ message, level });
   }
 

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -8,8 +8,6 @@ export type {
   EventHint,
   Exception,
   Session,
-  // eslint-disable-next-line deprecation/deprecation
-  Severity,
   SeverityLevel,
   Span,
   StackFrame,

--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -12,7 +12,6 @@ import type {
   Extra,
   Extras,
   Primitive,
-  Severity,
   SeverityLevel,
   User,
 } from '@sentry/types';
@@ -120,11 +119,7 @@ export function captureException(exception: unknown, hint?: ExclusiveEventHintOr
 }
 
 /** Record a message and send it to Sentry. */
-export function captureMessage(
-  message: string,
-  // eslint-disable-next-line deprecation/deprecation
-  captureContext?: CaptureContext | Severity | SeverityLevel,
-): string {
+export function captureMessage(message: string, captureContext?: CaptureContext | SeverityLevel): string {
   // This is necessary to provide explicit scopes upgrade, without changing the original
   // arity of the `captureMessage(message, level)` method.
   const level = typeof captureContext === 'string' ? captureContext : undefined;

--- a/packages/node-experimental/src/sdk/hub.ts
+++ b/packages/node-experimental/src/sdk/hub.ts
@@ -5,7 +5,6 @@ import type {
   Hub,
   Integration,
   IntegrationClass,
-  Severity,
   SeverityLevel,
   TransactionContext,
 } from '@sentry/types';
@@ -68,12 +67,7 @@ export function getCurrentHub(): Hub {
     captureException: (exception: unknown, hint?: EventHint) => {
       return getCurrentScope().captureException(exception, hint);
     },
-    captureMessage: (
-      message: string,
-      // eslint-disable-next-line deprecation/deprecation
-      level?: Severity | SeverityLevel,
-      hint?: EventHint,
-    ) => {
+    captureMessage: (message: string, level?: SeverityLevel, hint?: EventHint) => {
       return getCurrentScope().captureMessage(message, level, hint);
     },
     captureEvent,

--- a/packages/node-experimental/src/sdk/scope.ts
+++ b/packages/node-experimental/src/sdk/scope.ts
@@ -1,6 +1,6 @@
 import { getGlobalScope as _getGlobalScope, setGlobalScope } from '@sentry/core';
 import { OpenTelemetryScope } from '@sentry/opentelemetry';
-import type { Breadcrumb, Client, Event, EventHint, Severity, SeverityLevel } from '@sentry/types';
+import type { Breadcrumb, Client, Event, EventHint, SeverityLevel } from '@sentry/types';
 import { uuid4 } from '@sentry/utils';
 
 import { getGlobalCarrier } from './globals';
@@ -140,12 +140,7 @@ export class Scope extends OpenTelemetryScope implements ScopeInterface {
   }
 
   /** Capture a message for this scope. */
-  public captureMessage(
-    message: string,
-    // eslint-disable-next-line deprecation/deprecation
-    level?: Severity | SeverityLevel,
-    hint?: EventHint,
-  ): string {
+  public captureMessage(message: string, level?: SeverityLevel, hint?: EventHint): string {
     const eventId = hint && hint.event_id ? hint.event_id : uuid4();
     const syntheticException = new Error(message);
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -8,8 +8,6 @@ export type {
   EventHint,
   Exception,
   Session,
-  // eslint-disable-next-line deprecation/deprecation
-  Severity,
   SeverityLevel,
   Span,
   StackFrame,

--- a/packages/types/src/breadcrumb.ts
+++ b/packages/types/src/breadcrumb.ts
@@ -1,10 +1,9 @@
-import type { Severity, SeverityLevel } from './severity';
+import type { SeverityLevel } from './severity';
 
 /** JSDoc */
 export interface Breadcrumb {
   type?: string;
-  // eslint-disable-next-line deprecation/deprecation
-  level?: Severity | SeverityLevel;
+  level?: SeverityLevel;
   event_id?: string;
   category?: string;
   message?: string;

--- a/packages/types/src/client.ts
+++ b/packages/types/src/client.ts
@@ -14,7 +14,7 @@ import type { ParameterizedString } from './parameterize';
 import type { Scope } from './scope';
 import type { SdkMetadata } from './sdkmetadata';
 import type { Session, SessionAggregates } from './session';
-import type { Severity, SeverityLevel } from './severity';
+import type { SeverityLevel } from './severity';
 import type { StartSpanOptions } from './startSpanOptions';
 import type { Transaction } from './transaction';
 import type { Transport, TransportMakeRequestResponse } from './transport';
@@ -48,13 +48,7 @@ export interface Client<O extends ClientOptions = ClientOptions> {
    * @param scope An optional scope containing event metadata.
    * @returns The event id
    */
-  captureMessage(
-    message: string,
-    // eslint-disable-next-line deprecation/deprecation
-    level?: Severity | SeverityLevel,
-    hint?: EventHint,
-    scope?: Scope,
-  ): string | undefined;
+  captureMessage(message: string, level?: SeverityLevel, hint?: EventHint, scope?: Scope): string | undefined;
 
   /**
    * Captures a manually created event and sends it to Sentry.
@@ -175,12 +169,7 @@ export interface Client<O extends ClientOptions = ClientOptions> {
   eventFromException(exception: any, hint?: EventHint): PromiseLike<Event>;
 
   /** Creates an {@link Event} from primitive inputs to `captureMessage`. */
-  eventFromMessage(
-    message: ParameterizedString,
-    // eslint-disable-next-line deprecation/deprecation
-    level?: Severity | SeverityLevel,
-    hint?: EventHint,
-  ): PromiseLike<Event>;
+  eventFromMessage(message: ParameterizedString, level?: SeverityLevel, hint?: EventHint): PromiseLike<Event>;
 
   /** Submits the event to Sentry */
   sendEvent(event: Event, hint?: EventHint): void;

--- a/packages/types/src/event.ts
+++ b/packages/types/src/event.ts
@@ -10,7 +10,7 @@ import type { Primitive } from './misc';
 import type { Request } from './request';
 import type { CaptureContext } from './scope';
 import type { SdkInfo } from './sdkinfo';
-import type { Severity, SeverityLevel } from './severity';
+import type { SeverityLevel } from './severity';
 import type { Span, SpanJSON } from './span';
 import type { Thread } from './thread';
 import type { TransactionSource } from './transaction';
@@ -26,8 +26,7 @@ export interface Event {
   };
   timestamp?: number;
   start_timestamp?: number;
-  // eslint-disable-next-line deprecation/deprecation
-  level?: Severity | SeverityLevel;
+  level?: SeverityLevel;
   platform?: string;
   logger?: string;
   server_name?: string;

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -6,7 +6,7 @@ import type { Integration, IntegrationClass } from './integration';
 import type { Primitive } from './misc';
 import type { Scope } from './scope';
 import type { Session } from './session';
-import type { Severity, SeverityLevel } from './severity';
+import type { SeverityLevel } from './severity';
 import type { CustomSamplingContext, Transaction, TransactionContext } from './transaction';
 import type { User } from './user';
 
@@ -116,12 +116,7 @@ export interface Hub {
    *
    * @deprecated Use `Sentry.captureMessage()` instead.
    */
-  captureMessage(
-    message: string,
-    // eslint-disable-next-line deprecation/deprecation
-    level?: Severity | SeverityLevel,
-    hint?: EventHint,
-  ): string;
+  captureMessage(message: string, level?: SeverityLevel, hint?: EventHint): string;
 
   /**
    * Captures a manually created event and sends it to Sentry.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -87,8 +87,7 @@ export type {
   SerializedSession,
 } from './session';
 
-// eslint-disable-next-line deprecation/deprecation
-export type { Severity, SeverityLevel } from './severity';
+export type { SeverityLevel } from './severity';
 export type {
   Span,
   SpanContext,

--- a/packages/types/src/scope.ts
+++ b/packages/types/src/scope.ts
@@ -7,7 +7,7 @@ import type { EventProcessor } from './eventprocessor';
 import type { Extra, Extras } from './extra';
 import type { Primitive } from './misc';
 import type { RequestSession, Session } from './session';
-import type { Severity, SeverityLevel } from './severity';
+import type { SeverityLevel } from './severity';
 import type { Span } from './span';
 import type { PropagationContext } from './tracing';
 import type { Transaction } from './transaction';
@@ -19,8 +19,7 @@ export type CaptureContext = Scope | Partial<ScopeContext> | ((scope: Scope) => 
 /** JSDocs */
 export interface ScopeContext {
   user: User;
-  // eslint-disable-next-line deprecation/deprecation
-  level: Severity | SeverityLevel;
+  level: SeverityLevel;
   extra: Extras;
   contexts: Contexts;
   tags: { [key: string]: Primitive };
@@ -119,10 +118,7 @@ export interface Scope {
    * Sets the level on the scope for future events.
    * @param level string {@link SeverityLevel}
    */
-  setLevel(
-    // eslint-disable-next-line deprecation/deprecation
-    level: Severity | SeverityLevel,
-  ): this;
+  setLevel(level: SeverityLevel): this;
 
   /**
    * Sets the transaction name on the scope for future events.

--- a/packages/types/src/severity.ts
+++ b/packages/types/src/severity.ts
@@ -1,22 +1,3 @@
-/**
- * @deprecated Please use a `SeverityLevel` string instead of the `Severity` enum. Acceptable values are 'fatal',
- * 'error', 'warning', 'log', 'info', and 'debug'.
- */
-export enum Severity {
-  /** JSDoc */
-  Fatal = 'fatal',
-  /** JSDoc */
-  Error = 'error',
-  /** JSDoc */
-  Warning = 'warning',
-  /** JSDoc */
-  Log = 'log',
-  /** JSDoc */
-  Info = 'info',
-  /** JSDoc */
-  Debug = 'debug',
-}
-
 // Note: If this is ever changed, the `validSeverityLevels` array in `@sentry/utils` needs to be changed, also. (See
 // note there for why we can't derive one from the other.)
 export type SeverityLevel = 'fatal' | 'error' | 'warning' | 'log' | 'info' | 'debug';

--- a/packages/utils/src/eventbuilder.ts
+++ b/packages/utils/src/eventbuilder.ts
@@ -7,7 +7,6 @@ import type {
   Hub,
   Mechanism,
   ParameterizedString,
-  Severity,
   SeverityLevel,
   StackFrame,
   StackParser,
@@ -133,8 +132,7 @@ export function eventFromUnknownInput(
 export function eventFromMessage(
   stackParser: StackParser,
   message: ParameterizedString,
-  // eslint-disable-next-line deprecation/deprecation
-  level: Severity | SeverityLevel = 'info',
+  level: SeverityLevel = 'info',
   hint?: EventHint,
   attachStacktrace?: boolean,
 ): Event {

--- a/packages/utils/src/severity.ts
+++ b/packages/utils/src/severity.ts
@@ -1,5 +1,4 @@
-/* eslint-disable deprecation/deprecation */
-import type { Severity, SeverityLevel } from '@sentry/types';
+import type { SeverityLevel } from '@sentry/types';
 
 // Note: Ideally the `SeverityLevel` type would be derived from `validSeverityLevels`, but that would mean either
 //
@@ -12,18 +11,6 @@ import type { Severity, SeverityLevel } from '@sentry/types';
 // type, reminding anyone who changes it to change this list also, will have to do.
 
 export const validSeverityLevels = ['fatal', 'error', 'warning', 'log', 'info', 'debug'];
-
-/**
- * Converts a string-based level into a member of the deprecated {@link Severity} enum.
- *
- * @deprecated `severityFromString` is deprecated. Please use `severityLevelFromString` instead.
- *
- * @param level String representation of Severity
- * @returns Severity
- */
-export function severityFromString(level: Severity | SeverityLevel | string): Severity {
-  return severityLevelFromString(level) as Severity;
-}
 
 /**
  * Converts a string-based level into a `SeverityLevel`, normalizing it along the way.

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -8,8 +8,6 @@ export type {
   EventHint,
   Exception,
   Session,
-  // eslint-disable-next-line deprecation/deprecation
-  Severity,
   SeverityLevel,
   Span,
   StackFrame,


### PR DESCRIPTION
We deprecated this in https://github.com/getsentry/sentry-javascript/pull/4926, with v8 we can finally remove it.