### PR TITLE
fix(sveltekit): Avoid capturing Http 4xx errors on the client

### DIFF
--- a/packages/sveltekit/src/client/load.ts
+++ b/packages/sveltekit/src/client/load.ts
@@ -14,6 +14,7 @@ function sendErrorToSentry(e: unknown): unknown {
   const objectifiedErr = objectify(e);
 
   // We don't want to capture thrown `Redirect`s as these are not errors but expected behaviour
+  // Neither 400 errors, given that they are not valuable.
   if (
     isRedirect(objectifiedErr) ||
     (isHttpError(objectifiedErr) && objectifiedErr.status < 500 && objectifiedErr.status >= 400)

--- a/packages/sveltekit/src/client/load.ts
+++ b/packages/sveltekit/src/client/load.ts
@@ -4,7 +4,7 @@ import { addNonEnumerableProperty, objectify } from '@sentry/utils';
 import type { LoadEvent } from '@sveltejs/kit';
 
 import type { SentryWrappedFlag } from '../common/utils';
-import { isRedirect } from '../common/utils';
+import { isHttpError, isRedirect } from '../common/utils';
 
 type PatchedLoadEvent = LoadEvent & Partial<SentryWrappedFlag>;
 
@@ -14,7 +14,10 @@ function sendErrorToSentry(e: unknown): unknown {
   const objectifiedErr = objectify(e);
 
   // We don't want to capture thrown `Redirect`s as these are not errors but expected behaviour
-  if (isRedirect(objectifiedErr)) {
+  if (
+    isRedirect(objectifiedErr) ||
+    (isHttpError(objectifiedErr) && objectifiedErr.status < 500 && objectifiedErr.status >= 400)
+  ) {
     return objectifiedErr;
   }
 

--- a/packages/sveltekit/src/client/load.ts
+++ b/packages/sveltekit/src/client/load.ts
@@ -14,7 +14,7 @@ function sendErrorToSentry(e: unknown): unknown {
   const objectifiedErr = objectify(e);
 
   // We don't want to capture thrown `Redirect`s as these are not errors but expected behaviour
-  // Neither 400 errors, given that they are not valuable.
+  // Neither 4xx errors, given that they are not valuable.
   if (
     isRedirect(objectifiedErr) ||
     (isHttpError(objectifiedErr) && objectifiedErr.status < 500 && objectifiedErr.status >= 400)


### PR DESCRIPTION
This PR adds the Http 400 avoidance logic from our server-side `load` function instrumentation to the client-side wrapper. Didn't know that these errors were a thing on the client side but now that we know, we definitely don't want to capture them.

Also added tests

closes https://github.com/getsentry/sentry-javascript/issues/10568