### PR TITLE
feat(v8): Remove deprecated spanStatusfromHttpCode export

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -11,6 +11,10 @@ enum. If you were using the `Severity` enum, you should replace it with the `Sev
 The `Offline` integration has been removed in favor of the offline transport wrapper:
 http://docs.sentry.io/platforms/javascript/configuration/transports/#offline-caching
 
+## Other changes
+
+- Remove `spanStatusfromHttpCode` in favour of `getSpanStatusFromHttpCode` (#10361)
+
 # Deprecations in 7.x
 
 You can use the **Experimental** [@sentry/migr8](https://www.npmjs.com/package/@sentry/migr8) to automatically update

--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -46,8 +46,6 @@ export {
   setTag,
   setTags,
   setUser,
-  // eslint-disable-next-line deprecation/deprecation
-  spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
   setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -71,8 +71,6 @@ export {
   extractTraceparentData,
   // eslint-disable-next-line deprecation/deprecation
   getActiveTransaction,
-  // eslint-disable-next-line deprecation/deprecation
-  spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
   setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -64,8 +64,6 @@ export {
   setTag,
   setTags,
   setUser,
-  // eslint-disable-next-line deprecation/deprecation
-  spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
   setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/core/src/tracing/index.ts
+++ b/packages/core/src/tracing/index.ts
@@ -9,8 +9,6 @@ export { extractTraceparentData, getActiveTransaction } from './utils';
 export { SpanStatus } from './spanstatus';
 export {
   setHttpStatus,
-  // eslint-disable-next-line deprecation/deprecation
-  spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
 } from './spanstatus';
 export type { SpanStatusType } from './spanstatus';

--- a/packages/core/src/tracing/spanstatus.ts
+++ b/packages/core/src/tracing/spanstatus.ts
@@ -124,17 +124,6 @@ export function getSpanStatusFromHttpCode(httpStatus: number): SpanStatusType {
 }
 
 /**
- * Converts a HTTP status code into a {@link SpanStatusType}.
- *
- * @deprecated Use {@link spanStatusFromHttpCode} instead.
- * This export will be removed in v8 as the signature contains a typo.
- *
- * @param httpStatus The HTTP response status code.
- * @returns The span status or unknown_error.
- */
-export const spanStatusfromHttpCode = getSpanStatusFromHttpCode;
-
-/**
  * Sets the Http status attributes on the current span based on the http code.
  * Additionally, the span's status is updated, depending on the http code.
  */

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -63,8 +63,6 @@ export {
   setTag,
   setTags,
   setUser,
-  // eslint-disable-next-line deprecation/deprecation
-  spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
   setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -78,8 +78,6 @@ export {
   Hub,
   runWithAsyncContext,
   SDK_VERSION,
-  // eslint-disable-next-line deprecation/deprecation
-  spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
   setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -63,8 +63,6 @@ export {
   setTag,
   setTags,
   setUser,
-  // eslint-disable-next-line deprecation/deprecation
-  spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
   setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -50,8 +50,6 @@ export {
   setTag,
   setTags,
   setUser,
-  // eslint-disable-next-line deprecation/deprecation
-  spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
   setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -38,8 +38,6 @@ export {
   getGlobalScope,
   getIsolationScope,
   getHubFromCarrier,
-  // eslint-disable-next-line deprecation/deprecation
-  spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
   setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -44,8 +44,6 @@ export {
   setTag,
   setTags,
   setUser,
-  // eslint-disable-next-line deprecation/deprecation
-  spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
   setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation

--- a/packages/tracing-internal/src/exports/index.ts
+++ b/packages/tracing-internal/src/exports/index.ts
@@ -8,8 +8,6 @@ export {
   Span,
   // eslint-disable-next-line deprecation/deprecation
   SpanStatus,
-  // eslint-disable-next-line deprecation/deprecation
-  spanStatusfromHttpCode,
   startIdleTransaction,
   Transaction,
 } from '@sentry/core';

--- a/packages/tracing/src/index.ts
+++ b/packages/tracing/src/index.ts
@@ -23,7 +23,6 @@ import {
   getActiveTransaction as getActiveTransactionT,
   hasTracingEnabled as hasTracingEnabledT,
   instrumentOutgoingRequests as instrumentOutgoingRequestsT,
-  spanStatusfromHttpCode as spanStatusfromHttpCodeT,
   startIdleTransaction as startIdleTransactionT,
   stripUrlQueryAndFragment as stripUrlQueryAndFragmentT,
 } from '@sentry-internal/tracing';
@@ -74,14 +73,6 @@ export const getActiveTransaction = getActiveTransactionT;
  */
 // eslint-disable-next-line deprecation/deprecation
 export const extractTraceparentData = extractTraceparentDataT;
-
-/**
- * @deprecated `@sentry/tracing` has been deprecated and will be moved to to `@sentry/node`, `@sentry/browser`, or your framework SDK in the next major version.
- *
- * `spanStatusfromHttpCode` can be imported from `@sentry/node`, `@sentry/browser`, or your framework SDK
- */
-// eslint-disable-next-line deprecation/deprecation
-export const spanStatusfromHttpCode = spanStatusfromHttpCodeT;
 
 /**
  * @deprecated `@sentry/tracing` has been deprecated and will be moved to to `@sentry/node`, `@sentry/browser`, or your framework SDK in the next major version.

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -63,8 +63,6 @@ export {
   setTag,
   setTags,
   setUser,
-  // eslint-disable-next-line deprecation/deprecation
-  spanStatusfromHttpCode,
   getSpanStatusFromHttpCode,
   setHttpStatus,
   // eslint-disable-next-line deprecation/deprecation


### PR DESCRIPTION
Small removal for `spanStatusfromHttpCode`!