### PR TITLE
test(v8): Remove Sentry.Integrations usage in tests where possible

### DIFF
--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/dom/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/dom/init.js
@@ -5,6 +5,6 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   defaultIntegrations: false,
-  integrations: [new Sentry.Integrations.Breadcrumbs()],
+  integrations: [Sentry.breadcrumbsIntegration()],
   sampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/fetch/init.js
@@ -5,6 +5,6 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   defaultIntegrations: false,
-  integrations: [new Sentry.Integrations.Breadcrumbs()],
+  integrations: [Sentry.breadcrumbsIntegration()],
   sampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/init.js
+++ b/dev-packages/browser-integration-tests/suites/integrations/Breadcrumbs/xhr/init.js
@@ -5,6 +5,6 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   defaultIntegrations: false,
-  integrations: [new Sentry.Integrations.Breadcrumbs()],
+  integrations: [Sentry.breadcrumbsIntegration()],
   sampleRate: 1,
 });

--- a/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegrationHashShim/init.js
+++ b/dev-packages/browser-integration-tests/suites/tracing/browserTracingIntegrationHashShim/init.js
@@ -5,7 +5,7 @@ window.Sentry = Sentry;
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   sampleRate: 1,
-  integrations: [new Sentry.Integrations.BrowserTracing()],
+  integrations: [Sentry.browserTracingIntegration()],
 });
 
 // This should not fail

--- a/dev-packages/e2e-tests/test-applications/create-next-app/sentry.server.config.ts
+++ b/dev-packages/e2e-tests/test-applications/create-next-app/sentry.server.config.ts
@@ -20,7 +20,7 @@ Sentry.init({
   // `release` value here - use the environment variable `SENTRY_RELEASE`, so
   // that it will also get attached to your source maps
 
-  integrations: [new Sentry.Integrations.LocalVariables()],
+  integrations: [Sentry.localVariablesIntegration()],
 });
 
 Sentry.addEventProcessor(event => {

--- a/dev-packages/e2e-tests/test-applications/node-hapi-app/src/app.js
+++ b/dev-packages/e2e-tests/test-applications/node-hapi-app/src/app.js
@@ -10,7 +10,7 @@ Sentry.init({
   environment: 'qa', // dynamic sampling bias to keep transactions
   dsn: process.env.E2E_TEST_DSN,
   includeLocalVariables: true,
-  integrations: [new Sentry.Integrations.Hapi({ server })],
+  integrations: [Sentry.hapiIntegration({ server })],
   debug: true,
   tunnel: `http://localhost:3031/`, // proxy server
   tracesSampleRate: 1,

--- a/dev-packages/node-integration-tests/suites/anr/basic-session.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic-session.js
@@ -11,7 +11,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   debug: true,
-  integrations: [new Sentry.Integrations.Anr({ captureStackTrace: true, anrThreshold: 100 })],
+  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
 });
 
 function longWork() {

--- a/dev-packages/node-integration-tests/suites/anr/basic.js
+++ b/dev-packages/node-integration-tests/suites/anr/basic.js
@@ -12,7 +12,7 @@ Sentry.init({
   release: '1.0',
   debug: true,
   autoSessionTracking: false,
-  integrations: [new Sentry.Integrations.Anr({ captureStackTrace: true, anrThreshold: 100 })],
+  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
 });
 
 function longWork() {

--- a/dev-packages/node-integration-tests/suites/anr/forked.js
+++ b/dev-packages/node-integration-tests/suites/anr/forked.js
@@ -12,7 +12,7 @@ Sentry.init({
   release: '1.0',
   debug: true,
   autoSessionTracking: false,
-  integrations: [new Sentry.Integrations.Anr({ captureStackTrace: true, anrThreshold: 100 })],
+  integrations: [Sentry.anrIntegration({ captureStackTrace: true, anrThreshold: 100 })],
 });
 
 function longWork() {

--- a/dev-packages/node-integration-tests/suites/anr/should-exit-forced.js
+++ b/dev-packages/node-integration-tests/suites/anr/should-exit-forced.js
@@ -6,7 +6,7 @@ function configureSentry() {
     release: '1.0',
     debug: true,
     autoSessionTracking: false,
-    integrations: [new Sentry.Integrations.Anr({ captureStackTrace: true })],
+    integrations: [Sentry.anrIntegration({ captureStackTrace: true })],
   });
 }
 

--- a/dev-packages/node-integration-tests/suites/anr/should-exit.js
+++ b/dev-packages/node-integration-tests/suites/anr/should-exit.js
@@ -6,7 +6,7 @@ function configureSentry() {
     release: '1.0',
     debug: true,
     autoSessionTracking: false,
-    integrations: [new Sentry.Integrations.Anr({ captureStackTrace: true })],
+    integrations: [Sentry.anrIntegration({ captureStackTrace: true })],
   });
 }
 

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix-parameterized/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix-parameterized/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -9,8 +8,7 @@ const app = express();
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-infix/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -9,8 +8,7 @@ const app = express();
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized-reverse/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized-reverse/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -10,7 +9,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-parameterized/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -9,8 +8,7 @@ const app = express();
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized copy/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized copy/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -10,7 +9,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix-same-length-parameterized/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -10,7 +9,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/common-prefix/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -9,8 +8,7 @@ const app = express();
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/complex-router/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/complex-router/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import express from 'express';
 
 const app = express();
@@ -9,7 +8,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/multiple-routers/middle-layer-parameterized/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/multiple-routers/middle-layer-parameterized/server.ts
@@ -1,6 +1,5 @@
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import express from 'express';
 
 const app = express();
@@ -9,7 +8,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-header-out/server.ts
@@ -1,7 +1,6 @@
 import http from 'http';
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -15,7 +14,7 @@ Sentry.init({
   environment: 'prod',
   tracePropagationTargets: [/^(?!.*express).*$/],
   // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors-with-sentry-entries/server.ts
@@ -1,7 +1,6 @@
 import * as http from 'http';
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -16,7 +15,7 @@ Sentry.init({
   // disable requests to /express
   tracePropagationTargets: [/^(?!.*express).*$/],
   // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-other-vendors/server.ts
@@ -1,7 +1,6 @@
 import http from 'http';
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -16,7 +15,7 @@ Sentry.init({
   // disable requests to /express
   tracePropagationTargets: [/^(?!.*express).*$/],
   // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/baggage-transaction-name/server.ts
@@ -2,7 +2,6 @@ import http from 'http';
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import { SEMANTIC_ATTRIBUTE_SENTRY_SOURCE } from '@sentry/core';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -17,7 +16,7 @@ Sentry.init({
   // disable requests to /express
   tracePropagationTargets: [/^(?!.*express).*$/],
   // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   // TODO: We're rethinking the mechanism for including Pii data in DSC, hence commenting out sendDefaultPii for now
   // sendDefaultPii: true,

--- a/dev-packages/node-integration-tests/suites/express/sentry-trace/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/sentry-trace/server.ts
@@ -1,7 +1,6 @@
 import http from 'http';
 import { loggingTransport, startExpressServerAndSendPortToRunner } from '@sentry-internal/node-integration-tests';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import cors from 'cors';
 import express from 'express';
 
@@ -15,7 +14,7 @@ Sentry.init({
   environment: 'prod',
   tracePropagationTargets: [/^(?!.*express).*$/],
   // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Tracing.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/express/tracing/server.ts
+++ b/dev-packages/node-integration-tests/suites/express/tracing/server.ts
@@ -10,7 +10,7 @@ Sentry.init({
   release: '1.0',
   // disable attaching headers to /test/* endpoints
   tracePropagationTargets: [/^(?!.*test).*$/],
-  integrations: [new Sentry.Integrations.Http({ tracing: true }), new Sentry.Integrations.Express({ app })],
+  integrations: [Sentry.httpIntegration({ tracing: true }), new Sentry.Integrations.Express({ app })],
   tracesSampleRate: 1.0,
   transport: loggingTransport,
 });

--- a/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-memory-test.js
+++ b/dev-packages/node-integration-tests/suites/public-api/LocalVariables/local-variables-memory-test.js
@@ -7,7 +7,7 @@ Sentry.init({
   includeLocalVariables: true,
   transport: loggingTransport,
   // Stop the rate limiting from kicking in
-  integrations: [new Sentry.Integrations.LocalVariables({ maxExceptionsPerSecond: 10000000 })],
+  integrations: [new Sentry.localVariablesIntegration({ maxExceptionsPerSecond: 10000000 })],
 });
 
 class Some {

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-additional-listener-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-additional-listener-test-script.js
@@ -5,7 +5,7 @@ Sentry.init({
   integrations: integrations => {
     return integrations.map(integration => {
       if (integration.name === 'OnUncaughtException') {
-        return new Sentry.Integrations.OnUncaughtException({
+        return Sentry.onUncaughtExceptionIntegration({
           exitEvenIfOtherHandlersAreRegistered: false,
         });
       } else {

--- a/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-no-additional-listener-test-script.js
+++ b/dev-packages/node-integration-tests/suites/public-api/OnUncaughtException/mimic-native-behaviour-no-additional-listener-test-script.js
@@ -5,7 +5,7 @@ Sentry.init({
   integrations: integrations => {
     return integrations.map(integration => {
       if (integration.name === 'OnUncaughtException') {
-        return new Sentry.Integrations.OnUncaughtException({
+        return Sentry.onUncaughtExceptionIntegration({
           exitEvenIfOtherHandlersAreRegistered: false,
         });
       } else {

--- a/dev-packages/node-integration-tests/suites/tracing-new/tracePropagationTargets/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing-new/tracePropagationTargets/scenario.ts
@@ -1,5 +1,4 @@
 import * as http from 'http';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import * as Sentry from '@sentry/node';
 
 Sentry.init({
@@ -7,7 +6,7 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   tracePropagationTargets: [/\/v0/, 'v1'],
-  integrations: [new Sentry.Integrations.Http({ tracing: true })],
+  integrations: [Sentry.httpIntegration({ tracing: true })],
 });
 
 // eslint-disable-next-line deprecation/deprecation

--- a/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/apollo-graphql/scenario.ts
@@ -1,13 +1,11 @@
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 import { ApolloServer, gql } from 'apollo-server';
 
 Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Tracing.Integrations.GraphQL(), new Tracing.Integrations.Apollo()],
+  integrations: [new Sentry.Integrations.GraphQL(), new Sentry.Integrations.Apollo()],
 });
 
 const typeDefs = gql`

--- a/dev-packages/node-integration-tests/suites/tracing/prisma-orm/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/prisma-orm/scenario.ts
@@ -2,7 +2,6 @@ import { randomBytes } from 'crypto';
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { PrismaClient } from '@prisma/client';
 import * as Sentry from '@sentry/node';
-import * as Tracing from '@sentry/tracing';
 
 const client = new PrismaClient();
 
@@ -10,8 +9,7 @@ Sentry.init({
   dsn: 'https://public@dsn.ingest.sentry.io/1337',
   release: '1.0',
   tracesSampleRate: 1.0,
-  // eslint-disable-next-line deprecation/deprecation
-  integrations: [new Tracing.Integrations.Prisma({ client })],
+  integrations: [new Sentry.Integrations.Prisma({ client })],
 });
 
 async function run(): Promise<void> {

--- a/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/scenario.ts
+++ b/dev-packages/node-integration-tests/suites/tracing/tracePropagationTargets/scenario.ts
@@ -1,6 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import '@sentry/tracing';
-
 import * as http from 'http';
 import * as Sentry from '@sentry/node';
 
@@ -9,7 +6,7 @@ Sentry.init({
   release: '1.0',
   tracesSampleRate: 1.0,
   tracePropagationTargets: [/\/v0/, 'v1'],
-  integrations: [new Sentry.Integrations.Http({ tracing: true })],
+  integrations: [Sentry.httpIntegration({ tracing: true })],
 });
 
 // eslint-disable-next-line deprecation/deprecation

--- a/packages/browser/test/integration/common/init.js
+++ b/packages/browser/test/integration/common/init.js
@@ -22,7 +22,7 @@ var dsn =
 function initSDK() {
   Sentry.init({
     dsn: dsn,
-    integrations: [new Sentry.Integrations.Dedupe()],
+    integrations: [Sentry.dedupeIntegration()],
     attachStacktrace: true,
     ignoreErrors: ['ignoreErrorTest'],
     denyUrls: ['foo.js'],

--- a/packages/nextjs/test/integration/sentry.server.config.js
+++ b/packages/nextjs/test/integration/sentry.server.config.js
@@ -19,6 +19,6 @@ Sentry.init({
     ),
 
     // Used for testing http tracing
-    new Sentry.Integrations.Http({ tracing: true }),
+    Sentry.httpIntegration({ tracing: true }),
   ],
 });


### PR DESCRIPTION
This works toward https://github.com/getsentry/sentry-javascript/issues/8844, but only changes tests.

This should make the follow up deletion much easier in browser/node.