### PR TITLE
feat(core): Deprecate the `Hub` constructor

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -272,6 +272,45 @@ If you are using the `Hub` right now, see the following table on how to migrate 
 | endSession()           | `Sentry.endSession()`                                                                |
 | shouldSendDefaultPii() | REMOVED - The closest equivalent is `Sentry.getClient().getOptions().sendDefaultPii` |
 
+The `Hub` constructor is also deprecated and will be removed in the next major version. If you are creating Hubs for
+multi-client use like so:
+
+```ts
+// OLD
+const hub = new Hub();
+hub.bindClient(client);
+makeMain(hub);
+```
+
+instead initialize the client as follows:
+
+```ts
+// NEW
+Sentry.withIsolationScope(() => {
+  Sentry.setCurrentClient(client);
+  client.init();
+});
+```
+
+If you are using the Hub to capture events like so:
+
+```ts
+// OLD
+const client = new Client();
+const hub = new Hub(client);
+hub.captureException();
+```
+
+instead capture isolated events as follows:
+
+```ts
+// NEW
+const client = new Client();
+const scope = new Scope();
+scope.setClient(client);
+scope.captureException();
+```
+
 ## Deprecate `client.setupIntegrations()`
 
 Instead, use the new `client.init()` method. You should probably not use this directly and instead use `Sentry.init()`,

--- a/packages/bun/test/integrations/bunserver.test.ts
+++ b/packages/bun/test/integrations/bunserver.test.ts
@@ -19,6 +19,7 @@ describe('Bun Serve Integration', () => {
   beforeEach(() => {
     const options = getDefaultBunClientOptions({ tracesSampleRate: 1, debug: true });
     client = new BunClient(options);
+    // eslint-disable-next-line deprecation/deprecation
     hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -121,6 +121,46 @@ export class Hub implements HubInterface {
    * @param client bound to the hub.
    * @param scope bound to the hub.
    * @param version number, higher number means higher priority.
+   *
+   * @deprecated Instantiation of Hub objects is deprecated and the constructor will be removed in version 8 of the SDK.
+   *
+   * If you are currently using the Hub for multi-client use like so:
+   *
+   * ```
+   * // OLD
+   * const hub = new Hub();
+   * hub.bindClient(client);
+   * makeMain(hub)
+   * ```
+   *
+   * instead initialize the client as follows:
+   *
+   * ```
+   * // NEW
+   * Sentry.withIsolationScope(() => {
+   *    Sentry.setCurrentClient(client);
+   *    client.init();
+   * });
+   * ```
+   *
+   * If you are using the Hub to capture events like so:
+   *
+   * ```
+   * // OLD
+   * const client = new Client();
+   * const hub = new Hub(client);
+   * hub.captureException()
+   * ```
+   *
+   * instead capture isolated events as follows:
+   *
+   * ```
+   * // NEW
+   * const client = new Client();
+   * const scope = new Scope();
+   * scope.setClient(client);
+   * scope.captureException();
+   * ```
    */
   public constructor(
     client?: Client,
@@ -749,6 +789,7 @@ function getGlobalHub(registry: Carrier = getMainCarrier()): Hub {
     // eslint-disable-next-line deprecation/deprecation
     getHubFromCarrier(registry).isOlderThan(API_VERSION)
   ) {
+    // eslint-disable-next-line deprecation/deprecation
     setHubOnCarrier(registry, new Hub());
   }
 
@@ -774,6 +815,7 @@ export function ensureHubOnCarrier(carrier: Carrier, parent: Hub = getGlobalHub(
     const scope = parent.getScope();
     // eslint-disable-next-line deprecation/deprecation
     const isolationScope = parent.getIsolationScope();
+    // eslint-disable-next-line deprecation/deprecation
     setHubOnCarrier(carrier, new Hub(client, scope.clone(), isolationScope.clone()));
   }
 }
@@ -823,6 +865,7 @@ function hasHubOnCarrier(carrier: Carrier): boolean {
  * @hidden
  */
 export function getHubFromCarrier(carrier: Carrier): Hub {
+  // eslint-disable-next-line deprecation/deprecation
   return getGlobalSingleton<Hub>('hub', () => new Hub(), carrier);
 }
 

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -119,6 +119,7 @@ describe('BaseClient', () => {
       const options = getDefaultTestClientOptions({});
       const client = new TestClient(options);
       const scope = new Scope();
+      // eslint-disable-next-line deprecation/deprecation
       const hub = new Hub(client, scope);
 
       scope.addBreadcrumb({ message: 'hello' }, 100);
@@ -134,6 +135,7 @@ describe('BaseClient', () => {
       const options = getDefaultTestClientOptions({});
       const client = new TestClient(options);
       const scope = new Scope();
+      // eslint-disable-next-line deprecation/deprecation
       const hub = new Hub(client, scope);
 
       scope.addBreadcrumb({ message: 'hello' }, 100);
@@ -149,6 +151,7 @@ describe('BaseClient', () => {
       const options = getDefaultTestClientOptions({ maxBreadcrumbs: 1 });
       const client = new TestClient(options);
       const scope = new Scope();
+      // eslint-disable-next-line deprecation/deprecation
       const hub = new Hub(client, scope);
 
       scope.addBreadcrumb({ message: 'hello' }, 100);
@@ -165,6 +168,7 @@ describe('BaseClient', () => {
       const options = getDefaultTestClientOptions({});
       const client = new TestClient(options);
       const scope = new Scope();
+      // eslint-disable-next-line deprecation/deprecation
       const hub = new Hub(client, scope);
 
       scope.addBreadcrumb({ message: 'hello' });
@@ -181,6 +185,7 @@ describe('BaseClient', () => {
       const options = getDefaultTestClientOptions({ beforeBreadcrumb });
       const client = new TestClient(options);
       const scope = new Scope();
+      // eslint-disable-next-line deprecation/deprecation
       const hub = new Hub(client, scope);
 
       // eslint-disable-next-line deprecation/deprecation
@@ -196,6 +201,7 @@ describe('BaseClient', () => {
       const options = getDefaultTestClientOptions({ beforeBreadcrumb });
       const client = new TestClient(options);
       const scope = new Scope();
+      // eslint-disable-next-line deprecation/deprecation
       const hub = new Hub(client, scope);
 
       // eslint-disable-next-line deprecation/deprecation
@@ -211,6 +217,7 @@ describe('BaseClient', () => {
       const options = getDefaultTestClientOptions({ beforeBreadcrumb });
       const client = new TestClient(options);
       const scope = new Scope();
+      // eslint-disable-next-line deprecation/deprecation
       const hub = new Hub(client, scope);
 
       // eslint-disable-next-line deprecation/deprecation
@@ -226,6 +233,7 @@ describe('BaseClient', () => {
       const options = getDefaultTestClientOptions({ beforeBreadcrumb });
       const client = new TestClient(options);
       const scope = new Scope();
+      // eslint-disable-next-line deprecation/deprecation
       const hub = new Hub(client, scope);
 
       // eslint-disable-next-line deprecation/deprecation
@@ -620,6 +628,7 @@ describe('BaseClient', () => {
       const options = getDefaultTestClientOptions({ dsn: PUBLIC_DSN, maxBreadcrumbs: 1 });
       const client = new TestClient(options);
       const scope = new Scope();
+      // eslint-disable-next-line deprecation/deprecation
       const hub = new Hub(client, scope);
       // eslint-disable-next-line deprecation/deprecation
       hub.addBreadcrumb({ message: '1' });

--- a/packages/core/test/lib/exports.test.ts
+++ b/packages/core/test/lib/exports.test.ts
@@ -31,6 +31,7 @@ function getTestClient(): TestClient {
 describe('withScope', () => {
   beforeEach(() => {
     const client = getTestClient();
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
@@ -173,6 +174,7 @@ describe('withScope', () => {
 describe('session APIs', () => {
   beforeEach(() => {
     const client = getTestClient();
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
@@ -326,6 +328,7 @@ describe('isInitialized', () => {
 
   it('returns true if client is setup', () => {
     const client = getTestClient();
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);

--- a/packages/core/test/lib/integration.test.ts
+++ b/packages/core/test/lib/integration.test.ts
@@ -617,6 +617,7 @@ describe('addIntegration', () => {
     }
 
     const client = getTestClient();
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
@@ -635,6 +636,7 @@ describe('addIntegration', () => {
       setupOnce = jest.fn();
     }
 
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub();
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
@@ -660,6 +662,7 @@ describe('addIntegration', () => {
     }
 
     const client = getTestClient();
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
@@ -683,6 +686,7 @@ describe('addIntegration', () => {
     }
 
     const client = getTestClient();
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);

--- a/packages/core/test/lib/scope.test.ts
+++ b/packages/core/test/lib/scope.test.ts
@@ -522,6 +522,7 @@ describe('withActiveSpan()', () => {
     const options = getDefaultTestClientOptions({ enableTracing: true });
     const client = new TestClient(options);
     const scope = new Scope();
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client, scope);
     makeMain(hub); // eslint-disable-line deprecation/deprecation
   });

--- a/packages/core/test/lib/sdk.test.ts
+++ b/packages/core/test/lib/sdk.test.ts
@@ -87,6 +87,7 @@ describe('SDK', () => {
 
 describe('captureCheckIn', () => {
   afterEach(function () {
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub();
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);

--- a/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
+++ b/packages/core/test/lib/tracing/dynamicSamplingContext.test.ts
@@ -9,6 +9,7 @@ describe('getDynamicSamplingContextFromSpan', () => {
   beforeEach(() => {
     const options = getDefaultTestClientOptions({ tracesSampleRate: 1.0, release: '1.0.1' });
     const client = new TestClient(options);
+    // eslint-disable-next-line deprecation/deprecation
     hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);

--- a/packages/core/test/lib/tracing/errors.test.ts
+++ b/packages/core/test/lib/tracing/errors.test.ts
@@ -34,6 +34,7 @@ describe('registerErrorHandlers()', () => {
     mockAddGlobalErrorInstrumentationHandler.mockClear();
     mockAddGlobalUnhandledRejectionInstrumentationHandler.mockClear();
     const options = getDefaultBrowserClientOptions({ enableTracing: true });
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(new BrowserClient(options));
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);

--- a/packages/core/test/lib/tracing/trace.test.ts
+++ b/packages/core/test/lib/tracing/trace.test.ts
@@ -36,6 +36,7 @@ describe('startSpan', () => {
   beforeEach(() => {
     const options = getDefaultTestClientOptions({ tracesSampleRate: 0.0 });
     client = new TestClient(options);
+    // eslint-disable-next-line deprecation/deprecation
     hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
@@ -427,6 +428,7 @@ describe('startSpanManual', () => {
   beforeEach(() => {
     const options = getDefaultTestClientOptions({ tracesSampleRate: 1 });
     client = new TestClient(options);
+    // eslint-disable-next-line deprecation/deprecation
     hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
@@ -537,6 +539,7 @@ describe('startInactiveSpan', () => {
   beforeEach(() => {
     const options = getDefaultTestClientOptions({ tracesSampleRate: 1 });
     client = new TestClient(options);
+    // eslint-disable-next-line deprecation/deprecation
     hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
@@ -662,6 +665,7 @@ describe('continueTrace', () => {
   beforeEach(() => {
     const options = getDefaultTestClientOptions({ tracesSampleRate: 0.0 });
     client = new TestClient(options);
+    // eslint-disable-next-line deprecation/deprecation
     hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);

--- a/packages/deno/test/__snapshots__/mod.test.ts.snap
+++ b/packages/deno/test/__snapshots__/mod.test.ts.snap
@@ -82,7 +82,7 @@ snapshot[`captureException 1`] = `
               filename: "app:///test/mod.test.ts",
               function: "<anonymous>",
               in_app: true,
-              lineno: 46,
+              lineno: 47,
               post_context: [
                 "",
                 "  await delay(200);",
@@ -108,7 +108,7 @@ snapshot[`captureException 1`] = `
               filename: "app:///test/mod.test.ts",
               function: "something",
               in_app: true,
-              lineno: 43,
+              lineno: 44,
               post_context: [
                 "  }",
                 "",

--- a/packages/deno/test/mod.test.ts
+++ b/packages/deno/test/mod.test.ts
@@ -22,6 +22,7 @@ function getTestClient(
   });
 
   const scope = new Scope();
+  // eslint-disable-next-line deprecation/deprecation
   const hub = new Hub(client, scope);
 
   return [hub, client];

--- a/packages/node-experimental/src/sdk/hub.ts
+++ b/packages/node-experimental/src/sdk/hub.ts
@@ -144,7 +144,7 @@ export function getCurrentHub(): Hub {
  */
 export function makeMain(hub: Hub): Hub {
   // eslint-disable-next-line no-console
-  console.warn('makeMain is a noop in @sentry/node-experimental. Use `setCurrentScope` instead.');
+  console.warn('makeMain is a noop in @sentry/node-experimental. Use `setCurrentClient` instead.');
   return hub;
 }
 

--- a/packages/node/test/handlers.test.ts
+++ b/packages/node/test/handlers.test.ts
@@ -66,6 +66,7 @@ describe('requestHandler', () => {
   it('autoSessionTracking is enabled, sets requestSession status to ok, when handling a request', () => {
     const options = getDefaultNodeClientOptions({ autoSessionTracking: true, release: '1.2' });
     client = new NodeClient(options);
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client);
 
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
@@ -80,6 +81,7 @@ describe('requestHandler', () => {
   it('autoSessionTracking is disabled, does not set requestSession, when handling a request', () => {
     const options = getDefaultNodeClientOptions({ autoSessionTracking: false, release: '1.2' });
     client = new NodeClient(options);
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client);
 
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
@@ -94,6 +96,7 @@ describe('requestHandler', () => {
   it('autoSessionTracking is enabled, calls _captureRequestSession, on response finish', done => {
     const options = getDefaultNodeClientOptions({ autoSessionTracking: true, release: '1.2' });
     client = new NodeClient(options);
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client);
 
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
@@ -116,6 +119,7 @@ describe('requestHandler', () => {
   it('autoSessionTracking is disabled, does not call _captureRequestSession, on response finish', done => {
     const options = getDefaultNodeClientOptions({ autoSessionTracking: false, release: '1.2' });
     client = new NodeClient(options);
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client);
 
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
@@ -162,6 +166,7 @@ describe('requestHandler', () => {
   });
 
   it('stores request and request data options in `sdkProcessingMetadata`', () => {
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(new NodeClient(getDefaultNodeClientOptions()));
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
     mockAsyncContextStrategy(() => hub);
@@ -198,6 +203,7 @@ describe('tracingHandler', () => {
   }
 
   beforeEach(() => {
+    // eslint-disable-next-line deprecation/deprecation
     hub = new Hub(new NodeClient(getDefaultNodeClientOptions({ tracesSampleRate: 1.0 })));
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
@@ -322,6 +328,7 @@ describe('tracingHandler', () => {
   it('extracts request data for sampling context', () => {
     const tracesSampler = jest.fn();
     const options = getDefaultNodeClientOptions({ tracesSampler });
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(new NodeClient(options));
     mockAsyncContextStrategy(() => hub);
 
@@ -344,6 +351,7 @@ describe('tracingHandler', () => {
 
   it('puts its transaction on the scope', () => {
     const options = getDefaultNodeClientOptions({ tracesSampleRate: 1.0 });
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(new NodeClient(options));
 
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
@@ -474,6 +482,7 @@ describe('tracingHandler', () => {
 
   it('stores request in transaction metadata', () => {
     const options = getDefaultNodeClientOptions({ tracesSampleRate: 1.0 });
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(new NodeClient(options));
 
     jest.spyOn(sentryCore, 'getCurrentHub').mockReturnValue(hub);
@@ -532,6 +541,7 @@ describe('errorHandler()', () => {
     client.initSessionFlusher();
 
     const scope = getCurrentScope();
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client);
 
     jest.spyOn<any, any>(client, '_captureRequestSession');
@@ -548,6 +558,7 @@ describe('errorHandler()', () => {
     client = new NodeClient(options);
 
     const scope = getCurrentScope();
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client);
 
     jest.spyOn<any, any>(client, '_captureRequestSession');
@@ -566,6 +577,7 @@ describe('errorHandler()', () => {
     // by the`requestHandler`)
     client.initSessionFlusher();
     const scope = new Scope();
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client, scope);
     mockAsyncContextStrategy(() => hub);
 
@@ -588,6 +600,7 @@ describe('errorHandler()', () => {
     // by the`requestHandler`)
     client.initSessionFlusher();
     const scope = new Scope();
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client, scope);
 
     jest.spyOn<any, any>(client, '_captureRequestSession');
@@ -602,6 +615,7 @@ describe('errorHandler()', () => {
     const options = getDefaultNodeClientOptions({});
     client = new NodeClient(options);
 
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client);
     mockAsyncContextStrategy(() => hub);
     // eslint-disable-next-line deprecation/deprecation

--- a/packages/node/test/integrations/http.test.ts
+++ b/packages/node/test/integrations/http.test.ts
@@ -67,6 +67,7 @@ describe('tracing', () => {
       ...customOptions,
     });
     const client = new NodeClient(options);
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub();
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
@@ -270,6 +271,7 @@ describe('tracing', () => {
       environment: 'production',
       instrumenter: 'otel',
     });
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(new NodeClient(options));
 
     // eslint-disable-next-line deprecation/deprecation
@@ -371,6 +373,7 @@ describe('tracing', () => {
       });
 
       const client = new NodeClient(options);
+      // eslint-disable-next-line deprecation/deprecation
       const hub = new Hub(client);
       // eslint-disable-next-line deprecation/deprecation
       makeMain(hub);
@@ -622,6 +625,7 @@ describe('default protocols', () => {
       },
     });
     const client = new NodeClient(options);
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
@@ -715,6 +719,7 @@ describe('httpIntegration', () => {
       environment: 'production',
     });
     const client = new NodeClient(options);
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
@@ -775,6 +780,7 @@ describe('httpIntegration', () => {
 
 describe('_shouldCreateSpans', () => {
   beforeEach(function () {
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub();
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
@@ -796,6 +802,7 @@ describe('_shouldCreateSpans', () => {
 
 describe('_getShouldCreateSpanForRequest', () => {
   beforeEach(function () {
+    // eslint-disable-next-line deprecation/deprecation
     const hub = new Hub();
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);

--- a/packages/node/test/integrations/undici.test.ts
+++ b/packages/node/test/integrations/undici.test.ts
@@ -35,6 +35,7 @@ const DEFAULT_OPTIONS = getDefaultNodeClientOptions({
 
 beforeEach(() => {
   const client = new NodeClient(DEFAULT_OPTIONS);
+  // eslint-disable-next-line deprecation/deprecation
   hub = new Hub(client);
   // eslint-disable-next-line deprecation/deprecation
   makeMain(hub);
@@ -387,6 +388,7 @@ conditionalTest({ min: 16 })('Undici integration', () => {
         environment: 'production',
       });
       const client = new NodeClient(options);
+      // eslint-disable-next-line deprecation/deprecation
       const hub = new Hub(client);
       // eslint-disable-next-line deprecation/deprecation
       makeMain(hub);

--- a/packages/opentelemetry-node/test/propagator.test.ts
+++ b/packages/opentelemetry-node/test/propagator.test.ts
@@ -47,7 +47,8 @@ describe('SentryPropagator', () => {
         }),
       };
       // @ts-expect-error Use mock client for unit tests
-      const hub: Hub = new Hub(client);
+      // eslint-disable-next-line deprecation/deprecation
+      const hub = new Hub(client);
       // eslint-disable-next-line deprecation/deprecation
       makeMain(hub);
 

--- a/packages/opentelemetry-node/test/spanprocessor.test.ts
+++ b/packages/opentelemetry-node/test/spanprocessor.test.ts
@@ -46,6 +46,7 @@ describe('SentrySpanProcessor', () => {
     SPAN_MAP.clear();
 
     client = new NodeClient(DEFAULT_NODE_CLIENT_OPTIONS);
+    // eslint-disable-next-line deprecation/deprecation
     hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
@@ -964,6 +965,7 @@ describe('SentrySpanProcessor', () => {
         return null;
       },
     });
+    // eslint-disable-next-line deprecation/deprecation
     hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
@@ -1011,6 +1013,7 @@ describe('SentrySpanProcessor', () => {
         return null;
       },
     });
+    // eslint-disable-next-line deprecation/deprecation
     hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
@@ -1058,6 +1061,7 @@ describe('SentrySpanProcessor', () => {
       sentryTransaction = transaction;
     });
 
+    // eslint-disable-next-line deprecation/deprecation
     hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);

--- a/packages/opentelemetry/test/propagator.test.ts
+++ b/packages/opentelemetry/test/propagator.test.ts
@@ -40,8 +40,10 @@ describe('SentryPropagator', () => {
         publicKey: 'abc',
       }),
     };
+
     // @ts-expect-error Use mock client for unit tests
-    const hub: Hub = new Hub(client);
+    // eslint-disable-next-line deprecation/deprecation
+    const hub = new Hub(client);
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);
 

--- a/packages/sveltekit/test/server/handle.test.ts
+++ b/packages/sveltekit/test/server/handle.test.ts
@@ -91,6 +91,7 @@ beforeAll(() => {
 beforeEach(() => {
   const options = getDefaultNodeClientOptions({ tracesSampleRate: 1.0 });
   client = new NodeClient(options);
+  // eslint-disable-next-line deprecation/deprecation
   hub = new Hub(client);
   // eslint-disable-next-line deprecation/deprecation
   makeMain(hub);

--- a/packages/tracing-internal/test/browser/backgroundtab.test.ts
+++ b/packages/tracing-internal/test/browser/backgroundtab.test.ts
@@ -15,6 +15,7 @@ conditionalTest({ min: 10 })('registerBackgroundTabDetection', () => {
     global.document = dom.window.document;
 
     const options = getDefaultBrowserClientOptions({ tracesSampleRate: 1 });
+    // eslint-disable-next-line deprecation/deprecation
     hub = new Hub(new TestClient(options));
     // eslint-disable-next-line deprecation/deprecation
     makeMain(hub);


### PR DESCRIPTION
This PR is a backport of https://github.com/getsentry/sentry-javascript/pull/10574, deprecating the hub constructor.