### PR TITLE
fix(angular-ivy): Add `exports` field to `package.json`

### DIFF
--- a/packages/angular-ivy/scripts/prepack.ts
+++ b/packages/angular-ivy/scripts/prepack.ts
@@ -6,6 +6,7 @@ type PackageJson = {
   type?: string;
   nx?: string;
   volta?: any;
+  exports?: Record<string, string | Record<string, string>>;
 };
 
 const buildDir = path.join(process.cwd(), 'build');
@@ -17,6 +18,17 @@ const pkgJson: PackageJson = JSON.parse(fs.readFileSync(pkjJsonPath).toString())
 // use the fesm2015 bundle instead of the UMD bundle.
 delete pkgJson.main;
 pkgJson.type = 'module';
+
+pkgJson.exports = {
+  '.': {
+    es2015: './fesm2015/sentry-angular-ivy.js',
+    esm2015: './esm2015/sentry-angular-ivy.js',
+    fesm2015: './fesm2015/sentry-angular-ivy.js',
+    import: './fesm2015/sentry-angular-ivy.js',
+    require: './bundles/sentry-angular-ivy.umd.js',
+  },
+  './*': './*',
+};
 
 // no need to keep around other properties that are only relevant for our reop:
 delete pkgJson.nx;

--- a/packages/angular-ivy/scripts/prepack.ts
+++ b/packages/angular-ivy/scripts/prepack.ts
@@ -26,6 +26,7 @@ pkgJson.exports = {
     fesm2015: './fesm2015/sentry-angular-ivy.js',
     import: './fesm2015/sentry-angular-ivy.js',
     require: './bundles/sentry-angular-ivy.umd.js',
+    types: './sentry-angular-ivy.d.ts',
   },
   './*': './*',
 };


### PR DESCRIPTION
This PR adds an `exports` field to the `package.json` for `@sentry/angular-ivy`. While it seems like regular Angular apps didn't need it, tools like `vitest` expect the field as soon as `type: "module"` is specified.

IMO this is just a fix for v7 as we'll bump the APF from Angular 12 to at least Angular 14 in v8. So once this is in, I'll also backport the fix to `v7`.

In addition to the repro provided in #10511, I also tested with Angular 12 and Angular 17 test apps. Seemed to work so far.

closes #10511 