### PR TITLE
feat(core): Streamline custom hub creation for node-experimental

### DIFF
--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -20,15 +20,7 @@ import type {
   TransactionContext,
   User,
 } from '@sentry/types';
-import {
-  GLOBAL_OBJ,
-  consoleSandbox,
-  dateTimestampInSeconds,
-  getGlobalSingleton,
-  isThenable,
-  logger,
-  uuid4,
-} from '@sentry/utils';
+import { GLOBAL_OBJ, consoleSandbox, dateTimestampInSeconds, isThenable, logger, uuid4 } from '@sentry/utils';
 
 import { DEFAULT_ENVIRONMENT } from './constants';
 import { DEBUG_BUILD } from './debug-build';
@@ -87,19 +79,39 @@ export interface Layer {
  * @hidden
  */
 export interface Carrier {
-  __SENTRY__?: {
-    hub?: Hub;
-    acs?: AsyncContextStrategy;
-    /**
-     * Extra Hub properties injected by various SDKs
-     */
-    integrations?: Integration[];
-    extensions?: {
-      /** Extension methods for the hub, which are bound to the current Hub instance */
-      // eslint-disable-next-line @typescript-eslint/ban-types
-      [key: string]: Function;
-    };
+  __SENTRY__?: SentryCarrier;
+}
+
+type CreateHub = (...options: ConstructorParameters<typeof Hub>) => Hub;
+
+interface SentryCarrier {
+  hub?: Hub;
+  createHub?: CreateHub;
+  acs?: AsyncContextStrategy;
+  /**
+   * Extra Hub properties injected by various SDKs
+   */
+  integrations?: Integration[];
+  extensions?: {
+    /** Extension methods for the hub, which are bound to the current Hub instance */
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    [key: string]: Function;
   };
+}
+
+/**
+ * Create a hub. If a custom `createHub` is registered on the main carrier, use that instead.
+ * This only exists to make POTEL migration easier.
+ */
+function createHub(...options: ConstructorParameters<typeof Hub>): Hub {
+  const carrier = getMainCarrier();
+  const sentry = getSentryCarrier(carrier);
+
+  if (sentry.createHub) {
+    return sentry.createHub(...options);
+  }
+
+  return new Hub(...options);
 }
 
 /**
@@ -669,8 +681,8 @@ Sentry.init({...});
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _callExtensionMethod<T>(method: string, ...args: any[]): T {
     const carrier = getMainCarrier();
-    const sentry = carrier.__SENTRY__;
-    if (sentry && sentry.extensions && typeof sentry.extensions[method] === 'function') {
+    const sentry = getSentryCarrier(carrier);
+    if (sentry.extensions && typeof sentry.extensions[method] === 'function') {
       return sentry.extensions[method].apply(this, args);
     }
     DEBUG_BUILD && logger.warn(`Extension method ${method} couldn't be found, doing nothing.`);
@@ -685,10 +697,8 @@ Sentry.init({...});
  * at the call-site. We always access the carrier through this function, so we can guarantee that `__SENTRY__` is there.
  **/
 export function getMainCarrier(): Carrier {
-  GLOBAL_OBJ.__SENTRY__ = GLOBAL_OBJ.__SENTRY__ || {
-    extensions: {},
-    hub: undefined,
-  };
+  // This ensures a Sentry carrier exists
+  getSentryCarrier(GLOBAL_OBJ);
   return GLOBAL_OBJ;
 }
 
@@ -717,10 +727,11 @@ export function makeMain(hub: Hub): Hub {
  */
 export function getCurrentHub(): Hub {
   // Get main carrier (global for every environment)
-  const registry = getMainCarrier();
+  const carrier = getMainCarrier();
+  const sentry = getSentryCarrier(carrier);
 
-  if (registry.__SENTRY__ && registry.__SENTRY__.acs) {
-    const hub = registry.__SENTRY__.acs.getCurrentHub();
+  if (sentry.acs) {
+    const hub = sentry.acs.getCurrentHub();
 
     if (hub) {
       return hub;
@@ -728,7 +739,7 @@ export function getCurrentHub(): Hub {
   }
 
   // Return hub that lives on a global object
-  return getGlobalHub(registry);
+  return getGlobalHub();
 }
 
 /**
@@ -741,7 +752,9 @@ export function getIsolationScope(): Scope {
   return getCurrentHub().getIsolationScope();
 }
 
-function getGlobalHub(registry: Carrier = getMainCarrier()): Hub {
+function getGlobalHub(): Hub {
+  const registry = getMainCarrier();
+
   // If there's no hub, or its an old API, assign a new one
 
   if (
@@ -749,7 +762,7 @@ function getGlobalHub(registry: Carrier = getMainCarrier()): Hub {
     // eslint-disable-next-line deprecation/deprecation
     getHubFromCarrier(registry).isOlderThan(API_VERSION)
   ) {
-    setHubOnCarrier(registry, new Hub());
+    setHubOnCarrier(registry, createHub());
   }
 
   // Return hub that lives on a global object
@@ -774,7 +787,7 @@ export function ensureHubOnCarrier(carrier: Carrier, parent: Hub = getGlobalHub(
     const scope = parent.getScope();
     // eslint-disable-next-line deprecation/deprecation
     const isolationScope = parent.getIsolationScope();
-    setHubOnCarrier(carrier, new Hub(client, scope.clone(), isolationScope.clone()));
+    setHubOnCarrier(carrier, createHub(client, scope.clone(), isolationScope.clone()));
   }
 }
 
@@ -786,8 +799,8 @@ export function ensureHubOnCarrier(carrier: Carrier, parent: Hub = getGlobalHub(
 export function setAsyncContextStrategy(strategy: AsyncContextStrategy | undefined): void {
   // Get main carrier (global for every environment)
   const registry = getMainCarrier();
-  registry.__SENTRY__ = registry.__SENTRY__ || {};
-  registry.__SENTRY__.acs = strategy;
+  const sentry = getSentryCarrier(registry);
+  sentry.acs = strategy;
 }
 
 /**
@@ -799,9 +812,10 @@ export function setAsyncContextStrategy(strategy: AsyncContextStrategy | undefin
  */
 export function runWithAsyncContext<T>(callback: () => T, options: RunWithAsyncContextOptions = {}): T {
   const registry = getMainCarrier();
+  const sentry = getSentryCarrier(registry);
 
-  if (registry.__SENTRY__ && registry.__SENTRY__.acs) {
-    return registry.__SENTRY__.acs.runWithAsyncContext(callback, options);
+  if (sentry.acs) {
+    return sentry.acs.runWithAsyncContext(callback, options);
   }
 
   // if there was no strategy, fallback to just calling the callback
@@ -813,7 +827,7 @@ export function runWithAsyncContext<T>(callback: () => T, options: RunWithAsyncC
  * @param carrier object
  */
 function hasHubOnCarrier(carrier: Carrier): boolean {
-  return !!(carrier && carrier.__SENTRY__ && carrier.__SENTRY__.hub);
+  return !!getSentryCarrier(carrier).hub;
 }
 
 /**
@@ -823,7 +837,12 @@ function hasHubOnCarrier(carrier: Carrier): boolean {
  * @hidden
  */
 export function getHubFromCarrier(carrier: Carrier): Hub {
-  return getGlobalSingleton<Hub>('hub', () => new Hub(), carrier);
+  const sentry = getSentryCarrier(carrier);
+  if (!sentry.hub) {
+    sentry.hub = createHub();
+  }
+
+  return sentry.hub;
 }
 
 /**
@@ -834,7 +853,18 @@ export function getHubFromCarrier(carrier: Carrier): Hub {
  */
 export function setHubOnCarrier(carrier: Carrier, hub: Hub): boolean {
   if (!carrier) return false;
-  const __SENTRY__ = (carrier.__SENTRY__ = carrier.__SENTRY__ || {});
-  __SENTRY__.hub = hub;
+  const sentry = getSentryCarrier(carrier);
+  sentry.hub = hub;
   return true;
+}
+
+/** Will either get the existing sentry carrier, or create a new one. */
+function getSentryCarrier(carrier: Carrier): SentryCarrier {
+  if (!carrier.__SENTRY__) {
+    carrier.__SENTRY__ = {
+      extensions: {},
+      hub: undefined,
+    };
+  }
+  return carrier.__SENTRY__;
 }

--- a/packages/opentelemetry/src/contextManager.ts
+++ b/packages/opentelemetry/src/contextManager.ts
@@ -1,8 +1,8 @@
 import type { Context, ContextManager } from '@opentelemetry/api';
 import type { Carrier, Hub } from '@sentry/core';
+import { getCurrentHub, getHubFromCarrier } from '@sentry/core';
 import { ensureHubOnCarrier } from '@sentry/core';
 
-import { getCurrentHub, getHubFromCarrier } from './custom/hub';
 import { setHubOnContext } from './utils/contextData';
 
 function createNewHub(parent: Hub | undefined): Hub {
@@ -46,6 +46,7 @@ export function wrapContextManagerClass<ContextManagerInstance extends ContextMa
       thisArg?: ThisParameterType<F>,
       ...args: A
     ): ReturnType<F> {
+      // eslint-disable-next-line deprecation/deprecation
       const existingHub = getCurrentHub();
       const newHub = createNewHub(existingHub);
 

--- a/packages/opentelemetry/src/custom/hub.ts
+++ b/packages/opentelemetry/src/custom/hub.ts
@@ -1,7 +1,7 @@
 import type { Carrier, Scope } from '@sentry/core';
+import { getMainCarrier } from '@sentry/core';
 import { Hub } from '@sentry/core';
 import type { Client } from '@sentry/types';
-import { GLOBAL_OBJ, getGlobalSingleton } from '@sentry/utils';
 
 import { OpenTelemetryScope } from './scope';
 
@@ -15,144 +15,34 @@ export class OpenTelemetryHub extends Hub {
   }
 }
 
-/** Custom getClient method that uses the custom hub. */
-export function getClient<C extends Client>(): C | undefined {
-  // eslint-disable-next-line deprecation/deprecation
-  return getCurrentHub().getClient<C>();
-}
-
-/**
- * *******************************************************************************
- * Everything below here is a copy of the stuff from core's hub.ts,
- * only that we make sure to create our custom NodeExperimentalScope instead of the default Scope.
- * This is necessary to get the correct breadcrumbs behavior.
- *
- * Basically, this overwrites all places that do `new Scope()` with `new NodeExperimentalScope()`.
- * Which in turn means overwriting all places that do `new Hub()` and make sure to pass in a NodeExperimentalScope instead.
- * *******************************************************************************
- */
-
-/**
- * API compatibility version of this hub.
- *
- * WARNING: This number should only be increased when the global interface
- * changes and new methods are introduced.
- *
- * @hidden
- */
-const API_VERSION = 4;
-
-/**
- * Returns the default hub instance.
- *
- * If a hub is already registered in the global carrier but this module
- * contains a more recent version, it replaces the registered version.
- * Otherwise, the currently registered hub will be returned.
- */
-export function getCurrentHub(): Hub {
-  // Get main carrier (global for every environment)
-  const registry = getMainCarrier();
-
-  if (registry.__SENTRY__ && registry.__SENTRY__.acs) {
-    const hub = registry.__SENTRY__.acs.getCurrentHub();
-
-    if (hub) {
-      return hub;
-    }
-  }
-
-  // Return hub that lives on a global object
-  return getGlobalHub(registry);
-}
-
 /**
  * Ensure the global hub is an OpenTelemetryHub.
  */
 export function setupGlobalHub(): void {
-  const globalRegistry = getMainCarrier();
+  const carrier = getMainCarrier();
+  const sentry = getSentryCarrier(carrier);
 
-  if (getGlobalHub(globalRegistry) instanceof OpenTelemetryHub) {
+  // We register a custom hub creator
+  sentry.createHub = (...options: ConstructorParameters<typeof OpenTelemetryHub>) => {
+    return new OpenTelemetryHub(...options);
+  };
+
+  const hub = sentry.hub;
+
+  if (hub && hub instanceof OpenTelemetryHub) {
     return;
   }
-
   // If the current global hub is not correct, ensure we overwrite it
-  setHubOnCarrier(globalRegistry, new OpenTelemetryHub());
+  sentry.hub = new OpenTelemetryHub();
 }
 
-/**
- * This will create a new {@link Hub} and add to the passed object on
- * __SENTRY__.hub.
- * @param carrier object
- * @hidden
- */
-export function getHubFromCarrier(carrier: Carrier): Hub {
-  return getGlobalSingleton<Hub>('hub', () => new OpenTelemetryHub(), carrier);
-}
-
-/**
- * @private Private API with no semver guarantees!
- *
- * If the carrier does not contain a hub, a new hub is created with the global hub client and scope.
- */
-export function ensureHubOnCarrier(carrier: Carrier, parent: Hub = getGlobalHub()): void {
-  // If there's no hub on current domain, or it's an old API, assign a new one
-  if (
-    !hasHubOnCarrier(carrier) ||
-    // eslint-disable-next-line deprecation/deprecation
-    getHubFromCarrier(carrier).isOlderThan(API_VERSION)
-  ) {
-    // eslint-disable-next-line deprecation/deprecation
-    const globalHubTopStack = parent.getStackTop();
-    setHubOnCarrier(carrier, new OpenTelemetryHub(globalHubTopStack.client, globalHubTopStack.scope.clone()));
+/** Will either get the existing sentry carrier, or create a new one. */
+function getSentryCarrier(carrier: Carrier): Carrier['__SENTRY__'] & object {
+  if (!carrier.__SENTRY__) {
+    carrier.__SENTRY__ = {
+      extensions: {},
+      hub: undefined,
+    };
   }
-}
-
-function getGlobalHub(registry: Carrier = getMainCarrier()): Hub {
-  // If there's no hub, or its an old API, assign a new one
-  if (
-    !hasHubOnCarrier(registry) ||
-    // eslint-disable-next-line deprecation/deprecation
-    getHubFromCarrier(registry).isOlderThan(API_VERSION)
-  ) {
-    setHubOnCarrier(registry, new OpenTelemetryHub());
-  }
-
-  // Return hub that lives on a global object
-  return getHubFromCarrier(registry);
-}
-
-/**
- * This will tell whether a carrier has a hub on it or not
- * @param carrier object
- */
-function hasHubOnCarrier(carrier: Carrier): boolean {
-  return !!(carrier && carrier.__SENTRY__ && carrier.__SENTRY__.hub);
-}
-
-/**
- * Returns the global shim registry.
- *
- * FIXME: This function is problematic, because despite always returning a valid Carrier,
- * it has an optional `__SENTRY__` property, which then in turn requires us to always perform an unnecessary check
- * at the call-site. We always access the carrier through this function, so we can guarantee that `__SENTRY__` is there.
- **/
-function getMainCarrier(): Carrier {
-  GLOBAL_OBJ.__SENTRY__ = GLOBAL_OBJ.__SENTRY__ || {
-    extensions: {},
-    hub: undefined,
-  };
-  return GLOBAL_OBJ;
-}
-
-/**
- * This will set passed {@link Hub} on the passed object's __SENTRY__.hub attribute
- * @param carrier object
- * @param hub Hub
- * @returns A boolean indicating success or failure
- */
-function setHubOnCarrier(carrier: Carrier, hub: Hub): boolean {
-  if (!carrier) return false;
-  const __SENTRY__ = (carrier.__SENTRY__ = carrier.__SENTRY__ || {});
-  __SENTRY__.hub = hub;
-  return true;
+  return carrier.__SENTRY__;
 }

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -31,7 +31,7 @@ export { isSentryRequestSpan } from './utils/isSentryRequest';
 export { getActiveSpan, getRootSpan } from './utils/getActiveSpan';
 export { startSpan, startSpanManual, startInactiveSpan } from './trace';
 
-export { getCurrentHub, setupGlobalHub, getClient } from './custom/hub';
+export { setupGlobalHub } from './custom/hub';
 export { OpenTelemetryScope } from './custom/scope';
 export { addTracingExtensions } from './custom/hubextensions';
 export { setupEventContextTrace } from './setupEventContextTrace';
@@ -41,6 +41,10 @@ export { wrapContextManagerClass } from './contextManager';
 export { SentryPropagator } from './propagator';
 export { SentrySpanProcessor } from './spanProcessor';
 export { SentrySampler } from './sampler';
+
+// Legacy
+// eslint-disable-next-line deprecation/deprecation
+export { getCurrentHub, getClient } from '@sentry/core';
 
 /**
  * The following internal utils are not considered public API and are subject to change.

--- a/packages/opentelemetry/src/propagator.ts
+++ b/packages/opentelemetry/src/propagator.ts
@@ -1,12 +1,11 @@
 import type { Baggage, Context, SpanContext, TextMapGetter, TextMapSetter } from '@opentelemetry/api';
 import { TraceFlags, propagation, trace } from '@opentelemetry/api';
 import { W3CBaggagePropagator, isTracingSuppressed } from '@opentelemetry/core';
-import { getDynamicSamplingContextFromClient } from '@sentry/core';
+import { getClient, getDynamicSamplingContextFromClient } from '@sentry/core';
 import type { DynamicSamplingContext, PropagationContext } from '@sentry/types';
 import { SENTRY_BAGGAGE_KEY_PREFIX, generateSentryTraceHeader, propagationContextFromHeaders } from '@sentry/utils';
 
 import { SENTRY_BAGGAGE_HEADER, SENTRY_TRACE_HEADER } from './constants';
-import { getClient } from './custom/hub';
 import { getPropagationContextFromContext, setPropagationContextOnContext } from './utils/contextData';
 import { getSpanScope } from './utils/spanData';
 

--- a/packages/opentelemetry/src/spanExporter.ts
+++ b/packages/opentelemetry/src/spanExporter.ts
@@ -3,11 +3,10 @@ import type { ExportResult } from '@opentelemetry/core';
 import { ExportResultCode } from '@opentelemetry/core';
 import type { ReadableSpan, SpanExporter } from '@opentelemetry/sdk-trace-base';
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
-import { SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE, flush, getCurrentScope } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE, flush, getCurrentHub, getCurrentScope } from '@sentry/core';
 import type { Scope, Span as SentrySpan, SpanOrigin, TransactionSource } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
-import { getCurrentHub } from './custom/hub';
 import type { OpenTelemetryTransaction } from './custom/transaction';
 import { startTransaction } from './custom/transaction';
 import { DEBUG_BUILD } from './debug-build';
@@ -151,6 +150,7 @@ function parseSpan(span: ReadableSpan): { op?: string; origin?: SpanOrigin; sour
 
 function createTransactionForOtelSpan(span: ReadableSpan): OpenTelemetryTransaction {
   const scope = getSpanScope(span);
+  // eslint-disable-next-line deprecation/deprecation
   const hub = getSpanHub(span) || getCurrentHub();
   const spanContext = span.spanContext();
   const spanId = spanContext.spanId;

--- a/packages/opentelemetry/src/spanProcessor.ts
+++ b/packages/opentelemetry/src/spanProcessor.ts
@@ -2,9 +2,9 @@ import type { Context } from '@opentelemetry/api';
 import { ROOT_CONTEXT, trace } from '@opentelemetry/api';
 import type { Span, SpanProcessor as SpanProcessorInterface } from '@opentelemetry/sdk-trace-base';
 import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+import { getCurrentHub } from '@sentry/core';
 import { logger } from '@sentry/utils';
 
-import { getCurrentHub } from './custom/hub';
 import { OpenTelemetryScope } from './custom/scope';
 import { DEBUG_BUILD } from './debug-build';
 import { SentrySpanExporter } from './spanExporter';
@@ -26,6 +26,7 @@ function onSpanStart(span: Span, parentContext: Context, _ScopeClass: typeof Ope
   // We do this instead of just falling back to `getCurrentHub` to avoid attaching the wrong hub
   let actualHub = hub;
   if (parentContext === ROOT_CONTEXT) {
+    // eslint-disable-next-line deprecation/deprecation
     actualHub = getCurrentHub();
   }
 
@@ -45,6 +46,7 @@ function onSpanStart(span: Span, parentContext: Context, _ScopeClass: typeof Ope
 
 function onSpanEnd(span: Span): void {
   // Capture exceptions as events
+  // eslint-disable-next-line deprecation/deprecation
   const hub = getSpanHub(span) || getCurrentHub();
   span.events.forEach(event => {
     maybeCaptureExceptionForTimedEvent(hub, event, span);

--- a/packages/opentelemetry/src/trace.ts
+++ b/packages/opentelemetry/src/trace.ts
@@ -2,10 +2,9 @@ import type { Span, Tracer } from '@opentelemetry/api';
 import { context } from '@opentelemetry/api';
 import { SpanStatusCode, trace } from '@opentelemetry/api';
 import { suppressTracing } from '@opentelemetry/core';
-import { SDK_VERSION, handleCallbackErrors } from '@sentry/core';
+import { SDK_VERSION, getClient, handleCallbackErrors } from '@sentry/core';
 import type { Client } from '@sentry/types';
 
-import { getClient } from './custom/hub';
 import { InternalSentrySemanticAttributes } from './semanticAttributes';
 import type { OpenTelemetryClient, OpenTelemetrySpanContext } from './types';
 import { setSpanMetadata } from './utils/spanData';

--- a/packages/opentelemetry/test/asyncContextStrategy.test.ts
+++ b/packages/opentelemetry/test/asyncContextStrategy.test.ts
@@ -1,9 +1,9 @@
 import type { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import type { Hub } from '@sentry/core';
+import { getCurrentHub } from '@sentry/core';
 import { runWithAsyncContext, setAsyncContextStrategy } from '@sentry/core';
 
 import { setOpenTelemetryContextAsyncContextStrategy } from '../src/asyncContextStrategy';
-import { getCurrentHub } from '../src/custom/hub';
 import { TestClient, getDefaultTestClientOptions } from './helpers/TestClient';
 import { setupOtel } from './helpers/initOtel';
 import { cleanupOtel } from './helpers/mockSdkInit';
@@ -28,11 +28,13 @@ describe('asyncContextStrategy', () => {
   });
 
   test('hub scope inheritance', () => {
+    // eslint-disable-next-line deprecation/deprecation
     const globalHub = getCurrentHub();
     // eslint-disable-next-line deprecation/deprecation
     globalHub.setExtra('a', 'b');
 
     runWithAsyncContext(() => {
+      // eslint-disable-next-line deprecation/deprecation
       const hub1 = getCurrentHub();
       expect(hub1).toEqual(globalHub);
 
@@ -41,6 +43,7 @@ describe('asyncContextStrategy', () => {
       expect(hub1).not.toEqual(globalHub);
 
       runWithAsyncContext(() => {
+        // eslint-disable-next-line deprecation/deprecation
         const hub2 = getCurrentHub();
         expect(hub2).toEqual(hub1);
         expect(hub2).not.toEqual(globalHub);
@@ -63,10 +66,12 @@ describe('asyncContextStrategy', () => {
       });
     }
 
+    // eslint-disable-next-line deprecation/deprecation
     const globalHub = getCurrentHub();
     await addRandomExtra(globalHub, 'a');
 
     await runWithAsyncContext(async () => {
+      // eslint-disable-next-line deprecation/deprecation
       const hub1 = getCurrentHub();
       expect(hub1).toEqual(globalHub);
 
@@ -74,6 +79,7 @@ describe('asyncContextStrategy', () => {
       expect(hub1).not.toEqual(globalHub);
 
       await runWithAsyncContext(async () => {
+        // eslint-disable-next-line deprecation/deprecation
         const hub2 = getCurrentHub();
         expect(hub2).toEqual(hub1);
         expect(hub2).not.toEqual(globalHub);
@@ -85,16 +91,20 @@ describe('asyncContextStrategy', () => {
   });
 
   test('context single instance', () => {
+    // eslint-disable-next-line deprecation/deprecation
     const globalHub = getCurrentHub();
     runWithAsyncContext(() => {
+      // eslint-disable-next-line deprecation/deprecation
       expect(globalHub).not.toBe(getCurrentHub());
     });
   });
 
   test('context within a context not reused', () => {
     runWithAsyncContext(() => {
+      // eslint-disable-next-line deprecation/deprecation
       const hub1 = getCurrentHub();
       runWithAsyncContext(() => {
+        // eslint-disable-next-line deprecation/deprecation
         const hub2 = getCurrentHub();
         expect(hub1).not.toBe(hub2);
       });
@@ -103,9 +113,11 @@ describe('asyncContextStrategy', () => {
 
   test('context within a context reused when requested', () => {
     runWithAsyncContext(() => {
+      // eslint-disable-next-line deprecation/deprecation
       const hub1 = getCurrentHub();
       runWithAsyncContext(
         () => {
+          // eslint-disable-next-line deprecation/deprecation
           const hub2 = getCurrentHub();
           expect(hub1).toBe(hub2);
         },
@@ -119,6 +131,7 @@ describe('asyncContextStrategy', () => {
     let d2done = false;
 
     runWithAsyncContext(() => {
+      // eslint-disable-next-line deprecation/deprecation
       const hub = getCurrentHub();
       // eslint-disable-next-line deprecation/deprecation
       hub.getStack().push({ client: 'process' } as any);
@@ -135,6 +148,7 @@ describe('asyncContextStrategy', () => {
     });
 
     runWithAsyncContext(() => {
+      // eslint-disable-next-line deprecation/deprecation
       const hub = getCurrentHub();
       // eslint-disable-next-line deprecation/deprecation
       hub.getStack().push({ client: 'local' } as any);

--- a/packages/opentelemetry/test/custom/hub.test.ts
+++ b/packages/opentelemetry/test/custom/hub.test.ts
@@ -1,12 +1,19 @@
-import { OpenTelemetryHub, getCurrentHub } from '../../src/custom/hub';
+import { getCurrentHub } from '@sentry/core';
+import { OpenTelemetryHub, setupGlobalHub } from '../../src/custom/hub';
 import { OpenTelemetryScope } from '../../src/custom/scope';
 
 describe('OpenTelemetryHub', () => {
+  beforeEach(() => {
+    setupGlobalHub();
+  });
+
   it('getCurrentHub() returns the correct hub', () => {
+    // eslint-disable-next-line deprecation/deprecation
     const hub = getCurrentHub();
     expect(hub).toBeDefined();
     expect(hub).toBeInstanceOf(OpenTelemetryHub);
 
+    // eslint-disable-next-line deprecation/deprecation
     const hub2 = getCurrentHub();
     expect(hub2).toBe(hub);
 

--- a/packages/opentelemetry/test/custom/hubextensions.test.ts
+++ b/packages/opentelemetry/test/custom/hubextensions.test.ts
@@ -1,5 +1,4 @@
-import { setCurrentClient } from '@sentry/core';
-import { getCurrentHub } from '../../src/custom/hub';
+import { getCurrentHub, setCurrentClient } from '@sentry/core';
 import { addTracingExtensions } from '../../src/custom/hubextensions';
 import { TestClient, getDefaultTestClientOptions } from '../helpers/TestClient';
 

--- a/packages/opentelemetry/test/custom/transaction.test.ts
+++ b/packages/opentelemetry/test/custom/transaction.test.ts
@@ -1,5 +1,4 @@
-import { setCurrentClient, spanToJSON } from '@sentry/core';
-import { getCurrentHub } from '../../src/custom/hub';
+import { getCurrentHub, setCurrentClient, spanToJSON } from '@sentry/core';
 import { OpenTelemetryScope } from '../../src/custom/scope';
 import { OpenTelemetryTransaction, startTransaction } from '../../src/custom/transaction';
 import { TestClient, getDefaultTestClientOptions } from '../helpers/TestClient';
@@ -14,6 +13,7 @@ describe('NodeExperimentalTransaction', () => {
 
     const mockSend = jest.spyOn(client, 'captureEvent').mockImplementation(() => 'mocked');
 
+    // eslint-disable-next-line deprecation/deprecation
     const hub = getCurrentHub();
     setCurrentClient(client);
     client.init();
@@ -65,6 +65,7 @@ describe('NodeExperimentalTransaction', () => {
 
     const mockSend = jest.spyOn(client, 'captureEvent').mockImplementation(() => 'mocked');
 
+    // eslint-disable-next-line deprecation/deprecation
     const hub = getCurrentHub();
     setCurrentClient(client);
     client.init();
@@ -91,6 +92,7 @@ describe('NodeExperimentalTransaction', () => {
 
     const mockSend = jest.spyOn(client, 'captureEvent').mockImplementation(() => 'mocked');
 
+    // eslint-disable-next-line deprecation/deprecation
     const hub = getCurrentHub();
     setCurrentClient(client);
     client.init();
@@ -152,6 +154,7 @@ describe('startTranscation', () => {
 
   it('creates a NodeExperimentalTransaction', () => {
     const client = new TestClient(getDefaultTestClientOptions());
+    // eslint-disable-next-line deprecation/deprecation
     const hub = getCurrentHub();
     setCurrentClient(client);
     client.init();
@@ -182,6 +185,7 @@ describe('startTranscation', () => {
 
   it('allows to pass data to transaction', () => {
     const client = new TestClient(getDefaultTestClientOptions());
+    // eslint-disable-next-line deprecation/deprecation
     const hub = getCurrentHub();
     setCurrentClient(client);
     client.init();

--- a/packages/opentelemetry/test/helpers/initOtel.ts
+++ b/packages/opentelemetry/test/helpers/initOtel.ts
@@ -3,11 +3,10 @@ import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-ho
 import { Resource } from '@opentelemetry/resources';
 import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
-import { SDK_VERSION } from '@sentry/core';
+import { SDK_VERSION, getClient } from '@sentry/core';
 import { logger } from '@sentry/utils';
 
 import { wrapContextManagerClass } from '../../src/contextManager';
-import { getClient } from '../../src/custom/hub';
 import { DEBUG_BUILD } from '../../src/debug-build';
 import { SentryPropagator } from '../../src/propagator';
 import { SentrySampler } from '../../src/sampler';

--- a/packages/opentelemetry/test/integration/breadcrumbs.test.ts
+++ b/packages/opentelemetry/test/integration/breadcrumbs.test.ts
@@ -1,6 +1,6 @@
-import { addBreadcrumb, captureException, withScope } from '@sentry/core';
+import { addBreadcrumb, captureException, getClient, getCurrentHub, withScope } from '@sentry/core';
 
-import { OpenTelemetryHub, getClient, getCurrentHub } from '../../src/custom/hub';
+import { OpenTelemetryHub } from '../../src/custom/hub';
 import { startSpan } from '../../src/trace';
 import type { TestClientInterface } from '../helpers/TestClient';
 import { cleanupOtel, mockSdkInit } from '../helpers/mockSdkInit';
@@ -19,6 +19,7 @@ describe('Integration | breadcrumbs', () => {
 
       mockSdkInit({ beforeSend, beforeBreadcrumb });
 
+      // eslint-disable-next-line deprecation/deprecation
       const hub = getCurrentHub();
       const client = getClient() as TestClientInterface;
 
@@ -59,6 +60,7 @@ describe('Integration | breadcrumbs', () => {
 
       mockSdkInit({ beforeSend, beforeBreadcrumb });
 
+      // eslint-disable-next-line deprecation/deprecation
       const hub = getCurrentHub();
       const client = getClient() as TestClientInterface;
 

--- a/packages/opentelemetry/test/integration/otelTimedEvents.test.ts
+++ b/packages/opentelemetry/test/integration/otelTimedEvents.test.ts
@@ -1,6 +1,6 @@
 import { SemanticAttributes } from '@opentelemetry/semantic-conventions';
 
-import { getClient } from '../../src/custom/hub';
+import { getClient } from '@sentry/core';
 import { startSpan } from '../../src/trace';
 import type { TestClientInterface } from '../helpers/TestClient';
 import { cleanupOtel, mockSdkInit } from '../helpers/mockSdkInit';

--- a/packages/opentelemetry/test/integration/scope.test.ts
+++ b/packages/opentelemetry/test/integration/scope.test.ts
@@ -1,6 +1,6 @@
-import { captureException, getCurrentScope, setTag, withScope } from '@sentry/core';
+import { captureException, getClient, getCurrentHub, getCurrentScope, setTag, withScope } from '@sentry/core';
 
-import { OpenTelemetryHub, getClient, getCurrentHub } from '../../src/custom/hub';
+import { OpenTelemetryHub } from '../../src/custom/hub';
 import { OpenTelemetryScope } from '../../src/custom/scope';
 import { startSpan } from '../../src/trace';
 import { getSpanScope } from '../../src/utils/spanData';
@@ -22,6 +22,7 @@ describe('Integration | Scope', () => {
 
       mockSdkInit({ enableTracing, beforeSend, beforeSendTransaction });
 
+      // eslint-disable-next-line deprecation/deprecation
       const hub = getCurrentHub();
       const client = getClient() as TestClientInterface;
 
@@ -129,6 +130,7 @@ describe('Integration | Scope', () => {
 
       mockSdkInit({ enableTracing, beforeSend, beforeSendTransaction });
 
+      // eslint-disable-next-line deprecation/deprecation
       const hub = getCurrentHub();
       const client = getClient() as TestClientInterface;
       const rootScope = getCurrentScope();

--- a/packages/opentelemetry/test/integration/transactions.test.ts
+++ b/packages/opentelemetry/test/integration/transactions.test.ts
@@ -1,11 +1,10 @@
 import { TraceFlags, context, trace } from '@opentelemetry/api';
 import type { SpanProcessor } from '@opentelemetry/sdk-trace-base';
-import { addBreadcrumb, setTag } from '@sentry/core';
+import { addBreadcrumb, getClient, setTag } from '@sentry/core';
 import type { PropagationContext, TransactionEvent } from '@sentry/types';
 import { logger } from '@sentry/utils';
 
 import { spanToJSON } from '@sentry/core';
-import { getClient } from '../../src/custom/hub';
 import { SentrySpanProcessor } from '../../src/spanProcessor';
 import { startInactiveSpan, startSpan } from '../../src/trace';
 import { setPropagationContextOnContext } from '../../src/utils/contextData';

--- a/packages/opentelemetry/test/trace.test.ts
+++ b/packages/opentelemetry/test/trace.test.ts
@@ -3,10 +3,9 @@ import { SpanKind } from '@opentelemetry/api';
 import { TraceFlags, context, trace } from '@opentelemetry/api';
 import type { ReadableSpan } from '@opentelemetry/sdk-trace-base';
 import { Span as SpanClass } from '@opentelemetry/sdk-trace-base';
-import { SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE } from '@sentry/core';
+import { SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE, getClient } from '@sentry/core';
 import type { PropagationContext } from '@sentry/types';
 
-import { getClient } from '../src/custom/hub';
 import { InternalSentrySemanticAttributes } from '../src/semanticAttributes';
 import { startInactiveSpan, startSpan, startSpanManual } from '../src/trace';
 import type { AbstractSpan } from '../src/types';


### PR DESCRIPTION
This is an intermediate step to streamline what we need to customize in OTEL. This should make it easier to slowly remove customizations there.

The main change is that you can set a `createHub` method on the main carrier, which will be used if set. This way, all the code we have to duplicate in node-experimental right now just to create the correct `OpenTelemetryHub` can mostly go away.

We will remove this again during then v8 cycle.
