### PR TITLE
feat(v8/browser): Remove `_eventFromIncompleteOnError` usage

### DIFF
--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -111,4 +111,4 @@ export { linkedErrorsIntegration } from './integrations/linkederrors';
 export { browserApiErrorsIntegration } from './integrations/trycatch';
 
 // eslint-disable-next-line deprecation/deprecation
-export { GlobalHandlers, TryCatch, Breadcrumbs, LinkedErrors, HttpContext, Dedupe } from './integrations';
+export { TryCatch, Breadcrumbs, LinkedErrors, HttpContext, Dedupe } from './integrations';

--- a/packages/browser/src/integrations/globalhandlers.ts
+++ b/packages/browser/src/integrations/globalhandlers.ts
@@ -107,24 +107,23 @@ function _getUnhandledRejectionError(error: unknown): unknown {
     return error;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const e = error as any;
-
   // dig the object of the rejection out of known event types
   try {
+    type ErrorWithReason = { reason: unknown };
     // PromiseRejectionEvents store the object of the rejection under 'reason'
     // see https://developer.mozilla.org/en-US/docs/Web/API/PromiseRejectionEvent
-    if ('reason' in e) {
-      return e.reason;
+    if ('reason' in (error as ErrorWithReason)) {
+      return (error as ErrorWithReason).reason;
     }
 
+    type CustomEventWithDetail = { detail: { reason: unknown } };
     // something, somewhere, (likely a browser extension) effectively casts PromiseRejectionEvents
     // to CustomEvents, moving the `promise` and `reason` attributes of the PRE into
     // the CustomEvent's `detail` attribute, since they're not part of CustomEvent's spec
     // see https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent and
     // https://github.com/getsentry/sentry-javascript/issues/2380
-    else if ('detail' in e && 'reason' in e.detail) {
-      return e.detail.reason;
+    if ('detail' in (error as CustomEventWithDetail) && 'reason' in (error as CustomEventWithDetail).detail) {
+      return (error as CustomEventWithDetail).detail.reason;
     }
   } catch {} // eslint-disable-line no-empty
 

--- a/packages/browser/src/integrations/index.ts
+++ b/packages/browser/src/integrations/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable deprecation/deprecation */
-export { GlobalHandlers } from './globalhandlers';
 export { TryCatch } from './trycatch';
 export { Breadcrumbs } from './breadcrumbs';
 export { LinkedErrors } from './linkederrors';


### PR DESCRIPTION
closes https://github.com/getsentry/sentry-javascript/issues/5842

Also deletes `GlobalHandlers` integration deprecated export while I'm here.