### PR TITLE
ref(core): Make `withScope` callback run in isolated context

### DIFF
--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -184,27 +184,29 @@ export function withScope<T>(scope: ScopeInterface | undefined, callback: (scope
 export function withScope<T>(
   ...rest: [callback: (scope: Scope) => T] | [scope: ScopeInterface | undefined, callback: (scope: Scope) => T]
 ): T {
-  // eslint-disable-next-line deprecation/deprecation
-  const hub = getCurrentHub();
+  return runWithAsyncContext(() => {
+    // eslint-disable-next-line deprecation/deprecation
+    const hub = getCurrentHub();
 
-  // If a scope is defined, we want to make this the active scope instead of the default one
-  if (rest.length === 2) {
-    const [scope, callback] = rest;
-    if (!scope) {
+    // If a scope is defined, we want to make this the active scope instead of the default one
+    if (rest.length === 2) {
+      const [scope, callback] = rest;
+      if (!scope) {
+        // eslint-disable-next-line deprecation/deprecation
+        return hub.withScope(callback);
+      }
+
       // eslint-disable-next-line deprecation/deprecation
-      return hub.withScope(callback);
+      return hub.withScope(() => {
+        // eslint-disable-next-line deprecation/deprecation
+        hub.getStackTop().scope = scope as Scope;
+        return callback(scope as Scope);
+      });
     }
 
     // eslint-disable-next-line deprecation/deprecation
-    return hub.withScope(() => {
-      // eslint-disable-next-line deprecation/deprecation
-      hub.getStackTop().scope = scope as Scope;
-      return callback(scope as Scope);
-    });
-  }
-
-  // eslint-disable-next-line deprecation/deprecation
-  return hub.withScope(rest[0]);
+    return hub.withScope(rest[0]);
+  });
 }
 
 /**


### PR DESCRIPTION
The implementation of `withScope` is likely gonna change again but moving forward `withScope` wil retain async context so we can make the behaviour change right now so that we're good for the future.

Up until now we didn't do this because it would be behaviourally breaking.