### PR TITLE
docs(nextjs): Fix function name in deprecation message

### DIFF
--- a/packages/nextjs/src/common/wrapApiHandlerWithSentry.ts
+++ b/packages/nextjs/src/common/wrapApiHandlerWithSentry.ts
@@ -45,7 +45,7 @@ export const withSentryAPI = wrapApiHandlerWithSentry;
  * @param parameterizedRoute The route whose handler is being wrapped. Meant for internal use only.
  * @returns A wrapped version of the handler
  *
- * @deprecated Use `wrapApiWithSentry()` instead
+ * @deprecated Use `wrapApiHandlerWithSentry()` instead
  */
 export function withSentry(apiHandler: NextApiHandler, parameterizedRoute?: string): NextApiHandler {
   return new Proxy(apiHandler, {


### PR DESCRIPTION
Pretty self-explanatory- corrects the function name from the nonexistent `wrapApiWithSentry` (seems like it was intended to be `wrapApiHandlerWithSentry`) in a deprecation warning. 
