### PR TITLE
ref: Remove `lastEventId`

### DIFF
--- a/packages/astro/src/index.server.ts
+++ b/packages/astro/src/index.server.ts
@@ -58,8 +58,6 @@ export {
   defaultIntegrations,
   getDefaultIntegrations,
   defaultStackParser,
-  // eslint-disable-next-line deprecation/deprecation
-  lastEventId,
   flush,
   close,
   getSentryRelease,

--- a/packages/astro/src/index.types.ts
+++ b/packages/astro/src/index.types.ts
@@ -26,9 +26,4 @@ export declare const defaultStackParser: StackParser;
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
 
-/**
- * @deprecated This function will be removed in the next major version of the Sentry SDK.
- */
-export declare function lastEventId(): string | undefined;
-
 export default sentryAstro;

--- a/packages/browser/src/exports.ts
+++ b/packages/browser/src/exports.ts
@@ -42,8 +42,6 @@ export {
   getCurrentScope,
   Hub,
   // eslint-disable-next-line deprecation/deprecation
-  lastEventId,
-  // eslint-disable-next-line deprecation/deprecation
   // eslint-disable-next-line deprecation/deprecation
   makeMain,
   setCurrentClient,

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -198,13 +198,6 @@ export const showReportDialog: ShowReportDialogFunction = (
     };
   }
 
-  // TODO(v8): Remove this entire if statement. `eventId` will be a required option.
-  // eslint-disable-next-line deprecation/deprecation
-  if (!options.eventId) {
-    // eslint-disable-next-line deprecation/deprecation
-    options.eventId = hub.lastEventId();
-  }
-
   const script = WINDOW.document.createElement('script');
   script.async = true;
   script.crossOrigin = 'anonymous';

--- a/packages/bun/src/index.ts
+++ b/packages/bun/src/index.ts
@@ -49,8 +49,6 @@ export {
   getIsolationScope,
   Hub,
   // eslint-disable-next-line deprecation/deprecation
-  lastEventId,
-  // eslint-disable-next-line deprecation/deprecation
   makeMain,
   setCurrentClient,
   runWithAsyncContext,

--- a/packages/core/src/exports.ts
+++ b/packages/core/src/exports.ts
@@ -371,17 +371,6 @@ export async function close(timeout?: number): Promise<boolean> {
 }
 
 /**
- * This is the getter for lastEventId.
- *
- * @returns The last event id of a captured event.
- * @deprecated This function will be removed in the next major version of the Sentry SDK.
- */
-export function lastEventId(): string | undefined {
-  // eslint-disable-next-line deprecation/deprecation
-  return getCurrentHub().lastEventId();
-}
-
-/**
  * Get the currently active client.
  */
 export function getClient<C extends Client>(): C | undefined {

--- a/packages/core/src/hub.ts
+++ b/packages/core/src/hub.ts
@@ -121,9 +121,6 @@ export class Hub implements HubInterface {
   /** Is a {@link Layer}[] containing the client and scope */
   private readonly _stack: Layer[];
 
-  /** Contains the last event id of a captured event.  */
-  private _lastEventId?: string;
-
   private _isolationScope: Scope;
 
   /**
@@ -354,7 +351,7 @@ export class Hub implements HubInterface {
    * @deprecated Use `Sentry.captureException()` instead.
    */
   public captureException(exception: unknown, hint?: EventHint): string {
-    const eventId = (this._lastEventId = hint && hint.event_id ? hint.event_id : uuid4());
+    const eventId = hint && hint.event_id ? hint.event_id : uuid4();
     const syntheticException = new Error('Sentry syntheticException');
     // eslint-disable-next-line deprecation/deprecation
     this.getScope().captureException(exception, {
@@ -373,7 +370,7 @@ export class Hub implements HubInterface {
    * @deprecated Use  `Sentry.captureMessage()` instead.
    */
   public captureMessage(message: string, level?: SeverityLevel, hint?: EventHint): string {
-    const eventId = (this._lastEventId = hint && hint.event_id ? hint.event_id : uuid4());
+    const eventId = hint && hint.event_id ? hint.event_id : uuid4();
     const syntheticException = new Error(message);
     // eslint-disable-next-line deprecation/deprecation
     this.getScope().captureMessage(message, level, {
@@ -393,21 +390,9 @@ export class Hub implements HubInterface {
    */
   public captureEvent(event: Event, hint?: EventHint): string {
     const eventId = hint && hint.event_id ? hint.event_id : uuid4();
-    if (!event.type) {
-      this._lastEventId = eventId;
-    }
     // eslint-disable-next-line deprecation/deprecation
     this.getScope().captureEvent(event, { ...hint, event_id: eventId });
     return eventId;
-  }
-
-  /**
-   * @inheritDoc
-   *
-   * @deprecated This will be removed in v8.
-   */
-  public lastEventId(): string | undefined {
-    return this._lastEventId;
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,8 +20,6 @@ export {
   configureScope,
   flush,
   // eslint-disable-next-line deprecation/deprecation
-  lastEventId,
-  // eslint-disable-next-line deprecation/deprecation
   startTransaction,
   setContext,
   setExtra,

--- a/packages/deno/src/index.ts
+++ b/packages/deno/src/index.ts
@@ -48,8 +48,6 @@ export {
   getIsolationScope,
   Hub,
   // eslint-disable-next-line deprecation/deprecation
-  lastEventId,
-  // eslint-disable-next-line deprecation/deprecation
   makeMain,
   setCurrentClient,
   runWithAsyncContext,

--- a/packages/node-experimental/src/index.ts
+++ b/packages/node-experimental/src/index.ts
@@ -36,8 +36,6 @@ export {
   captureMessage,
   addGlobalEventProcessor,
   addEventProcessor,
-  // eslint-disable-next-line deprecation/deprecation
-  lastEventId,
   setContext,
   setExtra,
   setExtras,

--- a/packages/node-experimental/src/sdk/api.ts
+++ b/packages/node-experimental/src/sdk/api.ts
@@ -97,15 +97,6 @@ export function withIsolationScope<T>(callback: (isolationScope: Scope) => T): T
 }
 
 /**
- * Get the ID of the last sent error event.
- * @deprecated This function will be removed in the next major version of the Sentry SDK.
- */
-export function lastEventId(): string | undefined {
-  // eslint-disable-next-line deprecation/deprecation
-  return getCurrentScope().lastEventId();
-}
-
-/**
  * Configure the current scope.
  * @deprecated Use `getCurrentScope()` instead.
  */

--- a/packages/node-experimental/src/sdk/hub.ts
+++ b/packages/node-experimental/src/sdk/hub.ts
@@ -16,7 +16,6 @@ import {
   configureScope,
   getClient,
   getCurrentScope,
-  lastEventId,
   setContext,
   setExtra,
   setExtras,
@@ -71,7 +70,6 @@ export function getCurrentHub(): Hub {
       return getCurrentScope().captureMessage(message, level, hint);
     },
     captureEvent,
-    lastEventId,
     addBreadcrumb,
     setUser,
     setTags,

--- a/packages/node-experimental/src/sdk/scope.ts
+++ b/packages/node-experimental/src/sdk/scope.ts
@@ -74,8 +74,6 @@ export function isInitialized(): boolean {
 export class Scope extends OpenTelemetryScope implements ScopeInterface {
   protected _client: Client | undefined;
 
-  protected _lastEventId: string | undefined;
-
   /**
    * @inheritDoc
    */
@@ -131,8 +129,6 @@ export class Scope extends OpenTelemetryScope implements ScopeInterface {
       this,
     );
 
-    this._lastEventId = eventId;
-
     return eventId;
   }
 
@@ -153,26 +149,16 @@ export class Scope extends OpenTelemetryScope implements ScopeInterface {
       this,
     );
 
-    this._lastEventId = eventId;
-
     return eventId;
   }
 
   /** Capture a message for this scope. */
   public captureEvent(event: Event, hint?: EventHint): string {
     const eventId = hint && hint.event_id ? hint.event_id : uuid4();
-    if (!event.type) {
-      this._lastEventId = eventId;
-    }
 
     getClient().captureEvent(event, { ...hint, event_id: eventId }, this);
 
     return eventId;
-  }
-
-  /** Get the ID of the last sent error event. */
-  public lastEventId(): string | undefined {
-    return this._lastEventId;
   }
 
   /**

--- a/packages/node-experimental/src/sdk/types.ts
+++ b/packages/node-experimental/src/sdk/types.ts
@@ -30,10 +30,6 @@ export interface ScopeData {
 export interface Scope extends BaseScope {
   // @ts-expect-error typeof this is what we want here
   clone(scope?: Scope): typeof this;
-  /**
-   * @deprecated This function will be removed in the next major version of the Sentry SDK.
-   */
-  lastEventId(): string | undefined;
   getScopeData(): ScopeData;
 }
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -48,8 +48,6 @@ export {
   getIsolationScope,
   Hub,
   // eslint-disable-next-line deprecation/deprecation
-  lastEventId,
-  // eslint-disable-next-line deprecation/deprecation
   makeMain,
   setCurrentClient,
   runWithAsyncContext,

--- a/packages/react/src/errorboundary.tsx
+++ b/packages/react/src/errorboundary.tsx
@@ -111,8 +111,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
     if (client && client.on && props.showDialog) {
       this._openFallbackReportDialog = false;
       client.on('afterSendEvent', event => {
-        if (!event.type && event.event_id === this._lastEventId) {
-          // eslint-disable-next-line deprecation/deprecation
+        if (!event.type && this._lastEventId && event.event_id === this._lastEventId) {
           showReportDialog({ ...props.dialogOptions, eventId: this._lastEventId });
         }
       });

--- a/packages/remix/src/index.server.ts
+++ b/packages/remix/src/index.server.ts
@@ -62,8 +62,6 @@ export {
   defaultIntegrations,
   getDefaultIntegrations,
   defaultStackParser,
-  // eslint-disable-next-line deprecation/deprecation
-  lastEventId,
   flush,
   close,
   getSentryRelease,

--- a/packages/remix/src/index.types.ts
+++ b/packages/remix/src/index.types.ts
@@ -29,9 +29,3 @@ declare const runtime: 'client' | 'server';
 
 export const close = runtime === 'client' ? clientSdk.close : serverSdk.close;
 export const flush = runtime === 'client' ? clientSdk.flush : serverSdk.flush;
-
-/**
- * @deprecated This function will be removed in the next major version of the Sentry SDK.
- */
-// eslint-disable-next-line deprecation/deprecation
-export const lastEventId = runtime === 'client' ? clientSdk.lastEventId : serverSdk.lastEventId;

--- a/packages/serverless/src/index.ts
+++ b/packages/serverless/src/index.ts
@@ -63,8 +63,6 @@ export {
   flush,
   getSentryRelease,
   init,
-  // eslint-disable-next-line deprecation/deprecation
-  lastEventId,
   DEFAULT_USER_INCLUDES,
   addRequestDataToEvent,
   extractRequestData,

--- a/packages/sveltekit/src/index.types.ts
+++ b/packages/sveltekit/src/index.types.ts
@@ -48,8 +48,3 @@ export declare const defaultStackParser: StackParser;
 
 export declare function close(timeout?: number | undefined): PromiseLike<boolean>;
 export declare function flush(timeout?: number | undefined): PromiseLike<boolean>;
-
-/**
- * @deprecated This function will be removed in the next major version of the Sentry SDK.
- */
-export declare function lastEventId(): string | undefined;

--- a/packages/sveltekit/src/server/index.ts
+++ b/packages/sveltekit/src/server/index.ts
@@ -56,8 +56,6 @@ export {
   defaultIntegrations,
   getDefaultIntegrations,
   defaultStackParser,
-  // eslint-disable-next-line deprecation/deprecation
-  lastEventId,
   flush,
   close,
   getSentryRelease,

--- a/packages/types/src/hub.ts
+++ b/packages/types/src/hub.ts
@@ -129,15 +129,6 @@ export interface Hub {
   captureEvent(event: Event, hint?: EventHint): string;
 
   /**
-   * This is the getter for lastEventId.
-   *
-   * @returns The last event id of a captured event.
-   *
-   * @deprecated This will be removed in v8.
-   */
-  lastEventId(): string | undefined;
-
-  /**
    * Records a new breadcrumb which will be attached to future events.
    *
    * Breadcrumbs will be added to subsequent events to provide more context on

--- a/packages/vercel-edge/src/index.ts
+++ b/packages/vercel-edge/src/index.ts
@@ -48,8 +48,6 @@ export {
   getIsolationScope,
   Hub,
   // eslint-disable-next-line deprecation/deprecation
-  lastEventId,
-  // eslint-disable-next-line deprecation/deprecation
   makeMain,
   setCurrentClient,
   runWithAsyncContext,


### PR DESCRIPTION
After the deprecation in v7 we now remove `lastEventId`.