### PR TITLE
feat(v8): Remove `extractTraceparentData` export

### DIFF
--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -69,8 +69,6 @@ export {
   addTracingExtensions,
   setMeasurement,
   // eslint-disable-next-line deprecation/deprecation
-  extractTraceparentData,
-  // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
   getSpanStatusFromHttpCode,
   setHttpStatus,

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -32,8 +32,6 @@ export {
   captureMessage,
   close,
   createTransport,
-  // eslint-disable-next-line deprecation/deprecation
-  extractTraceparentData,
   flush,
   // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -4,7 +4,7 @@ export type { BeforeFinishCallback } from './idletransaction';
 export { Span } from './span';
 export { Transaction } from './transaction';
 // eslint-disable-next-line deprecation/deprecation
-export { extractTraceparentData, getActiveTransaction } from './utils';
+export { getActiveTransaction } from './utils';
 // eslint-disable-next-line deprecation/deprecation
 export { SpanStatus } from './spanstatus';
 export {

--- a/packages/core/src/tracing/utils.ts
+++ b/packages/core/src/tracing/utils.ts
@@ -1,5 +1,4 @@
 import type { Transaction } from '@sentry/types';
-import { extractTraceparentData as _extractTraceparentData } from '@sentry/utils';
 
 import type { Hub } from '../hub';
 import { getCurrentHub } from '../hub';
@@ -20,17 +19,3 @@ export function getActiveTransaction<T extends Transaction>(maybeHub?: Hub): T |
 
 // so it can be used in manual instrumentation without necessitating a hard dependency on @sentry/utils
 export { stripUrlQueryAndFragment } from '@sentry/utils';
-
-/**
- * The `extractTraceparentData` function and `TRACEPARENT_REGEXP` constant used
- * to be declared in this file. It was later moved into `@sentry/utils` as part of a
- * move to remove `@sentry/tracing` dependencies from `@sentry/node` (`extractTraceparentData`
- * is the only tracing function used by `@sentry/node`).
- *
- * These exports are kept here for backwards compatability's sake.
- *
- * See https://github.com/getsentry/sentry-javascript/issues/4642 for more details.
- *
- * @deprecated Import this function from `@sentry/utils` instead
- */
-export const extractTraceparentData = _extractTraceparentData;

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -30,8 +30,6 @@ export {
   captureMessage,
   close,
   createTransport,
-  // eslint-disable-next-line deprecation/deprecation
-  extractTraceparentData,
   continueTrace,
   flush,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -64,8 +64,6 @@ export {
   createGetModuleFromFilename,
   close,
   createTransport,
-  // eslint-disable-next-line deprecation/deprecation
-  extractTraceparentData,
   flush,
   Hub,
   runWithAsyncContext,

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -31,8 +31,6 @@ export {
   captureMessage,
   close,
   createTransport,
-  // eslint-disable-next-line deprecation/deprecation
-  extractTraceparentData,
   flush,
   // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -23,8 +23,6 @@ export {
   captureMessage,
   createTransport,
   // eslint-disable-next-line deprecation/deprecation
-  extractTraceparentData,
-  // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
   getHubFromCarrier,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -82,8 +82,6 @@ export {
   getModuleFromFilename,
   createGetModuleFromFilename,
   metrics,
-  // eslint-disable-next-line deprecation/deprecation
-  extractTraceparentData,
   runWithAsyncContext,
   consoleIntegration,
   onUncaughtExceptionIntegration,

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -16,8 +16,6 @@ export {
   withMonitor,
   createTransport,
   // eslint-disable-next-line deprecation/deprecation
-  extractTraceparentData,
-  // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
   getHubFromCarrier,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/tracing-internal/src/exports/index.ts
+++ b/packages/tracing-internal/src/exports/index.ts
@@ -1,7 +1,5 @@
 export {
   // eslint-disable-next-line deprecation/deprecation
-  extractTraceparentData,
-  // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
   hasTracingEnabled,
   IdleTransaction,

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -19,7 +19,6 @@ import {
   Transaction as TransactionT,
   addExtensionMethods as addExtensionMethodsT,
   defaultRequestInstrumentationOptions as defaultRequestInstrumentationOptionsT,
-  extractTraceparentData as extractTraceparentDataT,
   getActiveTransaction as getActiveTransactionT,
   hasTracingEnabled as hasTracingEnabledT,
   instrumentOutgoingRequests as instrumentOutgoingRequestsT,
@@ -65,14 +64,6 @@ export const addExtensionMethods = addExtensionMethodsT;
  */
 // eslint-disable-next-line deprecation/deprecation
 export const getActiveTransaction = getActiveTransactionT;
-
-/**
- * @deprecated `@sentry/tracing` has been deprecated and will be moved to to `@sentry/node`, `@sentry/browser`, or your framework SDK in the next major version.
- *
- * `extractTraceparentData` can be imported from `@sentry/node`, `@sentry/browser`, or your framework SDK
- */
-// eslint-disable-next-line deprecation/deprecation
-export const extractTraceparentData = extractTraceparentDataT;
 
 /**
  * @deprecated `@sentry/tracing` has been deprecated and will be moved to to `@sentry/node`, `@sentry/browser`, or your framework SDK in the next major version.

--- a/packages/tracing/test/hub.test.ts
+++ b/packages/tracing/test/hub.test.ts
@@ -3,9 +3,9 @@
 import { BrowserClient } from '@sentry/browser';
 import { Hub, SEMANTIC_ATTRIBUTE_SENTRY_SAMPLE_RATE, makeMain } from '@sentry/core';
 import * as utilsModule from '@sentry/utils'; // for mocking
-import { logger } from '@sentry/utils';
+import { extractTraceparentData, logger } from '@sentry/utils';
 
-import { BrowserTracing, TRACEPARENT_REGEXP, Transaction, addExtensionMethods, extractTraceparentData } from '../src';
+import { BrowserTracing, TRACEPARENT_REGEXP, Transaction, addExtensionMethods } from '../src';
 import {
   addDOMPropertiesToGlobal,
   getDefaultBrowserClientOptions,

--- a/packages/tracing/test/utils.test.ts
+++ b/packages/tracing/test/utils.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable deprecation/deprecation */
-import { extractTraceparentData, hasTracingEnabled } from '../src';
+import { hasTracingEnabled } from '../src';
 
 describe('hasTracingEnabled (deprecated)', () => {
   const tracesSampler = () => 1;
@@ -32,73 +32,4 @@ describe('hasTracingEnabled (deprecated)', () => {
       expect(hasTracingEnabled(input)).toBe(output);
     },
   );
-});
-
-describe('extractTraceparentData', () => {
-  test('no sample', () => {
-    const data = extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb') as any;
-
-    expect(data).toBeDefined();
-    expect(data.parentSpanId).toEqual('bbbbbbbbbbbbbbbb');
-    expect(data.traceId).toEqual('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
-    expect(data?.parentSampled).toBeUndefined();
-  });
-
-  test('sample true', () => {
-    const data = extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-1') as any;
-
-    expect(data).toBeDefined();
-    expect(data.parentSampled).toBeTruthy();
-  });
-
-  test('sample false', () => {
-    const data = extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-0') as any;
-
-    expect(data).toBeDefined();
-    expect(data.parentSampled).toBeFalsy();
-  });
-
-  test('just sample decision - false', () => {
-    const data = extractTraceparentData('0') as any;
-
-    expect(data).toBeDefined();
-    expect(data.traceId).toBeUndefined();
-    expect(data.spanId).toBeUndefined();
-    expect(data.parentSampled).toBeFalsy();
-  });
-
-  test('just sample decision - true', () => {
-    const data = extractTraceparentData('1') as any;
-
-    expect(data).toBeDefined();
-    expect(data.traceId).toBeUndefined();
-    expect(data.spanId).toBeUndefined();
-    expect(data.parentSampled).toBeTruthy();
-  });
-
-  test('invalid', () => {
-    // undefined
-    expect(extractTraceparentData(undefined)).toBeUndefined();
-
-    // empty string
-    expect(extractTraceparentData('')).toBeUndefined();
-
-    // trace id wrong length
-    expect(extractTraceparentData('a-bbbbbbbbbbbbbbbb-1')).toBeUndefined();
-
-    // parent span id wrong length
-    expect(extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-b-1')).toBeUndefined();
-
-    // parent sampling decision wrong length
-    expect(extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-11')).toBeUndefined();
-
-    // trace id invalid hex value
-    expect(extractTraceparentData('someStuffHereWhichIsNotAtAllHexy-bbbbbbbbbbbbbbbb-1')).toBeUndefined();
-
-    // parent span id invalid hex value
-    expect(extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-alsoNotSuperHexy-1')).toBeUndefined();
-
-    // bogus sampling decision
-    expect(extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-x')).toBeUndefined();
-  });
 });

--- a/packages/utils/test/tracing.test.ts
+++ b/packages/utils/test/tracing.test.ts
@@ -1,4 +1,4 @@
-import { propagationContextFromHeaders, tracingContextFromHeaders } from '../src/tracing';
+import { extractTraceparentData, propagationContextFromHeaders, tracingContextFromHeaders } from '../src/tracing';
 
 const EXAMPLE_SENTRY_TRACE = '12312012123120121231201212312012-1121201211212012-1';
 const EXAMPLE_BAGGAGE = 'sentry-release=1.2.3,sentry-foo=bar,other=baz';
@@ -62,5 +62,74 @@ describe('propagationContextFromHeaders()', () => {
         foo: 'bar',
       },
     });
+  });
+});
+
+describe('extractTraceparentData', () => {
+  test('no sample', () => {
+    const data = extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb') as any;
+
+    expect(data).toBeDefined();
+    expect(data.parentSpanId).toEqual('bbbbbbbbbbbbbbbb');
+    expect(data.traceId).toEqual('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+    expect(data?.parentSampled).toBeUndefined();
+  });
+
+  test('sample true', () => {
+    const data = extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-1') as any;
+
+    expect(data).toBeDefined();
+    expect(data.parentSampled).toBeTruthy();
+  });
+
+  test('sample false', () => {
+    const data = extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-0') as any;
+
+    expect(data).toBeDefined();
+    expect(data.parentSampled).toBeFalsy();
+  });
+
+  test('just sample decision - false', () => {
+    const data = extractTraceparentData('0') as any;
+
+    expect(data).toBeDefined();
+    expect(data.traceId).toBeUndefined();
+    expect(data.spanId).toBeUndefined();
+    expect(data.parentSampled).toBeFalsy();
+  });
+
+  test('just sample decision - true', () => {
+    const data = extractTraceparentData('1') as any;
+
+    expect(data).toBeDefined();
+    expect(data.traceId).toBeUndefined();
+    expect(data.spanId).toBeUndefined();
+    expect(data.parentSampled).toBeTruthy();
+  });
+
+  test('invalid', () => {
+    // undefined
+    expect(extractTraceparentData(undefined)).toBeUndefined();
+
+    // empty string
+    expect(extractTraceparentData('')).toBeUndefined();
+
+    // trace id wrong length
+    expect(extractTraceparentData('a-bbbbbbbbbbbbbbbb-1')).toBeUndefined();
+
+    // parent span id wrong length
+    expect(extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-b-1')).toBeUndefined();
+
+    // parent sampling decision wrong length
+    expect(extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-11')).toBeUndefined();
+
+    // trace id invalid hex value
+    expect(extractTraceparentData('someStuffHereWhichIsNotAtAllHexy-bbbbbbbbbbbbbbbb-1')).toBeUndefined();
+
+    // parent span id invalid hex value
+    expect(extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-alsoNotSuperHexy-1')).toBeUndefined();
+
+    // bogus sampling decision
+    expect(extractTraceparentData('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-x')).toBeUndefined();
   });
 });

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -31,8 +31,6 @@ export {
   captureMessage,
   close,
   createTransport,
-  // eslint-disable-next-line deprecation/deprecation
-  extractTraceparentData,
   flush,
   // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,


### PR DESCRIPTION
Instead, import this directly from `@sentry/utils`.

Should help when we move `@sentry/utils` into core.